### PR TITLE
fix: remove unneeded unit return types and redundant field names

### DIFF
--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -381,7 +381,7 @@ fn build_skeleton_for_obj_mesh(
     sub_object_idx: i32,
     current_parent: Option<u32>,
     bones: &mut Vec<Bone>,
-) -> () {
+) {
     if sub_object_idx == -1 {
         return;
     }

--- a/engine/src/audio/mod.rs
+++ b/engine/src/audio/mod.rs
@@ -152,21 +152,21 @@ where
     pub fn set_background_music(
         &mut self,
         background_music_player: Box<dyn BackgroundMusic<TCue>>,
-    ) -> () {
+    ) {
         self.background_music_player = Some(background_music_player);
         self.next_music_cue = None;
     }
 
-    pub fn stop_background_music(&mut self) -> () {
+    pub fn stop_background_music(&mut self) {
         self.background_music_player = None;
         self.next_music_cue = None;
     }
 
-    pub fn set_background_music_cue(&mut self, cue: TCue) -> () {
+    pub fn set_background_music_cue(&mut self, cue: TCue) {
         self.next_music_cue = Some(cue)
     }
 
-    pub fn set_environmental_sound(&mut self, clip: Rc<AudioClip>) -> () {
+    pub fn set_environmental_sound(&mut self, clip: Rc<AudioClip>) {
         let sink = rodio::Sink::try_new(&self.handle).unwrap();
         clip.add_to_sink(&sink);
         sink.set_volume(0.2);
@@ -320,13 +320,13 @@ pub struct AudioClip {
 }
 
 impl AudioClip {
-    pub fn add_to_spatial_sink(&self, sink: &SpatialSink) -> () {
+    pub fn add_to_spatial_sink(&self, sink: &SpatialSink) {
         match &self.source {
             SourceType::Bytes(source) => sink.append(source.clone()),
             SourceType::Raw(source) => sink.append(source.clone()),
         }
     }
-    pub fn add_to_sink(&self, sink: &Sink) -> () {
+    pub fn add_to_sink(&self, sink: &Sink) {
         match &self.source {
             SourceType::Bytes(source) => sink.append(source.clone()),
             SourceType::Raw(source) => sink.append(source.clone()),
@@ -351,7 +351,7 @@ impl AudioClip {
 pub fn stop_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     context: &mut AudioContext<TAmbientKey, TCue>,
     handle: AudioHandle,
-) -> () {
+) {
     let maybe_sink = context.handle_to_sink.remove(&handle.id);
 
     if let Some(sink) = maybe_sink {

--- a/engine/src/scene/cube_indexed.rs
+++ b/engine/src/scene/cube_indexed.rs
@@ -87,9 +87,9 @@ pub fn create() -> CubeIndexed {
     // uncomment this call to draw in wireframe polygons.
     // gl::PolygonMode(gl::FRONT_AND_BACK, gl::LINE);
     CubeIndexed {
-        vao: vao,
-        vbo: vbo,
-        ebo: ebo,
+        vao,
+        vbo,
+        ebo,
     }
 }
 

--- a/engine/src/scene/lines_mesh.rs
+++ b/engine/src/scene/lines_mesh.rs
@@ -51,9 +51,9 @@ pub fn create(raw_vertices: Vec<VertexPosition>) -> LinesMesh {
     // uncomment this call to draw in wireframe polygons.
     LinesMesh {
         index_count,
-        vao: vao,
-        vbo: vbo,
-        ebo: ebo,
+        vao,
+        vbo,
+        ebo,
     }
 }
 

--- a/engine/src/scene/mesh.rs
+++ b/engine/src/scene/mesh.rs
@@ -111,9 +111,9 @@ pub fn create<T: Vertex>(raw_vertices: Vec<T>) -> Mesh {
     // uncomment this call to draw in wireframe polygons.
     Mesh {
         triangle_count,
-        vao: vao,
-        vbo: vbo,
-        ebo: ebo,
+        vao,
+        vbo,
+        ebo,
     }
 }
 

--- a/engine/src/scene/particles.rs
+++ b/engine/src/scene/particles.rs
@@ -92,8 +92,8 @@ fn create_random_particle(system: &ParticleSystem) -> Particle {
     let scale = randf(system.particle_size.0, system.particle_size.1);
     Particle {
         remaining_life_in_seconds: lifetime,
-        position: position,
-        velocity: velocity,
+        position,
+        velocity,
         scale,
     }
 }
@@ -139,7 +139,7 @@ impl ParticleSystem {
 
     pub fn with_acceleration(self, acceleration: Vector3<f32>) -> ParticleSystem {
         ParticleSystem {
-            acceleration: acceleration,
+            acceleration,
             ..self
         }
     }

--- a/engine/src/scene/plane.rs
+++ b/engine/src/scene/plane.rs
@@ -80,9 +80,9 @@ pub fn create() -> Plane {
     // uncomment this call to draw in wireframe polygons.
     // gl::PolygonMode(gl::FRONT_AND_BACK, gl::LINE);
     Plane {
-        vao: vao,
-        vbo: vbo,
-        ebo: ebo,
+        vao,
+        vbo,
+        ebo,
     }
 }
 

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -19,15 +19,15 @@ unsafe impl Send for Texture {}
 unsafe impl Sync for Texture {}
 
 pub trait TextureTrait {
-    fn bind0(&self, render_context: &EngineRenderContext) -> ();
-    fn bind1(&self, render_context: &EngineRenderContext) -> ();
+    fn bind0(&self, render_context: &EngineRenderContext);
+    fn bind1(&self, render_context: &EngineRenderContext);
 }
 
 impl TextureTrait for Texture {
-    fn bind0(&self, _render_context: &EngineRenderContext) -> () {
+    fn bind0(&self, _render_context: &EngineRenderContext) {
         bind0(self);
     }
-    fn bind1(&self, _render_context: &EngineRenderContext) -> () {
+    fn bind1(&self, _render_context: &EngineRenderContext) {
         bind1(self);
     }
 }
@@ -47,12 +47,12 @@ impl AnimatedTexture {
 }
 
 impl TextureTrait for AnimatedTexture {
-    fn bind0(&self, render_context: &EngineRenderContext) -> () {
+    fn bind0(&self, render_context: &EngineRenderContext) {
         let frame = (render_context.time / self.time_per_frame) as usize;
         let frame = frame % self.textures.len();
         bind0(&self.textures[frame]);
     }
-    fn bind1(&self, render_context: &EngineRenderContext) -> () {
+    fn bind1(&self, render_context: &EngineRenderContext) {
         let frame = (render_context.time / self.time_per_frame) as usize;
         let frame = frame % self.textures.len();
         bind1(&self.textures[frame]);


### PR DESCRIPTION
## Summary
- Fixed 29 clippy warnings related to code style
- Removed 13 instances of unneeded `-> ()` return type annotations
- Fixed 16 instances of redundant field names in struct initialization
- Improves code clarity and follows Rust idioms

## Changes Made
- **engine/src/audio/mod.rs**: Removed 7 unneeded unit return types
- **engine/src/scene/particles.rs**: Fixed 3 redundant field names  
- **engine/src/scene/plane.rs**: Fixed 3 redundant field names
- **engine/src/scene/cube_indexed.rs**: Fixed 3 redundant field names
- **engine/src/scene/mesh.rs**: Fixed 3 redundant field names
- **engine/src/scene/lines_mesh.rs**: Fixed 3 redundant field names
- **engine/src/texture.rs**: Removed 6 unneeded unit return types
- **dark/src/ss2_bin_obj_loader.rs**: Removed 1 unneeded unit return type

## Test Plan
- [x] All core packages compile successfully (`cargo check --package engine --package dark --package shock2vr`)
- [x] All unit tests pass (`cargo test --package engine --package dark --package shock2vr`)
- [x] Verified the specific clippy warnings are eliminated
- [x] No functionality changes - purely code style improvements

## Before/After
**Before**: 29 clippy warnings for unneeded unit return types and redundant field names
**After**: 0 clippy warnings for these issues

🤖 Generated with [Claude Code](https://claude.ai/code)