### PR TITLE
feat(psi): sustained powers - timed effects with Photonic Redirection

### DIFF
--- a/projects/psi-powers.md
+++ b/projects/psi-powers.md
@@ -34,6 +34,21 @@ Landed (phase 1 - all powers selectable, projectile powers castable):
   Meter state is `RuntimePropPsiCharge` on the amp, driven by
   `PsiAmpScript`, exposed via `/v1/info` (`psi_charge`/`psi_charge_phase`)
   and covered by `psi-overload.e2e.test.ts`.
+- **Sustained powers** (phase 3): powers with activation type 1 activate a
+  timed player status instead of firing a projectile. Casting spends the
+  tier and activates for `duration_base + duration_per_psi × PSI` seconds
+  (from the power's `P$PsiShield` data); re-casting spends again and
+  refreshes the duration. Active powers live in the `ActivePsiPowers`
+  unique (`shock2vr/src/psi.rs`), ticked down/expired per frame by
+  `MissionCore::update`, and are exposed via `/v1/info`
+  (`active_psi_powers`) and the SDK. **Photonic Redirection** (`Inviso`,
+  tier 4, 30 s at PSI 5) is the first wired behavior: while active the
+  player fails every AI/camera/turret visibility check
+  (`scripts/ai/ai_util.rs`). The `debug_camera` scene auto-equips the amp
+  so this is testable end-to-end (`psi-sustained.e2e.test.ts`: cost,
+  refresh, expiry, and camera-does-not-spot-the-invisible-player).
+  Sustained powers without `P$PsiShield` data, and the other sustained
+  powers' actual effects (Berserk, Shield, ...), still log and no-op.
 
 - **Trained-power gating** (phase 3): the player only selects/casts powers
   they know. `dark` parses the learned-power dwords `P$PsiPowerD`/`P$PsiPower2`
@@ -57,7 +72,9 @@ Not yet implemented: applying a mission start marker's authored loadout
 (`earth.mis` `Starting_Location` carries `P$PsiPowerD` and
 `P$BaseStats`-style starting props that nothing reads yet), anything that
 emits `Effect::GrantPsiPower` (character creation, trainers, psi modules),
-sustained/shield/cursor power behaviors, PSI stat from `P$BaseStats` (the
+shield/cursor power behaviors and the remaining sustained-power effects,
+invisibility dropping when the player attacks, active-power persistence
+across save/load and level transitions, PSI stat from `P$BaseStats` (the
 overload zone size should also grow with PSI), burnout damage mitigation
 (PSI 8 = safe, Endurance reduces it), the VR meter (flat HUD only), psi
 point/selection/trained-power persistence across save/load and level

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -422,6 +422,9 @@ pub struct PlayerInfo {
     /// in progress. See `shock2vr::PlayerStateSnapshot`.
     pub psi_charge: Option<f32>,
     pub psi_charge_phase: Option<String>,
+    /// The gamesys names of the active sustained psi powers (e.g. "Inviso"),
+    /// in activation order; empty when none. See `shock2vr::PlayerStateSnapshot`.
+    pub active_psi_powers: Vec<String>,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1458,6 +1458,10 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                 psi_charge_phase: state
                     .as_ref()
                     .and_then(|s| s.psi_charge.map(|(_, p)| p.to_string())),
+                active_psi_powers: state
+                    .as_ref()
+                    .map(|s| s.active_psi_powers.clone())
+                    .unwrap_or_default(),
             }
         },
         entity_count,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -227,6 +227,9 @@ pub struct PlayerStateSnapshot {
     /// phase is "charging" / "overloaded" / "burnout". `None` when no charge
     /// is in progress.
     pub psi_charge: Option<(f32, &'static str)>,
+    /// The gamesys names of the currently active sustained psi powers (e.g.
+    /// "Inviso"), in activation order. Empty when none are active.
+    pub active_psi_powers: Vec<String>,
 }
 
 impl Game {
@@ -304,6 +307,10 @@ impl Game {
                     (c.fraction, phase)
                 })
             }),
