### PR TITLE
feat(render): per-entity transparency via P$RenderAlp and SetRenderAlpha

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -703,6 +703,12 @@ impl Links {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropPickBias(pub f32);
 
+/// Renderer\Transparency (alpha): 0.0 = invisible, 1.0 = opaque. Authored on
+/// holo/ghost entities (e.g. the CS9 cutscene exhibits) and animated by the
+/// Transluce script family.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRenderAlpha(pub f32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTranslatingDoor {
     pub door_type: i32,
@@ -1186,6 +1192,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$PickBias",
             |reader, _len| read_single(reader),
             PropPickBias,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RenderAlp",
+            |reader, _len| read_single(reader),
+            PropRenderAlpha,
             accumulator::latest,
         ),
         define_prop(

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -152,6 +152,7 @@ where
     diffuse_texture: T,
     emissivity: f32,
     transparency: f32,
+    base_transparency: f32,
 }
 
 impl<T> BasicMaterial<T>
@@ -241,6 +242,13 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn set_transparency_override(&mut self, transparency: Option<f32>) {
+        self.transparency = match transparency {
+            Some(value) => value.clamp(0.0, 1.0),
+            None => self.base_transparency,
+        };
     }
 
     fn has_initialized(&self) -> bool {
@@ -456,5 +464,6 @@ where
         has_initialized: false,
         emissivity,
         transparency,
+        base_transparency: transparency,
     })
 }

--- a/engine/src/scene/material.rs
+++ b/engine/src/scene/material.rs
@@ -44,4 +44,9 @@ pub trait Material: Any {
     ) -> bool {
         false
     }
+
+    /// Override the material's transparency (0.0 = opaque, 1.0 = invisible), or
+    /// reset to its authored value with `None`. Default is a no-op for
+    /// materials without transparency support.
+    fn set_transparency_override(&mut self, _transparency: Option<f32>) {}
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -43,6 +43,11 @@ pub struct SceneObject {
     /// depth-testing normally within itself. Used to draw the flatscreen
     /// first-person weapon viewmodel without clipping into geometry.
     pub clear_depth: bool,
+    /// Per-object transparency override (0.0 = opaque, 1.0 = invisible).
+    /// Materials are shared (`Rc`) across every object using the same model, so
+    /// a lasting material-level override would bleed between entities; instead
+    /// this is applied to the material only around this object's own draw.
+    pub transparency_override: Option<f32>,
 }
 
 impl SceneObject {
@@ -214,6 +219,7 @@ impl SceneObject {
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
             clear_depth: false,
+            transparency_override: None,
         }
     }
 
@@ -240,6 +246,9 @@ impl SceneObject {
             unsafe { gl::DepthMask(gl::FALSE) };
         }
 
+        if let Some(t) = self.transparency_override {
+            self.material.borrow_mut().set_transparency_override(Some(t));
+        }
         if self.material.borrow().draw_opaque(
             render_context,
             view,
@@ -248,6 +257,9 @@ impl SceneObject {
             lights,
         ) {
             self.geometry.draw();
+        }
+        if self.transparency_override.is_some() {
+            self.material.borrow_mut().set_transparency_override(None);
         }
 
         if !self.depth_write {
@@ -262,6 +274,9 @@ impl SceneObject {
         lights: &crate::scene::light::LightArray,
     ) {
         let xform = self.transform * self.local_transform;
+        if let Some(t) = self.transparency_override {
+            self.material.borrow_mut().set_transparency_override(Some(t));
+        }
         if self.material.borrow().draw_transparent(
             render_context,
             view,
@@ -270,6 +285,9 @@ impl SceneObject {
             lights,
         ) {
             self.geometry.draw();
+        }
+        if self.transparency_override.is_some() {
+            self.material.borrow_mut().set_transparency_override(None);
         }
     }
 
@@ -307,6 +325,7 @@ impl SceneObject {
             skinning_data: [Matrix4::identity(); 40],
             depth_write: true,
             clear_depth: false,
+            transparency_override: None,
         }
     }
 
@@ -319,6 +338,7 @@ impl SceneObject {
             skinning_data: self.skinning_data,
             depth_write: self.depth_write,
             clear_depth: self.clear_depth,
+            transparency_override: self.transparency_override,
         }
     }
 
@@ -342,5 +362,12 @@ impl SceneObject {
                 None => material.reset_transparency(),
             }
         }
