### PR TITLE
feat(hud): show the selected psi discipline in the ammo section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ references/
 
 # Local research notes (not committed)
 research/
+.claude/worktrees/

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -12,7 +12,7 @@ use shipyard::World;
 
 use super::{
     get_health_percentage, get_psi_percentage, get_wielded_ammo, get_wielded_ammo_icon,
-    get_wielded_ammo_type, get_wielded_psi_charge,
+    get_wielded_ammo_type, get_wielded_psi_charge, get_wielded_psi_power,
 };
 use crate::runtime_props::{PsiChargePhase, RuntimePropPsiCharge};
 use crate::ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign};
@@ -69,6 +69,16 @@ const AMMO_ICON: Rect = Rect::new(AMMO_X - 40.0, AMMO_Y + 16.0, 32.0, 32.0);
 const AMMO_TYPE_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 44.0, AMMO_W, 16.0);
 const AMMO_TYPE_TEXT_SIZE: f32 = 12.0;
 
+// Selected psi power display - drawn in the ammo section while the psi amp
+// is wielded (replacing the meaningless clip readout): the tier badge
+// (AmPsi<tier>1.PCX, 32x19 art), the psi point cost as the count, and the
+// discipline name below.
+const PSI_TIER_BADGE: Rect = Rect::new(AMMO_X - 44.0, AMMO_Y + 22.0, 32.0, 19.0);
+// The discipline names ("Projected Cryokinesis") are long, so the label rect
+// extends left of the gauge and uses a smaller size than the ammo-type label.
+const PSI_POWER_NAME: Rect = Rect::new(AMMO_X - 60.0, AMMO_Y + 44.0, AMMO_W + 60.0, 16.0);
+const PSI_POWER_NAME_SIZE: f32 = 10.0;
+
 // Psi overload meter - drawn center-screen below the crosshair while the psi
 // amp's trigger is held on an overloadable power (and briefly after release,
 // flashing the result). Uses the original meter art (res/iface, 64x16):
@@ -90,6 +100,7 @@ pub(crate) fn build_flat_hud_canvas(
     health_fraction: f32,
     psi_fraction: f32,
     psi_charge: Option<RuntimePropPsiCharge>,
+    psi_power: Option<(String, i32)>,
     ammo: Option<i32>,
     ammo_icon: Option<String>,
     ammo_type: Option<String>,
@@ -142,6 +153,32 @@ pub(crate) fn build_flat_hud_canvas(
         }
     }
 
+    // Selected psi power (psi amp wielded): the ammo section shows the
+    // discipline instead of a clip - tier badge, psi cost as the count, and
+    // the discipline name.
+    if let Some((power_name, tier)) = psi_power {
+        canvas
+            .image(AMMO_GAUGE, "AMMOBACK.PCX")
+            .image(PSI_TIER_BADGE, &format!("AmPsi{}1.PCX", tier.clamp(1, 5)))
+            .text(
+                AMMO_TEXT,
+                &format!("{tier}"),
+                "mainfont.fon",
+                AMMO_TEXT_SIZE,
+                HAlign::Center,
+                VAlign::Middle,
+            )
+            .text(
+                PSI_POWER_NAME,
+                &power_name.to_ascii_uppercase(),
+                "mainfont.fon",
+                PSI_POWER_NAME_SIZE,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        return canvas;
+    }
+
     // Ammo gauge (only when a weapon with a clip is wielded).
     if let Some(rounds) = ammo {
         canvas.image(AMMO_GAUGE, "AMMOBACK.PCX").text(
@@ -182,6 +219,7 @@ pub(crate) fn create_flat_hud(
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_psi_charge(world),
+        get_wielded_psi_power(world),
         get_wielded_ammo(world),
         get_wielded_ammo_icon(world),
         get_wielded_ammo_type(world),
@@ -197,14 +235,14 @@ mod tests {
     #[test]
     fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
         // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
-        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, None, None);
+        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, None, None, None);
         assert_eq!(canvas.element_count(), 6);
     }
 
     #[test]
     fn wielding_a_weapon_adds_the_ammo_gauge() {
         // ...plus the ammo backdrop + count when a clip is present.
-        let canvas = build_flat_hud_canvas(1.0, 0.75, None, Some(12), None, None);
+        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, Some(12), None, None);
         assert_eq!(canvas.element_count(), 8);
     }
 
@@ -215,9 +253,26 @@ mod tests {
             1.0,
             0.75,
             None,
+            None,
             Some(12),
             Some("STD_I.PCX".to_string()),
             Some("std".to_string()),
+        );
+        assert_eq!(canvas.element_count(), 10);
+    }
+
+    #[test]
+    fn psi_amp_shows_discipline_instead_of_clip() {
+        // Base 6 + gauge backdrop + tier badge + tier count + name = 10;
+        // the clip readout is suppressed even though the amp has ammo=0.
+        let canvas = build_flat_hud_canvas(
+            1.0,
+            0.75,
+            None,
+            Some(("Projected Cryokinesis".to_string(), 1)),
+            Some(0),
+            None,
+            None,
         );
         assert_eq!(canvas.element_count(), 10);
     }
