### PR TITLE
fix(sdk): only retry launch on genuine port races; fix drifted test assertion

### DIFF
--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -198,8 +198,10 @@ export class GameServer extends Game implements AsyncDisposable {
       } catch (error) {
         lastError = error;
         const message = String(error);
+        // "failed to bind" comes from the runtime's own logs (it binds in
+        // main() before the game starts); a crash for any other reason -
+        // bad mission, panic during load - must NOT retry.
         const lostPortRace =
-          message.includes("exited early") ||
           message.includes("different debug_runtime instance") ||
           message.includes("failed to bind");
         if (!lostPortRace) {

--- a/tools/shock2-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/shock2-sdk/test/launch-failure.e2e.test.ts
@@ -25,7 +25,7 @@ test(
         assert.match(error.message, /debug_runtime failed to start/);
         assert.match(
           error.message,
-          /exited early with code/,
+          /process exited early \(code/,
           "error should report the process exit",
         );
         assert.match(


### PR DESCRIPTION
## Summary

Tiny follow-up that missed #376's merge window by minutes:

- The launch retry treated ANY early child exit as a lost port race, so a genuinely crashing mission (bad file, panic during load) relaunched — and recompiled — three times before failing. Retry now keys only on the genuine race signatures ("failed to bind" from the runtime's fail-fast bind, foreign instance id).
- The launch-failure e2e assertion drifted when #369 merged (CI runs only unit tests): updated to the current error wording. Verified passing live.

## Test plan

- [x] 6 SDK unit tests
- [x] `launch-failure.e2e.test.ts` passes live (was the one suite failure on the final search-feature validation run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)