### PR TITLE
feat: programmatic joint animations

### DIFF
--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -48,10 +48,10 @@ fn process_model(
     _config: &(),
 ) -> Model {
     match mesh {
-        SystemShockContentModel::Obj(obj) => Model::from_static(obj, asset_cache),
+        SystemShockContentModel::Obj(obj) => Model::from_obj_bin(obj, asset_cache),
         SystemShockContentModel::Mesh(mesh, skeleton) => {
             //let skeleton = ss2_skeleton::Skeleton::empty();
-            Model::from_ai(mesh, skeleton, asset_cache)
+            Model::from_ai_bin(mesh, skeleton, asset_cache)
         }
     }
 }

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -50,7 +50,6 @@ fn process_model(
     match mesh {
         SystemShockContentModel::Obj(obj) => Model::from_obj_bin(obj, asset_cache),
         SystemShockContentModel::Mesh(mesh, skeleton) => {
-            //let skeleton = ss2_skeleton::Skeleton::empty();
             Model::from_ai_bin(mesh, skeleton, asset_cache)
         }
     }

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -4,7 +4,7 @@ use crate::{
     motion::{AnimationClip, AnimationPlayer},
     ss2_bin_ai_loader::{self, SystemShock2AIMesh},
     ss2_bin_obj_loader::{self, SystemShock2ObjectMesh, Vhot},
-    ss2_skeleton::{self, Skeleton},
+    ss2_skeleton::{self, AnimationInfo, Skeleton},
 };
 use cgmath::{Matrix4, SquareMatrix};
 use collision::Aabb3;
@@ -71,8 +71,10 @@ impl AnimatedModel {
     fn animate(&self, animation_clip: &AnimationClip, frame: u32) -> AnimatedModel {
         let animated_skeleton = ss2_skeleton::animate(
             &self.skeleton,
-            Some(&animation_clip),
-            frame,
+            Some(AnimationInfo {
+                animation_clip: &animation_clip,
+                frame,
+            }),
             &rpds::HashTrieMap::new(),
         );
         let new_data = animated_skeleton.get_transforms();

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -71,8 +71,7 @@ impl AnimatedModel {
     fn animate(&self, animation_clip: &AnimationClip, frame: u32) -> AnimatedModel {
         let animated_skeleton = ss2_skeleton::animate(
             &self.skeleton,
-            // TODO: is thi sused?
-            None,
+            Some(&animation_clip),
             frame,
             &rpds::HashTrieMap::new(),
         );

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -69,7 +69,12 @@ impl AnimatedModel {
     }
 
     fn animate(&self, animation_clip: &AnimationClip, frame: u32) -> AnimatedModel {
-        let animated_skeleton = ss2_skeleton::animate(&self.skeleton, animation_clip, frame);
+        let animated_skeleton = ss2_skeleton::animate(
+            &self.skeleton,
+            animation_clip,
+            frame,
+            &rpds::HashTrieMap::new(),
+        );
         let new_data = animated_skeleton.get_transforms();
 
         let new_scene_objects = self

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -4,7 +4,7 @@ use cgmath::{vec3, Deg, Matrix4, Vector3};
 use num::complex::ComplexFloat;
 use rpds as immutable;
 
-use crate::ss2_skeleton::{self, Skeleton};
+use crate::ss2_skeleton::{self, AnimationInfo, Skeleton};
 
 use super::{AnimationClip, MotionFlags};
 pub enum AnimationFlags {
@@ -199,7 +199,7 @@ impl AnimationPlayer {
         // If there is no animation, we still may need to apply joint transforms (ie, for camera or turret)
         if maybe_current_clip.is_none() {
             let animated_skeleton =
-                ss2_skeleton::animate(skeleton, None, 0, &self.additional_joint_transforms);
+                ss2_skeleton::animate(skeleton, None, &self.additional_joint_transforms);
             return animated_skeleton.get_transforms();
         }
 
@@ -214,8 +214,10 @@ impl AnimationPlayer {
 
         let animated_skeleton = ss2_skeleton::animate(
             skeleton,
-            Some(current_clip),
-            current_frame,
+            Some(AnimationInfo {
+                animation_clip: current_clip,
+                frame: current_frame,
+            }),
             &self.additional_joint_transforms,
         );
 

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -112,7 +112,7 @@ pub fn read<T: Read + Seek>(
 pub fn to_scene_objects(
     mesh: &SystemShock2ObjectMesh,
     asset_cache: &mut AssetCache,
-) -> Vec<SceneObject> {
+) -> (Vec<SceneObject>, Skeleton) {
     let mut hashToMaterial = HashMap::new();
 
     let material_len = mesh.materials.len();
@@ -217,7 +217,7 @@ pub fn to_scene_objects(
         .collect::<Vec<SceneObject>>();
 
     mesh_objects.append(&mut vhot_objs);
-    mesh_objects
+    (mesh_objects, skeleton)
 }
 
 // Data

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -293,17 +293,25 @@ fn calc_and_cache_global_transform(
 //     }
 // }
 
+pub struct AnimationInfo<'a> {
+    pub animation_clip: &'a AnimationClip,
+    pub frame: u32,
+}
+
 pub fn animate(
     base_skeleton: &Skeleton,
-    animation_clip: Option<&AnimationClip>,
-    frame: u32,
+    animation_info: Option<AnimationInfo>,
     additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
 ) -> Skeleton {
     let bones = base_skeleton.bones.clone();
 
     let mut animation_transforms = HashMap::new();
 
-    if let Some(animation_clip) = animation_clip {
+    if let Some(AnimationInfo {
+        animation_clip,
+        frame,
+    }) = animation_info
+    {
         let normalized_frame = frame % animation_clip.num_frames;
         let animations = &animation_clip.joint_to_frame;
         for key in animations {

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -2,7 +2,7 @@
 // Helper class to work with skeletons in AI meshes
 
 use rpds as immutable;
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, ops::Deref, rc::Rc};
 
 use cgmath::{vec3, Deg, Matrix4, SquareMatrix};
 
@@ -295,7 +295,7 @@ fn calc_and_cache_global_transform(
 
 pub fn animate(
     base_skeleton: &Skeleton,
-    animation_clip: Option<Rc<AnimationClip>>,
+    animation_clip: Option<&AnimationClip>,
     frame: u32,
     additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
 ) -> Skeleton {

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -1,6 +1,7 @@
 // ss2_skeleton.rs
 // Helper class to work with skeletons in AI meshes
 
+use rpds as immutable;
 use std::collections::HashMap;
 
 use cgmath::{vec3, Deg, Matrix4, SquareMatrix};
@@ -235,7 +236,12 @@ fn calc_and_cache_global_transform(
     }
 }
 
-pub fn animate(base_skeleton: &Skeleton, animation_clip: &AnimationClip, frame: u32) -> Skeleton {
+pub fn animate(
+    base_skeleton: &Skeleton,
+    animation_clip: &AnimationClip,
+    frame: u32,
+    additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
+) -> Skeleton {
     let bones = base_skeleton.bones.clone();
 
     let normalized_frame = frame % animation_clip.num_frames;

--- a/runtimes/tool/src/main.rs
+++ b/runtimes/tool/src/main.rs
@@ -283,15 +283,10 @@ pub fn main() {
             1,
             Matrix4::from_angle_x(Deg(90.0 + 45.0 * time.total.as_secs_f32().sin())),
         );
-        let obj = turret.to_animated_scene_objects(&animation_player);
+        let turret_scene_obj = turret.to_animated_scene_objects(&animation_player);
 
-        // let mut skinning_data = [Matrix4::identity(); 40];
-        // skinning_data[1] = Matrix4::from_translation(vec3(0.0, 1.0, 0.0));
-        //skinning_data[1] = Matrix4::from_translation(vec3(0.0, 1.0, 0.0));
-        for o in obj {
-            // let mut cloned_o = o.clone();
-            // cloned_o.set_skinning_data(skinning_data);
-            scene.push(o);
+        for so in turret_scene_obj {
+            scene.push(so);
         }
 
         let yaw_rad = camera_context.yaw.to_radians();
@@ -311,10 +306,8 @@ pub fn main() {
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 1.0, 0.0),
         );
-        let rot = mat.rot.invert();
 
         let cm = engine::scene::color_material::create(vec3(0.0, 1.0, 0.0));
-        let new_obj = SceneObject::new(cm, Box::new(engine::scene::cube::create()));
 
         let orig_camera_forward = orig_camera_rot * vec3(0.0, 0.0, -1.0);
         let pointer_mat = engine::scene::color_material::create(vec3(0.0, 1.0, 0.0));

--- a/runtimes/tool/src/main.rs
+++ b/runtimes/tool/src/main.rs
@@ -3,6 +3,7 @@ use self::glfw::{Action, Context, Key};
 
 use cgmath::point3;
 use cgmath::Decomposed;
+use cgmath::Deg;
 use cgmath::Matrix4;
 use cgmath::Rad;
 
@@ -243,7 +244,12 @@ pub fn main() {
     let start_time = last_time;
 
     let mut frame = 0;
-    //let mut animation_player = AnimationPlayer::from_animation(&animation_clip);
+    let mut animation_player = AnimationPlayer::empty();
+    animation_player = AnimationPlayer::set_additional_joint_transform(
+        &animation_player,
+        2,
+        Matrix4::from_translation(vec3(-0.5, 0.0, 0.0)) * Matrix4::from_angle_x(Deg(45.0)),
+    );
     // render loop
     // -----------
     while !window.should_close() {
@@ -267,8 +273,25 @@ pub fn main() {
         //let (mut scene, pawn_offset, pawn_rotation) = game.render();
 
         let mut scene = vec![];
+        animation_player = AnimationPlayer::set_additional_joint_transform(
+            &animation_player,
+            2,
+            Matrix4::from_translation(vec3(-0.8, 0.0, 0.0)),
+        );
+        animation_player = AnimationPlayer::set_additional_joint_transform(
+            &animation_player,
+            1,
+            Matrix4::from_angle_x(Deg(90.0 + 45.0 * time.total.as_secs_f32().sin())),
+        );
+        let obj = turret.to_animated_scene_objects(&animation_player);
+
+        // let mut skinning_data = [Matrix4::identity(); 40];
+        // skinning_data[1] = Matrix4::from_translation(vec3(0.0, 1.0, 0.0));
+        //skinning_data[1] = Matrix4::from_translation(vec3(0.0, 1.0, 0.0));
         for o in obj {
-            scene.push(o.clone());
+            // let mut cloned_o = o.clone();
+            // cloned_o.set_skinning_data(skinning_data);
+            scene.push(o);
         }
 
         let yaw_rad = camera_context.yaw.to_radians();

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -3,7 +3,7 @@ pub mod entity_populator;
 pub mod spawn_location;
 pub mod visibility_engine;
 
-use collision::{Aabb};
+use collision::Aabb;
 pub use spawn_location::*;
 pub use visibility_engine::*;
 
@@ -55,14 +55,12 @@ use shipyard::{self, View, World};
 use tracing::{info, trace, warn};
 
 use crate::{
-    creature::{
-        get_creature_definition, HitBoxManager,
-    },
+    creature::{get_creature_definition, HitBoxManager},
     gui::GuiManager,
     hud::{draw_item_name, draw_item_outline},
     input_context::{self},
     inventory::PlayerInventoryEntity,
-    mission::{entity_populator::EntityPopulator},
+    mission::entity_populator::EntityPopulator,
     physics::{self, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
@@ -956,6 +954,18 @@ impl Mission {
                                 !is_link_to_entity
                             })
                         }
+                    }
+                }
+                Effect::SetJointTransform {
+                    entity_id,
+                    joint_id,
+                    transform,
+                } => {
+                    let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
+                    if let Some(player) = maybe_player {
+                        *player = AnimationPlayer::set_additional_joint_transform(
+                            player, joint_id, transform,
+                        )
                     }
                 }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1,8 +1,6 @@
-use std::{cell::RefCell};
+use std::cell::RefCell;
 
-use cgmath::{
-    vec3, vec4, Deg, Quaternion, Rotation3,
-};
+use cgmath::{vec3, vec4, Deg, Quaternion, Rotation3};
 use dark::{
     motion::{MotionFlags, MotionQueryItem},
     SCALE_FACTOR,
@@ -51,7 +49,6 @@ impl AnimatedMonsterAI {
         let turn_velocity = self.current_behavior.borrow().turn_speed().0;
         let delta =
             clamp_to_minimal_delta_angle(steering_output.desired_heading - self.current_heading);
-        // clamp_to_minimal_delta_angle(steering_output.desired_heading - self.current_heading);
 
         let turn_amount = if delta.0 < 0.0 {
             (-turn_velocity * time.elapsed.as_secs_f32()).max(delta.0)
@@ -60,7 +57,7 @@ impl AnimatedMonsterAI {
         };
 
         self.current_heading = Deg(self.current_heading.0 + turn_amount);
-        
+
         Effect::SetRotation {
             entity_id,
             rotation: Quaternion::from_angle_y(self.current_heading),

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -1,43 +1,16 @@
-use std::cell::RefCell;
-
 use cgmath::{vec3, vec4, Deg, Matrix4, Quaternion, Rotation3};
-use dark::{
-    motion::{MotionFlags, MotionQueryItem},
-    SCALE_FACTOR,
-};
 use shipyard::{EntityId, World};
 
-use crate::{
-    physics::{InternalCollisionGroups, PhysicsWorld},
-    time::Time,
-};
+use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{
-    ai_util::*,
-    behavior::*,
-    steering::{Steering, SteeringOutput},
-    Effect, Message, MessagePayload, Script,
-};
+use super::{Effect, MessagePayload, Script};
 pub struct CameraAI {
-    // last_hit_sensor: Option<EntityId>,
-    // current_behavior: Box<RefCell<dyn Behavior>>,
-    // current_heading: Deg<f32>,
-    // is_dead: bool,
-    // took_damage: bool,
-    // animation_seq: u32,
+    // TODO: Implement logic (alert behavior, etc)
 }
 
 impl CameraAI {
     pub fn new() -> CameraAI {
-        CameraAI {
-            // is_dead: false,
-            // took_damage: false,
-            // //current_behavior: Box::new(RefCell::new(MeleeAttackBehavior)),
-            // current_behavior: Box::new(RefCell::new(ChaseBehavior::new())),
-            // current_heading: Deg(0.0),
-            // animation_seq: 0,
-            // last_hit_sensor: None,
-        }
+        CameraAI {}
     }
 }
 
@@ -53,19 +26,10 @@ impl Script for CameraAI {
         time: &Time,
     ) -> Effect {
         let quat = Quaternion::from_angle_x(Deg(time.total.as_secs_f32().sin() * 90.0));
-        // Effect::SetJointTransform {
-        //     entity_id,
-        //     joint_id: 1,
-        //     transform: quat.into(),
-        // }
         Effect::SetJointTransform {
             entity_id,
-            joint_id: 2,
-            transform: Matrix4::from_translation(vec3(
-                time.total.as_secs_f32().sin() - 1.0,
-                0.0,
-                0.0,
-            )),
+            joint_id: 1,
+            transform: quat.into(),
         }
     }
 

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -1,0 +1,81 @@
+use std::cell::RefCell;
+
+use cgmath::{vec3, vec4, Deg, Matrix4, Quaternion, Rotation3};
+use dark::{
+    motion::{MotionFlags, MotionQueryItem},
+    SCALE_FACTOR,
+};
+use shipyard::{EntityId, World};
+
+use crate::{
+    physics::{InternalCollisionGroups, PhysicsWorld},
+    time::Time,
+};
+
+use super::{
+    ai_util::*,
+    behavior::*,
+    steering::{Steering, SteeringOutput},
+    Effect, Message, MessagePayload, Script,
+};
+pub struct CameraAI {
+    // last_hit_sensor: Option<EntityId>,
+    // current_behavior: Box<RefCell<dyn Behavior>>,
+    // current_heading: Deg<f32>,
+    // is_dead: bool,
+    // took_damage: bool,
+    // animation_seq: u32,
+}
+
+impl CameraAI {
+    pub fn new() -> CameraAI {
+        CameraAI {
+            // is_dead: false,
+            // took_damage: false,
+            // //current_behavior: Box::new(RefCell::new(MeleeAttackBehavior)),
+            // current_behavior: Box::new(RefCell::new(ChaseBehavior::new())),
+            // current_heading: Deg(0.0),
+            // animation_seq: 0,
+            // last_hit_sensor: None,
+        }
+    }
+}
+
+impl Script for CameraAI {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        Effect::NoEffect
+    }
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let quat = Quaternion::from_angle_x(Deg(time.total.as_secs_f32().sin() * 90.0));
+        // Effect::SetJointTransform {
+        //     entity_id,
+        //     joint_id: 1,
+        //     transform: quat.into(),
+        // }
+        Effect::SetJointTransform {
+            entity_id,
+            joint_id: 2,
+            transform: Matrix4::from_translation(vec3(
+                time.total.as_secs_f32().sin() - 1.0,
+                0.0,
+                0.0,
+            )),
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        Effect::NoEffect
+    }
+}

--- a/shock2vr/src/scripts/ai/mod.rs
+++ b/shock2vr/src/scripts/ai/mod.rs
@@ -3,7 +3,9 @@ pub mod steering;
 
 mod animated_monster_ai;
 mod behavior;
+mod camera_ai;
 
 pub use animated_monster_ai::*;
+pub use camera_ai::*;
 
 use super::{Effect, Message, MessagePayload, Script};

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -2,7 +2,10 @@ use shipyard::{EntityId, World};
 
 use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{ai::AnimatedMonsterAI, Effect, MessagePayload, Script};
+use super::{
+    ai::{AnimatedMonsterAI, CameraAI},
+    Effect, MessagePayload, Script,
+};
 
 pub struct BaseMonster {
     ai: Box<dyn Script>,
@@ -10,7 +13,8 @@ pub struct BaseMonster {
 impl BaseMonster {
     pub fn new() -> BaseMonster {
         BaseMonster {
-            ai: Box::new(AnimatedMonsterAI::new()),
+            //ai: Box::new(AnimatedMonsterAI::new()),
+            ai: Box::new(CameraAI::new()),
         }
     }
 }

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -2,10 +2,7 @@ use shipyard::{EntityId, World};
 
 use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{
-    ai::{AnimatedMonsterAI, CameraAI},
-    Effect, MessagePayload, Script,
-};
+use super::{ai::AnimatedMonsterAI, Effect, MessagePayload, Script};
 
 pub struct BaseMonster {
     ai: Box<dyn Script>,

--- a/shock2vr/src/scripts/base_monster.rs
+++ b/shock2vr/src/scripts/base_monster.rs
@@ -13,8 +13,7 @@ pub struct BaseMonster {
 impl BaseMonster {
     pub fn new() -> BaseMonster {
         BaseMonster {
-            //ai: Box::new(AnimatedMonsterAI::new()),
-            ai: Box::new(CameraAI::new()),
+            ai: Box::new(AnimatedMonsterAI::new()),
         }
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -140,7 +140,11 @@ pub enum Effect {
         position: Vector3<f32>,
         rotation: Quaternion<f32>,
     },
-
+    SetJointTransform {
+        entity_id: EntityId,
+        joint_id: u32,
+        transform: Matrix4<f32>,
+    },
     SetPlayerPosition {
         position: Vector3<f32>,
         is_teleport: bool,


### PR DESCRIPTION
- Fix jointed object bin models - use same skeleton / skinning strategy used by animated models. This fixes a layout issue with the turret.
- Allow for setting joint transforms by joint index - needed for camera, turret, etc.

With this change, the turret is now rendered correctly: 
<img width="182" alt="image" src="https://github.com/tommybuilds/shock2quest/assets/110304079/69562d2b-0f8f-4455-8ab8-1eb28e7ffa0a">

And AI strategy is stubbed out for jointed object models (for camera)