### PR TITLE
chore: add pre-push hook running cargo fmt --check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Pre-push hook: reject pushes that would fail the CI "Format Check".
+#
+# Mirrors `.github/workflows/format.yml` (`cargo fmt --all -- --check`) so
+# unformatted Rust never reaches a PR. Enable once per clone with:
+#
+#   git config core.hooksPath .githooks
+#
+# Bypass in a pinch with `git push --no-verify`.
+set -euo pipefail
+
+# Run from the repo root so cargo finds the workspace regardless of $PWD.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "pre-push: cargo not found on PATH; skipping format check." >&2
+  exit 0
+fi
+
+echo "pre-push: checking formatting (cargo fmt --all -- --check)..."
+if ! cargo fmt --all -- --check; then
+  echo >&2
+  echo "pre-push: Rust code is not formatted. Run 'cargo fmt' and re-commit." >&2
+  echo "          (bypass with 'git push --no-verify' if you must)" >&2
+  exit 1
+fi
+
+echo "pre-push: formatting OK."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Workspace members in `Cargo.toml` include `dark` (Dark Engine formats), `engine`
 - Desktop preview: `cd runtimes/desktop_runtime && cargo run --release` to launch the OpenXR desktop harness.
 - Quest build: `cd runtimes/oculus_runtime && source ./set_up_android_sdk.sh && cargo apk run --release` to bundle, install, and start on device.
 - Lint and check: `cargo fmt --all` followed by `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` before pushing. CI compiles with `-D warnings`, so any warning fails the build. Avoid `--workspace` on desktop - Android-only crates (`ndk-sys`, `oboe-sys`) fail to compile for non-Android targets; always scope with `-p`.
+- Enable the committed git hooks once per clone (`git config core.hooksPath .githooks`); the pre-push hook runs `cargo fmt --all -- --check` so unformatted Rust can't reach a PR. See DEVELOPMENT.md §2b.
 
 ## Coding Style & Naming Conventions
 Use the default Rust style (four-space indent, trailing commas, snake_case functions, UpperCamelCase types) enforced by `cargo fmt`. Prefer explicit visibility such as `pub(crate)` and comment unsafe blocks to explain invariants. Align module paths with folder names, register new crates in `Cargo.toml`, and keep asset filenames lowercase with hyphens (for example, `assets/hud-icons/health.png`).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,6 +27,19 @@
 
 - Copy local game files (\*.mis, res folder) into the `shock2quest/Data` folder
 
+### 2b. Enable git hooks (recommended)
+
+The repo ships a pre-push hook that runs `cargo fmt --all -- --check` so
+unformatted Rust never reaches a PR (it would otherwise fail the CI "Format
+Check"). Enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook only checks formatting before a push (it does not slow down individual
+commits). Bypass in a pinch with `git push --no-verify`.
+
 ### 3. Build Locally
 
 #### 3a. Desktop (Windows, OSX)


### PR DESCRIPTION
## Why

Unformatted Rust has been slipping into PRs and failing the CI **Format Check** (e.g. #323 was green on everything except formatting). This adds a local guard that mirrors CI so it's caught before the push.

## What

- `.githooks/pre-push` runs `cargo fmt --all -- --check` (exactly what `.github/workflows/format.yml` runs) and blocks the push if formatting is off. It runs from the repo root, skips gracefully if `cargo` isn't on PATH, and can be bypassed with `git push --no-verify`.
- Opt-in per clone (git doesn't auto-load committed hooks):
  ```bash
  git config core.hooksPath .githooks
  ```
- Documented in **DEVELOPMENT.md §2b** and **AGENTS.md**.

Chosen pre-**push** (not pre-commit) so it doesn't slow down individual commits — it only checks the thing that would fail CI, right before it'd matter.

## Validation

The hook validated its own push (clean), and rejects when formatting is off:
```
pre-push: Rust code is not formatted. Run 'cargo fmt' and re-commit.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)