### PR TITLE
feat(flat): PresentationMode flag + screen-space 2D HUD (slice 1)

### DIFF
--- a/engine/src/scene/clipped_screen_material.rs
+++ b/engine/src/scene/clipped_screen_material.rs
@@ -8,7 +8,7 @@ use crate::scene::light::LightArray;
 use crate::shader_program::ShaderProgram;
 use crate::texture::TextureTrait;
 use c_string::*;
-use cgmath::{Matrix, Matrix4};
+use cgmath::{Matrix, Matrix4, SquareMatrix, ortho};
 use once_cell::sync::OnceCell;
 
 // Simple vertex shader - no normals needed for UI elements
@@ -73,6 +73,10 @@ where
     has_initialized: bool,
     diffuse_texture: T,
     clip_percentage: f32, // 0.0 to 1.0
+    // When true, draw in screen space: build an orthographic projection from the
+    // render context's screen size (pixels, origin top-left) and ignore the 3D
+    // camera. The world matrix then positions the quad directly in pixels.
+    screen_space: bool,
 }
 
 impl<T> ClippedScreenMaterial<T>
@@ -98,11 +102,26 @@ where
         unsafe {
             gl::UseProgram(shader_program.gl_id);
 
-            let projection = render_context.projection_matrix;
+            // In screen-space mode, substitute an orthographic projection (pixels,
+            // origin top-left) and an identity view so the world matrix places the
+            // quad directly in screen pixels - matching ScreenSpaceMaterial.
+            let (projection, view) = if self.screen_space {
+                let ortho_projection = ortho(
+                    0.0,
+                    render_context.screen_size.x,
+                    render_context.screen_size.y,
+                    0.0,
+                    0.0,
+                    1.0,
+                );
+                (ortho_projection, Matrix4::identity())
+            } else {
+                (render_context.projection_matrix, *view_matrix)
+            };
 
             // Set transformation matrices
             gl::UniformMatrix4fv(uniforms.world_loc, 1, gl::FALSE, world_matrix.as_ptr());
-            gl::UniformMatrix4fv(uniforms.view_loc, 1, gl::FALSE, view_matrix.as_ptr());
+            gl::UniformMatrix4fv(uniforms.view_loc, 1, gl::FALSE, view.as_ptr());
             gl::UniformMatrix4fv(uniforms.projection_loc, 1, gl::FALSE, projection.as_ptr());
 
             // Set clipping value
@@ -195,5 +214,21 @@ where
         diffuse_texture,
         has_initialized: false,
         clip_percentage: clip_percentage.clamp(0.0, 1.0),
+        screen_space: false,
+    })
+}
+
+/// Like [`create`], but draws in screen space (orthographic, pixel coordinates,
+/// origin top-left) rather than against the 3D camera. Used for the flat HUD's
+/// horizontally-filling bars.
+pub fn create_screen_space<T>(diffuse_texture: T, clip_percentage: f32) -> Box<dyn Material>
+where
+    T: Deref<Target = dyn TextureTrait> + 'static,
+{
+    Box::new(ClippedScreenMaterial {
+        diffuse_texture,
+        has_initialized: false,
+        clip_percentage: clip_percentage.clamp(0.0, 1.0),
+        screen_space: true,
     })
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -88,6 +88,11 @@ struct Args {
     /// Enable experimental features (comma-separated)
     #[arg(long)]
     experimental: Option<String>,
+
+    /// Use the flatscreen (non-VR) presentation: screen-space 2D HUD instead of
+    /// the VR forearm panels.
+    #[arg(long)]
+    flat: bool,
 }
 
 /// Default debug-camera head rotation.
@@ -307,8 +312,15 @@ fn run_game_blocking(
     let (mission, spawn_location) = parse_mission(&args.mission);
     info!("Mission parsed: {} with spawn location", mission);
 
+    let presentation_mode = if args.flat {
+        shock2vr::PresentationMode::Flat
+    } else {
+        shock2vr::PresentationMode::Vr
+    };
+
     let options = GameOptions {
         mission: mission.clone(),
+        presentation_mode,
         spawn_location,
         save_file: args.save_file,
         debug_draw: args.debug_draw,

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -1,0 +1,238 @@
+//! Flatscreen (non-VR) screen-space HUD.
+//!
+//! Where `virtual_arms` renders the HUD as world-space panels on the VR hands,
+//! this draws a classic 2D overlay: a centered crosshair plus health/psi bars,
+//! laid out on the original game's 640x480 virtual canvas and scaled to the
+//! actual screen. Built only in `PresentationMode::Flat`. See
+//! `projects/flatscreen-and-vr-architecture.md` (Slice 1).
+
+use std::rc::Rc;
+
+use cgmath::{Matrix4, Vector2, vec2, vec3};
+use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
+use engine::{
+    assets::asset_cache::AssetCache,
+    scene::SceneObject,
+    texture::{TextureOptions, TextureTrait},
+};
+use shipyard::World;
+
+use super::{get_health_percentage, get_psi_percentage};
+
+/// The original SS2 HUD is authored against a 640x480 display; we lay out in
+/// those virtual pixels and scale to the real screen.
+const VIRTUAL_W: f32 = 640.0;
+const VIRTUAL_H: f32 = 480.0;
+
+const CROSSHAIR_SIZE: f32 = 32.0;
+
+const BAR_W: f32 = 120.0;
+const BAR_H: f32 = 12.0;
+const HEALTH_BAR_X: f32 = 20.0;
+const HEALTH_BAR_Y: f32 = 448.0; // near the bottom edge
+const PSI_BAR_X: f32 = 20.0;
+const PSI_BAR_Y: f32 = 430.0; // stacked just above health
+
+const HEALTH_TEXT_X: f32 = 148.0; // right of the bars
+const HEALTH_TEXT_Y: f32 = 444.0;
+const HEALTH_TEXT_SIZE: f32 = 16.0;
+
+/// A single laid-out HUD element in screen pixels (origin top-left). Kept as a
+/// pure data description so the layout is unit-testable without a GL context.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum FlatHudElement {
+    Image {
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+        texture: String,
+    },
+    /// A horizontally-filling bar; `fill` (0..1) clips the texture from the left.
+    Bar {
+        position: Vector2<f32>,
+        size: Vector2<f32>,
+        texture: String,
+        fill: f32,
+    },
+    Text {
+        position: Vector2<f32>,
+        size: f32, // font height in screen pixels
+        text: String,
+    },
+}
+
+/// Compute the flat HUD layout in screen pixels for a given screen size and
+/// player stat fractions. Pure: no asset/GL access, so it can be tested.
+pub(crate) fn flat_hud_layout(
+    screen_size: Vector2<f32>,
+    health_fraction: f32,
+    psi_fraction: f32,
+) -> Vec<FlatHudElement> {
+    let scale = vec2(screen_size.x / VIRTUAL_W, screen_size.y / VIRTUAL_H);
+    // Scale a virtual-canvas point/size into actual screen pixels.
+    let s = |x: f32, y: f32| vec2(x * scale.x, y * scale.y);
+
+    let health = health_fraction.clamp(0.0, 1.0);
+    let psi = psi_fraction.clamp(0.0, 1.0);
+
+    let crosshair = s(CROSSHAIR_SIZE, CROSSHAIR_SIZE);
+
+    vec![
+        // Crosshair, centered on screen.
+        FlatHudElement::Image {
+            position: vec2(
+                (screen_size.x - crosshair.x) / 2.0,
+                (screen_size.y - crosshair.y) / 2.0,
+            ),
+            size: crosshair,
+            texture: "CROSSHAI.PCX".to_owned(),
+        },
+        // Health bar (bottom-left), filled to the health fraction.
+        FlatHudElement::Bar {
+            position: s(HEALTH_BAR_X, HEALTH_BAR_Y),
+            size: s(BAR_W, BAR_H),
+            texture: "HPBAR.PCX".to_owned(),
+            fill: health,
+        },
+        // Psi bar, stacked above health.
+        FlatHudElement::Bar {
+            position: s(PSI_BAR_X, PSI_BAR_Y),
+            size: s(BAR_W, BAR_H),
+            texture: "PSIBAR.PCX".to_owned(),
+            fill: psi,
+        },
+        // Health percentage readout.
+        FlatHudElement::Text {
+            position: s(HEALTH_TEXT_X, HEALTH_TEXT_Y),
+            size: HEALTH_TEXT_SIZE * scale.y,
+            text: format!("{}", (health * 100.0).round() as i32),
+        },
+    ]
+}
+
+/// Replicate `SceneObject::screen_space_quad`'s transform so a manually-built
+/// screen-space SceneObject (e.g. one using the clipped bar material) maps to
+/// the same pixel rectangle.
+fn screen_space_quad_transform(position: Vector2<f32>, size: Vector2<f32>) -> Matrix4<f32> {
+    Matrix4::from_translation(vec3(position.x, position.y, 0.0))
+        * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0)
+        * Matrix4::from_translation(vec3(0.5, 0.5, 0.0))
+}
+
+/// Build the flat HUD as screen-space scene objects for the current player state.
+pub(crate) fn create_flat_hud(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    screen_size: Vector2<f32>,
+) -> Vec<SceneObject> {
+    let layout = flat_hud_layout(
+        screen_size,
+        get_health_percentage(world),
+        get_psi_percentage(world),
+    );
+
+    let texture_options = TextureOptions { wrap: false };
+    let mut objs = Vec::with_capacity(layout.len());
+
+    for element in layout {
+        match element {
+            FlatHudElement::Image {
+                position,
+                size,
+                texture,
+            } => {
+                let tex = asset_cache.get_ext(&TEXTURE_IMPORTER, &texture, &texture_options);
+                objs.push(SceneObject::screen_space_quad(
+                    tex.clone() as Rc<dyn TextureTrait>,
+                    position,
+                    size,
+                ));
+            }
+            FlatHudElement::Bar {
+                position,
+                size,
+                texture,
+                fill,
+            } => {
+                let tex = asset_cache.get_ext(&TEXTURE_IMPORTER, &texture, &texture_options);
+                let material = engine::scene::clipped_screen_material::create_screen_space(
+                    tex.clone() as Rc<dyn TextureTrait>,
+                    fill,
+                );
+                let mut obj = SceneObject::new(material, Box::new(engine::scene::quad::create()));
+                obj.set_local_transform(screen_space_quad_transform(position, size));
+                objs.push(obj);
+            }
+            FlatHudElement::Text {
+                position,
+                size,
+                text,
+            } => {
+                let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon").clone();
+                objs.push(SceneObject::screen_space_text(
+                    &text, font, size, 0.0, position.x, position.y,
+                ));
+            }
+        }
+    }
+
+    objs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_has_crosshair_and_bars() {
+        let layout = flat_hud_layout(vec2(640.0, 480.0), 1.0, 1.0);
+
+        // Crosshair, two bars, one text readout.
+        assert_eq!(layout.len(), 4);
+
+        // Crosshair is centered on the 640x480 screen (32px wide -> 304,224).
+        match &layout[0] {
+            FlatHudElement::Image {
+                position, texture, ..
+            } => {
+                assert_eq!(texture, "CROSSHAI.PCX");
+                assert_eq!(*position, vec2(304.0, 224.0));
+            }
+            other => panic!("expected crosshair image, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bar_fill_tracks_health_and_psi() {
+        let layout = flat_hud_layout(vec2(640.0, 480.0), 0.25, 0.5);
+
+        let fills: Vec<f32> = layout
+            .iter()
+            .filter_map(|e| match e {
+                FlatHudElement::Bar { fill, texture, .. } if texture == "HPBAR.PCX" => Some(*fill),
+                FlatHudElement::Bar { fill, texture, .. } if texture == "PSIBAR.PCX" => Some(*fill),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fills, vec![0.25, 0.5]);
+    }
+
+    #[test]
+    fn fractions_are_clamped() {
+        let layout = flat_hud_layout(vec2(640.0, 480.0), 2.0, -1.0);
+        for e in &layout {
+            if let FlatHudElement::Bar { fill, .. } = e {
+                assert!((0.0..=1.0).contains(fill), "fill {fill} not clamped");
+            }
+        }
+    }
+
+    #[test]
+    fn layout_scales_with_screen_size() {
+        // At 2x the virtual canvas, the crosshair doubles in size.
+        let layout = flat_hud_layout(vec2(1280.0, 960.0), 1.0, 1.0);
+        match &layout[0] {
+            FlatHudElement::Image { size, .. } => assert_eq!(*size, vec2(64.0, 64.0)),
+            other => panic!("expected crosshair image, got {other:?}"),
+        }
+    }
+}

--- a/shock2vr/src/hud/mod.rs
+++ b/shock2vr/src/hud/mod.rs
@@ -3,3 +3,6 @@ pub use item_outline::*;
 
 mod virtual_arms;
 pub use virtual_arms::*;
+
+mod flat_hud;
+pub(crate) use flat_hud::*;

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -112,7 +112,7 @@ fn create_overlay_transform(
 }
 
 /// Get player health percentage (0.0 to 1.0)
-fn get_health_percentage(world: &World) -> f32 {
+pub(crate) fn get_health_percentage(world: &World) -> f32 {
     // Get player entity from PlayerInfo
     let player_info = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
     let player_entity = player_info.entity_id;
@@ -137,7 +137,7 @@ fn get_health_percentage(world: &World) -> f32 {
 
 /// Get player psi percentage (0.0 to 1.0)
 /// TODO: Implement actual psi property access when available
-fn get_psi_percentage(_world: &World) -> f32 {
+pub(crate) fn get_psi_percentage(_world: &World) -> f32 {
     0.75 // Placeholder - 75% psi for testing
 }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -71,8 +71,23 @@ pub fn resource_path(str: &str) -> String {
     paths::data_root().join(str).to_string_lossy().into_owned()
 }
 
+/// How the game is presented and controlled.
+///
+/// `Vr` is the existing head/hands interaction model (forearm HUD panels,
+/// `VirtualHand` grab-and-hold). `Flat` is the classic flatscreen presentation:
+/// a screen-space 2D HUD, 2D menus, and first-person interaction. The flag is
+/// threaded only to the presentation/interaction edges - the simulation is
+/// shared. See `projects/flatscreen-and-vr-architecture.md`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum PresentationMode {
+    #[default]
+    Vr,
+    Flat,
+}
+
 pub struct GameOptions {
     pub mission: String,
+    pub presentation_mode: PresentationMode,
     pub spawn_location: SpawnLocation,
     pub save_file: Option<String>,
     pub render_particles: bool,
@@ -90,6 +105,7 @@ impl Default for GameOptions {
     fn default() -> Self {
         Self {
             mission: "earth.mis".to_owned(),
+            presentation_mode: PresentationMode::Vr,
             spawn_location: SpawnLocation::MapDefault,
             save_file: None,
             debug_draw: false,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1768,6 +1768,16 @@ impl MissionCore {
             }
         }
 
+        // Flat (non-VR) presentation draws a screen-space 2D HUD here, where the
+        // screen size is available. The VR forearm HUD is built in `render`.
+        if options.presentation_mode == crate::PresentationMode::Flat {
+            ret.extend(crate::hud::create_flat_hud(
+                asset_cache,
+                &self.world,
+                screen_size,
+            ));
+        }
+
         ret
     }
 
@@ -1979,16 +1989,19 @@ impl MissionCore {
         scene.append(&mut self.left_hand.render());
         scene.append(&mut self.right_hand.render());
 
-        // Render forearm HUD panels with health/psi overlays
-        let mut hud_panels = crate::hud::create_arm_hud_panels(
-            asset_cache,
-            &self.world,
-            self.left_hand.get_position(),
-            self.left_hand.get_rotation(),
-            self.right_hand.get_position(),
-            self.right_hand.get_rotation(),
-        );
-        scene.append(&mut hud_panels);
+        // Render forearm HUD panels with health/psi overlays (VR only). The flat
+        // presentation draws a screen-space 2D HUD in `render_per_eye` instead.
+        if options.presentation_mode == crate::PresentationMode::Vr {
+            let mut hud_panels = crate::hud::create_arm_hud_panels(
+                asset_cache,
+                &self.world,
+                self.left_hand.get_position(),
+                self.left_hand.get_rotation(),
+                self.right_hand.get_position(),
+                self.right_hand.get_rotation(),
+            );
+            scene.append(&mut hud_panels);
+        }
 
         // Render inventory
         let inventory_objs = PlayerInventoryEntity::render(&self.world);

--- a/shock2vr/src/scenes/debug_teleport.rs
+++ b/shock2vr/src/scenes/debug_teleport.rs
@@ -21,6 +21,7 @@ impl DebugTeleportScene {
 
         let teleport_options = GameOptions {
             mission: game_options.mission.clone(),
+            presentation_mode: game_options.presentation_mode,
             spawn_location: game_options.spawn_location.clone(),
             save_file: game_options.save_file.clone(),
             render_particles: game_options.render_particles,

--- a/tools/shock2-sdk/test/flat-hud.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-hud.e2e.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end smoke test for the flatscreen (non-VR) presentation. Launches the
+// debug runtime with `--flat` so the game builds the screen-space 2D HUD in
+// `render_per_eye` instead of the VR forearm panels, then confirms a frame
+// renders end-to-end without panicking. Pixel-level correctness of the HUD
+// layout is covered by the Rust unit tests in `shock2vr/src/hud/flat_hud.rs`.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "flat presentation: renders a frame with the screen-space HUD",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8093),
+      debugFlags: ["--flat"],
+    });
+
+    // Advance enough frames for the mission to load and render.
+    await game.step({ frames: 30 });
+
+    const shot = await game.screenshot("flat-hud.png");
+
+    // A real rendered frame at the runtime's fixed resolution. If the flat
+    // render path panicked or produced nothing, this would fail.
+    assert.deepEqual(shot.resolution, [800, 600]);
+    assert.ok(
+      shot.size_bytes > 10_000,
+      `expected a non-trivial frame, got ${shot.size_bytes} bytes`,
+    );
+  },
+);


### PR DESCRIPTION
First slice of the flatscreen/VR split (design: `projects/flatscreen-and-vr-architecture.md`). Adds a `PresentationMode { Vr, Flat }` flag and a classic screen-space 2D HUD, so core gameplay can be played/tested without VR. **Default behavior is unchanged** (`Vr`).

## What's here
- **`PresentationMode` on `GameOptions`** — threaded only to the presentation edge; the simulation is fully shared. Default `Vr`.
- **Engine:** `clipped_screen_material::create_screen_space` — an orthographic, pixel-space variant of the existing clipped material so HUD bars fill horizontally without stretching the texture.
- **`hud/flat_hud.rs`** — crosshair + health/psi bars + health readout, laid out on the original game's 640×480 virtual canvas and scaled to the screen, drawn with the existing screen-space scene-object primitives and the already-registered `iface.crf` art (`CROSSHAI/HPBAR/PSIBAR.PCX`). Layout is a pure, unit-tested function.
- **`mission_core`** — builds the flat HUD in `render_per_eye` (where screen size is available) when `Flat`; gates the VR forearm panels to `Vr`.
- **`debug_runtime --flat`** — drive/screenshot the flat HUD headlessly.

## Verification
- Rust unit tests for the layout math (crosshair centering, bar fills track health/psi, clamping, screen scaling).
- SDK e2e smoke test (`flat-hud.e2e.test.ts`, gated by `SHOCK2_E2E`): a flat frame renders end-to-end.
- Manual: `--flat` screenshot shows centered crosshair + bottom-left bars; VR-mode screenshot confirms the screen-space HUD is absent (negative).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p engine -p debug_runtime` clean.

## Not in this slice (follow-ups)
- Flat first-person interaction / hands (a still-rendered VR hand model is visible in flat mode for now) — later slice.
- `desktop_runtime --flat` (revised: host both modes in desktop_runtime rather than a new crate) — next slice.
- Virtual-canvas letterboxing for non-4:3 windows; ammo readout.

Independent of #294 (the dev-deps debug-strip change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)