### PR TITLE
feat(gameplay): explosions damage and push their surroundings (radius stim blasts)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -373,6 +373,10 @@ pub enum Link {
     /// Names a destination object for scripted teleports (CS9 eggs/rumblers,
     /// TrapTeleport family, TrapDestroyTeleport's destroy target).
     Teleport,
+    /// Act/react stim source ("arSrcDesc"): the linked-to template is the stim
+    /// archetype this object emits (e.g. HE Explosion -> Standard Impact at
+    /// intensity 10 over a radius of 10).
+    StimSource(StimSourceOptions),
 }
 
 #[derive(
@@ -522,6 +526,51 @@ impl GunFlashOptions {
         let vhot = read_u32(reader);
         let flags = read_u32(reader);
         GunFlashOptions { vhot, flags }
+    }
+}
+
+/// How a stim source spreads from its object (the "Propagator" in DromEd's
+/// act/react sources editor).
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum StimPropagator {
+    Null,
+    /// Stimulates objects touching the source (melee weapons, hazards).
+    Contact,
+    /// Stimulates everything within `radius` of the source (explosions).
+    Radius {
+        radius: f32,
+    },
+    Unknown(u32),
+}
+
+/// Act/react stim source (L$arSrcDesc): the source object emits the stim
+/// archetype the link points to, at `intensity`, spread by `propagator`.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StimSourceOptions {
+    pub intensity: f32,
+    pub propagator: StimPropagator,
+}
+
+impl StimSourceOptions {
+    pub fn read(reader: &mut Box<dyn ReadAndSeek>, _len: u32) -> StimSourceOptions {
+        // sStimSourceDesc (108 bytes): propagator id, intensity, then
+        // propagator-specific params (a redundant propagator name string sits
+        // at +76). Only the fields the game consumes are parsed.
+        let propagator_id = read_u32(reader);
+        let intensity = read_single(reader);
+        let _unknown = read_u32(reader);
+        let propagator = match propagator_id {
+            0 => StimPropagator::Null,
+            1 => StimPropagator::Contact,
+            2 => StimPropagator::Radius {
+                radius: read_single(reader) / SCALE_FACTOR,
+            },
+            other => StimPropagator::Unknown(other),
+        };
+        StimSourceOptions {
+            intensity,
+            propagator,
+        }
     }
 }
 
@@ -828,6 +877,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "LD$Projecti",
             ProjectileOptions::read,
             Link::Projectile,
+        ),
+        define_link_with_versioned_data(
+            "L$arSrcDesc",
+            "LD$arSrcDes",
+            StimSourceOptions::read,
+            Link::StimSource,
         ),
     ];
 
@@ -1646,9 +1701,21 @@ struct LinkDefinitionStruct {
     converter: Converter<ToTemplateLinkInfo, Link>,
 }
 
+/// How an LD$ chunk frames its per-link records.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LinkDataFraming {
+    /// The chunk's leading u32 is the per-record data size (most chunks).
+    HeaderDeclared,
+    /// The leading u32 is a database version, not a size (the act/react
+    /// chunks LD$arSrcDes/LD$Receptro declare "2"); the record size must be
+    /// derived from the chunk length and the link count.
+    VersionHeader,
+}
+
 pub trait LinkDefinitionWithData: Send + Sync {
     fn link_chunk_name(&self) -> String;
     fn link_data_chunk_name(&self) -> String;
+    fn link_data_framing(&self) -> LinkDataFraming;
 
     fn convert(&self, data: Vec<u8>, prop_len: u32, link: ToTemplateLinkInfo) -> ToTemplateLink;
 }