+            active_psi_powers: world
+                .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+                .map(|active| active.0.iter().map(|p| p.name.clone()).collect())
+                .unwrap_or_default(),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -382,6 +382,7 @@ impl MissionCore {
         world.add_unique(psi_powers);
         world.add_unique(psi_selection);
         world.add_unique(known_powers);
+        world.add_unique(crate::psi::ActivePsiPowers::default());
 
         // ** Entity creation
 
@@ -780,6 +781,21 @@ impl MissionCore {
                 }
             },
         );
+
+        // Tick the player's sustained psi powers down and expire them.
+        self.world
+            .run(|mut active: UniqueViewMut<crate::psi::ActivePsiPowers>| {
+                let dt = time.elapsed.as_secs_f32();
+                active.0.retain_mut(|power| {
+                    power.remaining_secs -= dt;
+                    if power.remaining_secs <= 0.0 {
+                        game_log!(INFO, "Psi power expired: {}", power.name);
+                        false
+                    } else {
+                        true
+                    }
+                });
+            });
 
         let (player_pos, player_rot) = {
             let player_info = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
@@ -1685,6 +1701,30 @@ impl MissionCore {
                         .unwrap();
                     if let Ok(psi) = (&mut v_psi).get(player_entity) {
                         psi.psi_points = (psi.psi_points - amount).max(0);
+                    }
+                }
+
+                Effect::ActivatePsiPower {
+                    template_id,
+                    name,
+                    duration_secs,
+                } => {
+                    let mut active = self
+                        .world
+                        .borrow::<UniqueViewMut<crate::psi::ActivePsiPowers>>()
+                        .unwrap();
+                    if let Some(existing) =
+                        active.0.iter_mut().find(|p| p.template_id == template_id)
+                    {
+                        existing.remaining_secs = duration_secs;
+                        game_log!(INFO, "Psi power refreshed: {} ({}s)", name, duration_secs);
+                    } else {
+                        active.0.push(crate::psi::ActivePsiPower {
+                            template_id,
+                            name: name.clone(),
+                            remaining_secs: duration_secs,
+                        });
+                        game_log!(INFO, "Psi power active: {} ({}s)", name, duration_secs);
                     }
                 }
 

--- a/shock2vr/src/psi.rs
+++ b/shock2vr/src/psi.rs
@@ -10,7 +10,8 @@
 use std::collections::HashSet;
 
 use dark::properties::{
-    Link, ProjectileOptions, PropPsiPower, PropPsiPowerLearned, PropPsiPowerLearned2, PropSymName,
+    Link, ProjectileOptions, PropPsiPower, PropPsiPowerLearned, PropPsiPowerLearned2,
+    PropPsiShield, PropSymName,
 };
 use dark::ss2_entity_info::{self, SystemShock2EntityInfo};
 use shipyard::Unique;
@@ -24,6 +25,15 @@ const CRYOKINESIS_TEMPLATE_ID: i32 = -1143;
 /// The `Psi Powers` meta-prop root - every psi power template descends from
 /// it (`MetaProperty → Psi Powers → Level 1..5 → power`).
 const PSI_POWERS_ROOT_TEMPLATE_ID: i32 = -962;
+
+/// `Inviso` - Photonic Redirection (tier 4 sustained power): while active,
+/// the player is invisible to AI and security devices.
+pub const INVISO_TEMPLATE_ID: i32 = -3157;
+
+/// `PropPsiPower::activation_type` for sustained/timed self effects - the
+/// power activates for a duration given by its `P$PsiShield` data
+/// (`duration_base + duration_per_psi × PSI` seconds).
+pub const ACTIVATION_TYPE_SUSTAINED: i32 = 1;
 
 /// The powers that support hold-to-overload (per the published gameplay
 /// tables), by template id. Comments give the gamesys name and the
@@ -97,6 +107,10 @@ pub struct PsiPowerInfo {
     pub projectiles: Vec<(i32, ProjectileOptions)>,
     /// Whether the power supports hold-to-overload.
     pub overloadable: bool,
+    /// The sustained-power duration formula (`P$PsiShield`:
+    /// `duration_base + duration_per_psi × PSI` seconds). `None` for powers
+    /// without timed data.
+    pub duration: Option<PropPsiShield>,
 }
 
 impl PsiPowerInfo {
@@ -185,6 +199,28 @@ fn learned_bit_set(dword1: u32, dword2: u32, power_id: i32) -> bool {
     }
 }
 
+/// One currently-active sustained psi power on the player.
+#[derive(Clone, Debug)]
+pub struct ActivePsiPower {
+    pub template_id: i32,
+    /// The gamesys symbolic name (e.g. "Inviso").
+    pub name: String,
+    pub remaining_secs: f32,
+}
+
+/// The player's active sustained psi powers, ticked down each frame by
+/// `MissionCore::update` and removed on expiry. Re-casting an active power
+/// refreshes its duration. (Not yet persisted across save/load or level
+/// transitions - like the psi pool and selection.)
+#[derive(Unique, Clone, Default)]
+pub struct ActivePsiPowers(pub Vec<ActivePsiPower>);
+
+impl ActivePsiPowers {
+    pub fn is_active(&self, template_id: i32) -> bool {
+        self.0.iter().any(|p| p.template_id == template_id)
+    }
+}
+
 /// Hydrate every psi power template (those carrying `P$PsiPower`) into a
 /// registry, plus the default selection (Projected Cryokinesis).
 pub fn build_psi_power_registry(
@@ -221,6 +257,7 @@ pub fn build_psi_power_registry(
             power,
             projectiles,
             overloadable: OVERLOADABLE_TEMPLATE_IDS.contains(template_id),
+            duration: hydrate_template_component::<PropPsiShield>(*template_id, entity_info),
         });
     }
 

