### PR TITLE
fix(ai): scripted sequences survive alertness changes; Play waits for its clip

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2434,40 +2434,54 @@ impl MissionCore {
                     );
                 }
 
-                Effect::SetAIProperty { entity_id, update } => match update {
-                    AIPropertyUpdate::Alertness { level, peak } => {
-                        self.world
-                            .add_component(entity_id, PropAIAlertness { level, peak });
-                    }
-                    AIPropertyUpdate::Mode { mode } => {
-                        self.world.add_component(entity_id, PropAIMode { mode });
-                    }
-                    AIPropertyUpdate::Behavior { name } => {
-                        self.world
-                            .add_component(entity_id, RuntimePropAIBehavior(name));
-                    }
-                    AIPropertyUpdate::TargetAwareness {
-                        last_known_pos,
-                        has_line_of_sight,
-                    } => {
-                        self.world.add_component(
-                            entity_id,
-                            crate::runtime_props::RuntimePropAITargetAwareness {
+                Effect::SetAIProperty { entity_id, update } => {
+                    // The AI may have been destroyed earlier in this same
+                    // effect batch (e.g. a scripted sequence whose final
+                    // action frobs a slay trap, while the AI also published
+                    // a behavior change this frame); adding a component to a
+                    // dead entity panics.
+                    let is_alive = self
+                        .world
+                        .borrow::<shipyard::EntitiesView>()
+                        .map(|entities| entities.is_alive(entity_id))
+                        .unwrap_or(false);
+                    if is_alive {
+                        match update {
+                            AIPropertyUpdate::Alertness { level, peak } => {
+                                self.world
+                                    .add_component(entity_id, PropAIAlertness { level, peak });
+                            }
+                            AIPropertyUpdate::Mode { mode } => {
+                                self.world.add_component(entity_id, PropAIMode { mode });
+                            }
+                            AIPropertyUpdate::Behavior { name } => {
+                                self.world
+                                    .add_component(entity_id, RuntimePropAIBehavior(name));
+                            }
+                            AIPropertyUpdate::TargetAwareness {
                                 last_known_pos,
                                 has_line_of_sight,
-                            },
-                        );
+                            } => {
+                                self.world.add_component(
+                                    entity_id,
+                                    crate::runtime_props::RuntimePropAITargetAwareness {
+                                        last_known_pos,
+                                        has_line_of_sight,
+                                    },
+                                );
+                            }
+                            AIPropertyUpdate::ClearTargetAwareness => {
+                                self.world.run(
+                                    |mut v_awareness: ViewMut<
+                                        crate::runtime_props::RuntimePropAITargetAwareness,
+                                    >| {
+                                        v_awareness.remove(entity_id);
+                                    },
+                                );
+                            }
+                        }
                     }
-                    AIPropertyUpdate::ClearTargetAwareness => {
-                        self.world.run(
-                            |mut v_awareness: ViewMut<
-                                crate::runtime_props::RuntimePropAITargetAwareness,
-                            >| {
-                                v_awareness.remove(entity_id);
-                            },
-                        );
-                    }
-                },
+                }
                 Effect::SetAllAIAlertness { level } => {
                     let creature_ids: Vec<EntityId> = {
                         let v_creature = self.world.borrow::<View<PropCreature>>().unwrap();

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1122,6 +1122,16 @@ impl MissionCore {
                     result
                 });
 
+                // Animation failures are otherwise invisible (the scoped
+                // game_log is off by default) and have repeatedly hidden
+                // broken sequences - keep a tracing breadcrumb of every
+                // resolution.
+                tracing::debug!(
+                    "animation queries for {:?}: {:?} -> {:?}",
+                    entity_id,
+                    tried_queries.iter().map(|q| &q.items).collect::<Vec<_>>(),
+                    maybe_next_animation
+                );
                 if let Some(next_animation) = maybe_next_animation {
                     let maybe_clip = asset_cache
                         .get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", next_animation));
@@ -1134,6 +1144,13 @@ impl MissionCore {
                             "Unable to load animation clip: {:?}_.mc",
                             next_animation
                         );
+                        // Report completion just like the query-miss branch
+                        // below, so anything waiting on this animation
+                        // (scripted Play actions) is never left hanging.
+                        self.script_world.dispatch(Message {
+                            payload: MessagePayload::AnimationCompleted,
+                            to: entity_id,
+                        });
                     }
                 } else {
                     game_log!(

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -573,6 +573,12 @@ impl Script for AnimatedMonsterAI {
                 continue;
             }
 
+            // Don't preempt a performance in progress; the watch obj stays
+            // unplayed and can trigger once the current sequence finishes.
+            if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
+                break;
+            }
+
             if player_is_within_watch_obj(world, ent_id, watch_options.radius) {
                 // Immediately switch to Scripted sequence Behavior
                 self.played_ai_watch_obj.insert(ent_id);
@@ -601,6 +607,25 @@ impl Script for AnimatedMonsterAI {
             ));
 
         let rotation_effect = self.apply_steering_output(steering_output, time, entity_id);
+
+        // A finished scripted sequence (its final queued effects were drained
+        // by the steer above - scripted_state only reports Finished once they
+        // are) hands control back to the alertness-appropriate behavior. This
+        // runs every frame, so it also covers sequences ended by the
+        // watchdog, where no further AnimationCompleted may ever arrive.
+        let handback_effect =
+            if self.current_behavior.borrow().scripted_state() == ScriptedState::Finished {
+                self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
+                let is_locomotion = self.current_behavior.borrow().is_locomotion();
+                let selection_strategy = self.next_selection(is_locomotion);
+                Effect::QueueAnimationBySchema {
+                    entity_id,
+                    motion_queries: vec![self.current_behavior.borrow().animation()],
+                    selection_strategy,
+                }
+            } else {
+                Effect::NoEffect
+            };
 
         let sensor_effect = self.try_tickle_sensor(world, physics, entity_id);
 
@@ -632,6 +657,7 @@ impl Script for AnimatedMonsterAI {
             behavior_change_effect,
             steering_effects,
             rotation_effect,
+            handback_effect,
             sensor_effect,
             alertness_debug_effect,
             fov_debug_effect,
@@ -695,7 +721,12 @@ impl Script for AnimatedMonsterAI {
                 // reveals the attacker even without line of sight (the dead
                 // case already returned above)
                 let searching = self.current_behavior.borrow().name() == "Search";
-                let alert_effect = if !lethal {
+                // A running scripted sequence isn't preempted by nonlethal
+                // damage (force_alertness replaces the behavior); consistent
+                // with the alertness protection in update().
+                let running_sequence =
+                    self.current_behavior.borrow().scripted_state() == ScriptedState::Running;
+                let alert_effect = if !lethal && !running_sequence {
                     // Any surviving hit reveals the attacker's position -
                     // refresh the last-known even when already alerted, so
                     // an AI chasing a stale sighting turns toward where the
@@ -728,6 +759,11 @@ impl Script for AnimatedMonsterAI {
                 if self.is_dead || is_killed(entity_id, world) {
                     return Effect::NoEffect;
                 }
+                // A re-fired trigger must not restart a performance in
+                // progress (the tripwires driving these are rarely ONCE)
+                if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
+                    return Effect::NoEffect;
+                }
                 let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
 
                 if let Ok(prop_sig_resp) = v_prop_sig_resp.get(entity_id) {
@@ -750,6 +786,10 @@ impl Script for AnimatedMonsterAI {
             MessagePayload::Signal { name: _ } => {
                 // Dead AIs stay dead - level signals reach corpses too
                 if self.is_dead || is_killed(entity_id, world) {
+                    return Effect::NoEffect;
+                }
+                // A re-fired signal must not restart a performance in progress
+                if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
                     return Effect::NoEffect;
                 }
                 // Do we have a response to this signal?
@@ -814,15 +854,10 @@ impl Script for AnimatedMonsterAI {
                         selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
                     }
                 } else {
-                    // Let the behavior react first (e.g. a scripted Play
-                    // action marks itself complete when its clip finishes).
-                    {
-                        let _ = self
-                            .current_behavior
-                            .borrow_mut()
-                            .handle_message(entity_id, world, physics, msg);
-                    }
-
+                    // (The behavior already saw this message via the
+                    // unconditional forward at the top of handle_message -
+                    // that's what lets a scripted Play action mark itself
+                    // complete, even when the took_damage branch detours.)
                     let next_behavior = {
                         self.current_behavior
                             .borrow_mut()
@@ -837,12 +872,12 @@ impl Script for AnimatedMonsterAI {
                         }
                     };
 
-                    // A finished scripted sequence hands control back to the
-                    // alertness-appropriate behavior (alertness kept updating
-                    // during the performance; apply it now).
+                    // A sequence that just finished is handed back to the
+                    // alertness behavior by update() (whose steer call drains
+                    // the sequence's final effects first); don't re-queue its
+                    // animation here.
                     if self.current_behavior.borrow().scripted_state() == ScriptedState::Finished {
-                        self.current_behavior =
-                            self.behavior_for_alertness(world, physics, entity_id);
+                        return Effect::NoEffect;
                     }
                     //self.current_behavior = Rc::new(IdleBehavior);
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -491,57 +491,69 @@ impl Script for AnimatedMonsterAI {
                 // Level changed - sync to ECS and potentially change behavior
                 let sync_effect = alertness::sync_alertness_effect(entity_id, &self.alertness);
 
-                // AIAlertLevel is repr(u32) in escalation order
-                let decayed = (new_level as u32) < (old_level as u32);
-
-                // Losing contact after actively tracking the player doesn't
-                // drop straight to wandering: investigate the last-known
-                // position first. Further decay during an active search
-                // leaves it running - it hands off to Wander itself.
-                let searching = self.current_behavior.borrow().name() == "Search";
-                let new_behavior: Option<Box<RefCell<dyn Behavior>>> = if decayed && searching {
-                    // An active search keeps running across further decay
-                    // (it hands off on its own) - unless a fresher sighting
-                    // was recorded mid-search, which re-targets it. This
-                    // must be checked BEFORE the decay-from-tracking branch,
-                    // or a High-origin search is stomped one decay later.
-                    self.last_known_player_pos
-                        .take()
-                        .map(|goal| -> Box<RefCell<dyn Behavior>> {
-                            Box::new(RefCell::new(SearchBehavior::new(goal)))
-                        })
-                } else if decayed
-                    && matches!(old_level, AIAlertLevel::Moderate | AIAlertLevel::High)
-                {
-                    match self.last_known_player_pos.take() {
-                        Some(goal) => Some(Box::new(RefCell::new(SearchBehavior::new(goal)))),
-                        // Never actually saw the player (e.g. aggroed by
-                        // damage from behind) - nothing to investigate
-                        None => Some(self.behavior_for_alertness(world, physics, entity_id)),
-                    }
+                // A running scripted sequence (e.g. the rec1 Cortez window
+                // scene) must not be preempted - or have its current clip
+                // replaced - by alertness swings; the alertness state still
+                // updates and takes effect once the sequence finishes. (The
+                // original engine gates this via the response priority; we
+                // protect all sequences.)
+                if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
+                    (sync_effect, Effect::NoEffect)
                 } else {
-                    Some(self.behavior_for_alertness(world, physics, entity_id))
-                };
-                // Fully calmed: a sighting from this engagement must not
-                // trigger a cross-map search minutes later
-                if new_level == AIAlertLevel::Lowest {
-                    self.last_known_player_pos = None;
+                    // AIAlertLevel is repr(u32) in escalation order
+                    let decayed = (new_level as u32) < (old_level as u32);
+
+                    // Losing contact after actively tracking the player
+                    // doesn't drop straight to wandering: investigate the
+                    // last-known position first. Further decay during an
+                    // active search leaves it running - it hands off to
+                    // Wander itself.
+                    let searching = self.current_behavior.borrow().name() == "Search";
+                    let new_behavior: Option<Box<RefCell<dyn Behavior>>> = if decayed && searching {
+                        // An active search keeps running across further decay
+                        // (it hands off on its own) - unless a fresher
+                        // sighting was recorded mid-search, which re-targets
+                        // it. This must be checked BEFORE the decay-from-
+                        // tracking branch, or a High-origin search is stomped
+                        // one decay later.
+                        self.last_known_player_pos.take().map(
+                            |goal| -> Box<RefCell<dyn Behavior>> {
+                                Box::new(RefCell::new(SearchBehavior::new(goal)))
+                            },
+                        )
+                    } else if decayed
+                        && matches!(old_level, AIAlertLevel::Moderate | AIAlertLevel::High)
+                    {
+                        match self.last_known_player_pos.take() {
+                            Some(goal) => Some(Box::new(RefCell::new(SearchBehavior::new(goal)))),
+                            // Never actually saw the player (e.g. aggroed by
+                            // damage from behind) - nothing to investigate
+                            None => Some(self.behavior_for_alertness(world, physics, entity_id)),
+                        }
+                    } else {
+                        Some(self.behavior_for_alertness(world, physics, entity_id))
+                    };
+                    // Fully calmed: a sighting from this engagement must not
+                    // trigger a cross-map search minutes later
+                    if new_level == AIAlertLevel::Lowest {
+                        self.last_known_player_pos = None;
+                    }
+
+                    let animation_effect = if let Some(behavior) = new_behavior {
+                        self.current_behavior = behavior;
+                        let is_locomotion = self.current_behavior.borrow().is_locomotion();
+                        let selection_strategy = self.next_selection(is_locomotion);
+                        Effect::QueueAnimationBySchema {
+                            entity_id,
+                            motion_queries: vec![self.current_behavior.borrow().animation()],
+                            selection_strategy,
+                        }
+                    } else {
+                        Effect::NoEffect
+                    };
+
+                    (sync_effect, animation_effect)
                 }
-
-                let animation_effect = if let Some(behavior) = new_behavior {
-                    self.current_behavior = behavior;
-                    let is_locomotion = self.current_behavior.borrow().is_locomotion();
-                    let selection_strategy = self.next_selection(is_locomotion);
-                    Effect::QueueAnimationBySchema {
-                        entity_id,
-                        motion_queries: vec![self.current_behavior.borrow().animation()],
-                        selection_strategy,
-                    }
-                } else {
-                    Effect::NoEffect
-                };
-
-                (sync_effect, animation_effect)
             } else {
                 (Effect::NoEffect, Effect::NoEffect)
             }
@@ -802,6 +814,15 @@ impl Script for AnimatedMonsterAI {
                         selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
                     }
                 } else {
+                    // Let the behavior react first (e.g. a scripted Play
+                    // action marks itself complete when its clip finishes).
+                    {
+                        let _ = self
+                            .current_behavior
+                            .borrow_mut()
+                            .handle_message(entity_id, world, physics, msg);
+                    }
+
                     let next_behavior = {
                         self.current_behavior
                             .borrow_mut()
@@ -815,6 +836,14 @@ impl Script for AnimatedMonsterAI {
                             self.current_behavior = behavior;
                         }
                     };
+
+                    // A finished scripted sequence hands control back to the
+                    // alertness-appropriate behavior (alertness kept updating
+                    // during the performance; apply it now).
+                    if self.current_behavior.borrow().scripted_state() == ScriptedState::Finished {
+                        self.current_behavior =
+                            self.behavior_for_alertness(world, physics, entity_id);
+                    }
                     //self.current_behavior = Rc::new(IdleBehavior);
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();
                     let selection_strategy = self.next_selection(is_locomotion);

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -22,9 +22,24 @@ pub enum NextBehavior {
     Stay,
 }
 
+/// Whether a behavior is a data-authored scripted sequence, and if so whether
+/// it is still performing. Alertness changes must not preempt a running
+/// sequence (the original engine gates this via the response's priority
+/// field; we currently treat every sequence as protected).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ScriptedState {
+    NotScripted,
+    Running,
+    Finished,
+}
+
 pub trait Behavior {
     /// Short stable name for debug introspection (e.g. "Chase", "Wander")
     fn name(&self) -> &'static str;
+
+    fn scripted_state(&self) -> ScriptedState {
+        ScriptedState::NotScripted
+    }
 
     fn animation(&self) -> Vec<MotionQueryItem> {
         vec![]

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -31,6 +31,7 @@ pub struct ScriptedSequenceBehavior {
     queued_effects: Vec<Effect>,
     current_action_idx: i32,
     current_scripted_action: Box<RefCell<dyn ScriptedAction>>,
+    finished: bool,
 }
 
 impl ScriptedSequenceBehavior {
@@ -43,6 +44,7 @@ impl ScriptedSequenceBehavior {
             queued_effects: vec![initial_effect],
             current_action_idx: 0,
             current_scripted_action: current_behavior,
+            finished: false,
         }
     }
 }
@@ -50,6 +52,29 @@ impl ScriptedSequenceBehavior {
 impl Behavior for ScriptedSequenceBehavior {
     fn name(&self) -> &'static str {
         "ScriptedSequence"
+    }
+
+    fn scripted_state(&self) -> super::ScriptedState {
+        if self.finished {
+            super::ScriptedState::Finished
+        } else {
+            super::ScriptedState::Running
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &crate::scripts::MessagePayload,
+    ) -> Effect {
+        if matches!(msg, crate::scripts::MessagePayload::AnimationCompleted) {
+            self.current_scripted_action
+                .borrow_mut()
+                .on_animation_completed();
+        }
+        Effect::NoEffect
     }
 
     fn animation(&self) -> Vec<MotionQueryItem> {
@@ -98,6 +123,7 @@ impl Behavior for ScriptedSequenceBehavior {
             .is_complete(entity_id, world)
         {
             if self.current_action_idx >= ((self.actions.len() as i32) - 1) {
+                self.finished = true;
                 super::NextBehavior::NoOpinion
             } else {
                 let outgoing_effect = self.current_scripted_action.borrow().completion_effect();
@@ -171,6 +197,10 @@ trait ScriptedAction {
         Effect::NoEffect
     }
 
+    /// Called when the entity's current animation clip finishes (also fires
+    /// when a motion query fails, so waiting on this cannot deadlock).
+    fn on_animation_completed(&mut self) {}
+
     fn is_complete(&self, _entity_id: EntityId, _world: &World) -> bool {
         true
     }
@@ -189,17 +219,33 @@ trait ScriptedAction {
 
 pub struct PlayAnimationScriptedAction {
     animation_name: String,
+    /// Play is a timed beat: it holds the sequence until its clip actually
+    /// finishes (or its motion query fails, which also reports completion).
+    /// Without this the next action's animation replaces the clip a frame
+    /// after it starts.
+    completed: bool,
 }
 
 impl PlayAnimationScriptedAction {
     pub fn new(animation_name: String) -> PlayAnimationScriptedAction {
-        PlayAnimationScriptedAction { animation_name }
+        PlayAnimationScriptedAction {
+            animation_name,
+            completed: false,
+        }
     }
 }
 
 impl ScriptedAction for PlayAnimationScriptedAction {
     fn turn_speed(&self) -> Deg<f32> {
         Deg(0.0)
+    }
+
+    fn on_animation_completed(&mut self) {
+        self.completed = true;
+    }
+
+    fn is_complete(&self, _entity_id: EntityId, _world: &World) -> bool {
+        self.completed
     }
     fn animation(self: &PlayAnimationScriptedAction) -> Vec<MotionQueryItem> {
         if self.animation_name.find(",").is_some() {

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -26,12 +26,23 @@ use crate::{
 
 use super::Behavior;
 
+/// Watchdog: running sequences are protected from alertness/signal/damage
+/// preemption, so a stalled action (a Goto with an unreachable target, an
+/// animation whose queue was silently swallowed) must not wedge the AI
+/// forever. Generous enough for the longest authored beats (the rec1 cortez
+/// performance clip runs ~14s).
+const ACTION_TIMEOUT_SECONDS: f32 = 30.0;
+
 pub struct ScriptedSequenceBehavior {
     actions: Vec<AIScriptedAction>,
     queued_effects: Vec<Effect>,
     current_action_idx: i32,
     current_scripted_action: Box<RefCell<dyn ScriptedAction>>,
     finished: bool,
+    /// Time spent on the current action; drives the watchdog.
+    action_elapsed: f32,
+    /// Set by the watchdog: the current action is force-completed.
+    timed_out: bool,
 }
 
 impl ScriptedSequenceBehavior {
@@ -45,6 +56,8 @@ impl ScriptedSequenceBehavior {
             current_action_idx: 0,
             current_scripted_action: current_behavior,
             finished: false,
+            action_elapsed: 0.0,
+            timed_out: false,
         }
     }
 }
@@ -93,6 +106,24 @@ impl Behavior for ScriptedSequenceBehavior {
         entity_id: EntityId,
         time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
+        // Watchdog: force-complete a stalled action and nudge the sequence
+        // forward through the normal completion path (advancement is driven
+        // by AnimationCompleted, which a stalled action may never produce).
+        self.action_elapsed += time.elapsed.as_secs_f32();
+        if !self.timed_out && !self.finished && self.action_elapsed > ACTION_TIMEOUT_SECONDS {
+            self.timed_out = true;
+            tracing::warn!(
+                "scripted sequence action {} timed out after {ACTION_TIMEOUT_SECONDS}s; advancing",
+                self.current_action_idx
+            );
+            self.queued_effects.push(Effect::Send {
+                msg: crate::scripts::Message {
+                    to: entity_id,
+                    payload: crate::scripts::MessagePayload::AnimationCompleted,
+                },
+            });
+        }
+
         let queued_effects = Effect::combine(self.queued_effects.clone());
         self.queued_effects = vec![];
 
@@ -117,16 +148,27 @@ impl Behavior for ScriptedSequenceBehavior {
         _physics: &crate::physics::PhysicsWorld,
         entity_id: shipyard::EntityId,
     ) -> super::NextBehavior {
-        if self
-            .current_scripted_action
-            .borrow()
-            .is_complete(entity_id, world)
-        {
+        // Already ended (update() hands us back to a normal behavior; a
+        // repeat completion must not re-emit the final action's effect).
+        if self.finished {
+            return super::NextBehavior::NoOpinion;
+        }
+
+        let action_complete = self.timed_out
+            || self
+                .current_scripted_action
+                .borrow()
+                .is_complete(entity_id, world);
+        if action_complete {
+            let outgoing_effect = self.current_scripted_action.borrow().completion_effect();
+            self.queued_effects.push(outgoing_effect);
+            self.timed_out = false;
+            self.action_elapsed = 0.0;
+
             if self.current_action_idx >= ((self.actions.len() as i32) - 1) {
                 self.finished = true;
                 super::NextBehavior::NoOpinion
             } else {
-                let outgoing_effect = self.current_scripted_action.borrow().completion_effect();
                 self.current_action_idx += 1;
                 let behavior = get_behavior_from_action(
                     world,
@@ -134,10 +176,7 @@ impl Behavior for ScriptedSequenceBehavior {
                 );
                 self.current_scripted_action = behavior;
                 let incoming_effect = self.current_scripted_action.borrow().initial_effect();
-
-                // Queue up effects from the behavior
                 self.queued_effects.push(incoming_effect);
-                self.queued_effects.push(outgoing_effect);
 
                 super::NextBehavior::Stay
             }


### PR DESCRIPTION
Diagnoses and fixes the rec1 "entity tapping on the window" opening scene varying every round.

**The scene** is fully data-authored: the spawn-side tripwire signals `MaleRec`, whose `PropAISignalResponse` runs *frob button → goto the window waypoint → play `cs 152` (the `cortez` tap/gesture clip) → goto "runaway" → frob `killcrew`*.

**Why it varied**:
- Any alertness level change unconditionally replaced `current_behavior` and queued a new animation over the playing clip — so the moment the actor noticed the player (he performs at a window you're standing behind), the show was cancelled at a player-dependent point and he fell into unseeded-RNG wander. Two identical-input runs are byte-identical; all observed variance was player-visibility-coupled or RNG-after-interruption.
- `Play` actions reported complete immediately, relying on the accident that sequence advancement is only polled on `AnimationCompleted`; any interruption path (damage react, alertness re-queue) could skip the beat entirely.

**Fixes**:
- Running scripted sequences are protected from alertness behavior swaps and animation stomps; alertness keeps updating in the background and applies when the sequence finishes (finished sequences now hand back to the alertness behavior instead of lingering forever). The original engine's response `priority` gating is noted as future refinement.
- `PlayAnimationScriptedAction` explicitly waits for its clip via a newly wired `AnimationCompleted` → `Behavior::handle_message` path (the hook existed, was never called). Motion-query failures also dispatch `AnimationCompleted`, so the wait can't deadlock.
- Permanent `debug!` breadcrumb for animation query resolutions — silent failures there have now hidden three separate bugs.

**Verification**: full Cortez sequence completes with the player present (walk in → ~14s tap/gesture performance → sprint to "runaway" → despawn), confirmed via trajectory sampling + animation-query logs in the debug runtime. Full e2e: 51/52 — the one failure is pre-existing on main (#386, stale assertion vs #369's new launch-error format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)