### PR TITLE
feat: continue Phase 4 of improved logging with save/load system migration

### DIFF
--- a/engine_ffmpeg/src/video_player.rs
+++ b/engine_ffmpeg/src/video_player.rs
@@ -1,6 +1,6 @@
 extern crate ffmpeg_next as ffmpeg;
 
-use engine::texture_format::{PixelFormat, RawTextureData};
+use engine::{render_log, texture_format::{PixelFormat, RawTextureData}};
 use ffmpeg::format::{input, Pixel};
 use ffmpeg::media::Type;
 use ffmpeg::software::scaling::{context::Context, flag::Flags};
@@ -80,7 +80,7 @@ impl VideoPlayer {
             if stream.index() == video_stream_index {
                 match decoder.send_packet(&packet) {
                     Ok(()) => receive_and_process_decoded_frames(&mut decoder).unwrap(),
-                    Err(err) => println!("received err in send_packet: {:?}", err),
+                    Err(err) => render_log!(ERROR, "Video decoder send_packet error: {:?}", err),
                 }
             }
         }

--- a/projects/improved-logging.md
+++ b/projects/improved-logging.md
@@ -370,7 +370,47 @@ The script and game scopes now cover:
 - Rendering performance metrics
 - Cell/level navigation warnings
 
-**Ready for Phase 4**: Continue systematic migration of remaining subsystems with `println!` statements.
+### Phase 4: Save/Load System Migration - IN PROGRESS ⚡
+
+**Started in branch `feat/logging-phase4-systematic-migration`:**
+
+**Save/Load System Updates:**
+- `shock2vr/src/save_load/entity_save_data.rs`:
+  - Migrated property deserialization debug print: `println!("deserializing: {}")` → `game_log!(DEBUG, "Deserializing property: {}", name)`
+  - Added proper import for `game_log` macro
+- `shock2vr/src/lib.rs`:
+  - Migrated entity count logging: `println!("ALL ENTITIES: {}")` → `game_log!(DEBUG, "Saving {} entities to save data", count)`
+  - Enhanced message for better context and clarity
+- `engine_ffmpeg/src/video_player.rs`:
+  - Migrated video decoder error: `println!("received err in send_packet: {:?}", err)` → `render_log!(ERROR, "Video decoder send_packet error: {:?}", err)`
+  - Properly categorized as render scope error for FFmpeg integration
+
+**Benefits Achieved:**
+- **Save/Load Debugging Control**: Save/load operations can now be debugged with `SHOCK2_LOG=game=debug`
+- **Video System Integration**: FFmpeg video decoder errors properly categorized in render scope
+- **Consistent Message Format**: All logging now follows structured format with clear context
+- **Reduced Console Noise**: Debug-level logs only appear when explicitly requested
+
+**Usage Examples:**
+```bash
+# Debug save/load operations only
+SHOCK2_LOG=game=debug cargo run
+
+# Debug video/render issues
+SHOCK2_LOG=render=debug cargo run
+
+# Combined save/load and video debugging
+SHOCK2_LOG=warn,game=debug,render=debug cargo run
+```
+
+**Phase 4 Scope Coverage:**
+The game and render scopes now additionally cover:
+- Entity save/load serialization debugging
+- Property deserialization tracking
+- Save data entity count logging
+- FFmpeg video decoder error handling
+
+**Next Phase 4 Tasks**: Continue systematic migration of remaining subsystems with `println!` statements.
 
 ## Files to Modify
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -44,6 +44,7 @@ use engine::{
     assets::{asset_cache::AssetCache, asset_paths::AssetPath},
     audio::{AudioClip, AudioContext},
     file_system::FileSystem,
+    game_log,
     profile,
     scene::SceneObject,
 };
@@ -129,7 +130,7 @@ impl Game {
             .clone();
 
         let (current_save_data, held_data) = save_load::to_save_data(&self.active_mission.world);
-        println!("ALL ENTITIES: {}", &current_save_data.all_entities.len());
+        game_log!(DEBUG, "Saving {} entities to save data", current_save_data.all_entities.len());
 
         self.mission_to_save_data.insert(
             self.active_mission.level_name.to_ascii_lowercase(),

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fs::File};
 
 use dark::properties::{Links, WrappedEntityId};
+use engine::game_log;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, IntoIter, World};
 
@@ -48,7 +49,7 @@ impl EntitySaveData {
         for prop in all_properties {
             let name = prop.name();
             if let Some(prop_info) = self.properties.get(&name) {
-                println!("deserializing: {}", name);
+                game_log!(DEBUG, "Deserializing property: {}", name);
                 prop.deserialize(prop_info, world, &old_entity_id_to_new_entity_id);
             }
         }


### PR DESCRIPTION
## Summary
- Continues Phase 4 of the improved logging strategy with systematic migration of save/load system
- Migrated 3 remaining `println!` statements to use scoped logging infrastructure
- Enhanced save/load debugging capabilities and FFmpeg video decoder error reporting

## Save/Load System Updates
- **entity_save_data.rs**: Property deserialization logging now uses `game_log!(DEBUG, ...)`
- **lib.rs**: Entity count logging enhanced with better context and `game_log` scoping
- **video_player.rs**: FFmpeg decoder errors properly categorized as `render_log!(ERROR, ...)`

## Benefits
- **Controlled Save/Load Debugging**: Use `SHOCK2_LOG=game=debug` to debug save/load operations
- **Video System Integration**: FFmpeg errors now properly scoped for debugging video playback issues
- **Consistent Structured Logging**: All logging follows the Phase 1-3 infrastructure patterns
- **Reduced Noise**: Debug output only appears when explicitly requested

## Usage Examples
```bash
# Debug save/load operations only
SHOCK2_LOG=game=debug cargo run

# Debug video/render issues  
SHOCK2_LOG=render=debug cargo run

# Combined debugging
SHOCK2_LOG=warn,game=debug,render=debug cargo run
```

## Technical Details
- All imports use crate-root macro exports (e.g., `engine::game_log` not `engine::logging::game_log`)
- Log levels use uppercase constants (DEBUG, ERROR) as required by the macro infrastructure
- Messages enhanced with better context and formatting
- Maintains backwards compatibility with existing scoped logging system

## Test Plan
- [x] Code compiles successfully (`cargo check -p shock2vr`)
- [x] No breaking changes to public APIs
- [x] Logging infrastructure integration verified
- [x] Project documentation updated with Phase 4 progress

This continues the systematic migration started in Phase 3, focusing on core gameplay systems like save/load and video playback that are essential for the Mission system project's future cutscene support.

🤖 Generated with [Claude Code](https://claude.ai/code)