### PR TITLE
refactor(dark): Property Send+Sync + entity_info Rc→Arc (foundation complete)

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -86,6 +86,15 @@ pub struct SystemShock2Level {
     pub path_database: Option<PathDatabase>,
 }
 
+// Capstone for the loading-screen "foundation track" (projects/loading-screen.md, PR
+// S1+S2): the full level-parse output is now `Send + Sync`, so it can cross to a worker
+// thread for background loading (PR 3). This guard fails to compile if any future field
+// reintroduces a non-thread-safe type (e.g. an `Rc`).
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<SystemShock2Level>();
+};
+
 impl SystemShock2Level {
     pub fn get_cell_idx_from_position(&self, position: Vector3<f32>) -> Option<u32> {
         self.bsp_tree.cell_from_position(position)

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1477,7 +1477,10 @@ where
     }
 }
 
-pub trait Property: fmt::Debug {
+// `Send + Sync` is required so the level parse (which builds `Vec<Arc<Box<dyn Property>>>`)
+// can run on a background thread (projects/loading-screen.md, PR S2). This is satisfied
+// for free: both blanket impls below already require `C: Send + Sync`.
+pub trait Property: fmt::Debug + Send + Sync {
     fn initialize(&self, world: &mut World, entity: EntityId);
 }
 

--- a/dark/src/ss2_entity_info.rs
+++ b/dark/src/ss2_entity_info.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     io::{self, SeekFrom},
-    rc::Rc,
+    sync::Arc,
 };
 
 use shipyard::{EntityId, World};
