### PR TITLE
feat(weapon): track clip ammo, consume per shot, dry-fire when empty

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -14,6 +14,7 @@ mod prop_creature_pose;
 mod prop_frame_anim_config;
 mod prop_frame_anim_state;
 mod prop_frob_info;
+mod prop_gun_state;
 mod prop_hit_points;
 mod prop_key;
 mod prop_log;
@@ -47,6 +48,7 @@ pub use prop_creature_pose::*;
 pub use prop_frame_anim_config::*;
 pub use prop_frame_anim_state::*;
 pub use prop_frob_info::*;
+pub use prop_gun_state::*;
 pub use prop_hit_points::*;
 pub use prop_key::*;
 pub use prop_log::*;
@@ -883,6 +885,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         ),
         define_prop("P$KeyDst", KeyCard::read, PropKeyDst, accumulator::latest),
         define_prop("P$KeySrc", KeyCard::read, PropKeySrc, accumulator::latest),
+        define_prop(
+            "P$GunState",
+            PropGunState::read,
+            identity,
+            accumulator::latest,
+        ),
         define_prop(
             "P$HitPoints",
             PropHitPoints::read,

--- a/dark/src/properties/prop_gun_state.rs
+++ b/dark/src/properties/prop_gun_state.rs
@@ -1,0 +1,43 @@
+use std::io;
+
+use shipyard::Component;
+
+use crate::ss2_common::{read_i32, read_single};
+
+use serde::{Deserialize, Serialize};
+
+/// `P$GunState` - the mutable per-weapon firing state. Mirrors the Dark engine's
+/// `sGunState` (engfeat/gunbase.h): 20 bytes, in field order. For now only
+/// `ammo` is used at runtime (current rounds in the clip); the rest are parsed
+/// so the chunk round-trips and is available later (condition, fire setting,
+/// modification level, silencing).
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropGunState {
+    /// `m_ammoCount` - current rounds in the clip.
+    pub ammo: i32,
+    /// `m_condition` - 0..1 weapon condition (1 = perfect).
+    pub condition: f32,
+    /// `m_setting` - current fire setting.
+    pub setting: i32,
+    /// `m_modification` - current modification level.
+    pub modification: i32,
+    /// `m_silenceValue` - 0..1 amount of silencing (1 = perfect).
+    pub silence_value: f32,
+}
+
+impl PropGunState {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropGunState {
+        let ammo = read_i32(reader);
+        let condition = read_single(reader);
+        let setting = read_i32(reader);
+        let modification = read_i32(reader);
+        let silence_value = read_single(reader);
+        PropGunState {
+            ammo,
+            condition,
+            setting,
+            modification,
+            silence_value,
+        }
+    }
+}

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1206,6 +1206,17 @@ impl MissionCore {
                     }
                 }
 
+                Effect::AdjustAmmo { entity_id, delta } => {
+                    let mut v_gun_state = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropGunState>>()
+                        .unwrap();
+
+                    if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
+                        gun_state.ammo = (gun_state.ammo + delta).max(0);
+                    }
+                }
+
                 Effect::AwardXP { amount } => {
                     warn!("!! TODO !!: Award XP {}", amount);
                 }
@@ -2901,6 +2912,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             |v_pos: View<dark::properties::PropPosition>,
              v_sym_name: View<dark::properties::PropSymName>,
              v_scripts: View<dark::properties::PropScripts>,
+             v_gun_state: View<dark::properties::PropGunState>,
              v_links: View<dark::properties::Links>| {
                 let position = v_pos.get(id).ok()?;
                 let rotation_array = [
@@ -2943,6 +2955,14 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "Scripts".to_string(),
                         value: scripts.scripts.join(", "),
+                    });
+                }
+
+                // Add weapon ammo (current clip) when present
+                if let Ok(gun_state) = v_gun_state.get(id) {
+                    properties.push(DebugPropertyInfo {
+                        name: "Ammo".to_string(),
+                        value: gun_state.ammo.to_string(),
                     });
                 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -65,6 +65,13 @@ pub enum Effect {
         delta: i32,
     },
 
+    /// Adjust a weapon's current clip ammo (`PropGunState.ammo`) by `delta`
+    /// (negative to consume). No-op for entities without a gun state.
+    AdjustAmmo {
+        entity_id: EntityId,
+        delta: i32,
+    },
+
     ApplyForce {
         entity_id: EntityId,
         force: Vector3<f32>,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -90,6 +90,19 @@ impl Script for WeaponScript {
                     }
                 }
 
+                // Ammo gating: weapons that carry a `PropGunState` are limited by
+                // their clip. An empty clip dry-fires (no shot/flash); a live shot
+                // consumes one round (the per-shot `m_ammoUsage` from BaseGunDesc
+                // is a TODO - one round per pull for now). Weapons without a gun
+                // state (e.g. unlimited debug weapons) are unaffected.
+                let maybe_ammo = world
+                    .borrow::<View<dark::properties::PropGunState>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().map(|g| g.ammo));
+                if maybe_ammo == Some(0) {
+                    return dry_fire(world, entity_id);
+                }
+
                 // Include projectile class tags (ie, ammotype) and weaponmode for sound lookup
                 let mut projectile_class_tags: Vec<(String, String)> =
                     if let Some((projectile_template_id, _)) = &maybe_projectile {
@@ -148,7 +161,15 @@ impl Script for WeaponScript {
                 //         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Rad(PI / 2.0)),
                 // };
 
-                Effect::Multiple(vec![sound_effect, muzzle_flash_effect, projectile_effect])
+                // Consume a round when the weapon tracks ammo.
+                let mut effects = vec![sound_effect, muzzle_flash_effect, projectile_effect];
+                if maybe_ammo.is_some() {
+                    effects.push(Effect::AdjustAmmo {
+                        entity_id,
+                        delta: -1,
+                    });
+                }
+                Effect::Multiple(effects)
             }
             MessagePayload::TriggerRelease => Effect::NoEffect,
             _ => Effect::NoEffect,
@@ -190,6 +211,13 @@ fn melee_swing(
         });
     }
     Effect::Multiple(effects)
