### PR TITLE
feat(weapon): faithful flat HUD - ammo gauge + corrected health/psi meters

### DIFF
--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -10,7 +10,7 @@ use cgmath::vec2;
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::World;
 
-use super::{get_health_percentage, get_psi_percentage};
+use super::{get_health_percentage, get_psi_percentage, get_wielded_ammo};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
 
 /// The original SS2 HUD is authored against a 640x480 display.
@@ -25,17 +25,41 @@ const CROSSHAIR: Rect = Rect::new(
     CROSSHAIR_SIZE,
 );
 
-const BAR_W: f32 = 120.0;
-const BAR_H: f32 = 12.0;
-const HEALTH_BAR: Rect = Rect::new(20.0, 448.0, BAR_W, BAR_H); // near the bottom edge
-const PSI_BAR: Rect = Rect::new(20.0, 430.0, BAR_W, BAR_H); // stacked just above health
+// Health/PSI meters - positions transcribed from the original
+// (`shkmeter.cpp`): a 260x64 block at (BIO_X=2, BIO_Y=414), with health ABOVE
+// psi (HP_Y=18, PSI_Y=41) and the numeric readouts at the block's x+92. The
+// bar art (HPBAR/PSIBAR.PCX) is 80x14.
+const METERS_X: f32 = 2.0;
+const METERS_Y: f32 = 414.0;
+const BAR_W: f32 = 80.0;
+const BAR_H: f32 = 14.0;
+const TEXT_W: f32 = 60.0;
+const TEXT_SIZE: f32 = 16.0;
 
-const HEALTH_TEXT: Rect = Rect::new(148.0, 444.0, 80.0, 16.0); // right of the bars
-const HEALTH_TEXT_SIZE: f32 = 16.0;
+const HEALTH_BAR: Rect = Rect::new(METERS_X + 8.0, METERS_Y + 18.0, BAR_W, BAR_H); // (10, 432)
+const PSI_BAR: Rect = Rect::new(METERS_X + 8.0, METERS_Y + 41.0, BAR_W, BAR_H); //   (10, 455)
+const HEALTH_TEXT: Rect = Rect::new(METERS_X + 92.0, METERS_Y + 17.0, TEXT_W, BAR_H);
+const PSI_TEXT: Rect = Rect::new(METERS_X + 92.0, METERS_Y + 40.0, TEXT_W, BAR_H);
+
+// Ammo gauge - transcribed from `shkammov.cpp`: the compact AMMOBACK.PCX
+// (94x64) anchored at (AMMO_X=544, AMMO_Y=414), bottom-right, with the round
+// count drawn over it.
+const AMMO_X: f32 = 544.0;
+const AMMO_Y: f32 = 414.0;
+const AMMO_W: f32 = 94.0;
+const AMMO_H: f32 = 64.0;
+const AMMO_GAUGE: Rect = Rect::new(AMMO_X, AMMO_Y, AMMO_W, AMMO_H);
+const AMMO_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 22.0, AMMO_W, 20.0); // centered over the gauge
+const AMMO_TEXT_SIZE: f32 = 18.0;
 
 /// Build the flat HUD as a resolution-independent canvas for the given player
