### PR TITLE
fix: address issues blocking psiamp view model

### DIFF
--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -1618,7 +1618,6 @@ impl Mission {
                     rotation: _,
                 } => {
                     self.make_un_physical(entity_id);
-                    println!("!!debug - Holding entity: {:?}", entity_id);
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::Hold,
                         to: entity_id,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -941,6 +941,12 @@ impl Mission {
 
                     if self.right_hand.is_holding(entity_id) || self.left_hand.is_holding(entity_id)
                     {
+                        // Let the scripts know we are now holding the item..
+                        self.script_world.dispatch(Message {
+                            payload: MessagePayload::Hold,
+                            to: entity_id,
+                        });
+
                         let mut v_has_refs = self.world.borrow::<ViewMut<PropHasRefs>>().unwrap();
                         if let Ok(has_refs) = (&mut v_has_refs).get(entity_id) {
                             has_refs.0 = true;
@@ -1612,6 +1618,7 @@ impl Mission {
                     rotation: _,
                 } => {
                     self.make_un_physical(entity_id);
+                    println!("!!debug - Holding entity: {:?}", entity_id);
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::Hold,
                         to: entity_id,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -281,6 +281,19 @@ impl PanicOnLoadScript {
     }
 }
 
+struct PanicOnMessageScript;
+impl Script for PanicOnMessageScript {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _msg: &MessagePayload,
+    ) -> Effect {
+        panic!("Panic for this script");
+    }
+}
+
 impl Script for PanicOnLoadScript {
     fn initialize(&mut self, _entity_id: EntityId, _world: &World) -> Effect {
         panic!("Unimplemented script: {}", self.name);
@@ -501,10 +514,6 @@ impl ScriptWorld {
             "riflemodify" => Box::new(NoopScript::new()),
             "stasismodify" => Box::new(NoopScript::new()),
             "shotgunmodify" => Box::new(NoopScript::new()),
-            "psiampscript" => Box::new(CompositeScript::new(vec![
-                Box::new(MeleeWeapon::new()),
-                Box::new(InternalSwitchHeldModelScript::new()),
-            ])),
             "energyweapon" => Box::new(NoopScript::new()),
             "grenademodify" => Box::new(NoopScript::new()),
             "weapontrainer" => Box::new(UnimplementedScript::new(&script_name)),

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap};
+use std::collections::HashMap;
 
 use cgmath::{vec3, Deg, Quaternion, Rotation3, Vector3};
 use dark::properties::PropModelName;
@@ -100,7 +100,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     let items = vec![
         // Weapons
         ("atek_h", held_weapon.clone()),
-        ("amph_h", held_weapon.clone()),
+        ("amp_h", held_weapon.clone()),
         ("lasehand", held_weapon.clone()),
         ("empgun", held_weapon.clone()),
         ("wrench_h", default.clone()),


### PR DESCRIPTION
Fix a couple issues that were blocking the psiamp 'held' model to show
- Typo in allowlist name (`amph_h` -> `amp_h`)
- There was no 'Hold' message sent when pulling an amp from a container, so the model wouldn't be switched