### PR TITLE
feat(debug): physics body introspection over HTTP for debug scenes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,12 +157,20 @@ For debugging visual/rendering changes without a full interactive session:
 2. **Debug Runtime** (see `projects/debug-runtime.md`): HTTP-controlled game runtime for programmatic control and introspection:
 
    ```bash
-   # Start debug runtime
-   cargo dbgr -- --mission medsci1.mis --port 8080
+   # Start debug runtime. NOTE: do NOT add an extra `--` after `cargo dbgr` -
+   # the alias already ends in `--`, so `cargo dbgr -- --mission ...` passes a
+   # literal `--` to clap and fails with "unexpected argument '--mission'".
+   cargo dbgr --mission medsci1.mis --port 8080
 
    # Control via HTTP
    curl http://127.0.0.1:8080/v1/step -X POST -d '{"frames": 10}'
    curl http://127.0.0.1:8080/v1/screenshot -X POST -d '{"filename": "test.png"}'
+
+   # Inspect physics state (works for full missions AND debug_* scenes).
+   # Bodies are enumerated from Rapier directly, so many bodies can share one
+   # entity_id (e.g. ragdoll limbs) - use ?entity_id=N to scope to one entity.
+   curl "http://127.0.0.1:8080/v1/physics/bodies?entity_id=4"
+   curl http://127.0.0.1:8080/v1/physics/bodies/12   # detail by body_id
 
    # Trigger discrete input actions (same actions as desktop keybindings)
    curl http://127.0.0.1:8080/v1/input/actions
@@ -171,6 +179,12 @@ For debugging visual/rendering changes without a full interactive session:
    # IMPORTANT: Always shut down when done to avoid interfering with user's session
    curl -X POST http://127.0.0.1:8080/v1/shutdown
    ```
+
+   **Stepping & determinism**: time-based stepping (`-d '{"duration":"3s"}'`)
+   requires `-H 'Content-Type: application/json'`, and per-frame `delta_time` is
+   real wall-clock - a single frame after an idle period can carry a huge dt.
+   Prefer small frame batches (`{"frames": N}`) for deterministic, dt-independent
+   stepping; don't gate debug-scene logic on accumulated wall-clock time.
 
 3. **TypeScript SDK (`tools/shock2-sdk`)** — **preferred for multi-step testing and verification**. A Playwright-style wrapper over the debug runtime HTTP API that handles the full lifecycle: spawning the runtime, waiting for readiness, capturing logs, and automatic shutdown via `await using`. See `tools/shock2-sdk/README.md` for the full API.
 
@@ -210,10 +224,10 @@ For debugging visual/rendering changes without a full interactive session:
 
    ```bash
    # Use with debug runtime for programmatic control
-   cargo dbgr -- --mission debug_camera --port 8080
+   cargo dbgr --mission debug_camera --port 8080
    ```
 
-   Debug scenes are defined in `shock2vr/src/scenes/` and provide isolated environments for testing specific game systems without loading full missions.
+   Debug scenes are defined in `shock2vr/src/scenes/` and provide isolated environments for testing specific game systems without loading full missions. They are fully introspectable over HTTP (entities, physics bodies, raycast) just like real missions, via `GameScene::as_debuggable()`.
 
 ### Available Mission Files
 

--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -7,6 +7,40 @@
 - Spawn a dedicated ragdoll entity on death that inherits the deceased model pose, then simulate it using Rapier rigid bodies and joints.
 - Keep visual skinning and hit detection in sync with the simulated skeleton so the corpse interacts believably with the world.
 
