### PR TITLE
feat(weapon): ammo-type cycling + HUD indicator

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -403,6 +403,9 @@ pub struct PlayerInfo {
     pub reloading: bool,
     pub reload_pitch_deg: f32,
     pub reload_progress: f32,
+    /// The wielded weapon's selected ammo type (e.g. "std" / "he" / "ap"), or
+    /// `null` when unarmed / single-ammo. See `shock2vr::PlayerStateSnapshot`.
+    pub wielded_ammo_type: Option<String>,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -404,7 +404,7 @@ pub struct PlayerInfo {
     pub reload_pitch_deg: f32,
     pub reload_progress: f32,
     /// The wielded weapon's selected ammo type (e.g. "std" / "he" / "ap"), or
-    /// `null` when unarmed / single-ammo. See `shock2vr::PlayerStateSnapshot`.
+    /// `null` when unarmed / melee. See `shock2vr::PlayerStateSnapshot`.
     pub wielded_ammo_type: Option<String>,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1401,6 +1401,7 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                 reloading: state.as_ref().is_some_and(|s| s.reloading),
                 reload_pitch_deg: state.as_ref().map(|s| s.reload_pitch_deg).unwrap_or(0.0),
                 reload_progress: state.as_ref().map(|s| s.reload_progress).unwrap_or(0.0),
+                wielded_ammo_type: state.as_ref().and_then(|s| s.wielded_ammo_type.clone()),
             }
         },
         entity_count,

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -54,6 +54,11 @@ impl DesktopInputMapper {
                 action: InputAction::Reload,
             },
             Binding {
+                key: Key::T,
+                modifier: Modifier::None,
+                action: InputAction::CycleAmmo,
+            },
+            Binding {
                 key: Key::S,
                 modifier: Modifier::Alt,
                 action: InputAction::QuickSave,

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -10,7 +10,10 @@ use cgmath::vec2;
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::World;
 
-use super::{get_health_percentage, get_psi_percentage, get_wielded_ammo};
+use super::{
+    get_health_percentage, get_psi_percentage, get_wielded_ammo, get_wielded_ammo_icon,
+    get_wielded_ammo_type,
+};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
 
 /// The original SS2 HUD is authored against a 640x480 display.
@@ -57,6 +60,11 @@ const AMMO_H: f32 = 64.0;
 const AMMO_GAUGE: Rect = Rect::new(AMMO_X, AMMO_Y, AMMO_W, AMMO_H);
 const AMMO_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 22.0, AMMO_W, 20.0); // centered over the gauge
 const AMMO_TEXT_SIZE: f32 = 18.0;
+// Selected ammo-type indicator: the projectile's object icon (P$ObjIcon) just
+// left of the gauge, with its type label (std/he/ap) below the round count.
+const AMMO_ICON: Rect = Rect::new(AMMO_X - 40.0, AMMO_Y + 16.0, 32.0, 32.0);
+const AMMO_TYPE_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 44.0, AMMO_W, 16.0);
+const AMMO_TYPE_TEXT_SIZE: f32 = 12.0;
 
 /// Build the flat HUD as a resolution-independent canvas for the given player
 /// stat fractions and (optional) wielded-weapon ammo. Pure (no asset/GL
