### PR TITLE
feat(cutscene): apparitions materialize, perform, and vanish (medsci1 Grassi)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2419,6 +2419,16 @@ impl MissionCore {
                         dark::properties::PropRenderAlpha(alpha.clamp(0.0, 1.0)),
                     );
                 }
+                Effect::SetVisibility { entity_id, visible } => {
+                    let is_alive = self
+                        .world
+                        .borrow::<shipyard::EntitiesView>()
+                        .map(|entities| entities.is_alive(entity_id))
+                        .unwrap_or(false);
+                    if is_alive {
+                        self.world.add_component(entity_id, PropHasRefs(visible));
+                    }
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -111,6 +111,21 @@ impl AnimatedMonsterAI {
     }
 
     fn build_config(world: &World, entity_id: EntityId) -> Option<MonsterConfig> {
+        // Apparitions are non-interactive replays: they must never notice the
+        // player (an invisible ghost escalating to chase would wander off its
+        // authored mark). No config = no alertness processing.
+        if let Ok(v_class_tag) = world.borrow::<View<dark::properties::PropClassTag>>() {
+            if let Ok(tag) = v_class_tag.get(entity_id) {
+                if tag
+                    .class_tags()
+                    .iter()
+                    .any(|(k, v)| *k == "creaturetype" && *v == "apparition")
+                {
+                    return None;
+                }
+            }
+        }
+
         let (v_alert_cap, v_aware_delay): (View<PropAIAlertCap>, View<PropAIAwareDelay>) =
             world.borrow().ok()?;
 
@@ -584,6 +599,8 @@ impl Script for AnimatedMonsterAI {
                 self.played_ai_watch_obj.insert(ent_id);
                 self.current_behavior = Box::new(RefCell::new(ScriptedSequenceBehavior::new(
                     world,
+                    entity_id,
+                    None,
                     watch_options.scripted_actions.clone(),
                 )));
                 let is_locomotion = self.current_behavior.borrow().is_locomotion();
@@ -770,6 +787,8 @@ impl Script for AnimatedMonsterAI {
                     // Immediately switch to Scripted sequence Behavior
                     self.current_behavior = Box::new(RefCell::new(ScriptedSequenceBehavior::new(
                         world,
+                        entity_id,
+                        None,
                         prop_sig_resp.actions.clone(),
                     )));
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();
@@ -783,23 +802,45 @@ impl Script for AnimatedMonsterAI {
                     Effect::NoEffect
                 }
             }
-            MessagePayload::Signal { name: _ } => {
+            MessagePayload::Signal { name } => {
                 // Dead AIs stay dead - level signals reach corpses too
                 if self.is_dead || is_killed(entity_id, world) {
                     return Effect::NoEffect;
                 }
-                // A re-fired signal must not restart a performance in progress
+                // A re-fire of the signal that started the current
+                // performance must not restart it. A DIFFERENT signal may
+                // replace the sequence - a watch-obj sequence (origin None)
+                // hands off to the real response this way: its lone action
+                // sends the response's signal to itself. (A signal arriving
+                // during an unrelated TurnOn/watch performance could likewise
+                // interrupt it; no shipped content wires that, and the
+                // engine-faithful fix is response priority - deferred, as in
+                // the sequence-protection work this builds on.)
                 if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
-                    return Effect::NoEffect;
+                    let same_origin = self
+                        .current_behavior
+                        .borrow()
+                        .origin_signal()
+                        .is_some_and(|origin| origin.eq_ignore_ascii_case(name));
+                    if same_origin {
+                        return Effect::NoEffect;
+                    }
                 }
-                // Do we have a response to this signal?
-
+                // Respond only to a signal matching this AI's authored
+                // response signal name (named script messages like ApparBegin
+                // also arrive as signals and must not trigger the response).
                 let v_prop_sig_resp = world.borrow::<View<PropAISignalResponse>>().unwrap();
 
-                if let Ok(prop_sig_resp) = v_prop_sig_resp.get(entity_id) {
+                if let Some(prop_sig_resp) = v_prop_sig_resp
+                    .get(entity_id)
+                    .ok()
+                    .filter(|resp| resp.signal.eq_ignore_ascii_case(name))
+                {
                     // Immediately switch to Scripted sequence Behavior
                     self.current_behavior = Box::new(RefCell::new(ScriptedSequenceBehavior::new(
                         world,
+                        entity_id,
+                        Some(name.clone()),
                         prop_sig_resp.actions.clone(),
                     )));
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -41,6 +41,11 @@ pub trait Behavior {
         ScriptedState::NotScripted
     }
 
+    /// For scripted sequences: the signal that started them, if any.
+    fn origin_signal(&self) -> Option<&str> {
+        None
+    }
+
     fn animation(&self) -> Vec<MotionQueryItem> {
         vec![]
     }

--- a/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/scripted_sequence_behavior.rs
@@ -34,6 +34,13 @@ use super::Behavior;
 const ACTION_TIMEOUT_SECONDS: f32 = 30.0;
 
 pub struct ScriptedSequenceBehavior {
+    /// The AI entity performing this sequence.
+    owner: EntityId,
+    /// The signal that started this sequence (None for watch-obj/TurnOn
+    /// sequences). A re-fire of the SAME signal is ignored while running;
+    /// a different signal's response may replace the sequence (this is how
+    /// a watch-obj's Signal action hands off to the real signal response).
+    origin_signal: Option<String>,
     actions: Vec<AIScriptedAction>,
     queued_effects: Vec<Effect>,
     current_action_idx: i32,
@@ -46,11 +53,18 @@ pub struct ScriptedSequenceBehavior {
 }
 
 impl ScriptedSequenceBehavior {
-    pub fn new(world: &World, actions: Vec<AIScriptedAction>) -> ScriptedSequenceBehavior {
-        let current_behavior = get_behavior_from_action(world, &actions[0]);
+    pub fn new(
+        world: &World,
+        owner: EntityId,
+        origin_signal: Option<String>,
+        actions: Vec<AIScriptedAction>,
+    ) -> ScriptedSequenceBehavior {
+        let current_behavior = get_behavior_from_action(world, owner, &actions[0]);
         let initial_effect = current_behavior.borrow().initial_effect();
 
         ScriptedSequenceBehavior {
+            owner,
+            origin_signal,
             actions,
             queued_effects: vec![initial_effect],
             current_action_idx: 0,
@@ -65,6 +79,10 @@ impl ScriptedSequenceBehavior {
 impl Behavior for ScriptedSequenceBehavior {
     fn name(&self) -> &'static str {
         "ScriptedSequence"
+    }
+
+    fn origin_signal(&self) -> Option<&str> {
+        self.origin_signal.as_deref()
     }
 
     fn scripted_state(&self) -> super::ScriptedState {
@@ -172,6 +190,7 @@ impl Behavior for ScriptedSequenceBehavior {
                 self.current_action_idx += 1;
                 let behavior = get_behavior_from_action(
                     world,
+                    self.owner,
                     &self.actions[self.current_action_idx as usize],
                 );
                 self.current_scripted_action = behavior;
@@ -188,9 +207,21 @@ impl Behavior for ScriptedSequenceBehavior {
 
 fn get_behavior_from_action(
     world: &World,
+    owner: EntityId,
     action: &AIScriptedAction,
 ) -> Box<RefCell<dyn ScriptedAction>> {
     let current_behavior: Box<RefCell<dyn ScriptedAction>> = match &action.action_type {
+        AIScriptedActionType::ScriptMessage(message) => Box::new(RefCell::new(
+            ScriptMessageScriptedAction::new(owner, message.clone()),
+        )),
+        AIScriptedActionType::Signal {
+            entity_name,
+            signal,
+        } => Box::new(RefCell::new(SendSignalScriptedAction::new(
+            world,
+            entity_name,
+            signal.clone(),
+        ))),
         AIScriptedActionType::Play(action_name) => Box::new(RefCell::new(
             PlayAnimationScriptedAction::new(action_name.clone()),
         )),
@@ -313,6 +344,75 @@ pub struct IdleScriptedAction;
 impl ScriptedAction for IdleScriptedAction {
     fn animation(self: &IdleScriptedAction) -> Vec<MotionQueryItem> {
         vec![MotionQueryItem::new("idlegesture")]
+    }
+}
+
+/// Sends a named script message (as a Signal) to the performing entity's own
+/// scripts - e.g. the apparition sequences bracket their performance with
+/// ScriptMessage("ApparBegin") / ScriptMessage("ApparEnd"), which the
+/// Apparition script turns into materialize/vanish.
+pub struct ScriptMessageScriptedAction {
+    owner: EntityId,
+    message: String,
+}
+
+impl ScriptMessageScriptedAction {
+    pub fn new(owner: EntityId, message: String) -> ScriptMessageScriptedAction {
+        ScriptMessageScriptedAction { owner, message }
+    }
+}
+
+impl ScriptedAction for ScriptMessageScriptedAction {
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+
+    fn initial_effect(&self) -> Effect {
+        Effect::Send {
+            msg: Message {
+                to: self.owner,
+                payload: crate::scripts::MessagePayload::Signal {
+                    name: self.message.clone(),
+                },
+            },
+        }
+    }
+}
+
+/// Sends an AI signal to a named entity - the watch-obj pseudo-scripts use
+/// this to kick a signal response (e.g. the ectoplasm watches send
+/// "apparition" to the apparition entity).
+pub struct SendSignalScriptedAction {
+    target: Option<EntityId>,
+    signal: String,
+}
+
+impl SendSignalScriptedAction {
+    pub fn new(world: &World, entity_name: &str, signal: String) -> SendSignalScriptedAction {
+        SendSignalScriptedAction {
+            target: script_util::get_first_entity_by_name(world, entity_name),
+            signal,
+        }
+    }
+}
+
+impl ScriptedAction for SendSignalScriptedAction {
+    fn animation(&self) -> Vec<MotionQueryItem> {
+        vec![MotionQueryItem::new("__NULL_ANIMATION__")]
+    }
+
+    fn initial_effect(&self) -> Effect {
+        match self.target {
+            Some(to) => Effect::Send {
+                msg: Message {
+                    to,
+                    payload: crate::scripts::MessagePayload::Signal {
+                        name: self.signal.clone(),
+                    },
+                },
+            },
+            None => Effect::NoEffect,
+        }
     }
 }
 

--- a/shock2vr/src/scripts/apparition.rs
+++ b/shock2vr/src/scripts/apparition.rs
@@ -1,0 +1,71 @@
+//! Script `Apparition`: the ghostly crew replays scattered around the ship
+//! (e.g. the Grassi apparition in medsci1). The entity is authored invisible
+//! (`PropHasRefs(false)`, translucent ghost model); its scripted sequence
+//! (AISignalResponse / AIWatchObj actions) brackets the performance with
+//! ScriptMessage("ApparBegin") / ScriptMessage("ApparEnd"), which reach this
+//! script as signals: materialize (+ play the authored apparition sound) and
+//! vanish again.
+use dark::properties::PropObjectSound;
+use engine::audio::AudioHandle;
+use shipyard::{EntityId, Get, View, World};
+use tracing::info;
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+pub struct Apparition {
+    audio_handle: AudioHandle,
+}
+
+impl Apparition {
+    pub fn new() -> Apparition {
+        Apparition {
+            audio_handle: AudioHandle::new(),
+        }
+    }
+}
+
+impl Script for Apparition {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let MessagePayload::Signal { name } = msg else {
+            return Effect::NoEffect;
+        };
+        match name.as_str() {
+            "ApparBegin" => {
+                info!("apparition {:?} materializing", entity_id);
+                let v_sound = world.borrow::<View<PropObjectSound>>().unwrap();
+                let sound_effect = match v_sound.get(entity_id) {
+                    Ok(sound) => Effect::PlaySound {
+                        handle: self.audio_handle.clone(),
+                        name: sound.name.clone(),
+                    },
+                    Err(_) => Effect::NoEffect,
+                };
+                Effect::Combined {
+                    effects: vec![
+                        Effect::SetVisibility {
+                            entity_id,
+                            visible: true,
+                        },
+                        sound_effect,
+                    ],
+                }
+            }
+            "ApparEnd" => {
+                info!("apparition {:?} vanishing", entity_id);
+                Effect::SetVisibility {
+                    entity_id,
+                    visible: false,
+                }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -297,6 +297,13 @@ pub enum Effect {
         alpha: f32,
     },
 
+    /// Show or hide an entity (PropHasRefs) - e.g. apparitions materializing
+    /// on ApparBegin and vanishing on ApparEnd.
+    SetVisibility {
+        entity_id: EntityId,
+        visible: bool,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -3,6 +3,7 @@ pub mod effect;
 pub mod speech_registry;
 pub mod speech_util;
 
+mod apparition;
 mod base_button;
 mod base_elevator;
 mod base_monster;
@@ -606,7 +607,10 @@ impl ScriptWorld {
             "liquor" => Box::new(NoopScript::new()),
 
             // Not implemented - new medsci1 ones:
-            "apparition" => Box::new(UnimplementedScript::new(&script_name)),
+            "apparition" => Box::new(CompositeScript::new(vec![
+                Box::new(BaseMonster::new()),
+                Box::new(apparition::Apparition::new()),
+            ])),
             "ectoplasm" => Box::new(UnimplementedScript::new(&script_name)),
             "medpatchscript" => Box::new(UnimplementedScript::new(&script_name)),
             "psikitscript" => Box::new(UnimplementedScript::new(&script_name)),


### PR DESCRIPTION
Implements the ghostly crew-replay apparitions (previously `UnimplementedScript`) — e.g. the **Grassi apparition** in medsci1 that appears near an Ectoplasm splotch, gestures, and fades away. Stacked on #387 (it builds directly on the scripted-sequence infrastructure).

## How it works (all data-authored)
The apparition is authored invisible (`PropHasRefs(false)`, translucent FullBright ghost model) with an `AISignalResponse` whose actions bracket the performance: `ScriptMessage("ApparBegin")` → `Goto` → `Play cs28`/`Play cs26` → `ScriptMessage("ApparEnd")`. An `AIWatchObj` on the Ectoplasm fires a `Signal` action at the apparition when the player gets close.

## Pieces added
- **`Apparition` script** (composed with `BaseMonster`): on `Signal("ApparBegin")` → materialize (`Effect::SetVisibility{true}` + play the authored `PropObjectSound`); on `Signal("ApparEnd")` → vanish.
- **Two scripted-sequence actions**: `ScriptMessage` (send a named signal to self) and `Signal` (send a named signal to another named entity — how the watch-obj kicks the response).
- **`Effect::SetVisibility`** toggles `PropHasRefs` (liveness-guarded).
- **Signal responses now match on the response's authored signal name** (was: any signal triggered the sole response). Required so the self-sent `ApparBegin`/`ApparEnd` don't re-trigger the `"Apparition"` response in a loop; also engine-faithful. A sequence tracks its origin signal, so a re-fire of the same signal is ignored while running, but a different signal's response can hand off (watch-obj → response).
- **Apparitions opt out of alertness** (`creaturetype apparition`): an invisible ghost must never notice the player and wander off its mark.

## Verification
Headless in medsci1: approaching the ectoplasm materializes the Grassi ghost, which plays its talk/gesture animation and vanishes — full lifecycle, replayable via the `apparition` signal. The two frames below (same replay, ~0.7s apart) show the translucent ghost in distinct gesture poses:

![apparition pose 1](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/appar_pose1.png)
![apparition pose 2](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/appar_pose2.png)

Cross-engine review (Claude): no Critical/High. It verified the signal-name-match change against every shipped `TrapSignal`→AI wiring (including case-insensitive `nodeaf`/`NoDeaf`, `Ogmoan`/`OGMoan`) — no regression. Applied its response-lookup simplification and documented the one noted tradeoff (a matching signal can interrupt an unrelated `TurnOn`/watch performance; no shipped content wires that; engine-faithful fix is response priority, deferred consistently with #387).

Full e2e: 54/55 — the one failure is a flaky ragdoll-drift threshold (`corpse moved 0.82 units`, threshold 0.5) that passes 3/3 in isolation and is unrelated to this change (death path is upstream #375/#385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)