### PR TITLE
feat(ai): chase pursues the last-seen position, not the player's true location

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2401,6 +2401,18 @@ impl MissionCore {
                         self.world
                             .add_component(entity_id, RuntimePropAIBehavior(name));
                     }
+                    AIPropertyUpdate::TargetAwareness {
+                        last_known_pos,
+                        has_line_of_sight,
+                    } => {
+                        self.world.add_component(
+                            entity_id,
+                            crate::runtime_props::RuntimePropAITargetAwareness {
+                                last_known_pos,
+                                has_line_of_sight,
+                            },
+                        );
+                    }
                 },
                 Effect::SetAllAIAlertness { level } => {
                     let creature_ids: Vec<EntityId> = {
@@ -3853,6 +3865,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
              v_gun_state: View<dark::properties::PropGunState>,
              v_alertness: View<PropAIAlertness>,
              v_ai_behavior: View<RuntimePropAIBehavior>,
+             v_awareness: View<crate::runtime_props::RuntimePropAITargetAwareness>,
              v_links: View<dark::properties::Links>| {
                 let position = v_pos.get(id).ok()?;
                 let rotation_array = [
@@ -3927,6 +3940,21 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "AIBehavior".to_string(),
                         value: behavior.0.clone(),
+                    });
+                }
+                if let Ok(awareness) = v_awareness.get(id) {
+                    properties.push(DebugPropertyInfo {
+                        name: "AITargetVisible".to_string(),
+                        value: awareness.has_line_of_sight.to_string(),
+                    });
+                    properties.push(DebugPropertyInfo {
+                        name: "AILastKnown".to_string(),
+                        value: format!(
+                            "[{:.2}, {:.2}, {:.2}]",
+                            awareness.last_known_pos.x,
+                            awareness.last_known_pos.y,
+                            awareness.last_known_pos.z
+                        ),
                     });
                 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2413,6 +2413,15 @@ impl MissionCore {
                             },
                         );
                     }
+                    AIPropertyUpdate::ClearTargetAwareness => {
+                        self.world.run(
+                            |mut v_awareness: ViewMut<
+                                crate::runtime_props::RuntimePropAITargetAwareness,
+                            >| {
+                                v_awareness.remove(entity_id);
+                            },
+                        );
+                    }
                 },
                 Effect::SetAllAIAlertness { level } => {
                     let creature_ids: Vec<EntityId> = {

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -24,6 +24,18 @@ pub struct RuntimePropTransform(pub Matrix4<f32>);
 #[derive(Component)]
 pub struct RuntimePropAIBehavior(pub String);
 
+// What an AI knows about its target: where it last saw the player and
+// whether it can see them right now. Published by the AI script each frame
+// (the position tracks the player while visible and freezes when sight
+// breaks); chase steering targets THIS, not the player's true position, so
+// breaking line of sight actually works. Like all runtime props it is not
+// serialized - after a load the AI re-learns on its first sighting.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropAITargetAwareness {
+    pub last_known_pos: Vector3<f32>,
+    pub has_line_of_sight: bool,
+}
+
 #[derive(Component)]
 pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -273,6 +273,24 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
     }
 }
 
