### PR TITLE
feat(combat): restore data-driven impact spangs (blood effects)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -309,8 +309,7 @@ Can do these in parallel:
 - [ ] Create a localized string mapper
   - [ ] Use dictionary in lookup method.
 - [ ] Weapons: Source/Stim Act/React
-- [ ] Spangs: Particle system not working correctly for blood spatter - why?
-  - [ ] Observations: Len is 324 vs 380 - so there is some difference in format not accounting for. Both the alpha and scale velocity look way off. Get smoke effect fixed.
+- [x] Spangs: Particle system not working correctly for blood spatter - SOLVED: P$ParticleG ships in two struct versions (mission 324 bytes, gamesys 380 with 8 extra bytes after gravity); the parser now handles both, and one-shot spang groups expire with their burst.
 - [ ] AI Behavior Improvements
   - Wander: Scan rays up/down to try and capture more of environment?
   - Add 'cliff' detector

--- a/TODO.md
+++ b/TODO.md
@@ -108,8 +108,7 @@ Can do these in parallel:
 - [ ] VR: Is handedness already considered?
   - [ ] Where would the scale be factored in?
 - [ ] VR: Weapon scale
-- [ ] Hack for blood spangs
-  - [ ] Replace template with a different one
+- [x] Hack for blood spangs - replaced: projectile impacts now spawn the authored spangs (HitSpang links by victim class -> blood/sparks/grub/many; MissSpang -> terrain)
   - [ ] Add bitmap, tweq destroy
 - [ ] Camera AI - If player still visible after 3 seconds, switch to alarm - SwitchLink ecology ? How does triggering happen?
 - [ ] Security system AI

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -351,6 +351,11 @@ pub enum Link {
     Replicator,
     SwitchLink,
     MissSpang,
+    /// From a projectile archetype to a victim archetype class; the payload is
+    /// the template id of the spang (impact effect, e.g. a blood or sparks
+    /// particle group) to spawn when that projectile hits a descendant of the
+    /// class (e.g. pistol bullets -> Hybrids spawns the blood spang).
+    HitSpang(i32),
     TPathInit,
     TPath(TPathData),
 }
@@ -722,6 +727,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "LD$Contains",
             |reader, _len| read_u32(reader),
             Link::Contains,
