### PR TITLE
refactor: debug scenes use grid asset / default floor

### DIFF
--- a/shock2vr/src/scenes/debug_camera.rs
+++ b/shock2vr/src/scenes/debug_camera.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, Vector3, point3, vec3};
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, point3, vec3};
 use dark::SCALE_FACTOR;
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use shipyard::EntityId;
@@ -7,12 +7,10 @@ use tracing::info;
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    mission::{GlobalContext, SpawnLocation, entity_creator::CreateEntityOptions},
-    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneFloor},
+    mission::{GlobalContext, entity_creator::CreateEntityOptions},
+    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder},
 };
 
-const FLOOR_COLOR: Vector3<f32> = Vector3::new(0.15, 0.15, 0.20);
-const FLOOR_SIZE: Vector3<f32> = Vector3::new(120.0, 0.5, 120.0);
 const CAMERA_START_POS: Point3<f32> = point3(0.0, 4.0 / SCALE_FACTOR, 5.0 / SCALE_FACTOR);
 const CAMERA_TEMPLATE_ID: i32 = -367;
 
@@ -26,12 +24,7 @@ impl DebugCameraScene {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Box<dyn GameScene> {
-        let builder = DebugSceneBuilder::new("debug_camera")
-            .with_floor(DebugSceneFloor::ss2_units(FLOOR_SIZE, FLOOR_COLOR))
-            .with_spawn_location(SpawnLocation::PositionRotation(
-                vec3(0.0, 5.0 / SCALE_FACTOR, 0.0 / SCALE_FACTOR),
-                Quaternion::from_angle_y(Deg(90.0)),
-            ));
+        let builder = DebugSceneBuilder::new("debug_camera").with_default_floor();
 
         let build_options = DebugSceneBuildOptions {
             global_context,

--- a/shock2vr/src/scenes/debug_gloves.rs
+++ b/shock2vr/src/scenes/debug_gloves.rs
@@ -18,13 +18,10 @@ use crate::{
     game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneFloor, DebugSceneHooks,
-        HookedDebugScene,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
     },
 };
 
-const FLOOR_COLOR: Vector3<f32> = Vector3::new(0.15, 0.15, 0.20);
-const FLOOR_SIZE: Vector3<f32> = Vector3::new(120.0, 0.5, 120.0);
 const GLOVE_POSITION: Point3<f32> = point3(0.0, 3.0, 1.0);
 const GLOVE_SCALE: f32 = 1.0;
 
@@ -140,7 +137,7 @@ impl DebugGlovesScene {
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Box<dyn GameScene> {
         let builder = DebugSceneBuilder::new("debug_gloves")
-            .with_floor(DebugSceneFloor::world_units(FLOOR_SIZE, FLOOR_COLOR))
+            .with_default_floor()
             .with_spawn_location(SpawnLocation::PositionRotation(
                 vec3(0.0, 2.5, 0.0),
                 Quaternion::from_angle_y(Deg(90.0)),

--- a/shock2vr/src/scenes/debug_joint_constraint.rs
+++ b/shock2vr/src/scenes/debug_joint_constraint.rs
@@ -17,8 +17,7 @@ use crate::{
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     physics::CollisionGroup,
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
-        HookedDebugScene,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
     },
     time::Time,
 };

--- a/shock2vr/src/scenes/debug_joint_constraint.rs
+++ b/shock2vr/src/scenes/debug_joint_constraint.rs
@@ -17,14 +17,11 @@ use crate::{
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
     physics::CollisionGroup,
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneFloor, DebugSceneHooks,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
         HookedDebugScene,
     },
     time::Time,
 };
-
-const FLOOR_COLOR: Vector3<f32> = Vector3::new(0.12, 0.12, 0.18);
-const FLOOR_SIZE: Vector3<f32> = Vector3::new(60.0, 0.5, 60.0);
 
 const BOX_COUNT: usize = 5;
 const BOX_SIZE: Vector3<f32> = Vector3::new(1.5, 0.7, 0.7);
@@ -45,7 +42,7 @@ impl DebugJointConstraintScene {
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Box<dyn GameScene> {
         let builder = DebugSceneBuilder::new("debug_joint_constraint")
-            .with_floor(DebugSceneFloor::ss2_units(FLOOR_SIZE, FLOOR_COLOR))
+            .with_default_floor()
             .with_spawn_location(SpawnLocation::PositionRotation(
                 vec3(0.0, 5.0 / SCALE_FACTOR, -6.0 / SCALE_FACTOR),
                 Quaternion::new(1.0, 0.0, 0.0, 0.0),

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -12,8 +12,7 @@ use crate::{
         mission_core::MissionCore,
     },
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
-        HookedDebugScene,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
     },
     scripts::Effect,
     time::Time,

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -1,4 +1,4 @@
-use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, vec3};
 use dark::{SCALE_FACTOR, properties::PropTemplateId};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use shipyard::{EntityId, IntoIter, IntoWithId};
@@ -12,15 +12,12 @@ use crate::{
         mission_core::MissionCore,
     },
     scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneFloor, DebugSceneHooks,
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks,
         HookedDebugScene,
     },
     scripts::Effect,
     time::Time,
 };
-
-const FLOOR_COLOR: Vector3<f32> = Vector3::new(0.15, 0.15, 0.20);
-const FLOOR_SIZE: Vector3<f32> = Vector3::new(120.0, 0.5, 120.0);
 
 const IMPULSE_STRENGTH: f32 = 1.0;
 const PULL_FORCE: f32 = 1.0;
@@ -35,7 +32,7 @@ impl DebugRagdollScene {
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> Box<dyn GameScene> {
         let builder = DebugSceneBuilder::new("debug_ragdoll")
-            .with_floor(DebugSceneFloor::ss2_units(FLOOR_SIZE, FLOOR_COLOR))
+            .with_default_floor()
             .with_spawn_location(SpawnLocation::PositionRotation(
                 vec3(0.0, 5.0 / SCALE_FACTOR, 0.0),
                 Quaternion::new(1.0, 0.0, 0.0, 0.0),


### PR DESCRIPTION
refactor so that all debug scenes use grid asset / default floor

fix formatting