### PR TITLE
fix(entities): honor instance names, authored door state, and teleport trigger entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ For debugging visual/rendering changes without a full interactive session:
 
    # Move the player: right stick = locomotion [strafe, forward], left stick
    # x = turn, left stick y = fly up/down. Set a channel, then step to advance.
+   # (Teleporting into a trigger volume fires it, same as walking in.)
    curl -X POST http://127.0.0.1:8080/v1/control/input -d '{"right_hand.thumbstick": [0.0, 1.0]}'
 
    # IMPORTANT: Always shut down when done to avoid interfering with user's session

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -703,6 +703,12 @@ impl Links {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropPickBias(pub f32);
 
+/// Renderer\Transparency (alpha): 0.0 = invisible, 1.0 = opaque. Authored on
+/// holo/ghost entities (e.g. the CS9 cutscene exhibits) and animated by the
+/// Transluce script family.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRenderAlpha(pub f32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTranslatingDoor {
     pub door_type: i32,
@@ -1186,6 +1192,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$PickBias",
             |reader, _len| read_single(reader),
             PropPickBias,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RenderAlp",
+            |reader, _len| read_single(reader),
+            PropRenderAlpha,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -706,9 +706,27 @@ pub struct PropTranslatingDoor {
     pub open: f32,
     pub speed: f32,
     pub axis: i32,
+    /// Authored door state (Dark's DOOR_STATE): 0=closed, 1=open, 2=closing,
+    /// 3=opening, 4=halted. Doors must initialize to this pose - snapping
+    /// everything to closed shuts doors that were authored open.
+    pub state: i32,
     pub base_closed_location: Vector3<f32>,
     pub base_open_location: Vector3<f32>,
     pub base_location: Vector3<f32>,
+}
+
+impl PropTranslatingDoor {
+    /// The world position this door should occupy at load time, per its
+    /// authored state. In-motion/halted states resume from the authored
+    /// location.
+    pub fn initial_location(&self) -> Vector3<f32> {
+        match self.state {
+            0 => self.base_closed_location,
+            1 => self.base_open_location,
+            // closing / opening / halted / unknown: as authored
+            _ => self.base_location,
+        }
+    }
 }
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
@@ -1422,7 +1440,7 @@ fn read_prop_translating_door<T: io::Read + io::Seek>(
     let open = read_single(reader);
     let speed = read_single(reader) / SCALE_FACTOR;
     let axis = read_i32(reader);
-    let _state = read_i32(reader);
+    let state = read_i32(reader);
     let _hard_limits = read_bool(reader);
     let _sound_blocking = read_single(reader);
     let _vision_blocking = read_single(reader);
@@ -1444,6 +1462,7 @@ fn read_prop_translating_door<T: io::Read + io::Seek>(
         door_type,
         closed,
         open,
+        state,
         base_closed_location,
         base_open_location,
         base_location,

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -107,6 +107,10 @@ pub struct PropPosition {
 }
 
 #[derive(Debug, Component, Serialize, Deserialize)]
+/// Marks an entity as having just teleported (VR teleport locomotion, teleport
+/// traps, debug teleport). Currently has no readers - tripwires deliberately
+/// fire on teleport-entry like the original engine - but the marker is kept
+/// (and serialized in saves) for scripts that may need teleport-awareness.
 pub struct PropTeleported {
     pub countdown_timer: f32, // Remaining time to be considered 'recently teleported'
 }

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -152,6 +152,7 @@ where
     diffuse_texture: T,
     emissivity: f32,
     transparency: f32,
+    base_transparency: f32,
 }
 
 impl<T> BasicMaterial<T>
@@ -241,6 +242,13 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn set_transparency_override(&mut self, transparency: Option<f32>) {
+        self.transparency = match transparency {
+            Some(value) => value.clamp(0.0, 1.0),
+            None => self.base_transparency,
+        };
     }
 
     fn has_initialized(&self) -> bool {
@@ -456,5 +464,6 @@ where
         has_initialized: false,
         emissivity,
         transparency,
+        base_transparency: transparency,
     })
 }

--- a/engine/src/scene/material.rs
+++ b/engine/src/scene/material.rs
@@ -44,4 +44,9 @@ pub trait Material: Any {
     ) -> bool {
         false
     }