+        ),
+        define_link_with_data(
+            "L$Hit Spang",
+            "LD$Hit Span",
+            |reader, _len| read_i32(reader),
+            Link::HitSpang,
         ),
         define_link_with_data(
             "L$AIProject",

--- a/dark/src/properties/prop_particles.rs
+++ b/dark/src/properties/prop_particles.rs
@@ -84,98 +84,98 @@ pub struct PropParticleGroup {
 
 impl PropParticleGroup {
     pub fn read<T: io::Seek + io::Read>(reader: &mut T, len: u32) -> PropParticleGroup {
-        let _unk1 = read_bytes(reader, 36);
-        let _unk2 = read_u32(reader);
+        // The chunk is the engine's particle-group struct written verbatim,
+        // including runtime-only fields (vtable/list/heap pointers) that are
+        // garbage in the file. Two struct versions ship: mission files write a
+        // 324-byte layout, the gamesys writes a newer 380-byte layout that
+        // inserts 8 extra bytes after `gravity` (and appends a longer tail).
+        // Offsets below name the 324-byte layout; the 380-byte one is +8 from
+        // the color field onward. Verified against the shipped data by
+        // anchors: launch-info heap pointers, attach-object ids at the tail
+        // (e.g. a steam puff attached to its emitter), sane sizes/spins, and
+        // identity rotation matrices.
+        let _particle_class = read_bytes(reader, 36); // per-class fn pointers (runtime)
+        let _obj_id = read_u32(reader);
 
-        // let active = read_u32(reader);
-        let render_type = read_u32(reader);
-        let motion_type = read_u32(reader);
-        let animation_type = read_u32(reader);
+        let render_type = read_u32(reader); // 40
+        let motion_type = read_u32(reader); // 44
+        let animation_type = read_u32(reader); // 48
+        let _placeholder_enums = read_bytes(reader, 8); // 52
+        let num = read_u32(reader); // 60
 
-        let _unk3 = read_u32(reader);
-        let _unk4 = read_u32(reader);
+        let _particle_list = read_bytes(reader, 24); // 64: per-particle arrays (runtime)
 
-        let num = read_u32(reader);
+        let velocity = read_vec3(reader); // 88
+        let gravity = read_vec3(reader); // 100
 
-        let _unk5 = read_bytes(reader, 24);
+        if len >= 380 {
+            // The newer (gamesys) layout only: 8 unknown bytes (zero in the
+            // shipped data).
+            let _unk = read_bytes(reader, 8);
+        }
 
-        let velocity = read_vec3(reader);
-        let gravity = read_vec3(reader);
-
+        // 112: global color. `r` is an index into the game master palette (the
+        // renderer resolves it); `a` is the global alpha.
         let r = read_u8(reader);
         let g = read_u8(reader);
         let b = read_u8(reader);
         let a = read_u8(reader);
 
-        let _always_simulate = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
+        let _always_simulate = read_bool_u8(reader); // 116
+        let _always_simulate_group = read_bool_u8(reader);
+        let _cell_sort = read_bool_u8(reader);
+        let _zsort = read_bool_u8(reader);
 
-        let _terrain_collide = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
+        let _terrain_collide = read_bool_u8(reader); // 120
+        let _accelerate_cell = read_bool_u8(reader);
         let _ignore_attach_refs = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
+        let _pad = read_bool_u8(reader);
 
-        let _unk_launch_info = read_u32(reader);
-        let spin = read_vec3(reader);
-        let _pulse_period = read_u32(reader);
-        let _unk = read_u32(reader);
-        let _unk = read_u32(reader);
+        let _launch_info_ptr = read_u32(reader); // 124 (runtime heap pointer)
 
-        let _unk = read_u32(reader);
+        let spin = read_vec3(reader); // 128
+        let _pulse_period_ms = read_u32(reader); // 140
+        let _pulse_percentage = read_single(reader); // 144
+        let _fixed_scale = read_single(reader); // 148
 
-        let _unk = read_bool_u8(reader);
+        let _pre_launch = read_bool_u8(reader); // 152
+        let _spin_group = read_bool_u8(reader);
+        let _tiny_alpha = read_bool_u8(reader);
+        let _tiny_dropout = read_bool_u8(reader);
+
+        let _shared_list = read_bool_u8(reader); // 156
         let is_worldspace = read_bool_u8(reader);
-        let _unk = read_bool_u8(reader);
+        let _launching = read_bool_u8(reader);
         let is_active = read_bool_u8(reader);
 
-        let _ms_offset = read_u32(reader);
-        let size = read_single(reader);
-        let _unk = read_u32(reader);
-        let _unk = read_u32(reader);
+        let _ms_offset = read_u32(reader); // 160
+        let size = read_single(reader); // 164
+        let _reserved = read_bytes(reader, 8); // 168
 
-        let prev_loc = read_vec3(reader);
-        let scale_vel = read_single(reader);
+        let prev_loc = read_vec3(reader); // 176
+        let scale_vel = read_single(reader); // 188
 
-        let _unk = read_u32(reader);
-        let bbox_min = read_vec3(reader);
-        let bbox_max = read_vec3(reader);
-        let radius = read_single(reader);
+        let _render_datum = read_u32(reader); // 192
+        let bbox_min = read_vec3(reader); // 196
+        let bbox_max = read_vec3(reader); // 208
+        let radius = read_single(reader); // 220
+        let _cur_scale = read_single(reader); // 224
+        let _points_ptrs = read_bytes(reader, 8); // 228 (runtime pointers)
+        let _derived_flags = read_bytes(reader, 4); // 236
+        let _list_length = read_u32(reader); // 240
+        let _delete_count = read_u32(reader); // 244
+        let _next_launch = read_fixed(reader); // 248
+        // 252: time between particle launches (fix seconds).
+        let launch_period = read_fixed(reader);
+        let model_name = read_string_with_size(reader, 16); // 256 (bitmap name)
+        let _model_num = read_u32(reader); // 272
+        let fade_time = read_fixed(reader); // 276
 
-        // Runtime metadata?
-        let _unk = read_u32(reader);
-        let _unk = read_u32(reader);
-        let _unk = read_u32(reader);
-
-        // More runtime data?
-        let _unk = read_u8(reader);
-        let _unk = read_u8(reader);
-        let _unk = read_u8(reader);
-        let _unk = read_u8(reader);
-
-        // Even mor eruntime data?
-        let _unk = read_u32(reader);
-        let _unk = read_u32(reader);
-        let maybe_launch_time1 = read_fixed(reader);
-        let maybe_launch_time2 = read_fixed(reader);
-
-        let model_name = read_string_with_size(reader, 16);
-        let _unk = read_u32(reader);
-        let fade_time = read_fixed(reader);
-        // panic!(
-        //     "launch time: {} or {} or {}",
-        //     maybe_launch_time1, maybe_launch_time2, model_name
-        // );
-
-        // let motion = read_u32(reader);
-        // let num_particles = read_u32(reader);
-        // let particle_size = read_single(reader);
-        // let bitmap_name = read_string_with_size(reader, 16);
-
-        let consumed = 64 + 24 + 12 + 12 + 4 + 44 + 32 + 32 + 48 + 8;
-
+        // Remainder: rotation matrix, sim bookkeeping, attach object, and
+        // (380-byte entries only) trailing fields.
+        let consumed = if len >= 380 { 288u32 } else { 280u32 };
         let _rem = read_bytes(reader, (len - consumed) as usize);
+
         PropParticleGroup {
             render_type,
             motion_type,
@@ -196,7 +196,7 @@ impl PropParticleGroup {
             bbox_min,
             bbox_max,
             radius,
-            launch_time: maybe_launch_time2.max(maybe_launch_time1),
+            launch_time: launch_period,
             fade_time,
             model_name,
         }

--- a/dark/src/properties/prop_particles.rs
+++ b/dark/src/properties/prop_particles.rs
@@ -174,7 +174,7 @@ impl PropParticleGroup {
         // Remainder: rotation matrix, sim bookkeeping, attach object, and
         // (380-byte entries only) trailing fields.
         let consumed = if len >= 380 { 288u32 } else { 280u32 };
-        let _rem = read_bytes(reader, (len - consumed) as usize);
+        let _rem = read_bytes(reader, len.saturating_sub(consumed) as usize);
 
         PropParticleGroup {
             render_type,

--- a/engine/src/scene/particles.rs
+++ b/engine/src/scene/particles.rs
@@ -71,6 +71,11 @@ pub struct ParticleSystem {
     /// Tint applied to the sprite (resolved from the group's palette color
     /// index upstream). Defaults to white = untinted full texture.
     color: Vector3<f32>,
+    /// One-shot burst (impact spangs): all particles launch on the first
+    /// update and are never relaunched; `is_done()` reports when they have all
+    /// expired. `false` = continuous emitter (steam vents etc.).
+    one_shot: bool,
+    has_launched: bool,
 }
 
 fn randf(a: f32, b: f32) -> f32 {
@@ -123,11 +128,24 @@ impl ParticleSystem {
             particle_size: (0.08, 0.08),
             root_transform: Matrix4::identity(),
             color: vec3(1.0, 1.0, 1.0),
+            one_shot: false,
+            has_launched: false,
         }
     }
 
     pub fn with_color(self, color: Vector3<f32>) -> ParticleSystem {
         ParticleSystem { color, ..self }
+    }
+
+    pub fn with_one_shot(self, one_shot: bool) -> ParticleSystem {
+        ParticleSystem { one_shot, ..self }
+    }
+
+    /// A one-shot system whose burst has fully expired (never true for
+    /// continuous emitters). The owner can drop the system - and, for impact
+    /// spangs, the entity carrying it.
+    pub fn is_done(&self) -> bool {
+        self.one_shot && self.has_launched && self.particles.is_empty()
     }
 
     pub fn with_lifetime(self, min: f32, max: f32) -> ParticleSystem {
@@ -206,8 +224,17 @@ impl ParticleSystem {
 
         self.launch_time_remaining -= delta_time;
 
-        // Check if we should create a new particle
-        if self.particles.len() < self.max_particles && self.launch_time_remaining < 0.0 {
+        if self.one_shot {
+            // Launch the whole burst once; expired particles are never
+            // replaced (see `is_done`).
+            if !self.has_launched {
+                self.has_launched = true;
+                for _ in 0..self.max_particles {
+                    self.particles.push(create_random_particle(self));
+                }
+            }
+        } else if self.particles.len() < self.max_particles && self.launch_time_remaining < 0.0 {
+            // Continuous emitter: create a new particle per launch interval.
             self.launch_time_remaining = self.launch_time;
             self.particles.push(create_random_particle(self));
         }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -139,6 +139,10 @@ pub fn create_entity_with_position(
         }
     }
 
+    if additional_options.transient_fx {
+        world.add_component(entity_id, crate::runtime_props::RuntimePropTransientFx);
+    }
+
     create_entity_core(
         entity_id,
         template_id,
@@ -846,6 +850,10 @@ pub struct CreateEntityOptions {
     /// child then tracks the parent each frame - used so a weapon's muzzle flash
     /// follows the moving first-person viewmodel instead of snapshotting it once.
     pub attach_to: Option<EntityId>,
+    /// Mark the entity as a fire-and-forget effect (`RuntimePropTransientFx`):
+    /// it is destroyed once its one-shot particle burst expires. Used for
+    /// impact spangs so they don't accumulate at every bullet hole.
+    pub transient_fx: bool,
 }
 
 impl Default for CreateEntityOptions {
@@ -853,6 +861,7 @@ impl Default for CreateEntityOptions {
         CreateEntityOptions {
             force_visible: false,
             attach_to: None,
+            transient_fx: false,
         }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -161,6 +161,22 @@ pub struct GlobalTemplateClassTags(pub HashMap<i32, HashMap<String, String>>);
 #[derive(Unique, Clone)]
 pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 
+/// Global template inheritance hierarchy (template id -> MetaProp parents),
+/// so scripts can answer class questions about entities at runtime - e.g.
+/// picking a projectile's hit spang by whether the victim descends from the
+/// archetype class a `HitSpang` link targets (Hybrids, Robots, ...).
+#[derive(Unique, Clone)]
+pub struct GlobalTemplateHierarchy(pub HashMap<i32, Vec<i32>>);
+
+impl GlobalTemplateHierarchy {
+    /// Whether `template_id` is `class_template_id` or inherits from it.
+    pub fn is_or_descends_from(&self, template_id: i32, class_template_id: i32) -> bool {
+        template_id == class_template_id
+            || dark::ss2_entity_info::get_ancestors(&self.0, &template_id)
+                .contains(&class_template_id)
+    }
+}
+
 impl EffectQueue {
     pub fn push(&mut self, effect: Effect) {
         self.effects.push(effect);
@@ -299,6 +315,9 @@ impl MissionCore {
             .filter_map(|m| m.obj_icon.clone().map(|icon| (m.template_id, icon)))
             .collect();
         world.add_unique(GlobalTemplateObjIcons(template_obj_icons));
+        world.add_unique(GlobalTemplateHierarchy(
+            ss2_entity_info::get_hierarchy(&entity_info_rc).clone(),
+        ));
 
         // ** Entity creation
 
@@ -533,7 +552,20 @@ impl MissionCore {
 
         let up_value = input_context.left_hand.thumbstick.y / dark::SCALE_FACTOR;
 
-        let (new_character_pos, collision_events) = {
+        // Skip physics while time is frozen (the debug runtime's paused state
+        // calls update with zero dt): the Rapier pipeline advances by a fixed
+        // internal dt per call regardless of elapsed time, so stepping it here
+        // would keep integrating bodies at wall-clock rate while scripts,
+        // animations, and particles are frozen - creatures glide across the
+        // floor and effects stick around. A paused sim must not move.
+        let (new_character_pos, collision_events) = if time.elapsed.is_zero() {
+            let current_pos = self
+                .world
+                .borrow::<UniqueView<PlayerInfo>>()
+                .map(|p| p.pos)
+                .unwrap_or_else(|_| vec3(0.0, 0.0, 0.0));
+            (current_pos, Vec::new())
+        } else {
             profile!(
                 "shock2.update.physics",
                 self.physics.update(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -746,6 +746,7 @@ impl MissionCore {
         self.world.run(
             |prop_particle_group: View<PropParticleGroup>,
              prop_particle_launch_info: View<PropParticleLaunchInfo>,
+             v_transient_fx: View<crate::runtime_props::RuntimePropTransientFx>,
              transform: View<RuntimePropTransform>| {
                 for (id, (pg, launch_info, transform)) in
                     (&prop_particle_group, &prop_particle_launch_info, &transform)
@@ -785,13 +786,17 @@ impl MissionCore {
                                 .with_one_shot(pg.animation_type == 0)
                         });
                     particle_system.update(time.elapsed, transform.0);
-                    if particle_system.is_done() {
+                    // Only fire-and-forget effect entities (impact spangs) are
+                    // destroyed when their burst expires; a level-authored
+                    // one-shot group just goes dormant (the object persists,
+                    // like the original engine).
+                    if particle_system.is_done() && v_transient_fx.contains(id) {
                         finished_particle_entities.push(id);
                     }
                 }
             },
         );
-        // One-shot particle groups (impact spangs) expire with their burst -
+        // Transient one-shot effects (impact spangs) expire with their burst -
         // destroy the entity so spangs don't accumulate forever at every
         // bullet hole.
         for id in finished_particle_entities {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -557,14 +557,15 @@ impl MissionCore {
         // internal dt per call regardless of elapsed time, so stepping it here
         // would keep integrating bodies at wall-clock rate while scripts,
         // animations, and particles are frozen - creatures glide across the
-        // floor and effects stick around. A paused sim must not move.
+        // floor and effects stick around. A paused sim must not move. The
+        // player position is still read from the character body (not stepped)
+        // so a teleport - which writes the body directly - is reflected in
+        // PlayerInfo/introspection even before the next real step.
         let (new_character_pos, collision_events) = if time.elapsed.is_zero() {
-            let current_pos = self
-                .world
-                .borrow::<UniqueView<PlayerInfo>>()
-                .map(|p| p.pos)
-                .unwrap_or_else(|_| vec3(0.0, 0.0, 0.0));
-            (current_pos, Vec::new())
+            (
+                self.physics.get_player_translation(&self.player_handle),
+                Vec::new(),
+            )
         } else {
             profile!(
                 "shock2.update.physics",
@@ -741,6 +742,7 @@ impl MissionCore {
         effects.append(&mut current_effects.flush());
 
         // Update particle systems
+        let mut finished_particle_entities: Vec<EntityId> = Vec::new();
         self.world.run(
             |prop_particle_group: View<PropParticleGroup>,
              prop_particle_launch_info: View<PropParticleLaunchInfo>,
@@ -776,11 +778,25 @@ impl MissionCore {
                                 // resolve it to RGB. cg/cb (pg.g/pg.b) drive the
                                 // lifetime fade and are handled separately.
                                 .with_color(crate::palette::index_to_rgb(pg.r))
+                                // Animation type 0 = launch one shot: the burst
+                                // fires once and the group dies with its last
+                                // particle (impact spangs). Other types keep
+                                // launching (steam vents etc.).
+                                .with_one_shot(pg.animation_type == 0)
                         });
                     particle_system.update(time.elapsed, transform.0);
+                    if particle_system.is_done() {
+                        finished_particle_entities.push(id);
+                    }
                 }
             },
         );
+        // One-shot particle groups (impact spangs) expire with their burst -
+        // destroy the entity so spangs don't accumulate forever at every
+        // bullet hole.
+        for id in finished_particle_entities {
+            effects.push(Effect::DestroyEntity { entity_id: id });
+        }
 
         effects
     }
@@ -1152,6 +1168,10 @@ impl MissionCore {
         self.id_to_bitmap.remove(&entity_id);
         self.id_to_model.remove(&entity_id);
         self.id_to_physics.remove(&entity_id);
+        // Also drop the entity's particle system - the render loop iterates
+        // this map directly, so a stale entry would keep emitting at the
+        // entity's last transform forever.
+        self.id_to_particle_system.remove(&entity_id);
         self.physics.remove(entity_id);
 
         self.world.delete_entity(entity_id);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -412,6 +412,18 @@ impl PhysicsWorld {
         character_body.set_translation(vec_to_nvec(position), true)
     }
 
+    /// The character body's current translation, without stepping the
+    /// simulation. Used while time is frozen (debug-runtime pause) so
+    /// teleports - which write the physics body directly - are still
+    /// reflected in `PlayerInfo`/introspection before the next real step.
+    pub fn get_player_translation(&self, player_handle: &PlayerHandle) -> Vector3<f32> {
+        let character_body = self
+            .rigid_body_set
+            .get(player_handle.character_handle)
+            .unwrap();
+        nvec_to_cgmath(*character_body.translation())
+    }
+
     pub fn get_aabb2(&self, entity_id: EntityId) -> Option<Aabb3<f32>> {
         if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
             let maybe_rigid_body = self.rigid_body_set.get(*handle);

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -39,6 +39,13 @@ pub struct RuntimePropDoNotSerialize;
 #[derive(Component)]
 pub struct RuntimePropProxyEntity(pub shipyard::EntityId);
 
+// RuntimePropTransientFx - a runtime-spawned, fire-and-forget effect entity
+// (e.g. an impact spang): once its one-shot particle burst expires, the entity
+// is destroyed. Level-authored particle groups never get this - their one-shot
+// burst just goes dormant, matching the original engine (the object persists).
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropTransientFx;
+
 // RuntimePropAttachment - rigidly bolts an entity to a parent's transform. Each
 // frame the child's RuntimePropTransform is recomputed as
 // `parent.transform * local_transform`, so short-lived attached effects (e.g. the

--- a/shock2vr/src/scenes/debug_particles.rs
+++ b/shock2vr/src/scenes/debug_particles.rs
@@ -79,7 +79,7 @@ fn make_particle_group(color_index: u8) -> PropParticleGroup {
     PropParticleGroup {
         render_type: 4, // PRT_SINGLE_COLOR_DISK
         motion_type: 0,
-        animation_type: 0,
+        animation_type: 1, // launch continuous (a persistent plume showcase)
         num: 40,
         velocity: Vector3::new(0.0, 0.0, 0.0),
         // gravity is applied as acceleration (Dark units, /SCALE_FACTOR at use).

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -1,21 +1,25 @@
 use cgmath::{
     Deg, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3, vec4,
 };
-use dark::{SCALE_FACTOR, properties::Link};
+use dark::{
+    SCALE_FACTOR,
+    properties::{Link, PropTemplateId},
+};
 
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     creature::RuntimePropHitBox,
-    mission::entity_creator::CreateEntityOptions,
+    mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateHierarchy},
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::RuntimePropTransform,
     scripts::{
-        Message, ai::ai_util::does_entity_have_hitboxes,
-        script_util::get_first_link_with_template_and_data,
+        Message,
+        ai::ai_util::does_entity_have_hitboxes,
+        script_util::{get_all_links_with_template, get_first_link_with_template_and_data},
     },
     time::Time,
-    util::{get_position_from_transform, get_rotation_from_forward_vector},
+    util::{get_position_from_transform, get_rotation_from_forward_vector, resolve_proxy_entity},
 };
 
 use super::{Effect, MessagePayload, Script};
@@ -84,39 +88,36 @@ impl Script for InternalFastProjectileScript {
                 Effect::DestroyEntity { entity_id },
             ];
 
-            let miss_spang = get_first_link_with_template_and_data(world, entity_id, |link| {
-                if matches!(link, Link::MissSpang) {
-                    Some(())
-                } else {
-                    None
-                }
-            });
-
-            if miss_spang.is_some() {
-                // effects.push(Effect::CreateEntity {
-                //     //template_id: miss_spang.unwrap().0,
-                //     template_id: -2653, // assault flash
-                //     position: hit_point.to_vec() + hit_normal * 0.1,
-                //     orientation: Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
-                //     velocity: vec3(0.0, 0.0, 0.0),
-                //     root_transform: Matrix4::identity(),
-                // });
-            };
-
-            // TEMPORARY: Just so some effect until the blood is sorted
-            let template_id = if did_hit_hitbox {
-                -2653 /* assault flash */
+            // Impact effect, from the projectile's authored spang links:
+            // - a creature hit spawns the `HitSpang` whose victim archetype
+            //   class the victim descends from (blood for hybrids/midwives,
+            //   sparks for robots/turrets, ...);
+            // - a world hit spawns the `MissSpang` (terrain spang).
+            // No matching link (e.g. a victim class the projectile has no
+            // spang for) spawns nothing.
+            let spang_template = if did_hit_hitbox {
+                choose_hit_spang(world, entity_id, hit_entity_id)
             } else {
-                -3544 /* bullet hit */
+                get_first_link_with_template_and_data(world, entity_id, |link| {
+                    if matches!(link, Link::MissSpang) {
+                        Some(())
+                    } else {
+                        None
+                    }
+                })
+                .map(|(spang_template, ())| spang_template)
             };
-            effects.push(Effect::CreateEntity {
-                template_id,
-                position: hit_point + hit_normal * SCALE_FACTOR / 25.0,
-                orientation: get_rotation_from_forward_vector(hit_normal)
-                    * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
-                root_transform: Matrix4::identity(),
-                options: CreateEntityOptions::default(),
-            });
+
+            if let Some(template_id) = spang_template {
+                effects.push(Effect::CreateEntity {
+                    template_id,
+                    position: hit_point + hit_normal * SCALE_FACTOR / 25.0,
+                    orientation: get_rotation_from_forward_vector(hit_normal)
+                        * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
+                    root_transform: Matrix4::identity(),
+                    options: CreateEntityOptions::default(),
+                });
+            }
 
             Effect::combine(effects)
         } else {
@@ -141,6 +142,31 @@ impl Script for InternalFastProjectileScript {
     ) -> Effect {
         Effect::NoEffect
     }
+}
+
+/// The spang (impact effect) a projectile spawns on `victim`, from the
+/// projectile's `HitSpang` links: each link targets a victim archetype class
+/// (Hybrids, Robots, ...) and carries the spang template to spawn; the first
+/// link whose class the victim is or descends from wins. `victim` may be a
+/// hitbox proxy (resolved to its parent creature). `None` when the projectile
+/// has no spang authored for this victim's class.
+fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
+    let victim = resolve_proxy_entity(world, victim);
+    let victim_template = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|v| v.get(victim).ok().map(|t| t.template_id))?;
+    let hierarchy = world.borrow::<UniqueView<GlobalTemplateHierarchy>>().ok()?;
+    get_all_links_with_template(world, projectile, |link| {
+        if let Link::HitSpang(spang_template) = link {
+            Some(*spang_template)
+        } else {
+            None
+        }
+    })
+    .into_iter()
+    .find(|(victim_class, _)| hierarchy.is_or_descends_from(victim_template, *victim_class))
+    .map(|(_, spang_template)| spang_template)
 }
 
 fn projectile_ray_cast(

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -93,11 +93,12 @@ impl Script for InternalFastProjectileScript {
             //   class the victim descends from (blood for hybrids/midwives,
             //   sparks for robots/turrets, ...);
             // - a world hit spawns the `MissSpang` (terrain spang).
-            // No matching link (e.g. a victim class the projectile has no
-            // spang for) spawns nothing.
-            let spang_template = if did_hit_hitbox {
-                choose_hit_spang(world, entity_id, hit_entity_id)
-            } else {
+            // Any entity hit tries the HitSpang match first - not just hitbox
+            // hits, so victims without fitted hitboxes (and catch-all victim
+            // classes like the laser's `Physical`) still spang - and falls
+            // back to the terrain spang when the projectile has no spang
+            // authored for that entity's class.
+            let spang_template = choose_hit_spang(world, entity_id, hit_entity_id).or_else(|| {
                 get_first_link_with_template_and_data(world, entity_id, |link| {
                     if matches!(link, Link::MissSpang) {
                         Some(())
@@ -106,7 +107,7 @@ impl Script for InternalFastProjectileScript {
                     }
                 })
                 .map(|(spang_template, ())| spang_template)
-            };
+            });
 
             if let Some(template_id) = spang_template {
                 effects.push(Effect::CreateEntity {
@@ -146,10 +147,13 @@ impl Script for InternalFastProjectileScript {
 
 /// The spang (impact effect) a projectile spawns on `victim`, from the
 /// projectile's `HitSpang` links: each link targets a victim archetype class
-/// (Hybrids, Robots, ...) and carries the spang template to spawn; the first
-/// link whose class the victim is or descends from wins. `victim` may be a
-/// hitbox proxy (resolved to its parent creature). `None` when the projectile
-/// has no spang authored for this victim's class.
+/// (Hybrids, Robots, ...) and carries the spang template to spawn. Links are
+/// scanned most-derived-projectile-template first (entity links merge
+/// ancestors root-first, so without the reversal a base class's link would
+/// shadow an override authored on a derived projectile); the first link whose
+/// class the victim is or descends from wins. `victim` may be a hitbox proxy
+/// (resolved to its parent creature). `None` when the projectile has no spang
+/// authored for this victim's class.
 fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
     let victim = resolve_proxy_entity(world, victim);
     let victim_template = world
@@ -165,6 +169,7 @@ fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Op
         }
     })
     .into_iter()
+    .rev()
     .find(|(victim_class, _)| hierarchy.is_or_descends_from(victim_template, *victim_class))
     .map(|(_, spang_template)| spang_template)
 }

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -116,7 +116,10 @@ impl Script for InternalFastProjectileScript {
                     orientation: get_rotation_from_forward_vector(hit_normal)
                         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
                     root_transform: Matrix4::identity(),
-                    options: CreateEntityOptions::default(),
+                    options: CreateEntityOptions {
+                        transient_fx: true,
+                        ..CreateEntityOptions::default()
+                    },
                 });
             }
 

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -308,7 +308,7 @@ fn create_projectile(
                 root_transform: Matrix4::from_translation(origin.to_vec()) * rot,
                 options: CreateEntityOptions {
                     force_visible: true,
-                    attach_to: None,
+                    ..CreateEntityOptions::default()
                 },
             };
         }
@@ -354,7 +354,7 @@ fn create_projectile(
         root_transform: transform.0 * rot_matrix * projectile_rotation,
         options: CreateEntityOptions {
             force_visible: true,
-            attach_to: None,
+            ..CreateEntityOptions::default()
         },
     }
 }

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -381,6 +381,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::LandingPoint => "LandingPoint".to_string(),
                 Link::Replicator => "Replicator".to_string(),
                 Link::MissSpang => "MissSpang".to_string(),
+                Link::HitSpang(_) => "HitSpang".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
             })

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -582,6 +582,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::LandingPoint => "LandingPoint".to_string(),
         dark::properties::Link::Replicator => "Replicator".to_string(),
         dark::properties::Link::MissSpang => "MissSpang".to_string(),
+        dark::properties::Link::HitSpang(_) => "HitSpang".to_string(),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
     }

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for data-driven impact spangs: a projectile spawns the spang
+// its authored links say, not a hardcoded effect.
+//
+// - Terrain hit: the projectile's `MissSpang` link (pistol bullets -> the
+//   "Standard Terr Spang" particle effect).
+// - Creature hit: the `HitSpang` link whose victim archetype class the victim
+//   descends from (pistol bullets + a hybrid -> "Standard Blood Spang").
+//
+// Targets medsci1's stationary corridor OG-Pipe hybrid (near [-21.4, -4.7,
+// 14.9] - found by name + anchor since entity ids shuffle per launch), and
+// aims by computing head.look from the live player/victim positions. Relies
+// on the debug runtime's deterministic stepping (paused = fully frozen, so
+// positions are stable regardless of HTTP timing).
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
+
+test(
+  "projectile impacts spawn the authored spangs (terrain + blood)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8096),
+    });
+
+    // Wield the pistol (first CycleWeapon roster entry).
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    // Shot 1 - terrain: from spawn, the default facing looks at a wall.
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    const afterTerrain = (await game.entities.list({ filter: "Spang", limit: 10 }))
+      .entities;
+    assert.ok(
+      afterTerrain.some((e) => e.name === "Standard Terr Spang"),
+      `a wall hit should spawn the authored terrain spang (got: ${afterTerrain
+        .map((e) => e.name)
+        .join(", ")})`,
+    );
+
+    // Shot 2 - creature. Find the stationary corridor OG-Pipe by name +
+    // position anchor (entity ids are not stable across launches).
+    const anchor = { x: -21.4, y: -4.7, z: 14.9 };
+    const ogs = (await game.entities.list({ filter: "OG", limit: 10 })).entities.filter(
+      (e) => e.name === "OG-Pipe",
+    );
+    const og = ogs.find(
+      (e) =>
+        Math.hypot(
+          e.position[0] - anchor.x,
+          e.position[1] - anchor.y,
+          e.position[2] - anchor.z,
+        ) < 3.0,
+    );
+    assert.ok(og, `expected the corridor OG-Pipe near the anchor (got: ${JSON.stringify(ogs.map((e) => e.position))})`);
+
+    // Stand ~4.5 units south (+z) of it, then aim at its chest from the live
+    // positions. Empirical debug-runtime look mapping: yaw 0 faces -x, yaw 90
+    // faces -z (yaw = atan2(-dz, -dx)); positive pitch aims down.
+    await game.player.teleport({
+      x: og.position[0],
+      y: og.position[1] + 0.8,
+      z: og.position[2] + 4.5,
+    });
+    await game.step({ frames: 15 }); // settle on the floor
+
+    const player = (await game.info()).player;
+    const target = (await game.entities.detail(og.id)).position;
+    const eye = [
+      player.position[0],
+      player.position[1] + PLAYER_EYE_HEIGHT_WORLD,
+      player.position[2],
+    ];
+    const d = [
+      target[0] - eye[0],
+      target[1] + 0.7 - eye[1], // chest height above the entity origin
+      target[2] - eye[2],
+    ];
+    const yawDeg = (Math.atan2(-d[2], -d[0]) * 180) / Math.PI;
+    const pitchDeg =
+      (Math.atan2(-d[1], Math.hypot(d[0], d[2])) * 180) / Math.PI;
+
+    await game.input.set("head.look", [yawDeg, pitchDeg]);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    const afterBlood = (await game.entities.list({ filter: "Spang", limit: 10 }))
+      .entities;
+    assert.ok(
+      afterBlood.some((e) => e.name === "Standard Blood Spang"),
+      `a hybrid hit should spawn the authored blood spang (got: ${afterBlood
+        .map((e) => e.name)
+        .join(", ")})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -29,7 +29,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8096),
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8100),
     });
 
     // Wield the pistol (first CycleWeapon roster entry).
@@ -51,6 +51,8 @@ test(
         .map((e) => e.name)
         .join(", ")})`,
     );
+
+    const bloodBefore = afterTerrain.filter((e) => e.name === "Standard Blood Spang").length;
 
     // Shot 2 - creature. Find the stationary corridor OG-Pipe by name +
     // position anchor (entity ids are not stable across launches).
@@ -103,9 +105,35 @@ test(
 
     const afterBlood = (await game.entities.list({ filter: "Spang", limit: 10 }))
       .entities;
+    const bloodSpangs = afterBlood.filter((e) => e.name === "Standard Blood Spang");
     assert.ok(
-      afterBlood.some((e) => e.name === "Standard Blood Spang"),
-      `a hybrid hit should spawn the authored blood spang (got: ${afterBlood
+      bloodSpangs.length > bloodBefore,
+      `a hybrid hit should spawn a NEW blood spang (got: ${afterBlood
+        .map((e) => e.name)
+        .join(", ")})`,
+    );
+    // ...and it spawned at the victim, not somewhere else.
+    assert.ok(
+      bloodSpangs.some(
+        (e) =>
+          Math.hypot(
+            e.position[0] - target[0],
+            e.position[1] - (target[1] + 0.7),
+            e.position[2] - target[2],
+          ) < 2.0,
+      ),
+      `the blood spang should spawn near the victim (victim at ${JSON.stringify(target)}, spangs at ${JSON.stringify(bloodSpangs.map((e) => e.position))})`,
+    );
+
+    // Spangs are one-shot bursts: they expire with their particles instead of
+    // accumulating forever at every bullet hole.
+    await game.step({ frames: 120 }); // 2s >> the ~0.8s particle lifetime
+    const afterExpiry = (await game.entities.list({ filter: "Spang", limit: 10 }))
+      .entities;
+    assert.equal(
+      afterExpiry.length,
+      0,
+      `spangs should expire after their burst (still present: ${afterExpiry
         .map((e) => e.name)
         .join(", ")})`,
     );

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -43,7 +43,7 @@ test(
     await game.input.set("right_hand.trigger", 0.0);
     await game.step({ frames: 1 });
 
-    const afterTerrain = (await game.entities.list({ filter: "Spang", limit: 10 }))
+    const afterTerrain = (await game.entities.list({ filter: "Spang", limit: 50 }))
       .entities;
     assert.ok(
       afterTerrain.some((e) => e.name === "Standard Terr Spang"),
@@ -103,7 +103,7 @@ test(
     await game.input.set("right_hand.trigger", 0.0);
     await game.step({ frames: 1 });
 
-    const afterBlood = (await game.entities.list({ filter: "Spang", limit: 10 }))
+    const afterBlood = (await game.entities.list({ filter: "Spang", limit: 50 }))
       .entities;
     const bloodSpangs = afterBlood.filter((e) => e.name === "Standard Blood Spang");
     assert.ok(
@@ -128,7 +128,7 @@ test(
     // Spangs are one-shot bursts: they expire with their particles instead of
     // accumulating forever at every bullet hole.
     await game.step({ frames: 120 }); // 2s >> the ~0.8s particle lifetime
-    const afterExpiry = (await game.entities.list({ filter: "Spang", limit: 10 }))
+    const afterExpiry = (await game.entities.list({ filter: "Spang", limit: 50 }))
       .entities;
     assert.equal(
       afterExpiry.length,


### PR DESCRIPTION
Projectile impacts spawned a hardcoded stand-in ("TEMPORARY: Just so some effect until the blood is sorted" — assault flash on creatures, a fixed spang on walls). This restores the authored spang system, and fixes the particle-format mystery that motivated the hack in the first place.

## Visuals

![blood burst demo](https://gist.githubusercontent.com/tommy-xr/736a0f65cf6cf6c7807402e5e995f266/raw/blood_burst.gif)

<sub>Pistol shot on a medsci1 hybrid — the authored Standard Blood Spang bursts and expires; captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![blood burst still](https://gist.githubusercontent.com/tommy-xr/736a0f65cf6cf6c7807402e5e995f266/raw/blood_still.png)


## What changed

- **Hit Spang links parsed** (`L$Hit Spang` + `LD$Hit Span`): from a projectile archetype to a **victim archetype class**, carrying the spang to spawn. Pistol/rifle bullets: Hybrids/Midwife → Standard **Blood** Spang, Robots/Turrets → Standard Hit Spang (sparks), Grub → grubspang, Many Boss → many spang. A new `GlobalTemplateHierarchy` unique exposes template ancestry to scripts; the impact picks the spang whose victim class the (hitbox-proxy-resolved) victim descends from, scanning most-derived-projectile links first. World hits use the `MissSpang` link (Standard Terr Spang). No matching link spawns nothing.
- **The "len 324 vs 380" particle mystery (old TODO) solved**: `P$ParticleG` is the engine's particle-group struct written verbatim in **two versions** — mission files 324 bytes, gamesys 380 with 8 extra bytes after gravity. The old parser matched neither exactly: it read mission entries' active/size by accident (steam vents worked) while every gamesys spang parsed as inactive with garbage size/color/alpha — the real reason blood never rendered. Both layouts now parse correctly (verified against data anchors: attach-object ids, launch-info heap pointers, authored sizes/spins).
- **One-shot lifecycle**: animation type 0 groups burst all particles once; runtime-spawned spangs (marked `RuntimePropTransientFx`) are destroyed when the burst expires, so spangs no longer accumulate at every bullet hole. Level-authored one-shot groups go dormant instead (object persists, like the original). `remove_entity` also drops the entity's particle system (a stale entry kept emitting at its last transform forever).
- **Debug-runtime pause fix** (found while verifying): paused physics kept integrating at wall-clock rate while scripts/animations were frozen — creatures glided, effects stuck, and entity positions drifted with HTTP timing, breaking deterministic stepping. Physics is now skipped at zero dt (the player position still reads the character body, so teleports reflect immediately).

## Verification

- `blood-spang.e2e.test.ts` (fails on the pre-change build, verified): shoots a wall → authored terrain spang; self-aims at medsci1's corridor OG-Pipe → a NEW blood spang near the victim; steps 2s → all spangs expired.
- Visual: blood droplets burst from the hybrid and expire; steam vents (mission layout) and the debug_particles palette showcase (continuous emitters) unaffected.
- Full SDK e2e suite green (38/38); `-D warnings` check clean across dark/engine/shock2vr/runtimes/dark_query. (The 2 failing engine light tests are pre-existing on main.)
- Two cross-engine review passes; all Critical/High/Medium findings addressed (transient-FX gating, impact classification for hitbox-less victims, link-order shadowing, paused-teleport staleness) or documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
