### PR TITLE
feat(vr): keep world models on held weapons

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -130,6 +130,11 @@ pub struct DebugOptions {
     pub debug_ai: bool,
 }
 
+/// The active presentation mode, accessible from scripts via UniqueView -
+/// e.g. the held-entity viewmodel swap is flat-only.
+#[derive(Unique, Clone, Copy)]
+pub struct GlobalPresentationMode(pub crate::PresentationMode);
+
 /// Pathfinding service accessible from scripts (steering strategies) via
 /// UniqueView. None when the mission has no AIPATH data (e.g. debug scenes).
 #[derive(Unique, Clone)]
@@ -350,6 +355,7 @@ impl MissionCore {
         world.add_unique(DebugOptions {
             debug_ai: game_options.debug_ai,
         });
+        world.add_unique(GlobalPresentationMode(game_options.presentation_mode));
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
         // Reuse the obj-icons already hydrated into the template metadata above
@@ -3574,6 +3580,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             |v_pos: View<dark::properties::PropPosition>,
              v_sym_name: View<dark::properties::PropSymName>,
              v_scripts: View<dark::properties::PropScripts>,
+             v_model_name: View<dark::properties::PropModelName>,
              v_gun_state: View<dark::properties::PropGunState>,
              v_alertness: View<PropAIAlertness>,
              v_ai_behavior: View<RuntimePropAIBehavior>,
@@ -3619,6 +3626,15 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "Scripts".to_string(),
                         value: scripts.scripts.join(", "),
+                    });
+                }
+
+                // Add the current render model (e.g. to assert held-model
+                // behavior: VR keeps world models, flat swaps to _h viewmodels)
+                if let Ok(model_name) = v_model_name.get(id) {
+                    properties.push(DebugPropertyInfo {
+                        name: "Model".to_string(),
+                        value: model_name.0.clone(),
                     });
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1981,6 +1981,18 @@ impl MissionCore {
                         self.world.add_component(entity_id, RuntimePropVhots(vhots));
                     }
                 }
