### PR TITLE
fix(motion): drive entity movement by per-frame root velocity

### DIFF
--- a/dark/src/motion/animation_clip.rs
+++ b/dark/src/motion/animation_clip.rs
@@ -77,18 +77,24 @@ impl AnimationClip {
     }
 
     /// Instantaneous root-motion velocity at `frame`: the rate implied by
-    /// the clip's next per-frame root delta, so entity movement tracks the
+    /// the clip's per-frame root delta, so entity movement tracks the
     /// authored motion instead of the clip-average. `None` when the clip has
     /// no usable root stream (fall back to `sliding_velocity`).
+    ///
+    /// Samples the segment starting at `frame`; on the final frame (which has
+    /// no forward segment) it uses the trailing segment. That keeps a looping
+    /// walk moving at its stride rate across the wrap instead of stalling for
+    /// a frame, while a one-shot clip that rests at its end still reads ~0
+    /// there (its trailing frames don't move).
     pub fn root_velocity_at(&self, frame: u32) -> Option<Vector3<f32>> {
         if self.root_positions.len() < 2 {
             return None;
         }
         let last = self.root_positions.len() - 1;
-        let f0 = (frame as usize).min(last);
-        let f1 = (f0 + 1).min(last);
+        let f0 = (frame as usize).min(last - 1);
         Some(
-            (self.root_positions[f1] - self.root_positions[f0]) / self.time_per_frame.as_secs_f32(),
+            (self.root_positions[f0 + 1] - self.root_positions[f0])
+                / self.time_per_frame.as_secs_f32(),
         )
     }
 }

--- a/dark/src/motion/animation_clip.rs
+++ b/dark/src/motion/animation_clip.rs
@@ -17,6 +17,9 @@ pub struct AnimationClip {
     pub translation: Vector3<f32>,
     pub joint_to_frame: HashMap<JointId, Vec<Matrix4<f32>>>,
     pub root_transforms: Vec<Matrix4<f32>>, // root transforms per frame
+    /// Full per-frame root positions (scaled); drives per-frame root-motion
+    /// velocity. Empty for clips without a root stream (e.g. GLB clips).
+    pub root_positions: Vec<Vector3<f32>>,
     pub motion_flags: Vec<FrameFlags>,
     pub name: Option<String>, // Added for GLB animation support
 }
