### PR TITLE
docs: document entity message-injection endpoint (follow-up to #273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,10 @@ For debugging visual/rendering changes without a full interactive session:
    curl http://127.0.0.1:8080/v1/input/actions
    curl -X POST http://127.0.0.1:8080/v1/input/action -d '{"action": "PathfindingTestCycle"}'
 
+   # Inject a script message into an entity (damage/frob/AI signal) - drives script
+   # behavior directly without a world interaction. Body is a tagged DebugEntityMessage.
+   curl -X POST http://127.0.0.1:8080/v1/entities/122/message -d '{"type": "Damage", "amount": 5.0}'
+
    # IMPORTANT: Always shut down when done to avoid interfering with user's session
    curl -X POST http://127.0.0.1:8080/v1/shutdown
    ```

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -38,6 +38,10 @@ await game.player.teleport({ x: pos.x + 5, y: pos.y, z: pos.z });
 const doors = await game.entities.list({ filter: "*Door*", limit: 10 });
 const detail = await game.entities.detail(doors.entities[0].id);
 
+// Inject a script message into an entity (damage, frob, AI signal)
+await game.entities.sendMessage(doors.entities[0].id, { type: "Damage", amount: 5 });
+await game.entities.sendMessage(doors.entities[0].id, { type: "Frob" });
+
 // Discrete input actions (the keybinding system)
 await game.input.actions(); // ["PathfindingTestCycle", "QuickSave", ...]
 await game.input.trigger("PathfindingTestCycle");


### PR DESCRIPTION
Follow-up to #273, which added `POST /v1/entities/:id/message` and the SDK `entities.sendMessage(...)` but missed the doc updates.

- **`CLAUDE.md`** — adds a curl example for the message-injection endpoint to the debug-runtime section.
- **`tools/shock2-sdk/README.md`** — adds `entities.sendMessage(id, { type: "Damage", amount })` / `{ type: "Frob" }` to the API examples.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)