### PR TITLE
feat(debug_runtime): hide the window by default (--visible to show)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,10 @@ For debugging visual/rendering changes without a full interactive session:
    # viewmodel, screen-space HUD, right-hand trigger fires. Pass `--vr` for the
    # VR forearm/two-hand path. (Flat is what most weapon/aim testing needs; in VR
    # mode the flat weapon-wield / fire path is inactive.)
+   #
+   # The window is HIDDEN by default (offscreen render) so the runtime never
+   # steals focus or pops to the foreground - `/v1/screenshot` still works.
+   # Pass `--visible` to watch the game in a real window.
    cargo dbgr --mission medsci1.mis --port 8080
 
    # Control via HTTP

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -123,6 +123,13 @@ struct Args {
     /// flat path is what most headless weapon/aim testing exercises.
     #[arg(long)]
     vr: bool,
+
+    /// Show the game window. By default the runtime creates a hidden window so
+    /// it never steals focus or pops to the foreground - rendering and
+    /// `/v1/screenshot` still work via the offscreen framebuffer. Pass this to
+    /// watch the game interactively.
+    #[arg(long)]
+    visible: bool,
 }
 
 /// Default debug-camera head rotation.
@@ -327,6 +334,12 @@ fn run_game_blocking(
     ));
     #[cfg(target_os = "macos")]
     glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
+
+    // Default to a hidden window so the runtime never steals focus or pops to
+    // the foreground - it's an HTTP-driven automation tool. A hidden window
+    // still has a valid GL context and default framebuffer, so rendering and
+    // `/v1/screenshot` work unchanged. `--visible` opts into a normal window.
+    glfw.window_hint(glfw::WindowHint::Visible(args.visible));
 
     // Create window
     info!("Step 2: Creating GLFW window...");


### PR DESCRIPTION
The debug runtime is an HTTP-driven automation tool, but it created a normal visible GLFW window that popped to the foreground and stole input focus on launch. Default to a hidden window (WindowHint::Visible(false)); a hidden window keeps a valid GL context and default framebuffer, so rendering and /v1/screenshot work unchanged. Pass --visible to watch the game interactively.

Verified: all 23 missions load (missions.e2e.test.ts) and debug_weapons renders the pistol viewmodel + HUD via /v1/screenshot from a never-shown window.