### PR TITLE
feat(ai): force-alertness debug actions and AI state introspection

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -466,6 +466,10 @@ pub enum DebugEntityMessage {
     Frob,
     /// Send a named AI signal.
     Signal { name: String },
+    /// Force an AI's alertness level (clamped by its alert cap).
+    SetAlertness {
+        level: dark::properties::AIAlertLevel,
+    },
 }
 
 /// Status of the interactive pathfinding test system

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -45,6 +45,11 @@ pub enum InputAction {
     /// Reload the current level in place (debug). Exercises the level-transition path,
     /// including the experimental loading screen.
     DebugReloadLevel,
+
+    /// Force every AI to Moderate alertness (chase) - debug "make them angry"
+    DebugAlertAll,
+    /// Force every AI back to Lowest alertness (idle)
+    DebugCalmAll,
 }
 
 impl InputAction {
@@ -64,6 +69,8 @@ impl InputAction {
             InputAction::Reload,
             InputAction::CyclePsiPower,
             InputAction::DebugReloadLevel,
+            InputAction::DebugAlertAll,
+            InputAction::DebugCalmAll,
         ]
     }
 
@@ -81,6 +88,8 @@ impl InputAction {
             InputAction::Reload => "Reload",
             InputAction::CyclePsiPower => "CyclePsiPower",
             InputAction::DebugReloadLevel => "DebugReloadLevel",
+            InputAction::DebugAlertAll => "DebugAlertAll",
+            InputAction::DebugCalmAll => "DebugCalmAll",
         }
     }
 }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -46,9 +46,13 @@ pub enum InputAction {
     /// including the experimental loading screen.
     DebugReloadLevel,
 
-    /// Force every AI to Moderate alertness (chase) - debug "make them angry"
+    /// Force every monster to Moderate alertness (chase) - debug "make them
+    /// angry". A forced level is a behavior reset: it also cancels scripted
+    /// sequences (which won't restart). Dead AIs are unaffected; cameras and
+    /// turrets manage their own alertness and ignore this.
     DebugAlertAll,
-    /// Force every AI back to Lowest alertness (idle)
+    /// Force every monster back to Lowest alertness (idle). Same caveats as
+    /// DebugAlertAll.
     DebugCalmAll,
 }
 

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -1,5 +1,6 @@
 use crate::input_context::InputContext;
 use crate::scripts::{Effect, GlobalEffect};
+use dark::properties::AIAlertLevel;
 
 use super::{InputAction, InputActionState};
 
@@ -77,6 +78,18 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::DebugReloadLevel) {
             effects.push(Effect::GlobalEffect(GlobalEffect::TestReload));
         }
+        if state.just_triggered(InputAction::DebugAlertAll) {
+            // Moderate = chase; High maps to attack behaviors, which assume
+            // the player is already in range
+            effects.push(Effect::SetAllAIAlertness {
+                level: AIAlertLevel::Moderate,
+            });
+        }
+        if state.just_triggered(InputAction::DebugCalmAll) {
+            effects.push(Effect::SetAllAIAlertness {
+                level: AIAlertLevel::Lowest,
+            });
+        }
 
         effects
     }
