### PR TITLE
fix(scenes): repair debug_psi build after auto_wield semantic conflict

### DIFF
--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -124,11 +124,12 @@ impl DebugSceneHooks for PsiHooks {
         if self.equipped {
             return;
         }
-        // In flat presentation SpawnInFrontOfPlayer auto-wields a weapon when
-        // the player is unarmed - so this both spawns and equips the amp.
+        // In flat presentation this both spawns and equips the amp (the
+        // player starts unarmed).
         let spawn = Effect::SpawnInFrontOfPlayer {
             template_id: PSI_AMP_TEMPLATE_ID,
             head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            auto_wield: true,
         };
         core.handle_effects(
             vec![spawn],


### PR DESCRIPTION
## Summary

Main is currently broken: #345 (`debug_psi` scene) and the `SpawnDebugMonster` change (which added an `auto_wield` field to `Effect::SpawnInFrontOfPlayer`) merged concurrently with no textual conflict, so neither CI run saw the combination. One-line fix passing `auto_wield: true` — the scene's behavior (spawn + equip the psi amp) is unchanged.

## Test plan

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)