### PR TITLE
feat(ragdoll): experimental multibody joints + on-death ragdoll flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,14 @@ The project supports experimental flags for gating in-progress features during d
   - Alternative to smooth movement that can cause motion sickness
   - Triggered via controller trigger button
 
+- **`ragdoll`**: spawn a physics ragdoll on creature death (`SlayEntity`) instead of
+  just removing the entity. Without it, death is unchanged.
+
+- **`ragdoll_multibody`**: make ragdolls use reduced-coordinate (multibody) joints
+  anchored at the limb articulation points — limbs can't separate (no hip gap), but
+  the rig is experimental (extremities can jitter on floor contact). Without it,
+  ragdolls use the stable impulse-joint rig. See `projects/ragdoll-settling-followup.md`.
+
 #### Adding New Experimental Features
 
 1. **Gate the feature in code**:

--- a/projects/ragdoll-settling-followup.md
+++ b/projects/ragdoll-settling-followup.md
@@ -59,56 +59,160 @@ The hip gap is the same root cause (the heavy thigh stretches the compliant join
   to rest. 8× was noisier (more momentum); 4× was the sweet spot. This is the change in
   PR #301.
 
+## Investigation update — 2026-06-18 (hip "disconnect" deep-dive)
+
+Focused on the **thigh joint visually disconnecting from the hip**. Findings, all
+verified against `debug_ragdoll` / `debug_hitbox` over the debug runtime:
+
+- **Rotation extraction is NOT the bug (ruled out, hard).** Dumped the 3×3 of every
+  joint world-matrix the ragdoll consumes (`add_ragdoll`): **all perfectly
+  orthonormal** — column norms 1.000, off-diagonal dot-products 0.000, det 1.000,
+  including the thighs. So `get_rotation_from_matrix` (raw 3×3 → quat, no
+  orthonormalization) corrupts nothing, and red==green in `debug_hitbox`. The old
+  `debug_hitbox` doc comment ("red diverges at the thighs due to scale/shear") was a
+  wrong guess and has been corrected in code.
+
+- **The joints are positioned ~29 cm from where the limbs articulate (quantified).**
+  Added a joint overlay to `debug_hitbox` (see Tooling). For the hips:
+  `add_ragdoll` anchors **both** hip joints at the **same** point — the bone-8
+  (pelvis) origin — because `frame1`'s translation is `(0,0,0)`. That origin sits
+  ~11 cm above, ~13 cm behind, and ~18 cm lateral of each real hip socket — measured
+  anchor→socket distance **0.287 m / 0.289 m** for L/R. So each thigh pivots about a
+  point up at the sacrum, and its top swings off the pelvis as it rotates → the
+  pose-dependent disconnect.
+
+- **Anchoring at the correct hip socket (child origin) is geometrically right but
+  destabilizes (ruled out as a standalone fix).** A/B'd via a `RAGDOLL_ANCHOR=child`
+  env toggle: offsetting the anchor from the heavy pelvis hub torques it and *adds*
+  energy — left hip went 12→16 cm and the rig got jumpier. The parent-origin anchor
+  is the *stable* choice precisely because it doesn't torque the hub.
+
+- **Stiffening the soft translation lock closes the gap but diverges on contact
+  (confirms the doc's warning, even with the heavy core).** Swept
+  `natural_frequency` via `RAGDOLL_FREQ`. At 60 (current) the rig is **stable** —
+  `min_y` steady, `max_lin` decays 0.20→0.065 — but the left hip holds **9 cm** at
+  rest (right ~2.4 cm; the asymmetry is systematic, the loaded hip hitting its 60°
+  cone limit and the soft translation letting it squirt out). At 500/1e6 the hip gap
+  closes to ~2 cm transiently, then **`max_ang` climbs to 27+ once it hits the
+  floor**. So you cannot get correct-pivot + closed-gap + stability out of impulse
+  joints on this hub-and-spoke skeleton.
+
+**Conclusion:** the visible disconnect is a *real positioning issue* (anchor far
+from the articulation point) compounded by the *soft translation lock* (needed for
+hub stability) — and the two cannot be reconciled within impulse joints. The
+principled fix is **multibody joints** (next steps, now the chosen direction).
+
+## Investigation update — 2026-06-18 (multibody conversion, behind a flag)
+
+Implemented multibody joints and made them **opt-in via experimental flags**, with
+the impulse rig kept as the stable default:
+
+- `--experimental ragdoll` — spawn a ragdoll on creature death (`SlayEntity`) instead
+  of just removing the entity. Without it, death is unchanged. (Before this there was
+  *no* ragdoll-on-death path at all — ragdolls only existed in the `debug_ragdoll`
+  scene.)
+- `--experimental ragdoll_multibody` — the ragdoll uses reduced-coordinate multibody
+  joints (anchored at the child/hip articulation point, uniform mass, no softness);
+  otherwise it uses the impulse rig (parent-origin anchor, heavy core, soft
+  translation). Routing verified: default → 19 impulse joints; multibody flag → 0
+  impulse joints, bodies stay connected (~1.6 m extent).
+
+**What the multibody fixes:** translation is structurally not a DOF, so limbs
+**cannot separate** — the hip gap is gone, and we can finally anchor at the true
+articulation point (child origin) without the hub-torque instability impulse joints
+had. Forward-kinematics reproduces the captured death pose at spawn (frames are
+death-pose-aligned), so there's **no snap** — the failure mode of the earlier naive
+drop-in (which exploded because bodies spawned independently of the reduced-coord
+rest config).
+
+**Multibody stability findings (verified, env-swept then baked in):**
+- **Drop the heavy core — biggest win.** The 4× `CORE_BODY_MASS` is an *impulse* hub
+  crutch; a proper articulated solver is *destabilized* by the mass ratio. Uniform
+  mass took `max_ang` from ~44 → ~3. The multibody branch now uses `TARGET_BODY_MASS`
+  for the core.
+- **Joint-friction motors inject energy → explode** (`motor_velocity(0, factor)`,
+  Acceleration-based, drove `max_ang` to 9e4 and through the floor). Do **not** use
+  motors to damp; ruled out.
+- **Soft contacts** (`IntegrationParameters::contact_softness` natural_frequency
+  30→10) remove the spawn/floor-**impact** spike — but this is a *global* physics knob,
+  so it was reverted (not safe to change world-wide for an experimental rig).
+- **More solver iterations** (4→16) help marginally then *hurt* with uniform mass.
+- **Self-collision off** doesn't help the churn.
+- **Body-creation dedup bug found + fixed:** the Dark skeleton lists joint 18 twice,
+  and body creation (unlike joint creation) wasn't deduped → a second, never-jointed
+  **orphan body** for joint 18 fell away as an invisible stray (and inflated the body
+  bbox to 6 m). Now one body per joint id.
+
+**The remaining blocker (multibody):** even at the best config the corpse does **not
+fully settle on the floor** — the core comes to rest but **extremities jitter in a
+contact limit-cycle** (one-body `max_ang`~8, `lin`~5; bulk drift only ~0.08 m/s, so
+it's localized limb buzz, not bulk sliding). Body linear/angular damping doesn't bleed
+the multibody's *constrained* DOF, and the obvious fix (joint-friction motors) injects
+energy. This is why multibody stays **experimental / opt-in**, not the default.
+
+**Net trade-off (concrete):**
+- *Impulse (default):* settles cleanly (`lin`→0.065) but the hip **gaps ~9 cm**.
+- *Multibody (flag):* **no gap, can't separate**, but **extremities won't settle**
+  (contact jitter) and the in-game death path is gated behind `--experimental ragdoll`.
+
 ## Recommended next steps (ranked)
 
-### 1. Use Rapier auto-sleep for "stops twitching, still pokeable" (do this first)
-The user wants the corpse to stop twitching **without** losing interactivity. Rapier's
-**island sleeping** is exactly that: a body whose linear/angular velocity stays below a
-threshold for `time_to_sleep` seconds **sleeps** (drops out of simulation), but
-**auto-wakes on contact or applied force** — so you can still walk into / shoot / push
-the corpse and it springs back to life. We do **not** disable sleeping anywhere (we only
-read `is_sleeping` for debug).
+### 0. Crack the multibody floor-contact jitter (the one blocker left)
+Make the multibody rig settle so it can graduate from experimental to default. Ideas
+not yet tried / not yet working:
+- **Stable joint damping that doesn't inject energy** — the multibody's per-DOF
+  `damping` vector (set by `MultibodyJoint::default_damping` on append) rather than a
+  velocity *motor*; or a very low-gain Force-based motor. Motors at the gains tried
+  exploded; needs care.
+- **Contact handling for the ragdoll only** — per-collider contact softness/friction
+  (not the global `IntegrationParameters`), or temporarily softer contacts while the
+  rig is "fresh".
+- **Velocity clamp / extra substeps** for the first ~1 s after spawn to absorb the
+  transient, then release.
+- Watch with `/v1/ragdoll/metrics` (`max_ang`/`max_lin` should decay, not limit-cycle)
+  and the `debug_hitbox` joint overlay (anchor stays at the articulation point).
 
-- Check whether the ragdoll bodies actually sleep once quiescent:
-  `GET /v1/physics/bodies/:id` → `is_sleeping`. If the residual ~40 s twitch keeps them
-  awake, the fix is to help them cross the sleep threshold sooner: a bit more damping,
-  and/or lowering `IntegrationParameters::{normalized_linear_/angular_}? sleep thresholds`
-  / `time_to_sleep` for the ragdoll. (Confirm the exact field names in rapier 0.31.)
-- This is the interaction-friendly alternative to a hard freeze/kinematic-pin — **prefer
-  it.** A hard freeze would make the corpse un-pokeable; auto-sleep keeps the fun.
+### 1. ⭐ Multibody (reduced-coordinate) joints — IMPLEMENTED (behind `ragdoll_multibody`)
+Done in this pass (see `add_ragdoll`'s `use_multibody` branch): anchored at the
+child/hip articulation point, dropped `softness`, uniform core mass, death-pose-aligned
+frames so forward-kinematics reproduces the spawn pose (no snap), parent-before-child
+insertion (insert is order-robust given per-child dedup), body-creation dedup, joints
+auto-removed with bodies. `PhysicsWorld::create_multibody_joint` →
+`multibody_joint_set.insert`. **Remaining:** the floor-contact jitter (step 0) — until
+that's solved this stays experimental, and `/v1/physics/joints` + the `--debug-physics`
+anchor viz still iterate only the **impulse** set (extend to the multibody set for
+multibody diagnostics).
 
-### 2. Close the hip gap — per-joint stiffer hips
-Make just the **hip** (and probably shoulder) joints less compliant than the rest — a
-higher `SpringCoefficients::natural_frequency` (or a per-bone stiffness profile keyed off
-the joint id, like the existing per-bone `JointLimit` cone profile). The heavy core (step
-done in #301) now absorbs more joint stiffness without re-exploding, so stiffer hips are
-likely tolerable. Verify with the **joint-anchor viz** + `/v1/physics/joints` that the
-hip separation closes **without** re-introducing energy (watch `max_linear_speed`).
-
-### 3. Multibody (reduced-coordinate) joints, done properly (bigger, principled fix)
-Reduced-coordinate joints **cannot separate** (no hip gap) and inject **no** residual
-energy — the right tool for an articulated tree. To make them stable here:
-- **Forward-kinematic the body spawn poses from the root**: build the bodies root-first,
-  positioning each child from `parent_pose * joint_local_transform` (not from the
-  independently-captured death-pose transforms), so the multibody's rest config matches
-  the spawn state and nothing snaps.
-- Insert joints **parent-before-child** (topological / depth order — the Dark bone list is
-  not sorted).
-- **Drop the `softness`** (multibody is rigid; a spring oscillates).
-- Mind the tiny-hub inertia (combine with the heavy-core change, or give the hub real size).
-- API: `PhysicsWorld::create_multibody_joint(parent, child, GenericJoint)` →
-  `multibody_joint_set.insert(parent, child, joint, true)` (was prototyped then reverted;
-  re-add it). Note `/v1/physics/joints` + the joint-anchor viz currently iterate the
-  **impulse** joint set — extend them to the multibody set if you switch.
+### 2. Fallback if multibody proves too unstable — accept gap + auto-sleep
+Keep the stable soft impulse joints, stop fighting the residual ~9 cm hip gap, and add
+Rapier **island sleeping** so the corpse goes still but stays pokeable: a body whose
+linear/angular velocity stays below threshold for `time_to_sleep` **sleeps** (drops out
+of simulation) but **auto-wakes on contact or applied force** — so you can still walk
+into / shoot / push the corpse and it springs back to life. We don't disable sleeping
+anywhere (only read `is_sleeping` for debug); check `GET /v1/physics/bodies/:id` →
+`is_sleeping`, and help it cross the threshold sooner via a bit more damping and/or
+lower `IntegrationParameters` sleep thresholds / `time_to_sleep` (confirm field names in
+rapier 0.31). Interaction-friendly alternative to a hard freeze/kinematic-pin (which
+would make the corpse un-pokeable). The gap remains visible — pragmatic fallback, not
+the fix.
 
 ### Avoid
 - **Hard freeze / kinematic pin** of the settled corpse — kills interactivity (the user
-  explicitly wants to be able to poke it). Use auto-sleep (step 1) instead.
+  explicitly wants to be able to poke it). Use auto-sleep (fallback step 2) instead.
 
 ## Tooling & methodology (important gotchas)
 
 - `cargo dbgr --mission debug_ragdoll --debug-physics --port N` (no extra `--`). The
   joint-anchor viz draws cyan/magenta anchor crosses + a yellow gap line per joint.
+- `cargo dbgr --mission debug_hitbox --port N` — **physics-free** joint overlay
+  (added 2026-06-18). Per parent→child joint, drawn from the live posed skeleton:
+  **blue** = bone segment, **yellow** = the impulse-joint anchor `add_ragdoll` uses
+  (parent origin), **magenta** = closest/contact points between the two fitted shapes
+  (`parry::query::contact`). Cycle poses with the `DebugHitboxCyclePose` input action.
+  Use it to see joint placement *vs* where the limbs meet without any solver noise —
+  this is how the ~29 cm hip anchor↔socket offset was measured. (Caveat: the debug
+  scene camera is fixed and far; the markers read small from the side. Improving the
+  framing — move the creature closer / bigger per-joint markers — is a nice follow-up.)
 - `GET /v1/physics/joints` — anchor separation + linear/angular impulse, bone-labeled.
 - `GET /v1/ragdoll/metrics` — `max_linear_speed` / `max_angular_speed` (settle signal),
   `min_y` (floor contact), `max_drift`, `max_nonadjacent_overlap`.
@@ -133,3 +237,8 @@ energy — the right tool for an articulated tree. To make them stable here:
   overlay), `debug_list_joints`, `multibody_joint_set` (wired into `step`, ready to use).
 - `shock2vr/src/scenes/debug_ragdoll.rs`: the test scene (spawns a pipe hybrid, kills it,
   spawns the ragdoll).
+- `shock2vr/src/scenes/debug_hitbox.rs`: physics-free pose/joint inspector —
+  `draw_joint_debug` (bone/anchor/contact overlay) + `parry_shape` (build a parry shape +
+  world isometry from a fitted `HitBoxShape`, matching `add_ragdoll`'s collider placement).
+- `shock2vr/src/util.rs` → `get_rotation_from_matrix`: raw 3×3 → quat. Verified safe here
+  (joint matrices are orthonormal), but note it does NOT orthonormalize.

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -64,6 +64,8 @@ pub struct RagDollMetrics {
 
 pub struct RagDoll {
     physics_bodies: Vec<RigidBodyHandle>,
+    /// Impulse joints to clean up on removal. Empty for multibody rigs, whose
+    /// joints are removed automatically with their bodies.
     joint_handles: Vec<ImpulseJointHandle>,
     joint_to_body: HashMap<u32, RigidBodyHandle>,
     bone_frame_offsets: HashMap<u32, Matrix4<f32>>,
@@ -220,6 +222,12 @@ impl RagDollManager {
         joint_transforms: &[Matrix4<f32>; 40],
         root_offset: Vector3<f32>,
         joint_limits: &HashMap<u32, JointLimit>,
+        // When true, use reduced-coordinate (multibody) joints anchored at the
+        // articulation point: limbs can't separate (no hip gap), but the rig is
+        // experimental (extremities can jitter on floor contact). When false, the
+        // stable impulse-joint rig (heavier core, soft locked translation - settles
+        // but the hip can visibly sag/separate under load).
+        use_multibody: bool,
         physics: &mut PhysicsWorld,
     ) -> bool {
         if !model.can_create_rag_doll() {
@@ -259,6 +267,14 @@ impl RagDollManager {
         for bone in &bones {
             let joint_idx = bone.joint_id as usize;
             if joint_idx >= world_joint_transforms.len() {
+                continue;
+            }
+            // The Dark skeleton lists some joints twice (a torso's main joint is
+            // also a fixed point on its parent torso - see ss2_skeleton::create).
+            // Create exactly one body per joint id; a duplicate would otherwise
+            // spawn a second, never-jointed body that falls away as a stray
+            // (invisible: rendering only draws bodies tracked in joint_to_body).
+            if joint_to_body.contains_key(&(bone.joint_id as u32)) {
                 continue;
             }
 
@@ -305,7 +321,16 @@ impl RagDollManager {
                         half_extents.z.max(MIN_HALF_EXTENT),
                     );
                     let volume = 8.0 * he.x * he.y * he.z;
-                    let density = CORE_BODY_MASS / volume.max(MIN_VOLUME);
+                    // The 4x "core" mass stabilizes the *impulse* hub-and-spoke rig
+                    // (the tiny pelvis hub otherwise gets yanked by the heavy thighs).
+                    // A reduced-coordinate multibody solves that structurally and is
+                    // actually destabilized by the mass ratio, so it uses uniform mass.
+                    let core_mass = if use_multibody {
+                        TARGET_BODY_MASS
+                    } else {
+                        CORE_BODY_MASS
+                    };
+                    let density = core_mass / volume.max(MIN_VOLUME);
                     physics.attach_collider_with_offset(
                         handle,
                         SharedShape::cuboid(he.x, he.y, he.z),
@@ -366,30 +391,13 @@ impl RagDollManager {
                 let parent_rot = get_rotation_from_matrix(&parent_world);
                 let child_world = world_joint_transforms[child_idx];
                 let child_rot = get_rotation_from_matrix(&child_world);
-                let child_to_parent = parent_pos - child_pos;
-                let child_local_anchor = child_rot.conjugate().rotate_vector(child_to_parent);
 
-                // Ball joint (translation locked) with angular limits so the body
-                // can't fold/twist through itself.
-                //
-                // The limits are measured relative to the joints' local frames, so
-                // they only behave if "zero angle" corresponds to the bind/rest
-                // pose. We align both frames to the child's rest world orientation:
-                //   frame1 (parent-local) rotation = R_parent^-1 * R_child
-                //   frame2 (child-local)  rotation = identity
-                // At spawn, R_parent * frame1 == R_child == R_child * frame2, so the
-                // relative angle is exactly 0 and within limits - no energy is
-                // injected (the bug we hit when limits used identity frames).
+                // Both rigs align the joint frames' rotation to the rest/death pose
+                // (parent-local = R_parent^-1 * R_child, child-local = identity), so
+                // the cone limits are measured from there and the relative angle is
+                // exactly 0 at spawn - no energy injected. The anchor *translation*
+                // differs by rig type (see each branch).
                 let frame1_rot = quat_to_nquat(parent_rot.invert() * child_rot);
-                let frame1 = Isometry::from_parts(Translation3::new(0.0, 0.0, 0.0), frame1_rot);
-                let frame2 = Isometry::from_parts(
-                    Translation3::new(
-                        child_local_anchor.x,
-                        child_local_anchor.y,
-                        child_local_anchor.z,
-                    ),
-                    UnitQuaternion::identity(),
-                );
                 // Per-bone cone limit from the creature definition (e.g. tight for
                 // head/neck/spine, wide for shoulders/hips), falling back to a
                 // uniform default for joints/creatures without a profile.
@@ -397,31 +405,83 @@ impl RagDollManager {
                     .get(&(bone.joint_id as u32))
                     .map(|limit| limit.cone)
                     .unwrap_or(JOINT_CONE_LIMIT);
-                let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
-                    .local_frame1(frame1)
-                    .local_frame2(frame2)
-                    // Compliant joints (rapier 0.31+): the default softness is
-                    // near-rigid (natural_frequency 1e6), which rigidly fights the
-                    // unavoidable constraint residual on this hub-and-spoke
-                    // skeleton each step and pumps energy (the ragdoll never
-                    // settles). A spring-like, well-damped joint absorbs the
-                    // residual instead. ~60 Hz is well above the step rate (stiff
-                    // enough to hold limbs together) but far from rigid.
-                    .softness(SpringCoefficients {
-                        natural_frequency: 60.0,
-                        damping_ratio: 2.0,
-                    })
-                    .limits(JointAxis::AngX, [-cone, cone])
-                    .limits(JointAxis::AngY, [-cone, cone])
-                    .limits(JointAxis::AngZ, [-cone, cone])
-                    // Disable contacts between this directly-jointed parent/child
-                    // pair so they can overlap at the joint without being ejected;
-                    // non-adjacent limbs still collide (via CollisionGroup::ragdoll).
-                    .contacts_enabled(false)
+                let with_limits = |b: GenericJointBuilder| -> GenericJointBuilder {
+                    b.limits(JointAxis::AngX, [-cone, cone])
+                        .limits(JointAxis::AngY, [-cone, cone])
+                        .limits(JointAxis::AngZ, [-cone, cone])
+                        // Disable contacts between this directly-jointed parent/
+                        // child pair so they can overlap at the joint without
+                        // being ejected; non-adjacent limbs still collide.
+                        .contacts_enabled(false)
+                };
+
+                if use_multibody {
+                    // Reduced-coordinate ball joint anchored at the CHILD origin -
+                    // the true articulation point (e.g. the hip socket). Translation
+                    // is structurally not a DOF, so limbs can't separate (no hip gap)
+                    // and no spring energy is injected. parent_world*frame1 ==
+                    // child_world*frame2 at spawn, so multibody forward-kinematics
+                    // reproduces the captured death pose (no snap).
+                    let parent_to_child = child_pos - parent_pos;
+                    let parent_local_anchor = parent_rot.conjugate().rotate_vector(parent_to_child);
+                    let frame1 = Isometry::from_parts(
+                        Translation3::new(
+                            parent_local_anchor.x,
+                            parent_local_anchor.y,
+                            parent_local_anchor.z,
+                        ),
+                        frame1_rot,
+                    );
+                    let frame2 = Isometry::from_parts(
+                        Translation3::new(0.0, 0.0, 0.0),
+                        UnitQuaternion::identity(),
+                    );
+                    let joint = with_limits(
+                        GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
+                            .local_frame1(frame1)
+                            .local_frame2(frame2),
+                    )
                     .build();
-                let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
-                joint_handles.push(handle);
-                joint_pairs.push((parent_handle, child_handle));
+                    // Insert returns None only if the child is not a fresh root (a
+                    // duplicate edge / cycle) - dedup above prevents that, but skip
+                    // defensively rather than panic.
+                    if physics
+                        .create_multibody_joint(parent_handle, child_handle, joint)
+                        .is_some()
+                    {
+                        joint_pairs.push((parent_handle, child_handle));
+                    }
+                } else {
+                    // Impulse ball joint anchored at the PARENT origin (the heavy
+                    // hub), keeping the low-inertia pelvis from being torqued by the
+                    // joint spring. The locked translation is softened (compliant,
+                    // ~60 Hz) so this hub-and-spoke rig settles instead of pumping
+                    // energy - at the cost of the hip sagging/separating under load.
+                    let child_to_parent = parent_pos - child_pos;
+                    let child_local_anchor = child_rot.conjugate().rotate_vector(child_to_parent);
+                    let frame1 = Isometry::from_parts(Translation3::new(0.0, 0.0, 0.0), frame1_rot);
+                    let frame2 = Isometry::from_parts(
+                        Translation3::new(
+                            child_local_anchor.x,
+                            child_local_anchor.y,
+                            child_local_anchor.z,
+                        ),
+                        UnitQuaternion::identity(),
+                    );
+                    let joint = with_limits(
+                        GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
+                            .local_frame1(frame1)
+                            .local_frame2(frame2)
+                            .softness(SpringCoefficients {
+                                natural_frequency: 60.0,
+                                damping_ratio: 2.0,
+                            }),
+                    )
+                    .build();
+                    let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
+                    joint_handles.push(handle);
+                    joint_pairs.push((parent_handle, child_handle));
+                }
             }
         }
 
@@ -463,6 +523,10 @@ impl RagDollManager {
 
     pub fn remove_entity(&mut self, entity_id: EntityId, physics: &mut PhysicsWorld) {
         if let Some(ragdoll) = self.ragdolls.remove(&entity_id) {
+            // Impulse joints must be removed explicitly; multibody joints are
+            // removed automatically when their attached bodies are removed (see
+            // PhysicsWorld::remove_rigid_body_handle), so for multibody rigs
+            // joint_handles is empty and this loop is a no-op.
             for joint in ragdoll.joint_handles {
                 physics.remove_impulse_joint(joint);
             }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1058,11 +1058,14 @@ impl MissionCore {
     /// creature is removed. Using a separate entity id is important: the original
     /// creature is torn down via `remove_entity`, which also clears any ragdoll
     /// keyed by that id - so the corpse must live under its own id to survive.
-    pub fn spawn_debug_ragdoll(&mut self, entity_id: EntityId) {
+    /// Replace a creature with a physics ragdoll of its current pose. `use_multibody`
+    /// selects reduced-coordinate (multibody) joints over the default impulse joints.
+    /// Returns true if a ragdoll was spawned (the creature is then removed).
+    pub fn spawn_ragdoll(&mut self, entity_id: EntityId, use_multibody: bool) -> bool {
         let spawned = {
             let model = match self.id_to_model.get(&entity_id) {
                 Some(model) if model.can_create_rag_doll() => model,
-                _ => return,
+                _ => return false,
             };
 
             let (root_transform, joint_transforms) = {
@@ -1074,11 +1077,11 @@ impl MissionCore {
 
                 let root_transform = match v_transform.get(entity_id) {
                     Ok(transform) => transform.0,
-                    Err(_) => return,
+                    Err(_) => return false,
                 };
                 let joint_transforms = match v_joint_transforms.get(entity_id) {
                     Ok(joints) => joints.0,
-                    Err(_) => return,
+                    Err(_) => return false,
                 };
                 (root_transform, joint_transforms)
             };
@@ -1100,6 +1103,7 @@ impl MissionCore {
                 &joint_transforms,
                 vec3(0.0, 0.0, 0.0),
                 &joint_limits,
+                use_multibody,
                 &mut self.physics,
             )
         };
@@ -1110,6 +1114,7 @@ impl MissionCore {
             self.remove_entity(entity_id);
             println!("Spawned ragdoll and removed creature {:?}", entity_id);
         }
+        spawned
     }
 
     pub fn handle_effects(
@@ -1591,7 +1596,23 @@ impl MissionCore {
                             )
                         }
 
-                        self.remove_entity(entity_id);
+                        // With the `ragdoll` experimental flag, replace the slain
+                        // creature with a physics ragdoll of its death pose (the
+                        // spawn removes the creature itself). `ragdoll_multibody`
+                        // selects the experimental reduced-coordinate joints. Without
+                        // the flag (or for non-ragdoll-able entities), fall back to
+                        // the plain removal.
+                        let spawned_ragdoll =
+                            game_options.experimental_features.contains("ragdoll")
+                                && self.spawn_ragdoll(
+                                    entity_id,
+                                    game_options
+                                        .experimental_features
+                                        .contains("ragdoll_multibody"),
+                                );
+                        if !spawned_ragdoll {
+                            self.remove_entity(entity_id);
+                        }
                     }
                 }
                 Effect::StopSound { handle } => {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1148,6 +1148,23 @@ impl PhysicsWorld {
             .insert(parent, child, joint_params, true)
     }
 
+    /// Create a reduced-coordinate (multibody) joint between `parent` and `child`.
+    /// Unlike an impulse joint, the constraint is structural - translation is not a
+    /// DOF, so the bodies cannot separate, and no spring energy is injected. The
+    /// child must currently be the root of its own multibody (each rigid body has at
+    /// most one parent link); returns `None` if that invariant is violated (e.g. a
+    /// duplicate edge / cycle). Removing either body (via `remove_rigid_body_handle`)
+    /// also removes the joint.
+    pub fn create_multibody_joint(
+        &mut self,
+        parent: RigidBodyHandle,
+        child: RigidBodyHandle,
+        joint_params: GenericJoint,
+    ) -> Option<MultibodyJointHandle> {
+        self.multibody_joint_set
+            .insert(parent, child, joint_params, true)
+    }
+
     /// Get the transform (position and rotation) of a rigid body by handle
     pub fn get_body_transform(&self, handle: RigidBodyHandle) -> Option<Isometry<Real>> {
         self.rigid_body_set.get(handle).map(|body| *body.position())

--- a/shock2vr/src/scenes/debug_hitbox.rs
+++ b/shock2vr/src/scenes/debug_hitbox.rs
@@ -13,12 +13,37 @@
 //!
 //! Where red and green coincide, the ragdoll conversion is faithful; where they
 //! diverge (e.g. the thighs), the bug is in the hitbox->ragdoll conversion, not
-//! in the fit/joint mapping. Cycle poses with the `DebugHitboxCyclePose` input
-//! action (HTTP-triggerable via the debug runtime) to stress runtime placement.
+//! in the fit/joint mapping. (In practice the joint matrices are orthonormal, so
+//! red and green coincide - rotation extraction is *not* the bug.) Cycle poses
+//! with the `DebugHitboxCyclePose` input action (HTTP-triggerable via the debug
+//! runtime) to stress runtime placement.
+//!
+//! It also overlays how the ragdoll wires up each parent->child joint:
+//!
+//! - **blue**    - the bone segment (parent joint origin -> child joint origin).
+//! - **yellow**  - the impulse-joint anchor `add_ragdoll` actually uses: the
+//!   *parent* joint origin (frame1 translation is zero). This is the pivot the
+//!   child limb rotates about.
+//! - **magenta** - the closest/contact points between the parent and child fitted
+//!   shapes (`parry::query::contact`): where the two limb boxes actually meet.
+//!
+//! The yellow anchor sitting far from the magenta contact (e.g. the hip anchors
+//! ~29 cm above/behind the thigh sockets, both pinned to the same bone-8 origin)
+//! is the "joint positioned wrong" signal: the limb pivots about a point well
+//! away from where it visually connects to its parent.
 
-use cgmath::{Matrix4, Point3, Quaternion, Vector3, vec3};
-use dark::{SCALE_FACTOR, properties::PropTemplateId};
-use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
+use cgmath::{Matrix4, Point3, Quaternion, Rotation, Vector3, vec3};
+use dark::{SCALE_FACTOR, hit_box::HitBoxShape, properties::PropTemplateId, ss2_skeleton::Bone};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, VertexPosition, color_material, lines_mesh},
+};
+use rapier3d::{
+    na::{Point3 as NaPoint3, Translation3},
+    parry::query,
+    prelude::{Isometry, SharedShape},
+};
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, View};
 
 use crate::{
@@ -28,6 +53,7 @@ use crate::{
         GlobalContext, SpawnLocation, entity_creator::CreateEntityOptions,
         mission_core::MissionCore,
     },
+    physics::util::quat_to_nquat,
     runtime_props::{RuntimePropJointTransforms, RuntimePropTransform},
     scenes::debug_common::{
         DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
@@ -44,6 +70,15 @@ const CREATURE_TEMPLATE_ID: i32 = -397;
 const SHAPE_COLOR_DIRECT: Vector3<f32> = Vector3::new(0.2, 1.0, 0.3);
 /// Red: fitted shapes placed the way the ragdoll decomposes the joint matrix.
 const SHAPE_COLOR_RAGDOLL: Vector3<f32> = Vector3::new(1.0, 0.25, 0.2);
+/// Blue: the parent->child "bone" segments, as the ragdoll wires up joints.
+const JOINT_BONE_COLOR: Vector3<f32> = Vector3::new(0.35, 0.5, 1.0);
+/// Yellow: where `RagDollManager::add_ragdoll` anchors each impulse joint (the
+/// parent joint origin). This is the pivot the child limb rotates about.
+const JOINT_ANCHOR_COLOR: Vector3<f32> = Vector3::new(1.0, 0.9, 0.1);
+/// Magenta: the closest/contact points between the parent and child fitted shapes
+/// (`parry::query::contact`) - i.e. where the two limb boxes actually meet, the
+/// candidate "natural" joint location.
+const JOINT_CONTACT_COLOR: Vector3<f32> = Vector3::new(1.0, 0.2, 1.0);
 
 /// Where the creature spawns - straight ahead of the default player spawn.
 fn focus_point() -> Point3<f32> {
@@ -208,5 +243,133 @@ impl DebugSceneHooks for HitboxHooks {
             &world_ragdoll,
             SHAPE_COLOR_RAGDOLL,
         ));
+
+        // Joint overlay: how the ragdoll wires up each parent->child joint, drawn
+        // statically from the live pose (no physics). Lets us see joint placement
+        // (and compare the current anchor vs. where the limb boxes actually meet)
+        // across poses, separate from any runtime solver behavior.
+        if let Some((bones, _bind_world)) = model.ragdoll_source() {
+            scene_objects.extend(draw_joint_debug(&shapes, &bones, &world_direct));
+        }
+    }
+}
+
+/// Build the per-joint debug overlay (bones, current anchors, shape contact
+/// points) from the live posed joint world matrices.
+fn draw_joint_debug(
+    shapes: &std::collections::HashMap<u32, HitBoxShape>,
+    bones: &[Bone],
+    world: &[Matrix4<f32>],
+) -> Vec<SceneObject> {
+    let mut bone_verts: Vec<VertexPosition> = Vec::new();
+    let mut anchor_verts: Vec<VertexPosition> = Vec::new();
+    let mut contact_verts: Vec<VertexPosition> = Vec::new();
+
+    for bone in bones {
+        let Some(parent_id) = bone.parent_id else {
+            continue;
+        };
+        let (c, p) = (bone.joint_id as usize, parent_id as usize);
+        if c >= world.len() || p >= world.len() {
+            continue;
+        }
+
+        let cpos = point_to_vec(get_position_from_matrix(&world[c]));
+        let ppos = point_to_vec(get_position_from_matrix(&world[p]));
+
+        // Bone segment + a small tick at the child joint origin.
+        push_segment(&mut bone_verts, ppos, cpos);
+        push_cross(&mut bone_verts, cpos, 0.02);
+
+        // Current ragdoll anchor: the parent joint origin (frame1 translation is
+        // zero in add_ragdoll, so the pivot sits here).
+        push_cross(&mut anchor_verts, ppos, 0.07);
+
+        // Where the two fitted shapes actually meet (closest/contact points).
+        if let (Some(child_shape), Some(parent_shape)) =
+            (shapes.get(&(bone.joint_id)), shapes.get(&(parent_id)))
+        {
+            let (pg, pi) = parry_shape(parent_shape, &world[p]);
+            let (cg, ci) = parry_shape(child_shape, &world[c]);
+            if let Ok(Some(ct)) = query::contact(&pi, &*pg, &ci, &*cg, 0.5) {
+                let pt1 = Vector3::new(ct.point1.x, ct.point1.y, ct.point1.z);
+                let pt2 = Vector3::new(ct.point2.x, ct.point2.y, ct.point2.z);
+                push_cross(&mut contact_verts, pt1, 0.05);
+                push_cross(&mut contact_verts, pt2, 0.05);
+                push_segment(&mut contact_verts, pt1, pt2);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (verts, color) in [
+        (bone_verts, JOINT_BONE_COLOR),
+        (anchor_verts, JOINT_ANCHOR_COLOR),
+        (contact_verts, JOINT_CONTACT_COLOR),
+    ] {
+        if !verts.is_empty() {
+            out.push(SceneObject::new(
+                color_material::create(color),
+                Box::new(lines_mesh::create(verts)),
+            ));
+        }
+    }
+    out
+}
+
+/// Build a parry shape + world isometry for a fitted `HitBoxShape`, matching how
+/// the ragdoll places its collider (body origin at the joint, cuboid center
+/// folded into the transform).
+fn parry_shape(shape: &HitBoxShape, world: &Matrix4<f32>) -> (SharedShape, Isometry<f32>) {
+    let pos = get_position_from_matrix(world);
+    let rot = get_rotation_from_matrix(world);
+    let nrot = quat_to_nquat(rot);
+    match shape {
+        HitBoxShape::Capsule { a, b, radius } => (
+            SharedShape::capsule(
+                NaPoint3::new(a.x, a.y, a.z),
+                NaPoint3::new(b.x, b.y, b.z),
+                *radius,
+            ),
+            Isometry::from_parts(Translation3::new(pos.x, pos.y, pos.z), nrot),
+        ),
+        HitBoxShape::Cuboid {
+            half_extents,
+            center,
+        } => {
+            let cw = rot.rotate_vector(*center);
+            (
+                SharedShape::cuboid(
+                    half_extents.x.max(0.01),
+                    half_extents.y.max(0.01),
+                    half_extents.z.max(0.01),
+                ),
+                Isometry::from_parts(
+                    Translation3::new(pos.x + cw.x, pos.y + cw.y, pos.z + cw.z),
+                    nrot,
+                ),
+            )
+        }
+    }
+}
+
+fn point_to_vec(p: Point3<f32>) -> Vector3<f32> {
+    Vector3::new(p.x, p.y, p.z)
+}
+
+fn push_segment(verts: &mut Vec<VertexPosition>, a: Vector3<f32>, b: Vector3<f32>) {
+    verts.push(VertexPosition { position: a });
+    verts.push(VertexPosition { position: b });
+}
+
+/// A small 3-axis cross centered at `p` (six vertices / three segments).
+fn push_cross(verts: &mut Vec<VertexPosition>, p: Vector3<f32>, s: f32) {
+    for axis in [Vector3::unit_x(), Vector3::unit_y(), Vector3::unit_z()] {
+        verts.push(VertexPosition {
+            position: p - axis * s,
+        });
+        verts.push(VertexPosition {
+            position: p + axis * s,
+        });
     }
 }

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -171,7 +171,12 @@ impl RagdollHooks {
                 asset_cache,
                 audio_context,
             );
-            core.spawn_debug_ragdoll(entity_id);
+            core.spawn_ragdoll(
+                entity_id,
+                game_options
+                    .experimental_features
+                    .contains("ragdoll_multibody"),
+            );
             println!(
                 "Applied massive damage to pipe hybrid entity {:?} for ragdoll testing",
                 entity_id


### PR DESCRIPTION
Follow-up to #301. Adds reduced-coordinate **multibody** ragdoll joints and an **on-death** ragdoll path, both behind experimental flags, keeping the stable impulse rig as the default.

## Flags
- `--experimental ragdoll` — spawn a physics ragdoll on creature death (`SlayEntity`) instead of just removing the entity. (Before this there was *no* on-death ragdoll path; ragdolls only existed in the `debug_ragdoll` scene.)
- `--experimental ragdoll_multibody` — ragdoll uses multibody joints anchored at the limb articulation point. Translation isn't a DOF, so **limbs can't separate** (fixes the hip "disconnect"); without it, the stable impulse rig.

## Why multibody fixes the hip disconnect
The impulse rig has to anchor the hip joint at the heavy pelvis origin (~29 cm from the actual hip socket) and soften the locked translation for hub stability — so the thigh pivots away from where it visually connects *and* the joint sags under load. A reduced-coordinate joint removes translation as a DOF entirely, so we can anchor at the true articulation point with no separation and no spring energy. Death-pose-aligned frames make forward-kinematics reproduce the spawn pose (no snap).

## Key changes
- `physics`: `create_multibody_joint`
- `rag_doll`: `use_multibody` branch (child-origin anchor, no softness, **uniform core mass** — the 4× core is an impulse crutch that *destabilizes* the articulated solver); **one body per joint id** (fixes a duplicate-bone orphan-body bug)
- `mission_core`: `spawn_ragdoll(use_multibody)` + `SlayEntity` wiring
- `debug_hitbox`: joint-anchor overlay (bone / current anchor / closest points between limb shapes); corrected a stale "rotation extraction is the bug" comment — the joint matrices are orthonormal (verified by dumping them)
- docs: `projects/ragdoll-settling-followup.md` investigation write-up + flag docs in `CLAUDE.md`

## Known limitation
Multibody settling on floor contact isn't fully solved — the core settles but **extremities can jitter** in a contact limit-cycle (body damping doesn't bleed the constrained DOF; joint-friction motors inject energy). That's why it stays **experimental / opt-in**. Untried next approaches are written up as "step 0" in the project notes.

## Test plan
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `cargo test -p shock2vr` — 39 passed (incl. slay/health tests)
- Debug-runtime routing verified: default → 19 impulse joints; `--experimental ragdoll_multibody` → 0 impulse joints, bodies stay connected (~1.6 m extent, not exploded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
