### PR TITLE
feat(debug): TurnOn/TurnOff injection, shock2vr logs by default, input docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,9 +224,16 @@ For debugging visual/rendering changes without a full interactive session:
    curl http://127.0.0.1:8080/v1/input/actions
    curl -X POST http://127.0.0.1:8080/v1/input/action -d '{"action": "PathfindingTestCycle"}'
 
-   # Inject a script message into an entity (damage/frob/AI signal) - drives script
-   # behavior directly without a world interaction. Body is a tagged DebugEntityMessage.
+   # Inject a script message into an entity (damage/frob/AI signal/switch-link
+   # on/off) - drives script behavior directly without a world interaction.
+   # Body is a tagged DebugEntityMessage. TurnOn/TurnOff are what tripwires and
+   # buttons send over SwitchLinks - use them to exercise doors/traps directly.
    curl -X POST http://127.0.0.1:8080/v1/entities/122/message -d '{"type": "Damage", "amount": 5.0}'
+   curl -X POST http://127.0.0.1:8080/v1/entities/40/message -d '{"type": "TurnOn"}'
+
+   # Move the player: right stick = locomotion [strafe, forward], left stick
+   # x = turn, left stick y = fly up/down. Set a channel, then step to advance.
+   curl -X POST http://127.0.0.1:8080/v1/control/input -d '{"right_hand.thumbstick": [0.0, 1.0]}'
 
    # IMPORTANT: Always shut down when done to avoid interfering with user's session
    curl -X POST http://127.0.0.1:8080/v1/shutdown

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -199,11 +199,13 @@ fn parse_mission(mission: &str) -> (String, SpawnLocation) {
 }
 
 fn main() -> anyhow::Result<()> {
-    // Initialize tracing with info level by default
+    // Initialize tracing with info level by default. Include shock2vr so
+    // script/trigger activity (tripwires, quest bits, doors) is visible when
+    // driving the game over HTTP - essential for agent-driven debugging.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "debug_runtime=info".into()),
+                .unwrap_or_else(|_| "debug_runtime=info,shock2vr=info".into()),
         )
         .init();
 
@@ -1250,13 +1252,16 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
 /// - `{left,right}_hand.thumbstick` : `[x, y]`
 /// One line describing every recognized input channel, used in error messages so
-/// a bad request is self-documenting.
+/// a bad request is self-documenting. Includes the locomotion semantics (which
+/// stick does what) since that is the game's convention, not guessable.
 fn input_channels_help() -> &'static str {
     "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
-     {left,right}_hand.rotation [x,y,z,w]"
+     {left,right}_hand.rotation [x,y,z,w]; \
+     locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
+     left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
 }
 
 fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> Result<(), String> {

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -456,7 +456,7 @@ pub trait DebuggableScene {
 /// This is intentionally a small, serde-friendly subset of the engine's full
 /// `MessagePayload` enum, surfaced so remote clients (HTTP / SDK) can exercise
 /// script behaviors directly without simulating a world interaction. Extend it
-/// as new debug scenarios need more message kinds (e.g. `TurnOn` / `TurnOff`).
+/// as new debug scenarios need more message kinds.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum DebugEntityMessage {
@@ -470,6 +470,10 @@ pub enum DebugEntityMessage {
     SetAlertness {
         level: dark::properties::AIAlertLevel,
     },
+    /// Switch-link activate (what a tripwire/button sends to its targets).
+    TurnOn,
+    /// Switch-link deactivate.
+    TurnOff,
 }
 
 /// Status of the interactive pathfinding test system

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4054,6 +4054,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             DebugEntityMessage::Frob => MessagePayload::Frob,
             DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
             DebugEntityMessage::SetAlertness { level } => MessagePayload::SetAlertness { level },
+            // Debug injections have no real sender; use the target itself.
+            DebugEntityMessage::TurnOn => MessagePayload::TurnOn { from: id },
+            DebugEntityMessage::TurnOff => MessagePayload::TurnOff { from: id },
         };
 
         self.script_world.dispatch(Message { to: id, payload });


### PR DESCRIPTION
Three quality-of-life improvements for agent-driven debugging, found while diagnosing the ops1 cutscene (stack 1/4):

- **Default log filter now includes `shock2vr=info`** — script/trigger activity (tripwires, quest bits, doors) was invisible over HTTP because the debug runtime only logged its own target.
- **`DebugEntityMessage` gains `TurnOn`/`TurnOff`** — the switch-link messages tripwires/buttons send, injectable via `POST /v1/entities/{id}/message` to exercise doors and traps directly (previously anticipated in a TODO).
- **Locomotion semantics documented** where they're discovered: the input-channel error text and CLAUDE.md now state that the right stick moves, left stick x turns, left stick y flies — the game's convention, previously guessable only from source.

Verified live: `TurnOn` opened an ops1 airlock door over HTTP; tripwire logs appear without `RUST_LOG`. `RUSTFLAGS="-D warnings"` clean; full SDK e2e suite (40/40) passed on the combined stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)