### PR TITLE
feat(ai): search the last-known position after losing sight of the player

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -273,6 +273,14 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
     }
 }
 
+/// Distance from the entity to the player, when both positions are known
+pub fn player_distance(world: &World, entity_id: EntityId) -> Option<f32> {
+    let u_player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
+    let prop_pos = v_current_pos.get(entity_id).ok()?;
+    Some((prop_pos.position - u_player.pos).magnitude())
+}
+
 /// Current hit points, if the entity has a health pool
 pub fn hit_points(entity_id: EntityId, world: &World) -> Option<i32> {
     let v_prop_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -147,26 +147,11 @@ impl AnimatedMonsterAI {
             AIAlertLevel::Moderate => Box::new(RefCell::new(ChaseBehavior::new())),
             AIAlertLevel::High => {
                 // Attack only when in range; otherwise chase to close the
-                // distance (ChaseBehavior::next_behavior escalates back to an
-                // attack on arrival, using these same thresholds). Without
+                // distance (ChaseBehavior::next_behavior escalates back to
+                // an attack on arrival via the same shared helper). Without
                 // the range check, a far-away High AI stood still swinging.
-                let distance = player_distance(world, entity_id);
-                let melee_attack_distance = 8.0 / SCALE_FACTOR;
-                let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
-                let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
-                match distance {
-                    Some(d)
-                        if d > ranged_min_attack_distance
-                            && d < ranged_max_attack_distance
-                            && has_ranged_weapon(world, entity_id) =>
-                    {
-                        Box::new(RefCell::new(RangedAttackBehavior))
-                    }
-                    Some(d) if d < melee_attack_distance => {
-                        Box::new(RefCell::new(MeleeAttackBehavior))
-                    }
-                    _ => Box::new(RefCell::new(ChaseBehavior::new())),
-                }
+                attack_behavior_for_distance(world, entity_id)
+                    .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new())))
             }
         }
     }
