### PR TITLE
fix: refactor HeldItemSaveData::instantiate to return Result

### DIFF
--- a/.notes/journal.md
+++ b/.notes/journal.md
@@ -1,0 +1,91 @@
+## Compiler Warnings Cleanup Complete
+- Fixed 9 compiler warnings by addressing unused variables, imports, struct fields, and methods across multiple packages (reduced total warnings from 229 to 220).
+- Learning: The `cargo fix` tool helps with simple cases like unused imports, but for parsed data structures from game files, `#[allow(dead_code)]` attributes are more appropriate than removing fields that represent the binary format.
+
+## Teleport System Integration Complete
+- Integrated Phase 1 VR teleport system into main game loop by adding TeleportSystem to Game struct and wiring update calls to process input and generate SetPlayerPosition effects.
+- Learning: The existing command_effects pattern in Game::update() provided the perfect integration point, and following the established Effect system architecture made the integration seamless and testable.
+
+## Enhanced Lighting Hand Spotlights Complete
+- Successfully addressed PR #81 feedback by implementing functional hand spotlights for testing the enhanced lighting system, replacing visual cube indicators with actual SpotLight objects that participate in multi-pass lighting.
+- Learning: The architecture challenge of Mission trait returning Vec<SceneObject> vs Scene with lights was solved by adding a separate method for lights and integrating them at the runtime level after Scene creation, maintaining clean separation of concerns.
+
+## Asset Validation Mission Complete
+- Implemented Phase 2.2 of Mission System project with complete AssetValidationMission including VR UI framework, state machine, controller input, and comprehensive test coverage (5 passing tests).
+- Learning: The Mission trait infrastructure from Phase 1 provided an excellent foundation, and creating test-friendly asset validation logic required separating file system operations from core validation logic for better testability.
+
+## Multi-Pass Lighting Step 2 Complete
+- Implemented Step 2 of multi-pass lighting system with 3-pass rendering (base → per-light additive → transparent), proper OpenGL state management, and light culling foundation.
+- Learning: The existing two-pass rendering system in gl_engine.rs:125-137 was perfectly positioned for multi-pass lighting extension, and the Light trait's `affects_position()` method enables efficient culling at the object level.
+
+## Performance Optimization Complete
+- Implemented safe performance improvements including FxHashMap migration, Cargo resolver 2, AssetCache optimizations, and memory efficiency improvements.
+- Learning: FxHashMap provides significant performance benefits for numeric keys (EntityId), and analyzing performance bottlenecks with `cargo tree --duplicates` revealed optimization opportunities in the build system.
+
+## Clippy Code Style Warnings Fixed
+- Fixed 29 clippy warnings by removing unneeded unit return types and redundant field names across 8 files, improving code clarity and Rust idioms compliance.
+- Learning: The `cargo clippy` tool provides excellent actionable feedback for code style improvements, and fixing warnings systematically using MultiEdit tool made bulk changes efficient and error-free.
+
+## PR Review Complete
+- Reviewed all open PRs: #62 ready to auto-merge, #63 in progress, #31 needs major rework due to conflicts and age.
+- Learning: Large, long-running PRs accumulate significant technical debt - prefer smaller, frequent PRs as per CLAUDE.md guidelines.
+
+## Logging Phase 3 Migration Complete
+- Systematically migrated script and mission system println! statements to structured, scoped logging using the improved logging infrastructure.
+
+## Logging Phase 4 Save/Load Migration Complete
+
+## Multi-Pass Lighting Step 3 Material System Complete
+- Implemented Step 3 of multi-pass lighting with spotlight support for all material types (BasicMaterial, SkinnedMaterial, LightmapMaterial, BillboardMaterial) including proper shader compilation, uniform management, and performance optimizations.
+- Learning: The dual shader approach (base + lighting shaders per material) provides clean separation of concerns, and enhancing the Light trait with spotlight_params() eliminated the need for unsafe trait casting in shader uniform setup.
+- Continued systematic migration by updating save/load system and FFmpeg video decoder to use scoped logging, migrating 3 remaining println! statements to proper structured logging.
+- Learning: Macro exports are at crate root (engine::game_log) not submodules (engine::logging::game_log), and systematic migration is most effective when targeting related subsystems together rather than scattered files.
+- Learning: Match arm expressions can't contain statement-generating macros directly - wrap in braces for proper syntax; macro design needs to consider usage context for proper expansion.
+
+## Improved Logging Project Complete
+- Completed final migration of all active println! statements across entity system, speech database, physics, debugging utilities, and Android platform code to structured/scoped logging.
+- Learning: Thorough `rg "println!" --type rust` search and systematic file-by-file migration is more effective than trying to find patterns - ensures comprehensive coverage of scattered debug prints.
+
+## Entity Inspector CLI Tool Phase 1 Complete
+- Implemented comprehensive CLI tool for inspecting System Shock 2 entity data with support for gamesys/mission files, export formats (JSON/CSV), template queries, and basic validation.
+- Learning: The `dark::properties::get()` function returns a tuple `(properties, links, links_with_data)` not individual getter functions, and mission file parsing requires both AssetCache and Gamesys parameters for proper entity merging.
+
+## VR Teleport System Phase 1 Complete
+- Implemented foundational teleport system infrastructure with configurable input detection, per-hand state tracking, and integration with existing effect system.
+- Learning: Rust borrow checker requires careful API design - static methods with explicit config parameters avoid borrowing conflicts when updating multiple hand states simultaneously.
+
+## Entity Link Optimization Complete
+- Fixed TODO in ss2_entity_info.rs by implementing HashMap-based link lookups, optimizing performance from O(n) to O(1) for entity template relationship queries while maintaining backward compatibility.
+- Learning: Red/green TDD approach works well for performance optimizations - test existing behavior first, then enhance with optimized implementation and verify same results but better performance characteristics.
+
+## Multi-Pass Lighting Step 1 Complete
+- Implemented core Light data structure with SpotLight, LightSystem container, and enhanced Scene integration providing foundation for Doom 3-style multi-pass lighting while maintaining backwards compatibility.
+- Learning: Complex trait object systems benefit from manual trait bounds (Debug) and careful Clone implementations - derive macros can fail with trait objects requiring custom implementations for proper API design.
+
+## PR State Review Complete
+- Fixed compilation error in PR #70 by converting Vec<SceneObject> to Scene using Scene::from_objects() method, addressing type mismatch in engine render calls for both desktop_runtime and oculus_runtime.
+- Learning: API changes require systematic updates across all runtimes - backwards compatibility helpers like From<Vec<SceneObject>> for Scene enable gradual migration without breaking existing code paths.
+
+## PR Status Review and Triage Complete
+- Resolved critical HashMap import errors in PR #64, identified 2 immediately mergeable PRs (#69, #72), and confirmed 3 others likely ready (#68, #70, #73) with successful CI but pending merge status computation.
+- Learning: Systematic PR health checks reveal both immediate wins (missing imports) and complex type system issues (HashMap vs FxHashMap hasher conflicts) - prioritizing quick fixes enables faster iteration on harder problems.
+
+## Compiler Warnings Cleanup Complete
+- Systematically resolved compiler warnings by fixing workspace resolver configuration, removing all unused imports, and eliminating clearly unused functions while preserving struct fields needed for file format compatibility.
+- Learning: Using TodoWrite tool for tracking multi-step tasks proved invaluable for maintaining focus and demonstrating progress - breaking down "fix warnings" into specific categories (imports, functions, config) enabled systematic completion without scope creep.
+
+## Engine Clippy Warnings Resolution Complete
+- Fixed 54+ clippy warnings in engine crate, reducing from 64 to ~10 warnings through systematic refactoring including removing unnecessary return types, fixing trait object references, and improving parameter types.
+- Learning: The `cargo clippy --fix` command handles many basic warnings automatically, but trait object references (`&Box<T>` → `&T`) require manual fixes including updating both trait definitions and all implementations for compilation success.
+
+## PR State Review Complete
+- Reviewed 6 open PRs: identified PR #31 (FFmpeg integration) as blocking due to major build failures from FFmpeg system dependencies and Android cross-compilation conflicts, while other PRs show healthy CI status.
+- Learning: Build validation checklist items in PR descriptions can catch significant issues early - PR #31's unchecked "validate builds on all platforms" revealed system dependency problems that would block deployment.
+
+## VR Teleport System Phase 2 Complete
+- Implemented comprehensive arc trajectory physics engine with realistic parabolic motion, landing validation, and visual support foundation for Phase 3, replacing simple forward ray casting with proper kinematic equations.
+- Learning: Physics simulation benefits from comprehensive test coverage (6 tests for trajectory, validation, distance limits) and the project's incremental approach enabled clean separation between input detection (Phase 1) and physics calculation (Phase 2) without breaking existing functionality.
+
+## Held Item Save Data Error Handling
+- Converted held item instantiation to fail fast on invalid or missing remaps with slot-aware errors and unit coverage to address PR #93 feedback.
+- Learning: Targeting `rustfmt` at a single file avoids unintended workspace-wide formatting churn when making quick review follow-ups.

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -234,7 +234,10 @@ impl Mission {
         let mut left_hand = VirtualHand::new(vr_config::Handedness::Left);
         let mut right_hand = VirtualHand::new(vr_config::Handedness::Right);
         let (left_hand_entity, right_hand_entity, maybe_inventory_entity) =
-            held_item_save_data.instantiate(&mut world);
+            held_item_save_data.instantiate(&mut world).unwrap_or_else(|err| {
+                warn!("Failed to instantiate held items: {}", err);
+                (None, None, None)
+            });
 
         // Instantiate inventory
         // TODO: This should be move into the held_item_save_data

--- a/shock2vr/src/save_load/held_item_save_data.rs
+++ b/shock2vr/src/save_load/held_item_save_data.rs
@@ -3,6 +3,21 @@ use shipyard::{EntityId, World};
 
 use super::EntitySaveData;
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum HeldItemError {
+    InvalidEntityId(u64),
+}
+
+impl std::fmt::Display for HeldItemError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeldItemError::InvalidEntityId(id) => write!(f, "Invalid entity ID: {}", id),
+        }
+    }
+}
+
+impl std::error::Error for HeldItemError {}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct HeldItemSaveData {
     pub held_entities: EntitySaveData,
@@ -21,11 +36,10 @@ impl HeldItemSaveData {
         }
     }
 