+                Effect::SetVhotsFromModel {
+                    entity_id,
+                    model_name,
+                } => {
+                    if let Some(model) = self.id_to_model.get(&entity_id) {
+                        let xform = model.get_transform();
+                        let donor_model =
+                            asset_cache.get(&MODELS_IMPORTER, &format!("{model_name}.BIN"));
+                        let vhots = Model::transform(donor_model.as_ref(), xform).vhots();
+                        self.world.add_component(entity_id, RuntimePropVhots(vhots));
+                    }
+                }
                 Effect::PlayEmail { deck, email, force } => {
                     let email_file = get_email_sound_file(deck, email);
                     let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -122,6 +122,14 @@ pub enum Effect {
         entity_id: EntityId,
         model_name: String,
     },
+    /// Replace the entity's fire-point vhots with those of `model_name`
+    /// without changing the rendered model. Used by the VR held-weapon path:
+    /// the world model stays rendered (#352), but its mesh has no vhots -
+    /// the muzzle points live in the _h viewmodel.
+    SetVhotsFromModel {
+        entity_id: EntityId,
+        model_name: String,
+    },
     CreateEntityByTemplateName {
         template_name: String,
         position: Point3<f32>,

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -1,7 +1,7 @@
 use dark::properties::{InternalPropOriginalModelName, PropLimbModel, PropPlayerGun};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::{physics::PhysicsWorld, vr_config};
+use crate::{PresentationMode, mission::GlobalPresentationMode, physics::PhysicsWorld, vr_config};
 
 use super::{Effect, MessagePayload, Script};
 
@@ -22,6 +22,18 @@ impl Script for InternalSwitchHeldModelScript {
     ) -> Effect {
         match msg {
             MessagePayload::Hold => {
+                // The swap to the first-person hand model (_h mesh) is
+                // flat-only: those meshes have their never-visible faces
+                // stripped for the fixed flat camera and look broken from
+                // VR's free viewpoints, so VR keeps the world model (#352).
+                let is_vr = world
+                    .borrow::<UniqueView<GlobalPresentationMode>>()
+                    .map(|mode| mode.0 == PresentationMode::Vr)
+                    .unwrap_or(false);
+                if is_vr {
+                    return Effect::NoEffect;
+                }
+
                 if let Some(view_model) = get_view_model(world, entity_id) {
                     Effect::ChangeModel {
                         entity_id,

--- a/shock2vr/src/scripts/internal_switch_held_model.rs
+++ b/shock2vr/src/scripts/internal_switch_held_model.rs
@@ -31,7 +31,34 @@ impl Script for InternalSwitchHeldModelScript {
                     .map(|mode| mode.0 == PresentationMode::Vr)
                     .unwrap_or(false);
                 if is_vr {
-                    return Effect::NoEffect;
+                    let mut effects = Vec::new();
+
+                    // Self-heal cross-mode saves: a save made in flat while
+                    // wielding persists the _h viewmodel name; restore the
+                    // original world model (a no-op in the normal VR flow).
+                    if let (Some(original), Some(current)) = (
+                        get_previous_model(world, entity_id),
+                        get_current_model(world, entity_id),
+                    ) {
+                        if original != current {
+                            effects.push(Effect::ChangeModel {
+                                entity_id,
+                                model_name: original,
+                            });
+                        }
+                    }
+
+                    // The world model stays rendered, but its mesh has no
+                    // vhots - take the fire points (muzzle) from the hand
+                    // model so projectiles/flash don't spawn at the grip.
+                    if let Some(view_model) = get_view_model(world, entity_id) {
+                        effects.push(Effect::SetVhotsFromModel {
+                            entity_id,
+                            model_name: view_model,
+                        });
+                    }
+
+                    return Effect::Multiple(effects);
                 }
 
                 if let Some(view_model) = get_view_model(world, entity_id) {
@@ -75,6 +102,16 @@ fn get_view_model(world: &World, entity_id: EntityId) -> Option<String> {
     };
 
     ret.filter(|str| vr_config::is_allowed_hand_model(str))
+}
+
+fn get_current_model(world: &World, entity_id: EntityId) -> Option<String> {
+    let v_model_name = world
+        .borrow::<View<dark::properties::PropModelName>>()
+        .unwrap();
+    v_model_name
+        .get(entity_id)
+        .ok()
+        .map(|model| model.0.clone())
 }
 
 fn get_previous_model(world: &World, entity_id: EntityId) -> Option<String> {

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -101,7 +101,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     // Specify overrides for particular models with how they should be oriented
     // relative ot the virtual hand
     let items = vec![
-        // Weapons
+        // Weapons - first-person hand models (_h), used when wielded in flat
         ("atek_h", held_weapon.clone()),
         ("amp_h", held_weapon.clone()),
         (
@@ -110,9 +110,27 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
                 .clone()
                 .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
         ),
-        ("empgun", held_weapon.clone()),
         ("wrench_h", default.clone()),
+        // Weapons - world models, kept when held in VR (#352): the _h meshes
+        // have faces stripped for the fixed flat camera. sg_w/empgun predate
+        // this and show the world models grip fine with the same offsets.
+        ("atek_w", held_weapon.clone()),
+        ("ar15_w", held_weapon.clone()),
         ("sg_w", held_weapon.clone()),
+        (
+            "laser",
+            held_weapon
+                .clone()
+                .with_projectile_rotation(Quaternion::from_angle_y(Deg(12.))),
+        ),
+        ("empgun", held_weapon.clone()),
+        ("gren_w", held_weapon.clone()),
+        ("fsn_w", held_weapon.clone()),
+        ("sfg_w", held_weapon.clone()),
+        ("amp_w", held_weapon.clone()),
+        ("viro_w", held_weapon.clone()),
+        ("al_w", held_weapon.clone()),
+        ("wrench_w", default.clone()),
         // World items
         ("battery", held_item.clone()),
         ("batteryb", held_item.clone()),

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end regression tests for held-weapon models (#352): the first-person
+// hand models (_h meshes) have their never-visible faces stripped for the
+// fixed flat camera, so in VR a held weapon keeps its world model, while flat
+// still swaps to the viewmodel for the first-person weapon path.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function modelOf(detail: { properties: { name: string; value: string }[] }): string {
+  const p = detail.properties.find((x) => x.name === "Model");
+  assert.ok(p, "entity should expose a Model property");
+  return p.value;
+}
+
+test(
+  "VR: a grabbed weapon keeps its world model",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
+      debugFlags: ["--vr"],
+    });
+
+    // CycleWeapon spawns the pistol; VR wield is a no-op so it drops to the
+    // floor in front of the player.
+    await game.step({ frames: 10 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 90 });
+
+    const pistol = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.name === "Pistol",
+    );
+    assert.ok(pistol, "pistol should have spawned");
+    assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");
+
+    // Grab it: park the right hand on the pistol's forward raycast axis
+    // (debug_weapons spawns the pawn at the origin with identity rotation, so
+    // pawn-local == world minus the pawn position) and squeeze.
+    const pawnY = (await game.info()).player.position[1];
+    const [px, py, pz] = pistol.position;
+    await game.input.set("right_hand.position", [px + 0.4, py - pawnY, pz]);
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 10 });
+
+    const held = (await game.info()).player.right_hand_entity_id;
+    assert.equal(held, pistol.id, "pistol should be grabbed by the right hand");
+
+    // The held pistol keeps the world model - no _h viewmodel swap in VR.
+    assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_w");
+  },
+);
+
+test(
+  "flat: a wielded weapon swaps to its first-person viewmodel",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
+    });
+
+    // In flat, CycleWeapon spawns AND wields (sends Hold), which swaps the
+    // model to the atek_h viewmodel for the first-person weapon path.
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 10 });
+
+    const pistol = (await game.entities.list({ limit: 100 })).entities.find(
+      (e) => e.name === "Pistol",
+    );
+    assert.ok(pistol, "pistol should be wielded");
+    assert.equal(modelOf(await game.entities.detail(pistol.id)), "atek_h");
+  },
+);


