### PR TITLE
fix(debug): scale ragdoll debug impulse/pull for the new uniform mass

### DIFF
--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -125,6 +125,15 @@ verification harness and the headline realism fix are now done; the rest remain.
 5. **True hinge joints** for knees/elbows (single-axis limits) instead of cones —
    needs the per-bone hinge axis, which the fit/skeleton analysis (#3) can help
    determine.
+6. **Wire debug-scene input over HTTP (harness gap).** `DebuggableScene::set_input`
+   is stubbed for `MissionCore`, so the debug runtime can't drive contextual hand
+   input (trigger/grab/drop) or the `debug_ragdoll` force controls (left-trigger
+   impulse, right-squeeze pull) over HTTP — they only work interactively on
+   desktop. Wiring this would let an agent exercise force-on-ragdoll tests and hand
+   interactions headlessly (e.g. verify impulse → expected velocity via
+   `/v1/ragdoll/metrics`), closing a gap in the iteration loop. Note the debug
+   runtime owns the `InputContext` at the loop level, so the fix likely lives there
+   rather than in `MissionCore`.
 
 **Tooling unblocked (PR #276, merged):** `/v1/physics/bodies` enumerates the raw
 Rapier `RigidBodySet` (was a stub), `?entity_id=N` scopes to one ragdoll, debug

--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -123,21 +123,29 @@ verification harness and the headline realism fix are now done; the rest remain.
      `.cal` skeleton and reports, per joint: current model-space AABB, recommended
      **joint-local** AABB + center, inflation (model/local vol), and a recommended
      capsule (axis/radius/half-height).
-   - ⚠️ **Surprising v2 result — oriented boxes do NOT reduce volume for SS2.**
-     Across all creatures inflation ≈ 1.00× and the joint-local dims are the model
-     dims with axes **permuted**: SS2 bind rotations are axis-aligned (~90° swaps),
-     so a bone-aligned box is the same volume as the AABB. The earlier ~2.3× from
-     the v1 PCA bound was vs a *PCA* orientation, which the collider can't use (it
-     must live in the joint frame).
-   - ➡️ **The real, actionable bug it surfaced:** `rag_doll.rs` sizes colliders
-     from **model-space** `bbox.dim()`/`bbox.center()` but attaches them in the
-     **joint** frame, so the box is mis-oriented (long axis pointing the wrong way)
-     and mis-offset (e.g. GRUNT_P model `0.54,0.17,0.18` vs joint-local
-     `0.18,0.17,0.54`). **Next ragdoll PR:** transform each joint's hitbox verts by
-     the joint bind transform before computing the collider dims + center (use the
-     tool's "local dim"/"local center"), then re-measure `max_nonadjacent_overlap`.
-     Validate distal joints with large local centers (e.g. toe) visually under
-     `--debug-physics`.
+   - ⚠️ **v2 inflation ≈ 1.00× across all creatures** (joint-local dims = model
+     dims with axes permuted; SS2 bind rotations are axis-aligned ~90° swaps), so a
+     bone-aligned box is never smaller than the AABB. Oriented colliders give no
+     win.
+   - ❌ **Joint-local collider sizing was tried and REVERTED — the model-space
+     boxes are already correct.** The hypothesis was that `rag_doll.rs` sizes
+     colliders from model-space dims/center but attaches them in the joint frame
+     (mis-oriented). Implementing it (transform the hitbox AABB by the inverse bind
+     world transform) **regressed**: the ragdoll no longer settled (max angular
+     ~17 vs ~0.3) and overlap was unchanged (~0.27 vs ~0.24). Reason: the bodies
+     are placed at the same per-joint transforms the mesh skins with
+     (`Skeleton::get_transforms`/`world_transforms` are both the raw
+     `global_transforms` — **no inverse-bind**), so the hitbox vertices are already
+     effectively in the collider/body frame. Applying the inverse bind a second
+     time double-transforms the box (the tool's large joint-local "centers", e.g.
+     toe 1.40, were the tell). **Conclusion:** the current model-space sizing is
+     correct; the analyzer's `model dim` column is the meaningful collider size,
+     and its `local dim`/inflation/capsule columns are based on a wrong frame
+     assumption and should be ignored (a follow-up could drop them).
+   - ➡️ The residual ~0.24 `max_nonadjacent_overlap` is therefore **genuine limb
+     overlap** of a correctly-sized rig when crumpled, not a sizing bug. No
+     collider-resize work is warranted; further realism, if pursued, comes from the
+     death-handoff (velocity-seeded) and joint-tuning items, not box sizing.
 4. **Handoff pose-continuity / skinning convention.** Physics placement at handoff
    is exact *by construction* (corpse seeded from the same `world_joint_transforms`
    the renderer skins with; `max_drift` ≈ 0 right after spawn confirms no snap). The

--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -117,18 +117,27 @@ verification harness and the headline realism fix are now done; the rest remain.
      are the source of truth — the recommended upgrade is **oriented (bone-aligned)
      boxes/capsules** instead of axis-aligned (AABBs inflate for diagonal limbs),
      keeping `HUMANOID_HIT_BOXES` as the semantic (damage-role) layer.
-   - ✅ **`hitbox_analyzer` tool v1 (PR #285, off main):** `cargo run -p
-     hitbox_analyzer -- <mesh|dir>` reports per joint the AABB vs an oriented (PCA)
-     bound and the "inflation" (AABB vol / OBB vol). Added
-     `SystemShock2AIMesh::joint_vertex_positions()` to `dark`. Finding: limbs are
-     ~1.0× in the standing bind pose; the diagonally-held weapon joint is ~2.3×
-     (GRUNT_P), confirming oriented colliders help most for off-axis limbs.
-   - **Next (v2):** the ragdoll's colliders live in the *joint-local* frame, so the
-     directly-relevant analysis is the AABB in joint-local space (needs the `.cal`
-     skeleton bind orientations), emitting **recommended oriented box / capsule
-     sizes per joint** to feed back into `rag_doll.rs`. Then switch the ragdoll
-     from axis-aligned cuboids to those oriented shapes and re-measure
-     `max_nonadjacent_overlap`.
+   - ✅ **`hitbox_analyzer` tool (PR #285, off main):** `cargo run -p
+     hitbox_analyzer -- <mesh|dir>`. Added
+     `SystemShock2AIMesh::joint_vertex_positions()` to `dark`. v2 loads each mesh's
+     `.cal` skeleton and reports, per joint: current model-space AABB, recommended
+     **joint-local** AABB + center, inflation (model/local vol), and a recommended
+     capsule (axis/radius/half-height).
+   - ⚠️ **Surprising v2 result — oriented boxes do NOT reduce volume for SS2.**
+     Across all creatures inflation ≈ 1.00× and the joint-local dims are the model
+     dims with axes **permuted**: SS2 bind rotations are axis-aligned (~90° swaps),
+     so a bone-aligned box is the same volume as the AABB. The earlier ~2.3× from
+     the v1 PCA bound was vs a *PCA* orientation, which the collider can't use (it
+     must live in the joint frame).
+   - ➡️ **The real, actionable bug it surfaced:** `rag_doll.rs` sizes colliders
+     from **model-space** `bbox.dim()`/`bbox.center()` but attaches them in the
+     **joint** frame, so the box is mis-oriented (long axis pointing the wrong way)
+     and mis-offset (e.g. GRUNT_P model `0.54,0.17,0.18` vs joint-local
+     `0.18,0.17,0.54`). **Next ragdoll PR:** transform each joint's hitbox verts by
+     the joint bind transform before computing the collider dims + center (use the
+     tool's "local dim"/"local center"), then re-measure `max_nonadjacent_overlap`.
+     Validate distal joints with large local centers (e.g. toe) visually under
+     `--debug-physics`.
 4. **Handoff pose-continuity / skinning convention.** Physics placement at handoff
    is exact *by construction* (corpse seeded from the same `world_joint_transforms`
    the renderer skins with; `max_drift` ≈ 0 right after spawn confirms no snap). The

--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -107,15 +107,28 @@ verification harness and the headline realism fix are now done; the rest remain.
    `contacts_enabled(false)` on each joint so *directly jointed* pairs don't
    re-explode. **Verified:** `max_nonadjacent_overlap` 0.44 → 0.24 while staying
    settled (max linear ~0.03, max angular ~0.34, no floor penetration).
-3. **Hitbox-fit validation across the model corpus — next.** The residual ~0.24
-   overlap is largely from oversized hitbox AABBs (limb boxes bigger than the mesh;
-   Delta 4 in the investigation log). Build an offline check (extend
-   `dark_query`/`dark_viewer`, or a test) that, for every creature `.bin` per
-   ActorType, evaluates fit: % of a joint's skinned vertices contained in its box,
-   box oversize ratio vs. the vert cloud, and overlap between sibling boxes.
-   Surface outliers so we can fix the worst-fitting joints (and validate that the
-   model-space AABB + joint-local-center placement is geometrically right). Should
-   drive `max_nonadjacent_overlap` down further; may also move limbs to capsules.
+3. **Hitbox-fit validation across the model corpus — in progress.**
+   - ✅ **Reference check (background agent):** the Dark engine has *no* authored
+     per-joint collision data. Whole-body collision is a 1–2 sphere "SphereHat" /
+     OBB (`sPhysDimsProp`, whole creature only); damage hit-location is a raycast
+     against animated mesh polygons → segment index. The LGMM `mms_segment.bbox`
+     field is never populated; `.cal` skeletons store joint positions + bone
+     lengths/directions but **no limb thickness**. Conclusion: mesh-derived shapes
+     are the source of truth — the recommended upgrade is **oriented (bone-aligned)
+     boxes/capsules** instead of axis-aligned (AABBs inflate for diagonal limbs),
+     keeping `HUMANOID_HIT_BOXES` as the semantic (damage-role) layer.
+   - ✅ **`hitbox_analyzer` tool v1 (PR #285, off main):** `cargo run -p
+     hitbox_analyzer -- <mesh|dir>` reports per joint the AABB vs an oriented (PCA)
+     bound and the "inflation" (AABB vol / OBB vol). Added
+     `SystemShock2AIMesh::joint_vertex_positions()` to `dark`. Finding: limbs are
+     ~1.0× in the standing bind pose; the diagonally-held weapon joint is ~2.3×
+     (GRUNT_P), confirming oriented colliders help most for off-axis limbs.
+   - **Next (v2):** the ragdoll's colliders live in the *joint-local* frame, so the
+     directly-relevant analysis is the AABB in joint-local space (needs the `.cal`
+     skeleton bind orientations), emitting **recommended oriented box / capsule
+     sizes per joint** to feed back into `rag_doll.rs`. Then switch the ragdoll
+     from axis-aligned cuboids to those oriented shapes and re-measure
+     `max_nonadjacent_overlap`.
 4. **Handoff pose-continuity / skinning convention.** Physics placement at handoff
    is exact *by construction* (corpse seeded from the same `world_joint_transforms`
    the renderer skins with; `max_drift` ≈ 0 right after spawn confirms no snap). The

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -23,9 +23,9 @@ use crate::{
 // controls are scaled for that mass.
 /// Upward impulse applied to a single ragdoll body (left trigger) - intentionally
 /// one body so you can watch the force propagate through the joints to the rest.
-const IMPULSE_STRENGTH: f32 = 5.0;
+const IMPULSE_STRENGTH: f32 = 50.0;
 /// Per-body pull force for the debug "gather toward center" control (right squeeze).
-const PULL_FORCE: f32 = 12.0;
+const PULL_FORCE: f32 = 120.0;
 
 /// Number of update frames to wait after spawning the pipe hybrid before killing
 /// it and spawning the ragdoll. Frame-based (not wall-clock) so the trigger is

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -18,8 +18,14 @@ use crate::{
     time::Time,
 };
 
-const IMPULSE_STRENGTH: f32 = 1.0;
-const PULL_FORCE: f32 = 1.0;
+// Ragdoll limb bodies now use a uniform ~1.0 mass (see rag_doll.rs
+// TARGET_BODY_MASS), ~1000x heavier than the old point-balls, so these debug
+// controls are scaled for that mass.
+/// Upward impulse applied to a single ragdoll body (left trigger) - intentionally
+/// one body so you can watch the force propagate through the joints to the rest.
+const IMPULSE_STRENGTH: f32 = 5.0;
+/// Per-body pull force for the debug "gather toward center" control (right squeeze).
+const PULL_FORCE: f32 = 12.0;
 
 /// Number of update frames to wait after spawning the pipe hybrid before killing
 /// it and spawning the ragdoll. Frame-based (not wall-clock) so the trigger is
@@ -184,10 +190,12 @@ impl RagdollHooks {
             input_context.left_hand.trigger_value > 0.5 && !self.last_left_impulse;
 
         if left_impulse_pressed {
+            // Single body on purpose: lets you watch the impulse propagate through
+            // the joints to the rest of the ragdoll.
             if let Some(first_body) = core.rag_doll_manager.get_first_ragdoll_body() {
-                let impulse = vec3(0.0, IMPULSE_STRENGTH / SCALE_FACTOR, 0.0);
+                let impulse = vec3(0.0, IMPULSE_STRENGTH, 0.0);
                 core.physics.apply_impulse(first_body, impulse);
-                println!("Applied upward impulse to ragdoll");
+                println!("Applied upward impulse to a single ragdoll body");
             }
         }
 
@@ -203,7 +211,7 @@ impl RagdollHooks {
                     );
 
                     let pull_direction = (center_position - body_position).normalize();
-                    let pull_force = pull_direction * PULL_FORCE / SCALE_FACTOR;
+                    let pull_force = pull_direction * PULL_FORCE;
 
                     core.physics.apply_force(body_handle, pull_force);
                 }


### PR DESCRIPTION
Stacked on #283 (base = `feat/ragdoll-self-collision-exclude`).

## Why

Reported while testing: the debug "launch" control (left trigger) does nothing now. Cause: the uniform-mass change (#278) made ragdoll limb bodies ~1.0 mass — ~1000× the old point-balls — but the control still applied a fixed `1.0/SCALE_FACTOR ≈ 0.4` impulse, so Δv went from ~444 m/s to ~0.4 m/s.

## What

- Bump `IMPULSE_STRENGTH` for the new ~1.0 mass. Still applied to a **single** body on purpose, so you can watch the impulse propagate through the joints to the rest of the ragdoll (force-testing).
- Bump the gather/pull force (applied to all bodies) likewise.

`apply_impulse`/`apply_force` already pass `wake_up = true`, so a settled (sleeping) corpse still responds — magnitude was the issue, not sleep.

Debug-scene controls only; no gameplay impact.

## Note / follow-up

These can't be driven over HTTP yet because `DebuggableScene::set_input` is stubbed for `MissionCore`, so I verified by reasoning + interactively on desktop. Added that harness gap to the project backlog (`projects/ragdoll.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)