### PR TITLE
feat(physics): drive collider restitution + friction from P$PhysAttr

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,18 @@
 TODO:
 - [ ] Get CI green for changes
 
+Needs human verification (batch these — no automated test covers "feel"):
+- [ ] Object physics: drive collider **density → mass** from `P$PhysAttr.density`
+  (currently hardcoded `0.1`). Shipped default density `1.0` is ~10× heavier, so
+  grabbed/thrown dynamic items will feel different — needs an in-VR / flat
+  playtest. Must also clamp the `density = 1000000.0` "immovable" sentinel so it
+  can't destabilize the Rapier solver. Elasticity + friction already landed; see
+  projects/object-physics-attrs.md.
+- [ ] While playtesting the above, also eyeball the **friction** change that
+  already landed: authored friction (mostly `0.0`) replaced the flat Rapier
+  default `0.5`, so dynamic props are slightly slidier. Low magnitude and covered
+  by automated tests, but confirm it feels right in the same pass.
+
 Recent work
 - (in progress) flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
 - flat runtime -> fix alpha transparency / z-order break

--- a/projects/object-physics-attrs.md
+++ b/projects/object-physics-attrs.md
@@ -1,0 +1,77 @@
+# Object Physics Attributes → Rapier
+
+Threading Dark's authored per-object physics attributes (`P$PhysAttr`) into the
+Rapier simulation. Background and full gap analysis: `research/physics-system-differences.md`
+(Delta #2 is the core of this work).
+
+## Problem
+
+shock2quest parses `PropPhysAttr` (`mass`, `density`, `elasticity`, `friction`,
+`cog`, `rotation_axes`, `rest_axes`, …) but feeds Rapier almost none of it. Every
+dynamic collider was hardcoded to `restitution = 0.7`, `friction = 0.5` (Rapier
+default), `density = 0.1` — so bounce, surface friction, and mass were uniform
+and wrong, regardless of what each object authored.
+
+Only `gravity_scale` and `PhysInitialVelocity` were previously plumbed.
+
+## Scope of the *dynamic-body* change (important)
+
+Per Delta #1, only a small set of objects currently become **dynamic** Rapier
+bodies (creatures, frob-`MOVE` grab items, and `!immobile && SPHERE` objects).
+Everything else is a **kinematic** cuboid (`add_kinematic`), which these
+attributes do not touch. So this work only affects that dynamic subset; letting
+more objects (mobile OBB props) be dynamic is a separate follow-up (Delta #1).
+
+## Slice 1 — elasticity + friction (this PR)
+
+`DynamicPhysicsOptions` now carries `restitution` and `friction`, populated from
+`PropPhysAttr` in `entity_creator.rs` and applied in `physics::add_dynamic`.
+
+- **elasticity → restitution.** Calibrated, not 1:1. Dark's shipped `elasticity`
+  is essentially always `1.0`; a Rapier restitution of `1.0` is a perfect,
+  never-settling bounce. We scale by `ELASTICITY_TO_RESTITUTION = 0.7` so the
+  default-authored object reproduces the previously-hardcoded `0.7`. Net effect
+  on shipped data: **none** (it's a no-op until objects with non-1.0 elasticity
+  appear), but per-object variation now drives the sim correctly.
+- **friction → friction.** Authored friction (`0.0`–`0.4` in the data) replaces
+  the flat Rapier default of `0.5`. This is the one field that changes real-game
+  behavior in this slice: objects are slightly slidier (most author `0.0`). Low
+  magnitude and covered by the unit test, but flagged in `todo.md` to eyeball
+  alongside the density playtest.
+- Non-finite authored `elasticity`/`friction` fall back to the defaults (Dark
+  data can carry non-finite physics values — cf. `sanitize_collider_size`).
+- Entities **without** `PropPhysAttr` are unchanged — `DynamicPhysicsOptions::default()`
+  reproduces the old `{restitution 0.7, friction 0.5, density 0.1}`.
+
+### Verification
+
+- `shock2vr/src/physics/mod.rs` unit tests (deterministic, headless, fixed 1/60
+  step): `higher_restitution_bounces_higher`, `higher_friction_slides_less`.
+  Both were confirmed **red** with the wiring reverted (both bodies reported
+  identical apex / slide distance) and green with it in place.
+- `tools/shock2-sdk/test/missions.e2e.test.ts` — all 23 missions still load.
+
+## Deferred
+
+### Needs human (in-VR / flat) verification — batch these together
+
+- **density → mass.** Mapping `density` (shipped default `1.0`) onto the
+  collider replaces the hardcoded `0.1`, i.e. roughly **10× the mass** for
+  dynamic objects. That changes how grabbed/thrown items feel and how hard the
+  player can push them — there is no automated test for "feel", so it needs a
+  human in the loop. Also requires clamping the `density = 1000000.0`
+  "immovable" sentinel seen in the data so it can't destabilize the solver if
+  such an object ever becomes dynamic. Tracked in `todo.md` under the
+  human-verification batch.
+
+### Other follow-ups (no human gate, but out of scope here)
+
+- **center-of-mass (`cog`)** via `set_center_of_mass`.
+- **`rotation_axes` / `rest_axes`** → `set_enabled_rotations` (today rotations
+  are only ever fully locked, on creatures).
+- **Delta #1 — mobility-based dynamic bodies.** Decide dynamic-vs-kinematic from
+  a mobility flag (`PropImmobile` / Dark's translatable bit) instead of shape,
+  so mobile OBB props can tumble. This is the change that makes the attribute
+  work above *visible* on the majority of props.
+- **friction calibration.** Direct mapping is a reasonable first port;
+  cross-checking Dark's friction model may warrant a scale factor.

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -555,6 +555,36 @@ pub fn initialize_entity_with_props(
     }
 }
 
+/// Calibration constant mapping Dark's authored `elasticity` to a Rapier
+/// restitution. Dark stores elasticity in roughly `[0, 1]` (its shipped default
+/// is `1.0`, "fully elastic"); a Rapier restitution of `1.0` is a perfect,
+/// energy-conserving bounce that never settles and looks unnatural. We scale by
+/// this factor so the default-authored object (`elasticity == 1.0`) reproduces
+/// the value dynamic bodies used before this change (`0.7`), while still letting
+/// per-object variation drive the simulation. Tunable once a faithful
+/// calibration pass is done (see `projects/object-physics-attrs.md`).
+const ELASTICITY_TO_RESTITUTION: f32 = 0.7;
+
+fn dark_elasticity_to_restitution(elasticity: f32) -> f32 {
+    let restitution = elasticity * ELASTICITY_TO_RESTITUTION;
+    // Guard against corrupt/non-finite authored values (some Dark objects carry
+    // non-finite physics data - see `sanitize_collider_size`): `clamp` does not
+    // sanitize NaN, and a NaN/inf restitution can destabilize the solver.
+    if restitution.is_finite() {
+        restitution.clamp(0.0, 1.0)
+    } else {
+        DynamicPhysicsOptions::default().restitution
+    }
+}
+
+fn dark_friction(friction: f32) -> f32 {
+    if friction.is_finite() {
+        friction.max(0.0)
+    } else {
+        DynamicPhysicsOptions::default().friction
+    }
+}
+
 pub fn create_physics_representation(
     world: &mut World,
     physics: &mut PhysicsWorld,
@@ -600,6 +630,8 @@ pub fn create_physics_representation(
     let dynamics_options = if let Ok(phys_attr) = v_phys_attr.get(entity_id) {
         DynamicPhysicsOptions {
             gravity_scale: phys_attr.gravity_scale,
+            restitution: dark_elasticity_to_restitution(phys_attr.elasticity),
+            friction: dark_friction(phys_attr.friction),
         }
     } else {
         DynamicPhysicsOptions::default()

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -40,11 +40,23 @@ bitflags! {
 
 pub struct DynamicPhysicsOptions {
     pub gravity_scale: f32,
+    /// Coefficient of restitution (bounciness). Already calibrated from Dark's
+    /// authored `elasticity` at the call site; see `entity_creator`. The default
+    /// reproduces the value dynamic bodies used before per-object attributes
+    /// were threaded through.
+    pub restitution: f32,
+    /// Coefficient of friction, from Dark's authored `friction`. The default
+    /// reproduces Rapier's default friction (what dynamic bodies used before).
+    pub friction: f32,
 }
 
 impl Default for DynamicPhysicsOptions {
     fn default() -> DynamicPhysicsOptions {
-        DynamicPhysicsOptions { gravity_scale: 1.0 }
+        DynamicPhysicsOptions {
+            gravity_scale: 1.0,
+            restitution: 0.7,
+            friction: 0.5,
+        }
     }
 }
 
@@ -498,7 +510,8 @@ impl PhysicsWorld {
                     //.rotation(vector!(facing.z, facing.x, facing.y))
                     .translation(vec_to_nvec(offset))
                     //.position(test)
-                    .restitution(0.7)
+                    .restitution(opts.restitution)
+                    .friction(opts.friction)
                     .build()
             }
             PhysicsShape::Cuboid(size) => {
@@ -508,7 +521,8 @@ impl PhysicsWorld {
                     //.rotation(vector!(facing.z, facing.x, facing.y))
                     .translation(vec_to_nvec(offset))
                     //.position(test)
-                    .restitution(0.7)
+                    .restitution(opts.restitution)
+                    .friction(opts.friction)
                     .build()
             }
             PhysicsShape::Sphere(size) => {
@@ -517,7 +531,8 @@ impl PhysicsWorld {
                     //.rotation(vector!(facing.z, facing.x, facing.y))
                     .translation(vec_to_nvec(offset))
                     //.position(test)
-                    .restitution(0.7)
+                    .restitution(opts.restitution)
+                    .friction(opts.friction)
                     .build()
             }
         };
@@ -1374,4 +1389,141 @@ fn collision_group_names(bits: u32) -> Vec<String> {
         }
     }
     names
+}
+
+#[cfg(test)]
+mod tests {
+    //! Verify that per-object `DynamicPhysicsOptions` actually drive the Rapier
+    //! simulation. These are deterministic, headless physics tests (fixed 1/60
+    //! step, no mission/asset load) so an agent can confirm the plumbing.
+    use super::*;
+    use cgmath::{Quaternion, vec3};
+
+    fn identity_quat() -> Quaternion<f32> {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    /// A world with a large static floor whose top surface is at `y = 0`, plus a
+    /// throwaway player far away (so it never interacts with the test bodies but
+    /// satisfies `update`'s signature).
+    fn world_with_floor() -> (PhysicsWorld, PlayerHandle) {
+        let mut world = PhysicsWorld::new();
+        let floor = world.create_static_body(
+            Isometry::translation(0.0, -1.0, 0.0),
+            EntityId::from_inner(1000),
+        );
+        world.attach_collider(
+            floor,
+            SharedShape::cuboid(100.0, 1.0, 100.0),
+            1.0,
+            CollisionGroup::entity(),
+        );
+        let player = world.create_player(
+            vec3(1000.0, 1000.0, 1000.0),
+            EntityId::from_inner(1001).unwrap(),
+        );
+        (world, player)
+    }
+
+    fn step(world: &mut PhysicsWorld, player: &mut PlayerHandle, frames: usize) {
+        for _ in 0..frames {
+            world.update(Vector3::new(0.0, 0.0, 0.0), player);
+        }
+    }
+
+    /// A higher-elasticity object must rebound higher than a low-elasticity one
+    /// dropped from the same height. (Negative-first: before `add_dynamic`
+    /// honored `opts.restitution`, both used the hardcoded 0.7 and reached the
+    /// same height, so this assertion failed.)
+    #[test]
+    fn higher_restitution_bounces_higher() {
+        let (mut world, mut player) = world_with_floor();
+
+        let low = world.add_dynamic(
+            EntityId::from_inner(1).unwrap(),
+            vec3(-5.0, 5.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            PhysicsShape::Sphere(0.5),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions {
+                restitution: 0.1,
+                ..Default::default()
+            },
+        );
+        let high = world.add_dynamic(
+            EntityId::from_inner(2).unwrap(),
+            vec3(5.0, 5.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            PhysicsShape::Sphere(0.5),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions {
+                restitution: 0.95,
+                ..Default::default()
+            },
+        );
+
+        // Both balls fall identically (~58 frames to first impact from y=5).
+        // Measure the rebound apex *after* that first contact, so the shared
+        // initial drop height doesn't mask the difference.
+        const SETTLE_FRAMES: usize = 70;
+        let mut low_peak = f32::MIN;
+        let mut high_peak = f32::MIN;
+        for frame in 0..300 {
+            step(&mut world, &mut player, 1);
+            if frame >= SETTLE_FRAMES {
+                low_peak = low_peak.max(world.get_position(low).unwrap().y);
+                high_peak = high_peak.max(world.get_position(high).unwrap().y);
+            }
+        }
+        assert!(
+            high_peak > low_peak + 0.1,
+            "high-restitution apex {high_peak} should exceed low-restitution apex {low_peak}"
+        );
+    }
+
+    /// A higher-friction box, given the same initial horizontal velocity on the
+    /// floor, must travel less far than a low-friction one. (Negative-first:
+    /// before `add_dynamic` honored `opts.friction`, both used Rapier's default
+    /// and traveled the same distance.)
+    #[test]
+    fn higher_friction_slides_less() {
+        let (mut world, mut player) = world_with_floor();
+
+        let make_box = |world: &mut PhysicsWorld, id: u64, z: f32, friction: f32| {
+            let entity = EntityId::from_inner(id).unwrap();
+            let handle = world.add_dynamic(
+                entity,
+                vec3(0.0, 0.5, z),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                PhysicsShape::Cuboid(vec3(1.0, 1.0, 1.0)),
+                CollisionGroup::entity(),
+                false,
+                DynamicPhysicsOptions {
+                    friction,
+                    ..Default::default()
+                },
+            );
+            // Slide, don't tumble: isolate sliding friction from rolling.
+            world.set_enabled_rotations(entity, false, false, false);
+            world.set_velocity(entity, vec3(10.0, 0.0, 0.0));
+            handle
+        };
+
+        let slippery = make_box(&mut world, 1, -5.0, 0.0);
+        let grippy = make_box(&mut world, 2, 5.0, 1.0);
+
+        step(&mut world, &mut player, 120);
+
+        let slippery_x = world.get_position(slippery).unwrap().x;
+        let grippy_x = world.get_position(grippy).unwrap().x;
+        assert!(
+            slippery_x > grippy_x + 1.0,
+            "low-friction box ({slippery_x}) should out-slide high-friction box ({grippy_x})"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Dark's authored per-object physics attributes (`P$PhysAttr`) are parsed but were never fed to Rapier — every dynamic collider was hardcoded to `restitution = 0.7` / `friction = 0.5` (Rapier default), so bounce and surface friction were uniform regardless of what each object authored. This is the first slice of [`research/physics-system-differences.md`](research/physics-system-differences.md) Delta #2.

This PR threads **elasticity + friction** into the simulation. **Density is deliberately deferred** to its own slice (it ~10×'s dynamic-object mass and changes grab/throw *feel*, which needs a human playtest) — tracked in `todo.md` + `projects/object-physics-attrs.md`.

## What changed

- `DynamicPhysicsOptions` gains `restitution` + `friction`; `PhysicsWorld::add_dynamic` applies them across all three dynamic shape arms (Capsule/Cuboid/Sphere). `add_kinematic` is untouched.
- `entity_creator.rs` populates them from `PropPhysAttr`:
  - **elasticity → restitution**, calibrated `× 0.7` (`ELASTICITY_TO_RESTITUTION`) so the shipped default (`elasticity 1.0`) reproduces the old `0.7`; a Rapier restitution of 1.0 is a perfect never-settling bounce, so the scale avoids that.
  - **friction → friction** (authored values, mostly `0.0`).
  - Non-finite authored values fall back to defaults (Dark data can carry non-finite physics values — cf. `sanitize_collider_size`).
- Entities **without** `PropPhysAttr` keep the previous defaults (`0.7 / 0.5 / 0.1`), so behavior there is unchanged.

## Blast radius / regression safety

- Only the small *dynamic* body set is affected (creatures, frob-`MOVE` items, `!immobile && SPHERE`). All OBB/immobile props are kinematic and untouched.
- **restitution is a no-op on shipped data** — authored elasticity is uniformly `1.0` → `1.0 × 0.7 = 0.7` (today's value). The genuine change is **friction** (slightly slidier; flagged for the same playtest pass as density).

## Verification

- **Unit tests** (`shock2vr/src/physics/mod.rs`, deterministic / headless / fixed 1/60 step): `higher_restitution_bounces_higher`, `higher_friction_slides_less`. **Negative-first confirmed** — reverting the wiring makes both bodies report identical apex / slide distance and the tests go red.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt` applied.
- `tools/shock2-sdk/test/missions.e2e.test.ts` — **23/23 missions load**.
- Cross-engine `/xreview` (Claude + Codex): no Critical/High. Applied findings (non-finite sanitization, redundant-spread cleanup, friction/density doc symmetry) and re-validated.

## Follow-ups (documented, out of scope here)

- **density → mass** (needs human feel-verification — batched in `todo.md`).
- center-of-mass (`cog`), `rotation_axes`/`rest_axes` → `set_enabled_rotations`.
- Delta #1: mobility-based dynamic bodies (lets mobile OBB props tumble — makes these attributes *visible* on the majority of props).

🤖 Generated with [Claude Code](https://claude.com/claude-code)