### PR TITLE
feat(ragdoll): hitbox-sized limb colliders + stable settling

### DIFF
--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -7,39 +7,86 @@
 - Spawn a dedicated ragdoll entity on death that inherits the deceased model pose, then simulate it using Rapier rigid bodies and joints.
 - Keep visual skinning and hit detection in sync with the simulated skeleton so the corpse interacts believably with the world.
 
-## Current Status (2026-06-15): Broken — root causes identified
+## Status & Investigation Log (2026-06-15)
 
-The "✅ Implemented" markers on Parts 3–5 below are **misleading**: the rig was
-wired up end-to-end but is not convincing because it is broken, not merely
-untuned. Verified via the new physics-body introspection harness (run
-`debug_ragdoll`, frame-step ~30 frames, `GET /v1/physics/bodies?entity_id=<corpse>`):
-the ragdoll **explodes** — max linear speed ≈ 133, bodies driven from y≈1.8 down
-to y≈-904 (through the floor) within a few frames.
+The rig had been wired end-to-end (Parts 3–5 below marked "✅") but was not
+convincing because it was **broken, not merely untuned**. This section records
+what was wrong, how we found it, and how each fix was verified. The "✅" markers
+on the historical plan further down are left as-is for context.
 
-Root causes in `shock2vr/src/creature/rag_doll.rs`:
+### How we test (the iteration loop)
 