--- a/shock2vr/src/scenes/debug_camera.rs
+++ b/shock2vr/src/scenes/debug_camera.rs
@@ -8,11 +8,17 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     mission::{GlobalContext, entity_creator::CreateEntityOptions},
-    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder},
+    scenes::debug_common::{
+        AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene,
+    },
 };
 
 const CAMERA_START_POS: Point3<f32> = point3(0.0, 4.0 / SCALE_FACTOR, 5.0 / SCALE_FACTOR);
 const CAMERA_TEMPLATE_ID: i32 = -367;
+
+/// The Psi Amp player weapon - equipped so psi powers that affect AI
+/// perception (e.g. Photonic Redirection) can be cast against the camera.
+const PSI_AMP_TEMPLATE_ID: i32 = -247;
 
 /// Namespace for constructing debug camera scenes.
 pub struct DebugCameraScene;
@@ -33,10 +39,9 @@ impl DebugCameraScene {
             audio_context,
         };
 
-        let mut scene = builder.build(build_options);
+        let mut core = builder.build_core(build_options);
 
-        let camera_entity = scene
-            .core_mut()
+        let camera_entity = core
             .create_entity_with_position(
                 asset_cache,
                 CAMERA_TEMPLATE_ID,
@@ -49,6 +54,12 @@ impl DebugCameraScene {
 
         info!("Spawned debug camera entity {camera_entity:?}");
 
-        Box::new(scene)
+        // Equip the player with the psi amp on the first update (same
+        // pattern as `debug_psi`), so camera-perception powers are castable
+        // in this scene.
+        Box::new(HookedDebugScene::new(
+            core,
+            AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
+        ))
     }
 }

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -305,6 +305,54 @@ pub trait DebugSceneHooks {
     }
 }
 
