### PR TITLE
feat(flat): crosshair highlight + use/frob/pickup (slice 6)

### DIFF
--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -38,6 +38,10 @@ pub struct SceneObject {
     pub local_transform: Matrix4<f32>, //hack...
     pub skinning_data: [Matrix4<f32>; 40],
     pub depth_write: bool,
+    /// When false, the object ignores the depth buffer (draws on top). Used for
+    /// the flatscreen first-person weapon viewmodel so it doesn't clip into the
+    /// world. Combine with drawing it last.
+    pub depth_test: bool,
 }
 
 impl SceneObject {
@@ -208,6 +212,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
+            depth_test: true,
         }
     }
 
@@ -228,6 +233,9 @@ impl SceneObject {
         if !self.depth_write {
             unsafe { gl::DepthMask(gl::FALSE) };
         }
+        if !self.depth_test {
+            unsafe { gl::Disable(gl::DEPTH_TEST) };
+        }
 
         if self.material.borrow().draw_opaque(
             render_context,
@@ -239,6 +247,9 @@ impl SceneObject {
             self.geometry.draw();
         }
 
+        if !self.depth_test {
+            unsafe { gl::Enable(gl::DEPTH_TEST) };
+        }
         if !self.depth_write {
             unsafe { gl::DepthMask(gl::TRUE) };
         }
@@ -295,6 +306,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
+            depth_test: true,
         }
     }
 
@@ -306,11 +318,16 @@ impl SceneObject {
             local_transform: self.local_transform,
             skinning_data: self.skinning_data,
             depth_write: self.depth_write,
+            depth_test: self.depth_test,
         }
     }
 
     pub fn set_depth_write(&mut self, enabled: bool) {
         self.depth_write = enabled;
+    }
+
+    pub fn set_depth_test(&mut self, enabled: bool) {
+        self.depth_test = enabled;
     }
 
     pub fn set_skinned_transparency(&mut self, transparency: Option<f32>) {

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -38,10 +38,11 @@ pub struct SceneObject {
     pub local_transform: Matrix4<f32>, //hack...
     pub skinning_data: [Matrix4<f32>; 40],
     pub depth_write: bool,
-    /// When false, the object ignores the depth buffer (draws on top). Used for
-    /// the flatscreen first-person weapon viewmodel so it doesn't clip into the
-    /// world. Combine with drawing it last.
-    pub depth_test: bool,
+    /// When true, the depth buffer is cleared *before* drawing this object, so it
+    /// (and anything drawn after it) renders on top of the world while still
+    /// depth-testing normally within itself. Used to draw the flatscreen
+    /// first-person weapon viewmodel without clipping into geometry.
+    pub clear_depth: bool,
 }
 
 impl SceneObject {
@@ -212,7 +213,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
-            depth_test: true,
+            clear_depth: false,
         }
     }
 
@@ -230,11 +231,13 @@ impl SceneObject {
         }
 
         let xform = self.transform * self.local_transform;
+        // Clear the depth buffer first so this (and later objects) draw on top of
+        // the world while still depth-testing normally amongst themselves.
+        if self.clear_depth {
+            unsafe { gl::Clear(gl::DEPTH_BUFFER_BIT) };
+        }
         if !self.depth_write {
             unsafe { gl::DepthMask(gl::FALSE) };
-        }
-        if !self.depth_test {
-            unsafe { gl::Disable(gl::DEPTH_TEST) };
         }
 
         if self.material.borrow().draw_opaque(
@@ -247,9 +250,6 @@ impl SceneObject {
             self.geometry.draw();
         }
 
-        if !self.depth_test {
-            unsafe { gl::Enable(gl::DEPTH_TEST) };
-        }
         if !self.depth_write {
             unsafe { gl::DepthMask(gl::TRUE) };
         }
@@ -306,7 +306,7 @@ impl SceneObject {
             local_transform: Matrix4::identity(),
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
-            depth_test: true,
+            clear_depth: false,
         }
     }
 
