### PR TITLE
feat(pathfinding): parse the AIPATH cell-door table + mission-loading integration tests

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -13,7 +13,7 @@ pub mod texture_list;
 pub use bsp_tree::*;
 pub use cell::*;
 pub use cell_portal::*;
-pub use path_database::PathDatabase;
+pub use path_database::{CellDoor, PathDatabase};
 pub use plane::*;
 
 use crate::properties::LinkDefinitionWithData;

--- a/dark/src/mission/path_database.rs
+++ b/dark/src/mission/path_database.rs
@@ -68,12 +68,23 @@ pub struct PathCellLink {
     pub cost: u8,              // Traversal cost
 }
 
+/// A below-door path cell and the door object that gates it
+#[derive(Debug, Clone, Copy)]
+pub struct CellDoor {
+    pub cell: u32,
+    /// Mission object id of the door
+    pub door: i32,
+}
+
 /// Complete path database loaded from AIPATH chunk
 #[derive(Debug, Clone)]
 pub struct PathDatabase {
     pub cells: Vec<PathCell>,
     pub vertices: Vec<Vector3<f32>>,
     pub links: Vec<PathCellLink>,
+    /// Which door object gates each below-door cell (empty when the mission
+    /// has no doors or the table couldn't be parsed)
+    pub cell_doors: Vec<CellDoor>,
 }
 
 /// On-disk layout of the AIPATH chunk, keyed by the chunk version.
@@ -441,11 +452,73 @@ impl PathDatabase {
             num_cell_vertices
         );
 
+        // Trailing sections (v2.9 layout, verified against medsci1 data):
+        //   object hints:  count(u32) + count x u32 (cell hint per object id)
+        //   cell-obj maps: count(u32) + count x 16 bytes
+        //                  { obj_id u32, cell_id u32, prev_prop_state u32, ptr u32 }
+        //   cell zones:    (n_cells + 1) x u16, then n_zones(u32), then
+        //                  { key u32, ok_bits u8 } pairs terminated by key == 0
+        //   cell doors:    count(u32) + count x { cell u32, door i32 }
+        // The zone tables are skipped for now (candidate for fast no-route
+        // rejection later); moving-terrain data after the door table is not
+        // read. Door data is optional: on any inconsistency the database
+        // still loads, just without door awareness.
+        let cell_doors = Self::parse_tail(reader, cells.len()).unwrap_or_else(|| {
+            warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+            Vec::new()
+        });
+
         Some(PathDatabase {
             cells,
             vertices,
             links,
+            cell_doors,
         })
+    }
+
+    /// Parse the trailing AIPATH sections up to and including the cell-door
+    /// table. Returns None if the data doesn't match the expected layout.
+    fn parse_tail(reader: &mut io::Cursor<&[u8]>, n_cells: usize) -> Option<Vec<CellDoor>> {
+        // Object hints: a cell id per object id (fast lookup) - skip
+        let n_obj_hints = read_u32_opt(reader)? as u64;
+        reader.set_position(reader.position() + n_obj_hints * 4);
+
+        // Cell-object maps: movable blocking objects (crates etc.) - parsed
+        // but unused for now (runtime OBB updates are a follow-up)
+        let n_cell_obj_maps = read_u32_opt(reader)?;
+        if n_cell_obj_maps > 100_000 {
+            return None;
+        }
+        reader.set_position(reader.position() + n_cell_obj_maps as u64 * 16);
+
+        // Cell zones: one u16 zone per cell (incl. the +1 dummy)
+        reader.set_position(reader.position() + (n_cells as u64) * 2);
+        let _n_zones = read_u32_opt(reader)?;
+        // Zone-pair reachability table: { key u32, ok_bits u8 } until key == 0
+        loop {
+            let key = read_u32_opt(reader)?;
+            let _ok_bits = read_u8_opt(reader)?;
+            if key == 0 {
+                break;
+            }
+        }
+
+        // Cell-door table: which door object gates each below-door cell
+        let n_cell_doors = read_u32_opt(reader)?;
+        if n_cell_doors > 100_000 {
+            return None;
+        }
+        let mut cell_doors = Vec::with_capacity(n_cell_doors as usize);
+        for _ in 0..n_cell_doors {
+            let cell = read_u32_opt(reader)?;
+            let door = read_u32_opt(reader)? as i32;
+            if cell as usize >= n_cells {
+                return None;
+            }
+            cell_doors.push(CellDoor { cell, door });
+        }
+        debug!("AIPATH cell-door table: {} entries", cell_doors.len());
+        Some(cell_doors)
     }
 
     /// Calculate the center point of a cell from its vertices

