### PR TITLE
feat(gloves): retarget SteamVR hand poses onto the vr_glove GLB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ target/
 *.log
 *.sav
 output.txt
-projects/
 references/
 
 # Local research notes (not committed)

--- a/dark/src/glb_model.rs
+++ b/dark/src/glb_model.rs
@@ -121,7 +121,8 @@ impl GlbModel {
     /// Replace only the rotation of a joint's local transform, preserving the
     /// bind pose translation and scale (see `GlbAnimationState::set_joint_rotation`)
     pub fn set_joint_rotation(&mut self, joint_index: usize, rotation: cgmath::Quaternion<f32>) {
-        self.animation_state.set_joint_rotation(joint_index, rotation);
+        self.animation_state
+            .set_joint_rotation(joint_index, rotation);
     }
 
     /// Get the current local transform for a joint (uses joint index)

--- a/dark/src/glb_model.rs
+++ b/dark/src/glb_model.rs
@@ -18,11 +18,19 @@ pub struct GlbModel {
 impl GlbModel {
     /// Create a new GLB model with skeleton
     pub fn new(
-        scene_objects: Vec<SceneObject>,
+        mut scene_objects: Vec<SceneObject>,
         bounding_box: Aabb3<f32>,
         skeleton: GlbSkeleton,
     ) -> Self {
-        let animation_state = GlbAnimationState::new(skeleton);
+        let mut animation_state = GlbAnimationState::new(skeleton);
+
+        // Skinned vertices are stored in mesh space and need the joint
+        // matrices to reach model space, so bake the bind pose skinning in -
+        // consumers that never pose the model still render it correctly.
+        let bind_skinning = animation_state.get_skinning_matrices();
+        for scene_object in scene_objects.iter_mut() {
+            scene_object.set_skinning_data(bind_skinning);
+        }
 
         Self {
             scene_objects,
@@ -99,18 +107,6 @@ impl GlbModel {
         self.skeleton().joint_count() > 0
     }
 
-    /// Apply hand pose transforms (convenience method for VR gloves)
-    pub fn apply_hand_pose(
-        &mut self,
-        joint_transforms: &std::collections::HashMap<u32, Matrix4<f32>>,
-    ) {
-        for (joint_id, transform) in joint_transforms {
-            // Convert joint ID to node index if needed
-            let node_index = *joint_id as usize; // Assuming direct mapping for now
-            self.set_node_transform(node_index, *transform);
-        }
-    }
-
     /// Get global transform for a node (useful for debugging)
     pub fn get_global_transform(&mut self, node_index: usize) -> Option<Matrix4<f32>> {
         self.animation_state.get_global_transform(node_index)
@@ -120,6 +116,12 @@ impl GlbModel {
     pub fn set_joint_transform(&mut self, joint_index: usize, transform: Matrix4<f32>) {
         self.animation_state
             .set_joint_transform(joint_index, transform);
+    }
+
+    /// Replace only the rotation of a joint's local transform, preserving the
+    /// bind pose translation and scale (see `GlbAnimationState::set_joint_rotation`)
+    pub fn set_joint_rotation(&mut self, joint_index: usize, rotation: cgmath::Quaternion<f32>) {
+        self.animation_state.set_joint_rotation(joint_index, rotation);
     }
 
     /// Get the current local transform for a joint (uses joint index)

--- a/dark/src/glb_skeleton.rs
+++ b/dark/src/glb_skeleton.rs
@@ -1,7 +1,7 @@
 // glb_skeleton.rs
 // Standalone GLB skeleton system independent of SS2-specific abstractions
 
-use cgmath::{Matrix4, SquareMatrix};
+use cgmath::{InnerSpace, Matrix4, Quaternion, SquareMatrix};
 use std::collections::HashMap;
 
 /// A single node in a GLB skeleton hierarchy
@@ -256,6 +256,32 @@ impl GlbAnimationState {
             .iter()
             .position(|n| n.index == node_index)?;
         self.global_transforms.get(pos).copied()
+    }
+
+    /// Replace only the rotation of a joint's local transform, preserving the
+    /// bind pose translation (bone length) and scale. This is the safe way to
+    /// pose a skeleton from rotation-only data: bone segments can never
+    /// stretch, and joints carrying an export scale (e.g. an FBX unit
+    /// conversion baked into the root) keep it.
+    pub fn set_joint_rotation(&mut self, joint_index: usize, rotation: Quaternion<f32>) {
+        let Some(node_index) = self.skeleton.node_index_for_joint(joint_index) else {
+            return;
+        };
+        let Some(node) = self.skeleton.get_node(node_index) else {
+            return;
+        };
+
+        let bind = node.local_transform;
+        let translation = bind.w.truncate();
+        let scale = (
+            bind.x.truncate().magnitude(),
+            bind.y.truncate().magnitude(),
+            bind.z.truncate().magnitude(),
+        );
+        let local = Matrix4::from_translation(translation)
+            * Matrix4::from(rotation)
+            * Matrix4::from_nonuniform_scale(scale.0, scale.1, scale.2);
+        self.set_node_transform(node_index, local);
     }
 
     /// Set a transform for a specific joint (uses joint index, not node index)

--- a/dark/src/importers/glb_model_importer.rs
+++ b/dark/src/importers/glb_model_importer.rs
@@ -127,8 +127,12 @@ fn load_glb(
     for mesh in &meshes {
         if let GlbVertexData::Skinned(vertices) = &mesh.vertex_data {
             for vertex in vertices {
-                let pos =
-                    cgmath::Vector4::new(vertex.position.x, vertex.position.y, vertex.position.z, 1.0);
+                let pos = cgmath::Vector4::new(
+                    vertex.position.x,
+                    vertex.position.y,
+                    vertex.position.z,
+                    1.0,
+                );
                 let skinned = match &bind_skinning {
                     Some(skinning) => {
                         let mut skinned = cgmath::Vector4::new(0.0, 0.0, 0.0, 0.0);

--- a/dark/src/importers/glb_model_importer.rs
+++ b/dark/src/importers/glb_model_importer.rs
@@ -1,9 +1,12 @@
-use cgmath::{Matrix4, Vector3};
+use cgmath::{Matrix4, SquareMatrix, Vector3};
 use collision::Aabb3;
 use engine::assets::{asset_cache::AssetCache, asset_importer::AssetImporter};
 use once_cell::sync::Lazy;
 
-use crate::{glb_model::GlbModel, glb_skeleton::GlbSkeleton};
+use crate::{
+    glb_model::GlbModel,
+    glb_skeleton::{GlbAnimationState, GlbSkeleton},
+};
 use engine::scene::{
     SceneObject, SkinnedMaterial, VertexPositionTextureNormal, VertexPositionTextureSkinnedNormal,
 };
@@ -113,13 +116,49 @@ fn load_glb(
         }
     }
 
+    // Extract skeleton if present
+    let skeleton = extract_glb_skeleton(&document, &buffers);
+
+    // Bound skinned meshes with the bind pose skinning matrices - the same
+    // transforms that place their vertices at render time.
+    let bind_skinning = skeleton
+        .as_ref()
+        .map(|skeleton| GlbAnimationState::new(skeleton.clone()).get_skinning_matrices());
+    for mesh in &meshes {
+        if let GlbVertexData::Skinned(vertices) = &mesh.vertex_data {
+            for vertex in vertices {
+                let pos =
+                    cgmath::Vector4::new(vertex.position.x, vertex.position.y, vertex.position.z, 1.0);
+                let skinned = match &bind_skinning {
+                    Some(skinning) => {
+                        let mut skinned = cgmath::Vector4::new(0.0, 0.0, 0.0, 0.0);
+                        for (index, weight) in
+                            vertex.bone_indices.iter().zip(vertex.bone_weights.iter())
+                        {
+                            let matrix = skinning
+                                .get(*index as usize)
+                                .copied()
+                                .unwrap_or_else(Matrix4::identity);
+                            skinned += matrix * pos * *weight;
+                        }
+                        skinned
+                    }
+                    None => pos,
+                };
+                min_bounds.x = min_bounds.x.min(skinned.x);
+                min_bounds.y = min_bounds.y.min(skinned.y);
+                min_bounds.z = min_bounds.z.min(skinned.z);
+                max_bounds.x = max_bounds.x.max(skinned.x);
+                max_bounds.y = max_bounds.y.max(skinned.y);
+                max_bounds.z = max_bounds.z.max(skinned.z);
+            }
+        }
+    }
+
     let bounding_box = Aabb3::new(
         cgmath::Point3::new(min_bounds.x, min_bounds.y, min_bounds.z),
         cgmath::Point3::new(max_bounds.x, max_bounds.y, max_bounds.z),
     );
-
-    // Extract skeleton if present
-    let skeleton = extract_glb_skeleton(&document, &buffers);
 
     LoadedGlbData {
         meshes,
@@ -127,6 +166,26 @@ fn load_glb(
         skeleton,
         images,
     }
+}
+
+/// Build just the skeleton from raw GLB bytes - no GPU resources or asset
+/// cache required, so it works in headless tests and tools.
+pub fn skeleton_from_glb_bytes(bytes: &[u8]) -> Option<GlbSkeleton> {
+    let gltf = gltf::Gltf::from_slice(bytes).ok()?;
+    let document = gltf.document;
+    let blob = gltf.blob;
+
+    let mut buffers = Vec::new();
+    for buffer_obj in document.buffers() {
+        let data = match buffer_obj.source() {
+            gltf::buffer::Source::Bin => blob.as_ref()?.clone(),
+            // External buffers can't be resolved from raw bytes
+            gltf::buffer::Source::Uri(_) => return None,
+        };
+        buffers.push(gltf::buffer::Data(data));
+    }
+
+    extract_glb_skeleton(&document, &buffers)
 }
 
 /// Extract GLB skeleton from document
@@ -236,17 +295,11 @@ fn process_node(
                             max_bounds.z = max_bounds.z.max(pos.z);
                         }
                     }
-                    GlbVertexData::Skinned(vertices) => {
-                        for vertex in vertices {
-                            let pos = &vertex.position;
-                            min_bounds.x = min_bounds.x.min(pos.x);
-                            min_bounds.y = min_bounds.y.min(pos.y);
-                            min_bounds.z = min_bounds.z.min(pos.z);
-                            max_bounds.x = max_bounds.x.max(pos.x);
-                            max_bounds.y = max_bounds.y.max(pos.y);
-                            max_bounds.z = max_bounds.z.max(pos.z);
-                        }
-                    }
+                    // Skinned vertices stay in mesh space (see
+                    // process_primitive) and are placed by the skinning
+                    // matrices, not the node transform - they're bounded
+                    // after the skeleton is extracted (see load_glb).
+                    GlbVertexData::Skinned(_) => {}
                 }
                 meshes.push(glb_mesh);
             }
@@ -375,24 +428,16 @@ fn process_primitive(
                 [1.0, 0.0, 0.0, 0.0]
             };
 
-            // Apply transform
-            let transformed_pos = transform * cgmath::Vector4::new(pos[0], pos[1], pos[2], 1.0);
-            let transformed_norm = transform * cgmath::Vector4::new(norm[0], norm[1], norm[2], 0.0);
-
+            // Per the glTF spec, the mesh node's transform is ignored for
+            // skinned meshes - the joint matrices (which include any scale on
+            // the skeleton root, e.g. an FBX unit conversion) place vertices.
+            // Baking it here would apply that scale twice.
             skinned_vertices.push(VertexPositionTextureSkinnedNormal {
-                position: cgmath::Vector3::new(
-                    transformed_pos.x,
-                    transformed_pos.y,
-                    transformed_pos.z,
-                ),
+                position: cgmath::Vector3::new(pos[0], pos[1], pos[2]),
                 uv: cgmath::Vector2::new(tex[0], tex[1]),
                 bone_indices,
                 bone_weights: normalized_weights,
-                normal: cgmath::Vector3::new(
-                    transformed_norm.x,
-                    transformed_norm.y,
-                    transformed_norm.z,
-                ),
+                normal: cgmath::Vector3::new(norm[0], norm[1], norm[2]),
             });
         }
 

--- a/projects/vr-gloves.md
+++ b/projects/vr-gloves.md
@@ -1,0 +1,92 @@
+# VR Gloves: SteamVR Hand Poses on the Glove GLB
+
+Status: **working** — programmatic hand poses (open, point, fist, and blends)
+apply correctly to the SteamVR glove model. Verified by unit tests
+(`shock2vr/src/scenes/hand_pose.rs`) and visually in the `debug_gloves` scene.
+
+## Assets
+
+- `assets/vr_glove_model.glb` — right-hand glove, adapted from Valve's
+  [SteamVR Unity plugin](https://github.com/ValveSoftware/steamvr_unity_plugin)
+  (FBX2glTF export). 26 skin joints + 5 non-skinned aux nodes.
+- `assets/vr_glove_color.jpg` — external color texture.
+- Pose data in `shock2vr/src/scenes/hand_pose.rs`, transcribed from the
+  plugin's `SteamVR_Skeleton_Pose` assets (right hand): `ReferencePose_OpenHand`
+  (identical to `ReferencePose_BindPose`), `fallback_point`, `fallback_fist`.
+
+## The three bugs that broke previous attempts (PRs #214–#224, Nov 2025)
+
+Symptom back then: "skinning data causes a zoom" / exploded fingers. Three
+independent problems stacked:
+
+1. **Double scale.** FBX2glTF baked a ×100 unit conversion twice: as a scale on
+   the `Root` joint *and* on the `renderMesh0` node. The importer baked the
+   mesh-node transform into the skinned vertices, and the joint skinning
+   matrices (global × inverse-bind) carry the Root's ×100 as well — the IBMs
+   are authored without it — so real skinning rendered the glove ~100× too big.
+   The unposed glove only ever looked right because it was drawn *without*
+   skinning matrices. Fix: per the glTF spec, skinned meshes ignore the mesh
+   node's transform (`dark/src/importers/glb_model_importer.rs`), and
+   `GlbModel::new` now bakes bind-pose skinning into its scene objects so
+   unposed clones render correctly too.
+
+2. **Whole-transform pose application.** Poses were written as
+   translation×rotation local transforms, replacing the bind translations
+   (bone lengths) and the Root's scale. Fix:
+   `GlbAnimationState::set_joint_rotation` writes *rotation only*, preserving
+   bind translation and scale — bones can't stretch by construction.
+
+3. **Wrong coordinate conventions.** The pose data is authored in Unity
+   (left-handed) on Valve's hand rig; the GLB is right-handed and FBX2glTF
+   re-parameterized every joint's local frame by a constant rotation (bones
+   point down −X in the GLB, +X in the pose data; each joint frame differs by
+   up to ~44°). A single global mirror is not enough.
+
+## The retargeting solution (`HandPoseRetarget`)
+
+Each GLB joint's frame differs from the pose data's frame by a constant basis
+change `C_j`. Since the GLB's bind pose and the plugin's reference bind pose
+are the same physical hand pose, the `C_j` are recovered recursively from the
+two bind poses:
+
+```
+C_j = mirror(reference_bind_rotation_j)⁻¹ · C_parent(j) · glb_bind_rotation_j
+```
+
+where `mirror` is the handedness conversion (translation `x → −x`; quaternion
+`(x,y,z,w) → (x,−y,−z,w)`), seeded at the wrist with a constant rotation
+(~2.8°) solved once by a Kabsch fit aligning the five metacarpal bind offsets
+of the two rigs. Poses then map on per joint as:
+
+```
+glb_local_rotation_j = C_parent(j)⁻¹ · mirror(pose_rotation_j) · C_j
+```
+
+Only joints 2..=25 (fingers) are posed. Joint 0 (`Root`) keeps the exporter
+scale; joint 1 (wrist) keeps bind — its pose transform is the hand-to-
+controller offset, which the scene/hand attachment supplies instead.
+
+By construction the reference (open/bind) pose reproduces the GLB bind exactly
+— that's the calibration invariant the unit tests assert, along with bone
+lengths being preserved under every pose and the fist actually curling.
+
+`Pose::blend(a, b, t)` slerps per-bone for analog states (grip squeeze,
+trigger pull).
+
+## Verifying
+
+```bash
+cargo test -p shock2vr hand_pose         # invariants, headless
+cargo dbgr --mission debug_gloves --port 8080
+# line-up left→right: bind, open, point, fist
+curl -X POST http://127.0.0.1:8080/v1/step -d '{"frames": 30}'
+curl -X POST http://127.0.0.1:8080/v1/screenshot -d '{"filename": "gloves.png"}'
+```
+
+## Follow-ups
+
+- Left hand: mirror the right-hand pose data (the plugin assets also carry a
+  `leftHand` section) and confirm which GLB asset the left glove uses.
+- Drive poses from `InputContext` (trigger/grip values) on the VR hands via
+  `Pose::blend`, replacing/augmenting the static glove rendering.
+- More poses if needed (`fallback_relaxed`, pinch) — transcribe like the fist.

--- a/shock2vr/src/scenes/debug_gloves.rs
+++ b/shock2vr/src/scenes/debug_gloves.rs
@@ -63,7 +63,12 @@ impl GloveAnimation {
         let phase = self.total_time * std::f32::consts::TAU / Self::CYCLE_SECONDS;
         let amount = 0.5 - 0.5 * phase.cos();
         let pose = self.open.blend(&self.fist, amount);
-        build_posed_glove(&self.model, &self.retarget, Some(&pose), self.texture.as_ref())
+        build_posed_glove(
+            &self.model,
+            &self.retarget,
+            Some(&pose),
+            self.texture.as_ref(),
+        )
     }
 }
 
@@ -99,12 +104,10 @@ impl DebugSceneHooks for GloveHooks {
                 // camera looks along -X toward the gloves)
                 let offset = ((count - 1.0) / 2.0 - index as f32) * GLOVE_SPACING;
                 // Fingers point up, palm toward the camera
-                let world = Matrix4::from_translation(vec3(
-                    GLOVE_POSITION.x + offset,
-                    y,
-                    GLOVE_POSITION.z,
-                )) * Matrix4::from_angle_y(Deg(90.0))
-                    * Matrix4::from_angle_x(Deg(-90.0));
+                let world =
+                    Matrix4::from_translation(vec3(GLOVE_POSITION.x + offset, y, GLOVE_POSITION.z))
+                        * Matrix4::from_angle_y(Deg(90.0))
+                        * Matrix4::from_angle_x(Deg(-90.0));
                 scene_objects.extend(clone_with_transform(&glove.objects, world));
                 scene_objects.extend(glove.debug_cubes.iter().map(|cube| {
                     let mut clone = cube.clone();
@@ -201,8 +204,9 @@ impl DebugGlovesScene {
     ) -> Box<dyn GameScene> {
         let builder = DebugSceneBuilder::new("debug_gloves")
             .with_default_floor()
+            // Far enough back that the whole two-row line-up fits the FOV
             .with_spawn_location(SpawnLocation::PositionRotation(
-                vec3(0.0, 2.5, 0.0),
+                vec3(0.0, 2.5, -0.8),
                 Quaternion::from_angle_y(Deg(90.0)),
             ));
 

--- a/shock2vr/src/scenes/debug_gloves.rs
+++ b/shock2vr/src/scenes/debug_gloves.rs
@@ -17,20 +17,68 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
-    scenes::debug_common::{
-        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    scenes::{
+        debug_common::{
+            DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+        },
+        hand_pose::{self, HandPoseRetarget, Pose},
     },
 };
 
-const GLOVE_POSITION: Point3<f32> = point3(0.0, 3.0, 1.0);
-const GLOVE_SCALE: f32 = 1.0;
+const GLOVE_POSITION: Point3<f32> = point3(0.0, 3.3, 1.0);
+const GLOVE_SPACING: f32 = 0.28;
+const ROW_SPACING: f32 = 0.45;
+
+/// A glove with a pose baked into its skinning matrices, plus debug cubes at
+/// the posed joint positions. Both are in model space; `after_render` places
+/// them in the world.
+struct PosedGlove {
+    objects: Vec<SceneObject>,
+    debug_cubes: Vec<SceneObject>,
+}
 
 struct GloveHooks {
-    glove_template: Vec<SceneObject>,
-    glove_model: Rc<GlbModel>,
+    /// Rows of gloves, top to bottom. Row 1 (reference poses) reads bind,
+    /// open, point, fist left to right; row 2 (blends) reads open->fist at
+    /// 25/50/75%, then an index-only half-pull (trigger).
+    rows: Vec<Vec<PosedGlove>>,
+    /// Everything needed to re-pose the animated glove each frame
+    animation: GloveAnimation,
+}
+
+/// A glove cycling open->fist over time, rendered at the end of the blend row.
+struct GloveAnimation {
+    model: Rc<GlbModel>,
+    retarget: HandPoseRetarget,
+    texture: Option<Rc<dyn engine::texture::TextureTrait>>,
+    open: Pose,
+    fist: Pose,
+    total_time: f32,
+}
+
+impl GloveAnimation {
+    const CYCLE_SECONDS: f32 = 3.0;
+
+    fn current_glove(&self) -> PosedGlove {
+        let phase = self.total_time * std::f32::consts::TAU / Self::CYCLE_SECONDS;
+        let amount = 0.5 - 0.5 * phase.cos();
+        let pose = self.open.blend(&self.fist, amount);
+        build_posed_glove(&self.model, &self.retarget, Some(&pose), self.texture.as_ref())
+    }
 }
 
 impl DebugSceneHooks for GloveHooks {
+    fn before_update(
+        &mut self,
+        _core: &mut MissionCore,
+        time: &crate::time::Time,
+        _input_context: &crate::input_context::InputContext,
+        _asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+    ) {
+        self.animation.total_time = time.total.as_secs_f32();
+    }
+
     fn after_render(
         &mut self,
         _core: &mut MissionCore,
@@ -40,80 +88,95 @@ impl DebugSceneHooks for GloveHooks {
         _asset_cache: &mut AssetCache,
         _options: &GameOptions,
     ) {
-        let transform =
-            Matrix4::from_translation(vec3(GLOVE_POSITION.x, GLOVE_POSITION.y, GLOVE_POSITION.z))
-                * Matrix4::from_angle_y(Deg(0.0))
-                * Matrix4::from_scale(GLOVE_SCALE);
-
-        scene_objects.extend(clone_with_transform(&self.glove_template, transform));
-
-        let original_transform =
-            Matrix4::from_translation(vec3(GLOVE_POSITION.x, GLOVE_POSITION.y, GLOVE_POSITION.z))
-                * Matrix4::from_scale(GLOVE_SCALE);
-        let mut original_model_clone = self.glove_model.as_ref().clone();
-        let original_debug_cubes =
-            create_skeleton_debug_cubes(&mut original_model_clone, original_transform, 0.1, None);
-        scene_objects.extend(original_debug_cubes);
-    }
-}
-
-fn load_glove_template(asset_cache: &mut AssetCache) -> Vec<SceneObject> {
-    let model = asset_cache.get(&GLB_MODELS_IMPORTER, "vr_glove_model.glb");
-    let mut scene_objects = model.clone_scene_objects();
-
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        asset_cache.get::<_, engine::texture::Texture, _>(&TEXTURE_IMPORTER, "vr_glove_color.jpg")
-    })) {
-        Ok(external_texture) => {
-            let texture_rc = external_texture as Rc<dyn engine::texture::TextureTrait>;
-
-            for scene_object in scene_objects.iter_mut() {
-                let new_material = SkinnedMaterial::create(texture_rc.clone(), 1.0, 0.0);
-                *scene_object.material.borrow_mut() = new_material;
-            }
-
-            for scene_object in scene_objects.iter_mut() {
-                scene_object.set_transform(Matrix4::identity());
+        // The animated glove joins the end of the blend row (row 1)
+        let animated = self.animation.current_glove();
+        for (row_index, row) in self.rows.iter().enumerate() {
+            let animated_glove = (row_index == 1).then_some(&animated);
+            let count = (row.len() + animated_glove.map_or(0, |_| 1)) as f32;
+            let y = GLOVE_POSITION.y - row_index as f32 * ROW_SPACING;
+            for (index, glove) in row.iter().chain(animated_glove).enumerate() {
+                // Negated so each row reads left to right on screen (the
+                // camera looks along -X toward the gloves)
+                let offset = ((count - 1.0) / 2.0 - index as f32) * GLOVE_SPACING;
+                // Fingers point up, palm toward the camera
+                let world = Matrix4::from_translation(vec3(
+                    GLOVE_POSITION.x + offset,
+                    y,
+                    GLOVE_POSITION.z,
+                )) * Matrix4::from_angle_y(Deg(90.0))
+                    * Matrix4::from_angle_x(Deg(-90.0));
+                scene_objects.extend(clone_with_transform(&glove.objects, world));
+                scene_objects.extend(glove.debug_cubes.iter().map(|cube| {
+                    let mut clone = cube.clone();
+                    clone.set_transform(world * cube.get_transform());
+                    clone
+                }));
             }
         }
-        Err(_) => {}
     }
-
-    scene_objects
 }
 
-fn create_skeleton_debug_cubes(
-    glb_model: &mut GlbModel,
-    transform: Matrix4<f32>,
-    cube_size: f32,
-    highlight_node: Option<usize>,
-) -> Vec<SceneObject> {
+/// Bake `pose` (or the bind pose, for `None`) into a copy of the glove model
+/// and return its render objects plus per-joint debug cubes.
+fn build_posed_glove(
+    model: &GlbModel,
+    retarget: &HandPoseRetarget,
+    pose: Option<&Pose>,
+    texture: Option<&Rc<dyn engine::texture::TextureTrait>>,
+) -> PosedGlove {
+    let mut posed_model = model.clone();
+    if let Some(pose) = pose {
+        retarget.apply(pose, &mut posed_model);
+    }
+
+    let mut objects = posed_model.to_scene_objects_with_skinning();
+    for object in objects.iter_mut() {
+        if let Some(texture) = texture {
+            *object.material.borrow_mut() = SkinnedMaterial::create(texture.clone(), 1.0, 0.0);
+        }
+        object.set_transform(Matrix4::identity());
+    }
+
+    let debug_cubes = create_skeleton_debug_cubes(&mut posed_model, 0.005);
+
+    PosedGlove {
+        objects,
+        debug_cubes,
+    }
+}
+
+/// Small white cubes at every skin joint's posed position (model space).
+fn create_skeleton_debug_cubes(glb_model: &mut GlbModel, cube_size: f32) -> Vec<SceneObject> {
     let mut debug_cubes = Vec::new();
 
-    for node_index in 0..glb_model.skeleton().nodes().len() {
+    for joint in 0..glb_model.skeleton().joint_count() {
+        let Some(node_index) = glb_model.skeleton().node_index_for_joint(joint) else {
+            continue;
+        };
         if let Some(global_transform) = glb_model.get_global_transform(node_index) {
             let bone_position = global_transform.w.truncate();
 
-            let cube_color = if Some(node_index) == highlight_node {
-                vec3(1.0, 0.0, 0.0)
-            } else {
-                vec3(1.0, 1.0, 1.0)
-            };
-
-            let cube_material = color_material::create(cube_color);
+            let cube_material = color_material::create(vec3(1.0, 1.0, 1.0));
             let mut bone_cube =
                 SceneObject::new(cube_material, Box::new(engine::scene::cube::create()));
-
-            let bone_cube_transform = transform
-                * Matrix4::from_translation(bone_position * 1.0)
-                * Matrix4::from_scale(cube_size * 0.2);
-
-            bone_cube.set_transform(bone_cube_transform);
+            bone_cube.set_transform(
+                Matrix4::from_translation(bone_position) * Matrix4::from_scale(cube_size),
+            );
             debug_cubes.push(bone_cube);
         }
     }
 
     debug_cubes
+}
+
+fn load_glove_texture(
+    asset_cache: &mut AssetCache,
+) -> Option<Rc<dyn engine::texture::TextureTrait>> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        asset_cache.get::<_, engine::texture::Texture, _>(&TEXTURE_IMPORTER, "vr_glove_color.jpg")
+    }))
+    .ok()
+    .map(|texture| texture as Rc<dyn engine::texture::TextureTrait>)
 }
 
 fn clone_with_transform(template: &[SceneObject], transform: Matrix4<f32>) -> Vec<SceneObject> {
@@ -153,17 +216,59 @@ impl DebugGlovesScene {
         let core = builder.build_core(build_options);
 
         let glove_model = asset_cache.get(&GLB_MODELS_IMPORTER, "vr_glove_model.glb");
-        let glove_template = load_glove_template(asset_cache);
+        let texture = load_glove_texture(asset_cache);
+        let retarget = HandPoseRetarget::for_right_glove(glove_model.skeleton());
+
+        let open = hand_pose::open_right_hand();
+        let fist = hand_pose::fist_right_hand();
+
+        // Row 1: the reference poses
+        let reference_poses: [Option<Pose>; 4] = [
+            None, // bind pose
+            Some(open.clone()),
+            Some(hand_pose::point_right_hand()),
+            Some(fist.clone()),
+        ];
+        // Row 2: intermediate states - open->fist blends, then a trigger
+        // half-pull (only the index finger curls)
+        let blend_poses: [Option<Pose>; 4] = [
+            Some(open.blend(&fist, 0.25)),
+            Some(open.blend(&fist, 0.5)),
+            Some(open.blend(&fist, 0.75)),
+            Some(open.blend_per_finger(
+                &fist,
+                &hand_pose::FingerAmounts {
+                    index: 0.5,
+                    ..Default::default()
+                },
+            )),
+        ];
+
+        let rows = [reference_poses, blend_poses]
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|pose| {
+                        build_posed_glove(&glove_model, &retarget, pose.as_ref(), texture.as_ref())
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
 
         info!(
-            "Created debug gloves scene with {} glove nodes in template",
-            glove_template.len()
+            "Created debug gloves scene: row 1 bind/open/point/fist, row 2 open->fist blends + trigger half-pull + animated blend"
         );
 
-        let hooks = GloveHooks {
-            glove_template,
-            glove_model,
+        let animation = GloveAnimation {
+            model: glove_model,
+            retarget,
+            texture,
+            open,
+            fist,
+            total_time: 0.0,
         };
+
+        let hooks = GloveHooks { rows, animation };
 
         Box::new(HookedDebugScene::new(core, hooks))
     }

--- a/shock2vr/src/scenes/hand_pose.rs
+++ b/shock2vr/src/scenes/hand_pose.rs
@@ -1,94 +1,29 @@
-use cgmath::{Matrix4, Quaternion, Vector3};
-use num::Zero;
-use std::collections::HashMap;
+//! SteamVR hand poses for the vr_glove GLB model.
+//!
+//! Pose data is transcribed from the SteamVR Unity plugin's reference pose
+//! assets (`SteamVR_Skeleton_Pose`, right hand): 31 bones in the standard
+//! SteamVR hand skeleton order (root, wrist, 4 thumb + 4x5 finger bones,
+//! then 5 aux bones). The glove GLB's 26 skin joints correspond exactly to
+//! SteamVR bones 0..=25 (verified by bone name); the aux bones are not skin
+//! joints and are ignored.
+//!
+//! The GLB rig (exported with FBX2glTF) does not share the pose data's
+//! coordinate conventions: the source data is left-handed (Unity), and every
+//! joint's local frame in the GLB differs from the pose data's frame by a
+//! constant rotation. Poses are therefore retargeted per joint via
+//! [`HandPoseRetarget`] instead of being written to the rig directly.
 
-/// Joint indices for hand bones - mapped to actual GLB skeleton structure
-pub mod joint_indices {
-    // Root and wrist
-    pub const ROOT: usize = 0; // Since joint 0 maps to Root node
-    pub const WRIST: usize = 0; // Alias for ROOT
-    pub const FOREARM_STUB: usize = 1;
+use cgmath::{InnerSpace, Matrix3, Matrix4, Quaternion, Vector3};
+use dark::{glb_model::GlbModel, glb_skeleton::GlbSkeleton};
 
-    // Thumb (2-5)
-    pub const THUMB_METACARPAL: usize = 2;
-    pub const THUMB_PROXIMAL: usize = 3;
-    pub const THUMB_INTERMEDIATE: usize = 4;
-    pub const THUMB_DISTAL: usize = 5;
+/// GLB skin joints driven by pose data. Joint 0 (Root) carries the exporter's
+/// unit-conversion scale and joint 1 (wrist) is the hand's attachment point -
+/// both keep their bind transforms.
+const FIRST_POSED_JOINT: usize = 2;
+const LAST_POSED_JOINT: usize = 25;
 
-    // Index finger (6-10)
-    pub const INDEX_METACARPAL: usize = 6;
-    pub const INDEX_PROXIMAL: usize = 7;
-    pub const INDEX_INTERMEDIATE: usize = 8;
-    pub const INDEX_DISTAL: usize = 9;
-    pub const INDEX_TIP: usize = 10;
-
-    // Middle finger (11-15)
-    pub const MIDDLE_METACARPAL: usize = 11;
-    pub const MIDDLE_PROXIMAL: usize = 12;
-    pub const MIDDLE_INTERMEDIATE: usize = 13;
-    pub const MIDDLE_DISTAL: usize = 14;
-    pub const MIDDLE_TIP: usize = 15;
-
-    // Ring finger (16-20)
-    pub const RING_METACARPAL: usize = 16;
-    pub const RING_PROXIMAL: usize = 17;
-    pub const RING_INTERMEDIATE: usize = 18;
-    pub const RING_DISTAL: usize = 19;
-    pub const RING_TIP: usize = 20;
-
-    // Pinky finger (21-25)
-    pub const PINKY_METACARPAL: usize = 21;
-    pub const PINKY_PROXIMAL: usize = 22;
-    pub const PINKY_INTERMEDIATE: usize = 23;
-    pub const PINKY_DISTAL: usize = 24;
-    pub const PINKY_TIP: usize = 25;
-}
-
-/// Creates a map of joint relationships where key is child joint index and value is parent joint index
-pub fn joint_relationships() -> HashMap<usize, usize> {
-    use joint_indices::*;
-
-    let mut relationships = HashMap::new();
-    relationships.insert(WRIST, ROOT);
-
-    // Thumb chain (starts from wrist)
-    relationships.insert(THUMB_METACARPAL, WRIST);
-    relationships.insert(THUMB_PROXIMAL, THUMB_METACARPAL);
-    relationships.insert(THUMB_INTERMEDIATE, THUMB_PROXIMAL);
-    relationships.insert(THUMB_DISTAL, THUMB_INTERMEDIATE);
-
-    // Index finger chain (starts from wrist)
-    relationships.insert(INDEX_METACARPAL, WRIST);
-    relationships.insert(INDEX_PROXIMAL, INDEX_METACARPAL);
-    relationships.insert(INDEX_INTERMEDIATE, INDEX_PROXIMAL);
-    relationships.insert(INDEX_DISTAL, INDEX_INTERMEDIATE);
-    relationships.insert(INDEX_TIP, INDEX_DISTAL);
-
-    // Middle finger chain (starts from wrist)
-    relationships.insert(MIDDLE_METACARPAL, WRIST);
-    relationships.insert(MIDDLE_PROXIMAL, MIDDLE_METACARPAL);
-    relationships.insert(MIDDLE_INTERMEDIATE, MIDDLE_PROXIMAL);
-    relationships.insert(MIDDLE_DISTAL, MIDDLE_INTERMEDIATE);
-    relationships.insert(MIDDLE_TIP, MIDDLE_DISTAL);
-
-    // Ring finger chain (starts from wrist)
-    relationships.insert(RING_METACARPAL, WRIST);
-    relationships.insert(RING_PROXIMAL, RING_METACARPAL);
-    relationships.insert(RING_INTERMEDIATE, RING_PROXIMAL);
-    relationships.insert(RING_DISTAL, RING_INTERMEDIATE);
-    relationships.insert(RING_TIP, RING_DISTAL);
-
-    // Pinky finger chain (starts from wrist)
-    relationships.insert(PINKY_METACARPAL, WRIST);
-    relationships.insert(PINKY_PROXIMAL, PINKY_METACARPAL);
-    relationships.insert(PINKY_INTERMEDIATE, PINKY_PROXIMAL);
-    relationships.insert(PINKY_DISTAL, PINKY_INTERMEDIATE);
-    relationships.insert(PINKY_TIP, PINKY_DISTAL);
-
-    relationships
-}
-
-/// Represents a hand pose with bone positions and rotations
+/// A hand pose: per-bone parent-relative translations and rotations, in the
+/// SteamVR Unity plugin's conventions.
 #[derive(Debug, Clone)]
 pub struct Pose {
     /// Bone rotations as quaternions
@@ -96,40 +31,210 @@ pub struct Pose {
     pub bone_positions: Vec<Vector3<f32>>,
 }
 
-impl Pose {
-    /// Converts the pose to joint transforms suitable for skeleton overrides
-    ///
-    /// The skeleton system applies transforms as: parent_transform * animation_transform * local_transform
-    /// where local_transform often includes translation (bone length).
-    ///
-    /// For proper joint rotation without bone stretching, we need to provide transforms that
-    /// account for this multiplication order.
-    pub fn to_joint_transforms(&self) -> std::collections::HashMap<u32, Matrix4<f32>> {
-        use std::collections::HashMap;
+/// Per-finger blend amounts (0.0 = first pose, 1.0 = second pose) for
+/// [`Pose::blend_per_finger`]. `Default` leaves every finger at 0.0.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FingerAmounts {
+    pub thumb: f32,
+    pub index: f32,
+    pub middle: f32,
+    pub ring: f32,
+    pub pinky: f32,
+}
 
-        let mut joint_transforms = HashMap::new();
-        let no_rotation = Quaternion::zero();
-
-        for (bone_index, &rotation) in self.bone_rotations.iter().enumerate() {
-            // Skip bones with no rotation (quaternion zero)
-            if rotation != no_rotation {
-                // For now, just apply the rotation directly
-                // TODO: This may cause bone stretching because the rotation gets applied
-                // to the bone's local translation. A proper fix would modify the skeleton
-                // system to handle joint rotations correctly.
-                let translation_matrix = Matrix4::from_translation(self.bone_positions[bone_index]);
-                let rotation_matrix = Matrix4::from(rotation);
-                let xform = translation_matrix * rotation_matrix;
-                joint_transforms.insert(bone_index as u32, xform);
-            }
+impl FingerAmounts {
+    /// The blend amount for a SteamVR bone index (0.0 for non-finger bones).
+    fn for_bone(&self, bone: usize) -> f32 {
+        match bone {
+            2..=5 => self.thumb,
+            6..=10 => self.index,
+            11..=15 => self.middle,
+            16..=20 => self.ring,
+            21..=25 => self.pinky,
+            _ => 0.0,
         }
-
-        joint_transforms
     }
 }
 
-// Old poses:
-// /// Returns the open hand pose for the right hand
+impl Pose {
+    /// Interpolate between two poses (0.0 = self, 1.0 = other). Drives analog
+    /// hand state, e.g. open hand -> fist by grip squeeze.
+    /// (Positions are blended alongside rotations for completeness, but
+    /// [`HandPoseRetarget::apply`] only consumes rotations.)
+    pub fn blend(&self, other: &Pose, amount: f32) -> Pose {
+        self.blend_with(other, |_| amount)
+    }
+
+    /// Interpolate toward `other` with an independent amount per finger -
+    /// e.g. a trigger half-pull curls only the index finger.
+    pub fn blend_per_finger(&self, other: &Pose, amounts: &FingerAmounts) -> Pose {
+        self.blend_with(other, |bone| amounts.for_bone(bone))
+    }
+
+    fn blend_with(&self, other: &Pose, amount_for_bone: impl Fn(usize) -> f32) -> Pose {
+        debug_assert_eq!(
+            self.bone_rotations.len(),
+            other.bone_rotations.len(),
+            "blending poses with different bone counts"
+        );
+        let bone_rotations = self
+            .bone_rotations
+            .iter()
+            .zip(&other.bone_rotations)
+            .enumerate()
+            .map(|(bone, (a, b))| {
+                // Slerp along the shortest arc
+                let b = if a.dot(*b) < 0.0 { -*b } else { *b };
+                a.slerp(b, amount_for_bone(bone))
+            })
+            .collect();
+        let bone_positions = self
+            .bone_positions
+            .iter()
+            .zip(&other.bone_positions)
+            .enumerate()
+            .map(|(bone, (a, b))| a + (b - a) * amount_for_bone(bone))
+            .collect();
+        Pose {
+            bone_rotations,
+            bone_positions,
+        }
+    }
+}
+
+/// Convert a Unity-convention (left-handed) quaternion to the GLB's
+/// right-handed space: a mirror across the YZ plane.
+fn mirror_x(q: Quaternion<f32>) -> Quaternion<f32> {
+    Quaternion::new(q.s, q.v.x, -q.v.y, -q.v.z)
+}
+
+/// Rotation of the GLB wrist frame relative to the pose data's wrist frame
+/// (after handedness conversion). Solved once by aligning the five metacarpal
+/// bind offsets of the two rigs (Kabsch fit); see projects/vr-gloves.md.
+fn wrist_frame() -> Quaternion<f32> {
+    Quaternion::new(0.998_773_2, -0.008_677_66, -0.034_176_15, 0.034_767_6)
+}
+
+/// Extract the rotation part of a TRS matrix (columns normalized to strip
+/// scale; assumes a positive-determinant transform - a mirrored rig, e.g. a
+/// left hand authored as a mirrored right hand, would need sign handling).
+fn rotation_of(m: &Matrix4<f32>) -> Quaternion<f32> {
+    let rot = Matrix3::from_cols(
+        m.x.truncate().normalize(),
+        m.y.truncate().normalize(),
+        m.z.truncate().normalize(),
+    );
+    Quaternion::from(rot).normalize()
+}
+
+/// Per-joint retargeting from SteamVR pose space onto the glove GLB rig.
+///
+/// Both rigs describe the same physical hand, but each GLB joint's local
+/// frame is rotated by a constant basis change `C_j` relative to the pose
+/// data's frame for that bone. Because the GLB's bind pose is the same
+/// physical pose as the plugin's reference open-hand/bind pose, every `C_j`
+/// can be recovered recursively from the two bind poses:
+///
+/// ```text
+/// C_j = mirror(reference_rotation_j)^-1 * C_parent(j) * glb_bind_rotation_j
+/// ```
+///
+/// seeded with [`wrist_frame`]. A pose rotation then maps onto the rig as:
+///
+/// ```text
+/// glb_local_j = C_parent(j)^-1 * mirror(pose_rotation_j) * C_j
+/// ```
+///
+/// This reproduces the GLB bind pose exactly when applying the reference
+/// pose, and only ever writes rotations to the rig (via
+/// [`GlbModel::set_joint_rotation`]), so bone lengths cannot stretch.
+pub struct HandPoseRetarget {
+    /// Basis change `C_j` per joint
+    frames: Vec<Quaternion<f32>>,
+    /// Parent joint index per joint
+    parents: Vec<Option<usize>>,
+}
+
+/// Last posed joint clamped to what the skeleton and pose data actually have.
+fn posed_joint_range(joint_count: usize, bone_count: usize) -> std::ops::RangeInclusive<usize> {
+    let last = LAST_POSED_JOINT
+        .min(joint_count.saturating_sub(1))
+        .min(bone_count.saturating_sub(1));
+    FIRST_POSED_JOINT..=last
+}
+
+impl HandPoseRetarget {
+    /// Build the retarget for the right-hand glove model, using the open-hand
+    /// reference pose (identical to the plugin's bind pose) for calibration.
+    pub fn for_right_glove(skeleton: &GlbSkeleton) -> Self {
+        // Guard against being handed a non-glove skeleton: the calibration
+        // below is only meaningful for the SteamVR hand rig.
+        let wrist_name = skeleton
+            .node_index_for_joint(1)
+            .and_then(|n| skeleton.get_node(n))
+            .and_then(|n| n.name.clone());
+        if skeleton.joint_count() != 26 || wrist_name.as_deref() != Some("wrist_r") {
+            tracing::warn!(
+                "HandPoseRetarget::for_right_glove: skeleton does not look like the SteamVR right glove ({} joints, wrist joint {:?})",
+                skeleton.joint_count(),
+                wrist_name
+            );
+        }
+        Self::new(skeleton, &open_right_hand())
+    }
+
+    fn new(skeleton: &GlbSkeleton, reference: &Pose) -> Self {
+        let joint_count = skeleton.joint_count();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let mut frames = vec![identity; joint_count];
+        let mut parents = vec![None; joint_count];
+
+        if joint_count > 1 {
+            frames[1] = wrist_frame();
+        }
+
+        for joint in posed_joint_range(joint_count, reference.bone_rotations.len()) {
+            let Some(node) = skeleton
+                .node_index_for_joint(joint)
+                .and_then(|n| skeleton.get_node(n))
+            else {
+                continue;
+            };
+            let Some(parent) = node
+                .parent_index
+                .and_then(|p| skeleton.joint_index_for_node(p))
+            else {
+                continue;
+            };
+            // The recursion needs the parent's frame to be computed already;
+            // SteamVR skin joint order is topologically sorted so this holds.
+            debug_assert!(parent < joint, "joint {joint} precedes its parent {parent}");
+            parents[joint] = Some(parent);
+            let glb_bind = rotation_of(&node.local_transform);
+            let reference_bind = mirror_x(reference.bone_rotations[joint]);
+            frames[joint] = (reference_bind.conjugate() * frames[parent] * glb_bind).normalize();
+        }
+
+        Self { frames, parents }
+    }
+
+    /// Apply `pose` to the glove model's finger joints (the wrist and root
+    /// keep their bind transforms).
+    pub fn apply(&self, pose: &Pose, model: &mut GlbModel) {
+        for joint in posed_joint_range(self.frames.len(), pose.bone_rotations.len()) {
+            let Some(parent) = self.parents[joint] else {
+                continue;
+            };
+            let rotation = (self.frames[parent].conjugate()
+                * mirror_x(pose.bone_rotations[joint])
+                * self.frames[joint])
+                .normalize();
+            model.set_joint_rotation(joint, rotation);
+        }
+    }
+}
+
+/// Returns the open hand pose for the right hand (the plugin's bind pose)
 pub fn open_right_hand() -> Pose {
     let positions = vec![
         Vector3::new(0.0, 0.0, 0.0), // Wrist
@@ -278,5 +383,265 @@ pub fn point_right_hand() -> Pose {
     Pose {
         bone_positions: positions,
         bone_rotations: rotations,
+    }
+}
+
+/// Returns the fist pose for the right hand (transcribed from the SteamVR
+/// Unity plugin's fallback_fist reference pose)
+pub fn fist_right_hand() -> Pose {
+    let positions = vec![
+        Vector3::new(-0.0, 0.0, 0.0),
+        Vector3::new(-0.034037687, 0.03650266, 0.16472164),
+        Vector3::new(-0.016305087, 0.027528726, 0.017799662),
+        Vector3::new(0.040405963, -5.1561553e-08, 4.5447194e-08),
+        Vector3::new(0.032516792, -5.1137583e-08, -1.2933195e-08),
+        Vector3::new(0.030463902, 1.6269207e-07, 7.92839e-08),
+        Vector3::new(0.0038021489, 0.021514187, 0.012803366),
+        Vector3::new(0.074204385, 0.005002201, -0.00023377323),
+        Vector3::new(0.043286677, 5.9333324e-08, 1.8320057e-07),
+        Vector3::new(0.028275194, -9.297885e-08, -1.2653295e-07),
+        Vector3::new(0.022821384, -1.4365155e-07, 7.651614e-08),
+        Vector3::new(0.005786922, 0.0068064053, 0.016533904),
+        Vector3::new(0.07095288, -0.00077883265, -0.000997186),
+        Vector3::new(0.043108486, -9.950596e-08, -6.7041825e-09),
+        Vector3::new(0.03326598, -1.7544496e-08, -2.0628962e-08),
+        Vector3::new(0.025892371, 9.984198e-08, -2.0352908e-09),
+        Vector3::new(0.004123044, -0.0068582613, 0.016562859),
+        Vector3::new(0.06587581, -0.0017857892, -0.00069344096),
+        Vector3::new(0.040331207, -9.449958e-08, -2.273692e-08),
+        Vector3::new(0.028488781, 1.01152565e-07, 4.5493586e-08),
+        Vector3::new(0.022430236, 1.0846127e-07, -1.7428562e-08),
+        Vector3::new(0.0011314574, -0.019294508, 0.01542875),
+        Vector3::new(0.0628784, -0.0028440945, -0.0003315112),
+        Vector3::new(0.029874247, -3.4247638e-08, -9.126629e-08),
+        Vector3::new(0.017978692, -2.8448923e-09, -2.0797508e-07),
+        Vector3::new(0.01801794, -2.00012e-08, 6.59746e-08),
+        Vector3::new(0.019716311, 0.002801723, 0.093936935),
+        Vector3::new(-0.0075385696, 0.01764465, 0.10240429),
+        Vector3::new(-0.0031984635, 0.0072115273, 0.11665362),
+        Vector3::new(2.6269245e-05, -0.007118772, 0.13072418),
+        Vector3::new(-0.0018780098, -0.02256182, 0.14003526),
+    ];
+
+    let rotations = vec![
+        Quaternion::new(-4.371139e-08, -6.123234e-17, 1.0, 6.123234e-17),
+        Quaternion::new(-0.055146642, -0.078608155, -0.92027926, 0.3792963),
+        Quaternion::new(0.48333195, -0.2257035, -0.836342, 0.12641343),
+        Quaternion::new(0.89433527, -0.01330204, 0.0829018, -0.43944824),
+        Quaternion::new(0.80864674, 0.00072834245, -0.0012028969, -0.58829284),
+        Quaternion::new(1.0, -1.3877788e-17, -1.3877788e-17, -5.551115e-17),
+        Quaternion::new(0.39517453, -0.6173145, -0.44918522, -0.5108743),
+        Quaternion::new(0.67689514, -0.041852362, 0.11180638, -0.72633374),
+        Quaternion::new(0.56458294, -0.0005700487, 0.115204416, -0.81729656),
+        Quaternion::new(0.7452787, -0.010756178, 0.027241308, -0.66610956),
+        Quaternion::new(1.0, 6.938894e-18, 1.9428903e-16, -1.348151e-33),
+        Quaternion::new(0.522315, -0.5142028, -0.4836996, -0.47834843),
+        Quaternion::new(0.68225396, -0.09487112, -0.05422859, -0.7229027),
+        Quaternion::new(0.6382125, 0.0076794685, -0.09769542, -0.7635977),
+        Quaternion::new(0.6548623, -0.06366954, 0.00036316764, -0.7530614),
+        Quaternion::new(0.9991947, 1.1639192e-17, -5.602331e-17, -0.040125635),
+        Quaternion::new(0.523374, -0.489609, -0.46399677, -0.52064353),
+        Quaternion::new(0.7000152, -0.088269405, 0.012672794, -0.7085384),
+        Quaternion::new(0.66427904, -0.0005935501, -0.039828163, -0.74642265),
+        Quaternion::new(0.62664175, -0.027121458, -0.005438834, -0.7788164),
+        Quaternion::new(1.0, 6.938894e-18, -9.62965e-35, -1.3877788e-17),
+        Quaternion::new(0.47783276, -0.47976637, -0.37993452, -0.63019824),
+        Quaternion::new(0.7144873, -0.094065815, 0.062634066, -0.69046116),
+        Quaternion::new(0.7017823, 0.00313052, 0.03775632, -0.7113834),
+        Quaternion::new(0.6767216, -0.008087321, -0.003009417, -0.7361885),
+        Quaternion::new(1.0, 0.0, 0.0, 1.9081958e-17),
+        Quaternion::new(0.33249632, -0.54886997, 0.1177861, -0.7578353),
+        Quaternion::new(-0.114980996, 0.13243657, -0.8730836, -0.45493412),
+        Quaternion::new(-0.019245595, 0.17098099, -0.92266804, -0.34507802),
+        Quaternion::new(-0.064137466, 0.15011512, -0.952169, -0.25831383),
+        Quaternion::new(-0.0037347008, 0.07684197, -0.97957754, -0.18576658),
+    ];
+
+    Pose {
+        bone_positions: positions,
+        bone_rotations: rotations,
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::Point3;
+    use collision::Aabb3;
+    use dark::importers::skeleton_from_glb_bytes;
+
+    fn glove_model() -> GlbModel {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../assets/vr_glove_model.glb");
+        let bytes = std::fs::read(path).expect("read vr_glove_model.glb");
+        let skeleton = skeleton_from_glb_bytes(&bytes).expect("glove GLB has a skeleton");
+        let unit = Aabb3::new(Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, 0.0, 0.0));
+        GlbModel::new(Vec::new(), unit, skeleton)
+    }
+
+    /// World-space joint positions (the Root joint carries the exporter's
+    /// x100 unit scale, so these are in meters).
+    fn joint_positions(model: &mut GlbModel) -> Vec<Vector3<f32>> {
+        (0..model.skeleton().joint_count())
+            .map(|joint| {
+                let node = model.skeleton().node_index_for_joint(joint).unwrap();
+                model.get_global_transform(node).unwrap().w.truncate()
+            })
+            .collect()
+    }
+
+    fn parent_joints(model: &GlbModel) -> Vec<Option<usize>> {
+        (0..model.skeleton().joint_count())
+            .map(|joint| {
+                let node = model.skeleton().node_index_for_joint(joint).unwrap();
+                model
+                    .skeleton()
+                    .get_node(node)
+                    .and_then(|n| n.parent_index)
+                    .and_then(|p| model.skeleton().joint_index_for_node(p))
+            })
+            .collect()
+    }
+
+    fn segment_lengths(positions: &[Vector3<f32>], parents: &[Option<usize>]) -> Vec<f32> {
+        parents
+            .iter()
+            .enumerate()
+            .map(|(joint, parent)| match parent {
+                Some(p) => (positions[joint] - positions[*p]).magnitude(),
+                None => 0.0,
+            })
+            .collect()
+    }
+
+    /// Posing must never stretch bones: every parent->child segment keeps its
+    /// bind length under every pose.
+    #[test]
+    fn posing_preserves_bone_lengths() {
+        let mut model = glove_model();
+        let parents = parent_joints(&model);
+        let bind_lengths = segment_lengths(&joint_positions(&mut model), &parents);
+        let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+
+        for (name, pose) in [
+            ("open", open_right_hand()),
+            ("point", point_right_hand()),
+            ("fist", fist_right_hand()),
+        ] {
+            retarget.apply(&pose, &mut model);
+            let lengths = segment_lengths(&joint_positions(&mut model), &parents);
+            for (joint, (bind, posed)) in bind_lengths.iter().zip(&lengths).enumerate() {
+                assert!(
+                    (bind - posed).abs() < 1e-4,
+                    "{name}: joint {joint} segment length changed: bind {bind} vs posed {posed}"
+                );
+            }
+        }
+    }
+
+    /// The open-hand reference pose IS the GLB's bind pose, so applying it
+    /// must reproduce the bind joint positions exactly.
+    #[test]
+    fn open_pose_matches_bind_pose() {
+        let mut model = glove_model();
+        let bind = joint_positions(&mut model);
+        let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+
+        retarget.apply(&open_right_hand(), &mut model);
+        let posed = joint_positions(&mut model);
+        for (joint, (b, p)) in bind.iter().zip(&posed).enumerate() {
+            let err = (b - p).magnitude();
+            assert!(
+                err < 1e-4,
+                "joint {joint} moved {err} m under the open (bind) pose"
+            );
+        }
+    }
+
+    /// The fist pose must actually curl the fingers: fingertips end up much
+    /// closer to the wrist than in the open pose.
+    #[test]
+    fn fist_pose_curls_fingers() {
+        let mut model = glove_model();
+        let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+        let wrist = joint_positions(&mut model)[1];
+
+        // SteamVR joint order: tips are 10 (index), 15 (middle), 20 (ring), 25 (pinky)
+        for tip in [10usize, 15, 20, 25] {
+            let open_dist = (joint_positions(&mut model)[tip] - wrist).magnitude();
+            retarget.apply(&fist_right_hand(), &mut model);
+            let fist_dist = (joint_positions(&mut model)[tip] - wrist).magnitude();
+            assert!(
+                fist_dist < open_dist - 0.05,
+                "tip joint {tip}: fist ({fist_dist} m) should be >5cm closer to wrist than open ({open_dist} m)"
+            );
+            retarget.apply(&open_right_hand(), &mut model);
+        }
+    }
+
+    /// Blending open->fist matches the endpoints exactly and produces a
+    /// genuine intermediate pose at the midpoint.
+    #[test]
+    fn blend_interpolates_between_poses() {
+        let mut model = glove_model();
+        let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+        let open = open_right_hand();
+        let fist = fist_right_hand();
+
+        let tip = 15; // middle fingertip
+        retarget.apply(&open, &mut model);
+        let open_tip = joint_positions(&mut model)[tip];
+        retarget.apply(&fist, &mut model);
+        let fist_tip = joint_positions(&mut model)[tip];
+
+        retarget.apply(&open.blend(&fist, 0.0), &mut model);
+        assert!((joint_positions(&mut model)[tip] - open_tip).magnitude() < 1e-5);
+        retarget.apply(&open.blend(&fist, 1.0), &mut model);
+        assert!((joint_positions(&mut model)[tip] - fist_tip).magnitude() < 1e-5);
+
+        retarget.apply(&open.blend(&fist, 0.5), &mut model);
+        let mid_tip = joint_positions(&mut model)[tip];
+        let from_open = (mid_tip - open_tip).magnitude();
+        let from_fist = (mid_tip - fist_tip).magnitude();
+        assert!(
+            from_open > 0.01 && from_fist > 0.01,
+            "midpoint should be a real intermediate (from_open {from_open} m, from_fist {from_fist} m)"
+        );
+    }
+
+    /// Per-finger blending curls only the selected finger: with index=1.0 the
+    /// index tip matches the fist, while the middle tip stays at the open pose.
+    #[test]
+    fn per_finger_blend_curls_only_selected_finger() {
+        let mut model = glove_model();
+        let retarget = HandPoseRetarget::for_right_glove(model.skeleton());
+        let open = open_right_hand();
+        let fist = fist_right_hand();
+
+        let index_tip = 10;
+        let middle_tip = 15;
+        retarget.apply(&open, &mut model);
+        let open_positions = joint_positions(&mut model);
+        retarget.apply(&fist, &mut model);
+        let fist_index_tip = joint_positions(&mut model)[index_tip];
+
+        let trigger_pull = open.blend_per_finger(
+            &fist,
+            &FingerAmounts {
+                index: 1.0,
+                ..Default::default()
+            },
+        );
+        retarget.apply(&trigger_pull, &mut model);
+        let positions = joint_positions(&mut model);
+
+        let index_err = (positions[index_tip] - fist_index_tip).magnitude();
+        let middle_err = (positions[middle_tip] - open_positions[middle_tip]).magnitude();
+        assert!(
+            index_err < 1e-5,
+            "index tip should match the fist (err {index_err} m)"
+        );
+        assert!(
+            middle_err < 1e-5,
+            "middle tip should stay at the open pose (err {middle_err} m)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Programmatic SteamVR hand poses (open, point, fist, and analog blends) now apply correctly to the `vr_glove_model.glb` — the goal of the November glove attempts (#214–#224) that were abandoned at "skinning data causes a zoom". Three independent bugs were stacked on top of each other:

1. **Double ×100 scale (the "zoom")** — FBX2glTF baked a ×100 unit conversion into both the `Root` joint and the mesh node, and the importer baked the mesh-node transform into skinned vertices while the skinning matrices carry the Root's ×100 again. Per the glTF spec, skinned meshes now ignore the mesh node transform; `GlbModel::new` bakes bind-pose skinning so unposed clones render correctly; skinned bounding boxes are computed from bind-skinned positions.
2. **Bone stretching** — poses used to replace whole joint transforms (killing bind translations and the Root scale). New `GlbAnimationState::set_joint_rotation` writes rotation only, so bones cannot stretch by construction.
3. **Coordinate conventions** — the pose data is Unity (left-handed) on Valve's rig, and FBX2glTF rotated every GLB joint's local frame by a constant offset (up to ~44°), so no global mirror works. `HandPoseRetarget` recovers each joint's basis change from the two bind poses (Kabsch-seeded at the wrist) and reproduces the GLB bind exactly for the open-hand reference pose.

Also adds Valve's `fallback_fist` pose data, `Pose::blend` and `Pose::blend_per_finger` (trigger half-pull: index curls, other fingers stay), and rebuilds the `debug_gloves` scene as a two-row line-up — reference poses (bind/open/point/fist), 25/50/75% open→fist blends, an index-only half-pull, and a time-animated open→fist glove.

Full analysis in `projects/vr-gloves.md`.

## Test plan

- [x] New unit tests against the real GLB (headless, via `skeleton_from_glb_bytes`): bone-length invariant under every pose, open≡bind (calibration invariant, fails without retargeting), fist curls fingertips >5 cm, blend endpoints exact, per-finger blend isolates the index finger
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `cargo test -p dark -p shock2vr`
- [x] Full SDK e2e suite (39/39, including all-missions-load)
- [x] `/xreview` (Claude + Codex): no Critical/High; agreed Medium (skinned bbox) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![debug_gloves pose line-up demo](https://gist.githubusercontent.com/tommy-xr/6768d45f269b67c653f1526fd8c9d9e9/raw/demo.gif)

<sub>debug_gloves line-up — top row: bind / open / point / fist reference poses; bottom row: 25/50/75% open→fist blends, index-only trigger half-pull, and an animated open→fist blend. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![debug_gloves still](https://gist.githubusercontent.com/tommy-xr/6768d45f269b67c653f1526fd8c9d9e9/raw/still.png)