+/// Hooks that spawn-and-equip an item on the player on the first update. In
+/// flat presentation `SpawnInFrontOfPlayer { auto_wield: true }` both spawns
+/// and equips (the player starts unarmed). Used by scenes that need the
+/// player armed from frame one (e.g. the psi amp in `debug_psi` and
+/// `debug_camera`).
+pub struct AutoEquipHooks {
+    template_id: i32,
+    equipped: bool,
+}
+
+impl AutoEquipHooks {
+    pub fn new(template_id: i32) -> Self {
+        Self {
+            template_id,
+            equipped: false,
+        }
+    }
+}
+
+impl DebugSceneHooks for AutoEquipHooks {
+    fn before_handle_effects(
+        &mut self,
+        core: &mut MissionCore,
+        _effects: &mut Vec<Effect>,
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if self.equipped {
+            return;
+        }
+        let spawn = Effect::SpawnInFrontOfPlayer {
+            template_id: self.template_id,
+            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            auto_wield: true,
+        };
+        core.handle_effects(
+            vec![spawn],
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        );
+        self.equipped = true;
+    }
+}
+
 pub struct HookedDebugScene<H> {
     core: MissionCore,
     hooks: H,

--- a/shock2vr/src/scenes/debug_psi.rs
+++ b/shock2vr/src/scenes/debug_psi.rs
@@ -19,12 +19,11 @@ use shipyard::EntityId;
 use crate::{
     GameOptions,
     game_scene::GameScene,
-    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
-    scripts::Effect,
+    mission::{GlobalContext, SpawnLocation},
 };
 
 use super::debug_common::{
-    DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    AutoEquipHooks, DebugSceneBuildOptions, DebugSceneBuilder, HookedDebugScene,
 };
 
 /// The Psi Amp player weapon.
@@ -93,51 +92,13 @@ pub fn create_debug_psi_scene(
         asset_cache,
         audio_context,
     });
-    Box::new(HookedDebugScene::new(core, PsiHooks::new()))
-}
-
-struct PsiHooks {
-    equipped: bool,
-}
-
-impl PsiHooks {
-    fn new() -> Self {
-        println!(
-            "[debug_psi] Player is equipped with the Psi Amp.\n\
-             Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
-             then fire to cast it. Projectile powers land on the wall ahead."
-        );
-        Self { equipped: false }
-    }
-}
-
-impl DebugSceneHooks for PsiHooks {
-    fn before_handle_effects(
-        &mut self,
-        core: &mut MissionCore,
-        _effects: &mut Vec<Effect>,
-        global_context: &GlobalContext,
-        game_options: &GameOptions,
-        asset_cache: &mut AssetCache,
-        audio_context: &mut AudioContext<EntityId, String>,
-    ) {
-        if self.equipped {
-            return;
-        }
-        // In flat presentation this both spawns and equips the amp (the
-        // player starts unarmed).
-        let spawn = Effect::SpawnInFrontOfPlayer {
-            template_id: PSI_AMP_TEMPLATE_ID,
-            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            auto_wield: true,
-        };
-        core.handle_effects(
-            vec![spawn],
-            global_context,
-            game_options,
-            asset_cache,
-            audio_context,
-        );
-        self.equipped = true;
-    }
+    println!(
+        "[debug_psi] Player is equipped with the Psi Amp.\n\
+         Select a power with the `CyclePsiPower` input action (`Y` on desktop),\n\
+         then fire to cast it. Projectile powers land on the wall ahead."
+    );
+    Box::new(HookedDebugScene::new(
+        core,
+        AutoEquipHooks::new(PSI_AMP_TEMPLATE_ID),
+    ))
 }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -345,11 +345,25 @@ pub fn play_positional_sound(
     }
 }
 
