### PR TITLE
feat(dq): motion-info subcommand for per-clip metadata

### DIFF
--- a/dark/src/motion/mod.rs
+++ b/dark/src/motion/mod.rs
@@ -40,6 +40,11 @@ pub struct MotionDB {
 }
 
 impl MotionDB {
+    pub fn has_motion(&self, name: &str) -> bool {
+        self.animation_name_to_index
+            .contains_key(&name.to_ascii_lowercase())
+    }
+
     pub fn get_mps_motions(&self, name: String) -> &MpsMotion {
         let lowercase_name = &name.to_ascii_lowercase();
         let idx = self.animation_name_to_index.get(lowercase_name).unwrap();

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -80,6 +80,12 @@ enum Commands {
         #[arg(long)]
         limit: Option<usize>,
     },
+
+    /// Show per-clip motion metadata (flags, blend, root translation, frame flags)
+    MotionInfo {
+        /// Animation clip names (e.g. humdie1 ogpdiefw)
+        names: Vec<String>,
+    },
     /// Query map chunk data from interface files
     Maps {
         /// Mission name to load map data for (e.g., "MEDSCI1", "MEDSCI2")
@@ -173,6 +179,9 @@ fn main() -> Result<()> {
             limit,
         } => {
             handle_motion_command(&creature_type, &tags, limit)?;
+        }
+        Commands::MotionInfo { names } => {
+            handle_motion_info_command(&names)?;
         }
         Commands::Maps { mission } => {
             handle_maps_command(&mission)?;
@@ -603,6 +612,17 @@ fn handle_motion_command(creature_type: &str, tags: &[String], limit: Option<usi
         motion_analyzer.list_all_tags_and_animations(creature_id, limit)?;
     } else {
         motion_analyzer.query_with_tags(creature_id, tags, limit)?;
+    }
+
+    Ok(())
+}
+
+fn handle_motion_info_command(names: &[String]) -> Result<()> {
+    info!("Loading motion database...");
+    let motion_analyzer = MotionAnalyzer::new()?;
+
+    for name in names {
+        motion_analyzer.print_motion_info(name)?;
     }
 
     Ok(())

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -170,6 +170,68 @@ impl MotionAnalyzer {
         Ok(())
     }
 
+    /// Print per-clip metadata: motion-stuff (flags, blend length, end
+    /// rotation, root translation, duration) and the per-frame motion flags.
+    pub fn print_motion_info(&self, name: &str) -> Result<()> {
+        if !self.motion_db.has_motion(name) {
+            anyhow::bail!("No motion named '{}' in the motion database", name);
+        }
+
+        let stuff = self.motion_db.get_motion_stuff(name.to_string());
+        let mps = self.motion_db.get_mps_motions(name.to_string());
+
+        println!("=== {} ===", name);
+        println!("  flags:        {:#x}", stuff.flags);
+        println!("  blend_length: {} ms", stuff.blend_length);
+        println!("  end_dir:      {:?}", stuff.end_direction);
+        println!(
+            "  translation:  [{:.3}, {:.3}, {:.3}]",
+            stuff.translation.x, stuff.translation.y, stuff.translation.z
+        );
+        println!("  duration:     {:.3}", stuff.duration);
+        println!(
+            "  frames:       {} @ {} fps",
+            mps.frame_count, mps.frame_rate
+        );
+        for frame_flags in &mps.motion_flags {
+            println!(
+                "  frame {:>4}:   {:?}",
+                frame_flags.frame, frame_flags.flags
+            );
+        }
+
+        // The per-frame root-y stream lives in the clip file (res/motions/
+        // <name>_.mc), not the motion database - print its curve when the
+        // unpacked file is available
+        let mc_path = paths::data_root().join(format!("res/motions/{}_.mc", name));
+        if let Ok(file) = File::open(&mc_path) {
+            let mut reader = BufReader::new(file);
+            let clip = dark::motion::MotionClip::read(&mut reader, mps);
+            let ys: Vec<f32> = clip.root_transforms.iter().map(|m| m.w.y).collect();
+            if !ys.is_empty() {
+                let n = ys.len();
+                println!(
+                    "  root y:       start {:.3}  1/4 {:.3}  1/2 {:.3}  3/4 {:.3}  end {:.3}",
+                    ys[0],
+                    ys[n / 4],
+                    ys[n / 2],
+                    ys[3 * n / 4],
+                    ys[n - 1]
+                );
+                let (min, max) = ys
+                    .iter()
+                    .fold((f32::MAX, f32::MIN), |(a, b), y| (a.min(*y), b.max(*y)));
+                println!("                min {:.3}  max {:.3}", min, max);
+            }
+        } else {
+            println!(
+                "  root y:       (no unpacked clip at {})",
+                mc_path.display()
+            );
+        }
+        Ok(())
+    }
+
     pub fn parse_creature_type(&self, creature_type_str: &str) -> Result<u32> {
         // Try parsing as number first
         if let Ok(id) = creature_type_str.parse::<u32>() {


### PR DESCRIPTION
Small tooling PR (extracted from the #392 investigation — it was accidentally pushed onto the merged #385 branch; that branch is deleted again).

`cargo dq motion-info <names...>` prints a clip's motion-stuff (flags, blend length, end rotation, root translation, duration), its per-frame motion flags, and — when an unpacked `res/motions/<name>_.mc` is available — the per-frame root-y curve (start/quarter points/end, min/max).

This is what diagnosed #392 (floating corpses): death clips end with a root-y drop of ~−0.9 that our standing origin height doesn't meet, e.g.

```
=== humdie1 ===
  translation:  [-1.884, -0.937, 0.078]
  root y:       start 0.000  1/4 -0.082  1/2 -0.704  3/4 -0.512  end -0.937
```

Includes a `has_motion` accessor on `MotionDB` so unknown names error instead of panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)