-    // TODO: Refactor return value to result
     pub fn instantiate(
         &self,
         world: &mut World,
-    ) -> (Option<EntityId>, Option<EntityId>, Option<EntityId>) {
+    ) -> Result<(Option<EntityId>, Option<EntityId>, Option<EntityId>), HeldItemError> {
         let (_, entity_id_map) = self.held_entities.instantiate(world);
 
         let mut left_hand_entity_id = None;
@@ -33,27 +47,99 @@ impl HeldItemSaveData {
         let mut inventory_entity_id = None;
 
         if let Some(ent) = self.entity_in_left_hand {
-            if let Some(new_entity_id) = entity_id_map.get(&EntityId::from_inner(ent).unwrap()) {
+            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
+            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
                 left_hand_entity_id = Some(*new_entity_id);
             }
         }
 
         if let Some(ent) = self.entity_in_right_hand {
-            if let Some(new_entity_id) = entity_id_map.get(&EntityId::from_inner(ent).unwrap()) {
+            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
+            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
                 right_hand_entity_id = Some(*new_entity_id);
             }
         }
 
         if let Some(ent) = self.inventory_entity {
-            if let Some(new_entity_id) = entity_id_map.get(&EntityId::from_inner(ent).unwrap()) {
+            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
+            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
                 inventory_entity_id = Some(*new_entity_id);
             }
         }
 
-        (
+        Ok((
             left_hand_entity_id,
             right_hand_entity_id,
             inventory_entity_id,
-        )
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shipyard::World;
+
+    #[test]
+    fn test_instantiate_with_valid_entities() {
+        let mut world = World::new();
+
+        // Create a valid entity first
+        let valid_entity = world.add_entity(());
+        let valid_entity_inner = valid_entity.inner();
+
+        // Create save data with valid entity IDs
+        let save_data = HeldItemSaveData {
+            held_entities: EntitySaveData::empty(),
+            entity_in_left_hand: Some(valid_entity_inner),
+            entity_in_right_hand: None,
+            inventory_entity: None,
+        };
+
+        // This should succeed (though entity mapping may not exist)
+        let result = save_data.instantiate(&mut world);
+        assert!(result.is_ok());
+
+        let (left, right, inventory) = result.unwrap();
+        // Since we don't have proper entity mapping, these should be None
+        assert_eq!(left, None);
+        assert_eq!(right, None);
+        assert_eq!(inventory, None);
+    }
+
+    #[test]
+    fn test_instantiate_with_invalid_entity_fails() {
+        let mut world = World::new();
+
+        // Create save data with entity ID 0, which EntityId::from_inner treats as invalid
+        let save_data = HeldItemSaveData {
+            held_entities: EntitySaveData::empty(),
+            entity_in_left_hand: Some(0), // EntityId::from_inner(0) returns None
+            entity_in_right_hand: None,
+            inventory_entity: None,
+        };
+
+        // This should fail with our custom error
+        let result = save_data.instantiate(&mut world);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            HeldItemError::InvalidEntityId(id) => assert_eq!(id, 0),
+        }
+    }
+
+    #[test]
+    fn test_instantiate_with_no_entities() {
+        let mut world = World::new();
+
+        let save_data = HeldItemSaveData::empty();
+
+        let result = save_data.instantiate(&mut world);
+        assert!(result.is_ok());
+
+        let (left, right, inventory) = result.unwrap();
+        assert_eq!(left, None);
+        assert_eq!(right, None);
+        assert_eq!(inventory, None);
     }
 }

--- a/shock2vr/src/save_load/held_item_save_data.rs
+++ b/shock2vr/src/save_load/held_item_save_data.rs
@@ -3,15 +3,40 @@ use shipyard::{EntityId, World};
 
 use super::EntitySaveData;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HeldItemSlot {
+    LeftHand,
+    RightHand,
+    Inventory,
+}
+
+impl std::fmt::Display for HeldItemSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            HeldItemSlot::LeftHand => "left hand",
+            HeldItemSlot::RightHand => "right hand",
+            HeldItemSlot::Inventory => "inventory",
+        };
+        write!(f, "{label}")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum HeldItemError {
-    InvalidEntityId(u64),
+    InvalidEntityId { slot: HeldItemSlot, raw_id: u64 },
+    MissingEntityMapping { slot: HeldItemSlot, raw_id: u64 },
 }
 
 impl std::fmt::Display for HeldItemError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            HeldItemError::InvalidEntityId(id) => write!(f, "Invalid entity ID: {}", id),
+            HeldItemError::InvalidEntityId { slot, raw_id } => {
+                write!(f, "Invalid entity ID ({slot}): {raw_id}")
+            }
+            HeldItemError::MissingEntityMapping { slot, raw_id } => write!(
+                f,
+                "Missing remapped entity for {slot} (original id: {raw_id})"
+            ),
         }
     }
 }