### PR DESCRIPTION
Closes #352.

## Summary

In VR, holding a weapon used to swap it to its first-person **view model** (the `_h` mesh) — those meshes have their never-visible faces stripped for the fixed flat camera, so from VR's free viewpoints the gun has visible holes. Held weapons now keep their **world model** in VR, while flat keeps the swap for its viewmodel path.

- `InternalSwitchHeldModelScript` gates the `Hold` swap on a new `GlobalPresentationMode` unique (same script-visible pattern as `DebugOptions`). Flat behavior is unchanged (verified: `is_allowed_hand_model` filters on the `hand_model` name, and every new grip entry is a world-model name, so the flat swap set is identical).
- `vr_config::HAND_MODEL_POSITIONING` gains held-weapon grip offsets for every player weapon's world model (`atek_w`, `ar15_w`, `laser`, `gren_w`, `fsn_w`, `sfg_w`, `amp_w`, `viro_w`, `al_w`, `wrench_w`) — `sg_w` and `empgun` already used world models in hand, proving the offsets fit; the laser keeps its 12° projectile correction.
- **Muzzle vhots** (adversarial-review find): world models carry no vhots — the muzzle points live in the `_h` meshes — so a VR-held pistol fired from the grip. A new `Effect::SetVhotsFromModel` takes the fire points from the hand model while the world model stays rendered; verified in-game (the flash spawns 0.7 m ahead of the pistol at the barrel).
- **Cross-mode saves** (review find): a save made in flat while wielding persists the `_h` model name; the VR `Hold` path now restores the original world model when they differ, so such saves self-heal.
- The debug entity-detail endpoint exposes the current render `Model`, making held-model behavior assertable over HTTP.

## Test plan

- [x] New SDK e2e `vr-held-model.e2e.test.ts`: a grabbed pistol keeps `atek_w` in VR; a wielded one still swaps to `atek_h` in flat. Negative-tested: the VR case fails with the gate disabled.
- [x] In-game fire check: muzzle flash spawns at the barrel (0.7 m ahead of the held pistol), not the grip.
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr` (75)
- [x] Full SDK e2e suite
- [x] `/xreview` (adversarial): both Medium findings (vhots, cross-mode saves) fixed in the follow-up commit; Quest gate verified (`oculus_runtime` defaults to `PresentationMode::Vr`); unique regenerates on every world build so saves/transitions are safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)