### PR TITLE
feat(ragdoll): per-bone joint limits from creature definitions

### DIFF
--- a/shock2vr/src/creature/creature_definitions.rs
+++ b/shock2vr/src/creature/creature_definitions.rs
@@ -28,12 +28,27 @@ pub enum ActorType {
     Arachnid = 4,
 }
 
+/// Articulation limit for a single skeleton joint, used when building ragdolls.
+/// `cone` is a symmetric half-angle (radians) applied to each angular axis of the
+/// limb's ball joint, measured from the bind/rest pose.
+#[derive(Clone, Copy, Debug)]
+pub struct JointLimit {
+    pub cone: f32,
+}
+
+impl JointLimit {
+    pub fn cone(cone: f32) -> Self {
+        Self { cone }
+    }
+}
+
 pub struct CreatureDefinition {
     pub actor_type: ActorType,
     pub physics_offset_height: f32,
     pub bounding_size: Vector3<f32>,
     joint_map: Vec<i32>,
     pub hit_boxes: Arc<HashMap<u32, HitBoxType>>,
+    pub joint_limits: Arc<HashMap<u32, JointLimit>>,
 }
 
 impl CreatureDefinition {
@@ -88,6 +103,34 @@ pub const HUMANOID_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> = Lazy::new(||
     ]))
 });
 
+/// Per-joint articulation limits for humanoid ragdolls, keyed by the same
+/// skeleton joint ids as `HUMANOID_HIT_BOXES`. Wider cones for the big limb
+/// joints (shoulders/hips/knees/elbows), tight cones for head/neck/spine and
+/// extremities (toes/weapon hands) so they don't flop unrealistically.
+/// (Knees/elbows are really hinges; approximated as moderate cones for now.)
+pub const HUMANOID_JOINT_LIMITS: Lazy<Arc<HashMap<u32, JointLimit>>> = Lazy::new(|| {
+    Arc::new(HashMap::from_iter(vec![
+        (2, JointLimit::cone(0.3)),  // LToe
+        (3, JointLimit::cone(0.3)),  // RToe
+        (4, JointLimit::cone(1.2)),  // LKnee
+        (5, JointLimit::cone(1.2)),  // RKnee
+        (6, JointLimit::cone(1.2)),  // LThigh
+        (7, JointLimit::cone(1.2)),  // RThigh
+        (8, JointLimit::cone(0.5)),  // Neck
+        (9, JointLimit::cone(0.4)),  // Head
+        (10, JointLimit::cone(1.4)), // LShoulder
+        (11, JointLimit::cone(1.4)), // RShoulder
+        (12, JointLimit::cone(1.2)), // LElbow
+        (13, JointLimit::cone(1.2)), // RElbow
+        (14, JointLimit::cone(0.3)), // LWeap
+        (15, JointLimit::cone(0.3)), // RWeap
+        (18, JointLimit::cone(0.4)), // Abdomen
+    ]))
+});
+
+pub const EMPTY_JOINT_LIMITS: Lazy<Arc<HashMap<u32, JointLimit>>> =
+    Lazy::new(|| Arc::new(HashMap::new()));
+
 pub const SPIDER_HIT_BOXES: Lazy<Arc<HashMap<u32, HitBoxType>>> =
     Lazy::new(|| Arc::new(HashMap::from_iter(vec![(0, HitBoxType::Body)])));
 
@@ -106,6 +149,7 @@ pub const HUMAN: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 19, 9, 18, 8, 10, 11, 12, 13, 14, 15, 16, 17, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 
@@ -116,6 +160,7 @@ pub const PLAYER_LIMB: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
         actor_type: ActorType::PlayerLimb,
         joint_map: vec![],
         hit_boxes: EMPTY_HIT_BOXES.clone(),
+        joint_limits: EMPTY_JOINT_LIMITS.clone(),
     })
 });
 
@@ -128,6 +173,7 @@ pub const AVATAR: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 19, 9, 18, 8, 10, 11, 12, 13, 14, 15, 16, 17, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 
@@ -140,6 +186,7 @@ pub const RUMBLER: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 19, 9, 18, 8, 10, 11, 12, 13, 14, 15, 16, 17, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 
@@ -152,6 +199,7 @@ pub const DROID: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 17, 10, 9, 8, 11, 12, 13, 14, 15, 16, -1, -1, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 
@@ -162,6 +210,7 @@ pub const OVERLORD: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
         actor_type: ActorType::Overlord,
         joint_map: vec![],
         hit_boxes: OVERLORD_HIT_BOXES.clone(),
+        joint_limits: EMPTY_JOINT_LIMITS.clone(),
     })
 });
 
@@ -175,6 +224,7 @@ pub const ARACHNID: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, -1, -1,
         ],
         hit_boxes: SPIDER_HIT_BOXES.clone(),
+        joint_limits: EMPTY_JOINT_LIMITS.clone(),
     })
 });
 
@@ -187,6 +237,7 @@ pub const MONKEY: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 19, 9, 18, 8, 10, 11, 12, 13, 14, 15, 16, 17, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 
@@ -200,6 +251,7 @@ pub const BABY_ARACHNID: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, -1, -1,
         ],
         hit_boxes: SPIDER_HIT_BOXES.clone(),