@@ -482,7 +467,19 @@ impl Script for AnimatedMonsterAI {
                 // drop straight to wandering: investigate the last-known
                 // position first. Further decay during an active search
                 // leaves it running - it hands off to Wander itself.
-                let new_behavior: Option<Box<RefCell<dyn Behavior>>> = if decayed
+                let searching = self.current_behavior.borrow().name() == "Search";
+                let new_behavior: Option<Box<RefCell<dyn Behavior>>> = if decayed && searching {
+                    // An active search keeps running across further decay
+                    // (it hands off on its own) - unless a fresher sighting
+                    // was recorded mid-search, which re-targets it. This
+                    // must be checked BEFORE the decay-from-tracking branch,
+                    // or a High-origin search is stomped one decay later.
+                    self.last_known_player_pos
+                        .take()
+                        .map(|goal| -> Box<RefCell<dyn Behavior>> {
+                            Box::new(RefCell::new(SearchBehavior::new(goal)))
+                        })
+                } else if decayed
                     && matches!(old_level, AIAlertLevel::Moderate | AIAlertLevel::High)
                 {
                     match self.last_known_player_pos.take() {
@@ -491,11 +488,14 @@ impl Script for AnimatedMonsterAI {
                         // damage from behind) - nothing to investigate
                         None => Some(self.behavior_for_alertness(world, physics, entity_id)),
                     }
-                } else if decayed && self.current_behavior.borrow().name() == "Search" {
-                    None
                 } else {
                     Some(self.behavior_for_alertness(world, physics, entity_id))
                 };
+                // Fully calmed: a sighting from this engagement must not
+                // trigger a cross-map search minutes later
+                if new_level == AIAlertLevel::Lowest {
+                    self.last_known_player_pos = None;
+                }
 
                 let animation_effect = if let Some(behavior) = new_behavior {
                     self.current_behavior = behavior;
@@ -643,13 +643,15 @@ impl Script for AnimatedMonsterAI {
                 // actually raises the level, so a capped AI isn't reset -
                 // and doesn't restart its animation - on every hit
                 let target = alertness::clamp_level(AIAlertLevel::Moderate, &cap);
-                let alert_effect = if !lethal
-                    && matches!(
-                        self.alertness.current_level,
-                        AIAlertLevel::Lowest | AIAlertLevel::Low
-                    )
-                    && target != self.alertness.current_level
-                {
+                let escalates = matches!(
+                    self.alertness.current_level,
+                    AIAlertLevel::Lowest | AIAlertLevel::Low
+                ) && target != self.alertness.current_level;
+                // A searching AI that takes a hit re-aggros too: the shot
+                // reveals the attacker even without line of sight (the dead
+                // case already returned above)
+                let searching = self.current_behavior.borrow().name() == "Search";
+                let alert_effect = if !lethal && (escalates || searching) {
                     self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
                 } else {
                     Effect::NoEffect

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -63,6 +63,9 @@ pub struct AnimatedMonsterAI {
     config: Option<MonsterConfig>,
     /// Behavior name last published for debug introspection
     published_behavior: Option<&'static str>,
+    /// Where the player was last seen; investigated by SearchBehavior when
+    /// alertness decays after losing contact
+    last_known_player_pos: Option<cgmath::Vector3<f32>>,
 }
 
 impl AnimatedMonsterAI {
@@ -79,6 +82,7 @@ impl AnimatedMonsterAI {
             alertness: AlertnessState::default(),
             config: None,
             published_behavior: None,
+            last_known_player_pos: None,
         }
     }
 
@@ -96,6 +100,7 @@ impl AnimatedMonsterAI {
             alertness: AlertnessState::default(),
             config: None,
             published_behavior: None,
+            last_known_player_pos: None,
         }
     }
 
@@ -141,11 +146,26 @@ impl AnimatedMonsterAI {
             AIAlertLevel::Low => Box::new(RefCell::new(WanderBehavior::new())),
             AIAlertLevel::Moderate => Box::new(RefCell::new(ChaseBehavior::new())),
             AIAlertLevel::High => {
-                // Choose attack type based on whether monster has ranged weapon
-                if has_ranged_weapon(world, entity_id) {
-                    Box::new(RefCell::new(RangedAttackBehavior))
-                } else {
-                    Box::new(RefCell::new(MeleeAttackBehavior))
+                // Attack only when in range; otherwise chase to close the
+                // distance (ChaseBehavior::next_behavior escalates back to an
+                // attack on arrival, using these same thresholds). Without
+                // the range check, a far-away High AI stood still swinging.
+                let distance = player_distance(world, entity_id);
+                let melee_attack_distance = 8.0 / SCALE_FACTOR;
+                let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
+                let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
+                match distance {
+                    Some(d)
+                        if d > ranged_min_attack_distance
+                            && d < ranged_max_attack_distance
+                            && has_ranged_weapon(world, entity_id) =>
+                    {
+                        Box::new(RefCell::new(RangedAttackBehavior))
+                    }
+                    Some(d) if d < melee_attack_distance => {
+                        Box::new(RefCell::new(MeleeAttackBehavior))
+                    }
+                    _ => Box::new(RefCell::new(ChaseBehavior::new())),
                 }
             }
         }
@@ -436,9 +456,16 @@ impl Script for AnimatedMonsterAI {
         let is_visible =
             is_player_visible_in_fov(entity_id, world, physics, Deg(0.0), MONSTER_FOV_HALF_ANGLE);
 
+        // Remember where the player was last seen, for SearchBehavior
+        if is_visible {
+            if let Ok(player) = world.borrow::<shipyard::UniqueView<PlayerInfo>>() {
+                self.last_known_player_pos = Some(player.pos);
+            }
+        }
+
         // Update alertness state
         let (alertness_effect, behavior_change_effect) = if let Some(config) = &self.config {
-            if let Some((_old_level, _new_level)) = alertness::process_alertness_update(
+            if let Some((old_level, new_level)) = alertness::process_alertness_update(
                 &mut self.alertness,
                 is_visible,
                 delta,
@@ -448,16 +475,39 @@ impl Script for AnimatedMonsterAI {
                 // Level changed - sync to ECS and potentially change behavior
                 let sync_effect = alertness::sync_alertness_effect(entity_id, &self.alertness);
 
-                // When alertness changes, update behavior to match new level
-                let new_behavior = self.behavior_for_alertness(world, physics, entity_id);
-                self.current_behavior = new_behavior;
+                // AIAlertLevel is repr(u32) in escalation order
+                let decayed = (new_level as u32) < (old_level as u32);
 
-                let is_locomotion = self.current_behavior.borrow().is_locomotion();
-                let selection_strategy = self.next_selection(is_locomotion);
-                let animation_effect = Effect::QueueAnimationBySchema {
-                    entity_id,
-                    motion_queries: vec![self.current_behavior.borrow().animation()],
-                    selection_strategy,
+                // Losing contact after actively tracking the player doesn't
+                // drop straight to wandering: investigate the last-known
+                // position first. Further decay during an active search
+                // leaves it running - it hands off to Wander itself.
+                let new_behavior: Option<Box<RefCell<dyn Behavior>>> = if decayed
+                    && matches!(old_level, AIAlertLevel::Moderate | AIAlertLevel::High)
+                {
+                    match self.last_known_player_pos.take() {
+                        Some(goal) => Some(Box::new(RefCell::new(SearchBehavior::new(goal)))),
+                        // Never actually saw the player (e.g. aggroed by
+                        // damage from behind) - nothing to investigate
+                        None => Some(self.behavior_for_alertness(world, physics, entity_id)),
+                    }
+                } else if decayed && self.current_behavior.borrow().name() == "Search" {
+                    None
+                } else {
+                    Some(self.behavior_for_alertness(world, physics, entity_id))
+                };
+
+                let animation_effect = if let Some(behavior) = new_behavior {
+                    self.current_behavior = behavior;
+                    let is_locomotion = self.current_behavior.borrow().is_locomotion();
+                    let selection_strategy = self.next_selection(is_locomotion);
+                    Effect::QueueAnimationBySchema {
+                        entity_id,
+                        motion_queries: vec![self.current_behavior.borrow().animation()],
+                        selection_strategy,
+                    }
+                } else {
+                    Effect::NoEffect
                 };
 
                 (sync_effect, animation_effect)

--- a/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
@@ -1,13 +1,8 @@
-use std::cell::RefCell;
-
-use cgmath::{Deg, InnerSpace};
-use dark::{SCALE_FACTOR, motion::MotionQueryItem, properties::PropPosition};
-use rand::Rng;
+use cgmath::Deg;
+use dark::motion::MotionQueryItem;
 use shipyard::*;
 
-use crate::scripts::ai::ai_util::has_ranged_weapon;
 use crate::{
-    mission::PlayerInfo,
     physics::PhysicsWorld,
     scripts::{
         Effect,
@@ -19,7 +14,7 @@ use crate::{
     time::Time,
 };
 
-use super::{Behavior, MeleeAttackBehavior, NextBehavior, RangedAttackBehavior};
+use super::{Behavior, NextBehavior};
 
 pub struct ChaseBehavior {
     steering_strategy: Box<dyn SteeringStrategy>,
@@ -81,32 +76,9 @@ impl Behavior for ChaseBehavior {
         _physics: &PhysicsWorld,
         entity_id: EntityId,
     ) -> NextBehavior {
-        let _rand = rand::thread_rng().gen_range(0..100);
-        let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-        let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
-        //let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-
-        let melee_attack_distance = 8.0 / SCALE_FACTOR;
-        let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
-        let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
-
-        if let Ok(prop_pos) = v_current_pos.get(entity_id) {
-            let distance = (prop_pos.position - u_player.pos).magnitude();
-
-            // Only ranged-armed AIs stop to shoot; melee AIs must keep
-            // chasing or they stall at mid-range bouncing between chase and
-            // ranged-attack behaviors.
-            if distance > ranged_min_attack_distance
-                && distance < ranged_max_attack_distance
-                && has_ranged_weapon(world, entity_id)
-            {
-                return NextBehavior::Next(Box::new(RefCell::new(RangedAttackBehavior)));
-            }
-            if distance < melee_attack_distance {
-                return NextBehavior::Next(Box::new(RefCell::new(MeleeAttackBehavior)));
-            }
+        match super::attack_behavior_for_distance(world, entity_id) {
+            Some(behavior) => NextBehavior::Next(behavior),
+            None => NextBehavior::Stay,
         }
-
-        NextBehavior::Stay
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -18,3 +18,38 @@ pub use ranged_attack_behavior::*;
 pub use scripted_sequence_behavior::*;
 pub use search_behavior::*;
 pub use wander_behavior::*;
+
+use std::cell::RefCell;
+
+use dark::SCALE_FACTOR;
+use shipyard::{EntityId, World};
+
+use crate::scripts::ai::ai_util::{has_ranged_weapon, player_distance};
+
+/// The attack behavior for the current distance to the player, or None when
+/// out of attack range (the caller should chase to close the distance).
+/// Single source of truth for the combat-range thresholds - used both by
+/// the High-alertness behavior mapping and ChaseBehavior's transitions, so
+/// the two mechanisms can't disagree.
+pub fn attack_behavior_for_distance(
+    world: &World,
+    entity_id: EntityId,
+) -> Option<Box<RefCell<dyn Behavior>>> {
+    let distance = player_distance(world, entity_id)?;
+    let melee_attack_distance = 8.0 / SCALE_FACTOR;
+    let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
+    let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
+
+    // Only ranged-armed AIs stop to shoot; melee AIs must keep chasing or
+    // they stall at mid-range bouncing between chase and ranged-attack.
+    if distance > ranged_min_attack_distance
+        && distance < ranged_max_attack_distance
+        && has_ranged_weapon(world, entity_id)
+    {
+        Some(Box::new(RefCell::new(RangedAttackBehavior)))
+    } else if distance < melee_attack_distance {
+        Some(Box::new(RefCell::new(MeleeAttackBehavior)))
+    } else {
+        None
+    }
+}

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -16,4 +16,5 @@ pub use idle_behavior::*;
 pub use melee_attack_behavior::*;
 pub use ranged_attack_behavior::*;
 pub use scripted_sequence_behavior::*;
+pub use search_behavior::*;
 pub use wander_behavior::*;

--- a/shock2vr/src/scripts/ai/behavior/search_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/search_behavior.rs
@@ -3,7 +3,8 @@ use std::cell::RefCell;
 use cgmath::{Deg, Vector3};
 use dark::SCALE_FACTOR;
 use dark::motion::MotionQueryItem;
-use shipyard::{EntityId, World};
+use dark::properties::{AIAlertLevel, PropAIAlertness};
+use shipyard::{EntityId, Get, View, World};
 
 use crate::{
     physics::PhysicsWorld,
@@ -18,10 +19,15 @@ use crate::{
     time::Time,
 };
 
-use super::{Behavior, NextBehavior, WanderBehavior};
+use super::{Behavior, IdleBehavior, NextBehavior, WanderBehavior};
 
 /// Close enough to the last-known position to stop and look around
 const SEARCH_ARRIVE_DISTANCE: f32 = 4.0 / SCALE_FACTOR;
+/// ...and within this height difference (6 Dark feet - the recorded player
+/// position sits eye-height above the floor). Standing under a walkway the
+/// player was seen on is not arrival; the 20s total timeout covers goals
+/// the AI can never reach.
+const SEARCH_ARRIVE_HEIGHT: f32 = 6.0 / SCALE_FACTOR;
 /// How long to scan around the last-known position before giving up
 const SEARCH_SCAN_SECONDS: f32 = 6.0;
 /// Give up entirely after this long, arrived or not (unreachable positions,
@@ -82,7 +88,9 @@ impl Behavior for SearchBehavior {
             let (position, _) = ai_util::get_position_and_forward(world, entity_id);
             let dx = position.x - self.goal.x;
             let dz = position.z - self.goal.z;
-            if (dx * dx + dz * dz).sqrt() < SEARCH_ARRIVE_DISTANCE {
+            if (dx * dx + dz * dz).sqrt() < SEARCH_ARRIVE_DISTANCE
+                && (position.y - self.goal.y).abs() < SEARCH_ARRIVE_HEIGHT
+            {
                 self.arrived = true;
             }
         }
@@ -118,14 +126,25 @@ impl Behavior for SearchBehavior {
 
     fn next_behavior(
         &mut self,
-        _world: &World,
+        world: &World,
         _physics: &PhysicsWorld,
-        _entity_id: EntityId,
+        entity_id: EntityId,
     ) -> NextBehavior {
-        if self.give_up() {
-            NextBehavior::Next(Box::new(RefCell::new(WanderBehavior::new())))
+        if !self.give_up() {
+            return NextBehavior::Stay;
+        }
+        // Alertness kept decaying while we searched (and produces no more
+        // level-change events at Lowest), so pick the handoff from the
+        // synced level: fully calm goes back to Idle, anything else
+        // wanders the area
+        let level = world
+            .borrow::<View<PropAIAlertness>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|a| a.level));
+        if matches!(level, Some(AIAlertLevel::Lowest)) {
+            NextBehavior::Next(Box::new(RefCell::new(IdleBehavior)))
         } else {
-            NextBehavior::Stay
+            NextBehavior::Next(Box::new(RefCell::new(WanderBehavior::new())))
         }
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/search_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/search_behavior.rs
@@ -1,19 +1,131 @@
+use std::cell::RefCell;
+
+use cgmath::{Deg, Vector3};
+use dark::SCALE_FACTOR;
 use dark::motion::MotionQueryItem;
+use shipyard::{EntityId, World};
 
-use super::Behavior;
+use crate::{
+    physics::PhysicsWorld,
+    scripts::{
+        Effect,
+        ai::ai_util,
+        ai::steering::{
+            self, CollisionAvoidanceSteeringStrategy, PathFollowSteeringStrategy, SteeringOutput,
+            SteeringStrategy,
+        },
+    },
+    time::Time,
+};
 
-#[allow(dead_code)]
-pub struct SearchBehavior;
+use super::{Behavior, NextBehavior, WanderBehavior};
+
+/// Close enough to the last-known position to stop and look around
+const SEARCH_ARRIVE_DISTANCE: f32 = 4.0 / SCALE_FACTOR;
+/// How long to scan around the last-known position before giving up
+const SEARCH_SCAN_SECONDS: f32 = 6.0;
+/// Give up entirely after this long, arrived or not (unreachable positions,
+/// blocked routes)
+const SEARCH_MAX_SECONDS: f32 = 20.0;
+
+/// Investigate the target's last-known position: walk there via the nav
+/// mesh, scan around for a few seconds, then hand off to Wander. Alertness
+/// escalation (the player becoming visible) replaces this behavior through
+/// the normal level-change path.
+pub struct SearchBehavior {
+    goal: Vector3<f32>,
+    steering_strategy: Box<dyn SteeringStrategy>,
+    arrived: bool,
+    scan_seconds: f32,
+    total_seconds: f32,
+}
+
+impl SearchBehavior {
+    pub fn new(goal: Vector3<f32>) -> SearchBehavior {
+        SearchBehavior {
+            goal,
+            steering_strategy: steering::chained(vec![
+                Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
+                // Route to the fixed last-known position; without AIPATH
+                // data this returns None and the AI just scans in place
+                Box::new(PathFollowSteeringStrategy::to_point(goal)),
+            ]),
+            arrived: false,
+            scan_seconds: 0.0,
+            total_seconds: 0.0,
+        }
+    }
+
+    fn give_up(&self) -> bool {
+        (self.arrived && self.scan_seconds >= SEARCH_SCAN_SECONDS)
+            || self.total_seconds >= SEARCH_MAX_SECONDS
+    }
+}
 
 impl Behavior for SearchBehavior {
     fn name(&self) -> &'static str {
         "Search"
     }
 
-    fn animation(self: &SearchBehavior) -> Vec<MotionQueryItem> {
-        vec![
-            MotionQueryItem::new("search"),
-            MotionQueryItem::new("scan").optional(),
-        ]
+    fn steer(
+        &mut self,
+        current_heading: Deg<f32>,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+        time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        let dt = time.elapsed.as_secs_f32();
+        self.total_seconds += dt;
+
+        if !self.arrived {
+            let (position, _) = ai_util::get_position_and_forward(world, entity_id);
+            let dx = position.x - self.goal.x;
+            let dz = position.z - self.goal.z;
+            if (dx * dx + dz * dz).sqrt() < SEARCH_ARRIVE_DISTANCE {
+                self.arrived = true;
+            }
+        }
+
+        if self.arrived {
+            // Stand at the last-known position; the scan animation does the
+            // looking around
+            self.scan_seconds += dt;
+            return None;
+        }
+
+        self.steering_strategy
+            .steer(current_heading, world, physics, entity_id, time)
+    }
+
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        if self.arrived {
+            vec![
+                MotionQueryItem::new("search"),
+                MotionQueryItem::new("scan").optional(),
+            ]
+        } else {
+            vec![
+                MotionQueryItem::new("locourgent").optional(),
+                MotionQueryItem::new("locomote"),
+            ]
+        }
+    }
+
+    fn is_locomotion(&self) -> bool {
+        !self.arrived
+    }
+
+    fn next_behavior(
+        &mut self,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _entity_id: EntityId,
+    ) -> NextBehavior {
+        if self.give_up() {
+            NextBehavior::Next(Box::new(RefCell::new(WanderBehavior::new())))
+        } else {
+            NextBehavior::Stay
+        }
     }
 }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -21,6 +21,9 @@ pub enum PathTarget {
     Player,
     /// Roam to random reachable points within a radius of the AI
     Wander { radius: f32 },
+    /// Path to a fixed point (e.g. a last-known position). The owning
+    /// behavior decides when "arrived" - this just keeps routing there.
+    Point(Vector3<f32>),
 }
 
 /// A waypoint counts as reached within this XZ distance (2 Dark feet)
@@ -69,6 +72,10 @@ impl PathFollowSteeringStrategy {
 
     pub fn wander(radius: f32) -> PathFollowSteeringStrategy {
         PathFollowSteeringStrategy::new(PathTarget::Wander { radius })
+    }
+
+    pub fn to_point(goal: Vector3<f32>) -> PathFollowSteeringStrategy {
+        PathFollowSteeringStrategy::new(PathTarget::Point(goal))
     }
 
     fn new(target: PathTarget) -> PathFollowSteeringStrategy {
@@ -127,8 +134,8 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
 
         let desired_goal = match self.target {
             PathTarget::Player => Some(world.borrow::<UniqueView<PlayerInfo>>().ok()?.pos),
-            // Wander keeps its current destination until the path completes
-            PathTarget::Wander { .. } => None,
+            // Wander and Point keep their destination until the path completes
+            PathTarget::Wander { .. } | PathTarget::Point(_) => None,
         };
 
         let needs_repath = match (self.path_goal, desired_goal) {
@@ -162,6 +169,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 PathTarget::Wander { radius } => {
                     pick_wander_goal(&service, position, radius, &mut rand::thread_rng())
                 }
+                PathTarget::Point(point) => Some(point),
             };
             match goal {
                 // TODO: derive movement bits from the creature (small

--- a/tools/shock2-sdk/test/search-behavior.e2e.test.ts
+++ b/tools/shock2-sdk/test/search-behavior.e2e.test.ts
@@ -24,6 +24,64 @@ function distanceXZ(
 }
 
 test(
+  "a High-origin search survives further alertness decay",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
+    });
+
+    await game.step({ frames: 10 });
+
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    // Let it see the player while idle so a last-known position is recorded.
+    await game.step({ frames: 60 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // Force full combat alert, then vanish: decay runs High -> Moderate
+    // (search starts) -> Low (the search must keep running - it hands off
+    // on its own schedule, not on the next decay tick).
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    // A verified no-line-of-sight pocket around corners from the start area
+    // (NOT the farthest spawn: the omniscient chase walks toward the player
+    // during decay, and some routes reacquire sight, pinning alertness).
+    await game.player.teleport({ x: -13.61, y: -5.8, z: 30.75 });
+
+    await game.waitFor(
+      async () => {
+        await game.step({ frames: 30 });
+        const d = await game.entities.detail(monster.id);
+        return aiProp(d, "AIBehavior") === "Search" ? d : undefined;
+      },
+      {
+        timeoutMs: 120_000,
+        description: "High-origin decay to enter Search",
+      },
+    );
+
+    // 4 seconds later the Moderate->Low decay (3s) has fired; the search
+    // must still be running (its own give-up is ~7s+ out).
+    await game.step({ frames: 240 });
+    const detail = await game.entities.detail(monster.id);
+    assert.equal(
+      aiProp(detail, "AIBehavior"),
+      "Search",
+      "the search must survive the next decay step",
+    );
+  },
+);
+
+test(
   "losing sight of the player triggers a search of the last-known position",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {

--- a/tools/shock2-sdk/test/search-behavior.e2e.test.ts
+++ b/tools/shock2-sdk/test/search-behavior.e2e.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+function distanceXZ(
+  a: [number, number, number],
+  b: { x: number; z: number },
+): number {
+  const dx = a[0] - b.x;
+  const dz = a[2] - b.z;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+test(
+  "losing sight of the player triggers a search of the last-known position",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster in front of the player, identified by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // Alert it and let it see + chase the player for a moment, so a
+    // last-known position is recorded.
+    const lastKnown = await game.player.position();
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "Moderate",
+    });
+    await game.step({ frames: 60 });
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Moderate");
+
+    // Teleport the player to the farthest native OG-Pipe's spawn position:
+    // guaranteed floor-valid, and far enough through multiple rooms that the
+    // monster has no line of sight and cannot reach it before alertness
+    // decays. Sight breaks, and instead of dropping straight to wander the
+    // AI must investigate where the player WAS.
+    const farthest = preSpawn.entities.reduce((a, b) =>
+      b.distance > a.distance ? b : a,
+    );
+    assert.ok(
+      farthest.distance > 30,
+      `need a distant teleport target, farthest native is ${farthest.distance.toFixed(1)}`,
+    );
+    await game.player.teleport({
+      x: farthest.position[0],
+      y: farthest.position[1] + 0.5,
+      z: farthest.position[2],
+    });
+
+    const sawSearch = await game.waitFor(
+      async () => {
+        await game.step({ frames: 30 });
+        const d = await game.entities.detail(monster.id);
+        return aiProp(d, "AIBehavior") === "Search" ? d : undefined;
+      },
+      {
+        timeoutMs: 120_000,
+        description: "AI to enter Search after losing sight of the player",
+      },
+    );
+
+    // The searcher heads for the last-known position, not the player's new
+    // location: over the next seconds its distance to the OLD spot shrinks
+    // (it may already be close from the chase - accept either progress or
+    // arrival inside the search radius).
+    const before = distanceXZ(sawSearch.position, lastKnown);
+    await game.step({ frames: 120 });
+    detail = await game.entities.detail(monster.id);
+    const after = distanceXZ(detail.position, lastKnown);
+    assert.ok(
+      after < Math.max(before, 2.5),
+      `searcher should close on the last-known position (before=${before.toFixed(2)}, after=${after.toFixed(2)})`,
+    );
+
+    // After scanning the spot without reacquiring the player, the search
+    // hands off to Wander (or decays to Idle) - it must not chase the
+    // player's NEW position, which it never saw.
+    const settled = await game.waitFor(
+      async () => {
+        await game.step({ frames: 60 });
+        const d = await game.entities.detail(monster.id);
+        const behavior = aiProp(d, "AIBehavior");
+        return behavior === "Wander" || behavior === "Idle" ? d : undefined;
+      },
+      {
+        timeoutMs: 120_000,
+        description: "search to give up and hand off to Wander/Idle",
+      },
+    );
+    const newPlayer = await game.player.position();
+    assert.ok(
+      distanceXZ(settled.position, newPlayer) > 5,
+      "the AI must not have magically tracked the teleported player",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

The final item of the AI sequence: pursuit no longer dies at a broken line of sight.

- The AI records where it last saw the player; when alertness decays from Moderate/High after losing contact, it runs **SearchBehavior**: walk to the last-known position via the nav mesh (new `PathTarget::Point` mode), scan around, then hand off by current alertness (Idle when fully calm, Wander otherwise). Reacquiring the player mid-search escalates through the normal visibility path; a fresher sighting recorded mid-search re-targets it.
- An active search survives further decay (review-caught High: the branch order originally stomped High-origin searches one decay step later — the new e2e scenario fails without the fix, verified red).
- Arrival is height-aware (standing under a walkway the player was seen on is not arrival); the last-known position clears when fully calmed (no cross-map searches from dead engagements); a searching AI that takes damage re-aggros.
- **High alertness is now range-aware**: a far-away High AI chases to close the distance instead of standing in place swinging. The combat-range thresholds are extracted to one shared helper used by both the alertness mapping and `ChaseBehavior`'s transitions — the two mechanisms can't drift apart anymore (the long-standing dual-transition conflict).

## Verified

Two deterministic e2e scenarios (`search-behavior.e2e.test.ts`, 3/3 each), built entirely on the tooling from this sequence (forced alertness, AI introspection, teleport):
1. Chase → teleport the player away (sight breaks) → AI enters Search, closes on the **old** position, settles to Wander/Idle without ever tracking the teleported player.
2. High-origin: force High → vanish → decay chain High→Moderate (Search starts) →Low — the search survives the second decay (red without the review fix).

## Test plan

- [x] `cargo test -p shock2vr` — 80 passed; warning-free check across all four crates
- [x] Full SDK e2e suite: 53/54 — the 1 failure was a stale launch-failure assertion that drifted at #369's merge, fixed separately in #378
- [x] Cross-engine review (Claude + Codex): High + 2 Medium + 2 Low all fixed and re-validated (red/green on the High)

## Follow-up

Chase is still *omniscient* (targets `PlayerInfo.pos` regardless of visibility) — the natural next step is chase-to-last-seen with per-target awareness, which this PR's last-known plumbing sets up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)