### PR TITLE
feat(ai): taking damage alerts the AI

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -273,6 +273,12 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
     }
 }
 
+/// Current hit points, if the entity has a health pool
+pub fn hit_points(entity_id: EntityId, world: &World) -> Option<i32> {
+    let v_prop_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+    v_prop_hit_points.get(entity_id).ok().map(|p| p.hit_points)
+}
+
 pub fn is_killed(entity_id: EntityId, world: &World) -> bool {
     let v_prop_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -269,6 +269,40 @@ impl AnimatedMonsterAI {
             dark::motion::MotionQuerySelectionStrategy::Sequential(seq)
         }
     }
+
+    /// Force alertness to `level` (clamped by the alert cap), reset the
+    /// visibility timers, and swap in the canonical behavior for the
+    /// resulting level. Callers must check the AI is alive first.
+    fn force_alertness(
+        &mut self,
+        level: AIAlertLevel,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+    ) -> Effect {
+        let cap = self
+            .config
+            .as_ref()
+            .map(|c| c.alert_cap.clone())
+            .unwrap_or_else(default_alert_cap);
+        alertness::set_level(&mut self.alertness, level, &cap);
+        // Forced level starts fresh: no accumulated visibility time pushing
+        // an immediate escalation or decay
+        self.alertness.visible_time = 0.0;
+        self.alertness.hidden_time = 0.0;
+
+        self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
+        let is_locomotion = self.current_behavior.borrow().is_locomotion();
+        let selection_strategy = self.next_selection(is_locomotion);
+        Effect::combine(vec![
+            alertness::sync_alertness_effect(entity_id, &self.alertness),
+            Effect::QueueAnimationBySchema {
+                entity_id,
+                motion_query_items: self.current_behavior.borrow().animation(),
+                selection_strategy,
+            },
+        ])
+    }
 }
 
 impl Script for AnimatedMonsterAI {
@@ -453,10 +487,44 @@ impl Script for AnimatedMonsterAI {
             MessagePayload::Damage { amount } => {
                 // TODO: Let behavior handle this?
                 self.took_damage = true;
-                Effect::AdjustHitPoints {
+                let hit_points_effect = Effect::AdjustHitPoints {
                     entity_id,
                     delta: -(amount.round() as i32),
-                }
+                };
+                // Taking damage alerts the AI: escalate toward Moderate
+                // (chase) so a shot AI aggros even when it never saw the
+                // player. Escalation only - an already-alerted AI stays put.
+                // The hit-point adjustment applies after this handler
+                // returns, so lethality is checked against the incoming
+                // amount - a killing blow must not stand the AI up to chase
+                // for a frame. Note: the damage source isn't attributed, so
+                // any damage aggros toward the player (chase is
+                // player-centric like the other behaviors).
+                let lethal = hit_points(entity_id, world)
+                    .map(|hp| hp - amount.round() as i32 <= 0)
+                    .unwrap_or(false);
+                let cap = self
+                    .config
+                    .as_ref()
+                    .map(|c| c.alert_cap.clone())
+                    .unwrap_or_else(default_alert_cap);
+                // Respect alert caps: only force when the (clamped) target
+                // actually raises the level, so a capped AI isn't reset -
+                // and doesn't restart its animation - on every hit
+                let target = alertness::clamp_level(AIAlertLevel::Moderate, &cap);
+                let alert_effect = if !self.is_dead
+                    && !lethal
+                    && matches!(
+                        self.alertness.current_level,
+                        AIAlertLevel::Lowest | AIAlertLevel::Low
+                    )
+                    && target != self.alertness.current_level
+                {
+                    self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
+                } else {
+                    Effect::NoEffect
+                };
+                Effect::combine(vec![hit_points_effect, alert_effect])
             }
             MessagePayload::TurnOn { from: _ } => {
                 let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
@@ -506,31 +574,10 @@ impl Script for AnimatedMonsterAI {
                 if self.is_dead || is_killed(entity_id, world) {
                     return Effect::NoEffect;
                 }
-                let cap = self
-                    .config
-                    .as_ref()
-                    .map(|c| c.alert_cap.clone())
-                    .unwrap_or_else(default_alert_cap);
-                alertness::set_level(&mut self.alertness, *level, &cap);
-                // Forced level starts fresh: no accumulated visibility time
-                // pushing an immediate escalation or decay
-                self.alertness.visible_time = 0.0;
-                self.alertness.hidden_time = 0.0;
-
-                // Always reset the behavior to the canonical one for this
-                // level, even when the level didn't change - forcing is a
-                // debug reset, so it also cancels scripted sequences
-                self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
-                let is_locomotion = self.current_behavior.borrow().is_locomotion();
-                let selection_strategy = self.next_selection(is_locomotion);
-                Effect::combine(vec![
-                    alertness::sync_alertness_effect(entity_id, &self.alertness),
-                    Effect::QueueAnimationBySchema {
-                        entity_id,
-                        motion_query_items: self.current_behavior.borrow().animation(),
-                        selection_strategy,
-                    },
-                ])
+                // The behavior reset is unconditional, even when the level
+                // didn't change - forcing is a debug reset, so it also
+                // cancels scripted sequences
+                self.force_alertness(*level, world, physics, entity_id)
             }
             MessagePayload::AnimationCompleted => {
                 if self.is_dead {

--- a/tools/shock2-sdk/test/damage-alert.e2e.test.ts
+++ b/tools/shock2-sdk/test/damage-alert.e2e.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+test(
+  "taking damage alerts an unaware AI (it aggros and chases)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster, identified by diffing the entity list across the
+    // spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // Unaware before the shot.
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
+    assert.equal(aiProp(detail, "AIBehavior"), "Idle");
+
+    // A non-lethal hit aggros it: escalates straight to Moderate (chase),
+    // no line of sight required.
+    await game.entities.sendMessage(monster.id, { type: "Damage", amount: 1.0 });
+    await game.step({ frames: 30 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Moderate");
+    const behavior = aiProp(detail, "AIBehavior");
+    assert.ok(
+      behavior === "Chase" || behavior === "MeleeAttack",
+      `expected Chase or MeleeAttack after taking damage, got ${behavior}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Next item in the AI sequence (after #349): shooting an unaware monster now aggros it. The `Damage` handler escalates alertness toward Moderate (chase) — no line of sight required, so an AI shot from behind turns and comes after the player instead of standing idle.

- **Escalation only**: an already-alerted AI is unaffected; the forced level respects the entity's alert cap, and a capped AI whose level wouldn't actually rise is left untouched (no behavior/animation reset per hit).
- **Killing blows don't escalate** (review fix): the hit-point adjustment applies after the handler returns, so lethality is checked against the incoming damage amount — a lethal hit goes straight to the death flow instead of standing the dying AI up to chase for a frame.
- Extracts the forced-escalation path shared with `SetAlertness` into `force_alertness` (level clamp, timer reset, canonical behavior swap) — removes what would have been a fifth copy of the behavior-swap boilerplate.
- Known simplification (commented): damage isn't source-attributed, so any damage aggros toward the player — consistent with the codebase's player-centric behaviors.

## Test plan

- [x] New e2e `damage-alert.e2e.test.ts`: spawn monster (identified by entity-id diff), assert unaware, inject non-lethal `Damage`, assert Moderate + Chase. **Fails without this change** (verified red first).
- [x] `cargo test -p shock2vr` (70), `RUSTFLAGS="-D warnings" cargo check` across shock2vr/desktop/debug/bench
- [x] Full SDK e2e suite green (43/43)
- [x] Cross-engine review (Claude + Codex): agreed killing-blow race and alert-cap reset both fixed

Note: while validating this branch we hit an intermittent suite-start 503 in unrelated tests (never reproducible in isolation, correlated with cargo/rust-analyzer contention at suite start); harness diagnosability gaps filed as #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)