### PR TITLE
feat(psi): trained-power gating - only known powers select and cast

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1113,6 +1113,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$PsiPowerD",
+            PropPsiPowerLearned::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$PsiPower2",
+            PropPsiPowerLearned2::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$PsiShield",
             PropPsiShield::read,
             identity,

--- a/dark/src/properties/prop_psi.rs
+++ b/dark/src/properties/prop_psi.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use shipyard::Component;
 
-use crate::ss2_common::{read_i32, read_single};
+use crate::ss2_common::{read_i32, read_single, read_u32};
 
 use serde::{Deserialize, Serialize};
 
@@ -51,6 +51,51 @@ impl PropPsiPower {
             activation_type,
             psi_cost,
             data,
+        }
+    }
+}
+
+/// `P$PsiPowerD` - the first learned-psi-powers dword (4 bytes): a bitmask
+/// of psi disciplines by power id, **bit index = power id** (ids 0..=31).
+/// `The Player` template (-384) authors it `0x00000000` in the retail
+/// `shock2.gam` (the original grants powers at runtime - character creation
+/// and trainers); the one non-zero authored value in the shipped data is
+/// `earth.mis` entity 243 (`Starting_Location`, alongside `P$BaseStats`
+/// starting-loadout props): `0x49` = bits {0, 3, 6}.
+///
+/// The bit-index-equals-power-id layout is corroborated by `psihelp.str`,
+/// which keys every discipline's description as `Psi<power_id>` and shows
+/// the gaps at ids 0/8/16/24/32 are the five "Tier N Neural Capacity"
+/// pseudo-disciplines - so `0x49` reads as {First Tier Neural Capacity,
+/// Kinetic Redirection, Projected Cryokinesis}, a coherent psi starting
+/// loadout. See `shock2vr::psi` for where the bits are interpreted.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropPsiPowerLearned {
+    pub bits: u32,
+}
+
+impl PropPsiPowerLearned {
+    pub fn read<T: io::Read>(reader: &mut T, _len: u32) -> PropPsiPowerLearned {
+        PropPsiPowerLearned {
+            bits: read_u32(reader),
+        }
+    }
+}
+
+/// `P$PsiPower2` - the second learned-psi-powers dword (4 bytes), the
+/// companion to [`PropPsiPowerLearned`] for power ids 32..=63 as bit
+/// `power_id - 32` (ids run up to 39, so a single dword can't hold them
+/// all). Authored `0x00000000` everywhere in the shipped data (only `The
+/// Player` -384 carries it, in the gamesys).
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropPsiPowerLearned2 {
+    pub bits: u32,
+}
+
+impl PropPsiPowerLearned2 {
+    pub fn read<T: io::Read>(reader: &mut T, _len: u32) -> PropPsiPowerLearned2 {
+        PropPsiPowerLearned2 {
+            bits: read_u32(reader),
         }
     }
 }

--- a/projects/psi-powers.md
+++ b/projects/psi-powers.md
@@ -35,13 +35,34 @@ Landed (phase 1 - all powers selectable, projectile powers castable):
   `PsiAmpScript`, exposed via `/v1/info` (`psi_charge`/`psi_charge_phase`)
   and covered by `psi-overload.e2e.test.ts`.
 