+    }
+
+    /// Override transparency (0.0 = opaque, 1.0 = invisible) for this object
+    /// only, or reset with `None`. Applied around this object's draw so other
+    /// objects sharing the same material are unaffected.
+    pub fn set_transparency(&mut self, transparency: Option<f32>) {
+        self.transparency_override = transparency;
     }
 }

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -282,6 +282,13 @@ impl Material for SkinnedMaterial {
         self
     }
 
+    fn set_transparency_override(&mut self, transparency: Option<f32>) {
+        self.transparency = match transparency {
+            Some(value) => value.clamp(0.0, 1.0),
+            None => self.base_transparency,
+        };
+    }
+
     fn has_initialized(&self) -> bool {
         self.has_initialized
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2234,6 +2234,12 @@ impl MissionCore {
                             .add_component(player_entity, PropTeleported::new())
                     }
                 }
+                Effect::SetRenderAlpha { entity_id, alpha } => {
+                    self.world.add_component(
+                        entity_id,
+                        dark::properties::PropRenderAlpha(alpha.clamp(0.0, 1.0)),
+                    );
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,
@@ -2896,6 +2902,10 @@ impl MissionCore {
         let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
         let v_frame_state = self.world.borrow::<View<PropFrameAnimState>>().unwrap();
         let v_render_type = self.world.borrow::<View<PropRenderType>>().unwrap();
+        let v_render_alpha = self
+            .world
+            .borrow::<View<dark::properties::PropRenderAlpha>>()
+            .unwrap();
         let v_joint_transforms = self
             .world
             .borrow::<View<RuntimePropJointTransforms>>()
@@ -2967,6 +2977,14 @@ impl MissionCore {
             };
             let is_animated_model = objs.is_animated();
 
+            // Authored/scripted per-entity alpha (Renderer\Transparency (alpha):
+            // 1.0 = opaque, 0.0 = invisible), e.g. the CS9 holo exhibits.
+            let render_alpha = v_render_alpha
+                .get(*entity_id)
+                .ok()
+                .map(|a| a.0.clamp(0.0, 1.0))
+                .filter(|a| *a < 1.0);
+
             if let Ok(xform) = v_transform.get(*entity_id).map(|p| p.0) {
                 for obj in scene_objs {
                     let mut xformed_obj = obj.clone();
@@ -2974,6 +2992,9 @@ impl MissionCore {
                     if options.debug_skeletons && is_animated_model {
                         xformed_obj.set_depth_write(false);
                         xformed_obj.set_skinned_transparency(Some(0.35));
+                    } else if let Some(alpha) = render_alpha {
+                        xformed_obj.set_depth_write(false);
+                        xformed_obj.set_transparency(Some(1.0 - alpha));
                     } else {
                         xformed_obj.set_depth_write(true);
                         xformed_obj.set_skinned_transparency(None);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -253,6 +253,14 @@ pub enum Effect {
         is_teleport: bool,
     },
 
+    /// Set an entity's render alpha (Renderer\Transparency (alpha): 1.0 =
+    /// opaque, 0.0 = invisible). Drives holo/ghost fades (Transluce scripts,
+    /// CS9 cutscene exhibits).
+    SetRenderAlpha {
+        entity_id: EntityId,
+        alpha: f32,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },


### PR DESCRIPTION
Adds per-entity render alpha, the missing capability behind "entities teleported in at partial opacity" (stack 3/4, on #362):

- Parse `P$RenderAlp` (Renderer\Transparency (alpha)) — authored on holo/ghost entities like the CS9 cutscene exhibits — and honor it in the mission render pass.
- Materials are `Rc`-shared across every object using the same model, so a lasting material-level override would bleed between entities (and fight the per-frame reset the render loop already does). The override therefore lives on the `SceneObject` and is applied to the material only around that object's own draw, in both passes. Pass selection stays dynamic (`is_transparent()` is consulted inside each draw), so an alpha'd object automatically moves to the transparent pass.
- `Material` gains a defaulted `set_transparency_override`; basic + skinned materials implement it (`BasicMaterial` gains `base_transparency` for reset).
- New `Effect::SetRenderAlpha` lets scripts set/animate alpha (Transluce script family, holo fade-ins).

Exercised by the CS9 cutscene in the next PR in the stack (translucent rumbler holograms / egg exhibits — see its screenshots). `RUSTFLAGS="-D warnings"` clean; full SDK e2e suite (40/40) passed on the combined stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)