+}
+
+/// An empty-clip dry fire: no projectile or muzzle flash, just the weapon's
+/// "dryfire" click (best-effort - resolves via the gun's sound schema, like the
+/// "shoot" event). Reached when a `PropGunState` weapon has 0 rounds.
+fn dry_fire(world: &World, entity_id: EntityId) -> Effect {
+    play_environmental_sound(world, entity_id, "dryfire", vec![], AudioHandle::new())
 }
 
 fn create_muzzle_flash(

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
+
+// End-to-end regression test for weapon ammo (PropGunState): a weapon limited by
+// its clip decrements one round per shot and dry-fires (no projectile) at empty.
+// Uses the debug_weapons scene: wield the pistol (12 rounds), fire it dry, and
+// assert the ammo count and the number of bullet-hit impacts on the wall.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+export async function fireOnce(game: GameServer): Promise<void> {
+  // Edge-triggered: pull (fires on the rising edge), then release, stepping a
+  // frame for each so the next pull is a fresh edge.
+  await game.input.set("right_hand.trigger", 1.0);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0.0);
+  await game.step({ frames: 1 });
+}
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "weapon should expose an Ammo property");
+  return Number(p.value);
+}
+
+function bulletHits(entities: EntitySummary[]): number {
+  return entities.filter((e) => e.name === "Bullet Hit").length;
+}
+
+test(
+  "weapon ammo decrements per shot and dry-fires at empty",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8096),
+      // This branch's debug runtime defaults to VR; the flat path drives the
+      // first-person fire loop. (Drop once flat is the runtime default.)
+      debugFlags: ["--flat"],
+    });
+
+    // debug_weapons starts unarmed; CycleWeapon spawns + wields the pistol.
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    const pistolId = (await game.entities.list({ limit: 60 })).entities.find(
+      (e) => e.name === "Pistol",
+    )?.id;
+    assert.ok(pistolId !== undefined, "pistol should be wielded");
+
+    const startAmmo = ammoOf(await game.entities.detail(pistolId));
+    assert.ok(startAmmo > 0, `pistol should start with rounds (got ${startAmmo})`);
+
+    // Fire one round and confirm the count drops by exactly one.
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(pistolId)),
+      startAmmo - 1,
+      "one shot consumes one round",
+    );
+
+    // Drain the rest of the clip.
+    for (let i = 1; i < startAmmo; i++) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "clip should be empty");
+
+    // Baseline impact count at empty (absolute count is timing-sensitive since
+    // hit-spangs eventually despawn, so we only assert it does not grow below).
+    const hitsAtEmpty = bulletHits((await game.entities.list({ limit: 120 })).entities);
+
+    // Dry-fire: pulling on an empty clip must NOT spawn a projectile.
+    for (let i = 0; i < 3; i++) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "ammo stays at 0");
+    assert.ok(
+      bulletHits((await game.entities.list({ limit: 120 })).entities) <= hitsAtEmpty,
+      "dry-firing an empty clip spawns no new projectiles",
+    );
+  },
+);


### PR DESCRIPTION
First slice of weapon ammo — **data + firing**. The flat HUD ammo readout is a planned follow-up.

## What

- **Parse `P$GunState`** into a `PropGunState` component (`dark/properties`), mirroring the Dark engine `sGunState` (engfeat/gunbase.h) — 20 bytes: `ammo, condition, setting, modification, silence_value`. The pistol (`-17`) parses with `ammo: 12`.
- **`WeaponScript` gates firing on ammo** when the weapon carries a gun state:
  - empty clip → **dry-fire**: no projectile or muzzle flash, best-effort `"dryfire"` click,
  - live shot → consumes one round via a new **`Effect::AdjustAmmo`**.
  - Weapons *without* a gun state (unlimited debug weapons, melee) are unaffected.
- **Surface current ammo on `/v1/entities/:id`** (debug entity detail) so the loop is verifiable headlessly.

## Verification

`tools/shock2-sdk/test/weapon-ammo.e2e.test.ts` (gated behind `SHOCK2_E2E=1`): wield the pistol, drain **12 → 0** (asserting one round per shot), then dry-fire at empty — ammo stays 0 and **no new projectile** spawns. The test inherently fails on `main` (no `Ammo` property exists), so it's a real guard.

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; fmt clean; 53 `shock2vr` unit tests pass.

## Scope / follow-ups

- Per-shot `m_ammoUsage` and clip size come from `BaseGunDesc` (`P$BaseGunDe`) — not parsed here; one round per pull for now.
- Reload, ammo-type switching, and the **flat HUD ammo gauge** (AMMOBACK/AMMOFULL.PCX at the original 544,414) are later slices.
- The e2e passes `--flat` explicitly because this branch is off `main`; it simplifies once the flat-default change (#324) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)