-Not yet implemented: trained-power gating (the player template's unparsed
-`P$PsiPower2`/`P$PsiPowerD` look like the learned-power bits),
+- **Trained-power gating** (phase 3): the player only selects/casts powers
+  they know. `dark` parses the learned-power dwords `P$PsiPowerD`/`P$PsiPower2`
+  (`PropPsiPowerLearned`/`PropPsiPowerLearned2`): a bitmask with **bit index =
+  power id** (dword 1 ids 0..=31, dword 2 ids 32..=63 as `power_id - 32`).
+  `The Player` (-384) authors both `0` in the retail gamesys (the original
+  grants powers at runtime), but `earth.mis` entity 243 (`Starting_Location`)
+  authors `P$PsiPowerD = 0x49` = {First Tier Neural Capacity, Kinetic
+  Redirection, Projected Cryokinesis} - which pins the layout, along with
+  `psihelp.str`'s `Psi<id>` keys placing the five "Tier N Neural Capacity"
+  pseudo-disciplines at the power-id gaps 0/8/16/24/32. At mission load
+  `PlayerPsiKnownPowers` (`shock2vr/src/psi.rs`) seeds from the player
+  template's bits UNION Projected Cryokinesis (the default OSA power);
+  `debug_*` scenes unlock everything so `debug_psi` keeps exercising the
+  whole registry. `Effect::CyclePsiPower` skips untrained powers,
+  `PsiAmpScript` refuses to charge/cast them, and
+  `Effect::GrantPsiPower { template_id }` trains one at runtime (for
+  trainers/debug tooling). Covered by `psi-trained.e2e.test.ts`.
+
+Not yet implemented: applying a mission start marker's authored loadout
+(`earth.mis` `Starting_Location` carries `P$PsiPowerD` and
+`P$BaseStats`-style starting props that nothing reads yet), anything that
+emits `Effect::GrantPsiPower` (character creation, trainers, psi modules),
 sustained/shield/cursor power behaviors, PSI stat from `P$BaseStats` (the
 overload zone size should also grow with PSI), burnout damage mitigation
 (PSI 8 = safe, Endurance reduces it), the VR meter (flat HUD only), psi
-point/selection persistence across save/load and level transitions (both
-reset - the pool to the authored 40, the selection to Cryokinesis), and psi
+point/selection/trained-power persistence across save/load and level
+transitions (all reset - the pool to the authored 40, the selection to
+Cryokinesis, the trained set to the seeded default), and psi
 hypos/trainers.
 
 ## High-Level Context

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -19,7 +19,7 @@ use crate::mission::CullingInfo;
 use crate::mission::VisibilityEngine;
 use crate::mission::pathfinding_debug;
 use crate::pathfinding::{PathfindingService, path_visualization::PathVisualizationSystem};
