### PR TITLE
feat(particles): attached particle riders - restore projectile visuals

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -356,6 +356,12 @@ pub enum Link {
     /// particle group) to spawn when that projectile hits a descendant of the
     /// class (e.g. pistol bullets -> Hybrids spawns the blood spang).
     HitSpang(i32),
+    /// From a particle-group archetype to the object it rides
+    /// ("ParticleAttachement"). On an archetype host, the engine instantiates
+    /// the particle group when a concrete host is created (projectile trails,
+    /// psi bolt visuals); on a concrete (mission-placed) particle entity it
+    /// names the object to follow.
+    ParticleAttachement(ParticleAttachOptions),
     TPathInit,
     TPath(TPathData),
 }
@@ -472,6 +478,30 @@ impl CorpseOptions {
         CorpseOptions { propagate_scale }
     }
 }
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ParticleAttachOptions {
+    /// 0 = object, 1 = vhot, 2 = joint, 3 = submodel.
+    pub attach_type: u32,
+    pub vhot: i32,
+    pub joint: i32,
+    pub submodel: i32,
+}
+
+impl ParticleAttachOptions {
+    pub fn read(reader: &mut Box<dyn ReadAndSeek>, _len: u32) -> ParticleAttachOptions {
+        let attach_type = read_u32(reader);
+        let vhot = read_i32(reader);
+        let joint = read_i32(reader);
+        let submodel = read_i32(reader);
+        ParticleAttachOptions {
+            attach_type,
+            vhot,
+            joint,
+            submodel,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GunFlashOptions {
     pub vhot: u32,
@@ -733,6 +763,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "LD$Hit Span",
             |reader, _len| read_i32(reader),
             Link::HitSpang,
+        ),
+        define_link_with_data(
+            "L$ParticleA",
+            "LD$Particle",
+            ParticleAttachOptions::read,
+            Link::ParticleAttachement,
         ),
         define_link_with_data(
             "L$AIProject",

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -825,8 +825,14 @@ impl MissionCore {
                 {
                     // Dormant groups (authored inactive) do not emit. There is
                     // no runtime activation toggle yet; when one exists this
-                    // should flip the system on rather than skip it.
+                    // should flip the system on rather than skip it. A
+                    // transient (fire-and-forget) entity that is dormant would
+                    // never finish a burst, so reap it immediately instead of
+                    // leaking an invisible entity.
                     if !pg.is_active {
+                        if v_transient_fx.contains(id) {
+                            finished_particle_entities.push(id);
+                        }
                         continue;
                     }
                     let particle_system =
@@ -1150,6 +1156,28 @@ impl MissionCore {
         root_transform: Matrix4<f32>,
         additional_options: CreateEntityOptions,
     ) -> EntityCreationInfo {
+        self.create_entity_with_position_and_rider_depth(
+            asset_cache,
+            template_id,
+            position,
+            orientation,
+            root_transform,
+            additional_options,
+            0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_entity_with_position_and_rider_depth(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        template_id: i32,
+        position: Point3<f32>,
+        orientation: Quaternion<f32>,
+        root_transform: Matrix4<f32>,
+        additional_options: CreateEntityOptions,
+        rider_depth: u32,
+    ) -> EntityCreationInfo {
         let transient_fx = additional_options.transient_fx;
         let created_entity = {
             entity_creator::create_entity_with_position(
@@ -1185,7 +1213,12 @@ impl MissionCore {
         // template or an ancestor) - projectile trails, psi bolt visuals.
         // Mission-placed hosts already have their particle entities placed in
         // the level, so this only runs for runtime creations; the recursion
-        // also instantiates nested attachments (a spang's own rider).
+        // also instantiates nested attachments (a spang's own rider). The
+        // depth cap bounds authored cycles (shipped data nests 2 deep).
+        const MAX_RIDER_DEPTH: u32 = 3;
+        if rider_depth >= MAX_RIDER_DEPTH {
+            return info;
+        }
         let riders: Vec<(i32, dark::properties::ParticleAttachOptions)> = {
             let hierarchy = ss2_entity_info::get_hierarchy(&self.entity_info);
             let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
@@ -1204,7 +1237,7 @@ impl MissionCore {
             // vhot/joint offsets are not applied yet - the particle rides the
             // host origin (attach type "object" covers the shipped projectile
             // trails).
-            self.create_entity_with_position(
+            let rider = self.create_entity_with_position_and_rider_depth(
                 asset_cache,
                 particle_template,
                 position,
@@ -1215,7 +1248,18 @@ impl MissionCore {
                     transient_fx,
                     ..CreateEntityOptions::default()
                 },
+                rider_depth + 1,
             );
+            // Riders are pure visuals: strip any physics the template brought
+            // (some riders are full projectile archetypes - e.g. the droid
+            // fusion shot rides the player Fusion Shot for its looks - and
+            // must not fly off / collide / slay as a second live projectile),
+            // and keep them out of saves (they are recreated with their host
+            // and would otherwise load back orphaned, since attachments are
+            // runtime-only).
+            self.make_un_physical(rider.entity_id);
+            self.world
+                .add_component(rider.entity_id, RuntimePropDoNotSerialize {});
         }
 
         info
@@ -1277,25 +1321,38 @@ impl MissionCore {
     pub fn remove_entity(&mut self, entity_id: EntityId) {
         // Entities riding this one (attached particle trails/FX) die with it -
         // otherwise a projectile's trail would linger at its last transform
-        // forever after the projectile is destroyed.
-        let attached_children: Vec<EntityId> = {
-            match self
+        // forever after the projectile is destroyed. The transitive closure is
+        // collected iteratively with a visited set so mission-authored
+        // attachment cycles can't recurse forever.
+        let mut to_remove: Vec<EntityId> = vec![entity_id];
+        let mut visited: HashSet<EntityId> = HashSet::from([entity_id]);
+        let mut frontier = vec![entity_id];
+        while let Some(parent) = frontier.pop() {
+            let children: Vec<EntityId> = match self
                 .world
                 .borrow::<View<crate::runtime_props::RuntimePropAttachment>>()
             {
                 Ok(v_attach) => v_attach
                     .iter()
                     .with_id()
-                    .filter(|(_, a)| a.parent == entity_id)
+                    .filter(|(id, a)| a.parent == parent && !visited.contains(id))
                     .map(|(id, _)| id)
                     .collect(),
                 Err(_) => Vec::new(),
+            };
+            for child in children {
+                visited.insert(child);
+                to_remove.push(child);
+                frontier.push(child);
             }
-        };
-        for child in attached_children {
-            self.remove_entity(child);
         }
+        // Children first, host last (reverse discovery order).
+        for id in to_remove.into_iter().rev() {
+            self.remove_entity_single(id);
+        }
+    }
 
+    fn remove_entity_single(&mut self, entity_id: EntityId) {
         // TODO: gui - remove entity
         self.hit_boxes.remove_entity(
             entity_id,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -211,6 +211,11 @@ pub struct MissionCore {
     pub world: World,
     pub player_handle: PlayerHandle,
     pub spatial_data: Option<Box<dyn SpatialQueryEngine>>,
+    /// Host template -> the particle-group archetypes authored to ride it
+    /// (reverse of the archetype `ParticleAttachement` links). Runtime entity
+    /// creation instantiates these attached (projectile trails, psi bolt
+    /// visuals).
+    template_to_particle_riders: HashMap<i32, Vec<(i32, dark::properties::ParticleAttachOptions)>>,
     interaction: Box<dyn PlayerInteraction>,
     pub visibility_engine: Box<dyn VisibilityEngine>,
     pub teleport_system: TeleportSystem,
@@ -469,10 +474,75 @@ impl MissionCore {
             TeleportSystem::new(teleport_config)
         };
 
+        // Mission-placed particle entities follow the object their concrete
+        // ParticleAttachement link names (steam rides its machinery): bolt
+        // them with RuntimePropAttachment, preserving the authored relative
+        // pose.
+        {
+            let mut attachments: Vec<(EntityId, EntityId, Matrix4<f32>)> = Vec::new();
+            {
+                let v_links = world.borrow::<View<Links>>().unwrap();
+                let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+                for (id, links) in v_links.iter().with_id() {
+                    for link in &links.to_links {
+                        if !matches!(link.link, dark::properties::Link::ParticleAttachement(_)) {
+                            continue;
+                        }
+                        let Some(parent) = link.to_entity_id else {
+                            continue;
+                        };
+                        let (Ok(child_xform), Ok(parent_xform)) =
+                            (v_transform.get(id), v_transform.get(parent.0))
+                        else {
+                            continue;
+                        };
+                        if let Some(inv_parent) = parent_xform.0.invert() {
+                            attachments.push((id, parent.0, inv_parent * child_xform.0));
+                        }
+                    }
+                }
+            }
+            for (child, parent, local_transform) in attachments {
+                world.add_component(
+                    child,
+                    crate::runtime_props::RuntimePropAttachment {
+                        parent,
+                        local_transform,
+                    },
+                );
+            }
+        }
+
+        // Reverse map of the archetype ParticleAttachement links: host template
+        // -> the particle-group archetypes that ride it. Concrete (mission-
+        // placed) links are excluded - those particle entities already exist
+        // in the level and just follow their host (see the attachment pass
+        // below).
+        let mut template_to_particle_riders: HashMap<
+            i32,
+            Vec<(i32, dark::properties::ParticleAttachOptions)>,
+        > = HashMap::new();
+        for (src_template, links) in &entity_info_rc.template_to_links {
+            if *src_template >= 0 {
+                continue;
+            }
+            for link in &links.to_links {
+                if let dark::properties::Link::ParticleAttachement(opts) = &link.link {
+                    if link.to_template_id < 0 {
+                        template_to_particle_riders
+                            .entry(link.to_template_id)
+                            .or_default()
+                            .push((*src_template, *opts));
+                    }
+                }
+            }
+        }
+
         MissionCore {
             interaction,
             level_name: mission,
             entity_info: entity_info_rc.clone(),
+            template_to_particle_riders,
             script_world,
             id_to_model,
             id_to_animation_player,
@@ -753,6 +823,12 @@ impl MissionCore {
                         .iter()
                         .with_id()
                 {
+                    // Dormant groups (authored inactive) do not emit. There is
+                    // no runtime activation toggle yet; when one exists this
+                    // should flip the system on rather than skip it.
+                    if !pg.is_active {
+                        continue;
+                    }
                     let particle_system =
                         self.id_to_particle_system.entry(id).or_insert_with(|| {
                             ParticleSystem::new()
@@ -1074,6 +1150,7 @@ impl MissionCore {
         root_transform: Matrix4<f32>,
         additional_options: CreateEntityOptions,
     ) -> EntityCreationInfo {
+        let transient_fx = additional_options.transient_fx;
         let created_entity = {
             entity_creator::create_entity_with_position(
                 template_id,
@@ -1091,7 +1168,7 @@ impl MissionCore {
             )
         };
 
-        Self::finish_instantiating_entity(
+        let info = Self::finish_instantiating_entity(
             &mut self.id_to_model,
             &mut self.id_to_bitmap,
             &mut self.id_to_physics,
@@ -1101,7 +1178,47 @@ impl MissionCore {
             &mut self.script_world,
             created_entity,
             root_transform,
-        )
+        );
+
+        // Instantiate the particle groups authored to ride this archetype
+        // (`ParticleAttachement` links from particle archetypes to this
+        // template or an ancestor) - projectile trails, psi bolt visuals.
+        // Mission-placed hosts already have their particle entities placed in
+        // the level, so this only runs for runtime creations; the recursion
+        // also instantiates nested attachments (a spang's own rider).
+        let riders: Vec<(i32, dark::properties::ParticleAttachOptions)> = {
+            let hierarchy = ss2_entity_info::get_hierarchy(&self.entity_info);
+            let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
+            ancestors.push(template_id);
+            ancestors
+                .into_iter()
+                .flat_map(|t| {
+                    self.template_to_particle_riders
+                        .get(&t)
+                        .cloned()
+                        .unwrap_or_default()
+                })
+                .collect()
+        };
+        for (particle_template, _attach_options) in riders {
+            // vhot/joint offsets are not applied yet - the particle rides the
+            // host origin (attach type "object" covers the shipped projectile
+            // trails).
+            self.create_entity_with_position(
+                asset_cache,
+                particle_template,
+                position,
+                orientation,
+                root_transform,
+                CreateEntityOptions {
+                    attach_to: Some(info.entity_id),
+                    transient_fx,
+                    ..CreateEntityOptions::default()
+                },
+            );
+        }
+
+        info
     }
 
     fn finish_instantiating_entity(
@@ -1158,6 +1275,27 @@ impl MissionCore {
     }
 
     pub fn remove_entity(&mut self, entity_id: EntityId) {
+        // Entities riding this one (attached particle trails/FX) die with it -
+        // otherwise a projectile's trail would linger at its last transform
+        // forever after the projectile is destroyed.
+        let attached_children: Vec<EntityId> = {
+            match self
+                .world
+                .borrow::<View<crate::runtime_props::RuntimePropAttachment>>()
+            {
+                Ok(v_attach) => v_attach
+                    .iter()
+                    .with_id()
+                    .filter(|(_, a)| a.parent == entity_id)
+                    .map(|(id, _)| id)
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
+        };
+        for child in attached_children {
+            self.remove_entity(child);
+        }
+
         // TODO: gui - remove entity
         self.hit_boxes.remove_entity(
             entity_id,

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -382,6 +382,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::Replicator => "Replicator".to_string(),
                 Link::MissSpang => "MissSpang".to_string(),
                 Link::HitSpang(_) => "HitSpang".to_string(),
+                Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
             })

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -583,6 +583,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::Replicator => "Replicator".to_string(),
         dark::properties::Link::MissSpang => "MissSpang".to_string(),
         dark::properties::Link::HitSpang(_) => "HitSpang".to_string(),
+        dark::properties::Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
     }

--- a/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for attached particle riders: projectiles whose visuals are
+// particle-group archetypes linked to them via `ParticleAttachement` (laser
+// bolts, psi shots, the fusion orb) get those groups instantiated attached at
+// spawn, riding the projectile, and destroyed with it.
+//
+// Fires the laser pistol in `debug_weapons` and asserts the "Blue Laser Trail"
+// particle entity exists while the bolt is in flight and is gone after impact.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "projectile particle riders spawn attached and die with the projectile",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8101),
+    });
+
+    // Cycle to the laser pistol (4th roster entry).
+    await game.step({ frames: 5 });
+    for (let i = 0; i < 4; i++) {
+      await game.input.trigger("CycleWeapon");
+      await game.step({ frames: 3 });
+    }
+
+    // Fire at the wall ahead (the scene's backstop - firing away from it sends
+    // the bolt into the void where it never impacts). Check the rider one
+    // frame into flight, before the bolt reaches the wall.
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 1 });
+
+    const inFlight = (await game.entities.list({ limit: 100 })).entities;
+    const shot = inFlight.find((e) => e.name === "Laser Shot");
+    const trail = inFlight.find((e) => e.name === "Blue Laser Trail");
+    assert.ok(shot, "the laser bolt should be in flight");
+    assert.ok(trail, "the bolt's authored particle rider should be instantiated");
+    const dist = Math.hypot(
+      trail.position[0] - shot.position[0],
+      trail.position[1] - shot.position[1],
+      trail.position[2] - shot.position[2],
+    );
+    assert.ok(dist < 0.5, `the trail should ride the bolt (distance ${dist.toFixed(2)})`);
+
+    await game.input.set("right_hand.trigger", 0.0);
+
+    // After impact the bolt is destroyed - the trail must die with it, not
+    // linger at its last transform.
+    await game.step({ frames: 120 });
+    const after = (await game.entities.list({ limit: 100 })).entities;
+    assert.ok(
+      !after.some((e) => e.name === "Blue Laser Trail"),
+      "the trail should be destroyed with the projectile",
+    );
+  },
+);


### PR DESCRIPTION
Many projectiles were invisible: their models are the no-render `FX_Particle` placeholder, and their real visuals are particle-group archetypes linked to them via `ParticleAttachement` — which we neither parsed nor instantiated. The laser bolt's Blue Laser Trail, the fusion cannon's teal orb, the cryo/pyro psi shots, and the monkeys' psi bolts all render this way.

## Visuals

![fusion orb in flight](https://gist.githubusercontent.com/tommy-xr/97aa67f8bb8d6fd2fe8cf9984dae829c/raw/fusion_orb.gif)

<sub>Fusion cannon fired twice in `debug_weapons` — the previously-invisible teal orb rides the projectile; captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![fusion orb still](https://gist.githubusercontent.com/tommy-xr/97aa67f8bb8d6fd2fe8cf9984dae829c/raw/fusion_still.png)

<sub>The fusion orb just after firing: broad teal glow with bright cyan core.</sub>

![laser bolt still](https://gist.githubusercontent.com/tommy-xr/97aa67f8bb8d6fd2fe8cf9984dae829c/raw/laser_bolt.png)

<sub>Laser pistol bolt + Blue Laser Trail in flight — the small glowing dot at the crosshair.</sub>

## What changed

- **`L$ParticleA` + `LD$Particle` parsed** into `Link::ParticleAttachement` (attach type / vhot / joint / submodel, matching the engine's attachment struct).
- **Runtime rider instantiation**: creating an entity walks its template ancestors' incoming `ParticleAttachement` links (a reverse map built at load) and creates each particle archetype attached to the new entity, recursively (nested riders; depth-capped). This mirrors the original's on-create listener, which instantiates the archetypes "dangling off" a new concrete object.
- **Riders are pure visuals**: physics stripped after creation (some riders are full projectile archetypes — the droid fusion shot rides the player Fusion Shot for its looks — and must not fly/collide/slay as a second live projectile) and excluded from saves (they're recreated with their host).
- **Mission-placed particle entities follow their host**: a load pass bolts them to the object their concrete link names (steam rides its machinery), preserving the authored relative pose.
- **Attached children die with their host** (iterative closure with a cycle guard) — a destroyed projectile's trail can't linger.
- **`is_active` honored**: dormant groups no longer emit (runtime activation toggle is a follow-up; dormant *transient* FX are reaped rather than leaked).

## Verification

- `projectile-trail.e2e.test.ts` (fails pre-change): fires the laser pistol, asserts the Blue Laser Trail entity spawns riding the bolt (< 0.5 units apart) and is destroyed with it on impact.
- Visual: fusion orb (teal glow + cyan core) and laser bolt in flight in `debug_weapons`; blood spang + its `bspang` rider; medsci steam vents and the `debug_particles` showcase unaffected.
- Full SDK e2e suite green (39/39); `-D warnings` clean across all desktop packages.
- Cross-engine review: the High finding (projectile-archetype riders spawning as live projectiles for droid fusion fire) plus both cycle-guard and the save-orphan findings fixed; visual claims independently confirmed by both engines.

## Follow-ups

- vhot/joint attach offsets (riders currently sit on the host origin — covers all shipped projectile trails).
- `PRT_SCALED_BITMAP` rendering (16 bitmap particle groups, e.g. the blood spang's `bspang` rider, still render as palette-colored disks).
- Runtime particle activation toggle (`ObjParticleSetActive` equivalent) for triggered FX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