+/// Whether the player is psi-invisible: Photonic Redirection (`Inviso`) is
+/// among the active sustained psi powers. An invisible player fails every
+/// AI/camera/turret visibility check.
+fn is_player_psi_invisible(world: &World) -> bool {
+    world
+        .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
+        .map(|active| active.is_active(crate::psi::INVISO_TEMPLATE_ID))
+        .unwrap_or(false)
+}
+
 /// Check if the player is visible from an entity (raycast only, no FOV check)
 ///
 /// This is a basic visibility check that only verifies line-of-sight.
 /// For FOV-aware visibility, use `is_player_visible_in_fov`.
 pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &PhysicsWorld) -> bool {
+    if is_player_psi_invisible(world) {
+        return false;
+    }
+
     let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
@@ -412,6 +426,10 @@ pub fn is_player_visible_in_fov(
     heading: Deg<f32>,
     fov_half_angle: f32,
 ) -> bool {
+    if is_player_psi_invisible(world) {
+        return false;
+    }
+
     let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -99,6 +99,16 @@ pub enum Effect {
         amount: i32,
     },
 
+    /// Activate (or refresh) a sustained psi power on the player for
+    /// `duration_secs` (`ActivePsiPowers` unique). Emitted by the psi amp
+    /// when a sustained (activation type 1) power is cast; a per-frame tick
+    /// in `MissionCore::update` counts the duration down and expires it.
+    ActivatePsiPower {
+        template_id: i32,
+        name: String,
+        duration_secs: f32,
+    },
+
     /// Set the psi amp's hold-to-overload meter state
     /// (`RuntimePropPsiCharge`) on the amp entity - drives the HUD meter and
     /// debug introspection while a charge is in progress or flashing its

--- a/shock2vr/src/scripts/psi_amp_script.rs
+++ b/shock2vr/src/scripts/psi_amp_script.rs
@@ -325,6 +325,12 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
         return Effect::NoEffect;
     }
 
+    // Sustained (timed) powers activate a player status for a data-driven
+    // duration instead of firing a projectile.
+    if power.power.activation_type == psi::ACTIVATION_TYPE_SUSTAINED {
+        return cast_sustained_power(world, amp_entity, &power, effective_psi);
+    }
+
     let Some(projectile_template) = power.projectile_for_psi_stat(effective_psi) else {
         game_log!(
             INFO,
@@ -334,13 +340,6 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
         );
         return Effect::NoEffect;
     };
-
-    // The amp's GunFlash links supply the cast visual (Spinning Psi Ring).
-    let flashes =
-        super::script_util::get_all_links_with_template(world, amp_entity, |link| match link {
-            dark::properties::Link::GunFlash(data) => Some(*data),
-            _ => None,
-        });
 
     let mut effects = vec![
         play_environmental_sound(world, amp_entity, "shoot", vec![], AudioHandle::new()),
@@ -359,9 +358,7 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
             },
         ),
     ];
-    effects.extend(flashes.into_iter().map(|(template_id, options)| {
-        create_muzzle_flash(world, amp_entity, template_id, &options)
-    }));
+    effects.extend(amp_cast_flashes(world, amp_entity));
 
     game_log!(
         INFO,
@@ -371,4 +368,59 @@ fn cast_selected_power(world: &World, amp_entity: EntityId, effective_psi: i32) 
         effective_psi
     );
     Effect::Multiple(effects)
