### PR TITLE
feat(ai): killing blows interrupt the playing animation with a crossfade

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -132,10 +132,13 @@ impl AnimationPlayer {
                 )
             })
             .or_else(|| {
-                player
-                    .last_animation
-                    .as_ref()
-                    .map(|clip| (clip.clone(), clip.num_frames.saturating_sub(1) as f32, false))
+                player.last_animation.as_ref().map(|clip| {
+                    (
+                        clip.clone(),
+                        clip.num_frames.saturating_sub(1) as f32,
+                        false,
+                    )
+                })
             });
         let blend_state = blend_from.map(|(from_clip, from_frame, from_looping)| BlendState {
             from_clip,

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -22,6 +22,9 @@ pub enum AnimationEvent {
 struct BlendState {
     from_clip: Rc<AnimationClip>,
     from_frame: f32,
+    /// Whether the interrupted clip loops - a fade that outlives the clip
+    /// wraps a looping from-pose but holds a one-shot on its last frame
+    from_looping: bool,
     duration: f32,
     elapsed: f32,
 }
@@ -74,12 +77,13 @@ impl AnimationPlayer {
             .animation
             .push_front((animation.clone(), AnimationFlags::PlayOnce));
 
-        let blend_state = if let Some((current_clip, _)) = player.animation.first() {
+        let blend_state = if let Some((current_clip, flags)) = player.animation.first() {
             let duration = animation.blend_length.as_secs_f32();
             if duration > 0.0 {
                 Some(BlendState {
                     from_clip: current_clip.clone(),
                     from_frame: player.current_frame as f32,
+                    from_looping: matches!(flags, AnimationFlags::Loop),
                     duration,
                     elapsed: 0.0,
                 })
@@ -112,9 +116,31 @@ impl AnimationPlayer {
     ) -> AnimationPlayer {
         const MIN_INTERRUPT_BLEND_SECS: f32 = 0.15;
 
-        let blend_state = player.animation.first().map(|(current_clip, _)| BlendState {
-            from_clip: current_clip.clone(),
-            from_frame: player.current_frame as f32,
+        // Fade from the playing clip's current pose, or from the frozen
+        // last-frame pose when the queue already drained. Known limit: an
+        // interrupt landing mid-blend fades from the head clip's pure pose,
+        // not the blended one on screen - a small pop proportional to how
+        // fresh the interrupted blend was.
+        let blend_from = player
+            .animation
+            .first()
+            .map(|(clip, flags)| {
+                (
+                    clip.clone(),
+                    player.current_frame as f32,
+                    matches!(flags, AnimationFlags::Loop),
+                )
+            })
+            .or_else(|| {
+                player
+                    .last_animation
+                    .as_ref()
+                    .map(|clip| (clip.clone(), clip.num_frames.saturating_sub(1) as f32, false))
+            });
+        let blend_state = blend_from.map(|(from_clip, from_frame, from_looping)| BlendState {
+            from_clip,
+            from_frame,
+            from_looping,
             duration: animation
                 .blend_length
                 .as_secs_f32()
@@ -182,7 +208,11 @@ impl AnimationPlayer {
                 let mut frame = blend.from_frame + frames_advance;
                 let frame_count = blend.from_clip.num_frames as f32;
                 if frame >= frame_count && frame_count > 0.0 {
-                    frame = frame % frame_count;
+                    frame = if blend.from_looping {
+                        frame % frame_count
+                    } else {
+                        frame_count - 1.0
+                    };
                 }
                 blend.from_frame = frame;
             }

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -101,6 +101,38 @@ impl AnimationPlayer {
         }
     }
 
+    /// Play `animation` immediately, replacing the whole queue (unlike
+    /// `queue_animation`, which pushes on top and lets interrupted clips
+    /// resume later). Cross-fades from the interrupted pose over the clip's
+    /// authored blend length, floored so a zero-blend clip doesn't pop when
+    /// it cuts a clip mid-play.
+    pub fn play_animation(
+        player: &AnimationPlayer,
+        animation: Rc<AnimationClip>,
+    ) -> AnimationPlayer {
+        const MIN_INTERRUPT_BLEND_SECS: f32 = 0.15;
+
+        let blend_state = player.animation.first().map(|(current_clip, _)| BlendState {
+            from_clip: current_clip.clone(),
+            from_frame: player.current_frame as f32,
+            duration: animation
+                .blend_length
+                .as_secs_f32()
+                .max(MIN_INTERRUPT_BLEND_SECS),
+            elapsed: 0.0,
+        });
+
+        AnimationPlayer {
+            additional_joint_transforms: player.additional_joint_transforms.clone(),
+            animation: immutable::List::new().push_front((animation, AnimationFlags::PlayOnce)),
+            last_animation: None,
+            current_frame: 0,
+            remaining_time: 0.0,
+            blend_state,
+            cancel_root_motion: player.cancel_root_motion,
+        }
+    }
+
     /// A copy of `player` that poses with the clip's root motion cancelled
     /// (see `AnimationInfo::cancel_root_motion`).
     pub fn with_root_motion_cancelled(player: &AnimationPlayer) -> AnimationPlayer {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -31,7 +31,10 @@ use dark::{
     },
     mission::{SongParams, room_database::RoomDatabase},
     model::Model,
-    motion::{AnimationEvent, AnimationPlayer, MotionDB, MotionQuery, MotionQueryItem},
+    motion::{
+        AnimationClip, AnimationEvent, AnimationPlayer, MotionDB, MotionQuery, MotionQueryItem,
+        MotionQuerySelectionStrategy,
+    },
     properties::{
         AmbientSoundFlags, Link, LinkDefinition, LinkDefinitionWithData, Links, PhysicsModelType,
         PropAIAlertness, PropAIMode, PropAmbientHacked, PropClassTag, PropCreature,
@@ -1068,6 +1071,69 @@ impl MissionCore {
         self.world.run(run_attachment_update);
     }
 
+    /// Resolve a tag-based motion query for `entity_id` and hand the clip to
+    /// `apply` (`AnimationPlayer::queue_animation` to push on the queue,
+    /// `AnimationPlayer::play_animation` to interrupt and replace it). When
+    /// no motion matches, dispatches `AnimationCompleted` so the requesting
+    /// script isn't left waiting on a clip that never started.
+    fn apply_animation_by_schema(
+        &mut self,
+        global_context: &GlobalContext,
+        asset_cache: &mut AssetCache,
+        entity_id: EntityId,
+        motion_query_items: Vec<MotionQueryItem>,
+        selection_strategy: MotionQuerySelectionStrategy,
+        apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
+    ) {
+        let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
+        if let Some(player) = maybe_player {
+            let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
+
+            let v_motion_actor_tag = self.world.borrow::<View<PropMotionActorTags>>().unwrap();
+
+            if let (Ok(creature_type), Ok(motion_actor_tag)) = (
+                v_creature_type.get(entity_id),
+                v_motion_actor_tag.get(entity_id),
+            ) {
+                let mut actor_tags = motion_actor_tag
+                    .tags
+                    .iter()
+                    .map(|tag| MotionQueryItem::new(tag).optional())
+                    .collect::<Vec<MotionQueryItem>>();
+
+                let mut query_items = motion_query_items.clone();
+
+                query_items.append(&mut actor_tags);
+
+                let creature_definition = get_creature_definition(creature_type.0).unwrap();
+
+                let actor_type = creature_definition.actor_type.to_u32().unwrap();
+
+                let query =
+                    MotionQuery::new(actor_type, query_items).with_selection_strategy(selection_strategy);
+
+                let maybe_next_animation = global_context.motiondb.query(query.clone());
+                if let Some(next_animation) = maybe_next_animation {
+                    let maybe_clip = asset_cache
+                        .get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", next_animation));
+
+                    if let Some(clip) = maybe_clip {
+                        *player = apply(player, clip);
+                    } else {
+                        game_log!(WARN, "Unable to load animation clip: {:?}_.mc", next_animation);
+                    }
+                } else {
+                    game_log!(WARN, "Unable to find animation for query: {:?}", &query);
+                    // If we couldn't find an animation... just stop the current one
+                    self.script_world.dispatch(Message {
+                        payload: MessagePayload::AnimationCompleted,
+                        to: entity_id,
+                    });
+                }
+            }
+        }
+    }
+
     fn update_animations(&mut self, time: &Time) {
         for (id, player) in self.id_to_animation_player.iter_mut() {
             // self.id_to_animation_player.entry(*id).and_modify(|player| {
@@ -1886,61 +1952,29 @@ impl MissionCore {
                     motion_query_items,
                     selection_strategy,
                 } => {
-                    let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
-                    if let Some(player) = maybe_player {
-                        let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
+                    self.apply_animation_by_schema(
+                        global_context,
+                        asset_cache,
+                        entity_id,
+                        motion_query_items,
+                        selection_strategy,
+                        AnimationPlayer::queue_animation,
+                    );
+                }
 
-                        let v_motion_actor_tag =
-                            self.world.borrow::<View<PropMotionActorTags>>().unwrap();
-
-                        if let (Ok(creature_type), Ok(motion_actor_tag)) = (
-                            v_creature_type.get(entity_id),
-                            v_motion_actor_tag.get(entity_id),
-                        ) {
-                            let mut actor_tags = motion_actor_tag
-                                .tags
-                                .iter()
-                                .map(|tag| MotionQueryItem::new(tag).optional())
-                                .collect::<Vec<MotionQueryItem>>();
-
-                            let mut query_items = motion_query_items.clone();
-
-                            query_items.append(&mut actor_tags);
-
-                            let creature_definition =
-                                get_creature_definition(creature_type.0).unwrap();
-
-                            let actor_type = creature_definition.actor_type.to_u32().unwrap();
-
-                            let query = MotionQuery::new(actor_type, query_items)
-                                .with_selection_strategy(selection_strategy);
-
-                            let maybe_next_animation = global_context.motiondb.query(query.clone());
-                            if let Some(next_animation) = maybe_next_animation {
-                                let maybe_clip = asset_cache.get_opt(
-                                    &ANIMATION_CLIP_IMPORTER,
-                                    &format!("{}_.mc", next_animation),
-                                );
-
-                                if let Some(clip) = maybe_clip {
-                                    *player = AnimationPlayer::queue_animation(player, clip);
-                                } else {
-                                    game_log!(
-                                        WARN,
-                                        "Unable to load animation clip: {:?}_.mc",
-                                        next_animation
-                                    );
-                                }
-                            } else {
-                                game_log!(WARN, "Unable to find animation for query: {:?}", &query);
-                                // If we couldn't find an animation... just stop the current one
-                                self.script_world.dispatch(Message {
-                                    payload: MessagePayload::AnimationCompleted,
-                                    to: entity_id,
-                                });
-                            }
-                        }
-                    }
+                Effect::PlayAnimationBySchema {
+                    entity_id,
+                    motion_query_items,
+                    selection_strategy,
+                } => {
+                    self.apply_animation_by_schema(
+                        global_context,
+                        asset_cache,
+                        entity_id,
+                        motion_query_items,
+                        selection_strategy,
+                        AnimationPlayer::play_animation,
+                    );
                 }
 
                 Effect::DebugCycleHitboxPose => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1109,8 +1109,8 @@ impl MissionCore {
 
                 let actor_type = creature_definition.actor_type.to_u32().unwrap();
 
-                let query =
-                    MotionQuery::new(actor_type, query_items).with_selection_strategy(selection_strategy);
+                let query = MotionQuery::new(actor_type, query_items)
+                    .with_selection_strategy(selection_strategy);
 
                 let maybe_next_animation = global_context.motiondb.query(query.clone());
                 if let Some(next_animation) = maybe_next_animation {
@@ -1120,7 +1120,11 @@ impl MissionCore {
                     if let Some(clip) = maybe_clip {
                         *player = apply(player, clip);
                     } else {
-                        game_log!(WARN, "Unable to load animation clip: {:?}_.mc", next_animation);
+                        game_log!(
+                            WARN,
+                            "Unable to load animation clip: {:?}_.mc",
+                            next_animation
+                        );
                     }
                 } else {
                     game_log!(WARN, "Unable to find animation for query: {:?}", &query);

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -309,8 +309,8 @@ impl AnimatedMonsterAI {
     /// current pose) and clears the animation queue, so no interrupted clip
     /// resumes under the corpse. Latching `is_dead` up front makes the
     /// AnimationCompleted death branch a no-op afterwards (including the
-    /// synchronous re-dispatch when no crumple motion is found), so the
-    /// crumple and death sound play only once.
+    /// re-dispatch queued when no crumple motion is found), so the crumple
+    /// and death sound play only once.
     fn enter_death(&mut self, world: &World, entity_id: EntityId) -> Effect {
         self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
         self.is_dead = true;
@@ -551,6 +551,13 @@ impl Script for AnimatedMonsterAI {
         }
         match msg {
             MessagePayload::Damage { amount } => {
+                // Corpses don't bleed: no HP churn, aggro, or replayed death
+                // from shooting a dead monster. The world check also covers a
+                // post-load corpse, whose recreated script has is_dead reset
+                // while its hit points are still <= 0
+                if self.is_dead || is_killed(entity_id, world) {
+                    return Effect::NoEffect;
+                }
                 // TODO: Let behavior handle this?
                 self.took_damage = true;
                 let hit_points_effect = Effect::AdjustHitPoints {
@@ -578,8 +585,7 @@ impl Script for AnimatedMonsterAI {
                 // actually raises the level, so a capped AI isn't reset -
                 // and doesn't restart its animation - on every hit
                 let target = alertness::clamp_level(AIAlertLevel::Moderate, &cap);
-                let alert_effect = if !self.is_dead
-                    && !lethal
+                let alert_effect = if !lethal
                     && matches!(
                         self.alertness.current_level,
                         AIAlertLevel::Lowest | AIAlertLevel::Low
@@ -593,7 +599,7 @@ impl Script for AnimatedMonsterAI {
                 // A killing blow reacts immediately - the death animation
                 // interrupts the in-flight clip (cross-fading from its
                 // current pose) instead of waiting for it to complete
-                let death_effect = if lethal && !self.is_dead {
+                let death_effect = if lethal {
                     self.enter_death(world, entity_id)
                 } else {
                     Effect::NoEffect

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -304,6 +304,46 @@ impl AnimatedMonsterAI {
         ])
     }
 
+    /// Switch to DeadBehavior and start the death animation and sound. The
+    /// crumple interrupts whatever clip is playing (cross-fading from its
+    /// current pose) and clears the animation queue, so no interrupted clip
+    /// resumes under the corpse. Latching `is_dead` up front makes the
+    /// AnimationCompleted death branch a no-op afterwards (including the
+    /// synchronous re-dispatch when no crumple motion is found), so the
+    /// crumple and death sound play only once.
+    fn enter_death(&mut self, world: &World, entity_id: EntityId) -> Effect {
+        self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
+        self.is_dead = true;
+
+        let death_sound_effect = if let Some(voice_index) =
+            crate::scripts::speech_util::resolve_entity_voice_index(world, entity_id)
+        {
+            // Randomly choose between loud and soft death sound
+            let concept = if rand::random::<bool>() {
+                "comdieloud".to_string()
+            } else {
+                "comdiesoft".to_string()
+            };
+
+            Effect::PlaySpeech {
+                entity_id,
+                voice_index,
+                concept,
+                tags: vec![],
+            }
+        } else {
+            Effect::NoEffect
+        };
+
+        let death_animation = Effect::PlayAnimationBySchema {
+            entity_id,
+            motion_query_items: vec![MotionQueryItem::new("crumple")],
+            selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
+        };
+
+        Effect::combine(vec![death_sound_effect, death_animation])
+    }
+
     /// Publish the current behavior name for debug introspection. Update
     /// runs each frame, so this covers every behavior-change site with at
     /// most one frame of lag (e.g. handle_message changes, or the
@@ -550,7 +590,15 @@ impl Script for AnimatedMonsterAI {
                 } else {
                     Effect::NoEffect
                 };
-                Effect::combine(vec![hit_points_effect, alert_effect])
+                // A killing blow reacts immediately - the death animation
+                // interrupts the in-flight clip (cross-fading from its
+                // current pose) instead of waiting for it to complete
+                let death_effect = if lethal && !self.is_dead {
+                    self.enter_death(world, entity_id)
+                } else {
+                    Effect::NoEffect
+                };
+                Effect::combine(vec![hit_points_effect, alert_effect, death_effect])
             }
             MessagePayload::TurnOn { from: _ } => {
                 // Dead AIs stay dead - a corpse can still be a SwitchLink
@@ -619,41 +667,9 @@ impl Script for AnimatedMonsterAI {
                 if self.is_dead {
                     Effect::NoEffect
                 } else if is_killed(entity_id, world) {
-                    self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
-                    // Latch immediately: the is_dead branch above then
-                    // swallows every later completion (including the
-                    // synchronous re-dispatch when no crumple motion is
-                    // found), so the crumple and death sound play only once
-                    self.is_dead = true;
-
-                    // Play death sound effect immediately
-                    let death_sound_effect = if let Some(voice_index) =
-                        crate::scripts::speech_util::resolve_entity_voice_index(world, entity_id)
-                    {
-                        // Randomly choose between loud and soft death sound
-                        let concept = if rand::random::<bool>() {
-                            "comdieloud".to_string()
-                        } else {
-                            "comdiesoft".to_string()
-                        };
-
-                        Effect::PlaySpeech {
-                            entity_id,
-                            voice_index,
-                            concept,
-                            tags: vec![],
-                        }
-                    } else {
-                        Effect::NoEffect
-                    };
-
-                    let death_animation = Effect::QueueAnimationBySchema {
-                        entity_id,
-                        motion_query_items: vec![MotionQueryItem::new("crumple")],
-                        selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
-                    };
-
-                    Effect::combine(vec![death_sound_effect, death_animation])
+                    // Fallback for kills that didn't arrive as a Damage
+                    // message (the lethal-damage path enters death eagerly)
+                    self.enter_death(world, entity_id)
                 } else if self.took_damage {
                     self.took_damage = false;
                     Effect::QueueAnimationBySchema {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -195,6 +195,16 @@ pub enum Effect {
         motion_query_items: Vec<MotionQueryItem>,
     },
 
+    /// Like `QueueAnimationBySchema`, but interrupts the playing animation
+    /// immediately (cross-fading from its current pose) and clears the
+    /// queue instead of pushing on top of it. Used for reactions that must
+    /// not wait for the in-flight clip, e.g. death.
+    PlayAnimationBySchema {
+        entity_id: EntityId,
+        selection_strategy: MotionQuerySelectionStrategy,
+        motion_query_items: Vec<MotionQueryItem>,
+    },
+
     ReplaceEntity {
         entity_id: EntityId,
         template_id: i32,

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -44,26 +44,27 @@ test(
     // fire (escalation while the player is visible, decay afterwards) - the
     // regression this guards against is any alertness level change replacing
     // DeadBehavior.
+    // Only step a few frames past the alert: forcing alertness queues a
+    // fresh chase clip, so the kill below lands near the clip's start and
+    // the eager-death assertion actually discriminates (waiting for the
+    // clip to complete would blow the half-second window).
     await game.input.trigger("DebugAlertAll");
-    await game.step({ frames: 30 });
+    await game.step({ frames: 10 });
     let detail = await game.entities.detail(monster.id);
     assert.equal(aiProp(detail, "AIBehavior"), "Chase");
 
-    // Lethal damage. Death is animation-driven, so give it a few seconds to
-    // finish the in-flight clip and play the crumple.
+    // Lethal damage reacts eagerly: the death animation interrupts the
+    // in-flight chase clip instead of waiting for it to complete, so the
+    // behavior must read Dead within half a second of the killing blow.
     await game.entities.sendMessage(monster.id, {
       type: "Damage",
       amount: 1000,
     });
-    await game.waitFor(
-      async () => {
-        await game.step({ frames: 30 });
-        return (
-          aiProp(await game.entities.detail(monster.id), "AIBehavior") ===
-          "Dead"
-        );
-      },
-      { description: "monster entering Dead behavior", timeoutMs: 60_000 },
+    await game.step({ frames: 30 });
+    assert.equal(
+      aiProp(await game.entities.detail(monster.id), "AIBehavior"),
+      "Dead",
+      "killing blow should interrupt the playing clip immediately",
     );
 
     // Let the crumple (and any interrupted clip still in the animation


### PR DESCRIPTION
Stacked follow-up to #371 (dead monsters stay dead) — the second of the two PRs discussed there.

## Problem

Death was animation-driven: a killed monster finished its in-flight clip (walk, attack) before the `AnimationCompleted` handler noticed the kill and queued the crumple — so a monster shot mid-stride kept walking for up to a couple of seconds before dying (#371's e2e run measured ~3 s from killing blow to `Dead` behavior).

## Change

The lethal-damage path now enters death immediately, GoldenEye-style — the death reaction starts the frame the killing blow lands, easing out of the interrupted pose:

- **`Effect::PlayAnimationBySchema`** — like `QueueAnimationBySchema`, but interrupts the playing clip and **replaces the whole animation queue**. `queue_animation` pushes on top and lets interrupted clips resume (from frame 0) when the pushed clip pops — fine for the completion-driven flow, wrong for death, where a stale walk cycle would play out under the corpse.
- **`AnimationPlayer::play_animation`** — cross-fades from the interrupted pose over the incoming clip's authored blend length (per-motion blend data from `motiondb.bin`), floored at 150 ms so a zero-blend clip doesn't pop when cut mid-play. Fades from the frozen last-frame pose if the queue already drained; a fade that outlives a one-shot from-clip holds its last frame instead of wrapping to frame 0.
- **`enter_death`** — shared by the eager path (lethal `Damage`) and the `AnimationCompleted` fallback (kills that don't arrive as damage), so the death sound and crumple play exactly once either way.
- **Corpse damage short-circuits**: a dead monster's HP is ≤ 0, so any later hit computes as "lethal" and would replay the death (reachable after a load, which recreates the script with `is_dead` reset). Found by cross-engine review.

Known cosmetic limit (documented in code): an interrupt landing mid-blend fades from the head clip's pure pose rather than the blended on-screen pose — a small pop proportional to how fresh the interrupted blend was.

## Testing

- `monster-death.e2e.test.ts` tightened: the corpse must publish `Dead` within **30 frames (0.5 s)** of the killing blow, mid-chase. (Not a strict negative against #371 alone — chase walk cycles are short enough to occasionally finish inside any window — but deterministic under the eager path; visuals below are the eagerness evidence.)
- Full e2e suite: 49/52, all three failures independent of this change — two are the cross-agent port/target-dir interference class from #358 (both tests pass in isolation, including this branch's death test), and `launch-failure` is broken on main by #369's message rewording (filed as #374).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr -p dark`: pass.
- Cross-engine review (`/xreview`): agreed findings fixed (corpse-damage guard, one-shot blend wrap, empty-queue hard cut) and re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

### After — killing blow interrupts the chase immediately
![after gif](https://gist.githubusercontent.com/tommy-xr/503f5fef3950b8fe85ecd873e7e70e6e/raw/death_after.gif)

### Before (main) — the clip finishes before the crumple
![before gif](https://gist.githubusercontent.com/tommy-xr/503f5fef3950b8fe85ecd873e7e70e6e/raw/death_before.gif)

## Before → after (same frame index after the killing blow)
![beforeafter](https://gist.githubusercontent.com/tommy-xr/503f5fef3950b8fe85ecd873e7e70e6e/raw/beforeafter.png)

<sub>Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep): spawn OG-Pipe → DebugAlertAll → lethal Damage message → screenshot every 6 frames.</sub>
