### PR TITLE
fix(ai): dead monsters stay dead

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -361,9 +361,22 @@ impl Script for AnimatedMonsterAI {
         // sensors. A corpse keeps a live script, and any alertness level
         // change here (escalation while the player is visible, or decay)
         // would replace DeadBehavior and resurrect it. Still publish the
-        // behavior so introspection shows "Dead".
+        // behavior so introspection shows "Dead", and release a sensor the
+        // ray was intersecting at death so its end-intersect isn't stranded.
         if self.is_dead || is_killed(entity_id, world) {
-            return self.publish_behavior(entity_id);
+            let sensor_release_effect = match self.last_hit_sensor.take() {
+                Some(sensor_id) => Effect::Send {
+                    msg: Message {
+                        to: sensor_id,
+                        payload: MessagePayload::SensorEndIntersect { with: entity_id },
+                    },
+                },
+                None => Effect::NoEffect,
+            };
+            return Effect::combine(vec![
+                sensor_release_effect,
+                self.publish_behavior(entity_id),
+            ]);
         }
 
         let delta = time.elapsed.as_secs_f32();
@@ -540,6 +553,12 @@ impl Script for AnimatedMonsterAI {
                 Effect::combine(vec![hit_points_effect, alert_effect])
             }
             MessagePayload::TurnOn { from: _ } => {
+                // Dead AIs stay dead - a corpse can still be a SwitchLink
+                // target (e.g. a tripwire), and the scripted sequence would
+                // animate it
+                if self.is_dead || is_killed(entity_id, world) {
+                    return Effect::NoEffect;
+                }
                 let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
 
                 if let Ok(prop_sig_resp) = v_prop_sig_resp.get(entity_id) {
@@ -560,6 +579,10 @@ impl Script for AnimatedMonsterAI {
                 }
             }
             MessagePayload::Signal { name: _ } => {
+                // Dead AIs stay dead - level signals reach corpses too
+                if self.is_dead || is_killed(entity_id, world) {
+                    return Effect::NoEffect;
+                }
                 // Do we have a response to this signal?
 
                 let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
@@ -596,16 +619,12 @@ impl Script for AnimatedMonsterAI {
                 if self.is_dead {
                     Effect::NoEffect
                 } else if is_killed(entity_id, world) {
-                    if self.current_behavior.borrow().name() == "Dead" {
-                        // The crumple animation completed - latch the corpse
-                        // as final. The UNK7 motion flag below latches earlier
-                        // when the clip carries it, but not every death clip
-                        // does, and without this the death branch would
-                        // replay the crumple (and death sound) forever.
-                        self.is_dead = true;
-                        return Effect::NoEffect;
-                    }
                     self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
+                    // Latch immediately: the is_dead branch above then
+                    // swallows every later completion (including the
+                    // synchronous re-dispatch when no crumple motion is
+                    // found), so the crumple and death sound play only once
+                    self.is_dead = true;
 
                     // Play death sound effect immediately
                     let death_sound_effect = if let Some(voice_index) =
@@ -741,9 +760,6 @@ impl Script for AnimatedMonsterAI {
                 //         //     //"direction".to_owned(),
                 //         // ],
                 //     }
-                } else if motion_flags.contains(MotionFlags::UNK7 /* die? */) {
-                    self.is_dead = true;
-                    Effect::NoEffect
                 } else {
                     Effect::NoEffect
                 }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -303,6 +303,25 @@ impl AnimatedMonsterAI {
             },
         ])
     }
+
+    /// Publish the current behavior name for debug introspection. Update
+    /// runs each frame, so this covers every behavior-change site with at
+    /// most one frame of lag (e.g. handle_message changes, or the
+    /// AIWatchObj early-return, publish on the next update)
+    fn publish_behavior(&mut self, entity_id: EntityId) -> Effect {
+        let behavior_name = self.current_behavior.borrow().name();
+        if self.published_behavior != Some(behavior_name) {
+            self.published_behavior = Some(behavior_name);
+            Effect::SetAIProperty {
+                entity_id,
+                update: crate::scripts::AIPropertyUpdate::Behavior {
+                    name: behavior_name.to_string(),
+                },
+            }
+        } else {
+            Effect::NoEffect
+        }
+    }
 }
 
 impl Script for AnimatedMonsterAI {
@@ -338,6 +357,15 @@ impl Script for AnimatedMonsterAI {
         physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
+        // Dead AIs are inert - no alertness, scripted sequences, steering, or
+        // sensors. A corpse keeps a live script, and any alertness level
+        // change here (escalation while the player is visible, or decay)
+        // would replace DeadBehavior and resurrect it. Still publish the
+        // behavior so introspection shows "Dead".
+        if self.is_dead || is_killed(entity_id, world) {
+            return self.publish_behavior(entity_id);
+        }
+
         let delta = time.elapsed.as_secs_f32();
 
         // Monster FOV is 60 degrees half-angle (matches FovDebugConfig::monster())
@@ -442,22 +470,7 @@ impl Script for AnimatedMonsterAI {
             &FovDebugConfig::monster(),
         );
 
-        // Publish the current behavior name for debug introspection. Update
-        // runs each frame, so this covers every behavior-change site with at
-        // most one frame of lag (e.g. handle_message changes, or the
-        // AIWatchObj early-return above, publish on the next update)
-        let behavior_name = self.current_behavior.borrow().name();
-        let behavior_publish_effect = if self.published_behavior != Some(behavior_name) {
-            self.published_behavior = Some(behavior_name);
-            Effect::SetAIProperty {
-                entity_id,
-                update: crate::scripts::AIPropertyUpdate::Behavior {
-                    name: behavior_name.to_string(),
-                },
-            }
-        } else {
-            Effect::NoEffect
-        };
+        let behavior_publish_effect = self.publish_behavior(entity_id);
 
         Effect::combine(vec![
             alertness_effect,
@@ -583,6 +596,15 @@ impl Script for AnimatedMonsterAI {
                 if self.is_dead {
                     Effect::NoEffect
                 } else if is_killed(entity_id, world) {
+                    if self.current_behavior.borrow().name() == "Dead" {
+                        // The crumple animation completed - latch the corpse
+                        // as final. The UNK7 motion flag below latches earlier
+                        // when the clip carries it, but not every death clip
+                        // does, and without this the death branch would
+                        // replay the crumple (and death sound) forever.
+                        self.is_dead = true;
+                        return Effect::NoEffect;
+                    }
                     self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
 
                     // Play death sound effect immediately
@@ -703,6 +725,11 @@ impl Script for AnimatedMonsterAI {
             }
             MessagePayload::AnimationFlagTriggered { motion_flags } => {
                 if motion_flags.contains(MotionFlags::FIRE) {
+                    // A killed monster's in-flight attack clip keeps playing
+                    // until the death is processed - don't let it fire
+                    if self.is_dead || is_killed(entity_id, world) {
+                        return Effect::NoEffect;
+                    }
                     fire_ranged_projectile(world, entity_id)
                 // } else if motion_flags.contains(MotionFlags::END) {
                 //     Effect::QueueAnimationBySchema {

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+test(
+  "a killed monster dies and stays dead",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(
+      monster,
+      `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((e) => e.id))}`,
+    );
+
+    // Alert it first so the post-death alertness machinery has both paths to
+    // fire (escalation while the player is visible, decay afterwards) - the
+    // regression this guards against is any alertness level change replacing
+    // DeadBehavior.
+    await game.input.trigger("DebugAlertAll");
+    await game.step({ frames: 30 });
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIBehavior"), "Chase");
+
+    // Lethal damage. Death is animation-driven, so give it a few seconds to
+    // finish the in-flight clip and play the crumple.
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+    await game.waitFor(
+      async () => {
+        await game.step({ frames: 30 });
+        return (
+          aiProp(await game.entities.detail(monster.id), "AIBehavior") ===
+          "Dead"
+        );
+      },
+      { description: "monster entering Dead behavior", timeoutMs: 60_000 },
+    );
+
+    // Let the crumple (and any interrupted clip still in the animation
+    // queue) finish - death clips carry root motion, so the body still
+    // translates for a couple of seconds after DeadBehavior is set.
+    await game.step({ frames: 240 });
+    assert.equal(
+      aiProp(await game.entities.detail(monster.id), "AIBehavior"),
+      "Dead",
+    );
+
+    // The corpse must stay dead: the alertness escalate (1.5s) and decay (3s)
+    // windows both elapse several times over while the player stands in view.
+    const deadPos = (await game.entities.detail(monster.id)).position;
+    for (let i = 0; i < 5; i++) {
+      await game.step({ frames: 120 });
+      detail = await game.entities.detail(monster.id);
+      assert.equal(
+        aiProp(detail, "AIBehavior"),
+        "Dead",
+        `corpse resurrected after ${(i + 1) * 2}s`,
+      );
+    }
+
+    // ... and must not wander off.
+    const finalPos = detail.position;
+    const drift = Math.hypot(
+      finalPos[0] - deadPos[0],
+      finalPos[2] - deadPos[2],
+    );
+    assert.ok(
+      drift < 0.5,
+      `corpse moved ${drift.toFixed(2)} units after death`,
+    );
+  },
+);


### PR DESCRIPTION
## Problem

Two long-standing symptoms around monster death (reported in-play): the death animation sometimes kept playing/replaying, and monsters sometimes wouldn't fully die. Reproduced live in `medsci1.mis`: a hybrid that had been dead for 30+ seconds (HP ≤ −900) stood back up, walked 2.6 units, and resumed `MeleeAttack` the moment the player entered its field of view.

## Causes

A killed monster's AI script stays alive (the corpse keeps running `update()` and receiving messages), and several paths could animate it back to life:

1. **`update()` ran the full alertness state machine on corpses.** Any level change — escalation while the player stood in the dead monster's FOV, or decay if it died alerted — replaced `DeadBehavior` with a live behavior and queued fresh animations. The `AIWatchObj` scripted-sequence branch could do the same.
2. **`TurnOn` / `Signal` handlers swapped a corpse into `ScriptedSequenceBehavior`** (found by cross-engine review; tripwire SwitchLinks and level signals reach corpses too).
3. **`is_dead` only latched via an uncertain motion flag** (`UNK7`, present on some death clips). Without it, every subsequent `AnimationCompleted` re-entered the death branch and replayed the crumple + death sound.
4. **A monster killed mid-attack kept honoring the `FIRE` motion flag** on its still-playing clip — a dead monster could still shoot.

## Fix

- `update()` goes inert once the monster is killed: no alertness, scripted sequences, steering, or sensors. It still publishes the behavior name for introspection, and releases a sensor the ray was intersecting at death so a tripwire's `SensorEndIntersect` isn't stranded.
- `TurnOn`/`Signal` get the same dead-guard the `SetAlertness` handler already had.
- `is_dead` latches when `DeadBehavior` is installed, so the crumple and death sound play exactly once. The redundant `UNK7` latch is removed (it could also freeze a *live* monster if a non-death clip carried the flag).
- `FIRE` is ignored once killed.

Pre-existing adjacent issue (corpses replay their death after save/load) filed as #370.

## Testing

- New SDK e2e test `monster-death.e2e.test.ts`: spawns a monster, alerts it (so both the escalation and decay alertness windows elapse post-mortem), kills it, and asserts the corpse reaches `Dead` behavior, stays there for 10s with the player in view, and doesn't move once the death animation settles. **Negative-tested**: fails on `main` with `corpse resurrected after 2s (MeleeAttack)`.
- Full e2e suite (51 tests, including every-mission load smoke test): pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr` (80 unit tests): pass.
- Cross-engine review (`/xreview`, Claude + Codex): both High/Medium agreed findings fixed and re-validated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)