### PR TITLE
feat(cutscene): SHODAN theatre screens fade in after the walls open

### DIFF
--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -47,9 +47,6 @@ const SCHEMAS: [(&str, f32); 9] = [
 const INITIAL_DELAY: f32 = 2.0;
 const INTER_SCHEMA_GAP: f32 = 0.6;
 
-/// Render alpha for the holographic exhibits (eggs, grubs, rumblers).
-const HOLO_ALPHA: f32 = 0.55;
-
 #[derive(Clone, Copy, Debug)]
 enum Cs9Action {
     /// Send TurnOn to every entity with this sym name.
@@ -199,19 +196,16 @@ fn marker_pose(world: &World, name: &str) -> Option<(Vector3<f32>, cgmath::Quate
     v_pos.get(marker).ok().map(|p| (p.position, p.rotation))
 }
 
-/// Teleport an entity to a named marker and set its holo alpha; used by the
-/// CS9 exhibit scripts. Returns NoEffect when the marker is missing.
-fn teleport_to_marker(world: &World, entity_id: EntityId, marker: &str, alpha: f32) -> Effect {
+/// Teleport an entity to a named marker; used by the CS9 exhibit scripts.
+/// Returns NoEffect when the marker is missing. (The holo look itself comes
+/// from `TransluceInOutHolo`, composed on the same entities, which fades to
+/// the authored alpha on the same TurnOn.)
+fn teleport_to_marker(world: &World, entity_id: EntityId, marker: &str) -> Effect {
     match marker_pose(world, marker) {
-        Some((position, rotation)) => Effect::Combined {
-            effects: vec![
-                Effect::SetPositionRotation {
-                    entity_id,
-                    position,
-                    rotation,
-                },
-                Effect::SetRenderAlpha { entity_id, alpha },
-            ],
+        Some((position, rotation)) => Effect::SetPositionRotation {
+            entity_id,
+            position,
+            rotation,
         },
         None => {
             info!("cs9: marker '{}' not found", marker);
@@ -221,9 +215,10 @@ fn teleport_to_marker(world: &World, entity_id: EntityId, marker: &str, alpha: f
 }
 
 /// Script `CS9_HoloRumbler`: the four rumblers are parked out of sight; on
-/// TurnOn each appears as a translucent hologram at its matching
-/// `RumblerLoc<N>` marker, and on TurnOff is stashed at `SafeTeleportLoc`.
-/// (The original also plays a walk-in-place motion; we keep them idle.)
+/// TurnOn each appears at its matching `RumblerLoc<N>` marker (fading in via
+/// the composed `TransluceInOutHolo`), and on TurnOff is stashed at
+/// `SafeTeleportLoc`. (The original also plays a walk-in-place motion; we keep
+/// them idle.)
 pub struct CS9HoloRumbler {}
 
 impl CS9HoloRumbler {
@@ -252,11 +247,11 @@ impl Script for CS9HoloRumbler {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => match Self::loc_marker_name(world, entity_id) {
-                Some(marker) => teleport_to_marker(world, entity_id, &marker, HOLO_ALPHA),
+                Some(marker) => teleport_to_marker(world, entity_id, &marker),
                 None => Effect::NoEffect,
             },
             MessagePayload::TurnOff { from: _ } => {
-                teleport_to_marker(world, entity_id, "SafeTeleportLoc", HOLO_ALPHA)
+                teleport_to_marker(world, entity_id, "SafeTeleportLoc")
             }
             _ => Effect::NoEffect,
         }
@@ -342,7 +337,7 @@ impl Script for CS9EggsAndGrubs {
                     .revealed
                     .drain(..)
                     .chain(self.pending.drain(..))
-                    .map(|e| teleport_to_marker(world, e, "SafeTeleportLoc", HOLO_ALPHA))
+                    .map(|e| teleport_to_marker(world, e, "SafeTeleportLoc"))
                     .collect();
                 Effect::Combined { effects: stash }
             }
@@ -369,6 +364,14 @@ impl Script for CS9EggsAndGrubs {
 
         let egg = self.pending.remove(0);
         self.revealed.push(egg);
+        // TurnOn fades the exhibit in (TransluceInOutHolo) and opens the egg
+        // (GrubEgg tweq), both composed on the egg entity itself.
+        let turn_on = Effect::Send {
+            msg: Message {
+                to: egg,
+                payload: MessagePayload::TurnOn { from: egg },
+            },
+        };
         match Self::display_pose(world, egg) {
             Some((position, rotation)) => Effect::Combined {
                 effects: vec![
@@ -377,18 +380,12 @@ impl Script for CS9EggsAndGrubs {
                         position,
                         rotation,
                     },
-                    Effect::SetRenderAlpha {
-                        entity_id: egg,
-                        alpha: HOLO_ALPHA,
-                    },
+                    turn_on,
                 ],
             },
             // No Teleport link: leave the object where it is (it may already
-            // sit at its display spot and only need the holo look).
-            None => Effect::SetRenderAlpha {
-                entity_id: egg,
-                alpha: HOLO_ALPHA,
-            },
+            // sit at its display spot and only need the fade-in).
+            None => turn_on,
         }
     }
 }

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -25,7 +25,11 @@ use crate::{physics::PhysicsWorld, time::Time};
 
 use super::{
     Effect, Message, MessagePayload, Script,
-    script_util::{get_all_links_of_type, get_entities_by_name, get_first_entity_by_name},
+    script_util::{
+        get_all_links_of_type, get_entities_by_name, get_first_entity_by_name,
+        send_to_all_switch_links,
+    },
+    transluce::AlphaFader,
 };
 
 /// The nine SHODAN monologue schemas with their audio lengths in seconds
@@ -209,6 +213,68 @@ impl Script for CS9MasterControl {
         } else {
             Effect::Combined { effects }
         }
+    }
+}
+
+/// Script `CS9_ShodanScreen`: a theatre screen piece. Starts invisible, fades
+/// in/out on TurnOn/TurnOff like a hologram, and - unlike the plain Transluce
+/// script - FORWARDS the message to its SwitchLinked screen copies: the master
+/// addresses only the six named controller screens on the front wall, and each
+/// controller relays to its counterparts on the side walls (the mission wires
+/// this relay as SwitchLinks; the original script uses them the same way).
+pub struct CS9ShodanScreen {
+    fader: AlphaFader,
+    visible_alpha: f32,
+}
+
+impl CS9ShodanScreen {
+    pub fn new() -> CS9ShodanScreen {
+        CS9ShodanScreen {
+            fader: AlphaFader::new(0.0),
+            visible_alpha: 1.0,
+        }
+    }
+}
+
+impl Script for CS9ShodanScreen {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        let v_alpha = world
+            .borrow::<View<dark::properties::PropRenderAlpha>>()
+            .unwrap();
+        self.visible_alpha = v_alpha.get(entity_id).map(|a| a.0).unwrap_or(1.0);
+        self.fader.snap_to(0.0);
+        Effect::SetRenderAlpha {
+            entity_id,
+            alpha: 0.0,
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => self.fader.fade_to(self.visible_alpha),
+            MessagePayload::TurnOff { from: _ } => self.fader.fade_to(0.0),
+            _ => return Effect::NoEffect,
+        }
+        // Relay to the SwitchLinked screen copies. Loops are impossible in the
+        // mission data (controllers link one-way to copies), and a re-received
+        // message would only re-set an identical fade target anyway.
+        send_to_all_switch_links(world, entity_id, msg.clone())
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        self.fader.update(entity_id, time)
     }
 }
 

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -69,6 +69,15 @@ pub struct CS9MasterControl {
 
 impl CS9MasterControl {
     pub fn new() -> CS9MasterControl {
+        const SCREENS: [&str; 6] = [
+            "ShodanScreenTL",
+            "ShodanScreenTM",
+            "ShodanScreenTR",
+            "ShodanScreenBL",
+            "ShodanScreenBM",
+            "ShodanScreenBR",
+        ];
+
         let mut schedule: Vec<(f32, Cs9Action)> = vec![
             // Seal the player in and start pulling the theatre apart.
             (0.0, Cs9Action::TurnOnByName("MasterForceField")),
@@ -79,6 +88,16 @@ impl CS9MasterControl {
         for (i, (schema, duration)) in SCHEMAS.iter().enumerate() {
             schedule.push((t, Cs9Action::PlaySchema(schema)));
             match i {
+                // cs0901: SHODAN appears. The screens fade in once the moving
+                // walls have pulled back (~6s into the panel stagger), so the
+                // reveal shows dark screens and the face materializes during
+                // the opening line. (PR-later: gate on CS9_DoorReporter's
+                // MovingWallsOpen instead of a timed offset.)
+                0 => {
+                    for s in SCREENS {
+                        schedule.push((t + 6.0, Cs9Action::TurnOnByName(s)));
+                    }
+                }
                 // cs0903: the "garden grove" section - the exhibits appear.
                 2 => {
                     schedule.push((t, Cs9Action::TurnOnByName("EggsandGrubsControl")));
@@ -97,7 +116,11 @@ impl CS9MasterControl {
             t += duration + INTER_SCHEMA_GAP;
         }
 
-        // Teardown: stash the exhibits, close the walls, release the player.
+        // Teardown: fade the screens, stash the exhibits, close the walls,
+        // release the player.
+        for s in SCREENS {
+            schedule.push((t, Cs9Action::TurnOffByName(s)));
+        }
         schedule.push((t, Cs9Action::TurnOffByName("EggsandGrubsControl")));
         schedule.push((t, Cs9Action::TurnOffByName("SlowDoorControl")));
         schedule.push((t + 2.0, Cs9Action::TurnOffByName("MasterForceField")));

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -88,7 +88,8 @@ use self::{
     core_room::*,
     create_sound::*,
     cs9::{
-        CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, SitDownRightNowMP, TrapDestroyTeleport,
+        CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, CS9ShodanScreen, SitDownRightNowMP,
+        TrapDestroyTeleport,
     },
     dead_power_cell::DeadPowerCell,
     destroy_all_by_name::DestroyAllByName,
@@ -446,9 +447,9 @@ impl ScriptWorld {
             "cs9_eggsandgrubs" => Box::new(CS9EggsAndGrubs::new()),
             "cs9_mastercontrol" => Box::new(CS9MasterControl::new()),
             "cs9_holorumbler" => Box::new(CS9HoloRumbler::new()),
-            // The theatre screens fade in/out like holograms (alpha; the original
-            // uses an extra-light ramp + ScreenSwap model swaps - future polish).
-            "cs9_shodanscreen" => Box::new(TransluceInOutHolo::new()),
+            // Screens fade in/out (alpha; the original uses an extra-light ramp +
+            // ScreenSwap model swaps - future polish) and relay to their copies.
+            "cs9_shodanscreen" => Box::new(CS9ShodanScreen::new()),
             "sitdownrightnowmp" => Box::new(SitDownRightNowMP::new()),
             "trapdestroyteleport" => Box::new(TrapDestroyTeleport::new()),
             "triggerdamage" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -33,6 +33,7 @@ pub mod script_util;
 mod setup_initial_debrief;
 mod std_door;
 mod tool_consumable;
+mod transluce;
 mod trap_delay;
 mod trap_destroyer;
 mod trap_email;
@@ -105,6 +106,7 @@ use self::{
     room_trigger::RoomTrigger,
     std_door::StdDoor,
     tool_consumable::ToolConsumable,
+    transluce::TransluceInOutHolo,
     trap_delay::TrapDelay,
     trap_destroyer::TrapDestroyer,
     trap_email::TrapEmail,
@@ -439,7 +441,7 @@ impl ScriptWorld {
             "radroom" => Box::new(NoopScript::new()),
             "trapspawn" => Box::new(NoopScript::new()),
             // ops1 cutscene (the "Polito is SHODAN" reveal) - see scripts/cs9.rs
-            "transluceinoutholo" => Box::new(NoopScript::new()),
+            "transluceinoutholo" => Box::new(TransluceInOutHolo::new()),
             "cs9_doorreporter" => Box::new(NoopScript::new()), // master runs on a timeline instead of door events
             "cs9_eggsandgrubs" => Box::new(CS9EggsAndGrubs::new()),
             "cs9_mastercontrol" => Box::new(CS9MasterControl::new()),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -446,7 +446,9 @@ impl ScriptWorld {
             "cs9_eggsandgrubs" => Box::new(CS9EggsAndGrubs::new()),
             "cs9_mastercontrol" => Box::new(CS9MasterControl::new()),
             "cs9_holorumbler" => Box::new(CS9HoloRumbler::new()),
-            "cs9_shodanscreen" => Box::new(NoopScript::new()), // screens are static in the theatre walls for now
+            // The theatre screens fade in/out like holograms (alpha; the original
+            // uses an extra-light ramp + ScreenSwap model swaps - future polish).
+            "cs9_shodanscreen" => Box::new(TransluceInOutHolo::new()),
             "sitdownrightnowmp" => Box::new(SitDownRightNowMP::new()),
             "trapdestroyteleport" => Box::new(TrapDestroyTeleport::new()),
             "triggerdamage" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/transluce.rs
+++ b/shock2vr/src/scripts/transluce.rs
@@ -1,0 +1,112 @@
+//! The Transluce script family: entities that fade their render alpha in and
+//! out at a fixed rate (50%/second in the original scripts). Used by the CS9
+//! cutscene's holographic exhibits (eggs, grubs, rumblers), which are authored
+//! with a partial `PropRenderAlpha` and composed with the exhibit scripts on
+//! the same entity - a single TurnOn both stages the exhibit and fades it in.
+use dark::properties::PropRenderAlpha;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::{physics::PhysicsWorld, time::Time};
+
+use super::{Effect, MessagePayload, Script};
+
+/// Fade rate: alpha units per second ("fade in or out 50% per second").
+const FADE_RATE: f32 = 0.5;
+
+/// Drives an entity's render alpha toward a target, one `SetRenderAlpha` per
+/// frame while moving. Shared by the Transluce scripts and the CS9 screens.
+pub struct AlphaFader {
+    current: f32,
+    target: f32,
+}
+
+impl AlphaFader {
+    pub fn new(initial: f32) -> AlphaFader {
+        AlphaFader {
+            current: initial,
+            target: initial,
+        }
+    }
+
+    pub fn fade_to(&mut self, target: f32) {
+        self.target = target.clamp(0.0, 1.0);
+    }
+
+    /// Jump immediately (no fade) - e.g. to start invisible before a fade-in.
+    pub fn snap_to(&mut self, value: f32) {
+        self.current = value.clamp(0.0, 1.0);
+        self.target = self.current;
+    }
+
+    pub fn update(&mut self, entity_id: EntityId, time: &Time) -> Effect {
+        if self.current == self.target {
+            return Effect::NoEffect;
+        }
+        let step = FADE_RATE * time.elapsed.as_secs_f32();
+        self.current = if self.current < self.target {
+            (self.current + step).min(self.target)
+        } else {
+            (self.current - step).max(self.target)
+        };
+        Effect::SetRenderAlpha {
+            entity_id,
+            alpha: self.current,
+        }
+    }
+}
+
+/// Script `TransluceInOutHolo`: a hologram that starts invisible, fades in to
+/// its authored alpha on TurnOn, and fades back out on TurnOff.
+pub struct TransluceInOutHolo {
+    fader: AlphaFader,
+    /// The authored "visible" alpha (PropRenderAlpha), captured at initialize.
+    visible_alpha: f32,
+}
+
+impl TransluceInOutHolo {
+    pub fn new() -> TransluceInOutHolo {
+        TransluceInOutHolo {
+            fader: AlphaFader::new(0.0),
+            visible_alpha: 1.0,
+        }
+    }
+}
+
+impl Script for TransluceInOutHolo {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        let v_alpha = world.borrow::<View<PropRenderAlpha>>().unwrap();
+        self.visible_alpha = v_alpha.get(entity_id).map(|a| a.0).unwrap_or(1.0);
+        self.fader.snap_to(0.0);
+
+        // Holograms are hidden until something fades them in.
+        Effect::SetRenderAlpha {
+            entity_id,
+            alpha: 0.0,
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => self.fader.fade_to(self.visible_alpha),
+            MessagePayload::TurnOff { from: _ } => self.fader.fade_to(0.0),
+            _ => {}
+        }
+        Effect::NoEffect
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        self.fader.update(entity_id, time)
+    }
+}


### PR DESCRIPTION
Phase 2 of the CS9 reveal, 2/4 (stacked on #365). Restores the reveal's dramatic beat: the moving walls now open onto **dark** screens, and SHODAN's face materializes during her opening line.

- `CS9_ShodanScreen` is the holo fade script (start invisible → fade in on TurnOn → fade out on TurnOff); the master schedules the fade ~6s into cs0901, after the wall-panel stagger has pulled back (to be replaced by `CS9_DoorReporter`'s `MovingWallsOpen` event in a later PR).
- Screen pieces SwitchLinked from `Wall Delay 7` in the mission data fade in data-driven with their panel.
- The original uses an extra-light ramp + `ScreenSwap` model swaps; alpha is a close stand-in until materials expose a runtime emissive override.

Walls open, screens dark (t≈7s) → SHODAN materializing (t≈9.5s):

![dark screens](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/screens_dark.png)
![materializing](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/screens_mid.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)