### PR TITLE
fix(flat): reload tilt pivots around the eye, not the gun's own origin

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -20,6 +20,7 @@ use dark::{
 use crate::{
     input_context::Hand,
     physics::{InternalCollisionGroups, PhysicsWorld},
+    runtime_props::RuntimePropReloading,
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
     virtual_hand::{VirtualHandEffect, can_grab_item},
@@ -188,15 +189,31 @@ impl FlatPlayerController {
             // Melee arms take the camera rotation directly (camSynch semantics:
             // root = ang offset * camera rotation, and the authored ang offset
             // is zero); the gun meshes share one orientation corrected by a
-            // single base yaw, plus the carry pitch (which also swings the
-            // framing offset down around the camera).
+            // single base yaw, plus a pitch (which also swings the framing
+            // offset down around the camera - the gun pivots around the EYE,
+            // not around its own origin, matching the original's pitch
+            // mechanism). At rest the pitch is the carry angle; a reload ramps
+            // it from there to the weapon's authored peak and back, so the gun
+            // dips out of view instead of spinning in place and exposing the
+            // FP mesh's open rear.
             let (rotation, position) = if is_melee {
                 (
                     look * Quaternion::from_angle_y(Deg(180.0)),
                     camera_pos + look.rotate_vector(offset / SCALE_FACTOR),
                 )
             } else {
-                let pitch = Quaternion::from_angle_x(Deg(GUN_CARRY_PITCH_DEG));
+                let pitch_deg = match world
+                    .borrow::<View<RuntimePropReloading>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().copied())
+                {
+                    Some(r) if r.peak_deg.abs() > f32::EPSILON => {
+                        let frac = r.pitch_deg() / r.peak_deg; // ramp 0..1..0
+                        GUN_CARRY_PITCH_DEG + (r.peak_deg - GUN_CARRY_PITCH_DEG) * frac
+                    }
+                    _ => GUN_CARRY_PITCH_DEG,
+                };
+                let pitch = Quaternion::from_angle_x(Deg(pitch_deg));
                 (
                     look * pitch * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG)),
                     camera_pos + (look * pitch).rotate_vector(offset / SCALE_FACTOR),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -197,9 +197,11 @@ pub struct PlayerStateSnapshot {
     pub wielded_entity_id: Option<i32>,
     pub right_hand_entity_id: Option<i32>,
     /// Whether the wielded weapon is mid-reload, and (if so) the current
-    /// viewmodel tilt angle in degrees and the reload progress (0..1). When not
-    /// reloading: `false`, `0.0`, `0.0`. Lets tooling verify the reload
-    /// animation headlessly (the angle ramps down, holds, then back to 0).
+    /// reload RAMP angle in degrees (0 -> authored peak -> 0) and the reload
+    /// progress (0..1). When not reloading: `false`, `0.0`, `0.0`. Lets tooling
+    /// verify the reload animation headlessly. NB: the applied viewmodel pitch
+    /// is not this value verbatim - the flat controller interpolates from its
+    /// carry pitch to the peak using this ramp (see `FlatPlayerController`).
     pub reloading: bool,
     pub reload_pitch_deg: f32,
     pub reload_progress: f32,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2185,30 +2185,11 @@ impl MissionCore {
                 let is_melee = limb_model.is_some();
                 let fp_model_name = gun_model.or(limb_model);
                 if let Some(xform) = maybe_xform {
-                    // While reloading, tilt the viewmodel by the current reload
-                    // angle (ramps up, holds, then back down - see
-                    // RuntimePropReloading). Rotate about the camera's horizontal
-                    // (screen-right) axis through the gun's position, so the gun
-                    // reads as a reload tilt regardless of the model's local
-                    // orientation.
-                    let xform = match self
-                        .world
-                        .borrow::<View<RuntimePropReloading>>()
-                        .ok()
-                        .and_then(|v| v.get(weapon).ok().map(|r| r.pitch_deg()))
-                    {
-                        Some(deg) if deg.abs() > f32::EPSILON => {
-                            // Camera-right in world space = row 0 of the view
-                            // rotation (column-major: (x.x, y.x, z.x)).
-                            let right = vec3(view.x.x, view.y.x, view.z.x).normalize();
-                            let p = xform.w.truncate();
-                            Matrix4::from_translation(p)
-                                * Matrix4::from_axis_angle(right, cgmath::Deg(deg))
-                                * Matrix4::from_translation(-p)
-                                * xform
-                        }
-                        _ => xform,
-                    };
+                    // The reload tilt is part of the entity transform itself:
+                    // the flat controller folds the reload pitch into the gun's
+                    // camera-pivot pitch (see `FlatPlayerController::update`),
+                    // so the gun dips around the eye like the original instead
+                    // of spinning in place around its own origin.
                     let scene_objs = if let Some(name) = fp_model_name {
                         let model = asset_cache.get(&MODELS_IMPORTER, &format!("{name}.BIN"));
                         // FP meshes are articulated (hand + arm + weapon as


### PR DESCRIPTION
The flat first-person reload tilt rotated the viewmodel about **its own position** at render time, so long guns spun in place mid-reload — on the assault rifle and shotgun you could see the open "chopped" rear cross-section of the FP mesh (the pistol got away with it because its origin sits near the grip, close to the eye).

The original engine's pitch mechanism rotates the gun's facing **and swings the framing offset around the camera** — the same path the carry pitch already uses since #335. This change folds the reload pitch into that path: the flat controller interpolates the gun pitch from the carry angle (−11.25°) to the weapon's authored reload peak and back, and the gun dips down around the eye like a classic FPS weapon-lower. The render-time pivot hack in `mission_core` is removed; `RuntimePropReloading` (data, timings, fire gate, `/v1/info` introspection) is unchanged.

## Visuals

![assault rifle reload — dip, hold, rise](https://gist.githubusercontent.com/tommy-xr/54f45ce5fc3a154f8e14e93ad32e5348/raw/ar_reload.gif)

<sub>Full assault-rifle reload: the gun dips down around the eye, holds while reloading, and rises back with the clip refilled. Captured headlessly via the debug runtime's deterministic `/v1/step` + `/v1/screenshot`.</sub>

### Before → after (assault rifle, mid-reload)

![before/after: pivot-in-place vs eye-pivot dip](https://gist.githubusercontent.com/tommy-xr/54f45ce5fc3a154f8e14e93ad32e5348/raw/assault_reload_ba.png)

## Verification

- Deterministic before/after captures in `debug_weapons` (same request sequence): AR mid-reload before shows the exposed rear cross-section; after shows the receiver-top dipping out of the lower-right, then fully lowered at peak, then raising back.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; unit tests green; full SDK e2e suite green (37/37 — the reload e2e asserts the ramp via `/v1/info`, which is unchanged).
- Cross-engine review: no Critical/High; both engines confirmed the after-captures show the fix. One accepted Low: the controller samples the reload prop one frame behind the animation system (invisible at 60 Hz over a multi-second animation); one Low fixed (introspection doc drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
