### PR TITLE
feat(flat): melee weapon idle + swing animations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,9 @@ Recent work
 - modernize combat: add recoil / accuracy modifier (like counter-strike)
 
 - Fable: finish ragdolls (in progress) - hitbox-fitted colliders + rapier 0.31 compliant joints settle into a heap; on-death ragdoll behind `--experimental ragdoll`; multibody rig still experimental (extremity jitter / hip-sag), see projects/ragdoll-settling-followup.md
-- Fabel: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped; broader AI behavior testing ongoing
+- Fable: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped; broader AI behavior testing ongoing
+- Fable: fix flat screen first-person melee weapon orientation
+- Fable: fix flat screen first-person ranged weapon positioning
 
 
 SNACKS:

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -70,14 +70,45 @@ Remaining (follow-ups):
   vhot / render it in viewmodel space.
 - **Melee weapons** — Wrench / Electro Shock / Crystal Shard / PsiSword.
   - Done: render their `PropLimbModel` FP mesh in the flat viewmodel (they have
-    no `PropPlayerGun`), added to the CycleWeapon roster, and a basic flat swing
+    no `PropPlayerGun`), added to the CycleWeapon roster, a flat swing
     (no-projectile branch in `WeaponScript`: short raycast along the crosshair
-    ray + `MELEE_DAMAGE` to the hit entity). All four render correctly bottom-
-    right; VR melee (physical-collision `MeleeWeapon`) is unchanged.
-  - Remaining: verify swing damage against a live enemy (debug_weapons has no
-    target in reach); derive damage from the weapon's `Melee Typ`; add a swing
-    arc/animation + sound. (Player melee `-928` etc. use `WeaponScript`, not the
+    ray + `MELEE_DAMAGE`, damage verified on a live enemy), a closer melee
+    viewmodel offset, the **idle pose**, and the **swing animation**. VR melee
+    (physical-collision `MeleeWeapon`) is unchanged.
+  - Remaining: derive damage from the weapon's `Melee Typ`; swing sound;
+    camSynch (below). (Player melee `-928` etc. use `WeaponScript`, not the
     `wrench`->`MeleeWeapon` script, which belongs to the Maintenance Tool -2949.)
+
+### First-person weapon animation (from the darkEngine reference)
+
+The FP weapon is a **skeletoned actor (ActorType 1 = `PlayerLimb`)** driven by
+the motion system, not a static prop. The original engine layers two motions:
+
+1. **`camSynch`** (virtual, every frame) — bolts the arm's root joint to the
+   camera: `armPos = camPos + camRot*posOffset`, `armRoot = angOffset ∘ camRot`.
+   This **cancels the clips' root motion**; the relative joints carry the gesture.
+2. **a gesture clip** — the idle (`+plyrmelee:0` = `ph212203`, the ready stance)
+   or a swing (`+plyrmelee:2 +plyrmeleeswing` = `leftswing`/`rightswing`/
+   `highswing`; shipped game uses left). Press=windup, release=swing.
+
+Other reference facts: orientation/placement come from a **separate**
+`sMPlayerLimbOffsets` property ("Arm Pos/Ang Offset"), NOT `PropPlayerGun`; no
+FP-specific FOV/scale; melee damage opens a collision window on a swing keyframe
+(`MF_TRIGGER1`) and lands on physical overlap.
+
+What we implemented (this PR):
+- Pose the FP mesh via an `AnimationPlayer` (was unskinned -> looked mid-swing).
+- **Idle**: the static frame-0 of `ph212203` (head-up ready stance). Static
+  because the looping clip carries root motion we'd otherwise need camSynch to
+  cancel.
+- **Swing**: `Effect::FlatMeleeSwing` plays `leftswing` once on attack, then
+  returns to the static idle.
+
+**TODO(camSynch / root override)**: implement the camSynch equivalent - override
+the FP model's root joint to our viewmodel transform each frame so the clips'
+root motion is cancelled. Then the idle can loop animated and the swing won't
+drift. Also: derive the swing direction/length from hold time (medium vs. long),
+and tie damage to the swing keyframe rather than a fixed raycast.
 - **Crouch-accurate aim** — `PLAYER_EYE_HEIGHT` is the standing value; desktop
   crouch (1.5) lowers the camera but the flat controller's shot origin is fixed,
   so crouched shots land slightly high. Pass the actual eye height into the

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -104,11 +104,41 @@ What we implemented (this PR):
 - **Swing**: `Effect::FlatMeleeSwing` plays `leftswing` once on attack, then
   returns to the static idle.
 
