### PR TITLE
feat(ragdoll): joint angular limits measured from rest pose

### DIFF
--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -80,7 +80,22 @@ the debug-runtime physics introspection added for this effort:
 2. **Seamless death→ragdoll handoff.** `debug_ragdoll` (and real death) should
    remove the original creature and spawn the ragdoll from the creature's *current*
    bone world transforms (no +1-unit debug offset), so the corpse takes over in
-   place instead of standing alongside a separate ragdoll.
+   place instead of standing alongside a separate ragdoll. Options for *when* to
+   hand off, simplest first:
+   - **Swap when the death animation finishes** (easiest, good fallback): let the
+     canned crumple animation play, then on its last frame capture the bone world
+     transforms, remove the animated creature, and spawn the ragdoll from that
+     pose. The body is mostly on the ground already, so the ragdoll just relaxes —
+     low risk of an ugly transition.
+   - **Swap at the moment of death** (more dynamic): skip/curtail the canned
+     animation and let physics do the fall, seeding the ragdoll bodies with the
+     creature's current linear/angular velocity (and ideally an impulse from the
+     killing blow) so it reacts to how it died.
+   - **Blend** animation→physics over a few frames for the smoothest result, but
+     this is the most complex (per-bone weight blend between animated and simulated
+     transforms) and only worth it if the hard swap looks jarring.
+   Prerequisite either way: the spawn-from-current-pose + creature-removal plumbing
+   above. Start with the finish-animation swap and only escalate if needed.
 
 **Tooling unblocked (PR #276, merged):** `/v1/physics/bodies` enumerates the raw
 Rapier `RigidBodySet` (was a stub), `?entity_id=N` scopes to one ragdoll, debug

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -5,10 +5,10 @@ use collision::Aabb;
 use dark::model::Model;
 use engine::scene::SceneObject;
 use rapier3d::{
-    na::{Point3, Translation3},
+    na::{Translation3, UnitQuaternion},
     prelude::{
-        GenericJointBuilder, ImpulseJointHandle, Isometry, JointAxesMask, RigidBodyHandle,
-        SharedShape,
+        GenericJointBuilder, ImpulseJointHandle, Isometry, JointAxesMask, JointAxis,
+        RigidBodyHandle, SharedShape,
     },
 };
 use shipyard::EntityId;
@@ -33,6 +33,10 @@ const TARGET_BODY_MASS: f32 = 1.0;
 /// Floor on collider volume when deriving density, to avoid div-by-zero / huge
 /// density on degenerate shapes.
 const MIN_VOLUME: f32 = 1e-4;
+/// Uniform per-axis angular limit (radians, ~60°) for the limb ball joints,
+/// measured from the bind/rest pose. Keeps the rig from folding/twisting through
+/// itself. Per-bone limit profiles (hinge knees, cone shoulders) are a follow-up.
+const JOINT_CONE_LIMIT: f32 = 1.05;
 
 pub struct RagDoll {
     physics_bodies: Vec<RigidBodyHandle>,
@@ -224,24 +228,40 @@ impl RagDollManager {
 
                 let parent_pos = joint_positions[parent_idx];
                 let child_pos = joint_positions[child_idx];
+                let parent_world = world_joint_transforms[parent_idx];
+                let parent_rot = get_rotation_from_matrix(&parent_world);
                 let child_world = world_joint_transforms[child_idx];
                 let child_rot = get_rotation_from_matrix(&child_world);
                 let child_to_parent = parent_pos - child_pos;
                 let child_local_anchor = child_rot.conjugate().rotate_vector(child_to_parent);
 
-                // Ball joint (translation locked). NOTE: angular limits are
-                // intentionally not set here yet - naive per-axis limits measured
-                // from identity joint frames inject energy (the rig spins up),
-                // because the limit "zero" doesn't match the bind-pose relative
-                // orientation. Correct cone/twist limits need local_frame1/2 set
-                // to the rest pose first (tracked as follow-up).
-                let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
-                    .local_anchor1(Point3::origin())
-                    .local_anchor2(Point3::new(
+                // Ball joint (translation locked) with angular limits so the body
+                // can't fold/twist through itself.
+                //
+                // The limits are measured relative to the joints' local frames, so
+                // they only behave if "zero angle" corresponds to the bind/rest
+                // pose. We align both frames to the child's rest world orientation:
+                //   frame1 (parent-local) rotation = R_parent^-1 * R_child
+                //   frame2 (child-local)  rotation = identity
+                // At spawn, R_parent * frame1 == R_child == R_child * frame2, so the
+                // relative angle is exactly 0 and within limits - no energy is
+                // injected (the bug we hit when limits used identity frames).
+                let frame1_rot = quat_to_nquat(parent_rot.invert() * child_rot);
+                let frame1 = Isometry::from_parts(Translation3::new(0.0, 0.0, 0.0), frame1_rot);
+                let frame2 = Isometry::from_parts(
+                    Translation3::new(
                         child_local_anchor.x,
                         child_local_anchor.y,
                         child_local_anchor.z,
-                    ))
+                    ),
+                    UnitQuaternion::identity(),
+                );
+                let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
+                    .local_frame1(frame1)
+                    .local_frame2(frame2)
+                    .limits(JointAxis::AngX, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
+                    .limits(JointAxis::AngY, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
+                    .limits(JointAxis::AngZ, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
                     .build();
                 let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
                 joint_handles.push(handle);


### PR DESCRIPTION
Stacked on #278 (base = `feat/ragdoll-hitbox-colliders`). Review/merge that first.

## Why

After #278 the corpse settled stably but folded **flat** — joints were free spherical (`LOCKED_SPHERICAL_AXES`, no angular limits). Adding limits naively (per-axis limits on identity joint frames) had previously made the rig **spin up / inject energy**, because the limit "zero angle" didn't match the bind pose, so the limit was violated at spawn.

## What

Add ~60° per-axis angular limits to the limb ball joints, **measured from the rest pose**. The fix is setting the joint local frames so zero angle == bind pose:

```
frame1 (parent-local) rotation = R_parent⁻¹ · R_child
frame2 (child-local)  rotation = identity
```

At spawn, `R_parent · frame1 == R_child == R_child · frame2`, so the relative angle is exactly 0 and within limits — no energy injected.

## Verification (`/v1/physics/bodies?entity_id=<corpse>`)

Angular velocity stays **bounded and converges** (≈0 while falling → peaks ~17 on floor impact → decays toward ~0), versus the divergence (climbing past 88) seen with identity-frame limits. The corpse holds a slumped shape instead of collapsing fully flat (screenshot confirmed).

## Follow-ups

- **Per-bone limit profiles** from the creature definitions (`creature/creature_definitions.rs` already maps each joint id to Head/Neck/Abdomen/Shoulder/Elbow/Knee/…): hinge for knees/elbows, wider cone for shoulders, small twist for spine/neck.
- **Seamless death→ragdoll handoff**: remove the original creature and spawn the ragdoll from its *current* bone transforms (no debug offset); optionally blend from the death animation or swap when it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)