### PR TITLE
chore: strip debug info from third-party deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 [profile.dev.package.rapier3d]
 opt-level = 3
 
+# Strip debug info from all third-party dependencies to shrink target/.
+# Our own crates keep full debug info; opt in per-dep above if needed.
+[profile.dev.package."*"]
+debug = false
+
 [workspace]
 resolver = "2"
 


### PR DESCRIPTION
Adds `[profile.dev.package."*"] debug = false` so dependency crates build without debug info, shrinking the dev `target/` substantially (it had grown large enough to fill the disk during builds). Our own crates keep full debug info, and per-dep `opt-level` overrides (e.g. `rapier3d`) still apply.

Separate from the hitbox/ragdoll debug-tooling work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)