-**TODO(camSynch / root override)**: implement the camSynch equivalent - override
-the FP model's root joint to our viewmodel transform each frame so the clips'
-root motion is cancelled. Then the idle can loop animated and the swing won't
-drift. Also: derive the swing direction/length from hold time (medium vs. long),
-and tie damage to the swing keyframe rather than a fixed raycast.
+**TODO(camSynch / root override)** — the remaining orientation issue. Symptom:
+the idle/swing arm hangs somewhat low and the arm *stub* (open cut end) is
+visible, because the clip's root motion isn't cancelled (the original engine's
+camSynch re-anchors the arm root to the camera every frame; we don't).
+
+Investigation (how our animation system applies the root — `dark/src/`):
+- A posed FP model has **two** root-motion sources, both in
+  `ss2_skeleton::animate(skeleton, anim_info, additional_joint_transforms)`:
+  1. the **root joint's** per-frame animation transform (the joint entry for the
+     root bone in `animation_transforms`), and
+  2. a **separate per-frame `root_transform`** (`AnimationClip.root_transforms[frame]`),
+     passed into `calc_and_cache_global_transform(..., root_transform)` as the
+     base of the whole hierarchy.
+- `AnimationPlayer.additional_joint_transforms` **completely override** a joint's
+  animation transform (`animate`: `animation_transforms.insert(joint, transform)`,
+  commented "Have joint transforms completely override animation transforms").
+  So overriding the root *joint* there cancels source (1) - but NOT (2).
+
+Plan:
+1. Find the FP skeleton's root joint id (the bone with no parent / id 0).
+2. Set `additional_joint_transforms[root_joint] = identity` (or the desired arm
+   root orientation) on the melee `AnimationPlayer` to cancel source (1). The
+   `AnimationPlayer` builders already thread `additional_joint_transforms`; add a
+   small constructor/setter for it.
+3. Cancel/replace source (2): either feed an identity `root_transform` for the FP
+   weapon path, or add a flag to `animate`/`get_transforms` to ignore
+   `root_transforms`. (Cleanest: a "no root motion" mode on the player or a
+   variant of `to_animated_scene_objects` for view models.)
+4. Then re-anchor the arm to our viewmodel transform (the `SetPositionRotation`
+   already positions the model; with root motion cancelled it should sit
+   correctly) and verify: idle can loop animated without drift, arm stub
+   off-screen, swing stays anchored.
+
+Then also: derive the swing direction/length from hold time (medium vs. long),
+and tie damage to the swing keyframe (`MF_TRIGGER1`) rather than a fixed raycast.
 - **Crouch-accurate aim** — `PLAYER_EYE_HEIGHT` is the standing value; desktop
   crouch (1.5) lowers the camera but the flat controller's shot origin is fixed,
   so crouched shots land slightly high. Pass the actual eye height into the

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -109,6 +109,10 @@ pub struct PlayerInfo {
 /// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
 /// used to pose the flat melee viewmodel in its ready stance.
 const MELEE_IDLE_CLIP: &str = "ph212203";
+/// First-person player-melee swing clip (motiondb `+plyrmelee:2 +plyrmeleeswing`),
+/// played once on a melee attack then auto-returns to the idle. The shipped game
+/// always uses the medium-left swing.
+const MELEE_SWING_CLIP: &str = "leftswing";
 
 /// Debug options accessible from scripts via UniqueView
 #[derive(Unique, Clone, Default)]
@@ -196,6 +200,11 @@ pub struct MissionCore {
     /// Sequential index for `Effect::DebugCycleWeapon` so each trigger wields the
     /// next weapon in `DEBUG_WEAPONS` (flat-mode aim/viewmodel testing).
     pub debug_weapon_index: usize,
+
+    /// First-person animation for the flat melee viewmodel: the wielded melee
+    /// entity and its motion player (loops the player-melee idle; a swing is
+    /// queued on attack and auto-returns to idle). `None` for guns / no weapon.
+    flat_melee_anim: Option<(EntityId, AnimationPlayer)>,
 }
 
 pub struct GlobalContext {
@@ -458,6 +467,7 @@ impl MissionCore {
             pathfinding_test: crate::mission::pathfinding_test::PathfindingTest::new(),
             debug_pose_index: 0,
             debug_weapon_index: 0,
+            flat_melee_anim: None,
         }
     }
 
@@ -632,6 +642,9 @@ impl MissionCore {
             self.world
                 .add_component(weapon, RuntimePropFlatAim { origin, forward });
         }
+
+        // Advance the flat melee swing animation (returns to static idle on end).
+        self.update_flat_melee_anim(time.elapsed);
 
         // Sync up the position of all the physics objects
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position
@@ -1190,6 +1203,10 @@ impl MissionCore {
                             })
                         }
                     }