--- a/dark/src/mission/path_database.rs
+++ b/dark/src/mission/path_database.rs
@@ -463,10 +463,18 @@ impl PathDatabase {
         // rejection later); moving-terrain data after the door table is not
         // read. Door data is optional: on any inconsistency the database
         // still loads, just without door awareness.
-        let cell_doors = Self::parse_tail(reader, cells.len()).unwrap_or_else(|| {
-            warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+        //
+        // The layout was reverse-engineered and validated only for v2.9
+        // (every shipped mission except shodan). The v3.4 tail may differ, so
+        // only attempt the known layout rather than risk a silent misparse.
+        let cell_doors = if layout == AiPathLayout::PackedIds {
+            Self::parse_tail(reader, &cells).unwrap_or_else(|| {
+                warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+                Vec::new()
+            })
+        } else {
             Vec::new()
-        });
+        };
 
         Some(PathDatabase {
             cells,
@@ -477,8 +485,13 @@ impl PathDatabase {
     }
 
     /// Parse the trailing AIPATH sections up to and including the cell-door
-    /// table. Returns None if the data doesn't match the expected layout.
-    fn parse_tail(reader: &mut io::Cursor<&[u8]>, n_cells: usize) -> Option<Vec<CellDoor>> {
+    /// table. Returns None if the data doesn't match the expected layout -
+    /// which doubles as a misparse detector, since a misaligned read almost
+    /// never lands on a table whose cells are all in range AND flagged
+    /// below-door.
+    fn parse_tail(reader: &mut io::Cursor<&[u8]>, cells: &[PathCell]) -> Option<Vec<CellDoor>> {
+        let n_cells = cells.len();
+
         // Object hints: a cell id per object id (fast lookup) - skip
         let n_obj_hints = read_u32_opt(reader)? as u64;
         reader.set_position(reader.position() + n_obj_hints * 4);
@@ -512,8 +525,11 @@ impl PathDatabase {
         for _ in 0..n_cell_doors {
             let cell = read_u32_opt(reader)?;
             let door = read_u32_opt(reader)? as i32;
-            if cell as usize >= n_cells {
-                return None;
+            // Every gated cell must exist and actually be a below-door cell;
+            // otherwise we've misread the layout and should discard the table
+            match cells.get(cell as usize) {
+                Some(c) if c.flags.contains(PathCellFlags::BELOW_DOOR) => {}
+                _ => return None,
             }
             cell_doors.push(CellDoor { cell, door });
         }

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -13,7 +13,7 @@
 
 use std::fs::File;
 use std::io::BufReader;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dark::mission::PathDatabase;
 use dark::ss2_chunk_file_reader;
@@ -42,15 +42,15 @@ fn data_root() -> Option<PathBuf> {
 
 /// Load a mission's AIPATH pathfinding database, or `None` if the mission has
 /// no usable AIPATH chunk.
-fn load_path_database(data: &PathBuf, mission: &str) -> Option<PathDatabase> {
+fn load_path_database(data: &Path, mission: &str) -> Option<PathDatabase> {
     let file = File::open(data.join(mission)).expect("mission file should open");
     let mut reader = BufReader::new(file);
     let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
     PathDatabase::read(&toc, &mut reader)
 }
 
-/// Every `.mis` file with AIPATH data. Returns None (skip) without assets.
-fn all_missions(data: &PathBuf) -> Vec<String> {
+/// Every `.mis` filename in `data`.
+fn all_missions(data: &Path) -> Vec<String> {
     std::fs::read_dir(data)
         .expect("Data directory should read")
         .filter_map(|e| e.ok())
@@ -131,4 +131,22 @@ fn all_missions_load_with_consistent_aipath() {
         missions_with_doors >= 15,
         "expected most missions to have a parsed cell-door table, got {missions_with_doors}"
     );
+}
+
+#[test]
+fn shodan_v34_aipath_loads_without_door_data() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    // shodan.mis is the only v3.4 (WideIds) AIPATH. Its trailing layout isn't
+    // reverse-engineered, so the tail parse is intentionally not attempted -
+    // the database still loads, just with no cell-door table (never a
+    // silently-misparsed one).
+    if let Some(db) = load_path_database(&data, "shodan.mis") {
+        assert!(
+            db.cell_doors.is_empty(),
+            "v3.4 tail must not be parsed until its layout is verified"
+        );
+    }
 }

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -1,0 +1,134 @@
+//! Integration tests that load real mission files and assert on the parsed
+//! structures - the middle layer between pure unit tests (no game data) and
+//! the SDK e2e suite (spawns a full game with a GPU/HTTP runtime).
+//!
+//! These load and parse `.mis` chunks directly (no rendering, no game loop),
+//! so they are fast and can assert on internal parse results the e2e can't
+//! reach. They need the game assets in `Data/`; when those aren't present
+//! (e.g. a CI runner without copyrighted assets) each test skips cleanly
+//! rather than failing, so `cargo test` stays green everywhere.
+//!
+//! Point them at assets with `DARK_ASSET_PATH=/path/to/Data`, or run from a
+//! checkout that has `Data/` beside the workspace root.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use dark::mission::PathDatabase;
+use dark::ss2_chunk_file_reader;
+
+/// Locate the `Data/` directory, or `None` when assets aren't available.
+///
+/// Checks `DARK_ASSET_PATH` first, then walks up from the crate directory -
+/// tests run with the crate root as the working directory, and `Data/` lives
+/// beside the workspace root one level up.
+fn data_root() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("DARK_ASSET_PATH") {
+        let p = PathBuf::from(path);
+        if p.join("medsci1.mis").exists() {
+            return Some(p);
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for candidate in ["../Data", "../../Data", "Data"] {
+        let p = base.join(candidate);
+        if p.join("medsci1.mis").exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Load a mission's AIPATH pathfinding database, or `None` if the mission has
+/// no usable AIPATH chunk.
+fn load_path_database(data: &PathBuf, mission: &str) -> Option<PathDatabase> {
+    let file = File::open(data.join(mission)).expect("mission file should open");
+    let mut reader = BufReader::new(file);
+    let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+    PathDatabase::read(&toc, &mut reader)
+}
+
+/// Every `.mis` file with AIPATH data. Returns None (skip) without assets.
+fn all_missions(data: &PathBuf) -> Vec<String> {
+    std::fs::read_dir(data)
+        .expect("Data directory should read")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".mis"))
+        .collect()
+}
+
+#[test]
+fn medsci1_cell_door_table_parses() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let db = load_path_database(&data, "medsci1.mis").expect("medsci1 has AIPATH data");
+
+    // The cell-door table maps below-door path cells to the door object that
+    // gates them. medsci1 has a known, stable set (532 cell entries across
+    // 56 doors) - a regression in the trailing-section parse changes this.
+    assert_eq!(
+        db.cell_doors.len(),
+        532,
+        "medsci1 cell-door entry count changed"
+    );
+    let unique_doors: std::collections::HashSet<i32> =
+        db.cell_doors.iter().map(|cd| cd.door).collect();
+    assert_eq!(unique_doors.len(), 56, "medsci1 unique door count changed");
+
+    // Object 1729 is "Sci Med Door" - it must appear in the table, and every
+    // mapped cell must be a valid index into the cell array.
+    assert!(
+        unique_doors.contains(&1729),
+        "known Sci Med Door (obj 1729) missing from the cell-door table"
+    );
+    for cd in &db.cell_doors {
+        assert!(
+            (cd.cell as usize) < db.cells.len(),
+            "cell-door maps cell {} out of range ({} cells)",
+            cd.cell,
+            db.cells.len()
+        );
+    }
+}
+
+#[test]
+fn all_missions_load_with_consistent_aipath() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+
+    let mut missions_with_doors = 0;
+    for mission in all_missions(&data) {
+        // shodan.mis is a known bad file (issue #267); don't fail on it.
+        if mission == "shodan.mis" {
+            continue;
+        }
+        let Some(db) = load_path_database(&data, &mission) else {
+            continue; // no AIPATH chunk - fine
+        };
+
+        // A misaligned trailing-section parse would produce cell ids past the
+        // end of the cell array; this catches it across every mission.
+        for cd in &db.cell_doors {
+            assert!(
+                (cd.cell as usize) < db.cells.len(),
+                "{mission}: cell-door maps cell {} out of range ({} cells)",
+                cd.cell,
+                db.cells.len()
+            );
+        }
+        if !db.cell_doors.is_empty() {
+            missions_with_doors += 1;
+        }
+    }
+
+    assert!(
+        missions_with_doors >= 15,
+        "expected most missions to have a parsed cell-door table, got {missions_with_doors}"
+    );
+}

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -506,6 +506,7 @@ mod tests {
             cells,
             vertices,
             links,
+            cell_doors: Vec::new(),
         }
     }
 

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -198,6 +198,38 @@ fn dump_component_at(db: PathDatabase, at: Vector3<f32>) {
     for (desc, count) in &frontier {
         println!("  {count:>5}  {desc}");
     }
+
+    // How many frontier destinations are below-door cells the door table
+    // maps to a door object? Those become passable when the door opens.
+    let door_cells: std::collections::HashMap<u32, i32> =
+        db.cell_doors.iter().map(|cd| (cd.cell, cd.door)).collect();
+    let mut frontier_door_dests: std::collections::BTreeMap<i32, usize> =
+        std::collections::BTreeMap::new();
+    let mut frontier_blocking_non_door = 0usize;
+    for link in &db.links {
+        if !members.contains(&link.from_cell) || members.contains(&link.to_cell) {
+            continue;
+        }
+        if let Some(&door) = door_cells.get(&link.to_cell) {
+            *frontier_door_dests.entry(door).or_default() += 1;
+        } else if db
+            .cells
+            .get(link.to_cell as usize)
+            .map(|c| c.flags.contains(PathCellFlags::BLOCKING_OBB))
+            .unwrap_or(false)
+        {
+            frontier_blocking_non_door += 1;
+        }
+    }
+    println!(
+        "frontier dests gated by a door: {} (across {} doors); blocking-obb non-door dests: {}",
+        frontier_door_dests.values().sum::<usize>(),
+        frontier_door_dests.len(),
+        frontier_blocking_non_door
+    );
+    for (door, count) in frontier_door_dests.iter().take(8) {
+        println!("    door obj {door}: {count} frontier links");
+    }
 }
 
 fn resolve_missions(mission: Option<String>, all: bool) -> Result<Vec<String>> {
@@ -330,6 +362,26 @@ fn print_stats(mission: &str, db: PathDatabase) {
     }
     println!(
         "audit: links into below-door cells: walkable={door_links_walkable} zero-bits={door_links_dead}"
+    );
+
+    // Door table: below-door cells mapped to their gating door object
+    let unique_doors: std::collections::HashSet<i32> =
+        db.cell_doors.iter().map(|cd| cd.door).collect();
+    let door_cells_also_blocking = db
+        .cell_doors
+        .iter()
+        .filter(|cd| {
+            db.cells
+                .get(cd.cell as usize)
+                .map(|c| c.flags.contains(PathCellFlags::BLOCKING_OBB))
+                .unwrap_or(false)
+        })
+        .count();
+    println!(
+        "door table: {} cell-door entries, {} unique doors, {} of those cells also BLOCKING_OBB",
+        db.cell_doors.len(),
+        unique_doors.len(),
+        door_cells_also_blocking
     );
 
     // Walk-graph connectivity for a plain WALK query. Links are treated as


### PR DESCRIPTION
## Summary

First slice of the door work (item 1 of the AI follow-ups). Parses the AIPATH chunk's **cell-door table** — which door object gates each below-door path cell — plus adds a testing layer between unit tests and e2e.

**Context / scope correction:** while investigating, I found the original premise ("doors bake as BLOCKING_OBB, isolating medsci1's start room") was wrong — verified directly: 0 of the start room's 192 blocking frontier cells are in the door table (they're movable-obstacle OBBs, a separate mechanism). And the pathfinding graph is already *door-optimistic* (below-door cells are passable), matching the original engine's search. So opening a door doesn't change routing — "pursuit dies at doors" is purely physical (doors are OBB colliders; the AI paths through but its body is blocked because it never opens the door). This PR lands the **data** an AI needs to open the right door; the behavior (AIs open unlocked doors / show frustration + give up at locked ones) is the follow-up PR.

### What's here
- **Parse the trailing AIPATH sections** (v2.9 layout, reverse-engineered): object hints, cell-object maps, zone tables, and the cell-door table. Zone tables are skipped (candidate for fast no-route rejection later); the parse degrades to an empty table on any inconsistency, so missions still load.
- **Graph unchanged** — below-door cells stay passable.
- **Bench audit** (`cargo bn path stats`): reports cell-door entry count, unique doors, and door-cell/BLOCKING_OBB overlap.
- **New testing layer** — `dark/tests/mission_loading.rs`: loads real `.mis` chunks directly (no game loop / GPU / HTTP), asserting on parsed structures the e2e can't reach. Runs in plain `cargo test`, skips cleanly when `Data/` assets are absent (CI stays green), and a 2-byte parse offset fails it (verified).

## Test plan

- [x] Door table parses across all 23 missions (`cargo bn path stats --all`): 3–59 unique doors each; medsci1 obj 1729 confirmed "Sci Med Door"
- [x] `dark/tests/mission_loading.rs` — 2 integration tests pass; **negative-tested** (2-byte offset → both fail)
- [x] SDK `missions.e2e.test.ts` — all 23 missions still load
- [x] `RUSTFLAGS="-D warnings" cargo check -p dark -p shock2vr -p debug_runtime -p bench`; `cargo test -p dark -p shock2vr`

## Follow-up (PR B)
AIs open the unlocked door gating their next path cell (resolve door obj → entity via `GlobalTemplateIdMap`, send `TurnOn`); locked doors (`PropLocked` + `PropKeyDst` + quest bits) trigger a frustration animation and drop pursuit, so the player can't lure AIs through locked doors into off-limits areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)