@@ -65,6 +73,8 @@ pub(crate) fn build_flat_hud_canvas(
     health_fraction: f32,
     psi_fraction: f32,
     ammo: Option<i32>,
+    ammo_icon: Option<String>,
+    ammo_type: Option<String>,
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
 
@@ -105,6 +115,21 @@ pub(crate) fn build_flat_hud_canvas(
             HAlign::Center,
             VAlign::Middle,
         );
+
+        // Selected ammo-type indicator: the projectile's icon + type label.
+        if let Some(icon) = ammo_icon {
+            canvas.image(AMMO_ICON, &icon);
+        }
+        if let Some(ammo_type) = ammo_type {
+            canvas.text(
+                AMMO_TYPE_TEXT,
+                &ammo_type.to_ascii_uppercase(),
+                "mainfont.fon",
+                AMMO_TYPE_TEXT_SIZE,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        }
     }
 
     canvas
@@ -120,6 +145,8 @@ pub(crate) fn create_flat_hud(
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_ammo(world),
+        get_wielded_ammo_icon(world),
+        get_wielded_ammo_type(world),
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
@@ -132,15 +159,28 @@ mod tests {
     #[test]
     fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
         // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
-        let canvas = build_flat_hud_canvas(1.0, 0.75, None);
+        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, None);
         assert_eq!(canvas.element_count(), 6);
     }
 
     #[test]
     fn wielding_a_weapon_adds_the_ammo_gauge() {
         // ...plus the ammo backdrop + count when a clip is present.
-        let canvas = build_flat_hud_canvas(1.0, 0.75, Some(12));
+        let canvas = build_flat_hud_canvas(1.0, 0.75, Some(12), None, None);
         assert_eq!(canvas.element_count(), 8);
+    }
+
+    #[test]
+    fn ammo_type_adds_icon_and_label() {
+        // ...plus the ammo-type icon + label when a type is selected.
+        let canvas = build_flat_hud_canvas(
+            1.0,
+            0.75,
+            Some(12),
+            Some("STD_I.PCX".to_string()),
+            Some("std".to_string()),
+        );
+        assert_eq!(canvas.element_count(), 10);
     }
 
     #[test]
@@ -157,6 +197,6 @@ mod tests {
     #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(2.0, -1.0, None);
+        let _ = build_flat_hud_canvas(2.0, -1.0, None, None, None);
     }
 }

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -160,14 +160,7 @@ pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
 pub(crate) fn wielded_selected_projectile_template(world: &World) -> Option<i32> {
     let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
     let weapon = player_info.left_hand_entity_id?;
-    let projectiles = crate::scripts::script_util::get_all_links_with_template(
-        world,
-        weapon,
-        |link| match link {
-            dark::properties::Link::Projectile(_) => Some(()),
-            _ => None,
-        },
-    );
+    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
     if projectiles.is_empty() {
         return None;
     }
@@ -189,6 +182,19 @@ pub(crate) fn get_wielded_ammo_type(world: &World) -> Option<String> {
         .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
         .ok()?;
     class_tags.0.get(&template_id)?.get("ammotype").cloned()
+}
+
+/// The object-icon bitmap filename (e.g. "STD_I.pcx") of the wielded weapon's
+/// selected ammo type, or `None`. Resolved from the selected projectile
+/// template's `P$ObjIcon` (projectiles are templates, not instantiated entities,
+/// so this reads the precomputed [`GlobalTemplateObjIcons`] map rather than a
+/// `View`).
+pub(crate) fn get_wielded_ammo_icon(world: &World) -> Option<String> {
+    let template_id = wielded_selected_projectile_template(world)?;
+    let icons = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateObjIcons>>()
+        .ok()?;
+    icons.0.get(&template_id).cloned()
 }
 
 /// Create layered forearm HUD with health and psi bar overlays

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -154,6 +154,43 @@ pub(crate) fn get_wielded_ammo(world: &World) -> Option<i32> {
     v_gun_state.get(weapon).ok().map(|g| g.ammo)
 }
 
+/// The template id of the wielded weapon's currently selected `Projectile` link
+/// (its ammo type), or `None` when unarmed or the weapon has no projectile links
+/// (melee). Honors `RuntimePropSelectedAmmo` (absent = the first link).
+pub(crate) fn wielded_selected_projectile_template(world: &World) -> Option<i32> {
+    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    let weapon = player_info.left_hand_entity_id?;
+    let projectiles = crate::scripts::script_util::get_all_links_with_template(
+        world,
+        weapon,
+        |link| match link {
+            dark::properties::Link::Projectile(_) => Some(()),
+            _ => None,
+        },
+    );
+    if projectiles.is_empty() {
+        return None;
+    }
+    let selected = world
+        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|s| s.0))
+        .unwrap_or(0);
+    projectiles
+        .get(selected % projectiles.len())
+        .map(|(template_id, _)| *template_id)
+}
+
+/// The `ammotype` class-tag of the wielded weapon's selected ammo (e.g. "std",
+/// "he", "ap"), or `None`.
+pub(crate) fn get_wielded_ammo_type(world: &World) -> Option<String> {
+    let template_id = wielded_selected_projectile_template(world)?;
+    let class_tags = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
+        .ok()?;
+    class_tags.0.get(&template_id)?.get("ammotype").cloned()
+}
+
 /// Create layered forearm HUD with health and psi bar overlays
 fn create_forearm_hud_with_overlays(
     asset_cache: &mut AssetCache,

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -33,6 +33,8 @@ pub enum InputAction {
     /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
     /// testing.
     CycleWeapon,
+    /// Cycle the wielded weapon's ammo type (its next Projectile link).
+    CycleAmmo,
     /// Reload the wielded weapon: refill its clip to capacity.
     Reload,
     /// Reload the current level in place (debug). Exercises the level-transition path,
@@ -52,6 +54,7 @@ impl InputAction {
             InputAction::MoveInventory,
             InputAction::DebugHitboxCyclePose,
             InputAction::CycleWeapon,
+            InputAction::CycleAmmo,
             InputAction::Reload,
             InputAction::DebugReloadLevel,
         ]
@@ -66,6 +69,7 @@ impl InputAction {
             InputAction::MoveInventory => "MoveInventory",
             InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
             InputAction::CycleWeapon => "CycleWeapon",
+            InputAction::CycleAmmo => "CycleAmmo",
             InputAction::Reload => "Reload",
             InputAction::DebugReloadLevel => "DebugReloadLevel",
         }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -54,6 +54,9 @@ impl ActionDispatcher {
                 head_rotation: input_context.head.rotation,
             });
         }