+}
+
+/// Cast a sustained (activation type 1) power: spend the tier, activate the
+/// player status for `duration_base + duration_per_psi × PSI` seconds (from
+/// the power's `P$PsiShield` data), and play the amp's cast flash/sound like
+/// a projectile cast. Re-casting an active power spends again and refreshes
+/// the duration.
+fn cast_sustained_power(
+    world: &World,
+    amp_entity: EntityId,
+    power: &PsiPowerInfo,
+    effective_psi: i32,
+) -> Effect {
+    let Some(duration) = &power.duration else {
+        game_log!(
+            INFO,
+            "Sustained psi power {} has no duration data (P$PsiShield) - not implemented yet",
+            power.name
+        );
+        return Effect::NoEffect;
+    };
+    let duration_secs = (duration.duration_base + duration.duration_per_psi * effective_psi) as f32;
+
+    let mut effects = vec![
+        play_environmental_sound(world, amp_entity, "shoot", vec![], AudioHandle::new()),
+        Effect::SpendPsiPoints {
+            amount: power.power.psi_cost,
+        },
+        Effect::ActivatePsiPower {
+            template_id: power.template_id,
+            name: power.name.clone(),
+            duration_secs,
+        },
+    ];
+    effects.extend(amp_cast_flashes(world, amp_entity));
+
+    game_log!(
+        INFO,
+        "Cast psi power: {} (tier {}, sustained {}s)",
+        power.name,
+        power.power.psi_cost,
+        duration_secs
+    );
+    Effect::Multiple(effects)
+}
+
+/// The amp's `GunFlash` links supply the cast visual (Spinning Psi Ring).
+fn amp_cast_flashes(world: &World, amp_entity: EntityId) -> Vec<Effect> {
+    super::script_util::get_all_links_with_template(world, amp_entity, |link| match link {
+        dark::properties::Link::GunFlash(data) => Some(*data),
+        _ => None,
+    })
+    .into_iter()
+    .map(|(template_id, options)| create_muzzle_flash(world, amp_entity, template_id, &options))
+    .collect()
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -153,6 +153,9 @@ export interface PlayerSnapshot {
    * ("charging" / "overloaded" / "burnout"), or null when idle. */
   psi_charge: number | null;
   psi_charge_phase: string | null;
+  /** The gamesys names of the active sustained psi powers (e.g. "Inviso"),
+   * in activation order; empty when none. */
+  active_psi_powers: string[];
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
+++ b/tools/shock2-sdk/test/psi-sustained.e2e.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end tests for sustained (timed) psi powers. Photonic Redirection
+// ("Inviso" in the gamesys, tier 4) is the reference power: casting it spends
+// 4 psi points and makes the player invisible to AI/cameras for
+// duration_base + duration_per_psi x PSI = 5 + 5*5 = 30 seconds; the active
+// power list is published via /v1/info as player.active_psi_powers.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const INVISO_COST = 4;
+/** Inviso duration at the effective PSI stat of 5: 5 + 5*5 seconds. */
+const INVISO_DURATION_FRAMES = 30 * 60;
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+/** Cycle the psi power selection until Inviso is selected (bounded). */
+async function selectInviso(game: GameServer): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    const selected = (await game.info()).player.selected_psi_power;
+    if (selected === "Inviso") return;
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 1 });
+  }
+  assert.fail("could not cycle the psi power selection to Inviso");
+}
+
+/** Step `frames` in chunks so a single /v1/step call stays small. */
+async function stepFrames(game: GameServer, frames: number): Promise<void> {
+  const chunk = 300;
+  for (let done = 0; done < frames; done += chunk) {
+    await game.step({ frames: Math.min(chunk, frames - done) });
+  }
+}
+
+test(
+  "sustained psi power (Inviso): cast spends psi, refresh, and timed expiry",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8120),
+    });
+
+    // The scene auto-equips the Psi Amp on the first update.
+    await game.step({ frames: 10 });
+    let player = (await game.info()).player;
+    assert.ok(player.wielded_entity_id !== null, "psi amp should be auto-wielded");
+    assert.deepEqual(player.active_psi_powers, [], "no sustained powers active at start");
+    const startPsi = player.psi_points;
+    assert.ok(startPsi !== null && startPsi >= 2 * INVISO_COST);
+
+    // Cast Photonic Redirection (tier 4 sustained power).
+    await selectInviso(game);
+    await fireOnce(game);
+    player = (await game.info()).player;
+    assert.equal(player.psi_points, startPsi! - INVISO_COST, "Inviso cast costs 4 psi points");
+    assert.deepEqual(player.active_psi_powers, ["Inviso"], "Inviso is active after the cast");
+
+    // Re-casting spends again and refreshes the duration (no duplicate entry).
+    await fireOnce(game);
+    player = (await game.info()).player;
+    assert.equal(player.psi_points, startPsi! - 2 * INVISO_COST, "re-cast spends again");
+    assert.deepEqual(player.active_psi_powers, ["Inviso"], "re-cast refreshes, not duplicates");
+
+    // Still active just before the 30 s duration elapses...
+    await stepFrames(game, INVISO_DURATION_FRAMES - 60);
+    player = (await game.info()).player;
+    assert.deepEqual(player.active_psi_powers, ["Inviso"], "still active before expiry");
+
+    // ...and expired just after.
+    await stepFrames(game, 120);
+    player = (await game.info()).player;
+    assert.deepEqual(player.active_psi_powers, [], "Inviso expires after 30 seconds");
+  },
+);
+
+test(
+  "Photonic Redirection hides the player from the security camera",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Control: the camera in debug_camera spots the visible player and
+    // escalates its alertness within ~15 s. This guards the invisibility
+    // assertion below against a camera that never detects anything.
+    let detectionFrames: number;
+    {
+      await using game = await GameServer.launch({
+        mission: "debug_camera",
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8121),
+      });
+      await game.step({ frames: 10 });
+      const camera = (await game.entities.list({ filter: "Security Camera", limit: 5 }))
+        .entities[0];
+      assert.ok(camera, "debug_camera should contain a Security Camera");
+      assert.equal(aiProp(await game.entities.detail(camera.id), "AIAlertness"), "Lowest");
+
+      // Step until the camera escalates (bounded at 20 s).
+      detectionFrames = 0;
+      let alertness = "Lowest";
+      while (detectionFrames < 20 * 60) {
+        await game.step({ frames: 60 });
+        detectionFrames += 60;
+        alertness = aiProp(await game.entities.detail(camera.id), "AIAlertness") ?? "Lowest";
+        if (alertness !== "Lowest") break;
+      }
+      assert.notEqual(alertness, "Lowest", "camera should spot the visible player within 20 s");
+    }
+
+    // With Inviso active the camera must NOT detect the player, watched for
+    // the same number of frames that sufficed to spot the visible player
+    // (plus slack), all well inside the 30 s duration.
+    {
+      await using game = await GameServer.launch({
+        mission: "debug_camera",
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8122),
+      });
+      await game.step({ frames: 10 });
+      const camera = (await game.entities.list({ filter: "Security Camera", limit: 5 }))
+        .entities[0];
+      assert.ok(camera, "debug_camera should contain a Security Camera");
+
+      // Cast Inviso immediately (~0.5 s in, long before the camera reacts).
+      await selectInviso(game);
+      await fireOnce(game);
+      const player = (await game.info()).player;
+      assert.deepEqual(player.active_psi_powers, ["Inviso"], "Inviso active in debug_camera");
+      assert.equal(
+        aiProp(await game.entities.detail(camera.id), "AIAlertness"),
+        "Lowest",
+        "camera has not reacted yet at cast time (else this test proves nothing)",
+      );
+
+      const watchFrames = Math.min(detectionFrames + 5 * 60, INVISO_DURATION_FRAMES - 10 * 60);
+      await stepFrames(game, watchFrames);
+      assert.deepEqual(
+        (await game.info()).player.active_psi_powers,
+        ["Inviso"],
+        "Inviso still active for the whole watch window",
+      );
+      assert.equal(
+        aiProp(await game.entities.detail(camera.id), "AIAlertness"),
+        "Lowest",
+        "camera must not spot the psi-invisible player",
+      );
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Implements **sustained (timed) psi powers** — the `activation_type == 1` disciplines that previously logged "not implemented":

