### PR TITLE
feat(physics): upgrade to rapier 0.31 — settling ragdoll + collider hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,9 @@ For debugging visual/rendering changes without a full interactive session:
 
    ```bash
    cargo dv grunt_p.bin --debug-no-render
+   # Overlay the fitted per-joint hitbox shapes (capsules/boxes) on the animated
+   # mesh - physics-free, animatable - to eyeball fit across poses:
+   cargo dv grunt_p.bin --animation <clip> --debug-hitboxes --debug-skeletons
    ```
 
 2. **Debug Runtime** (see `projects/debug-runtime.md`): HTTP-controlled game runtime for programmatic control and introspection:
@@ -171,6 +174,13 @@ For debugging visual/rendering changes without a full interactive session:
    curl "http://127.0.0.1:8080/v1/physics/bodies?entity_id=4"
    curl http://127.0.0.1:8080/v1/physics/bodies/12   # detail by body_id
 
+   # Inspect impulse joints (ragdoll constraint health): per-joint anchor
+   # separation + applied impulse, labeled by skeleton bone. A healthy ball
+   # joint at rest has separation ~0 and a small impulse; persistent values mean
+   # the rig is fighting itself.
+   curl http://127.0.0.1:8080/v1/physics/joints
+   curl http://127.0.0.1:8080/v1/ragdoll/metrics   # per-ragdoll settle metrics
+
    # Trigger discrete input actions (same actions as desktop keybindings)
    curl http://127.0.0.1:8080/v1/input/actions
    curl -X POST http://127.0.0.1:8080/v1/input/action -d '{"action": "PathfindingTestCycle"}'
@@ -183,11 +193,13 @@ For debugging visual/rendering changes without a full interactive session:
    curl -X POST http://127.0.0.1:8080/v1/shutdown
    ```
 
-   **Stepping & determinism**: time-based stepping (`-d '{"duration":"3s"}'`)
-   requires `-H 'Content-Type: application/json'`, and per-frame `delta_time` is
-   real wall-clock - a single frame after an idle period can carry a huge dt.
-   Prefer small frame batches (`{"frames": N}`) for deterministic, dt-independent
-   stepping; don't gate debug-scene logic on accumulated wall-clock time.
+   **Stepping & determinism**: stepping uses a **fixed 60 Hz timestep**, so
+   `{"frames": N}` advances exactly `N/60` s of simulation time and
+   `{"duration":"3s"}` runs exactly `3 * 60` frames - deterministic and
+   independent of HTTP request timing (a settling ragdoll falls at a real rate
+   regardless of how fast you poll). Time-based stepping (`-d '{"duration":"3s"}'`)
+   requires `-H 'Content-Type: application/json'`. Only free-running (not stepping)
+   uses real wall-clock dt.
 
 3. **TypeScript SDK (`tools/shock2-sdk`)** — **preferred for multi-step testing and verification**. A Playwright-style wrapper over the debug runtime HTTP API that handles the full lifecycle: spawning the runtime, waiting for readiness, capturing logs, and automatic shutdown via `await using`. See `tools/shock2-sdk/README.md` for the full API.
 
@@ -218,6 +230,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_camera`           | Test security camera AI behavior             |
    | `debug_turret`           | Test turret AI and targeting                 |
    | `debug_ragdoll`          | Test ragdoll physics                         |
+   | `debug_hitbox`           | View fitted hitbox shapes vs ragdoll colliders across poses |
    | `debug_gloves`           | Test VR hand/glove rendering                 |
    | `debug_teleport`         | Test VR teleport locomotion                  |
    | `debug_joint_constraint` | Test physics joint constraints               |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -370,6 +370,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -466,7 +472,7 @@ dependencies = [
  "log",
  "ndk-build",
  "serde",
- "thiserror",
+ "thiserror 1.0.48",
  "toml",
 ]
 
@@ -733,7 +739,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "stdweb",
- "thiserror",
+ "thiserror 1.0.48",
  "web-sys",
  "windows 0.37.0",
 ]
@@ -782,19 +788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,15 +811,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1099,9 +1083,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dunce"
@@ -1114,6 +1098,15 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1311,6 +1304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1429,168 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "glfw"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1725,26 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1585,7 +1774,7 @@ dependencies = [
  "clap",
  "dark",
  "glob",
- "nalgebra",
+ "nalgebra 0.32.6",
 ]
 
 [[package]]
@@ -1922,7 +2111,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.48",
  "walkdir",
 ]
 
@@ -1936,7 +2125,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.48",
  "walkdir",
 ]
 
@@ -2202,11 +2391,45 @@ checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
 dependencies = [
  "approx 0.5.1",
  "matrixmultiply",
- "nalgebra-macros",
+ "nalgebra-macros 0.2.2",
  "num-complex",
  "num-rational 0.4.1",
  "num-traits",
- "simba",
+ "simba 0.8.1",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx 0.5.1",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros 0.3.0",
+ "num-complex",
+ "num-rational 0.4.1",
+ "num-traits",
+ "simba 0.9.1",
  "typenum",
 ]
 
@@ -2215,6 +2438,17 @@ name = "nalgebra-macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2240,7 +2474,7 @@ dependencies = [
  "jni-sys",
  "ndk-sys 0.3.0",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -2254,7 +2488,7 @@ dependencies = [
  "ndk-sys 0.4.1+23.1.7779620",
  "num_enum",
  "raw-window-handle 0.5.2",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -2267,7 +2501,7 @@ dependencies = [
  "dunce",
  "quick-xml",
  "serde",
- "thiserror",
+ "thiserror 1.0.48",
  "which",
 ]
 
@@ -2652,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -2690,24 +2924,30 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.15.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa342e0cdfc774fed0196714290ba2d85408b8ce9f295c40a0b1e05f3f8256ab"
+checksum = "e99471b7b6870f7fe406d5611dd4b4c9b07aa3e5436b1d27e1515f9832bb0c6b"
 dependencies = [
  "approx 0.5.1",
  "arrayvec",
- "bitflags 1.3.2",
+ "bitflags 2.9.4",
  "downcast-rs",
  "either",
+ "ena",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
  "log",
- "nalgebra",
+ "nalgebra 0.34.2",
  "num-derive 0.4.2",
  "num-traits",
- "rustc-hash 1.1.0",
- "simba",
+ "ordered-float 5.3.0",
+ "rstar",
+ "simba 0.9.1",
  "slab",
  "smallvec",
  "spade",
+ "static_assertions",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2739,7 +2979,7 @@ dependencies = [
  "integer-sqrt",
  "num-traits",
  "rustc-hash 1.1.0",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -2864,6 +3104,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,24 +3188,27 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.19.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ce0398df94b282787ddd36a3a9c7e1ca19fa1e79722a2debc49c9f7c06e889"
+checksum = "68073fdc88f6b709002767ce8deffffb05ac06824bf9f98a23e270bcea64ba9f"
 dependencies = [
  "approx 0.5.1",
  "arrayvec",
- "bit-vec",
- "bitflags 1.3.2",
- "crossbeam",
+ "bit-vec 0.8.0",
+ "bitflags 2.9.4",
  "downcast-rs",
  "log",
- "nalgebra",
+ "nalgebra 0.34.2",
  "num-derive 0.4.2",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "parry3d",
- "rustc-hash 1.1.0",
- "simba",
+ "profiling",
+ "rustc-hash 2.1.1",
+ "simba 0.9.1",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wide",
 ]
 
 [[package]]
@@ -3021,7 +3283,7 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.10",
  "redox_syscall 0.2.16",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -3160,6 +3422,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd6ce569b15c331b1e5fd8cf6adb0bf240678b5f0cdc4d0f41e11683f6feba9"
 dependencies = [
  "archery",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -3521,6 +3794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx 0.5.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3857,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -3870,7 +4162,16 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.48",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3878,6 +4179,17 @@ name = "thiserror-impl"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dark/src/hit_box.rs
+++ b/dark/src/hit_box.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 
 use cgmath::{InnerSpace, Matrix4, Point3, SquareMatrix, Vector3, Vector4};
+use engine::scene::{SceneObject, VertexPosition, color_material, lines_mesh};
 
 use crate::motion::JointId;
 use crate::ss2_bin_ai_loader::SystemShock2AIMesh;
@@ -145,4 +146,170 @@ fn point_segment_distance(p: Vector3<f32>, a: Vector3<f32>, b: Vector3<f32>) -> 
     }
     let t = ((p - a).dot(ab) / len2).clamp(0.0, 1.0);
     (p - (a + ab * t)).magnitude()
+}
+
+// ---------------------------------------------------------------------------
+// Debug rendering
+// ---------------------------------------------------------------------------
+
+/// Number of segments per ring/arc in the capsule wireframe.
+const WIRE_SEGMENTS: usize = 12;
+
+/// Build a line-list wireframe of the per-joint fitted shapes, each transformed
+/// by its joint's world matrix (`world_joints[joint_id]`). Mirrors
+/// `Skeleton::debug_draw`: a single `SceneObject` of colored lines that overlays
+/// the animated mesh. Shared by `dark_viewer --debug-hitboxes` and the
+/// `debug_hitbox` scene so both render exactly what `fit_hit_box_shapes`
+/// produced (no physics round-trip), which separates a fit/mapping bug from a
+/// ragdoll-conversion bug.
+pub fn draw_debug_hit_box_shapes(
+    shapes: &HashMap<JointId, HitBoxShape>,
+    world_joints: &[Matrix4<f32>],
+    color: Vector3<f32>,
+) -> Vec<SceneObject> {
+    let mut verts: Vec<VertexPosition> = Vec::new();
+
+    for (joint, shape) in shapes {
+        let idx = *joint as usize;
+        if idx >= world_joints.len() {
+            continue;
+        }
+        let xform = world_joints[idx];
+        match shape {
+            HitBoxShape::Cuboid {
+                half_extents,
+                center,
+            } => append_box_lines(&mut verts, &xform, *center, *half_extents),
+            HitBoxShape::Capsule { a, b, radius } => {
+                append_capsule_lines(&mut verts, &xform, *a, *b, *radius)
+            }
+        }
+    }
+
+    if verts.is_empty() {
+        return Vec::new();
+    }
+
+    vec![SceneObject::new(
+        color_material::create(color),
+        Box::new(lines_mesh::create(verts)),
+    )]
+}
+
+/// Transform a joint-local point to world space (homogeneous, w=1).
+fn xform_point(xform: &Matrix4<f32>, p: Vector3<f32>) -> Vector3<f32> {
+    let c = xform * Vector4::new(p.x, p.y, p.z, 1.0);
+    Vector3::new(c.x, c.y, c.z)
+}
+
+fn push_segment(verts: &mut Vec<VertexPosition>, xform: &Matrix4<f32>, a: Vector3<f32>, b: Vector3<f32>) {
+    verts.push(VertexPosition {
+        position: xform_point(xform, a),
+    });
+    verts.push(VertexPosition {
+        position: xform_point(xform, b),
+    });
+}
+
+/// 12 edges of an axis-aligned box (joint-local), transformed by `xform`.
+fn append_box_lines(
+    verts: &mut Vec<VertexPosition>,
+    xform: &Matrix4<f32>,
+    center: Vector3<f32>,
+    he: Vector3<f32>,
+) {
+    // 8 corners.
+    let mut corner = [Vector3::new(0.0, 0.0, 0.0); 8];
+    let mut i = 0;
+    for sx in [-1.0f32, 1.0] {
+        for sy in [-1.0f32, 1.0] {
+            for sz in [-1.0f32, 1.0] {
+                corner[i] = center + Vector3::new(sx * he.x, sy * he.y, sz * he.z);
+                i += 1;
+            }
+        }
+    }
+    // Index layout: bit2=x, bit1=y, bit0=z.
+    let edges = [
+        (0, 1),
+        (0, 2),
+        (0, 4),
+        (1, 3),
+        (1, 5),
+        (2, 3),
+        (2, 6),
+        (3, 7),
+        (4, 5),
+        (4, 6),
+        (5, 7),
+        (6, 7),
+    ];
+    for (s, e) in edges {
+        push_segment(verts, xform, corner[s], corner[e]);
+    }
+}
+
+/// Capsule wireframe (joint-local) between `a` and `b`: end rings, longitudinal
+/// lines, and two great-circle arcs over each hemispherical cap.
+fn append_capsule_lines(
+    verts: &mut Vec<VertexPosition>,
+    xform: &Matrix4<f32>,
+    a: Vector3<f32>,
+    b: Vector3<f32>,
+    radius: f32,
+) {
+    let axis_vec = b - a;
+    let len = axis_vec.magnitude();
+    if len < 1e-5 {
+        return;
+    }
+    let axis = axis_vec / len;
+    // Two unit vectors perpendicular to the axis.
+    let mut helper = Vector3::new(0.0, 1.0, 0.0);
+    if axis.dot(helper).abs() > 0.99 {
+        helper = Vector3::new(1.0, 0.0, 0.0);
+    }
+    let u = axis.cross(helper).normalize();
+    let v = axis.cross(u).normalize();
+
+    let ring = |center: Vector3<f32>| -> Vec<Vector3<f32>> {
+        (0..WIRE_SEGMENTS)
+            .map(|k| {
+                let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::TAU;
+                center + (u * t.cos() + v * t.sin()) * radius
+            })
+            .collect()
+    };
+
+    let ring_a = ring(a);
+    let ring_b = ring(b);
+
+    // End rings.
+    for r in [&ring_a, &ring_b] {
+        for k in 0..WIRE_SEGMENTS {
+            push_segment(verts, xform, r[k], r[(k + 1) % WIRE_SEGMENTS]);
+        }
+    }
+    // Longitudinal lines at 4 evenly spaced angles.
+    for k in (0..WIRE_SEGMENTS).step_by(WIRE_SEGMENTS / 4) {
+        push_segment(verts, xform, ring_a[k], ring_b[k]);
+    }
+    // Hemispherical caps: semicircle arcs over each end, in the (axis,u) and
+    // (axis,v) planes, bulging away from the segment.
+    let arc = |center: Vector3<f32>, plane: Vector3<f32>, cap_dir: Vector3<f32>| {
+        let mut pts = Vec::with_capacity(WIRE_SEGMENTS + 1);
+        for k in 0..=WIRE_SEGMENTS {
+            let t = (k as f32) / (WIRE_SEGMENTS as f32) * std::f32::consts::PI;
+            pts.push(center + (plane * t.cos() + cap_dir * t.sin()) * radius);
+        }
+        pts
+    };
+    for (center, cap_dir) in [(a, -axis), (b, axis)] {
+        for plane in [u, v] {
+            let pts = arc(center, plane, cap_dir);
+            for k in 0..WIRE_SEGMENTS {
+                push_segment(verts, xform, pts[k], pts[k + 1]);
+            }
+        }
+    }
 }

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, rc::Rc};
 
 use crate::{
+    hit_box::{HitBoxShape, fit_hit_box_shapes},
     motion::{AnimationClip, AnimationPlayer},
     ss2_bin_ai_loader::{self, SystemShock2AIMesh},
     ss2_bin_obj_loader::{self, SystemShock2ObjectMesh, Vhot},
@@ -49,6 +50,7 @@ pub struct AnimatedModel {
     skeleton: Rc<Skeleton>,
     scene_objects: Vec<SceneObject>,
     hit_boxes: Rc<HashMap<u32, Aabb3<f32>>>,
+    hit_box_shapes: Rc<HashMap<u32, HitBoxShape>>,
     vhots: Vec<Vhot>,
 }
 
@@ -96,6 +98,7 @@ impl AnimatedModel {
             skeleton: self.skeleton.clone(),
             scene_objects: new_scene_objects,
             hit_boxes: self.hit_boxes.clone(),
+            hit_box_shapes: self.hit_box_shapes.clone(),
             vhots: self.vhots.clone(),
         }
     }
@@ -116,6 +119,7 @@ impl AnimatedModel {
             skeleton: model.skeleton.clone(),
             scene_objects: new_scene_objects,
             hit_boxes: model.hit_boxes.clone(),
+            hit_box_shapes: model.hit_box_shapes.clone(),
             vhots: model.vhots.clone(),
         }
     }