+        joint_limits: EMPTY_JOINT_LIMITS.clone(),
     })
 });
 
@@ -212,6 +264,7 @@ pub const SHODAN: Lazy<Arc<CreatureDefinition>> = Lazy::new(|| {
             -1, 19, 9, 18, 8, 10, 11, 12, 13, 14, 15, 16, 17, 6, 7, 4, 5, 2, 3, 0, 1, -1,
         ],
         hit_boxes: HUMANOID_HIT_BOXES.clone(),
+        joint_limits: HUMANOID_JOINT_LIMITS.clone(),
     })
 });
 

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -18,6 +18,8 @@ use crate::{
     util::{get_position_from_matrix, get_rotation_from_matrix, point3_to_vec3},
 };
 
+use super::JointLimit;
+
 const DEFAULT_JOINT_RADIUS: f32 = 0.06;
 /// Minimum collider half-extent, so degenerate joint AABBs (e.g. a joint with a
 /// single skinned vertex) still get a valid, non-zero box.
@@ -114,6 +116,7 @@ impl RagDollManager {
         root_transform: Matrix4<f32>,
         joint_transforms: &[Matrix4<f32>; 40],
         root_offset: Vector3<f32>,
+        joint_limits: &HashMap<u32, JointLimit>,
         physics: &mut PhysicsWorld,
     ) -> bool {
         if !model.can_create_rag_doll() {
@@ -256,12 +259,19 @@ impl RagDollManager {
                     ),
                     UnitQuaternion::identity(),
                 );
+                // Per-bone cone limit from the creature definition (e.g. tight for
+                // head/neck/spine, wide for shoulders/hips), falling back to a
+                // uniform default for joints/creatures without a profile.
+                let cone = joint_limits
+                    .get(&(bone.joint_id as u32))
+                    .map(|limit| limit.cone)
+                    .unwrap_or(JOINT_CONE_LIMIT);
                 let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
                     .local_frame1(frame1)
                     .local_frame2(frame2)
-                    .limits(JointAxis::AngX, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
-                    .limits(JointAxis::AngY, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
-                    .limits(JointAxis::AngZ, [-JOINT_CONE_LIMIT, JOINT_CONE_LIMIT])
+                    .limits(JointAxis::AngX, [-cone, cone])
+                    .limits(JointAxis::AngY, [-cone, cone])
+                    .limits(JointAxis::AngZ, [-cone, cone])
                     .build();
                 let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
                 joint_handles.push(handle);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1052,6 +1052,12 @@ impl MissionCore {
             Err(_) => return,
         };
 
+        // Per-bone joint limits from the creature definition (empty for creatures
+        // without a humanoid skeleton -> ragdoll falls back to a uniform cone).
+        let joint_limits = crate::creature::get_entity_creature(&self.world, entity_id)
+            .map(|creature| creature.joint_limits.clone())
+            .unwrap_or_else(|| std::sync::Arc::new(std::collections::HashMap::new()));
+
         let offset = vec3(0.0, 1.0, 0.0);
         if self.rag_doll_manager.add_ragdoll(
             entity_id,
@@ -1059,6 +1065,7 @@ impl MissionCore {
             root_transform,
             &joint_transforms,
             offset,
+            &joint_limits,
             &mut self.physics,
         ) {
             println!("Spawned debug ragdoll for entity {:?}", entity_id);


### PR DESCRIPTION
Stacked on #279 (base = `feat/ragdoll-joint-limits`). Review/merge that first.

## Why

#279 added uniform ~60° cone limits to every joint. Real corpses don't articulate uniformly — the head/neck/spine are stiff while shoulders/hips are loose — so the slump looked generic.

## What

Move the limits into the creature definition, mirroring how hit boxes are described (`HUMANOID_HIT_BOXES` → `HUMANOID_JOINT_LIMITS`), keyed by the same skeleton joint ids:

- tight cones for head/neck/spine and extremities (toes, weapon hands)
- wide cones for shoulders/hips
- moderate for knees/elbows (true hinges = follow-up)

Non-humanoid creatures use an empty map and fall back to the uniform default cone.

- `creature_definitions.rs`: add `JointLimit`, `HUMANOID_JOINT_LIMITS` / `EMPTY_JOINT_LIMITS`, and a `joint_limits` field on every `CreatureDefinition`.
- `rag_doll`: `add_ragdoll` takes the per-joint limit map and uses each child joint's cone (still measured from the rest-pose local frames from #279, so no energy injection).
- `mission_core`: `spawn_debug_ragdoll` looks up the dying entity's creature definition and passes its joint limits.

## Verification

`debug_ragdoll` stays stable/converges, and the corpse holds a recognizable humanoid slump (head/torso upright-ish, limbs draped) instead of an even cone collapse (screenshot confirmed).

## Follow-ups

- True hinges for knees/elbows (single-axis), needs per-bone hinge axis.
- Death→ragdoll handoff (next): remove the original creature and spawn the ragdoll from its current pose. Per discussion, we'll experiment with **swap at the moment of death seeded with the creature's velocity**, keeping animation→physics blend on deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)