### PR TITLE
feat(flat): mouse-driven main menu; boot into it by default (slice 3)

### DIFF
--- a/dark/src/hit_box.rs
+++ b/dark/src/hit_box.rs
@@ -202,7 +202,12 @@ fn xform_point(xform: &Matrix4<f32>, p: Vector3<f32>) -> Vector3<f32> {
     Vector3::new(c.x, c.y, c.z)
 }
 
-fn push_segment(verts: &mut Vec<VertexPosition>, xform: &Matrix4<f32>, a: Vector3<f32>, b: Vector3<f32>) {
+fn push_segment(
+    verts: &mut Vec<VertexPosition>,
+    xform: &Matrix4<f32>,
+    a: Vector3<f32>,
+    b: Vector3<f32>,
+) {
     verts.push(VertexPosition {
         position: xform_point(xform, a),
     });

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -405,6 +405,7 @@ fn run_game_blocking(
                 squeeze_value: 0.0,
                 a_value: 0.0,
             },
+            pointer: None,
         };
 
         let game_time = Time {

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -90,9 +90,10 @@ impl HandContext {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Name of the person to greet
-    #[arg(short, long, default_value = "earth.mis")]
-    mission: String,
+    /// Mission or debug scene to load. If omitted, boots the main menu in flat
+    /// mode, or earth.mis in --vr mode.
+    #[arg(short, long)]
+    mission: Option<String>,
 
     #[arg(long = "debug-physics")]
     debug_physics: bool,
@@ -240,8 +241,6 @@ pub fn main() {
     let experimental_features: HashSet<String> =
         args.experimental.unwrap_or(vec![]).into_iter().collect();
 
-    let (mission, spawn_location) = parse_mission(&args.mission);
-
     // Flatscreen is the default desktop presentation; --vr opts into the
     // emulated VR rig.
     let presentation_mode = if args.vr {
@@ -249,6 +248,17 @@ pub fn main() {
     } else {
         shock2vr::PresentationMode::Flat
     };
+
+    // With no explicit mission, flat boots the (mouse-driven) main menu; the VR
+    // rig has no pointer, so it boots straight into the first mission.
+    let mission_arg = args.mission.clone().unwrap_or_else(|| {
+        if args.vr {
+            "earth.mis".to_owned()
+        } else {
+            "main_menu".to_owned()
+        }
+    });
+    let (mission, spawn_location) = parse_mission(&mission_arg);
 
     let options = GameOptions {
         mission,
@@ -284,6 +294,10 @@ pub fn main() {
 
     let mut _frame = 0;
     let mut input_mapper = DesktopInputMapper::new();
+
+    // Tracks whether the OS cursor is currently visible (Normal) vs captured
+    // for mouse-look (Disabled). The window starts with the cursor disabled.
+    let mut cursor_visible = false;
     let mut action_state = InputActionState::new();
 
     let _mode = Mode::Gameplay;
@@ -296,6 +310,18 @@ pub fn main() {
         let delta_time = time - last_time;
         last_time = time;
 
+        // A scene (e.g. the main menu) may want a visible 2D cursor instead of
+        // captured mouse-look. Toggle the OS cursor when that changes.
+        let wants_pointer = game.wants_pointer();
+        if wants_pointer != cursor_visible {
+            window.set_cursor_mode(if wants_pointer {
+                glfw::CursorMode::Normal
+            } else {
+                glfw::CursorMode::Disabled
+            });
+            cursor_visible = wants_pointer;
+        }
+
         let (input_context, input_state) = process_events(
             &mut window,
             &mut camera_context,
@@ -304,6 +330,7 @@ pub fn main() {
             delta_time,
             &mut input_mapper,
             &mut action_state,
+            wants_pointer,
         );
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
         let projection_matrix: cgmath::Matrix4<f32> =
@@ -318,6 +345,11 @@ pub fn main() {
             "game.update",
             game.update(&time, &input_context, &mut action_state)
         );
+
+        // A scene may request quitting (e.g. the main menu's Quit item).
+        if game.should_quit() {
+            window.set_should_close(true);
+        }
 
         let screen_size = vec2(SCR_WIDTH as f32, SCR_HEIGHT as f32);
 
@@ -422,6 +454,7 @@ fn process_events(
     delta_time: f32,
     input_mapper: &mut DesktopInputMapper,
     action_state: &mut InputActionState,
+    wants_pointer: bool,
 ) -> (InputContext, InputState) {
     let _speed = 20.0;
     let head_rot_speed = 10.0;
@@ -583,6 +616,17 @@ fn process_events(
     input_context.left_hand.a_value = f32_from_bool(hand_context.left_a_pressed);
     // input_context.left_hand.trigger_value = trigger_value;
     // input_context.left_hand.squeeze_value = squeeze_value;
+
+    // Flatscreen UI (menus) reads an absolute 2D pointer rather than the VR
+    // hands. The cursor is in Normal mode here, so positions are window coords.
+    if wants_pointer {
+        if let Some(MousePosition { x, y }) = &camera_context.mouse_position {
+            input_context.pointer = Some(shock2vr::input_context::Pointer2D {
+                position: vec2(x / SCR_WIDTH as f32, y / SCR_HEIGHT as f32),
+                pressed: window.get_mouse_button(MouseButton::Button1) == Action::Press,
+            });
+        }
+    }
 
     let mut input_state = InputState::new();
     input_state.is_crouching = window.get_key(Key::LeftControl) == Action::Press;

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -84,6 +84,13 @@ pub trait GameScene {
         Vec::new()
     }
 
+    /// Whether this scene wants a 2D mouse cursor (e.g. a menu). Flat runtimes
+    /// show the OS cursor and populate `InputContext::pointer` when true; by
+    /// default scenes capture the mouse for look.
+    fn wants_pointer(&self) -> bool {
+        false
+    }
+
     /// Get lighting information for VR enhancement
     fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight>;
 

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -13,6 +13,11 @@ pub struct InputContext {
     // Information about each of the hands
     pub left_hand: Hand,
     pub right_hand: Hand,
+
+    // 2D screen pointer (mouse) for flatscreen UI. `None` in VR, where
+    // interaction is hand/pointer-ray based. Populated by flat runtimes when a
+    // scene wants a cursor (e.g. menus).
+    pub pointer: Option<Pointer2D>,
 }
 
 impl InputContext {
@@ -22,8 +27,18 @@ impl InputContext {
 
             left_hand: Hand::default(),
             right_hand: Hand::default(),
+            pointer: None,
         }
     }
+}
+
+/// A 2D screen-space pointer for flatscreen UI. Position is normalized to
+/// `[0, 1]` on each axis with the origin at the top-left, so it is
+/// resolution-independent; scenes scale it to their own canvas.
+#[derive(Debug, Clone, Copy)]
+pub struct Pointer2D {
+    pub position: Vector2<f32>,
+    pub pressed: bool,
 }
 
 #[derive(Debug)]

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -137,6 +137,10 @@ pub struct Game {
     last_env_sound: Option<String>,
 
     mission_to_save_data: HashMap<String, EntitySaveData>,
+
+    // Set when a scene requests quitting (e.g. the main menu's Quit). The
+    // runtime observes this via `should_quit` and closes its window.
+    should_quit: bool,
 }
 
 impl Game {
@@ -207,6 +211,19 @@ impl Game {
     /// Get access to the world for debugging purposes
     pub fn world(&self) -> &shipyard::World {
         self.active_game_scene.world()
+    }
+
+    /// Whether a scene has requested to quit the game (e.g. the main menu's
+    /// Quit). Runtimes should observe this and close their window.
+    pub fn should_quit(&self) -> bool {
+        self.should_quit
+    }
+
+    /// Whether the active scene wants a 2D mouse cursor (e.g. a menu). Flat
+    /// runtimes use this to show the OS cursor and feed `InputContext::pointer`
+    /// rather than capturing the mouse for look.
+    pub fn wants_pointer(&self) -> bool {
+        self.active_game_scene.wants_pointer()
     }
 
     /// Name of the currently active scene (e.g. "medsci1.mis"), tracking
@@ -403,6 +420,7 @@ impl Game {
             last_env_sound: None,
             options,
             mission_to_save_data,
+            should_quit: false,
         }
     }
 
@@ -594,6 +612,9 @@ impl Game {
                     self.active_game_scene.scene_name().to_string(),
                     SpawnLocation::PositionRotation(position, rotation),
                 );
+            }
+            GlobalEffect::Quit => {
+                self.should_quit = true;
             }
         }
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1341,7 +1341,8 @@ impl MissionCore {
                         "BH413001", // combat
                         "BH212oo8", // reach
                     ];
-                    let clip_name = DEBUG_POSE_CLIPS[self.debug_pose_index as usize % DEBUG_POSE_CLIPS.len()];
+                    let clip_name =
+                        DEBUG_POSE_CLIPS[self.debug_pose_index as usize % DEBUG_POSE_CLIPS.len()];
 
                     let creature_ids: Vec<EntityId> = {
                         let v_creature = self.world.borrow::<View<PropCreature>>().unwrap();

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -186,11 +186,7 @@ pub struct PhysicsWorld {
 /// AABB. The old SAP broad-phase tolerated that; rapier's BVH broad-phase panics
 /// on it (parry binned build, "index out of bounds"). Sanitize at the source and
 /// log the offender so the bad data is traceable.
-fn sanitize_collider_size(
-    entity_id: EntityId,
-    context: &str,
-    size: Vector3<f32>,
-) -> Vector3<f32> {
+fn sanitize_collider_size(entity_id: EntityId, context: &str, size: Vector3<f32>) -> Vector3<f32> {
     const MIN_SIZE: f32 = 0.01;
     const MAX_SIZE: f32 = 1.0e4;
     let clamp = |v: f32| -> f32 {
@@ -958,8 +954,7 @@ impl PhysicsWorld {
             filter,
         );
 
-        if let Some((handle, intersection)) =
-            queries.cast_ray_and_get_normal(&ray, max_toi, solid)
+        if let Some((handle, intersection)) = queries.cast_ray_and_get_normal(&ray, max_toi, solid)
         {
             // This is similar to `QueryPipeline::cast_ray` illustrated above except
             // that it also returns the normal of the collider shape at the hit point.
@@ -1207,8 +1202,7 @@ impl PhysicsWorld {
                 let separation = (a1.translation.vector - a2.translation.vector).norm();
                 // impulses: first 3 components are linear (translation), last 3 angular.
                 let imp = joint.impulses;
-                let linear_impulse =
-                    (imp[0] * imp[0] + imp[1] * imp[1] + imp[2] * imp[2]).sqrt();
+                let linear_impulse = (imp[0] * imp[0] + imp[1] * imp[1] + imp[2] * imp[2]).sqrt();
                 let angular_impulse = if imp.len() >= 6 {
                     (imp[3] * imp[3] + imp[4] * imp[4] + imp[5] * imp[5]).sqrt()
                 } else {

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -43,20 +43,28 @@ enum MenuAction {
 struct MenuItem {
     label: &'static str,
     action: MenuAction,
-    /// Normalized [0, 1] hit rect: (min_x, min_y, max_x, max_y), origin top-left.
+    /// Normalized [0, 1] hit rect over the MAIN.PCX button:
+    /// (min_x, min_y, max_x, max_y), origin top-left.
     rect: (f32, f32, f32, f32),
+    /// Normalized [0, 1] top-left where the label text is drawn (inside `rect`).
+    text_pos: (f32, f32),
 }
 
+// MAIN.PCX has a vertical stack of buttons down the right side. New Game goes in
+// the top button, Quit in the bottom one. Coordinates are normalized to the
+// full-screen backdrop.
 const MENU_ITEMS: &[MenuItem] = &[
     MenuItem {
         label: "NEW GAME",
         action: MenuAction::NewGame,
-        rect: (0.40, 0.46, 0.60, 0.52),
+        rect: (0.635, 0.030, 0.965, 0.155),
+        text_pos: (0.665, 0.072),
     },
     MenuItem {
         label: "QUIT",
         action: MenuAction::Quit,
-        rect: (0.40, 0.55, 0.60, 0.61),
+        rect: (0.635, 0.755, 0.965, 0.880),
+        text_pos: (0.755, 0.797),
     },
 ];
 
@@ -201,10 +209,9 @@ impl GameScene for MainMenuScene {
         let pointer_pos = self.pointer.map(|p| p.position);
         for item in MENU_ITEMS {
             let hovered = pointer_pos.is_some_and(|pp| in_rect(item.rect, pp));
-            let (min_x, min_y, _, _) = item.rect;
-            let x = min_x * screen_size.x;
-            let y = min_y * screen_size.y;
-            let font_size = 0.045 * screen_size.y;
+            let x = item.text_pos.0 * screen_size.x;
+            let y = item.text_pos.1 * screen_size.y;
+            let font_size = 0.04 * screen_size.y;
             let opacity = if hovered { 1.0 } else { 0.6 };
             objs.push(SceneObject::screen_space_text(
                 item.label,
@@ -266,22 +273,22 @@ mod tests {
 
     #[test]
     fn rising_edge_over_new_game_activates_it() {
-        // Press edge: not pressed last frame, pressed now, over "NEW GAME".
-        let (action, last) = resolve_click(pointer_at(0.5, 0.49, true), false);
+        // Press edge: not pressed last frame, pressed now, over the top button.
+        let (action, last) = resolve_click(pointer_at(0.8, 0.09, true), false);
         assert_eq!(action, Some(MenuAction::NewGame));
         assert!(last);
     }
 
     #[test]
     fn rising_edge_over_quit_activates_it() {
-        let (action, _) = resolve_click(pointer_at(0.5, 0.58, true), false);
+        let (action, _) = resolve_click(pointer_at(0.8, 0.82, true), false);
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
     #[test]
     fn held_press_does_not_re_activate() {
         // Already pressed last frame -> no new activation even over an item.
-        let (action, last) = resolve_click(pointer_at(0.5, 0.49, true), true);
+        let (action, last) = resolve_click(pointer_at(0.8, 0.09, true), true);
         assert_eq!(action, None);
         assert!(last);
     }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -1,0 +1,310 @@
+//! Flatscreen main menu.
+//!
+//! A minimal `GameScene` that draws the original `MAIN.PCX` backdrop with
+//! mouse-clickable "New Game" / "Quit" items. It reads `InputContext::pointer`
+//! (normalized screen coords) and emits a `GlobalEffect` on click:
+//! New Game -> `TransitionLevel` into the first mission, Quit -> `Quit`.
+//!
+//! See `projects/flatscreen-and-vr-architecture.md` (Slice 3).
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, light::SpotLight},
+    texture::{TextureOptions, TextureTrait},
+};
+use shipyard::{EntityId, UniqueViewMut, World};
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::{InputContext, Pointer2D},
+    inventory::PlayerInventoryEntity,
+    mission::{GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
+    quest_info::QuestInfo,
+    scripts::{Effect, GlobalEffect},
+    time::Time,
+};
+
+/// Mission loaded when the player chooses "New Game".
+const NEW_GAME_MISSION: &str = "earth.mis";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MenuAction {
+    NewGame,
+    Quit,
+}
+
+struct MenuItem {
+    label: &'static str,
+    action: MenuAction,
+    /// Normalized [0, 1] hit rect: (min_x, min_y, max_x, max_y), origin top-left.
+    rect: (f32, f32, f32, f32),
+}
+
+const MENU_ITEMS: &[MenuItem] = &[
+    MenuItem {
+        label: "NEW GAME",
+        action: MenuAction::NewGame,
+        rect: (0.40, 0.46, 0.60, 0.52),
+    },
+    MenuItem {
+        label: "QUIT",
+        action: MenuAction::Quit,
+        rect: (0.40, 0.55, 0.60, 0.61),
+    },
+];
+
+fn in_rect(rect: (f32, f32, f32, f32), p: Vector2<f32>) -> bool {
+    p.x >= rect.0 && p.y >= rect.1 && p.x <= rect.2 && p.y <= rect.3
+}
+
+/// Pure click resolution: on a rising press edge over an item, return its
+/// action. Also returns the new `last_pressed` to track for the next frame.
+fn resolve_click(pointer: Option<Pointer2D>, last_pressed: bool) -> (Option<MenuAction>, bool) {
+    match pointer {
+        Some(p) => {
+            let action = if p.pressed && !last_pressed {
+                MENU_ITEMS
+                    .iter()
+                    .find(|it| in_rect(it.rect, p.position))
+                    .map(|it| it.action)
+            } else {
+                None
+            };
+            (action, p.pressed)
+        }
+        None => (None, false),
+    }
+}
+
+pub struct MainMenuScene {
+    world: World,
+    scene_name: String,
+    /// Pointer from the latest update, used for hover highlighting in render.
+    pointer: Option<Pointer2D>,
+    /// Whether the pointer was pressed last frame (for rising-edge clicks).
+    last_pressed: bool,
+}
+
+impl MainMenuScene {
+    pub fn new() -> Self {
+        let mut world = World::new();
+
+        let player_entity = world.add_entity(());
+
+        let inventory_entity = PlayerInventoryEntity::create(&mut world);
+        PlayerInventoryEntity::set_position_rotation(
+            &mut world,
+            vec3(0.0, -1000.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        );
+
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player_entity,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory_entity,
+        });
+        world.add_unique(QuestInfo::new());
+        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
+        world.add_unique(GlobalEntityMetadata(HashMap::new()));
+        world.add_unique(Time::default());
+
+        Self {
+            world,
+            scene_name: "main_menu".to_owned(),
+            pointer: None,
+            last_pressed: false,
+        }
+    }
+}
+
+impl Default for MainMenuScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameScene for MainMenuScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        _asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+        _command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        self.pointer = input_context.pointer;
+        let (action, last_pressed) = resolve_click(input_context.pointer, self.last_pressed);
+        self.last_pressed = last_pressed;
+
+        match action {
+            Some(MenuAction::NewGame) => {
+                vec![Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                    level_file: NEW_GAME_MISSION.to_owned(),
+                    loc: None,
+                    entities_to_trigger: vec![],
+                })]
+            }
+            Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
+            None => Vec::new(),
+        }
+    }
+
+    fn render(
+        &mut self,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        // The menu is drawn in screen space in `render_per_eye` (which has the
+        // screen size); the 3D scene is empty.
+        (
+            Vec::new(),
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        )
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        _options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        let texture_options = TextureOptions { wrap: false };
+        let mut objs = Vec::new();
+
+        // Full-screen backdrop.
+        let bg = asset_cache.get_ext(&TEXTURE_IMPORTER, "MAIN.PCX", &texture_options);
+        objs.push(SceneObject::screen_space_quad(
+            bg.clone() as Rc<dyn TextureTrait>,
+            vec2(0.0, 0.0),
+            screen_size,
+        ));
+
+        // Clickable items, brighter when hovered.
+        let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon").clone();
+        let pointer_pos = self.pointer.map(|p| p.position);
+        for item in MENU_ITEMS {
+            let hovered = pointer_pos.is_some_and(|pp| in_rect(item.rect, pp));
+            let (min_x, min_y, _, _) = item.rect;
+            let x = min_x * screen_size.x;
+            let y = min_y * screen_size.y;
+            let font_size = 0.045 * screen_size.y;
+            let opacity = if hovered { 1.0 } else { 0.6 };
+            objs.push(SceneObject::screen_space_text(
+                item.label,
+                font.clone(),
+                font_size,
+                opacity,
+                x,
+                y,
+            ));
+        }
+
+        objs
+    }
+
+    fn handle_effects(
+        &mut self,
+        effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        _asset_cache: &mut AssetCache,
+        _audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        effects
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::GlobalEffect(g) => Some(g),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn wants_pointer(&self) -> bool {
+        true
+    }
+
+    fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
+        Vec::new()
+    }
+
+    fn world(&self) -> &World {
+        &self.world
+    }
+
+    fn scene_name(&self) -> &str {
+        &self.scene_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pointer_at(x: f32, y: f32, pressed: bool) -> Option<Pointer2D> {
+        Some(Pointer2D {
+            position: vec2(x, y),
+            pressed,
+        })
+    }
+
+    #[test]
+    fn rising_edge_over_new_game_activates_it() {
+        // Press edge: not pressed last frame, pressed now, over "NEW GAME".
+        let (action, last) = resolve_click(pointer_at(0.5, 0.49, true), false);
+        assert_eq!(action, Some(MenuAction::NewGame));
+        assert!(last);
+    }
+
+    #[test]
+    fn rising_edge_over_quit_activates_it() {
+        let (action, _) = resolve_click(pointer_at(0.5, 0.58, true), false);
+        assert_eq!(action, Some(MenuAction::Quit));
+    }
+
+    #[test]
+    fn held_press_does_not_re_activate() {
+        // Already pressed last frame -> no new activation even over an item.
+        let (action, last) = resolve_click(pointer_at(0.5, 0.49, true), true);
+        assert_eq!(action, None);
+        assert!(last);
+    }
+
+    #[test]
+    fn click_outside_items_does_nothing() {
+        let (action, _) = resolve_click(pointer_at(0.05, 0.05, true), false);
+        assert_eq!(action, None);
+    }
+
+    #[test]
+    fn no_pointer_means_no_action() {
+        let (action, last) = resolve_click(None, true);
+        assert_eq!(action, None);
+        assert!(!last);
+    }
+
+    #[test]
+    fn world_supports_transition_save_data() {
+        // On "New Game", `switch_mission` calls `to_save_data` on the outgoing
+        // scene's world, so the menu world must support it (PlayerInfo,
+        // GlobalTemplateIdMap, ...). This would panic if a unique were missing.
+        let scene = MainMenuScene::new();
+        let _ = crate::save_load::to_save_data(scene.world());
+    }
+}

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -50,21 +50,27 @@ struct MenuItem {
     text_pos: (f32, f32),
 }
 
-// MAIN.PCX has a vertical stack of buttons down the right side. New Game goes in
-// the top button, Quit in the bottom one. Coordinates are normalized to the
-// full-screen backdrop.
+// MAIN.PCX (native 640x480) has a vertical stack of six buttons down the right
+// side; their normalized vertical centers (measured from the art's red marker
+// rows) are 0.078, 0.236, 0.395, 0.553, 0.711, 0.870, each ~0.158 tall, with the
+// left edge at x ~= 0.633. New Game goes in the top button, Quit in the bottom.
+// Text is left-aligned at a common inset and vertically centered on the button
+// (label top = center - font_height/2, with TEXT_FONT_FRAC/2 = 0.02).
+const TEXT_LEFT: f32 = 0.670;
+const TEXT_FONT_FRAC: f32 = 0.04; // font height as a fraction of screen height
+
 const MENU_ITEMS: &[MenuItem] = &[
     MenuItem {
         label: "NEW GAME",
         action: MenuAction::NewGame,
-        rect: (0.635, 0.030, 0.965, 0.155),
-        text_pos: (0.665, 0.072),
+        rect: (0.633, 0.000, 0.965, 0.157),
+        text_pos: (TEXT_LEFT, 0.078 - TEXT_FONT_FRAC / 2.0),
     },
     MenuItem {
         label: "QUIT",
         action: MenuAction::Quit,
-        rect: (0.635, 0.755, 0.965, 0.880),
-        text_pos: (0.755, 0.797),
+        rect: (0.633, 0.791, 0.965, 0.949),
+        text_pos: (TEXT_LEFT, 0.870 - TEXT_FONT_FRAC / 2.0),
     },
 ];
 
@@ -211,7 +217,7 @@ impl GameScene for MainMenuScene {
             let hovered = pointer_pos.is_some_and(|pp| in_rect(item.rect, pp));
             let x = item.text_pos.0 * screen_size.x;
             let y = item.text_pos.1 * screen_size.y;
-            let font_size = 0.04 * screen_size.y;
+            let font_size = TEXT_FONT_FRAC * screen_size.y;
             let opacity = if hovered { 1.0 } else { 0.6 };
             objs.push(SceneObject::screen_space_text(
                 item.label,
@@ -274,21 +280,21 @@ mod tests {
     #[test]
     fn rising_edge_over_new_game_activates_it() {
         // Press edge: not pressed last frame, pressed now, over the top button.
-        let (action, last) = resolve_click(pointer_at(0.8, 0.09, true), false);
+        let (action, last) = resolve_click(pointer_at(0.8, 0.078, true), false);
         assert_eq!(action, Some(MenuAction::NewGame));
         assert!(last);
     }
 
     #[test]
     fn rising_edge_over_quit_activates_it() {
-        let (action, _) = resolve_click(pointer_at(0.8, 0.82, true), false);
+        let (action, _) = resolve_click(pointer_at(0.8, 0.870, true), false);
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
     #[test]
     fn held_press_does_not_re_activate() {
         // Already pressed last frame -> no new activation even over an item.
-        let (action, last) = resolve_click(pointer_at(0.8, 0.09, true), true);
+        let (action, last) = resolve_click(pointer_at(0.8, 0.078, true), true);
         assert_eq!(action, None);
         assert!(last);
     }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -31,6 +31,7 @@ pub mod debug_ragdoll;
 pub mod debug_teleport;
 pub mod debug_turret;
 pub mod hand_pose;
+pub mod main_menu;
 
 pub use cutscene_player::CutscenePlayerScene;
 pub use debug_camera::DebugCameraScene;
@@ -43,6 +44,7 @@ pub use debug_minimal::DebugMinimalScene;
 pub use debug_ragdoll::DebugRagdollScene;
 pub use debug_teleport::DebugTeleportScene;
 pub use debug_turret::DebugTurretScene;
+pub use main_menu::MainMenuScene;
 
 pub struct SceneInitResult {
     pub scene: Box<dyn GameScene>,
@@ -72,6 +74,13 @@ pub fn create_initial_scene(
         });
         return SceneInitResult {
             scene: Box::new(cutscene),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("main_menu") {
+        return SceneInitResult {
+            scene: Box::new(MainMenuScene::new()),
             mission_save_data: HashMap::new(),
         };
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -35,6 +35,10 @@ pub enum GlobalEffect {
 
     // Test the reload functionality (as if saving + loading)
     TestReload,
+
+    // Quit the game (e.g. from the main menu). The runtime is responsible for
+    // observing this via `Game::should_quit` and closing its window.
+    Quit,
 }
 
 #[derive(Clone, Debug)]

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -303,7 +303,9 @@ pub fn main() {
         if lower.ends_with(".bin") || lower.ends_with(".ai") {
             true
         } else {
-            eprintln!("Warning: --debug-hitboxes is only available for .bin/.ai AI meshes. Ignoring flag.");
+            eprintln!(
+                "Warning: --debug-hitboxes is only available for .bin/.ai AI meshes. Ignoring flag."
+            );
             false
         }
     } else {


### PR DESCRIPTION
Slice 3 of the flatscreen/VR split (design: `projects/flatscreen-and-vr-architecture.md`). **Stacked on #296** (targets `slice2-flat-desktop`).

## What's here
A flatscreen **main menu** as the default desktop boot screen, mouse-driven.

**Core (shock2vr):**
- `InputContext` gains an optional **`Pointer2D`** (normalized [0,1] screen coords); `None` in VR. `GameScene::wants_pointer()` lets a scene request a cursor — this is the keystone's input half (Slice 1 did the render half).
- `GlobalEffect::Quit` + `Game::should_quit()` so a scene can request exit.
- **`MainMenuScene`** — draws the original `MAIN.PCX` backdrop with clickable **New Game** / **Quit**, hit-tests the pointer, and emits `TransitionLevel` (→ `earth.mis`) or `Quit`. Click resolution is a pure, unit-tested helper. Registered as the `main_menu` scene.

**desktop_runtime:**
- Boots the main menu when no `--mission` is given (flat); `--vr` still boots `earth.mis` (no pointer there). Shows the OS cursor and feeds `InputContext.pointer` while a scene `wants_pointer`; closes the window on `should_quit`.

## Verification
- 6 Rust unit tests: click rising-edge over each item, held-press doesn't re-fire, click-outside is inert, no-pointer is inert, and the **transition save-data path** (`to_save_data` on the menu world, the one risky bit of New Game).
- Menu renders via `debug_runtime --mission main_menu` (screenshot: MAIN.PCX + items).
- `RUSTFLAGS="-D warnings" cargo check` + `cargo fmt --check` clean.
- **Needs an interactive spot-check** (desktop window, can't drive headlessly): `cargo dr` → main menu; click **New Game** → loads earth.mis; **Quit** → exits.

## Not in this slice
- Matching the click hotspots to MAIN.PCX's baked-in label positions (items are currently overlaid text) — polish.
- Load/Continue/Options; pause / quit-to-menu from in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)