### PR TITLE
feat(particles): render bitmap particles (PRT_SCALED_BITMAP sprites)

### DIFF
--- a/dark/src/importers/texture_importer.rs
+++ b/dark/src/importers/texture_importer.rs
@@ -11,14 +11,17 @@ pub(crate) fn load_texture(
     name: String,
     reader: &mut Box<dyn engine::assets::asset_paths::ReadableAndSeekable>,
     _assets: &mut AssetCache,
-    _config: &TextureOptions,
+    config: &TextureOptions,
 ) -> RawTextureData {
     let extension = Path::new(&name).extension().unwrap();
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).unwrap();
+    if config.transparent_index_0 && extension.eq_ignore_ascii_case("pcx") {
+        return engine::texture_format::PCX.load_indexed(&buf, true);
+    }
     let format =
         engine::texture_format::extension_to_format(extension.to_str().unwrap().to_string())
             .unwrap();
-    let mut buf = Vec::new();
-    reader.read_to_end(&mut buf).unwrap();
     format.load(&buf)
 }
 

--- a/engine/src/scene/particles.rs
+++ b/engine/src/scene/particles.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{rc::Rc, sync::Arc, time::Duration};
 
 use cgmath::{Matrix4, SquareMatrix, Vector3, vec3};
 use rand::Rng;
@@ -76,6 +76,9 @@ pub struct ParticleSystem {
     /// expired. `false` = continuous emitter (steam vents etc.).
     one_shot: bool,
     has_launched: bool,
+    /// Sprite for bitmap particles (PRT_SCALED_BITMAP); `None` renders the
+    /// default radial glow disk.
+    sprite_texture: Option<Rc<dyn TextureTrait>>,
 }
 
 fn randf(a: f32, b: f32) -> f32 {
@@ -130,6 +133,7 @@ impl ParticleSystem {
             color: vec3(1.0, 1.0, 1.0),
             one_shot: false,
             has_launched: false,
+            sprite_texture: None,
         }
     }
 
