### PR TITLE
feat(flat): faithful first-person viewmodel framing (all 15 weapons)

### DIFF
--- a/.claude/skills/pr-visuals/SKILL.md
+++ b/.claude/skills/pr-visuals/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: pr-visuals
+description: >-
+  Capture a looping GIF + a still PNG of a visual/rendering change and embed them
+  in its pull request. Uses the headless debug runtime (cargo dbgr + HTTP
+  /v1/step + /v1/screenshot - no window interaction, deterministic fixed-timestep
+  stepping), assembles a GIF with PIL, hosts the binaries in a gist (pushed via
+  git, the only token-friendly host for binary images), and embeds them in the PR
+  body. Use whenever a change adds or alters something visible (a viewmodel/HUD/
+  rendering/material/lighting feature, a debug scene, an animation) and you're
+  opening or updating a PR - see CLAUDE.md "Visual changes".
+---
+
+# pr-visuals — capture & embed PR screenshots / GIFs
+
+Produce a short looping GIF **and** a still PNG of a visual change and embed them
+in its PR. Everything runs headlessly through the debug runtime (no manual
+clicking) and deterministically (fixed 60 Hz stepping).
+
+## Context discipline (important)
+
+Verifying the look means **reading PNGs** (image tokens) and running many capture
+commands — that bloats the main context. So **delegate the whole capture → assemble
+→ upload → embed flow to a subagent** and let it return only the final URLs +
+markdown block. Do this with the `Agent` tool (`general-purpose`):
+
+> Spawn a `general-purpose` subagent. Tell it to **read this file**
+> (`.claude/skills/pr-visuals/SKILL.md`) for the full technique and execute it for
+> the given target, then return the gist raw URLs and the markdown block it
+> embedded. Pass it: the scene/mission (e.g. `debug_weapons`), the exact HTTP
+> sequence that shows the feature (actions/inputs/frames), a one-line caption,
+> and the PR number (or "current branch").
+
+The rest of this file is the technique the subagent (or you, if running inline)
+follows.
+
+## 1. Prerequisites
+
+- Built runtime: `cargo build -p debug_runtime` (incremental after a change is
+  seconds; a cold build takes minutes).
+- `python3` with PIL (`Pillow`) for GIF assembly + verification.
+- Run multi-step shell blocks under **`bash`** (heredoc), not the default zsh —
+  zsh misparses hex gist IDs like `832ee3…` as math expressions and aborts.
+
+## 2. Capture stills
+
+Drive the debug runtime over HTTP (see CLAUDE.md "Iterating on Visual Features"
+for the full API):
+
+```bash
+mkdir -p /tmp/shots            # /v1/screenshot does NOT create directories
+cargo dbgr --mission debug_weapons --port 8085 &   # NO extra `--` after dbgr
+until curl -s -m 2 http://127.0.0.1:8085/v1/info >/dev/null; do sleep 2; done
+# ...drive the feature: actions, inputs, stepping...
+curl -s -X POST http://127.0.0.1:8085/v1/input/action -d '{"action":"CycleWeapon"}'
+curl -s -X POST http://127.0.0.1:8085/v1/step -d '{"frames":10}'
+curl -s -X POST http://127.0.0.1:8085/v1/screenshot -d '{"filename":"/tmp/shots/after.png"}'
+# ALWAYS shut down when done:
+curl -s -X POST http://127.0.0.1:8085/v1/shutdown
+```
+
+- **The screenshot path must be ABSOLUTE and its directory must already exist** —
+  the endpoint won't `mkdir`, and `curl` exits 0 on the error response, so a
+  missing dir fails silently. Echo the JSON response instead of `> /dev/null`.
+- `/v1/step` is a **fixed 60 Hz timestep** and blocks until the frames ran;
+  `/v1/screenshot` captures the fully-rendered frame. The same request sequence
+  from a fresh launch produces **byte-identical** images — that determinism is
+  what makes before/after comparable (and `cmp` a cheap "did anything change?").
+- Input channels are dotted paths in flat JSON: `{"right_hand.trigger": 1.0}`,
+  `{"head.look": [yaw_deg, pitch_deg]}` — not nested objects.
+- **`debug_weapons` gotcha:** `CycleWeapon` drops the previously wielded weapon
+  into the world in the look direction, so repeated cycling piles weapon models
+  on the floor — they photobomb screenshots and look like broken viewmodels.
+  Face away before shooting (`{"head.look": [180.0, 0.0]}`) or teleport
+  (`/v1/player/teleport`). To confirm something is camera-anchored (viewmodel)
+  vs world litter, rotate the camera: the viewmodel stays screen-fixed.
+
+## 3. Capture a looping GIF
+
+Step a fixed number of frames between screenshots and stitch:
+
+```bash
+for i in $(seq -w 0 23); do
+  curl -s -X POST http://127.0.0.1:8085/v1/step -d '{"frames":3}' >/dev/null
+  curl -s -X POST http://127.0.0.1:8085/v1/screenshot -d "{\"filename\":\"/tmp/frames/frame_$i.png\"}" >/dev/null
+done
+```
+
+- 3 sim frames per GIF frame at 60 Hz ≈ 20 fps playback with `duration=50`.
+- **Seamless loop:** span one cycle of the animation (e.g. a full melee swing
+  from idle back to idle, one tweq period). If the motion doesn't loop, a small
+  seam is fine for a demo — or bracket it with a few idle frames on each end.
+- Assemble + downscale with PIL (~600px wide is plenty):
+
+```python
+from PIL import Image
+import glob
+files = sorted(glob.glob('/tmp/frames/frame_*.png'))
+W = 600
+frames = []
+for f in files:
+    im = Image.open(f).convert('RGB')
+    frames.append(im.resize((W, int(im.height * W / im.width)), Image.LANCZOS))
+frames[0].save('/tmp/demo.gif', save_all=True, append_images=frames[1:],
+               duration=50, loop=0, optimize=True, disposal=2)
+```
+
+## 4. Before/after (when the change MODIFIES an existing visual)
+
+If the change alters an *existing* rendered element (not a net-new feature),
+include a **before/after** so reviewers see the delta — a one-sided "after"
+can't show what improved. Capture both with the **same request sequence** from a
+fresh launch (deterministic stepping makes them frame-comparable).
+
+- **Cheapest "before":** if you captured baseline screenshots from the pre-change
+  build while iterating, reuse them.
+- **Otherwise build the base ref in a throwaway worktree** (doesn't disturb your
+  branch; point it at the main checkout's game data):
+
+  ```bash
+  BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+  git worktree add /tmp/before "$BASE"
+  ( cd /tmp/before && cargo build -p debug_runtime \
+      && DARK_ASSET_PATH="$(git -C "$(git rev-parse --show-toplevel)" rev-parse --show-toplevel)/Data" \
+         ./target/debug/debug_runtime --mission debug_weapons --port 8086 & )
+  # ...same capture sequence against port 8086, then /v1/shutdown...
+  git worktree remove /tmp/before --force
+  ```
+
+  (The worktree gets its own cold `target/` — budget several minutes.)
+
+- Compose the two into one labeled side-by-side PNG (renders everywhere, one
+  attachment):
+
+  ```python
+  from PIL import Image, ImageDraw, ImageFont
+  b = Image.open('/tmp/before.png').convert('RGB'); a = Image.open('/tmp/after.png').convert('RGB')
+  H = 440; fit = lambda im: im.resize((int(im.width*H/im.height), H), Image.LANCZOS)
+  b, a = fit(b), fit(a); gap = 8
+  c = Image.new('RGB', (b.width+gap+a.width, H+28), (18,8,28)); c.paste(b,(0,28)); c.paste(a,(b.width+gap,28))
+  d = ImageDraw.Draw(c); f = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial Bold.ttf", 20)
+  d.text((8,4), "BEFORE", fill=(255,255,255), font=f); d.text((b.width+gap+8,4), "AFTER", fill=(255,255,255), font=f)
+  c.save('/tmp/beforeafter.png', optimize=True)
+  ```
+
+  Host it with the GIF (host step) and embed it under a "Before → after" heading
+  (embed step). **Skip before/after for net-new features** — there's no prior state.
+
+## 5. Verify
+
+Read a couple of frames (and/or the GIF) back to confirm the look, and confirm the
+animation actually moves (diff two frames with `PIL.ImageChops.difference(...).getbbox()`
+— `None` means identical). Fix framing/timing and re-capture before uploading.
+Watch for the `debug_weapons` floor-litter gotcha (step 2) — make sure what you
+captured is the feature, not a dropped world object.
+
+## 6. Host the media in a gist (binary-safe)
+
+The browser drag-drop `user-attachments` host needs your web session cookies — not
+reachable with a token. A **gist works** as a token-based equivalent, BUT you must
+push binaries via **git** — `gh gist create` flat-out **rejects** a binary file
+(`binary file not supported`), so create the gist with a small **text placeholder**
+first, then git-push the images into it. Gist raw URLs serve the correct `image/*`
+content-type, so they render inline in markdown.
+
+```bash
+bash <<'EOF'
+set -e
+# Create with a TEXT placeholder (gh gist create rejects binary), then git-push the media.
+printf '# shock2quest <feature> — media for PR #<N>\n' > /tmp/gist-readme.md
+URL=$(gh gist create --desc "shock2quest <feature> — media for PR #<N>" /tmp/gist-readme.md 2>&1 | tail -1)
+GID=$(basename "$URL"); USER=$(gh api user -q .login); TOKEN=$(gh auth token)
+rm -rf /tmp/gist && git clone "https://x-access-token:$TOKEN@gist.github.com/$GID.git" /tmp/gist
+cp /tmp/demo.gif /tmp/beforeafter.png /tmp/gist/
+git -C /tmp/gist add -A
+git -C /tmp/gist -c user.email="$(git config user.email)" -c user.name="$(git config user.name)" commit -qm "media"
+git -C /tmp/gist push -q
+for f in demo.gif beforeafter.png; do
+  RAW="https://gist.githubusercontent.com/$USER/$GID/raw/$f"
+  echo "$RAW  [$(curl -sIL "$RAW" | grep -i '^content-type:' | tr -d '\r')]"
+done
+EOF
+```
+
+Confirm each raw URL reports `content-type: image/gif` / `image/png` (proof the
+binary survived and markdown will render it).
+
+## 7. Embed in the PR body
+
+**Do NOT use `gh pr edit --body-file`** here — it hits a Projects-classic GraphQL
+path that errors out and silently leaves the body unchanged. Use the REST API:
+
+```bash
+# fetch current body, insert the media markdown, write to /tmp/body.md, then:
+gh api -X PATCH repos/<owner>/<repo>/pulls/<N> -F body=@/tmp/body.md -q .html_url
+```
+
+Markdown to embed (a caption reads nicely under the GIF):
+
+```markdown
+![<feature> demo](<gif raw url>)
+
+<sub>Short caption. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>
+
+## Before → after
+
+![before/after](<png raw url>)
+```
+
+## 8. Report
+
+Return the gist URL, the raw image URLs, **and the local media paths** (keep the
+captured files on disk, e.g. `/tmp/demo.gif` + the stills, don't delete them), plus
+a confirmation that the PR body was updated (verify with
+`gh pr view <N> --json body -q .body | grep gist`).
+
+## 9. Hand the media to the review (visual verification)
+
+The point of the media isn't just decoration — a reviewer should confirm the
+render **actually exercises the feature and looks correct**. After embedding, run
+`/xreview` and pass the local media paths so **both** image-capable reviewers
+analyze them against the change's claims (e.g. "the GIF should show the wrench
+swinging and returning to the raised idle"):
+
+```
+/xreview --media /tmp/demo.gif,/tmp/shot-t0.png,/tmp/shot-t2.png
+```
+
+Pass the GIF **plus two stills captured at different sim times** — a single image
+is one frame, so motion must be evidenced by distinct stills. Both engines do the
+visual check (Claude via `Read`, Codex via `-i`), so a visual issue both raise is
+high-confidence. Treat a reviewer that can't see the claimed feature in the media
+as a finding to resolve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,20 @@ For a concise contributor checklist, see `AGENTS.md`. This document serves as th
 - Run tests after each change (if available)
 - Use descriptive commit messages that explain the "why"
 
+### 3. Visual Changes
+
+Whenever a change adds or alters something visible (a viewmodel/HUD/rendering/
+material/lighting feature, a debug scene, an animation, a shader), capture a
+short looping GIF and a still PNG of it and embed them in the PR — this is part
+of the definition of done for visual work, so reviewers (human and LLM) can see
+the result. When the change modifies an existing visual, include a before/after
+too (capture the base ref with the same deterministic request sequence). Use the
+**pr-visuals skill** (`.claude/skills/pr-visuals/`): it drives the headless
+debug-runtime capture path (`/v1/step` + `/v1/screenshot` — no window
+interaction, deterministic fixed-timestep), assembles the GIF, hosts the
+binaries in a gist, and embeds them in the PR body — and it runs the capture in
+a subagent so the image-heavy work stays out of the main context.
+
 ## Project Documentation
 
 ### Essential Reading

--- a/TODO.md
+++ b/TODO.md
@@ -17,15 +17,15 @@ Recent work
 - (in progress) flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
 - flat runtime -> fix alpha transparency / z-order break
 - [x] flat runtime -> camera-origin aim along the crosshair (#315); muzzle flash now tracks the weapon via RuntimePropAttachment (#323)
-- flat runtime -> per-weapon viewmodel framing from PropPlayerGun.model_offset (needs a separate wider-FOV viewmodel projection; see projects/flat-weapon-handling.md)
+- [x] flat runtime -> per-weapon viewmodel framing from PropPlayerGun.model_offset (viewmodel-FOV scale + authored offsets + 11.25deg carry pitch; see projects/flat-weapon-handling.md)
 - modernize combat: add recoil / accuracy modifier (like counter-strike)
 - weapon ammo next slices: per-shot m_ammoUsage + clip size from BaseGunDesc (P$BaseGunDe), reload, ammo-type switching (see projects/flat-weapon-handling.md)
 
 - Fable: finish ragdolls (in progress) - hitbox-fitted colliders + rapier 0.31 compliant joints settle into a heap; on-death ragdoll behind `--experimental ragdoll`; multibody rig still experimental (extremity jitter / hip-sag), see projects/ragdoll-settling-followup.md
 - Fable: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped; broader AI behavior testing ongoing
 - Fable: check to see feasibility of loading the 25th anniversary assets
-- Fable: fix flat screen first-person melee weapon orientation (camSynch / root-override; arm hangs low + stub visible - plan in projects/flat-weapon-handling.md)
-- Fable: fix flat screen first-person ranged weapon positioning (per-weapon model_offset framing, above)
+- [x] Fable: fix flat screen first-person melee weapon orientation (camSynch equivalent: root-motion cancel + authored PlayerMelee arm anchor; projects/flat-weapon-handling.md)
+- [x] Fable: fix flat screen first-person ranged weapon positioning (per-weapon model_offset framing, above)
 
 
 SNACKS:

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -78,6 +78,7 @@ impl AnimatedModel {
             Some(AnimationInfo {
                 animation_clip: &animation_clip,
                 frame,
+                cancel_root_motion: false,
             }),
             &rpds::HashTrieMap::new(),
         );

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -34,6 +34,10 @@ pub struct AnimationPlayer {
     current_frame: u32,
     remaining_time: f32,
     blend_state: Option<BlendState>,
+    /// Pose with the clip's root motion cancelled (see
+    /// `AnimationInfo::cancel_root_motion`). Set for first-person viewmodels,
+    /// whose entity transform is re-anchored to the camera every frame.
+    cancel_root_motion: bool,
 }
 
 impl AnimationPlayer {
@@ -46,6 +50,7 @@ impl AnimationPlayer {
             current_frame: 0,
             remaining_time: 0.0,
             blend_state: None,
+            cancel_root_motion: false,
         }
     }
     pub fn from_animation(animation_clip: Rc<AnimationClip>) -> AnimationPlayer {
@@ -58,6 +63,7 @@ impl AnimationPlayer {
             current_frame: 0,
             remaining_time: 0.0,
             blend_state: None,
+            cancel_root_motion: false,
         }
     }
     pub fn queue_animation(
@@ -91,7 +97,16 @@ impl AnimationPlayer {
             current_frame: 0,
             remaining_time: 0.0,
             blend_state,
+            cancel_root_motion: player.cancel_root_motion,
         }
+    }
+
+    /// A copy of `player` that poses with the clip's root motion cancelled
+    /// (see `AnimationInfo::cancel_root_motion`).
+    pub fn with_root_motion_cancelled(player: &AnimationPlayer) -> AnimationPlayer {
+        let mut new_player = player.clone();
+        new_player.cancel_root_motion = true;
+        new_player
     }
 
     pub fn set_additional_joint_transform(
@@ -109,6 +124,7 @@ impl AnimationPlayer {
             current_frame: player.current_frame,
             remaining_time: player.remaining_time,
             blend_state: player.blend_state.clone(),
+            cancel_root_motion: player.cancel_root_motion,
         }
     }
 
@@ -193,6 +209,7 @@ impl AnimationPlayer {
                             current_frame: next_frame - current_clip.num_frames,
                             remaining_time: remaining_duration,
                             blend_state,
+                            cancel_root_motion: player.cancel_root_motion,
                         },
                         motion_flags,
                         events,
@@ -211,6 +228,7 @@ impl AnimationPlayer {
                                 current_frame: 0,
                                 remaining_time: 0.0,
                                 blend_state,
+                                cancel_root_motion: player.cancel_root_motion,
                             },
                             motion_flags,
                             events,
@@ -238,6 +256,7 @@ impl AnimationPlayer {
                         current_frame: next_frame,
                         remaining_time: remaining_duration,
                         blend_state,
+                        cancel_root_motion: player.cancel_root_motion,
                     },
                     motion_flags,
                     events,
@@ -277,6 +296,7 @@ impl AnimationPlayer {
             current_clip,
             current_frame,
             &self.additional_joint_transforms,
+            self.cancel_root_motion,
         );
 
         if let Some(blend) = &self.blend_state {
@@ -293,6 +313,7 @@ impl AnimationPlayer {
                     &blend.from_clip,
                     frame,
                     &self.additional_joint_transforms,
+                    self.cancel_root_motion,
                 );
 
                 animated_transforms =
@@ -308,12 +329,14 @@ impl AnimationPlayer {
         clip: &AnimationClip,
         frame: u32,
         additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
+        cancel_root_motion: bool,
     ) -> [Matrix4<f32>; 40] {
         let animated_skeleton = ss2_skeleton::animate(
             skeleton,
             Some(AnimationInfo {
                 animation_clip: clip,
                 frame,
+                cancel_root_motion,
             }),
             additional_joint_transforms,
         );

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -389,6 +389,14 @@ fn calc_and_cache_global_transform(
 pub struct AnimationInfo<'a> {
     pub animation_clip: &'a AnimationClip,
     pub frame: u32,
+    /// Cancel the clip's root motion: both the per-frame clip root transform
+    /// and the root joint's animation transform are replaced with identity, so
+    /// the posed skeleton stays anchored at the model origin and only the
+    /// relative joints carry the gesture. Used for the first-person viewmodel,
+    /// where the entity transform is re-anchored to the camera every frame (the
+    /// original engine does this with a virtual "camSynch" motion that bolts
+    /// the arm root to the camera).
+    pub cancel_root_motion: bool,
 }
 
 pub fn animate(
@@ -403,6 +411,7 @@ pub fn animate(
     let root_transform = if let Some(AnimationInfo {
         animation_clip,
         frame,
+        cancel_root_motion,
     }) = animation_info
     {
         let normalized_frame = frame % animation_clip.num_frames;
@@ -412,12 +421,29 @@ pub fn animate(
             animation_transforms.insert(*joint, frames[normalized_frame as usize]);
         }
 
-        // Get the root transform for this frame
-        if animation_clip.root_transforms.is_empty() {
+        if cancel_root_motion {
+            // Drop the clip's transform for the root joint(s) so only the bind
+            // local applies; the per-frame clip root transform below is also
+            // skipped. The remaining joints keep only their ROTATION - the
+            // gesture is an orientation overlay on the rig's fixed bone
+            // lengths, and the clips' per-joint translations carry root-motion
+            // style displacement that would stretch the limbs. See
+            // `AnimationInfo::cancel_root_motion`.
+            for bone in &bones {
+                if bone.parent_id.is_none() {
+                    animation_transforms.remove(&bone.joint_id);
+                }
+            }
+            for transform in animation_transforms.values_mut() {
+                transform.w.x = 0.0;
+                transform.w.y = 0.0;
+                transform.w.z = 0.0;
+            }
+            Matrix4::identity()
+        } else if animation_clip.root_transforms.is_empty() {
             Matrix4::identity()
         } else {
-            let root_transform = animation_clip.root_transforms[normalized_frame as usize];
-            root_transform
+            animation_clip.root_transforms[normalized_frame as usize]
         }
     } else {
         Matrix4::identity()
@@ -450,4 +476,99 @@ pub fn animate(
 
 fn translation_from_matrix(matrix: &Matrix4<f32>) -> Vector3<f32> {
     matrix.w.truncate()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::motion::AnimationClip;
+    use std::time::Duration;
+
+    /// Two-bone skeleton (root joint 0, child joint 1 offset (1,0,0)) posed by
+    /// a one-frame clip whose root joint, child joint, and per-frame root
+    /// transform all carry translations.
+    fn test_skeleton_and_clip() -> (Skeleton, AnimationClip) {
+        let bones = vec![
+            Bone {
+                joint_id: 0,
+                parent_id: None,
+                local_transform: Matrix4::identity(),
+            },
+            Bone {
+                joint_id: 1,
+                parent_id: Some(0),
+                local_transform: Matrix4::from_translation(Vector3::new(1.0, 0.0, 0.0)),
+            },
+        ];
+        let mut joint_to_frame = HashMap::new();
+        joint_to_frame.insert(
+            0,
+            vec![Matrix4::from_translation(Vector3::new(5.0, 0.0, 0.0))],
+        );
+        joint_to_frame.insert(
+            1,
+            vec![Matrix4::from_translation(Vector3::new(2.0, 0.0, 0.0))],
+        );
+        let clip = AnimationClip {
+            num_frames: 1,
+            time_per_frame: Duration::from_millis(33),
+            duration: Duration::from_millis(33),
+            blend_length: Duration::ZERO,
+            end_rotation: Deg(0.0),
+            sliding_velocity: Vector3::new(0.0, 0.0, 0.0),
+            translation: Vector3::new(0.0, 0.0, 0.0),
+            joint_to_frame,
+            root_transforms: vec![Matrix4::from_translation(Vector3::new(0.0, 10.0, 0.0))],
+            motion_flags: Vec::new(),
+            name: None,
+        };
+        (Skeleton::create_from_bones(bones), clip)
+    }
+
+    #[test]
+    fn animate_applies_clip_root_motion_by_default() {
+        let (skeleton, clip) = test_skeleton_and_clip();
+        let posed = animate(
+            &skeleton,
+            Some(AnimationInfo {
+                animation_clip: &clip,
+                frame: 0,
+                cancel_root_motion: false,
+            }),
+            &immutable::HashTrieMap::new(),
+        );
+        let transforms = posed.get_transforms();
+        // Root = clip root transform (0,10,0) * root joint anim (5,0,0).
+        assert_eq!(
+            translation_from_matrix(&transforms[0]),
+            Vector3::new(5.0, 10.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn animate_cancel_root_motion_pins_root_and_strips_joint_translations() {
+        let (skeleton, clip) = test_skeleton_and_clip();
+        let posed = animate(
+            &skeleton,
+            Some(AnimationInfo {
+                animation_clip: &clip,
+                frame: 0,
+                cancel_root_motion: true,
+            }),
+            &immutable::HashTrieMap::new(),
+        );
+        let transforms = posed.get_transforms();
+        // Root stays at the model origin: both the per-frame clip root
+        // transform and the root joint's animation transform are cancelled.
+        assert_eq!(
+            translation_from_matrix(&transforms[0]),
+            Vector3::new(0.0, 0.0, 0.0)
+        );
+        // The child keeps its bind offset; the clip's per-joint translation
+        // (which would stretch the limb) is stripped.
+        assert_eq!(
+            translation_from_matrix(&transforms[1]),
+            Vector3::new(1.0, 0.0, 0.0)
+        );
+    }
 }

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -10,6 +10,53 @@ See also: `projects/flatscreen-and-vr-architecture.md` (the intent/outcome seam
 that all of this must respect), `projects/melee-combat.md`,
 `projects/player-damage.md`.
 
+## Status / progress (2026-07-01): faithful viewmodel framing + camSynch
+
+Both long-standing viewmodel TODOs below are **done** - per-weapon gun framing
+from `model_offset` (the FOV blocker is solved) and the melee camSynch/root
+override. All 15 roster weapons (11 guns + 4 melee) now frame correctly in
+`debug_weapons`.
+
+- **Viewmodel FOV, without a second render pass.** SS2 frames the FP models for
+  its original wide FOV (90 deg horizontal / ~74 vertical at 4:3); our world
+  projection is 45 deg vertical, which made faithful offsets render the
+  close-up viewmodel enormous. Instead of a separate projection pass, the
+  viewmodel is scaled toward the view axis in camera space by
+  `tan(world_fov/2) / tan(viewmodel_fov/2)` (`VIEWMODEL_FOV_Y_DEG = 73.74` in
+  `mission_core`): every vertex lands on exactly the pixel the wider-FOV
+  projection would produce (depth unchanged; only lighting normals are
+  slightly non-uniform). This one transform is what unblocked faithful
+  `model_offset` framing for every gun at once.
+- **Per-weapon gun framing** (`flat_player_controller`): guns place at their
+  authored `PropPlayerGun.model_offset`, converted from Dark view axes with
+  `look = vec3(-mo.y, mo.z, mo.x)`, plus the original's **carry pitch**: the
+  wielded gun idles pitched down 11.25 deg, and the same pitch swings the
+  framing offset down around the camera (the original raises the gun to level
+  only around firing - raise-on-fire is a possible follow-up). The old shared
+  `VIEWMODEL_OFFSET` remains only as the non-gun fallback. `heading` stays
+  deliberately unused (see 2026-06-21 note).
+- **Melee camSynch equivalent** (the "arm hangs low / stub visible" fix):
+  - `AnimationPlayer::with_root_motion_cancelled` -> `ss2_skeleton::animate`
+    `AnimationInfo.cancel_root_motion`: cancels the clip's per-frame root
+    transform AND the root joint's animation transform, and strips per-joint
+    translations so the gesture is a pure **orientation overlay** on the rig's
+    fixed bone lengths (the clips' joint translations otherwise stretch the
+    arm mid-swing). Unit-tested in `ss2_skeleton::tests`.
+  - The flat controller anchors the melee arm at the **authored** offset from
+    the gamesys `PlayerMelee` motion archetype (-761, `P$MotPlyrLi`: pos
+    (0.2, -0.6, -2.4) Dark axes, ang 0) - `MELEE_VIEWMODEL_OFFSET` documents
+    this; the property itself is still unparsed (single consumer). Rotation is
+    the camera rotation plus an empirical 180 deg yaw (the FP arm rig comes
+    out back-to-front through our CAL->skeleton conversion; the baked +90 root
+    yaw in `ss2_skeleton::create` is creature-tuned).
+  - The melee idle is still the static frame 0 of `ph212203`; a looping,
+    ticking idle player is now trivially possible (root motion no longer
+    drifts) and is a nice follow-up.
+- **Verification**: `debug_weapons` + screenshots per weapon (idle for all 15,
+  swing phases for the wrench); full SDK e2e suite green (the muzzle-flash
+  test's movement threshold was recalibrated - the pistol now sits ~0.5 world
+  units from the eye, so a 30 deg turn moves it ~0.25, not >0.3).
+
 ## Status / progress (2026-06-27)
 
 Weapon **ammo** landed (#326 data/firing, #327 HUD):
@@ -72,7 +119,8 @@ Verified: the pistol hit-spang and the grenade land dead-center on the crosshair
 
 Remaining (follow-ups):
 
-- **TODO(fable model): per-weapon viewmodel framing from `PropPlayerGun.model_offset`.**
+- ~~**TODO(fable model): per-weapon viewmodel framing from `PropPlayerGun.model_offset`.**~~
+  **(done 2026-07-01 - see status at top: viewmodel-FOV scale + authored offsets + carry pitch.)**
   Currently the flat viewmodel uses a single shared `VIEWMODEL_OFFSET` for every
   weapon (playable: all 11 frame bottom-right with the crosshair clear).
   Investigated wiring per-weapon `model_offset` and it does NOT reduce to one
@@ -140,7 +188,8 @@ What we implemented (this PR):
 - **Swing**: `Effect::FlatMeleeSwing` plays `leftswing` once on attack, then
   returns to the static idle.
 
-**TODO(camSynch / root override)** — the remaining orientation issue. Symptom:
+~~**TODO(camSynch / root override)**~~ **(done 2026-07-01 - see status at top:
+`cancel_root_motion` + authored `PlayerMelee` arm anchor.)** The original issue: Symptom:
 the idle/swing arm hangs somewhat low and the arm *stub* (open cut end) is
 visible, because the clip's root motion isn't cancelled (the original engine's
 camSynch re-anchors the arm root to the camera every frame; we don't).

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -27,15 +27,19 @@ use crate::{
 
 /// Fallback viewmodel framing offset (look space: +x right, +y up, -z forward),
 /// before the world-scale divide. Used only for wielded items with no
-/// `PropPlayerGun` (guns use their authored per-weapon `model_offset`).
+/// `PropPlayerGun` and no `PropLimbModel` (guns and melee use authored
+/// offsets). Tuned before the viewmodel-FOV scale existed, so such items now
+/// read a bit smaller; retune if a real pickup ends up on this path.
 const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
 /// Viewmodel offset for melee weapons (PropLimbModel, no PropPlayerGun): the
 /// authored arm anchor from the gamesys `PlayerMelee` motion archetype's
-/// "Arm Pos Offset" (0.2, -0.6, -2.4) - Dark view axes (x fwd, y left, z up) -
-/// converted to look space. The arm ROOT sits there (below/right of the eye);
-/// the melee pose (root motion cancelled) raises the hand from it. Its "Arm
-/// Ang Offset" is zero, so the arm root takes the camera rotation directly.
-const MELEE_VIEWMODEL_OFFSET: Vector3<f32> = vec3(0.6, -2.4, -0.2);
+/// "Arm Pos Offset" (0.2, -0.6, -2.4) - Dark camera axes (x back, y left,
+/// z up), same convention as `PropPlayerGun.model_offset` - pre-converted to
+/// look space. The arm ROOT sits there (below/right of and just behind the
+/// eye); the melee pose (root motion cancelled) raises the hand from it. Its
+/// "Arm Ang Offset" is zero, so the arm root takes the camera rotation
+/// directly.
+const MELEE_VIEWMODEL_OFFSET: Vector3<f32> = vec3(0.6, -2.4, 0.2);
 /// Camera (eye) height above the player's feet, in SS2 units before the
 /// world-scale divide. Shared with the runtimes' render-camera `head_offset` via
 /// `crate::PLAYER_EYE_HEIGHT` so the shot/viewmodel origin coincides with the
@@ -151,24 +155,25 @@ impl FlatPlayerController {
 
         // Place the viewmodel + fire on the trigger edge.
         if let Some(entity_id) = self.wielded_entity {
-            // First-person framing from the weapon's native PropPlayerGun
-            // (model_offset + heading), falling back to a fixed offset for
-            // non-gun pickups. This intentionally ignores the VR hand-model
-            // table, which is keyed inconsistently and drops per-weapon heading.
-            // The first-person `hand_model` meshes all share one orientation,
-            // corrected by a single base yaw. NB: PropPlayerGun.heading is NOT
-            // the FP model's rotation - applying it over-rotates exactly by its
-            // value (the shotgun/assault 90deg, the psi-amp 180deg), so it is
-            // deliberately not used here. Position uses a shared framing offset
-            // for now (per-weapon model_offset placement is a TODO).
-            // Melee weapons (PropLimbModel, no model_offset) use a closer offset
-            // so they read larger; guns use the shared offset.
+            // First-person framing: guns place at their authored per-weapon
+            // `PropPlayerGun.model_offset` (plus the carry pitch below); melee
+            // arms anchor at the authored PlayerMelee arm offset; anything
+            // else falls back to `VIEWMODEL_OFFSET`. This intentionally
+            // ignores the VR hand-model table, which is keyed inconsistently
+            // and drops per-weapon heading. The first-person `hand_model`
+            // meshes all share one orientation, corrected by a single base
+            // yaw. NB: PropPlayerGun.heading is NOT the FP model's rotation -
+            // applying it over-rotates exactly by its value (the
+            // shotgun/assault 90deg, the psi-amp 180deg), so it is
+            // deliberately not used here.
             let is_melee = world
                 .borrow::<View<PropLimbModel>>()
                 .map(|v| v.get(entity_id).is_ok())
                 .unwrap_or(false);
-            // Guns use their authored per-weapon `model_offset`, converted from
-            // Dark view axes (x back, y left, z up) to look space.
+            // Authored offsets are in Dark camera axes (x back, y left, z up);
+            // look space is (+x right, +y up, -z forward), so the conversion
+            // is `vec3(-o.y, o.z, o.x)` (`MELEE_VIEWMODEL_OFFSET` is stored
+            // pre-converted).
             let gun_offset = world
                 .borrow::<View<PropPlayerGun>>()
                 .ok()

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -14,7 +14,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use dark::{
     SCALE_FACTOR,
-    properties::{PropFrobInfo, PropLimbModel},
+    properties::{PropFrobInfo, PropLimbModel, PropPlayerGun},
 };
 
 use crate::{
@@ -25,14 +25,17 @@ use crate::{
     virtual_hand::{VirtualHandEffect, can_grab_item},
 };
 
-/// Shared viewmodel framing offset (look space: +x right, +y up, -z forward),
-/// before the world-scale divide. Used for guns for now; per-weapon
-/// `PropPlayerGun.model_offset` placement is a TODO.
+/// Fallback viewmodel framing offset (look space: +x right, +y up, -z forward),
+/// before the world-scale divide. Used only for wielded items with no
+/// `PropPlayerGun` (guns use their authored per-weapon `model_offset`).
 const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
-/// Viewmodel offset for melee weapons (PropLimbModel, no PropPlayerGun). They
-/// sit closer to the camera (smaller forward) than guns so they read larger /
-/// further back, matching how the FP melee meshes are framed.
-const MELEE_VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -3.0);
+/// Viewmodel offset for melee weapons (PropLimbModel, no PropPlayerGun): the
+/// authored arm anchor from the gamesys `PlayerMelee` motion archetype's
+/// "Arm Pos Offset" (0.2, -0.6, -2.4) - Dark view axes (x fwd, y left, z up) -
+/// converted to look space. The arm ROOT sits there (below/right of the eye);
+/// the melee pose (root motion cancelled) raises the hand from it. Its "Arm
+/// Ang Offset" is zero, so the arm root takes the camera rotation directly.
+const MELEE_VIEWMODEL_OFFSET: Vector3<f32> = vec3(0.6, -2.4, -0.2);
 /// Camera (eye) height above the player's feet, in SS2 units before the
 /// world-scale divide. Shared with the runtimes' render-camera `head_offset` via
 /// `crate::PLAYER_EYE_HEIGHT` so the shot/viewmodel origin coincides with the
@@ -44,6 +47,11 @@ const HEAD_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT;
 /// at -90deg; `heading` then corrects models authored at other angles (e.g. the
 /// shotgun's 90deg). Tuned against the FP models, NOT the VR hand-model table.
 const VIEWMODEL_BASE_YAW_DEG: f32 = -90.0;
+
+/// Carried guns idle pitched down slightly; the original raises the gun to
+/// level only around firing. The same pitch also swings the framing offset
+/// down around the camera, so the carried gun sits lower on screen.
+const GUN_CARRY_PITCH_DEG: f32 = -11.25;
 
 pub struct FlatPlayerController {
     wielded_entity: Option<EntityId>,
@@ -159,15 +167,39 @@ impl FlatPlayerController {
                 .borrow::<View<PropLimbModel>>()
                 .map(|v| v.get(entity_id).is_ok())
                 .unwrap_or(false);
+            // Guns use their authored per-weapon `model_offset`, converted from
+            // Dark view axes (x back, y left, z up) to look space.
+            let gun_offset = world
+                .borrow::<View<PropPlayerGun>>()
+                .ok()
+                .and_then(|v| v.get(entity_id).ok().map(|g| g.model_offset));
             let offset = if is_melee {
                 MELEE_VIEWMODEL_OFFSET
+            } else if let Some(mo) = gun_offset {
+                vec3(-mo.y, mo.z, mo.x)
             } else {
                 VIEWMODEL_OFFSET
             };
-            let rotation = look * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG));
+            // Melee arms take the camera rotation directly (camSynch semantics:
+            // root = ang offset * camera rotation, and the authored ang offset
+            // is zero); the gun meshes share one orientation corrected by a
+            // single base yaw, plus the carry pitch (which also swings the
+            // framing offset down around the camera).
+            let (rotation, position) = if is_melee {
+                (
+                    look * Quaternion::from_angle_y(Deg(180.0)),
+                    camera_pos + look.rotate_vector(offset / SCALE_FACTOR),
+                )
+            } else {
+                let pitch = Quaternion::from_angle_x(Deg(GUN_CARRY_PITCH_DEG));
+                (
+                    look * pitch * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG)),
+                    camera_pos + (look * pitch).rotate_vector(offset / SCALE_FACTOR),
+                )
+            };
             effects.push(VirtualHandEffect::SetPositionRotation {
                 entity_id,
-                position: camera_pos + look.rotate_vector(offset / SCALE_FACTOR),
+                position,
                 rotation,
                 scale: vec3(1.0, 1.0, 1.0),
             });

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2217,6 +2217,12 @@ impl MissionCore {
                         // uses its swing player; otherwise melee holds the static
                         // player-melee idle (frame 0 = head-up ready stance); guns
                         // use the empty/bind pose. No-op for static meshes.
+                        // Melee poses cancel the clip's root motion: the arm is
+                        // anchored to the camera by the entity transform every
+                        // frame (the original engine's camSynch virtual motion),
+                        // so only the relative joints carry the gesture -
+                        // otherwise the arm hangs low and its open cut end is
+                        // visible.
                         let swing_player = self
                             .flat_melee_anim
                             .as_ref()
@@ -2233,6 +2239,11 @@ impl MissionCore {
                                 .unwrap_or_else(AnimationPlayer::empty),
                             (false, None) => AnimationPlayer::empty(),
                         };
+                        let player = if is_melee {
+                            AnimationPlayer::with_root_motion_cancelled(&player)
+                        } else {
+                            player
+                        };
                         model.as_ref().to_animated_scene_objects(&player)
                     } else if let Some(model) = self.id_to_model.get(&weapon) {
                         match self.id_to_animation_player.get(&weapon) {
@@ -2242,9 +2253,24 @@ impl MissionCore {
                     } else {
                         Vec::new()
                     };
+                    // The FP models are framed for the game's original, much
+                    // wider field of view (90 deg horizontal / ~74 vertical at
+                    // 4:3); under our narrower world projection the close-up
+                    // viewmodel fills the screen. Instead of a second render
+                    // pass with its own projection, scale the viewmodel toward
+                    // the view axis in camera space by
+                    // tan(world_fov/2) / tan(viewmodel_fov/2): every vertex
+                    // lands on exactly the pixel the wider-FOV projection would
+                    // put it on (depth is unchanged).
+                    const VIEWMODEL_FOV_Y_DEG: f32 = 73.74; // 90 deg horizontal at 4:3
+                    let tan_world = 1.0 / projection.y.y;
+                    let tan_vm = (VIEWMODEL_FOV_Y_DEG / 2.0).to_radians().tan();
+                    let s = tan_world / tan_vm;
+                    let squish =
+                        view.invert().unwrap() * Matrix4::from_nonuniform_scale(s, s, 1.0) * view;
                     for (i, obj) in scene_objs.into_iter().enumerate() {
                         let mut o = obj.clone();
-                        o.set_transform(xform);
+                        o.set_transform(squish * xform);
                         if i == 0 {
                             o.set_clear_depth(true);
                         }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -74,8 +74,9 @@ use crate::{
     physics::{self, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
-        RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropAttachment, RuntimePropDoNotSerialize, RuntimePropFlatAim,
+        RuntimePropJointTransforms, RuntimePropReloading, RuntimePropSelectedAmmo,
+        RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -2276,6 +2277,36 @@ impl MissionCore {
                         }
                         ret.push(o);
                     }
+
+                    // Entities bolted to the viewmodel (muzzle flash etc.,
+                    // skipped in the world pass) draw here too so they share
+                    // the viewmodel-FOV scale - otherwise they keep their true
+                    // camera-space offset while the weapon is scaled toward
+                    // the view axis, and float away from the barrel.
+                    let attached: Vec<(EntityId, Matrix4<f32>)> = {
+                        let v_attach = self.world.borrow::<View<RuntimePropAttachment>>().unwrap();
+                        let v_transform =
+                            self.world.borrow::<View<RuntimePropTransform>>().unwrap();
+                        v_attach
+                            .iter()
+                            .with_id()
+                            .filter(|(_, a)| a.parent == weapon)
+                            .filter_map(|(id, _)| v_transform.get(id).ok().map(|t| (id, t.0)))
+                            .collect()
+                    };
+                    for (attached_id, attached_xform) in attached {
+                        if let Some(model) = self.id_to_model.get(&attached_id) {
+                            let objs = match self.id_to_animation_player.get(&attached_id) {
+                                Some(player) => model.to_animated_scene_objects(player),
+                                None => model.to_scene_objects().clone(),
+                            };
+                            for obj in objs {
+                                let mut o = obj.clone();
+                                o.set_transform(squish * attached_xform);
+                                ret.push(o);
+                            }
+                        }
+                    }
                 }
             }
 
@@ -2391,17 +2422,36 @@ impl MissionCore {
         let mut rendered_model_count = 0;
 
         // In flat mode the wielded weapon is drawn as a first-person viewmodel in
-        // `render_per_eye` (on top, depth-test off), so skip it in the world pass.
-        let flat_viewmodel_entity = if options.presentation_mode == crate::PresentationMode::Flat {
-            self.interaction.viewmodel_entity()
-        } else {
-            None
-        };
+        // `render_per_eye` (on top, depth-test off), so skip it in the world
+        // pass - along with anything attached to it (muzzle flash), which is
+        // drawn in the same viewmodel pass so it shares the viewmodel-FOV
+        // scale (in the world pass the flash would keep its true camera-space
+        // offset while the weapon is scaled toward the view axis, and float
+        // away from the barrel).
+        let flat_viewmodel_skip: HashSet<EntityId> =
+            if options.presentation_mode == crate::PresentationMode::Flat {
+                self.interaction
+                    .viewmodel_entity()
+                    .map(|vm| {
+                        let v_attach = self.world.borrow::<View<RuntimePropAttachment>>().unwrap();
+                        let mut skip: HashSet<EntityId> = v_attach
+                            .iter()
+                            .with_id()
+                            .filter(|(_, a)| a.parent == vm)
+                            .map(|(id, _)| id)
+                            .collect();
+                        skip.insert(vm);
+                        skip
+                    })
+                    .unwrap_or_default()
+            } else {
+                HashSet::new()
+            };
 
         // Render models
         for (entity_id, objs) in &self.id_to_model {
             total_model_count += 1;
-            if Some(*entity_id) == flat_viewmodel_entity {
+            if flat_viewmodel_skip.contains(entity_id) {
                 continue;
             }
             if !has_refs(&self.world, *entity_id) {

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -75,14 +75,16 @@ test(
 
     const offsetB = dist(pistolB, flashB);
 
-    // The viewmodel actually moved with the camera...
+    // The viewmodel actually moved with the camera... (the pistol's authored
+    // model_offset keeps it ~0.5 world units from the eye, so a 30deg turn
+    // moves it ~0.25)
     assert.ok(
-      dist(pistolA, pistolB) > 0.3,
+      dist(pistolA, pistolB) > 0.15,
       `pistol should move when the camera turns (moved ${dist(pistolA, pistolB).toFixed(3)})`,
     );
     // ...the flash moved too (it isn't pinned at the spawn pose)...
     assert.ok(
-      dist(flashA, flashB) > 0.3,
+      dist(flashA, flashB) > 0.15,
       `flash should move with the weapon, not stay pinned (moved ${dist(flashA, flashB).toFixed(3)})`,
     );
     // ...and crucially its rigid offset from the weapon is preserved.


### PR DESCRIPTION
Fixes the flat first-person viewmodel mispositioning across the whole roster (11 guns + 4 melee), verified per-weapon in `debug_weapons`.

## Visuals

![wrench melee swing](https://gist.githubusercontent.com/tommy-xr/52730e13c75e29c7fcdf5a43ce7161d1/raw/wrench_swing.gif)

<sub>Wrench swing returning to the raised idle. Captured headlessly via the debug runtime's deterministic `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![pistol before/after](https://gist.githubusercontent.com/tommy-xr/52730e13c75e29c7fcdf5a43ce7161d1/raw/pistol_ba.png)

<sub>Pistol: before, the gun renders as a tiny model tucked into the corner; after, authored per-weapon offset + carry pitch under the viewmodel-FOV scale gives classic FPS framing.</sub>

![wrench before/after](https://gist.githubusercontent.com/tommy-xr/52730e13c75e29c7fcdf5a43ce7161d1/raw/wrench_ba.png)

<sub>Wrench: before, the arm hangs low with the severed cut end visible; after, the camSynch-equivalent root-motion cancel holds it at the raised ready stance.</sub>


## What was wrong

- Guns used one shared eyeballed framing offset (per-weapon `model_offset` was blocked on a FOV mismatch - see `projects/flat-weapon-handling.md`).
- Melee arms hung low with the arm's open cut end visible in the corner: the gesture clips carry root motion that the original engine cancels by re-anchoring the arm root to the camera every frame (its `camSynch` virtual motion), which we didn't implement.

## What changed

- **Viewmodel FOV without a second render pass** (`mission_core`): the FP models are framed for the game's original ~74°-vertical FOV; under our 45° world projection faithful offsets rendered them enormous. The viewmodel is scaled toward the view axis in camera space by `tan(world_fov/2)/tan(viewmodel_fov/2)` - every vertex lands on exactly the pixel a wider-FOV viewmodel projection would produce (depth unchanged).
- **Guns** (`flat_player_controller`): placed at their authored `PropPlayerGun.model_offset` (Dark camera axes → look space), plus the original's 11.25° carry pitch, which also swings the framing offset down around the camera. The shared offset remains only as a non-gun fallback.
- **Melee camSynch equivalent** (`dark`): `AnimationPlayer::with_root_motion_cancelled` → `AnimationInfo.cancel_root_motion` in `ss2_skeleton::animate` cancels the per-frame clip root transform and the root joint's animation transform, and strips per-joint translations so the gesture is a pure orientation overlay on the rig's fixed bone lengths (no more mid-swing arm stretching). The arm anchors at the authored `PlayerMelee` motion-archetype arm offset. Unit-tested (`ss2_skeleton::tests`).
- **Attachments follow** (from cross-engine review - both engines flagged it): the muzzle flash renders in the viewmodel pass with the same FOV scale instead of the world pass, so it stays on the barrel instead of floating ~1.8× further from screen center.

## Verification

- Screenshots of all 15 roster weapons idle + wrench swing phases + a firing frame (flash on the muzzle) via the debug runtime.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p dark -p shock2vr` green.
- Full SDK e2e suite green (37/37). The muzzle-flash test's movement threshold was recalibrated: the pistol now sits ~0.5 world units from the eye (authored framing), so a 30° turn moves it ~0.25, not >0.3.

## Follow-ups (documented in projects/flat-weapon-handling.md)

- Gun raise-to-level around firing (we apply the constant carry pitch only).
- Looping melee idle (now trivially possible since root motion no longer drifts).
- The shotgun FP mesh shows two untextured-looking blue quads (pre-existing model/texture issue, unrelated to framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