+                }
+
+                Effect::FlatMeleeSwing { entity_id } => {
+                    self.queue_flat_melee_swing(asset_cache, entity_id);
                 }
 
                 Effect::CreateEntityByTemplateName {
@@ -1833,6 +1850,41 @@ impl MissionCore {
 
         global_effects
     }
+
+    /// Advance the flat melee swing animation. Only an active swing uses the
+    /// persistent player; the idle is the static head-up pose (rendered directly,
+    /// since the looping idle clip carries root motion meant to be cancelled by
+    /// the original engine's camSynch, which we don't implement). When the swing
+    /// completes - or the weapon changes - we drop the player and fall back to
+    /// the static idle.
+    fn update_flat_melee_anim(&mut self, dt: std::time::Duration) {
+        let Some((entity, player)) = self.flat_melee_anim.take() else {
+            return;
+        };
+        if self.interaction.viewmodel_entity() != Some(entity) {
+            return; // weapon changed; leave None -> static idle
+        }
+        let (next, _flags, events, _disp) = AnimationPlayer::update(&player, dt);
+        let completed = events
+            .iter()
+            .any(|e| matches!(e, AnimationEvent::Completed));
+        if !completed {
+            self.flat_melee_anim = Some((entity, next));
+        }
+    }
+
+    /// Start a one-shot swing on the flat melee viewmodel (it plays once, then
+    /// `update_flat_melee_anim` drops it back to the static idle). Driven by
+    /// `Effect::FlatMeleeSwing` on a melee attack.
+    fn queue_flat_melee_swing(&mut self, asset_cache: &mut AssetCache, entity_id: EntityId) {
+        if let Some(clip) =
+            asset_cache.get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{MELEE_SWING_CLIP}_.mc"))
+        {
+            let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip);
+            self.flat_melee_anim = Some((entity_id, player));
+        }
+    }
+
     pub fn render_per_eye(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -1937,19 +1989,25 @@ impl MissionCore {
                         // FP meshes are articulated (hand + arm + weapon as
                         // skeleton sub-objects), so the unskinned `to_scene_objects`
                         // leaves them unposed (the wrench looked mid-swing). Pose
-                        // them with an AnimationPlayer: melee weapons hold the
-                        // player-melee idle stance (motiondb ActorType 1); guns use
-                        // the empty/bind pose. No-op for static meshes.
-                        let player = if is_melee {
-                            asset_cache
+                        // them with an AnimationPlayer: a melee weapon mid-swing
+                        // uses its swing player; otherwise melee holds the static
+                        // player-melee idle (frame 0 = head-up ready stance); guns
+                        // use the empty/bind pose. No-op for static meshes.
+                        let swing_player = self
+                            .flat_melee_anim
+                            .as_ref()
+                            .filter(|(e, _)| *e == weapon)
+                            .map(|(_, p)| p.clone());
+                        let player = match (is_melee, swing_player) {
+                            (_, Some(p)) => p,
+                            (true, None) => asset_cache
                                 .get_opt(
                                     &ANIMATION_CLIP_IMPORTER,
                                     &format!("{MELEE_IDLE_CLIP}_.mc"),
                                 )
                                 .map(AnimationPlayer::from_animation)
-                                .unwrap_or_else(AnimationPlayer::empty)
-                        } else {
-                            AnimationPlayer::empty()
+                                .unwrap_or_else(AnimationPlayer::empty),
+                            (false, None) => AnimationPlayer::empty(),
                         };
                         model.as_ref().to_animated_scene_objects(&player)
                     } else if let Some(model) = self.id_to_model.get(&weapon) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -106,6 +106,10 @@ pub struct PlayerInfo {
     pub inventory_entity_id: EntityId,
 }
 
+/// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
+/// used to pose the flat melee viewmodel in its ready stance.
+const MELEE_IDLE_CLIP: &str = "ph212203";
+
 /// Debug options accessible from scripts via UniqueView
 #[derive(Unique, Clone, Default)]
 pub struct DebugOptions {
@@ -1915,28 +1919,39 @@ impl MissionCore {
                 // so EVERY weapon gets its proper FP model, not just those listed
                 // in the VR hand-model table. Other items fall back to the
                 // entity's current model.
-                let fp_model_name = self
+                let gun_model = self
                     .world
                     .borrow::<View<PropPlayerGun>>()
                     .ok()
-                    .and_then(|v| v.get(weapon).ok().map(|g| g.hand_model.clone()))
-                    .or_else(|| {
-                        self.world
-                            .borrow::<View<PropLimbModel>>()
-                            .ok()
-                            .and_then(|v| v.get(weapon).ok().map(|m| m.0.clone()))
-                    });
+                    .and_then(|v| v.get(weapon).ok().map(|g| g.hand_model.clone()));
+                let limb_model = self
+                    .world
+                    .borrow::<View<PropLimbModel>>()
+                    .ok()
+                    .and_then(|v| v.get(weapon).ok().map(|m| m.0.clone()));
+                let is_melee = limb_model.is_some();
+                let fp_model_name = gun_model.or(limb_model);
                 if let Some(xform) = maybe_xform {
                     let scene_objs = if let Some(name) = fp_model_name {
                         let model = asset_cache.get(&MODELS_IMPORTER, &format!("{name}.BIN"));
-                        // Pose at the rest/bind pose: FP meshes are articulated
-                        // (hand + arm + weapon as skeleton sub-objects), so the
-                        // unskinned `to_scene_objects` leaves the parts unposed
-                        // (the wrench looked mid-swing). An empty AnimationPlayer
-                        // applies the bind transforms; a no-op for static meshes.
-                        model
-                            .as_ref()
-                            .to_animated_scene_objects(&AnimationPlayer::empty())
+                        // FP meshes are articulated (hand + arm + weapon as
+                        // skeleton sub-objects), so the unskinned `to_scene_objects`
+                        // leaves them unposed (the wrench looked mid-swing). Pose
+                        // them with an AnimationPlayer: melee weapons hold the
+                        // player-melee idle stance (motiondb ActorType 1); guns use
+                        // the empty/bind pose. No-op for static meshes.
+                        let player = if is_melee {
+                            asset_cache
+                                .get_opt(
+                                    &ANIMATION_CLIP_IMPORTER,
+                                    &format!("{MELEE_IDLE_CLIP}_.mc"),
+                                )
+                                .map(AnimationPlayer::from_animation)
+                                .unwrap_or_else(AnimationPlayer::empty)
+                        } else {
+                            AnimationPlayer::empty()
+                        };
+                        model.as_ref().to_animated_scene_objects(&player)
                     } else if let Some(model) = self.id_to_model.get(&weapon) {
                         match self.id_to_animation_player.get(&weapon) {
                             Some(player) => model.to_animated_scene_objects(player),

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -92,6 +92,12 @@ pub enum Effect {
         lines: Vec<(Point3<f32>, Point3<f32>, Vector4<f32>)>,
     },
 
+    /// Play the flat melee viewmodel's swing animation for `entity_id` (the
+    /// wielded melee weapon). Emitted by the melee attack; a no-op in VR.
+    FlatMeleeSwing {
+        entity_id: EntityId,
+    },
+
     DestroyEntity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -86,7 +86,7 @@ impl Script for WeaponScript {
                         .get(entity_id)
                         .copied()
                     {
-                        return melee_swing(world, physics, aim);
+                        return melee_swing(physics, entity_id, aim, world);
                     }
                 }
 
@@ -156,9 +156,17 @@ impl Script for WeaponScript {
     }
 }
 
-/// A flat melee swing: raycast a short distance along the crosshair ray and, if
-/// it hits an entity, deal melee damage (hitbox proxies resolve to their parent).
-fn melee_swing(world: &World, physics: &PhysicsWorld, aim: RuntimePropFlatAim) -> Effect {
+/// A flat melee swing: play the swing animation, and raycast a short distance
+/// along the crosshair ray - a hit deals melee damage (hitbox proxies resolve to
+/// their parent). The swing animation plays whether or not the swing connects.
+fn melee_swing(
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+    aim: RuntimePropFlatAim,
+    world: &World,
+) -> Effect {
+    let mut effects = vec![Effect::FlatMeleeSwing { entity_id }];
+
     let hit = physics.ray_cast(
         aim.origin,
         aim.forward.normalize() * MELEE_RANGE,
@@ -172,17 +180,16 @@ fn melee_swing(world: &World, physics: &PhysicsWorld, aim: RuntimePropFlatAim) -
     }) = hit
     {
         let target = resolve_proxy_entity(world, target);
-        Effect::Send {
+        effects.push(Effect::Send {
             msg: Message {
                 to: target,
                 payload: MessagePayload::Damage {
                     amount: MELEE_DAMAGE,
                 },
             },
-        }
-    } else {
-        Effect::NoEffect
+        });
     }
+    Effect::Multiple(effects)
 }
 
 fn create_muzzle_flash(


### PR DESCRIPTION
Stacked on #319 (melee render/damage). Plays the first-person idle stance and swing animation for flat melee weapons.

## What & why
The FP weapon is a skeletoned actor (ActorType 1 = PlayerLimb) driven by the motion system, not a static prop — so the flat melee viewmodel rendered its unposed bind pose (the wrench/swords looked "forward / mid-swing"). This poses them with their actual player-melee motions.

## Changes
- **Pose the FP mesh** with an `AnimationPlayer` (it was unskinned — articulated hand/arm/weapon not posed).
- **Idle** — pose melee weapons at the player-melee idle (`ph212203`, `+plyrmelee:0`): the wrench head and swords now point **up**, held ready. Guns keep the bind pose.
- **Swing** — `Effect::FlatMeleeSwing` (emitted by the melee attack) plays `leftswing` once, then returns to the idle.

## Verified (debug runtime)
Wrench & PsiSword hold the head-up/blade-up idle; attacking plays the swing arc and returns to idle.

## Known limitation → follow-up
The original engine bolts the FP arm's root joint to the camera each frame (the `camSynch` virtual motion), cancelling the clips' root motion. We don't implement camSynch yet, so:
- the idle is the **static** frame-0 pose (the looping clip drifts without camSynch);
- the swing carries some **root drift**.

**camSynch (root-joint override)** is the next step for a tight animated idle + swing. The full darkEngine FP-animation findings and roadmap are in `projects/flat-weapon-handling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)