@@ -318,7 +318,7 @@ impl SceneObject {
             local_transform: self.local_transform,
             skinning_data: self.skinning_data,
             depth_write: self.depth_write,
-            depth_test: self.depth_test,
+            clear_depth: self.clear_depth,
         }
     }
 
@@ -326,8 +326,8 @@ impl SceneObject {
         self.depth_write = enabled;
     }
 
-    pub fn set_depth_test(&mut self, enabled: bool) {
-        self.depth_test = enabled;
+    pub fn set_clear_depth(&mut self, enabled: bool) {
+        self.clear_depth = enabled;
     }
 
     pub fn set_skinned_transparency(&mut self, transparency: Option<f32>) {

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -333,15 +333,21 @@ pub fn main() {
             wants_pointer,
         );
 
-        // Flat first-person: left mouse button fires the wielded weapon (the
-        // flat controller reads the right-hand trigger).
+        // Flat first-person: left mouse button fires the wielded weapon and
+        // right mouse button uses/frobs/picks up (the flat controller reads the
+        // right-hand trigger + squeeze).
         if !args.vr {
-            input_context.right_hand.trigger_value =
-                if window.get_mouse_button(MouseButton::Button1) == Action::Press {
-                    1.0
-                } else {
-                    0.0
-                };
+            let pressed = |b| window.get_mouse_button(b) == Action::Press;
+            input_context.right_hand.trigger_value = if pressed(MouseButton::Button1) {
+                1.0
+            } else {
+                0.0
+            };
+            input_context.right_hand.squeeze_value = if pressed(MouseButton::Button2) {
+                1.0
+            } else {
+                0.0
+            };
         }
 
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -333,21 +333,22 @@ pub fn main() {
             wants_pointer,
         );
 
-        // Flat first-person: left mouse button fires the wielded weapon and
-        // right mouse button uses/frobs/picks up (the flat controller reads the
-        // right-hand trigger + squeeze).
+        // Flat first-person: left mouse button fires the wielded weapon; right
+        // mouse button - or shift+left-click, which is easier on a trackpad -
+        // uses/frobs/picks up. (The flat controller reads the right-hand trigger
+        // + squeeze.)
         if !args.vr {
             let pressed = |b| window.get_mouse_button(b) == Action::Press;
-            input_context.right_hand.trigger_value = if pressed(MouseButton::Button1) {
-                1.0
-            } else {
-                0.0
-            };
-            input_context.right_hand.squeeze_value = if pressed(MouseButton::Button2) {
-                1.0
-            } else {
-                0.0
-            };
+            let shift = window.get_key(Key::LeftShift) == Action::Press
+                || window.get_key(Key::RightShift) == Action::Press;
+            let lmb = pressed(MouseButton::Button1);
+            input_context.right_hand.trigger_value = if lmb && !shift { 1.0 } else { 0.0 };
+            input_context.right_hand.squeeze_value =
+                if pressed(MouseButton::Button2) || (lmb && shift) {
+                    1.0
+                } else {
+                    0.0
+                };
         }
 
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -1,22 +1,25 @@
 //! Flatscreen first-person player controller.
 //!
 //! The dedicated flatscreen analog of `VirtualHand`: it wields a single weapon
-//! as a first-person viewmodel and fires it on the trigger. It produces the
-//! same `VirtualHandEffect`s the VR hands do (`HoldItem`, `SetPositionRotation`,
-//! `OutMessage { TriggerPull/Release }`), so `mission_core` processes VR and
-//! flat through one shared path, and the weapon-firing scripts fire unchanged.
+//! as a first-person viewmodel, fires it on the trigger, and uses/frobs/picks
+//! up the object under the crosshair. It produces the same `VirtualHandEffect`s
+//! the VR hands do (`HoldItem`, `DropItem`, `SetPositionRotation`,
+//! `OutMessage { TriggerPull/Release/Frob }`), so `mission_core` processes VR
+//! and flat through one shared path, and the weapon/frob scripts run unchanged.
 //!
-//! See `projects/flatscreen-and-vr-architecture.md` (Slice 5).
+//! See `projects/flatscreen-and-vr-architecture.md` (Slices 5-6).
 
-use cgmath::{Quaternion, Rotation, Vector3, vec3};
-use shipyard::{EntityId, World};
+use cgmath::{Quaternion, Rotation, Vector3, point3, vec3};
+use shipyard::{EntityId, Get, View, World};
 
-use dark::SCALE_FACTOR;
+use dark::{SCALE_FACTOR, properties::PropFrobInfo};
 
 use crate::{
     input_context::Hand,
+    physics::{InternalCollisionGroups, PhysicsWorld},
     scripts::{Message, MessagePayload},
-    virtual_hand::VirtualHandEffect,
+    util::resolve_proxy_entity,
+    virtual_hand::{VirtualHandEffect, can_grab_item},
     vr_config::{self, Handedness},
 };
 
@@ -29,6 +32,7 @@ const HEAD_HEIGHT: f32 = 5.0;
 pub struct FlatPlayerController {
     wielded_entity: Option<EntityId>,
     last_fire_pressed: bool,
+    last_use_pressed: bool,
 }
 
 impl FlatPlayerController {
@@ -36,19 +40,31 @@ impl FlatPlayerController {
         Self {
             wielded_entity: None,
             last_fire_pressed: false,
+            last_use_pressed: false,
         }
     }
 
-    /// Wield `entity_id` as the first-person weapon: hold it (becomes
-    /// non-physical and swaps to its hand model) and track it.
-    pub fn wield(&mut self, entity_id: EntityId) -> Vec<VirtualHandEffect> {
-        self.wielded_entity = Some(entity_id);
-        self.last_fire_pressed = false;
-        vec![VirtualHandEffect::HoldItem { entity_id }]
+    pub fn is_wielding(&self) -> bool {
+        self.wielded_entity.is_some()
     }
 
-    /// Per-frame: place the viewmodel in front of the camera and fire on the
-    /// trigger's rising edge (release on the falling edge).
+    /// Wield `entity_id` as the first-person weapon. Any previously-wielded
+    /// weapon is dropped back into the world (regains physics + world model).
+    pub fn wield(&mut self, entity_id: EntityId) -> Vec<VirtualHandEffect> {
+        let mut effects = Vec::new();
+        if let Some(prev) = self.wielded_entity {
+            if prev != entity_id {
+                effects.push(VirtualHandEffect::DropItem { entity_id: prev });
+            }
+        }
+        self.wielded_entity = Some(entity_id);
+        self.last_fire_pressed = false;
+        effects.push(VirtualHandEffect::HoldItem { entity_id });
+        effects
+    }
+
+    /// Per-frame update. Returns the effects to apply plus the entity currently
+    /// under the crosshair (for highlight rendering), if any.
     pub fn update(
         &mut self,
         input: &Hand,
@@ -56,54 +72,71 @@ impl FlatPlayerController {
         player_rotation: Quaternion<f32>,
         head_rotation: Quaternion<f32>,
         world: &World,
-    ) -> Vec<VirtualHandEffect> {
+        physics: &PhysicsWorld,
+    ) -> (Vec<VirtualHandEffect>, Option<EntityId>) {
         let mut effects = Vec::new();
 
-        let Some(entity_id) = self.wielded_entity else {
-            self.last_fire_pressed = false;
-            return effects;
-        };
-
-        // Camera/look transform. Position the weapon in front of the camera,
-        // oriented to fire forward (the same orientation correction the VR hand
-        // uses, so the firing scripts launch along the look direction).
         let look = player_rotation * head_rotation;
         let camera_pos = player_pos + vec3(0.0, HEAD_HEIGHT / SCALE_FACTOR, 0.0);
-        let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
-            entity_id,
-            world,
-            Handedness::Right,
-        );
-        let position = camera_pos + look.rotate_vector(VIEWMODEL_OFFSET / SCALE_FACTOR);
-        let rotation = look * adjustments.rotation;
 
-        effects.push(VirtualHandEffect::SetPositionRotation {
-            entity_id,
-            position,
-            rotation,
-            scale: adjustments.scale,
-        });
+        // Crosshair raycast: the frobbable entity under the reticle (resolving
+        // hitbox proxies to their parent, and ignoring the weapon we hold).
+        let forward = look.rotate_vector(vec3(0.0, 0.0, -1.0));
+        let highlighted = physics
+            .ray_cast(
+                point3(camera_pos.x, camera_pos.y, camera_pos.z),
+                forward,
+                InternalCollisionGroups::ENTITY
+                    | InternalCollisionGroups::SELECTABLE
+                    | InternalCollisionGroups::WORLD
+                    | InternalCollisionGroups::UI
+                    | InternalCollisionGroups::RAYCAST,
+            )
+            .and_then(|r| r.maybe_entity_id)
+            .map(|e| resolve_proxy_entity(world, e))
+            .filter(|e| Some(*e) != self.wielded_entity && is_frobbable(world, *e));
 
-        // Fire on the trigger edge.
-        let fire_pressed = input.trigger_value > 0.5;
-        if fire_pressed && !self.last_fire_pressed {
-            effects.push(VirtualHandEffect::OutMessage {
-                message: Message {
-                    to: entity_id,
-                    payload: MessagePayload::TriggerPull,
-                },
+        // Place the viewmodel + fire on the trigger edge.
+        if let Some(entity_id) = self.wielded_entity {
+            let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
+                entity_id,
+                world,
+                Handedness::Right,
+            );
+            effects.push(VirtualHandEffect::SetPositionRotation {
+                entity_id,
+                position: camera_pos + look.rotate_vector(VIEWMODEL_OFFSET / SCALE_FACTOR),
+                rotation: look * adjustments.rotation,
+                scale: adjustments.scale,
             });
-        } else if !fire_pressed && self.last_fire_pressed {
-            effects.push(VirtualHandEffect::OutMessage {
-                message: Message {
-                    to: entity_id,
-                    payload: MessagePayload::TriggerRelease,
-                },
-            });
+
+            let fire_pressed = input.trigger_value > 0.5;
+            if fire_pressed && !self.last_fire_pressed {
+                effects.push(out_message(entity_id, MessagePayload::TriggerPull));
+            } else if !fire_pressed && self.last_fire_pressed {
+                effects.push(out_message(entity_id, MessagePayload::TriggerRelease));
+            }
+            self.last_fire_pressed = fire_pressed;
+        } else {
+            self.last_fire_pressed = false;
         }
-        self.last_fire_pressed = fire_pressed;
 
-        effects
+        // Use / frob / pickup on the use-button (squeeze) rising edge.
+        let use_pressed = input.squeeze_value > 0.5;
+        if use_pressed && !self.last_use_pressed {
+            if let Some(target) = highlighted {
+                if can_grab_item(world, target) {
+                    // A pickup-able object (e.g. a weapon): wield it.
+                    effects.extend(self.wield(target));
+                } else {
+                    // Otherwise interact with it.
+                    effects.push(out_message(target, MessagePayload::Frob));
+                }
+            }
+        }
+        self.last_use_pressed = use_pressed;
+
+        (effects, highlighted)
     }
 }
 
@@ -111,4 +144,19 @@ impl Default for FlatPlayerController {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn out_message(to: EntityId, payload: MessagePayload) -> VirtualHandEffect {
+    VirtualHandEffect::OutMessage {
+        message: Message { to, payload },
+    }
+}
+
+/// Whether an entity is worth highlighting / interacting with (it has frob
+/// info), which excludes plain world geometry the ray also hits.
+fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropFrobInfo>>()
+        .map(|v| v.get(entity_id).is_ok())
+        .unwrap_or(false)
 }

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -48,6 +48,10 @@ impl FlatPlayerController {
         self.wielded_entity.is_some()
     }
 
+    pub fn wielded_entity(&self) -> Option<EntityId> {
+        self.wielded_entity
+    }
+
     /// Wield `entity_id` as the first-person weapon. Any previously-wielded
     /// weapon is dropped back into the world (regains physics + world model).
     pub fn wield(&mut self, entity_id: EntityId) -> Vec<VirtualHandEffect> {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1892,8 +1892,9 @@ impl MissionCore {
 
         if options.presentation_mode == crate::PresentationMode::Flat {
             // First-person weapon viewmodel: draw the wielded weapon's model on
-            // top of the world with depth-test disabled, so it does not clip into
-            // geometry. It is skipped in the world pass and drawn here, last.
+            // top of the world. It is skipped in the world pass and drawn here,
+            // last; the depth buffer is cleared before its first object so it
+            // renders over geometry while still depth-testing within itself.
             if let Some(weapon) = self.flat_player.wielded_entity() {
                 if let Some(model) = self.id_to_model.get(&weapon) {
                     let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
@@ -1902,10 +1903,12 @@ impl MissionCore {
                             Some(player) => model.to_animated_scene_objects(player),
                             None => model.to_scene_objects().clone(),
                         };
-                        for obj in scene_objs {
+                        for (i, obj) in scene_objs.into_iter().enumerate() {
                             let mut o = obj.clone();
                             o.set_transform(xform);
-                            o.set_depth_test(false);
+                            if i == 0 {
+                                o.set_clear_depth(true);
+                            }
                             ret.push(o);
                         }
                     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -179,6 +179,8 @@ pub struct MissionCore {
     pub left_hand: VirtualHand,
     pub right_hand: VirtualHand,
     pub flat_player: FlatPlayerController,
+    /// Entity under the crosshair in flat mode (for hover-highlight rendering).
+    flat_highlighted: Option<EntityId>,
     pub visibility_engine: Box<dyn VisibilityEngine>,
     pub teleport_system: TeleportSystem,
     pub pending_entity_triggers: Vec<String>,
@@ -411,6 +413,7 @@ impl MissionCore {
             left_hand,
             right_hand,
             flat_player: FlatPlayerController::new(),
+            flat_highlighted: None,
             level_name: mission,
             entity_info: entity_info_rc.clone(),
             script_world,
@@ -603,13 +606,15 @@ impl MissionCore {
         if game_options.presentation_mode == crate::PresentationMode::Vr {
             self.update_avatar_hands(asset_cache, player_pos, player_rot, input_context);
         } else {
-            let msgs = self.flat_player.update(
+            let (msgs, highlighted) = self.flat_player.update(
                 &input_context.right_hand,
                 player_pos,
                 player_rot,
                 input_context.head.rotation,
                 &self.world,
+                &self.physics,
             );
+            self.flat_highlighted = highlighted;
             self.process_virtual_hand_effects(asset_cache, msgs);
         }
 
@@ -1730,8 +1735,12 @@ impl MissionCore {
                         CreateEntityOptions::default(),
                     );
                     // Flat presentation: auto-wield the spawned weapon as the
-                    // first-person viewmodel (debug spawn-and-wield for Slice 5).
-                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                    // first-person viewmodel for debug testing, but only when not
+                    // already armed - extra spawns fall to the ground as world
+                    // pickups (world model + physics) to be picked up.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat
+                        && !self.flat_player.is_wielding()
+                    {
                         let msgs = self.flat_player.wield(info.entity_id);
                         self.process_virtual_hand_effects(asset_cache, msgs);
                     }
@@ -1818,6 +1827,29 @@ impl MissionCore {
                 options.debug_show_ids,
             ));
         };
+
+        // Flat presentation: highlight the entity under the crosshair, reusing
+        // the same brackets + name overlay as the VR hover.
+        if let Some(hit_entity) = self.flat_highlighted {
+            ret.extend(draw_item_outline(
+                asset_cache,
+                &self.physics,
+                hit_entity,
+                view,
+                projection,
+                screen_size,
+            ));
+            ret.extend(draw_item_name(
+                asset_cache,
+                &self.physics,
+                hit_entity,
+                &self.world,
+                view,
+                projection,
+                screen_size,
+                options.debug_show_ids,
+            ));
+        }
 
         ret.extend(self.visibility_engine.debug_render(asset_cache));
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1890,9 +1890,30 @@ impl MissionCore {
             }
         }
 
-        // Flat (non-VR) presentation draws a screen-space 2D HUD here, where the
-        // screen size is available. The VR forearm HUD is built in `render`.
         if options.presentation_mode == crate::PresentationMode::Flat {
+            // First-person weapon viewmodel: draw the wielded weapon's model on
+            // top of the world with depth-test disabled, so it does not clip into
+            // geometry. It is skipped in the world pass and drawn here, last.
+            if let Some(weapon) = self.flat_player.wielded_entity() {
+                if let Some(model) = self.id_to_model.get(&weapon) {
+                    let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
+                    if let Ok(xform) = v_transform.get(weapon).map(|p| p.0) {
+                        let scene_objs = match self.id_to_animation_player.get(&weapon) {
+                            Some(player) => model.to_animated_scene_objects(player),
+                            None => model.to_scene_objects().clone(),
+                        };
+                        for obj in scene_objs {
+                            let mut o = obj.clone();
+                            o.set_transform(xform);
+                            o.set_depth_test(false);
+                            ret.push(o);
+                        }
+                    }
+                }
+            }
+
+            // Flat 2D HUD (screen size is available here; the VR forearm HUD is
+            // built in `render`). Drawn after the viewmodel so it stays on top.
             ret.extend(crate::hud::create_flat_hud(
                 asset_cache,
                 &self.world,
@@ -2002,9 +2023,20 @@ impl MissionCore {
         let mut total_model_count = 0;
         let mut rendered_model_count = 0;
 
+        // In flat mode the wielded weapon is drawn as a first-person viewmodel in
+        // `render_per_eye` (on top, depth-test off), so skip it in the world pass.
+        let flat_viewmodel_entity = if options.presentation_mode == crate::PresentationMode::Flat {
+            self.flat_player.wielded_entity()
+        } else {
+            None
+        };
+
         // Render models
         for (entity_id, objs) in &self.id_to_model {
             total_model_count += 1;
+            if Some(*entity_id) == flat_viewmodel_entity {
+                continue;
+            }
             if !has_refs(&self.world, *entity_id) {
                 continue;
             }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -482,7 +482,7 @@ fn get_held_position_orientation(
     vr_config::get_vr_hand_model_adjustments_from_entity(entity_id, world, handedness)
 }
 
-fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
+pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     let v_prop_frobinfo = world.borrow::<View<PropFrobInfo>>().unwrap();
 
     if let Ok(frob_info) = v_prop_frobinfo.get(entity_id) {


### PR DESCRIPTION
Slice 6 of the flatscreen/VR split. **Stacked on #302** (slice 5).

Extends `FlatPlayerController` with the crosshair interaction model — all reusing the existing message/effect paths the research mapped.

## What's here
- **Hover-highlight**: a camera raycast each frame finds the frobbable entity under the crosshair; `mission_core` renders the *same* brackets + name overlay as the VR hover (`hud::item_outline`) for it.
- **Use / Frob / pickup** (right mouse -> squeeze): a grabbable target (`PropFrobInfo` MOVE) is picked up by wielding it; otherwise `MessagePayload::Frob` interacts.
- **Drop-on-rewield**: wielding a new weapon drops the previous one back into the world (regains physics + world model), so swaps leave a pickup behind.
- **Floating-arm bug fix**: debug spawn-and-wield only auto-wields when unarmed, so extra `Space` spawns fall to the ground as world pickups instead of replacing the held weapon.
- `desktop_runtime`: right mouse button drives use/frob in flat mode.

## Verification
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime` clean.
- Headless: confirmed the pistol spawns + wields in flat mode (the viewmodel framing offsets still need interactive tuning — three constants in `flat_player_controller.rs`).
- **Needs interactive verification**: crosshair highlight on frobbable objects, right-click pickup/frob, weapon swap drops the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)