### PR TITLE
feat(cli): specify spawn loc from command line

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -144,7 +144,7 @@ pub struct PropConsumeType(pub String);
 pub struct PropDestLevel(pub String);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
-pub struct PropDestLoc(pub u32);
+pub struct PropDestLoc(pub i32);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropExp(pub i32);
@@ -228,7 +228,7 @@ pub struct PropScale(pub Vector3<f32>);
 pub struct PropSignalType(pub String);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
-pub struct PropStartLoc(pub u32);
+pub struct PropStartLoc(pub i32);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropHasRefs(pub bool);
@@ -751,7 +751,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         ),
         define_prop(
             "P$DestLoc",
-            |reader, _len| read_u32(reader),
+            |reader, _len| read_i32(reader),
             PropDestLoc,
             accumulator::latest,
         ),
@@ -1045,7 +1045,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         ),
         define_prop(
             "P$StartLoc",
-            |reader, _len| read_u32(reader),
+            |reader, _len| read_i32(reader),
             PropStartLoc,
             accumulator::latest,
         ),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -82,6 +82,7 @@ pub fn resource_path(str: &str) -> String {
 
 pub struct GameOptions {
     pub mission: String,
+    pub spawn_location: SpawnLocation,
     pub save_file: Option<String>,
     pub render_particles: bool,
     pub debug_physics: bool,
@@ -94,6 +95,7 @@ impl Default for GameOptions {
     fn default() -> Self {
         Self {
             mission: "earth.mis".to_owned(),
+            spawn_location: SpawnLocation::MapDefault,
             save_file: None,
             debug_draw: false,
             debug_portals: false,
@@ -318,7 +320,7 @@ impl Game {
                     &mut asset_cache,
                     &mut audio_context,
                     &global_context,
-                    SpawnLocation::MapDefault,
+                    options.spawn_location.clone(),
                     QuestInfo::new(),
                     //Box::new(MissionEntityPopulator::create()),
                     Box::new(MissionEntityPopulator::create()),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -19,6 +19,7 @@ mod vr_config;
 mod zip_asset_path;
 
 pub use mission::visibility_engine::CullingInfo;
+pub use mission::SpawnLocation;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -49,10 +50,7 @@ use engine::{
 };
 use std::time::Instant;
 
-use mission::{
-    entity_populator::{EntityPopulator, MissionEntityPopulator, SaveFileEntityPopulator},
-    SpawnLocation,
-};
+use mission::entity_populator::{EntityPopulator, MissionEntityPopulator, SaveFileEntityPopulator};
 use quest_info::QuestInfo;
 
 use save_load::{EntitySaveData, GlobalData, HeldItemSaveData, SaveData};
@@ -240,15 +238,6 @@ impl Game {
         let motiondb = MotionDB::read(&mut motiondb_reader);
 
         let mut audio_context = AudioContext::new();
-
-        // let mut music_hash = HashMap::new();
-
-        // let audio = asset_cache.get(&AUDIO_IMPORTER, "08beg.WAV".to_owned());
-        // music_hash.insert("08beg.wav".to_owned(), audio.clone());
-
-        // let wrapped = Box::leak(Box::new(music_hash));
-        // audio_context
-        //     .set_music_callback(Box::new(|| Some(wrapped.get("08beg.wav").unwrap().clone())));
 
         let global_context = GlobalContext {
             links,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -1,6 +1,6 @@
 pub mod entity_creator;
 pub mod entity_populator;
-pub mod spawn_location;
+mod spawn_location;
 pub mod visibility_engine;
 
 use collision::Aabb;

--- a/shock2vr/src/mission/spawn_location.rs
+++ b/shock2vr/src/mission/spawn_location.rs
@@ -13,7 +13,7 @@ use crate::scripts::script_util::{get_all_links_of_type, get_first_link_of_type}
 #[derive(Clone)]
 pub enum SpawnLocation {
     MapDefault,
-    Marker(u32),
+    Marker(i32),
     PositionRotation(Vector3<f32>, Quaternion<f32>),
 }
 

--- a/shock2vr/src/mission/spawn_location.rs
+++ b/shock2vr/src/mission/spawn_location.rs
@@ -10,6 +10,7 @@ use shipyard::{Get, IntoIter, IntoWithId, View, World};
 
 use crate::scripts::script_util::{get_all_links_of_type, get_first_link_of_type};
 
+#[derive(Clone)]
 pub enum SpawnLocation {
     MapDefault,
     Marker(u32),

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -29,7 +29,7 @@ pub enum GlobalEffect {
 
     TransitionLevel {
         level_file: String,
-        loc: Option<u32>,
+        loc: Option<i32>,
     },
 
     // Test the reload functionality (as if saving + loading)


### PR DESCRIPTION
This PR supports specifying the spawn marker to start at, ie:
```sh
cargo run --release -- -m=command2.mis:100
```

