### PR TITLE
docs: record weapon ammo + flat HUD progress (#323-#327)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,14 +4,16 @@ TODO:
 Recent work
 - (in progress) flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
 - flat runtime -> fix alpha transparency / z-order break
-- flat runtime -> fix aiming ofset (viewmodel framing offsets still first-pass, want interactive tuning)
+- [x] flat runtime -> camera-origin aim along the crosshair (#315); muzzle flash now tracks the weapon via RuntimePropAttachment (#323)
+- flat runtime -> per-weapon viewmodel framing from PropPlayerGun.model_offset (needs a separate wider-FOV viewmodel projection; see projects/flat-weapon-handling.md)
 - modernize combat: add recoil / accuracy modifier (like counter-strike)
+- weapon ammo next slices: per-shot m_ammoUsage + clip size from BaseGunDesc (P$BaseGunDe), reload, ammo-type switching (see projects/flat-weapon-handling.md)
 
 - Fable: finish ragdolls (in progress) - hitbox-fitted colliders + rapier 0.31 compliant joints settle into a heap; on-death ragdoll behind `--experimental ragdoll`; multibody rig still experimental (extremity jitter / hip-sag), see projects/ragdoll-settling-followup.md
 - Fable: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped; broader AI behavior testing ongoing
 - Fable: check to see feasibility of loading the 25th anniversary assets
-- Fable: fix flat screen first-person melee weapon orientation
-- Fable: fix flat screen first-person ranged weapon positioning
+- Fable: fix flat screen first-person melee weapon orientation (camSynch / root-override; arm hangs low + stub visible - plan in projects/flat-weapon-handling.md)
+- Fable: fix flat screen first-person ranged weapon positioning (per-weapon model_offset framing, above)
 
 
 SNACKS:
@@ -451,6 +453,11 @@ Release Checklist
 - UiCanvas: placement-agnostic 2D UI layer (HUD + menu migrated, #300)
 - Ragdoll (in progress): hitbox-fitted limb colliders, rapier 0.19 -> 0.31 upgrade, compliant joints that settle into a heap; on-death ragdoll + corpse handoff behind `--experimental` (#278-#304)
 - Debug runtime: physics body/joint introspection, ragdoll metrics, fixed-timestep deterministic stepping
+- Flat weapons: first-person aim + viewmodel from PropPlayerGun (#315); melee render/idle/swing (#319-#321)
+- Muzzle flash follows the weapon: generic `RuntimePropAttachment` mechanism (parent transform + captured local pose, re-anchored each frame), reusable for later attached effects (#323)
+- Debug runtime ergonomics: defaults to flat (`--vr` to opt in), `/v1/info` reports player + wielded entity, `/v1/control/input` accepts both body shapes and validates (actionable 400s), e2e suite runs serially (#324)
+- Weapon ammo: parse `P$GunState`, consume a round per shot, dry-fire at empty (#326); faithful flat HUD - ammo gauge (AMMOBACK) + corrected health/psi meters + BIOFULL bio-monitor backdrop, all positioned from the original `shkmeter.cpp`/`shkammov.cpp` coords (#327)
+- Dev workflow: pre-push git hook running `cargo fmt --check` (#325)
 
 2026: Things I hope we can do
 

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -10,6 +10,36 @@ See also: `projects/flatscreen-and-vr-architecture.md` (the intent/outcome seam
 that all of this must respect), `projects/melee-combat.md`,
 `projects/player-damage.md`.
 
+## Status / progress (2026-06-27)
+
+Weapon **ammo** landed (#326 data/firing, #327 HUD):
+
+- Parse `P$GunState` into a `PropGunState` component (`dark`), mirroring the Dark
+  engine `sGunState` (ammo, condition, setting, modification, silence). The
+  pistol reads `ammo: 12`.
+- `WeaponScript` gates firing on ammo when a gun state is present: a live shot
+  consumes one round (`Effect::AdjustAmmo`); an empty clip dry-fires (no
+  projectile/flash, best-effort "dryfire" click). Weapons without a gun state
+  (melee, unlimited debug weapons) are unchanged. Current ammo is exposed on the
+  debug runtime's `/v1/entities/:id`; e2e test `weapon-ammo.e2e.test.ts`.
+- **Faithful flat HUD** (positions transcribed from `shkmeter.cpp` / `shkammov.cpp`,
+  not eyeballed): ammo gauge `AMMOBACK.PCX` (94×64) at (544, 414); health/psi
+  meters corrected to the 260×64 block at (2, 414) with **health above psi** (was
+  swapped) and both numeric readouts; `BIOFULL.PCX` bio-monitor backdrop behind
+  them. Note SS2 anchors HUD chrome to screen edges at native pixel size; our
+  `UiCanvas` instead scales the whole 640×480 layout (`PreserveAspect`).
+
+Ammo follow-ups (not yet done): per-shot `m_ammoUsage` and clip size from
+`BaseGunDesc` (`P$BaseGunDe`, 136 bytes, unparsed), **reload** (animation gates
+the refill), and **ammo-type switching** (guns carry multiple `Projectile`
+links - standard/AP/HE; firing currently always uses the first). A faithful
+HUD would also need an edge-anchored `ScaleMode` to keep chrome at native size.
+
+Also landed since the last entry (out of this doc's scope but related):
+muzzle flash follows the weapon via a generic `RuntimePropAttachment` (#323),
+and debug-runtime ergonomics - flat by default, wielded-entity in `/v1/info`,
+validated input (#324).
+
 ## Status / progress (2026-06-21)
 
 Landed on branch `feat/flat-aim-viewmodel` (PR: flat first-person weapons — aim +


### PR DESCRIPTION
Doc-only update capturing the work that landed this pass.

## TODO.md
- 2026 "so far" summary: muzzle-flash attachment (#323), debug-runtime ergonomics (#324), fmt pre-push hook (#325), weapon ammo + faithful flat HUD (#326/#327).
- "Recent work" / Fable items: mark camera-origin aim + muzzle-flash done; reframe the remaining flat-weapon polish (per-weapon `model_offset` framing, melee camSynch, recoil/accuracy) and list the next ammo slices.

## projects/flat-weapon-handling.md
- New status entry (2026-06-27) recording ammo data/firing/dry-fire and the HUD, BIOFULL backdrop, the resolution-mapping note), plus the remaining ammo follow-ups (`m_ammoUsage`/clip size from `BaseGunDesc`, reload, ammo-type switching).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)