### PR TITLE
feat(flat): first-person weapon viewmodel + click-to-fire (slice 5)

### DIFF
--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -322,7 +322,7 @@ pub fn main() {
             cursor_visible = wants_pointer;
         }
 
-        let (input_context, input_state) = process_events(
+        let (mut input_context, input_state) = process_events(
             &mut window,
             &mut camera_context,
             &mut hand_context,
@@ -332,6 +332,18 @@ pub fn main() {
             &mut action_state,
             wants_pointer,
         );
+
+        // Flat first-person: left mouse button fires the wielded weapon (the
+        // flat controller reads the right-hand trigger).
+        if !args.vr {
+            input_context.right_hand.trigger_value =
+                if window.get_mouse_button(MouseButton::Button1) == Action::Press {
+                    1.0
+                } else {
+                    0.0
+                };
+        }
+
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
         let projection_matrix: cgmath::Matrix4<f32> =
             cgmath::perspective(cgmath::Deg(45.0), ratio, 0.1, 1000.0);

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -1,0 +1,114 @@
+//! Flatscreen first-person player controller.
+//!
+//! The dedicated flatscreen analog of `VirtualHand`: it wields a single weapon
+//! as a first-person viewmodel and fires it on the trigger. It produces the
+//! same `VirtualHandEffect`s the VR hands do (`HoldItem`, `SetPositionRotation`,
+//! `OutMessage { TriggerPull/Release }`), so `mission_core` processes VR and
+//! flat through one shared path, and the weapon-firing scripts fire unchanged.
+//!
+//! See `projects/flatscreen-and-vr-architecture.md` (Slice 5).
+
+use cgmath::{Quaternion, Rotation, Vector3, vec3};
+use shipyard::{EntityId, World};
+
+use dark::SCALE_FACTOR;
+
+use crate::{
+    input_context::Hand,
+    scripts::{Message, MessagePayload},
+    virtual_hand::VirtualHandEffect,
+    vr_config::{self, Handedness},
+};
+
+/// Where the wielded weapon sits relative to the camera, in look space (+x
+/// right, +y up, -z forward), before the world-scale divide. Tunable framing.
+const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
+/// Camera height above the player's feet position (world units before scale).
+const HEAD_HEIGHT: f32 = 5.0;
+
+pub struct FlatPlayerController {
+    wielded_entity: Option<EntityId>,
+    last_fire_pressed: bool,
+}
+
+impl FlatPlayerController {
+    pub fn new() -> Self {
+        Self {
+            wielded_entity: None,
+            last_fire_pressed: false,
+        }
+    }
+
+    /// Wield `entity_id` as the first-person weapon: hold it (becomes
+    /// non-physical and swaps to its hand model) and track it.
+    pub fn wield(&mut self, entity_id: EntityId) -> Vec<VirtualHandEffect> {
+        self.wielded_entity = Some(entity_id);
+        self.last_fire_pressed = false;
+        vec![VirtualHandEffect::HoldItem { entity_id }]
+    }
+
+    /// Per-frame: place the viewmodel in front of the camera and fire on the
+    /// trigger's rising edge (release on the falling edge).
+    pub fn update(
+        &mut self,
+        input: &Hand,
+        player_pos: Vector3<f32>,
+        player_rotation: Quaternion<f32>,
+        head_rotation: Quaternion<f32>,
+        world: &World,
+    ) -> Vec<VirtualHandEffect> {
+        let mut effects = Vec::new();
+
+        let Some(entity_id) = self.wielded_entity else {
+            self.last_fire_pressed = false;
+            return effects;
+        };
+
+        // Camera/look transform. Position the weapon in front of the camera,
+        // oriented to fire forward (the same orientation correction the VR hand
+        // uses, so the firing scripts launch along the look direction).
+        let look = player_rotation * head_rotation;
+        let camera_pos = player_pos + vec3(0.0, HEAD_HEIGHT / SCALE_FACTOR, 0.0);
+        let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
+            entity_id,
+            world,
+            Handedness::Right,
+        );
+        let position = camera_pos + look.rotate_vector(VIEWMODEL_OFFSET / SCALE_FACTOR);
+        let rotation = look * adjustments.rotation;
+
+        effects.push(VirtualHandEffect::SetPositionRotation {
+            entity_id,
+            position,
+            rotation,
+            scale: adjustments.scale,
+        });
+
+        // Fire on the trigger edge.
+        let fire_pressed = input.trigger_value > 0.5;
+        if fire_pressed && !self.last_fire_pressed {
+            effects.push(VirtualHandEffect::OutMessage {
+                message: Message {
+                    to: entity_id,
+                    payload: MessagePayload::TriggerPull,
+                },
+            });
+        } else if !fire_pressed && self.last_fire_pressed {
+            effects.push(VirtualHandEffect::OutMessage {
+                message: Message {
+                    to: entity_id,
+                    payload: MessagePayload::TriggerRelease,
+                },
+            });
+        }
+        self.last_fire_pressed = fire_pressed;
+
+        effects
+    }
+}
+
+impl Default for FlatPlayerController {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -9,6 +9,7 @@ pub mod teleport;
 pub mod time;
 
 mod creature;
+mod flat_player_controller;
 mod gui;
 mod hud;
 mod mission;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -63,6 +63,7 @@ use tracing::{info, trace, warn};
 use crate::{
     GameOptions,
     creature::{HitBoxManager, RagDollManager, get_creature_definition},
+    flat_player_controller::FlatPlayerController,
     game_scene::AmbientAudioState,
     gui::GuiManager,
     hud::{draw_item_name, draw_item_outline},
@@ -177,6 +178,7 @@ pub struct MissionCore {
     pub spatial_data: Option<Box<dyn SpatialQueryEngine>>,
     pub left_hand: VirtualHand,
     pub right_hand: VirtualHand,
+    pub flat_player: FlatPlayerController,
     pub visibility_engine: Box<dyn VisibilityEngine>,
     pub teleport_system: TeleportSystem,
     pub pending_entity_triggers: Vec<String>,
@@ -408,6 +410,7 @@ impl MissionCore {
         MissionCore {
             left_hand,
             right_hand,
+            flat_player: FlatPlayerController::new(),
             level_name: mission,
             entity_info: entity_info_rc.clone(),
             script_world,
@@ -595,7 +598,20 @@ impl MissionCore {
             &mut self.id_to_physics,
         );
 
-        self.update_avatar_hands(asset_cache, player_pos, player_rot, input_context);
+        // VR drives two hands; flat drives a single first-person weapon
+        // controller. Both feed the same effect-processing path.
+        if game_options.presentation_mode == crate::PresentationMode::Vr {
+            self.update_avatar_hands(asset_cache, player_pos, player_rot, input_context);
+        } else {
+            let msgs = self.flat_player.update(
+                &input_context.right_hand,
+                player_pos,
+                player_rot,
+                input_context.head.rotation,
+                &self.world,
+            );
+            self.process_virtual_hand_effects(asset_cache, msgs);
+        }
 
         // Sync up the position of all the physics objects
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position
@@ -1684,7 +1700,7 @@ impl MissionCore {
                         (vec3_to_point3(player.pos), player.rotation * head_rotation)
                     };
                     let forward = rot * vec3(0.0, 2.5 / SCALE_FACTOR, -10.0 / SCALE_FACTOR);
-                    self.create_entity_with_position(
+                    let info = self.create_entity_with_position(
                         asset_cache,
                         template_id,
                         pos + forward,
@@ -1692,6 +1708,12 @@ impl MissionCore {
                         Matrix4::identity(),
                         CreateEntityOptions::default(),
                     );
+                    // Flat presentation: auto-wield the spawned weapon as the
+                    // first-person viewmodel (debug spawn-and-wield for Slice 5).
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        let msgs = self.flat_player.wield(info.entity_id);
+                        self.process_virtual_hand_effects(asset_cache, msgs);
+                    }
                 }
                 Effect::PositionInventoryRelativeToPlayer { head_rotation } => {
                     let (pos, rot) = {
@@ -2240,7 +2262,18 @@ impl MissionCore {
 
         left_hand_msgs.append(&mut right_hand_msgs);
 
-        for msg in left_hand_msgs {
+        self.process_virtual_hand_effects(asset_cache, left_hand_msgs);
+    }
+
+    /// Apply the effects produced by an interaction controller (the VR hands or
+    /// the flat first-person controller). Shared so both presentations go
+    /// through one path.
+    fn process_virtual_hand_effects(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        msgs: Vec<VirtualHandEffect>,
+    ) {
+        for msg in msgs {
             match msg {
                 VirtualHandEffect::OutMessage { message } => self.script_world.dispatch(message),
                 VirtualHandEffect::ApplyForce {


### PR DESCRIPTION
Slice 5 of the flatscreen/VR split (design: `projects/flatscreen-and-vr-architecture.md`). **Branches off `main`** (gameplay, independent of the menu/canvas UI stack #297/#300).

## What's here
A dedicated **`FlatPlayerController`** — the flatscreen analog of `VirtualHand`. It wields one weapon as a first-person viewmodel and fires it on the trigger, emitting the *same* `VirtualHandEffect`s the VR hands do (`HoldItem` / `SetPositionRotation` / `OutMessage{TriggerPull|Release}`). So the existing weapon-firing scripts + projectile path run **unchanged** — no VR-specific firing code, per the research.

- **`mission_core`**: factored the hand-effect processing into one shared `process_virtual_hand_effects`; `update()` drives the VR hands in `Vr` and the flat controller in `Flat` through it.
- **Debug spawn-and-wield**: `SpawnDebugItem` (Space) spawns the pistol and, in flat mode, auto-wields it as the viewmodel.
- **`desktop_runtime`**: left mouse button drives the fire trigger in flat mode.

## Verification
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime` clean.
- **Needs interactive verification** (desktop window): `cargo dr` → Space (spawn+wield pistol) → it appears as a viewmodel → left-click fires (projectile via the existing weapon script). Viewmodel framing offsets are first-pass and meant for tuning.

## Not in this slice (next: Slice 6)
- Crosshair raycast → hover-highlight via `item_outline` (the VR border path, reused).
- Use/Frob + pickup on right-click.
- Bob/sway/recoil; proper weapon selection from inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)