### PR TITLE
fix(engine): render the viewmodel overlay after the world's transparent pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Needs human verification (batch these — no automated test covers "feel"):
 
 Recent work
 - (in progress) flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
-- flat runtime -> fix alpha transparency / z-order break
+- [x] flat runtime -> fix alpha transparency / z-order break (viewmodel depth-clear wiped world depth before the transparent pass; engine now renders the overlay group after the world's passes)
 - [x] flat runtime -> camera-origin aim along the crosshair (#315); muzzle flash now tracks the weapon via RuntimePropAttachment (#323)
 - [x] flat runtime -> per-weapon viewmodel framing from PropPlayerGun.model_offset (viewmodel-FOV scale + authored offsets + 11.25deg carry pitch; see projects/flat-weapon-handling.md)
 - modernize combat: add recoil / accuracy modifier (like counter-strike)

--- a/engine/src/gl_engine.rs
+++ b/engine/src/gl_engine.rs
@@ -111,17 +111,42 @@ impl Engine for OpenGLEngine {
             // // );
             // floor.draw(&self, render_context, &view);
 
-            // SINGLE-PASS LIGHTING: Opaque pass with all lighting calculated in shaders
-            scene
+            // The scene may end with an overlay group (e.g. the first-person
+            // viewmodel + its attachments + HUD): everything from the first
+            // `clear_depth` object onward. It renders AFTER the world's opaque
+            // and transparent passes, so the depth clear does not wipe the
+            // world's depth mid-frame - otherwise the world's transparent pass
+            // depth-tests against an almost-empty buffer and transparent
+            // surfaces (glass, particles) bleed through walls whenever a
+            // viewmodel is up. With no `clear_depth` object (VR, no weapon)
+            // the overlay group is empty and rendering is unchanged.
+            //
+            // NB: this assumes overlay objects come AFTER the world in the
+            // scene list (desktop/debug append per-eye objects last; the
+            // oculus runtime prepends them instead, which is fine only while
+            // nothing in VR sets `clear_depth`).
+            let objects = scene.objects();
+            let overlay_start = objects
                 .iter()
-                .for_each(|s| s.draw_opaque(self, render_context, &view, scene.lights()));
+                .position(|s| s.clear_depth)
+                .unwrap_or(objects.len());
+            let (world, overlay) = objects.split_at(overlay_start);
 
-            // Transparent pass with all lighting calculated in shaders
-            gl::DepthMask(gl::FALSE);
-            scene
-                .iter()
-                .for_each(|s| s.draw_transparent(self, render_context, &view, scene.lights()));
-            gl::DepthMask(gl::TRUE);
+            for group in [world, overlay] {
+                // SINGLE-PASS LIGHTING: Opaque pass with all lighting calculated
+                // in shaders. (The overlay group's first object carries the
+                // depth clear, executed in its draw_opaque.)
+                group
+                    .iter()
+                    .for_each(|s| s.draw_opaque(self, render_context, &view, scene.lights()));
+
+                // Transparent pass with all lighting calculated in shaders
+                gl::DepthMask(gl::FALSE);
+                group
+                    .iter()
+                    .for_each(|s| s.draw_transparent(self, render_context, &view, scene.lights()));
+                gl::DepthMask(gl::TRUE);
+            }
 
             //cube.destroy();
         }


### PR DESCRIPTION
Fixes the long-standing "flat alpha transparency / z-order break" (TODO.md): whenever a first-person weapon was wielded, transparent world surfaces (steam particles, glass) bled through walls.

## Root cause

The engine rendered the whole scene list in one opaque pass then one transparent pass. The flat viewmodel's first object carries `clear_depth` (so the weapon draws on top of the world) — and that clear executed **mid-opaque-pass**, wiping the world's depth before the transparent pass ran. Transparent surfaces then depth-tested against an almost-empty buffer and drew through geometry that should occlude them. No weapon → no `clear_depth` object → no bug, which is why it only showed in flat mode with a weapon up.

## Visuals

![fixed build panning across the windows](https://gist.githubusercontent.com/tommy-xr/ab3ef3eb88bede3b90ad45b44bfda8e8/raw/occlusion_pan.gif)

<sub>fixed build panning across the windows — the plume stays clipped by the wall; captured headlessly via the debug runtime</sub>

### Before → after (pre-fix vs fixed, pistol wielded)

![before/after](https://gist.githubusercontent.com/tommy-xr/ab3ef3eb88bede3b90ad45b44bfda8e8/raw/occlusion_ba.png)

The plume shape differs run-to-run (particles are launch-nondeterministic); the signal is the smoke crossing the wall pillar (before) vs staying clipped to the window openings (after).

## Fix

Partition the scene list at the first `clear_depth` object into a **world group** and an **overlay group** (viewmodel + attachments + HUD), and run the opaque + transparent passes per group: world opaque → world transparent → depth clear → overlay opaque → overlay transparent. With no `clear_depth` object (VR, unarmed) the overlay is empty and rendering is unchanged.

## Verification

- **Binary repro in medsci1** (robust to particle launch-nondeterminism): a steam plume in the next room, viewed through two window openings with a wall pillar between them. Pre-fix + pistol: the plume streaks across the pillar. Fixed + pistol: clipped to the openings. No-weapon controls clip correctly on both builds.
- **Time-aligned no-weapon captures are byte-identical pre/post fix** — the change is a strict no-op without a viewmodel.
- `RUSTFLAGS="-D warnings"` check clean across engine/shock2vr/runtimes; unit tests green; full SDK e2e suite green (37/37).
- Cross-engine review: no Critical/High/Medium (Codex: fully clean); one Low addressed (documented the overlay-comes-last ordering assumption, which the oculus runtime's prepend order would violate if VR ever set `clear_depth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