@@ -1656,6 +1723,7 @@ pub trait LinkDefinitionWithData: Send + Sync {
 struct LinkDefinitionWithDataStruct<TData> {
     link_name: String,
     link_data_name: String,
+    framing: LinkDataFraming,
     converter: Converter<TData, Link>,
     reader: Reader<Box<dyn ReadAndSeek>, TData>,
 }
@@ -1670,6 +1738,10 @@ impl<TData> LinkDefinitionWithData for LinkDefinitionWithDataStruct<TData> {
 
     fn link_data_chunk_name(&self) -> String {
         self.link_data_name.to_owned()
+    }
+
+    fn link_data_framing(&self) -> LinkDataFraming {
+        self.framing
     }
 
     fn convert(
@@ -1803,7 +1875,71 @@ pub fn define_link_with_data<TData: 'static + fmt::Debug + Send + Sync + Clone>(
     Box::new(LinkDefinitionWithDataStruct {
         link_name: link_name.to_string(),
         link_data_name: link_data_name.to_string(),
+        framing: LinkDataFraming::HeaderDeclared,
         reader,
         converter,
     })
+}
+
+/// Like `define_link_with_data`, but for the act/react chunks whose LD$ header
+/// is a version number rather than the record size (see `LinkDataFraming`).
+pub fn define_link_with_versioned_data<TData: 'static + fmt::Debug + Send + Sync + Clone>(
+    link_name: &str,
+    link_data_name: &str,
+    reader: Reader<Box<dyn ReadAndSeek>, TData>,
+    converter: Converter<TData, Link>,
+) -> Box<dyn LinkDefinitionWithData> {
+    Box::new(LinkDefinitionWithDataStruct {
+        link_name: link_name.to_string(),
+        link_data_name: link_data_name.to_string(),
+        framing: LinkDataFraming::VersionHeader,
+        reader,
+        converter,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a 108-byte sStimSourceDesc payload the way shock2.gam lays it
+    /// out: propagator id, intensity, unknown, then propagator params.
+    fn stim_source_payload(propagator_id: u32, intensity: f32, radius: f32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&propagator_id.to_le_bytes());
+        bytes.extend_from_slice(&intensity.to_le_bytes());
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&radius.to_le_bytes());
+        bytes.resize(108, 0);
+        bytes
+    }
+
+    fn read_stim_source(payload: Vec<u8>) -> StimSourceOptions {
+        let mut cursor: Box<dyn ReadAndSeek> = Box::new(Cursor::new(payload));
+        StimSourceOptions::read(&mut cursor, 108)
+    }
+
+    #[test]
+    fn stim_source_radius_matches_incendiary_explosion_data() {
+        // Incendiary Explosion -> Incendiary stim in shock2.gam: intensity 15,
+        // radius 10 (dark units).
+        let opts = read_stim_source(stim_source_payload(2, 15.0, 10.0));
+        assert_eq!(opts.intensity, 15.0);
+        assert_eq!(
+            opts.propagator,
+            StimPropagator::Radius {
+                radius: 10.0 / SCALE_FACTOR
+            }
+        );
+    }
+
+    #[test]
+    fn stim_source_contact_and_null_have_no_radius() {
+        let contact = read_stim_source(stim_source_payload(1, 8.0, 0.0));
+        assert_eq!(contact.intensity, 8.0);
+        assert_eq!(contact.propagator, StimPropagator::Contact);
+
+        let null = read_stim_source(stim_source_payload(0, 16.0, 0.0));
+        assert_eq!(null.propagator, StimPropagator::Null);
+    }
 }

--- a/dark/src/ss2_entity_info.rs
+++ b/dark/src/ss2_entity_info.rs
@@ -5,13 +5,13 @@ use std::{
 };
 
 use shipyard::{EntityId, World};
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::{
     Gamesys,
     properties::{
-        LinkDefinition, LinkDefinitionWithData, PropSymName, PropTemplateId, Property,
-        PropertyDefinition, TemplateLinks, ToTemplateLinkInfo,
+        LinkDataFraming, LinkDefinition, LinkDefinitionWithData, PropSymName, PropTemplateId,
+        Property, PropertyDefinition, TemplateLinks, ToTemplateLinkInfo,
     },
     ss2_chunk_file_reader::ChunkFileTableOfContents,
     ss2_common::{read_bytes, read_i32, read_u16, read_u32},
@@ -386,7 +386,13 @@ fn read_all_data_links<R1: io::Read + io::Seek>(
         let data_chunk_name = link.link_data_chunk_name();
 
         let link_infos = read_link(&chunk_name, ref_reader, toc);
-        let link_data = read_link_data(&data_chunk_name, ref_reader, toc, link_infos.len() as u32);
+        let link_data = read_link_data(
+            &data_chunk_name,
+            ref_reader,
+            toc,
+            link_infos.len() as u32,
+            link.link_data_framing(),
+        );
 
         for link_info in link_infos {
             let to_link = ToTemplateLinkInfo {
@@ -414,6 +420,7 @@ pub fn read_link_data<T: io::Read + io::Seek>(
     reader: &mut T,
     toc: &ChunkFileTableOfContents,
     count: u32,
+    framing: LinkDataFraming,
 ) -> HashMap<i32, Vec<u8>> {
     let mut data = HashMap::new();
 
@@ -425,20 +432,32 @@ pub fn read_link_data<T: io::Read + io::Seek>(
             );
             reader.seek(SeekFrom::Start(chunk_pos.offset)).unwrap();
 
-            // Figure out the size for each individual link entry
-            let _link_data_size = (chunk_pos.length / count as u64) - 4;
-
             let end_pos = chunk_pos.offset + chunk_pos.length;
-            let data_len = read_u32(reader) as u64;
-            // trace!("data_len: {} link_data_size: {}", data_len, link_data_size);
-            // assert!(data_len == link_data_size);
+            let data_len = match framing {
+                // Most chunks declare the per-record data size up front.
+                LinkDataFraming::HeaderDeclared => read_u32(reader) as u64,
+                // Act/react chunks put a version there instead; derive the
+                // record size from the chunk length and link count.
+                LinkDataFraming::VersionHeader => {
+                    let _version = read_u32(reader);
+                    let record_size = chunk_pos.length.saturating_sub(4) / count as u64;
+                    // Records are (i32 link id + payload); fail loud on a
+                    // malformed chunk instead of feeding garbage downstream.
+                    if record_size < 4 || (chunk_pos.length - 4) % count as u64 != 0 {
+                        warn!(
+                            "{}: chunk length {} does not hold {} uniform records; skipping",
+                            link_data_chunk_name, chunk_pos.length, count
+                        );
+                        return data;
+                    }
+                    record_size - 4
+                }
+            };
             while reader.stream_position().unwrap() < end_pos {
                 let id = read_i32(reader);
-                // println!("link id: {}", id);
                 let bytes = read_bytes(reader, data_len as usize);
                 data.insert(id, bytes);
             }
-            // panic!("link data size: {}", link_data_size);
         }
     }
 

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -19,11 +19,12 @@ use dark::{
     model::Model,
     motion::AnimationPlayer,
     properties::{
-        FrobFlag, InternalPropOriginalModelName, Links, PhysicsModelType, PoseType,
-        PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo, PropHUDSelect,
-        PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropModelName, PropPhysAttr,
-        PropPhysDimensions, PropPhysState, PropPhysType, PropPosition, PropRenderType, PropScale,
-        PropSymName, PropTemplateId, PropTripFlags, RenderType, TemplateLinks, WrappedEntityId,
+        FrobFlag, InternalPropOriginalModelName, Link, Links, PhysicsModelType, PoseType,
+        PropClassTag, PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo,
+        PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropModelName,
+        PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
+        PropRenderType, PropScale, PropSymName, PropTemplateId, PropTripFlags, RenderType,
+        StimPropagator, StimSourceOptions, TemplateLinks, WrappedEntityId,
     },
     ss2_entity_info,
 };
@@ -305,6 +306,46 @@ pub fn create_entity_core(
     let v_keysrc = world.borrow::<View<PropKeySrc>>().unwrap();
     if v_keysrc.get(entity_id).is_ok() {
         processed_scripts.push("internal_keycard".to_owned());
+    }
+
+    // Explosion SFX templates (class tag "explosiontype", e.g. HE / Incendiary
+    // Explosion) with radius stim sources (arSrcDesc) blast once on spawn.
+    // Radius sources WITHOUT the tag (electrical sparks, Swarm, Rad Burst) are
+    // periodic emitters in the original engine - not one-shot blasts - and are
+    // not handled yet.
+    let is_explosion = {
+        let v_class_tag = world.borrow::<View<PropClassTag>>().unwrap();
+        let v_links = world.borrow::<View<Links>>().unwrap();
+        v_class_tag
+            .get(entity_id)
+            .map(|tag| tag.class_tags().iter().any(|(k, _)| *k == "explosiontype"))
+            .unwrap_or(false)
+            && v_links.get(entity_id).is_ok_and(|links| {
+                links.to_links.iter().any(|l| {
+                    matches!(
+                        l.link,
+                        Link::StimSource(StimSourceOptions {
+                            propagator: StimPropagator::Radius { .. },
+                            ..
+                        })
+                    )
+                })
+            })
+    };
+    // Release the property views before add_component below needs the world
+    // mutably; nothing after this point reads them.
+    drop(v_scripts);
+    drop(v_collision_type);
+    drop(v_creature);
+    drop(v_hp);
+    drop(v_keysrc);
+
+    if is_explosion {
+        processed_scripts.push("internal_explosion".to_owned());
+        // One-shot SFX: never save explosion entities. Script state
+        // (has_fired) is not persisted, so a saved mid-animation explosion
+        // would re-detonate on every load.
+        world.add_component(entity_id, RuntimePropDoNotSerialize);
     }
 
     // ...and remove any duplicates!

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -127,6 +127,11 @@ const MELEE_IDLE_CLIP: &str = "ph212203";
 /// always uses the medium-left swing.
 const MELEE_SWING_CLIP: &str = "leftswing";
 
+/// Velocity (world units/s) a radius blast adds per point of stim intensity to
+/// a dynamic body at its center (falling off linearly to zero at the radius).
+/// Tuned so a barrel blast (intensity 15) gives nearby props a solid toss.
+const BLAST_PUSH_SPEED_PER_INTENSITY: f32 = 0.5;
+
 /// Debug options accessible from scripts via UniqueView
 #[derive(Unique, Clone, Default)]
 pub struct DebugOptions {
@@ -1273,6 +1278,44 @@ impl MissionCore {
         did_slay
     }
 
+    /// Apply a radius stim blast (Effect::RadiusBlast): falloff-scaled damage
+    /// to every entity with hit points in range, and an outward shove to every
+    /// dynamic body. Falloff is linear from full at the center to zero at the
+    /// blast radius.
+    fn radius_blast(&mut self, center: Vector3<f32>, radius: f32, intensity: f32) {
+        let mut damage_targets = Vec::new();
+        {
+            let v_hit_points = self
+                .world
+                .borrow::<View<dark::properties::PropHitPoints>>()
+                .unwrap();
+            let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
+            for (entity_id, (_hit_points, transform)) in
+                (&v_hit_points, &v_transform).iter().with_id()
+            {
+                let position = transform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+                let distance = (crate::util::point3_to_vec3(position) - center).magnitude();
+                if distance < radius {
+                    let falloff = 1.0 - distance / radius;
+                    damage_targets.push((entity_id, intensity * falloff));
+                }
+            }
+        }
+
+        for (entity_id, amount) in damage_targets {
+            self.script_world.dispatch(Message {
+                to: entity_id,
+                payload: MessagePayload::Damage { amount },
+            });
+        }
+
+        self.physics.apply_radial_impulse(
+            center,
+            radius,
+            intensity * BLAST_PUSH_SPEED_PER_INTENSITY,
+        );
+    }
+
     pub fn create_entity_by_template_name(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -1708,6 +1751,14 @@ impl MissionCore {
                     if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
                         gun_state.ammo = (gun_state.ammo + delta).max(0);
                     }
+                }
+
+                Effect::RadiusBlast {
+                    center,
+                    radius,
+                    intensity,
+                } => {
+                    self.radius_blast(center, radius, intensity);
                 }
 
                 Effect::ReloadWeapon => {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use util::*;
 
 use bitflags::bitflags;
-use cgmath::{InnerSpace, Point3, Quaternion, Vector3, point3};
+use cgmath::{InnerSpace, Point3, Quaternion, Vector3, point3, vec3};
 use dark::{SCALE_FACTOR, mission::SystemShock2Level};
 use engine::scene::SceneObject;
 use rapier3d::{
@@ -373,6 +373,33 @@ impl PhysicsWorld {
     pub fn apply_impulse(&mut self, handle: RigidBodyHandle, impulse: Vector3<f32>) {
         if let Some(rigid_body) = self.rigid_body_set.get_mut(handle) {
             rigid_body.apply_impulse(vec_to_nvec(impulse), true);
+        }
+    }
+
+    /// Shove every dynamic body within `radius` of `center` directly away
+    /// from it, adding `speed * (1 - d/radius)` to its velocity (explosion
+    /// blasts). Mass-independent, like the game's other impulse-as-speed
+    /// launches (flinderize).
+    pub fn apply_radial_impulse(&mut self, center: Vector3<f32>, radius: f32, speed: f32) {
+        for (_handle, body) in self.rigid_body_set.iter_mut() {
+            if !body.is_dynamic() {
+                continue;
+            }
+            let translation = body.translation();
+            let offset = vec3(translation.x, translation.y, translation.z) - center;
+            let distance = offset.magnitude();
+            if distance >= radius {
+                continue;
+            }
+            // A body at the exact center has no outward direction; toss it up.
+            let direction = if distance > 1e-3 {
+                offset / distance
+            } else {
+                vec3(0.0, 1.0, 0.0)
+            };
+            let delta = direction * speed * (1.0 - distance / radius);
+            let new_velocity = body.linvel() + vec_to_nvec(delta);
+            body.set_linvel(new_velocity, true);
         }
     }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -136,6 +136,16 @@ pub enum Effect {
         force: Vector3<f32>,
     },
 
+    /// A radius stim blast (explosions): every entity with hit points within
+    /// `radius` of `center` takes `intensity`-scaled damage with linear
+    /// distance falloff, and every dynamic body in range is shoved outward.
+    /// Emitted once by `internal_explosion` from the entity's arSrcDesc data.
+    RadiusBlast {
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+    },
+
     ChangeModel {
         entity_id: EntityId,
         model_name: String,

--- a/shock2vr/src/scripts/internal_explosion.rs
+++ b/shock2vr/src/scripts/internal_explosion.rs
@@ -1,0 +1,89 @@
+use cgmath::{Transform, point3};
+use dark::properties::{Link, StimPropagator, StimSourceOptions};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+use crate::runtime_props::RuntimePropTransform;
+use crate::time::Time;
+use crate::util::point3_to_vec3;
+
+use super::{Effect, Script, script_util::get_all_links_with_template};
+
+// Detonates an entity carrying radius stim sources (L$arSrcDesc): explosion
+// SFX templates like "HE Explosion" and "Incendiary Explosion". One frame
+// after the entity spawns, everything within the blast radius takes
+// falloff-scaled damage and dynamic bodies are shoved outward. The visual
+// (bitmap animation) and sound are handled by the entity's other properties;
+// this script is only the blast.
+/// The ShakeStim archetype (-3558): every explosion links it for camera shake.
+/// It is not damage, and its numbers are unrelated to the blast's.
+const SHAKE_STIM_TEMPLATE_ID: i32 = -3558;
+
+pub struct InternalExplosion {
+    has_fired: bool,
+}
+
+impl InternalExplosion {
+    pub fn new() -> InternalExplosion {
+        InternalExplosion { has_fired: false }
+    }
+}
+
+impl Script for InternalExplosion {
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        if self.has_fired {
+            return Effect::NoEffect;
+        }
+        self.has_fired = true;
+
+        let radius_sources = get_all_links_with_template(world, entity_id, |link| match link {
+            Link::StimSource(opts) => Some(*opts),
+            _ => None,
+        });
+
+        // Explosions carry an impact stim (the blast) plus a ShakeStim (camera
+        // shake - unimplemented, and with unrelated numbers: Droid Fusion's
+        // shake is 15 @ r0.4 next to its 12 @ r4 damage stim). Skip the shake
+        // and take the strongest remaining source as (intensity, radius) - a
+        // pair from one authored stim, never a mix.
+        let mut blast: Option<(f32, f32)> = None;
+        for (
+            stim_template_id,
+            StimSourceOptions {
+                intensity,
+                propagator,
+            },
+        ) in radius_sources
+        {
+            if stim_template_id == SHAKE_STIM_TEMPLATE_ID {
+                continue;
+            }
+            if let StimPropagator::Radius { radius } = propagator {
+                if blast.is_none_or(|(max_intensity, _)| intensity > max_intensity) {
+                    blast = Some((intensity, radius));
+                }
+            }
+        }
+        let Some((intensity, radius)) = blast else {
+            return Effect::NoEffect;
+        };
+
+        let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+        let Ok(transform) = v_transform.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+        let center = point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)));
+
+        Effect::RadiusBlast {
+            center,
+            radius,
+            intensity,
+        }
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -17,6 +17,7 @@ mod energy_station;
 mod frob_qb;
 mod gui;
 mod internal_collision_type;
+mod internal_explosion;
 pub mod internal_fast_projectile;
 mod internal_keycard_script;
 mod internal_simple_health;
@@ -96,6 +97,7 @@ use self::{
     energy_station::EnergyStation,
     frob_qb::FrobQB,
     internal_collision_type::InternalCollisionType,
+    internal_explosion::InternalExplosion,
     internal_keycard_script::KeyCardScript,
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
@@ -480,6 +482,7 @@ impl ScriptWorld {
             "internal_collision_type" => Box::new(InternalCollisionType::new()),
             "internal_inventory" => gui_script(Box::new(ContainerGui::inv_container())),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
+            "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),
             "internal_room_trigger" => Box::new(RoomTrigger::new()),
             "internal_simple_health" => Box::new(InternalSimpleHealth::new()),

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -386,6 +386,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
                 Link::Teleport => "Teleport".to_string(),
+                Link::StimSource(_) => "StimSource".to_string(),
             })
             .collect();
 

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -587,6 +587,9 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
         dark::properties::Link::Teleport => "Teleport".to_string(),
+        // Include the payload: blast tuning (intensity/radius) is exactly what
+        // one inspects these links for.
+        dark::properties::Link::StimSource(opts) => format!("StimSource({:?})", opts),
     }
 }
 

--- a/tools/shock2-sdk/test/explosion.e2e.test.ts
+++ b/tools/shock2-sdk/test/explosion.e2e.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// medsci1 "Explode Barrel" (template -498, 2 HP) has Corpse -> Incendiary
+// Explosion, whose arSrcDesc stim sources are intensity 15 over a 10ft (4
+// world-unit) radius. Slaying a barrel must therefore damage entities and
+// push dynamic bodies within that radius - not just play the fireball.
+const BARREL_NAME = "Explode Barrel";
+// A neighbor must sit well inside the 4-unit blast radius so falloff damage
+// still exceeds the barrel's 2 HP.
+const CHAIN_DISTANCE = 3.0;
+
+function dist(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function speed(v: Vec3): number {
+  return Math.hypot(v[0], v[1], v[2]);
+}
+
+async function listBarrels(game: GameServer): Promise<EntitySummary[]> {
+  const { entities } = await game.entities.list({
+    filter: BARREL_NAME,
+    limit: 500,
+  });
+  return entities.filter((e) => e.name === BARREL_NAME);
+}
+
+test(
+  "Explosion: a slain barrel chain-damages and pushes its surroundings",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8114),
+    });
+
+    await game.step({ frames: 2 });
+
+    // Find two barrels within chain range of each other. Entity ids are
+    // per-session, so sort by position for a deterministic pick.
+    const barrels = (await listBarrels(game)).sort(
+      (a, b) => a.position[0] - b.position[0] || a.position[2] - b.position[2],
+    );
+    assert.ok(barrels.length >= 2, `expected >=2 barrels, got ${barrels.length}`);
+    let pair: [EntitySummary, EntitySummary] | undefined;
+    outer: for (const a of barrels) {
+      for (const b of barrels) {
+        if (a.id !== b.id && dist(a.position, b.position) < CHAIN_DISTANCE) {
+          pair = [a, b];
+          break outer;
+        }
+      }
+    }
+    assert.ok(
+      pair !== undefined,
+      `expected two barrels within ${CHAIN_DISTANCE} units of each other`,
+    );
+    const [barrelA, barrelB] = pair;
+
+    // Plant a loose pistol next to barrel A. SpawnDebugItem auto-wields; the
+    // second spawn drops the first pistol into the world ~4 units along the
+    // camera facing. Stand 4 units +X of the barrel facing -X (head.look yaw
+    // 0 = -X) so the drop lands at the barrel.
+    const [bx, by, bz] = barrelA.position;
+    await game.player.teleport({ x: bx + 4.0, y: by + 0.5, z: bz });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 2 });
+    for (let i = 0; i < 2; i++) {
+      await game.input.trigger("SpawnDebugItem");
+      await game.step({ frames: 5 });
+    }
+
+    const findLoosePistols = async () => {
+      const { bodies } = await game.physics.bodies();
+      return bodies.filter(
+        (b) =>
+          b.entity_name?.includes("Pistol") &&
+          b.body_type === "dynamic" &&
+          dist(b.position, barrelA.position) < 4.0,
+      );
+    };
+    // Let the dropped pistol fall, bounce, and come to rest (a few seconds).
+    let pistolsBefore = await findLoosePistols();
+    for (let i = 0; i < 15; i++) {
+      await game.step({ frames: 30 });
+      pistolsBefore = await findLoosePistols();
+      if (
+        pistolsBefore.length >= 1 &&
+        pistolsBefore.every((b) => speed(b.velocity) < 0.05)
+      ) {
+        break;
+      }
+    }
+    assert.ok(
+      pistolsBefore.length >= 1,
+      "expected a loose pistol body near the barrel before the blast",
+    );
+    const pistolId = pistolsBefore[0].body_id;
+    assert.ok(
+      speed(pistolsBefore[0].velocity) < 0.05,
+      `pistol did not settle before the blast (speed ${speed(
+        pistolsBefore[0].velocity,
+      ).toFixed(3)} after ~7s)`,
+    );
+
+    // Move the player well clear of the blast, then set off barrel A.
+    await game.player.teleport({ x: bx + 9.0, y: by + 0.5, z: bz });
+    await game.step({ frames: 2 });
+    await game.entities.sendMessage(barrelA.id, { type: "Damage", amount: 5.0 });
+    // Slay + corpse-spawn happen on the next frame; the explosion's radius
+    // blast fires on the frame after that.
+    await game.step({ frames: 3 });
+
+    // Push: the pistol beside the barrel must be moving.
+    const { bodies: after } = await game.physics.bodies();
+    const pistolAfter = after.find((b) => b.body_id === pistolId);
+    assert.ok(pistolAfter !== undefined, "pistol body should still exist");
+    assert.ok(
+      speed(pistolAfter.velocity) > 0.5,
+      `expected the blast to push the pistol (speed > 0.5), got ${speed(
+        pistolAfter.velocity,
+      ).toFixed(3)}`,
+    );
+
+    // Damage: barrel B sat inside the blast radius with 2 HP; the blast must
+    // chain-slay it. Give the chain a few frames to resolve.
+    await game.step({ frames: 5 });
+    const remaining = await listBarrels(game);
+    const ids = new Set(remaining.map((e) => e.id));
+    assert.ok(!ids.has(barrelA.id), "barrel A should be destroyed");
+    assert.ok(
+      !ids.has(barrelB.id),
+      "expected the blast to chain-destroy barrel B inside its radius",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Implements the blast half of explosions (TODO: "Explosions (ie, re301 in barrel)" — both sub-items: physics push + damage). Slaying an Explode Barrel previously played the `re301_` fireball and sound but affected nothing.

**`dark`: parse the act/react stim-source links (`L$arSrcDesc`)** — previously unparsed. Each link says what stimulus an object emits: the linked-to template is the stim archetype, the data carries `intensity` and a propagator (`Radius { radius }` / `Contact` / `Null`). The LD chunk's leading u32 is an act/react database *version* (2), not the record size every other LD chunk declares, so link definitions gain a `LinkDataFraming::VersionHeader` mode that derives the record size from chunk length ÷ link count (with loud malformed-chunk guards). Verified against real data — `HE Explosion` → Standard Impact intensity 10 @ 4.0 wu; `Incendiary Explosion` → 15 @ 4.0. `dark_query` displays the payload on these links.

**`shock2vr`: one-shot radius blasts** — `internal_explosion` auto-attaches to templates with class tag `explosiontype` + a Radius stim source, and one frame after spawn emits `Effect::RadiusBlast` from the strongest non-ShakeStim source:
- **Damage**: every entity with hit points in radius gets `Damage` with linear falloff — barrel chain reactions come free through the existing damage path.
- **Push**: `PhysicsWorld::apply_radial_impulse` shoves every dynamic body outward at `intensity × 0.5 × falloff`.
- Explosion entities are `RuntimePropDoNotSerialize` (script state isn't persisted; a saved mid-animation explosion would otherwise re-detonate on every load).

## Deliberate scope cuts (from cross-engine review, tracked in issues)

- **ShakeStim is skipped** — camera shake, unimplemented; its numbers are unrelated to the blast (Droid Fusion: shake 15 @ r0.4 beside damage 12 @ r4), which is why the blast takes the strongest source's *(intensity, radius) pair* rather than folding sources.
- **Periodic emitters excluded** (electrical sparks, Swarm, Rad Burst — no `explosiontype` tag): the original fires those on a period, not once.
- **Player is explosion-immune** for now — the player entity has no script pipeline, so `Damage` messages to it are dropped (pre-existing, affects all damage sources).
- **Stim types are not receptron-aware** — EMP/Stasis/Psi blasts currently deal generic damage instead of type-filtered effects.

## Test plan

- [x] New `dark` unit tests for `StimSourceOptions::read` (Radius/Contact/Null, SCALE_FACTOR)
- [x] New e2e `explosion.e2e.test.ts`: slays a medsci1 Explode Barrel with a pistol planted beside it and a second barrel in chain range — asserts the pistol gets pushed and barrel B chain-slays. **Failed before the implementation** (pistol speed 0.000).
- [x] `RUSTFLAGS="-D warnings" cargo check` on shock2vr / desktop_runtime / debug_runtime / dark_query; rustfmt clean
- [x] Full e2e suite: 23/23 mission loads, flinderize, all weapon/AI/psi tests green (the one unrelated failure is `launch-failure.e2e.test.ts`, broken on main by #376's error-message wording)
- [x] Cross-engine review (Claude + Codex): both High findings fixed (ShakeStim fold, save/load re-blast), parser guards added; remaining items are the documented scope cuts above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![explosion radius blast demo](https://gist.githubusercontent.com/tommy-xr/727b53c09112f8d39a399467d26cead2/raw/expl-demo.gif)

<sub>Slaying an explosive barrel in `medsci1.mis` now detonates its authored radius blast: the neighboring barrel (~2.1 units away) chain-explodes a few frames later, and the pistol resting beside it is thrown across the room. Before (main), the fireball played but nothing was affected — the neighbor barrel and pistol survive untouched. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep); both sides run the identical request sequence, frame-aligned at the detonation.</sub>

### Before → after

![before/after at the chain-detonation moment](https://gist.githubusercontent.com/tommy-xr/727b53c09112f8d39a399467d26cead2/raw/expl-beforeafter.png)

<sub>Same sim frame on both sides (8 frames after the triggering barrel is slain): before, one fireball and an intact neighbor with the pistol still perched on it; after, both barrels are detonating and the pistol is airborne (upper right).</sub>
