### PR TITLE
feat: migrate physics logging to scoped system (Phase 2)

### DIFF
--- a/projects/improved-logging.md
+++ b/projects/improved-logging.md
@@ -91,7 +91,7 @@ Create `engine/src/logging/mod.rs` with:
 
 **Phase 2: High-Impact Areas - IN PROGRESS**
 - Migrate performance-critical rendering code
-- Update physics logging
+- ✅ Update physics logging (completed: 4 profile! macros migrated to scoped system)
 - ✅ Replace audio debug prints
 
 **Phase 3: Systematic Migration**

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -706,8 +706,7 @@ impl PhysicsWorld {
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
         /* Run the game loop, stepping the simulation once per frame. */
-        profile!(
-            "physics.step",
+        profile!(scope: "physics", level: TRACE, "physics.step", {
             self.physics_pipeline.step(
                 &self.gravity,
                 &self.integration_parameters,
@@ -723,13 +722,12 @@ impl PhysicsWorld {
                 &(),
                 &self.events,
             )
-        );
+        });
 
-        profile!(
-            "physics.update_query_pipeline",
+        profile!(scope: "physics", level: TRACE, "physics.update_query_pipeline", {
             self.query_pipeline
                 .update(&self.rigid_body_set, &self.collider_set)
-        );
+        });
 
         // Update character controller
         let desired_movement = vec_to_nvec(desired_movement);
@@ -761,8 +759,7 @@ impl PhysicsWorld {
         let movement_with_gravity = desired_movement + Vector::y() * gravity;
 
         //let mut collisions = vec![];
-        let mvt = profile!(
-            "physics.move_player",
+        let mvt = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &self.rigid_body_set,
@@ -781,11 +778,11 @@ impl PhysicsWorld {
                 |_c| (),
                 //|c| collisions.push(c),
             )
-        );
+        });
 
         let mut collision_events = Vec::new();
         let mut current_sensor_intersections = HashSet::new();
-        profile!("physics.intersections_with_shape", {
+        profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
             &self.query_pipeline.intersections_with_shape(
                 &self.rigid_body_set,
                 &self.collider_set,


### PR DESCRIPTION
## Summary
- Implements Phase 2 physics logging migration from the improved logging strategy
- Migrates 4 high-frequency `profile!` macro calls in physics module to use scoped logging
- Reduces log noise while maintaining debugging capabilities for physics performance analysis

## Key Changes
- **Physics Performance Monitoring**: Updated `profile!` calls to use `scope: "physics", level: TRACE`
- **Controllable Logging**: Physics profiling now responds to `SHOCK2_LOG` environment variable
- **High-Frequency Operations**: Proper scoping for operations that run every frame
- **Project Documentation**: Updated to reflect Phase 2 progress

## Modified Files
- `shock2vr/src/physics/mod.rs`: Updated 4 profile macro calls to use scoped system
- `projects/improved-logging.md`: Documented completion of physics migration

## Usage Examples
```bash
# Silent physics (only errors)
SHOCK2_LOG=error cargo run

# Physics performance tracing
SHOCK2_LOG=warn,physics=trace cargo run

# Default behavior (physics logs disabled)
SHOCK2_LOG=warn cargo run
```

## Benefits
- **Reduced Noise**: Physics performance logs no longer spam console by default
- **Targeted Debugging**: Enable physics logging only when investigating performance issues
- **Consistent Architecture**: Follows established Phase 1 scoped logging infrastructure
- **VR Performance**: Critical for 90+ FPS VR requirements

## Test Plan
- [x] Code compiles successfully (`cargo check -p shock2vr`)
- [x] Physics module functionality unchanged (only logging behavior modified)
- [x] Environment variable configuration working as expected
- [x] Project documentation updated with progress tracking

This continues the systematic migration outlined in the improved logging strategy and prepares for Phase 2 rendering code updates.

🤖 Generated with [Claude Code](https://claude.ai/code)