+/// Where this AI should chase: its last-known target position when it has
+/// published awareness (frozen at the point sight broke), falling back to
+/// the player's true position for entities without awareness (scripts that
+/// don't track it, debug scenes).
+pub fn chase_target(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
+    if let Ok(v_awareness) =
+        world.borrow::<View<crate::runtime_props::RuntimePropAITargetAwareness>>()
+    {
+        if let Ok(awareness) = v_awareness.get(entity_id) {
+            return Some(awareness.last_known_pos);
+        }
+    }
+    world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .ok()
+        .map(|player| player.pos)
+}
+
 /// Distance from the entity to the player, when both positions are known
 pub fn player_distance(world: &World, entity_id: EntityId) -> Option<f32> {
     let u_player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -291,12 +291,15 @@ pub fn chase_target(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> 
         .map(|player| player.pos)
 }
 
-/// Distance from the entity to the player, when both positions are known
-pub fn player_distance(world: &World, entity_id: EntityId) -> Option<f32> {
-    let u_player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+/// Distance from the entity to its chase target (the last-known position
+/// when awareness is published, the player's true position otherwise).
+/// Combat gates use this so attacks trigger against what the AI KNOWS,
+/// consistent with where chase steering faces.
+pub fn chase_target_distance(world: &World, entity_id: EntityId) -> Option<f32> {
+    let target = chase_target(world, entity_id)?;
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
     let prop_pos = v_current_pos.get(entity_id).ok()?;
-    Some((prop_pos.position - u_player.pos).magnitude())
+    Some((prop_pos.position - target).magnitude())
 }
 
 /// Current hit points, if the entity has a health pool

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -66,6 +66,10 @@ pub struct AnimatedMonsterAI {
     /// Where the player was last seen; investigated by SearchBehavior when
     /// alertness decays after losing contact
     last_known_player_pos: Option<cgmath::Vector3<f32>>,
+    /// Awareness state last published to the ECS, so the component tracks
+    /// the script's knowledge exactly (including forgetting) without
+    /// per-frame effect churn
+    published_awareness: Option<(cgmath::Vector3<f32>, bool)>,
 }
 
 impl AnimatedMonsterAI {
@@ -83,6 +87,7 @@ impl AnimatedMonsterAI {
             config: None,
             published_behavior: None,
             last_known_player_pos: None,
+            published_awareness: None,
         }
     }
 
@@ -101,6 +106,7 @@ impl AnimatedMonsterAI {
             config: None,
             published_behavior: None,
             last_known_player_pos: None,
+            published_awareness: None,
         }
     }
 
@@ -450,13 +456,23 @@ impl Script for AnimatedMonsterAI {
 
         // Publish what this AI knows about its target: chase steering
         // pursues the last-known position (frozen when sight breaks), not
-        // the player's true location
-        let awareness_effect = if let Some(pos) = self.last_known_player_pos {
-            Effect::SetAIProperty {
-                entity_id,
-                update: crate::scripts::AIPropertyUpdate::TargetAwareness {
-                    last_known_pos: pos,
-                    has_line_of_sight: is_visible,
+        // the player's true location. Published only on change, and CLEARED
+        // when the script forgets (search consumed it / fully calmed) so a
+        // stale component can't hijack the true-position fallback forever.
+        let desired_awareness = self.last_known_player_pos.map(|pos| (pos, is_visible));
+        let awareness_effect = if desired_awareness != self.published_awareness {
+            self.published_awareness = desired_awareness;
+            match desired_awareness {
+                Some((pos, visible)) => Effect::SetAIProperty {
+                    entity_id,
+                    update: crate::scripts::AIPropertyUpdate::TargetAwareness {
+                        last_known_pos: pos,
+                        has_line_of_sight: visible,
+                    },
+                },
+                None => Effect::SetAIProperty {
+                    entity_id,
+                    update: crate::scripts::AIPropertyUpdate::ClearTargetAwareness,
                 },
             }
         } else {
@@ -667,8 +683,19 @@ impl Script for AnimatedMonsterAI {
                 // reveals the attacker even without line of sight (the dead
                 // case already returned above)
                 let searching = self.current_behavior.borrow().name() == "Search";
-                let alert_effect = if !lethal && (escalates || searching) {
-                    self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
+                let alert_effect = if !lethal {
+                    // Any surviving hit reveals the attacker's position -
+                    // refresh the last-known even when already alerted, so
+                    // an AI chasing a stale sighting turns toward where the
+                    // shot actually came from (the dead case returned above)
+                    if let Ok(player) = world.borrow::<shipyard::UniqueView<PlayerInfo>>() {
+                        self.last_known_player_pos = Some(player.pos);
+                    }
+                    if escalates || searching {
+                        self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
+                    } else {
+                        Effect::NoEffect
+                    }
                 } else {
                     Effect::NoEffect
                 };

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -448,6 +448,21 @@ impl Script for AnimatedMonsterAI {
             }
         }
 
+        // Publish what this AI knows about its target: chase steering
+        // pursues the last-known position (frozen when sight breaks), not
+        // the player's true location
+        let awareness_effect = if let Some(pos) = self.last_known_player_pos {
+            Effect::SetAIProperty {
+                entity_id,
+                update: crate::scripts::AIPropertyUpdate::TargetAwareness {
+                    last_known_pos: pos,
+                    has_line_of_sight: is_visible,
+                },
+            }
+        } else {
+            Effect::NoEffect
+        };
+
         // Update alertness state
         let (alertness_effect, behavior_change_effect) = if let Some(config) = &self.config {
             if let Some((old_level, new_level)) = alertness::process_alertness_update(
@@ -585,6 +600,7 @@ impl Script for AnimatedMonsterAI {
 
         Effect::combine(vec![
             alertness_effect,
+            awareness_effect,
             behavior_change_effect,
             steering_effects,
             rotation_effect,

--- a/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/melee_attack_behavior.rs
@@ -1,12 +1,11 @@
 use std::cell::RefCell;
 
-use cgmath::{Deg, InnerSpace};
-use dark::{SCALE_FACTOR, motion::MotionQueryItem, properties::PropPosition};
+use cgmath::Deg;
+use dark::{SCALE_FACTOR, motion::MotionQueryItem};
 
 use shipyard::*;
 
 use crate::{
-    mission::PlayerInfo,
     physics::PhysicsWorld,
     scripts::{
         Effect,
@@ -49,14 +48,12 @@ impl Behavior for MeleeAttackBehavior {
         _physics: &PhysicsWorld,
         entity_id: EntityId,
     ) -> NextBehavior {
-        let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-        let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
-
+        // Gate on the KNOWN target distance (consistent with where the
+        // attack faces), not the player's true position - a player sneaking
+        // behind an attacking AI must not pin it swinging at empty space
         let melee_attack_distance = 8.0 / SCALE_FACTOR;
-
-        if let Ok(prop_pos) = v_current_pos.get(entity_id) {
-            let distance = (prop_pos.position - u_player.pos).magnitude();
-
+        if let Some(distance) = crate::scripts::ai::ai_util::chase_target_distance(world, entity_id)
+        {
             if distance < melee_attack_distance {
                 return NextBehavior::Stay;
             }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use dark::SCALE_FACTOR;
 use shipyard::{EntityId, World};
 
-use crate::scripts::ai::ai_util::{has_ranged_weapon, player_distance};
+use crate::scripts::ai::ai_util::{chase_target_distance, has_ranged_weapon};
 
 /// The attack behavior for the current distance to the player, or None when
 /// out of attack range (the caller should chase to close the distance).
@@ -35,7 +35,7 @@ pub fn attack_behavior_for_distance(
     world: &World,
     entity_id: EntityId,
 ) -> Option<Box<RefCell<dyn Behavior>>> {
-    let distance = player_distance(world, entity_id)?;
+    let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
     let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
     let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;

--- a/shock2vr/src/scripts/ai/steering/chase_player_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/chase_player_steering_strategy.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, InnerSpace};
+use cgmath::Deg;
 use dark::SCALE_FACTOR;
 use dark::properties::PropPosition;
 
@@ -10,10 +10,12 @@ use crate::{
 
 use super::{Steering, SteeringOutput, SteeringStrategy};
 
-/// Standing on the target position, there is nowhere left to steer (2 Dark
-/// feet) - without this an AI that reached a stale last-known position spins
-/// on heading noise
+/// On the target position there is nowhere left to steer (2 Dark feet XZ,
+/// 6 ft height tolerance - the recorded position sits eye-height above the
+/// floor). This stops the heading from spinning on noise; locomotion root
+/// motion may still pace nearby until Search takes over on the next decay.
 const CHASE_ARRIVE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
+const CHASE_ARRIVE_HEIGHT: f32 = 6.0 / SCALE_FACTOR;
 
 pub struct ChasePlayerSteeringStrategy;
 
@@ -32,7 +34,10 @@ impl SteeringStrategy for ChasePlayerSteeringStrategy {
         let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
         if let Ok(prop_pos) = v_current_pos.get(entity_id) {
-            if (target - prop_pos.position).magnitude() < CHASE_ARRIVE_DISTANCE {
+            let dx = target.x - prop_pos.position.x;
+            let dz = target.z - prop_pos.position.z;
+            let dy = (target.y - prop_pos.position.y).abs();
+            if (dx * dx + dz * dz).sqrt() < CHASE_ARRIVE_DISTANCE && dy < CHASE_ARRIVE_HEIGHT {
                 return None;
             }
             return Some((

--- a/shock2vr/src/scripts/ai/steering/chase_player_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/chase_player_steering_strategy.rs
@@ -1,13 +1,19 @@
-use cgmath::Deg;
+use cgmath::{Deg, InnerSpace};
+use dark::SCALE_FACTOR;
 use dark::properties::PropPosition;
 
-use shipyard::{EntityId, Get, UniqueView, View, World};
+use shipyard::{EntityId, Get, View, World};
 
 use crate::{
-    mission::PlayerInfo, physics::PhysicsWorld, scripts::Effect, time::Time, util::vec3_to_point3,
+    physics::PhysicsWorld, scripts::Effect, scripts::ai::ai_util, time::Time, util::vec3_to_point3,
 };
 
 use super::{Steering, SteeringOutput, SteeringStrategy};
+
+/// Standing on the target position, there is nowhere left to steer (2 Dark
+/// feet) - without this an AI that reached a stale last-known position spins
+/// on heading noise
+const CHASE_ARRIVE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
 
 pub struct ChasePlayerSteeringStrategy;
 
@@ -20,16 +26,17 @@ impl SteeringStrategy for ChasePlayerSteeringStrategy {
         entity_id: EntityId,
         _time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
-        let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+        // Pursue what this AI KNOWS (its last-known target position, frozen
+        // when sight breaks) rather than the player's true location
+        let target = ai_util::chase_target(world, entity_id)?;
         let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
-        // TODO: Check if player is visible?
         if let Ok(prop_pos) = v_current_pos.get(entity_id) {
+            if (target - prop_pos.position).magnitude() < CHASE_ARRIVE_DISTANCE {
+                return None;
+            }
             return Some((
-                Steering::turn_to_point(
-                    vec3_to_point3(prop_pos.position),
-                    vec3_to_point3(u_player.pos),
-                ),
+                Steering::turn_to_point(vec3_to_point3(prop_pos.position), vec3_to_point3(target)),
                 Effect::NoEffect,
             ));
         };

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use shipyard::{EntityId, UniqueView, World};
 
 use crate::{
-    mission::{GlobalPathfinding, PlayerInfo},
+    mission::GlobalPathfinding,
     pathfinding::{PathfindingFrameBudget, PathfindingService},
     physics::PhysicsWorld,
     scripts::{Effect, ai::ai_util},
@@ -133,7 +133,9 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         }
 
         let desired_goal = match self.target {
-            PathTarget::Player => Some(world.borrow::<UniqueView<PlayerInfo>>().ok()?.pos),
+            // The last-known target position (frozen when sight breaks),
+            // not the player's true location - breaking line of sight works
+            PathTarget::Player => Some(ai_util::chase_target(world, entity_id)?),
             // Wander and Point keep their destination until the path completes
             PathTarget::Wander { .. } | PathTarget::Point(_) => None,
         };

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -54,6 +54,12 @@ pub enum AIPropertyUpdate {
     Behavior {
         name: String,
     },
+    /// What the AI knows about its target (last-known position + current
+    /// line of sight) - drives non-omniscient chase steering
+    TargetAwareness {
+        last_known_pos: Vector3<f32>,
+        has_line_of_sight: bool,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -60,6 +60,9 @@ pub enum AIPropertyUpdate {
         last_known_pos: Vector3<f32>,
         has_line_of_sight: bool,
     },
+    /// The AI forgot its target (fully calmed / position consumed by a
+    /// search) - chase falls back to the true player position again
+    ClearTargetAwareness,
 }
 
 #[derive(Clone, Debug)]

--- a/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
+++ b/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
 // End-to-end test against a real debug runtime. Requires game assets in
 // Data/ and compiles the runtime on first run, so it is opt-in:
@@ -57,12 +58,7 @@ test(
     // OLD position: awareness freezes, and during the pre-decay window the
     // monster gains no ground on the player's NEW location.
     const oldPos = await game.player.position();
-    for (let attempt = 0; attempt < 3; attempt++) {
-      await game.player.teleport({ x: -13.61, y: -5.8, z: 30.75 });
-      await game.step({ frames: 5 });
-      const pos = await game.player.position();
-      if (Math.hypot(pos.x - -13.61, pos.z - 30.75) < 3) break;
-    }
+    await teleportVerified(game, { x: -13.61, y: -5.8, z: 30.75 });
     await game.step({ frames: 10 });
     detail = await game.entities.detail(monster.id);
     assert.equal(

--- a/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
+++ b/tools/shock2-sdk/test/chase-last-seen.e2e.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+function distanceXZ(
+  a: [number, number, number],
+  b: { x: number; z: number },
+): number {
+  const dx = a[0] - b.x;
+  const dz = a[2] - b.z;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+test(
+  "a chasing AI pursues the last-seen position, not the vanished player",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8110),
+    });
+
+    await game.step({ frames: 10 });
+
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // Chase with the player in sight: awareness tracks the live position.
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "Moderate",
+    });
+    await game.step({ frames: 30 });
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AITargetVisible"), "true");
+
+    // Vanish to a no-line-of-sight pocket. The chase must keep working the
+    // OLD position: awareness freezes, and during the pre-decay window the
+    // monster gains no ground on the player's NEW location.
+    const oldPos = await game.player.position();
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await game.player.teleport({ x: -13.61, y: -5.8, z: 30.75 });
+      await game.step({ frames: 5 });
+      const pos = await game.player.position();
+      if (Math.hypot(pos.x - -13.61, pos.z - 30.75) < 3) break;
+    }
+    await game.step({ frames: 10 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(
+      aiProp(detail, "AITargetVisible"),
+      "false",
+      "line of sight must break after the teleport",
+    );
+    const newPos = await game.player.position();
+    const distNewBefore = distanceXZ(detail.position, newPos);
+    const distOldBefore = distanceXZ(detail.position, oldPos);
+
+    // Two seconds of chasing (inside the ~3s decay window).
+    await game.step({ frames: 120 });
+    detail = await game.entities.detail(monster.id);
+    const distNewAfter = distanceXZ(detail.position, newPos);
+    const distOldAfter = distanceXZ(detail.position, oldPos);
+
+    assert.ok(
+      distNewAfter > distNewBefore - 1.0,
+      `the chase must not gain ground on the vanished player (before=${distNewBefore.toFixed(2)}, after=${distNewAfter.toFixed(2)})`,
+    );
+    assert.ok(
+      distOldAfter <= Math.max(distOldBefore, 2.5),
+      `the chase should stay on the last-seen position (before=${distOldBefore.toFixed(2)}, after=${distOldAfter.toFixed(2)})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/helpers/teleport.ts
+++ b/tools/shock2-sdk/test/helpers/teleport.ts
@@ -1,0 +1,24 @@
+import type { GameServer } from "../../src/index.js";
+
+/**
+ * Teleport the player and verify it took effect, retrying a few times.
+ * Teleports have been observed to intermittently no-op (reported success,
+ * position unchanged - see issue #383); a stranded player silently
+ * invalidates line-of-sight scenarios.
+ */
+export async function teleportVerified(
+  game: GameServer,
+  target: { x: number; y: number; z: number },
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await game.player.teleport(target);
+    await game.step({ frames: 5 });
+    const pos = await game.player.position();
+    const dx = pos.x - target.x;
+    const dz = pos.z - target.z;
+    if (Math.sqrt(dx * dx + dz * dz) < 3) {
+      return;
+    }
+  }
+  throw new Error("teleport did not take effect after 3 attempts");
+}

--- a/tools/shock2-sdk/test/search-behavior.e2e.test.ts
+++ b/tools/shock2-sdk/test/search-behavior.e2e.test.ts
@@ -23,6 +23,26 @@ function distanceXZ(
   return Math.sqrt(dx * dx + dz * dz);
 }
 
+async function teleportVerified(
+  game: Awaited<ReturnType<typeof GameServer.launch>>,
+  target: { x: number; y: number; z: number },
+): Promise<void> {
+  // Teleports have been observed to intermittently no-op (reported success,
+  // position unchanged) - verify and retry so a stranded player doesn't
+  // invalidate the scenario.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await game.player.teleport(target);
+    await game.step({ frames: 5 });
+    const pos = await game.player.position();
+    const dx = pos.x - target.x;
+    const dz = pos.z - target.z;
+    if (Math.sqrt(dx * dx + dz * dz) < 3) {
+      return;
+    }
+  }
+  throw new Error("teleport did not take effect after 3 attempts");
+}
+
 test(
   "a High-origin search survives further alertness decay",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -53,9 +73,8 @@ test(
       level: "High",
     });
     // A verified no-line-of-sight pocket around corners from the start area
-    // (NOT the farthest spawn: the omniscient chase walks toward the player
-    // during decay, and some routes reacquire sight, pinning alertness).
-    await game.player.teleport({ x: -13.61, y: -5.8, z: 30.75 });
+    // (NOT the farthest spawn: routes toward it can reacquire sight).
+    await teleportVerified(game, { x: -13.61, y: -5.8, z: 30.75 });
 
     await game.waitFor(
       async () => {
@@ -69,14 +88,18 @@ test(
       },
     );
 
-    // 4 seconds later the Moderate->Low decay (3s) has fired; the search
-    // must still be running (its own give-up is ~7s+ out).
-    await game.step({ frames: 240 });
+    // 3.2 sim-seconds later the Moderate->Low decay (exactly 3.0s after
+    // Search entry) has fired, while the search's own give-up (6s of
+    // scanning) is still well out - even when the polling loop detected
+    // the entry a step late. With chase-to-last-seen the monster is
+    // already standing on the last-known spot when Search begins, so the
+    // scan clock starts immediately.
+    await game.step({ frames: 192 });
     const detail = await game.entities.detail(monster.id);
     assert.equal(
       aiProp(detail, "AIBehavior"),
       "Search",
-      "the search must survive the next decay step",
+      `the search must survive the next decay step (alertness=${aiProp(detail, "AIAlertness")}, visible=${aiProp(detail, "AITargetVisible")})`,
     );
   },
 );
@@ -127,7 +150,7 @@ test(
       farthest.distance > 30,
       `need a distant teleport target, farthest native is ${farthest.distance.toFixed(1)}`,
     );
-    await game.player.teleport({
+    await teleportVerified(game, {
       x: farthest.position[0],
       y: farthest.position[1] + 0.5,
       z: farthest.position[2],

--- a/tools/shock2-sdk/test/search-behavior.e2e.test.ts
+++ b/tools/shock2-sdk/test/search-behavior.e2e.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
 // End-to-end test against a real debug runtime. Requires game assets in
 // Data/ and compiles the runtime on first run, so it is opt-in:
@@ -21,26 +22,6 @@ function distanceXZ(
   const dx = a[0] - b.x;
   const dz = a[2] - b.z;
   return Math.sqrt(dx * dx + dz * dz);
-}
-
-async function teleportVerified(
-  game: Awaited<ReturnType<typeof GameServer.launch>>,
-  target: { x: number; y: number; z: number },
-): Promise<void> {
-  // Teleports have been observed to intermittently no-op (reported success,
-  // position unchanged) - verify and retry so a stranded player doesn't
-  // invalidate the scenario.
-  for (let attempt = 0; attempt < 3; attempt++) {
-    await game.player.teleport(target);
-    await game.step({ frames: 5 });
-    const pos = await game.player.position();
-    const dx = pos.x - target.x;
-    const dz = pos.z - target.z;
-    if (Math.sqrt(dx * dx + dz * dz) < 3) {
-      return;
-    }
-  }
-  throw new Error("teleport did not take effect after 3 attempts");
 }
 
 test(


### PR DESCRIPTION
## Summary

Stacked on #379 (its follow-up). Chase was omniscient: both chase steering strategies read `PlayerInfo.pos` directly, so a chasing AI tracked the player through walls — and even through a teleport. Now the AI script publishes what it actually *knows* — `RuntimePropAITargetAwareness { last_known_pos, has_line_of_sight }`, updated while the player is visible, **frozen the moment sight breaks**, refreshed by taking damage (the shot reveals the attacker), and **cleared when the AI forgets** (search consumed it / fully calmed). Chase steering, path-following, and all combat range gates target that knowledge; entities without published awareness fall back to the true position, unchanged.

Emergent flow with no new transitions: run to where the player was last seen → alertness decays → SearchBehavior takes over at the same spot (from #379). Resolves the old `// TODO: Check if player is visible?` in the chase strategy.

- Combat gates measure distance to the *known* target, consistent with where attacks face — a player circling behind a chasing AI can't pin it swinging at empty space.
- `/v1/entities/:id` reports `AITargetVisible` / `AILastKnown` for tests and debugging.
- Cross-engine review: High (append-only awareness lifetime hijacking the fallback) + 3 Medium, all fixed; Codex verified the fixes and added the "refresh on any survivable hit" case.

## Verified

- New e2e (`chase-last-seen.e2e.test.ts`): a chasing AI **gains no ground on a teleported player** and holds the last-seen position — fails at 5.3 units gained on the omniscient code (verified red), 3/3 green after.
- All 5 AI e2e scenarios green together, 4+ consecutive rounds; full suite 54/55 (the 1 failure is the launch-failure assertion already fixed in #378).
- Teleports in LOS-break scenarios are verified-with-retry via a shared helper — the runtime can silently no-op them (filed #383).

## Test plan

- [x] `cargo test -p shock2vr` (80), warning-free check across all four crates
- [x] Red/green on the new e2e; 5-scenario AI set green post-fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)