- **Infrastructure**: casting a sustained power spends its tier and activates a timed effect (`ActivePsiPowers`), with the duration from the power's authored `P$PsiShield` data (`base + per_psi × PSI` seconds, PSI fixed at the placeholder 5). A per-frame tick expires powers; re-casting spends again and refreshes the duration. Activation plays the amp's cast flash/sound like projectile powers.
- **First observable power — Photonic Redirection** (`Inviso`, tier 4, 5+5×PSI = 30s): while active, the player is invisible to AI and security cameras via the shared player-visibility checks in `ai_util.rs`.
- **Introspection**: `active_psi_powers` (names) in `/v1/info` and the SDK snapshot.
- The `debug_camera` scene now auto-equips the psi amp (shared `AutoEquipHooks` deduped with `debug_psi`), so the invisibility loop is testable headlessly.

## Test plan

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean (re-verified after rebasing onto main past #353); `cargo fmt --check` clean; `cargo test -p shock2vr -p dark` — 76+ pass
- **Negative test first**: with the `ai_util.rs` hook reverted, the camera e2e fails at `"camera must not spot the psi-invisible player: 'High' !== 'Lowest'"`; with it, passes. The test includes a control phase (the camera must spot the *visible* player first) so the assertion can't pass vacuously.
- New `psi-sustained.e2e.test.ts`: cast Inviso → psi −4 + active list contains it; re-cast refreshes; 30s expiry empties the list; camera detection blocked while active (asserted via the `AIAlertness` introspection from #349)
- All-missions e2e: **23/23 load**; psi + psi-overload + psi-sustained: 4/4 post-rebase
- Cross-engine review: no Critical/High, no agreed findings; applied the dedupe + test-assertion improvements. Active powers don't persist across save/load — documented, consistent with the rest of the psi state (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)