### PR TITLE
feat(loading): background level parse on a worker thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,13 @@ The project supports experimental flags for gating in-progress features during d
   the rig is experimental (extremities can jitter on floor contact). Without it,
   ragdolls use the stable impulse-joint rig. See `projects/ragdoll-settling-followup.md`.
 
+- **`loading_screen`**: show the animated loading screen during level transitions
+  (`GlobalEffect::TransitionLevel` / `TestReload`) instead of switching instantly. The
+  transition is deferred: the outgoing scene is saved, the `LoadingScene` renders for a
+  brief minimum, then the (currently synchronous) load runs. The `DebugReloadLevel` input
+  action reloads the current level in place to exercise this. See
+  `projects/loading-screen.md`. Without it, transitions are synchronous and unchanged.
+
 #### Adding New Experimental Features
 
 1. **Gate the feature in code**:

--- a/engine/src/assets/asset_cache.rs
+++ b/engine/src/assets/asset_cache.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{HashMap, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
     rc::Rc,
+    sync::Arc,
 };
 use tracing::{self, debug, info};
 
@@ -13,14 +14,16 @@ type ImporterAssetMap = HashMap<TypeId, HashMap<u64, HashMap<String, Option<Rc<d
 pub struct AssetCache {
     base_path: String,
     importer_to_assets: ImporterAssetMap,
-    path: Rc<Box<dyn AbstractAssetPath>>,
+    // `Arc` (not `Rc`) so the `Send + Sync` asset-path layer can be cloned out and handed
+    // to a background level-parse thread (projects/loading-screen.md).
+    path: Arc<Box<dyn AbstractAssetPath>>,
 }
 
 impl AssetCache {
     pub fn new(base_path: String, path: Box<dyn AbstractAssetPath>) -> AssetCache {
         AssetCache {
             base_path,
-            path: Rc::new(path),
+            path: Arc::new(path),
             importer_to_assets: HashMap::new(),
         }
     }
@@ -30,6 +33,12 @@ impl AssetCache {
     /// `AssetCache`. This is what lets `read()` drop its `&mut AssetCache`.
     pub fn asset_paths(&self) -> &dyn AbstractAssetPath {
         &**self.path
+    }
+
+    /// An owned, `Send + Sync` handle to the asset-path layer — for moving into a
+    /// background level-parse thread.
+    pub fn asset_paths_arc(&self) -> Arc<Box<dyn AbstractAssetPath>> {
+        Arc::clone(&self.path)
     }
 
     pub fn base_path(&self) -> &str {

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -33,6 +33,9 @@ pub enum InputAction {
     /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
     /// testing.
     CycleWeapon,
+    /// Reload the current level in place (debug). Exercises the level-transition path,
+    /// including the experimental loading screen.
+    DebugReloadLevel,
 }
 
 impl InputAction {
@@ -47,6 +50,7 @@ impl InputAction {
             InputAction::MoveInventory,
             InputAction::DebugHitboxCyclePose,
             InputAction::CycleWeapon,
+            InputAction::DebugReloadLevel,
         ]
     }
 
@@ -59,6 +63,7 @@ impl InputAction {
             InputAction::MoveInventory => "MoveInventory",
             InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
             InputAction::CycleWeapon => "CycleWeapon",
+            InputAction::DebugReloadLevel => "DebugReloadLevel",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -54,6 +54,9 @@ impl ActionDispatcher {
                 head_rotation: input_context.head.rotation,
             });
         }
+        if state.just_triggered(InputAction::DebugReloadLevel) {
+            effects.push(Effect::GlobalEffect(GlobalEffect::TestReload));
+        }
 
         effects
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -48,6 +48,7 @@ use std::{
     io::BufReader,
     rc::Rc,
     sync::Arc,
+    thread,
 };
 
 use cgmath::{Matrix4, Quaternion, Vector2, Vector3, vec3};
@@ -144,21 +145,26 @@ struct PendingTransition {
     entities_to_trigger: Vec<String>,
     quest_info: QuestInfo,
     held_data: HeldItemSaveData,
+    /// The CPU parse running on a worker thread. While this is in flight the loading
+    /// screen renders (and animates) every frame; once it finishes, the main thread runs
+    /// the GPU `build` and swaps to the mission.
+    parse_handle: thread::JoinHandle<dark::mission::SystemShock2Level>,
     /// Frames the loading screen has rendered so far (frame-counted, so it works under
-    /// the debug runtime's zero-dt stepping). The load is deferred until this reaches
-    /// [`MIN_LOADING_FRAMES`] so the loading screen is shown (and animates) for a
-    /// perceptible moment rather than a single flash.
+    /// the debug runtime's zero-dt stepping). A minimum display so the loading screen is
+    /// shown for a perceptible moment even if the parse finishes very quickly.
     frames_shown: u32,
 }
 
-/// Minimum number of frames to show the loading screen before performing the (currently
-/// synchronous, blocking) load. ~0.4s at 60fps.
+/// Minimum number of frames to show the loading screen before swapping to the mission,
+/// even if the background parse finished sooner. ~0.4s at 60fps.
 const MIN_LOADING_FRAMES: u32 = 24;
 
 pub struct Game {
     options: GameOptions,
     pub asset_cache: AssetCache,
-    global_context: GlobalContext,
+    // `Arc` so the gamesys + definitions can be cloned into a background level-parse
+    // thread (projects/loading-screen.md). Shared immutably after init.
+    global_context: Arc<GlobalContext>,
     active_game_scene: Box<dyn GameScene>,
     /// Set while a deferred transition is in flight (loading screen showing).
     pending_transition: Option<PendingTransition>,
@@ -255,17 +261,32 @@ impl Game {
         self.load_mission_into_scene(level_name, spawn_loc, quest_info, held_data);
     }
 
-    /// Start a deferred transition: save the outgoing scene now, swap to the loading
-    /// screen, and defer the blocking load to the next `update` (so the loading screen
-    /// renders at least one frame before the loop stalls on the load).
+    /// Start a background transition: save the outgoing scene, spawn the GL-free level
+    /// parse on a worker thread, and swap to the loading screen. The loading screen
+    /// animates while the parse runs; `update` completes it once the parse finishes.
     fn begin_transition(
         &mut self,
         level_name: String,
         spawn_loc: SpawnLocation,
         entities_to_trigger: Vec<String>,
     ) {
-        tracing::info!("[loading-screen] begin_transition -> {} (showing loading scene)", level_name);
+        tracing::info!(
+            "[loading-screen] begin_transition -> {} (background parse)",
+            level_name
+        );
         let (quest_info, held_data) = self.save_active_scene();
+
+        // Spawn the GL-free parse off-thread. It owns `Arc`s of the asset-path layer and
+        // the global context (gamesys + definitions), all `Send + Sync`, and produces a
+        // `Send` `SystemShock2Level`.
+        let asset_paths = self.asset_cache.asset_paths_arc();
+        let base_path = self.asset_cache.base_path().to_string();
+        let global_context = Arc::clone(&self.global_context);
+        let parse_name = level_name.clone();
+        let parse_handle = thread::spawn(move || {
+            Mission::parse(&**asset_paths, &base_path, &parse_name, &global_context)
+        });
+
         self.active_game_scene = Box::new(LoadingScene::new());
         self.pending_transition = Some(PendingTransition {
             level_name,
@@ -273,19 +294,48 @@ impl Game {
             entities_to_trigger,
             quest_info,
             held_data,
+            parse_handle,
             frames_shown: 0,
         });
     }
 
-    /// Complete a deferred transition queued by [`begin_transition`].
+    /// Complete a background transition queued by [`begin_transition`]: join the finished
+    /// parse and run the main-thread GPU `build`, then swap to the mission.
     fn finish_transition(&mut self, pending: PendingTransition) {
-        tracing::info!("[loading-screen] finish_transition -> {} (loading now)", pending.level_name);
-        self.load_mission_into_scene(
+        tracing::info!(
+            "[loading-screen] finish_transition -> {} (parse done, building)",
+            pending.level_name
+        );
+        let level = pending
+            .parse_handle
+            .join()
+            .expect("background level-parse thread panicked");
+
+        let populator: Box<dyn EntityPopulator> = {
+            if let Some(save_data) = self
+                .mission_to_save_data
+                .get(&pending.level_name.to_ascii_lowercase())
+            {
+                Box::new(SaveFileEntityPopulator::create(save_data.clone()))
+            } else {
+                Box::new(MissionEntityPopulator::create())
+            }
+        };
+
+        let mission = Mission::build(
+            level,
             pending.level_name,
+            &mut self.asset_cache,
+            &mut self.audio_context,
+            &self.global_context,
             pending.spawn_loc,
             pending.quest_info,
+            populator,
             pending.held_data,
+            &self.options,
         );
+        self.active_game_scene = Box::new(mission);
+
         for entity_name in pending.entities_to_trigger {
             self.active_game_scene.queue_entity_trigger(entity_name);
         }
@@ -515,7 +565,7 @@ impl Game {
             audio_context,
             active_game_scene,
             pending_transition: None,
-            global_context,
+            global_context: Arc::new(global_context),
             last_music_cue: None,
             last_env_sound: None,
             options,
@@ -535,11 +585,14 @@ impl Game {
         let delta_time = time.elapsed.as_secs_f32();
         trace!("delta_time: {}", delta_time);
 
-        // Drive a deferred transition: show the loading screen for a minimum number of
-        // frames, then perform the (blocking) load and swap to the mission.
+        // Drive a background transition: the loading screen animates while the parse
+        // runs on its worker thread. Once the parse has finished AND the loading screen
+        // has shown for its minimum, run the main-thread build and swap to the mission.
         if let Some(pending) = self.pending_transition.as_mut() {
             pending.frames_shown += 1;
-            if pending.frames_shown >= MIN_LOADING_FRAMES {
+            let ready =
+                pending.parse_handle.is_finished() && pending.frames_shown >= MIN_LOADING_FRAMES;
+            if ready {
                 let pending = self.pending_transition.take().unwrap();
                 self.finish_transition(pending);
             }
@@ -633,7 +686,7 @@ impl Game {
             save_data,
             &mut self.asset_cache,
             &mut self.audio_context,
-            &mut self.global_context,
+            &self.global_context,
             &self.options,
         );
         self.active_game_scene = Box::new(mission);

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -67,7 +67,8 @@ use engine::{
 use mission::entity_populator::{EntityPopulator, MissionEntityPopulator, SaveFileEntityPopulator};
 use quest_info::QuestInfo;
 
-use save_load::{EntitySaveData, GlobalData, SaveData};
+use save_load::{EntitySaveData, GlobalData, HeldItemSaveData, SaveData};
+use scenes::LoadingScene;
 use scripts::GlobalEffect;
 use shipyard::*;
 use time::Time;
@@ -134,11 +135,33 @@ impl Default for GameOptions {
     }
 }
 
+/// A level transition that has been started (outgoing scene already saved, loading
+/// screen showing) and whose blocking load is deferred to the next `update` frame.
+/// Only used when the experimental `loading_screen` feature is enabled.
+struct PendingTransition {
+    level_name: String,
+    spawn_loc: SpawnLocation,
+    entities_to_trigger: Vec<String>,
+    quest_info: QuestInfo,
+    held_data: HeldItemSaveData,
+    /// Frames the loading screen has rendered so far (frame-counted, so it works under
+    /// the debug runtime's zero-dt stepping). The load is deferred until this reaches
+    /// [`MIN_LOADING_FRAMES`] so the loading screen is shown (and animates) for a
+    /// perceptible moment rather than a single flash.
+    frames_shown: u32,
+}
+
+/// Minimum number of frames to show the loading screen before performing the (currently
+/// synchronous, blocking) load. ~0.4s at 60fps.
+const MIN_LOADING_FRAMES: u32 = 24;
+
 pub struct Game {
     options: GameOptions,
     pub asset_cache: AssetCache,
     global_context: GlobalContext,
     active_game_scene: Box<dyn GameScene>,
+    /// Set while a deferred transition is in flight (loading screen showing).
+    pending_transition: Option<PendingTransition>,
     // physics: PhysicsWorld,
     // script_world: ScriptWorld,
     audio_context: AudioContext<EntityId, String>,
@@ -157,7 +180,17 @@ pub struct Game {
 }
 
 impl Game {
-    fn switch_mission(&mut self, level_name: String, spawn_loc: SpawnLocation) {
+    /// Whether the experimental loading screen (deferred transitions) is enabled.
+    fn loading_screen_enabled(&self) -> bool {
+        self.options
+            .experimental_features
+            .contains("loading_screen")
+    }
+
+    /// Capture the outgoing scene's save data (so its state survives the transition)
+    /// and return the context the new mission needs. Must run while the outgoing scene
+    /// is still active.
+    fn save_active_scene(&mut self) -> (QuestInfo, HeldItemSaveData) {
         let current_quest_info = self
             .active_game_scene
             .world()
@@ -178,6 +211,18 @@ impl Game {
             current_save_data,
         );
 
+        (current_quest_info, held_data)
+    }
+
+    /// Load a mission (using previously-captured save context) and make it the active
+    /// scene. This is the blocking part of a transition.
+    fn load_mission_into_scene(
+        &mut self,
+        level_name: String,
+        spawn_loc: SpawnLocation,
+        quest_info: QuestInfo,
+        held_data: HeldItemSaveData,
+    ) {
         let populator: Box<dyn EntityPopulator> = {
             if let Some(save_data) = self
                 .mission_to_save_data
@@ -197,12 +242,53 @@ impl Game {
             &mut self.audio_context,
             &self.global_context,
             spawn_loc,
-            current_quest_info,
+            quest_info,
             populator,
             held_data,
             &self.options,
         );
         self.active_game_scene = Box::new(active_mission);
+    }
+
+    fn switch_mission(&mut self, level_name: String, spawn_loc: SpawnLocation) {
+        let (quest_info, held_data) = self.save_active_scene();
+        self.load_mission_into_scene(level_name, spawn_loc, quest_info, held_data);
+    }
+
+    /// Start a deferred transition: save the outgoing scene now, swap to the loading
+    /// screen, and defer the blocking load to the next `update` (so the loading screen
+    /// renders at least one frame before the loop stalls on the load).
+    fn begin_transition(
+        &mut self,
+        level_name: String,
+        spawn_loc: SpawnLocation,
+        entities_to_trigger: Vec<String>,
+    ) {
+        tracing::info!("[loading-screen] begin_transition -> {} (showing loading scene)", level_name);
+        let (quest_info, held_data) = self.save_active_scene();
+        self.active_game_scene = Box::new(LoadingScene::new());
+        self.pending_transition = Some(PendingTransition {
+            level_name,
+            spawn_loc,
+            entities_to_trigger,
+            quest_info,
+            held_data,
+            frames_shown: 0,
+        });
+    }
+
+    /// Complete a deferred transition queued by [`begin_transition`].
+    fn finish_transition(&mut self, pending: PendingTransition) {
+        tracing::info!("[loading-screen] finish_transition -> {} (loading now)", pending.level_name);
+        self.load_mission_into_scene(
+            pending.level_name,
+            pending.spawn_loc,
+            pending.quest_info,
+            pending.held_data,
+        );
+        for entity_name in pending.entities_to_trigger {
+            self.active_game_scene.queue_entity_trigger(entity_name);
+        }
     }
 
     fn switch_mission_with_trigger(
@@ -428,6 +514,7 @@ impl Game {
             asset_cache,
             audio_context,
             active_game_scene,
+            pending_transition: None,
             global_context,
             last_music_cue: None,
             last_env_sound: None,
@@ -447,6 +534,16 @@ impl Game {
         let _enter = span.enter();
         let delta_time = time.elapsed.as_secs_f32();
         trace!("delta_time: {}", delta_time);
+
+        // Drive a deferred transition: show the loading screen for a minimum number of
+        // frames, then perform the (blocking) load and swap to the mission.
+        if let Some(pending) = self.pending_transition.as_mut() {
+            pending.frames_shown += 1;
+            if pending.frames_shown >= MIN_LOADING_FRAMES {
+                let pending = self.pending_transition.take().unwrap();
+                self.finish_transition(pending);
+            }
+        }
 
         // Convert triggered actions into effects; triggered actions are
         // consumed here so injected actions (e.g. from the debug runtime)
@@ -610,7 +707,11 @@ impl Game {
                     Some(marker) => SpawnLocation::Marker(marker),
                 };
 
-                self.switch_mission_with_trigger(level_file, spawn_loc, entities_to_trigger);
+                if self.loading_screen_enabled() {
+                    self.begin_transition(level_file, spawn_loc, entities_to_trigger);
+                } else {
+                    self.switch_mission_with_trigger(level_file, spawn_loc, entities_to_trigger);
+                }
             }
             GlobalEffect::TestReload => {
                 let (position, rotation) = {
@@ -621,10 +722,13 @@ impl Game {
                         .unwrap();
                     (player_info.pos, player_info.rotation)
                 };
-                self.switch_mission(
-                    self.active_game_scene.scene_name().to_string(),
-                    SpawnLocation::PositionRotation(position, rotation),
-                );
+                let level_name = self.active_game_scene.scene_name().to_string();
+                let spawn_loc = SpawnLocation::PositionRotation(position, rotation);
+                if self.loading_screen_enabled() {
+                    self.begin_transition(level_name, spawn_loc, vec![]);
+                } else {
+                    self.switch_mission(level_name, spawn_loc);
+                }
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -19,7 +19,7 @@ use cgmath::{Matrix4, Quaternion, Vector2, Vector3};
 use rapier3d::prelude::{Collider, ColliderBuilder};
 
 use engine::{
-    assets::asset_cache::AssetCache,
+    assets::{asset_cache::AssetCache, asset_paths::AbstractAssetPath},
     audio::AudioContext,
     scene::{SceneObject, light::SpotLight},
 };
@@ -43,7 +43,35 @@ pub struct Mission {
 }
 
 impl Mission {
-    pub fn load(
+    /// The GL-free, CPU-only first phase of a level load: read + parse the `.mis` into a
+    /// `Send` `SystemShock2Level`. Takes only the `Send + Sync` asset-path layer and the
+    /// gamesys/definitions (borrowed), so a worker thread can run it by owning `Arc`s of
+    /// those and passing references in (projects/loading-screen.md). No GL, no AssetCache.
+    pub fn parse(
+        asset_paths: &dyn AbstractAssetPath,
+        base_path: &str,
+        mission: &str,
+        global_context: &GlobalContext,
+    ) -> dark::mission::SystemShock2Level {
+        info!("starting level load");
+        let f = File::open(resource_path(mission)).unwrap();
+        let mut reader = BufReader::new(f);
+        dark::mission::read(
+            asset_paths,
+            base_path,
+            &mut reader,
+            &global_context.gamesys,
+            &global_context.links,
+            &global_context.links_with_data,
+            &global_context.properties,
+        )
+    }
+
+    /// The main-thread second phase: GPU upload (`to_scene`) + physics/spatial build +
+    /// entity instantiation. Consumes the parsed level.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        level: dark::mission::SystemShock2Level,
         mission: String,
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
@@ -54,27 +82,6 @@ impl Mission {
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
     ) -> Mission {
-        let properties = &global_context.properties;
-        let links = &global_context.links;
-        let links_with_data = &global_context.links_with_data;
-        let _motiondb = &global_context.motiondb;
-
-        info!("starting level load");
-
-        let f = File::open(resource_path(&mission)).unwrap();
-        let mut reader = BufReader::new(f);
-        // `read` is GL-free: it takes the Send + Sync asset-path layer, not the cache.
-        let base_path = asset_cache.base_path().to_string();
-        let level = dark::mission::read(
-            asset_cache.asset_paths(),
-            &base_path,
-            &mut reader,
-            &global_context.gamesys,
-            links,
-            links_with_data,
-            properties,
-        );
-
         let scene_objects = dark::mission::to_scene(&level, asset_cache);
         let song_params = level.song_params.clone();
         let room_db = level.room_database.clone();
@@ -107,6 +114,40 @@ impl Mission {
             game_options,
         );
         Mission { mission_core }
+    }
+
+    /// Synchronous load: `parse` then `build` on the calling thread (unchanged behavior).
+    #[allow(clippy::too_many_arguments)]
+    pub fn load(
+        mission: String,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+        global_context: &GlobalContext,
+        spawn_loc: SpawnLocation,
+        quest_info: QuestInfo,
+        entity_populator: Box<dyn EntityPopulator>,
+        held_item_save_data: HeldItemSaveData,
+        game_options: &GameOptions,
+    ) -> Mission {
+        let base_path = asset_cache.base_path().to_string();
+        let level = Self::parse(
+            asset_cache.asset_paths(),
+            &base_path,
+            &mission,
+            global_context,
+        );
+        Self::build(
+            level,
+            mission,
+            asset_cache,
+            audio_context,
+            global_context,
+            spawn_loc,
+            quest_info,
+            entity_populator,
+            held_item_save_data,
+            game_options,
+        )
     }
 
     pub fn update(


### PR DESCRIPTION
**The headline async win.** With the experimental `loading_screen` flag, the GL-free level parse now runs on a **worker thread** while the loading screen animates, then the main thread builds + swaps to the mission. The parse phase no longer freezes the loop.

> **Stacking:** this branch includes #316's transition wiring (cherry-picked, since the worker thread replaces its synchronous load) plus #318's GL-free parse (already in `main`). Recommend merging #316 first, then I'll rebase this to a clean background-parse-only diff — or review/merge them together. Builds on the `Send` foundation #309/#312/#317.

## What

- **`Mission::load` split into `parse` + `build`.** `parse` is GL-free, CPU-only, and returns a `Send` `SystemShock2Level`; `build` is the main-thread GPU upload + entity instantiation. `parse` takes borrows; the worker closure owns the `Arc`s and derefs them.
- **`AssetCache` holds its asset-path layer as `Arc`** (was `Rc`) + `asset_paths_arc()`, so a `Send + Sync` handle can move to the worker.
- **`Game::global_context` is `Arc<GlobalContext>`** so the gamesys + definitions clone into the worker.
- **`begin_transition` spawns `Mission::parse` via `thread::spawn`**; `PendingTransition` carries the `JoinHandle`; `Game::update` completes the transition once `is_finished()` *and* the minimum display elapsed, then runs `build` on the main thread.

## Verified

- The loading screen renders/animates **during** the parse — confirmed by a screenshot taken mid-parse on a `medsci1` reload (`--experimental loading_screen` + `DebugReloadLevel`), with logs showing `begin_transition (background parse)` → `finish_transition (parse done, building)` ~2.4s apart and no freeze.
- Builds `-D warnings` (dark/shock2vr/debug_runtime/dark_query/dark_viewer); `shock2vr` (11) + `dark` (51) tests pass.
- Synchronous path (flag off) unchanged: `earth`/`eng1` load fine.

## Known limitation (next step)

The `build` phase (`to_scene` + entity instantiation) still runs on the main thread, so there's a shorter hitch at the end while it uploads/instantiates. Two follow-ups: move physics/spatial into the off-thread `parse`, and **time-slice `build`** across frames so even that phase doesn't hitch. Also: real progress → `set_progress` (the bar is still indeterminate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)