@@ -236,6 +291,6 @@ mod tests {
     #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(2.0, -1.0, None, None, None, None);
+        let _ = build_flat_hud_canvas(2.0, -1.0, None, None, None, None, None);
     }
 }

--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -148,6 +148,42 @@ pub(crate) fn get_psi_percentage(world: &World) -> f32 {
     0.0 // No psi pool - empty bar
 }
 
+/// The selected psi power to display in the HUD's weapon/ammo section:
+/// `(discipline name, tier)`. `Some` only while the wielded weapon is the
+/// psi amp (class tag `weapontype psiamp`).
+pub(crate) fn get_wielded_psi_power(world: &World) -> Option<(String, i32)> {
+    let player_info = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    let weapon = player_info.left_hand_entity_id?;
+
+    // Is the wielded weapon the psi amp? Resolved via its template's class
+    // tags, the same mechanism as `get_wielded_ammo_type`.
+    let template_id = world
+        .borrow::<View<dark::properties::PropTemplateId>>()
+        .ok()?
+        .get(weapon)
+        .ok()?
+        .template_id;
+    let class_tags = world
+        .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
+        .ok()?;
+    if class_tags.0.get(&template_id)?.get("weapontype")? != "psiamp" {
+        return None;
+    }
+
+    let powers = world
+        .borrow::<UniqueView<crate::psi::GlobalPsiPowers>>()
+        .ok()?;
+    let selection = world
+        .borrow::<UniqueView<crate::psi::PsiPowerSelection>>()
+        .ok()?;
+    let power = powers.0.get(selection.index)?;
+    let name = power
+        .display_name
+        .clone()
+        .unwrap_or_else(|| power.name.clone());
+    Some((name, power.power.psi_cost))
+}
+
 /// The wielded psi amp's hold-to-overload meter state, or `None` when no
 /// charge is in progress (or nothing is wielded).
 pub(crate) fn get_wielded_psi_charge(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -362,7 +362,14 @@ impl MissionCore {
         world.add_unique(GlobalTemplateHierarchy(
             ss2_entity_info::get_hierarchy(&entity_info_rc).clone(),
         ));
-        let (psi_powers, psi_selection) = crate::psi::build_psi_power_registry(&entity_info_rc);
+        let (mut psi_powers, psi_selection) = crate::psi::build_psi_power_registry(&entity_info_rc);
+        // Player-facing discipline names come from the psihelp string table;
+        // a data install without it just keeps the gamesys symbolic names.
+        if let Some(psi_strings) =
+            asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "psihelp.str")
+        {
+            crate::psi::apply_display_names(&mut psi_powers, &psi_strings);
+        }
         world.add_unique(psi_powers);
         world.add_unique(psi_selection);
 

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -83,6 +83,10 @@ pub struct PsiPowerInfo {
     pub template_id: i32,
     /// The gamesys symbolic name (e.g. "Cryokinesis", "Inviso").
     pub name: String,
+    /// The player-facing discipline name (e.g. "Projected Cryokinesis",
+    /// "Photonic Redirection"), from `psihelp.str` (`Psi<power_id>` entries).
+    /// `None` if the strings file lacks the power.
+    pub display_name: Option<String>,
     pub power: PropPsiPower,
     /// The power's `Projectile` links, sorted by `order` (the required PSI
     /// stat level, 1..8). Empty for non-projectile powers.
@@ -148,6 +152,7 @@ pub fn build_psi_power_registry(
         powers.push(PsiPowerInfo {
             template_id: *template_id,
             name,
+            display_name: None,
             power,
             projectiles,
             overloadable: OVERLOADABLE_TEMPLATE_IDS.contains(template_id),
@@ -167,6 +172,24 @@ pub fn build_psi_power_registry(
             index: default_index,
         },
     )
+}
+
+/// Fill in player-facing discipline names from the `psihelp.str` string
+/// table: each power's entry is keyed `Psi<power_id>` and its first line is
+/// the discipline name (the rest is the help text).
+pub fn apply_display_names(
+    powers: &mut GlobalPsiPowers,
+    strings: &std::collections::HashMap<String, String>,
+) {
+    for power in &mut powers.0 {
+        // The strings importer lowercases keys ("Psi6:" -> "psi6").
+        let key = format!("psi{}", power.power.power_id);
+        power.display_name = strings
+            .get(&key)
+            .and_then(|text| text.lines().next())
+            .map(|line| line.trim().to_owned())
+            .filter(|line| !line.is_empty());
+    }
 }
 
 /// A template's `Projectile` links (with data), walking the inheritance


### PR DESCRIPTION
## Summary

When the psi amp is wielded, the flat HUD's ammo section previously showed a meaningless "0" clip readout. It now shows the **selected discipline**: the amp's tier badge (`AmPsi<tier>1.PCX`), the psi point cost as the count, and the discipline's player-facing name below. Cycle with `CyclePsiPower` (`Y` on desktop) and the display follows.

Display names come from the `psihelp.str` string table — each power's entry is keyed by its power id and its first line is the discipline name — so the HUD shows "PROJECTED CRYOKINESIS" / "MOLECULAR TRANSMUTATION" rather than the gamesys's internal symbols ("Cryokinesis", "Alchemy"). Names hydrate into the psi power registry at mission load (`get_opt`, so a data install without the file just keeps the symbolic names); `/v1/info` and logs still use the stable gamesys names.

Also gitignores `.claude/worktrees/` (agent worktrees; kept them out of `git add -A`).

## Demo

![psi discipline HUD demo](https://gist.githubusercontent.com/tommy-xr/76cb8381321cb655b16fa41a040792df/raw/psi-hud-demo.gif)

<sub>Cycling psi disciplines (`CyclePsiPower`, `Y` on desktop) with the amp wielded: the ammo section shows each discipline's tier badge, psi cost, and name from `psihelp.str`. Captured headlessly via the debug runtime.</sub>

![tier 1 selected](https://gist.githubusercontent.com/tommy-xr/76cb8381321cb655b16fa41a040792df/raw/hud-tier1.png)
![tier 5 selected](https://gist.githubusercontent.com/tommy-xr/76cb8381321cb655b16fa41a040792df/raw/hud-tier5.png)

## Test plan

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean; `cargo fmt --check` — clean
- `cargo test -p shock2vr` — 71 pass (new canvas test: amp wielded → discipline display, clip readout suppressed)
- Full SDK e2e suite — **42/42**
- Cross-engine review (Claude + Codex): no Critical/High/Medium. Applied the Lows (non-panicking `get_opt` for the strings file, comment fix). Accepted one theoretical Low: with an *empty* psi registry the section falls back to the old ammo readout — graceful degradation for a state real gamesys data can't produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