@@ -63,6 +66,7 @@ impl AnimationClip {
             blend_length: Duration::from_millis(motion_stuff.blend_length as u64),
             joint_to_frame,
             root_transforms: motion_clip.root_transforms.clone(),
+            root_positions: motion_clip.root_positions.clone(),
             time_per_frame,
             motion_flags: mps_motion.motion_flags.clone(),
             sliding_velocity,
@@ -70,5 +74,21 @@ impl AnimationClip {
             end_rotation,
             name: Some(mps_motion.name.clone()), // Use motion name for traditional SS2 animations
         }
+    }
+
+    /// Instantaneous root-motion velocity at `frame`: the rate implied by
+    /// the clip's next per-frame root delta, so entity movement tracks the
+    /// authored motion instead of the clip-average. `None` when the clip has
+    /// no usable root stream (fall back to `sliding_velocity`).
+    pub fn root_velocity_at(&self, frame: u32) -> Option<Vector3<f32>> {
+        if self.root_positions.len() < 2 {
+            return None;
+        }
+        let last = self.root_positions.len() - 1;
+        let f0 = (frame as usize).min(last);
+        let f1 = (f0 + 1).min(last);
+        Some(
+            (self.root_positions[f1] - self.root_positions[f0]) / self.time_per_frame.as_secs_f32(),
+        )
     }
 }

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -241,7 +241,14 @@ impl AnimationPlayer {
             // Move at the rate the mocap root actually moves this frame -
             // the clip-average (`sliding_velocity`) integrates to the same
             // endpoint but smears non-uniform motion (a death keeps gliding
-            // at constant speed while the body is already down)
+            // at constant speed while the body is already down). The value is
+            // a rate (units/sec) keyed to the clip's own frame time, so it is
+            // independent of the render/physics refresh. Sampled from the
+            // frame at the start of the tick: whenever the tick is shorter
+            // than a clip frame (true at 60/90/120Hz against 30fps clips) it
+            // crosses at most one frame, so multi-frame advance only happens
+            // on a hitch and briefly commanding the first frame's rate isn't
+            // worth averaging over.
             let velocity = current_clip
                 .root_velocity_at(player.current_frame)
                 .unwrap_or(current_clip.sliding_velocity);
@@ -542,6 +549,28 @@ mod tests {
             velocity.x.abs() < 1e-4,
             "expected zero while the root rests, got {:?}",
             velocity
+        );
+    }
+
+    #[test]
+    fn root_velocity_uses_trailing_delta_on_the_final_frame() {
+        // Monotonic stride: each frame advances 1 unit. A looping clip lands
+        // on the final frame once per cycle; using the forward segment there
+        // would read positions[last]-positions[last] = 0 and stall the walk,
+        // so the final frame must fall back to the trailing segment's rate.
+        let mut clip = (*clip_with_root_motion()).clone();
+        clip.root_positions = vec![
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(2.0, 0.0, 0.0),
+        ];
+
+        assert!((clip.root_velocity_at(0).unwrap().x - 10.0).abs() < 1e-4);
+        assert!((clip.root_velocity_at(1).unwrap().x - 10.0).abs() < 1e-4);
+        assert!(
+            (clip.root_velocity_at(2).unwrap().x - 10.0).abs() < 1e-4,
+            "final frame should keep the stride rate, not drop to zero: {:?}",
+            clip.root_velocity_at(2)
         );
     }
 

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -238,7 +238,13 @@ impl AnimationPlayer {
             (updated_player, motion_flags, vec![], vec3(0.0, 0.0, 0.0))
         } else {
             let (current_clip, flags) = maybe_current_clip.unwrap();
-            let velocity = current_clip.sliding_velocity;
+            // Move at the rate the mocap root actually moves this frame -
+            // the clip-average (`sliding_velocity`) integrates to the same
+            // endpoint but smears non-uniform motion (a death keeps gliding
+            // at constant speed while the body is already down)
+            let velocity = current_clip
+                .root_velocity_at(player.current_frame)
+                .unwrap_or(current_clip.sliding_velocity);
             let mut next_frame = player.current_frame;
             let time_per_frame = current_clip.time_per_frame.as_secs_f32();
             while remaining_duration >= time_per_frame {
@@ -483,5 +489,73 @@ impl AnimationPlayer {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// 3-frame clip at 10fps whose root moves 1 unit in x during frame 0->1
+    /// and then rests: per-frame velocity is (10,0,0) then zero, while the
+    /// clip-average (`sliding_velocity`) smears it to ~(3.33,0,0).
+    fn clip_with_root_motion() -> Rc<AnimationClip> {
+        let time_per_frame = Duration::from_millis(100);
+        Rc::new(AnimationClip {
+            num_frames: 3,
+            time_per_frame,
+            duration: time_per_frame * 3,
+            blend_length: Duration::ZERO,
+            end_rotation: Deg(0.0),
+            sliding_velocity: vec3(1.0, 0.0, 0.0) / 0.3,
+            translation: vec3(1.0, 0.0, 0.0),
+            joint_to_frame: HashMap::new(),
+            root_transforms: Vec::new(),
+            root_positions: vec![
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 0.0, 0.0),
+                vec3(1.0, 0.0, 0.0),
+            ],
+            motion_flags: Vec::new(),
+            name: None,
+        })
+    }
+
+    #[test]
+    fn update_returns_per_frame_root_velocity_not_clip_average() {
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+
+        // Frame 0 -> 1: the root moves a full unit in one 100ms frame
+        let (player, _, _, velocity) = AnimationPlayer::update(&player, Duration::from_millis(100));
+        assert!(
+            (velocity.x - 10.0).abs() < 1e-4,
+            "expected the frame's own rate (10.0), got {:?}",
+            velocity
+        );
+
+        // Frame 1 -> 2: the root rests, so the entity must stop
+        let (_, _, _, velocity) = AnimationPlayer::update(&player, Duration::from_millis(100));
+        assert!(
+            velocity.x.abs() < 1e-4,
+            "expected zero while the root rests, got {:?}",
+            velocity
+        );
+    }
+
+    #[test]
+    fn update_falls_back_to_sliding_velocity_without_root_stream() {
+        let mut clip = (*clip_with_root_motion()).clone();
+        clip.root_positions = Vec::new();
+        let player = AnimationPlayer::queue_animation(&AnimationPlayer::empty(), Rc::new(clip));
+
+        let (_, _, _, velocity) = AnimationPlayer::update(&player, Duration::from_millis(100));
+        assert!(
+            (velocity.x - 1.0 / 0.3).abs() < 1e-4,
+            "expected the clip-average fallback, got {:?}",
+            velocity
+        );
     }
 }

--- a/dark/src/motion/motion_clip.rs
+++ b/dark/src/motion/motion_clip.rs
@@ -1,6 +1,6 @@
 use std::io::{self, SeekFrom};
 
-use cgmath::{Matrix4, SquareMatrix, vec3};
+use cgmath::{Matrix4, SquareMatrix, Vector3, vec3};
 
 use crate::{
     SCALE_FACTOR,
@@ -12,7 +12,10 @@ use crate::{
 pub struct MotionClip {
     pub num_joints: u32,
     pub root_transforms: Vec<Matrix4<f32>>, // root transforms across frames
-    pub animation: Vec<Vec<Matrix4<f32>>>,  // joint -> animations across frames
+    /// Full per-frame root positions (scaled). The y also drives
+    /// `root_transforms`; the x/z deltas drive entity movement.
+    pub root_positions: Vec<Vector3<f32>>,
+    pub animation: Vec<Vec<Matrix4<f32>>>, // joint -> animations across frames
 }
 
 impl MotionClip {
@@ -26,6 +29,7 @@ impl MotionClip {
         // Read transforms for root joint
         let mut animation = Vec::new();
         let mut root_transforms = Vec::new();
+        let mut root_positions = Vec::new();
         let mut frame_transforms = Vec::new();
         for _frame in 0..num_frames {
             // We handle the root transforms in a special way,
@@ -33,9 +37,11 @@ impl MotionClip {
             // to work correctly
             frame_transforms.push(Matrix4::identity());
 
-            // Record the root translation - we _only_ record the y, because
-            // the x/z transform is handled by our movement system.
+            // The pose only carries the root's y (vertical bob/descent); the
+            // x/z displacement moves the entity instead, driven by the
+            // per-frame deltas of `root_positions`.
             let xform = read_vec3(reader);
+            root_positions.push(xform / SCALE_FACTOR);
             root_transforms.push(Matrix4::from_translation(vec3(
                 0.0,
                 xform.y / SCALE_FACTOR,
@@ -57,7 +63,8 @@ impl MotionClip {
         }
 
         MotionClip {
-            root_transforms: root_transforms,
+            root_transforms,
+            root_positions,
             num_joints,
             animation,
         }

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -519,6 +519,7 @@ mod tests {
             translation: Vector3::new(0.0, 0.0, 0.0),
             joint_to_frame,
             root_transforms: vec![Matrix4::from_translation(Vector3::new(0.0, 10.0, 0.0))],
+            root_positions: Vec::new(),
             motion_flags: Vec::new(),
             name: None,
         };

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -223,6 +223,26 @@ impl MotionAnalyzer {
                     .fold((f32::MAX, f32::MIN), |(a, b), y| (a.min(*y), b.max(*y)));
                 println!("                min {:.3}  max {:.3}", min, max);
             }
+            // Horizontal root motion: net displacement, and how long the
+            // root is still (per-frame delta < 1cm) at the clip's tail
+            let ps = &clip.root_positions;
+            if ps.len() > 1 {
+                let net = ps[ps.len() - 1] - ps[0];
+                let mut still_frames = 0;
+                for i in (1..ps.len()).rev() {
+                    let d = ps[i] - ps[i - 1];
+                    if (d.x * d.x + d.z * d.z).sqrt() < 0.01 {
+                        still_frames += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let still_secs = still_frames as f32 / mps.frame_rate as f32;
+                println!(
+                    "  root xz:      net [{:.3}, {:.3}]  still tail {:.2}s ({} frames)",
+                    net.x, net.z, still_secs, still_frames
+                );
+            }
         } else {
             println!(
                 "  root y:       (no unpacked clip at {})",

--- a/tools/shock2-sdk/test/root-motion-velocity.e2e.test.ts
+++ b/tools/shock2-sdk/test/root-motion-velocity.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "root motion drives entities at the mocap's per-frame rate, not a constant average",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster, identifying it by diffing the entity list.
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // A killing blow interrupts into the death clip immediately, so the
+    // whole sampled window is one clip. The death clips carry ~1.8 units of
+    // net root motion whose rate varies strongly across the clip (windup,
+    // fall, rest) - per-frame root velocity must reproduce that profile,
+    // while the old clip-average made the body glide at constant speed.
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+
+    const positions: [number, number, number][] = [];
+    for (let i = 0; i < 34; i++) {
+      await game.step({ frames: 15 });
+      positions.push((await game.entities.detail(monster.id)).position);
+    }
+
+    const speeds: number[] = [];
+    for (let i = 1; i < positions.length; i++) {
+      const dx = positions[i][0] - positions[i - 1][0];
+      const dz = positions[i][2] - positions[i - 1][2];
+      speeds.push(Math.hypot(dx, dz));
+    }
+    const moving = speeds.filter((s) => s > 0.02);
+    const total = speeds.reduce((a, b) => a + b, 0);
+    assert.ok(
+      total > 0.5,
+      `expected the death's root motion to move the body (total ${total.toFixed(2)})`,
+    );
+    assert.ok(
+      moving.length >= 3,
+      `expected several moving intervals, got ${moving.length}`,
+    );
+
+    const mean = moving.reduce((a, b) => a + b, 0) / moving.length;
+    const max = Math.max(...moving);
+    assert.ok(
+      max / mean > 1.6,
+      `expected a non-uniform speed profile (max/mean ${(max / mean).toFixed(2)}; ` +
+        `a constant-velocity glide is ~1.0)`,
+    );
+  },
+);


### PR DESCRIPTION
Follow-up from the movement audit (the root-transform → velocity mapping). Fixes the constant-velocity glide called out there.

## Problem

Creature movement used a single clip-**average** velocity — `MotionStuff.translation / duration` — pushed into the physics body every frame (`mission_core::update_animations` → `physics.set_velocity`). It integrates to the correct endpoint, but smears any non-uniform motion within a clip:

- A dying creature **glided across the floor at constant speed for the entire collapse** instead of decelerating as the body went down (`ogpdie03` has a 1.8s still tail the average ignored).
- Lunge/step clips desync from their poses (foot-slide), since the pose moves non-linearly while the entity moves linearly.

## Change

Keep the full per-frame root positions at parse — we already kept the root's **y** for the vertical pose bob and discarded x/z; now `motion_clip.rs` keeps all of it in `root_positions` (scaled consistently with `sliding_velocity`). `AnimationPlayer::update` returns the **instantaneous per-frame delta rate** (`AnimationClip::root_velocity_at`) instead of the clip average. Clips without a root stream (e.g. GLB) fall back to the old average.

`root_velocity_at` samples the segment starting at the current frame, and on the **final frame** (no forward segment) uses the *trailing* segment — so a looping walk keeps its stride rate across the wrap instead of stalling for a frame, while a one-shot clip that rests at its end still reads ~0 there. (That loop-wrap dropout was caught by cross-engine review — both engines flagged it High.)

The returned value is a rate keyed to the clip's own frame time, so it's **independent of render/physics refresh** (verified fine for 60/90/120Hz against 30fps clips). One documented, benign limitation: `update` samples the tick's starting frame, so a multi-frame advance (only on a hitch, since a tick is shorter than a clip frame at any of those refreshes) briefly commands the first frame's rate rather than an average.

`dq motion-info` also gained net-horizontal-root-motion + still-tail reporting, used to characterise the death clips.

## Testing

- New SDK e2e test (`root-motion-velocity.e2e.test.ts`), **negative-tested**: kills a creature and samples body speed across the death; asserts a non-uniform speed profile (max/mean > 1.6). On the old code it fails with `max/mean 1.06` — a flat glide.
- New unit tests: per-frame rate vs clip-average, the trailing-delta loop-wrap guard, and the no-root-stream fallback.
- Re-ran `monster-death` and `ai-alertness` (chase steering) e2e: pass — normal locomotion still closes on the player.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime`, `cargo test -p dark` (20), `cargo test -p shock2vr` (80): pass.
- Cross-engine review (`/xreview`): the one AGREED High finding (loop-wrap dropout) fixed and re-validated; the Medium multi-frame-advance gap documented as benign.

Note: does **not** address the floating-corpse vertical offset (#392) — that's the root-**y**/origin-height mismatch, a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)