### PR TITLE
fix(sdk): shutdown requires the owner's instance id

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1592,7 +1592,30 @@ async fn step_frame(
 /// Shutdown the debug runtime gracefully
 async fn shutdown_server(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    body: Option<Json<Value>>,
 ) -> Json<Value> {
+    // When launched with --instance-id (SDK-owned), only the owner may shut
+    // us down: a client on another checkout whose own runtime failed to bind
+    // this port still POSTs /v1/shutdown here during its cleanup, and
+    // without this check it kills OUR game mid-test.
+    if let Some(Some(expected)) = INSTANCE_ID.get() {
+        let provided = body
+            .as_ref()
+            .and_then(|json| json.0.get("instance_id"))
+            .and_then(|v| v.as_str());
+        if provided != Some(expected.as_str()) {
+            tracing::warn!(
+                "Rejected shutdown request with missing/mismatched instance_id (expected {})",
+                expected
+            );
+            return Json(json!({
+                "status": "rejected",
+                "message": "This runtime is owned by another client; shutdown requires its instance_id",
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            }));
+        }
+    }
+
     tracing::info!("Shutdown request received via HTTP API");
 
     // Send shutdown command to game loop

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -364,7 +364,11 @@ export class GameServer extends Game implements AsyncDisposable {
     // THEIR instance. Only speak to the port while our child owns it.
     if (!this.childIsDead()) {
       try {
-        await super.shutdown();
+        // The runtime rejects shutdowns without its instance id, so a stale
+        // client on another checkout can't kill it - include ours.
+        await this.client.post("/v1/shutdown", {
+          instance_id: this.instanceId,
+        });
       } catch {
         // Server may already be down; fall through to process cleanup.
       }


### PR DESCRIPTION
## Summary

Closes the last cross-checkout kill path (follow-up to #369, observed live after it merged): a client on another checkout running a *pre-#369* SDK, whose runtime failed to bind a contested port, still POSTs `/v1/shutdown` to that port during its cleanup — killing the runtime that does own it, mid-test ("Game loop ended due to shutdown request" during an unrelated scenario).

SDK-owned runtimes (launched with `--instance-id`) now reject shutdown requests without the matching id; manually-started runtimes (no id) accept unauthenticated shutdown as before, so curl workflows are unchanged. `GameServer.shutdown()` sends its id.

(Rebased: originally also carried the #369 review-fixes commit under the mistaken belief it had missed the squash — it hadn't.)

## Test plan

- [x] 6 SDK unit tests; `RUSTFLAGS="-D warnings" cargo check -p debug_runtime`
- [x] Live: reproduced the cross-checkout shutdown kill pre-guard; with the guard the same scenario runs to completion (search-behavior e2e, previously killed mid-test, now passes 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)