### PR TITLE
fix(combat): props respect hit points instead of one-hit-kill

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -60,6 +60,13 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Option<EntityDetailResult>>,
     },
 
+    /// Inject a script message into a specific entity (damage, frob, signal)
+    SendEntityMessage {
+        id: i32,
+        message: shock2vr::game_scene::DebugEntityMessage,
+        reply: oneshot::Sender<CommandResult>,
+    },
+
     /// List physics rigid bodies
     ListPhysicsBodies {
         limit: Option<usize>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -886,24 +886,34 @@ fn process_command(
             }
         }
         RuntimeCommand::SendEntityMessage { id, message, reply } => {
-            let result = if let Some(debug_scene) = game.debug_scene_mut() {
-                let entity_id = EntityId::new_from_index_and_gen(id as u64, 0);
-                let queued = debug_scene.send_entity_message(entity_id, message);
-                CommandResult {
-                    success: queued,
-                    message: if queued {
-                        format!("Message queued for entity {}", id)
-                    } else {
-                        format!("Entity {} not found or not alive", id)
-                    },
-                    data: None,
+            // The list/detail endpoints expose `EntityId::inner() as i32`, which
+            // for a live entity is `index + 1`. `from_inner` is the exact
+            // inverse; `new_from_index_and_gen(id, 0)` would double the +1 and
+            // resolve the wrong entity.
+            let entity_id = EntityId::from_inner(id as u64);
+            let result = match (entity_id, game.debug_scene_mut()) {
+                (Some(entity_id), Some(debug_scene)) => {
+                    let queued = debug_scene.send_entity_message(entity_id, message);
+                    CommandResult {
+                        success: queued,
+                        message: if queued {
+                            format!("Message queued for entity {}", id)
+                        } else {
+                            format!("Entity {} not found or not alive", id)
+                        },
+                        data: None,
+                    }
                 }
-            } else {
-                CommandResult {
+                (None, _) => CommandResult {
+                    success: false,
+                    message: format!("Invalid entity id {}", id),
+                    data: None,
+                },
+                (_, None) => CommandResult {
                     success: false,
                     message: "No debuggable scene available".to_string(),
                     data: None,
-                }
+                },
             };
 
             if let Err(_) = reply.send(result) {

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -164,6 +164,10 @@ async fn start_http_server(
         .route("/v1/shutdown", axum::routing::post(shutdown_server))
         .route("/v1/entities", get(list_entities))
         .route("/v1/entities/:id", get(get_entity_detail))
+        .route(
+            "/v1/entities/:id/message",
+            axum::routing::post(send_entity_message),
+        )
         .route("/v1/player/position", get(get_player_position))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
@@ -196,6 +200,7 @@ async fn start_http_server(
     info!("  POST /v1/shutdown         - Shutdown the debug runtime gracefully");
     info!("  GET  /v1/entities         - List entities with optional limit and filter");
     info!("  GET  /v1/entities/{{id}}    - Get detailed entity information");
+    info!("  POST /v1/entities/{{id}}/message - Inject a script message (damage/frob/signal)");
     info!("  GET  /v1/player/position  - Get current player position");
     info!("  POST /v1/player/teleport  - Teleport player to coordinates");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
@@ -880,6 +885,31 @@ fn process_command(
                 tracing::warn!("Failed to send entity detail - receiver dropped");
             }
         }
+        RuntimeCommand::SendEntityMessage { id, message, reply } => {
+            let result = if let Some(debug_scene) = game.debug_scene_mut() {
+                let entity_id = EntityId::new_from_index_and_gen(id as u64, 0);
+                let queued = debug_scene.send_entity_message(entity_id, message);
+                CommandResult {
+                    success: queued,
+                    message: if queued {
+                        format!("Message queued for entity {}", id)
+                    } else {
+                        format!("Entity {} not found or not alive", id)
+                    },
+                    data: None,
+                }
+            } else {
+                CommandResult {
+                    success: false,
+                    message: "No debuggable scene available".to_string(),
+                    data: None,
+                }
+            };
+
+            if let Err(_) = reply.send(result) {
+                tracing::warn!("Failed to send entity message result - receiver dropped");
+            }
+        }
         RuntimeCommand::ListPhysicsBodies { limit, reply } => {
             if let Some(debug_scene) = game.debug_scene() {
                 let bodies = debug_scene.list_physics_bodies(limit);
@@ -1294,6 +1324,42 @@ async fn get_entity_detail(
         Err(_) => {
             tracing::error!("Failed to receive entity detail - sender dropped");
             Json(None)
+        }
+    }
+}
+
+/// Inject a script message (damage, frob, signal) into a specific entity.
+///
+/// Body is a tagged `DebugEntityMessage`, e.g. `{"type":"Damage","amount":1.0}`.
+async fn send_entity_message(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Path(id): Path<i32>,
+    Json(message): Json<shock2vr::game_scene::DebugEntityMessage>,
+) -> Json<CommandResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if let Err(_) = command_tx.send(RuntimeCommand::SendEntityMessage {
+        id,
+        message,
+        reply: reply_tx,
+    }) {
+        tracing::error!("Failed to send SendEntityMessage command - game loop receiver dropped");
+        return Json(CommandResult {
+            success: false,
+            message: "Game loop unavailable".to_string(),
+            data: None,
+        });
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive send-message result - sender dropped");
+            Json(CommandResult {
+                success: false,
+                message: "No response from game loop".to_string(),
+                data: None,
+            })
         }
     }
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -839,10 +839,12 @@ fn process_command(
         }
         RuntimeCommand::EntityDetail { id, reply } => {
             let result = if let Some(debug_scene) = game.debug_scene() {
-                // Convert i32 id to EntityId
-                let entity_id = EntityId::new_from_index_and_gen(id as u64, 0);
-                debug_scene
-                    .entity_detail(entity_id)
+                // `id` is `EntityId::inner() as i32` (= index + 1) from the list
+                // endpoint; `from_inner` is its exact inverse. Using
+                // `new_from_index_and_gen(id, 0)` here resolved the wrong entity.
+                let entity_id = EntityId::from_inner(id as u64);
+                entity_id
+                    .and_then(|entity_id| debug_scene.entity_detail(entity_id))
                     .map(|detail| EntityDetailResult {
                         entity_id: detail.entity_id,
                         name: detail.name,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -4,7 +4,7 @@ use engine::{
     audio::AudioContext,
     scene::{SceneObject, light::SpotLight},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 use std::any::Any;
 
@@ -379,6 +379,31 @@ pub trait DebuggableScene {
     /// remote clients (e.g. the debug runtime) can verify that triggered
     /// pathfinding actions actually executed.
     fn pathfinding_test_status(&self) -> DebugPathfindingTestStatus;
+
+    /// Inject a script message into a specific entity.
+    ///
+    /// Queues the message for delivery on the next scene update, letting debug
+    /// clients exercise script behaviors (damage, frob, AI signals) without a
+    /// physical interaction in the world. Returns `true` if the entity is alive
+    /// and the message was queued.
+    fn send_entity_message(&mut self, id: EntityId, message: DebugEntityMessage) -> bool;
+}
+
+/// A script message a debug client can inject into a specific entity.
+///
+/// This is intentionally a small, serde-friendly subset of the engine's full
+/// `MessagePayload` enum, surfaced so remote clients (HTTP / SDK) can exercise
+/// script behaviors directly without simulating a world interaction. Extend it
+/// as new debug scenarios need more message kinds (e.g. `TurnOn` / `TurnOff`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum DebugEntityMessage {
+    /// Deal `amount` damage (drives `InternalSimpleHealth` / AI health).
+    Damage { amount: f32 },
+    /// Frob (use) the entity.
+    Frob,
+    /// Send a named AI signal.
+    Signal { name: String },
 }
 
 /// Status of the interactive pathfinding test system

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2886,10 +2886,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
         };
 
-        self.script_world.dispatch(Message {
-            to: id,
-            payload,
-        });
+        self.script_world.dispatch(Message { to: id, payload });
         true
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2860,6 +2860,38 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             test_path_waypoints,
         }
     }
+
+    fn send_entity_message(
+        &mut self,
+        id: EntityId,
+        message: crate::game_scene::DebugEntityMessage,
+    ) -> bool {
+        use crate::game_scene::DebugEntityMessage;
+        use shipyard::EntitiesView;
+
+        let is_alive = self
+            .world
+            .borrow::<EntitiesView>()
+            .map(|entities| entities.is_alive(id))
+            .unwrap_or(false);
+
+        if !is_alive {
+            tracing::warn!("send_entity_message: entity {:?} is not alive", id);
+            return false;
+        }
+
+        let payload = match message {
+            DebugEntityMessage::Damage { amount } => MessagePayload::Damage { amount },
+            DebugEntityMessage::Frob => MessagePayload::Frob,
+            DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
+        };
+
+        self.script_world.dispatch(Message {
+            to: id,
+            payload,
+        });
+        true
+    }
 }
 
 // Helper function for wildcard matching

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -279,6 +279,14 @@ impl crate::game_scene::DebuggableScene for Mission {
     fn pathfinding_test_status(&self) -> crate::game_scene::DebugPathfindingTestStatus {
         self.mission_core.pathfinding_test_status()
     }
+
+    fn send_entity_message(
+        &mut self,
+        id: EntityId,
+        message: crate::game_scene::DebugEntityMessage,
+    ) -> bool {
+        self.mission_core.send_entity_message(id, message)
+    }
 }
 
 /// Creates a physics collider from level geometry

--- a/shock2vr/src/scripts/internal_simple_health.rs
+++ b/shock2vr/src/scripts/internal_simple_health.rs
@@ -1,10 +1,13 @@
-use shipyard::{EntityId, World};
+use dark::properties::PropHitPoints;
+use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
-// Script to handle simple health behavior
+// Script to handle simple health behavior for non-creature entities that carry
+// a `PropHitPoints` (e.g. breakable crates, canisters, computer panels).
+// Creatures route damage through their AI / hitbox scripts instead.
 pub struct InternalSimpleHealth {}
 
 impl InternalSimpleHealth {
@@ -17,13 +20,108 @@ impl Script for InternalSimpleHealth {
     fn handle_message(
         &mut self,
         entity_id: EntityId,
-        _world: &World,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Damage { .. } => Effect::SlayEntity { entity_id },
+            MessagePayload::Damage { amount } => {
+                // Damage amounts are authored as floats but hit points are an
+                // integer pool; round to match the AI damage path
+                // (animated_monster_ai).
+                let damage = amount.round() as i32;
+
+                let remaining_after = {
+                    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+                    v_hit_points
+                        .get(entity_id)
+                        .ok()
+                        .map(|hp| hp.hit_points - damage)
+                };
+
+                match remaining_after {
+                    // Still alive: decrement the pool and keep the entity around.
+                    Some(remaining) if remaining > 0 => Effect::AdjustHitPoints {
+                        entity_id,
+                        delta: -damage,
+                    },
+                    // Hit points exhausted (or, defensively, no pool to draw
+                    // from): the entity dies.
+                    _ => Effect::SlayEntity { entity_id },
+                }
+            }
             _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn world_with_hit_points(hit_points: i32) -> (World, EntityId) {
+        let mut world = World::new();
+        let entity_id = world.add_entity((PropHitPoints { hit_points },));
+        (world, entity_id)
+    }
+
+    fn damage(world: &World, entity_id: EntityId, amount: f32) -> Effect {
+        let physics = PhysicsWorld::new();
+        let mut script = InternalSimpleHealth::new();
+        script.handle_message(
+            entity_id,
+            world,
+            &physics,
+            &MessagePayload::Damage { amount },
+        )
+    }
+
+    #[test]
+    fn non_lethal_damage_decrements_hit_points_without_slaying() {
+        let (world, entity_id) = world_with_hit_points(3);
+
+        match damage(&world, entity_id, 1.0) {
+            Effect::AdjustHitPoints {
+                entity_id: id,
+                delta,
+            } => {
+                assert_eq!(id, entity_id);
+                assert_eq!(delta, -1);
+            }
+            other => panic!("expected AdjustHitPoints, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn damage_meeting_hit_points_slays() {
+        let (world, entity_id) = world_with_hit_points(1);
+
+        match damage(&world, entity_id, 1.0) {
+            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
+            other => panic!("expected SlayEntity, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn damage_exceeding_hit_points_slays() {
+        let (world, entity_id) = world_with_hit_points(5);
+
+        match damage(&world, entity_id, 6.0) {
+            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
+            other => panic!("expected SlayEntity, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn entity_without_hit_points_is_slain() {
+        use dark::properties::PropMaxHitPoints;
+        let mut world = World::new();
+        // An entity that has *some* component but no PropHitPoints pool.
+        let entity_id = world.add_entity((PropMaxHitPoints { hit_points: 10 },));
+
+        match damage(&world, entity_id, 1.0) {
+            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
+            other => panic!("expected SlayEntity, got {:?}", other),
         }
     }
 }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from "./client.js";
 import type {
   CommandResult,
+  DebugEntityMessage,
   EntityDetailResult,
   EntityListResult,
   FrameSnapshot,
@@ -62,6 +63,24 @@ export class EntitiesApi {
 
   async detail(id: number): Promise<EntityDetailResult> {
     return this.client.get<EntityDetailResult>(`/v1/entities/${id}`);
+  }
+
+  /**
+   * Inject a script message into an entity (damage, frob, AI signal).
+   *
+   * The message is queued and delivered on the next step(); throws if the
+   * entity is not found or not alive.
+   */
+  async sendMessage(
+    id: number,
+    message: DebugEntityMessage,
+  ): Promise<CommandResult> {
+    return unwrap(
+      await this.client.post<CommandResult>(
+        `/v1/entities/${id}/message`,
+        message,
+      ),
+    );
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -41,6 +41,16 @@ export interface PathfindingTestStatus {
   test_path_waypoints: number;
 }
 
+/**
+ * A script message that can be injected into a specific entity.
+ *
+ * Mirrors the engine's `DebugEntityMessage`; the `type` field is the serde tag.
+ */
+export type DebugEntityMessage =
+  | { type: "Damage"; amount: number }
+  | { type: "Frob" }
+  | { type: "Signal"; name: string };
+
 export interface EntitySummary {
   id: number;
   name: string;

--- a/tools/shock2-sdk/test/health.e2e.test.ts
+++ b/tools/shock2-sdk/test/health.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// medsci1 "Junction Box" is a non-creature prop with PropHitPoints { 3 }, so it
+// routes damage through InternalSimpleHealth. It should survive two 1-point
+// hits and only be slain (removed from the world) on the third.
+const TARGET_NAME = "Junction Box";
+const TARGET_HP = 3;
+
+async function findTarget(game: GameServer): Promise<number | undefined> {
+  const { entities } = await game.entities.list({
+    filter: TARGET_NAME,
+    limit: 500,
+  });
+  return entities.find((e) => e.name === TARGET_NAME)?.id;
+}
+
+async function isAlive(game: GameServer, id: number): Promise<boolean> {
+  const { entities } = await game.entities.list({
+    filter: TARGET_NAME,
+    limit: 500,
+  });
+  return entities.some((e) => e.id === id);
+}
+
+test(
+  "InternalSimpleHealth: prop survives damage up to its hit points, then dies",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8092),
+    });
+
+    // Let the mission load and initialize scripts.
+    await game.step({ frames: 2 });
+
+    const id = await findTarget(game);
+    assert.ok(id !== undefined, `expected to find a '${TARGET_NAME}' entity`);
+    assert.ok(await isAlive(game, id), "target should start alive");
+
+    // The first (HP - 1) hits are non-lethal: the entity must remain in world.
+    for (let hit = 1; hit < TARGET_HP; hit++) {
+      await game.entities.sendMessage(id, { type: "Damage", amount: 1.0 });
+      await game.step({ frames: 1 });
+      assert.ok(
+        await isAlive(game, id),
+        `target should survive hit ${hit} of ${TARGET_HP} (regression: one-hit-kill)`,
+      );
+    }
+
+    // The final hit drops hit points to zero and slays the entity, which
+    // removes it from the world.
+    await game.entities.sendMessage(id, { type: "Damage", amount: 1.0 });
+    await game.step({ frames: 1 });
+    assert.ok(
+      !(await isAlive(game, id)),
+      `target should be slain after ${TARGET_HP} hits`,
+    );
+
+    // Messaging a now-dead entity is reported as a failure.
+    await assert.rejects(
+      game.entities.sendMessage(id, { type: "Damage", amount: 1.0 }),
+      /not found or not alive/,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Non-creature props with a `PropHitPoints` pool (crates, canisters, computer panels, junction boxes) were slain by **any** `Damage` message — `InternalSimpleHealth` ignored hit points entirely and always emitted `SlayEntity`. They now take damage incrementally and only die when hit points reach zero, matching the AI damage path (`animated_monster_ai` + `is_killed`). Creatures were already correct.

## What changed

- **`InternalSimpleHealth`** now reads `PropHitPoints`, decrements by the damage amount, and only slays at ≤ 0 (`shock2vr/src/scripts/internal_simple_health.rs`).
- **Extensible debug message seam** so this is testable end-to-end: `POST /v1/entities/:id/message` + SDK `game.entities.sendMessage(id, msg)` inject a script message into a specific entity. Body is a serde-tagged `DebugEntityMessage` (`Damage`/`Frob`/`Signal`), dispatched through `ScriptWorld`. Easy to extend — add a variant in `game_scene.rs` + an arm in `MissionCore::send_entity_message`.
- **Entity-id round-trip fix**: list/detail expose `EntityId::inner() as i32` (= `index + 1`); the debug runtime reconstructed with `new_from_index_and_gen(id, 0)`, doubling the `+1` and resolving the **wrong** entity. Now uses `EntityId::from_inner`. Fixes both the new message endpoint and the pre-existing `entity_detail` quirk.

## Validation

- **Unit tests** (negative-first): verified `non_lethal_damage_decrements...` *fails* against the old one-hit-kill code, then passes with the fix. Covers decrement, death-at-zero, over-damage, and no-HP fallback.
- **SDK e2e** (`tools/shock2-sdk/test/health.e2e.test.ts`, opt-in via `SHOCK2_E2E=1`): damages a medsci1 Junction Box (HP 3) through a real debug runtime — survives 2 hits, slain on the 3rd, and messaging the dead entity is rejected. Passes.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr` green (35 passed).

## Notes / follow-ups

This closes the "props are one-hit-kill" delta from `research/damage-model-differences.md`. The larger gaps remain out of scope: damage producers still hardcode amounts (melee 1.0, projectile 6.0), and damage is an untyped scalar (no `kind` for fire/toxic/EMP/armor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)