### PR TITLE
feat(cutscene): event-driven wall timing via CS9_DoorReporter

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -429,8 +429,12 @@ fn create_model(
                     let transformed_model = Model::transform(posed_model_ref, transform);
                     (transformed_model, None)
                 } else {
+                    // TAG poses (e.g. the CS9 rumblers' "cs 131" walk-in-place)
+                    // aren't statically applied yet; keep such creatures
+                    // animatable so scripts can drive the tagged motion.
                     let transformed_model = Model::transform(model_ref, transform);
-                    (transformed_model, None)
+                    let player = model.is_animated().then(AnimationPlayer::empty);
+                    (transformed_model, player)
                 }
             } else if model.is_animated() {
                 // let animation_clip =

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -52,6 +52,17 @@ const SCHEMAS: [(&str, f32); 9] = [
 const INITIAL_DELAY: f32 = 2.0;
 const INTER_SCHEMA_GAP: f32 = 0.6;
 
+/// The six named controller screens on the theatre's front wall (each relays
+/// to its side-wall copies via SwitchLinks).
+const SCREENS: [&str; 6] = [
+    "ShodanScreenTL",
+    "ShodanScreenTM",
+    "ShodanScreenTR",
+    "ShodanScreenBL",
+    "ShodanScreenBM",
+    "ShodanScreenBR",
+];
+
 #[derive(Clone, Copy, Debug)]
 enum Cs9Action {
     /// Send TurnOn to every entity with this sym name.
@@ -60,6 +71,9 @@ enum Cs9Action {
     TurnOffByName(&'static str),
     /// Start a monologue schema.
     PlaySchema(&'static str),
+    /// Fade the theatre screens in, if the MovingWallsOpen report from
+    /// CS9_DoorReporter hasn't already done so.
+    ScreensOnFallback,
 }
 
 /// Master sequencer for the reveal (script `CS9_MasterControl`, on the
@@ -70,19 +84,13 @@ pub struct CS9MasterControl {
     /// (fire time, action), sorted by time; `next` indexes the first unfired.
     schedule: Vec<(f32, Cs9Action)>,
     next: usize,
+    /// Set when the theatre screens have been faded in (by the DoorReporter's
+    /// MovingWallsOpen event, or the timed fallback).
+    screens_faded_in: bool,
 }
 
 impl CS9MasterControl {
     pub fn new() -> CS9MasterControl {
-        const SCREENS: [&str; 6] = [
-            "ShodanScreenTL",
-            "ShodanScreenTM",
-            "ShodanScreenTR",
-            "ShodanScreenBL",
-            "ShodanScreenBM",
-            "ShodanScreenBR",
-        ];
-
         let mut schedule: Vec<(f32, Cs9Action)> = vec![
             // Seal the player in and start pulling the theatre apart.
             (0.0, Cs9Action::TurnOnByName("MasterForceField")),
@@ -93,15 +101,13 @@ impl CS9MasterControl {
         for (i, (schema, duration)) in SCHEMAS.iter().enumerate() {
             schedule.push((t, Cs9Action::PlaySchema(schema)));
             match i {
-                // cs0901: SHODAN appears. The screens fade in once the moving
-                // walls have pulled back (~6s into the panel stagger), so the
-                // reveal shows dark screens and the face materializes during
-                // the opening line. (PR-later: gate on CS9_DoorReporter's
-                // MovingWallsOpen instead of a timed offset.)
+                // cs0901: SHODAN appears. The screens fade in when the
+                // reporter panel signals MovingWallsOpen (dark screens are
+                // revealed, then the face materializes during the opening
+                // line); this scheduled entry is a fallback in case the
+                // report never arrives.
                 0 => {
-                    for s in SCREENS {
-                        schedule.push((t + 6.0, Cs9Action::TurnOnByName(s)));
-                    }
+                    schedule.push((t + 16.0, Cs9Action::ScreensOnFallback));
                 }
                 // cs0903: the "garden grove" section - the exhibits appear.
                 2 => {
@@ -137,56 +143,84 @@ impl CS9MasterControl {
             elapsed: 0.0,
             schedule,
             next: 0,
+            screens_faded_in: false,
         }
     }
 
-    fn run_action(&self, entity_id: EntityId, world: &World, action: Cs9Action) -> Effect {
+    /// Fade the theatre screens in, once.
+    fn fire_screens_on(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        if self.screens_faded_in {
+            return Effect::NoEffect;
+        }
+        self.screens_faded_in = true;
+        info!("cs9: fading theatre screens in");
+        let effects = SCREENS
+            .iter()
+            .map(|name| send_by_name(entity_id, world, name, /* on */ true))
+            .collect();
+        Effect::Combined { effects }
+    }
+
+    fn run_action(&mut self, entity_id: EntityId, world: &World, action: Cs9Action) -> Effect {
         info!("cs9: firing action {:?}", action);
         match action {
-            Cs9Action::TurnOnByName(name) | Cs9Action::TurnOffByName(name) => {
-                let targets = get_entities_by_name(world, name);
-                if targets.is_empty() {
-                    info!("cs9: no entities named '{}'", name);
-                }
-                let effects = targets
-                    .into_iter()
-                    .map(|to| {
-                        let payload = match action {
-                            Cs9Action::TurnOnByName(_) => {
-                                MessagePayload::TurnOn { from: entity_id }
-                            }
-                            _ => MessagePayload::TurnOff { from: entity_id },
-                        };
-                        Effect::Send {
-                            msg: Message { to, payload },
-                        }
-                    })
-                    .collect();
-                Effect::Combined { effects }
-            }
+            Cs9Action::TurnOnByName(name) => send_by_name(entity_id, world, name, true),
+            Cs9Action::TurnOffByName(name) => send_by_name(entity_id, world, name, false),
             Cs9Action::PlaySchema(schema) => Effect::PlaySound {
                 handle: AudioHandle::new(),
                 name: schema.to_string(),
             },
+            Cs9Action::ScreensOnFallback => self.fire_screens_on(entity_id, world),
         }
     }
+}
+
+/// Send TurnOn/TurnOff to every entity with the given sym name.
+fn send_by_name(from: EntityId, world: &World, name: &str, on: bool) -> Effect {
+    let targets = get_entities_by_name(world, name);
+    if targets.is_empty() {
+        info!("cs9: no entities named '{}'", name);
+    }
+    let effects = targets
+        .into_iter()
+        .map(|to| {
+            let payload = if on {
+                MessagePayload::TurnOn { from }
+            } else {
+                MessagePayload::TurnOff { from }
+            };
+            Effect::Send {
+                msg: Message { to, payload },
+            }
+        })
+        .collect();
+    Effect::Combined { effects }
 }
 
 impl Script for CS9MasterControl {
     fn handle_message(
         &mut self,
-        _entity_id: EntityId,
-        _world: &World,
+        entity_id: EntityId,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        if let MessagePayload::TurnOn { from: _ } = msg {
-            if !self.started {
-                info!("cs9: master control tripped - starting cutscene");
-                self.started = true;
+        match msg {
+            MessagePayload::TurnOn { from: _ } => {
+                if !self.started {
+                    info!("cs9: master control tripped - starting cutscene");
+                    self.started = true;
+                }
+                Effect::NoEffect
             }
+            // CS9_DoorReporter tells us the moving walls finished opening -
+            // reveal SHODAN on the now-exposed screens.
+            MessagePayload::Signal { name } if name == "MovingWallsOpen" && self.started => {
+                info!("cs9: MovingWallsOpen reported");
+                self.fire_screens_on(entity_id, world)
+            }
+            _ => Effect::NoEffect,
         }
-        Effect::NoEffect
     }
 
     fn update(
@@ -517,6 +551,51 @@ impl Script for CS9EggsAndGrubs {
             // No Teleport link: leave the object where it is (it may already
             // sit at its display spot and only need the fade-in).
             None => turn_on,
+        }
+    }
+}
+
+/// Script `CS9_DoorReporter` (on one designated moving-wall panel): forwards
+/// the door's open/close completion to the cutscene master as
+/// MovingWallsOpen/MovingWallsClose, so the show reacts to the walls actually
+/// finishing instead of a guessed time.
+pub struct CS9DoorReporter {}
+
+impl CS9DoorReporter {
+    pub fn new() -> CS9DoorReporter {
+        CS9DoorReporter {}
+    }
+}
+
+impl Script for CS9DoorReporter {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let MessagePayload::Signal { name } = msg else {
+            return Effect::NoEffect;
+        };
+        let report = match name.as_str() {
+            "DoorOpen" => "MovingWallsOpen",
+            "DoorClose" => "MovingWallsClose",
+            _ => return Effect::NoEffect,
+        };
+        match get_first_entity_by_name(world, "CutSceneNine") {
+            Some(master) => Effect::Send {
+                msg: Message {
+                    to: master,
+                    payload: MessagePayload::Signal {
+                        name: report.to_string(),
+                    },
+                },
+            },
+            None => {
+                info!("cs9: door reporter found no CutSceneNine");
+                Effect::NoEffect
+            }
         }
     }
 }

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -15,6 +15,7 @@
 //!   script runs a fixed timeline using the measured lengths of the cs090x
 //!   audio files (see SCHEMAS below).
 use cgmath::Vector3;
+use dark::motion::{MotionQueryItem, MotionQuerySelectionStrategy};
 use dark::properties::{Link, PropPosition};
 use shipyard::{EntityId, Get, View, World};
 use tracing::info;
@@ -305,14 +306,16 @@ fn teleport_to_marker(world: &World, entity_id: EntityId, marker: &str) -> Effec
 
 /// Script `CS9_HoloRumbler`: the four rumblers are parked out of sight; on
 /// TurnOn each appears at its matching `RumblerLoc<N>` marker (fading in via
-/// the composed `TransluceInOutHolo`), and on TurnOff is stashed at
-/// `SafeTeleportLoc`. (The original also plays a walk-in-place motion; we keep
-/// them idle.)
-pub struct CS9HoloRumbler {}
+/// the composed `TransluceInOutHolo`) and walks in place, like the original's
+/// `WalkInPlace` motion; on TurnOff it stops and is stashed at
+/// `SafeTeleportLoc`.
+pub struct CS9HoloRumbler {
+    walking: bool,
+}
 
 impl CS9HoloRumbler {
     pub fn new() -> CS9HoloRumbler {
-        CS9HoloRumbler {}
+        CS9HoloRumbler { walking: false }
     }
 
     /// "Rumbler3" -> "RumblerLoc3", matched via this entity's own sym name.
@@ -323,6 +326,33 @@ impl CS9HoloRumbler {
         let name = v_name.get(entity_id).ok()?.0.clone();
         let digit = name.chars().rev().find(|c| c.is_ascii_digit())?;
         Some(format!("RumblerLoc{digit}"))
+    }
+
+    /// The hologram's walk cycle: the rumblers are authored with
+    /// `PropCreaturePose { TAG, "cs 131" }` - the cutscene's walk-in-place
+    /// motion (resolves to `rmbplace`). The entity has no AI script, so this
+    /// script owns the animation and re-queues it on completion to loop.
+    fn walk_animation(world: &World, entity_id: EntityId) -> Effect {
+        let v_pose = world
+            .borrow::<View<dark::properties::PropCreaturePose>>()
+            .unwrap();
+        let Ok(pose) = v_pose.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+
+        // "cs 131" -> tag "cs" with value 131; a plain tag has no value.
+        let mut parts = pose.motion_or_tag_name.split_whitespace();
+        let item = match (parts.next(), parts.next().and_then(|v| v.parse().ok())) {
+            (Some(tag), Some(value)) => MotionQueryItem::with_value(tag, value),
+            (Some(tag), None) => MotionQueryItem::new(tag),
+            (None, _) => return Effect::NoEffect,
+        };
+
+        Effect::QueueAnimationBySchema {
+            entity_id,
+            selection_strategy: MotionQuerySelectionStrategy::Random,
+            motion_query_items: vec![item],
+        }
     }
 }
 
@@ -336,11 +366,23 @@ impl Script for CS9HoloRumbler {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => match Self::loc_marker_name(world, entity_id) {
-                Some(marker) => teleport_to_marker(world, entity_id, &marker),
+                Some(marker) => {
+                    self.walking = true;
+                    Effect::Combined {
+                        effects: vec![
+                            teleport_to_marker(world, entity_id, &marker),
+                            Self::walk_animation(world, entity_id),
+                        ],
+                    }
+                }
                 None => Effect::NoEffect,
             },
             MessagePayload::TurnOff { from: _ } => {
+                self.walking = false;
                 teleport_to_marker(world, entity_id, "SafeTeleportLoc")
+            }
+            MessagePayload::AnimationCompleted if self.walking => {
+                Self::walk_animation(world, entity_id)
             }
             _ => Effect::NoEffect,
         }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -88,8 +88,8 @@ use self::{
     core_room::*,
     create_sound::*,
     cs9::{
-        CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, CS9ShodanScreen, SitDownRightNowMP,
-        TrapDestroyTeleport,
+        CS9DoorReporter, CS9EggsAndGrubs, CS9HoloRumbler, CS9MasterControl, CS9ShodanScreen,
+        SitDownRightNowMP, TrapDestroyTeleport,
     },
     dead_power_cell::DeadPowerCell,
     destroy_all_by_name::DestroyAllByName,
@@ -443,7 +443,7 @@ impl ScriptWorld {
             "trapspawn" => Box::new(NoopScript::new()),
             // ops1 cutscene (the "Polito is SHODAN" reveal) - see scripts/cs9.rs
             "transluceinoutholo" => Box::new(TransluceInOutHolo::new()),
-            "cs9_doorreporter" => Box::new(NoopScript::new()), // master runs on a timeline instead of door events
+            "cs9_doorreporter" => Box::new(CS9DoorReporter::new()),
             "cs9_eggsandgrubs" => Box::new(CS9EggsAndGrubs::new()),
             "cs9_mastercontrol" => Box::new(CS9MasterControl::new()),
             "cs9_holorumbler" => Box::new(CS9HoloRumbler::new()),

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -6,7 +6,7 @@ use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{Effect, MessagePayload, Script, script_util::play_environmental_sound};
+use super::{Effect, Message, MessagePayload, Script, script_util::play_environmental_sound};
 
 pub struct StdDoor {
     audio_handle: AudioHandle,
@@ -57,22 +57,42 @@ impl Script for StdDoor {
         let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
             let dir = self.desired_position - self.current_position;
-            if dir.magnitude2() > 0.001 {
+            let step = time.elapsed.as_secs_f32() * trans_door.speed;
+            // Complete once within one frame-step of the target - stepping by
+            // a fixed amount can otherwise overshoot and oscillate around a
+            // small distance threshold forever, so the door never finishes.
+            if dir.magnitude() > step.max(0.001) {
                 let normalized = dir.normalize();
-                //dir *= trans_door.speed;
 
                 trace!(
                     "desired: {:?} current: {:?} dir: {:?}",
                     self.desired_position, self.current_position, normalized
                 );
 
-                self.current_position += normalized * time.elapsed.as_secs_f32() * trans_door.speed;
+                self.current_position += normalized * step;
                 Effect::SetPosition {
                     entity_id,
                     position: self.current_position,
                 }
             } else if self.is_moving {
                 self.is_moving = false;
+                // Announce which endpoint we reached to this entity's other
+                // scripts (the Dark engine's DoorOpen/DoorClose messages);
+                // e.g. CS9_DoorReporter forwards these to the cutscene master.
+                let reached_open =
+                    (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001;
+                let state_signal = Effect::Send {
+                    msg: Message {
+                        to: entity_id,
+                        payload: MessagePayload::Signal {
+                            name: if reached_open {
+                                "DoorOpen".to_string()
+                            } else {
+                                "DoorClose".to_string()
+                            },
+                        },
+                    },
+                };
                 Effect::Combined {
                     effects: vec![
                         Effect::SetPosition {
@@ -86,6 +106,7 @@ impl Script for StdDoor {
                             vec![("openstate", "closed"), ("oldopenstate", "closing")],
                             self.audio_handle.clone(),
                         ),
+                        state_signal,
                     ],
                 }
             } else {


### PR DESCRIPTION
Phase 2 of the CS9 reveal, 4/4 (stacked on #372). The screen reveal now reacts to the walls actually finishing instead of a guessed time:

- **`StdDoor`** announces `DoorOpen`/`DoorClose` to its own entity's scripts on reaching an endpoint (the Dark engine's door messages).
- **`CS9_DoorReporter`** (carried by one designated wall panel in the mission data) forwards these to the cutscene master as `MovingWallsOpen`/`MovingWallsClose`.
- The master fades the theatre screens in on `MovingWallsOpen`; the timed entry remains only as a fallback (verified: the report fires first, the fallback no-ops).

Also fixes a real `StdDoor` completion bug found while wiring this: stepping a fixed distance per frame could overshoot the tiny completion threshold and oscillate forever, so doors with step-incommensurate travel **never completed** — no completion sound, and (now) no completion signal. Doors complete once within one frame-step of the target.

Log evidence of the event-driven path:
```
cs9: MovingWallsOpen reported
cs9: fading theatre screens in
cs9: firing action ScreensOnFallback   <- later, guarded no-op
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)