### PR TITLE
fix: entity gravity handling

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -105,7 +105,7 @@ where
             for (id, door) in (&v_property).iter().with_id() {
                 let maybe_template_id = v_template_id.get(id);
                 let maybe_sym_name = v_symname.get(id);
-                info!("({id:?})[{maybe_template_id:?}|{maybe_sym_name:?}] prop: {door:?}")
+                println!("({id:?})[{maybe_template_id:?}|{maybe_sym_name:?}] prop: {door:?}")
             }
         },
     );

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -12,6 +12,7 @@ mod prop_hit_points;
 mod prop_key;
 mod prop_log;
 mod prop_particles;
+mod prop_phys_attr;
 mod prop_phys_initial_velocity;
 mod prop_phys_type;
 mod prop_player_gun;
@@ -36,6 +37,7 @@ pub use prop_hit_points::*;
 pub use prop_key::*;
 pub use prop_log::*;
 pub use prop_particles::*;
+pub use prop_phys_attr::*;
 pub use prop_phys_initial_velocity::*;
 pub use prop_phys_type::*;
 pub use prop_player_gun::*;
@@ -877,6 +879,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$Position",
             read_prop_position,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$PhysAttr",
+            PropPhysAttr::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_phys_attr.rs
+++ b/dark/src/properties/prop_phys_attr.rs
@@ -23,7 +23,7 @@ pub struct PropPhysAttr {
 
 impl PropPhysAttr {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropPhysAttr {
-        let gravity_scale = read_single(reader);
+        let gravity_scale = read_single(reader) / 100.0;
         let mass = read_single(reader);
         let density = read_single(reader);
         let elasticity = read_single(reader);

--- a/dark/src/properties/prop_phys_attr.rs
+++ b/dark/src/properties/prop_phys_attr.rs
@@ -1,0 +1,61 @@
+use std::io;
+
+use cgmath::Vector3;
+use shipyard::Component;
+
+use crate::ss2_common::*;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropPhysAttr {
+    pub gravity_scale: f32,
+    pub mass: f32,
+    pub density: f32,
+    pub elasticity: f32,
+    pub friction: f32,
+    pub cog: Vector3<f32>,  // ?
+    pub rotation_axes: u32, // ?
+    pub rest_axes: u32,     // ?
+    pub climbable: u32,     // ?
+    pub edge_trigger: bool,
+}
+
+impl PropPhysAttr {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropPhysAttr {
+        let gravity_scale = read_single(reader);
+        let mass = read_single(reader);
+        let density = read_single(reader);
+        let elasticity = read_single(reader);
+        let friction = read_single(reader);
+        let cog = read_vec3(reader);
+
+        let rotation_axes = read_u32(reader);
+        let rest_axes = read_u32(reader);
+        let climbable = read_u32(reader);
+        let edge_trigger = read_bool(reader);
+
+        let size = 48;
+        let remainder = _len - size;
+
+        // HACK: I'm unsure why this property can be variable length. Sometimes, it's length is reported
+        // as 48, and others as 52. To handle this - we'll eat up the remaining bytes. But we could be
+        // missing an interesting property.
+        if remainder > 0 {
+            read_bytes(reader, remainder as usize);
+        }
+
+        PropPhysAttr {
+            gravity_scale,
+            mass,
+            density,
+            elasticity,
+            friction,
+            cog,
+            rotation_axes,
+            rest_axes,
+            climbable,
+            edge_trigger,
+        }
+    }
+}

--- a/dark/src/ss2_entity_info.rs
+++ b/dark/src/ss2_entity_info.rs
@@ -409,7 +409,8 @@ fn read_all_properties<R: io::Read + io::Seek>(
                 let props = ent_to_props.get_mut(&obj_id).unwrap();
                 assert!(
                     expected_pos == ref_reader.stream_position().unwrap(),
-                    "len: {}, expected_pos: {}, actual_pos: {}",
+                    "prop name: {} len: {}, expected_pos: {}, actual_pos: {}",
+                    name,
                     prop_len,
                     expected_pos,
                     ref_reader.stream_position().unwrap()

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -35,8 +35,8 @@ use dark::{
     log_property,
     motion::MotionDB,
     properties::{
-        AmbientSoundFlags, InternalPropOriginalModelName, PropAmbientHacked,
-        PropModelName, PropPosition, PropPhysAttr,
+        AmbientSoundFlags, InternalPropOriginalModelName, PropAmbientHacked, PropModelName,
+        PropPhysAttr, PropPosition,
     },
     SCALE_FACTOR,
 };
@@ -334,8 +334,8 @@ impl Game {
         // panic!();
 
         // log_property::<PropAI>(&active_mission.world);
-        log_property::<PropPhysAttr>(&active_mission.world);
-        panic!();
+        // log_property::<PropPhysAttr>(&active_mission.world);
+        // panic!();
 
         // log_entity(
         //     &active_mission.world,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -36,7 +36,7 @@ use dark::{
     motion::MotionDB,
     properties::{
         AmbientSoundFlags, InternalPropOriginalModelName, PropAmbientHacked,
-        PropModelName, PropPosition,
+        PropModelName, PropPosition, PropPhysAttr,
     },
     SCALE_FACTOR,
 };
@@ -334,9 +334,8 @@ impl Game {
         // panic!();
 
         // log_property::<PropAI>(&active_mission.world);
-        log_property::<PropModelName>(&active_mission.world);
-        log_property::<InternalPropOriginalModelName>(&active_mission.world);
-        // panic!();
+        log_property::<PropPhysAttr>(&active_mission.world);
+        panic!();
 
         // log_entity(
         //     &active_mission.world,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -1217,16 +1217,12 @@ impl Mission {
                     self.remove_entity(entity_id);
                 }
                 Effect::ResetGravity { entity_id } => {
-                    self.physics.reset_gravity(entity_id);
+                    self.physics.set_gravity(entity_id, 1.0);
                 }
                 Effect::SetGravity {
                     entity_id,
                     gravity_percent,
                 } => {
-                    println!(
-                        "!! debug - setting gravity: {:?} -> {}",
-                        entity_id, gravity_percent
-                    );
                     self.physics.set_gravity(entity_id, gravity_percent);
                 }
                 Effect::SetPlayerPosition {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -1225,6 +1225,10 @@ impl Mission {
                     entity_id,
                     gravity_percent,
                 } => {
+                    println!(
+                        "!! debug - setting gravity: {:?} -> {}",
+                        entity_id, gravity_percent
+                    );
                     self.physics.set_gravity(entity_id, gravity_percent);
                 }
                 Effect::SetPlayerPosition {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -39,6 +39,16 @@ bitflags! {
     }
 }
 
+pub struct DynamicPhysicsOptions {
+    pub gravity_scale: f32,
+}
+
+impl Default for DynamicPhysicsOptions {
+    fn default() -> DynamicPhysicsOptions {
+        DynamicPhysicsOptions { gravity_scale: 1.0 }
+    }
+}
+
 pub struct CollisionGroup(InteractionGroups);
 
 impl CollisionGroup {
@@ -445,6 +455,7 @@ impl PhysicsWorld {
         shape: PhysicsShape,
         collision_group: CollisionGroup,
         is_sensor: bool,
+        opts: DynamicPhysicsOptions,
     ) -> RigidBodyHandle {
         let nquat =
             nalgebra::geometry::Quaternion::new(facing.s, facing.v.x, facing.v.y, facing.v.z);
@@ -462,6 +473,7 @@ impl PhysicsWorld {
             .position(test)
             .build();
         rigid_body.user_data = entity_id.inner() as u128;
+        rigid_body.set_gravity_scale(opts.gravity_scale, false);
         //rigid_body.set_additional_mass(5.0, false);
         let handle = &self.rigid_body_set.insert(rigid_body);
         let mut collider = match shape {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -624,6 +624,9 @@ impl PhysicsWorld {
         });
         controller.offset = CharacterLength::Absolute(0.2 / SCALE_FACTOR);
 
+        self.entity_id_to_body
+            .insert(player_entity, character_handle);
+
         PlayerHandle {
             controller,
             character_handle,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -298,10 +298,6 @@ impl PhysicsWorld {
         }
     }
 
-    pub fn reset_gravity(&mut self, entity: EntityId) {
-        self.set_gravity(entity, 1.0);
-    }
-
     pub fn set_gravity(&mut self, entity_id: EntityId, percent: f32) {
         if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
             let maybe_rigid_body = self.rigid_body_set.get_mut(*handle);
@@ -759,10 +755,6 @@ impl PhysicsWorld {
         let _character_mass = character_body.mass();
 
         let mut gravity = -0.5 / SCALE_FACTOR;
-        println!(
-            "!! debug: gravity scale: {}",
-            character_body.gravity_scale()
-        );
         gravity *= character_body.gravity_scale();
 
         let movement_with_gravity = desired_movement + Vector::y() * gravity;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -297,8 +297,17 @@ impl PhysicsWorld {
         self.entity_to_gravity.remove(&entity);
     }
 
-    pub fn set_gravity(&mut self, entity: EntityId, percent: f32) {
-        self.entity_to_gravity.insert(entity, percent);
+    pub fn set_gravity(&mut self, entity_id: EntityId, percent: f32) {
+        // TODO: Is this still needed?
+        self.entity_to_gravity.insert(entity_id, percent);
+
+        if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
+            let maybe_rigid_body = self.rigid_body_set.get_mut(*handle);
+
+            if let Some(rigid_body) = maybe_rigid_body {
+                rigid_body.set_gravity_scale(percent, true);
+            }
+        }
     }
 
     pub fn get_size(&self, handle: RigidBodyHandle) -> Option<f32> {


### PR DESCRIPTION
- Parse `P$PhysAttr`
- Apply gravity scale to dynamic entities
- Remove dictionary for tracking gravity overrides in physics, just rely on physics engine for that
- Remove unnecessary `reset_gravity` function