### PR TITLE
refactor(dark): make GlobalContext Send + Sync (PR S3)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1484,7 +1484,9 @@ pub trait Property: fmt::Debug + Send + Sync {
     fn initialize(&self, world: &mut World, entity: EntityId);
 }
 
-pub trait PropertyDefinition<R: io::Read + io::Seek> {
+// `Send + Sync` so the shared `GlobalContext` (which holds these definition objects)
+// can be borrowed by the background level-parse thread (projects/loading-screen.md, PR S3).
+pub trait PropertyDefinition<R: io::Read + io::Seek>: Send + Sync {
     fn name(&self) -> String;
 
     fn read(&self, reader: &mut R, prop_len: u32) -> Box<dyn Property>;
@@ -1499,7 +1501,7 @@ pub trait PropertyDefinition<R: io::Read + io::Seek> {
     );
 }
 
-pub trait LinkDefinition {
+pub trait LinkDefinition: Send + Sync {
     fn name(&self) -> String;
 
     fn convert(&self, link: ToTemplateLinkInfo) -> ToTemplateLink;
@@ -1510,7 +1512,7 @@ struct LinkDefinitionStruct {
     converter: Converter<ToTemplateLinkInfo, Link>,
 }
 
-pub trait LinkDefinitionWithData {
+pub trait LinkDefinitionWithData: Send + Sync {
     fn link_chunk_name(&self) -> String;
     fn link_data_chunk_name(&self) -> String;
 

--- a/dark/src/tag_database.rs
+++ b/dark/src/tag_database.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, io, rc::Rc};
+use std::{collections::HashMap, io, sync::Arc};
 
 use crate::ss2_common::{read_i32, read_single, read_u32};
 
 #[derive(Debug, Clone)]
 pub struct TagDatabase {
     data: Vec<TagDatabaseData>,
-    branches: HashMap<TagDatabaseKey, Rc<TagDatabase>>,
+    branches: HashMap<TagDatabaseKey, Arc<TagDatabase>>,
 }
 
 #[derive(Clone, Debug)]
@@ -75,7 +75,7 @@ impl TagDatabase {
             let key = TagDatabaseKey::read(reader);
             let db = TagDatabase::read(reader);
 
-            branches.insert(key, Rc::new(db));
+            branches.insert(key, Arc::new(db));
         }
 
         TagDatabase { data, branches }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -202,6 +202,14 @@ pub struct GlobalContext {
     pub motiondb: MotionDB,
 }
 
+// [Gate A / PR S3] Background level loading parses on a worker thread that borrows the
+// shared `GlobalContext` (gamesys + property/link definitions), so it must be
+// `Send + Sync`. This compile-time assertion guards that.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<GlobalContext>();
+};
+
 pub struct AbstractMission {
     pub scene_objects: Vec<SceneObject>,
     pub song_params: SongParams,


### PR DESCRIPTION
Foundation refactor for background level loading (`projects/loading-screen.md`, PR S3). Independent of the loading-scene PRs (#313/#316) — branches off `main`.

## Why

The level parse borrows the shared `GlobalContext` (gamesys + property/link *definitions*), so for it to run on a worker thread, `GlobalContext` must be `Send + Sync`. S1/S2 made the parse *output* (`SystemShock2Level`) `Send`; this makes the *inputs* `Send` too — the last `Send`-foundation piece before the worker-thread parse.

## What

`assert_send_sync::<GlobalContext>()` named exactly four blockers, all fixed mechanically:

- Add `Send + Sync` supertraits to **`PropertyDefinition`**, **`LinkDefinition`**, **`LinkDefinitionWithData`** — compiles for free (the parser impls are stateless).
- **`TagDatabase`**: `Rc<TagDatabase>` → `Arc<TagDatabase>` (the env tag-tree branches; the one non-trait-object blocker).

`MotionDB`, `SpeechDB`, `SoundSchema` were already `Send + Sync` (not flagged). **No behavior change** — supertrait additions + transparent `Rc → Arc`.

## Verification (negative-test-first)

- `assert_send_sync::<GlobalContext>()` **fails before** (4 named blockers), **passes after** — added as a permanent guard.
- Builds clean `-D warnings`: `dark`, `shock2vr`, `debug_runtime`, `dark_query`, `dark_viewer`.
- `cargo test -p dark` — 9 passed.
- Debug runtime: `medsci1` loads and runs 60 frames with no panic (exercises the `TagDatabase` speech/motion query paths).

## Next

With S1/S2/S3, both the parse *output* and *inputs* are `Send + Sync`. The background-parse PR (split `Mission::load` into off-thread `parse` + main-thread `build`, spawn the worker, drive `LoadingScene::set_progress`) is now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)