### PR TITLE
feat(weapon): first-person reload animation + fire gate

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -398,6 +398,11 @@ pub struct PlayerInfo {
     pub wielded_entity_id: Option<i32>,
     /// The entity held in the right hand (VR), `None` otherwise.
     pub right_hand_entity_id: Option<i32>,
+    /// Whether the wielded weapon is mid-reload, plus the current viewmodel tilt
+    /// (degrees) and reload progress (0..1). See `shock2vr::PlayerStateSnapshot`.
+    pub reloading: bool,
+    pub reload_pitch_deg: f32,
+    pub reload_progress: f32,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1398,6 +1398,9 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                 camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
                 right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),
+                reloading: state.as_ref().is_some_and(|s| s.reloading),
+                reload_pitch_deg: state.as_ref().map(|s| s.reload_pitch_deg).unwrap_or(0.0),
+                reload_progress: state.as_ref().map(|s| s.reload_progress).unwrap_or(0.0),
             }
         },
         entity_count,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -196,6 +196,13 @@ pub struct PlayerStateSnapshot {
     pub rotation: [f32; 4],
     pub wielded_entity_id: Option<i32>,
     pub right_hand_entity_id: Option<i32>,
+    /// Whether the wielded weapon is mid-reload, and (if so) the current
+    /// viewmodel tilt angle in degrees and the reload progress (0..1). When not
+    /// reloading: `false`, `0.0`, `0.0`. Lets tooling verify the reload
+    /// animation headlessly (the angle ramps down, holds, then back to 0).
+    pub reloading: bool,
+    pub reload_pitch_deg: f32,
+    pub reload_progress: f32,
 }
 
 impl Game {
@@ -204,8 +211,18 @@ impl Game {
     /// menu). Reads the `PlayerInfo` unique from the active world.
     pub fn player_state(&self) -> Option<PlayerStateSnapshot> {
         use crate::mission::mission_core::PlayerInfo;
+        use crate::runtime_props::RuntimePropReloading;
         let world = self.world();
         let info = world.borrow::<shipyard::UniqueView<PlayerInfo>>().ok()?;
+        let reload = info.left_hand_entity_id.and_then(|weapon| {
+            world
+                .borrow::<shipyard::View<RuntimePropReloading>>()
+                .ok()
+                .and_then(|v| {
+                    use shipyard::Get;
+                    v.get(weapon).ok().map(|r| (r.pitch_deg(), r.progress()))
+                })
+        });
         Some(PlayerStateSnapshot {
             entity_id: info.entity_id.inner() as i32,
             position: [info.pos.x, info.pos.y, info.pos.z],
@@ -217,6 +234,9 @@ impl Game {
             ],
             wielded_entity_id: info.left_hand_entity_id.map(|e| e.inner() as i32),
             right_hand_entity_id: info.right_hand_entity_id.map(|e| e.inner() as i32),
+            reloading: reload.is_some(),
+            reload_pitch_deg: reload.map(|(p, _)| p).unwrap_or(0.0),
+            reload_progress: reload.map(|(_, p)| p).unwrap_or(0.0),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -75,7 +75,7 @@ use crate::{
     quest_info::QuestInfo,
     runtime_props::{
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropTransform, RuntimePropVhots,
+        RuntimePropReloading, RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -648,6 +648,9 @@ impl MissionCore {
         // Advance the flat melee swing animation (returns to static idle on end).
         self.update_flat_melee_anim(time.elapsed);
 
+        // Advance any in-progress reload (clears itself when complete).
+        self.update_flat_reload_anim(time.elapsed);
+
         // Sync up the position of all the physics objects
         // The timing of this is important - things like the GUI rendering depend on an up-to-date position
         // from physics
@@ -1218,8 +1221,6 @@ impl MissionCore {
                 }
 
                 Effect::ReloadWeapon => {
-                    // Refill the wielded weapon's clip to capacity. Reserve ammo
-                    // is unlimited for now (no inventory ammo model yet).
                     let wielded = self
                         .world
                         .borrow::<UniqueView<PlayerInfo>>()
@@ -1227,26 +1228,7 @@ impl MissionCore {
                         .left_hand_entity_id;
 
                     if let Some(weapon) = wielded {
-                        let clip = self
-                            .world
-                            .borrow::<View<dark::properties::PropBaseGunDesc>>()
-                            .unwrap()
-                            .get(weapon)
-                            .ok()
-                            .map(|d| d.clip);
-
-                        if let Some(clip) = clip {
-                            let mut v_gun_state = self
-                                .world
-                                .borrow::<ViewMut<dark::properties::PropGunState>>()
-                                .unwrap();
-                            if let Ok(gun_state) = (&mut v_gun_state).get(weapon) {
-                                // Refill to magazine capacity (clamp guards bad
-                                // data); reload sets the clip, it does not just
-                                // top up to "at least clip".
-                                gun_state.ammo = clip.max(0);
-                            }
-                        }
+                        self.begin_reload(weapon);
                     }
                 }
 
@@ -1947,6 +1929,118 @@ impl MissionCore {
         }
     }
 
+    /// Begin a reload on `weapon`: refill its clip to capacity and start the
+    /// reload animation (a `RuntimePropReloading` on the weapon). SS2's
+    /// first-person reload tilts the gun down to a peak angle, holds while the
+    /// clip is swapped, then raises it back up; the peak angle and pitch speed
+    /// come from the weapon's own data (`PropPlayerGun`'s reload pitch/rate, as
+    /// 16-bit angle units where 65536 = 360 deg) and the hold from its reload
+    /// time (`PropBaseGunDesc.reload_time_ms`). No-op for non-guns (no
+    /// `PropBaseGunDesc`) and while a reload is already in progress. Reserve ammo
+    /// is unlimited for now (no inventory ammo model yet).
+    fn begin_reload(&mut self, weapon: EntityId) {
+        // Sensible fallbacks used only when a gun has no PropPlayerGun at all, so
+        // the reload is still visible.
+        const FALLBACK_PEAK_DEG: f32 = -45.0;
+        const FALLBACK_RATE_DEG_PER_S: f32 = 180.0;
+        // 16-bit angle units (65536 = 360 deg). The tilt target is a signed
+        // shortest-path angle (e.g. the pistol's -67.5 deg); the rate is an
+        // unsigned magnitude (deg/sec), so it must NOT be read as signed.
+        fn ang16_signed_deg(a: u16) -> f32 {
+            (a as i16 as f32) / 65536.0 * 360.0
+        }
+        fn ang16_unsigned_deg(a: u16) -> f32 {
+            (a as f32) / 65536.0 * 360.0
+        }
+
+        // Only guns reload; bail (and don't restart an in-progress reload).
+        let (clip, hold) = {
+            let v_desc = self
+                .world
+                .borrow::<View<dark::properties::PropBaseGunDesc>>();
+            match v_desc.as_ref().ok().and_then(|v| v.get(weapon).ok()) {
+                Some(d) => (d.clip, d.reload_time_ms as f32 / 1000.0),
+                None => return,
+            }
+        };
+        if let Ok(v) = self.world.borrow::<View<RuntimePropReloading>>() {
+            if v.get(weapon).is_ok_and(|r| !r.is_done()) {
+                return;
+            }
+        }
+
+        // Use the weapon's own pitch/rate when it has a PropPlayerGun (even a
+        // near-zero pitch is honored - some psi weapons intentionally barely tilt
+        // - so we only fall back when the data is genuinely absent).
+        let (peak_deg, rate) = {
+            let v_gun = self.world.borrow::<View<PropPlayerGun>>();
+            match v_gun.as_ref().ok().and_then(|v| v.get(weapon).ok()) {
+                Some(g) => (
+                    ang16_signed_deg(g.reload_pitch),
+                    ang16_unsigned_deg(g.reload_rate),
+                ),
+                None => (FALLBACK_PEAK_DEG, FALLBACK_RATE_DEG_PER_S),
+            }
+        };
+        // Guard the divisor only (a zero rate would blow up `leg`).
+        let rate = if rate < 1.0 {
+            FALLBACK_RATE_DEG_PER_S
+        } else {
+            rate
+        };
+        let leg = peak_deg.abs() / rate; // tilt-down (and tilt-up) duration
+
+        // Refill now: firing is gated for the whole reload, so the exact moment
+        // the clip refills is not observable.
+        {
+            let mut v_gun_state = self
+                .world
+                .borrow::<ViewMut<dark::properties::PropGunState>>()
+                .unwrap();
+            if let Ok(gun_state) = (&mut v_gun_state).get(weapon) {
+                gun_state.ammo = clip.max(0);
+            }
+        }
+
+        self.world.add_component(
+            weapon,
+            RuntimePropReloading {
+                elapsed: 0.0,
+                down: leg,
+                hold,
+                up: leg,
+                peak_deg,
+            },
+        );
+    }
+
+    /// Advance any in-progress reload by `dt` and clear it when complete.
+    fn update_flat_reload_anim(&self, dt: std::time::Duration) {
+        let dt_s = dt.as_secs_f32();
+        let mut done = Vec::new();
+        {
+            let mut v = self
+                .world
+                .borrow::<ViewMut<RuntimePropReloading>>()
+                .unwrap();
+            for (id, r) in (&mut v).iter().with_id() {
+                r.elapsed += dt_s;
+                if r.is_done() {
+                    done.push(id);
+                }
+            }
+        }
+        if !done.is_empty() {
+            let mut v = self
+                .world
+                .borrow::<ViewMut<RuntimePropReloading>>()
+                .unwrap();
+            for id in done {
+                v.remove(id);
+            }
+        }
+    }
+
     pub fn render_per_eye(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -2046,6 +2140,30 @@ impl MissionCore {
                 let is_melee = limb_model.is_some();
                 let fp_model_name = gun_model.or(limb_model);
                 if let Some(xform) = maybe_xform {
+                    // While reloading, tilt the viewmodel by the current reload
+                    // angle (ramps up, holds, then back down - see
+                    // RuntimePropReloading). Rotate about the camera's horizontal
+                    // (screen-right) axis through the gun's position, so the gun
+                    // reads as a reload tilt regardless of the model's local
+                    // orientation.
+                    let xform = match self
+                        .world
+                        .borrow::<View<RuntimePropReloading>>()
+                        .ok()
+                        .and_then(|v| v.get(weapon).ok().map(|r| r.pitch_deg()))
+                    {
+                        Some(deg) if deg.abs() > f32::EPSILON => {
+                            // Camera-right in world space = row 0 of the view
+                            // rotation (column-major: (x.x, y.x, z.x)).
+                            let right = vec3(view.x.x, view.y.x, view.z.x).normalize();
+                            let p = xform.w.truncate();
+                            Matrix4::from_translation(p)
+                                * Matrix4::from_axis_angle(right, cgmath::Deg(deg))
+                                * Matrix4::from_translation(-p)
+                                * xform
+                        }
+                        _ => xform,
+                    };
                     let scene_objs = if let Some(name) = fp_model_name {
                         let model = asset_cache.get(&MODELS_IMPORTER, &format!("{name}.BIN"));
                         // FP meshes are articulated (hand + arm + weapon as

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -53,6 +53,63 @@ pub struct RuntimePropAttachment {
     pub local_transform: Matrix4<f32>,
 }
 
+// RuntimePropReloading - an in-progress weapon reload, set on the wielded weapon
+// while it reloads. Models SS2's first-person reload: the gun pitches DOWN to a
+// peak angle, HOLDS while the clip is swapped, then pitches back UP. The peak
+// angle and pitch speed come from the weapon's own data (`PropPlayerGun`'s
+// reload pitch/rate), the hold from its reload time. Drives three things from one
+// source of truth: the viewmodel tilt (render), the fire gate (you cannot fire
+// mid-reload), and debug introspection. Durations are in seconds; `peak_deg` is
+// the (signed) peak tilt in degrees.
+//
+// Like all runtime props this is not serialized: a save taken mid-reload loads
+// with the reload already "finished" (no tilt, firing allowed). That is benign -
+// `begin_reload` refills the clip up front, so there is no ammo inconsistency.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropReloading {
+    pub elapsed: f32,
+    pub down: f32,
+    pub hold: f32,
+    pub up: f32,
+    pub peak_deg: f32,
+}
+
+impl RuntimePropReloading {
+    pub fn total(&self) -> f32 {
+        self.down + self.hold + self.up
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.elapsed >= self.total()
+    }
+
+    /// Fraction complete, 0..1.
+    pub fn progress(&self) -> f32 {
+        let total = self.total();
+        if total <= 0.0 {
+            1.0
+        } else {
+            (self.elapsed / total).clamp(0.0, 1.0)
+        }
+    }
+
+    /// Current tilt angle (degrees): ramp 0 -> peak over `down`, hold at peak for
+    /// `hold`, then ramp peak -> 0 over `up`.
+    pub fn pitch_deg(&self) -> f32 {
+        let t = self.elapsed;
+        if self.down > 0.0 && t < self.down {
+            self.peak_deg * (t / self.down)
+        } else if t < self.down + self.hold {
+            self.peak_deg
+        } else if self.up > 0.0 && t < self.total() {
+            let u = (t - self.down - self.hold) / self.up;
+            self.peak_deg * (1.0 - u)
+        } else {
+            0.0
+        }
+    }
+}
+
 // RuntimePropFlatAim - the flatscreen camera/crosshair fire ray (world space),
 // set each frame on the player's wielded weapon. When present, weapon firing
 // spawns projectiles from `origin` along `forward` (camera-origin aim) instead

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -11,7 +11,9 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::{
     mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
-    runtime_props::{RuntimePropFlatAim, RuntimePropTransform, RuntimePropVhots},
+    runtime_props::{
+        RuntimePropFlatAim, RuntimePropReloading, RuntimePropTransform, RuntimePropVhots,
+    },
     util::{get_rotation_from_forward_vector, resolve_proxy_entity},
     vr_config,
 };
@@ -60,6 +62,16 @@ impl Script for WeaponScript {
     ) -> Effect {
         match msg {
             MessagePayload::TriggerPull => {
+                // Firing is blocked while a reload is in progress.
+                if world
+                    .borrow::<View<RuntimePropReloading>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().map(|r| !r.is_done()))
+                    == Some(true)
+                {
+                    return Effect::NoEffect;
+                }
+
                 //Create muzzle flash
                 let muzzle_flashes =
                     get_all_links_with_template(world, entity_id, |link| match link {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -127,6 +127,11 @@ export interface PlayerSnapshot {
   wielded_entity_id: number | null;
   /** The entity held in the right hand (VR); null otherwise. */
   right_hand_entity_id: number | null;
+  /** Whether the wielded weapon is mid-reload, plus the current viewmodel tilt
+   * (degrees) and reload progress (0..1). false/0/0 when not reloading. */
+  reloading: boolean;
+  reload_pitch_deg: number;
+  reload_progress: number;
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end regression test for the reload ANIMATION + fire gate. The wielded
+// weapon tilts during reload (a three-phase pitch: down -> hold -> up) and
+// firing is blocked while it reloads. Both are observable headlessly via
+// /v1/info (reloading / reload_pitch_deg / reload_progress) - no screenshots.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "weapon should expose an Ammo property");
+  return Number(p.value);
+}
+
+test(
+  "reload tilts the viewmodel and blocks firing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
+    });
+
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    const pistolId = (await game.entities.list({ limit: 60 })).entities.find(
+      (e) => e.name === "Pistol",
+    )?.id;
+    assert.ok(pistolId !== undefined, "pistol should be wielded");
+
+    const clip = ammoOf(await game.entities.detail(pistolId));
+
+    // Not reloading at rest.
+    let snap = (await game.info()).player;
+    assert.equal(snap.reloading, false, "not reloading at rest");
+    assert.equal(snap.reload_pitch_deg, 0, "no tilt at rest");
+
+    // Drain a few rounds, then start a reload.
+    for (let i = 0; i < 4; i++) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), clip - 4, "fired 4 rounds");
+
+    await game.input.trigger("Reload");
+    await game.step({ frames: 6 });
+
+    // Reload is in progress and the viewmodel has begun to tilt.
+    snap = (await game.info()).player;
+    assert.equal(snap.reloading, true, "reloading after trigger");
+    assert.ok(
+      Math.abs(snap.reload_pitch_deg) > 1,
+      `viewmodel should be tilting (got ${snap.reload_pitch_deg} deg)`,
+    );
+    assert.ok(
+      snap.reload_progress > 0 && snap.reload_progress < 1,
+      `reload should be partway (got ${snap.reload_progress})`,
+    );
+
+    // Fire gate: firing mid-reload must NOT consume ammo.
+    const ammoMidReload = ammoOf(await game.entities.detail(pistolId));
+    await fireOnce(game);
+    await fireOnce(game);
+    assert.equal((await game.info()).player.reloading, true, "still reloading");
+    assert.equal(
+      ammoOf(await game.entities.detail(pistolId)),
+      ammoMidReload,
+      "firing is blocked during reload (no ammo consumed)",
+    );
+
+    // The tilt reaches a clear peak partway through (the pistol dips ~67 deg).
+    await game.step({ frames: 30 });
+    assert.ok(
+      Math.abs((await game.info()).player.reload_pitch_deg) > 40,
+      "viewmodel reaches a clear peak tilt mid-reload",
+    );
+
+    // Step well past the total reload; it completes and the tilt returns to 0.
+    await game.step({ frames: 120 });
+    snap = (await game.info()).player;
+    assert.equal(snap.reloading, false, "reload completes");
+    assert.equal(snap.reload_pitch_deg, 0, "viewmodel returns to rest (no tilt)");
+
+    // And the clip is full again (reload refilled it).
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), clip, "clip refilled to capacity");
+  },
+);

--- a/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
@@ -58,6 +58,11 @@ test(
       "reload refills the clip to capacity",
     );
 
+    // Firing is blocked while the reload animation plays, so let it finish
+    // before draining the clip again.
+    await game.step({ frames: 130 });
+    assert.equal((await game.info()).player.reloading, false, "reload finished");
+
     // Drain to empty, then a reload restores a full clip (so an empty weapon is
     // usable again - the core point of reload).
     for (let i = 0; i < clip; i++) await fireOnce(game);


### PR DESCRIPTION
Stacked on #330 (← #329).

## What

While a weapon reloads, the flatscreen viewmodel tilts in a three-phase pitch (down → hold → back up). The peak angle and pitch speed come from the weapon's own data (`PropPlayerGun` reload pitch/rate); the hold from its reload time (`PropBaseGunDesc.reload_time_ms`). Firing is blocked for the duration (`TriggerPull` is a no-op mid-reload).

Modeled as a `RuntimePropReloading` component on the wielded weapon — one source of truth for the render tilt, the fire gate, and debug introspection. The tilt rotates the viewmodel about the camera's screen-horizontal axis through the gun, so it reads correctly regardless of the model's local orientation.

## Verifiable headlessly

Reload state is surfaced on the debug runtime's `/v1/info` (`reloading` / `reload_pitch_deg` / `reload_progress`), so the animation is testable without screenshots. `weapon-reload-animation.e2e.test.ts` asserts the tilt ramps, peaks, blocks firing, then completes and refills the clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)