### PR TITLE
feat(debug-runtime): default to flat, surface player/wielded state, validate input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,11 @@ For debugging visual/rendering changes without a full interactive session:
    # Start debug runtime. NOTE: do NOT add an extra `--` after `cargo dbgr` -
    # the alias already ends in `--`, so `cargo dbgr -- --mission ...` passes a
    # literal `--` to clap and fails with "unexpected argument '--mission'".
+   #
+   # Presentation defaults to FLATSCREEN (like desktop_runtime) - first-person
+   # viewmodel, screen-space HUD, right-hand trigger fires. Pass `--vr` for the
+   # VR forearm/two-hand path. (Flat is what most weapon/aim testing needs; in VR
+   # mode the flat weapon-wield / fire path is inactive.)
    cargo dbgr --mission medsci1.mis --port 8080
 
    # Control via HTTP

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -26,8 +26,10 @@ pub enum RuntimeCommand {
     /// Get current input state
     GetInput(oneshot::Sender<InputState>),
 
-    /// Set input channel values
-    SetInput(InputPatch),
+    /// Set one or more input channel values. Replies `Ok(())` when every patch
+    /// applied, or `Err(message)` describing the first invalid channel/value so
+    /// the HTTP layer can return an actionable 400 instead of a silent success.
+    SetInput(Vec<InputPatch>, oneshot::Sender<Result<(), String>>),
 
     /// Move the player to a position
     MovePlayer(Vector3<f32>),
@@ -391,6 +393,11 @@ pub struct PlayerInfo {
     pub rotation: [f32; 4], // quaternion
     pub camera_offset: [f32; 3],
     pub camera_rotation: [f32; 4], // quaternion
+    /// The wielded/first-person weapon in flatscreen mode (the player's left-hand
+    /// slot); `None` when unarmed. See `shock2vr::PlayerStateSnapshot`.
+    pub wielded_entity_id: Option<i32>,
+    /// The entity held in the right hand (VR), `None` otherwise.
+    pub right_hand_entity_id: Option<i32>,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1242,9 +1242,9 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
             .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))
     }
     fn arr(channel: &str, v: &Value, n: usize) -> Result<Vec<f32>, String> {
-        let a = v
-            .as_array()
-            .ok_or_else(|| format!("channel '{channel}' expects an array of {n} numbers, got {v}"))?;
+        let a = v.as_array().ok_or_else(|| {
+            format!("channel '{channel}' expects an array of {n} numbers, got {v}")
+        })?;
         if a.len() != n {
             return Err(format!(
                 "channel '{channel}' expects {n} numbers, got {} ({v})",
@@ -1386,7 +1386,10 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
             let state = game.player_state();
             PlayerInfo {
                 entity_id: state.as_ref().map(|s| s.entity_id),
-                position: state.as_ref().map(|s| s.position).unwrap_or([0.0, 0.0, 0.0]),
+                position: state
+                    .as_ref()
+                    .map(|s| s.position)
+                    .unwrap_or([0.0, 0.0, 0.0]),
                 rotation: state
                     .as_ref()
                     .map(|s| s.rotation)

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -117,10 +117,12 @@ struct Args {
     #[arg(long)]
     experimental: Option<String>,
 
-    /// Use the flatscreen (non-VR) presentation: screen-space 2D HUD instead of
-    /// the VR forearm panels.
+    /// Opt into the VR presentation (forearm panels, two-handed interaction).
+    /// The debug runtime defaults to flatscreen (screen-space 2D HUD,
+    /// first-person viewmodel) to match `desktop_runtime` and because the
+    /// flat path is what most headless weapon/aim testing exercises.
     #[arg(long)]
-    flat: bool,
+    vr: bool,
 }
 
 /// Default debug-camera head rotation.
@@ -366,11 +368,14 @@ fn run_game_blocking(
     let (mission, spawn_location) = parse_mission(&args.mission);
     info!("Mission parsed: {} with spawn location", mission);
 
-    let presentation_mode = if args.flat {
-        shock2vr::PresentationMode::Flat
-    } else {
+    // Flatscreen is the default debug presentation (matching desktop_runtime);
+    // --vr opts into the VR forearm/hands path.
+    let presentation_mode = if args.vr {
         shock2vr::PresentationMode::Vr
+    } else {
+        shock2vr::PresentationMode::Flat
     };
+    info!("Presentation mode: {:?}", presentation_mode);
 
     let options = GameOptions {
         mission: mission.clone(),
@@ -1149,20 +1154,28 @@ fn process_command(
                 tracing::warn!("Failed to send input state - receiver dropped");
             }
         }
-        RuntimeCommand::SetInput(patch) => {
+        RuntimeCommand::SetInput(patches, reply) => {
             // Patch the runtime-owned input state directly; it is fed to
-            // game.update each frame and persists until changed.
-            let success = apply_input_patch(current_input, &patch.channel, &patch.value);
-            if success {
-                tracing::info!(
-                    "Successfully set input channel '{}' via remote control",
-                    patch.channel
-                );
-            } else {
-                tracing::warn!(
-                    "Failed to set input channel '{}' (unrecognized channel or bad value)",
-                    patch.channel
-                );
+            // game.update each frame and persists until changed. Apply all
+            // patches, stopping at the first invalid channel/value so the HTTP
+            // caller gets an actionable error instead of a silent partial apply.
+            let mut result = Ok(());
+            for patch in &patches {
+                match apply_input_patch(current_input, &patch.channel, &patch.value) {
+                    Ok(()) => tracing::info!(
+                        "Set input channel '{}' = {} via remote control",
+                        patch.channel,
+                        patch.value
+                    ),
+                    Err(msg) => {
+                        tracing::warn!("Rejected input patch: {}", msg);
+                        result = Err(msg);
+                        break;
+                    }
+                }
+            }
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send SetInput result - receiver dropped");
             }
         }
         RuntimeCommand::Shutdown => {
@@ -1210,18 +1223,37 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
 /// - `{left,right}_hand.thumbstick` : `[x, y]`
-fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> bool {
+/// One line describing every recognized input channel, used in error messages so
+/// a bad request is self-documenting.
+fn input_channels_help() -> &'static str {
+    "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
+     {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
+     {left,right}_hand.thumbstick [x,y]"
+}
+
+fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> Result<(), String> {
     use cgmath::Vector2;
 
-    fn parse_f32(v: &Value) -> Option<f32> {
-        v.as_f64().map(|f| f as f32)
+    // Parse a scalar/array value for `channel`, attributing a clear error to the
+    // channel and value shape when it doesn't match.
+    fn num(channel: &str, v: &Value) -> Result<f32, String> {
+        v.as_f64()
+            .map(|f| f as f32)
+            .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))
     }
-    fn parse_arr(v: &Value, n: usize) -> Option<Vec<f32>> {
-        let a = v.as_array()?;
+    fn arr(channel: &str, v: &Value, n: usize) -> Result<Vec<f32>, String> {
+        let a = v
+            .as_array()
+            .ok_or_else(|| format!("channel '{channel}' expects an array of {n} numbers, got {v}"))?;
         if a.len() != n {
-            return None;
+            return Err(format!(
+                "channel '{channel}' expects {n} numbers, got {} ({v})",
+                a.len()
+            ));
         }
-        a.iter().map(parse_f32).collect()
+        a.iter()
+            .map(|e| num(channel, e))
+            .collect::<Result<Vec<_>, _>>()
     }
 
     // Hand channels: "<left|right>_hand.<field>"
@@ -1229,60 +1261,56 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         let hand = match side {
             "left" => &mut input.left_hand,
             "right" => &mut input.right_hand,
-            _ => return false,
+            _ => {
+                return Err(format!(
+                    "unknown input channel '{channel}'; {}",
+                    input_channels_help()
+                ));
+            }
         };
         return match field {
-            "trigger" | "trigger_value" => match parse_f32(value) {
-                Some(v) => {
-                    hand.trigger_value = v;
-                    true
-                }
-                None => false,
-            },
-            "squeeze" | "squeeze_value" => match parse_f32(value) {
-                Some(v) => {
-                    hand.squeeze_value = v;
-                    true
-                }
-                None => false,
-            },
-            "a" | "a_value" => match parse_f32(value) {
-                Some(v) => {
-                    hand.a_value = v;
-                    true
-                }
-                None => false,
-            },
-            "thumbstick" => match parse_arr(value, 2) {
-                Some(a) => {
-                    hand.thumbstick = Vector2::new(a[0], a[1]);
-                    true
-                }
-                None => false,
-            },
-            _ => false,
+            "trigger" | "trigger_value" => {
+                hand.trigger_value = num(channel, value)?;
+                Ok(())
+            }
+            "squeeze" | "squeeze_value" => {
+                hand.squeeze_value = num(channel, value)?;
+                Ok(())
+            }
+            "a" | "a_value" => {
+                hand.a_value = num(channel, value)?;
+                Ok(())
+            }
+            "thumbstick" => {
+                let a = arr(channel, value, 2)?;
+                hand.thumbstick = Vector2::new(a[0], a[1]);
+                Ok(())
+            }
+            _ => Err(format!(
+                "unknown input channel '{channel}'; {}",
+                input_channels_help()
+            )),
         };
     }
 
     match channel {
-        "head.rotation" => match parse_arr(value, 4) {
-            Some(q) => {
-                input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
-                true
-            }
-            None => false,
-        },
+        "head.rotation" => {
+            let q = arr(channel, value, 4)?;
+            input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
+            Ok(())
+        }
         // Desktop camera convention (yaw=pitch=0 looks toward -X); drives both
         // the render camera and the viewmodel. Convenient for pointing the
         // camera without hand-authoring a quaternion.
-        "head.look" => match parse_arr(value, 2) {
-            Some(yp) => {
-                input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
-                true
-            }
-            None => false,
-        },
-        _ => false,
+        "head.look" => {
+            let yp = arr(channel, value, 2)?;
+            input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
+            Ok(())
+        }
+        _ => Err(format!(
+            "unknown input channel '{channel}'; {}",
+            input_channels_help()
+        )),
     }
 }
 
@@ -1352,12 +1380,22 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
             total_ms: time.total.as_millis() as f32,
         },
         mission: game.scene_name().to_string(),
-        player: PlayerInfo {
-            entity_id: None,                       // TODO: Get player entity ID
-            position: [0.0, 0.0, 0.0],             // TODO: Get player position
-            rotation: [1.0, 0.0, 0.0, 0.0],        // TODO: Get player rotation
-            camera_offset: [0.0, 1.6, 0.0],        // TODO: Get camera offset
-            camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
+        player: {
+            // Real player state from the active world (position, look, and the
+            // held/wielded entities), or zeros when the scene has no player.
+            let state = game.player_state();
+            PlayerInfo {
+                entity_id: state.as_ref().map(|s| s.entity_id),
+                position: state.as_ref().map(|s| s.position).unwrap_or([0.0, 0.0, 0.0]),
+                rotation: state
+                    .as_ref()
+                    .map(|s| s.rotation)
+                    .unwrap_or([1.0, 0.0, 0.0, 0.0]),
+                camera_offset: [0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0],
+                camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
+                wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
+                right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),
+            }
         },
         entity_count,
         debug_features: vec![], // TODO: List active debug features
@@ -2004,24 +2042,77 @@ async fn get_input_state(
     }
 }
 
-/// HTTP endpoint handler: Set input channel value
-async fn set_input_channel(
-    State(command_tx): State<tokio::sync::mpsc::UnboundedSender<commands::RuntimeCommand>>,
-    LenientJson(patch): LenientJson<commands::InputPatch>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    if command_tx
-        .send(commands::RuntimeCommand::SetInput(patch))
-        .is_err()
-    {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+/// Parse a `/v1/control/input` POST body into input patches, accepting either
+/// shape:
+/// - explicit:  `{"channel": "right_hand.trigger", "value": 1.0}`
+/// - map form:  `{"right_hand.trigger": 1.0, "head.look": [30, 0]}`
+///
+/// The map form is detected when the object does NOT have both `channel` and
+/// `value` keys. Returns an actionable error (not a silent empty patch) when the
+/// body isn't a usable object, so a malformed request fails loudly.
+fn parse_input_patches(body: &serde_json::Value) -> Result<Vec<commands::InputPatch>, String> {
+    let obj = body.as_object().ok_or_else(|| {
+        format!(
+            "request body must be a JSON object, e.g. {{\"channel\":\"right_hand.trigger\",\"value\":1.0}} \
+             or {{\"right_hand.trigger\":1.0}}; {}",
+            input_channels_help()
+        )
+    })?;
+
+    // Explicit {channel, value} form.
+    if obj.contains_key("channel") && obj.contains_key("value") {
+        let channel = obj["channel"]
+            .as_str()
+            .ok_or_else(|| "\"channel\" must be a string".to_string())?
+            .to_string();
+        return Ok(vec![commands::InputPatch {
+            channel,
+            value: obj["value"].clone(),
+        }]);
     }
 
-    // SetInput doesn't return a value, so just return success
-    let response = serde_json::json!({
-        "success": true,
-        "message": "Input channel updated"
-    });
-    Ok(Json(response))
+    if obj.is_empty() {
+        return Err(format!(
+            "no input channels in request; {}",
+            input_channels_help()
+        ));
+    }
+
+    // Map form: every key is a channel name.
+    Ok(obj
+        .iter()
+        .map(|(channel, value)| commands::InputPatch {
+            channel: channel.clone(),
+            value: value.clone(),
+        })
+        .collect())
+}
+
+/// HTTP endpoint handler: Set one or more input channel values.
+async fn set_input_channel(
+    State(command_tx): State<tokio::sync::mpsc::UnboundedSender<commands::RuntimeCommand>>,
+    LenientJson(body): LenientJson<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let patches = parse_input_patches(&body).map_err(|msg| (StatusCode::BAD_REQUEST, msg))?;
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    if command_tx
+        .send(commands::RuntimeCommand::SetInput(patches, reply_tx))
+        .is_err()
+    {
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(Ok(())) => Ok(Json(serde_json::json!({
+            "success": true,
+            "message": "Input channel(s) updated"
+        }))),
+        // An invalid channel/value: surface it as an actionable 400 instead of
+        // the previous silent success.
+        Ok(Err(msg)) => Err((StatusCode::BAD_REQUEST, msg)),
+        Err(_) => Err(game_loop_unavailable()),
+    }
 }
 
 /// HTTP endpoint handler: Execute a gameplay command via the runtime

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -185,7 +185,41 @@ pub struct Game {
     should_quit: bool,
 }
 
+/// Player state for debug introspection. Entity ids use `EntityId::inner() as
+/// i32`, matching the debug runtime's entity endpoints. In flatscreen mode
+/// `wielded_entity_id` is the first-person weapon (the controller wields into the
+/// player's "left hand" slot); in VR the two hand slots hold whatever is grabbed.
+#[derive(Clone, Debug)]
+pub struct PlayerStateSnapshot {
+    pub entity_id: i32,
+    pub position: [f32; 3],
+    pub rotation: [f32; 4],
+    pub wielded_entity_id: Option<i32>,
+    pub right_hand_entity_id: Option<i32>,
+}
+
 impl Game {
+    /// A snapshot of the player (position, look rotation, held/wielded entities)
+    /// for debug tooling, or `None` if the active scene has no player (e.g. a
+    /// menu). Reads the `PlayerInfo` unique from the active world.
+    pub fn player_state(&self) -> Option<PlayerStateSnapshot> {
+        use crate::mission::mission_core::PlayerInfo;
+        let world = self.world();
+        let info = world.borrow::<shipyard::UniqueView<PlayerInfo>>().ok()?;
+        Some(PlayerStateSnapshot {
+            entity_id: info.entity_id.inner() as i32,
+            position: [info.pos.x, info.pos.y, info.pos.z],
+            rotation: [
+                info.rotation.v.x,
+                info.rotation.v.y,
+                info.rotation.v.z,
+                info.rotation.s,
+            ],
+            wielded_entity_id: info.left_hand_entity_id.map(|e| e.inner() as i32),
+            right_hand_entity_id: info.right_hand_entity_id.map(|e| e.inner() as i32),
+        })
+    }
+
     /// Whether the experimental loading screen (deferred transitions) is enabled.
     fn loading_screen_enabled(&self) -> bool {
         self.options

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -83,4 +83,10 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
   message and full callstack — `launch()` sets `RUST_BACKTRACE=1` for the
   spawned runtime (export `RUST_BACKTRACE=full` yourself for more frames).
 - Writing a new scenario test: copy `test/pathfinding.e2e.test.ts`. Gate
-  long-running tests behind `SHOCK2_E2E=1` so `npm test` stays fast.
+  long-running tests behind `SHOCK2_E2E=1` so `npm test` stays fast. Give each
+  e2e file a **unique default port** — `node --test` runs files concurrently, so
+  a shared port lets one test's health poll see another's runtime.
+- Reliability runs (catch flakiness in timing-sensitive tests): `npm run
+  test:e2e:reliability` runs the e2e suite 10x with a fresh port each time.
+  `node scripts/reliability.mjs <count> "<name pattern>"` targets one test, e.g.
+  `node scripts/reliability.mjs 20 "muzzle flash"`.

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -83,10 +83,12 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
   message and full callstack — `launch()` sets `RUST_BACKTRACE=1` for the
   spawned runtime (export `RUST_BACKTRACE=full` yourself for more frames).
 - Writing a new scenario test: copy `test/pathfinding.e2e.test.ts`. Gate
-  long-running tests behind `SHOCK2_E2E=1` so `npm test` stays fast. Give each
-  e2e file a **unique default port** — `node --test` runs files concurrently, so
-  a shared port lets one test's health poll see another's runtime.
+  long-running tests behind `SHOCK2_E2E=1` so `npm test` stays fast.
+- The e2e suite runs **serially** (`--test-concurrency=1`): each test spawns its
+  own heavy debug runtime, so one-at-a-time avoids port/resource contention
+  without hand-syncing ports across files (a unique default port per file is
+  still kept as a courtesy for running files individually).
 - Reliability runs (catch flakiness in timing-sensitive tests): `npm run
-  test:e2e:reliability` runs the e2e suite 10x with a fresh port each time.
-  `node scripts/reliability.mjs <count> "<name pattern>"` targets one test, e.g.
+  test:e2e:reliability` runs the e2e suite 10x (also serial). Target one test
+  with `node scripts/reliability.mjs <count> "<name pattern>"`, e.g.
   `node scripts/reliability.mjs 20 "muzzle flash"`.

--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
-    "test:e2e": "tsc && SHOCK2_E2E=1 node --test \"dist/test/*.test.js\""
+    "test:e2e": "tsc && SHOCK2_E2E=1 node --test \"dist/test/*.test.js\"",
+    "test:e2e:reliability": "tsc && node scripts/reliability.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
-    "test:e2e": "tsc && SHOCK2_E2E=1 node --test \"dist/test/*.test.js\"",
+    "test:e2e": "tsc && SHOCK2_E2E=1 node --test --test-concurrency=1 \"dist/test/*.test.js\"",
     "test:e2e:reliability": "tsc && node scripts/reliability.mjs"
   },
   "engines": {

--- a/tools/shock2-sdk/scripts/reliability.mjs
+++ b/tools/shock2-sdk/scripts/reliability.mjs
@@ -1,0 +1,50 @@
+// Repeatedly runs the e2e suite to surface flakiness in timing-sensitive tests
+// (e.g. the muzzle-flash tracking test, whose flash is alive only a couple of
+// deterministic frames). Each run gets a unique port so leftover runtimes can't
+// collide. Exits non-zero on the first failing run.
+//
+// Usage (build first, or rely on the npm script which runs `tsc`):
+//   node scripts/reliability.mjs [count] [namePattern]
+//     count        repetitions (default 10)
+//     namePattern  --test-name-pattern filter (default: every e2e test)
+//
+//   npm run test:e2e:reliability                  # all e2e tests, 10x
+//   node scripts/reliability.mjs 20 "muzzle flash" # one test, 20x
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const count = Number(process.argv[2] ?? 10);
+const pattern = process.argv[3];
+
+const testDir = "dist/test";
+const files = readdirSync(testDir)
+  .filter((f) => f.endsWith(".e2e.test.js"))
+  .map((f) => join(testDir, f));
+
+if (files.length === 0) {
+  console.error(`No compiled e2e tests in ${testDir}/ - run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+let passed = 0;
+for (let i = 1; i <= count; i++) {
+  const args = ["--test"];
+  if (pattern) args.push(`--test-name-pattern=${pattern}`);
+  args.push(...files);
+
+  console.log(`=== run ${i}/${count} ===`);
+  const res = spawnSync("node", args, {
+    stdio: "inherit",
+    env: { ...process.env, SHOCK2_E2E: "1", SHOCK2_E2E_PORT: String(8200 + i) },
+  });
+
+  if (res.status === 0) {
+    passed++;
+  } else {
+    console.error(`\nreliability: run ${i}/${count} FAILED (${passed} passed before this)`);
+    process.exit(1);
+  }
+}
+
+console.log(`\nreliability: ${passed}/${count} passed`);

--- a/tools/shock2-sdk/scripts/reliability.mjs
+++ b/tools/shock2-sdk/scripts/reliability.mjs
@@ -29,7 +29,9 @@ if (files.length === 0) {
 
 let passed = 0;
 for (let i = 1; i <= count; i++) {
-  const args = ["--test"];
+  // Serialize files (--test-concurrency=1): each e2e test spawns its own heavy
+  // debug runtime, so running them one at a time avoids port/resource contention.
+  const args = ["--test", "--test-concurrency=1"];
   if (pattern) args.push(`--test-name-pattern=${pattern}`);
   args.push(...files);
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -5,6 +5,7 @@ export type InputAction =
   | "QuickLoad"
   | "SpawnDebugItem"
   | "MoveInventory"
+  | "CycleWeapon"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 
@@ -115,11 +116,23 @@ export interface RayCastResult {
   is_sensor: boolean;
 }
 
+export interface PlayerSnapshot {
+  entity_id: number | null;
+  position: Vec3;
+  rotation: [number, number, number, number];
+  camera_offset: Vec3;
+  camera_rotation: [number, number, number, number];
+  /** The wielded/first-person weapon in flatscreen mode; null when unarmed. */
+  wielded_entity_id: number | null;
+  /** The entity held in the right hand (VR); null otherwise. */
+  right_hand_entity_id: number | null;
+}
+
 export interface FrameSnapshot {
   frame_index: number;
   time: { total: number; delta: number };
   mission: string;
-  player: unknown;
+  player: PlayerSnapshot;
   entity_count: number;
   debug_features: string[];
   inputs: unknown;

--- a/tools/shock2-sdk/test/flat-hud.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-hud.e2e.test.ts
@@ -3,9 +3,9 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 
-// End-to-end smoke test for the flatscreen (non-VR) presentation. Launches the
-// debug runtime with `--flat` so the game builds the screen-space 2D HUD in
-// `render_per_eye` instead of the VR forearm panels, then confirms a frame
+// End-to-end smoke test for the flatscreen (non-VR) presentation. The debug
+// runtime defaults to flatscreen, so the game builds the screen-space 2D HUD in
+// `render_per_eye` instead of the VR forearm panels; this confirms a frame
 // renders end-to-end without panicking. Pixel-level correctness of the HUD
 // layout is covered by the Rust unit tests in `shock2vr/src/hud/flat_hud.rs`.
 //
@@ -20,7 +20,7 @@ test(
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8093),
-      debugFlags: ["--flat"],
+      // Flatscreen is the debug runtime's default presentation now.
     });
 
     // Advance enough frames for the mission to load and render.

--- a/tools/shock2-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/shock2-sdk/test/launch-failure.e2e.test.ts
@@ -16,7 +16,10 @@ test(
     await assert.rejects(
       GameServer.launch({
         mission: "doesnotexist.mis",
-        port: Number(process.env.SHOCK2_E2E_PORT ?? 8093),
+        // Unique port: `node --test` runs e2e files concurrently, and a port
+        // shared with another test (flat-hud was also 8093) makes this launch's
+        // health poll see the OTHER test's healthy runtime and wrongly succeed.
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8095),
       }),
       (error: Error) => {
         assert.match(error.message, /debug_runtime failed to start/);

--- a/tools/shock2-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/shock2-sdk/test/launch-failure.e2e.test.ts
@@ -16,9 +16,9 @@ test(
     await assert.rejects(
       GameServer.launch({
         mission: "doesnotexist.mis",
-        // Unique port: `node --test` runs e2e files concurrently, and a port
-        // shared with another test (flat-hud was also 8093) makes this launch's
-        // health poll see the OTHER test's healthy runtime and wrongly succeed.
+        // The e2e suite runs serially (`--test-concurrency=1`), so ports don't
+        // collide across files; a unique default is just belt-and-suspenders for
+        // anyone running this file alongside others by hand.
         port: Number(process.env.SHOCK2_E2E_PORT ?? 8095),
       }),
       (error: Error) => {

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/index.js";
+
+// End-to-end regression test for "muzzle flash follows the weapon" (the generic
+// RuntimePropAttachment mechanism). In the `debug_weapons` scene we wield the
+// pistol, fire (spawning the flash), then TURN the camera while the flash is
+// still alive. The flash must track the first-person viewmodel - its offset from
+// the weapon stays constant - instead of staying pinned at its spawn pose.
+//
+// This is the headless counterpart to the Rust unit tests in
+// `shock2vr/src/systems/attachment.rs` (which cover the system in isolation).
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function dist(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function posOf(entities: EntitySummary[], name: string): Vec3 | undefined {
+  return entities.find((e) => e.name === name)?.position;
+}
+
+test(
+  "muzzle flash tracks the weapon when the camera turns",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8094),
+    });
+
+    // debug_weapons starts unarmed; CycleWeapon spawns and wields the pistol.
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    // The wielded-entity field (new /v1/info player data) should report the pistol.
+    const before = (await game.entities.list({ limit: 60 })).entities;
+    const pistolId = before.find((e) => e.name === "Pistol")?.id;
+    assert.ok(pistolId !== undefined, "the pistol should exist after CycleWeapon");
+    const info = await game.info();
+    assert.equal(
+      info.player.wielded_entity_id,
+      pistolId,
+      "the pistol should be reported as wielded",
+    );
+
+    // Face the wall (yaw 0) and fire: TriggerPull spawns the muzzle flash.
+    await game.input.set("head.look", [0, 0]);
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 1 });
+
+    const listA = (await game.entities.list({ limit: 60 })).entities;
+    const pistolA = posOf(listA, "Pistol");
+    const flashA = posOf(listA, "Assault Flash");
+    assert.ok(pistolA, "pistol present after firing");
+    assert.ok(flashA, "muzzle flash should spawn on fire");
+    const offsetA = dist(pistolA, flashA);
+
+    // Turn the camera 30deg while the flash is still alive (it lives a couple of
+    // frames). The viewmodel re-places against the new look direction.
+    await game.input.set("head.look", [30, 0]);
+    await game.step({ frames: 1 });
+
+    const listB = (await game.entities.list({ limit: 60 })).entities;
+    const pistolB = posOf(listB, "Pistol");
+    const flashB = posOf(listB, "Assault Flash");
+    assert.ok(pistolB, "pistol present after turning");
+    assert.ok(flashB, "muzzle flash should still be alive after the turn");
+
+    const offsetB = dist(pistolB, flashB);
+
+    // The viewmodel actually moved with the camera...
+    assert.ok(
+      dist(pistolA, pistolB) > 0.3,
+      `pistol should move when the camera turns (moved ${dist(pistolA, pistolB).toFixed(3)})`,
+    );
+    // ...the flash moved too (it isn't pinned at the spawn pose)...
+    assert.ok(
+      dist(flashA, flashB) > 0.3,
+      `flash should move with the weapon, not stay pinned (moved ${dist(flashA, flashB).toFixed(3)})`,
+    );
+    // ...and crucially its rigid offset from the weapon is preserved.
+    assert.ok(
+      Math.abs(offsetA - offsetB) < 0.02,
+      `flash should keep a constant offset from the weapon (before=${offsetA.toFixed(3)}, after=${offsetB.toFixed(3)})`,
+    );
+  },
+);


### PR DESCRIPTION
**Stacked on #323** (muzzle-flash fix). Review/merge that first; this branch targets it as its base.

Debug-runtime ergonomics, motivated by verifying the flat first-person weapon loop headlessly (the #323 work surfaced these gaps).

## Changes

- **Default to flatscreen + `--vr` opt-in.** The runtime previously defaulted to VR, where the flat weapon wield/fire path is inactive — a silent foot-gun when testing weapons (it cost real time in #323's verification). Now flat by default, matching `desktop_runtime`; `--vr` selects the VR forearm/two-hand path. CLAUDE.md updated; the `flat-hud` e2e test drops the now-removed `--flat`.

- **`/v1/info` reports real player state** — position, look rotation, and held/wielded entities, via a new `Game::player_state()` accessor reading `PlayerInfo`. In flat mode `wielded_entity_id` is the first-person weapon, so tooling can finally see what's wielded (there was no way before).

- **`POST /v1/control/input` ergonomics + validation.** Accepts both the explicit `{channel,value}` body and a `{"<channel>": value, ...}` map form. And it now **validates**: an unknown channel or wrong value shape returns an actionable **400** listing the valid channels, instead of the previous silent **200** (which masked a malformed request during #323 verification). `SetInput` replies through a oneshot so the HTTP layer reports the real outcome.

- **SDK**: typed `PlayerSnapshot` (incl. `wielded_entity_id`), `CycleWeapon` action.

## Regression test

`tools/shock2-sdk/test/muzzle-flash.e2e.test.ts` (gated behind `SHOCK2_E2E=1`) is the durable end-to-end guard for #323: wield the pistol, fire, turn the camera 30°, and assert the flash keeps a constant offset from the weapon (and actually moves) rather than staying pinned.

- **Positive** (with the #323 fix in this stack): passes.
- **Negative** (fix disabled): fails with `flash should move with the weapon, not stay pinned (moved 0.000)`.

## Validation

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; SDK `tsc` + unit tests pass; the new e2e test passes against the stacked fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)