-1. **Self-collision between jointed bodies.** Each bone body uses
-   `CollisionGroup::selectable()`, whose filter `ALL_COLLIDABLE` *includes*
-   `SELECTABLE`. Adjacent joint bodies spawn overlapping and the solver ejects
-   them every frame. Fix: disable contacts between jointed bodies (joint
-   `contacts_enabled(false)` or a self-excluding group). **This is the dominant bug.**
-2. **No joint limits.** Joints use `JointAxesMask::LOCKED_SPHERICAL_AXES` — a free
-   ball joint with no cone/twist/hinge limits, so the body folds through itself.
-3. **Colliders ignore hitboxes.** Every bone is a uniform `SharedShape::ball(0.06)`;
-   `model.get_hit_boxes()` is never consulted (Part 5's "derive capsules/boxes from
-   hitbox data" was never actually done). Limbs have no length/volume; mass is
-   uniform and tiny; `bone_frame_offsets` are all identity.
-4. (Separate, pre-existing) the hitbox AABBs in `hit_boxes.rs` are computed in model
-   space then re-offset by `bbox.center()` in joint-local space — likely mis-sized.
+All diagnosis was done **headlessly**, without watching a VR/desktop window, using
+the debug-runtime physics introspection added for this effort:
 
-Suggested fix order: (1) → (2) → (3). Each is now objectively verifiable via the
-harness (settled ragdoll = body speeds → ~0 and y near the floor).
+1. `cargo dbgr --mission debug_ragdoll --port N` (optionally `--debug-physics` to
+   draw colliders/joints). NOTE: no extra `--` after `cargo dbgr`.
+2. Frame-step in small deterministic batches (`POST /v1/step {"frames":10}`); the
+   scene kills the pipe hybrid and spawns the ragdoll at a fixed frame count.
+3. `GET /v1/physics/bodies?entity_id=<corpse>` and compute metrics over the
+   ragdoll's bodies: min/max **y** (floor penetration / launch), max/mean **linear
+   speed**, and max/mean **angular speed**.
+4. Interpretation: a healthy ragdoll **settles** (speeds → ~0, y near the floor);
+   a broken one either **explodes** (huge speed, y → large negative) or **diverges**
+   (speed *grows* over time = solver instability / energy injection).
+5. `POST /v1/screenshot` for a visual sanity check (camera matches desktop).
 
-**Tooling unblocked (PR #276, branch `feat/debug-physics-body-introspection`):**
-`/v1/physics/bodies` now enumerates the raw Rapier `RigidBodySet` (was a stub),
-`?entity_id=N` scopes to one ragdoll, debug scenes are introspectable via
-`GameScene::as_debuggable()`, and `debug_ragdoll` spawns the ragdoll on a
-deterministic frame counter with a fixed camera aimed at the spawn.
+### Findings, fixes, and verification (in order)
+
+1. **Spawn-time explosion — self-collision between jointed bodies.** Bodies used
+   `CollisionGroup::selectable()`, whose filter `ALL_COLLIDABLE` includes
+   `SELECTABLE`, so adjacent overlapping joint bodies ejected each other every
+   frame. **Fix:** new `CollisionGroup::ragdoll()` (members `SELECTABLE`, filter
+   `WORLD` only) — limbs hit the floor but never each other. **Verified:** max
+   speed 133 → ~1.8, y −904 → resting on floor. (PR #277)
+
+2. **Limbs were point-balls (flat puddle).** `model.get_hit_boxes()` was never
+   used. **Fix:** size each limb collider as a cuboid from the joint's hitbox
+   AABB, offset to the box center in joint-local space (body origin stays at the
+   joint so skinning is unaffected). **Verified:** limb-shaped boxes visible under
+   `--debug-physics`. (PR #278)
+
+3. **New instability after (2): the rig flailed and limbs spun forever and never
+   settled.** Root cause = **mass ratio**, not collision or joint limits. Box
+   sizing produced masses from ~0.0009 (extremity) to ~0.33 (torso), a **~365:1**
+   ratio, and Rapier's impulse-joint solver injects energy with large connected-
+   body mass ratios. **Diagnosis:** measured angular speed *climbing past 88 rad/s
+   and diverging*; reproduced with joint limits removed (so limits were not the
+   cause) and with damping-only (still diverged). **Fix:** derive per-collider
+   density for a **uniform target mass** (~1:1 ratios; inertia still scales with
+   shape) + linear/angular **damping**. **Verified:** angular speed now *decreases*
+   and fully settles (max angular → ~0.0, max linear ~0.3). (PR #278)
+
+#### Hypotheses ruled out
+
+- **Ragdoll colliding with the unremoved creature capsule / its AI hitboxes:** no.
+  The ragdoll group filters to `WORLD` only; the creature capsule is `ENTITY` and
+  its hitboxes are `HITBOX`, so the bidirectional group check fails both ways.
+- **Joint limits causing the spin-up:** no — divergence reproduced with limits
+  removed. (Naive limits *do* cause a separate problem, see below.)
+- **Rapier version:** did not upgrade (0.19 → 0.33 is a large breaking jump; a
+  newer solver might mask but wouldn't fix an extreme-mass-ratio config).
+
+### Remaining work (subsequent PRs on the stack)
+
+1. **Per-bone joint limits.** Joints are still free spherical
+   (`LOCKED_SPHERICAL_AXES`, no angular limits), so the body folds flat.
+   **Prerequisite:** naive per-axis limits inject energy because the limit "zero"
+   is measured from identity joint frames, not the bind pose — must set
+   `local_frame1/2` to the rest relative orientation first, then apply limits
+   measured from there. Per-bone limit profiles belong in the creature definitions
+   (`creature/creature_definitions.rs`), which already map each joint id to a
+   semantic role (`HUMANOID_HIT_BOXES`: Head/Neck/Abdomen/Shoulder/Elbow/Knee/…).
+2. **Seamless death→ragdoll handoff.** `debug_ragdoll` (and real death) should
+   remove the original creature and spawn the ragdoll from the creature's *current*
+   bone world transforms (no +1-unit debug offset), so the corpse takes over in
+   place instead of standing alongside a separate ragdoll.
+
+**Tooling unblocked (PR #276, merged):** `/v1/physics/bodies` enumerates the raw
+Rapier `RigidBodySet` (was a stub), `?entity_id=N` scopes to one ragdoll, debug
+scenes are introspectable via `GameScene::as_debuggable()`, and `debug_ragdoll`
+spawns the ragdoll on a deterministic frame counter with a fixed camera matching
+the desktop default view.
 
 ## Files To Reference
 - shock2vr/src/physics/mod.rs

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use cgmath::{Matrix4, Quaternion, Rotation, SquareMatrix, Vector3, vec3};
+use collision::Aabb;
 use dark::model::Model;
 use engine::scene::SceneObject;
 use rapier3d::{
@@ -18,6 +19,20 @@ use crate::{
 };
 
 const DEFAULT_JOINT_RADIUS: f32 = 0.06;
+/// Minimum collider half-extent, so degenerate joint AABBs (e.g. a joint with a
+/// single skinned vertex) still get a valid, non-zero box.
+const MIN_HALF_EXTENT: f32 = DEFAULT_JOINT_RADIUS;
+/// Linear/angular damping on ragdoll limb bodies so they bleed off momentum and
+/// settle instead of spinning or flailing forever (limbs out of world contact
+/// have nothing else to slow them).
+const LINEAR_DAMPING: f32 = 0.5;
+const ANGULAR_DAMPING: f32 = 2.0;
+/// Target mass for every ragdoll limb body. Densities are derived per-collider to
+/// hit this, keeping connected-body mass ratios near 1:1 for solver stability.
+const TARGET_BODY_MASS: f32 = 1.0;
+/// Floor on collider volume when deriving density, to avoid div-by-zero / huge
+/// density on degenerate shapes.
+const MIN_VOLUME: f32 = 1e-4;
 
 pub struct RagDoll {
     physics_bodies: Vec<RigidBodyHandle>,
@@ -106,6 +121,11 @@ impl RagDollManager {
             None => return false,
         };
 
+        // Per-joint bind-pose AABBs (model space), the same data that drives the
+        // damage hitboxes. We size each limb's collider from its joint's box so
+        // limbs have real volume/length instead of being point-like balls.
+        let hit_boxes = model.get_hit_boxes();
+
         let offset_transform = Matrix4::from_translation(root_offset) * root_transform;
         let mut world_joint_transforms = [Matrix4::identity(); 40];
         for bone in &bones {
@@ -136,12 +156,49 @@ impl RagDollManager {
             let isometry = isometry_from_parts(pos_vec, rotation);
 
             let handle = physics.create_dynamic_body(isometry, Some(entity_id));
-            physics.attach_collider(
-                handle,
-                SharedShape::ball(DEFAULT_JOINT_RADIUS),
-                1.0,
-                CollisionGroup::ragdoll(),
-            );
+            physics.set_body_damping(handle, LINEAR_DAMPING, ANGULAR_DAMPING);
+
+            // Size the collider from the joint's hitbox AABB when available: a
+            // cuboid spanning the box, offset to the box center (in joint-local
+            // space, matching how HitBoxManager places damage hitboxes). The body
+            // origin stays at the joint, so skinning is unaffected. Fall back to a
+            // small ball for joints with no hitbox (no skinned verts).
+            match hit_boxes.get(&(bone.joint_id as u32)) {
+                Some(bbox) => {
+                    let dim = bbox.dim();
+                    let center = bbox.center();
+                    let half_extents = vec3(
+                        (dim.x.abs() * 0.5).max(MIN_HALF_EXTENT),
+                        (dim.y.abs() * 0.5).max(MIN_HALF_EXTENT),
+                        (dim.z.abs() * 0.5).max(MIN_HALF_EXTENT),
+                    );
+                    // Density chosen so every limb has ~TARGET_BODY_MASS regardless
+                    // of box size: an impulse-jointed chain is unstable when mass
+                    // ratios between connected bodies are large (a tiny extremity
+                    // box jointed to a big torso box spins up). Inertia still scales
+                    // with the box's shape.
+                    let volume = 8.0 * half_extents.x * half_extents.y * half_extents.z;
+                    let density = TARGET_BODY_MASS / volume.max(MIN_VOLUME);
+                    physics.attach_collider_with_offset(
+                        handle,
+                        SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z),
+                        vec3(center.x, center.y, center.z),
+                        density,
+                        CollisionGroup::ragdoll(),
+                    );
+                }
+                None => {
+                    let r = DEFAULT_JOINT_RADIUS;
+                    let volume = 4.0 / 3.0 * std::f32::consts::PI * r * r * r;
+                    let density = TARGET_BODY_MASS / volume.max(MIN_VOLUME);
+                    physics.attach_collider(
+                        handle,
+                        SharedShape::ball(r),
+                        density,
+                        CollisionGroup::ragdoll(),
+                    );
+                }
+            }
 
             joint_to_body.insert(bone.joint_id as u32, handle);
             bone_offsets.insert(bone.joint_id as u32, Matrix4::identity());
@@ -172,6 +229,12 @@ impl RagDollManager {
                 let child_to_parent = parent_pos - child_pos;
                 let child_local_anchor = child_rot.conjugate().rotate_vector(child_to_parent);
 
+                // Ball joint (translation locked). NOTE: angular limits are
+                // intentionally not set here yet - naive per-axis limits measured
+                // from identity joint frames inject energy (the rig spins up),
+                // because the limit "zero" doesn't match the bind-pose relative
+                // orientation. Correct cone/twist limits need local_frame1/2 set
+                // to the rest pose first (tracked as follow-up).
                 let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
                     .local_anchor1(Point3::origin())
                     .local_anchor2(Point3::new(

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1013,6 +1013,17 @@ impl PhysicsWorld {
         self.rigid_body_set.insert(rigid_body)
     }
 
+    /// Set linear and angular damping on a rigid body. Ragdoll limbs need
+    /// non-zero damping (especially angular) so that a limb not in contact with
+    /// the world bleeds off momentum and comes to rest, instead of spinning or
+    /// flailing indefinitely.
+    pub fn set_body_damping(&mut self, handle: RigidBodyHandle, linear: f32, angular: f32) {
+        if let Some(body) = self.rigid_body_set.get_mut(handle) {
+            body.set_linear_damping(linear);
+            body.set_angular_damping(angular);
+        }
+    }
+
     /// Create a static (fixed) rigid body without requiring an EntityId
     /// Returns the handle for use in ragdoll systems
     pub fn create_static_body(
@@ -1037,8 +1048,29 @@ impl PhysicsWorld {
         density: f32,
         collision_group: CollisionGroup,
     ) {
+        self.attach_collider_with_offset(
+            handle,
+            shape,
+            Vector3::new(0.0, 0.0, 0.0),
+            density,
+            collision_group,
+        );
+    }
+
+    /// Attach a collider to a body with a local-space translation offset. Used by
+    /// the ragdoll rig so a limb's collider can sit at its hitbox center rather
+    /// than at the joint origin.
+    pub fn attach_collider_with_offset(
+        &mut self,
+        handle: RigidBodyHandle,
+        shape: SharedShape,
+        offset: Vector3<f32>,
+        density: f32,
+        collision_group: CollisionGroup,
+    ) {
         let collider = ColliderBuilder::new(shape)
             .density(density)
+            .translation(vec_to_nvec(offset))
             .collision_groups(collision_group.0)
             .active_events(ActiveEvents::COLLISION_EVENTS | ActiveEvents::CONTACT_FORCE_EVENTS)
             .build();


### PR DESCRIPTION
Stacked on #277 (base = `feat/ragdoll-fix-self-collision`). Review/merge that first.

## Why

After #277 stopped the spawn-time explosion, the ragdoll was still a flat point-puddle: limbs were uniform 0.06m balls with no volume (no capsules under `--debug-physics`). Giving them real volume surfaced a second instability — the rig flailed and limbs spun forever and never settled.

## What

- **Hitbox-sized colliders**: each limb collider is now a cuboid derived from its joint's hitbox AABB (same data the damage hitboxes use), offset to the box center in joint-local space. Body origin stays at the joint, so skinning is unaffected. Joints with no skinned verts fall back to a small ball; a minimum half-extent guards degenerate AABBs.
- **Uniform body mass** (the real stability fix): box sizing produced masses from ~0.0009 (extremity) to ~0.33 (torso) — a **~365:1 ratio**, which makes Rapier's impulse-joint solver inject energy (angular velocity climbed past 88 rad/s and diverged). Density is now derived per-collider so every limb hits a target mass (~1:1 ratios); inertia still scales with shape.
- **Linear + angular damping** so out-of-contact limbs bleed off momentum and come to rest instead of spinning indefinitely.
- Adds `PhysicsWorld::attach_collider_with_offset` and `set_body_damping`.

## Verification (`/v1/physics/bodies?entity_id=<corpse>`)

| | before (this PR's colliders, no mass fix) | after |
| --- | --- | --- |
| max angular vel @ ~500f | ~88 and **climbing** (diverging) | ~0.0 |
| max linear vel @ settle | 34+ | ~0.3 |
| outcome | flails, never settles | collapses with limb volume, fully settles |

Confirmed limb-shaped box colliders under `--debug-physics`, and full settle by ~1000 frames.

## Investigated and ruled out

- **Colliding with the unremoved creature / its AI hitboxes** (good hypothesis): no — the ragdoll group filters to `WORLD` only, while the creature capsule is `ENTITY` and its hitboxes are `HITBOX`; the bidirectional group check fails both ways, so no contact. The instability was purely the mass ratio.

## Remaining (follow-up)

- Joints are still free spherical (no angular limits), so the body folds flat. Naive per-axis limits inject energy because the limit zero is measured from identity joint frames, not the bind pose — correct cone/twist limits need `local_frame1/2` set to the rest relative orientation.
- `debug_ragdoll` still leaves the original creature standing beside the ragdoll (it never removes it on slay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)