### PR TITLE
feat(flat): first-person weapon aim + viewmodel from PropPlayerGun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_hud`              | Test HUD rendering                           |
    | `debug_map`              | Test map/automap rendering                   |
    | `debug_minimal`          | Bare minimum scene for basic testing         |
+   | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `CycleWeapon`) |
 
    ```bash
    # Use with debug runtime for programmatic control

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -42,12 +42,29 @@ Verified: the pistol hit-spang and the grenade land dead-center on the crosshair
 
 Remaining (follow-ups):
 
-- **Viewmodel framing / per-weapon position** — the viewmodel sits low after the
-  eye-height drop, and position still uses a single shared `VIEWMODEL_OFFSET`.
-  Wire per-weapon `PropPlayerGun.model_offset` (original-engine view-space units;
-  needs axis-mapping + scale calibration — raw values put the gun off-screen;
-  ref `darkengine` `PlayerGunDescGetModelOffset` / `m_posOffset`). Nudge the
-  shared offset up in the meantime.
+- **TODO(fable model): per-weapon viewmodel framing from `PropPlayerGun.model_offset`.**
+  Currently the flat viewmodel uses a single shared `VIEWMODEL_OFFSET` for every
+  weapon (playable: all 11 frame bottom-right with the crosshair clear).
+  Investigated wiring per-weapon `model_offset` and it does NOT reduce to one
+  scalar — revisit with a fresh approach (a Fable-model pass). Findings:
+  - Axis mapping that works: Dark view space `(x=forward, y=left, z=up)` ->
+    look space `(+x right, +y up, -z forward)` = `vec3(-mo.y, mo.z, mo.x)`.
+  - **FOV mismatch is the blocker.** SS2 authors the *pistol* more cornered
+    (`model_offset` ~38° down-right) than the *big guns* (EMP/AR ~18°). Our
+    renderer's FOV clips the cornered pistol, while we'd want the opposite for
+    playability. So:
+    - a uniform scale on the whole offset keeps each weapon's authored angle ->
+      big guns frame great (bottom-right, reticle clear) but the pistol clips
+      off the corner at any scale;
+    - a forward-only gain (`mo.x * ~2`) pulls the pistol in nicely but centers
+      the big guns over the crosshair ("breaks visibility");
+    - `/SCALE_FACTOR` puts every gun ~0.4 world units from the eye (fills view).
+  - Likely correct fix: render the viewmodel pass with its own **wider FOV /
+    separate projection** (standard FPS technique), then faithful `model_offset`
+    frames all weapons as authored. Verify per weapon in `debug_weapons`.
+  - Ref: `darkengine` `PlayerGunDescGetModelOffset` / `m_posOffset`. The
+    experiment code lived on the abandoned `feat/flat-viewmodel-offset` branch
+    (see git reflog) if useful.
 - **Muzzle flash is world-pinned** — created at the weapon's fire-time transform
   and not re-parented, so it doesn't track the weapon. Attach it to the muzzle
   vhot / render it in viewmodel space.

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -1,0 +1,223 @@
+# Flat-runtime weapon handling & feel
+
+Status: planning (2026-06-20). Follow-on to the flatscreen runtime (slices 1-6,
+#295-#305). The flatscreen runtime is now the **default desktop experience**, so
+the first-person weapon loop is the most-exercised gameplay code and worth
+getting right. This doc collects the aiming/viewmodel polish work and the
+"modern FPS feel" wishlist into one place.
+
+See also: `projects/flatscreen-and-vr-architecture.md` (the intent/outcome seam
+that all of this must respect), `projects/melee-combat.md`,
+`projects/player-damage.md`.
+
+## Status / progress (2026-06-21)
+
+Landed on branch `feat/flat-aim-viewmodel` (PR: flat first-person weapons — aim +
+viewmodel):
+
+Done:
+
+- **Camera-origin aim** — flat shots spawn at the camera and travel straight
+  along the crosshair, for both hitscan bullets and slow physics projectiles
+  (e.g. the grenade). `RuntimePropFlatAim` carries the fire ray; the flat
+  controller sets it on the wielded weapon and `weapon_script::create_projectile`
+  consumes it (the "fire intent" seam above). VR/AI weapons are unchanged.
+- **First-person viewmodel from `PropPlayerGun.hand_model`** — render each
+  weapon's native FP mesh, dropping the inconsistent VR `HAND_MODEL_POSITIONING`
+  table. Fixes the per-weapon rotation (shotgun / EMP / assault / psi-amp were
+  sideways or facing the player). NB: `PropPlayerGun.heading` is NOT the model
+  rotation — applying it over-rotates each gun by exactly its heading — so it is
+  deliberately unused.
+- **Eye-height alignment** — the shot origin + viewmodel use the shared
+  `shock2vr::PLAYER_EYE_HEIGHT` (4.0 SS2 units), matching every runtime's render
+  camera, so shots land on the crosshair and the debug-runtime camera matches
+  desktop (was rendering ~1 world unit low).
+- **Tooling**: debug-runtime controllable input over HTTP (`head.look` + hand
+  trigger; the render camera now honors the input head rotation), a `CycleWeapon`
+  action (`B` / HTTP) over the 11-weapon roster, and the `debug_weapons` scene (a
+  wall straight ahead) for headless aim verification.
+
+Verified: the pistol hit-spang and the grenade land dead-center on the crosshair
+(`debug_weapons`); all 11 player weapons render their FP mesh oriented correctly.
+
+Remaining (follow-ups):
+
+- **Viewmodel framing / per-weapon position** — the viewmodel sits low after the
+  eye-height drop, and position still uses a single shared `VIEWMODEL_OFFSET`.
+  Wire per-weapon `PropPlayerGun.model_offset` (original-engine view-space units;
+  needs axis-mapping + scale calibration — raw values put the gun off-screen;
+  ref `darkengine` `PlayerGunDescGetModelOffset` / `m_posOffset`). Nudge the
+  shared offset up in the meantime.
+- **Muzzle flash is world-pinned** — created at the weapon's fire-time transform
+  and not re-parented, so it doesn't track the weapon. Attach it to the muzzle
+  vhot / render it in viewmodel space.
+- **Melee weapons (deferred)** — use `PropLimbModel` (no `PropPlayerGun`, so no
+  `model_offset` / `heading`); need a parallel flat placement path before they
+  can be cycled/wielded.
+- **Crouch-accurate aim** — `PLAYER_EYE_HEIGHT` is the standing value; desktop
+  crouch (1.5) lowers the camera but the flat controller's shot origin is fixed,
+  so crouched shots land slightly high. Pass the actual eye height into the
+  controller to fix.
+- **Latent**: the Hybrid Shotgun (-4073) panics on creation (unimplemented
+  `trashedshotgun` script) — excluded from the cycle roster; the
+  panic-on-unknown-script is a separate crash risk worth its own issue.
+
+The "feel" wishlist below (recoil, dynamic crosshair, reload animations, look
+inertia, ammo) remains open.
+
+## Architectural constraint (read first)
+
+From the flatscreen architecture doc: **anything that affects simulation outcome
+lives in the core and is expressed as a resolved intent**, not baked into a
+runtime. Aim direction, recoil, accuracy/spread, and ammo consumption are all
+simulation outcomes. The flat front-end's job is to *produce the intent* ("fire
+a shot from point P toward crosshair convergence point C, with spread S"); the
+VR front-end produces the same intent from hand pose. If we instead special-case
+ballistics inside `flat_player_controller`, the same tuning will have to be
+re-done for VR. Draw the line at intent, not device.
+
+Concretely, this argues for a small **fire intent** that the controller emits and
+the weapon script consumes, rather than the weapon script deriving everything
+from its own transform (which is what produces the current aim divergence).
+
+## Current state (grounding)
+
+- `shock2vr/src/flat_player_controller.rs`
+  - Wields one weapon as a viewmodel at `VIEWMODEL_OFFSET = (2.0, -2.5, -5.0)`
+    (right/down/forward in look space) — `:28`.
+  - Already casts a **camera-forward ray** each frame for the crosshair frob
+    target (`:103-116`). This is the ray we want to aim shots along.
+  - Fires by emitting `OutMessage{TriggerPull/Release}` to the weapon entity on
+    the trigger edge — same effects the VR hand emits.
+- `shock2vr/src/scripts/weapon_script.rs`
+  - On `TriggerPull`, spawns the projectile and muzzle flash from the **weapon's
+    own transform + vhot** (`create_projectile`, `create_muzzle_flash`).
+  - Muzzle flash is `Effect::CreateEntity { position: vhot_offset,
+    root_transform: transform.0 (at fire time) }` — a free entity pinned to the
+    world pose captured at the trigger pull (`:155`). It does not re-parent to or
+    track the weapon.
+  - `// TODO: Handle setting or ammo type? This just picks the very first
+    projectile` (`:54`) — ammo selection is unimplemented; the first
+    `Link::Projectile` always wins.
+- `shock2vr/src/input/dispatcher.rs`
+  - `SpawnDebugItem` spawns a single hardcoded template (`-17`, a pistol; `:9`),
+    bound to Space. No weapon cycling / number keys yet.
+
+## Work items
+
+### 1. Fix the aim direction (highest priority — correctness)
+
+Symptom: shots leave the offset barrel along the weapon-model axis, so they do
+not hit where the crosshair points. The viewmodel is intentionally offset
+right/down for framing, which makes the divergence obvious at range.
+
+Approach:
+- Define a **fire intent** carrying the firing ray: origin at (or near) the
+  weapon muzzle vhot, **direction toward the crosshair convergence point** — i.e.
+  the camera-forward raycast hit point (reuse the ray the controller already
+  computes at `flat_player_controller.rs:103`), falling back to a far point along
+  camera-forward when the ray hits nothing.
+- The weapon script spawns the projectile with that direction instead of the
+  weapon's local barrel axis. (VR continues to supply muzzle-forward as its
+  direction — same intent, different producer.)
+- Decide the convergence model: true "barrel -> crosshair point" convergence
+  (parallax-correct, shots cross the reticle at the hit distance) vs.
+  "camera-origin ray" (shots always exactly on the reticle, barrel is cosmetic).
+  Camera-origin is simplest and what most flat FPS do; revisit if it looks wrong
+  for the viewmodel.
+
+**Debug raycast visualization (do this first — it's the measurement tool):**
+- Add a debug flag / `InputAction` that draws the fire ray: a line from the
+  origin (weapon muzzle / camera) through the crosshair to the hit point, plus a
+  marker at the hit. This makes "where is it actually pointing vs. the crosshair"
+  directly visible and is reusable for tuning every later item.
+- Drive it headlessly via the debug runtime (screenshot + `/v1/physics/raycast`)
+  so aim regressions are catchable without an interactive session.
+
+### 2. `debug_weapons` scene + weapon cycling (the test rig)
+
+We need to exercise many weapons quickly without hunting them in a mission.
+
+- New debug scene `debug_weapons` (in `shock2vr/src/scenes/`, registered like the
+  others) that spawns the player in a simple room with the full weapon set
+  available.
+- Flat-runtime weapon cycling on number keys **1-9 and 0**: add
+  `InputAction::SelectWeapon(n)` (or ten discrete actions, matching the existing
+  `all()`/`as_str()` pattern in `input/actions.rs`), map to wielding the n-th
+  weapon in the dispatcher, bind digits in `DesktopInputMapper`. Per the input
+  doc this is then automatically HTTP/SDK-triggerable.
+- Seed a canonical weapon template list (the SS2 player weapons). Reuse for the
+  `SpawnDebugItem` family so debug spawns aren't a single hardcoded pistol.
+
+### 3. Ammo usage / ammo switching
+
+Currently `weapon_script.rs:54` always fires the first projectile link and never
+decrements anything.
+
+- Track ammo on the player (or weapon) state. SS2 models ammo as items/links;
+  resolve the equipped projectile from an **ammo-type selection** rather than
+  "first link wins."
+- Consume a round per shot; block fire (and play dry-fire) at zero.
+- Ammo switch input (cycle ammo types for the held weapon — many SS2 guns take
+  multiple ammo types, e.g. standard vs. AP).
+- Surface current ammo in the flat HUD (we already have the `UiCanvas` HUD layer
+  from #300 — add an ammo readout next to health/psi).
+- Reload: see weapon animations below; reload is where ammo, animation, and input
+  meet.
+
+### 4. Muzzle flash should follow the weapon
+
+Bug: the muzzle flash is spawned as a free entity at the weapon's fire-time world
+pose (`weapon_script.rs:155`), so during its (brief) lifetime it stays put while
+the weapon keeps moving (sway/recoil/look). Visible as the flash detaching from
+the barrel.
+
+Options (cheapest first):
+- Parent/attach the flash to the weapon's muzzle vhot for its lifetime so it
+  tracks the weapon transform, instead of snapshotting `transform.0` once.
+- Or render the flash as a short-lived viewmodel-space effect (like the weapon
+  viewmodel itself, which is re-placed every frame in `render_per_eye`).
+- Same concern applies to any short-lived attached effect (shell ejection, smoke)
+  added later.
+
+## Feel wishlist (modern-FPS-of-the-era polish)
+
+These are what made late-90s/early-2000s shooters feel good; SS2's stats give us
+real inputs to drive them.
+
+- **Dynamic crosshair / accuracy.** Spread widens when moving/jumping, tightens
+  when still/crouched. Drive from SS2 stats already in the data: agility,
+  strength, and per-weapon accuracy stats. The crosshair *shows* the current
+  spread (reticle bloom). Spread is applied as a randomized cone on the fire
+  intent (item 1), so it stays a sim outcome, not a render trick.
+- **Recoil — spring/physical model.** Prefer a spring-damper kick (per-shot
+  impulse to a viewmodel + aim offset that decays back) over a scripted curve, so
+  sustained fire walks the aim and settles naturally. Ties into the dynamic
+  crosshair (recoil feeds spread). Recoil is an aim *outcome*, so it belongs in
+  the intent/core layer (VR two-handed bracing reduces it — same knob).
+- **Weapon animations (reload / attack / swing / idle).** Several weapons ship
+  with these animations; we currently don't play them. Hook the viewmodel to play
+  the weapon's reload/fire/idle clips. Reload animation gates the ammo refill
+  (item 3); swing animations feed melee (`projects/melee-combat.md`).
+- **Look inertia / weapon sway.** GoldenEye/Perfect Dark/TimeSplitters-style lag:
+  the viewmodel trails the camera on fast turns and eases back, plus a subtle idle
+  bob. Pure viewmodel-space transform on top of `VIEWMODEL_OFFSET`; does not
+  affect the fire intent (cosmetic), but should be considered alongside recoil so
+  they compose rather than fight.
+
+## Proposed sequencing
+
+1. **Debug fire-ray visualization** (item 1's tool) — measurement first.
+2. **Fix aim direction** via a fire intent aimed at the crosshair convergence
+   point — the core correctness fix; unblocks honest testing of everything else.
+3. **`debug_weapons` scene + 1-9/0 cycling** — the rig to validate aim/feel
+   across the whole arsenal.
+4. **Muzzle flash follows weapon** — small, self-contained visual fix.
+5. **Ammo usage + HUD readout + ammo switch** — gameplay completeness.
+6. **Feel pass**: recoil spring -> dynamic crosshair -> look inertia ->
+   weapon animations (reload ties ammo + animation together).
+
+Items 1-4 are bounded and headlessly verifiable via the debug runtime; the feel
+pass (6) is interactive-tuning-heavy and should be gated so it doesn't absorb all
+the energy (the flatscreen doc's warning: polish flat *enough to be a faithful
+instrument*, reserve real polish for the VR product).

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -267,6 +267,11 @@ async fn start_http_server(
     // Bind to localhost only for security
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     info!("Debug runtime listening on http://{}", addr);
+    info!(
+        "camera eye height (standing): {} SS2 units = {} world units (above pawn) - shared with desktop via PLAYER_EYE_HEIGHT",
+        shock2vr::PLAYER_EYE_HEIGHT,
+        shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR
+    );
 
     // Log available endpoints
     info!("Available endpoints:");
@@ -635,10 +640,10 @@ fn run_game_blocking(
             time: actual_game_time, // Use accumulated game time, not real time
             camera_offset: pawn_offset,
             camera_rotation: pawn_rotation,
-            // Standing eye height, matching desktop (head_height 4.0) and the
-            // flat controller's HEAD_HEIGHT, so shots originate at the rendered
-            // eye and land on the crosshair.
-            head_offset: vec3(0.0, 4.0 / SCALE_FACTOR, 0.0),
+            // Standing eye height, shared with desktop and the flat controller
+            // via shock2vr::PLAYER_EYE_HEIGHT, so the debug-runtime camera sits
+            // at the same height as desktop and shots land on the crosshair.
+            head_offset: vec3(0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0),
             // Same head rotation fed to game.update, so the rendered view and the
             // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
             head_rotation: current_input.head.rotation,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -635,7 +635,10 @@ fn run_game_blocking(
             time: actual_game_time, // Use accumulated game time, not real time
             camera_offset: pawn_offset,
             camera_rotation: pawn_rotation,
-            head_offset: vec3(0.0, 1.6 / SCALE_FACTOR, 0.0), // Default head height
+            // Standing eye height, matching desktop (head_height 4.0) and the
+            // flat controller's HEAD_HEIGHT, so shots originate at the rendered
+            // eye and land on the crosshair.
+            head_offset: vec3(0.0, 4.0 / SCALE_FACTOR, 0.0),
             // Same head rotation fed to game.update, so the rendered view and the
             // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
             head_rotation: current_input.head.rotation,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -140,13 +140,28 @@ struct Args {
 /// simulation time (60 Hz, matching the game's target frame rate).
 const FIXED_STEP_DT: f32 = 1.0 / 60.0;
 
-fn default_camera_head_rotation() -> Quaternion<f32> {
+/// Head rotation for a yaw/pitch (degrees), matching the desktop runtime's
+/// camera convention (`camera_forward` / `camera_rotation`): at `yaw=pitch=0`
+/// the forward is `(1,0,0)` fed through `look_at_rh`, i.e. looking toward `-X`.
+/// The SAME rotation drives both the render camera and `InputContext.head`, so
+/// the flat viewmodel (placed relative to the head) and the rendered view always
+/// agree - otherwise the viewmodel renders off-axis as a giant side-on slab.
+fn head_rotation_from_yaw_pitch(yaw_deg: f32, pitch_deg: f32) -> Quaternion<f32> {
     use cgmath::{Decomposed, Rotation, Transform, point3};
-    let forward = point3(1.0, 0.0, 0.0);
+    let (yaw, pitch) = (yaw_deg.to_radians(), pitch_deg.to_radians());
+    let forward = point3(
+        yaw.cos() * pitch.cos(),
+        pitch.sin(),
+        yaw.sin() * pitch.cos(),
+    );
     let up = vec3(0.0, 1.0, 0.0);
     let decomposed: Decomposed<Vector3<f32>, Quaternion<f32>> =
         Transform::look_at_rh(forward, point3(0.0, 0.0, 0.0), up);
     decomposed.rot.invert()
+}
+
+fn default_camera_head_rotation() -> Quaternion<f32> {
+    head_rotation_from_yaw_pitch(0.0, 0.0)
 }
 
 /// Parse mission string (supports mission:spawn_location format)
@@ -388,6 +403,16 @@ fn run_game_blocking(
     let mut target_step_time: Option<f32> = None;
     let mut action_state = InputActionState::new();
 
+    // Persistent input state, patched over HTTP via `/v1/control/input` and fed
+    // to `game.update` each frame. Unlike discrete actions (consumed once),
+    // these are level-held values (trigger held down, head aimed somewhere), so
+    // they must persist across frames rather than be rebuilt to zero each frame.
+    // The head starts at the desktop default view; the SAME head rotation also
+    // drives the render camera (below), so the flat viewmodel stays aligned with
+    // what is rendered.
+    let mut current_input = InputContext::default();
+    current_input.head.rotation = default_camera_head_rotation();
+
     // Deferred replies so HTTP commands observe a complete, post-render frame:
     // - `Step` replies only after all requested frames have actually run, so
     //   `/v1/step` blocks until stepping is done (otherwise screenshots/queries
@@ -423,30 +448,6 @@ fn run_game_blocking(
                 _ => {}
             }
         }
-
-        // Create minimal input context (no actual input for now)
-        let input_context = InputContext {
-            head: shock2vr::input_context::Head {
-                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            },
-            left_hand: shock2vr::input_context::Hand {
-                position: vec3(0.0, 0.0, 0.0),
-                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-                thumbstick: vec2(0.0, 0.0),
-                trigger_value: 0.0,
-                squeeze_value: 0.0,
-                a_value: 0.0,
-            },
-            right_hand: shock2vr::input_context::Hand {
-                position: vec3(0.0, 0.0, 0.0),
-                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-                thumbstick: vec2(0.0, 0.0),
-                trigger_value: 0.0,
-                squeeze_value: 0.0,
-                a_value: 0.0,
-            },
-            pointer: None,
-        };
 
         let game_time = Time {
             elapsed: Duration::from_secs_f32(delta_time),
@@ -517,6 +518,7 @@ fn run_game_blocking(
                         &game_time,
                         frame_counter,
                         &mut action_state,
+                        &mut current_input,
                     );
                 }
             }
@@ -541,7 +543,7 @@ fn run_game_blocking(
             };
             profile!(
                 "game.update",
-                game.update(&game_time, &input_context, &mut action_state)
+                game.update(&game_time, &current_input, &mut action_state)
             );
 
             if step_requested {
@@ -614,7 +616,7 @@ fn run_game_blocking(
             // Still call update with zero time to maintain state consistency
             profile!(
                 "game.update",
-                game.update(&zero_time, &input_context, &mut action_state)
+                game.update(&zero_time, &current_input, &mut action_state)
             );
             accumulated_time // Use accumulated time, not real time
         };
@@ -634,7 +636,9 @@ fn run_game_blocking(
             camera_offset: pawn_offset,
             camera_rotation: pawn_rotation,
             head_offset: vec3(0.0, 1.6 / SCALE_FACTOR, 0.0), // Default head height
-            head_rotation: default_camera_head_rotation(),   // Match desktop default view (-X)
+            // Same head rotation fed to game.update, so the rendered view and the
+            // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
+            head_rotation: current_input.head.rotation,
             projection_matrix,
             screen_size,
         };
@@ -705,6 +709,7 @@ fn process_command(
     time: &Time,
     frame_counter: u64,
     action_state: &mut InputActionState,
+    current_input: &mut InputContext,
 ) {
     match command {
         RuntimeCommand::GetInfo(reply) => {
@@ -1130,84 +1135,25 @@ fn process_command(
             }
         }
         RuntimeCommand::GetInput(reply) => {
-            // Get current input state from the debug scene
-            if let Some(debuggable) = game.debug_scene() {
-                let input_context = debuggable.get_input_state();
-                let input_state = commands::InputState {
-                    head: commands::InputHead {
-                        rotation: [
-                            input_context.head.rotation.v.x,
-                            input_context.head.rotation.v.y,
-                            input_context.head.rotation.v.z,
-                            input_context.head.rotation.s,
-                        ],
-                    },
-                    left_hand: commands::InputHand {
-                        position: [
-                            input_context.left_hand.position.x,
-                            input_context.left_hand.position.y,
-                            input_context.left_hand.position.z,
-                        ],
-                        rotation: [
-                            input_context.left_hand.rotation.v.x,
-                            input_context.left_hand.rotation.v.y,
-                            input_context.left_hand.rotation.v.z,
-                            input_context.left_hand.rotation.s,
-                        ],
-                        thumbstick: [
-                            input_context.left_hand.thumbstick.x,
-                            input_context.left_hand.thumbstick.y,
-                        ],
-                        trigger_value: input_context.left_hand.trigger_value,
-                        squeeze_value: input_context.left_hand.squeeze_value,
-                        a_value: input_context.left_hand.a_value,
-                    },
-                    right_hand: commands::InputHand {
-                        position: [
-                            input_context.right_hand.position.x,
-                            input_context.right_hand.position.y,
-                            input_context.right_hand.position.z,
-                        ],
-                        rotation: [
-                            input_context.right_hand.rotation.v.x,
-                            input_context.right_hand.rotation.v.y,
-                            input_context.right_hand.rotation.v.z,
-                            input_context.right_hand.rotation.s,
-                        ],
-                        thumbstick: [
-                            input_context.right_hand.thumbstick.x,
-                            input_context.right_hand.thumbstick.y,
-                        ],
-                        trigger_value: input_context.right_hand.trigger_value,
-                        squeeze_value: input_context.right_hand.squeeze_value,
-                        a_value: input_context.right_hand.a_value,
-                    },
-                };
-                if let Err(_) = reply.send(input_state) {
-                    tracing::warn!("Failed to send input state - receiver dropped");
-                }
-            } else {
-                tracing::warn!("Current scene is not a debuggable mission scene");
-                if let Err(_) = reply.send(commands::InputState::default()) {
-                    tracing::warn!("Failed to send default input state - receiver dropped");
-                }
+            // Report the runtime-owned input state (what is fed to game.update).
+            let input_state = input_state_from_context(current_input);
+            if let Err(_) = reply.send(input_state) {
+                tracing::warn!("Failed to send input state - receiver dropped");
             }
         }
         RuntimeCommand::SetInput(patch) => {
-            // Set input channel value on the debug scene
-            if let Some(debuggable) = game.debug_scene_mut() {
-                let success = debuggable.set_input(&patch.channel, patch.value);
-                if success {
-                    tracing::info!(
-                        "Successfully set input channel '{}' via remote control",
-                        patch.channel
-                    );
-                } else {
-                    tracing::warn!("Failed to set input channel '{}'", patch.channel);
-                }
+            // Patch the runtime-owned input state directly; it is fed to
+            // game.update each frame and persists until changed.
+            let success = apply_input_patch(current_input, &patch.channel, &patch.value);
+            if success {
+                tracing::info!(
+                    "Successfully set input channel '{}' via remote control",
+                    patch.channel
+                );
             } else {
                 tracing::warn!(
-                    "Current scene is not a debuggable mission scene - cannot set input"
+                    "Failed to set input channel '{}' (unrecognized channel or bad value)",
+                    patch.channel
                 );
             }
         }
@@ -1215,6 +1161,120 @@ fn process_command(
             // Shutdown is handled in the main loop, this is just for completeness
             tracing::info!("Processing shutdown command");
         }
+    }
+}
+
+/// Build the serializable `InputState` reported by `GET /v1/control/input`.
+fn input_state_from_context(input: &InputContext) -> commands::InputState {
+    fn hand(h: &shock2vr::input_context::Hand) -> commands::InputHand {
+        commands::InputHand {
+            position: [h.position.x, h.position.y, h.position.z],
+            rotation: [h.rotation.v.x, h.rotation.v.y, h.rotation.v.z, h.rotation.s],
+            thumbstick: [h.thumbstick.x, h.thumbstick.y],
+            trigger_value: h.trigger_value,
+            squeeze_value: h.squeeze_value,
+            a_value: h.a_value,
+        }
+    }
+    commands::InputState {
+        head: commands::InputHead {
+            rotation: [
+                input.head.rotation.v.x,
+                input.head.rotation.v.y,
+                input.head.rotation.v.z,
+                input.head.rotation.s,
+            ],
+        },
+        left_hand: hand(&input.left_hand),
+        right_hand: hand(&input.right_hand),
+    }
+}
+
+/// Patch a single channel of the runtime-owned input state, returning false for
+/// an unrecognized channel or a value of the wrong shape. These persist across
+/// frames (a held trigger, a fixed aim), unlike the edge-triggered actions of
+/// `/v1/input/action`.
+///
+/// Recognized channels:
+/// - `head.rotation`                : `[x, y, z, w]` quaternion
+/// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z)
+/// - `{left,right}_hand.trigger`    : number in [0, 1] (alias `trigger_value`)
+/// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
+/// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
+/// - `{left,right}_hand.thumbstick` : `[x, y]`
+fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> bool {
+    use cgmath::Vector2;
+
+    fn parse_f32(v: &Value) -> Option<f32> {
+        v.as_f64().map(|f| f as f32)
+    }
+    fn parse_arr(v: &Value, n: usize) -> Option<Vec<f32>> {
+        let a = v.as_array()?;
+        if a.len() != n {
+            return None;
+        }
+        a.iter().map(parse_f32).collect()
+    }
+
+    // Hand channels: "<left|right>_hand.<field>"
+    if let Some((side, field)) = channel.split_once("_hand.") {
+        let hand = match side {
+            "left" => &mut input.left_hand,
+            "right" => &mut input.right_hand,
+            _ => return false,
+        };
+        return match field {
+            "trigger" | "trigger_value" => match parse_f32(value) {
+                Some(v) => {
+                    hand.trigger_value = v;
+                    true
+                }
+                None => false,
+            },
+            "squeeze" | "squeeze_value" => match parse_f32(value) {
+                Some(v) => {
+                    hand.squeeze_value = v;
+                    true
+                }
+                None => false,
+            },
+            "a" | "a_value" => match parse_f32(value) {
+                Some(v) => {
+                    hand.a_value = v;
+                    true
+                }
+                None => false,
+            },
+            "thumbstick" => match parse_arr(value, 2) {
+                Some(a) => {
+                    hand.thumbstick = Vector2::new(a[0], a[1]);
+                    true
+                }
+                None => false,
+            },
+            _ => false,
+        };
+    }
+
+    match channel {
+        "head.rotation" => match parse_arr(value, 4) {
+            Some(q) => {
+                input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
+                true
+            }
+            None => false,
+        },
+        // Desktop camera convention (yaw=pitch=0 looks toward -X); drives both
+        // the render camera and the viewmodel. Convenient for pointing the
+        // camera without hand-authoring a quaternion.
+        "head.look" => match parse_arr(value, 2) {
+            Some(yp) => {
+                input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
+                true
+            }
+            None => false,
+        },
+        _ => false,
     }
 }
 

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -44,6 +44,11 @@ impl DesktopInputMapper {
                 action: InputAction::MoveInventory,
             },
             Binding {
+                key: Key::B,
+                modifier: Modifier::None,
+                action: InputAction::CycleWeapon,
+            },
+            Binding {
                 key: Key::S,
                 modifier: Modifier::Alt,
                 action: InputAction::QuickSave,

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -235,6 +235,11 @@ pub fn main() {
         "es3 extension supported: {}",
         glfw.extension_supported("GL_ARB_ES3_compatibility")
     );
+    println!(
+        "camera eye height (standing): {} SS2 units = {} world units (above pawn)",
+        shock2vr::PLAYER_EYE_HEIGHT,
+        shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR
+    );
 
     let engine = engine::opengl();
     let bundle_storage = engine.get_storage();
@@ -374,7 +379,11 @@ pub fn main() {
 
         let (mut scene, pawn_offset, pawn_rotation) = profile!("game.render", game.render());
 
-        let head_height = if input_state.is_crouching { 1.5 } else { 4.0 };
+        let head_height = if input_state.is_crouching {
+            1.5
+        } else {
+            shock2vr::PLAYER_EYE_HEIGHT
+        };
         let render_context = engine::EngineRenderContext {
             time: glfw.get_time() as f32,
             camera_offset: pawn_offset,

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -9,7 +9,7 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slices 5-6).
 
-use cgmath::{Quaternion, Rotation, Vector3, point3, vec3};
+use cgmath::{Deg, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
 use shipyard::{EntityId, Get, View, World};
 
 use dark::{SCALE_FACTOR, properties::PropFrobInfo};
@@ -20,14 +20,20 @@ use crate::{
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
     virtual_hand::{VirtualHandEffect, can_grab_item},
-    vr_config::{self, Handedness},
 };
 
-/// Where the wielded weapon sits relative to the camera, in look space (+x
-/// right, +y up, -z forward), before the world-scale divide. Tunable framing.
+/// Shared viewmodel framing offset (look space: +x right, +y up, -z forward),
+/// before the world-scale divide. Used for all wielded items for now; per-weapon
+/// `PropPlayerGun.model_offset` placement is a TODO.
 const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
 /// Camera height above the player's feet position (world units before scale).
 const HEAD_HEIGHT: f32 = 5.0;
+
+/// Base yaw applied to every first-person gun model before its per-weapon
+/// `PropPlayerGun.heading`. The pistol (`atek_h`, heading 0) renders correctly
+/// at -90deg; `heading` then corrects models authored at other angles (e.g. the
+/// shotgun's 90deg). Tuned against the FP models, NOT the VR hand-model table.
+const VIEWMODEL_BASE_YAW_DEG: f32 = -90.0;
 
 pub struct FlatPlayerController {
     wielded_entity: Option<EntityId>,
@@ -117,16 +123,22 @@ impl FlatPlayerController {
 
         // Place the viewmodel + fire on the trigger edge.
         if let Some(entity_id) = self.wielded_entity {
-            let adjustments = vr_config::get_vr_hand_model_adjustments_from_entity(
-                entity_id,
-                world,
-                Handedness::Right,
-            );
+            // First-person framing from the weapon's native PropPlayerGun
+            // (model_offset + heading), falling back to a fixed offset for
+            // non-gun pickups. This intentionally ignores the VR hand-model
+            // table, which is keyed inconsistently and drops per-weapon heading.
+            // The first-person `hand_model` meshes all share one orientation,
+            // corrected by a single base yaw. NB: PropPlayerGun.heading is NOT
+            // the FP model's rotation - applying it over-rotates exactly by its
+            // value (the shotgun/assault 90deg, the psi-amp 180deg), so it is
+            // deliberately not used here. Position uses a shared framing offset
+            // for now (per-weapon model_offset placement is a TODO).
+            let rotation = look * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG));
             effects.push(VirtualHandEffect::SetPositionRotation {
                 entity_id,
                 position: camera_pos + look.rotate_vector(VIEWMODEL_OFFSET / SCALE_FACTOR),
-                rotation: look * adjustments.rotation,
-                scale: adjustments.scale,
+                rotation,
+                scale: vec3(1.0, 1.0, 1.0),
             });
 
             let fire_pressed = input.trigger_value > 0.5;

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -9,7 +9,7 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slices 5-6).
 
-use cgmath::{Deg, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
 use shipyard::{EntityId, Get, View, World};
 
 use dark::{SCALE_FACTOR, properties::PropFrobInfo};
@@ -39,6 +39,9 @@ pub struct FlatPlayerController {
     wielded_entity: Option<EntityId>,
     last_fire_pressed: bool,
     last_use_pressed: bool,
+    /// Camera/crosshair fire ray (world space) from the last `update`, so the
+    /// firing path can spawn projectiles along the crosshair (camera-origin aim).
+    last_aim: Option<(Point3<f32>, Vector3<f32>)>,
 }
 
 impl FlatPlayerController {
@@ -47,6 +50,7 @@ impl FlatPlayerController {
             wielded_entity: None,
             last_fire_pressed: false,
             last_use_pressed: false,
+            last_aim: None,
         }
     }
 
@@ -56,6 +60,11 @@ impl FlatPlayerController {
 
     pub fn wielded_entity(&self) -> Option<EntityId> {
         self.wielded_entity
+    }
+
+    /// The camera/crosshair fire ray (origin, forward) from the last `update`.
+    pub fn aim_ray(&self) -> Option<(Point3<f32>, Vector3<f32>)> {
+        self.last_aim
     }
 
     /// Stop wielding `entity_id` if it was the held weapon (e.g. it was
@@ -107,6 +116,7 @@ impl FlatPlayerController {
         // Crosshair raycast: the frobbable entity under the reticle (resolving
         // hitbox proxies to their parent, and ignoring the weapon we hold).
         let forward = look.rotate_vector(vec3(0.0, 0.0, -1.0));
+        self.last_aim = Some((point3(camera_pos.x, camera_pos.y, camera_pos.z), forward));
         let highlighted = physics
             .ray_cast(
                 point3(camera_pos.x, camera_pos.y, camera_pos.z),

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -26,8 +26,11 @@ use crate::{
 /// before the world-scale divide. Used for all wielded items for now; per-weapon
 /// `PropPlayerGun.model_offset` placement is a TODO.
 const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
-/// Camera height above the player's feet position (world units before scale).
-const HEAD_HEIGHT: f32 = 5.0;
+/// Camera (eye) height above the player's feet, in SS2 units before the
+/// world-scale divide. MUST match the runtimes' render-camera `head_offset`
+/// (desktop standing = 4.0) so the shot origin coincides with the rendered eye -
+/// otherwise horizontal shots land above/below the crosshair.
+const HEAD_HEIGHT: f32 = 4.0;
 
 /// Base yaw applied to every first-person gun model before its per-weapon
 /// `PropPlayerGun.heading`. The pistol (`atek_h`, heading 0) renders correctly

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -27,10 +27,10 @@ use crate::{
 /// `PropPlayerGun.model_offset` placement is a TODO.
 const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
 /// Camera (eye) height above the player's feet, in SS2 units before the
-/// world-scale divide. MUST match the runtimes' render-camera `head_offset`
-/// (desktop standing = 4.0) so the shot origin coincides with the rendered eye -
-/// otherwise horizontal shots land above/below the crosshair.
-const HEAD_HEIGHT: f32 = 4.0;
+/// world-scale divide. Shared with the runtimes' render-camera `head_offset` via
+/// `crate::PLAYER_EYE_HEIGHT` so the shot/viewmodel origin coincides with the
+/// rendered eye - otherwise horizontal shots land above/below the crosshair.
+const HEAD_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT;
 
 /// Base yaw applied to every first-person gun model before its per-weapon
 /// `PropPlayerGun.heading`. The pistol (`atek_h`, heading 0) renders correctly

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -28,6 +28,11 @@ pub enum InputAction {
 
     /// Cycle creatures to their next animation pose (debug hitbox/ragdoll inspection)
     DebugHitboxCyclePose,
+
+    /// Wield the next player weapon (debug: spawn-and-wield, dropping the
+    /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
+    /// testing.
+    CycleWeapon,
 }
 
 impl InputAction {
@@ -41,6 +46,7 @@ impl InputAction {
             InputAction::SpawnDebugItem,
             InputAction::MoveInventory,
             InputAction::DebugHitboxCyclePose,
+            InputAction::CycleWeapon,
         ]
     }
 
@@ -52,6 +58,7 @@ impl InputAction {
             InputAction::SpawnDebugItem => "SpawnDebugItem",
             InputAction::MoveInventory => "MoveInventory",
             InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
+            InputAction::CycleWeapon => "CycleWeapon",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -49,6 +49,11 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::DebugHitboxCyclePose) {
             effects.push(Effect::DebugCycleHitboxPose);
         }
+        if state.just_triggered(InputAction::CycleWeapon) {
+            effects.push(Effect::DebugCycleWeapon {
+                head_rotation: input_context.head.rotation,
+            });
+        }
 
         effects
     }

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -5,7 +5,7 @@
 
 use cgmath::{Quaternion, Vector2, Vector3, Zero};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InputContext {
     // Information about the head position
     pub head: Head,
@@ -41,7 +41,7 @@ pub struct Pointer2D {
     pub pressed: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Head {
     pub rotation: Quaternion<f32>,
 }
@@ -58,7 +58,7 @@ impl Head {
 }
 
 // Context for an individual hand (motion controller)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hand {
     pub position: Vector3<f32>,
     pub rotation: Quaternion<f32>,

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -8,7 +8,7 @@
 //! Both implementations speak the same `VirtualHandEffect` language, which
 //! `mission_core` already processes in one place.
 
-use cgmath::{InnerSpace, Quaternion, Vector3, Vector4};
+use cgmath::{InnerSpace, Point3, Quaternion, Vector3, Vector4};
 use engine::{
     assets::asset_cache::AssetCache,
     scene::{SceneObject, light::SpotLight},
@@ -92,6 +92,12 @@ pub trait PlayerInteraction {
 
     fn is_wielding(&self) -> bool {
         false
+    }
+
+    /// The flatscreen camera/crosshair fire ray (origin, forward), if this
+    /// controller drives a crosshair. `None` for VR (which aims by hand pose).
+    fn flat_aim_ray(&self) -> Option<(Point3<f32>, Vector3<f32>)> {
+        None
     }
 }
 
@@ -294,5 +300,9 @@ impl PlayerInteraction for FlatInteraction {
 
     fn is_wielding(&self) -> bool {
         self.controller.is_wielding()
+    }
+
+    fn flat_aim_ray(&self) -> Option<(Point3<f32>, Vector3<f32>)> {
+        self.controller.aim_ray()
     }
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -33,6 +33,15 @@ use scenes::{SceneInitResult, create_initial_scene, load_mission_from_save_data}
 pub use mission::SpawnLocation;
 pub use mission::visibility_engine::CullingInfo;
 
+/// Player eye (camera) height above the body/feet position, in SS2 units
+/// (before the `dark::SCALE_FACTOR` world-scale divide). Shared by every
+/// runtime's render camera (`head_offset`) AND the flat controller's
+/// shot/viewmodel origin, so the rendered view and where shots come from stay
+/// consistent - if these drift, shots no longer line up with the crosshair and
+/// the debug runtime renders at a different height than desktop. Desktop crouch
+/// lowers the camera separately.
+pub const PLAYER_EYE_HEIGHT: f32 = 4.0;
+
 use std::{
     collections::{HashMap, HashSet},
     fs::{File, OpenOptions},

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -74,8 +74,8 @@ use crate::{
     physics::{self, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
-        RuntimePropDoNotSerialize, RuntimePropJointTransforms, RuntimePropTransform,
-        RuntimePropVhots,
+        RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
+        RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -608,6 +608,18 @@ impl MissionCore {
             head_rotation: input_context.head.rotation,
         });
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
+
+        // Tag the wielded weapon with the flat camera/crosshair fire ray so its
+        // firing scripts spawn projectiles along the crosshair (camera-origin
+        // aim) rather than the offset barrel. Only the player's wielded weapon
+        // gets this; AI/VR weapons are untouched.
+        if let (Some((origin, forward)), Some(weapon)) = (
+            self.interaction.flat_aim_ray(),
+            self.interaction.viewmodel_entity(),
+        ) {
+            self.world
+                .add_component(weapon, RuntimePropFlatAim { origin, forward });
+        }
 
         // Sync up the position of all the physics objects
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -187,6 +187,10 @@ pub struct MissionCore {
     /// Sequential index for `Effect::DebugCycleHitboxPose` so each trigger picks
     /// the next animation deterministically (debug hitbox inspection).
     pub debug_pose_index: u32,
+
+    /// Sequential index for `Effect::DebugCycleWeapon` so each trigger wields the
+    /// next weapon in `DEBUG_WEAPONS` (flat-mode aim/viewmodel testing).
+    pub debug_weapon_index: usize,
 }
 
 pub struct GlobalContext {
@@ -440,6 +444,7 @@ impl MissionCore {
             path_visualization: PathVisualizationSystem::new(),
             pathfinding_test: crate::mission::pathfinding_test::PathfindingTest::new(),
             debug_pose_index: 0,
+            debug_weapon_index: 0,
         }
     }
 
@@ -1724,6 +1729,48 @@ impl MissionCore {
                         let msgs = self.interaction.wield(info.entity_id);
                         self.process_virtual_hand_effects(asset_cache, msgs);
                     }
+                }
+                Effect::DebugCycleWeapon { head_rotation } => {
+                    // The SS2 player-weapon roster (templates with PropPlayerGun),
+                    // cycled for flat-mode aim/viewmodel testing.
+                    const DEBUG_WEAPONS: &[i32] = &[
+                        -17, // Pistol
+                        -18, // Assault Rifle
+                        -19, // Shotgun
+                        -22, // Laser Pistol
+                        -23, // EMP Rifle
+                        -21, // Gren Launcher
+                        -25, // Stasis Field Generator
+                        -26, // Fusion Cannon
+                        -27, // Worm Launcher
+                        -29, // Viral Prolif
+                        -247, // Psi Amp
+                             // NB: Hybrid Shotgun (-4073) is omitted - it has an
+                             // unimplemented `trashedshotgun` script that panics on
+                             // creation (scripts/mod.rs). It is an enemy weapon
+                             // variant, not part of the player arsenal.
+                    ];
+                    let template_id = DEBUG_WEAPONS[self.debug_weapon_index % DEBUG_WEAPONS.len()];
+                    self.debug_weapon_index = self.debug_weapon_index.wrapping_add(1);
+
+                    let (pos, rot) = {
+                        let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                        (vec3_to_point3(player.pos), player.rotation * head_rotation)
+                    };
+                    let forward = rot * vec3(0.0, 2.5 / SCALE_FACTOR, -10.0 / SCALE_FACTOR);
+                    let info = self.create_entity_with_position(
+                        asset_cache,
+                        template_id,
+                        pos + forward,
+                        rot,
+                        Matrix4::identity(),
+                        CreateEntityOptions::default(),
+                    );
+                    // Force-wield (unlike SpawnDebugItem): `wield` drops the
+                    // previously held weapon back into the world, so each cycle
+                    // swaps the viewmodel. No-op in VR (wield returns nothing).
+                    let msgs = self.interaction.wield(info.entity_id);
+                    self.process_virtual_hand_effects(asset_cache, msgs);
                 }
                 Effect::PositionInventoryRelativeToPlayer { head_rotation } => {
                     let (pos, rot) = {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -34,8 +34,9 @@ use dark::{
         PropAIAlertness, PropAIMode, PropAmbientHacked, PropClassTag, PropCreature,
         PropFrameAnimState, PropHasRefs, PropLocalPlayer, PropModelName, PropMotionActorTags,
         PropParticleGroup, PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity,
-        PropPhysState, PropPhysType, PropPosition, PropRenderType, PropScripts, PropTeleported,
-        PropTripFlags, PropertyDefinition, RenderType, ToLink, TripFlags, WrappedEntityId,
+        PropPhysState, PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts,
+        PropTeleported, PropTripFlags, PropertyDefinition, RenderType, ToLink, TripFlags,
+        WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -1879,21 +1880,39 @@ impl MissionCore {
             // last; the depth buffer is cleared before its first object so it
             // renders over geometry while still depth-testing within itself.
             if let Some(weapon) = self.interaction.viewmodel_entity() {
-                if let Some(model) = self.id_to_model.get(&weapon) {
+                let maybe_xform = {
                     let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
-                    if let Ok(xform) = v_transform.get(weapon).map(|p| p.0) {
-                        let scene_objs = match self.id_to_animation_player.get(&weapon) {
+                    v_transform.get(weapon).map(|p| p.0).ok()
+                };
+                // Flat first-person model: prefer the weapon's native
+                // PropPlayerGun.hand_model (the SS2 FP mesh), loaded directly so
+                // EVERY gun gets its proper first-person model - not just those
+                // listed in the VR hand-model table. Non-guns fall back to the
+                // entity's current model.
+                let hand_model_name = self
+                    .world
+                    .borrow::<View<PropPlayerGun>>()
+                    .ok()
+                    .and_then(|v| v.get(weapon).ok().map(|g| g.hand_model.clone()));
+                if let Some(xform) = maybe_xform {
+                    let scene_objs = if let Some(name) = hand_model_name {
+                        let model = asset_cache.get(&MODELS_IMPORTER, &format!("{name}.BIN"));
+                        model.as_ref().to_scene_objects().clone()
+                    } else if let Some(model) = self.id_to_model.get(&weapon) {
+                        match self.id_to_animation_player.get(&weapon) {
                             Some(player) => model.to_animated_scene_objects(player),
                             None => model.to_scene_objects().clone(),
-                        };
-                        for (i, obj) in scene_objs.into_iter().enumerate() {
-                            let mut o = obj.clone();
-                            o.set_transform(xform);
-                            if i == 0 {
-                                o.set_clear_depth(true);
-                            }
-                            ret.push(o);
                         }
+                    } else {
+                        Vec::new()
+                    };
+                    for (i, obj) in scene_objs.into_iter().enumerate() {
+                        let mut o = obj.clone();
+                        o.set_transform(xform);
+                        if i == 0 {
+                            o.set_clear_depth(true);
+                        }
+                        ret.push(o);
                     }
                 }
             }

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -7,7 +7,7 @@
  * - They are not part of SS2 / Dark - just convenience properties for implementing the game.
  * - They are not serialized / deserialized
  */
-use cgmath::Matrix4;
+use cgmath::{Matrix4, Point3, Vector3};
 use dark::ss2_bin_obj_loader::Vhot;
 use shipyard::Component;
 
@@ -38,3 +38,14 @@ pub struct RuntimePropDoNotSerialize;
 // RuntimePropProxyEntity - pointer to the parent entity (for example, hitboxes use this to point to the parent entity)
 #[derive(Component)]
 pub struct RuntimePropProxyEntity(pub shipyard::EntityId);
+
+// RuntimePropFlatAim - the flatscreen camera/crosshair fire ray (world space),
+// set each frame on the player's wielded weapon. When present, weapon firing
+// spawns projectiles from `origin` along `forward` (camera-origin aim) instead
+// of the weapon's barrel transform, so shots track the crosshair regardless of
+// the viewmodel's framing. Absent on AI/VR weapons, leaving their aim unchanged.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropFlatAim {
+    pub origin: Point3<f32>,
+    pub forward: Vector3<f32>,
+}

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -1,0 +1,94 @@
+//! Debug scene for first-person weapon work (viewmodel framing + aim).
+//!
+//! A clean, controlled environment: the player stands on a floor facing a flat
+//! wall a known distance straight ahead. Cycle weapons with `CycleWeapon`
+//! (`B` on desktop / `POST /v1/input/action {"action":"CycleWeapon"}`) and fire;
+//! shots land on the wall as hit-spangs, so it's easy to see whether a weapon's
+//! barrel and its projectiles track the crosshair - without a real mission's
+//! cluttered geometry hiding the viewmodel or swallowing the shot.
+
+use cgmath::{Deg, Matrix4, Quaternion, Rotation3, vec3};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, color_material, cube},
+};
+use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
+use shipyard::EntityId;
+
+use crate::{
+    GameOptions,
+    mission::{GlobalContext, SpawnLocation},
+};
+
+use super::debug_common::{DebugScene, DebugSceneBuildOptions, DebugSceneBuilder};
+
+/// Distance (world units) from the player to the test wall, straight ahead (-X,
+/// the default-view forward).
+const WALL_DISTANCE: f32 = 12.0;
+
+fn cube_object(
+    color: cgmath::Vector3<f32>,
+    translation: cgmath::Vector3<f32>,
+    scale: cgmath::Vector3<f32>,
+) -> SceneObject {
+    let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+    object.set_transform(
+        Matrix4::from_translation(translation)
+            * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
+    );
+    object
+}
+
+pub fn create_debug_weapons_scene(
+    global_context: &GlobalContext,
+    game_options: &GameOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> DebugScene {
+    // Visual floor (under the player) + a vertical wall straight ahead. The unit
+    // cube spans [-0.5, 0.5], so a `cuboid` collider half-extent matches a
+    // nonuniform scale of 2x the half-extent.
+    let floor = cube_object(
+        vec3(0.18, 0.18, 0.22),
+        vec3(0.0, -0.5, 0.0),
+        vec3(40.0, 1.0, 40.0),
+    );
+    let wall = cube_object(
+        vec3(0.45, 0.45, 0.5),
+        vec3(-WALL_DISTANCE, 5.0, 0.0),
+        vec3(1.0, 30.0, 30.0),
+    );
+
+    // One static compound collider (floor + wall) in the ALL_COLLIDABLE group,
+    // so the wall stops shots (hitscan checks WORLD) and shows hit-spangs.
+    let collider = ColliderBuilder::compound(vec![
+        (
+            Isometry::translation(0.0, -0.5, 0.0),
+            SharedShape::cuboid(20.0, 0.5, 20.0),
+        ),
+        (
+            Isometry::translation(-WALL_DISTANCE, 5.0, 0.0),
+            SharedShape::cuboid(0.5, 15.0, 15.0),
+        ),
+    ])
+    .build();
+
+    // Spawn at the floor with identity yaw: the default view forward is -X, so
+    // the wall sits dead ahead.
+    let builder = DebugSceneBuilder::new("debug_weapons")
+        .with_spawn_location(SpawnLocation::PositionRotation(
+            vec3(0.0, 2.0, 0.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+        ))
+        .with_physics_geometry(collider)
+        .add_scene_object(floor)
+        .add_scene_object(wall);
+
+    builder.build(DebugSceneBuildOptions {
+        global_context,
+        game_options,
+        asset_cache,
+        audio_context,
+    })
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -31,6 +31,7 @@ pub mod debug_particles;
 pub mod debug_ragdoll;
 pub mod debug_teleport;
 pub mod debug_turret;
+pub mod debug_weapons;
 pub mod hand_pose;
 pub mod main_menu;
 
@@ -46,6 +47,7 @@ pub use debug_particles::DebugParticlesScene;
 pub use debug_ragdoll::DebugRagdollScene;
 pub use debug_teleport::DebugTeleportScene;
 pub use debug_turret::DebugTurretScene;
+pub use debug_weapons::create_debug_weapons_scene;
 pub use main_menu::MainMenuScene;
 
 pub struct SceneInitResult {
@@ -90,6 +92,18 @@ pub fn create_initial_scene(
     if options.mission.eq_ignore_ascii_case("debug_minimal") {
         return SceneInitResult {
             scene: Box::new(DebugMinimalScene::create(
+                global_context,
+                options,
+                asset_cache,
+                audio_context,
+            )),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("debug_weapons") {
+        return SceneInitResult {
+            scene: Box::new(create_debug_weapons_scene(
                 global_context,
                 options,
                 asset_cache,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -231,6 +231,13 @@ pub enum Effect {
         head_rotation: Quaternion<f32>,
     },
 
+    /// Debug: spawn the next player weapon in front of the player and wield it
+    /// as the flat viewmodel (dropping the previously wielded one). Cycles the
+    /// SS2 weapon roster for aim/viewmodel testing.
+    DebugCycleWeapon {
+        head_rotation: Quaternion<f32>,
+    },
+
     /// Reposition the inventory in front of the player
     PositionInventoryRelativeToPlayer {
         head_rotation: Quaternion<f32>,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -1,14 +1,25 @@
-use cgmath::{Deg, Matrix4, Quaternion, Rotation, Rotation3, Transform, point3};
-use dark::properties::{GunFlashOptions, Link, ProjectileOptions};
+use cgmath::{
+    Deg, EuclideanSpace, InnerSpace, Matrix4, Quaternion, Rotation, Rotation3, Transform, point3,
+};
+use dark::{
+    SCALE_FACTOR,
+    properties::{GunFlashOptions, Link, ProjectileOptions},
+};
 use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
     physics::PhysicsWorld,
-    runtime_props::{RuntimePropTransform, RuntimePropVhots},
+    runtime_props::{RuntimePropFlatAim, RuntimePropTransform, RuntimePropVhots},
+    util::get_rotation_from_forward_vector,
     vr_config,
 };
+
+/// How far in front of the camera a flat-aimed projectile spawns, so a slow
+/// physics projectile (e.g. a grenade) clears the player's own collider instead
+/// of spawning inside it. World units.
+const FLAT_MUZZLE_CLEARANCE: f32 = SCALE_FACTOR;
 
 use super::{
     Effect, MessagePayload, Script,
@@ -167,6 +178,32 @@ fn create_projectile(
     projectile_template_id: i32,
     _options: &ProjectileOptions,
 ) -> Effect {
+    // Flatscreen camera-origin aim: if the weapon carries a flat fire ray, spawn
+    // the projectile just ahead of the camera travelling straight along the
+    // crosshair, ignoring the offset/rotated barrel transform. This makes both
+    // hitscan bullets and slow physics projectiles (grenades) track the
+    // crosshair. VR/AI weapons have no RuntimePropFlatAim and fall through.
+    {
+        let v_flat_aim = world.borrow::<View<RuntimePropFlatAim>>().unwrap();
+        if let Ok(aim) = v_flat_aim.get(entity_id) {
+            let origin = aim.origin + aim.forward.normalize() * FLAT_MUZZLE_CLEARANCE;
+            // get_rotation_from_forward_vector puts `forward` in the +Z column,
+            // and projectile velocity is root_transform * (0,0,mag) - so the
+            // shot travels along the crosshair ray.
+            let rot: Matrix4<f32> =
+                get_rotation_from_forward_vector(aim.forward.normalize()).into();
+            return Effect::CreateEntity {
+                template_id: projectile_template_id,
+                position: point3(0.0, 0.0, 0.0),
+                orientation: Quaternion::from_angle_y(Deg(90.0)),
+                root_transform: Matrix4::from_translation(origin.to_vec()) * rot,
+                options: CreateEntityOptions {
+                    force_visible: true,
+                },
+            };
+        }
+    }
+
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let v_vhots = world.borrow::<View<RuntimePropVhots>>().unwrap();
 


### PR DESCRIPTION
Fixes flat-mode weapon aim and first-person viewmodel rendering, and adds the tooling to verify it headlessly.

## What & why

In flatscreen mode the wielded weapon's projectiles inherited the offset/rotated barrel transform, so shots missed the crosshair (assault rifle 90° right, grenade off to the side), and most guns rendered their *world* mesh sideways because the flat path leaned on the inconsistent VR `HAND_MODEL_POSITIONING` table. This reworks both onto the weapon's native SS2 data and a single shared eye height.

## Changes

- **Camera-origin aim** — flat shots spawn at the camera and travel straight along the crosshair, covering both hitscan bullets and slow physics projectiles (the grenade now launches straight ahead, then arcs). The flat controller tags the wielded weapon with `RuntimePropFlatAim`; `weapon_script::create_projectile` consumes it. VR/AI weapons are untouched.
- **First-person viewmodel from `PropPlayerGun.hand_model`** — render each weapon's native FP mesh directly, so every gun gets its correct first-person model. `PropPlayerGun.heading` is intentionally *not* applied to the model (it over-rotates by exactly its value).
- **Shared eye height** — new `shock2vr::PLAYER_EYE_HEIGHT` (4.0 SS2) used by the flat controller's shot/viewmodel origin and both runtimes' render cameras, so shots align with the crosshair and the debug-runtime camera matches desktop (it was rendering ~1 world unit low).

## Tooling (enables headless verification)

- Debug-runtime **controllable input over HTTP** (`/v1/control/input`: `head.look`, hand `trigger`/`squeeze`); the render camera now honors the input head rotation.
- **`CycleWeapon`** input action (`B` on desktop / `POST /v1/input/action`) over the 11-weapon roster.
- **`debug_weapons`** scene — player facing a wall straight ahead; `cargo dbgr --mission debug_weapons --flat --debug-draw`. This scene surfaced the eye-height bug.

## Verification

In `debug_weapons`: the pistol hit-spang and the grenade land **dead-center on the crosshair**; all 11 player weapons render their FP mesh oriented correctly (verified via debug-runtime screenshots).

## Follow-ups (tracked in `projects/flat-weapon-handling.md`)

- Per-weapon viewmodel position from `PropPlayerGun.model_offset` (+ nudge the now-low viewmodel up)
- Muzzle flash is world-pinned (doesn't track the weapon)
- Melee weapons (`PropLimbModel`, no `PropPlayerGun`) — deferred
- Crouch-accurate aim (eye height is the standing value)
- Latent: Hybrid Shotgun (-4073) panics on creation (`trashedshotgun` script) — excluded from the cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)