-use crate::psi::{GlobalPsiPowers, PsiPowerSelection};
+use crate::psi::{GlobalPsiPowers, PlayerPsiKnownPowers, PsiPowerSelection};
 use crate::{mission::entity_creator, scripts::AIPropertyUpdate};
 
 use dark::{
@@ -370,8 +370,18 @@ impl MissionCore {
         {
             crate::psi::apply_display_names(&mut psi_powers, &psi_strings);
         }
+        // Debug scenes unlock every power (debug_psi exercises the whole
+        // registry); real missions start with the player template's learned
+        // bits plus the default OSA loadout (Cryokinesis).
+        let known_powers = crate::psi::build_known_powers(
+            &entity_info_rc,
+            &psi_powers,
+            THE_PLAYER_TEMPLATE_ID,
+            mission.starts_with("debug_"),
+        );
         world.add_unique(psi_powers);
         world.add_unique(psi_selection);
+        world.add_unique(known_powers);
 
         // ** Entity creation
 
@@ -1597,12 +1607,26 @@ impl MissionCore {
 
                 Effect::CyclePsiPower => {
                     let powers = self.world.borrow::<UniqueView<GlobalPsiPowers>>().unwrap();
+                    let known = self
+                        .world
+                        .borrow::<UniqueView<PlayerPsiKnownPowers>>()
+                        .unwrap();
                     let mut selection = self
                         .world
                         .borrow::<UniqueViewMut<PsiPowerSelection>>()
                         .unwrap();
                     if !powers.0.is_empty() {
-                        selection.index = (selection.index + 1) % powers.0.len();
+                        // Advance to the next *trained* power, wrapping (at
+                        // most one lap - with a single trained power the lap
+                        // lands back on it, so the selection never moves onto
+                        // an untrained power).
+                        for step in 1..=powers.0.len() {
+                            let index = (selection.index + step) % powers.0.len();
+                            if known.0.contains(&powers.0[index].template_id) {
+                                selection.index = index;
+                                break;
+                            }
+                        }
                         let power = &powers.0[selection.index];
                         game_log!(
                             INFO,
@@ -1610,6 +1634,23 @@ impl MissionCore {
                             power.name,
                             power.power.psi_cost
                         );
+                    }
+                }
+
+                Effect::GrantPsiPower { template_id } => {
+                    let powers = self.world.borrow::<UniqueView<GlobalPsiPowers>>().unwrap();
+                    let mut known = self
+                        .world
+                        .borrow::<UniqueViewMut<PlayerPsiKnownPowers>>()
+                        .unwrap();
+                    if known.0.insert(template_id) {
+                        let name = powers
+                            .0
+                            .iter()
+                            .find(|p| p.template_id == template_id)
+                            .map(|p| p.name.as_str())
+                            .unwrap_or("<unknown power>");
+                        game_log!(INFO, "Psi power trained: {} ({})", name, template_id);
                     }
                 }
 

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -7,7 +7,11 @@
 //! mission load; the psi amp script casts whichever power the selection
 //! unique points at.
 
-use dark::properties::{Link, ProjectileOptions, PropPsiPower, PropSymName};
+use std::collections::HashSet;
+
+use dark::properties::{
+    Link, ProjectileOptions, PropPsiPower, PropPsiPowerLearned, PropPsiPowerLearned2, PropSymName,
+};
 use dark::ss2_entity_info::{self, SystemShock2EntityInfo};
 use shipyard::Unique;
 
@@ -120,6 +124,67 @@ pub struct PsiPowerSelection {
     pub index: usize,
 }
 
+/// The psi powers the player has been trained in, by power template id -
+/// the only powers selectable (`Effect::CyclePsiPower`) and castable
+/// (`PsiAmpScript`). Grown at runtime via `Effect::GrantPsiPower`.
+#[derive(Unique, Clone)]
+pub struct PlayerPsiKnownPowers(pub HashSet<i32>);
+
+/// Seed the trained-power set at mission load.
+///
+/// - Debug scenes (`all_known`) unlock every power in the registry so the
+///   `debug_psi` scene keeps exercising everything.
+/// - Real missions read the learned-power bits from the player template's
+///   `P$PsiPowerD`/`P$PsiPower2` dwords (authored `0x00000000` in the retail
+///   gamesys - the original grants powers at runtime), then union the
+///   default OSA loadout: Projected Cryokinesis, which every trained OSA
+///   agent starts with.
+pub fn build_known_powers(
+    entity_info: &SystemShock2EntityInfo,
+    powers: &GlobalPsiPowers,
+    player_template_id: i32,
+    all_known: bool,
+) -> PlayerPsiKnownPowers {
+    if all_known {
+        return PlayerPsiKnownPowers(powers.0.iter().map(|p| p.template_id).collect());
+    }
+
+    let dword1 = hydrate_template_component::<PropPsiPowerLearned>(player_template_id, entity_info)
+        .map(|p| p.bits)
+        .unwrap_or(0);
+    let dword2 =
+        hydrate_template_component::<PropPsiPowerLearned2>(player_template_id, entity_info)
+            .map(|p| p.bits)
+            .unwrap_or(0);
+
+    let mut known: HashSet<i32> = powers
+        .0
+        .iter()
+        .filter(|p| learned_bit_set(dword1, dword2, p.power.power_id))
+        .map(|p| p.template_id)
+        .collect();
+    known.insert(CRYOKINESIS_TEMPLATE_ID);
+    PlayerPsiKnownPowers(known)
+}
+
+/// Whether a power id's learned bit is set across the two learned-power
+/// dwords. Layout: **bit index = power id** - dword 1 (`P$PsiPowerD`)
+/// covers ids 0..=31, dword 2 (`P$PsiPower2`) covers ids 32..=63 as bit
+/// `power_id - 32`. Verified against the shipped data: `earth.mis` entity
+/// 243 (`Starting_Location`) authors `P$PsiPowerD = 0x49` = bits {0, 3, 6}
+/// = {First Tier Neural Capacity, Kinetic Redirection, Projected
+/// Cryokinesis} under this layout - a coherent psi starting loadout
+/// (id-keyed discipline names from `psihelp.str`, whose `Psi<id>` keys also
+/// place the five tier-capacity pseudo-disciplines at the power-id gaps
+/// 0/8/16/24/32).
+fn learned_bit_set(dword1: u32, dword2: u32, power_id: i32) -> bool {
+    match power_id {
+        0..=31 => dword1 & (1u32 << power_id) != 0,
+        32..=63 => dword2 & (1u32 << (power_id - 32)) != 0,
+        _ => false,
+    }
+}
+
 /// Hydrate every psi power template (those carrying `P$PsiPower`) into a
 /// registry, plus the default selection (Projected Cryokinesis).
 pub fn build_psi_power_registry(
@@ -189,6 +254,29 @@ pub fn apply_display_names(
             .and_then(|text| text.lines().next())
             .map(|line| line.trim().to_owned())
             .filter(|line| !line.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn learned_bits_split_across_dwords_by_power_id() {
+        // Dword 1 covers power ids 0..=31 as bit `power_id`. The reference
+        // value from the shipped data: earth.mis Starting_Location authors
+        // 0x49 = {tier-1 capacity (0), Kinetic Redirection (3), Projected
+        // Cryokinesis (6)}.
+        assert!(learned_bit_set(0x49, 0, 0));
+        assert!(learned_bit_set(0x49, 0, 3));
+        assert!(learned_bit_set(0x49, 0, 6));
+        assert!(!learned_bit_set(0x49, 0, 1));
+        assert!(learned_bit_set(1 << 31, 0, 31));
+        assert!(!learned_bit_set(0, 1 << 6, 6));
+        // Dword 2 covers power ids 32..=63 as bit `power_id - 32`.
+        assert!(learned_bit_set(0, 0b10, 33));
+        assert!(learned_bit_set(0, 1 << 7, 39));
+        assert!(!learned_bit_set(0, 0, 39));
     }
 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -81,9 +81,17 @@ pub enum Effect {
     /// two projectile links.
     CycleAmmo,
 
-    /// Select the player's next psi power (advances `PsiPowerSelection`
-    /// through the `GlobalPsiPowers` registry, wrapping).
+    /// Select the player's next *trained* psi power (advances
+    /// `PsiPowerSelection` through the `GlobalPsiPowers` registry, wrapping,
+    /// skipping powers not in `PlayerPsiKnownPowers`).
     CyclePsiPower,
+
+    /// Train the player in a psi power (insert its template id into
+    /// `PlayerPsiKnownPowers`), making it selectable and castable - for
+    /// trainers and debug tooling. No-op if already trained.
+    GrantPsiPower {
+        template_id: i32,
+    },
 
     /// Deduct psi points from the player's pool (`PropPsiState`), clamped at
     /// zero. Emitted by the psi amp when a power is cast.

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -76,6 +76,14 @@ impl Script for PsiAmpScript {
                 let Some(power) = selected_power(world) else {
                     return Effect::NoEffect;
                 };
+                // Untrained powers can't be cast (selection gating should
+                // make this unreachable, but don't start a charge - which
+                // can burn out into damage - for a power the player doesn't
+                // know).
+                if !power_is_known(world, power.template_id) {
+                    game_log!(INFO, "Psi power {} is not trained", power.name);
+                    return Effect::NoEffect;
+                }
                 // Hold-to-overload runs only in flat presentation (the meter
                 // renders on the flat HUD; a flat-aimed amp carries
                 // RuntimePropFlatAim). In VR the amp keeps cast-on-pull until
@@ -280,10 +288,26 @@ fn burnout(world: &World, amp_entity: EntityId) -> Effect {
     ])
 }
 
+/// Whether the player has been trained in the power. Selection gating
+/// (`Effect::CyclePsiPower`) means an untrained power should never be
+/// selected; this is the belt-and-braces check on the cast paths. Fails
+/// closed: the unique is seeded unconditionally at mission load, so a
+/// missing one is a setup bug - don't let it disable the gate.
+fn power_is_known(world: &World, template_id: i32) -> bool {
+    world
+        .borrow::<UniqueView<crate::psi::PlayerPsiKnownPowers>>()
+        .map(|known| known.0.contains(&template_id))
+        .unwrap_or(false)
+}
+
 fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) -> Effect {
     let Some(power) = selected_power(world) else {
         return Effect::NoEffect;
     };
+    if !power_is_known(world, power.template_id) {
+        game_log!(INFO, "Psi power {} is not trained", power.name);
+        return Effect::NoEffect;
+    }
 
     // Gate on the player's psi pool: a cast costs the power's tier in points.
     // (The check here and the deduction - Effect::SpendPsiPoints - are split

--- a/tools/shock2-sdk/test/psi-trained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-trained.e2e.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end tests for trained-power gating: the player can only select (and
+// cast) psi powers they have been trained in. In real missions the trained
+// set is seeded from The Player template's learned-power bits (authored empty
+// in the retail gamesys) plus the default OSA loadout - Projected Cryokinesis
+// only - so `CyclePsiPower` must never move the selection off Cryokinesis.
+// Debug scenes (`debug_*`) unlock every power so `debug_psi` keeps exercising
+// the whole registry.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "debug scenes unlock every psi power (cycling reaches many powers)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8110),
+    });
+
+    await game.step({ frames: 10 });
+    let player = (await game.info()).player;
+    assert.equal(player.selected_psi_power, "Cryokinesis", "default selection");
+
+    const seen = new Set([player.selected_psi_power!]);
+    for (let i = 0; i < 6; i++) {
+      await game.input.trigger("CyclePsiPower");
+      await game.step({ frames: 2 });
+      player = (await game.info()).player;
+      seen.add(player.selected_psi_power!);
+    }
+    assert.ok(
+      seen.size >= 5,
+      `cycling in a debug scene should reach many distinct powers (got ${[...seen].join(", ")})`,
+    );
+  },
+);
+
+test(
+  "real missions gate CyclePsiPower to trained powers only",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT2 ?? 8111),
+    });
+
+    await game.step({ frames: 10 });
+    let player = (await game.info()).player;
+    assert.equal(
+      player.selected_psi_power,
+      "Cryokinesis",
+      "selection starts on the default OSA power",
+    );
+
+    // With only Cryokinesis trained, cycling must never leave it.
+    for (let i = 0; i < 5; i++) {
+      await game.input.trigger("CyclePsiPower");
+      await game.step({ frames: 2 });
+      player = (await game.info()).player;
+      assert.equal(
+        player.selected_psi_power,
+        "Cryokinesis",
+        `cycle ${i + 1}: selection must stay on the only trained power`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Gates psi power selection and casting to the powers the player has actually learned, replacing the everything-unlocked behavior from #345.

**The learned-power data, decoded from the game files**: `P$PsiPowerD` / `P$PsiPower2` are a 64-bit learned-power bitmask split across two dwords, indexed by **power id** (`PsiPowerD` covers ids 0–31, `PsiPower2` ids 32–63). This was pinned against real data: `earth.mis` entity 243 (`Starting_Location`, which also authors the other starting-loadout props) sets `P$PsiPowerD = 0x49` — bits {0, 3, 6} = First Tier Neural Capacity + Kinetic Redirection + Projected Cryokinesis, a coherent OSA starting loadout matching the chargen strings. The power-id gaps (0/8/16/24/32) are the five "Tier N Neural Capacity" pseudo-disciplines from `psihelp.str`.

**Runtime behavior**:
- `PlayerPsiKnownPowers` (set of power template ids) seeded at mission load from the learned bits, plus Projected Cryokinesis as the default OSA power. **Debug scenes seed all 35 powers**, so `debug_psi` keeps exercising everything.
- `CyclePsiPower` skips unknown powers; the psi amp refuses to cast (and won't start an overload charge for) unknown powers — fail-closed if the known set is missing.
- `Effect::GrantPsiPower { template_id }` for future trainers/debug tooling (no producer yet, documented).

## Test plan

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean; `cargo fmt` clean; `cargo test -p shock2vr -p dark` — pass, including a new bit-layout unit test asserting against the real `0x49` reference value
- **Negative test first**: the new `psi-trained.e2e.test.ts` medsci1 assertion fails without the gating (cycling escaped to Codebreaker), passes with it
- e2e: psi-trained + psi + psi-overload — 4/4 pass; earth.mis (the only mission authoring the new prop) smoke-tested: loads, selection starts and stays on Cryokinesis
- Cross-engine review: fixed the [AGREED] finding (fail-open → fail-closed known-power fallback); known-powers persistence across save/load is documented as out of scope in `projects/psi-powers.md` (all psi state currently resets on transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)