@@ -139,6 +143,13 @@ impl ParticleSystem {
 
     pub fn with_one_shot(self, one_shot: bool) -> ParticleSystem {
         ParticleSystem { one_shot, ..self }
+    }
+
+    pub fn with_sprite_texture(self, texture: Rc<dyn TextureTrait>) -> ParticleSystem {
+        ParticleSystem {
+            sprite_texture: Some(texture),
+            ..self
+        }
     }
 
     /// A one-shot system whose burst has fully expired (never true for
@@ -253,18 +264,25 @@ impl ParticleSystem {
                 if adj_time > 0.0 {
                     alpha = 1.0 - (adj_time / self.particle_fade_time);
                 }
-                // TODO: Switch to billboard material
-                //    let mat = BillboardMaterial::create(some_texture, 1.0, 0.0);
-                let mat = BillboardMaterial::create(
-                    particle_texture.clone(),
-                    self.color,
-                    // Emissive so particles self-glow (visible in dark scenes); the
-                    // glow is tinted by `color` in the shader, so it stays the
-                    // palette color rather than washing to white.
-                    1.0,
-                    1.0 - (self.particle_alpha * alpha),
-                    p.scale,
-                );
+                // Emissive so particles self-glow (visible in dark scenes); the
+                // glow is tinted by `color` in the shader, so it stays the
+                // palette color rather than washing to white.
+                let mat = match &self.sprite_texture {
+                    Some(sprite) => BillboardMaterial::create(
+                        sprite.clone(),
+                        self.color,
+                        1.0,
+                        1.0 - (self.particle_alpha * alpha),
+                        p.scale,
+                    ),
+                    None => BillboardMaterial::create(
+                        particle_texture.clone(),
+                        self.color,
+                        1.0,
+                        1.0 - (self.particle_alpha * alpha),
+                        p.scale,
+                    ),
+                };
                 let mut scene_obj = SceneObject::new(mat, Box::new(quad::create()));
                 scene_obj.set_local_transform(
                     Matrix4::from_translation(p.position) * Matrix4::from_scale(p.scale),

--- a/engine/src/scene/particles.rs
+++ b/engine/src/scene/particles.rs
@@ -268,10 +268,13 @@ impl ParticleSystem {
                 // glow is tinted by `color` in the shader, so it stays the
                 // palette color rather than washing to white.
                 let mat = match &self.sprite_texture {
+                    // Sprites render unlit at their authored texel colors -
+                    // adding emissive on top would double the brightness and
+                    // clip the sprite's gradients to white.
                     Some(sprite) => BillboardMaterial::create(
                         sprite.clone(),
                         self.color,
-                        1.0,
+                        0.0,
                         1.0 - (self.particle_alpha * alpha),
                         p.scale,
                     ),

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -97,11 +97,18 @@ pub fn bind(texture: &Texture) {
 #[derive(Hash)]
 pub struct TextureOptions {
     pub wrap: bool,
+    /// Treat palette index 0 as transparent when decoding paletted formats
+    /// (PCX). Dark bitmap sprites (particles) are keyed this way; wall/UI
+    /// textures are not, so this is opt-in.
+    pub transparent_index_0: bool,
 }
 
 impl Default for TextureOptions {
     fn default() -> TextureOptions {
-        TextureOptions { wrap: true }
+        TextureOptions {
+            wrap: true,
+            transparent_index_0: false,
+        }
     }
 }
 

--- a/engine/src/texture_format.rs
+++ b/engine/src/texture_format.rs
@@ -69,8 +69,10 @@ pub fn read_pcx_dimensions(buffer: &[u8]) -> Option<(u32, u32)> {
 
 pub struct PcxFormat {}
 
-impl TextureFormat for PcxFormat {
-    fn load(&self, buffer: &[u8]) -> RawTextureData {
+impl PcxFormat {
+    /// Decode with optional palette-index-0 transparency (Dark bitmap sprites
+    /// are keyed on index 0; most PCX art is fully opaque).
+    pub fn load_indexed(&self, buffer: &[u8], transparent_index_0: bool) -> RawTextureData {
         let mut pcx = pcx::Reader::new(buffer).unwrap();
         let width = pcx.width() as u32;
         let height = pcx.height() as u32;
@@ -108,7 +110,11 @@ impl TextureFormat for PcxFormat {
                 data[idx] = pcx_r;
                 data[idx + 1] = pcx_g;
                 data[idx + 2] = pcx_b;
-                data[idx + 3] = 255;
+                data[idx + 3] = if transparent_index_0 && i == 0 {
+                    0
+                } else {
+                    255
+                };
             }
         }
 
@@ -120,6 +126,12 @@ impl TextureFormat for PcxFormat {
             height,
             format: PixelFormat::RGBA,
         }
+    }
+}
+
+impl TextureFormat for PcxFormat {
+    fn load(&self, buffer: &[u8]) -> RawTextureData {
+        self.load_indexed(buffer, false)
     }
 }
 

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -90,7 +90,10 @@ pub fn draw_item_outline(
         return vec![];
     }
 
-    let options = TextureOptions { wrap: false };
+    let options = TextureOptions {
+        wrap: false,
+        ..Default::default()
+    };
 
     let aabb = maybe_bbox.unwrap();
     let top_left_brack = asset_cache.get_ext(&TEXTURE_IMPORTER, "BRACK0.PCX", &options);

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -271,7 +271,10 @@ fn create_bar_overlay(
     z_offset: f32,
 ) -> Option<SceneObject> {
     // Load bar texture
-    let texture_options = TextureOptions { wrap: false };
+    let texture_options = TextureOptions {
+        wrap: false,
+        ..Default::default()
+    };
     let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture_name, &texture_options);
 
     // Create clipped screen material
@@ -310,7 +313,10 @@ fn create_forearm_hud_panel(
     let forearm_position = hand_position + hand_rotation.rotate_vector(FOREARM_OFFSET);
 
     // Load appropriate texture based on handedness
-    let texture_options = TextureOptions { wrap: false };
+    let texture_options = TextureOptions {
+        wrap: false,
+        ..Default::default()
+    };
     let texture = match handedness {
         Handedness::Left => asset_cache.get_ext(&TEXTURE_IMPORTER, "BIOFULL.PCX", &texture_options),
         Handedness::Right => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -25,7 +25,9 @@ use dark::{
     BitmapAnimation, SCALE_FACTOR,
     audio::SongPlayer,
     gamesys::Gamesys,
-    importers::{ANIMATION_CLIP_IMPORTER, AUDIO_IMPORTER, MODELS_IMPORTER, SONG_IMPORTER},
+    importers::{
+        ANIMATION_CLIP_IMPORTER, AUDIO_IMPORTER, MODELS_IMPORTER, SONG_IMPORTER, TEXTURE_IMPORTER,
+    },
     mission::{SongParams, room_database::RoomDatabase},
     model::Model,
     motion::{AnimationEvent, AnimationPlayer, MotionDB, MotionQuery, MotionQueryItem},
@@ -837,7 +839,7 @@ impl MissionCore {
                     }
                     let particle_system =
                         self.id_to_particle_system.entry(id).or_insert_with(|| {
-                            ParticleSystem::new()
+                            let mut system = ParticleSystem::new()
                                 .with_lifetime(launch_info.min_time, launch_info.max_time)
                                 .with_velocity(
                                     launch_info.vel_min / SCALE_FACTOR,
@@ -865,7 +867,28 @@ impl MissionCore {
                                 // fires once and the group dies with its last
                                 // particle (impact spangs). Other types keep
                                 // launching (steam vents etc.).
-                                .with_one_shot(pg.animation_type == 0)
+                                .with_one_shot(pg.animation_type == 0);
+                            // Render type 5 (scaled bitmap) draws the authored
+                            // sprite (res/bitmap/<name>.PCX) instead of the
+                            // default glow disk; a missing bitmap falls back
+                            // to the disk. The sprite carries its own colors,
+                            // so the palette tint is left white.
+                            const PRT_SCALED_BITMAP: u32 = 5;
+                            if pg.render_type == PRT_SCALED_BITMAP && !pg.model_name.is_empty() {
+                                let bitmap_name = format!("{}.PCX", pg.model_name);
+                                if let Some(texture) = asset_cache.get_ext_opt(
+                                    &TEXTURE_IMPORTER,
+                                    &bitmap_name,
+                                    &engine::texture::TextureOptions { wrap: false },
+                                ) {
+                                    system = system
+                                        .with_sprite_texture(texture)
+                                        .with_color(cgmath::vec3(1.0, 1.0, 1.0));
+                                } else {
+                                    warn!("particle bitmap not found: {bitmap_name}");
+                                }
+                            }
+                            system
                         });
                     particle_system.update(time.elapsed, transform.0);
                     // Only fire-and-forget effect entities (impact spangs) are

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -879,7 +879,13 @@ impl MissionCore {
                                 if let Some(texture) = asset_cache.get_ext_opt(
                                     &TEXTURE_IMPORTER,
                                     &bitmap_name,
-                                    &engine::texture::TextureOptions { wrap: false },
+                                    &engine::texture::TextureOptions {
+                                        wrap: false,
+                                        // Dark sprites key transparency on
+                                        // palette index 0 (the magenta color
+                                        // key only covers some of them).
+                                        transparent_index_0: true,
+                                    },
                                 ) {
                                     system = system
                                         .with_sprite_texture(texture)
@@ -1281,6 +1287,9 @@ impl MissionCore {
             // and would otherwise load back orphaned, since attachments are
             // runtime-only).
             self.make_un_physical(rider.entity_id);
+            // ...and any gameplay scripts (a projectile-archetype rider must
+            // not raycast/damage as a live projectile).
+            self.script_world.remove_entity(rider.entity_id);
             self.world
                 .add_component(rider.entity_id, RuntimePropDoNotSerialize {});
         }

--- a/shock2vr/src/mission/visibility_engine/portal_visibility_engine.rs
+++ b/shock2vr/src/mission/visibility_engine/portal_visibility_engine.rs
@@ -384,7 +384,7 @@ impl VisibilityEngine for PortalVisibilityEngine {
         //         let mut debug_objs = vec![debug];
 
         //         if portal_debug_info.to_cell == 82 && portal_debug_info.from_cell == 84 {
-        //             let options = TextureOptions { wrap: false };
+        //             let options = TextureOptions { wrap: false, ..Default::default() };
         //             let highlight = asset_cache.get_ext(&TEXTURE_IMPORTER, "TURQ.GIF", &options);
 
         //             let position = vec2(aabb.min.x, aabb.min.y);

--- a/shock2vr/src/scenes/cutscene_player.rs
+++ b/shock2vr/src/scenes/cutscene_player.rs
@@ -176,7 +176,10 @@ impl CutscenePlayerScene {
             (
                 Rc::new(init_from_memory2(
                     texture_data,
-                    &TextureOptions { wrap: false },
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
                 )),
                 aspect_ratio,
             )
@@ -195,7 +198,10 @@ impl CutscenePlayerScene {
             (
                 Rc::new(init_from_memory2(
                     texture_data,
-                    &TextureOptions { wrap: false },
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
                 )),
                 aspect_ratio,
             )

--- a/shock2vr/src/scenes/debug_particles.rs
+++ b/shock2vr/src/scenes/debug_particles.rs
@@ -35,7 +35,7 @@ const BITMAP_SHOWCASE: &[(&str, i32)] = &[
     ("stars (star2)", -4119),
     ("stasis tail (blood)", -2921),
     ("viral ball (viral)", -1528),
-    ("new blood spang (bspang)", -1971),
+    ("new blood spang (bspang; one-shot, bursts once)", -1971),
 ];
 
 /// Showcased emitters: `(label, master-palette color index)`. Indices chosen as

--- a/shock2vr/src/scenes/debug_particles.rs
+++ b/shock2vr/src/scenes/debug_particles.rs
@@ -1,10 +1,13 @@
-//! Debug scene for inspecting particle-group colors.
+//! Debug scene for inspecting particle rendering.
 //!
-//! Builds a row of particle emitters with authored test params, each using a
-//! different **master-palette color index**, so the palette -> RGB -> `inColor`
-//! color path can be eyeballed. (Bare gamesys *templates* carry zeroed runtime
-//! state, so we set the params directly rather than spawning a template; placed
-//! `.mis` instances do carry authored params and render in real missions.)
+//! Two rows:
+//! - a row of hand-authored emitters, each using a different **master-palette
+//!   color index**, so the palette -> RGB -> `inColor` color path can be
+//!   eyeballed;
+//! - a row of **real gamesys templates** with bitmap particle groups
+//!   (PRT_SCALED_BITMAP), so the sprite path (water drops, stars, stasis,
+//!   viral) can be eyeballed. Spawning templates directly works now that both
+//!   `P$ParticleG` layouts parse correctly.
 
 use cgmath::{Matrix4, Point3, Vector3, point3, vec3};
 use dark::{
@@ -23,6 +26,17 @@ use crate::{
         DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
     },
 };
+
+/// Bitmap-particle templates spawned from the gamesys: `(label, template id)`.
+/// All carry PRT_SCALED_BITMAP particle groups with authored sprites.
+const BITMAP_SHOWCASE: &[(&str, i32)] = &[
+    ("dripping water (drop)", -3417),
+    ("water fountain (drop)", -2218),
+    ("stars (star2)", -4119),
+    ("stasis tail (blood)", -2921),
+    ("viral ball (viral)", -1528),
+    ("new blood spang (bspang)", -1971),
+];
 
 /// Showcased emitters: `(label, master-palette color index)`. Indices chosen as
 /// vivid, visually distinct colors in SHOCKPAL.PCX.
@@ -130,11 +144,19 @@ impl ParticleHooks {
             .map(|(i, (label, idx))| format!("  [{i}] {label} (palette index {idx})"))
             .collect::<Vec<_>>()
             .join("\n");
-        println!("[debug_particles] palette-colored emitters, left-to-right:\n{layout}");
+        let bitmaps = BITMAP_SHOWCASE
+            .iter()
+            .enumerate()
+            .map(|(i, (label, id))| format!("  [{i}] {label} (template {id})"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        println!(
+            "[debug_particles] palette-colored emitters, left-to-right:\n{layout}\nbitmap templates (back row):\n{bitmaps}"
+        );
         Self { spawned: false }
     }
 
-    fn spawn_emitters(&mut self, core: &mut MissionCore) {
+    fn spawn_emitters(&mut self, core: &mut MissionCore, asset_cache: &mut AssetCache) {
         if self.spawned {
             return;
         }
@@ -147,6 +169,21 @@ impl ParticleHooks {
                 make_launch_info(),
             ));
         }
+        // Second row (further back, higher): real gamesys bitmap-particle
+        // templates. Spawned as display pieces - any physics the template
+        // brings is stripped so projectiles don't fly off.
+        for (i, (_, template_id)) in BITMAP_SHOWCASE.iter().enumerate() {
+            let position = showcase_position(i, BITMAP_SHOWCASE.len());
+            let info = core.create_entity_with_position(
+                asset_cache,
+                *template_id,
+                point3(position.x - 3.0, position.y + 1.5, position.z),
+                cgmath::Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                Matrix4::from_scale(1.0),
+                crate::mission::entity_creator::CreateEntityOptions::default(),
+            );
+            core.make_un_physical(info.entity_id);
+        }
         self.spawned = true;
     }
 }
@@ -157,9 +194,9 @@ impl DebugSceneHooks for ParticleHooks {
         core: &mut MissionCore,
         _time: &crate::time::Time,
         _input_context: &crate::input_context::InputContext,
-        _asset_cache: &mut AssetCache,
+        asset_cache: &mut AssetCache,
         _game_options: &GameOptions,
     ) {
-        self.spawn_emitters(core);
+        self.spawn_emitters(core, asset_cache);
     }
 }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -223,7 +223,10 @@ impl UiCanvas {
         mode: ScaleMode,
     ) -> Vec<SceneObject> {
         let (scale, offset) = fit(self.size, screen_size, mode);
-        let texture_options = TextureOptions { wrap: false };
+        let texture_options = TextureOptions {
+            wrap: false,
+            ..Default::default()
+        };
         let mut objs = Vec::with_capacity(self.elements.len());
 
         for element in &self.elements {

--- a/tools/dark_viewer/src/scenes/video_player.rs
+++ b/tools/dark_viewer/src/scenes/video_player.rs
@@ -77,7 +77,10 @@ impl ToolScene for VideoPlayerScene {
                 let texture_data = self.video_player.get_current_frame();
                 Rc::new(init_from_memory2(
                     texture_data,
-                    &TextureOptions { wrap: false },
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
                 ))
             }
             #[cfg(not(feature = "ffmpeg"))]
@@ -92,7 +95,10 @@ impl ToolScene for VideoPlayerScene {
                 };
                 Rc::new(init_from_memory2(
                     texture_data,
-                    &TextureOptions { wrap: false },
+                    &TextureOptions {
+                        wrap: false,
+                        ..Default::default()
+                    },
                 ))
             }
         };


### PR DESCRIPTION
Follow-up to #340. Particle groups with render type 5 (`PRT_SCALED_BITMAP`) now draw their authored sprite (`res/bitmap/<name>.PCX`) instead of the generated radial glow disk.

## Visuals

![bitmap particle showcase](https://gist.githubusercontent.com/tommy-xr/938e0e8861cc02b47b0ca38de54e0e3b/raw/bitmap_particles.gif)

<sub>The `debug_particles` bitmap row — viral orb, bspang splatter, star sprites, water drops — with palette glow-disk plumes in the periphery. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Emissive fix (review follow-up)

![before/after](https://gist.githubusercontent.com/tommy-xr/938e0e8861cc02b47b0ca38de54e0e3b/raw/sprite_ba.png)

<sub>The viral orb's authored gradient: flat grey before the unlit-sprite fix, salmon gradient after.</sub>

## What this restores

- **New Blood Spang** — the `bspang` red splatter sprite riding blood spangs
- **Water drips / fountains** — `drop` sprites (mission-placed in medsci1, eng1)
- **Psi FX** — `star2` sparkles (Psi Pull, Charm trail, stars)
- **Projectile cores** — `viral` (Viral Prolif), `fusion` (Fusion Shot core), stasis effects
- **The swarm enemy** — 70 `bug` sprites per swarm (was a dot cloud)

Sprites carry their own colors, so the palette tint is left white; a missing bitmap (`stat2` is absent from the shipped resources) falls back to the disk with a warning.

## Verification

The `debug_particles` scene grows a second row of **real gamesys bitmap-particle templates** (dripping water, fountain, stars, stasis tail, viral ball, blood spang) next to the palette-disk row — spawnable now that both `P$ParticleG` layouts parse. Screenshots show the bspang splatter, the ringed viral orb, and 4-pointed stars rendering as sprites; no bitmap-not-found warnings. Full SDK e2e suite green (39/39); `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
