### PR TITLE
feat(gameplay): scatter and launch flinderize gibs on slay

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -520,10 +520,10 @@ impl GunFlashOptions {
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FlinderizeOptions {
-    count: u32,
-    impulse: f32,
-    scatter: bool,
-    offset: Vector3<f32>,
+    pub count: u32,
+    pub impulse: f32,
+    pub scatter: bool,
+    pub offset: Vector3<f32>,
 }
 
 impl FlinderizeOptions {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1144,26 +1144,53 @@ impl MissionCore {
         if let Some(handle) = &self.id_to_physics.get(&entity_id) {
             let position = self.physics.get_position(**handle).unwrap();
             let rotation = self.physics.get_rotation(**handle).unwrap();
+            let aabb = self.physics.get_aabb2(entity_id);
+            let mut rng = thread_rng();
 
-            for (template_id, _flinderize_options) in flinderize_links {
-                // let flinderize_position = flinderize.position;
-                // let flinderize_orientation = flinderize.orientation;
+            for (template_id, flinderize_options) in flinderize_links {
+                // Real gamesys data carries count >= 1 (e.g. Breakable Windows:
+                // 4 links, count 1 each); max(1) guards links with zeroed data
+                // so they still yield one flinder, like the pre-options behavior.
+                for _ in 0..flinderize_options.count.max(1) {
+                    // scatter spawns the flinder at a random point within the
+                    // object's bounds; otherwise at the object-relative offset.
+                    let spawn_position = match (flinderize_options.scatter, &aabb) {
+                        (true, Some(aabb)) => Point3::new(
+                            rng.gen_range(aabb.min.x..=aabb.max.x),
+                            rng.gen_range(aabb.min.y..=aabb.max.y),
+                            rng.gen_range(aabb.min.z..=aabb.max.z),
+                        ),
+                        _ => vec3_to_point3(position + rotation * flinderize_options.offset),
+                    };
 
-                self.create_entity_with_position(
-                    asset_cache,
-                    template_id,
-                    vec3_to_point3(position),
-                    rotation,
-                    Matrix4::identity(),
-                    CreateEntityOptions::default(),
-                );
-                //did_slay = true;
+                    let spawn_rotation = Quaternion::from_angle_y(cgmath::Rad(
+                        rng.gen_range(0.0..std::f32::consts::TAU),
+                    )) * Quaternion::from_angle_x(cgmath::Rad(
+                        rng.gen_range(0.0..std::f32::consts::TAU),
+                    )) * Quaternion::from_angle_z(cgmath::Rad(
+                        rng.gen_range(0.0..std::f32::consts::TAU),
+                    ));
+
+                    let created = self.create_entity_with_position(
+                        asset_cache,
+                        template_id,
+                        spawn_position,
+                        spawn_rotation,
+                        Matrix4::identity(),
+                        CreateEntityOptions::default(),
+                    );
+
+                    if created.rigid_body.is_some() {
+                        let speed = flinderize_options.impulse / SCALE_FACTOR;
+                        self.physics.set_velocity(
+                            created.entity_id,
+                            random_unit_vector(&mut rng) * speed,
+                        );
+                    }
+                }
             }
 
             for (template_id, _corpse_options) in corpse_links {
-                // let flinderize_position = flinderize.position;
-                // let flinderize_orientation = flinderize.orientation;
-
                 self.create_entity_with_position(
                     asset_cache,
                     template_id,
@@ -1172,7 +1199,6 @@ impl MissionCore {
                     Matrix4::identity(),
                     CreateEntityOptions::default(),
                 );
-                //did_slay = true;
             }
         }
 
@@ -3445,6 +3471,20 @@ fn create_room_entities(
             link,
         ));
         entities_to_initialize.insert((_room, room.obj_id));
+    }
+}
+
+fn random_unit_vector(rng: &mut impl Rng) -> Vector3<f32> {
+    loop {
+        let v = vec3(
+            rng.gen_range(-1.0f32..=1.0),
+            rng.gen_range(-1.0f32..=1.0),
+            rng.gen_range(-1.0f32..=1.0),
+        );
+        let mag2 = v.magnitude2();
+        if mag2 > 1e-4 && mag2 <= 1.0 {
+            return v / mag2.sqrt();
+        }
     }
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1182,10 +1182,8 @@ impl MissionCore {
 
                     if created.rigid_body.is_some() {
                         let speed = flinderize_options.impulse / SCALE_FACTOR;
-                        self.physics.set_velocity(
-                            created.entity_id,
-                            random_unit_vector(&mut rng) * speed,
-                        );
+                        self.physics
+                            .set_velocity(created.entity_id, random_unit_vector(&mut rng) * speed);
                     }
                 }
             }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -8,6 +8,7 @@ import type {
   InputAction,
   PathfindingStats,
   PathfindingTestStatus,
+  PhysicsBodyListResult,
   Position,
   RayCastRequest,
   RayCastResult,
@@ -108,6 +109,27 @@ export class InputApi {
   }
 }
 
+/** Physics rigid-body inspection (positions, velocities). */
+export class PhysicsApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /**
+   * List rigid bodies, optionally scoped to one entity id (a single entity
+   * can own several bodies, e.g. ragdoll limbs).
+   */
+  async bodies(options?: {
+    entityId?: number;
+    limit?: number;
+  }): Promise<PhysicsBodyListResult> {
+    const params = new URLSearchParams();
+    if (options?.entityId !== undefined)
+      params.set("entity_id", String(options.entityId));
+    if (options?.limit !== undefined) params.set("limit", String(options.limit));
+    const query = params.size > 0 ? `?${params}` : "";
+    return this.client.get<PhysicsBodyListResult>(`/v1/physics/bodies${query}`);
+  }
+}
+
 /** Interactive pathfinding test (visual A* debugging). */
 export class PathfindingTestApi {
   constructor(private readonly client: HttpClient) {}
@@ -154,6 +176,7 @@ export class Game {
   readonly input: InputApi;
   readonly pathfindingTest: PathfindingTestApi;
   readonly pathfinding: PathfindingApi;
+  readonly physics: PhysicsApi;
 
   constructor(protected readonly client: HttpClient) {
     this.player = new PlayerApi(client);
@@ -161,6 +184,7 @@ export class Game {
     this.input = new InputApi(client);
     this.pathfindingTest = new PathfindingTestApi(client);
     this.pathfinding = new PathfindingApi(client);
+    this.physics = new PhysicsApi(client);
   }
 
   get baseUrl(): string {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -127,6 +127,28 @@ export interface RayCastResult {
   is_sensor: boolean;
 }
 
+/** Summary of one rigid body, as reported by GET /v1/physics/bodies. */
+export interface PhysicsBodySummary {
+  body_id: number;
+  entity_id: number | null;
+  entity_name: string | null;
+  body_type: "dynamic" | "static" | "kinematic";
+  position: Vec3;
+  rotation: Quat;
+  mass: number | null;
+  velocity: Vec3;
+  angular_velocity: Vec3;
+  collision_groups: string[];
+  is_sensor: boolean;
+  is_enabled: boolean;
+}
+
+export interface PhysicsBodyListResult {
+  bodies: PhysicsBodySummary[];
+  total_count: number;
+  player_position: Vec3;
+}
+
 export interface PlayerSnapshot {
   entity_id: number | null;
   position: Vec3;

--- a/tools/shock2-sdk/test/flinderize.e2e.test.ts
+++ b/tools/shock2-sdk/test/flinderize.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, Vec3 } from "../src/types.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// medsci1 "Window 1" entities inherit from "Breakable Windows" (-1587), which
+// carries 4 Flinderize links (Glass1..Glass4 shards with scatter=true and
+// impulses 2/4/10/14). Slaying one must spawn shards scattered across the
+// window's bounds and flying apart - not stacked at the center at rest.
+const TARGET_NAME = "Window 1";
+
+function horizontalSpeed(v: Vec3): number {
+  return Math.hypot(v[0], v[2]);
+}
+
+function maxPairwiseDistance(bodies: PhysicsBodySummary[]): number {
+  let max = 0;
+  for (let i = 0; i < bodies.length; i++) {
+    for (let j = i + 1; j < bodies.length; j++) {
+      const [ax, ay, az] = bodies[i].position;
+      const [bx, by, bz] = bodies[j].position;
+      max = Math.max(max, Math.hypot(bx - ax, by - ay, bz - az));
+    }
+  }
+  return max;
+}
+
+test(
+  "Flinderize: slaying a breakable window scatters shards with an impulse",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8112),
+    });
+
+    // Let the mission load and initialize scripts.
+    await game.step({ frames: 2 });
+
+    const { entities } = await game.entities.list({
+      filter: TARGET_NAME,
+      limit: 500,
+    });
+    const window = entities.find((e) => e.name === TARGET_NAME);
+    assert.ok(window !== undefined, `expected to find a '${TARGET_NAME}' entity`);
+
+    const before = await game.physics.bodies();
+    const knownBodyIds = new Set(before.bodies.map((b) => b.body_id));
+
+    // Breakable windows have 1 HP; one hit slays and flinderizes.
+    await game.entities.sendMessage(window.id, { type: "Damage", amount: 5.0 });
+    await game.step({ frames: 1 });
+
+    const after = await game.physics.bodies();
+    const shards = after.bodies.filter(
+      (b) => !knownBodyIds.has(b.body_id) && b.body_type === "dynamic",
+    );
+
+    // The window's 4 Flinderize links each spawn one shard.
+    assert.ok(
+      shards.length >= 4,
+      `expected 4 spawned shard bodies (one per Flinderize link), got ${shards.length}`,
+    );
+
+    // scatter=true: shards spawn spread across the window's bounds, not all
+    // at the object center.
+    const spread = maxPairwiseDistance(shards);
+    assert.ok(
+      spread > 0.3,
+      `expected shards scattered over the window (max pairwise distance > 0.3), got ${spread.toFixed(3)}`,
+    );
+
+    // Each link carries an impulse: one frame in, shards must be flying, not
+    // just starting to free-fall (gravity alone gives ~0 horizontal speed).
+    const fastest = Math.max(...shards.map((b) => horizontalSpeed(b.velocity)));
+    assert.ok(
+      fastest > 0.3,
+      `expected at least one shard with horizontal speed > 0.3, got ${fastest.toFixed(3)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Slaying a breakable (window, computer screen) previously spawned one entity per Flinderize link at the object's center with zero velocity — all gibs stacked at one point and fell straight down. The parsed `FlinderizeOptions` (count / impulse / scatter / offset) were bound as `_flinderize_options` and ignored.

This PR honors the link data the way the Dark Engine intends:

- spawn `count` gibs per link (min 1, preserving the old one-per-link behavior for links with zeroed data)
- `scatter`: place each gib at a random point inside the object's world AABB (via `physics.get_aabb2`); otherwise at the object-relative `offset` (already SCALE_FACTOR-corrected at parse time)
- give each gib a fully random orientation
- launch it at `impulse / SCALE_FACTOR` in a random direction

Real gamesys data exercises all of this: **Breakable Windows** (-1587) carry 4 links (Glass1–4, `scatter`, impulses 2/4/10/14) and **Misc Screens** (-4841) carry 4 links (Comp_Part_1–4, impulses 3/5/10/15) — the graduated impulses are what make the break read as a burst. The shard templates already have physics + a 30s offscreen delete tweq, so cleanup is free.

Also:
- `FlinderizeOptions` fields are now `pub` (`dark`)
- new `game.physics.bodies()` SDK wrapper over the existing `GET /v1/physics/bodies` endpoint

## Test plan

- [x] New e2e test `tools/shock2-sdk/test/flinderize.e2e.test.ts`: slays a medsci1 breakable window via `/v1/entities/{id}/message`, asserts ≥4 new dynamic shard bodies with real spatial spread (>0.3) and horizontal speed (>0.3). **Fails against the old behavior** (spread was 0.010, zero horizontal speed); passes with this change.
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] SDK unit tests (`npm test`)
- [x] Full e2e suite including all 23 mission-load smoke tests
- [x] Cross-engine review (Claude + Codex): no Critical/High findings; both minor findings addressed (documented `count.max(1)` semantics, added roll to random orientation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![flinderize scatter demo — before vs after](https://gist.githubusercontent.com/tommy-xr/9e5c02c31c01128667b80aa7b7bbe320/raw/demo.gif)

<sub>Slaying a breakable window now scatters its glass shards across the pane with an outward impulse — previously all shards spawned at the window's center at rest and dropped as a single clump (left). MedSci deck 1 "Window 1", same deterministic request sequence on both builds; frames brightened uniformly (×1.35) for visibility. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![before/after mid-flight still (~0.2 s after slay)](https://gist.githubusercontent.com/tommy-xr/9e5c02c31c01128667b80aa7b7bbe320/raw/beforeafter.png)

<sub>Mid-flight ~0.2 s after the slay: before (left) the four shards overlap in one clump at the pane's center; after (right) they are spread across the pane's bounds, randomly oriented, flying outward at graduated speeds.</sub>