+
+    /// Override the material's transparency (0.0 = opaque, 1.0 = invisible), or
+    /// reset to its authored value with `None`. Default is a no-op for
+    /// materials without transparency support.
+    fn set_transparency_override(&mut self, _transparency: Option<f32>) {}
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -247,7 +247,9 @@ impl SceneObject {
         }
 
         if let Some(t) = self.transparency_override {
-            self.material.borrow_mut().set_transparency_override(Some(t));
+            self.material
+                .borrow_mut()
+                .set_transparency_override(Some(t));
         }
         if self.material.borrow().draw_opaque(
             render_context,
@@ -275,7 +277,9 @@ impl SceneObject {
     ) {
         let xform = self.transform * self.local_transform;
         if let Some(t) = self.transparency_override {
-            self.material.borrow_mut().set_transparency_override(Some(t));
+            self.material
+                .borrow_mut()
+                .set_transparency_override(Some(t));
         }
         if self.material.borrow().draw_transparent(
             render_context,

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -43,6 +43,11 @@ pub struct SceneObject {
     /// depth-testing normally within itself. Used to draw the flatscreen
     /// first-person weapon viewmodel without clipping into geometry.
     pub clear_depth: bool,
+    /// Per-object transparency override (0.0 = opaque, 1.0 = invisible).
+    /// Materials are shared (`Rc`) across every object using the same model, so
+    /// a lasting material-level override would bleed between entities; instead
+    /// this is applied to the material only around this object's own draw.
+    pub transparency_override: Option<f32>,
 }
 
 impl SceneObject {
@@ -214,6 +219,7 @@ impl SceneObject {
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
             clear_depth: false,
+            transparency_override: None,
         }
     }
 
@@ -240,6 +246,9 @@ impl SceneObject {
             unsafe { gl::DepthMask(gl::FALSE) };
         }
 
+        if let Some(t) = self.transparency_override {
+            self.material.borrow_mut().set_transparency_override(Some(t));
+        }
         if self.material.borrow().draw_opaque(
             render_context,
             view,
@@ -248,6 +257,9 @@ impl SceneObject {
             lights,
         ) {
             self.geometry.draw();
+        }
+        if self.transparency_override.is_some() {
+            self.material.borrow_mut().set_transparency_override(None);
         }
 
         if !self.depth_write {
@@ -262,6 +274,9 @@ impl SceneObject {
         lights: &crate::scene::light::LightArray,
     ) {
         let xform = self.transform * self.local_transform;
+        if let Some(t) = self.transparency_override {
+            self.material.borrow_mut().set_transparency_override(Some(t));
+        }
         if self.material.borrow().draw_transparent(
             render_context,
             view,
@@ -270,6 +285,9 @@ impl SceneObject {
             lights,
         ) {
             self.geometry.draw();
+        }
+        if self.transparency_override.is_some() {
+            self.material.borrow_mut().set_transparency_override(None);
         }
     }
 
@@ -307,6 +325,7 @@ impl SceneObject {
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
             clear_depth: false,
+            transparency_override: None,
         }
     }
 
@@ -319,6 +338,7 @@ impl SceneObject {
             skinning_data: self.skinning_data,
             depth_write: self.depth_write,
             clear_depth: self.clear_depth,
+            transparency_override: self.transparency_override,
         }
     }
 
@@ -342,5 +362,12 @@ impl SceneObject {
                 None => material.reset_transparency(),
             }
         }
+    }
+
+    /// Override transparency (0.0 = opaque, 1.0 = invisible) for this object
+    /// only, or reset with `None`. Applied around this object's draw so other
+    /// objects sharing the same material are unaffected.
+    pub fn set_transparency(&mut self, transparency: Option<f32>) {
+        self.transparency_override = transparency;
     }
 }

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -282,6 +282,13 @@ impl Material for SkinnedMaterial {
         self
     }
 
+    fn set_transparency_override(&mut self, transparency: Option<f32>) {
+        self.transparency = match transparency {
+            Some(value) => value.clamp(0.0, 1.0),
+            None => self.base_transparency,
+        };
+    }
+
     fn has_initialized(&self) -> bool {
         self.has_initialized
     }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -333,13 +333,24 @@ fn initialize_sym_name_from_obj_map(
     obj_map: &HashMap<i32, String>,
     world: &mut World,
 ) {
+    // A mission entity hydrated by the populator already carries its
+    // instance-specific sym name (e.g. "SlowDoorControl"); the obj map only
+    // holds archetype names ("Marker"), so overwriting here would clobber the
+    // designer-given name every by-name script lookup depends on.
+    {
+        let v_name = world.borrow::<View<PropSymName>>().unwrap();
+        if v_name.contains(entity) {
+            return;
+        }
+    }
+
     let hierarchy = ss2_entity_info::get_hierarchy(entity_info);
     let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
     ancestors.push(template_id);
 
     let _template_links = TemplateLinks::empty();
     for parent_id in ancestors {
-        // Add, override name if specified in name map
+        // Add name if specified in the obj map
         if let Some(name) = obj_map.get(&parent_id) {
             world.add_component(entity, PropSymName(name.to_owned()))
         }
@@ -543,6 +554,7 @@ pub fn initialize_entity_with_props(
             world.add_component(entity_id, PropSymName(name.to_owned()))
         }
     }
+
     // Augment any props
 
     let maybe_mod = {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2247,6 +2247,12 @@ impl MissionCore {
                             .add_component(player_entity, PropTeleported::new())
                     }
                 }
+                Effect::SetRenderAlpha { entity_id, alpha } => {
+                    self.world.add_component(
+                        entity_id,
+                        dark::properties::PropRenderAlpha(alpha.clamp(0.0, 1.0)),
+                    );
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,
@@ -2909,6 +2915,10 @@ impl MissionCore {
         let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
         let v_frame_state = self.world.borrow::<View<PropFrameAnimState>>().unwrap();
         let v_render_type = self.world.borrow::<View<PropRenderType>>().unwrap();
+        let v_render_alpha = self
+            .world
+            .borrow::<View<dark::properties::PropRenderAlpha>>()
+            .unwrap();
         let v_joint_transforms = self
             .world
             .borrow::<View<RuntimePropJointTransforms>>()
@@ -2980,6 +2990,14 @@ impl MissionCore {
             };
             let is_animated_model = objs.is_animated();
 
+            // Authored/scripted per-entity alpha (Renderer\Transparency (alpha):
+            // 1.0 = opaque, 0.0 = invisible), e.g. the CS9 holo exhibits.
+            let render_alpha = v_render_alpha
+                .get(*entity_id)
+                .ok()
+                .map(|a| a.0.clamp(0.0, 1.0))
+                .filter(|a| *a < 1.0);
+
             if let Ok(xform) = v_transform.get(*entity_id).map(|p| p.0) {
                 for obj in scene_objs {
                     let mut xformed_obj = obj.clone();
@@ -2987,6 +3005,9 @@ impl MissionCore {
                     if options.debug_skeletons && is_animated_model {
                         xformed_obj.set_depth_write(false);
                         xformed_obj.set_skinned_transparency(Some(0.35));
+                    } else if let Some(alpha) = render_alpha {
+                        xformed_obj.set_depth_write(false);
+                        xformed_obj.set_transparency(Some(1.0 - alpha));
                     } else {
                         xformed_obj.set_depth_write(true);
                         xformed_obj.set_skinned_transparency(None);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -253,6 +253,14 @@ pub enum Effect {
         is_teleport: bool,
     },
 
+    /// Set an entity's render alpha (Renderer\Transparency (alpha): 1.0 =
+    /// opaque, 0.0 = invisible). Drives holo/ghost fades (Transluce scripts,
+    /// CS9 cutscene exhibits).
+    SetRenderAlpha {
+        entity_id: EntityId,
+        alpha: f32,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -29,12 +29,16 @@ impl Script for StdDoor {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
-            self.desired_position = trans_door.base_closed_location;
-            self.current_position = trans_door.base_closed_location;
+            // Respect the authored door state - a door saved open must start
+            // open. Snapping everything to base_closed_location shut doors the
+            // level designer left open.
+            let initial = trans_door.initial_location();
+            self.desired_position = initial;
+            self.current_position = initial;
 
             Effect::SetPosition {
                 entity_id,
-                position: trans_door.base_closed_location,
+                position: initial,
             }
         } else {
             Effect::NoEffect

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 
-use dark::properties::{
-    PropLocalPlayer, PropTeleported, PropTranslatingDoor, PropTripFlags, TripFlags,
-};
+use dark::properties::{PropLocalPlayer, PropTranslatingDoor, PropTripFlags, TripFlags};
 use shipyard::{EntityId, Get, View, World};
 use tracing::info;
 
@@ -19,15 +17,9 @@ pub fn is_player(world: &World, entity_id: EntityId) -> bool {
     v_prop_player.get(entity_id).is_ok()
 }
 
-fn did_entity_just_teleport(world: &World, entity_id: EntityId) -> bool {
-    let teleported = world.borrow::<View<PropTeleported>>().unwrap();
-    teleported.contains(entity_id)
-}
-
 pub struct TrapNewTripwire {
     has_activated: bool,
     entity_in_trap: HashSet<EntityId>,
-    teleported_entities_to_ignore: HashSet<EntityId>,
     trip_flags: TripFlags,
 }
 impl TrapNewTripwire {
@@ -36,8 +28,6 @@ impl TrapNewTripwire {
             trip_flags: TripFlags::DEFAULT,
             has_activated: false,
             entity_in_trap: HashSet::new(),
-            //entity_to_time: HashMap::new(),
-            teleported_entities_to_ignore: HashSet::new(),
         }
     }
 
@@ -112,6 +102,11 @@ impl Script for TrapNewTripwire {
         let default_flags = PropTripFlags::default();
         let trip_flags = v_trip_flags.get(entity_id).unwrap_or(&default_flags);
 
+        // NOTE: intersections count no matter how the entity got here - walking,
+        // VR teleport locomotion, a teleport trap, or a debug teleport. The Dark
+        // engine fires PhysEnter/PhysExit for teleports too, and suppressing
+        // them made teleported-in players silently skip triggers (e.g. the ops1
+        // cutscene tripwire).
         match msg {
             MessagePayload::SensorBeginIntersect { with } => {
                 if self.should_activate(world, entity_id, *with, &trip_flags.trip_flags) {
@@ -119,17 +114,9 @@ impl Script for TrapNewTripwire {
                     self.has_activated = true;
                     let was_empty = self.entity_in_trap.is_empty();
 
-                    let did_entity_just_teleport = did_entity_just_teleport(world, *with);
                     self.entity_in_trap.insert(*with);
 
-                    if did_entity_just_teleport {
-                        self.teleported_entities_to_ignore.insert(*with);
-                    }
-
-                    if was_empty
-                        && self.trip_flags.contains(TripFlags::ENTER)
-                        && !did_entity_just_teleport
-                    {
+                    if was_empty && self.trip_flags.contains(TripFlags::ENTER) {
                         send_to_all_switch_links(
                             world,
                             entity_id,
@@ -145,25 +132,16 @@ impl Script for TrapNewTripwire {
             MessagePayload::SensorEndIntersect { with } => {
                 let had_keys_before = !self.entity_in_trap.is_empty();
 
-                // If the entity teleported, we should disregard
-                let did_teleport = did_entity_just_teleport(world, *with)
-                    || self.teleported_entities_to_ignore.contains(with);
-
-                self.teleported_entities_to_ignore.remove(with);
                 self.entity_in_trap.remove(with);
 
                 let has_keys_now = !self.entity_in_trap.is_empty();
 
                 info!(
-                    "sensor end intersect for {:?} - did_teleport: {} has_keys_now: {} had_keys_before: {} trip_flags: {:?}",
-                    with, did_teleport, has_keys_now, had_keys_before, trip_flags
+                    "sensor end intersect for {:?} - has_keys_now: {} had_keys_before: {} trip_flags: {:?}",
+                    with, has_keys_now, had_keys_before, trip_flags
                 );
 
-                if !did_teleport
-                    && !has_keys_now
-                    && had_keys_before
-                    && self.trip_flags.contains(TripFlags::EXIT)
-                {
+                if !has_keys_now && had_keys_before && self.trip_flags.contains(TripFlags::EXIT) {
                     send_to_all_switch_links(
                         world,
                         entity_id,


### PR DESCRIPTION
Three engine-faithfulness fixes uncovered while debugging why the ops1 SHODAN-reveal cutscene never fired (stack 2/4, on #361):

- **Instance sym names were clobbered engine-wide.** The instantiate pass re-stamped `PropSymName` from the OBJ_MAP via the template chain — but OBJ_MAP only holds archetype ids, so designer names like `SlowDoorControl`/`EggsandGrubsControl` were replaced with `Marker` right after the populator set them, and every `get_entities_by_name` lookup silently missed. The obj-map name is now only a fallback for entities with no name (runtime spawns hydrated purely from a template). This affects all missions.
- **Door state was discarded.** `P$TransDoor`'s state field is now parsed, and `StdDoor` initializes doors at their authored pose instead of force-closing everything (which shut doors designers left open).
- **Tripwires now fire on teleport-entry**, matching the Dark engine's PhysEnter behavior. Previously VR teleport locomotion, teleport traps, and the debug teleport silently skipped triggers. Level spawn never used the teleport marker, so load behavior is unchanged; `PropTeleported` remains written (and save-serialized) but documented as currently unread.

Verified live in ops1 (by-name lookups resolve; teleporting into the cutscene tripwire fires it; airlock doors unchanged since all ops1 doors are authored closed). Full SDK e2e suite (40/40, all 23 missions load) passed on the combined stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)