### PR TITLE
ci: build & test in a single cargo invocation per OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,39 +56,31 @@ jobs:
       # Build and test both run in --release so the optimized dependency tree
       # is compiled once and reused by the test step, instead of compiling the
       # whole graph a second time in the dev profile.
-      - name: Build Desktop Runtime
-        run: cargo build --verbose --release
-        working-directory: runtimes/desktop_runtime
-        env:
-          RUSTFLAGS: "-D warnings"
-      - name: Run Desktop Runtime tests
-        run: cargo test --verbose --release
-        working-directory: runtimes/desktop_runtime
-        env:
-          RUSTFLAGS: "-D warnings"
-
-      # Build and test the tools in a single cargo invocation each, so the
-      # shared dependency graph is resolved and compiled once.
+      #
+      # Everything is built (and tested) in a single cargo invocation per OS so
+      # features resolve once and the large shared workspace crates (shock2vr,
+      # engine) compile a single time, rather than being partially recompiled
+      # when each package is built in its own step.
       # Note: dark_viewer is excluded on Windows due to compilation issues.
       # TODO: Fix dark_viewer Windows compatibility and include it everywhere.
-      - name: Build tools (Unix)
+      - name: Build all (Unix)
         if: runner.os != 'Windows'
-        run: cargo build --verbose --release -p dark_viewer -p dark_query -p debug_runtime -p debug_command
+        run: cargo build --verbose --release -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
-      - name: Run tools tests (Unix)
+      - name: Run all tests (Unix)
         if: runner.os != 'Windows'
-        run: cargo test --verbose --release -p dark_viewer -p dark_query -p debug_runtime -p debug_command
+        run: cargo test --verbose --release -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
 
-      - name: Build tools (Windows)
+      - name: Build all (Windows)
         if: runner.os == 'Windows'
-        run: cargo build --verbose --release -p dark_query -p debug_runtime -p debug_command
+        run: cargo build --verbose --release -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
-      - name: Run tools tests (Windows)
+      - name: Run all tests (Windows)
         if: runner.os == 'Windows'
-        run: cargo test --verbose --release -p dark_query -p debug_runtime -p debug_command
+        run: cargo test --verbose --release -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
## What

Follow-up to #287. Collapses the separate "Build Desktop Runtime" and "Build tools" steps into a **single `cargo build --release -p …`** invocation per OS (and likewise a single `cargo test`).

## Why

After #287 the test steps dropped to 3–4s (release artifacts are reused — the double-compile fix worked). But the two *build* steps remained separate, and on the Windows runner they cost **389s + 246s**. Because each cargo invocation resolves features independently, the large shared workspace crates (`shock2vr`, `engine`) get partially recompiled in the second step rather than reused.

`Swatinem/rust-cache` caches the *dependency* graph but deliberately drops the workspace's own crates, so those recompile every run — and currently ~twice. One invocation → features resolve once → `shock2vr`/`engine` compile a single time and every binary + test harness reuses them.

## Measured baseline (steady-state, warm cache, per #287)

| Job | Baseline | After #287 |
|-----|----------|-----------|
| Ubuntu | 8.2 min | 5.2 min |
| macOS | 13.0 min | 5.8 min |
| Windows | 15.0 min | ~11–12 min |

Windows is the long pole; this PR targets it. Compare this PR's per-job timings (once cache warms) against the numbers above.

## Note

On Unix, building `desktop_runtime` together with the tools means the shared `shock2vr` is compiled once with the ffmpeg feature enabled (the shipping desktop config), and the tool tests run against that variant. On Windows ffmpeg is disabled everywhere via `default-features = false`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)