### PR TITLE
chore(build): strip debug info from third-party deps in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 [profile.dev.package.rapier3d]
 opt-level = 3
 
+# Strip debug info from third-party dependencies (our own crates keep it). Keeps
+# the dev `target/` dir far smaller without affecting debuggability of our code.
+[profile.dev.package."*"]
+debug = false
+
 [workspace]
 resolver = "2"
 


### PR DESCRIPTION
Add `[profile.dev.package."*"] debug = false` so only our own crates carry debug info in dev builds; third-party dependencies don't.

**Why:** the dev `target/` directory had grown large enough to exhaust local disk. Stripping debug info from dependencies shrinks it substantially with **no effect on debuggability of our own code** (our crates keep full debug info). Dependency builds are also slightly faster to link.

**Scope:** only the workspace root `Cargo.toml`. The existing `[profile.dev.package.rapier3d] opt-level = 3` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)