@@ -154,6 +158,7 @@ impl Model {
                     skeleton: Rc::new(skeleton),
                     scene_objects,
                     hit_boxes: Rc::new(hit_boxes),
+                    hit_box_shapes: Rc::new(HashMap::new()),
                     vhots: static_mesh.vhots.clone(),
                 }),
             }
@@ -176,6 +181,7 @@ impl Model {
     ) -> Model {
         let (scene_objects, hit_boxes) =
             ss2_bin_ai_loader::to_scene_objects(&ai_mesh, &skeleton, asset_cache);
+        let hit_box_shapes = fit_hit_box_shapes(&ai_mesh, &skeleton);
         Model {
             transform: Matrix4::identity(),
             inner: InnerModel::Animated(AnimatedModel {
@@ -183,6 +189,7 @@ impl Model {
                 skeleton,
                 scene_objects,
                 hit_boxes: Rc::new(hit_boxes),
+                hit_box_shapes: Rc::new(hit_box_shapes),
                 vhots: vec![],
             }),
         }
@@ -206,6 +213,7 @@ impl Model {
                     skeleton: Rc::new(skeleton),
                     scene_objects,
                     hit_boxes: Rc::new(hit_boxes),
+                    hit_box_shapes: Rc::new(HashMap::new()),
                     vhots: vec![],
                 }),
             }
@@ -241,6 +249,16 @@ impl Model {
         match &self.inner {
             InnerModel::Animated(animated_model) => animated_model.vhots.clone(),
             InnerModel::Static(static_model) => static_model.vhots.clone(),
+        }
+    }
+
+    /// Per-joint fitted collision shapes (capsule-toward-child / box), the shared
+    /// source of truth for the ragdoll and damage hitboxes. Empty for static or
+    /// non-AI-bin models.
+    pub fn hit_box_shapes(&self) -> Rc<HashMap<u32, HitBoxShape>> {
+        match &self.inner {
+            InnerModel::Animated(animated_model) => animated_model.hit_box_shapes.clone(),
+            InnerModel::Static(_) => Rc::new(HashMap::new()),
         }
     }
 

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -58,11 +58,21 @@ The debug runtime binds to `127.0.0.1:8080` (localhost only) and provides a REST
 | Raycast (`/v1/physics/raycast`)                 | ✅     |
 | Physics body listing (`/v1/physics/bodies`)     | ✅     |
 | Physics body detail (`/v1/physics/bodies/{id}`) | ✅     |
+| Impulse joint diagnostics (`/v1/physics/joints`) | ✅    |
+| Per-ragdoll metrics (`/v1/ragdoll/metrics`)     | ✅     |
 | Screenshot capture (`/v1/screenshot`)           | ✅     |
 | macOS Retina scaling fix                        | ✅     |
 | Input state read (`/v1/control/input`)          | ✅     |
 | Input state write (`/v1/control/input` POST)    | ✅     |
 | Multi-level testing (earth.mis, medsci2.mis)    | ✅     |
+
+**Deterministic stepping (2026-06-18):** `/v1/step` advances at a fixed 60 Hz
+timestep, so `{"frames":N}` == N/60 s of sim time and `{"duration":T}` runs
+exactly T·60 frames, independent of HTTP request timing. (Previously it used the
+real wall-clock dt between requests, which made physics-settle measurements —
+e.g. a ragdoll falling — erratic.) `/v1/physics/joints` reports each impulse
+joint's anchor separation + applied impulse (bone-labeled) for ragdoll
+constraint diagnostics.
 
 ### Phase 5: Game Commands 🔴 NOT STARTED
 

--- a/projects/hitbox_improvements.md
+++ b/projects/hitbox_improvements.md
@@ -51,31 +51,69 @@ Baseline numbers (GRUNT_P): bone coverage **aabb 59% → fitted 98%**, vertex
 coverage **99%**, overall overlap **4%** (worst: LThigh 24%, due partly to the
 skeleton hierarchy quirk below). MONKEY/ASSASSIN similar.
 
