### PR TITLE
fix(sdk-test): match the launch-failure error wording from #376

### DIFF
--- a/tools/shock2-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/shock2-sdk/test/launch-failure.e2e.test.ts
@@ -25,7 +25,7 @@ test(
         assert.match(error.message, /debug_runtime failed to start/);
         assert.match(
           error.message,
-          /exited early with code/,
+          /exited early \(code/,
           "error should report the process exit",
         );
         assert.match(


### PR DESCRIPTION
The full e2e suite has been failing on `launch-failure.e2e.test.ts` since #376: the SDK's early-exit error message became `process exited early (code N, signal S)` but the test still asserts `/exited early with code/`. One-line regex update.

Verified: `SHOCK2_E2E=1 node --test dist/test/launch-failure.e2e.test.js` fails before, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)