### PR TITLE
fix(sdk): make concurrent agent e2e runs safe

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -230,8 +230,16 @@ fn main() -> anyhow::Result<()> {
     // Create command channel for communication between HTTP server and game loop
     let (command_tx, command_rx) = mpsc::unbounded_channel::<RuntimeCommand>();
 
+    // Bind BEFORE starting the game: a taken port (another runtime raced us
+    // to it) must be a fast, loud exit - not a headless game loop that a
+    // client waits on until its launch timeout.
+    let addr = SocketAddr::from(([127, 0, 0, 1], args.port));
+    let listener = rt
+        .block_on(tokio::net::TcpListener::bind(addr))
+        .map_err(|e| anyhow::anyhow!("failed to bind {}: {}", addr, e))?;
+
     // Start the HTTP server in a background task
-    let server_handle = rt.spawn(start_http_server(args.port, command_tx));
+    let server_handle = rt.spawn(start_http_server(listener, command_tx));
 
     // Run the game on the main thread (required for GLFW)
     let game_result = run_game_blocking(args, command_rx);
@@ -244,9 +252,10 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Start the HTTP server
+/// Start the HTTP server on an already-bound listener (binding happens in
+/// main so a taken port fails the process fast)
 async fn start_http_server(
-    port: u16,
+    listener: tokio::net::TcpListener,
     command_tx: mpsc::UnboundedSender<RuntimeCommand>,
 ) -> anyhow::Result<()> {
     // Create the router with health endpoint
@@ -284,8 +293,7 @@ async fn start_http_server(
         .route("/v1/screenshot", axum::routing::post(take_screenshot))
         .with_state(command_tx);
 
-    // Bind to localhost only for security
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = listener.local_addr()?;
     info!("Debug runtime listening on http://{}", addr);
     info!(
         "camera eye height (standing): {} SS2 units = {} world units (above pawn) - shared with desktop via PLAYER_EYE_HEIGHT",
@@ -320,7 +328,6 @@ async fn start_http_server(
     info!("Test with: curl -X POST http://{}/v1/shutdown", addr);
 
     // Start the server with graceful shutdown
-    let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await?;

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -130,7 +130,16 @@ struct Args {
     /// watch the game interactively.
     #[arg(long)]
     visible: bool,
+
+    /// Opaque instance identifier echoed by /v1/health, so the client that
+    /// launched this process can verify it is talking to its own instance
+    /// and not another agent's runtime that happens to hold the same port.
+    #[arg(long)]
+    instance_id: Option<String>,
 }
+
+/// Instance identifier from --instance-id, echoed by /v1/health
+static INSTANCE_ID: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
 
 /// Default debug-camera head rotation.
 ///
@@ -208,6 +217,7 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
+    let _ = INSTANCE_ID.set(args.instance_id.clone());
 
     info!(
         "Starting debug runtime on port {} with mission: {}",
@@ -1505,7 +1515,8 @@ async fn health_check() -> Json<Value> {
         "status": "ok",
         "service": "debug_runtime",
         "version": "0.1.0",
-        "timestamp": chrono::Utc::now().to_rfc3339()
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "instance_id": INSTANCE_ID.get().cloned().flatten(),
     }))
 }
 

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -1,5 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 
 import { HttpClient } from "./client.js";
@@ -8,7 +10,12 @@ import { Game } from "./game.js";
 export interface LaunchOptions {
   /** Mission file or debug scene, e.g. "medsci1.mis" or "debug_minimal". */
   mission: string;
-  /** Port for the debug runtime HTTP server (default 8080). */
+  /**
+   * Port for the debug runtime HTTP server (default 8080). Treated as a
+   * HINT: if it is already taken (another agent's test run, a lingering
+   * runtime), the next free port is used instead - read `game.baseUrl` for
+   * the actual address.
+   */
   port?: number;
   /** Experimental feature flags, e.g. ["teleport"]. */
   experimental?: string[];
@@ -48,6 +55,36 @@ const MAX_LOG_LINES = 2000;
 /** Max lines included in a launch-failure error message. */
 const MAX_ERROR_LOG_LINES = 120;
 
+/** How many ports to try, walking up from the requested one. */
+const MAX_PORT_ATTEMPTS = 50;
+
+/** Resolves true when the port can be bound on localhost right now. */
+function portIsFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(false));
+    probe.listen({ port, host: "127.0.0.1" }, () => {
+      probe.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Walk up from `start` to the first free port. Multiple agents commonly run
+ * e2e suites with the same hardcoded test ports on one machine; treating the
+ * port as a hint keeps them out of each other's way.
+ */
+export async function findFreePort(start: number): Promise<number> {
+  for (let port = start; port < start + MAX_PORT_ATTEMPTS; port++) {
+    if (await portIsFree(port)) {
+      return port;
+    }
+  }
+  throw new Error(
+    `no free port found in [${start}, ${start + MAX_PORT_ATTEMPTS})`,
+  );
+}
+
 /**
  * Pick the most useful slice of runtime output for an error message.
  *
@@ -78,6 +115,7 @@ export class GameServer extends Game implements AsyncDisposable {
     client: HttpClient,
     private readonly child: ChildProcess | undefined,
     private readonly logLines: string[],
+    private readonly instanceId: string | undefined,
   ) {
     super(client);
   }
@@ -89,20 +127,27 @@ export class GameServer extends Game implements AsyncDisposable {
 
   /** Connect to an already-running debug runtime. shutdown() will stop it; dispose will not spawn-kill anything. */
   static async connect(baseUrl = "http://127.0.0.1:8080"): Promise<GameServer> {
-    const server = new GameServer(new HttpClient(baseUrl), undefined, []);
+    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined);
     await server.health();
     return server;
   }
 
   /** Spawn a debug runtime via `cargo run -p debug_runtime` and wait for it to be ready. */
   static async launch(options: LaunchOptions): Promise<GameServer> {
-    const port = options.port ?? 8080;
+    const port = await findFreePort(options.port ?? 8080);
     const repoRoot = options.repoRoot ?? findRepoRoot(process.cwd());
     if (repoRoot === undefined) {
       throw new Error(
         "Could not find cargo workspace root; pass repoRoot explicitly",
       );
     }
+
+    // Identifies OUR runtime: /v1/health echoes it, and readiness checks
+    // reject a different instance on the same port (e.g. another agent's
+    // runtime grabbing the port between our free-port probe and the child's
+    // bind). Cross-talk with a foreign runtime looks like impossible test
+    // failures, so fail loudly instead.
+    const instanceId = randomUUID();
 
     const args = [
       "run",
@@ -113,6 +158,8 @@ export class GameServer extends Game implements AsyncDisposable {
       options.mission,
       "--port",
       String(port),
+      "--instance-id",
+      instanceId,
       ...(options.experimental?.length
         ? ["--experimental", options.experimental.join(",")]
         : []),
@@ -130,6 +177,10 @@ export class GameServer extends Game implements AsyncDisposable {
         RUST_BACKTRACE: process.env.RUST_BACKTRACE ?? "1",
       },
       stdio: ["ignore", "pipe", "pipe"],
+      // Own process group, so the kill fallback can take out the whole tree.
+      // `cargo run` execs the game binary as a child; killing only cargo
+      // orphans a runtime that keeps the port bound and burns CPU forever.
+      detached: true,
     });
 
     const capture = (chunk: Buffer) => {
@@ -147,18 +198,41 @@ export class GameServer extends Game implements AsyncDisposable {
       new HttpClient(`http://127.0.0.1:${port}`),
       child,
       logLines,
+      instanceId,
     );
 
     try {
       await server.waitUntilReady(options.launchTimeoutMs ?? 300_000);
     } catch (error) {
-      child.kill("SIGKILL");
+      server.killProcessTree();
       throw new Error(
         `debug_runtime failed to start: ${error}\nRecent output:\n${formatCrashOutput(logLines)}`,
       );
     }
 
     return server;
+  }
+
+  /**
+   * SIGKILL the child's whole process group (cargo + the game binary it
+   * exec'd). Falls back to killing just the direct child if the group is
+   * already gone.
+   */
+  private killProcessTree(): void {
+    const pid = this.child?.pid;
+    if (pid === undefined) {
+      return;
+    }
+    try {
+      // Negative pid = the process group created by detached: true
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      try {
+        this.child?.kill("SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
   }
 
   private async waitUntilReady(timeoutMs: number): Promise<void> {
@@ -168,6 +242,21 @@ export class GameServer extends Game implements AsyncDisposable {
         throw new Error(`process exited early with code ${this.child.exitCode}`);
       }
       try {
+        // Verify we're talking to OUR instance before trusting the port. A
+        // different (or missing) instance id means another process holds the
+        // port - keep waiting only if our child is still alive, since the
+        // holder may be an older runtime mid-shutdown.
+        const health = await this.client.get<{ instance_id?: string | null }>(
+          "/v1/health",
+        );
+        if (
+          this.instanceId !== undefined &&
+          health.instance_id !== this.instanceId
+        ) {
+          throw new Error(
+            `port is held by a different debug_runtime instance (expected ${this.instanceId}, got ${health.instance_id ?? "none"}) - likely another agent's test run`,
+          );
+        }
         // /v1/info round-trips through the game loop's command channel, so
         // it only succeeds once the game thread is actually running. (The
         // HTTP server starts before - and can outlive - the game thread,
@@ -175,16 +264,16 @@ export class GameServer extends Game implements AsyncDisposable {
         // crashed during mission load.)
         await this.info();
         return;
-      } catch {
+      } catch (error) {
         if (Date.now() >= deadline) {
-          throw new Error(`server not ready after ${timeoutMs}ms`);
+          throw new Error(`server not ready after ${timeoutMs}ms: ${error}`);
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
     }
   }
 
-  /** Gracefully stop the runtime; escalates to SIGKILL if it doesn't exit. */
+  /** Gracefully stop the runtime; escalates to a process-group SIGKILL if it doesn't exit. */
   override async shutdown(): Promise<void> {
     try {
       await super.shutdown();
@@ -197,7 +286,7 @@ export class GameServer extends Game implements AsyncDisposable {
     }
     await new Promise<void>((resolve) => {
       const killTimer = setTimeout(() => {
-        child.kill("SIGKILL");
+        this.killProcessTree();
       }, 10_000);
       child.once("exit", () => {
         clearTimeout(killTimer);

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -52,6 +52,35 @@ export function findRepoRoot(startDir: string): string | undefined {
 
 const MAX_LOG_LINES = 2000;
 
+/**
+ * Ports handed out by findFreePort that are still in use by this process.
+ * The OS probe alone can't see a sibling launch that probed the same port
+ * but whose child hasn't bound yet (cargo may compile for minutes first).
+ */
+const reservedPorts = new Set<number>();
+
+/** Children that must not outlive this process (see hookSignalCleanup). */
+const liveServers = new Set<GameServer>();
+let signalCleanupHooked = false;
+
+/**
+ * Detached children receive no terminal signals, so a Ctrl-C of the test
+ * runner would orphan every runtime it spawned - kill their process groups
+ * before dying, then re-raise the signal for the default behavior.
+ */
+function hookSignalCleanup(): void {
+  if (signalCleanupHooked) return;
+  signalCleanupHooked = true;
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      for (const server of liveServers) {
+        server.killProcessTreeForSignalCleanup();
+      }
+      process.kill(process.pid, signal);
+    });
+  }
+}
+
 /** Max lines included in a launch-failure error message. */
 const MAX_ERROR_LOG_LINES = 120;
 
@@ -76,7 +105,8 @@ function portIsFree(port: number): Promise<boolean> {
  */
 export async function findFreePort(start: number): Promise<number> {
   for (let port = start; port < start + MAX_PORT_ATTEMPTS; port++) {
-    if (await portIsFree(port)) {
+    if (!reservedPorts.has(port) && (await portIsFree(port))) {
+      reservedPorts.add(port);
       return port;
     }
   }
@@ -116,8 +146,24 @@ export class GameServer extends Game implements AsyncDisposable {
     private readonly child: ChildProcess | undefined,
     private readonly logLines: string[],
     private readonly instanceId: string | undefined,
+    private readonly port: number | undefined,
   ) {
     super(client);
+  }
+
+  /** The spawned child has exited (normally or by signal). */
+  private childIsDead(): boolean {
+    return (
+      this.child !== undefined &&
+      (this.child.exitCode !== null || this.child.signalCode !== null)
+    );
+  }
+
+  private releaseResources(): void {
+    if (this.port !== undefined) {
+      reservedPorts.delete(this.port);
+    }
+    liveServers.delete(this);
   }
 
   /** Recent stdout/stderr from the spawned runtime (ring buffer). */
@@ -125,16 +171,50 @@ export class GameServer extends Game implements AsyncDisposable {
     return [...this.logLines];
   }
 
+  /** @internal Used by the module-level signal cleanup hook. */
+  killProcessTreeForSignalCleanup(): void {
+    this.killProcessTree();
+  }
+
   /** Connect to an already-running debug runtime. shutdown() will stop it; dispose will not spawn-kill anything. */
   static async connect(baseUrl = "http://127.0.0.1:8080"): Promise<GameServer> {
-    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined);
+    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined, undefined);
     await server.health();
     return server;
   }
 
-  /** Spawn a debug runtime via `cargo run -p debug_runtime` and wait for it to be ready. */
+  /**
+   * Spawn a debug runtime via `cargo run -p debug_runtime` and wait for it
+   * to be ready. Retries on the next free port when another process wins a
+   * port race (bind failure / foreign instance id) between our probe and
+   * the child's bind.
+   */
   static async launch(options: LaunchOptions): Promise<GameServer> {
-    const port = await findFreePort(options.port ?? 8080);
+    const hint = options.port ?? 8080;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await GameServer.launchOnce(options, hint + attempt);
+      } catch (error) {
+        lastError = error;
+        const message = String(error);
+        const lostPortRace =
+          message.includes("exited early") ||
+          message.includes("different debug_runtime instance") ||
+          message.includes("failed to bind");
+        if (!lostPortRace) {
+          throw error;
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  private static async launchOnce(
+    options: LaunchOptions,
+    portHint: number,
+  ): Promise<GameServer> {
+    const port = await findFreePort(portHint);
     const repoRoot = options.repoRoot ?? findRepoRoot(process.cwd());
     if (repoRoot === undefined) {
       throw new Error(
@@ -199,12 +279,16 @@ export class GameServer extends Game implements AsyncDisposable {
       child,
       logLines,
       instanceId,
+      port,
     );
+    liveServers.add(server);
+    hookSignalCleanup();
 
     try {
       await server.waitUntilReady(options.launchTimeoutMs ?? 300_000);
     } catch (error) {
       server.killProcessTree();
+      server.releaseResources();
       throw new Error(
         `debug_runtime failed to start: ${error}\nRecent output:\n${formatCrashOutput(logLines)}`,
       );
@@ -227,19 +311,19 @@ export class GameServer extends Game implements AsyncDisposable {
       // Negative pid = the process group created by detached: true
       process.kill(-pid, "SIGKILL");
     } catch {
-      try {
-        this.child?.kill("SIGKILL");
-      } catch {
-        // Already gone.
-      }
+      // ESRCH: the group is already gone. Deliberately NO fallback to a
+      // positive-pid kill - the pid may have been reused by an unrelated
+      // process by now.
     }
   }
 
   private async waitUntilReady(timeoutMs: number): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      if (this.child && this.child.exitCode !== null) {
-        throw new Error(`process exited early with code ${this.child.exitCode}`);
+      if (this.childIsDead()) {
+        throw new Error(
+          `process exited early (code ${this.child?.exitCode}, signal ${this.child?.signalCode})`,
+        );
       }
       try {
         // Verify we're talking to OUR instance before trusting the port. A
@@ -275,13 +359,19 @@ export class GameServer extends Game implements AsyncDisposable {
 
   /** Gracefully stop the runtime; escalates to a process-group SIGKILL if it doesn't exit. */
   override async shutdown(): Promise<void> {
-    try {
-      await super.shutdown();
-    } catch {
-      // Server may already be down; fall through to process cleanup.
+    // If our child already exited, the port is no longer ours - another
+    // agent's runtime may have rebound it, and an HTTP shutdown would stop
+    // THEIR instance. Only speak to the port while our child owns it.
+    if (!this.childIsDead()) {
+      try {
+        await super.shutdown();
+      } catch {
+        // Server may already be down; fall through to process cleanup.
+      }
     }
     const child = this.child;
-    if (child === undefined || child.exitCode !== null) {
+    if (child === undefined || this.childIsDead()) {
+      this.releaseResources();
       return;
     }
     await new Promise<void>((resolve) => {
@@ -293,6 +383,7 @@ export class GameServer extends Game implements AsyncDisposable {
         resolve();
       });
     });
+    this.releaseResources();
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/tools/shock2-sdk/test/unit.test.ts
+++ b/tools/shock2-sdk/test/unit.test.ts
@@ -56,3 +56,23 @@ test("waitFor times out with a descriptive error", async () => {
     /Timed out after 30ms waiting for the impossible/,
   );
 });
+
+test("findFreePort skips ports that are already bound", async () => {
+  const { findFreePort } = await import("../src/server.js");
+  const { createServer } = await import("node:net");
+
+  // Occupy a port, then ask for it: the next one up should come back.
+  const blocker = createServer();
+  await new Promise<void>((resolve) =>
+    blocker.listen({ port: 0, host: "127.0.0.1" }, resolve),
+  );
+  const address = blocker.address();
+  assert.ok(address && typeof address === "object");
+  const taken = address.port;
+  try {
+    const free = await findFreePort(taken);
+    assert.ok(free > taken, `expected a port above ${taken}, got ${free}`);
+  } finally {
+    await new Promise((resolve) => blocker.close(resolve));
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the cross-agent e2e collisions from #358. Multiple agents run suites on this machine and the SDK's fixed test ports made them fight — a test could silently drive *another agent's* runtime (impossible 503s mid-test), and the SIGKILL fallback orphaned `cargo run` grandchildren that kept ports bound and CPU burning, which is what made broad process cleanup (and its collateral kills) necessary.

`GameServer.launch` changes:
- **Port is a hint**: test-bind, walk up to the first free port (`game.baseUrl` has the actual address).
- **Instance identity**: a random `--instance-id` per launch, echoed by `/v1/health`, verified at readiness — cross-talk with a foreign runtime fails loudly with a clear message instead of corrupting the test.
- **Process-group kill**: child spawned `detached`, kill fallback takes out the whole group (cargo + the exec'd game binary). No more orphans.

## Test plan

- [x] New unit test: `findFreePort` skips bound ports (6 unit tests pass)
- [x] Live: two concurrent launches with the same port hint → adjacent ports, both step, clean shutdown, zero leftover processes
- [x] e2e tests (ai-alertness, pathfinding-budget) pass **while another agent's suite is actively running** — the scenario that previously failed
- [x] `RUSTFLAGS="-D warnings" cargo check -p debug_runtime` (the `--instance-id` arg + health echo)

Closes the mystery in #358 (root-cause comment there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)