### PR TITLE
fix(engine): restore spotlight affects_position culling (#339)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,22 +65,22 @@ jobs:
       # TODO: Fix dark_viewer Windows compatibility and include it everywhere.
       - name: Build all (Unix)
         if: runner.os != 'Windows'
-        run: cargo build --verbose --release -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
+        run: cargo build --verbose --release -p engine -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
       - name: Run all tests (Unix)
         if: runner.os != 'Windows'
-        run: cargo test --verbose --release -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
+        run: cargo test --verbose --release -p engine -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
 
       - name: Build all (Windows)
         if: runner.os == 'Windows'
-        run: cargo build --verbose --release -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
+        run: cargo build --verbose --release -p engine -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"
       - name: Run all tests (Windows)
         if: runner.os == 'Windows'
-        run: cargo test --verbose --release -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
+        run: cargo test --verbose --release -p engine -p desktop_runtime -p dark_query -p debug_runtime -p debug_command
         env:
           RUSTFLAGS: "-D warnings"

--- a/engine/src/macros.rs
+++ b/engine/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! offset_of {
 /// Enhanced profile macro with scope and level awareness
 ///
 /// Usage:
-/// ```
+/// ```ignore
 /// profile!(scope: "physics", level: debug, "collision_detection", {
 ///     // expensive computation
 /// });

--- a/engine/src/scene/light.rs
+++ b/engine/src/scene/light.rs
@@ -164,24 +164,23 @@ impl Light for SpotLight {
         LightType::Spotlight
     }
 
-    fn affects_position(&self, _world_pos: Vector3<f32>) -> bool {
+    fn affects_position(&self, world_pos: Vector3<f32>) -> bool {
         // Quick range check
-        true
-        // let distance = (world_pos - self.position).magnitude();
-        // if distance > self.range {
-        //     return false;
-        // }
+        let distance = (world_pos - self.position).magnitude();
+        if distance > self.range {
+            return false;
+        }
 
-        // // Cone check - ensure position is within the outer cone
-        // if distance > 0.0 {
-        //     let to_position = (world_pos - self.position).normalize();
-        //     let dot = to_position.dot(self.direction);
-        //     let cos_outer = self.outer_cone_angle.cos();
-        //     dot >= cos_outer
-        // } else {
-        //     // Position is exactly at light source
-        //     true
-        // }
+        // Cone check - ensure position is within the outer cone
+        if distance > 0.0 {
+            let to_position = (world_pos - self.position).normalize();
+            let dot = to_position.dot(self.direction);
+            let cos_outer = self.outer_cone_angle.cos();
+            dot >= cos_outer
+        } else {
+            // Position is exactly at light source
+            true
+        }
     }
 
     fn spotlight_params(&self) -> Option<SpotlightParams> {


### PR DESCRIPTION
## What & why

Fixes #339 — two `engine` unit tests fail on `main`:
- `scene::light::tests::test_spotlight_affects_position`
- `scene::light_system::tests::test_lights_affecting_position`

`SpotLight::affects_position` was stubbed to unconditionally `return true` (in #116, single-pass lighting), with the real range + outer-cone check left commented out directly below it. The two tests assert real culling behavior, so they failed.

This restores the range check (`distance > self.range` → false) and the outer-cone dot-product check.

## Why this is safe for rendering

The change is **behavior-neutral for the actual renderer**. `affects_position` is only reached through `LightSystem` (`lights_affecting_position` / `cull_lights_for_bounds`), which is `pub`-exported but **never instantiated anywhere outside its own `#[cfg(test)]` module**. The live render path lights geometry via `LightArray` (in `Scene` + all materials) and per-fragment shader math — it never calls `affects_position`. Verified by grepping `engine/`, `shock2vr/`, `runtimes/`, `dark/`.

## Closing the CI gap

These failures went unnoticed because the **Build & Unit Test** workflow only tested the runtime/tool packages (`-p desktop_runtime …`), and `cargo test -p <pkg>` does **not** run its dependencies' tests — so `engine`'s tests never ran in CI. This PR adds `-p engine` to the build + test invocations (Unix and Windows).

Adding `engine` surfaced one pre-existing broken doc example (`macros.rs` `profile!` usage — illustrative pseudocode that doesn't compile). Marked ```` ```ignore ````.

## Verification

```
RUSTFLAGS="-D warnings" cargo test -p engine
# 17 passed; 0 failed  (incl. both previously-failing light tests); doctest ignored
```

## Review

Ran cross-engine adversarial review (Claude + Codex). Both independently verified the safety claim (no live caller of `affects_position`) and found **no Critical/High issues**. Codex noted two latent points in the *never-called* `LightSystem` scaffolding (`cull_lights_for_bounds` corner-only AABB test; `direction` normalization assumption) — left as-is to avoid scope creep into dead code; neither affects #339 or real rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)