### PR TITLE
feat(ragdoll): stop ragdoll explosion (no self-collision) + match debug camera

### DIFF
--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -297,6 +297,15 @@ curl -X POST http://127.0.0.1:8080/v1/screenshot \
 4. **Phase 7: CLI Tool** - Build out `debug_command` with all subcommands
 5. **Error Handling** - Standardize error responses with codes and suggestions
 6. **Documentation** - Add OpenAPI spec and usage examples
+7. **Aimable debug camera** - Let callers point the debug camera at an arbitrary
+   world position/orientation, so agents can frame whatever they're inspecting
+   (e.g. wherever a ragdoll lands) instead of relying on a fixed default view.
+   Either a new `/v1/camera` endpoint (set position + look-at target, or
+   position + rotation) or by honoring the head rotation already present in
+   `POST /v1/control/input`. Today the debug runtime hardcodes the camera head
+   rotation to the desktop default (`default_camera_head_rotation()` in
+   `runtimes/debug_runtime/src/main.rs`, looking toward -X); screenshots are only
+   representative when the subject happens to be in that default view.
 
 ## Technical Notes
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -90,6 +90,27 @@ struct Args {
     experimental: Option<String>,
 }
 
+/// Default debug-camera head rotation.
+///
+/// Matches the desktop runtime's default view orientation (`cargo dr`): at
+/// `yaw=0, pitch=0` the desktop camera forward is `(1,0,0)` fed through
+/// `look_at_rh`, so it looks toward `-X`. Mirroring it here keeps debug-runtime
+/// screenshots framed the same as what you see interactively on desktop.
+///
+/// TODO(camera-endpoint): make the debug camera aimable over HTTP - either a new
+/// `/v1/camera` endpoint or by honoring the head rotation in `/v1/control/input`
+/// - so an agent can point the camera at an arbitrary world point (e.g. wherever
+/// a ragdoll lands) instead of relying on this fixed default. Tracked in
+/// projects/debug-runtime.md.
+fn default_camera_head_rotation() -> Quaternion<f32> {
+    use cgmath::{Decomposed, Rotation, Transform, point3};
+    let forward = point3(1.0, 0.0, 0.0);
+    let up = vec3(0.0, 1.0, 0.0);
+    let decomposed: Decomposed<Vector3<f32>, Quaternion<f32>> =
+        Transform::look_at_rh(forward, point3(0.0, 0.0, 0.0), up);
+    decomposed.rot.invert()
+}
+
 /// Parse mission string (supports mission:spawn_location format)
 fn parse_mission(mission: &str) -> (String, SpawnLocation) {
     if !mission.contains(':') {
@@ -510,7 +531,7 @@ fn run_game_blocking(
             camera_offset: pawn_offset,
             camera_rotation: pawn_rotation,
             head_offset: vec3(0.0, 1.6 / SCALE_FACTOR, 0.0), // Default head height
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0), // Identity rotation
+            head_rotation: default_camera_head_rotation(),   // Match desktop default view (-X)
             projection_matrix,
             screen_size,
         };

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -140,7 +140,7 @@ impl RagDollManager {
                 handle,
                 SharedShape::ball(DEFAULT_JOINT_RADIUS),
                 1.0,
-                CollisionGroup::selectable(),
+                CollisionGroup::ragdoll(),
             );
 
             joint_to_body.insert(bone.joint_id as u32, handle);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -84,6 +84,20 @@ impl CollisionGroup {
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
         })
     }
