### PR TITLE
feat(vr): grip pose and fitted weapon offsets for held items

### DIFF
--- a/projects/vr-gloves.md
+++ b/projects/vr-gloves.md
@@ -105,6 +105,19 @@ Test headlessly with `cargo dbgr --vr`: the debug runtime's
 (pawn-local), `.rotation [x,y,z,w]`, `.trigger`, and `.squeeze` channels, so
 hand placement and finger state are fully scriptable for screenshots.
 
+## Weapon grip (#352 follow-up)
+
+While a hand is holding an entity (`HandState::Grabbing`), the glove switches
+from input-driven blending to a grip pose: fingers wrapped on the handle,
+thumb locked, and the index resting on the trigger, curling with
+`trigger_value` (constants in `hand_glove.rs`, tuned visually). Held-model
+placement offsets are hand-local (`VRHandModelPerHandAdjustments::with_offset`,
+mirrored by `flip_x`) and were tuned per weapon against screenshots: pistol,
+assault rifle, shotgun, and wrench have fitted grips; the remaining weapons
+use the generic held-weapon placement. Note the model long axes differ per
+weapon (pistol/AR along model Y, wrench along model X), so offset axes are
+per-model — probe with exaggerated single-axis offsets when tuning a new one.
+
 ## Follow-ups
 
 - On-headset tuning of `grip_rotation()` / wrist offset once tested in a real

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -85,15 +85,31 @@ impl GloveRenderer {
         handedness: Handedness,
         trigger_value: f32,
         squeeze_value: f32,
+        holding: bool,
     ) -> Vec<SceneObject> {
-        // Index follows the trigger; the other fingers follow the squeeze. A
-        // full squeeze also curls the index so a gripped fist looks like a fist.
-        let amounts = FingerAmounts {
-            thumb: squeeze_value,
-            index: trigger_value.max(squeeze_value),
-            middle: squeeze_value,
-            ring: squeeze_value,
-            pinky: squeeze_value,
+        let amounts = if holding {
+            // Gripping a held item: fingers wrapped on the handle, thumb
+            // locked, index resting on the trigger and curling with the pull
+            // (the squeeze is what holds the item, so it doesn't drive the
+            // pose here). Constants tuned visually against the held pistol.
+            FingerAmounts {
+                thumb: 0.85,
+                index: 0.5 + 0.5 * trigger_value,
+                middle: 0.9,
+                ring: 0.9,
+                pinky: 0.9,
+            }
+        } else {
+            // Empty hand: index follows the trigger; the other fingers follow
+            // the squeeze. A full squeeze also curls the index so a squeezed
+            // fist looks like a fist.
+            FingerAmounts {
+                thumb: squeeze_value,
+                index: trigger_value.max(squeeze_value),
+                middle: squeeze_value,
+                ring: squeeze_value,
+                pinky: squeeze_value,
+            }
         };
         let pose = self.open.blend_per_finger(&self.fist, &amounts);
         self.retarget.apply(&pose, &mut self.model);

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -278,7 +278,9 @@ impl VirtualHand {
 
                     msgs.push(VirtualHandEffect::SetPositionRotation {
                         entity_id,
-                        position: hand_position + vr_offsets.offset,
+                        // The offset is hand-local (e.g. seating a weapon's
+                        // grip in the palm), so it must rotate with the hand
+                        position: hand_position + hand_rotation.rotate_vector(vr_offsets.offset),
                         rotation: hand_rotation * vr_offsets.rotation,
                         scale: vec3(1.0, 1.0, 1.0), //vr_offsets.scale,
                     });
@@ -348,6 +350,7 @@ impl VirtualHand {
                     self.handedness,
                     self.trigger_value,
                     self.squeeze_value,
+                    self.get_held_entity().is_some(),
                 )
             })
             .unwrap_or_default();

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -37,8 +37,15 @@ impl VRHandModelPerHandAdjustments {
     pub fn flip_x(self) -> VRHandModelPerHandAdjustments {
         VRHandModelPerHandAdjustments {
             scale: vec3(-self.scale.x, self.scale.y, self.scale.z),
+            offset: vec3(-self.offset.x, self.offset.y, self.offset.z),
             ..self
         }
+    }
+
+    /// Hand-local translation (meters): +X toward the thumb side of the right
+    /// hand, +Y up out of the back of the hand, -Z along the fingers.
+    pub fn with_offset(self, offset: Vector3<f32>) -> VRHandModelPerHandAdjustments {
+        VRHandModelPerHandAdjustments { offset, ..self }
     }
 }
 
@@ -80,9 +87,16 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     let held_weapon_left = held_weapon_right.clone().flip_x();
     let held_weapon = VRHandModelAdjustments::new(
         held_weapon_left,
-        held_weapon_right,
+        held_weapon_right.clone(),
         Quaternion::from_angle_y(Deg(0.0)),
     );
+
+    // The wrench's long axis runs opposite the guns' after the -90 yaw (its
+    // model is authored along X where guns are along Y), so it takes +90 and
+    // slides toward its handle end
+    let wrench_right = VRHandModelPerHandAdjustments::new()
+        .rotate_y(Deg(90.0))
+        .with_offset(vec3(0.0, 0.0, -0.4));
 
     let held_item_hand = VRHandModelPerHandAdjustments::new().rotate_y(Deg(180.0));
     let held_item = VRHandModelAdjustments::new(
@@ -114,9 +128,45 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // Weapons - world models, kept when held in VR (#352): the _h meshes
         // have faces stripped for the fixed flat camera. sg_w/empgun predate
         // this and show the world models grip fine with the same offsets.
-        ("atek_w", held_weapon.clone()),
-        ("ar15_w", held_weapon.clone()),
-        ("sg_w", held_weapon.clone()),
+        (
+            "atek_w",
+            VRHandModelAdjustments::new(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.02, 0.04, -0.045))
+                    .flip_x(),
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(0.02, 0.04, -0.045)),
+                Quaternion::from_angle_y(Deg(0.0)),
+            ),
+        ),
+        (
+            "ar15_w",
+            VRHandModelAdjustments::new(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(-0.19, 0.0, -0.045))
+                    .flip_x(),
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(-0.19, 0.0, -0.045)),
+                Quaternion::from_angle_y(Deg(0.0)),
+            ),
+        ),
+        (
+            "sg_w",
+            VRHandModelAdjustments::new(
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(-0.21, 0.0, -0.045))
+                    .flip_x(),
+                held_weapon_right
+                    .clone()
+                    .with_offset(vec3(-0.21, 0.0, -0.045)),
+                Quaternion::from_angle_y(Deg(0.0)),
+            ),
+        ),
         (
             "laser",
             held_weapon
@@ -130,7 +180,16 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ("amp_w", held_weapon.clone()),
         ("viro_w", held_weapon.clone()),
         ("al_w", held_weapon.clone()),
-        ("wrench_w", default.clone()),
+        // The wrench's handle runs along the weapon axis, so it takes the
+        // held-weapon rotation (handle through the fist, head forward)
+        (
+            "wrench_w",
+            VRHandModelAdjustments::new(
+                wrench_right.clone().flip_x(),
+                wrench_right.clone(),
+                Quaternion::from_angle_y(Deg(0.0)),
+            ),
+        ),
         // World items
         ("battery", held_item.clone()),
         ("batteryb", held_item.clone()),

--- a/shock2vr/src/vr_config.rs
+++ b/shock2vr/src/vr_config.rs
@@ -35,9 +35,13 @@ impl VRHandModelPerHandAdjustments {
     }
 
     pub fn flip_x(self) -> VRHandModelPerHandAdjustments {
+        // NOTE: the scale mirror is currently inert (SetPositionRotation
+        // hardcodes scale 1), so the left hand holds the *unmirrored* model.
+        // The offset must therefore NOT be mirrored - it seats the same
+        // unmirrored geometry at the same hand-local point (verified against
+        // left-hand grip screenshots).
         VRHandModelPerHandAdjustments {
             scale: vec3(-self.scale.x, self.scale.y, self.scale.z),
-            offset: vec3(-self.offset.x, self.offset.y, self.offset.z),
             ..self
         }
     }
@@ -114,6 +118,16 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
     // Hand model adjustments for VR
     // Specify overrides for particular models with how they should be oriented
     // relative ot the virtual hand
+    // A weapon whose left-hand placement is the right-hand adjustments
+    // mirrored (flip_x)
+    fn symmetric(right: VRHandModelPerHandAdjustments) -> VRHandModelAdjustments {
+        VRHandModelAdjustments::new(
+            right.clone().flip_x(),
+            right,
+            Quaternion::from_angle_y(Deg(0.0)),
+        )
+    }
+
     let items = vec![
         // Weapons - first-person hand models (_h), used when wielded in flat
         ("atek_h", held_weapon.clone()),
@@ -130,41 +144,26 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         // this and show the world models grip fine with the same offsets.
         (
             "atek_w",
-            VRHandModelAdjustments::new(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(0.02, 0.04, -0.045))
-                    .flip_x(),
+            symmetric(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(0.02, 0.04, -0.045)),
-                Quaternion::from_angle_y(Deg(0.0)),
             ),
         ),
         (
             "ar15_w",
-            VRHandModelAdjustments::new(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(-0.19, 0.0, -0.045))
-                    .flip_x(),
+            symmetric(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(-0.19, 0.0, -0.045)),
-                Quaternion::from_angle_y(Deg(0.0)),
             ),
         ),
         (
             "sg_w",
-            VRHandModelAdjustments::new(
-                held_weapon_right
-                    .clone()
-                    .with_offset(vec3(-0.21, 0.0, -0.045))
-                    .flip_x(),
+            symmetric(
                 held_weapon_right
                     .clone()
                     .with_offset(vec3(-0.21, 0.0, -0.045)),
-                Quaternion::from_angle_y(Deg(0.0)),
             ),
         ),
         (
@@ -182,14 +181,7 @@ static HAND_MODEL_POSITIONING: Lazy<HashMap<&str, VRHandModelAdjustments>> = Laz
         ("al_w", held_weapon.clone()),
         // The wrench's handle runs along the weapon axis, so it takes the
         // held-weapon rotation (handle through the fist, head forward)
-        (
-            "wrench_w",
-            VRHandModelAdjustments::new(
-                wrench_right.clone().flip_x(),
-                wrench_right.clone(),
-                Quaternion::from_angle_y(Deg(0.0)),
-            ),
-        ),
+        ("wrench_w", symmetric(wrench_right.clone())),
         // World items
         ("battery", held_item.clone()),
         ("batteryb", held_item.clone()),


### PR DESCRIPTION
Builds on #356 (world models on held weapons) — makes VR weapon handling look *held*, not coexisting.

## Summary

**Grip pose** (`hand_glove.rs`): while a hand holds an entity, the glove switches from input-driven blending to a grip pose — fingers wrapped on the handle, thumb locked, and the **index resting on the trigger, curling with the analog trigger pull**. Previously a full squeeze (required to keep holding) balled the hand into a fist through the weapon.

**Fitted grip offsets** (`vr_config.rs` / `virtual_hand.rs`): held-model placement offsets are now hand-local (they rotate with the hand — they were world-space before, safe since every offset was zero), and the pistol, assault rifle, shotgun, and wrench get per-weapon offsets tuned against deterministic headless screenshots so the handle seats in the glove's fist. The wrench also gets its own yaw — its model's long axis runs opposite the guns' under the shared held-weapon rotation (guns are authored along model Y, the wrench along model X). Remaining weapons keep the generic placement (noted as future polish in `projects/vr-gloves.md`).

Adversarial-review fixes included:
- `flip_x` does **not** mirror the offset: the scale mirror it pairs with is inert (`SetPositionRotation` hardcodes scale 1), so the left hand holds the unmirrored model — mirroring the offset displaced left-held rifles by ~38 cm (verified with left-hand grip captures before/after).
- `symmetric()` helper so each tuned offset literal exists exactly once.

Known limitations (documented): non-weapon held items (batteries etc.) share the weapon grip pose; the left glove's palm sits a few cm off the hold point until the scale mirror is made real.

## Test plan

- [x] Visual verification (headless, deterministic): pistol/AR/shotgun/wrench grips inspected from multiple hand rotations, right and left hands; trigger pull curls the index on the held pistol
- [x] `cargo test -p shock2vr` (77), `RUSTFLAGS="-D warnings"` checks for shock2vr/desktop_runtime/debug_runtime
- [x] Full SDK e2e suite (pre-review-fix commit) + `vr-held-model` e2e re-run post-fix
- [x] Flat mode unaffected: muzzle-flash/projectile paths read only the adjustment rotation (unchanged); flat viewmodel uses `PropPlayerGun.model_offset`, not this table
- [x] `/xreview`: High finding (left-hand offset mirroring) fixed and re-verified; Medium (duplication) fixed via `symmetric()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![held pistol grip pose demo](https://gist.githubusercontent.com/tommy-xr/7589eb8af4728f57cd223b5b28b7f30b/raw/demo.gif)

<sub>Held pistol with the grip pose: the index finger rides the trigger and curls with the analog pull — a full pull fires (muzzle flash at the barrel). Captured headlessly (`--vr` debug runtime, deterministic `/v1/step`).</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/7589eb8af4728f57cd223b5b28b7f30b/raw/beforeafter.png)

<sub>Before (main): the weapon floats centered on the hand and the squeezed fist clips through it. After: hand-local fitted offsets seat the handle in the glove's fist.</sub>