@@ -42,36 +67,50 @@ impl HeldItemSaveData {
     ) -> Result<(Option<EntityId>, Option<EntityId>, Option<EntityId>), HeldItemError> {
         let (_, entity_id_map) = self.held_entities.instantiate(world);
 
-        let mut left_hand_entity_id = None;
-        let mut right_hand_entity_id = None;
-        let mut inventory_entity_id = None;
+        let left_hand_entity_id = Self::remap_entity(
+            self.entity_in_left_hand,
+            HeldItemSlot::LeftHand,
+            &entity_id_map,
+        )?;
 
-        if let Some(ent) = self.entity_in_left_hand {
-            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
-            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
-                left_hand_entity_id = Some(*new_entity_id);
-            }
-        }
+        let right_hand_entity_id = Self::remap_entity(
+            self.entity_in_right_hand,
+            HeldItemSlot::RightHand,
+            &entity_id_map,
+        )?;
 
-        if let Some(ent) = self.entity_in_right_hand {
-            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
-            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
-                right_hand_entity_id = Some(*new_entity_id);
-            }
-        }
-
-        if let Some(ent) = self.inventory_entity {
-            let entity_id = EntityId::from_inner(ent).ok_or(HeldItemError::InvalidEntityId(ent))?;
-            if let Some(new_entity_id) = entity_id_map.get(&entity_id) {
-                inventory_entity_id = Some(*new_entity_id);
-            }
-        }
+        let inventory_entity_id = Self::remap_entity(
+            self.inventory_entity,
+            HeldItemSlot::Inventory,
+            &entity_id_map,
+        )?;
 
         Ok((
             left_hand_entity_id,
             right_hand_entity_id,
             inventory_entity_id,
         ))
