### PR TITLE
feat(debug): ragdoll quality metrics endpoint (verification harness)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -82,6 +82,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Option<PhysicsBodyDetailResult>>,
     },
 
+    /// Get per-ragdoll quality/settle metrics
+    RagdollMetrics {
+        reply: oneshot::Sender<RagdollMetricsResult>,
+    },
+
     /// Shutdown the debug runtime gracefully
     Shutdown,
 }
@@ -165,6 +170,23 @@ pub struct PhysicsBodySummary {
     pub collision_groups: Vec<String>,
     pub is_sensor: bool,
     pub is_enabled: bool,
+}
+
+/// Per-ragdoll quality/settle metrics
+#[derive(Debug, Serialize)]
+pub struct RagdollMetricsResult {
+    pub ragdolls: Vec<RagdollMetricsEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RagdollMetricsEntry {
+    pub entity_id: i32,
+    pub body_count: usize,
+    pub max_linear_speed: f32,
+    pub max_angular_speed: f32,
+    pub min_y: f32,
+    pub max_nonadjacent_overlap: f32,
+    pub max_drift: f32,
 }
 
 /// Detailed information about a physics body

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -194,6 +194,7 @@ async fn start_http_server(
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
+        .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
         .route("/v1/control/input", get(get_input_state))
         .route("/v1/control/input", axum::routing::post(set_input_channel))
         .route("/v1/control/command", axum::routing::post(run_game_command))
@@ -1028,6 +1029,29 @@ fn process_command(
                 tracing::warn!("Failed to send physics body detail - receiver dropped");
             }
         }
+        RuntimeCommand::RagdollMetrics { reply } => {
+            let ragdolls = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .ragdoll_metrics()
+                        .into_iter()
+                        .map(|m| commands::RagdollMetricsEntry {
+                            entity_id: m.entity_id,
+                            body_count: m.body_count,
+                            max_linear_speed: m.max_linear_speed,
+                            max_angular_speed: m.max_angular_speed,
+                            min_y: m.min_y,
+                            max_nonadjacent_overlap: m.max_nonadjacent_overlap,
+                            max_drift: m.max_drift,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if let Err(_) = reply.send(commands::RagdollMetricsResult { ragdolls }) {
+                tracing::warn!("Failed to send ragdoll metrics - receiver dropped");
+            }
+        }
         RuntimeCommand::GetInput(reply) => {
             // Get current input state from the debug scene
             if let Some(debuggable) = game.debug_scene() {
@@ -1609,6 +1633,26 @@ async fn get_physics_body_detail(
         Err(_) => {
             tracing::error!("Failed to receive physics body detail - sender dropped");
             Json(None)
+        }
+    }
+}
+
+/// HTTP handler for per-ragdoll quality metrics
+async fn get_ragdoll_metrics(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Json<RagdollMetricsResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if let Err(_) = command_tx.send(RuntimeCommand::RagdollMetrics { reply: reply_tx }) {
+        tracing::error!("Failed to send RagdollMetrics command - game loop receiver dropped");
+        return Json(RagdollMetricsResult { ragdolls: vec![] });
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive ragdoll metrics - sender dropped");
+            Json(RagdollMetricsResult { ragdolls: vec![] })
         }
     }
 }

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{Matrix4, Quaternion, Rotation, SquareMatrix, Vector3, vec3};
+use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, SquareMatrix, Vector3, vec3};
 use collision::Aabb;
 use dark::model::Model;
 use engine::scene::SceneObject;
@@ -40,6 +40,23 @@ const MIN_VOLUME: f32 = 1e-4;
 /// itself. Per-bone limit profiles (hinge knees, cone shoulders) are a follow-up.
 const JOINT_CONE_LIMIT: f32 = 1.05;
 
+/// Quality/settle metrics for one ragdoll, for the verification harness.
+#[derive(Clone, Debug)]
+pub struct RagDollMetrics {
+    pub body_count: usize,
+    /// Max body linear speed (a settled ragdoll trends to ~0).
+    pub max_linear_speed: f32,
+    /// Max body angular speed (catches "spinning forever" / divergence).
+    pub max_angular_speed: f32,
+    /// Lowest body position (floor penetration shows up as min_y below the floor).
+    pub min_y: f32,
+    /// Largest interpenetration depth between non-adjacent limb AABBs - the
+    /// realism signal for self-collision work (lower is better).
+    pub max_nonadjacent_overlap: f32,
+    /// Largest distance any body has moved from where it spawned.
+    pub max_drift: f32,
+}
+
 pub struct RagDoll {
     physics_bodies: Vec<RigidBodyHandle>,
     joint_handles: Vec<ImpulseJointHandle>,
@@ -47,9 +64,16 @@ pub struct RagDoll {
     bone_frame_offsets: HashMap<u32, Matrix4<f32>>,
     latest_global_transforms: [Matrix4<f32>; 40],
     scene_objects: Vec<SceneObject>,
+    /// Directly jointed body pairs (parent/child), excluded from the
+    /// non-adjacent-overlap metric since they are meant to overlap at the joint.
+    joint_pairs: Vec<(RigidBodyHandle, RigidBodyHandle)>,
+    /// World position each body was spawned at, for the drift / pose-continuity
+    /// metric.
+    spawn_positions: HashMap<RigidBodyHandle, Vector3<f32>>,
 }
 
 impl RagDoll {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         joint_to_body: HashMap<u32, RigidBodyHandle>,
         physics_bodies: Vec<RigidBodyHandle>,
@@ -57,6 +81,8 @@ impl RagDoll {
         initial_world: [Matrix4<f32>; 40],
         bone_frame_offsets: HashMap<u32, Matrix4<f32>>,
         scene_objects: Vec<SceneObject>,
+        joint_pairs: Vec<(RigidBodyHandle, RigidBodyHandle)>,
+        spawn_positions: HashMap<RigidBodyHandle, Vector3<f32>>,
     ) -> Self {
         Self {
             physics_bodies,
@@ -65,6 +91,66 @@ impl RagDoll {
             bone_frame_offsets,
             latest_global_transforms: initial_world,
             scene_objects,
+            joint_pairs,
+            spawn_positions,
+        }
+    }
+
+    /// Compute settle/quality metrics for this ragdoll from the live physics state.
+    fn metrics(&self, physics: &PhysicsWorld) -> RagDollMetrics {
+        let mut max_linear_speed: f32 = 0.0;
+        let mut max_angular_speed: f32 = 0.0;
+        let mut min_y = f32::INFINITY;
+        let mut max_drift: f32 = 0.0;
+
+        for handle in &self.physics_bodies {
+            if let Some((lin, ang)) = physics.body_velocities(*handle) {
+                max_linear_speed = max_linear_speed.max(lin.magnitude());
+                max_angular_speed = max_angular_speed.max(ang.magnitude());
+            }
+            if let Some(iso) = physics.get_body_transform(*handle) {
+                min_y = min_y.min(iso.translation.y);
+                if let Some(spawn) = self.spawn_positions.get(handle) {
+                    let pos = Vector3::new(iso.translation.x, iso.translation.y, iso.translation.z);
+                    max_drift = max_drift.max((pos - spawn).magnitude());
+                }
+            }
+        }
+
+        // Largest interpenetration between non-adjacent limb AABBs (axis-aligned
+        // overlap depth = min over axes; 0 if separated on any axis).
+        let adjacent = |a: RigidBodyHandle, b: RigidBodyHandle| {
+            self.joint_pairs
+                .iter()
+                .any(|(p, c)| (*p == a && *c == b) || (*p == b && *c == a))
+        };
+        let mut max_nonadjacent_overlap: f32 = 0.0;
+        for i in 0..self.physics_bodies.len() {
+            for j in (i + 1)..self.physics_bodies.len() {
+                let (ha, hb) = (self.physics_bodies[i], self.physics_bodies[j]);
+                if adjacent(ha, hb) {
+                    continue;
+                }
+                if let (Some((amin, amax)), Some((bmin, bmax))) =
+                    (physics.body_world_aabb(ha), physics.body_world_aabb(hb))
+                {
+                    let ox = (amax.x.min(bmax.x) - amin.x.max(bmin.x)).max(0.0);
+                    let oy = (amax.y.min(bmax.y) - amin.y.max(bmin.y)).max(0.0);
+                    let oz = (amax.z.min(bmax.z) - amin.z.max(bmin.z)).max(0.0);
+                    if ox > 0.0 && oy > 0.0 && oz > 0.0 {
+                        max_nonadjacent_overlap = max_nonadjacent_overlap.max(ox.min(oy).min(oz));
+                    }
+                }
+            }
+        }
+
+        RagDollMetrics {
+            body_count: self.physics_bodies.len(),
+            max_linear_speed,
+            max_angular_speed,
+            min_y: if min_y.is_finite() { min_y } else { 0.0 },
+            max_nonadjacent_overlap,
+            max_drift,
         }
     }
 
@@ -148,6 +234,8 @@ impl RagDollManager {
         let mut joint_handles = Vec::new();
         let mut joint_to_body = HashMap::new();
         let mut bone_offsets = HashMap::new();
+        let mut joint_pairs = Vec::new();
+        let mut spawn_positions = HashMap::new();
         let mut joint_positions = vec![Vector3::new(0.0, 0.0, 0.0); world_joint_transforms.len()];
 
         for bone in &bones {
@@ -164,6 +252,7 @@ impl RagDollManager {
 
             let handle = physics.create_dynamic_body(isometry, Some(entity_id));
             physics.set_body_damping(handle, LINEAR_DAMPING, ANGULAR_DAMPING);
+            spawn_positions.insert(handle, pos_vec);
 
             // Size the collider from the joint's hitbox AABB when available: a
             // cuboid spanning the box, offset to the box center (in joint-local
@@ -275,6 +364,7 @@ impl RagDollManager {
                     .build();
                 let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
                 joint_handles.push(handle);
+                joint_pairs.push((parent_handle, child_handle));
             }
         }
 
@@ -285,6 +375,8 @@ impl RagDollManager {
             world_joint_transforms,
             bone_offsets,
             model.clone_scene_objects(),
+            joint_pairs,
+            spawn_positions,
         );
         self.ragdolls.insert(entity_id, ragdoll);
         true
@@ -294,6 +386,14 @@ impl RagDollManager {
         for ragdoll in self.ragdolls.values_mut() {
             ragdoll.update(physics);
         }
+    }
+
+    /// Per-ragdoll quality metrics (keyed by the corpse entity id).
+    pub fn debug_metrics(&self, physics: &PhysicsWorld) -> Vec<(EntityId, RagDollMetrics)> {
+        self.ragdolls
+            .iter()
+            .map(|(id, ragdoll)| (*id, ragdoll.metrics(physics)))
+            .collect()
     }
 
     pub fn render_scene_objects(&self) -> Vec<SceneObject> {

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -263,6 +263,18 @@ pub struct DebugPhysicsBodyDetail {
     pub contact_count: usize,
 }
 
+/// Per-ragdoll quality/settle metrics for the verification harness.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugRagdollMetrics {
+    pub entity_id: i32,
+    pub body_count: usize,
+    pub max_linear_speed: f32,
+    pub max_angular_speed: f32,
+    pub min_y: f32,
+    pub max_nonadjacent_overlap: f32,
+    pub max_drift: f32,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -357,6 +369,13 @@ pub trait DebuggableScene {
     /// # Returns
     /// Detailed physics body information, or None if body doesn't exist
     fn physics_body_detail(&self, body_id: u32) -> Option<DebugPhysicsBodyDetail>;
+
+    /// Quality/settle metrics for every active ragdoll, for the verification
+    /// harness (settle speeds, floor penetration, non-adjacent interpenetration,
+    /// drift). Empty when the scene has no ragdolls.
+    fn ragdoll_metrics(&self) -> Vec<DebugRagdollMetrics> {
+        Vec::new()
+    }
 
     /// Get current input context state
     ///

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2912,6 +2912,22 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         })
     }
 
+    fn ragdoll_metrics(&self) -> Vec<crate::game_scene::DebugRagdollMetrics> {
+        self.rag_doll_manager
+            .debug_metrics(&self.physics)
+            .into_iter()
+            .map(|(id, m)| crate::game_scene::DebugRagdollMetrics {
+                entity_id: id.inner() as i32,
+                body_count: m.body_count,
+                max_linear_speed: m.max_linear_speed,
+                max_angular_speed: m.max_angular_speed,
+                min_y: m.min_y,
+                max_nonadjacent_overlap: m.max_nonadjacent_overlap,
+                max_drift: m.max_drift,
+            })
+            .collect()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -276,6 +276,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.physics_body_detail(body_id)
     }
 
+    fn ragdoll_metrics(&self) -> Vec<crate::game_scene::DebugRagdollMetrics> {
+        self.mission_core.ragdoll_metrics()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1095,6 +1095,38 @@ impl PhysicsWorld {
         self.rigid_body_set.get(handle).map(|body| *body.position())
     }
 
+    /// Linear and angular velocity of a rigid body by handle.
+    pub fn body_velocities(&self, handle: RigidBodyHandle) -> Option<(Vector3<f32>, Vector3<f32>)> {
+        self.rigid_body_set.get(handle).map(|body| {
+            let l = body.linvel();
+            let a = body.angvel();
+            (Vector3::new(l.x, l.y, l.z), Vector3::new(a.x, a.y, a.z))
+        })
+    }
+
+    /// World-space AABB enclosing all of a body's colliders (min, max).
+    pub fn body_world_aabb(&self, handle: RigidBodyHandle) -> Option<(Vector3<f32>, Vector3<f32>)> {
+        let body = self.rigid_body_set.get(handle)?;
+        let mut min: Option<Vector3<f32>> = None;
+        let mut max: Option<Vector3<f32>> = None;
+        for collider_handle in body.colliders() {
+            if let Some(collider) = self.collider_set.get(*collider_handle) {
+                let aabb = collider.compute_aabb();
+                let lo = Vector3::new(aabb.mins.x, aabb.mins.y, aabb.mins.z);
+                let hi = Vector3::new(aabb.maxs.x, aabb.maxs.y, aabb.maxs.z);
+                min = Some(match min {
+                    Some(m) => Vector3::new(m.x.min(lo.x), m.y.min(lo.y), m.z.min(lo.z)),
+                    None => lo,
+                });
+                max = Some(match max {
+                    Some(m) => Vector3::new(m.x.max(hi.x), m.y.max(hi.y), m.z.max(hi.z)),
+                    None => hi,
+                });
+            }
+        }
+        Some((min?, max?))
+    }
+
     /// Enumerate every rigid body in the simulation for debug tooling.
     ///
     /// This iterates the raw Rapier `RigidBodySet` rather than the


### PR DESCRIPTION
Stacked on #281 (base = `feat/ragdoll-death-handoff`). This is **C** from the plan (measure before tuning); **A** (self-collision exclusion) builds on it.

## Why

The crumple still isn't passable (limbs interpenetrate), but we had no objective way to measure "is this right." This adds a metrics endpoint so realism/settle can be judged headlessly and we can verify the self-collision fix (A) actually reduces interpenetration without re-introducing instability.

## What

`GET /v1/ragdoll/metrics` → per active ragdoll:
- `max_linear_speed` / `max_angular_speed` — settle vs. divergence
- `min_y` — floor penetration
- `max_nonadjacent_overlap` — interpenetration depth between **non-adjacent** limb AABBs (adjacent/jointed pairs excluded, since they meet at a joint). **This is the realism signal for A.**
- `max_drift` — how far each body moved from spawn (~0 right after handoff → also a pose-continuity/stability signal)

Implementation:
- `PhysicsWorld::body_velocities()` and `body_world_aabb()`.
- `RagDoll` records jointed body pairs (adjacency) + spawn positions; computes `RagDollMetrics`. `RagDollManager::debug_metrics` aggregates per corpse.
- `DebuggableScene::ragdoll_metrics` (MissionCore impl, Mission delegates).
- debug_runtime: `RagdollMetrics` command + route.

## Baseline (debug_ragdoll, self-collision OFF)

Settled corpse: `max_linear_speed ~0.09`, `min_y ~0.16` (no floor penetration), **`max_nonadjacent_overlap ~0.44`**. That ~0.44 is the interpenetration A should drive down while keeping speeds low.

## Note on pose-continuity (question from review)

Physics placement at handoff is exact *by construction* — the corpse is seeded from the same `world_joint_transforms` the renderer skins with, so body positions == joint positions at spawn (drift ~0 immediately after). The remaining open question is the **physics→skinning convention** (does the mesh skin to the same place), which stays a backlog item; it needs a render-side check, not a physics metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)