### PR TITLE
feat(ai): path-following steering for chase and wander behaviors

### DIFF
--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -23,6 +23,9 @@ pub enum InputAction {
     /// Spawn a debug item in front of the player
     SpawnDebugItem,
 
+    /// Spawn a debug monster (og-pipe hybrid) in front of the player
+    SpawnDebugMonster,
+
     /// Reposition the inventory in front of the player
     MoveInventory,
 
@@ -51,6 +54,7 @@ impl InputAction {
             InputAction::QuickSave,
             InputAction::QuickLoad,
             InputAction::SpawnDebugItem,
+            InputAction::SpawnDebugMonster,
             InputAction::MoveInventory,
             InputAction::DebugHitboxCyclePose,
             InputAction::CycleWeapon,
@@ -66,6 +70,7 @@ impl InputAction {
             InputAction::QuickSave => "QuickSave",
             InputAction::QuickLoad => "QuickLoad",
             InputAction::SpawnDebugItem => "SpawnDebugItem",
+            InputAction::SpawnDebugMonster => "SpawnDebugMonster",
             InputAction::MoveInventory => "MoveInventory",
             InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
             InputAction::CycleWeapon => "CycleWeapon",

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -42,12 +42,14 @@ impl ActionDispatcher {
             effects.push(Effect::SpawnInFrontOfPlayer {
                 template_id: DEBUG_SPAWN_TEMPLATE_ID,
                 head_rotation: input_context.head.rotation,
+                auto_wield: true,
             });
         }
         if state.just_triggered(InputAction::SpawnDebugMonster) {
             effects.push(Effect::SpawnInFrontOfPlayer {
                 template_id: DEBUG_MONSTER_TEMPLATE_ID,
                 head_rotation: input_context.head.rotation,
+                auto_wield: false,
             });
         }
         if state.just_triggered(InputAction::MoveInventory) {

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -8,6 +8,9 @@ use super::{InputAction, InputActionState};
 /// grunt og-pipe: -397, monkey - red: -1432
 const DEBUG_SPAWN_TEMPLATE_ID: i32 = -17;
 
+/// Template spawned by InputAction::SpawnDebugMonster (grunt og-pipe)
+const DEBUG_MONSTER_TEMPLATE_ID: i32 = -397;
+
 const QUICK_SAVE_FILE: &str = "save1.sav";
 
 pub struct ActionDispatcher;
@@ -38,6 +41,12 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::SpawnDebugItem) {
             effects.push(Effect::SpawnInFrontOfPlayer {
                 template_id: DEBUG_SPAWN_TEMPLATE_ID,
+                head_rotation: input_context.head.rotation,
+            });
+        }
+        if state.just_triggered(InputAction::SpawnDebugMonster) {
+            effects.push(Effect::SpawnInFrontOfPlayer {
+                template_id: DEBUG_MONSTER_TEMPLATE_ID,
                 head_rotation: input_context.head.rotation,
             });
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2112,6 +2112,7 @@ impl MissionCore {
                 Effect::SpawnInFrontOfPlayer {
                     template_id,
                     head_rotation,
+                    auto_wield,
                 } => {
                     let (pos, rot) = {
                         let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
@@ -2130,7 +2131,8 @@ impl MissionCore {
                     // first-person viewmodel for debug testing, but only when not
                     // already armed - extra spawns fall to the ground as world
                     // pickups (world model + physics) to be picked up.
-                    if game_options.presentation_mode == crate::PresentationMode::Flat
+                    if auto_wield
+                        && game_options.presentation_mode == crate::PresentationMode::Flat
                         && !self.interaction.is_wielding()
                     {
                         let msgs = self.interaction.wield(info.entity_id);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3390,6 +3390,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         self.world.run(
             |_entities_iter: EntitiesView,
              v_pos: View<dark::properties::PropPosition>,
+             v_transform: View<crate::runtime_props::RuntimePropTransform>,
              v_sym_name: View<dark::properties::PropSymName>,
              v_scripts: View<dark::properties::PropScripts>,
              v_links: View<dark::properties::Links>| {
@@ -3406,7 +3407,17 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         }
                     }
 
-                    let position = [pos.position.x, pos.position.y, pos.position.z];
+                    // Prefer the live transform; PropPosition can lag for
+                    // entities moved by animation/physics (e.g. walking AIs)
+                    let live_pos = v_transform
+                        .get(entity_id)
+                        .map(|xform| {
+                            use cgmath::Transform;
+                            let p = xform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+                            cgmath::vec3(p.x, p.y, p.z)
+                        })
+                        .unwrap_or(pos.position);
+                    let position = [live_pos.x, live_pos.y, live_pos.z];
                     let distance = (cgmath::Vector3::from(position) - player_pos).magnitude();
 
                     let script_count = v_scripts

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -125,6 +125,11 @@ pub struct DebugOptions {
     pub debug_ai: bool,
 }
 
+/// Pathfinding service accessible from scripts (steering strategies) via
+/// UniqueView. None when the mission has no AIPATH data (e.g. debug scenes).
+#[derive(Unique, Clone)]
+pub struct GlobalPathfinding(pub Option<Arc<PathfindingService>>);
+
 #[derive(Unique, Clone)]
 pub struct EffectQueue {
     effects: Vec<Effect>,
@@ -223,7 +228,7 @@ pub struct MissionCore {
     pub teleport_system: TeleportSystem,
     pub pending_entity_triggers: Vec<String>,
     pub path_database: Option<dark::mission::PathDatabase>,
-    pub pathfinding_service: Option<PathfindingService>,
+    pub pathfinding_service: Option<Arc<PathfindingService>>,
     pub path_visualization: PathVisualizationSystem,
     pub pathfinding_test: crate::mission::pathfinding_test::PathfindingTest,
     /// Sequential index for `Effect::DebugCycleHitboxPose` so each trigger picks
@@ -540,6 +545,14 @@ impl MissionCore {
             }
         }
 
+        let pathfinding_service = abstract_mission
+            .path_database
+            .as_ref()
+            .map(|db| Arc::new(PathfindingService::new(Arc::new(db.clone()))));
+        // Steering strategies path through this unique; MissionCore keeps its
+        // own handle for the interactive pathfinding test.
+        world.add_unique(GlobalPathfinding(pathfinding_service.clone()));
+
         MissionCore {
             interaction,
             level_name: mission,
@@ -567,10 +580,7 @@ impl MissionCore {
             pending_entity_triggers: Vec::new(),
             obj_map: abstract_mission.obj_map,
             path_database: abstract_mission.path_database.clone(),
-            pathfinding_service: abstract_mission
-                .path_database
-                .as_ref()
-                .map(|db| PathfindingService::new(Arc::new(db.clone()))),
+            pathfinding_service,
             path_visualization: PathVisualizationSystem::new(),
             pathfinding_test: crate::mission::pathfinding_test::PathfindingTest::new(),
             debug_pose_index: 0,

--- a/shock2vr/src/mission/pathfinding_test.rs
+++ b/shock2vr/src/mission/pathfinding_test.rs
@@ -4,6 +4,7 @@ use crate::pathfinding::{PathfindingService, path_visualization::PathVisualizati
 /// Provides P-key cycling through pathfinding test states and HTTP commands
 /// for the debug runtime to test A* pathfinding with visual feedback.
 use cgmath::Vector3;
+use std::sync::Arc;
 
 /// State machine for interactive pathfinding testing
 #[derive(Debug, Clone, PartialEq)]
@@ -40,7 +41,7 @@ impl PathfindingTest {
         &mut self,
         action: &str,
         player_position: Vector3<f32>,
-        pathfinding_service: &Option<PathfindingService>,
+        pathfinding_service: &Option<Arc<PathfindingService>>,
         path_visualization: &mut PathVisualizationSystem,
     ) -> String {
         // If a specific action is requested, use it
@@ -104,7 +105,7 @@ impl PathfindingTest {
     fn set_goal(
         &mut self,
         position: Vector3<f32>,
-        pathfinding_service: &Option<PathfindingService>,
+        pathfinding_service: &Option<Arc<PathfindingService>>,
         path_visualization: &mut PathVisualizationSystem,
     ) -> String {
         if !path_visualization.has_path("test_start") {

--- a/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
@@ -5,14 +5,15 @@ use dark::{SCALE_FACTOR, motion::MotionQueryItem, properties::PropPosition};
 use rand::Rng;
 use shipyard::*;
 
+use crate::scripts::ai::ai_util::has_ranged_weapon;
 use crate::{
     mission::PlayerInfo,
     physics::PhysicsWorld,
     scripts::{
         Effect,
         ai::steering::{
-            self, ChasePlayerSteeringStrategy, CollisionAvoidanceSteeringStrategy, SteeringOutput,
-            SteeringStrategy,
+            self, ChasePlayerSteeringStrategy, CollisionAvoidanceSteeringStrategy,
+            PathFollowSteeringStrategy, SteeringOutput, SteeringStrategy,
         },
     },
     time::Time,
@@ -31,6 +32,10 @@ impl ChaseBehavior {
                 Box::new(
                     CollisionAvoidanceSteeringStrategy::conservative(), /* conservative so we can focus on the chase */
                 ),
+                // Route to the player through the navigation mesh; falls
+                // through to the direct chase when there is no AIPATH data
+                // or no route.
+                Box::new(PathFollowSteeringStrategy::chase_player()),
                 Box::new(ChasePlayerSteeringStrategy),
             ]),
         }
@@ -84,7 +89,13 @@ impl Behavior for ChaseBehavior {
         if let Ok(prop_pos) = v_current_pos.get(entity_id) {
             let distance = (prop_pos.position - u_player.pos).magnitude();
 
-            if distance > ranged_min_attack_distance && distance < ranged_max_attack_distance {
+            // Only ranged-armed AIs stop to shoot; melee AIs must keep
+            // chasing or they stall at mid-range bouncing between chase and
+            // ranged-attack behaviors.
+            if distance > ranged_min_attack_distance
+                && distance < ranged_max_attack_distance
+                && has_ranged_weapon(world, entity_id)
+            {
                 return NextBehavior::Next(Box::new(RefCell::new(RangedAttackBehavior)));
             }
             if distance < melee_attack_distance {

--- a/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
@@ -2,16 +2,24 @@ use cgmath::Deg;
 use dark::motion::MotionQueryItem;
 use shipyard::{EntityId, World};
 
+use dark::SCALE_FACTOR;
+
 use crate::{
     physics::PhysicsWorld,
     scripts::{
         Effect,
-        ai::steering::{CollisionAvoidanceSteeringStrategy, SteeringOutput, SteeringStrategy},
+        ai::steering::{
+            self, CollisionAvoidanceSteeringStrategy, PathFollowSteeringStrategy, SteeringOutput,
+            SteeringStrategy,
+        },
     },
     time::Time,
 };
 
 use super::Behavior;
+
+/// How far afield a wandering AI will pick destinations (50 Dark feet)
+const WANDER_RADIUS: f32 = 50.0 / SCALE_FACTOR;
 
 pub struct WanderBehavior {
     steering_strategy: Box<dyn SteeringStrategy>,
@@ -20,7 +28,13 @@ pub struct WanderBehavior {
 impl WanderBehavior {
     pub fn new() -> WanderBehavior {
         WanderBehavior {
-            steering_strategy: Box::new(CollisionAvoidanceSteeringStrategy::comprehensive()),
+            steering_strategy: steering::chained(vec![
+                Box::new(CollisionAvoidanceSteeringStrategy::comprehensive()),
+                // Roam to random reachable spots; without AIPATH data this
+                // returns None and the AI just walks its current heading
+                // (the previous behavior).
+                Box::new(PathFollowSteeringStrategy::wander(WANDER_RADIUS)),
+            ]),
         }
     }
 }

--- a/shock2vr/src/scripts/ai/steering/mod.rs
+++ b/shock2vr/src/scripts/ai/steering/mod.rs
@@ -2,12 +2,14 @@ mod chained_steering_strategy;
 mod chase_entity_steering_strategy;
 mod chase_player_steering_strategy;
 mod collision_avoidance_steering_strategy;
+mod path_follow_steering_strategy;
 mod wander_steering_strategy;
 
 pub use chained_steering_strategy::*;
 pub use chase_entity_steering_strategy::*;
 pub use chase_player_steering_strategy::*;
 pub use collision_avoidance_steering_strategy::*;
+pub use path_follow_steering_strategy::*;
 
 use cgmath::{Deg, EuclideanSpace, Point3};
 use shipyard::{EntityId, World};

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -1,0 +1,229 @@
+use cgmath::{Deg, EuclideanSpace, Vector3, vec4};
+use dark::SCALE_FACTOR;
+use dark::mission::path_database::MovementBits;
+use rand::Rng;
+use shipyard::{EntityId, UniqueView, World};
+
+use crate::{
+    mission::{GlobalPathfinding, PlayerInfo},
+    pathfinding::PathfindingService,
+    physics::PhysicsWorld,
+    scripts::{Effect, ai::ai_util},
+    time::Time,
+    util::vec3_to_point3,
+};
+
+use super::{Steering, SteeringOutput, SteeringStrategy};
+
+/// How the strategy picks its destination
+pub enum PathTarget {
+    /// Follow the player, re-pathing as they move
+    Player,
+    /// Roam to random reachable points within a radius of the AI
+    Wander { radius: f32 },
+}
+
+/// A waypoint counts as reached within this XZ distance (2 Dark feet)
+const WAYPOINT_ADVANCE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
+/// Re-path when a moving target strays this far from the path's goal
+const REPATH_TARGET_DRIFT: f32 = 6.0 / SCALE_FACTOR;
+/// Minimum seconds between A* queries per AI
+const REPATH_COOLDOWN_SECONDS: f32 = 0.5;
+
+/// Steers along a route computed by the PathfindingService, the counterpart
+/// of the original engine's cAIPath following (Advance / UpdateTargetEdge in
+/// aipath.cpp). Returns None when no pathfinding data or no route exists so
+/// chained fallback strategies (e.g. direct chase) take over.
+pub struct PathFollowSteeringStrategy {
+    target: PathTarget,
+    path: Vec<Vector3<f32>>,
+    next_waypoint: usize,
+    /// Goal position the current path was computed against
+    path_goal: Option<Vector3<f32>>,
+    repath_cooldown: f32,
+}
+
+impl PathFollowSteeringStrategy {
+    pub fn chase_player() -> PathFollowSteeringStrategy {
+        PathFollowSteeringStrategy::new(PathTarget::Player)
+    }
+
+    pub fn wander(radius: f32) -> PathFollowSteeringStrategy {
+        PathFollowSteeringStrategy::new(PathTarget::Wander { radius })
+    }
+
+    fn new(target: PathTarget) -> PathFollowSteeringStrategy {
+        PathFollowSteeringStrategy {
+            target,
+            path: Vec::new(),
+            next_waypoint: 0,
+            path_goal: None,
+            repath_cooldown: 0.0,
+        }
+    }
+
+    fn clear_path(&mut self) {
+        self.path.clear();
+        self.next_waypoint = 0;
+        self.path_goal = None;
+    }
+}
+
+impl SteeringStrategy for PathFollowSteeringStrategy {
+    fn steer(
+        &mut self,
+        _current_heading: Deg<f32>,
+        world: &World,
+        _physics: &PhysicsWorld,
+        entity_id: EntityId,
+        time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        let service = world
+            .borrow::<UniqueView<GlobalPathfinding>>()
+            .ok()?
+            .0
+            .clone()?;
+        // Live transform, not PropPosition - the latter lags behind
+        // animation-driven movement
+        let (position_point, _forward) = ai_util::get_position_and_forward(world, entity_id);
+        let position = position_point.to_vec();
+
+        self.repath_cooldown = (self.repath_cooldown - time.elapsed.as_secs_f32()).max(0.0);
+
+        // Path is exhausted - forget it so we re-path (chase) or pick a new
+        // destination (wander)
+        if self.next_waypoint >= self.path.len() {
+            self.clear_path();
+        }
+
+        let desired_goal = match self.target {
+            PathTarget::Player => Some(world.borrow::<UniqueView<PlayerInfo>>().ok()?.pos),
+            // Wander keeps its current destination until the path completes
+            PathTarget::Wander { .. } => None,
+        };
+
+        let needs_repath = match (self.path_goal, desired_goal) {
+            (None, _) => true,
+            (Some(prev), Some(now)) => xz_distance(prev, now) > REPATH_TARGET_DRIFT,
+            (Some(_), None) => false,
+        };
+
+        if needs_repath && self.repath_cooldown <= 0.0 {
+            self.repath_cooldown = REPATH_COOLDOWN_SECONDS;
+            let goal = match self.target {
+                PathTarget::Player => desired_goal,
+                PathTarget::Wander { radius } => {
+                    pick_wander_goal(&service, position, radius, &mut rand::thread_rng())
+                }
+            };
+            match goal.and_then(|goal| {
+                service
+                    .find_path(position, goal, MovementBits::WALK)
+                    .map(|path| (goal, path))
+            }) {
+                Some((goal, path)) => {
+                    self.path = path;
+                    self.path_goal = Some(goal);
+                    // waypoint 0 is our own position
+                    self.next_waypoint = 1;
+                }
+                None => self.clear_path(),
+            }
+        }
+
+        self.next_waypoint = advance_waypoint(position, &self.path, self.next_waypoint);
+
+        // No route (or none yet) - let the next strategy in the chain steer
+        let waypoint = *self.path.get(self.next_waypoint)?;
+
+        let mut lines = vec![(
+            vec3_to_point3(position),
+            vec3_to_point3(waypoint),
+            vec4(0.2, 0.9, 1.0, 1.0),
+        )];
+        for pair in self.path[self.next_waypoint..].windows(2) {
+            lines.push((
+                vec3_to_point3(pair[0]),
+                vec3_to_point3(pair[1]),
+                vec4(0.2, 0.5, 1.0, 1.0),
+            ));
+        }
+
+        Some((
+            Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(waypoint)),
+            Effect::DrawDebugLines { lines },
+        ))
+    }
+}
+
+/// Skip every waypoint already within reach, returning the new index
+fn advance_waypoint(position: Vector3<f32>, path: &[Vector3<f32>], mut index: usize) -> usize {
+    while index < path.len() && xz_distance(position, path[index]) < WAYPOINT_ADVANCE_DISTANCE {
+        index += 1;
+    }
+    index
+}
+
+/// Horizontal distance; AI position and waypoint heights differ (feet vs
+/// cell floor), so Y is ignored for "have we reached it" checks
+fn xz_distance(a: Vector3<f32>, b: Vector3<f32>) -> f32 {
+    let dx = a.x - b.x;
+    let dz = a.z - b.z;
+    (dx * dx + dz * dz).sqrt()
+}
+
+/// Pick a random pathable cell center within `radius` of `position` to roam
+/// to. Reachability is verified by the find_path call that follows.
+fn pick_wander_goal(
+    service: &PathfindingService,
+    position: Vector3<f32>,
+    radius: f32,
+    rng: &mut impl Rng,
+) -> Option<Vector3<f32>> {
+    let cells = &service.path_database.cells;
+    if cells.is_empty() {
+        return None;
+    }
+    for _ in 0..8 {
+        let cell = &cells[rng.gen_range(0..cells.len())];
+        let center = cell.center;
+        let distance = xz_distance(position, center);
+        if cell.flags.is_empty()
+            && distance > WAYPOINT_ADVANCE_DISTANCE
+            && distance <= radius
+            && (position.y - center.y).abs() <= radius
+        {
+            return Some(center);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec3;
+
+    #[test]
+    fn advance_skips_reached_waypoints() {
+        let path = vec![
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.1, 0.0, 0.0),
+            vec3(0.2, 0.0, 0.0),
+            vec3(10.0, 0.0, 0.0),
+        ];
+        // Standing at the origin: the first three are all within reach
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 1), 3);
+        // The far waypoint is not
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 3), 3);
+        // Index past the end stays put
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 4), 4);
+    }
+
+    #[test]
+    fn advance_ignores_height_differences() {
+        let path = vec![vec3(0.0, 5.0, 0.0), vec3(10.0, 0.0, 0.0)];
+        // Waypoint directly overhead still counts as reached
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
+    }
+}

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -25,10 +25,24 @@ pub enum PathTarget {
 
 /// A waypoint counts as reached within this XZ distance (2 Dark feet)
 const WAYPOINT_ADVANCE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
+/// ...and within this height difference (4 Dark feet): feet-vs-cell-floor
+/// offsets are small, a waypoint on the floor above/below is not "reached"
+const WAYPOINT_ADVANCE_HEIGHT: f32 = 4.0 / SCALE_FACTOR;
 /// Re-path when a moving target strays this far from the path's goal
 const REPATH_TARGET_DRIFT: f32 = 6.0 / SCALE_FACTOR;
-/// Minimum seconds between A* queries per AI
+/// Minimum seconds between A* queries per strategy instance (behaviors are
+/// recreated on transitions, so a combat flip can re-path sooner - that's
+/// fine, those paths are short)
 const REPATH_COOLDOWN_SECONDS: f32 = 0.5;
+/// After a failed pathfind, wait longer before retrying: failure is the
+/// worst case (the search exhausts the reachable component, twice with the
+/// stressed second pass) and rarely resolves within one cooldown
+const REPATH_FAILURE_BACKOFF_SECONDS: f32 = 2.0;
+/// Drop the path when we can't get closer to the current waypoint for this
+/// long (blocked by a prop, another AI, or unreachable geometry)
+const STALL_SECONDS: f32 = 3.0;
+/// Progress smaller than this doesn't count toward un-stalling (jitter)
+const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
 
 /// Steers along a route computed by the PathfindingService, the counterpart
 /// of the original engine's cAIPath following (Advance / UpdateTargetEdge in
@@ -41,6 +55,11 @@ pub struct PathFollowSteeringStrategy {
     /// Goal position the current path was computed against
     path_goal: Option<Vector3<f32>>,
     repath_cooldown: f32,
+    /// Stall tracking: closest we've been to the current waypoint, and how
+    /// long since that improved
+    stall_waypoint: usize,
+    stall_best: f32,
+    stall_seconds: f32,
 }
 
 impl PathFollowSteeringStrategy {
@@ -59,6 +78,9 @@ impl PathFollowSteeringStrategy {
             next_waypoint: 0,
             path_goal: None,
             repath_cooldown: 0.0,
+            stall_waypoint: usize::MAX,
+            stall_best: f32::INFINITY,
+            stall_seconds: 0.0,
         }
     }
 
@@ -66,6 +88,13 @@ impl PathFollowSteeringStrategy {
         self.path.clear();
         self.next_waypoint = 0;
         self.path_goal = None;
+        self.reset_stall();
+    }
+
+    fn reset_stall(&mut self) {
+        self.stall_waypoint = usize::MAX;
+        self.stall_best = f32::INFINITY;
+        self.stall_seconds = 0.0;
     }
 }
 
@@ -116,6 +145,8 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     pick_wander_goal(&service, position, radius, &mut rand::thread_rng())
                 }
             };
+            // TODO: derive movement bits from the creature (small creature /
+            // fly / swim) - everything walks for now
             match goal.and_then(|goal| {
                 service
                     .find_path(position, goal, MovementBits::WALK)
@@ -126,8 +157,15 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     self.path_goal = Some(goal);
                     // waypoint 0 is our own position
                     self.next_waypoint = 1;
+                    self.reset_stall();
                 }
-                None => self.clear_path(),
+                None => {
+                    self.clear_path();
+                    // Failure exhausted the reachable component (twice, with
+                    // the stressed retry) and won't resolve immediately -
+                    // back off harder than the normal cooldown
+                    self.repath_cooldown = REPATH_FAILURE_BACKOFF_SECONDS;
+                }
             }
         }
 
@@ -135,6 +173,25 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
 
         // No route (or none yet) - let the next strategy in the chain steer
         let waypoint = *self.path.get(self.next_waypoint)?;
+
+        // Stall escape: if we stop making progress toward the current
+        // waypoint (blocked by a prop, another AI, or bad geometry), drop
+        // the path so the next re-path - or wander goal - starts fresh
+        // instead of pushing into the obstacle forever.
+        let distance = xz_distance(position, waypoint);
+        if self.next_waypoint != self.stall_waypoint
+            || distance < self.stall_best - STALL_PROGRESS_EPSILON
+        {
+            self.stall_waypoint = self.next_waypoint;
+            self.stall_best = distance;
+            self.stall_seconds = 0.0;
+        } else {
+            self.stall_seconds += time.elapsed.as_secs_f32();
+            if self.stall_seconds >= STALL_SECONDS {
+                self.clear_path();
+                return None;
+            }
+        }
 
         let mut lines = vec![(
             vec3_to_point3(position),
@@ -158,14 +215,22 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
 
 /// Skip every waypoint already within reach, returning the new index
 fn advance_waypoint(position: Vector3<f32>, path: &[Vector3<f32>], mut index: usize) -> usize {
-    while index < path.len() && xz_distance(position, path[index]) < WAYPOINT_ADVANCE_DISTANCE {
+    while index < path.len() && waypoint_reached(position, path[index]) {
         index += 1;
     }
     index
 }
 
-/// Horizontal distance; AI position and waypoint heights differ (feet vs
-/// cell floor), so Y is ignored for "have we reached it" checks
+/// Reached = close in XZ *and* roughly at the same height. Feet-vs-floor
+/// offsets are tolerated; a waypoint on a floor stacked above/below in XZ
+/// (stairwells, walkways) is not reached just by standing under/over it.
+fn waypoint_reached(position: Vector3<f32>, waypoint: Vector3<f32>) -> bool {
+    xz_distance(position, waypoint) < WAYPOINT_ADVANCE_DISTANCE
+        && (position.y - waypoint.y).abs() < WAYPOINT_ADVANCE_HEIGHT
+}
+
+/// Horizontal distance; AI position and waypoint heights differ slightly
+/// (feet vs cell floor), so Y is checked separately with its own tolerance
 fn xz_distance(a: Vector3<f32>, b: Vector3<f32>) -> f32 {
     let dx = a.x - b.x;
     let dz = a.z - b.z;
@@ -221,9 +286,17 @@ mod tests {
     }
 
     #[test]
-    fn advance_ignores_height_differences() {
-        let path = vec![vec3(0.0, 5.0, 0.0), vec3(10.0, 0.0, 0.0)];
-        // Waypoint directly overhead still counts as reached
+    fn advance_tolerates_small_height_offsets() {
+        // Feet vs cell-floor offset (well under 4 Dark feet) still reaches
+        let path = vec![vec3(0.0, 0.5, 0.0), vec3(10.0, 0.0, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
+    }
+
+    #[test]
+    fn advance_does_not_reach_waypoints_on_other_floors() {
+        // A waypoint 5 units directly overhead (a stacked floor) is NOT
+        // reached by standing beneath it
+        let path = vec![vec3(0.0, 5.0, 0.0), vec3(10.0, 5.0, 0.0)];
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 0);
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -249,10 +249,13 @@ pub enum Effect {
 
     /// Spawn an entity in front of the player (player position is resolved
     /// by the effect handler; head rotation comes from the input context,
-    /// since it isn't stored in the world)
+    /// since it isn't stored in the world). `auto_wield` lets flat mode pick
+    /// the spawn up as the viewmodel when empty-handed - for item spawns
+    /// only, never creatures.
     SpawnInFrontOfPlayer {
         template_id: i32,
         head_rotation: Quaternion<f32>,
+        auto_wield: bool,
     },
 
     /// Debug: spawn the next player weapon in front of the player and wield it

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -87,6 +87,14 @@ enum PathCommand {
         #[arg(long)]
         at: String,
     },
+    /// Show the walk component containing a position and its frontier links
+    /// (how the component connects - or fails to connect - to neighbors)
+    Component {
+        mission: String,
+        /// Position as "x,y,z"
+        #[arg(long)]
+        at: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -139,9 +147,57 @@ fn run_path_command(command: PathCommand) -> Result<()> {
             let db = load_path_database(&mission)?;
             dump_cells_at(db, parse_vec3(&at)?);
         }
+        PathCommand::Component { mission, at } => {
+            let db = load_path_database(&mission)?;
+            dump_component_at(db, parse_vec3(&at)?);
+        }
     }
 
     Ok(())
+}
+
+/// Show the walk component containing a position, plus every link that
+/// leaves the component and why it doesn't extend it (okBits / dest flags).
+fn dump_component_at(db: PathDatabase, at: Vector3<f32>) {
+    let service = PathfindingService::new(Arc::new(db));
+    let Some(cell_id) = service.cell_from_position(at) else {
+        println!("no cell contains that position");
+        return;
+    };
+    let db = &service.path_database;
+    let components = walk_components(db);
+    let Some(component) = components.iter().find(|c| c.contains(&cell_id)) else {
+        println!("cell {cell_id} is not in any walk component (unpathable?)");
+        return;
+    };
+    let members: std::collections::HashSet<u32> = component.iter().copied().collect();
+    println!(
+        "cell {cell_id} is in a walk component of {} cells",
+        component.len()
+    );
+
+    // Collect frontier links: source inside, destination outside
+    let mut frontier: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for link in &db.links {
+        if !members.contains(&link.from_cell) || members.contains(&link.to_cell) {
+            continue;
+        }
+        let dest_flags = db
+            .cells
+            .get(link.to_cell as usize)
+            .map(|c| format!("{:?}", c.flags))
+            .unwrap_or_else(|| "out-of-range".to_string());
+        let key = format!(
+            "okBits=[{}] dest_flags={}",
+            describe_bits(link.ok_bits),
+            dest_flags
+        );
+        *frontier.entry(key).or_default() += 1;
+    }
+    println!("frontier links (leaving the component): ");
+    for (desc, count) in &frontier {
+        println!("  {count:>5}  {desc}");
+    }
 }
 
 fn resolve_missions(mission: Option<String>, all: bool) -> Result<Vec<String>> {
@@ -255,6 +311,25 @@ fn print_stats(mission: &str, db: PathDatabase) {
     );
     println!(
         "audit: walk links into unpathable/blocking-OBB cells (rejected): {into_blocked_cell}"
+    );
+
+    // Door audit: how are links into BELOW_DOOR cells tagged? If they carry
+    // no okBits the mesh fragments at every doorway.
+    let mut door_links_walkable = 0;
+    let mut door_links_dead = 0;
+    for link in &db.links {
+        if let Some(dest) = db.cells.get(link.to_cell as usize) {
+            if dest.flags.contains(PathCellFlags::BELOW_DOOR) {
+                if link.ok_bits.intersects(MovementBits::WALK) {
+                    door_links_walkable += 1;
+                } else if link.ok_bits.is_empty() {
+                    door_links_dead += 1;
+                }
+            }
+        }
+    }
+    println!(
+        "audit: links into below-door cells: walkable={door_links_walkable} zero-bits={door_links_dead}"
     );
 
     // Walk-graph connectivity for a plain WALK query. Links are treated as
@@ -665,6 +740,17 @@ fn dump_cells_at(db: PathDatabase, at: Vector3<f32>) {
         }
     }
 
+    // Component membership helps explain "no path found" between two
+    // positions that each look fine in isolation.
+    let components = walk_components(db);
+    let component_of = |cell_id: u32| -> Option<(usize, usize)> {
+        components
+            .iter()
+            .enumerate()
+            .find(|(_, c)| c.contains(&cell_id))
+            .map(|(i, c)| (i, c.len()))
+    };
+
     println!(
         "{} cell(s) contain ({:.2}, {:.2}, {:.2}) in the XZ plane:",
         matches.len(),
@@ -673,8 +759,11 @@ fn dump_cells_at(db: PathDatabase, at: Vector3<f32>) {
         at.z
     );
     for cell in matches {
+        let component = component_of(cell.id)
+            .map(|(idx, size)| format!("walk component #{idx} ({size} cells)"))
+            .unwrap_or_else(|| "no walk component (unpathable?)".to_string());
         println!(
-            "  cell {} center=({:.2}, {:.2}, {:.2}) flags={:?}",
+            "  cell {} center=({:.2}, {:.2}, {:.2}) flags={:?} {component}",
             cell.id, cell.center.x, cell.center.y, cell.center.z, cell.flags
         );
         for link in db.links.iter().filter(|l| l.from_cell == cell.id) {


### PR DESCRIPTION
## Summary

Stacked on #270. AIs now consume the pathfinding service instead of steering blindly at their target — path following along the taut edge waypoints, with re-pathing as targets move.

- **`PathFollowSteeringStrategy`** computes a route via `PathfindingService` and steers along the taut edge waypoints, re-pathing (throttled to 0.5 s per AI; A* is ~0.5 ms p95 after #270) when the target drifts from the path's goal. Returns `None` when there's no AIPATH data or no route, so chained fallbacks take over.
  - **Waypoint-reached checks are height-aware** (review fix): reached = close in XZ *and* within 4 Dark feet vertically, so stacked floors (stairwells, walkways) can't cause waypoint skips.
  - **Stall escape** (review fix): no progress toward the current waypoint for 3 s (blocked by a prop, another AI, or bad geometry) drops the path so the next re-path / wander goal starts fresh — wander previously had no way out of that state.
  - **Failure backoff** (review fix): failed pathfinds retry after 2 s instead of 0.5 s; failure is the worst case (exhausts the reachable component, twice with #270's stressed second pass).
- **ChaseBehavior**: collision avoidance → path follow → direct chase. AIs route around corners instead of pinning on walls.
- **WanderBehavior**: roams to random reachable cells within 50 ft (previously: walk straight + whisker avoidance; the dedicated wander strategy was dead code).
- **`GlobalPathfinding`** shipyard unique shares the service with scripts (`None` for debug scenes without AIPATH).
- **Bug fix**: melee-only AIs froze whenever the player was 6–16 units away — `ChaseBehavior::next_behavior` switched to `RangedAttackBehavior` without checking `has_ranged_weapon`, and RangedAttack immediately bounces back to Chase, so hybrids ping-ponged forever between the two without ever walking.
- **Debug runtime**: `/v1/entities` now reports live `RuntimePropTransform` positions (`PropPosition` lags animation-driven movement — walking AIs looked frozen over HTTP), plus a `SpawnDebugMonster` input action (which does **not** auto-wield the monster as the flat viewmodel — `SpawnInFrontOfPlayer` grew an `auto_wield` flag, review fix).
- **bench**: `bn path component` + per-cell component sizes + below-door link audit, added while debugging connectivity.

## Verified in the debug runtime (medsci1)

An alerted OG-Pipe hybrid closes from ~4 units to melee range on a visible player, and after losing the player it wanders the corridor junction via real routes without sticking on geometry. Pre-fix, the same hybrid froze at mid-range (the chase↔ranged ping-pong).

Known gaps observed while testing, left for follow-ups:
- No "search last known position" behavior: alertness decays ~3–6 s after line of sight breaks, so pursuit around corners is cut short by design of the current alertness model.
- medsci1's start area bakes as a small isolated walk component (doors bake as BLOCKING_OBB cells; the original engine updates those flags at runtime via the cell→object map) — tracked in the pathfinding backlog.
- A deterministic SDK e2e for steering needs alertness introspection/forcing in the debug runtime (AI FOV + idle state varies per run); planned next.
- Movement bits are hardcoded to WALK — small creatures / flying / swimming AIs should derive their bits from creature type (TODO in code).

## Test plan

- [x] `cargo test -p shock2vr` — 68 passed (includes waypoint-advance and height-tolerance unit tests)
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p bench`
- [x] Full SDK e2e suite (`SHOCK2_E2E=1 npm run test:e2e`) — all 23 missions load, pathfinding scenario passes
- [x] Manual debug-runtime sessions on medsci1 (chase approach, mid-range stall fix, wander navigation)
- [x] Cross-engine review (Claude + Codex): all Critical/High/Medium findings addressed (stall escape, height-aware waypoints, failure backoff, auto-wield flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