-/// stat fractions. Pure (no asset/GL access), so it is unit-testable.
-pub(crate) fn build_flat_hud_canvas(health_fraction: f32, psi_fraction: f32) -> UiCanvas {
+/// stat fractions and (optional) wielded-weapon ammo. Pure (no asset/GL
+/// access), so it is unit-testable.
+pub(crate) fn build_flat_hud_canvas(
+    health_fraction: f32,
+    psi_fraction: f32,
+    ammo: Option<i32>,
+) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
 
     canvas
@@ -43,15 +67,37 @@ pub(crate) fn build_flat_hud_canvas(health_fraction: f32, psi_fraction: f32) -> 
         .bar(HEALTH_BAR, "HPBAR.PCX", health_fraction)
         .bar(PSI_BAR, "PSIBAR.PCX", psi_fraction);
 
-    let pct = (health_fraction.clamp(0.0, 1.0) * 100.0).round() as i32;
-    canvas.text(
-        HEALTH_TEXT,
-        &format!("{pct}"),
-        "mainfont.fon",
-        HEALTH_TEXT_SIZE,
-        HAlign::Left,
-        VAlign::Middle,
-    );
+    let health_pct = (health_fraction.clamp(0.0, 1.0) * 100.0).round() as i32;
+    let psi_pct = (psi_fraction.clamp(0.0, 1.0) * 100.0).round() as i32;
+    canvas
+        .text(
+            HEALTH_TEXT,
+            &format!("{health_pct}"),
+            "mainfont.fon",
+            TEXT_SIZE,
+            HAlign::Left,
+            VAlign::Middle,
+        )
+        .text(
+            PSI_TEXT,
+            &format!("{psi_pct}"),
+            "mainfont.fon",
+            TEXT_SIZE,
+            HAlign::Left,
+            VAlign::Middle,
+        );
+
+    // Ammo gauge (only when a weapon with a clip is wielded).
+    if let Some(rounds) = ammo {
+        canvas.image(AMMO_GAUGE, "AMMOBACK.PCX").text(
+            AMMO_TEXT,
+            &format!("{rounds}"),
+            "mainfont.fon",
+            AMMO_TEXT_SIZE,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+    }
 
     canvas
 }
@@ -62,7 +108,11 @@ pub(crate) fn create_flat_hud(
     world: &World,
     screen_size: cgmath::Vector2<f32>,
 ) -> Vec<SceneObject> {
-    let canvas = build_flat_hud_canvas(get_health_percentage(world), get_psi_percentage(world));
+    let canvas = build_flat_hud_canvas(
+        get_health_percentage(world),
+        get_psi_percentage(world),
+        get_wielded_ammo(world),
+    );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
 }
@@ -72,9 +122,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn canvas_has_crosshair_two_bars_and_readout() {
-        let canvas = build_flat_hud_canvas(1.0, 0.75);
-        assert_eq!(canvas.element_count(), 4);
+    fn canvas_has_crosshair_bars_and_readouts() {
+        // Crosshair + 2 bars + 2 stat numbers = 5 (no weapon wielded).
+        let canvas = build_flat_hud_canvas(1.0, 0.75, None);
+        assert_eq!(canvas.element_count(), 5);
+    }
+
+    #[test]
+    fn wielding_a_weapon_adds_the_ammo_gauge() {
+        // ...plus the ammo backdrop + count when a clip is present.
+        let canvas = build_flat_hud_canvas(1.0, 0.75, Some(12));
+        assert_eq!(canvas.element_count(), 7);
+    }
+
+    #[test]
+    fn health_sits_above_psi() {
+        // Matches SS2 (shkmeter.cpp): HP_Y=18 < PSI_Y=41.
+        assert!(HEALTH_BAR.y < PSI_BAR.y);
     }
 
     #[test]
@@ -85,6 +149,6 @@ mod tests {
     #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(2.0, -1.0);
+        let _ = build_flat_hud_canvas(2.0, -1.0, None);
     }
 }

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -31,10 +31,16 @@ const CROSSHAIR: Rect = Rect::new(
 // bar art (HPBAR/PSIBAR.PCX) is 80x14.
 const METERS_X: f32 = 2.0;
 const METERS_Y: f32 = 414.0;
+const METERS_W: f32 = 260.0;
+const METERS_H: f32 = 64.0;
 const BAR_W: f32 = 80.0;
 const BAR_H: f32 = 14.0;
 const TEXT_W: f32 = 60.0;
 const TEXT_SIZE: f32 = 16.0;
+
+/// Bio-monitor backdrop (BIOFULL.PCX, 260x64) the bars/numbers sit on, the
+/// health/psi equivalent of the ammo gauge's AMMOBACK frame (`shkmeter.cpp`).
+const METERS_BACKDROP: Rect = Rect::new(METERS_X, METERS_Y, METERS_W, METERS_H);
 
 const HEALTH_BAR: Rect = Rect::new(METERS_X + 8.0, METERS_Y + 18.0, BAR_W, BAR_H); // (10, 432)
 const PSI_BAR: Rect = Rect::new(METERS_X + 8.0, METERS_Y + 41.0, BAR_W, BAR_H); //   (10, 455)
@@ -64,6 +70,8 @@ pub(crate) fn build_flat_hud_canvas(
 
     canvas
         .image(CROSSHAIR, "CROSSHAI.PCX")
+        // Bio-monitor backdrop first; the bars + numbers render on top of it.
+        .image(METERS_BACKDROP, "BIOFULL.PCX")
         .bar(HEALTH_BAR, "HPBAR.PCX", health_fraction)
         .bar(PSI_BAR, "PSIBAR.PCX", psi_fraction);
 
@@ -122,17 +130,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn canvas_has_crosshair_bars_and_readouts() {
-        // Crosshair + 2 bars + 2 stat numbers = 5 (no weapon wielded).
+    fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
+        // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
         let canvas = build_flat_hud_canvas(1.0, 0.75, None);
-        assert_eq!(canvas.element_count(), 5);
+        assert_eq!(canvas.element_count(), 6);
     }
 
     #[test]
     fn wielding_a_weapon_adds_the_ammo_gauge() {
         // ...plus the ammo backdrop + count when a clip is present.
         let canvas = build_flat_hud_canvas(1.0, 0.75, Some(12));
-        assert_eq!(canvas.element_count(), 7);
+        assert_eq!(canvas.element_count(), 8);
     }
 
     #[test]

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -141,6 +141,19 @@ pub(crate) fn get_psi_percentage(_world: &World) -> f32 {
     0.75 // Placeholder - 75% psi for testing
 }
 
+/// Current clip ammo of the wielded weapon, or `None` when unarmed or the held
+/// item has no `PropGunState` (melee / unlimited debug weapons). In flatscreen
+/// mode the wielded weapon is the player's left-hand slot (see
+/// `FlatInteraction::held_entities`).
+pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
+    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    let weapon = player_info.left_hand_entity_id?;
+    let v_gun_state = world
+        .borrow::<View<dark::properties::PropGunState>>()
+        .ok()?;
+    v_gun_state.get(weapon).ok().map(|g| g.ammo)
+}
+
 /// Create layered forearm HUD with health and psi bar overlays
 fn create_forearm_hud_with_overlays(
     asset_cache: &mut AssetCache,

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -39,9 +39,8 @@ test(
     await using game = await GameServer.launch({
       mission: "debug_weapons",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8096),
-      // This branch's debug runtime defaults to VR; the flat path drives the
-      // first-person fire loop. (Drop once flat is the runtime default.)
-      debugFlags: ["--flat"],
+      // Flat is the debug runtime's default presentation; the flat path drives
+      // the first-person fire loop.
     });
 
     // debug_weapons starts unarmed; CycleWeapon spawns + wields the pistol.


### PR DESCRIPTION
**Stacked on #326** (ammo data + firing). Review/merge that first.

Slice 2 of weapon ammo: the flat HUD readout — positions transcribed from the original engine, not eyeballed.

## What

- **Ammo gauge** — `AMMOBACK.PCX` (94×64) at **(544, 414)** bottom-right, with the wielded weapon's round count drawn over it. Shown only when a weapon with a `PropGunState` clip is wielded; reads live via `get_wielded_ammo` (the player's left-hand slot in flat mode).
- **Fixed the health/psi meters**: a 260×64 block at (2, 414) with **health ABOVE psi** (HP_Y=18, PSI_Y=41) and the numbers at x+92. Previously the two bars were eyeballed *and vertically swapped* (psi was on top). Now uses the real 80×14 `HPBAR`/`PSIBAR` art and adds the psi number.

## Verification

Screenshotted in `debug_weapons` (flat): health **100** (top) / psi **75** (below) bottom-left; ammo gauge bottom-right counting **12 → 9** as the pistol fires.

Unit tests cover the canvas element counts (with/without a wielded weapon) and assert health sits above psi. `cargo check -p shock2vr` clean; fmt clean.

### Before / after (health/psi order)
The original flat HUD drew **psi on top, health below** at x=20; SS2 draws **health on top, psi below** at x≈10. This corrects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)