### PR TITLE
feat(gameplay): explosions resolve damage through receptrons

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1286,12 +1286,19 @@ impl MissionCore {
         did_slay
     }
 
-    /// Apply a radius stim blast (Effect::RadiusBlast): falloff-scaled damage
-    /// to every entity with hit points in range, and an outward shove to every
-    /// dynamic body. Falloff is linear from full at the center to zero at the
-    /// blast radius.
-    fn radius_blast(&mut self, center: Vector3<f32>, radius: f32, intensity: f32) {
-        let mut damage_targets = Vec::new();
+    /// Apply a radius stim blast (Effect::RadiusBlast): every entity with hit
+    /// points in range receives the stim at linear-falloff intensity, and its
+    /// receptrons decide the damage (no receptron for the stim = no response -
+    /// the type-effectiveness mechanism: EMP does nothing to organics).
+    /// Dynamic bodies in range are shoved outward regardless.
+    fn radius_blast(
+        &mut self,
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+        stim_template_id: i32,
+    ) {
+        let mut in_range = Vec::new();
         {
             let v_hit_points = self
                 .world
@@ -1305,16 +1312,34 @@ impl MissionCore {
                 let distance = (crate::util::point3_to_vec3(position) - center).magnitude();
                 if distance < radius {
                     let falloff = 1.0 - distance / radius;
-                    damage_targets.push((entity_id, intensity * falloff));
+                    in_range.push((entity_id, intensity * falloff));
                 }
             }
         }
 
-        for (entity_id, amount) in damage_targets {
-            self.script_world.dispatch(Message {
-                to: entity_id,
-                payload: MessagePayload::Damage { amount },
-            });
+        for (entity_id, felt_intensity) in in_range {
+            let receptrons =
+                get_all_links_with_template(&self.world, entity_id, |link| match link {
+                    Link::Receptron(options) => Some(options.clone()),
+                    _ => None,
+                });
+            let maybe_damage = crate::mission::stim_response::resolve_stim_damage(
+                &receptrons,
+                stim_template_id,
+                felt_intensity,
+            );
+            // Explosions only ever deal damage: dispatch a Damage message only
+            // for a positive result. A zero amount (fully shielded) would still
+            // read as "took damage" and aggro AI; a negative one (a heal
+            // receptron) has no meaning through the damage path.
+            if let Some(amount) = maybe_damage {
+                if amount > 0.0 {
+                    self.script_world.dispatch(Message {
+                        to: entity_id,
+                        payload: MessagePayload::Damage { amount },
+                    });
+                }
+            }
         }
 
         self.physics.apply_radial_impulse(
@@ -1765,8 +1790,9 @@ impl MissionCore {
                     center,
                     radius,
                     intensity,
+                    stim_template_id,
                 } => {
-                    self.radius_blast(center, radius, intensity);
+                    self.radius_blast(center, radius, intensity, stim_template_id);
                 }
 
                 Effect::ReloadWeapon => {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -8,6 +8,7 @@ pub mod pathfinding_debug;
 pub mod pathfinding_test;
 pub mod spatial_query;
 mod spawn_location;
+pub mod stim_response;
 pub mod visibility_engine;
 
 pub use mission_core::*;

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -1,0 +1,171 @@
+use dark::properties::{ReceptronEffect, ReceptronOptions};
+
+/// Resolve what damage a stim deals to a receiver, given the receiver's
+/// receptron links (as `(stim_template_id, options)` pairs, i.e. the entity's
+/// flattened `Link::Receptron`s).
+///
+/// Among the receptrons matching the stim: any `Abort` swallows it (returns
+/// `None`); every `Amplify` scales the intensity (shields/armor - all
+/// damage-reduction in SS2 data); then every `Damage` deals
+/// `intensity * multiplier` (or a flat `multiplier` when `use_intensity` is
+/// false; negative values heal), summed. `None` means the receiver has no
+/// response to this stim at all - the Dark Engine's type-effectiveness
+/// mechanism (e.g. humans have no receptron for EMP).
+///
+/// Amplify is applied before Damage regardless of the receptrons' `order`
+/// field: in the shipped data the shield/armor Amplify receptrons carry a
+/// *higher* order than the vulnerability Damage receptrons (PsiShield 78-79 vs
+/// Human Vulnerability 15-36), yet a damage-reduction shield only means
+/// anything if it reduces the intensity the damage receptron then reads. The
+/// `order` field currently drives nothing else we chain.
+pub fn resolve_stim_damage(
+    receptrons: &[(i32, ReceptronOptions)],
+    stim_template_id: i32,
+    intensity: f32,
+) -> Option<f32> {
+    let mut amplify = 1.0;
+    let mut has_damage = false;
+    // Sum of damage multipliers, split by whether they scale with intensity, so
+    // the (final) amplified intensity can be applied after all Amplifies are known.
+    let mut intensity_multiplier = 0.0;
+    let mut flat_damage = 0.0;
+
+    for (_, options) in receptrons
+        .iter()
+        .filter(|(stim, _)| *stim == stim_template_id)
+    {
+        match &options.effect {
+            ReceptronEffect::Abort => return None,
+            ReceptronEffect::Amplify { factor } => amplify *= factor,
+            ReceptronEffect::Damage {
+                multiplier,
+                use_intensity,
+            } => {
+                has_damage = true;
+                if *use_intensity {
+                    intensity_multiplier += multiplier;
+                } else {
+                    flat_damage += multiplier;
+                }
+            }
+            ReceptronEffect::Unhandled(_) => {}
+        }
+    }
+
+    has_damage.then(|| flat_damage + intensity * amplify * intensity_multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HIGH_EXPLOSIVE: i32 = -376;
+    const EMP: i32 = -374;
+
+    fn receptron(order: i32, effect: ReceptronEffect) -> ReceptronOptions {
+        ReceptronOptions { order, effect }
+    }
+
+    fn damage(order: i32, multiplier: f32) -> ReceptronOptions {
+        receptron(
+            order,
+            ReceptronEffect::Damage {
+                multiplier,
+                use_intensity: true,
+            },
+        )
+    }
+
+    #[test]
+    fn no_matching_receptron_means_no_response() {
+        // A human has no EMP receptron: EMP blasts do nothing to it.
+        let human = vec![(HIGH_EXPLOSIVE, damage(33, 4.0))];
+        assert_eq!(resolve_stim_damage(&human, EMP, 10.0), None);
+    }
+
+    #[test]
+    fn damage_scales_intensity_by_the_multiplier() {
+        // Human Vulnerability vs High Explosive: x4 (shock2.gam).
+        let human = vec![(HIGH_EXPLOSIVE, damage(33, 4.0))];
+        assert_eq!(
+            resolve_stim_damage(&human, HIGH_EXPLOSIVE, 10.0),
+            Some(40.0)
+        );
+    }
+
+    #[test]
+    fn amplify_reduces_damage_even_at_higher_order_than_the_damage_receptron() {
+        // Real data: shield/armor Amplify receptrons carry a HIGHER order than
+        // the vulnerability Damage receptron (PsiShield 79 vs Human 33). The
+        // shield must still reduce the damage the receptron computes.
+        let shielded = vec![
+            (HIGH_EXPLOSIVE, damage(33, 4.0)),
+            (
+                HIGH_EXPLOSIVE,
+                receptron(79, ReceptronEffect::Amplify { factor: 0.5 }),
+            ),
+        ];
+        // 10 intensity * 0.5 shield * 4.0 vulnerability = 20.
+        assert_eq!(
+            resolve_stim_damage(&shielded, HIGH_EXPLOSIVE, 10.0),
+            Some(20.0)
+        );
+    }
+
+    #[test]
+    fn multiple_amplifies_multiply_together() {
+        let doubly_shielded = vec![
+            (
+                HIGH_EXPLOSIVE,
+                receptron(79, ReceptronEffect::Amplify { factor: 0.5 }),
+            ),
+            (
+                HIGH_EXPLOSIVE,
+                receptron(90, ReceptronEffect::Amplify { factor: 0.4 }),
+            ),
+            (HIGH_EXPLOSIVE, damage(33, 1.0)),
+        ];
+        // 10 * 0.5 * 0.4 * 1.0 = 2.
+        assert_eq!(
+            resolve_stim_damage(&doubly_shielded, HIGH_EXPLOSIVE, 10.0),
+            Some(2.0)
+        );
+    }
+
+    #[test]
+    fn abort_swallows_the_stim() {
+        // Invulnerable: Abort ahead of any damage.
+        let invulnerable = vec![
+            (HIGH_EXPLOSIVE, receptron(1, ReceptronEffect::Abort)),
+            (HIGH_EXPLOSIVE, damage(33, 4.0)),
+        ];
+        assert_eq!(
+            resolve_stim_damage(&invulnerable, HIGH_EXPLOSIVE, 10.0),
+            None
+        );
+    }
+
+    #[test]
+    fn flat_damage_ignores_intensity_and_unhandled_effects_are_inert() {
+        let receiver = vec![
+            (
+                HIGH_EXPLOSIVE,
+                receptron(5, ReceptronEffect::Unhandled("EnvSound".to_string())),
+            ),
+            (
+                HIGH_EXPLOSIVE,
+                receptron(
+                    10,
+                    ReceptronEffect::Damage {
+                        multiplier: 7.0,
+                        use_intensity: false,
+                    },
+                ),
+            ),
+        ];
+        assert_eq!(
+            resolve_stim_damage(&receiver, HIGH_EXPLOSIVE, 100.0),
+            Some(7.0)
+        );
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -136,14 +136,17 @@ pub enum Effect {
         force: Vector3<f32>,
     },
 
-    /// A radius stim blast (explosions): every entity with hit points within
-    /// `radius` of `center` takes `intensity`-scaled damage with linear
-    /// distance falloff, and every dynamic body in range is shoved outward.
-    /// Emitted once by `internal_explosion` from the entity's arSrcDesc data.
+    /// A radius stim blast (explosions): entities within `radius` of `center`
+    /// receive the stim at `intensity` with linear distance falloff - damage
+    /// is resolved per target through its receptrons for `stim_template_id`
+    /// (no receptron = no response) - and every dynamic body in range is
+    /// shoved outward. Emitted once by `internal_explosion` from the entity's
+    /// arSrcDesc data.
     RadiusBlast {
         center: Vector3<f32>,
         radius: f32,
         intensity: f32,
+        stim_template_id: i32,
     },
 
     ChangeModel {

--- a/shock2vr/src/scripts/internal_explosion.rs
+++ b/shock2vr/src/scripts/internal_explosion.rs
@@ -50,9 +50,9 @@ impl Script for InternalExplosion {
         // Explosions carry an impact stim (the blast) plus a ShakeStim (camera
         // shake - unimplemented, and with unrelated numbers: Droid Fusion's
         // shake is 15 @ r0.4 next to its 12 @ r4 damage stim). Skip the shake
-        // and take the strongest remaining source as (intensity, radius) - a
-        // pair from one authored stim, never a mix.
-        let mut blast: Option<(f32, f32)> = None;
+        // and take the strongest remaining source as the blast - one authored
+        // stim, never a mix.
+        let mut blast: Option<(i32, f32, f32)> = None;
         for (
             stim_template_id,
             StimSourceOptions {
@@ -65,12 +65,12 @@ impl Script for InternalExplosion {
                 continue;
             }
             if let StimPropagator::Radius { radius } = propagator {
-                if blast.is_none_or(|(max_intensity, _)| intensity > max_intensity) {
-                    blast = Some((intensity, radius));
+                if blast.is_none_or(|(_, max_intensity, _)| intensity > max_intensity) {
+                    blast = Some((stim_template_id, intensity, radius));
                 }
             }
         }
-        let Some((intensity, radius)) = blast else {
+        let Some((stim_template_id, intensity, radius)) = blast else {
             return Effect::NoEffect;
         };
 
@@ -84,6 +84,7 @@ impl Script for InternalExplosion {
             center,
             radius,
             intensity,
+            stim_template_id,
         }
     }
 }


### PR DESCRIPTION
## Summary

Step 2 of 3 for #390 — builds on the receptron parser (#395, now merged). Radius blasts previously dealt generic falloff damage to everything with hit points. Now each in-range target's receptrons decide the damage for the blast's stim type (`Effect::RadiusBlast` carries the stim template id of its strongest non-shake source):

- **No receptron for the stim → no damage** — the type-effectiveness mechanism. An EMP blast does nothing to organics (they have no EMP receptron).
- **`Abort`** swallows it (Invulnerable).
- **`Amplify`** factors scale the intensity (shields / armor / low-grav — all damage reduction in SS2 data).
- **`Damage`** deals `intensity × amplify × multiplier`, summed.

The core is a pure function, `stim_response::resolve_stim_damage(receptrons, stim_id, intensity) -> Option<f32>`, with 6 unit tests.

### Design note: order-independent Amplify/Abort

The resolver applies Amplify (and Abort) **before** Damage regardless of the receptrons' `order` field. Deliberate and verified against shipped data: the shield/armor Amplify receptrons carry a *higher* order than the vulnerability Damage receptrons (PsiShield 78-79 vs Human Vulnerability 15-36), and Invulnerable's Abort (order 70-71) outranks Basic Vulnerability's Damage (67-68). Processing strictly by ascending order would make both shields **and** invulnerability silent no-ops. (Both review engines and the data check converged on this.)

`radius_blast` only dispatches a `Damage` message for a **positive** result — a zero (fully shielded) would still register as "took damage" and aggro AI, and a negative (heal receptron) has no meaning through the damage path.

## Test plan

- [x] 6 `stim_response` unit tests: no-match → None, damage×multiplier, Amplify-at-higher-order still reduces, multiple Amplifies multiply, Abort → None, flat damage + inert Unhandled
- [x] Explosion barrel-chain e2e passes through the new path (Basic Vulnerability's Incendiary ×1 = same `intensity×falloff` as before — no regression)
- [x] `RUSTFLAGS="-D warnings" cargo check` (shock2vr, desktop_runtime, debug_runtime); rustfmt clean; full e2e suite 55/55
- [x] Cross-engine review (Claude + Codex): both flagged the zero/negative-dispatch issue (fixed); the order-independence decision was independently validated against gamesys data by both

Follow-up (step 3, #390): periodic emitters (electrical sparks, Rad Burst); player damage (#389) would let blasts hurt the player through this same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)