+## Analyzer verification (all 75 creature meshes, 2026-06-17)
+
+Ran `hitbox_analyzer` across every creature. **Fit/coverage is essentially solved**:
+fitted bone coverage **81–100%** (only 3-joint *held weapons* like `WRENCH_H` sit
+at ~81%), vertex (surface) coverage **97–100%** everywhere. No coverage work left
+on the actual creatures.
+
+**Overlap is the only remaining tuning lever, and it's localized:**
+- humanoids (grunts, corpses, players, assassin, …): **2–4%** — already good.
+- monkeys / headless / `exphazhh` / `shodan`: 7–14%.
+- overlords (`OVERLORD`/`OVERLORO`/`overlote`): **26–31%** — a big root cuboid
+  (`j0` half ≈ 1.07×0.95×0.86) that all limb capsules sit inside, *plus* the
+  hub-topology artifact (limbs are non-adjacent to the root in the metric).
+- robots (`secbot`/`mainbot`/`mpbot`/`prototest`): **37–38%** — bulky boxy bodies
+  give fat **max-perpendicular-distance** capsule radii (e.g. `secbot` LToe r=0.90,
+  RShoulder r=0.68) packed around a compact torso.
+- `test.bin`: **69%** — junk/test mesh; one stray vertex blows a capsule to r=2.21.
+
+Two takeaways the doc didn't have: (a) the **max-distance radius** is the overlap
+culprit for robots/degenerate meshes — a high-percentile radius (lever #4) would
+target exactly those while leaving humanoids unchanged; (b) much of the
+overlord/robot overlap is the **hub-topology metric artifact** (#5), so fix the
+analyzer's adjacency before tuning shapes or you'll chase a phantom.
+
 ## Open issues / next work
 
 1. **Runtime capsule misplacement — thighs don't connect torso→knee.** In
    `debug_ragdoll --debug-physics` some capsules (notably the thighs) point off-
    axis and don't reach the child body, even though the **bind-pose analyzer shows
-   100% coverage**. So the *fit* is right but the *runtime placement* is wrong —
-   the all-bind analyzer can't see it. Hypotheses to chase:
-   - **Bind-vs-spawn frame mismatch:** the fitted capsule endpoint `b` is computed
-     in the bind skeleton frame (`fit_hit_box_shapes` uses
-     `skeleton.world_transforms()`), but ragdoll bodies spawn in the *death/animated*
-     pose (`RuntimePropJointTransforms`). Candidate fix: re-derive the capsule far
-     endpoint in the ragdoll from the actual spawn transforms (single-child offset
-     in the joint's current-local frame), keeping the radius from the shape. (A
-     partial attempt was started and reverted to keep the branch clean.)
-   - **Joint misconfigured in hitbox→ragdoll conversion** (user hypothesis): verify
-     the per-joint body orientation / collider frame used when converting the shape
-     to a Rapier collider matches the joint frame the mesh skins with.
-   - Add a non-bind check to the analyzer (or a `debug_hitboxes` scene, below) so
-     this class of bug is catchable offline.
+   100% coverage**. So the *fit* is right but the *runtime placement* is wrong.
+
+   **Analysis (2026-06-17): the doc's leading "bind-vs-spawn" hypothesis is almost
+   certainly NOT the cause.** Working the math: `fit_hit_box_shapes` sets the
+   capsule far endpoint `b = inv(bind_world[parent]) · bind_world[child]`, which
+   reduces to the child's *local bone offset* `L`. At spawn the body is oriented at
+   `R_anim[parent]`, so the capsule points along `R_anim[parent]·b = R_anim[parent]·L
+   = child_anim − parent_anim` — i.e. **reach is pose-independent** and `b` need not
+   be re-derived. The real suspect is the **conversion**: `add_ragdoll` sets body
+   orientation via `get_rotation_from_matrix` (`util.rs`), which shoves the raw
+   upper-3×3 into `Matrix3→Quaternion` with **no orthonormalization**. If the joint
+   world matrices carry any scale/shear (these meshes use `SCALE_FACTOR`), the
+   extracted rotation is wrong *and* the unscaled local `b` is the wrong length →
+   capsules point off-axis and fall short. This is the hitbox→ragdoll conversion,
+   not the joint/hitbox mapping.
+
+   The new `debug_hitbox` scene (below) renders both placements side by side to
+   confirm: **green** = shapes by the full joint matrix (tracks the mesh), **red** =
+   shapes by `add_ragdoll`'s decomposed `(position, get_rotation_from_matrix)`.
+   Where red diverges from green, the conversion is at fault.
 2. **Wire `HitBoxShape` into `HitBoxManager`** (damage hitboxes). `add_kinematic`
    currently takes a box size; needs capsule support. Fixes location-based damage
    coverage too (same root cause).
-3. **`debug_hitboxes` scene** — spawn a creature and render its colliders in a few
-   poses (bind + a couple animated) to eyeball fit and catch the runtime-placement
-   class of bug. (User-requested.)
+3. **`debug_hitbox` scene** — ✅ **built.** `cargo dbgr --mission debug_hitbox`
+   spawns a creature and overlays, every frame, the fitted shapes placed two ways:
+   **green** by the full joint matrix (tracks the mesh) and **red** by the ragdoll's
+   decomposed `(position, get_rotation_from_matrix)`. Cycle animation poses with the
+   `DebugHitboxCyclePose` input action (HTTP: `POST /v1/input/action`), so it's
+   drivable headlessly via the debug runtime. Composes with `--debug-physics` /
+   `--debug-skeletons`. The shared wireframe renderer is
+   `dark::hit_box::draw_debug_hit_box_shapes`, also wired into
+   `dark_viewer --debug-hitboxes` (physics-free, animatable via `--animation`) as
+   the fastest fit-only diagnostic. Remaining: act on the red/green divergence to
+   fix the conversion (`get_rotation_from_matrix` / scale handling).
 4. **Overlap / bounds tuning** — overall overlap is low (4%) but some shapes are
    loose (LThigh 24%; head bounds look big visually). Levers: tighten capsule
    radius (e.g. high-percentile instead of max vertex distance), inset endpoints,

--- a/projects/hitbox_improvements.md
+++ b/projects/hitbox_improvements.md
@@ -1,0 +1,95 @@
+# Hitbox Improvements
+
+Split out from `projects/ragdoll.md`. The physics **ragdoll core is working**
+(no explosion, settles, per-bone capsule colliders, joint limits, self-collision,
+single-corpse death handoff). What remains is getting the **per-joint collision
+shapes (hitboxes) correctly fit and tuned**, and using them consistently for both
+the ragdoll and location-based damage.
+
+## Background: how creature hitboxes work
+
+- Creature AI meshes (LGMM `.bin`, `Data/res/mesh/*.BIN`) store vertices in
+  **joint-local space** — each joint's verts cluster around that joint's origin
+  (confirmed by comparing per-joint vertex-AABB centers ≈ origin to the joints'
+  world positions). Skinning = `joint_transform * vert` (the skeleton transforms,
+  `Skeleton::get_transforms`/`world_transforms`, are the raw `global_transforms`
+  with **no inverse-bind**).
+- The Dark engine has **no authored per-joint collision data** (whole-body
+  collision is a 1-2 sphere "SphereHat"/OBB; damage is a mesh-polygon raycast →
+  segment index). So mesh-derived shapes are the source of truth. (See the
+  reference-engine notes in `projects/ragdoll.md`.)
+
+## What's been built
+
+### Shared shape: `dark::hit_box`
+
+`HitBoxShape` (`Cuboid { half_extents, center }` | `Capsule { a, b, radius }`,
+joint-local) + `fit_hit_box_shapes(mesh, skeleton)`:
+- joint with a **single child** → capsule spanning toward that child (covers the
+  bone), radius = max perpendicular distance of the joint's verts to the axis;
+- leaf / branching joints → vertex AABB box.
+
+This is the **single source of truth**, consumed by:
+- `RagDollManager` (`rag_doll.rs`) — ✅ done (PR #291): builds `SharedShape::capsule`/
+  `cuboid` per joint, density for ~uniform mass.
+- `hitbox_analyzer` (tool) — ✅ validates fit/coverage/overlap.
+- `HitBoxManager` (`hit_boxes.rs`, damage) — ❌ **not yet**; still uses the old
+  per-joint AABB (`model.get_hit_boxes()`), so location-based damage volumes are
+  still under-covering.
+
+### Tool: `hitbox_analyzer`
+
+`cargo run -p hitbox_analyzer -- <mesh.bin | Data/res/mesh>`. Per creature:
+- **bone-segment coverage** (legacy AABB vs fitted) — fraction of each bone
+  (parent→child) inside the union of shapes;
+- **vertex (surface) coverage** — fraction of skinned verts inside the union
+  (sensitive to radius, unlike segment coverage);
+- **shape overlap** — fraction of each shape's volume inside a non-adjacent shape;
+- per-joint fitted shape dump.
+
+Baseline numbers (GRUNT_P): bone coverage **aabb 59% → fitted 98%**, vertex
+coverage **99%**, overall overlap **4%** (worst: LThigh 24%, due partly to the
+skeleton hierarchy quirk below). MONKEY/ASSASSIN similar.
+
+## Open issues / next work
+
+1. **Runtime capsule misplacement — thighs don't connect torso→knee.** In
+   `debug_ragdoll --debug-physics` some capsules (notably the thighs) point off-
+   axis and don't reach the child body, even though the **bind-pose analyzer shows
+   100% coverage**. So the *fit* is right but the *runtime placement* is wrong —
+   the all-bind analyzer can't see it. Hypotheses to chase:
+   - **Bind-vs-spawn frame mismatch:** the fitted capsule endpoint `b` is computed
+     in the bind skeleton frame (`fit_hit_box_shapes` uses
+     `skeleton.world_transforms()`), but ragdoll bodies spawn in the *death/animated*
+     pose (`RuntimePropJointTransforms`). Candidate fix: re-derive the capsule far
+     endpoint in the ragdoll from the actual spawn transforms (single-child offset
+     in the joint's current-local frame), keeping the radius from the shape. (A
+     partial attempt was started and reverted to keep the branch clean.)
+   - **Joint misconfigured in hitbox→ragdoll conversion** (user hypothesis): verify
+     the per-joint body orientation / collider frame used when converting the shape
+     to a Rapier collider matches the joint frame the mesh skins with.
+   - Add a non-bind check to the analyzer (or a `debug_hitboxes` scene, below) so
+     this class of bug is catchable offline.
+2. **Wire `HitBoxShape` into `HitBoxManager`** (damage hitboxes). `add_kinematic`
+   currently takes a box size; needs capsule support. Fixes location-based damage
+   coverage too (same root cause).
+3. **`debug_hitboxes` scene** — spawn a creature and render its colliders in a few
+   poses (bind + a couple animated) to eyeball fit and catch the runtime-placement
+   class of bug. (User-requested.)
+4. **Overlap / bounds tuning** — overall overlap is low (4%) but some shapes are
+   loose (LThigh 24%; head bounds look big visually). Levers: tighten capsule
+   radius (e.g. high-percentile instead of max vertex distance), inset endpoints,
+   special-case head/leaf joints. Use vertex-coverage as the guard so tightening
+   doesn't drop coverage.
+5. **Skeleton hierarchy quirk** — the humanoid skeleton has joint 8 ("Neck") as a
+   hub whose children include the thighs (`8:Neck->6:LThigh`), so anatomically
+   adjacent parts (thigh/abdomen) count as *non-adjacent* in the overlap metric and
+   the parent→child bone direction is unintuitive. Worth understanding before
+   over-tuning overlap.
+
+## Status of PRs (as of writing)
+
+Ragdoll stack merged through #284. Hitbox chain (stacked, in review):
+`#289 coverage metric` ← `#290 shared fitter` ← `#291 ragdoll capsules`. The
+analyzer overlap/vertex-coverage metrics are a further increment on top
+(`feat/hitbox-overlap-tune`), to be PR'd.

--- a/projects/hitbox_improvements.md
+++ b/projects/hitbox_improvements.md
@@ -77,29 +77,25 @@ analyzer's adjacency before tuning shapes or you'll chase a phantom.
 
 ## Open issues / next work
 
-1. **Runtime capsule misplacement — thighs don't connect torso→knee.** In
-   `debug_ragdoll --debug-physics` some capsules (notably the thighs) point off-
-   axis and don't reach the child body, even though the **bind-pose analyzer shows
-   100% coverage**. So the *fit* is right but the *runtime placement* is wrong.
+1. **Construction is correct — the "thigh misplacement" is NOT a construction
+   bug (resolved 2026-06-17).** Verified end-to-end with the new `debug_hitbox`
+   scene and the actual ragdoll:
+   - **Fit** is right (green overlay tracks the mesh limbs in every pose; analyzer
+     100% coverage).
+   - **Conversion is faithful.** The scene's *red* overlay (shapes placed by
+     `add_ragdoll`'s decomposed `(position, get_rotation_from_matrix)`) was measured
+     against *green* (shapes by the full joint matrix) for **every joint**:
+     `green ≡ red`, with all joint matrices reporting column scale **1.000** and a
+     **unit** quaternion. So `get_rotation_from_matrix` is *not* scale-contaminated
+     here and the earlier "bind-vs-spawn / scale" hypotheses are both **wrong**.
+   - **`debug_ragdoll --debug-physics` at the spawn frame** shows all Rapier
+     colliders — head, torso boxes, arms, **thighs**, feet — correctly on the mesh.
 
-   **Analysis (2026-06-17): the doc's leading "bind-vs-spawn" hypothesis is almost
-   certainly NOT the cause.** Working the math: `fit_hit_box_shapes` sets the
-   capsule far endpoint `b = inv(bind_world[parent]) · bind_world[child]`, which
-   reduces to the child's *local bone offset* `L`. At spawn the body is oriented at
-   `R_anim[parent]`, so the capsule points along `R_anim[parent]·b = R_anim[parent]·L
-   = child_anim − parent_anim` — i.e. **reach is pose-independent** and `b` need not
-   be re-derived. The real suspect is the **conversion**: `add_ragdoll` sets body
-   orientation via `get_rotation_from_matrix` (`util.rs`), which shoves the raw
-   upper-3×3 into `Matrix3→Quaternion` with **no orthonormalization**. If the joint
-   world matrices carry any scale/shear (these meshes use `SCALE_FACTOR`), the
-   extracted rotation is wrong *and* the unscaled local `b` is the wrong length →
-   capsules point off-axis and fall short. This is the hitbox→ragdoll conversion,
-   not the joint/hitbox mapping.
-
-   The new `debug_hitbox` scene (below) renders both placements side by side to
-   confirm: **green** = shapes by the full joint matrix (tracks the mesh), **red** =
-   shapes by `add_ragdoll`'s decomposed `(position, get_rotation_from_matrix)`.
-   Where red diverges from green, the conversion is at fault.
+   What *does* go wrong: after ~15+ frames of simulation a single **cuboid** body
+   separates and floats off (`rag_settle` screenshot). That is a **dynamics**
+   problem (a body the joint chain fails to hold), not collider construction. Next
+   step is to identify the detaching body/joint (root/abdomen cuboid?) and why its
+   impulse joint doesn't constrain it — *not* a change to the placement math.
 2. **Wire `HitBoxShape` into `HitBoxManager`** (damage hitboxes). `add_kinematic`
    currently takes a box size; needs capsule support. Fixes location-based damage
    coverage too (same root cause).
@@ -112,8 +108,9 @@ analyzer's adjacency before tuning shapes or you'll chase a phantom.
    `--debug-skeletons`. The shared wireframe renderer is
    `dark::hit_box::draw_debug_hit_box_shapes`, also wired into
    `dark_viewer --debug-hitboxes` (physics-free, animatable via `--animation`) as
-   the fastest fit-only diagnostic. Remaining: act on the red/green divergence to
-   fix the conversion (`get_rotation_from_matrix` / scale handling).
+   the fastest fit-only diagnostic. Used to prove construction is correct (#1);
+   now the regression check for the ragdoll-dynamics work (red should stay on
+   green, colliders should stay on the mesh).
 4. **Overlap / bounds tuning** — overall overlap is low (4%) but some shapes are
    loose (LThigh 24%; head bounds look big visually). Levers: tighten capsule
    radius (e.g. high-percentile instead of max vertex distance), inset endpoints,

--- a/projects/ragdoll.md
+++ b/projects/ragdoll.md
@@ -7,6 +7,60 @@
 - Spawn a dedicated ragdoll entity on death that inherits the deceased model pose, then simulate it using Rapier rigid bodies and joints.
 - Keep visual skinning and hit detection in sync with the simulated skeleton so the corpse interacts believably with the world.
 
+## Update (2026-06-18): the rig settles — rapier 0.31 + compliant joints
+
+The 2026-06-15 work below got the rig *built*, but it never came to rest: it
+perpetually jittered (`max_linear_speed` stuck at 3–7 even after landing). Root
+cause and fixes, all verified headlessly via the debug runtime:
+
+- **Not detachment or self-collision — the joints injected energy.** The new
+  `GET /v1/physics/joints` endpoint (per-joint anchor separation + applied
+  impulse, labeled by bone) showed the impulse joints holding a permanent
+  unsatisfiable residual at "rest". rapier's near-rigid default joint stiffness
+  (`SpringCoefficients.natural_frequency` defaults to 1e6) rigidly fights that
+  residual every step on the hub-and-spoke skeleton and pumps energy.
+- **Fix: upgrade rapier 0.19 → 0.31 + compliant joints.** 0.31 brings the v0.29
+  velocity-solver rework and v0.31 per-joint `softness`. Compliant joints
+  (`SpringCoefficients { natural_frequency: 60, damping_ratio: 2.0 }`) absorb the
+  residual instead of fighting it — the rig now collapses into a heap and rests.
+  (0.31 is the last nalgebra-based release; 0.32+ migrates the math to glam, a
+  much larger change, so we pinned 0.31. Note: higher `damping_ratio` = *more*
+  compliant per rapier's API.)
+- **Dedupe joints.** The Dark skeleton lists some joints twice (a torso's main
+  joint is also a fixed point on the parent torso; see `ss2_skeleton::create`),
+  building a *duplicate* impulse joint between the same body pair (pelvis hub 8 ↔
+  abdomen 18) and over-constraining the hub. Now exactly one joint per child body.
+- **Degenerate colliders crashed the new broad-phase.** rapier 0.31's BVH
+  broad-phase panics (`parry bvh_binned_build`, "index out of bounds") on a
+  collider with a non-finite/zero AABB. We were creating such colliders for some
+  objects (zero-size triggers; earth.mis entity 7 had an *infinite* dimension) —
+  `add_kinematic`'s `size >= 0.0` assert passed both 0 and ∞. The old SAP
+  broad-phase tolerated them; the BVH one does not. **Fix:**
+  `sanitize_collider_size` clamps every cuboid collider's size to a finite,
+  positive, bounded range at the `add_dynamic`/`add_kinematic` boundary.
+- **Deterministic stepping.** The debug runtime now steps at a fixed 60 Hz, so
+  `{"frames":N}` advances a real, predictable amount of sim time (it used to use
+  wall-clock dt, which made ragdoll-settle measurements erratic).
+
+### Known remaining issue: the hips sag (~4 cm)
+
+`GET /v1/physics/joints` localizes it: only the two hip joints (bone 8 → 6/7)
+hold ~4 cm separation while every other joint closes to <0.5 cm — the heavy
+thighs stretch the compliant joint under gravity. Stiffness tuning is
+non-monotonic (stiffer re-introduces energy). Candidate fixes (untried / partly
+tried): per-joint stiffer hips/shoulders; child-origin joint anchoring (worse on
+0.19, may behave on 0.31's solver); or giving the tiny pelvis-hub body real
+inertia.
+
+### New diagnostic tooling (this effort)
+
+- `GET /v1/physics/joints` — per-impulse-joint anchor separation + impulse, bone-labeled.
+- `debug_hitbox` scene + `dark_viewer --debug-hitboxes` — overlay fitted hitbox
+  shapes (green) vs the ragdoll's decomposed collider placement (red) to separate
+  a fit/mapping bug from a conversion bug; the `DebugHitboxCyclePose` input action
+  cycles poses (HTTP-drivable). The construction/fit was verified correct; the
+  remaining issues are dynamics, not placement.
+
 ## Status & Investigation Log (2026-06-15)
 
 The rig had been wired end-to-end (Parts 3–5 below marked "✅") but was not

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -87,6 +87,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<RagdollMetricsResult>,
     },
 
+    /// List impulse joints with anchor separation + applied impulse
+    ListPhysicsJoints {
+        reply: oneshot::Sender<PhysicsJointsResult>,
+    },
+
     /// Shutdown the debug runtime gracefully
     Shutdown,
 }
@@ -187,6 +192,25 @@ pub struct RagdollMetricsEntry {
     pub min_y: f32,
     pub max_nonadjacent_overlap: f32,
     pub max_drift: f32,
+}
+
+/// Impulse joint diagnostics (ragdoll constraint health).
+#[derive(Debug, Serialize)]
+pub struct PhysicsJointsResult {
+    pub joints: Vec<PhysicsJointEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PhysicsJointEntry {
+    pub body1_id: u32,
+    pub body2_id: u32,
+    pub bone1: Option<u32>,
+    pub bone2: Option<u32>,
+    pub anchor1: [f32; 3],
+    pub anchor2: [f32; 3],
+    pub separation: f32,
+    pub linear_impulse: f32,
+    pub angular_impulse: f32,
 }
 
 /// Detailed information about a physics body

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -194,6 +194,7 @@ async fn start_http_server(
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
+        .route("/v1/physics/joints", get(list_physics_joints))
         .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
         .route("/v1/control/input", get(get_input_state))
         .route("/v1/control/input", axum::routing::post(set_input_channel))
@@ -1052,6 +1053,31 @@ fn process_command(
                 tracing::warn!("Failed to send ragdoll metrics - receiver dropped");
             }
         }
+        RuntimeCommand::ListPhysicsJoints { reply } => {
+            let joints = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .list_physics_joints()
+                        .into_iter()
+                        .map(|j| commands::PhysicsJointEntry {
+                            body1_id: j.body1_id,
+                            body2_id: j.body2_id,
+                            bone1: j.bone1,
+                            bone2: j.bone2,
+                            anchor1: j.anchor1,
+                            anchor2: j.anchor2,
+                            separation: j.separation,
+                            linear_impulse: j.linear_impulse,
+                            angular_impulse: j.angular_impulse,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if let Err(_) = reply.send(commands::PhysicsJointsResult { joints }) {
+                tracing::warn!("Failed to send physics joints - receiver dropped");
+            }
+        }
         RuntimeCommand::GetInput(reply) => {
             // Get current input state from the debug scene
             if let Some(debuggable) = game.debug_scene() {
@@ -1653,6 +1679,26 @@ async fn get_ragdoll_metrics(
         Err(_) => {
             tracing::error!("Failed to receive ragdoll metrics - sender dropped");
             Json(RagdollMetricsResult { ragdolls: vec![] })
+        }
+    }
+}
+
+/// HTTP handler for impulse-joint diagnostics (ragdoll constraint health).
+async fn list_physics_joints(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Json<commands::PhysicsJointsResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if let Err(_) = command_tx.send(RuntimeCommand::ListPhysicsJoints { reply: reply_tx }) {
+        tracing::error!("Failed to send ListPhysicsJoints command - game loop receiver dropped");
+        return Json(commands::PhysicsJointsResult { joints: vec![] });
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive physics joints - sender dropped");
+            Json(commands::PhysicsJointsResult { joints: vec![] })
         }
     }
 }

--- a/shock2vr/Cargo.toml
+++ b/shock2vr/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.17.0"
 ordered-float = "3.4.0"
 pathfinding = "4"
 pcx = "0.2.3"
-rapier3d = { version = "0.19.0", features = ["debug-render"] }
+rapier3d = { version = "0.31", features = ["debug-render"] }
 serde_json = "1.0.91"
 shipyard = "0.6.2"
 dark = { path = "../dark" }

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -327,8 +327,19 @@ impl RagDollManager {
             body_handles.push(handle);
         }
 
+        // A child body must be jointed to its parent exactly once. The Dark
+        // skeleton legitimately lists some joints twice - once as a torso's main
+        // joint and once as a fixed point on the parent torso (see
+        // ss2_skeleton::create) - which would otherwise create a duplicate
+        // impulse joint between the same body pair and over-constrain the hub
+        // (e.g. the abdomen, joint 18, under the pelvis hub, joint 8).
+        let mut jointed_children: HashMap<u32, ()> = HashMap::new();
+
         for bone in &bones {
             if let Some(parent_id) = bone.parent_id {
+                if jointed_children.insert(bone.joint_id as u32, ()).is_some() {
+                    continue;
+                }
                 let parent_handle = match joint_to_body.get(&(parent_id as u32)) {
                     Some(handle) => *handle,
                     None => continue,

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, SquareMatrix, Vector3, vec3};
-use collision::Aabb;
+use dark::hit_box::HitBoxShape;
 use dark::model::Model;
 use engine::scene::SceneObject;
 use rapier3d::{
-    na::{Translation3, UnitQuaternion},
+    na::{Point3 as NaPoint3, Translation3, UnitQuaternion},
     prelude::{
         GenericJointBuilder, ImpulseJointHandle, Isometry, JointAxesMask, JointAxis,
         RigidBodyHandle, SharedShape,
@@ -214,10 +214,11 @@ impl RagDollManager {
             None => return false,
         };
 
-        // Per-joint bind-pose AABBs (model space), the same data that drives the
-        // damage hitboxes. We size each limb's collider from its joint's box so
-        // limbs have real volume/length instead of being point-like balls.
-        let hit_boxes = model.get_hit_boxes();
+        // Per-joint fitted collision shapes (joint-local) - capsule spanning the
+        // bone toward the child for chain joints, box otherwise. Shared with the
+        // damage hitboxes (dark::hit_box). Covers the limbs far better than the
+        // old per-joint AABB (which left bones uncovered).
+        let hit_box_shapes = model.hit_box_shapes();
 
         let offset_transform = Matrix4::from_translation(root_offset) * root_transform;
         let mut world_joint_transforms = [Matrix4::identity(); 40];
@@ -254,30 +255,43 @@ impl RagDollManager {
             physics.set_body_damping(handle, LINEAR_DAMPING, ANGULAR_DAMPING);
             spawn_positions.insert(handle, pos_vec);
 
-            // Size the collider from the joint's hitbox AABB when available: a
-            // cuboid spanning the box, offset to the box center (in joint-local
-            // space, matching how HitBoxManager places damage hitboxes). The body
-            // origin stays at the joint, so skinning is unaffected. Fall back to a
-            // small ball for joints with no hitbox (no skinned verts).
-            match hit_boxes.get(&(bone.joint_id as u32)) {
-                Some(bbox) => {
-                    let dim = bbox.dim();
-                    let center = bbox.center();
-                    let half_extents = vec3(
-                        (dim.x.abs() * 0.5).max(MIN_HALF_EXTENT),
-                        (dim.y.abs() * 0.5).max(MIN_HALF_EXTENT),
-                        (dim.z.abs() * 0.5).max(MIN_HALF_EXTENT),
+            // Build the collider from the joint's fitted shape. Density is chosen
+            // so every limb has ~TARGET_BODY_MASS regardless of size: an
+            // impulse-jointed chain is unstable when connected bodies have very
+            // different masses. Inertia still scales with the shape. Shapes are in
+            // joint-local space; the body origin is the joint, so skinning is
+            // unaffected.
+            match hit_box_shapes.get(&(bone.joint_id as u32)) {
+                Some(HitBoxShape::Capsule { a, b, radius }) => {
+                    let h = (*b - *a).magnitude();
+                    let volume = std::f32::consts::PI * radius * radius * h
+                        + 4.0 / 3.0 * std::f32::consts::PI * radius * radius * radius;
+                    let density = TARGET_BODY_MASS / volume.max(MIN_VOLUME);
+                    physics.attach_collider(
+                        handle,
+                        SharedShape::capsule(
+                            NaPoint3::new(a.x, a.y, a.z),
+                            NaPoint3::new(b.x, b.y, b.z),
+                            *radius,
+                        ),
+                        density,
+                        CollisionGroup::ragdoll(),
                     );
-                    // Density chosen so every limb has ~TARGET_BODY_MASS regardless
-                    // of box size: an impulse-jointed chain is unstable when mass
-                    // ratios between connected bodies are large (a tiny extremity
-                    // box jointed to a big torso box spins up). Inertia still scales
-                    // with the box's shape.
-                    let volume = 8.0 * half_extents.x * half_extents.y * half_extents.z;
+                }
+                Some(HitBoxShape::Cuboid {
+                    half_extents,
+                    center,
+                }) => {
+                    let he = vec3(
+                        half_extents.x.max(MIN_HALF_EXTENT),
+                        half_extents.y.max(MIN_HALF_EXTENT),
+                        half_extents.z.max(MIN_HALF_EXTENT),
+                    );
+                    let volume = 8.0 * he.x * he.y * he.z;
                     let density = TARGET_BODY_MASS / volume.max(MIN_VOLUME);
                     physics.attach_collider_with_offset(
                         handle,
-                        SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z),
+                        SharedShape::cuboid(he.x, he.y, he.z),
                         vec3(center.x, center.y, center.z),
                         density,
                         CollisionGroup::ragdoll(),

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -8,7 +8,7 @@ use rapier3d::{
     na::{Point3 as NaPoint3, Translation3, UnitQuaternion},
     prelude::{
         GenericJointBuilder, ImpulseJointHandle, Isometry, JointAxesMask, JointAxis,
-        RigidBodyHandle, SharedShape,
+        RigidBodyHandle, SharedShape, SpringCoefficients,
     },
 };
 use shipyard::EntityId;
@@ -395,6 +395,17 @@ impl RagDollManager {
                 let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
                     .local_frame1(frame1)
                     .local_frame2(frame2)
+                    // Compliant joints (rapier 0.31+): the default softness is
+                    // near-rigid (natural_frequency 1e6), which rigidly fights the
+                    // unavoidable constraint residual on this hub-and-spoke
+                    // skeleton each step and pumps energy (the ragdoll never
+                    // settles). A spring-like, well-damped joint absorbs the
+                    // residual instead. ~60 Hz is well above the step rate (stiff
+                    // enough to hold limbs together) but far from rigid.
+                    .softness(SpringCoefficients {
+                        natural_frequency: 60.0,
+                        damping_ratio: 2.0,
+                    })
                     .limits(JointAxis::AngX, [-cone, cone])
                     .limits(JointAxis::AngY, [-cone, cone])
                     .limits(JointAxis::AngZ, [-cone, cone])

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -195,6 +195,18 @@ impl RagDollManager {
         }
     }
 
+    /// Map each ragdoll body's raw handle id to the skeleton joint id it
+    /// represents, so debug tooling can label physics bodies/joints by bone.
+    pub fn body_to_joint_id(&self) -> HashMap<u32, u32> {
+        let mut out = HashMap::new();
+        for ragdoll in self.ragdolls.values() {
+            for (joint_id, handle) in &ragdoll.joint_to_body {
+                out.insert(handle.into_raw_parts().0, *joint_id);
+            }
+        }
+        out
+    }
+
     pub fn add_ragdoll(
         &mut self,
         entity_id: EntityId,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -275,6 +275,22 @@ pub struct DebugRagdollMetrics {
     pub max_drift: f32,
 }
 
+/// One impulse joint's state, for ragdoll diagnostics. `separation` and the
+/// impulses staying non-zero at rest mean the constraint can't be satisfied.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugPhysicsJoint {
+    pub body1_id: u32,
+    pub body2_id: u32,
+    /// Skeleton joint id each body represents, if it's a ragdoll body.
+    pub bone1: Option<u32>,
+    pub bone2: Option<u32>,
+    pub anchor1: [f32; 3],
+    pub anchor2: [f32; 3],
+    pub separation: f32,
+    pub linear_impulse: f32,
+    pub angular_impulse: f32,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -374,6 +390,12 @@ pub trait DebuggableScene {
     /// harness (settle speeds, floor penetration, non-adjacent interpenetration,
     /// drift). Empty when the scene has no ragdolls.
     fn ragdoll_metrics(&self) -> Vec<DebugRagdollMetrics> {
+        Vec::new()
+    }
+
+    /// Every impulse joint with its anchor separation + applied impulse, for
+    /// ragdoll diagnostics. Empty when the scene has no joints.
+    fn list_physics_joints(&self) -> Vec<DebugPhysicsJoint> {
         Vec::new()
     }
 

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -25,6 +25,9 @@ pub enum InputAction {
 
     /// Reposition the inventory in front of the player
     MoveInventory,
+
+    /// Cycle creatures to their next animation pose (debug hitbox/ragdoll inspection)
+    DebugHitboxCyclePose,
 }
 
 impl InputAction {
@@ -37,6 +40,7 @@ impl InputAction {
             InputAction::QuickLoad,
             InputAction::SpawnDebugItem,
             InputAction::MoveInventory,
+            InputAction::DebugHitboxCyclePose,
         ]
     }
 
@@ -47,6 +51,7 @@ impl InputAction {
             InputAction::QuickLoad => "QuickLoad",
             InputAction::SpawnDebugItem => "SpawnDebugItem",
             InputAction::MoveInventory => "MoveInventory",
+            InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -46,6 +46,9 @@ impl ActionDispatcher {
                 head_rotation: input_context.head.rotation,
             });
         }
+        if state.just_triggered(InputAction::DebugHitboxCyclePose) {
+            effects.push(Effect::DebugCycleHitboxPose);
+        }
 
         effects
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -184,6 +184,9 @@ pub struct MissionCore {
     pub pathfinding_service: Option<PathfindingService>,
     pub path_visualization: PathVisualizationSystem,
     pub pathfinding_test: crate::mission::pathfinding_test::PathfindingTest,
+    /// Sequential index for `Effect::DebugCycleHitboxPose` so each trigger picks
+    /// the next animation deterministically (debug hitbox inspection).
+    pub debug_pose_index: u32,
 }
 
 pub struct GlobalContext {
@@ -435,6 +438,7 @@ impl MissionCore {
                 .map(|db| PathfindingService::new(Arc::new(db.clone()))),
             path_visualization: PathVisualizationSystem::new(),
             pathfinding_test: crate::mission::pathfinding_test::PathfindingTest::new(),
+            debug_pose_index: 0,
         }
     }
 
@@ -1318,6 +1322,48 @@ impl MissionCore {
                                 });
                             }
                         }
+                    }
+                }
+
+                Effect::DebugCycleHitboxPose => {
+                    // Advance every creature to the next pose in a fixed playlist of
+                    // distinct biped-human clips, so repeated triggers walk
+                    // deterministically through clearly-different poses. Used by the
+                    // `debug_hitbox` scene to inspect per-joint hitbox/ragdoll fit
+                    // across poses. We load clips by name directly (as `dark_viewer`
+                    // does) rather than via the tag-based motion query, which needs
+                    // an AI intent we don't have here.
+                    const DEBUG_POSE_CLIPS: &[&str] = &[
+                        "bh111005", // stand / idle
+                        "BH111001", // gesture
+                        "BH112020", // locomotion
+                        "bh114001", // action
+                        "BH413001", // combat
+                        "BH212oo8", // reach
+                    ];
+                    let clip_name = DEBUG_POSE_CLIPS[self.debug_pose_index as usize % DEBUG_POSE_CLIPS.len()];
+
+                    let creature_ids: Vec<EntityId> = {
+                        let v_creature = self.world.borrow::<View<PropCreature>>().unwrap();
+                        self.id_to_animation_player
+                            .keys()
+                            .filter(|id| v_creature.get(**id).is_ok())
+                            .copied()
+                            .collect()
+                    };
+
+                    if let Some(clip) =
+                        asset_cache.get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{clip_name}_.mc"))
+                    {
+                        for entity_id in creature_ids {
+                            if let Some(player) = self.id_to_animation_player.get_mut(&entity_id) {
+                                *player = AnimationPlayer::queue_animation(player, clip.clone());
+                            }
+                        }
+                        self.debug_pose_index = self.debug_pose_index.wrapping_add(1);
+                        game_log!(INFO, "[debug_hitbox] cycled to pose '{}'", clip_name);
+                    } else {
+                        game_log!(WARN, "[debug_hitbox] missing pose clip '{}_.mc'", clip_name);
                     }
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2974,6 +2974,25 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .collect()
     }
 
+    fn list_physics_joints(&self) -> Vec<crate::game_scene::DebugPhysicsJoint> {
+        let body_to_bone = self.rag_doll_manager.body_to_joint_id();
+        self.physics
+            .debug_list_joints()
+            .into_iter()
+            .map(|j| crate::game_scene::DebugPhysicsJoint {
+                bone1: body_to_bone.get(&j.body1_id).copied(),
+                bone2: body_to_bone.get(&j.body2_id).copied(),
+                body1_id: j.body1_id,
+                body2_id: j.body2_id,
+                anchor1: j.anchor1,
+                anchor2: j.anchor2,
+                separation: j.separation,
+                linear_impulse: j.linear_impulse,
+                angular_impulse: j.angular_impulse,
+            })
+            .collect()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -280,6 +280,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.ragdoll_metrics()
     }
 
+    fn list_physics_joints(&self) -> Vec<crate::game_scene::DebugPhysicsJoint> {
+        self.mission_core.list_physics_joints()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -347,5 +347,7 @@ pub fn create_physics_collider(level: &dark::mission::SystemShock2Level) -> Opti
         }
     }
 
-    Some(ColliderBuilder::trimesh(vertices, indices).build())
+    ColliderBuilder::trimesh(vertices, indices)
+        .ok()
+        .map(|builder| builder.build())
 }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -180,6 +180,39 @@ pub struct PhysicsWorld {
     events: PhysicsEvents,
 }
 
+/// Clamp a collider's full size to finite, positive, bounded values. Some Dark
+/// objects (notably certain trigger/`Ecology` objects) resolve to a non-finite
+/// (e.g. infinite) collider dimension, producing a collider with a NaN/infinite
+/// AABB. The old SAP broad-phase tolerated that; rapier's BVH broad-phase panics
+/// on it (parry binned build, "index out of bounds"). Sanitize at the source and
+/// log the offender so the bad data is traceable.
+fn sanitize_collider_size(
+    entity_id: EntityId,
+    context: &str,
+    size: Vector3<f32>,
+) -> Vector3<f32> {
+    const MIN_SIZE: f32 = 0.01;
+    const MAX_SIZE: f32 = 1.0e4;
+    let clamp = |v: f32| -> f32 {
+        if v.is_finite() && v > 0.0 {
+            v.min(MAX_SIZE)
+        } else {
+            MIN_SIZE
+        }
+    };
+    let out = Vector3::new(clamp(size.x), clamp(size.y), clamp(size.z));
+    if out != size {
+        tracing::warn!(
+            "[physics] {} entity {:?}: invalid collider size {:?} -> clamped to {:?}",
+            context,
+            entity_id,
+            size,
+            out
+        );
+    }
+    out
+}
+
 impl PhysicsWorld {
     pub fn add_level_geometry(&mut self, entity_id: EntityId, level: &SystemShock2Level) {
         /* Create the ground. */
@@ -473,7 +506,7 @@ impl PhysicsWorld {
                     .build()
             }
             PhysicsShape::Cuboid(size) => {
-                assert!(size.x > 0.0 && size.y > 0.0 && size.z > 0.0);
+                let size = sanitize_collider_size(entity_id, "add_dynamic", size);
                 ColliderBuilder::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0)
                     //.rotation(vector!(angles.0, angles.1, angles.2))
                     //.rotation(vector!(facing.z, facing.x, facing.y))
@@ -541,7 +574,7 @@ impl PhysicsWorld {
             .build();
         rigid_body.user_data = entity_id.inner() as u128;
         let handle = &self.rigid_body_set.insert(rigid_body);
-        assert!(size.x >= 0.0 && size.y >= 0.0 && size.z >= 0.0);
+        let size = sanitize_collider_size(entity_id, "add_kinematic", size);
         let mut collider = ColliderBuilder::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0)
             //.rotation(vector!(angles.0, angles.1, angles.2))
             //.rotation(vector!(facing.z, facing.x, facing.y))

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1153,6 +1153,41 @@ impl PhysicsWorld {
             .map(|(handle, body)| self.debug_body_info(handle, body))
     }
 
+    /// Enumerate every impulse joint with its anchor separation and applied
+    /// impulse, for ragdoll diagnostics. A healthy ball joint at rest has
+    /// `separation ≈ 0` and a small impulse; a persistent separation/impulse
+    /// means the constraint can't be satisfied (the rig fights itself).
+    pub fn debug_list_joints(&self) -> Vec<DebugJointInfo> {
+        self.impulse_joint_set
+            .iter()
+            .filter_map(|(_handle, joint)| {
+                let b1 = self.rigid_body_set.get(joint.body1)?;
+                let b2 = self.rigid_body_set.get(joint.body2)?;
+                let a1 = b1.position() * joint.data.local_frame1;
+                let a2 = b2.position() * joint.data.local_frame2;
+                let separation = (a1.translation.vector - a2.translation.vector).norm();
+                // impulses: first 3 components are linear (translation), last 3 angular.
+                let imp = joint.impulses;
+                let linear_impulse =
+                    (imp[0] * imp[0] + imp[1] * imp[1] + imp[2] * imp[2]).sqrt();
+                let angular_impulse = if imp.len() >= 6 {
+                    (imp[3] * imp[3] + imp[4] * imp[4] + imp[5] * imp[5]).sqrt()
+                } else {
+                    0.0
+                };
+                Some(DebugJointInfo {
+                    body1_id: joint.body1.into_raw_parts().0,
+                    body2_id: joint.body2.into_raw_parts().0,
+                    anchor1: [a1.translation.x, a1.translation.y, a1.translation.z],
+                    anchor2: [a2.translation.x, a2.translation.y, a2.translation.z],
+                    separation,
+                    linear_impulse,
+                    angular_impulse,
+                })
+            })
+            .collect()
+    }
+
     fn debug_body_info(&self, handle: RigidBodyHandle, body: &RigidBody) -> DebugBodyInfo {
         let (index, generation) = handle.into_raw_parts();
 
@@ -1207,6 +1242,22 @@ impl PhysicsWorld {
             is_sleeping: body.is_sleeping(),
         }
     }
+}
+
+/// Rapier-free description of an impulse joint, for ragdoll diagnostics.
+#[derive(Debug, Clone)]
+pub struct DebugJointInfo {
+    pub body1_id: u32,
+    pub body2_id: u32,
+    /// World anchor on each body (should coincide for a satisfied ball joint).
+    pub anchor1: [f32; 3],
+    pub anchor2: [f32; 3],
+    /// Distance between the two anchors - the translation-constraint violation.
+    pub separation: f32,
+    /// Magnitude of the linear (translation) constraint impulse this step.
+    pub linear_impulse: f32,
+    /// Magnitude of the angular (limit) constraint impulse this step.
+    pub angular_impulse: f32,
 }
 
 /// Rapier-free description of a rigid body, for debug tooling / HTTP introspection.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -57,6 +57,7 @@ impl CollisionGroup {
                 | InternalCollisionGroups::RAYCAST.bits)
                 .into(),
             filter: InternalCollisionGroups::RAYCAST.bits.into(),
+            test_mode: Default::default(),
         })
     }
 
@@ -64,6 +65,7 @@ impl CollisionGroup {
         CollisionGroup(InteractionGroups {
             memberships: InternalCollisionGroups::UI.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            test_mode: Default::default(),
         })
     }
 
@@ -75,6 +77,7 @@ impl CollisionGroup {
                 | InternalCollisionGroups::SELECTABLE.bits
                 | InternalCollisionGroups::ENTITY.bits)
                 .into(),
+            test_mode: Default::default(),
         })
     }
 
@@ -82,6 +85,7 @@ impl CollisionGroup {
         CollisionGroup(InteractionGroups {
             memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            test_mode: Default::default(),
         })
     }
 
@@ -100,6 +104,7 @@ impl CollisionGroup {
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::SELECTABLE.bits)
                 .into(),
+            test_mode: Default::default(),
         })
     }
 }
@@ -149,12 +154,11 @@ pub struct PhysicsWorld {
     integration_parameters: IntegrationParameters,
     physics_pipeline: PhysicsPipeline,
     island_manager: IslandManager,
-    broad_phase: BroadPhaseMultiSap,
+    broad_phase: DefaultBroadPhase,
     narrow_phase: NarrowPhase,
     impulse_joint_set: ImpulseJointSet,
     multibody_joint_set: MultibodyJointSet,
     ccd_solver: CCDSolver,
-    query_pipeline: QueryPipeline,
     collider_set: ColliderSet,
     rigid_body_set: RigidBodySet,
 
@@ -202,11 +206,14 @@ impl PhysicsWorld {
             }
         }
 
-        let mut collider = ColliderBuilder::trimesh(vertices, indices).build();
+        let mut collider = ColliderBuilder::trimesh(vertices, indices)
+            .expect("level geometry trimesh")
+            .build();
         collider.user_data = entity_id.inner() as u128;
         collider.set_collision_groups(InteractionGroups {
             memberships: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            test_mode: Default::default(),
         });
         self.collider_set.insert(collider);
     }
