### PR TITLE
test: identify flinder shards by name; note AABB approximation

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1236,7 +1236,9 @@ impl MissionCore {
                 // so they still yield one flinder, like the pre-options behavior.
                 for _ in 0..flinderize_options.count.max(1) {
                     // scatter spawns the flinder at a random point within the
-                    // object's bounds; otherwise at the object-relative offset.
+                    // object's bounds (world AABB - over-covers rotated objects,
+                    // close enough for gibs); otherwise at the object-relative
+                    // offset.
                     let spawn_position = match (flinderize_options.scatter, &aabb) {
                         (true, Some(aabb)) => Point3::new(
                             rng.gen_range(aabb.min.x..=aabb.max.x),

--- a/tools/shock2-sdk/test/flinderize.e2e.test.ts
+++ b/tools/shock2-sdk/test/flinderize.e2e.test.ts
@@ -58,9 +58,14 @@ test(
     await game.entities.sendMessage(window.id, { type: "Damage", amount: 5.0 });
     await game.step({ frames: 1 });
 
+    // Identify shards by name, not just body novelty: body_id is a bare arena
+    // index (reusable), and unrelated dynamic bodies could spawn the same frame.
     const after = await game.physics.bodies();
     const shards = after.bodies.filter(
-      (b) => !knownBodyIds.has(b.body_id) && b.body_type === "dynamic",
+      (b) =>
+        !knownBodyIds.has(b.body_id) &&
+        b.body_type === "dynamic" &&
+        b.entity_name?.startsWith("Glass"),
     );
 
     // The window's 4 Flinderize links each spawn one shard.


### PR DESCRIPTION
## Summary

Small follow-up from the cross-engine review of #377 (both reviewers flagged the same Low-severity robustness gap, which arrived after the PR was merged):

- The flinderize e2e test identified shards as "any new dynamic body". `body_id` is a bare arena index (reusable), and an unrelated dynamic body spawning in the same frame could satisfy the assertions. The test now also requires the body's `entity_name` to be a Glass shard.
- Comment noting that `scatter` samples the world AABB, which over-covers rotated objects (fine for gibs).

## Test plan

- [x] `cargo fmt --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr`
- [x] Flinderize e2e re-run green with the stricter filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)