### PR TITLE
chore: line-tables-only debug info for own crates (debug = 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,14 @@
 
+# Line-tables-only debug info for our own crates: keeps file/line numbers in
+# backtraces and panics, but drops full DWARF (no local-variable inspection in
+# a debugger). Roughly halves the size of our workspace .rlib artifacts.
+[profile.dev]
+debug = 1
+
 [profile.dev.package.rapier3d]
 opt-level = 3
 
 # Strip debug info from all third-party dependencies to shrink target/.
-# Our own crates keep full debug info; opt in per-dep above if needed.
 [profile.dev.package."*"]
 debug = false
 


### PR DESCRIPTION
## Why

Our workspace crates were being built with full debug info (`debug = 2`), which dominated `target/` size — each workspace `.rlib` was ~85 MB, mostly DWARF debug info. Third-party deps were already stripped via `profile.dev.package."*"`, but our own crates were **not** covered by that, so `target/debug` ballooned (13+ GB on a working checkout, much of it stale duplicate `.rlib`s that Cargo never garbage-collects).

## What

Set `[profile.dev] debug = 1` (line-tables-only) for our own crates:

- ✅ **Kept:** file/line numbers in backtraces and panic messages
- ❌ **Dropped:** full DWARF — no local-variable inspection when stepping in a debugger (lldb/gdb)

## Impact

Roughly **halves** workspace `.rlib` sizes and slows the stale-artifact pile-up in `target/` between rebuilds. A fresh `target/debug` should land closer to ~5–7 GB instead of ~13 GB once old full-debug artifacts age out.

If full debugger inspection is needed for a specific debugging session, bump back to `debug = 2` locally (or per-package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)