+## Current Status (2026-06-15): Broken — root causes identified
+
+The "✅ Implemented" markers on Parts 3–5 below are **misleading**: the rig was
+wired up end-to-end but is not convincing because it is broken, not merely
+untuned. Verified via the new physics-body introspection harness (run
+`debug_ragdoll`, frame-step ~30 frames, `GET /v1/physics/bodies?entity_id=<corpse>`):
+the ragdoll **explodes** — max linear speed ≈ 133, bodies driven from y≈1.8 down
+to y≈-904 (through the floor) within a few frames.
+
+Root causes in `shock2vr/src/creature/rag_doll.rs`:
+
+1. **Self-collision between jointed bodies.** Each bone body uses
+   `CollisionGroup::selectable()`, whose filter `ALL_COLLIDABLE` *includes*
+   `SELECTABLE`. Adjacent joint bodies spawn overlapping and the solver ejects
+   them every frame. Fix: disable contacts between jointed bodies (joint
+   `contacts_enabled(false)` or a self-excluding group). **This is the dominant bug.**
+2. **No joint limits.** Joints use `JointAxesMask::LOCKED_SPHERICAL_AXES` — a free
+   ball joint with no cone/twist/hinge limits, so the body folds through itself.
+3. **Colliders ignore hitboxes.** Every bone is a uniform `SharedShape::ball(0.06)`;
+   `model.get_hit_boxes()` is never consulted (Part 5's "derive capsules/boxes from
+   hitbox data" was never actually done). Limbs have no length/volume; mass is
+   uniform and tiny; `bone_frame_offsets` are all identity.
+4. (Separate, pre-existing) the hitbox AABBs in `hit_boxes.rs` are computed in model
+   space then re-offset by `bbox.center()` in joint-local space — likely mis-sized.
+
+Suggested fix order: (1) → (2) → (3). Each is now objectively verifiable via the
+harness (settled ragdoll = body speeds → ~0 and y near the floor).
+
+**Tooling unblocked (PR #276, branch `feat/debug-physics-body-introspection`):**
+`/v1/physics/bodies` now enumerates the raw Rapier `RigidBodySet` (was a stub),
+`?entity_id=N` scopes to one ragdoll, debug scenes are introspectable via
+`GameScene::as_debuggable()`, and `debug_ragdoll` spawns the ragdoll on a
+deterministic frame counter with a fixed camera aimed at the spawn.
+
 ## Files To Reference
 - shock2vr/src/physics/mod.rs
 - dark/src/ss2_skeleton.rs

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -70,6 +70,9 @@ pub enum RuntimeCommand {
     /// List physics rigid bodies
     ListPhysicsBodies {
         limit: Option<usize>,
+        /// Optional filter: only return bodies owned by this entity id. Useful
+        /// for scoping to the many bodies of a single ragdoll.
+        entity_id: Option<i32>,
         reply: oneshot::Sender<PhysicsBodyListResult>,
     },
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -922,12 +922,25 @@ fn process_command(
                 tracing::warn!("Failed to send entity message result - receiver dropped");
             }
         }
-        RuntimeCommand::ListPhysicsBodies { limit, reply } => {
+        RuntimeCommand::ListPhysicsBodies {
+            limit,
+            entity_id,
+            reply,
+        } => {
             if let Some(debug_scene) = game.debug_scene() {
-                let bodies = debug_scene.list_physics_bodies(limit);
+                // Fetch all bodies (limit applied after filtering), then scope to
+                // the requested entity id if one was provided.
+                let mut bodies = debug_scene.list_physics_bodies(None);
+                if let Some(entity_id) = entity_id {
+                    bodies.retain(|b| b.entity_id == Some(entity_id));
+                }
+                let total_count = bodies.len();
+                if let Some(limit) = limit {
+                    bodies.truncate(limit);
+                }
                 let player_pos = debug_scene.player_position();
                 let result = PhysicsBodyListResult {
-                    total_count: bodies.len(),
+                    total_count,
                     player_position: [player_pos.x, player_pos.y, player_pos.z],
                     bodies: bodies
                         .into_iter()
@@ -1514,6 +1527,8 @@ async fn perform_raycast(
 #[derive(Deserialize)]
 struct PhysicsBodyQueryParams {
     limit: Option<usize>,
+    /// Only return bodies whose owning entity id matches (scopes to one ragdoll).
+    entity_id: Option<i32>,
 }
 
 /// HTTP handler for listing physics bodies
@@ -1526,6 +1541,7 @@ async fn list_physics_bodies(
     // Send command to game loop
     if let Err(_) = command_tx.send(RuntimeCommand::ListPhysicsBodies {
         limit: params.limit,
+        entity_id: params.entity_id,
         reply: reply_tx,
     }) {
         tracing::error!("Failed to send ListPhysicsBodies command - game loop receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -122,6 +122,20 @@ pub trait GameScene {
     fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
         None
     }
+
+    /// Expose this scene's debug/introspection interface, if it has one.
+    ///
+    /// Implemented by full missions and by the debug scenes (which forward to
+    /// their inner `MissionCore`), so the debug runtime's HTTP endpoints work
+    /// against `debug_*` scenes too.
+    fn as_debuggable(&self) -> Option<&dyn DebuggableScene> {
+        None
+    }
+
+    /// Mutable variant of [`as_debuggable`].
+    fn as_debuggable_mut(&mut self) -> Option<&mut dyn DebuggableScene> {
+        None
+    }
 }
 
 // ============================================================================

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -207,10 +207,7 @@ impl Game {
     ///
     /// Returns None if the current scene doesn't implement DebuggableScene.
     pub fn debug_scene(&self) -> Option<&dyn game_scene::DebuggableScene> {
-        self.active_game_scene
-            .as_any()
-            .and_then(|any| any.downcast_ref::<mission::Mission>())
-            .map(|mission| mission as &dyn game_scene::DebuggableScene)
+        self.active_game_scene.as_debuggable()
     }
 
     /// Get mutable access to the debug scene interface if available
@@ -221,10 +218,7 @@ impl Game {
     ///
     /// Returns None if the current scene doesn't implement DebuggableScene.
     pub fn debug_scene_mut(&mut self) -> Option<&mut dyn game_scene::DebuggableScene> {
-        self.active_game_scene
-            .as_any_mut()
-            .and_then(|any| any.downcast_mut::<mission::Mission>())
-            .map(|mission| mission as &mut dyn game_scene::DebuggableScene)
+        self.active_game_scene.as_debuggable_mut()
     }
 
     pub fn init(options: GameOptions, bundle_storage: Arc<dyn Storage>) -> Game {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2544,6 +2544,22 @@ fn play_environmental_sound(
 // DebuggableScene Implementation for MissionCore
 // ============================================================================
 
+impl MissionCore {
+    /// Build a lookup from `EntityId::inner() as i32` to symbolic name, matching
+    /// the id convention used by the entity-listing debug endpoints.
+    fn entity_names_by_inner(&self) -> std::collections::HashMap<i32, String> {
+        use shipyard::*;
+        let mut names = std::collections::HashMap::new();
+        self.world
+            .run(|v_sym_name: View<dark::properties::PropSymName>| {
+                for (entity_id, sym_name) in v_sym_name.iter().with_id() {
+                    names.insert(entity_id.inner() as i32, sym_name.0.clone());
+                }
+            });
+        names
+    }
+}
+
 impl crate::game_scene::DebuggableScene for MissionCore {
     fn list_entities(
         &self,
@@ -2805,22 +2821,68 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
     fn list_physics_bodies(
         &self,
-        _limit: Option<usize>,
+        limit: Option<usize>,
     ) -> Vec<crate::game_scene::DebugPhysicsBodySummary> {
-        // TODO: Implement physics body enumeration
-        // For now, return empty list as placeholder
-        tracing::warn!("Physics body enumeration not yet implemented");
-        vec![]
+        let names = self.entity_names_by_inner();
+        let mut bodies: Vec<_> = self
+            .physics
+            .debug_list_bodies()
+            .into_iter()
+            .map(|info| {
+                let entity_name = info.entity_id.and_then(|id| names.get(&id).cloned());
+                crate::game_scene::DebugPhysicsBodySummary {
+                    body_id: info.body_id,
+                    entity_id: info.entity_id,
+                    entity_name,
+                    body_type: info.body_type.to_string(),
+                    position: info.position,
+                    rotation: info.rotation,
+                    mass: Some(info.mass),
+                    velocity: info.linear_velocity,
+                    angular_velocity: info.angular_velocity,
+                    collision_groups: info.collision_groups,
+                    is_sensor: info.is_sensor,
+                    is_enabled: info.is_enabled,
+                }
+            })
+            .collect();
+
+        if let Some(limit) = limit {
+            bodies.truncate(limit);
+        }
+        bodies
     }
 
     fn physics_body_detail(
         &self,
-        _body_id: u32,
+        body_id: u32,
     ) -> Option<crate::game_scene::DebugPhysicsBodyDetail> {
-        // TODO: Implement physics body detail inspection
-        // For now, return None as placeholder
-        tracing::warn!("Physics body detail inspection not yet implemented");
-        None
+        let info = self.physics.debug_body_detail(body_id)?;
+        let entity_name = info
+            .entity_id
+            .and_then(|id| self.entity_names_by_inner().get(&id).cloned());
+        Some(crate::game_scene::DebugPhysicsBodyDetail {
+            body_id: info.body_id,
+            entity_id: info.entity_id,
+            entity_name,
+            body_type: info.body_type.to_string(),
+            position: info.position,
+            rotation: info.rotation,
+            linear_velocity: info.linear_velocity,
+            angular_velocity: info.angular_velocity,
+            mass: Some(info.mass),
+            center_of_mass: info.center_of_mass,
+            // Not yet surfaced from Rapier; velocity is the primary settle signal.
+            moment_of_inertia: None,
+            gravity_scale: info.gravity_scale,
+            linear_damping: info.linear_damping,
+            angular_damping: info.angular_damping,
+            collision_groups: info.collision_groups,
+            is_sensor: info.is_sensor,
+            is_enabled: info.is_enabled,
+            is_sleeping: info.is_sleeping,
+            contact_count: 0,
+        })
     }
 
     fn get_input_state(&self) -> crate::input_context::InputContext {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -218,6 +218,14 @@ impl crate::game_scene::GameScene for Mission {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
     }
+
+    fn as_debuggable(&self) -> Option<&dyn crate::game_scene::DebuggableScene> {
+        Some(self)
+    }
+
+    fn as_debuggable_mut(&mut self) -> Option<&mut dyn crate::game_scene::DebuggableScene> {
+        Some(self)
+    }
 }
 
 // ============================================================================

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1048,4 +1048,127 @@ impl PhysicsWorld {
     pub fn get_body_transform(&self, handle: RigidBodyHandle) -> Option<Isometry<Real>> {
         self.rigid_body_set.get(handle).map(|body| *body.position())
     }
+
+    /// Enumerate every rigid body in the simulation for debug tooling.
+    ///
+    /// This iterates the raw Rapier `RigidBodySet` rather than the
+    /// `entity_id_to_body` map, so it surfaces *all* bodies - including the
+    /// many bodies that share a single `EntityId` (e.g. ragdoll limbs) and
+    /// bodies with no entity at all.
+    pub fn debug_list_bodies(&self) -> Vec<DebugBodyInfo> {
+        self.rigid_body_set
+            .iter()
+            .map(|(handle, body)| self.debug_body_info(handle, body))
+            .collect()
+    }
+
+    /// Look up a single body's debug info by its `body_id` (the rigid body
+    /// handle index, as reported by [`debug_list_bodies`]).
+    pub fn debug_body_detail(&self, body_id: u32) -> Option<DebugBodyInfo> {
+        self.rigid_body_set
+            .iter()
+            .find(|(handle, _)| handle.into_raw_parts().0 == body_id)
+            .map(|(handle, body)| self.debug_body_info(handle, body))
+    }
+
+    fn debug_body_info(&self, handle: RigidBodyHandle, body: &RigidBody) -> DebugBodyInfo {
+        let (index, generation) = handle.into_raw_parts();
+
+        let entity_id = if body.user_data != 0 {
+            Some(body.user_data as i32)
+        } else {
+            None
+        };
+
+        let body_type = match body.body_type() {
+            RigidBodyType::Dynamic => "dynamic",
+            RigidBodyType::Fixed => "static",
+            RigidBodyType::KinematicPositionBased | RigidBodyType::KinematicVelocityBased => {
+                "kinematic"
+            }
+        };
+
+        let translation = body.translation();
+        let rotation = body.rotation();
+        let linvel = body.linvel();
+        let angvel = body.angvel();
+        let com = body.center_of_mass();
+
+        // Pull shape/group/sensor data from the body's first collider, if any.
+        let mut collision_groups = Vec::new();
+        let mut is_sensor = false;
+        if let Some(collider_handle) = body.colliders().first() {
+            if let Some(collider) = self.collider_set.get(*collider_handle) {
+                is_sensor = collider.is_sensor();
+                collision_groups =
+                    collision_group_names(collider.collision_groups().memberships.bits());
+            }
+        }
+
+        DebugBodyInfo {
+            body_id: index,
+            generation,
+            entity_id,
+            body_type,
+            position: [translation.x, translation.y, translation.z],
+            rotation: [rotation.i, rotation.j, rotation.k, rotation.w],
+            linear_velocity: [linvel.x, linvel.y, linvel.z],
+            angular_velocity: [angvel.x, angvel.y, angvel.z],
+            mass: body.mass(),
+            center_of_mass: [com.x, com.y, com.z],
+            gravity_scale: body.gravity_scale(),
+            linear_damping: body.linear_damping(),
+            angular_damping: body.angular_damping(),
+            collision_groups,
+            is_sensor,
+            is_enabled: body.is_enabled(),
+            is_sleeping: body.is_sleeping(),
+        }
+    }
+}
+
+/// Rapier-free description of a rigid body, for debug tooling / HTTP introspection.
+#[derive(Debug, Clone)]
+pub struct DebugBodyInfo {
+    /// Stable-within-session id: the rigid body handle's index.
+    pub body_id: u32,
+    /// Handle generation - distinguishes a reused index across removals.
+    pub generation: u32,
+    /// Owning entity (from `RigidBody::user_data`). Non-unique: many bodies
+    /// (e.g. ragdoll limbs) can report the same entity.
+    pub entity_id: Option<i32>,
+    pub body_type: &'static str,
+    pub position: [f32; 3],
+    pub rotation: [f32; 4],
+    pub linear_velocity: [f32; 3],
+    pub angular_velocity: [f32; 3],
+    pub mass: f32,
+    pub center_of_mass: [f32; 3],
+    pub gravity_scale: f32,
+    pub linear_damping: f32,
+    pub angular_damping: f32,
+    pub collision_groups: Vec<String>,
+    pub is_sensor: bool,
+    pub is_enabled: bool,
+    pub is_sleeping: bool,
+}
+
+/// Decode an `InteractionGroups` membership bitmask into human-readable names.
+fn collision_group_names(bits: u32) -> Vec<String> {
+    let mut names = Vec::new();
+    let candidates = [
+        (InternalCollisionGroups::WORLD, "world"),
+        (InternalCollisionGroups::ENTITY, "entity"),
+        (InternalCollisionGroups::SELECTABLE, "selectable"),
+        (InternalCollisionGroups::PLAYER, "player"),
+        (InternalCollisionGroups::UI, "ui"),
+        (InternalCollisionGroups::HITBOX, "hitbox"),
+        (InternalCollisionGroups::RAYCAST, "raycast"),
+    ];
+    for (group, name) in candidates {
+        if bits & group.bits != 0 {
+            names.push(name.to_string());
+        }
+    }
+    names
 }

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -259,6 +259,14 @@ impl GameScene for DebugScene {
     fn queue_entity_trigger(&mut self, entity_name: String) {
         self.core.queue_entity_trigger(entity_name)
     }
+
+    fn as_debuggable(&self) -> Option<&dyn crate::game_scene::DebuggableScene> {
+        Some(&self.core)
+    }
+
+    fn as_debuggable_mut(&mut self) -> Option<&mut dyn crate::game_scene::DebuggableScene> {
+        Some(&mut self.core)
+    }
 }
 
 pub trait DebugSceneHooks {
@@ -414,6 +422,14 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn queue_entity_trigger(&mut self, entity_name: String) {
         self.core.queue_entity_trigger(entity_name)
+    }
+
+    fn as_debuggable(&self) -> Option<&dyn crate::game_scene::DebuggableScene> {
+        Some(&self.core)
+    }
+
+    fn as_debuggable_mut(&mut self) -> Option<&mut dyn crate::game_scene::DebuggableScene> {
+        Some(&mut self.core)
     }
 }
 

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -1,4 +1,4 @@
-use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, vec3};
+use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, Vector3, vec3};
 use dark::{SCALE_FACTOR, properties::PropTemplateId};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use shipyard::{EntityId, IntoIter, IntoWithId};
@@ -20,6 +20,20 @@ use crate::{
 
 const IMPULSE_STRENGTH: f32 = 1.0;
 const PULL_FORCE: f32 = 1.0;
+
+/// Number of update frames to wait after spawning the pipe hybrid before killing
+/// it and spawning the ragdoll. Frame-based (not wall-clock) so the trigger is
+/// deterministic under headless stepping, where a single frame can carry a large
+/// or irregular delta time.
+const KILL_DELAY_FRAMES: u32 = 30;
+
+/// World-space point where the pipe hybrid (and therefore the ragdoll) spawns.
+/// Placed directly in front of the default player spawn (which faces -Z) so the
+/// corpse is straight ahead, and used as the look-at target for the fixed debug
+/// camera so the spawn is always framed.
+fn ragdoll_focus_point() -> Point3<f32> {
+    Point3::new(0.0, 5.0 / SCALE_FACTOR, -5.0)
+}
 
 pub struct DebugRagdollScene;
 
@@ -52,7 +66,8 @@ impl DebugRagdollScene {
 
 struct RagdollHooks {
     pipe_hybrid_spawned: bool,
-    slay_timer: f32,
+    frames_since_spawn: u32,
+    killed: bool,
     last_left_impulse: bool,
     last_right_pull: bool,
 }
@@ -67,7 +82,8 @@ impl RagdollHooks {
 
         Self {
             pipe_hybrid_spawned: false,
-            slay_timer: 0.0,
+            frames_since_spawn: 0,
+            killed: false,
             last_left_impulse: false,
             last_right_pull: false,
         }
@@ -85,7 +101,7 @@ impl RagdollHooks {
             return;
         }
 
-        let spawn_position = Point3::new(-5.0, 5.0 / SCALE_FACTOR, -0.0);
+        let spawn_position = ragdoll_focus_point();
 
         let spawn_effect = Effect::CreateEntity {
             template_id: -397,
@@ -109,7 +125,7 @@ impl RagdollHooks {
         );
 
         self.pipe_hybrid_spawned = true;
-        self.slay_timer = 1.0;
+        self.frames_since_spawn = 0;
         println!("Spawned pipe hybrid for ragdoll testing");
     }
 
@@ -198,9 +214,9 @@ impl RagdollHooks {
         self.last_right_pull = input_context.right_hand.squeeze_value > 0.05;
     }
 
-    fn update_slay_timer(&mut self, delta: f32) {
-        if self.pipe_hybrid_spawned && self.slay_timer > 0.0 {
-            self.slay_timer -= delta;
+    fn advance_kill_counter(&mut self) {
+        if self.pipe_hybrid_spawned && !self.killed {
+            self.frames_since_spawn += 1;
         }
     }
 }
@@ -214,8 +230,9 @@ impl DebugSceneHooks for RagdollHooks {
         _asset_cache: &mut AssetCache,
         _game_options: &GameOptions,
     ) {
+        let _ = time;
         self.handle_ragdoll_input(core, input_context);
-        self.update_slay_timer(time.elapsed.as_secs_f32());
+        self.advance_kill_counter();
     }
 
     fn before_handle_effects(
@@ -235,7 +252,7 @@ impl DebugSceneHooks for RagdollHooks {
                 asset_cache,
                 audio_context,
             );
-        } else if self.slay_timer <= 0.0 && self.slay_timer > -0.5 {
+        } else if !self.killed && self.frames_since_spawn >= KILL_DELAY_FRAMES {
             self.kill_spawned_entity(
                 core,
                 global_context,
@@ -243,7 +260,25 @@ impl DebugSceneHooks for RagdollHooks {
                 asset_cache,
                 audio_context,
             );
-            self.slay_timer = -1.0;
+            self.killed = true;
         }
+    }
+
+    fn after_render(
+        &mut self,
+        _core: &mut MissionCore,
+        _scene_objects: &mut Vec<engine::scene::SceneObject>,
+        camera_position: &mut Vector3<f32>,
+        camera_rotation: &mut Quaternion<f32>,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) {
+        // Pin the camera to a fixed vantage point aimed at the ragdoll spawn so
+        // the corpse is always framed, independent of player head orientation.
+        let target = ragdoll_focus_point();
+        let cam_pos = vec3(0.0, target.y + 2.0, 4.0);
+        let forward = (vec3(target.x, target.y, target.z) - cam_pos).normalize();
+        *camera_position = cam_pos;
+        *camera_rotation = Quaternion::from_arc(vec3(0.0, 0.0, -1.0), forward, None);
     }
 }


### PR DESCRIPTION
## Why

Debugging physics-driven features like the ragdoll is hard for an agent (and tedious for a human) because it's a VR/visual feature — you have to *watch* it. This PR builds the headless observability foundation so physics state can be inspected and asserted over HTTP, unblocking agentic iteration on physics bugs.

While wiring this up, two pre-existing gaps turned out to be blocking everything:

1. **`/v1/physics/bodies` was a stub** — `list_physics_bodies`/`physics_body_detail` returned `[]`/`None`. No physics body (ragdoll or otherwise) was ever inspectable.
2. **No debug scene was introspectable at all** — `Game::debug_scene()` only downcast to `Mission`, but `debug_*` scenes are a `HookedDebugScene` wrapping a `MissionCore`, so entities/physics/raycast endpoints all returned empty for them.

## What

- **Generalize `/v1/physics/bodies`**: enumerate the raw Rapier `RigidBodySet` instead of the `entity_id → body` map. This surfaces *all* bodies, including the many bodies that share one `EntityId` (ragdoll limbs) or have none. `entity_id` is now a derived (from `user_data`), optional, non-unique field per body.
- **Make debug scenes introspectable**: add `GameScene::as_debuggable()` and forward it from `Mission` and the debug-scene wrappers to their inner `MissionCore`. Replaces the `Any`-downcast in `debug_scene()`. Fixes entities/physics/raycast for every `debug_*` scene.
- **Add `?entity_id=N` filter** to `/v1/physics/bodies` to scope to a single entity (e.g. one ragdoll's bodies), applied before the limit.
- **`debug_ragdoll` determinism**: switch the kill/ragdoll-spawn trigger from a wall-clock timer to a frame counter. Headless stepping can carry a large/irregular `delta_time` in a single frame, which overshot the old `slay_timer` window so the ragdoll never spawned.
- **`debug_ragdoll` camera**: pin a fixed camera aimed at the spawn point and move the spawn directly in front of the player, so the corpse is always framed.

## Verification

Against a running `debug_ragdoll` via the debug runtime:

- `GET /v1/physics/bodies?entity_id=4` returns the ragdoll's **22 dynamic bodies** under one entity id (plus the kinematic hitbox bodies on the full list).
- The data immediately surfaces that **the ragdoll explodes**: max linear speed ≈ 133, bodies driven from y≈1.8 down to y≈-904 (through the floor). This matches the self-collision + missing-joint-limit diagnosis.
- Fixed camera confirmed to frame the creature centered (screenshot via `/v1/screenshot`).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` passes; `cargo fmt` clean.

## Follow-up (not in this PR)

The actual ragdoll explosion fix — disable self-collision between jointed bodies, size colliders from hitboxes, add joint limits — is next, and is now verifiable objectively via this endpoint (settle = speeds → ~0, y near floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)