+        if state.just_triggered(InputAction::CycleAmmo) {
+            effects.push(Effect::CycleAmmo);
+        }
         if state.just_triggered(InputAction::Reload) {
             effects.push(Effect::ReloadWeapon);
         }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -204,7 +204,9 @@ pub struct PlayerStateSnapshot {
     pub reload_pitch_deg: f32,
     pub reload_progress: f32,
     /// The wielded weapon's selected ammo type (`ammotype` class-tag, e.g. "std"
-    /// / "he" / "ap"), or `None` when unarmed / single-ammo / melee.
+    /// / "he" / "ap"), or `None` when unarmed or the weapon has no projectile
+    /// links (melee). Reported whenever there is a projectile link, even if there
+    /// is only one (it just cannot be cycled).
     pub wielded_ammo_type: Option<String>,
 }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -203,6 +203,9 @@ pub struct PlayerStateSnapshot {
     pub reloading: bool,
     pub reload_pitch_deg: f32,
     pub reload_progress: f32,
+    /// The wielded weapon's selected ammo type (`ammotype` class-tag, e.g. "std"
+    /// / "he" / "ap"), or `None` when unarmed / single-ammo / melee.
+    pub wielded_ammo_type: Option<String>,
 }
 
 impl Game {
@@ -237,6 +240,7 @@ impl Game {
             reloading: reload.is_some(),
             reload_pitch_deg: reload.map(|(p, _)| p).unwrap_or(0.0),
             reload_progress: reload.map(|(_, p)| p).unwrap_or(0.0),
+            wielded_ammo_type: crate::hud::get_wielded_ammo_type(world),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -153,6 +153,13 @@ pub struct GlobalTemplateIdMap(pub HashMap<i32, WrappedEntityId>);
 #[derive(Unique, Clone)]
 pub struct GlobalTemplateClassTags(pub HashMap<i32, HashMap<String, String>>);
 
+/// Global template id -> object-icon (`P$ObjIcon`) bitmap filename (e.g.
+/// "STD_I.pcx"). Used to show a projectile/ammo's icon (e.g. the wielded
+/// weapon's selected ammo type) without the projectile being an instantiated
+/// entity. Derived from the template metadata hydrated at load.
+#[derive(Unique, Clone)]
+pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
+
 impl EffectQueue {
     pub fn push(&mut self, effect: Effect) {
         self.effects.push(effect);
@@ -284,6 +291,13 @@ impl MissionCore {
         });
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
+        // Reuse the obj-icons already hydrated into the template metadata above
+        // (keyed by template id) rather than rescanning every template.
+        let template_obj_icons: HashMap<i32, String> = template_name_to_template_id
+            .values()
+            .filter_map(|m| m.obj_icon.clone().map(|icon| (m.template_id, icon)))
+            .collect();
+        world.add_unique(GlobalTemplateObjIcons(template_obj_icons));
 
         // ** Entity creation
 
@@ -2030,13 +2044,7 @@ impl MissionCore {
     /// the weapon has fewer than two projectile links.
     fn cycle_ammo(&mut self, weapon: EntityId) {
         let count =
-            crate::scripts::script_util::get_all_links_with_template(&self.world, weapon, |link| {
-                match link {
-                    dark::properties::Link::Projectile(_) => Some(()),
-                    _ => None,
-                }
-            })
-            .len();
+            crate::scripts::script_util::ordered_projectile_links(&self.world, weapon).len();
         if count < 2 {
             return; // single ammo type (or melee) - nothing to cycle
         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -75,7 +75,7 @@ use crate::{
     quest_info::QuestInfo,
     runtime_props::{
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropReloading, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -1232,6 +1232,18 @@ impl MissionCore {
                     }
                 }
 
+                Effect::CycleAmmo => {
+                    let wielded = self
+                        .world
+                        .borrow::<UniqueView<PlayerInfo>>()
+                        .unwrap()
+                        .left_hand_entity_id;
+
+                    if let Some(weapon) = wielded {
+                        self.cycle_ammo(weapon);
+                    }
+                }
+
                 Effect::AwardXP { amount } => {
                     warn!("!! TODO !!: Award XP {}", amount);
                 }
@@ -2012,6 +2024,30 @@ impl MissionCore {
                 peak_deg,
             },
         );
+    }
+
+    /// Cycle `weapon` to its next ammo type (next `Projectile` link). No-op when
+    /// the weapon has fewer than two projectile links.
+    fn cycle_ammo(&mut self, weapon: EntityId) {
+        let count =
+            crate::scripts::script_util::get_all_links_with_template(&self.world, weapon, |link| {
+                match link {
+                    dark::properties::Link::Projectile(_) => Some(()),
+                    _ => None,
+                }
+            })
+            .len();
+        if count < 2 {
+            return; // single ammo type (or melee) - nothing to cycle
+        }
+        let current = self
+            .world
+            .borrow::<View<RuntimePropSelectedAmmo>>()
+            .ok()
+            .and_then(|v| v.get(weapon).ok().map(|s| s.0))
+            .unwrap_or(0);
+        self.world
+            .add_component(weapon, RuntimePropSelectedAmmo((current + 1) % count));
     }
 
     /// Advance any in-progress reload by `dt` and clear it when complete.

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -111,10 +111,17 @@ impl RuntimePropReloading {
 }
 
 // RuntimePropSelectedAmmo - which of the wielded weapon's Projectile links is
-// selected (index into its ordered Projectile links). Many SS2 guns carry
-// several ammo types (e.g. the pistol: standard / HE / AP); firing uses the
-// selected one. Absent = index 0 (the first/default link). Cleared/ignored for
-// weapons with no Projectile links (melee).
+// selected (index into `ordered_projectile_links`). Many SS2 guns carry several
+// ammo types (e.g. the pistol: standard / HE / AP); firing uses the selected
+// one. Absent = index 0 (the first/default link). Ignored for weapons with no
+// Projectile links (melee).
+//
+// Scope notes (deliberate simplifications for now):
+// - Not serialized (like all runtime props), so the selection resets to the
+//   first link across save/load and level transitions.
+// - All ammo types share one clip (`PropGunState.ammo`); switching type does not
+//   switch loaded rounds. Per-ammo-type counts need an inventory-ammo model we
+//   don't have yet, so this behaves like a fire-mode selector for now.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropSelectedAmmo(pub usize);
 

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -110,6 +110,14 @@ impl RuntimePropReloading {
     }
 }
 
+// RuntimePropSelectedAmmo - which of the wielded weapon's Projectile links is
+// selected (index into its ordered Projectile links). Many SS2 guns carry
+// several ammo types (e.g. the pistol: standard / HE / AP); firing uses the
+// selected one. Absent = index 0 (the first/default link). Cleared/ignored for
+// weapons with no Projectile links (melee).
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropSelectedAmmo(pub usize);
+
 // RuntimePropFlatAim - the flatscreen camera/crosshair fire ray (world space),
 // set each frame on the player's wielded weapon. When present, weapon firing
 // spawns projectiles from `origin` along `forward` (camera-origin aim) instead

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -72,6 +72,11 @@ pub enum Effect {
         delta: i32,
     },
 
+    /// Cycle the player's wielded weapon to its next ammo type (the next
+    /// `Projectile` link). No-op when no weapon is wielded or it has fewer than
+    /// two projectile links.
+    CycleAmmo,
+
     /// Reload the player's wielded weapon: refill its clip (`PropGunState.ammo`)
     /// to the magazine capacity (`PropBaseGunDesc.clip`). No-op when no weapon is
     /// wielded or it has no gun state / clip. (Reserve ammo is unlimited for now -

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -4,7 +4,8 @@ use cgmath::{Transform, point3};
 use dark::{
     EnvSoundQuery,
     properties::{
-        Link, Links, PropClassTag, PropSymName, PropTemplateId, PropTweqModelConfig, ToLink,
+        Link, Links, ProjectileOptions, PropClassTag, PropGunState, PropSymName, PropTemplateId,
+        PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -38,6 +39,27 @@ pub fn get_all_links_with_template<TData>(
     };
 
     linked_entities
+}
+
+/// A weapon's selectable `Projectile` links (its ammo types), filtered to the
+/// current gun setting and ordered by `ProjectileOptions.order`. This is the
+/// canonical ammo-type list - firing, ammo-type cycling, and the HUD all derive
+/// from it so they agree. A link with a negative `setting` matches any setting;
+/// otherwise it must match the weapon's current `PropGunState.setting`
+/// (defaulting to 0 when the weapon has no gun state).
+pub fn ordered_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, ProjectileOptions)> {
+    let setting = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|g| g.setting))
+        .unwrap_or(0);
+    let mut links = get_all_links_with_template(world, weapon, |link| match link {
+        Link::Projectile(data) => Some(*data),
+        _ => None,
+    });
+    links.retain(|(_, opts)| opts.setting < 0 || opts.setting == setting);
+    links.sort_by_key(|(_, opts)| opts.order);
+    links
 }
 
 pub fn get_first_link_with_template_and_data<TData: Clone>(

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -12,7 +12,8 @@ use crate::{
     mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateClassTags},
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::{
-        RuntimePropFlatAim, RuntimePropReloading, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropFlatAim, RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform,
+        RuntimePropVhots,
     },
     util::{get_rotation_from_forward_vector, resolve_proxy_entity},
     vr_config,
@@ -30,10 +31,7 @@ const MELEE_DAMAGE: f32 = 6.0;
 
 use super::{
     Effect, Message, MessagePayload, Script,
-    script_util::{
-        get_all_links_with_template, get_first_link_with_template_and_data,
-        play_environmental_sound,
-    },
+    script_util::{get_all_links_with_template, play_environmental_sound},
 };
 
 /// Get ammunition type from projectile template using pre-populated class tag map
@@ -79,12 +77,22 @@ impl Script for WeaponScript {
                         _ => None,
                     });
 
-                // TODO: Handle setting or ammo type? This just picks the very first projectile
-                let maybe_projectile =
-                    get_first_link_with_template_and_data(world, entity_id, |link| match link {
+                // Pick the selected ammo type: guns carry several Projectile
+                // links (standard / HE / AP, ...); RuntimePropSelectedAmmo indexes
+                // into them (absent = the first/default link).
+                let projectiles =
+                    get_all_links_with_template(world, entity_id, |link| match link {
                         Link::Projectile(data) => Some(*data),
                         _ => None,
                     });
+                let selected_ammo = world
+                    .borrow::<View<RuntimePropSelectedAmmo>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().map(|s| s.0))
+                    .unwrap_or(0);
+                let maybe_projectile = projectiles
+                    .get(selected_ammo % projectiles.len().max(1))
+                    .cloned();
 
                 // A weapon with no Projectile link is melee. In flat mode a swing
                 // is a short forward raycast along the crosshair ray

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -31,7 +31,9 @@ const MELEE_DAMAGE: f32 = 6.0;
 
 use super::{
     Effect, Message, MessagePayload, Script,
-    script_util::{get_all_links_with_template, play_environmental_sound},
+    script_util::{
+        get_all_links_with_template, ordered_projectile_links, play_environmental_sound,
+    },
 };
 
 /// Get ammunition type from projectile template using pre-populated class tag map
@@ -79,12 +81,8 @@ impl Script for WeaponScript {
 
                 // Pick the selected ammo type: guns carry several Projectile
                 // links (standard / HE / AP, ...); RuntimePropSelectedAmmo indexes
-                // into them (absent = the first/default link).
-                let projectiles =
-                    get_all_links_with_template(world, entity_id, |link| match link {
-                        Link::Projectile(data) => Some(*data),
-                        _ => None,
-                    });
+                // into the ordered, setting-filtered list (absent = the first).
+                let projectiles = ordered_projectile_links(world, entity_id);
                 let selected_ammo = world
                     .borrow::<View<RuntimePropSelectedAmmo>>()
                     .ok()

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -6,6 +6,7 @@ export type InputAction =
   | "SpawnDebugItem"
   | "MoveInventory"
   | "CycleWeapon"
+  | "CycleAmmo"
   | "Reload"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
@@ -132,6 +133,9 @@ export interface PlayerSnapshot {
   reloading: boolean;
   reload_pitch_deg: number;
   reload_progress: number;
+  /** The wielded weapon's selected ammo type (e.g. "std"/"he"/"ap"), or null
+   * when unarmed / single-ammo / melee. */
+  wielded_ammo_type: string | null;
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -134,7 +134,7 @@ export interface PlayerSnapshot {
   reload_pitch_deg: number;
   reload_progress: number;
   /** The wielded weapon's selected ammo type (e.g. "std"/"he"/"ap"), or null
-   * when unarmed / single-ammo / melee. */
+   * when unarmed / melee (no projectile links). */
   wielded_ammo_type: string | null;
 }
 

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end regression test for ammo-type cycling (InputAction::CycleAmmo). The
+// pistol carries three Projectile links (std / he / ap); cycling advances the
+// selected one and wraps. Observable headlessly via /v1/info.wielded_ammo_type.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function ammoType(game: GameServer): Promise<string | null> {
+  return (await game.info()).player.wielded_ammo_type;
+}
+
+test(
+  "cycling advances the wielded weapon's ammo type and wraps",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8099),
+    });
+
+    // Unarmed: no ammo type.
+    await game.step({ frames: 5 });
+    assert.equal(await ammoType(game), null, "unarmed has no ammo type");
+
+    // Wield the pistol (std / he / ap).
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+    assert.equal(await ammoType(game), "std", "pistol starts on its first ammo type");
+
+    // Cycle through all three and wrap back.
+    const sequence: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      await game.input.trigger("CycleAmmo");
+      await game.step({ frames: 2 });
+      sequence.push((await ammoType(game)) ?? "<null>");
+    }
+    assert.deepEqual(
+      sequence,
+      ["he", "ap", "std"],
+      "cycling advances std -> he -> ap and wraps back to std",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -40,10 +40,12 @@ test(
       await game.step({ frames: 2 });
       sequence.push((await ammoType(game)) ?? "<null>");
     }
+    // The cycle order follows ProjectileOptions.order (the data's intended
+    // order), not the raw link order: std -> ap -> he -> std.
     assert.deepEqual(
       sequence,
-      ["he", "ap", "std"],
-      "cycling advances std -> he -> ap and wraps back to std",
+      ["ap", "he", "std"],
+      "cycling advances in ProjectileOptions.order and wraps back to std",
     );
   },
 );


