### PR TITLE
refactor(dark): make level parse GL-free (drop &mut AssetCache from read)

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -31,11 +31,10 @@ use texture_list::*;
 use crate::properties::LinkDefinition;
 use crate::ss2_common::read_i32;
 
-use crate::importers::TEXTURE_IMPORTER;
 use crate::ss2_common::read_u32;
 use cgmath::Vector4;
 use cgmath::vec4;
-use engine::assets::asset_cache::AssetCache;
+use engine::assets::asset_paths::AbstractAssetPath;
 use engine::scene::VertexPositionTextureLightmapAtlasNormal;
 pub use scene_builder::to_scene;
 
@@ -131,8 +130,13 @@ pub struct UVCalculationInfo {
     lrs_y: f32,
 }
 
+// `read` takes only the `Send + Sync` asset-path layer + base path, NOT `&mut
+// AssetCache`. With no `AssetCache` in scope it cannot touch the GPU — the level parse
+// is GL-free *by construction*, so it can run on a worker thread (the background-load
+// goal, projects/loading-screen.md).
 pub fn read<T: io::Read + io::Seek>(
-    asset_cache: &mut AssetCache,
+    asset_paths: &dyn AbstractAssetPath,
+    base_path: &str,
     reader: &mut T,
     gamesys: &Gamesys,
     links: &Vec<Box<dyn LinkDefinition>>,
@@ -217,7 +221,7 @@ pub fn read<T: io::Read + io::Seek>(
         obj_texture_families,
         reader,
     );
-    let all_geometry = create_geometry(asset_cache, &cells, &textures.0);
+    let all_geometry = create_geometry(asset_paths, base_path, &cells, &textures.0);
 
     let _render_params = RenderParams::read(&table_of_contents, reader);
     let room_database = RoomDatabase::read(&table_of_contents, reader);
@@ -290,7 +294,8 @@ fn read_obj_map<T: io::Read + io::Seek>(
 }
 
 fn create_geometry(
-    asset_cache: &mut AssetCache,
+    asset_paths: &dyn AbstractAssetPath,
+    base_path: &str,
     cells: &Vec<Cell>,
     textures: &Vec<SystemShock2Texture>,
 ) -> Vec<SystemShock2Geometry> {
@@ -330,7 +335,7 @@ fn create_geometry(
             let sh_v = render_poly.v / 4096.0;
 
             let tex_info = &textures[render_poly.texture_num as usize];
-            let texture_dim = texture_dimensions(asset_cache, tex_info);
+            let texture_dim = texture_dimensions(asset_paths, base_path, tex_info);
 
             let rs_x = (texture_dim.width as f32) / 64.0;
             let rs_y = (texture_dim.height as f32) / 64.0;
@@ -486,23 +491,45 @@ fn vert(
     }
 }
 
-fn texture_dimensions(asset_cache: &mut AssetCache, tex_info: &SystemShock2Texture) -> TextureSize {
+// GL-free: dimensions come from the PCX header via the `AbstractAssetPath` layer
+// (Send + Sync), NOT from `asset_cache.get` (decode + GPU upload). This is what keeps
+// `dark::mission::read` GL-free so it can run on a worker thread. The header read uses
+// the same `pcx::Reader` parse as the decoder, so the dimensions are identical.
+fn texture_dimensions(
+    asset_paths: &dyn AbstractAssetPath,
+    base_path: &str,
+    tex_info: &SystemShock2Texture,
+) -> TextureSize {
     if tex_info.texture_filename == "null" {
-        TextureSize {
+        return TextureSize {
             width: 1,
             height: 1,
-        }
-    } else {
-        let tex_name = format!(
-            "{}/{}.PCX",
-            tex_info.family.to_uppercase(),
-            tex_info.texture_filename
-        );
-        let texture = asset_cache.get(&TEXTURE_IMPORTER, &tex_name);
+        };
+    }
+    // Lowercase to match the case-insensitive asset resolution (zip index is lowercased).
+    let tex_name = format!(
+        "{}/{}.PCX",
+        tex_info.family.to_uppercase(),
+        tex_info.texture_filename
+    )
+    .to_ascii_lowercase();
 
-        TextureSize {
-            width: texture.width(),
-            height: texture.height(),
+    let dims = asset_paths
+        .get_reader(base_path.to_string(), tex_name.clone())
+        .and_then(|r| {
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut *r.borrow_mut(), &mut bytes).ok()?;
+            engine::texture_format::read_pcx_dimensions(&bytes)
+        });
+
+    match dims {
+        Some((width, height)) => TextureSize { width, height },
+        None => {
+            tracing::warn!("texture_dimensions: could not read PCX header for {tex_name}");
+            TextureSize {
+                width: 1,
+                height: 1,
+            }
         }
     }
 }

--- a/engine/src/assets/asset_cache.rs
+++ b/engine/src/assets/asset_cache.rs
@@ -25,6 +25,29 @@ impl AssetCache {
         }
     }
 
+    /// The `Send + Sync` asset-path layer + base path, so GL-free code (e.g.
+    /// `dark::mission::read`) can resolve raw files WITHOUT holding the `!Send`
+    /// `AssetCache`. This is what lets `read()` drop its `&mut AssetCache`.
+    pub fn asset_paths(&self) -> &dyn AbstractAssetPath {
+        &**self.path
+    }
+
+    pub fn base_path(&self) -> &str {
+        &self.base_path
+    }
+
+    /// Raw byte access to an asset, bypassing the importer/GL — straight to the
+    /// `AbstractAssetPath` layer (already `Send + Sync`). Used to read a PCX header for
+    /// its dimensions without decoding+uploading the whole texture. Names are resolved
+    /// case-insensitively (matching `get_ext_opt`).
+    pub fn get_raw_reader(
+        &self,
+        asset_name: &str,
+    ) -> Option<std::cell::RefCell<Box<dyn super::asset_paths::ReadableAndSeekable>>> {
+        self.path
+            .get_reader(self.base_path.clone(), asset_name.to_ascii_lowercase())
+    }
+
     pub fn load_from_cache<TData: 'static, TOutput: 'static, TConfig: 'static + Hash + Default>(
         &mut self,
         importer: &AssetImporter<TData, TOutput, TConfig>,

--- a/engine/src/texture_format.rs
+++ b/engine/src/texture_format.rs
@@ -58,6 +58,15 @@ fn apply_color_key(pixels: &mut [u8], width: u32, height: u32) {
     }
 }
 
+/// GL-free PCX dimension read. Reuses the same `pcx::Reader` header parse as the full
+/// decode in `PcxFormat::load`, so `(width, height)` are guaranteed to match
+/// `Texture::width()/height()` — but WITHOUT decoding pixels or touching the GPU. This
+/// lets the level parse compute texture dimensions on a worker thread (no GL context).
+pub fn read_pcx_dimensions(buffer: &[u8]) -> Option<(u32, u32)> {
+    let pcx = pcx::Reader::new(buffer).ok()?;
+    Some((pcx.width() as u32, pcx.height() as u32))
+}
+
 pub struct PcxFormat {}
 
 impl TextureFormat for PcxFormat {
@@ -134,5 +143,32 @@ pub fn extension_to_format(str: String) -> Option<Box<dyn TextureFormat>> {
         "jpeg" => Some(Box::new(JPEG)),
         "jpg" => Some(Box::new(JPEG)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_pcx_dimensions_matches_written_size() {
+        // Round-trip: write a PCX of a known size, then read just its dimensions back.
+        let (w, h): (u16, u16) = (7, 5);
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = pcx::WriterRgb::new(&mut buf, (w, h), (96, 96)).unwrap();
+            let row = vec![0u8; (w as usize) * 3];
+            for _ in 0..h {
+                writer.write_row(&row).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+        assert_eq!(read_pcx_dimensions(&buf), Some((w as u32, h as u32)));
+    }
+
+    #[test]
+    fn read_pcx_dimensions_rejects_non_pcx() {
+        assert_eq!(read_pcx_dimensions(&[0u8; 4]), None);
+        assert_eq!(read_pcx_dimensions(&[]), None);
     }
 }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -63,8 +63,11 @@ impl Mission {
 
         let f = File::open(resource_path(&mission)).unwrap();
         let mut reader = BufReader::new(f);
+        // `read` is GL-free: it takes the Send + Sync asset-path layer, not the cache.
+        let base_path = asset_cache.base_path().to_string();
         let level = dark::mission::read(
-            asset_cache,
+            asset_cache.asset_paths(),
+            &base_path,
             &mut reader,
             &global_context.gamesys,
             links,


### PR DESCRIPTION
Foundation for the background-load worker thread (`projects/loading-screen.md`). Independent of the loading-scene PRs — branches off `main`.

## Why

A worker-thread parse has no GL context, so `dark::mission::read` must not touch the GPU. The *only* GL call inside parse was `texture_dimensions`, which called `asset_cache.get` (decode **+ GPU upload**) just to read a texture's width/height — two integers that live in the PCX header.

## What

- **`engine::texture_format::read_pcx_dimensions(&[u8])`** — reads dims from the PCX header via the same `pcx::Reader` parse as the decoder, no GPU. Unit-tested with a write→read round-trip.
- **`AssetCache::get_raw_reader` / `asset_paths` / `base_path`** — raw file access through the `Send + Sync` `AbstractAssetPath` layer, bypassing the importer/GL.
- **`read()` / `create_geometry()` / `texture_dimensions()`** now take `&dyn AbstractAssetPath` + base path instead of `&mut AssetCache`. **With no cache in scope, the parse is GL-free by construction** — the compile is the proof.

*Honest nuance:* this **relocates** the texture decode+upload into `to_scene` (a cold load there), so total work is unchanged. Its value is enabling the off-thread parse, not a speedup.

## Verification

- **Dual-path validation across all 23 missions: 1863 textures, 0 mismatches** — the GL-free dims are byte-identical to the old decode+upload dims, so geometry UVs are unchanged. (Done with a temporary check, since removed.)
- Builds clean `-D warnings`: `dark`, `shock2vr`, `debug_runtime`, `dark_query`, `dark_viewer`.
- `read_pcx_dimensions` unit tests pass; `dark` tests pass (11); missions load and render with no panic.
- Note: 2 pre-existing `engine` light-math test failures (`scene::light`) are on `main` already, unrelated to this change.

## Next

With this + the `Send` foundation (S1/S2/S3), `dark::mission::read` is both GL-free *and* takes `Send` inputs producing a `Send` output. The background-parse PR (split `Mission::load` into off-thread `parse` + main-thread `build`, spawn the worker, drive `LoadingScene::set_progress`) is fully unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)