@@ -128,6 +141,34 @@ mod tests {
             }
             other => panic!("expected SpawnInFrontOfPlayer, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn alert_all_maps_to_moderate_broadcast() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::DebugAlertAll);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(matches!(
+            effects[0],
+            Effect::SetAllAIAlertness {
+                level: AIAlertLevel::Moderate
+            }
+        ));
+    }
+
+    #[test]
+    fn calm_all_maps_to_lowest_broadcast() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::DebugCalmAll);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(matches!(
+            effects[0],
+            Effect::SetAllAIAlertness {
+                level: AIAlertLevel::Lowest
+            }
+        ));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -77,9 +77,9 @@ use crate::{
     physics::{self, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
-        RuntimePropAttachment, RuntimePropDoNotSerialize, RuntimePropFlatAim,
-        RuntimePropJointTransforms, RuntimePropReloading, RuntimePropSelectedAmmo,
-        RuntimePropTransform, RuntimePropVhots,
+        RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDoNotSerialize,
+        RuntimePropFlatAim, RuntimePropJointTransforms, RuntimePropReloading,
+        RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -2114,7 +2114,23 @@ impl MissionCore {
                     AIPropertyUpdate::Mode { mode } => {
                         self.world.add_component(entity_id, PropAIMode { mode });
                     }
+                    AIPropertyUpdate::Behavior { name } => {
+                        self.world
+                            .add_component(entity_id, RuntimePropAIBehavior(name));
+                    }
                 },
+                Effect::SetAllAIAlertness { level } => {
+                    let creature_ids: Vec<EntityId> = {
+                        let v_creature = self.world.borrow::<View<PropCreature>>().unwrap();
+                        v_creature.iter().ids().collect()
+                    };
+                    for id in creature_ids {
+                        self.script_world.dispatch(Message {
+                            to: id,
+                            payload: MessagePayload::SetAlertness { level },
+                        });
+                    }
+                }
                 Effect::SetPositionRotation {
                     entity_id,
                     rotation,
@@ -3522,6 +3538,8 @@ impl crate::game_scene::DebuggableScene for MissionCore {
              v_sym_name: View<dark::properties::PropSymName>,
              v_scripts: View<dark::properties::PropScripts>,
              v_gun_state: View<dark::properties::PropGunState>,
+             v_alertness: View<PropAIAlertness>,
+             v_ai_behavior: View<RuntimePropAIBehavior>,
              v_links: View<dark::properties::Links>| {
                 let position = v_pos.get(id).ok()?;
                 let rotation_array = [
@@ -3572,6 +3590,21 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "Ammo".to_string(),
                         value: gun_state.ammo.to_string(),
+                    });
+                }
+
+                // AI state (alertness mirrored by the script, behavior name
+                // published for introspection)
+                if let Ok(alertness) = v_alertness.get(id) {
+                    properties.push(DebugPropertyInfo {
+                        name: "AIAlertness".to_string(),
+                        value: format!("{:?}", alertness.level),
+                    });
+                }
+                if let Ok(behavior) = v_ai_behavior.get(id) {
+                    properties.push(DebugPropertyInfo {
+                        name: "AIBehavior".to_string(),
+                        value: behavior.0.clone(),
                     });
                 }
 
@@ -3867,6 +3900,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             DebugEntityMessage::Damage { amount } => MessagePayload::Damage { amount },
             DebugEntityMessage::Frob => MessagePayload::Frob,
             DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
+            DebugEntityMessage::SetAlertness { level } => MessagePayload::SetAlertness { level },
         };
 
         self.script_world.dispatch(Message { to: id, payload });

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -19,6 +19,11 @@ pub struct RuntimePropGazeAmount(pub f32);
 #[derive(Component)]
 pub struct RuntimePropTransform(pub Matrix4<f32>);
 
+// Name of the behavior an AI script is currently running (published by the
+// script when it changes; read by debug introspection)
+#[derive(Component)]
+pub struct RuntimePropAIBehavior(pub String);
+
 #[derive(Component)]
 pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -37,6 +37,15 @@ struct MonsterConfig {
     timings: AlertnessTimings,
 }
 
+/// Alert cap for monsters without a PropAIAlertCap property
+fn default_alert_cap() -> PropAIAlertCap {
+    PropAIAlertCap {
+        max_level: AIAlertLevel::High,
+        min_level: AIAlertLevel::Lowest,
+        min_relax: AIAlertLevel::Low,
+    }
+}
+
 pub struct AnimatedMonsterAI {
     last_hit_sensor: Option<EntityId>,
     current_behavior: Box<RefCell<dyn Behavior>>,
@@ -98,11 +107,7 @@ impl AnimatedMonsterAI {
             .get(entity_id)
             .ok()
             .cloned()
-            .unwrap_or(PropAIAlertCap {
-                max_level: AIAlertLevel::High,
-                min_level: AIAlertLevel::Lowest,
-                min_relax: AIAlertLevel::Low,
-            });
+            .unwrap_or_else(default_alert_cap);
 
         // Build default aware delay for monsters (faster than cameras/turrets)
         let default_aware_delay = PropAIAwareDelay {
@@ -403,8 +408,10 @@ impl Script for AnimatedMonsterAI {
             &FovDebugConfig::monster(),
         );
 
-        // Publish the current behavior name for debug introspection (covers
-        // every behavior-change site, since update runs each frame)
+        // Publish the current behavior name for debug introspection. Update
+        // runs each frame, so this covers every behavior-change site with at
+        // most one frame of lag (e.g. handle_message changes, or the
+        // AIWatchObj early-return above, publish on the next update)
         let behavior_name = self.current_behavior.borrow().name();
         let behavior_publish_effect = if self.published_behavior != Some(behavior_name) {
             self.published_behavior = Some(behavior_name);
@@ -494,23 +501,25 @@ impl Script for AnimatedMonsterAI {
                 }
             }
             MessagePayload::SetAlertness { level } => {
-                let cap =
-                    self.config
-                        .as_ref()
-                        .map(|c| c.alert_cap.clone())
-                        .unwrap_or(PropAIAlertCap {
-                            max_level: AIAlertLevel::High,
-                            min_level: AIAlertLevel::Lowest,
-                            min_relax: AIAlertLevel::Low,
-                        });
-                if !alertness::set_level(&mut self.alertness, *level, &cap) {
+                // Dead AIs stay dead - a corpse keeps a live script, and the
+                // broadcast (DebugAlertAll) reaches every creature
+                if self.is_dead || is_killed(entity_id, world) {
                     return Effect::NoEffect;
                 }
+                let cap = self
+                    .config
+                    .as_ref()
+                    .map(|c| c.alert_cap.clone())
+                    .unwrap_or_else(default_alert_cap);
+                alertness::set_level(&mut self.alertness, *level, &cap);
                 // Forced level starts fresh: no accumulated visibility time
                 // pushing an immediate escalation or decay
                 self.alertness.visible_time = 0.0;
                 self.alertness.hidden_time = 0.0;
 
+                // Always reset the behavior to the canonical one for this
+                // level, even when the level didn't change - forcing is a
+                // debug reset, so it also cancels scripted sequences
                 self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
                 let is_locomotion = self.current_behavior.borrow().is_locomotion();
                 let selection_strategy = self.next_selection(is_locomotion);

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -52,6 +52,8 @@ pub struct AnimatedMonsterAI {
     alertness: AlertnessState,
     /// Alertness configuration (loaded from entity properties)
     config: Option<MonsterConfig>,
+    /// Behavior name last published for debug introspection
+    published_behavior: Option<&'static str>,
 }
 
 impl AnimatedMonsterAI {
@@ -67,6 +69,7 @@ impl AnimatedMonsterAI {
             played_ai_watch_obj: HashSet::new(),
             alertness: AlertnessState::default(),
             config: None,
+            published_behavior: None,
         }
     }
 
@@ -83,6 +86,7 @@ impl AnimatedMonsterAI {
             played_ai_watch_obj: HashSet::new(),
             alertness: AlertnessState::default(),
             config: None,
+            published_behavior: None,
         }
     }
 
@@ -399,6 +403,21 @@ impl Script for AnimatedMonsterAI {
             &FovDebugConfig::monster(),
         );
 
+        // Publish the current behavior name for debug introspection (covers
+        // every behavior-change site, since update runs each frame)
+        let behavior_name = self.current_behavior.borrow().name();
+        let behavior_publish_effect = if self.published_behavior != Some(behavior_name) {
+            self.published_behavior = Some(behavior_name);
+            Effect::SetAIProperty {
+                entity_id,
+                update: crate::scripts::AIPropertyUpdate::Behavior {
+                    name: behavior_name.to_string(),
+                },
+            }
+        } else {
+            Effect::NoEffect
+        };
+
         Effect::combine(vec![
             alertness_effect,
             behavior_change_effect,
@@ -407,6 +426,7 @@ impl Script for AnimatedMonsterAI {
             sensor_effect,
             alertness_debug_effect,
             fov_debug_effect,
+            behavior_publish_effect,
         ])
     }
 
@@ -472,6 +492,36 @@ impl Script for AnimatedMonsterAI {
                 } else {
                     Effect::NoEffect
                 }
+            }
+            MessagePayload::SetAlertness { level } => {
+                let cap =
+                    self.config
+                        .as_ref()
+                        .map(|c| c.alert_cap.clone())
+                        .unwrap_or(PropAIAlertCap {
+                            max_level: AIAlertLevel::High,
+                            min_level: AIAlertLevel::Lowest,
+                            min_relax: AIAlertLevel::Low,
+                        });
+                if !alertness::set_level(&mut self.alertness, *level, &cap) {
+                    return Effect::NoEffect;
+                }
+                // Forced level starts fresh: no accumulated visibility time
+                // pushing an immediate escalation or decay
+                self.alertness.visible_time = 0.0;
+                self.alertness.hidden_time = 0.0;
+
+                self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
+                let is_locomotion = self.current_behavior.borrow().is_locomotion();
+                let selection_strategy = self.next_selection(is_locomotion);
+                Effect::combine(vec![
+                    alertness::sync_alertness_effect(entity_id, &self.alertness),
+                    Effect::QueueAnimationBySchema {
+                        entity_id,
+                        motion_query_items: self.current_behavior.borrow().animation(),
+                        selection_strategy,
+                    },
+                ])
             }
             MessagePayload::AnimationCompleted => {
                 if self.is_dead {

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -23,6 +23,9 @@ pub enum NextBehavior {
 }
 
 pub trait Behavior {
+    /// Short stable name for debug introspection (e.g. "Chase", "Wander")
+    fn name(&self) -> &'static str;
+
     fn animation(&self) -> Vec<MotionQueryItem> {
         vec![]
     }

--- a/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
@@ -43,6 +43,10 @@ impl ChaseBehavior {
 }
 
 impl Behavior for ChaseBehavior {
+    fn name(&self) -> &'static str {
+        "Chase"
+    }
+
     fn turn_speed(&self) -> Deg<f32> {
         Deg(360.0)
     }

--- a/shock2vr/src/scripts/ai/behavior/dead_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/dead_behavior.rs
@@ -16,6 +16,10 @@ use super::Behavior;
 pub struct DeadBehavior {}
 
 impl Behavior for DeadBehavior {
+    fn name(&self) -> &'static str {
+        "Dead"
+    }
+
     fn turn_speed(&self) -> Deg<f32> {
         Deg(0.0)
     }

--- a/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
@@ -5,6 +5,10 @@ use super::Behavior;
 pub struct IdleBehavior;
 
 impl Behavior for IdleBehavior {
+    fn name(&self) -> &'static str {
+        "Idle"
+    }
+
     fn animation(self: &IdleBehavior) -> Vec<MotionQueryItem> {
         vec![MotionQueryItem::new("idlegesture")]
         //vec![MotionQueryItem::new("stand")]

--- a/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
@@ -20,6 +20,10 @@ use super::{Behavior, ChaseBehavior, NextBehavior};
 pub struct MeleeAttackBehavior;
 
 impl Behavior for MeleeAttackBehavior {
+    fn name(&self) -> &'static str {
+        "MeleeAttack"
+    }
+
     fn animation(self: &MeleeAttackBehavior) -> Vec<MotionQueryItem> {
         vec![
             MotionQueryItem::new("meleecombat"),

--- a/shock2vr/src/scripts/ai/behavior/noop_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/noop_behavior.rs
@@ -3,4 +3,8 @@ use super::Behavior;
 #[allow(dead_code)]
 pub struct NoopBehavior;
 
-impl Behavior for NoopBehavior {}
+impl Behavior for NoopBehavior {
+    fn name(&self) -> &'static str {
+        "Noop"
+    }
+}

--- a/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/ranged_attack_behavior.rs
@@ -19,6 +19,10 @@ use super::{Behavior, ChaseBehavior, NextBehavior};
 pub struct RangedAttackBehavior;
 
 impl Behavior for RangedAttackBehavior {
+    fn name(&self) -> &'static str {
+        "RangedAttack"
+    }
+
     fn animation(self: &RangedAttackBehavior) -> Vec<MotionQueryItem> {
         vec![
             MotionQueryItem::new("rangedcombat").optional(),

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -48,6 +48,10 @@ impl ScriptedSequenceBehavior {
 }
 
 impl Behavior for ScriptedSequenceBehavior {
+    fn name(&self) -> &'static str {
+        "ScriptedSequence"
+    }
+
     fn animation(&self) -> Vec<MotionQueryItem> {
         self.current_scripted_action.borrow().animation()
     }

--- a/shock2vr/src/scripts/ai/behavior/search_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/search_behavior.rs
@@ -6,6 +6,10 @@ use super::Behavior;
 pub struct SearchBehavior;
 
 impl Behavior for SearchBehavior {
+    fn name(&self) -> &'static str {
+        "Search"
+    }
+
     fn animation(self: &SearchBehavior) -> Vec<MotionQueryItem> {
         vec![
             MotionQueryItem::new("search"),

--- a/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
@@ -40,6 +40,10 @@ impl WanderBehavior {
 }
 
 impl Behavior for WanderBehavior {
+    fn name(&self) -> &'static str {
+        "Wander"
+    }
+
     fn steer(
         &mut self,
         current_heading: Deg<f32>,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -50,6 +50,10 @@ pub enum AIPropertyUpdate {
     Mode {
         mode: AIMode,
     },
+    /// Name of the behavior the AI is currently running (debug introspection)
+    Behavior {
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -224,6 +228,12 @@ pub enum Effect {
     SetAIProperty {
         entity_id: EntityId,
         update: AIPropertyUpdate,
+    },
+
+    /// Debug: force the alertness level of every AI in the mission (broadcast
+    /// as a SetAlertness message to each creature's script)
+    SetAllAIAlertness {
+        level: AIAlertLevel,
     },
 
     AcquireKeyCard {

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -133,6 +133,11 @@ pub enum MessagePayload {
         name: String,
     },
 
+    // Debug: force an AI's alertness level (clamped by its alert cap)
+    SetAlertness {
+        level: dark::properties::AIAlertLevel,
+    },
+
     Slay, // kill the entity
 
     // Interaction events

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -53,7 +53,8 @@ export interface PathfindingTestStatus {
 export type DebugEntityMessage =
   | { type: "Damage"; amount: number }
   | { type: "Frob" }
-  | { type: "Signal"; name: string };
+  | { type: "Signal"; name: string }
+  | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" };
 
 export interface EntitySummary {
   id: number;

--- a/tools/shock2-sdk/test/ai-alertness.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-alertness.e2e.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+function distanceXZ(a: [number, number, number], b: { x: number; z: number }): number {
+  const dx = a[0] - b.x;
+  const dz = a[2] - b.z;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+test(
+  "forced alertness deterministically drives AI behavior and chase steering",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(
+      monster,
+      `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((e) => e.id))}`,
+    );
+
+    // Freshly spawned: unaware and idle.
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
+    assert.equal(aiProp(detail, "AIBehavior"), "Idle");
+
+    // Baseline distance while the monster is still idle (stationary).
+    const player = await game.player.position();
+    const before = distanceXZ(detail.position, player);
+
+    // DebugAlertAll forces Moderate alertness -> Chase behavior, with no
+    // dependence on FOV or visibility timing.
+    await game.input.trigger("DebugAlertAll");
+    await game.step({ frames: 30 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Moderate");
+    assert.equal(aiProp(detail, "AIBehavior"), "Chase");
+
+    // The chasing monster closes on the player.
+    await game.step({ frames: 120 });
+    detail = await game.entities.detail(monster.id);
+    const after = distanceXZ(detail.position, player);
+    assert.ok(
+      after < before - 1.0,
+      `expected the monster to close on the player (before=${before.toFixed(2)}, after=${after.toFixed(2)})`,
+    );
+
+    // DebugCalmAll returns it to idle.
+    await game.input.trigger("DebugCalmAll");
+    await game.step({ frames: 30 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
+    assert.equal(aiProp(detail, "AIBehavior"), "Idle");
+
+    // Per-entity forcing via the message endpoint works too. The monster is
+    // already at melee range from the chase, so Chase may legitimately
+    // escalate to MeleeAttack via next_behavior - the alertness level is the
+    // deterministic assertion here.
+    const accepted = await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "Moderate",
+    });
+    assert.ok(accepted);
+    await game.step({ frames: 30 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Moderate");
+    const behavior = aiProp(detail, "AIBehavior");
+    assert.ok(
+      behavior === "Chase" || behavior === "MeleeAttack",
+      `expected Chase or MeleeAttack, got ${behavior}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

First follow-up from the pathfinding sequence (after #270/#271): deterministic AI testing. Natural AI alerting depends on FOV and visibility timing, which varies per run — this was the blocker for reliable steering e2e tests. AIs can now be forced into a known alertness state and observed remotely.

- **`MessagePayload::SetAlertness`** forces an AI's alertness through the same path natural escalation uses (`alertness::set_level`, clamped by the entity's alert cap), swaps in the canonical behavior for that level, and resets visibility timers. Dead AIs ignore it (corpses keep live scripts — without the guard, a broadcast stood them back up). A forced level is a deliberate behavior reset: it also cancels scripted sequences (documented on the actions).
- **`DebugAlertAll` / `DebugCalmAll` input actions** broadcast it to every creature (Moderate = chase, Lowest = idle) — the "make every monster angry" cheat, instantly available as a keybinding, `POST /v1/input/action`, and `game.input.trigger(...)` via the existing action plumbing. Cameras/turrets manage their own alertness and ignore it for now.
- **Per-entity forcing** via the existing message endpoint: `POST /v1/entities/:id/message {"type": "SetAlertness", "level": "Moderate"}` (+ SDK type).
- **Introspection**: `Behavior` trait gained `name()`; `AnimatedMonsterAI` publishes it on change as `RuntimePropAIBehavior`. `/v1/entities/:id` now reports `AIBehavior` and `AIAlertness` in `properties`, so remote clients can assert on AI state.

## Verified

New e2e (`test/ai-alertness.e2e.test.ts`, medsci1): spawn a monster (identified by diffing entity ids against native OG-Pipes), assert Idle/Lowest → `DebugAlertAll` → Moderate/Chase → closes >1 unit on the player over 120 frames → `DebugCalmAll` → Lowest/Idle → per-entity `SetAlertness` → Moderate again. Passes 4/4 runs.

## Test plan

- [x] `cargo test -p shock2vr` — 70 passed (includes new dispatcher mapping tests)
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p bench`
- [x] Full SDK e2e suite — 41/41 (all 23 missions load + the new alertness scenario)
- [x] Cross-engine review (Claude + Codex): High fixed (dead-AI resurrection), agreed Medium resolved as documented reset semantics, port collision fixed

## Follow-ups (per the AI sequence)

- Damage→alert (shooting an AI still doesn't aggro it) + taut-waypoint corner clearance
- Per-frame pathfinding budget (with a query counter exposed via the debug runtime)
- Search-last-known-position behavior — now testable deterministically with this PR's forcing + introspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)