### PR TITLE
chore: upgrade rapier3d to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,15 +2651,16 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.13.8"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d27f5ab3d42400056b5b6a6306dbaa91fc3033d8628146dca0d8ed7fbc20730"
+checksum = "aa342e0cdfc774fed0196714290ba2d85408b8ce9f295c40a0b1e05f3f8256ab"
 dependencies = [
  "approx 0.5.1",
  "arrayvec",
  "bitflags 1.3.2",
  "downcast-rs",
  "either",
+ "log",
  "nalgebra",
  "num-derive 0.4.2",
  "num-traits",
@@ -2865,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d07a833e0aa3bc57010caaa50bf75fa78afc03a74207607db740da4e4579a1"
+checksum = "93ce0398df94b282787ddd36a3a9c7e1ca19fa1e79722a2debc49c9f7c06e889"
 dependencies = [
  "approx 0.5.1",
  "arrayvec",
@@ -2875,9 +2885,11 @@ dependencies = [
  "bitflags 1.3.2",
  "crossbeam",
  "downcast-rs",
+ "log",
  "nalgebra",
  "num-derive 0.4.2",
  "num-traits",
+ "ordered-float 4.6.0",
  "parry3d",
  "rustc-hash 1.1.0",
  "simba",
@@ -3430,7 +3442,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.9.1",
  "pcx",
  "rand",
  "rapier3d",

--- a/shock2vr/Cargo.toml
+++ b/shock2vr/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2.15"
 once_cell = "1.17.0"
 ordered-float = "3.4.0"
 pcx = "0.2.3"
-rapier3d = { version = "0.18.0", features = ["debug-render"] }
+rapier3d = { version = "0.19.0", features = ["debug-render"] }
 serde_json = "1.0.91"
 shipyard = "0.6.2"
 dark = { path = "../dark" }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -129,7 +129,7 @@ pub struct PhysicsWorld {
     integration_parameters: IntegrationParameters,
     physics_pipeline: PhysicsPipeline,
     island_manager: IslandManager,
-    broad_phase: BroadPhase,
+    broad_phase: BroadPhaseMultiSap,
     narrow_phase: NarrowPhase,
     impulse_joint_set: ImpulseJointSet,
     multibody_joint_set: MultibodyJointSet,
@@ -584,9 +584,10 @@ impl PhysicsWorld {
         let mut controller = KinematicCharacterController::default();
         controller.autostep = Some(CharacterAutostep {
             include_dynamic_bodies: true,
-            ..CharacterAutostep::default()
+            max_height: CharacterLength::Relative(0.5),
+            min_width: CharacterLength::Relative(1.0),
         });
-        controller.offset = CharacterLength::Absolute(0.2 / SCALE_FACTOR);
+        controller.offset = CharacterLength::Absolute(0.5 / SCALE_FACTOR);
 
         self.entity_id_to_body
             .insert(player_entity, character_handle);
@@ -609,7 +610,7 @@ impl PhysicsWorld {
         };
         let physics_pipeline = PhysicsPipeline::new();
         let island_manager = IslandManager::new();
-        let broad_phase = BroadPhase::new();
+        let broad_phase = BroadPhaseMultiSap::new();
         let narrow_phase = NarrowPhase::new();
         let impulse_joint_set = ImpulseJointSet::new();
         let multibody_joint_set = MultibodyJointSet::new();
@@ -873,7 +874,7 @@ impl PhysicsWorld {
         ) {
             // This is similar to `QueryPipeline::cast_ray` illustrated above except
             // that it also returns the normal of the collider shape at the hit point.
-            let hit_point = ray.point_at(intersection.toi);
+            let hit_point = ray.point_at(intersection.time_of_impact);
             let hit_normal = intersection.normal;
             let collider = self.collider_set.get(handle).unwrap();
             let maybe_rigid_body_handle = collider.parent();

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -587,7 +587,9 @@ impl PhysicsWorld {
             max_height: CharacterLength::Relative(0.5),
             min_width: CharacterLength::Relative(1.0),
         });
-        controller.offset = CharacterLength::Absolute(0.5 / SCALE_FACTOR);
+        // controller.offset = CharacterLength::Absolute(0.1 / SCALE_FACTOR);
+        // controller.snap_to_ground = Some(CharacterLength::Absolute(0.2));
+        // controller.normal_nudge_factor = 0.1;
 
         self.entity_id_to_body
             .insert(player_entity, character_handle);
@@ -721,21 +723,24 @@ impl PhysicsWorld {
         let character_collider = &self.collider_set[character_body.colliders()[0]];
         let _character_mass = character_body.mass();
 
+        let movement_with_upward = desired_movement + Vector::y() * 0.25;
+
         let mut gravity = -0.5 / SCALE_FACTOR;
         gravity *= character_body.gravity_scale();
 
-        let movement_with_gravity = desired_movement + Vector::y() * gravity;
+        let graivty_moment = Vector::y() * gravity - Vector::y() * 0.25;
 
         //let mut collisions = vec![];
-        let mvt = profile!(scope: "physics", level: TRACE, "physics.move_player", {
-            player_handle.controller.move_shape(
+        let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {
+            // First, move the player horizontally
+            (player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &self.rigid_body_set,
                 &self.collider_set,
                 &self.query_pipeline,
                 character_collider.shape(),
                 character_collider.position(),
-                movement_with_gravity.cast::<Real>(),
+                movement_with_upward.cast::<Real>(),
                 QueryFilter::new()
                     .groups(InteractionGroups::new(
                         InternalCollisionGroups::PLAYER.bits.into(),
@@ -745,7 +750,26 @@ impl PhysicsWorld {
                     .exclude_sensors(),
                 |_c| (),
                 //|c| collisions.push(c),
-            )
+            ),
+
+            player_handle.controller.move_shape(
+                self.integration_parameters.dt,
+                &self.rigid_body_set,
+                &self.collider_set,
+                &self.query_pipeline,
+                character_collider.shape(),
+                character_collider.position(),
+                graivty_moment.cast::<Real>(),
+                QueryFilter::new()
+                    .groups(InteractionGroups::new(
+                        InternalCollisionGroups::PLAYER.bits.into(),
+                        InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+                    ))
+                    .exclude_rigid_body(player_handle.character_handle)
+                    .exclude_sensors(),
+                |_c| (),
+                //|c| collisions.push(c),
+            ))
         });
 
         let mut collision_events = Vec::new();
@@ -825,7 +849,9 @@ impl PhysicsWorld {
         let character_body = &mut self.rigid_body_set[player_handle.character_handle];
         let _original_pos = character_body.position().translation.vector;
         let pos = character_body.position();
-        character_body.set_next_kinematic_translation(pos.translation.vector + mvt.translation);
+        character_body.set_next_kinematic_translation(
+            pos.translation.vector + mvt1.translation + mvt2.translation,
+        );
         (collision_events, character_body)
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -22,6 +22,8 @@ use physics_events::*;
 
 use self::debug_render_pipeline::DebugRenderer;
 
+const MOVEMENT_STEP_SIZE: f32 = 0.25;
+
 bitflags! {
     pub struct InternalCollisionGroups: u32 {
         const WORLD = 1 << 0; // 1
@@ -564,32 +566,26 @@ impl PhysicsWorld {
             .translation(vec_to_nvec(start_pos))
             .ccd_enabled(true)
             .build();
-        //rigid_body.ccd_enabled(true);
+
         let player_entity_user_data = player_entity.inner() as u128;
         rigid_body.user_data = player_entity_user_data;
         let character_handle = self.rigid_body_set.insert(rigid_body);
         let mut collider =
             ColliderBuilder::cuboid(0.8 / SCALE_FACTOR, 2.4 / SCALE_FACTOR, 0.8 / SCALE_FACTOR);
-        //let mut collider = ColliderBuilder::capsule_y(2.4 / SCALE_FACTOR, 0.8 / SCALE_FACTOR);
         collider = collider.collision_groups(InteractionGroups::new(
             InternalCollisionGroups::PLAYER.bits.into(),
             InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
         ));
         collider = collider.user_data(player_entity_user_data);
 
-        //collider.user_data = player_entity_user_data;
         self.collider_set
             .insert_with_parent(collider, character_handle, &mut self.rigid_body_set);
 
         let mut controller = KinematicCharacterController::default();
-        controller.autostep = Some(CharacterAutostep {
-            include_dynamic_bodies: true,
-            max_height: CharacterLength::Relative(0.5),
-            min_width: CharacterLength::Relative(1.0),
-        });
-        // controller.offset = CharacterLength::Absolute(0.1 / SCALE_FACTOR);
-        // controller.snap_to_ground = Some(CharacterLength::Absolute(0.2));
-        // controller.normal_nudge_factor = 0.1;
+
+        controller.offset = CharacterLength::Absolute(0.1 / SCALE_FACTOR);
+        controller.snap_to_ground = Some(CharacterLength::Absolute(0.1 / SCALE_FACTOR));
+        controller.normal_nudge_factor = 0.1;
 
         self.entity_id_to_body
             .insert(player_entity, character_handle);
@@ -723,16 +719,23 @@ impl PhysicsWorld {
         let character_collider = &self.collider_set[character_body.colliders()[0]];
         let _character_mass = character_body.mass();
 
-        let movement_with_upward = desired_movement + Vector::y() * 0.25;
+        // We do our player movement in two passes
+        // First: move the player forward and a bit upwards
+        // Second: Drop the player down for gravity
+        // This wasn't necessary until upgrading to rapier v0.19.0 - when we upgraded to that version,
+        // we started to snag on geometry.
+        let movement_with_upward = desired_movement + Vector::y() * MOVEMENT_STEP_SIZE;
 
         let mut gravity = -0.5 / SCALE_FACTOR;
         gravity *= character_body.gravity_scale();
 
-        let graivty_moment = Vector::y() * gravity - Vector::y() * 0.25;
+        let gravity_movement = Vector::y() * gravity - Vector::y() * MOVEMENT_STEP_SIZE;
 
         //let mut collisions = vec![];
         let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {
-            // First, move the player horizontally
+            // HACK: For rapier v0.19.0, our previous strategy of combining the movement + gravity
+            // caused us to snag on physics geometry. In order to counter this, we'll do the movement in two phases
+            // a forward phase to move and then an application of gravity
             (player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &self.rigid_body_set,
@@ -752,6 +755,7 @@ impl PhysicsWorld {
                 //|c| collisions.push(c),
             ),
 
+            // Second pass: Apply gravity and undo our step size
             player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &self.rigid_body_set,
@@ -759,7 +763,7 @@ impl PhysicsWorld {
                 &self.query_pipeline,
                 character_collider.shape(),
                 character_collider.position(),
-                graivty_moment.cast::<Real>(),
+                gravity_movement.cast::<Real>(),
                 QueryFilter::new()
                     .groups(InteractionGroups::new(
                         InternalCollisionGroups::PLAYER.bits.into(),

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -22,7 +22,7 @@ use physics_events::*;
 
 use self::debug_render_pipeline::DebugRenderer;
 
-const MOVEMENT_STEP_SIZE: f32 = 0.25;
+const MOVEMENT_STEP_SIZE: f32 = 20.0;
 
 bitflags! {
     pub struct InternalCollisionGroups: u32 {
@@ -719,17 +719,19 @@ impl PhysicsWorld {
         let character_collider = &self.collider_set[character_body.colliders()[0]];
         let _character_mass = character_body.mass();
 
+        let step_size = Vector::y() * MOVEMENT_STEP_SIZE * self.integration_parameters.dt;
+
         // We do our player movement in two passes
         // First: move the player forward and a bit upwards
         // Second: Drop the player down for gravity
         // This wasn't necessary until upgrading to rapier v0.19.0 - when we upgraded to that version,
         // we started to snag on geometry.
-        let movement_with_upward = desired_movement + Vector::y() * MOVEMENT_STEP_SIZE;
+        let movement_with_upward = desired_movement + step_size;
 
         let mut gravity = -0.5 / SCALE_FACTOR;
         gravity *= character_body.gravity_scale();
 
-        let gravity_movement = Vector::y() * gravity - Vector::y() * MOVEMENT_STEP_SIZE;
+        let gravity_movement = Vector::y() * gravity - step_size;
 
         //let mut collisions = vec![];
         let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -12,7 +12,7 @@ use cgmath::{InnerSpace, Point3, Quaternion, Vector3, point3};
 use dark::{SCALE_FACTOR, mission::SystemShock2Level};
 use engine::scene::SceneObject;
 use rapier3d::{
-    control::{CharacterAutostep, CharacterLength, KinematicCharacterController},
+    control::{CharacterLength, KinematicCharacterController},
     na::UnitQuaternion,
     prelude::*,
 };


### PR DESCRIPTION
chore: upgrade rapier3d to 0.19.0

fix: add kludges for rapier v0.19.0 character controller changes