+    }
+
+    fn remap_entity(
+        entity: Option<u64>,
+        slot: HeldItemSlot,
+        entity_id_map: &std::collections::HashMap<EntityId, EntityId>,
+    ) -> Result<Option<EntityId>, HeldItemError> {
+        let raw_id = match entity {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        let entity_id =
+            EntityId::from_inner(raw_id).ok_or(HeldItemError::InvalidEntityId { slot, raw_id })?;
+
+        let remapped = entity_id_map
+            .get(&entity_id)
+            .copied()
+            .ok_or(HeldItemError::MissingEntityMapping { slot, raw_id })?;
+
+        Ok(Some(remapped))
     }
 }
 
@@ -84,27 +123,29 @@ mod tests {
     fn test_instantiate_with_valid_entities() {
         let mut world = World::new();
 
-        // Create a valid entity first
-        let valid_entity = world.add_entity(());
-        let valid_entity_inner = valid_entity.inner();
+        let left_item = world.add_entity(());
+        let right_item = world.add_entity(());
+        let inventory_item = world.add_entity(());
 
-        // Create save data with valid entity IDs
+        let mut held_entities = EntitySaveData::empty();
+        held_entities.all_entities = vec![
+            left_item.inner(),
+            right_item.inner(),
+            inventory_item.inner(),
+        ];
+
         let save_data = HeldItemSaveData {
-            held_entities: EntitySaveData::empty(),
-            entity_in_left_hand: Some(valid_entity_inner),
-            entity_in_right_hand: None,
-            inventory_entity: None,
+            held_entities,
+            entity_in_left_hand: Some(left_item.inner()),
+            entity_in_right_hand: Some(right_item.inner()),
+            inventory_entity: Some(inventory_item.inner()),
         };
 
-        // This should succeed (though entity mapping may not exist)
-        let result = save_data.instantiate(&mut world);
-        assert!(result.is_ok());
+        let (left, right, inventory) = save_data.instantiate(&mut world).unwrap();
 
-        let (left, right, inventory) = result.unwrap();
-        // Since we don't have proper entity mapping, these should be None
-        assert_eq!(left, None);
-        assert_eq!(right, None);
-        assert_eq!(inventory, None);
+        assert!(left.is_some());
+        assert!(right.is_some());
+        assert!(inventory.is_some());
     }
 
     #[test]
@@ -124,7 +165,36 @@ mod tests {
         assert!(result.is_err());
 
         match result.unwrap_err() {
-            HeldItemError::InvalidEntityId(id) => assert_eq!(id, 0),
+            HeldItemError::InvalidEntityId { slot, raw_id } => {
+                assert_eq!(slot, HeldItemSlot::LeftHand);
+                assert_eq!(raw_id, 0);
+            }
+            other => panic!("Unexpected error variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_instantiate_returns_error_when_mapping_missing() {
+        let mut world = World::new();
+        let dangling_entity = world.add_entity(());
+        let entity_id = dangling_entity.inner();
+
+        let save_data = HeldItemSaveData {
+            held_entities: EntitySaveData::empty(),
+            entity_in_left_hand: Some(entity_id),
+            entity_in_right_hand: None,
+            inventory_entity: None,
+        };
+
+        let result = save_data.instantiate(&mut world);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            HeldItemError::MissingEntityMapping { slot, raw_id } => {
+                assert_eq!(slot, HeldItemSlot::LeftHand);
+                assert_eq!(raw_id, entity_id);
+            }
+            other => panic!("Unexpected error variant: {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Summary
- Resolves TODO: "Refactor return value to result" in `held_item_save_data.rs:24`
- Improves error handling in save/load system by replacing panic-prone `.unwrap()` calls
- Adds proper error types and comprehensive test coverage

## Key Changes
- **Error Type**: Added `HeldItemError::InvalidEntityId` for invalid entity ID cases
- **Return Type**: Changed `instantiate()` from returning tuple to `Result<(Option<EntityId>, Option<EntityId>, Option<EntityId>), HeldItemError>`
- **Error Handling**: `EntityId::from_inner()` failures now return proper errors instead of panicking
- **Caller Updates**: Modified `mission/mod.rs` to handle Result gracefully with fallback behavior

## Technical Details
- Uses `EntityId::from_inner().ok_or(HeldItemError::InvalidEntityId(id))?` pattern
- Maintains backward compatibility through `unwrap_or_else` with warning log
- Error type implements `std::error::Error` and `Display` traits

## Test Coverage
- **Red/Green TDD**: Verified test fails before fix, passes after
- `test_instantiate_with_valid_entities`: Verifies successful operation
- `test_instantiate_with_invalid_entity_fails`: Verifies error handling for invalid entity ID (0)
- `test_instantiate_with_no_entities`: Verifies empty case handling

## Impact
- **Robustness**: Prevents potential panics when save data contains invalid entity IDs
- **Debugging**: Provides meaningful error messages for invalid entity cases
- **Maintenance**: Removes TODO comment and improves code quality

This change makes the save/load system more resilient to corrupted or invalid save data.

🤖 Generated with [Claude Code](https://claude.ai/code)