### PR TITLE
feat: implement Step 2 of multi-pass lighting system

### DIFF
--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -122,15 +122,48 @@ impl Engine for OpenGLEngine {
             // // );
             // floor.draw(&self, render_context, &view);
 
-            // STEP 1: Opaque pass
+            // STEP 1: Base opaque pass (no lighting, just base material properties)
             scene
                 .iter()
                 .for_each(|s| s.draw_opaque(self, render_context, &view));
 
+            // STEP 2: Multi-pass lighting for opaque objects
+            if scene.light_count() > 0 {
+                // Setup additive blending for light accumulation
+                gl::Enable(gl::BLEND);
+                gl::BlendFunc(gl::ONE, gl::ONE); // Additive blending
+                gl::DepthMask(gl::FALSE); // Read-only depth testing
+                gl::DepthFunc(gl::EQUAL); // Only render pixels with exact depth match
+
+                // Render one pass per light
+                for light in scene.lights().lights() {
+                    scene.iter().for_each(|scene_object| {
+                        // Check if this light affects this object's position
+                        // For now, use object's transform position as a simple check
+                        let world_pos = scene_object.get_world_position();
+                        if light.affects_position(world_pos) {
+                            scene_object.draw_light_pass(
+                                self,
+                                render_context,
+                                &view,
+                                light.as_ref(),
+                                None, // No shadow map yet
+                            );
+                        }
+                    });
+                }
+
+                // Restore normal blend state
+                gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+                gl::DepthFunc(gl::LESS); // Restore normal depth testing
+                gl::DepthMask(gl::TRUE); // Re-enable depth writes
+            }
+
             gl::DepthMask(gl::FALSE);
 
-            // STEP 2: Transparent pass
+            // STEP 3: Transparent pass
             // TODO: Properly order back-to-front..
+            // TODO: Add lighting support for transparent materials
             scene
                 .iter()
                 .for_each(|s| s.draw_transparent(self, render_context, &view));

--- a/engine/src/scene/material.rs
+++ b/engine/src/scene/material.rs
@@ -1,4 +1,5 @@
 use crate::engine::EngineRenderContext;
+use crate::scene::light::Light;
 use cgmath::Matrix4;
 
 pub trait Material {
@@ -18,6 +19,33 @@ pub trait Material {
         _world_matrix: &Matrix4<f32>,
         _skinning_data: &[Matrix4<f32>],
     ) -> bool {
+        false
+    }
+
+    /// Draw material with lighting pass for multi-pass lighting system
+    ///
+    /// This method is called once per light that affects the geometry.
+    /// The material should render with additive blending to accumulate light contributions.
+    ///
+    /// Parameters:
+    /// - render_context: Engine rendering context
+    /// - view_matrix: Camera view matrix
+    /// - world_matrix: Object world transformation matrix
+    /// - skinning_data: Bone matrices for skinned meshes
+    /// - light: The light to render with
+    /// - shadow_map: Optional shadow map texture (future extension)
+    ///
+    /// Returns: true if the material rendered something, false otherwise
+    fn draw_light_pass(
+        &self,
+        _render_context: &EngineRenderContext,
+        _view_matrix: &Matrix4<f32>,
+        _world_matrix: &Matrix4<f32>,
+        _skinning_data: &[Matrix4<f32>],
+        _light: &dyn Light,
+        _shadow_map: Option<&()>, // Placeholder for future ShadowMap type
+    ) -> bool {
+        // Default implementation: no lighting support
         false
     }
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -245,6 +245,44 @@ impl SceneObject {
             self.geometry.draw();
         }
     }
+
+    /// Draw the scene object with a specific light for multi-pass lighting
+    pub fn draw_light_pass(
+        &self,
+        engine_context: &OpenGLEngine,
+        render_context: &EngineRenderContext,
+        view: &Matrix4<f32>,
+        light: &dyn crate::scene::light::Light,
+        shadow_map: Option<&()>,
+    ) {
+        if !self.material.borrow().has_initialized() {
+            self.material
+                .borrow_mut()
+                .initialize(engine_context.is_opengl_es, &engine_context.storage);
+        }
+
+        let xform = self.transform * self.local_transform;
+        if self.material.borrow().draw_light_pass(
+            render_context,
+            view,
+            &xform,
+            &self.skinning_data,
+            light,
+            shadow_map,
+        ) {
+            self.geometry.draw();
+        }
+    }
+
+    /// Get the world position of this scene object from its transform matrix
+    pub fn get_world_position(&self) -> cgmath::Vector3<f32> {
+        let final_transform = self.transform * self.local_transform;
+        cgmath::Vector3::new(
+            final_transform[3][0],
+            final_transform[3][1],
+            final_transform[3][2],
+        )
+    }
     pub fn set_transform(&mut self, transform: Matrix4<f32>) {
         self.transform = transform;
     }

--- a/projects/multi-pass-lighting.md
+++ b/projects/multi-pass-lighting.md
@@ -33,21 +33,31 @@ Implement Doom 3-style multi-pass lighting system starting with spotlight suppor
   - Comprehensive test coverage (8 passing tests)
   - Foundation for portal-based light culling integration
 
-### Step 2: Multi-Pass Rendering Foundation
-- Modify `gl_engine.rs` render loop to support multiple light passes
-- Implement additive blending for light accumulation after base pass
-- Add depth buffer management for light passes (read-only depth testing)
-- Structure for future shadow map integration
+### Step 2: Multi-Pass Rendering Foundation ✅ COMPLETED
+- ✅ Modify `gl_engine.rs` render loop to support multiple light passes
+- ✅ Implement additive blending for light accumulation after base pass
+- ✅ Add depth buffer management for light passes (read-only depth testing)
+- ✅ Structure for future shadow map integration
+
+**Implementation Details:**
+- **Files Modified:**
+  - `engine/src/gl_engine.rs` - Enhanced render loop with 3-pass system (base → lighting → transparent)
+  - `engine/src/scene/material.rs` - Added `draw_light_pass()` method to Material trait
+  - `engine/src/scene/scene_object.rs` - Added `draw_light_pass()` and `get_world_position()` methods
+- **Features Delivered:**
+  - Three-pass rendering system: base opaque pass, per-light additive passes, transparent pass
+  - Proper OpenGL state management: additive blending (GL_ONE, GL_ONE) for light accumulation
+  - Read-only depth testing (GL_EQUAL) prevents overdraw during light passes
+  - Light culling: only render objects affected by each light using `affects_position()`
+  - Future-ready shadow map parameter in `draw_light_pass()` interface
+  - Backwards compatibility: default `draw_light_pass()` implementation returns false (no-op)
 
 ### Step 3: Extended Material System
-- Add `draw_light_pass()` method to base `Material` trait
-- Signature supports future features: `draw_light_pass(context, matrices, light, shadow_map: Option<&ShadowMap>)`
 - Implement lighting in each material type:
   - `BasicMaterial`: Standard Phong/Blinn-Phong lighting
   - `SkinnedMaterial`: Phong lighting with bone transformations
   - `LightmapMaterial`: Combine dynamic lights with existing lightmaps
   - `BillboardMaterial`: Simple diffuse or skip light passes
-- Default implementation returns `false` (no-op) for backwards compatibility
 
 ### Step 4: Portal-Based Light Culling
 - Integrate with existing `PortalVisibilityEngine`


### PR DESCRIPTION
## Summary
- Implements Step 2 of the multi-pass lighting strategy from `projects/multi-pass-lighting.md`
- Adds multi-pass rendering foundation with proper OpenGL state management
- Enhanced Material trait with `draw_light_pass()` method for future shader implementations

## Key Features
- **3-Pass Rendering System**: Base opaque → per-light additive → transparent
- **Proper OpenGL State Management**: Additive blending (GL_ONE, GL_ONE) and read-only depth testing (GL_EQUAL)
- **Light Culling**: Only render objects affected by each light using `affects_position()`
- **Future-Ready Interface**: Shadow map parameter prepared for Step 6 implementation
- **Backwards Compatibility**: Default no-op `draw_light_pass()` implementation

## Implementation Details
### Files Modified
- `engine/src/gl_engine.rs`: Enhanced render loop with multi-pass lighting
- `engine/src/scene/material.rs`: Added `draw_light_pass()` method to Material trait
- `engine/src/scene/scene_object.rs`: Added lighting support and world position access
- `projects/multi-pass-lighting.md`: Updated with Step 2 completion status

### Technical Architecture
- Base pass renders opaque geometry without lighting
- Light passes use additive blending to accumulate lighting contributions
- Depth testing ensures only pixels at correct depth receive lighting
- Light culling prevents unnecessary draw calls for distant objects

## Test Plan
- [x] Engine builds successfully (`cargo check -p engine`)
- [x] Desktop runtime compiles without errors
- [x] Backwards compatibility maintained for existing materials
- [x] No performance regression in scenes without lights

This establishes the foundation for Step 3 which will implement actual lighting in specific material types (BasicMaterial, SkinnedMaterial, etc.).

🤖 Generated with [Claude Code](https://claude.ai/code)