### PR TITLE
feat(flat): muzzle flash follows the weapon (generic attachment)

### DIFF
--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -65,9 +65,15 @@ Remaining (follow-ups):
   - Ref: `darkengine` `PlayerGunDescGetModelOffset` / `m_posOffset`. The
     experiment code lived on the abandoned `feat/flat-viewmodel-offset` branch
     (see git reflog) if useful.
-- **Muzzle flash is world-pinned** — created at the weapon's fire-time transform
-  and not re-parented, so it doesn't track the weapon. Attach it to the muzzle
-  vhot / render it in viewmodel space.
+- ~~**Muzzle flash is world-pinned**~~ **(done)** — added a generic attachment
+  mechanism: `RuntimePropAttachment { parent, local_transform }` plus a
+  `CreateEntityOptions.attach_to` that captures the spawn-time relative pose
+  (`parent.transform.invert() * child.transform`), and a per-frame
+  `run_attachment_update` system (`systems/attachment.rs`, runs after physics
+  sync) that re-anchors `child.transform = parent.transform * local`. The muzzle
+  flash now attaches to its firing weapon, so it tracks the per-frame re-placed
+  first-person viewmodel (and VR weapon) instead of snapshotting the fire-time
+  pose. Reusable for later attached effects (shell ejection, smoke).
 - **Melee weapons** — Wrench / Electro Shock / Crystal Shard / PsiSword.
   - Done: render their `PropLimbModel` FP mesh in the flat viewmodel (they have
     no `PropPlayerGun`), added to the CycleWeapon roster, a flat swing

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -10,7 +10,7 @@ use crate::{
 use engine::physics_log;
 
 use cgmath::{
-    EuclideanSpace, Matrix4, Point3, Quaternion, Rotation, Transform, Vector3, Zero,
+    EuclideanSpace, Matrix4, Point3, Quaternion, Rotation, SquareMatrix, Transform, Vector3, Zero,
     num_traits::abs, vec3,
 };
 use dark::{
@@ -114,6 +114,30 @@ pub fn create_entity_with_position(
         * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z);
 
     world.add_component(entity_id, RuntimePropTransform(transform));
+
+    // Optionally bolt this entity to a parent's transform (e.g. a muzzle flash to
+    // its weapon) so it tracks the parent each frame. Capture the spawn-time
+    // relative pose; if the parent has no transform yet, fall back to no
+    // attachment (the entity stays at its initial pose).
+    if let Some(parent) = additional_options.attach_to {
+        let maybe_local = {
+            let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+            v_transform
+                .get(parent)
+                .ok()
+                .and_then(|p| p.0.invert())
+                .map(|inv_parent| inv_parent * transform)
+        };
+        if let Some(local_transform) = maybe_local {
+            world.add_component(
+                entity_id,
+                RuntimePropAttachment {
+                    parent,
+                    local_transform,
+                },
+            );
+        }
+    }
 
     create_entity_core(
         entity_id,
@@ -785,12 +809,18 @@ pub fn create_physics_representation(
 #[derive(Clone, Debug)]
 pub struct CreateEntityOptions {
     pub force_visible: bool,
+    /// Bolt the new entity to this parent's transform for its lifetime (see
+    /// `RuntimePropAttachment`). The spawn-time relative pose is captured and the
+    /// child then tracks the parent each frame - used so a weapon's muzzle flash
+    /// follows the moving first-person viewmodel instead of snapshotting it once.
+    pub attach_to: Option<EntityId>,
 }
 
 impl Default for CreateEntityOptions {
     fn default() -> Self {
         CreateEntityOptions {
             force_visible: false,
+            attach_to: None,
         }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -84,7 +84,7 @@ use crate::{
         script_util::{get_all_links_with_template, get_environmental_sound_query},
         speech_registry::SpeechVoiceRegistry,
     },
-    systems::{run_bitmap_animation, run_tweq, turn_off_tweqs, turn_on_tweqs},
+    systems::{run_attachment_update, run_bitmap_animation, run_tweq, turn_off_tweqs, turn_on_tweqs},
     teleport::{TeleportSystem, TeleportUI, TeleportVisualStyle},
     time::Time,
     util::{get_email_sound_file, has_refs, vec3_to_point3},
@@ -651,6 +651,11 @@ impl MissionCore {
         // from physics
         self.synchronize_physics_positions();
 
+        // Re-anchor attached entities (e.g. a muzzle flash) to their parent's
+        // now-current transform, so they track a moving parent rather than their
+        // spawn pose. Runs after physics sync so parents' transforms are current.
+        self.update_attached_entities();
+
         // Update scripts
         let mut script_effects = profile!(
             scope: "game", level: DEBUG, "script_world.update",
@@ -769,6 +774,17 @@ impl MissionCore {
                 v_entities.add_component(*entity_id, &mut v_transform, RuntimePropTransform(xform));
             }
         };
+    }
+
+    ///
+    /// update_attached_entities
+    ///
+    /// For every entity bolted to a parent (RuntimePropAttachment), recompute its
+    /// RuntimePropTransform as `parent.transform * local_transform`, so it tracks
+    /// the parent each frame (e.g. a muzzle flash following the first-person
+    /// weapon). Entities whose parent has gone away keep their last transform.
+    fn update_attached_entities(&mut self) {
+        self.world.run(run_attachment_update);
     }
 
     fn update_animations(&mut self, time: &Time) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -84,7 +84,9 @@ use crate::{
         script_util::{get_all_links_with_template, get_environmental_sound_query},
         speech_registry::SpeechVoiceRegistry,
     },
-    systems::{run_attachment_update, run_bitmap_animation, run_tweq, turn_off_tweqs, turn_on_tweqs},
+    systems::{
+        run_attachment_update, run_bitmap_animation, run_tweq, turn_off_tweqs, turn_on_tweqs,
+    },
     teleport::{TeleportSystem, TeleportUI, TeleportVisualStyle},
     time::Time,
     util::{get_email_sound_file, has_refs, vec3_to_point3},

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -39,6 +39,20 @@ pub struct RuntimePropDoNotSerialize;
 #[derive(Component)]
 pub struct RuntimePropProxyEntity(pub shipyard::EntityId);
 
+// RuntimePropAttachment - rigidly bolts an entity to a parent's transform. Each
+// frame the child's RuntimePropTransform is recomputed as
+// `parent.transform * local_transform`, so short-lived attached effects (e.g. the
+// muzzle flash, and later shell ejection / smoke) track a moving parent - notably
+// the flat first-person weapon, which is re-placed against the camera every frame
+// - instead of staying pinned at their spawn pose. `local_transform` is captured
+// at spawn as `parent.transform.invert() * child.transform`, preserving the
+// child's own scale/orientation relative to the parent.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropAttachment {
+    pub parent: shipyard::EntityId,
+    pub local_transform: Matrix4<f32>,
+}
+
 // RuntimePropFlatAim - the flatscreen camera/crosshair fire ray (world space),
 // set each frame on the player's wielded weapon. When present, weapon firing
 // spawns projectiles from `origin` along `forward` (camera-origin aim) instead

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -225,7 +225,13 @@ fn create_muzzle_flash(
         position: vhot_offset,
         orientation,
         root_transform: transform.0,
-        options: CreateEntityOptions::default(),
+        // Bolt the flash to the firing weapon so it tracks the (per-frame
+        // re-placed) first-person viewmodel during its brief lifetime instead of
+        // staying pinned at the fire-time pose.
+        options: CreateEntityOptions {
+            attach_to: Some(entity_id),
+            ..CreateEntityOptions::default()
+        },
     }
 }
 
@@ -256,6 +262,7 @@ fn create_projectile(
                 root_transform: Matrix4::from_translation(origin.to_vec()) * rot,
                 options: CreateEntityOptions {
                     force_visible: true,
+                    attach_to: None,
                 },
             };
         }
@@ -301,6 +308,7 @@ fn create_projectile(
         root_transform: transform.0 * rot_matrix * projectile_rotation,
         options: CreateEntityOptions {
             force_visible: true,
+            attach_to: None,
         },
     }
 }

--- a/shock2vr/src/systems/attachment.rs
+++ b/shock2vr/src/systems/attachment.rs
@@ -1,0 +1,141 @@
+use cgmath::{Matrix4, Vector3};
+use dark::properties::PropPosition;
+use shipyard::{Get, IntoIter, IntoWithId, View, ViewMut};
+
+use crate::runtime_props::{RuntimePropAttachment, RuntimePropTransform};
+use crate::util::get_rotation_from_matrix;
+
+///
+/// run_attachment_update
+///
+/// For every entity bolted to a parent (`RuntimePropAttachment`), recompute its
+/// transform as `parent.transform * local_transform`, so it tracks the parent
+/// each frame (e.g. a muzzle flash following the first-person weapon viewmodel).
+/// Updates both `RuntimePropTransform` (the render transform) and `PropPosition`
+/// (the logical position), mirroring `synchronize_physics_positions`, so the
+/// rendered pose and the reported position stay consistent. Entities whose
+/// parent has gone away keep their last transform.
+pub fn run_attachment_update(
+    v_attach: View<RuntimePropAttachment>,
+    mut v_transform: ViewMut<RuntimePropTransform>,
+    mut v_position: ViewMut<PropPosition>,
+) {
+    // Read parents first (the immutable borrow ends with the statement), then
+    // write children, to avoid aliasing the transform view.
+    let updates = (&v_attach)
+        .iter()
+        .with_id()
+        .filter_map(|(id, attach)| {
+            (&v_transform)
+                .get(attach.parent)
+                .ok()
+                .map(|parent_xform| (id, parent_xform.0 * attach.local_transform))
+        })
+        .collect::<Vec<_>>();
+
+    for (id, xform) in updates {
+        if let Ok(transform) = (&mut v_transform).get(id) {
+            transform.0 = xform;
+        }
+        // Keep the logical position in sync with the render transform, when the
+        // entity carries one (real spawned entities always do; some test
+        // entities may not).
+        if let Ok(position) = (&mut v_position).get(id) {
+            position.position = translation_of(&xform);
+            position.rotation = get_rotation_from_matrix(&xform);
+        }
+    }
+}
+
+/// The translation component (4th column) of a transform matrix.
+fn translation_of(m: &Matrix4<f32>) -> Vector3<f32> {
+    Vector3::new(m.w.x, m.w.y, m.w.z)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Matrix4, SquareMatrix, Vector3};
+    use shipyard::World;
+
+    fn translation(x: f32, y: f32, z: f32) -> Matrix4<f32> {
+        Matrix4::from_translation(Vector3::new(x, y, z))
+    }
+
+    #[test]
+    fn child_tracks_parent_after_parent_moves() {
+        let mut world = World::new();
+
+        // Parent at the origin; child one unit ahead of it (local offset +1 z).
+        let parent = world.add_entity((RuntimePropTransform(Matrix4::identity()),));
+        let local = translation(0.0, 0.0, 1.0);
+        let child = world.add_entity((
+            RuntimePropTransform(local),
+            // PropPosition so we also exercise the logical-position sync (this is
+            // what the debug runtime's /v1/entities endpoint reports).
+            PropPosition {
+                position: Vector3::new(0.0, 0.0, 1.0),
+                cell: 0,
+                rotation: cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            RuntimePropAttachment {
+                parent,
+                local_transform: local,
+            },
+        ));
+
+        // Move the parent. Without the system the child stays put (negative case);
+        // running the system re-anchors the child to parent * local.
+        world.run(|mut v_transform: ViewMut<RuntimePropTransform>| {
+            (&mut v_transform).get(parent).unwrap().0 = translation(10.0, 0.0, 0.0);
+        });
+
+        // Negative check: child has not moved yet.
+        world.run(|v_transform: View<RuntimePropTransform>| {
+            let c = v_transform.get(child).unwrap().0;
+            assert_eq!(c, local, "child should not move until the system runs");
+        });
+
+        world.run(run_attachment_update);
+
+        // Child should now be at parent (10,0,0) composed with local (+1 z) - in
+        // both the render transform and the reported logical position.
+        world.run(
+            |v_transform: View<RuntimePropTransform>, v_position: View<PropPosition>| {
+                let c = v_transform.get(child).unwrap().0;
+                let expected = translation(10.0, 0.0, 0.0) * local;
+                assert_eq!(c, expected, "child should follow the moved parent");
+
+                let pos = v_position.get(child).unwrap().position;
+                assert_eq!(
+                    pos,
+                    Vector3::new(10.0, 0.0, 1.0),
+                    "logical position should track the parent too"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn child_keeps_transform_when_parent_missing() {
+        let mut world = World::new();
+
+        let local = translation(0.0, 1.0, 0.0);
+        // Parent id that has no transform (e.g. a destroyed weapon).
+        let orphan_parent = world.add_entity(());
+        let child = world.add_entity((
+            RuntimePropTransform(local),
+            RuntimePropAttachment {
+                parent: orphan_parent,
+                local_transform: local,
+            },
+        ));
+
+        world.run(run_attachment_update);
+
+        world.run(|v_transform: View<RuntimePropTransform>| {
+            let c = v_transform.get(child).unwrap().0;
+            assert_eq!(c, local, "child keeps its last transform without a parent");
+        });
+    }
+}

--- a/shock2vr/src/systems/mod.rs
+++ b/shock2vr/src/systems/mod.rs
@@ -1,6 +1,8 @@
+mod attachment;
 mod bitmap_animation;
 mod tweq;
 mod update_teleported_state;
 
+pub use attachment::*;
 pub use bitmap_animation::*;
 pub use tweq::*;


### PR DESCRIPTION
## Problem

The muzzle flash was spawned as a free entity snapshotting the weapon's fire-time transform (`weapon_script::create_muzzle_flash`), so it stayed pinned in place while the first-person viewmodel — re-placed against the camera every frame — kept moving. The flash visibly detached from the barrel on fast turns / sustained fire.

## Fix

A small, **generic** attachment mechanism (reusable for later attached effects like shell ejection / smoke):

- **`RuntimePropAttachment { parent, local_transform }`** (`runtime_props.rs`)
- **`CreateEntityOptions.attach_to: Option<EntityId>`** — captures the spawn-time relative pose `parent.transform.invert() * child.transform` (preserving the child's own scale/orientation) at creation (`entity_creator.rs`)
- **`run_attachment_update`** system (`systems/attachment.rs`), run after physics sync, re-anchoring `child = parent * local` each frame. It writes **both** `RuntimePropTransform` (render) and `PropPosition` (logical), mirroring `synchronize_physics_positions` / `set_entity_position_rotation`, so the reported position stays consistent for scripts / sound / the debug endpoint.

`create_muzzle_flash` now sets `attach_to = weapon`, so the flash tracks the viewmodel (and the VR weapon) for its brief lifetime.

## Tests

- Unit tests (`systems/attachment.rs`): parent moves → child follows (render + logical position); orphaned-parent fallback keeps the last transform.
- Verified end-to-end in the `debug_weapons` scene (`--flat`): firing spawns the `Assault Flash` at the pistol; after a **30° camera turn** the flash-to-pistol distance stays constant at **0.702** (both moved ~0.9u together) instead of growing.

## Validation

`RUSTFLAGS="-D warnings" cargo check -p shock2vr` clean; all 53 `shock2vr` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)