### PR TITLE
fix(ai): wound and death motion queries reach the clips the data actually has

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1071,17 +1071,18 @@ impl MissionCore {
         self.world.run(run_attachment_update);
     }
 
-    /// Resolve a tag-based motion query for `entity_id` and hand the clip to
-    /// `apply` (`AnimationPlayer::queue_animation` to push on the queue,
+    /// Resolve tag-based motion queries for `entity_id` (tried in order,
+    /// first match wins) and hand the clip to `apply`
+    /// (`AnimationPlayer::queue_animation` to push on the queue,
     /// `AnimationPlayer::play_animation` to interrupt and replace it). When
-    /// no motion matches, dispatches `AnimationCompleted` so the requesting
+    /// no query matches, dispatches `AnimationCompleted` so the requesting
     /// script isn't left waiting on a clip that never started.
     fn apply_animation_by_schema(
         &mut self,
         global_context: &GlobalContext,
         asset_cache: &mut AssetCache,
         entity_id: EntityId,
-        motion_query_items: Vec<MotionQueryItem>,
+        motion_queries: Vec<Vec<MotionQueryItem>>,
         selection_strategy: MotionQuerySelectionStrategy,
         apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
     ) {
@@ -1095,24 +1096,27 @@ impl MissionCore {
                 v_creature_type.get(entity_id),
                 v_motion_actor_tag.get(entity_id),
             ) {
-                let mut actor_tags = motion_actor_tag
+                let actor_tags = motion_actor_tag
                     .tags
                     .iter()
                     .map(|tag| MotionQueryItem::new(tag).optional())
                     .collect::<Vec<MotionQueryItem>>();
 
-                let mut query_items = motion_query_items.clone();
-
-                query_items.append(&mut actor_tags);
-
                 let creature_definition = get_creature_definition(creature_type.0).unwrap();
 
                 let actor_type = creature_definition.actor_type.to_u32().unwrap();
 
-                let query = MotionQuery::new(actor_type, query_items)
-                    .with_selection_strategy(selection_strategy);
+                let mut tried_queries = Vec::new();
+                let maybe_next_animation = motion_queries.into_iter().find_map(|items| {
+                    let mut query_items = items;
+                    query_items.extend(actor_tags.iter().cloned());
+                    let query = MotionQuery::new(actor_type, query_items)
+                        .with_selection_strategy(selection_strategy.clone());
+                    let result = global_context.motiondb.query(query.clone());
+                    tried_queries.push(query);
+                    result
+                });
 
-                let maybe_next_animation = global_context.motiondb.query(query.clone());
                 if let Some(next_animation) = maybe_next_animation {
                     let maybe_clip = asset_cache
                         .get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", next_animation));
@@ -1127,7 +1131,11 @@ impl MissionCore {
                         );
                     }
                 } else {
-                    game_log!(WARN, "Unable to find animation for query: {:?}", &query);
+                    game_log!(
+                        WARN,
+                        "Unable to find animation for queries: {:?}",
+                        &tried_queries
+                    );
                     // If we couldn't find an animation... just stop the current one
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::AnimationCompleted,
@@ -1977,14 +1985,14 @@ impl MissionCore {
 
                 Effect::QueueAnimationBySchema {
                     entity_id,
-                    motion_query_items,
+                    motion_queries,
                     selection_strategy,
                 } => {
                     self.apply_animation_by_schema(
                         global_context,
                         asset_cache,
                         entity_id,
-                        motion_query_items,
+                        motion_queries,
                         selection_strategy,
                         AnimationPlayer::queue_animation,
                     );
@@ -1992,14 +2000,14 @@ impl MissionCore {
 
                 Effect::PlayAnimationBySchema {
                     entity_id,
-                    motion_query_items,
+                    motion_queries,
                     selection_strategy,
                 } => {
                     self.apply_animation_by_schema(
                         global_context,
                         asset_cache,
                         entity_id,
-                        motion_query_items,
+                        motion_queries,
                         selection_strategy,
                         AnimationPlayer::play_animation,
                     );

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -298,7 +298,7 @@ impl AnimatedMonsterAI {
             alertness::sync_alertness_effect(entity_id, &self.alertness),
             Effect::QueueAnimationBySchema {
                 entity_id,
-                motion_query_items: self.current_behavior.borrow().animation(),
+                motion_queries: vec![self.current_behavior.borrow().animation()],
                 selection_strategy,
             },
         ])
@@ -337,14 +337,14 @@ impl AnimatedMonsterAI {
 
         // Death clips are keyed differently per creature: hybrid-style
         // deaths hang directly under the crumple key, but human deaths sit
-        // one level deeper, under crumple -> die. The optional "die" lets the
-        // query descend that extra level when the creature's clips need it
-        // (verified across creature types with `cargo dq motion`).
+        // one level deeper, under crumple -> die. Prefer the creature's
+        // directly-keyed clips; only when there are none, retry through the
+        // die level (verified across creature types with `cargo dq motion`).
         let death_animation = Effect::PlayAnimationBySchema {
             entity_id,
-            motion_query_items: vec![
-                MotionQueryItem::new("crumple"),
-                MotionQueryItem::new("die").optional(),
+            motion_queries: vec![
+                vec![MotionQueryItem::new("crumple")],
+                vec![MotionQueryItem::new("crumple"), MotionQueryItem::new("die")],
             ],
             selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
         };
@@ -392,7 +392,7 @@ impl Script for AnimatedMonsterAI {
         let selection_strategy = self.next_selection(is_locomotion);
         let animation_effect = Effect::QueueAnimationBySchema {
             entity_id,
-            motion_query_items: self.current_behavior.borrow().animation(),
+            motion_queries: vec![self.current_behavior.borrow().animation()],
             selection_strategy,
         };
 
@@ -456,7 +456,7 @@ impl Script for AnimatedMonsterAI {
                 let selection_strategy = self.next_selection(is_locomotion);
                 let animation_effect = Effect::QueueAnimationBySchema {
                     entity_id,
-                    motion_query_items: self.current_behavior.borrow().animation(),
+                    motion_queries: vec![self.current_behavior.borrow().animation()],
                     selection_strategy,
                 };
 
@@ -491,7 +491,7 @@ impl Script for AnimatedMonsterAI {
                 let selection_strategy = self.next_selection(is_locomotion);
                 return Effect::QueueAnimationBySchema {
                     entity_id,
-                    motion_query_items: self.current_behavior.borrow().animation(),
+                    motion_queries: vec![self.current_behavior.borrow().animation()],
                     selection_strategy,
                 };
             }
@@ -633,7 +633,7 @@ impl Script for AnimatedMonsterAI {
                     let selection_strategy = self.next_selection(is_locomotion);
                     Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_query_items: self.current_behavior.borrow().animation(),
+                        motion_queries: vec![self.current_behavior.borrow().animation()],
                         selection_strategy,
                     }
                 } else {
@@ -659,7 +659,7 @@ impl Script for AnimatedMonsterAI {
                     let selection_strategy = self.next_selection(is_locomotion);
                     Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_query_items: self.current_behavior.borrow().animation(),
+                        motion_queries: vec![self.current_behavior.borrow().animation()],
                         selection_strategy,
                     }
                 } else {
@@ -689,16 +689,20 @@ impl Script for AnimatedMonsterAI {
                     // Hybrid wound clips are keyed under a combat-context
                     // level (receivewound -> meleecombat -> grunt -> ...),
                     // not directly under the creature tags, so a bare
-                    // receivewound query matches nothing for them. The
-                    // optional "meleecombat" descends that level when the
-                    // creature's clips need it; creatures with directly-keyed
-                    // clips (droids, humans) still resolve (verified across
-                    // creature types with `cargo dq motion`).
+                    // receivewound query matches nothing for them. Prefer
+                    // the creature's directly-keyed clips (droids, humans
+                    // keep their full sets, including damage-type variants);
+                    // only when there are none, retry through the
+                    // combat-context level (verified across creature types
+                    // with `cargo dq motion`).
                     Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_query_items: vec![
-                            MotionQueryItem::new("receivewound"),
-                            MotionQueryItem::new("meleecombat").optional(),
+                        motion_queries: vec![
+                            vec![MotionQueryItem::new("receivewound")],
+                            vec![
+                                MotionQueryItem::new("receivewound"),
+                                MotionQueryItem::new("meleecombat"),
+                            ],
                         ],
                         selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
                     }
@@ -743,7 +747,7 @@ impl Script for AnimatedMonsterAI {
 
                     let queue_animation_effect = Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_query_items,
+                        motion_queries: vec![motion_query_items],
                         selection_strategy,
                         //tag: "idlegesture".to_owned(),
                         // motion_query_items: vec![

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -335,9 +335,17 @@ impl AnimatedMonsterAI {
             Effect::NoEffect
         };
 
+        // Death clips are keyed differently per creature: hybrid-style
+        // deaths hang directly under the crumple key, but human deaths sit
+        // one level deeper, under crumple -> die. The optional "die" lets the
+        // query descend that extra level when the creature's clips need it
+        // (verified across creature types with `cargo dq motion`).
         let death_animation = Effect::PlayAnimationBySchema {
             entity_id,
-            motion_query_items: vec![MotionQueryItem::new("crumple")],
+            motion_query_items: vec![
+                MotionQueryItem::new("crumple"),
+                MotionQueryItem::new("die").optional(),
+            ],
             selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
         };
 
@@ -678,9 +686,20 @@ impl Script for AnimatedMonsterAI {
                     self.enter_death(world, entity_id)
                 } else if self.took_damage {
                     self.took_damage = false;
+                    // Hybrid wound clips are keyed under a combat-context
+                    // level (receivewound -> meleecombat -> grunt -> ...),
+                    // not directly under the creature tags, so a bare
+                    // receivewound query matches nothing for them. The
+                    // optional "meleecombat" descends that level when the
+                    // creature's clips need it; creatures with directly-keyed
+                    // clips (droids, humans) still resolve (verified across
+                    // creature types with `cargo dq motion`).
                     Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_query_items: vec![MotionQueryItem::new("receivewound")],
+                        motion_query_items: vec![
+                            MotionQueryItem::new("receivewound"),
+                            MotionQueryItem::new("meleecombat").optional(),
+                        ],
                         selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
                     }
                 } else {

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -385,7 +385,7 @@ impl CS9HoloRumbler {
         Effect::QueueAnimationBySchema {
             entity_id,
             selection_strategy: MotionQuerySelectionStrategy::Random,
-            motion_query_items: vec![item],
+            motion_queries: vec![vec![item]],
         }
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -192,7 +192,10 @@ pub enum Effect {
         // ActorType, MotActorTags get inferred from the entity id
         entity_id: EntityId,
         selection_strategy: MotionQuerySelectionStrategy,
-        motion_query_items: Vec<MotionQueryItem>,
+        /// Queries tried in order; the first one that matches a motion wins.
+        /// Lets a caller prefer a creature's directly-keyed clips and fall
+        /// back to a context-tagged variant only when there are none.
+        motion_queries: Vec<Vec<MotionQueryItem>>,
     },
 
     /// Like `QueueAnimationBySchema`, but interrupts the playing animation
@@ -202,7 +205,8 @@ pub enum Effect {
     PlayAnimationBySchema {
         entity_id: EntityId,
         selection_strategy: MotionQuerySelectionStrategy,
-        motion_query_items: Vec<MotionQueryItem>,
+        /// Queries tried in order; the first one that matches a motion wins.
+        motion_queries: Vec<Vec<MotionQueryItem>>,
     },
 
     ReplaceEntity {

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -207,6 +207,9 @@ fn parse_tags(tags: &[String]) -> Result<Vec<MotionQueryItem>> {
             Some(stripped) => (stripped, true),
             None => (tag_content, false),
         };
+        if tag_content.is_empty() {
+            anyhow::bail!("Empty tag name in: {}", tag);
+        }
 
         // Check if it's a tag with value (e.g., "cs:184")
         let item = if let Some(colon_pos) = tag_content.find(':') {

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -201,20 +201,28 @@ fn parse_tags(tags: &[String]) -> Result<Vec<MotionQueryItem>> {
 
         let tag_content = &tag[1..]; // Remove the '+'
 
+        // A trailing '?' marks the tag optional (e.g. "+meleecombat?"),
+        // matching the optional query items AI scripts use in-game
+        let (tag_content, optional) = match tag_content.strip_suffix('?') {
+            Some(stripped) => (stripped, true),
+            None => (tag_content, false),
+        };
+
         // Check if it's a tag with value (e.g., "cs:184")
-        if let Some(colon_pos) = tag_content.find(':') {
+        let item = if let Some(colon_pos) = tag_content.find(':') {
             let tag_name = &tag_content[..colon_pos];
             let value_str = &tag_content[colon_pos + 1..];
 
             if let Ok(value) = value_str.parse::<i32>() {
-                motion_query_items.push(MotionQueryItem::with_value(tag_name, value));
+                MotionQueryItem::with_value(tag_name, value)
             } else {
                 anyhow::bail!("Invalid tag value: {}. Expected integer after ':'", tag);
             }
         } else {
             // Simple tag without value
-            motion_query_items.push(MotionQueryItem::new(tag_content));
-        }
+            MotionQueryItem::new(tag_content)
+        };
+        motion_query_items.push(if optional { item.optional() } else { item });
     }
 
     Ok(motion_query_items)

--- a/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
+++ b/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+// A motion query that matches nothing logs a WARN naming the query; the
+// animation silently never plays. These assertions pin the wound and death
+// queries to resolving clips for the creatures medsci1 actually contains.
+function failedQueries(logs: string[], tag: string): string[] {
+  return logs.filter(
+    (line) => line.includes("Unable to find animation") && line.includes(tag),
+  );
+}
+
+test(
+  "wound and death motion queries resolve (hybrid wound, human death)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a pipe hybrid, identifying it by diffing the entity list.
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const hybrid = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(hybrid, "expected a newly spawned OG-Pipe");
+
+    // Non-lethal damage: the wound reaction queries `receivewound` at the
+    // next clip completion. Hybrid wound clips sit under a combat-context
+    // key in the motion db, so without the context tag the query fails.
+    await game.entities.sendMessage(hybrid.id, { type: "Damage", amount: 1 });
+    await game.step({ frames: 180 });
+    assert.deepEqual(
+      failedQueries(game.logs(), "receivewound"),
+      [],
+      "hybrid wound query should resolve a clip",
+    );
+
+    // Human death: FemaleMedsci's death clips are keyed one level deeper
+    // (under die); without that tag she dies frozen with no animation.
+    const humans = await game.entities.list({
+      filter: "FemaleMedsci",
+      limit: 5,
+    });
+    const human = humans.entities[0];
+    assert.ok(human, "expected FemaleMedsci in medsci1");
+    await game.entities.sendMessage(human.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+    await game.step({ frames: 180 });
+    assert.deepEqual(
+      failedQueries(game.logs(), "crumple"),
+      [],
+      "human death query should resolve a clip",
+    );
+    assert.equal(
+      aiProp(await game.entities.detail(human.id), "AIBehavior"),
+      "Dead",
+    );
+  },
+);


### PR DESCRIPTION
Follow-up to #375; fixes the two motion-query bugs found while confirming wound animations (#381 is the human-death half).

## Problem

- **Wound animations never played for hybrids** — the most common enemy. The wound reaction queries `receivewound` + the creature's actor tags (`grunt`, `pipe`), but in the motion database the hybrid wound clips sit under a combat-context level: `receivewound → meleecombat → grunt → …`. The tag matcher only collects clips from nodes it descends through, so the query matched nothing: `WARN Unable to find animation for query …` and the flinch was silently skipped.
- **Human NPCs died frozen with no death animation** (#381). Human death clips sit under `crumple → die → human`, one level deeper than the `crumple` + actor-tags query reaches.

## Fix

Both animation-by-schema effects now carry a **list of queries, tried in order — first match wins**. The wound and death sites pass the bare query first, then the context-tagged fallback:

- wound: `[receivewound]`, then `[receivewound + meleecombat]`
- death: `[crumple]`, then `[crumple + die]`

Bare-first means every previously-resolving creature keeps its exact clip set — an earlier revision used a single query with an optional context item, and cross-engine review caught that a matching context branch *shadows* directly-keyed sets (humans lost their damage-type wound reactions `humhitblt`/`humhitshtgn`, protocol droids dropped from three wound clips to one). The fallback only runs when the bare query finds nothing. Verified across creature types with `cargo dq motion`, which this PR teaches the in-game optional-tag query form (trailing `?`, e.g. `+grunt?`):

| query | result |
|---|---|
| `+receivewound +grunt? +pipe?` (old wound query) | ∅ — the bug |
| `+receivewound +meleecombat +grunt? +pipe?` (fallback) | `ogprwnd1-6, ogprecsw, ogprecwd` |
| `+crumple +human? +unarmed?` (old death query) | ∅ — the bug |
| `+crumple +die +human? +unarmed?` (fallback) | `humdieup1, humdie1-3, humdie01` |
| `+crumple +grunt? +pipe?` (bare) | `plydie01, plydie2, ogpdie*` (unchanged) |
| `+receivewound +droid? +maintenance?` (bare) | `mbtwndft` (unchanged) |

## Testing

- New SDK e2e test (`motion-query-tags.e2e.test.ts`), **negative-tested**: without the query fix it fails on the `receivewound` failed-query log assertion; with it, neither the hybrid wound nor the human death logs a motion-query failure, and FemaleMedsci reaches `Dead` behavior.
- `monster-death.e2e.test.ts` re-run (death query changed): pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr`: pass.

Not addressed here (still open): #382 (droid idlegesture failure loop), and the eager/interrupting wound reaction discussed earlier — this PR only makes the queries resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

### Hybrid wound flinch (new — the query used to find no clip)

| After | Before |
| --- | --- |
| ![wound flinch after](https://gist.githubusercontent.com/tommy-xr/ad3e92458f7927983adf7cf4bc0a356b/raw/w385_wound_after.gif) | ![wound flinch before](https://gist.githubusercontent.com/tommy-xr/ad3e92458f7927983adf7cf4bc0a356b/raw/w385_wound_before.gif) |

After a non-lethal hit, the hybrid doubles over in a wound-reaction clip before turning to chase; on main it snaps straight from idle into the alert/turn posture with no recoil.

### Human NPC death animation (new — she used to die frozen standing)

| After | Before |
| --- | --- |
| ![death after](https://gist.githubusercontent.com/tommy-xr/ad3e92458f7927983adf7cf4bc0a356b/raw/w385_death_after.gif) | ![death before](https://gist.githubusercontent.com/tommy-xr/ad3e92458f7927983adf7cf4bc0a356b/raw/w385_death_before.gif) |

## Human death: before → after (final frame)

![death before/after](https://gist.githubusercontent.com/tommy-xr/ad3e92458f7927983adf7cf4bc0a356b/raw/w385_death_beforeafter.png)

<sub>Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