### PR DESCRIPTION
Stacked on #331 (← #330 ← #329).

## What

Cycle a weapon's ammo type and show it on the HUD. Many SS2 guns carry several `Projectile` links (the pistol: std / HE / AP).

- **Cycling** — `InputAction::CycleAmmo` (bound to `T`) → `Effect::CycleAmmo` → advances `RuntimePropSelectedAmmo` on the wielded weapon. Firing uses the selected projectile link.
- **HUD indicator** — the selected ammo's object icon (`P$ObjIcon`, e.g. `STD_I`) + a short label (STD/HE/AP) next to the ammo gauge. The icon is resolved from a template-id→obj-icon map derived from the template metadata already hydrated at load.
- **Ordered/filtered links** — `ordered_projectile_links` filters to the current gun setting and sorts by `ProjectileOptions.order` (the data's intended order — the pistol cycles std → ap → he). Firing, cycling, the HUD, and the API all derive from this one helper.

## Verifiable headlessly

The selected type is on `/v1/info` (`wielded_ammo_type`); `weapon-ammo-type.e2e.test.ts` cycles std → ap → he and wraps. HUD icon/label verified by screenshot (icon swaps on cycle).

## Scope notes (deliberate, documented on `RuntimePropSelectedAmmo`)

- Ammo types share one clip (`PropGunState.ammo`) — switching type doesn't switch loaded rounds. Per-type counts need an inventory-ammo model we don't have yet, so this currently behaves like a fire-mode selector.
- The selection isn't persisted across save/load (consistent with the other runtime props).

🤖 Generated with [Claude Code](https://claude.com/claude-code)