+
+    /// Collision group for ragdoll limb bodies. Members are `SELECTABLE` (so
+    /// they remain raycast/selectable), but they only *collide* with `WORLD`
+    /// geometry. Crucially the filter excludes `SELECTABLE` itself, so ragdoll
+    /// limbs do not self-collide - adjacent jointed bodies that spawn slightly
+    /// overlapping would otherwise be violently ejected by the solver every
+    /// frame (the ragdoll "explosion"). It also avoids fighting the leftover
+    /// creature capsule (`ENTITY`) and per-joint hitboxes (`HITBOX`).
+    pub fn ragdoll() -> CollisionGroup {
+        CollisionGroup(InteractionGroups {
+            memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
+            filter: InternalCollisionGroups::WORLD.bits.into(),
+        })
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -32,7 +32,7 @@ const KILL_DELAY_FRAMES: u32 = 30;
 /// corpse is straight ahead, and used as the look-at target for the fixed debug
 /// camera so the spawn is always framed.
 fn ragdoll_focus_point() -> Point3<f32> {
-    Point3::new(0.0, 5.0 / SCALE_FACTOR, -5.0)
+    Point3::new(-5.0, 5.0 / SCALE_FACTOR, -0.0)
 }
 
 pub struct DebugRagdollScene;
@@ -262,23 +262,5 @@ impl DebugSceneHooks for RagdollHooks {
             );
             self.killed = true;
         }
-    }
-
-    fn after_render(
-        &mut self,
-        _core: &mut MissionCore,
-        _scene_objects: &mut Vec<engine::scene::SceneObject>,
-        camera_position: &mut Vector3<f32>,
-        camera_rotation: &mut Quaternion<f32>,
-        _asset_cache: &mut AssetCache,
-        _options: &GameOptions,
-    ) {
-        // Pin the camera to a fixed vantage point aimed at the ragdoll spawn so
-        // the corpse is always framed, independent of player head orientation.
-        let target = ragdoll_focus_point();
-        let cam_pos = vec3(0.0, target.y + 2.0, 4.0);
-        let forward = (vec3(target.x, target.y, target.z) - cam_pos).normalize();
-        *camera_position = cam_pos;
-        *camera_rotation = Quaternion::from_arc(vec3(0.0, 0.0, -1.0), forward, None);
     }
 }

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -1,4 +1,4 @@
-use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix4, Point3, Quaternion, vec3};
 use dark::{SCALE_FACTOR, properties::PropTemplateId};
 use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
 use shipyard::{EntityId, IntoIter, IntoWithId};


### PR DESCRIPTION
Stacked on #276 (base = `feat/debug-physics-body-introspection`). Review/merge that one first.

## Why

With the introspection harness from #276, the ragdoll was confirmed to **explode** on spawn — bodies driven to max speed ~133 and y ≈ −904 (through the floor). This PR fixes the dominant cause and makes the debug-runtime view match desktop so the result is actually watchable.

## What

- **No ragdoll self-collision** (`CollisionGroup::ragdoll()`): ragdoll limb bodies were using `selectable()`, whose filter `ALL_COLLIDABLE` includes `SELECTABLE` — so adjacent jointed bodies, which spawn slightly overlapping, ejected each other every frame. New group members are `SELECTABLE` (still raycast/selectable) but only *collide* with `WORLD`, so limbs rest on the floor without fighting each other (or the leftover creature capsule / hitboxes).
- **Debug camera matches desktop** (`default_camera_head_rotation()`): the debug runtime hardcoded the camera `head_rotation` to identity (looking −Z) while desktop's default looks −X, so scene subjects were off-screen in screenshots. Now mirrors desktop's `look_at_rh` default.
- TODO filed (`projects/debug-runtime.md`) for an aimable `/v1/camera` endpoint so agents can frame any point rather than the fixed default.

## Verification

Scoped to the ragdoll via `GET /v1/physics/bodies?entity_id=<corpse>`:

| | before | after |
| --- | --- | --- |
| max linear speed | ~133 | ~1.8 |
| y range | 1.8 … −904 | 0.15 … 1.8 (on floor) |

Screenshot confirms the corpse is framed without turning (matches `cargo dr`). `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime -p desktop_runtime` passes; `cargo fmt` clean.

## Known remaining work (next PR)

The mesh still collapses into a flat puddle: colliders are uniform 0.06 balls (no limb length/volume — visible as missing capsules under `--debug-physics`) and joints have no angular limits. Next: hitbox-derived capsule/box colliders, joint limits, and verifying the physics→skinning transform. Also `debug_ragdoll` leaves the original creature standing beside the ragdoll (debug-scene artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)