@@ -32,7 +32,7 @@ pub struct UnparsedLinkData {
 
 #[derive(Debug)]
 pub struct SystemShock2EntityInfo {
-    pub entity_to_properties: HashMap<i32, Vec<Rc<Box<dyn Property>>>>,
+    pub entity_to_properties: HashMap<i32, Vec<Arc<Box<dyn Property>>>>,
     pub template_to_links: HashMap<i32, TemplateLinks>,
     pub unparsed_properties: HashMap<String, Vec<UnparsedProperty>>,
     pub unparsed_links: HashMap<String, Vec<Link>>,
@@ -46,6 +46,14 @@ pub struct SystemShock2EntityInfo {
     // For each template id, store a list of ancestor template ids
     hierarchy: HashMap<i32, Vec<i32>>,
 }
+
+// Background level loading (projects/loading-screen.md, PR S2) parses the level on a
+// worker thread, so the parse output must be `Send + Sync`. This compile-time assertion
+// guards that the entity-info (the second `Rc` blocker) stays thread-safe.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<SystemShock2EntityInfo>();
+};
 
 impl SystemShock2EntityInfo {
     /// Create an empty SystemShock2EntityInfo for debug or testing purposes
@@ -474,7 +482,7 @@ fn read_all_properties<R: io::Read + io::Seek>(
     toc: &ChunkFileTableOfContents,
     properties: &Vec<Box<dyn PropertyDefinition<R>>>,
     ref_reader: &mut R,
-) -> HashMap<i32, Vec<Rc<Box<dyn Property>>>> {
+) -> HashMap<i32, Vec<Arc<Box<dyn Property>>>> {
     let mut ent_to_props = HashMap::new();
     for prop in properties {
         let name = prop.name();
@@ -507,7 +515,7 @@ fn read_all_properties<R: io::Read + io::Seek>(
                     ref_reader.stream_position().unwrap()
                 );
 
-                props.push(Rc::new(prop));
+                props.push(Arc::new(prop));
 
                 ref_reader.seek(SeekFrom::Start(expected_pos)).unwrap();
             }

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -6,7 +6,7 @@ use dark::{
 };
 use glob::Pattern;
 use shipyard::{Get, View, World};
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Debug, Clone)]
 pub enum EntityType {
@@ -66,7 +66,7 @@ pub struct FilterCriteria {
 }
 
 /// Extract name properties by creating a temporary world and reading components
-pub fn extract_names_public(properties: &[Rc<Box<dyn Property>>]) -> EntityNames {
+pub fn extract_names_public(properties: &[Arc<Box<dyn Property>>]) -> EntityNames {
     extract_names(properties)
 }
 
@@ -132,7 +132,7 @@ pub fn extract_template_id_with_inheritance(
     ancestors.last().copied()
 }
 
-fn extract_names(properties: &[Rc<Box<dyn Property>>]) -> EntityNames {
+fn extract_names(properties: &[Arc<Box<dyn Property>>]) -> EntityNames {
     let mut world = World::new();
     let entity = world.add_entity(());
 
@@ -172,7 +172,7 @@ fn extract_names(properties: &[Rc<Box<dyn Property>>]) -> EntityNames {
     }
 }
 
-fn extract_template_id(properties: &[Rc<Box<dyn Property>>]) -> Option<i32> {
+fn extract_template_id(properties: &[Arc<Box<dyn Property>>]) -> Option<i32> {
     let mut world = World::new();
     let entity = world.add_entity(());
 
@@ -294,7 +294,7 @@ fn pattern_matches_simple_glob(text: &str, pattern: &str) -> bool {
 }
 
 /// Get property type names from the property list
-fn get_property_names(properties: &[Rc<Box<dyn Property>>]) -> Vec<String> {
+fn get_property_names(properties: &[Arc<Box<dyn Property>>]) -> Vec<String> {
     properties
         .iter()
         .map(|prop| {
@@ -419,7 +419,7 @@ fn get_link_types_with_inheritance(
 }
 
 /// Extract script names from properties
-fn get_script_names(properties: &[Rc<Box<dyn Property>>]) -> Vec<String> {
+fn get_script_names(properties: &[Arc<Box<dyn Property>>]) -> Vec<String> {
     // Create a temporary world to extract script information
     let mut world = World::new();
     let entity = world.add_entity(());

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -456,7 +456,7 @@ fn show_inheritance_tree(
 
 fn show_properties_for_entity(
     _entity_id: i32,
-    properties: &[std::rc::Rc<Box<dyn dark::properties::Property>>],
+    properties: &[std::sync::Arc<Box<dyn dark::properties::Property>>],
     depth: usize,
 ) {
     let indent = "  ".repeat(depth);

--- a/tools/dark_query/src/speech_analyzer.rs
+++ b/tools/dark_query/src/speech_analyzer.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    rc::Rc,
+    sync::Arc,
 };
 
 use anyhow::{Result, anyhow, bail};
@@ -391,7 +391,7 @@ impl SpeechAnalyzer {
         None
     }
 
-    fn extract_voice_index_from_properties(properties: &[Rc<Box<dyn Property>>]) -> Option<i32> {
+    fn extract_voice_index_from_properties(properties: &[Arc<Box<dyn Property>>]) -> Option<i32> {
         let mut world = World::new();
         let entity = world.add_entity(());
 


### PR DESCRIPTION
## What

Makes the `Property` trait `Send + Sync` and converts `entity_to_properties` from `Rc` to `Arc`, removing the **second and final** `Send` blocker in the level-parse output. Stacks on #309 (PR S1, BspTree).

## Why

Preparatory refactor for **background level loading** (`projects/loading-screen.md`, PR S2 — the "foundation track"). After this, the entire parse output (`SystemShock2Level`) is `Send + Sync`, so it can be produced on a worker thread (PR 3). No loading-screen code changes here — pure foundation.

This is guaranteed safe (proven during the PR 0 spike): both `Property` blanket impls (`impl<C> Property for C` and `… for WrappedProperty<C>`) **already require `C: Send + Sync`** (shipyard `Component` storage demands it), and the whole `dark/src/properties/` module has zero `Rc`/`RefCell`/`Cell`/raw pointers. So adding the supertrait compiles for free — the `Rc` wrapper was the sole blocker.

## Changes

- `Property: fmt::Debug` → `Property: fmt::Debug + Send + Sync` (`properties/mod.rs`).
- `entity_to_properties: Vec<Rc<Box<dyn Property>>>` → `Vec<Arc<…>>` (`ss2_entity_info.rs`: field, `read_all_properties` return, construction).
- `dark_query` consumers whose helpers took `&[Rc<Box<dyn Property>>]` (`entity_analyzer`, `speech_analyzer`, `main`).

Transparent `Rc → Arc`, **no behavior change**, no logic touched. Other `Rc<dyn Geometry>`/`Rc<dyn TextureTrait>` usages are GPU/render types (not parse output) and are intentionally left alone.

## Verification (negative-test-first)

- `assert_send_sync::<SystemShock2EntityInfo>()` **fails before** (`Rc<Box<dyn Property>>` is `!Send`), **passes after**.
- **Capstone guard added**: `assert_send_sync::<SystemShock2Level>()` — with S1 (BspTree) + S2, the *whole* parse output is now `Send + Sync`. (This guard fails CI if any future field reintroduces a non-thread-safe type.)
- Builds clean `-D warnings`: `dark`, `shock2vr`, `debug_runtime`, `dark_query`, `dark_viewer`.
- `cargo test -p dark` — 9 passed, 0 failed.
- Debug-runtime smoke test (`earth`, `medsci1`, `station`): load + step, **no panic**; entities instantiate correctly (physics bodies present with names like "Sci Med Door" and full properties).

## Foundation track complete

With #309 + this PR, the `Send` half of Gate A is fully closed — `SystemShock2Level` is `Send + Sync`. PR 3 (background parse) no longer contains any `Rc → Arc` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)