@@ -216,6 +223,7 @@ impl PhysicsWorld {
         collider.set_collision_groups(InteractionGroups {
             memberships: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            test_mode: Default::default(),
         });
         self.collider_set.insert(collider);
     }
@@ -447,7 +455,7 @@ impl PhysicsWorld {
         let mut rigid_body = RigidBodyBuilder::dynamic()
             // TODO: How can we make this more reliable? Seems to slow down the projectile randomly...
             // .ccd_enabled(true)
-            .position(test)
+            .pose(test)
             .build();
         rigid_body.user_data = entity_id.inner() as u128;
         rigid_body.set_gravity_scale(opts.gravity_scale, false);
@@ -529,7 +537,7 @@ impl PhysicsWorld {
         };
 
         let mut rigid_body = RigidBodyBuilder::kinematic_position_based()
-            .position(test)
+            .pose(test)
             .build();
         rigid_body.user_data = entity_id.inner() as u128;
         let handle = &self.rigid_body_set.insert(rigid_body);
@@ -593,6 +601,7 @@ impl PhysicsWorld {
         collider = collider.collision_groups(InteractionGroups::new(
             InternalCollisionGroups::PLAYER.bits.into(),
             InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            Default::default(),
         ));
         collider = collider.user_data(player_entity_user_data);
 
@@ -626,12 +635,11 @@ impl PhysicsWorld {
         };
         let physics_pipeline = PhysicsPipeline::new();
         let island_manager = IslandManager::new();
-        let broad_phase = BroadPhaseMultiSap::new();
+        let broad_phase = DefaultBroadPhase::new();
         let narrow_phase = NarrowPhase::new();
         let impulse_joint_set = ImpulseJointSet::new();
         let multibody_joint_set = MultibodyJointSet::new();
         let ccd_solver = CCDSolver::new();
-        let mut query_pipeline = QueryPipeline::new();
 
         let debug_pipeline = DebugRenderPipeline::new(
             DebugRenderStyle::default(),
@@ -641,7 +649,6 @@ impl PhysicsWorld {
                 | DebugRenderMode::CONTACTS,
         );
 
-        query_pipeline.update(&rigid_body_set, &collider_set);
         PhysicsWorld {
             gravity,
             integration_parameters,
@@ -653,7 +660,6 @@ impl PhysicsWorld {
             impulse_joint_set,
             multibody_joint_set,
             ccd_solver,
-            query_pipeline,
             rigid_body_set,
             rigid_bodies_with_forces: Vec::new(),
             // TODO:
@@ -702,15 +708,9 @@ impl PhysicsWorld {
                 &mut self.impulse_joint_set,
                 &mut self.multibody_joint_set,
                 &mut self.ccd_solver,
-                Some(&mut self.query_pipeline),
                 &(),
                 &self.events,
             )
-        });
-
-        profile!(scope: "physics", level: TRACE, "physics.update_query_pipeline", {
-            self.query_pipeline
-                .update(&self.rigid_body_set, &self.collider_set)
         });
 
         // Update character controller
@@ -734,8 +734,16 @@ impl PhysicsWorld {
     ) -> (Vec<CollisionEvent>, &RigidBody) {
         let character_body = &self.rigid_body_set[player_handle.character_handle];
         let original_position = *character_body.position();
+        let character_user_data = character_body.user_data;
         let character_collider = &self.collider_set[character_body.colliders()[0]];
         let _character_mass = character_body.mass();
+
+        // In rapier 0.31 the `QueryPipeline` is a transient view built from the
+        // broad-phase BVH, and it borrows the body/collider sets. Snapshot the
+        // character shape (cheap Arc clone) and position up front so those
+        // borrows are released before we build the query pipeline below.
+        let character_shape = character_collider.shared_shape().clone();
+        let character_pos = *character_collider.position();
 
         let step_size = Vector::y() * MOVEMENT_STEP_SIZE * self.integration_parameters.dt;
 
@@ -747,30 +755,39 @@ impl PhysicsWorld {
         let movement_with_upward = desired_movement + step_size;
 
         let mut gravity = -0.5 / SCALE_FACTOR;
-        gravity *= character_body.gravity_scale();
+        gravity *= self.rigid_body_set[player_handle.character_handle].gravity_scale();
 
         let gravity_movement = Vector::y() * gravity - step_size;
+
+        // Filter shared by both movement passes: only collide with the
+        // collidable groups as the player, ignore the player body and sensors.
+        let movement_filter = QueryFilter::new()
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::PLAYER.bits.into(),
+                InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+                Default::default(),
+            ))
+            .exclude_rigid_body(player_handle.character_handle)
+            .exclude_sensors();
+        let dispatcher = self.narrow_phase.query_dispatcher();
 
         //let mut collisions = vec![];
         let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             // HACK: For rapier v0.19.0, our previous strategy of combining the movement + gravity
             // caused us to snag on physics geometry. In order to counter this, we'll do the movement in two phases
             // a forward phase to move and then an application of gravity
-            (player_handle.controller.move_shape(
-                self.integration_parameters.dt,
+            let queries = self.broad_phase.as_query_pipeline(
+                dispatcher,
                 &self.rigid_body_set,
                 &self.collider_set,
-                &self.query_pipeline,
-                character_collider.shape(),
-                character_collider.position(),
+                movement_filter,
+            );
+            (player_handle.controller.move_shape(
+                self.integration_parameters.dt,
+                &queries,
+                character_shape.as_ref(),
+                &character_pos,
                 movement_with_upward.cast::<Real>(),
-                QueryFilter::new()
-                    .groups(InteractionGroups::new(
-                        InternalCollisionGroups::PLAYER.bits.into(),
-                        InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
-                    ))
-                    .exclude_rigid_body(player_handle.character_handle)
-                    .exclude_sensors(),
                 |_c| (),
                 //|c| collisions.push(c),
             ),
@@ -778,19 +795,10 @@ impl PhysicsWorld {
             // Second pass: Apply gravity and undo our step size
             player_handle.controller.move_shape(
                 self.integration_parameters.dt,
-                &self.rigid_body_set,
-                &self.collider_set,
-                &self.query_pipeline,
-                character_collider.shape(),
-                character_collider.position(),
+                &queries,
+                character_shape.as_ref(),
+                &character_pos,
                 gravity_movement.cast::<Real>(),
-                QueryFilter::new()
-                    .groups(InteractionGroups::new(
-                        InternalCollisionGroups::PLAYER.bits.into(),
-                        InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
-                    ))
-                    .exclude_rigid_body(player_handle.character_handle)
-                    .exclude_sensors(),
                 |_c| (),
                 //|c| collisions.push(c),
             ))
@@ -799,36 +807,31 @@ impl PhysicsWorld {
         let mut collision_events = Vec::new();
         let mut current_sensor_intersections = HashSet::new();
         profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
-            self.query_pipeline.intersections_with_shape(
+            // Only consider sensor colliders for player/sensor intersections.
+            let sensor_filter = QueryFilter::new()
+                .predicate(&|_collider_handle: ColliderHandle, _c: &Collider| _c.is_sensor());
+            let queries = self.broad_phase.as_query_pipeline(
+                dispatcher,
                 &self.rigid_body_set,
                 &self.collider_set,
-                &original_position,
-                //&(mvt.translation + vector![0.00, 0.01, 0.00]),
-                character_collider.shape(),
-                //1.1,
-                //true,
-                //QueryFilter::new().exclude_rigid_body(player_handle.character_handle),
-                QueryFilter::new()
-                    .predicate(&|_collider_handle: ColliderHandle, _c: &Collider| _c.is_sensor()),
-                |handle| {
-                    let collider = &self.collider_set.get(handle).unwrap();
-                    // if collider.is_sensor() {
-                    //     println!("!!--!! COLLISION: {} {:?}", collider.user_data, toi)
-                    // }
-                    if collider.is_sensor() {
-                        if let (Some(_entity1_id), Some(entity2_id)) = (
-                            EntityId::from_inner(character_body.user_data as u64),
-                            EntityId::from_inner(collider.user_data as u64),
-                        ) {
-                            current_sensor_intersections.insert(entity2_id);
-                        }
+                sensor_filter,
+            );
+            for (handle, collider) in
+                queries.intersect_shape(original_position, character_shape.as_ref())
+            {
+                if collider.is_sensor() {
+                    if let (Some(_entity1_id), Some(entity2_id)) = (
+                        EntityId::from_inner(character_user_data as u64),
+                        EntityId::from_inner(collider.user_data as u64),
+                    ) {
+                        current_sensor_intersections.insert(entity2_id);
                     }
-                    true
-                },
-            )
+                }
+                let _ = handle;
+            }
         });
 
-        let player_id = EntityId::from_inner(character_body.user_data as u64).unwrap();
+        let player_id = EntityId::from_inner(character_user_data as u64).unwrap();
 
         let new_collisions: HashSet<EntityId> = current_sensor_intersections
             .difference(&self.player_sensor_intersections)
@@ -912,16 +915,19 @@ impl PhysicsWorld {
         filter = filter.groups(InteractionGroups::new(
             InternalCollisionGroups::ALL.bits.into(),
             collision_groups.bits.into(),
+            Default::default(),
         ));
 
-        if let Some((handle, intersection)) = self.query_pipeline.cast_ray_and_get_normal(
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
             &self.rigid_body_set,
             &self.collider_set,
-            &ray,
-            max_toi,
-            solid,
             filter,
-        ) {
+        );
+
+        if let Some((handle, intersection)) =
+            queries.cast_ray_and_get_normal(&ray, max_toi, solid)
+        {
             // This is similar to `QueryPipeline::cast_ray` illustrated above except
             // that it also returns the normal of the collider shape at the hit point.
             let hit_point = ray.point_at(intersection.time_of_impact);
@@ -1007,7 +1013,7 @@ impl PhysicsWorld {
         isometry: Isometry<Real>,
         user_tag: Option<EntityId>,
     ) -> RigidBodyHandle {
-        let mut rigid_body = RigidBodyBuilder::dynamic().position(isometry).build();
+        let mut rigid_body = RigidBodyBuilder::dynamic().pose(isometry).build();
 
         // Set user data if provided
         if let Some(entity_id) = user_tag {
@@ -1035,7 +1041,7 @@ impl PhysicsWorld {
         isometry: Isometry<Real>,
         user_tag: Option<EntityId>,
     ) -> RigidBodyHandle {
-        let mut rigid_body = RigidBodyBuilder::fixed().position(isometry).build();
+        let mut rigid_body = RigidBodyBuilder::fixed().pose(isometry).build();
 
         if let Some(entity_id) = user_tag {
             rigid_body.user_data = entity_id.inner() as u128;

--- a/shock2vr/src/scenes/debug_hitbox.rs
+++ b/shock2vr/src/scenes/debug_hitbox.rs
@@ -1,0 +1,212 @@
+//! Debug scene for inspecting per-joint creature hitboxes across animation poses.
+//!
+//! Spawns a creature and overlays, every frame, two wireframes of the *same*
+//! fitted `HitBoxShape`s (`dark::hit_box`), transformed two different ways:
+//!
+//! - **green** - by the full joint world matrix (`root * joint`), exactly how the
+//!   mesh is skinned and how the damage hitboxes are placed. This is the source
+//!   of truth and tracks the animated mesh.
+//! - **red** - by the *decomposed* `(position, get_rotation_from_matrix)` the
+//!   ragdoll uses when it spawns a body per joint (see `RagDollManager::add_ragdoll`).
+//!   `get_rotation_from_matrix` reads the raw 3x3 with no orthonormalization, so
+//!   any scale/shear in the joint matrix makes red diverge from green.
+//!
+//! Where red and green coincide, the ragdoll conversion is faithful; where they
+//! diverge (e.g. the thighs), the bug is in the hitbox->ragdoll conversion, not
+//! in the fit/joint mapping. Cycle poses with the `DebugHitboxCyclePose` input
+//! action (HTTP-triggerable via the debug runtime) to stress runtime placement.
+
+use cgmath::{Matrix4, Point3, Quaternion, Vector3, vec3};
+use dark::{SCALE_FACTOR, properties::PropTemplateId};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View};
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    mission::{
+        GlobalContext, SpawnLocation, entity_creator::CreateEntityOptions,
+        mission_core::MissionCore,
+    },
+    runtime_props::{RuntimePropJointTransforms, RuntimePropTransform},
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    },
+    scripts::Effect,
+    util::{get_position_from_matrix, get_rotation_from_matrix},
+};
+
+/// Template spawned for inspection. -397 = grunt og-pipe (pipe hybrid), the same
+/// humanoid the ragdoll debug scene uses.
+const CREATURE_TEMPLATE_ID: i32 = -397;
+
+/// Green: fitted shapes placed by the full joint matrix (matches the mesh).
+const SHAPE_COLOR_DIRECT: Vector3<f32> = Vector3::new(0.2, 1.0, 0.3);
+/// Red: fitted shapes placed the way the ragdoll decomposes the joint matrix.
+const SHAPE_COLOR_RAGDOLL: Vector3<f32> = Vector3::new(1.0, 0.25, 0.2);
+
+/// Where the creature spawns - straight ahead of the default player spawn.
+fn focus_point() -> Point3<f32> {
+    Point3::new(-5.0, 5.0 / SCALE_FACTOR, 0.0)
+}
+
+pub struct DebugHitboxScene;
+
+impl DebugHitboxScene {
+    pub fn new(
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Box<dyn GameScene> {
+        let builder = DebugSceneBuilder::new("debug_hitbox")
+            .with_default_floor()
+            .with_spawn_location(SpawnLocation::PositionRotation(
+                vec3(0.0, 5.0 / SCALE_FACTOR, 0.0),
+                Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            ));
+
+        let build_options = DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        };
+
+        let core = builder.build_core(build_options);
+        Box::new(HookedDebugScene::new(core, HitboxHooks::new()))
+    }
+}
+
+struct HitboxHooks {
+    spawned: bool,
+}
+
+impl HitboxHooks {
+    fn new() -> Self {
+        println!(
+            "[debug_hitbox] Overlays the fitted per-joint hitbox shapes:\n\
+             - green = placed by the full joint matrix (matches the mesh)\n\
+             - red   = placed the way the ragdoll decomposes the joint matrix\n\
+             Trigger the `DebugHitboxCyclePose` input action to cycle animation poses\n\
+             (e.g. `curl -XPOST .../v1/input/action -d '{{\"action\":\"DebugHitboxCyclePose\"}}'`)."
+        );
+        Self { spawned: false }
+    }
+
+    fn spawn_creature(
+        &mut self,
+        core: &mut MissionCore,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if self.spawned {
+            return;
+        }
+        let position = focus_point();
+        let spawn = Effect::CreateEntity {
+            template_id: CREATURE_TEMPLATE_ID,
+            position,
+            orientation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            root_transform: Matrix4::from_translation(vec3(position.x, position.y, position.z)),
+            options: CreateEntityOptions::default(),
+        };
+        core.handle_effects(
+            vec![spawn],
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+        self.spawned = true;
+    }
+}
+
+impl DebugSceneHooks for HitboxHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        _effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        self.spawn_creature(
+            core,
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+    }
+
+    fn after_render(
+        &mut self,
+        core: &mut MissionCore,
+        scene_objects: &mut Vec<engine::scene::SceneObject>,
+        _camera_position: &mut Vector3<f32>,
+        _camera_rotation: &mut Quaternion<f32>,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) {
+        // Find the spawned creature.
+        let entity_id = core.world().run(|v_template: View<PropTemplateId>| {
+            v_template
+                .iter()
+                .with_id()
+                .find(|(_, t)| t.template_id == CREATURE_TEMPLATE_ID)
+                .map(|(id, _)| id)
+        });
+        let Some(entity_id) = entity_id else {
+            return;
+        };
+
+        let Some(model) = core.id_to_model.get(&entity_id) else {
+            return;
+        };
+        let shapes = model.hit_box_shapes();
+
+        // Live root + per-joint world transforms (written each frame by
+        // update_animations).
+        let transforms = core.world().run(
+            |v_transform: View<RuntimePropTransform>,
+             v_joints: View<RuntimePropJointTransforms>| {
+                match (v_transform.get(entity_id), v_joints.get(entity_id)) {
+                    (Ok(transform), Ok(joints)) => Some((transform.0, joints.0)),
+                    _ => None,
+                }
+            },
+        );
+        let Some((root, joints)) = transforms else {
+            return;
+        };
+
+        // Green: full joint matrix (how the mesh is skinned / hitboxes placed).
+        let world_direct: Vec<Matrix4<f32>> = joints.iter().map(|j| root * *j).collect();
+        scene_objects.extend(dark::hit_box::draw_debug_hit_box_shapes(
+            &shapes,
+            &world_direct,
+            SHAPE_COLOR_DIRECT,
+        ));
+
+        // Red: position + extracted rotation, exactly as `add_ragdoll` builds the
+        // per-joint body isometry. Diverges from green wherever the joint matrix
+        // carries scale/shear that `get_rotation_from_matrix` drops.
+        let world_ragdoll: Vec<Matrix4<f32>> = world_direct
+            .iter()
+            .map(|m| {
+                let pos = get_position_from_matrix(m);
+                let rot = get_rotation_from_matrix(m);
+                Matrix4::from_translation(vec3(pos.x, pos.y, pos.z)) * Matrix4::from(rot)
+            })
+            .collect();
+        scene_objects.extend(dark::hit_box::draw_debug_hit_box_shapes(
+            &shapes,
+            &world_ragdoll,
+            SHAPE_COLOR_RAGDOLL,
+        ));
+    }
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -22,6 +22,7 @@ pub mod cutscene_player;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;
+pub mod debug_hitbox;
 pub mod debug_hud;
 pub mod debug_joint_constraint;
 pub mod debug_map;
@@ -34,6 +35,7 @@ pub mod hand_pose;
 pub use cutscene_player::CutscenePlayerScene;
 pub use debug_camera::DebugCameraScene;
 pub use debug_gloves::DebugGlovesScene;
+pub use debug_hitbox::DebugHitboxScene;
 pub use debug_hud::DebugHudScene;
 pub use debug_joint_constraint::DebugJointConstraintScene;
 pub use debug_map::DebugMapScene;
@@ -151,6 +153,13 @@ pub fn create_initial_scene(
     if options.mission.eq_ignore_ascii_case("debug_ragdoll") {
         return SceneInitResult {
             scene: DebugRagdollScene::new(global_context, options, asset_cache, audio_context),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("debug_hitbox") {
+        return SceneInitResult {
+            scene: DebugHitboxScene::new(global_context, options, asset_cache, audio_context),
             mission_save_data: HashMap::new(),
         };
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -231,6 +231,10 @@ pub enum Effect {
     PositionInventoryRelativeToPlayer {
         head_rotation: Quaternion<f32>,
     },
+
+    /// Advance every creature to its next animation pose. Debug-only, used by the
+    /// `debug_hitbox` scene to inspect per-joint hitbox/ragdoll fit across poses.
+    DebugCycleHitboxPose,
 }
 
 impl Effect {

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -78,6 +78,10 @@ struct Cli {
     /// Overlay skeleton joints for supported model files (.bin/.ai).
     #[arg(long)]
     debug_skeletons: bool,
+
+    /// Overlay the fitted per-joint hit-box shapes (capsules/boxes) for AI meshes (.bin).
+    #[arg(long)]
+    debug_hitboxes: bool,
 }
 
 fn resolve_data_path(resource: &str) -> String {
@@ -220,6 +224,7 @@ fn create_scene(
     asset_cache: &mut engine::assets::asset_cache::AssetCache,
     data_resolver: fn(&str) -> String,
     debug_skeletons: bool,
+    debug_hit_boxes: bool,
 ) -> Result<Box<dyn ToolScene>, Box<dyn std::error::Error>> {
     let lower = filename.to_ascii_lowercase();
     if lower.ends_with(".avi") {
@@ -231,8 +236,12 @@ fn create_scene(
         }
     } else if lower.ends_with(".bin") {
         if animations.is_empty() {
-            let scene =
-                BinObjViewerScene::from_model(filename.to_string(), asset_cache, debug_skeletons)?;
+            let scene = BinObjViewerScene::from_model(
+                filename.to_string(),
+                asset_cache,
+                debug_skeletons,
+                debug_hit_boxes,
+            )?;
             Ok(Box::new(scene))
         } else {
             let scene = BinAiViewerScene::from_clips(
@@ -240,6 +249,7 @@ fn create_scene(
                 animations.to_vec(),
                 asset_cache,
                 debug_skeletons,
+                debug_hit_boxes,
             )?;
             Ok(Box::new(scene))
         }
@@ -282,6 +292,18 @@ pub fn main() {
             eprintln!(
                 "Warning: --debug-skeletons is only available for .bin, .ai, or .glb files. Ignoring flag."
             );
+            false
+        }
+    } else {
+        false
+    };
+
+    let debug_hit_boxes = if cli.debug_hitboxes {
+        let lower = filename.to_ascii_lowercase();
+        if lower.ends_with(".bin") || lower.ends_with(".ai") {
+            true
+        } else {
+            eprintln!("Warning: --debug-hitboxes is only available for .bin/.ai AI meshes. Ignoring flag.");
             false
         }
     } else {
@@ -350,6 +372,7 @@ pub fn main() {
             &mut game.asset_cache,
             resolve_data_path,
             debug_skeletons,
+            debug_hit_boxes,
         ) {
             Ok(_) => println!("Scene creation succeeded."),
             Err(err) => println!("Error creating scene: {err}"),
@@ -365,6 +388,7 @@ pub fn main() {
         &mut game.asset_cache,
         resolve_data_path,
         debug_skeletons,
+        debug_hit_boxes,
     ) {
         Ok(scene) => scene,
         Err(err) => {

--- a/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_ai_viewer.rs
@@ -46,6 +46,7 @@ pub struct BinAiViewerScene {
     animation_player: AnimationPlayer,
     animation_controller: Option<AnimationController>,
     debug_skeletons: bool,
+    debug_hit_boxes: bool,
 }
 
 impl BinAiViewerScene {
@@ -54,6 +55,7 @@ impl BinAiViewerScene {
         clip_names: Vec<String>,
         asset_cache: &mut AssetCache,
         debug_skeletons: bool,
+        debug_hit_boxes: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let model = asset_cache.get(&MODELS_IMPORTER, mesh_file_path.as_str());
 
@@ -72,6 +74,7 @@ impl BinAiViewerScene {
             animation_player,
             animation_controller: Some(controller),
             debug_skeletons,
+            debug_hit_boxes,
         })
     }
 }
@@ -110,6 +113,7 @@ impl ToolScene for BinAiViewerScene {
             Some(&self.animation_player),
             objects,
             self.debug_skeletons,
+            self.debug_hit_boxes,
         )
     }
 }

--- a/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
+++ b/tools/dark_viewer/src/scenes/bin_obj_viewer.rs
@@ -18,6 +18,7 @@ pub struct BinObjViewerScene {
     total_time: Duration,
     animation_player: AnimationPlayer,
     debug_skeletons: bool,
+    debug_hit_boxes: bool,
 }
 
 impl BinObjViewerScene {
@@ -25,6 +26,7 @@ impl BinObjViewerScene {
         model_name: String,
         _asset_cache: &AssetCache,
         debug_skeletons: bool,
+        debug_hit_boxes: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // We don't load the model here, we'll load it during render using the asset cache
         let mut animation_player = AnimationPlayer::empty();
@@ -39,6 +41,7 @@ impl BinObjViewerScene {
             total_time: Duration::ZERO,
             animation_player,
             debug_skeletons,
+            debug_hit_boxes,
         })
     }
 }
@@ -76,6 +79,7 @@ impl ToolScene for BinObjViewerScene {
             Some(&self.animation_player),
             turret_scene_objects,
             self.debug_skeletons,
+            self.debug_hit_boxes,
         )
     }
 }

--- a/tools/dark_viewer/src/scenes/render_helpers.rs
+++ b/tools/dark_viewer/src/scenes/render_helpers.rs
@@ -6,14 +6,22 @@ use engine::scene::{
     cube, lines_mesh,
 };
 
-/// Compose a scene for a model, optionally overlaying debug skeletons
+/// Color of the fitted hit-box wireframe overlay (bright green).
+const HIT_BOX_OVERLAY_COLOR: Vector3<f32> = Vector3::new(0.2, 1.0, 0.3);
+
+/// Compose a scene for a model, optionally overlaying debug skeletons and/or the
+/// fitted per-joint hit-box shapes (`dark::hit_box`). The hit-box overlay renders
+/// exactly what `fit_hit_box_shapes` produced, transformed by the live joint
+/// transforms - so it tracks the animated mesh and reveals fit/mapping issues
+/// independent of the physics ragdoll.
 pub fn build_model_scene_with_debug_skeletons(
     model: &Model,
     animation_player: Option<&AnimationPlayer>,
     mut objects: Vec<SceneObject>,
     debug_skeletons: bool,
+    debug_hit_boxes: bool,
 ) -> Scene {
-    if debug_skeletons && model.is_animated() {
+    if (debug_skeletons || debug_hit_boxes) && model.is_animated() {
         if let Some(player) = animation_player {
             objects.iter_mut().for_each(|obj| {
                 obj.set_depth_write(false);
@@ -27,8 +35,19 @@ pub fn build_model_scene_with_debug_skeletons(
                 .map(|joint| model_transform * *joint)
                 .collect();
 
-            let mut debug_skeleton = model.draw_debug_skeleton(&world_joints);
-            objects.append(&mut debug_skeleton);
+            if debug_skeletons {
+                let mut debug_skeleton = model.draw_debug_skeleton(&world_joints);
+                objects.append(&mut debug_skeleton);
+            }
+
+            if debug_hit_boxes {
+                let mut debug_hit_boxes = dark::hit_box::draw_debug_hit_box_shapes(
+                    &model.hit_box_shapes(),
+                    &world_joints,
+                    HIT_BOX_OVERLAY_COLOR,
+                );
+                objects.append(&mut debug_hit_boxes);
+            }
         }
     }
 

--- a/tools/hitbox_analyzer/src/main.rs
+++ b/tools/hitbox_analyzer/src/main.rs
@@ -16,7 +16,7 @@
 //!     fraction of the segment is inside the union of the joint boxes. Low
 //!     coverage = the limb is not enclosed (the "small cubes at joints" problem).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::panic::{self, AssertUnwindSafe};
@@ -136,6 +136,37 @@ fn analyze_file(file: &Path, samples: usize) -> Result<bool> {
 
     let name = file.file_name().unwrap_or_default().to_string_lossy();
     println!("\n=== {name} ===");
+    let mut shape_rows: Vec<(u32, String)> = fitted
+        .iter()
+        .map(|(j, (s, _))| {
+            let desc = match s {
+                HitBoxShape::Capsule { a, b, radius } => format!(
+                    "capsule a=({:.2},{:.2},{:.2}) b=({:.2},{:.2},{:.2}) r={:.3} len={:.2}",
+                    a.x,
+                    a.y,
+                    a.z,
+                    b.x,
+                    b.y,
+                    b.z,
+                    radius,
+                    (b - a).magnitude()
+                ),
+                HitBoxShape::Cuboid {
+                    half_extents,
+                    center,
+                } => format!(
+                    "cuboid half=({:.2},{:.2},{:.2}) center=({:.2},{:.2},{:.2})",
+                    half_extents.x, half_extents.y, half_extents.z, center.x, center.y, center.z
+                ),
+            };
+            (*j, format!("{} {}", joint_label(*j), desc))
+        })
+        .collect();
+    shape_rows.sort_by_key(|(j, _)| *j);
+    println!("  fitted shapes:");
+    for (_, d) in &shape_rows {
+        println!("    {d}");
+    }
 
     // Per-bone segment coverage, comparing the legacy per-joint AABB to the
     // fitted shapes.
@@ -199,33 +230,137 @@ fn analyze_file(file: &Path, samples: usize) -> Result<bool> {
         pct(fit_cov, fit_tot),
         fitted.len()
     );
+
+    // Vertex (surface) coverage: fraction of the mesh's skinned verts inside the
+    // union of shapes. Unlike bone-segment coverage this IS sensitive to radius,
+    // so it's the guard when tightening capsule radii.
+    let (mut v_tot, mut v_in) = (0usize, 0usize);
+    for (joint_id, verts) in mesh.joint_vertex_positions() {
+        if (joint_id as usize) >= world.len() {
+            continue;
+        }
+        let jw = world[joint_id as usize];
+        for v in &verts {
+            let w = jw * Vector4::new(v.x, v.y, v.z, 1.0);
+            if point_covered_shapes([w.x, w.y, w.z], &fitted) {
+                v_in += 1;
+            }
+            v_tot += 1;
+        }
+    }
+    println!("  vertex (surface) coverage: {:.0}%", pct(v_in, v_tot));
+
+    // Overlap: fraction of each shape's volume that lies inside a NON-adjacent
+    // shape (adjacent/jointed pairs are meant to meet at the joint).
+    let mut adjacency: HashSet<(u32, u32)> = HashSet::new();
+    for bone in skeleton.bones() {
+        if let Some(p) = bone.parent_id {
+            adjacency.insert((p.min(bone.joint_id), p.max(bone.joint_id)));
+        }
+    }
+    let (mut ov_total, mut ov_hit) = (0usize, 0usize);
+    let mut ov_rows: Vec<(String, f32)> = Vec::new();
+    for (jid, (shape, world)) in &fitted {
+        let samples = sample_shape_points(shape);
+        if samples.is_empty() {
+            continue;
+        }
+        let mut overlapped = 0usize;
+        for s in &samples {
+            let w = world * Vector4::new(s.x, s.y, s.z, 1.0);
+            let wp = [w.x, w.y, w.z];
+            let in_other = fitted.iter().any(|(ojid, (osh, ow))| {
+                if ojid == jid {
+                    return false;
+                }
+                let key = (*jid.min(ojid), *jid.max(ojid));
+                if adjacency.contains(&key) {
+                    return false;
+                }
+                point_in_shape_world(wp, osh, ow)
+            });
+            if in_other {
+                overlapped += 1;
+            }
+        }
+        ov_total += samples.len();
+        ov_hit += overlapped;
+        ov_rows.push((joint_label(*jid), overlapped as f32 / samples.len() as f32));
+    }
+    ov_rows.sort_by(|a, b| b.1.total_cmp(&a.1));
+    println!("  shape overlap into non-adjacent shapes (worst first):");
+    for (label, f) in ov_rows.iter().take(8) {
+        println!("    {:<22} {:>5.0}%", label, f * 100.0);
+    }
+    println!("  OVERALL shape overlap: {:.0}%", pct(ov_hit, ov_total));
     Ok(true)
 }
 
 /// True if world point `p` is inside any fitted joint shape (tested in the
 /// joint's local frame).
 fn point_covered_shapes(p: [f32; 3], shapes: &HashMap<u32, (HitBoxShape, Matrix4<f32>)>) -> bool {
-    for (shape, world) in shapes.values() {
-        let Some(inv) = world.invert() else { continue };
-        let h = inv * Vector4::new(p[0], p[1], p[2], 1.0);
-        let l = Vector3::new(h.x, h.y, h.z);
-        let inside = match shape {
-            HitBoxShape::Cuboid {
-                half_extents,
-                center,
-            } => {
-                let d = l - center;
-                d.x.abs() <= half_extents.x
-                    && d.y.abs() <= half_extents.y
-                    && d.z.abs() <= half_extents.z
+    shapes
+        .values()
+        .any(|(shape, world)| point_in_shape_world(p, shape, world))
+}
+
+/// True if world point `p` is inside `shape` placed at `world`.
+fn point_in_shape_world(p: [f32; 3], shape: &HitBoxShape, world: &Matrix4<f32>) -> bool {
+    let Some(inv) = world.invert() else {
+        return false;
+    };
+    let h = inv * Vector4::new(p[0], p[1], p[2], 1.0);
+    shape_contains_local(shape, Vector3::new(h.x, h.y, h.z))
+}
+
+fn shape_contains_local(shape: &HitBoxShape, l: Vector3<f32>) -> bool {
+    match shape {
+        HitBoxShape::Cuboid {
+            half_extents,
+            center,
+        } => {
+            let d = l - center;
+            d.x.abs() <= half_extents.x
+                && d.y.abs() <= half_extents.y
+                && d.z.abs() <= half_extents.z
+        }
+        HitBoxShape::Capsule { a, b, radius } => point_segment_dist(l, *a, *b) <= *radius,
+    }
+}
+
+/// Sample points inside `shape` (joint-local), for overlap estimation.
+fn sample_shape_points(shape: &HitBoxShape) -> Vec<Vector3<f32>> {
+    let (min, max) = match shape {
+        HitBoxShape::Cuboid {
+            half_extents,
+            center,
+        } => (center - half_extents, center + half_extents),
+        HitBoxShape::Capsule { a, b, radius } => {
+            let r = Vector3::new(*radius, *radius, *radius);
+            (
+                Vector3::new(a.x.min(b.x), a.y.min(b.y), a.z.min(b.z)) - r,
+                Vector3::new(a.x.max(b.x), a.y.max(b.y), a.z.max(b.z)) + r,
+            )
+        }
+    };
+    let n = 5;
+    let mut pts = Vec::new();
+    for i in 0..n {
+        for j in 0..n {
+            for k in 0..n {
+                let t = |idx: usize| (idx as f32 + 0.5) / n as f32;
+                let p = Vector3::new(
+                    min.x + (max.x - min.x) * t(i),
+                    min.y + (max.y - min.y) * t(j),
+                    min.z + (max.z - min.z) * t(k),
+                );
+                if shape_contains_local(shape, p) {
+                    pts.push(p);
+                }
             }
-            HitBoxShape::Capsule { a, b, radius } => point_segment_dist(l, *a, *b) <= *radius,
-        };
-        if inside {
-            return true;
         }
     }
-    false
+    pts
 }
 
 fn point_segment_dist(p: Vector3<f32>, a: Vector3<f32>, b: Vector3<f32>) -> f32 {


### PR DESCRIPTION
Stacks on #292. Upgrades rapier 0.19 → **0.31** to fix the ragdoll that never settled, and hardens collider creation against the stricter BVH broad-phase.

## Why
The ragdoll was *built* (#291/#292) but perpetually jittered — `max_linear_speed` stuck at 3–7 even after landing. Using the new `/v1/physics/joints` endpoint (#292) we saw the impulse joints holding a permanent unsatisfiable residual at "rest": rapier's near-rigid default joint stiffness rigidly fights it every step on the hub-and-spoke skeleton and pumps energy.

## What
- **rapier 0.19 → 0.31** (last nalgebra-based release; 0.32+ migrates math to glam, a much larger change). Brings the v0.29 velocity-solver rework + v0.31 per-joint `softness`. API migration: `InteractionGroups.test_mode`, `BroadPhaseMultiSap`→`DefaultBroadPhase` (BVH), transient `QueryPipeline`, `PhysicsPipeline::step`/character-controller signatures, `ColliderBuilder::trimesh`→`Result`, `RigidBodyBuilder::position`→`pose`.
- **Compliant ragdoll joints** (`SpringCoefficients { natural_frequency: 60, damping_ratio: 2.0 }`) — absorb the residual instead of fighting it. The rig now collapses into a heap and comes to rest.
- **`sanitize_collider_size`** — we created colliders with zero (triggers) or **infinite** (earth.mis entity 7) dimensions; `add_kinematic`'s `>= 0.0` assert passed both. The old SAP broad-phase tolerated the NaN/∞ AABBs; rapier 0.31's BVH broad-phase **panics** (`parry bvh_binned_build`, "index out of bounds"). Clamp every cuboid collider size to a finite, positive, bounded range at the boundary.
- Docs: `projects/ragdoll.md` (root cause + fixes), `projects/debug-runtime.md`, `CLAUDE.md`.

## Validation
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean.
- earth.mis / medsci1.mis / station.mis load + step + stay alive (earth.mis previously crashed on the first step).
- debug_ragdoll: settles into a heap on the floor.

## Known remaining
The two hip joints still sag ~4 cm (heavy thighs stretching the compliant joint) — see `projects/ragdoll.md` for candidate fixes. Follow-up.

> Note: the deterministic fixed-timestep this was tuned with is a separate PR (#298, off main); the docs here reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)