### PR TITLE
fix(build): debug_psi missing auto_wield field after crossing merges

### DIFF
--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -129,6 +129,7 @@ impl DebugSceneHooks for PsiHooks {
         let spawn = Effect::SpawnInFrontOfPlayer {
             template_id: PSI_AMP_TEMPLATE_ID,
             head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            auto_wield: true,
         };
         core.handle_effects(
             vec![spawn],


### PR DESCRIPTION
## Summary

Main does not compile: #345 (psi amp) was based on a pre-#271 main and merged after #271 added the `auto_wield` flag to `Effect::SpawnInFrontOfPlayer`. One-line fix — `debug_psi` relies on the auto-wield to equip the amp, so it passes `true`.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `cargo test -p shock2vr` (68 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)