### PR TITLE
feat(cutscene): implement the ops1 SHODAN reveal (CS9)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -370,6 +370,9 @@ pub enum Link {
     ParticleAttachement(ParticleAttachOptions),
     TPathInit,
     TPath(TPathData),
+    /// Names a destination object for scripted teleports (CS9 eggs/rumblers,
+    /// TrapTeleport family, TrapDestroyTeleport's destroy target).
+    Teleport,
 }
 
 #[derive(
@@ -767,6 +770,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_link("L$LandingPo", |_| Link::LandingPoint),
         define_link("L$Replicato", |_| Link::Replicator),
         define_link("L$SwitchLin", |_| Link::SwitchLink),
+        define_link("L$Teleport", |_| Link::Teleport),
         define_link("L$TPathInit", |_| Link::TPathInit),
         define_link("L$Miss Span", |_| Link::MissSpang),
         //define_link("L$TPath", |_| Link::TPath),

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -127,7 +127,9 @@ impl CS9MasterControl {
                     .into_iter()
                     .map(|to| {
                         let payload = match action {
-                            Cs9Action::TurnOnByName(_) => MessagePayload::TurnOn { from: entity_id },
+                            Cs9Action::TurnOnByName(_) => {
+                                MessagePayload::TurnOn { from: entity_id }
+                            }
                             _ => MessagePayload::TurnOff { from: entity_id },
                         };
                         Effect::Send {
@@ -249,12 +251,10 @@ impl Script for CS9HoloRumbler {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::TurnOn { from: _ } => {
-                match Self::loc_marker_name(world, entity_id) {
-                    Some(marker) => teleport_to_marker(world, entity_id, &marker, HOLO_ALPHA),
-                    None => Effect::NoEffect,
-                }
-            }
+            MessagePayload::TurnOn { from: _ } => match Self::loc_marker_name(world, entity_id) {
+                Some(marker) => teleport_to_marker(world, entity_id, &marker, HOLO_ALPHA),
+                None => Effect::NoEffect,
+            },
             MessagePayload::TurnOff { from: _ } => {
                 teleport_to_marker(world, entity_id, "SafeTeleportLoc", HOLO_ALPHA)
             }

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -1,0 +1,450 @@
+//! Scripts for CS9, the in-engine "Polito is SHODAN" reveal cutscene staged in
+//! ops1.mis. Behavioral spec reconstructed from Tom N Harris' `allobjs.osm`
+//! script analysis (thiefmissions.com/telliamed/allscripts.html) and the
+//! mission data:
+//!
+//! - A walk-in tripwire sends TurnOn to `CutSceneNine` (CS9_MasterControl),
+//!   which runs the whole show: raises the exit barriers (`MasterForceField`),
+//!   pulls the office walls apart (`SlowDoorControl` delay chains driving
+//!   StdDoor wall panels), plays SHODAN's monologue schemas cs0901..cs0909 in
+//!   sequence, brings in the holographic exhibits (eggs/grubs via
+//!   `EggsandGrubsControl`, rumblers at `RumblerLoc1-4`) during the "grove"
+//!   section, then tears everything back down and releases the player.
+//! - In the original the wall/schema transitions are event-driven (SchemaDone,
+//!   CS9_DoorReporter). Our audio layer has no completion events, so the master
+//!   script runs a fixed timeline using the measured lengths of the cs090x
+//!   audio files (see SCHEMAS below).
+use cgmath::Vector3;
+use dark::properties::{Link, PropPosition};
+use shipyard::{EntityId, Get, View, World};
+use tracing::info;
+
+use engine::audio::AudioHandle;
+
+use crate::{physics::PhysicsWorld, time::Time};
+
+use super::{
+    Effect, Message, MessagePayload, Script,
+    script_util::{get_all_links_of_type, get_entities_by_name, get_first_entity_by_name},
+};
+
+/// The nine SHODAN monologue schemas with their audio lengths in seconds
+/// (measured from the shipped `vCs/<language>/cs090x.wav` files; English).
+const SCHEMAS: [(&str, f32); 9] = [
+    ("cs0901", 28.7),
+    ("cs0902", 30.8),
+    ("cs0903", 23.8),
+    ("cs0904", 15.7),
+    ("cs0905", 11.7),
+    ("cs0906", 27.4),
+    ("cs0907", 14.1),
+    ("cs0908", 23.4),
+    ("cs0909", 38.4),
+];
+
+/// Pause before the first schema (the walls start moving first) and between
+/// consecutive schemas.
+const INITIAL_DELAY: f32 = 2.0;
+const INTER_SCHEMA_GAP: f32 = 0.6;
+
+/// Render alpha for the holographic exhibits (eggs, grubs, rumblers).
+const HOLO_ALPHA: f32 = 0.55;
+
+#[derive(Clone, Copy, Debug)]
+enum Cs9Action {
+    /// Send TurnOn to every entity with this sym name.
+    TurnOnByName(&'static str),
+    /// Send TurnOff to every entity with this sym name.
+    TurnOffByName(&'static str),
+    /// Start a monologue schema.
+    PlaySchema(&'static str),
+}
+
+/// Master sequencer for the reveal (script `CS9_MasterControl`, on the
+/// `CutSceneNine` marker). Fires a one-shot timeline of actions once tripped.
+pub struct CS9MasterControl {
+    started: bool,
+    elapsed: f32,
+    /// (fire time, action), sorted by time; `next` indexes the first unfired.
+    schedule: Vec<(f32, Cs9Action)>,
+    next: usize,
+}
+
+impl CS9MasterControl {
+    pub fn new() -> CS9MasterControl {
+        let mut schedule: Vec<(f32, Cs9Action)> = vec![
+            // Seal the player in and start pulling the theatre apart.
+            (0.0, Cs9Action::TurnOnByName("MasterForceField")),
+            (0.0, Cs9Action::TurnOnByName("SlowDoorControl")),
+        ];
+
+        let mut t = INITIAL_DELAY;
+        for (i, (schema, duration)) in SCHEMAS.iter().enumerate() {
+            schedule.push((t, Cs9Action::PlaySchema(schema)));
+            match i {
+                // cs0903: the "garden grove" section - the exhibits appear.
+                2 => {
+                    schedule.push((t, Cs9Action::TurnOnByName("EggsandGrubsControl")));
+                    for r in ["Rumbler1", "Rumbler2", "Rumbler3", "Rumbler4"] {
+                        schedule.push((t, Cs9Action::TurnOnByName(r)));
+                    }
+                }
+                // cs0907: "and now they seek to destroy me" - exhibits leave.
+                6 => {
+                    for r in ["Rumbler1", "Rumbler2", "Rumbler3", "Rumbler4"] {
+                        schedule.push((t, Cs9Action::TurnOffByName(r)));
+                    }
+                }
+                _ => {}
+            }
+            t += duration + INTER_SCHEMA_GAP;
+        }
+
+        // Teardown: stash the exhibits, close the walls, release the player.
+        schedule.push((t, Cs9Action::TurnOffByName("EggsandGrubsControl")));
+        schedule.push((t, Cs9Action::TurnOffByName("SlowDoorControl")));
+        schedule.push((t + 2.0, Cs9Action::TurnOffByName("MasterForceField")));
+
+        schedule.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+        CS9MasterControl {
+            started: false,
+            elapsed: 0.0,
+            schedule,
+            next: 0,
+        }
+    }
+
+    fn run_action(&self, entity_id: EntityId, world: &World, action: Cs9Action) -> Effect {
+        info!("cs9: firing action {:?}", action);
+        match action {
+            Cs9Action::TurnOnByName(name) | Cs9Action::TurnOffByName(name) => {
+                let targets = get_entities_by_name(world, name);
+                if targets.is_empty() {
+                    info!("cs9: no entities named '{}'", name);
+                }
+                let effects = targets
+                    .into_iter()
+                    .map(|to| {
+                        let payload = match action {
+                            Cs9Action::TurnOnByName(_) => MessagePayload::TurnOn { from: entity_id },
+                            _ => MessagePayload::TurnOff { from: entity_id },
+                        };
+                        Effect::Send {
+                            msg: Message { to, payload },
+                        }
+                    })
+                    .collect();
+                Effect::Combined { effects }
+            }
+            Cs9Action::PlaySchema(schema) => Effect::PlaySound {
+                handle: AudioHandle::new(),
+                name: schema.to_string(),
+            },
+        }
+    }
+}
+
+impl Script for CS9MasterControl {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if let MessagePayload::TurnOn { from: _ } = msg {
+            if !self.started {
+                info!("cs9: master control tripped - starting cutscene");
+                self.started = true;
+            }
+        }
+        Effect::NoEffect
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if !self.started || self.next >= self.schedule.len() {
+            return Effect::NoEffect;
+        }
+
+        self.elapsed += time.elapsed.as_secs_f32();
+
+        let mut effects = Vec::new();
+        while self.next < self.schedule.len() && self.schedule[self.next].0 <= self.elapsed {
+            let (_, action) = self.schedule[self.next];
+            effects.push(self.run_action(entity_id, world, action));
+            self.next += 1;
+        }
+
+        if effects.is_empty() {
+            Effect::NoEffect
+        } else {
+            Effect::Combined { effects }
+        }
+    }
+}
+
+/// Position + rotation of a named marker, if it exists.
+fn marker_pose(world: &World, name: &str) -> Option<(Vector3<f32>, cgmath::Quaternion<f32>)> {
+    let marker = get_first_entity_by_name(world, name)?;
+    let v_pos = world.borrow::<View<PropPosition>>().unwrap();
+    v_pos.get(marker).ok().map(|p| (p.position, p.rotation))
+}
+
+/// Teleport an entity to a named marker and set its holo alpha; used by the
+/// CS9 exhibit scripts. Returns NoEffect when the marker is missing.
+fn teleport_to_marker(world: &World, entity_id: EntityId, marker: &str, alpha: f32) -> Effect {
+    match marker_pose(world, marker) {
+        Some((position, rotation)) => Effect::Combined {
+            effects: vec![
+                Effect::SetPositionRotation {
+                    entity_id,
+                    position,
+                    rotation,
+                },
+                Effect::SetRenderAlpha { entity_id, alpha },
+            ],
+        },
+        None => {
+            info!("cs9: marker '{}' not found", marker);
+            Effect::NoEffect
+        }
+    }
+}
+
+/// Script `CS9_HoloRumbler`: the four rumblers are parked out of sight; on
+/// TurnOn each appears as a translucent hologram at its matching
+/// `RumblerLoc<N>` marker, and on TurnOff is stashed at `SafeTeleportLoc`.
+/// (The original also plays a walk-in-place motion; we keep them idle.)
+pub struct CS9HoloRumbler {}
+
+impl CS9HoloRumbler {
+    pub fn new() -> CS9HoloRumbler {
+        CS9HoloRumbler {}
+    }
+
+    /// "Rumbler3" -> "RumblerLoc3", matched via this entity's own sym name.
+    fn loc_marker_name(world: &World, entity_id: EntityId) -> Option<String> {
+        let v_name = world
+            .borrow::<View<dark::properties::PropSymName>>()
+            .unwrap();
+        let name = v_name.get(entity_id).ok()?.0.clone();
+        let digit = name.chars().rev().find(|c| c.is_ascii_digit())?;
+        Some(format!("RumblerLoc{digit}"))
+    }
+}
+
+impl Script for CS9HoloRumbler {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => {
+                match Self::loc_marker_name(world, entity_id) {
+                    Some(marker) => teleport_to_marker(world, entity_id, &marker, HOLO_ALPHA),
+                    None => Effect::NoEffect,
+                }
+            }
+            MessagePayload::TurnOff { from: _ } => {
+                teleport_to_marker(world, entity_id, "SafeTeleportLoc", HOLO_ALPHA)
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+/// Script `CS9_EggsandGrubs` (on the `EggsandGrubsControl` marker): on TurnOn,
+/// walks the SwitchLink chain starting at `FirstEgg`, teleporting one object
+/// per tick to its own `Teleport`-linked display marker (the eggs rise into
+/// the exhibit one at a time). On TurnOff everything is stashed back at
+/// `SafeTeleportLoc`.
+pub struct CS9EggsAndGrubs {
+    /// Remaining chain to reveal, one per NEXT_ITERATION_SECONDS.
+    pending: Vec<EntityId>,
+    revealed: Vec<EntityId>,
+    tick_timer: f32,
+    active: bool,
+}
+
+const NEXT_ITERATION_SECONDS: f32 = 1.2;
+
+impl CS9EggsAndGrubs {
+    pub fn new() -> CS9EggsAndGrubs {
+        CS9EggsAndGrubs {
+            pending: Vec::new(),
+            revealed: Vec::new(),
+            tick_timer: 0.0,
+            active: false,
+        }
+    }
+
+    /// FirstEgg -> SwitchLink -> next -> ... collects the whole exhibit chain.
+    fn collect_chain(world: &World, first: EntityId) -> Vec<EntityId> {
+        let mut chain = vec![first];
+        let mut current = first;
+        loop {
+            let next = get_all_links_of_type(world, current, Link::SwitchLink);
+            match next.into_iter().find(|e| !chain.contains(e)) {
+                Some(e) => {
+                    chain.push(e);
+                    current = e;
+                }
+                None => break,
+            }
+        }
+        chain
+    }
+
+    /// An exhibit object's display pose is its own `Teleport` link target.
+    fn display_pose(
+        world: &World,
+        entity_id: EntityId,
+    ) -> Option<(Vector3<f32>, cgmath::Quaternion<f32>)> {
+        let marker = get_all_links_of_type(world, entity_id, Link::Teleport)
+            .into_iter()
+            .next()?;
+        let v_pos = world.borrow::<View<PropPosition>>().unwrap();
+        v_pos.get(marker).ok().map(|p| (p.position, p.rotation))
+    }
+}
+
+impl Script for CS9EggsAndGrubs {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => {
+                if let Some(first) = get_first_entity_by_name(world, "FirstEgg") {
+                    self.pending = Self::collect_chain(world, first);
+                    info!("cs9: eggs/grubs chain of {} objects", self.pending.len());
+                    self.active = true;
+                    self.tick_timer = 0.0;
+                }
+                Effect::NoEffect
+            }
+            MessagePayload::TurnOff { from: _ } => {
+                self.active = false;
+                let stash: Vec<Effect> = self
+                    .revealed
+                    .drain(..)
+                    .chain(self.pending.drain(..))
+                    .map(|e| teleport_to_marker(world, e, "SafeTeleportLoc", HOLO_ALPHA))
+                    .collect();
+                Effect::Combined { effects: stash }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+
+    fn update(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        if !self.active || self.pending.is_empty() {
+            return Effect::NoEffect;
+        }
+
+        self.tick_timer -= time.elapsed.as_secs_f32();
+        if self.tick_timer > 0.0 {
+            return Effect::NoEffect;
+        }
+        self.tick_timer = NEXT_ITERATION_SECONDS;
+
+        let egg = self.pending.remove(0);
+        self.revealed.push(egg);
+        match Self::display_pose(world, egg) {
+            Some((position, rotation)) => Effect::Combined {
+                effects: vec![
+                    Effect::SetPositionRotation {
+                        entity_id: egg,
+                        position,
+                        rotation,
+                    },
+                    Effect::SetRenderAlpha {
+                        entity_id: egg,
+                        alpha: HOLO_ALPHA,
+                    },
+                ],
+            },
+            // No Teleport link: leave the object where it is (it may already
+            // sit at its display spot and only need the holo look).
+            None => Effect::SetRenderAlpha {
+                entity_id: egg,
+                alpha: HOLO_ALPHA,
+            },
+        }
+    }
+}
+
+/// Script `TrapDestroyTeleport`: destroys whatever its `Teleport` links point
+/// at when tripped/turned on. (In ops1 the marker carrying it has no Teleport
+/// links, so it is inert there - implemented for data-faithfulness.)
+pub struct TrapDestroyTeleport {}
+
+impl TrapDestroyTeleport {
+    pub fn new() -> TrapDestroyTeleport {
+        TrapDestroyTeleport {}
+    }
+}
+
+impl Script for TrapDestroyTeleport {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } | MessagePayload::SensorBeginIntersect { .. } => {
+                let effects = get_all_links_of_type(world, entity_id, Link::Teleport)
+                    .into_iter()
+                    .map(|target| Effect::DestroyEntity { entity_id: target })
+                    .collect();
+                Effect::Combined { effects }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+/// Script `SitDownRightNowMP`: in the original this freezes players into the
+/// Seat1-4 markers *in multiplayer only* - single-player relies on the
+/// barriers alone (players can move freely inside them during the show). We
+/// only support single player, so this is deliberately inert.
+pub struct SitDownRightNowMP {}
+
+impl SitDownRightNowMP {
+    pub fn new() -> SitDownRightNowMP {
+        SitDownRightNowMP {}
+    }
+}
+
+impl Script for SitDownRightNowMP {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _msg: &MessagePayload,
+    ) -> Effect {
+        Effect::NoEffect
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -11,6 +11,7 @@ mod choose_service;
 mod core_room;
 mod create_sound;
 mod dead_power_cell;
+mod cs9;
 mod destroy_all_by_name;
 mod energy_station;
 mod frob_qb;
@@ -81,7 +82,9 @@ use self::psi_amp_script::PsiAmpScript;
 use self::trap_signal::TrapSignal;
 use self::{
     base_button::BaseButton, base_elevator::BaseElevator, base_monster::BaseMonster, core_room::*,
-    create_sound::*, dead_power_cell::DeadPowerCell, destroy_all_by_name::DestroyAllByName,
+    create_sound::*,
+    cs9::{CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, SitDownRightNowMP, TrapDestroyTeleport},
+    dead_power_cell::DeadPowerCell, destroy_all_by_name::DestroyAllByName,
     energy_station::EnergyStation, frob_qb::FrobQB, internal_collision_type::InternalCollisionType,
     internal_keycard_script::KeyCardScript, internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton, logdiscscript::LogDiscScript,
@@ -405,15 +408,15 @@ impl ScriptWorld {
             "engineremoverad" => Box::new(NoopScript::new()),
             "radroom" => Box::new(NoopScript::new()),
             "trapspawn" => Box::new(NoopScript::new()),
-            // ops1 cutscene
+            // ops1 cutscene (the "Polito is SHODAN" reveal) - see scripts/cs9.rs
             "transluceinoutholo" => Box::new(NoopScript::new()),
-            "cs9_doorreporter" => Box::new(NoopScript::new()),
-            "cs9_eggsandgrubs" => Box::new(NoopScript::new()),
-            "cs9_mastercontrol" => Box::new(NoopScript::new()),
-            "cs9_holorumbler" => Box::new(NoopScript::new()),
-            "cs9_shodanscreen" => Box::new(NoopScript::new()),
-            "sitdownrightnowmp" => Box::new(NoopScript::new()),
-            "trapdestroyteleport" => Box::new(NoopScript::new()),
+            "cs9_doorreporter" => Box::new(NoopScript::new()), // master runs on a timeline instead of door events
+            "cs9_eggsandgrubs" => Box::new(CS9EggsAndGrubs::new()),
+            "cs9_mastercontrol" => Box::new(CS9MasterControl::new()),
+            "cs9_holorumbler" => Box::new(CS9HoloRumbler::new()),
+            "cs9_shodanscreen" => Box::new(NoopScript::new()), // screens are static in the theatre walls for now
+            "sitdownrightnowmp" => Box::new(SitDownRightNowMP::new()),
+            "trapdestroyteleport" => Box::new(TrapDestroyTeleport::new()),
             "triggerdamage" => Box::new(NoopScript::new()),
             // many.micontain
             "brain" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -10,8 +10,8 @@ mod choose_mission;
 mod choose_service;
 mod core_room;
 mod create_sound;
-mod dead_power_cell;
 mod cs9;
+mod dead_power_cell;
 mod destroy_all_by_name;
 mod energy_station;
 mod frob_qb;
@@ -81,24 +81,54 @@ use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::psi_amp_script::PsiAmpScript;
 use self::trap_signal::TrapSignal;
 use self::{
-    base_button::BaseButton, base_elevator::BaseElevator, base_monster::BaseMonster, core_room::*,
+    base_button::BaseButton,
+    base_elevator::BaseElevator,
+    base_monster::BaseMonster,
+    core_room::*,
     create_sound::*,
-    cs9::{CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, SitDownRightNowMP, TrapDestroyTeleport},
-    dead_power_cell::DeadPowerCell, destroy_all_by_name::DestroyAllByName,
-    energy_station::EnergyStation, frob_qb::FrobQB, internal_collision_type::InternalCollisionType,
-    internal_keycard_script::KeyCardScript, internal_simple_health::InternalSimpleHealth,
-    level_change_button::LevelChangeButton, logdiscscript::LogDiscScript,
-    melee_weapon::MeleeWeapon, obj_consume_button::ObjConsumeButton, once_room::OnceRoom,
-    once_router::OnceRouter, room_trigger::RoomTrigger, std_door::StdDoor,
-    tool_consumable::ToolConsumable, trap_delay::TrapDelay, trap_destroyer::TrapDestroyer,
-    trap_email::TrapEmail, trap_exp_once::TrapEXPOnce, trap_inverter::TrapInverter,
-    trap_new_tripwire::TrapNewTripwire, trap_on_filter::TrapOffFilter,
-    trap_qb_filter::TrapQBFilter, trap_qb_neg_filter::TrapQBNegFilter, trap_qb_set::TrapQBSet,
-    trap_questbit_simple::TrapQuestbitSimple, trap_router::TrapRouter, trap_slayer::TrapSlayer,
-    trap_sound::TrapSound, trap_teleport::TrapTeleport, trap_teleport_player::TrapTeleportPlayer,
-    trap_trip_level::TrapTripLevel, trap_tweq::TrapTweq, trigger_collide::TriggerCollide,
-    trigger_multi::TriggerMulti, tweq_depressable::TweqDepressable, tweqable::Tweqable,
-    use_sound::UseSound, weapon_script::WeaponScript,
+    cs9::{
+        CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, SitDownRightNowMP, TrapDestroyTeleport,
+    },
+    dead_power_cell::DeadPowerCell,
+    destroy_all_by_name::DestroyAllByName,
+    energy_station::EnergyStation,
+    frob_qb::FrobQB,
+    internal_collision_type::InternalCollisionType,
+    internal_keycard_script::KeyCardScript,
+    internal_simple_health::InternalSimpleHealth,
+    level_change_button::LevelChangeButton,
+    logdiscscript::LogDiscScript,
+    melee_weapon::MeleeWeapon,
+    obj_consume_button::ObjConsumeButton,
+    once_room::OnceRoom,
+    once_router::OnceRouter,
+    room_trigger::RoomTrigger,
+    std_door::StdDoor,
+    tool_consumable::ToolConsumable,
+    trap_delay::TrapDelay,
+    trap_destroyer::TrapDestroyer,
+    trap_email::TrapEmail,
+    trap_exp_once::TrapEXPOnce,
+    trap_inverter::TrapInverter,
+    trap_new_tripwire::TrapNewTripwire,
+    trap_on_filter::TrapOffFilter,
+    trap_qb_filter::TrapQBFilter,
+    trap_qb_neg_filter::TrapQBNegFilter,
+    trap_qb_set::TrapQBSet,
+    trap_questbit_simple::TrapQuestbitSimple,
+    trap_router::TrapRouter,
+    trap_slayer::TrapSlayer,
+    trap_sound::TrapSound,
+    trap_teleport::TrapTeleport,
+    trap_teleport_player::TrapTeleportPlayer,
+    trap_trip_level::TrapTripLevel,
+    trap_tweq::TrapTweq,
+    trigger_collide::TriggerCollide,
+    trigger_multi::TriggerMulti,
+    tweq_depressable::TweqDepressable,
+    tweqable::Tweqable,
+    use_sound::UseSound,
+    weapon_script::WeaponScript,
 };
 
 #[derive(Clone, Debug)]

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -385,6 +385,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
+                Link::Teleport => "Teleport".to_string(),
             })
             .collect();
 

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -586,6 +586,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
+        dark::properties::Link::Teleport => "Teleport".to_string(),
     }
 }
 


### PR DESCRIPTION
Implements the "Polito is SHODAN" in-engine cutscene in ops1.mis — previously every CS9 script was a `NoopScript` stub, so tripping the cutscene did nothing (stack 4/4, on #363).

**Behavior** (reconstructed from Tom N Harris' `allobjs.osm` script analysis, SCP notes, and the mission data): the walk-in tripwire TurnOns `CutSceneNine`; `CS9MasterControl` raises the exit barriers, opens the theatre walls through the authored `SlowDoorControl` delay chains, plays SHODAN's monologue (`cs0901`–`cs0909`), brings in the grove exhibits during cs0903 (eggs/grubs revealed one-per-tick along the FirstEgg SwitchLink chain via their Teleport-link display markers; four translucent holo-rumblers at `RumblerLoc1-4`), dismisses them at cs0907, then closes the walls and releases the player. Targets resolve by sym name, as the original script does. `TrapDestroyTeleport` and `SitDownRightNowMP` (multiplayer-only in the original; SP uses barriers) are implemented faithfully.

The timeline uses the measured wav lengths since our audio layer doesn't surface completion events; known follow-ups (screen fades/model swaps, animated Transluce fades, rumbler walk-in-place, `CS9_DoorReporter` event-driven wall timing) are listed in the commit message and will be filed as issues.

**Verification**: driven headless end-to-end via the debug runtime (teleport into tripwire → step ~230s) — barriers up, walls open, all nine schemas play (ADPCM decodes fine), exhibits appear/leave, walls close, barriers release. Cross-engine review (Codex): no Critical/High findings. Full SDK e2e suite 40/40, all 23 missions load.

## The reveal

![CS9 SHODAN reveal](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/cs9_reveal.gif)

<sub>Walking into the trigger: the office walls pull apart on the authored delay chains and the SHODAN screen-wall is revealed (~16s of sim time, timelapsed). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| Full reveal | Grove exhibits (holo-rumbler + egg pods, cs0903) |
| --- | --- |
| ![reveal still](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/cs9_reveal_still.png) | ![grove still](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/cs9_grove_still.png) |



🤖 Generated with [Claude Code](https://claude.com/claude-code)
