### PR TITLE
feat(ai): pursuing AIs open unlocked doors, give up at locked ones

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -13,7 +13,7 @@ pub mod texture_list;
 pub use bsp_tree::*;
 pub use cell::*;
 pub use cell_portal::*;
-pub use path_database::PathDatabase;
+pub use path_database::{CellDoor, PathDatabase};
 pub use plane::*;
 
 use crate::properties::LinkDefinitionWithData;

--- a/dark/src/mission/path_database.rs
+++ b/dark/src/mission/path_database.rs
@@ -68,12 +68,23 @@ pub struct PathCellLink {
     pub cost: u8,              // Traversal cost
 }
 
+/// A below-door path cell and the door object that gates it
+#[derive(Debug, Clone, Copy)]
+pub struct CellDoor {
+    pub cell: u32,
+    /// Mission object id of the door
+    pub door: i32,
+}
+
 /// Complete path database loaded from AIPATH chunk
 #[derive(Debug, Clone)]
 pub struct PathDatabase {
     pub cells: Vec<PathCell>,
     pub vertices: Vec<Vector3<f32>>,
     pub links: Vec<PathCellLink>,
+    /// Which door object gates each below-door cell (empty when the mission
+    /// has no doors or the table couldn't be parsed)
+    pub cell_doors: Vec<CellDoor>,
 }
 
 /// On-disk layout of the AIPATH chunk, keyed by the chunk version.
@@ -441,11 +452,73 @@ impl PathDatabase {
             num_cell_vertices
         );
 
+        // Trailing sections (v2.9 layout, verified against medsci1 data):
+        //   object hints:  count(u32) + count x u32 (cell hint per object id)
+        //   cell-obj maps: count(u32) + count x 16 bytes
+        //                  { obj_id u32, cell_id u32, prev_prop_state u32, ptr u32 }
+        //   cell zones:    (n_cells + 1) x u16, then n_zones(u32), then
+        //                  { key u32, ok_bits u8 } pairs terminated by key == 0
+        //   cell doors:    count(u32) + count x { cell u32, door i32 }
+        // The zone tables are skipped for now (candidate for fast no-route
+        // rejection later); moving-terrain data after the door table is not
+        // read. Door data is optional: on any inconsistency the database
+        // still loads, just without door awareness.
+        let cell_doors = Self::parse_tail(reader, cells.len()).unwrap_or_else(|| {
+            warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+            Vec::new()
+        });
+
         Some(PathDatabase {
             cells,
             vertices,
             links,
+            cell_doors,
         })
+    }
+
+    /// Parse the trailing AIPATH sections up to and including the cell-door
+    /// table. Returns None if the data doesn't match the expected layout.
+    fn parse_tail(reader: &mut io::Cursor<&[u8]>, n_cells: usize) -> Option<Vec<CellDoor>> {
+        // Object hints: a cell id per object id (fast lookup) - skip
+        let n_obj_hints = read_u32_opt(reader)? as u64;
+        reader.set_position(reader.position() + n_obj_hints * 4);
+
+        // Cell-object maps: movable blocking objects (crates etc.) - parsed
+        // but unused for now (runtime OBB updates are a follow-up)
+        let n_cell_obj_maps = read_u32_opt(reader)?;
+        if n_cell_obj_maps > 100_000 {
+            return None;
+        }
+        reader.set_position(reader.position() + n_cell_obj_maps as u64 * 16);
+
+        // Cell zones: one u16 zone per cell (incl. the +1 dummy)
+        reader.set_position(reader.position() + (n_cells as u64) * 2);
+        let _n_zones = read_u32_opt(reader)?;
+        // Zone-pair reachability table: { key u32, ok_bits u8 } until key == 0
+        loop {
+            let key = read_u32_opt(reader)?;
+            let _ok_bits = read_u8_opt(reader)?;
+            if key == 0 {
+                break;
+            }
+        }
+
+        // Cell-door table: which door object gates each below-door cell
+        let n_cell_doors = read_u32_opt(reader)?;
+        if n_cell_doors > 100_000 {
+            return None;
+        }
+        let mut cell_doors = Vec::with_capacity(n_cell_doors as usize);
+        for _ in 0..n_cell_doors {
+            let cell = read_u32_opt(reader)?;
+            let door = read_u32_opt(reader)? as i32;
+            if cell as usize >= n_cells {
+                return None;
+            }
+            cell_doors.push(CellDoor { cell, door });
+        }
+        debug!("AIPATH cell-door table: {} entries", cell_doors.len());
+        Some(cell_doors)
     }
 
     /// Calculate the center point of a cell from its vertices

--- a/dark/src/mission/path_database.rs
+++ b/dark/src/mission/path_database.rs
@@ -463,10 +463,18 @@ impl PathDatabase {
         // rejection later); moving-terrain data after the door table is not
         // read. Door data is optional: on any inconsistency the database
         // still loads, just without door awareness.
-        let cell_doors = Self::parse_tail(reader, cells.len()).unwrap_or_else(|| {
-            warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+        //
+        // The layout was reverse-engineered and validated only for v2.9
+        // (every shipped mission except shodan). The v3.4 tail may differ, so
+        // only attempt the known layout rather than risk a silent misparse.
+        let cell_doors = if layout == AiPathLayout::PackedIds {
+            Self::parse_tail(reader, &cells).unwrap_or_else(|| {
+                warn!("AIPATH trailing sections malformed; door-aware pathfinding disabled");
+                Vec::new()
+            })
+        } else {
             Vec::new()
-        });
+        };
 
         Some(PathDatabase {
             cells,
@@ -477,8 +485,13 @@ impl PathDatabase {
     }
 
     /// Parse the trailing AIPATH sections up to and including the cell-door
-    /// table. Returns None if the data doesn't match the expected layout.
-    fn parse_tail(reader: &mut io::Cursor<&[u8]>, n_cells: usize) -> Option<Vec<CellDoor>> {
+    /// table. Returns None if the data doesn't match the expected layout -
+    /// which doubles as a misparse detector, since a misaligned read almost
+    /// never lands on a table whose cells are all in range AND flagged
+    /// below-door.
+    fn parse_tail(reader: &mut io::Cursor<&[u8]>, cells: &[PathCell]) -> Option<Vec<CellDoor>> {
+        let n_cells = cells.len();
+
         // Object hints: a cell id per object id (fast lookup) - skip
         let n_obj_hints = read_u32_opt(reader)? as u64;
         reader.set_position(reader.position() + n_obj_hints * 4);
@@ -512,8 +525,11 @@ impl PathDatabase {
         for _ in 0..n_cell_doors {
             let cell = read_u32_opt(reader)?;
             let door = read_u32_opt(reader)? as i32;
-            if cell as usize >= n_cells {
-                return None;
+            // Every gated cell must exist and actually be a below-door cell;
+            // otherwise we've misread the layout and should discard the table
+            match cells.get(cell as usize) {
+                Some(c) if c.flags.contains(PathCellFlags::BELOW_DOOR) => {}
+                _ => return None,
             }
             cell_doors.push(CellDoor { cell, door });
         }

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -13,7 +13,7 @@
 
 use std::fs::File;
 use std::io::BufReader;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dark::mission::PathDatabase;
 use dark::ss2_chunk_file_reader;
@@ -42,15 +42,15 @@ fn data_root() -> Option<PathBuf> {
 
 /// Load a mission's AIPATH pathfinding database, or `None` if the mission has
 /// no usable AIPATH chunk.
-fn load_path_database(data: &PathBuf, mission: &str) -> Option<PathDatabase> {
+fn load_path_database(data: &Path, mission: &str) -> Option<PathDatabase> {
     let file = File::open(data.join(mission)).expect("mission file should open");
     let mut reader = BufReader::new(file);
     let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
     PathDatabase::read(&toc, &mut reader)
 }
 
-/// Every `.mis` file with AIPATH data. Returns None (skip) without assets.
-fn all_missions(data: &PathBuf) -> Vec<String> {
+/// Every `.mis` filename in `data`.
+fn all_missions(data: &Path) -> Vec<String> {
     std::fs::read_dir(data)
         .expect("Data directory should read")
         .filter_map(|e| e.ok())
@@ -131,4 +131,22 @@ fn all_missions_load_with_consistent_aipath() {
         missions_with_doors >= 15,
         "expected most missions to have a parsed cell-door table, got {missions_with_doors}"
     );
+}
+
+#[test]
+fn shodan_v34_aipath_loads_without_door_data() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    // shodan.mis is the only v3.4 (WideIds) AIPATH. Its trailing layout isn't
+    // reverse-engineered, so the tail parse is intentionally not attempted -
+    // the database still loads, just with no cell-door table (never a
+    // silently-misparsed one).
+    if let Some(db) = load_path_database(&data, "shodan.mis") {
+        assert!(
+            db.cell_doors.is_empty(),
+            "v3.4 tail must not be parsed until its layout is verified"
+        );
+    }
 }

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -1,0 +1,134 @@
+//! Integration tests that load real mission files and assert on the parsed
+//! structures - the middle layer between pure unit tests (no game data) and
+//! the SDK e2e suite (spawns a full game with a GPU/HTTP runtime).
+//!
+//! These load and parse `.mis` chunks directly (no rendering, no game loop),
+//! so they are fast and can assert on internal parse results the e2e can't
+//! reach. They need the game assets in `Data/`; when those aren't present
+//! (e.g. a CI runner without copyrighted assets) each test skips cleanly
+//! rather than failing, so `cargo test` stays green everywhere.
+//!
+//! Point them at assets with `DARK_ASSET_PATH=/path/to/Data`, or run from a
+//! checkout that has `Data/` beside the workspace root.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+use dark::mission::PathDatabase;
+use dark::ss2_chunk_file_reader;
+
+/// Locate the `Data/` directory, or `None` when assets aren't available.
+///
+/// Checks `DARK_ASSET_PATH` first, then walks up from the crate directory -
+/// tests run with the crate root as the working directory, and `Data/` lives
+/// beside the workspace root one level up.
+fn data_root() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("DARK_ASSET_PATH") {
+        let p = PathBuf::from(path);
+        if p.join("medsci1.mis").exists() {
+            return Some(p);
+        }
+    }
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for candidate in ["../Data", "../../Data", "Data"] {
+        let p = base.join(candidate);
+        if p.join("medsci1.mis").exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Load a mission's AIPATH pathfinding database, or `None` if the mission has
+/// no usable AIPATH chunk.
+fn load_path_database(data: &PathBuf, mission: &str) -> Option<PathDatabase> {
+    let file = File::open(data.join(mission)).expect("mission file should open");
+    let mut reader = BufReader::new(file);
+    let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+    PathDatabase::read(&toc, &mut reader)
+}
+
+/// Every `.mis` file with AIPATH data. Returns None (skip) without assets.
+fn all_missions(data: &PathBuf) -> Vec<String> {
+    std::fs::read_dir(data)
+        .expect("Data directory should read")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".mis"))
+        .collect()
+}
+
+#[test]
+fn medsci1_cell_door_table_parses() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let db = load_path_database(&data, "medsci1.mis").expect("medsci1 has AIPATH data");
+
+    // The cell-door table maps below-door path cells to the door object that
+    // gates them. medsci1 has a known, stable set (532 cell entries across
+    // 56 doors) - a regression in the trailing-section parse changes this.
+    assert_eq!(
+        db.cell_doors.len(),
+        532,
+        "medsci1 cell-door entry count changed"
+    );
+    let unique_doors: std::collections::HashSet<i32> =
+        db.cell_doors.iter().map(|cd| cd.door).collect();
+    assert_eq!(unique_doors.len(), 56, "medsci1 unique door count changed");
+
+    // Object 1729 is "Sci Med Door" - it must appear in the table, and every
+    // mapped cell must be a valid index into the cell array.
+    assert!(
+        unique_doors.contains(&1729),
+        "known Sci Med Door (obj 1729) missing from the cell-door table"
+    );
+    for cd in &db.cell_doors {
+        assert!(
+            (cd.cell as usize) < db.cells.len(),
+            "cell-door maps cell {} out of range ({} cells)",
+            cd.cell,
+            db.cells.len()
+        );
+    }
+}
+
+#[test]
+fn all_missions_load_with_consistent_aipath() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+
+    let mut missions_with_doors = 0;
+    for mission in all_missions(&data) {
+        // shodan.mis is a known bad file (issue #267); don't fail on it.
+        if mission == "shodan.mis" {
+            continue;
+        }
+        let Some(db) = load_path_database(&data, &mission) else {
+            continue; // no AIPATH chunk - fine
+        };
+
+        // A misaligned trailing-section parse would produce cell ids past the
+        // end of the cell array; this catches it across every mission.
+        for cd in &db.cell_doors {
+            assert!(
+                (cd.cell as usize) < db.cells.len(),
+                "{mission}: cell-door maps cell {} out of range ({} cells)",
+                cd.cell,
+                db.cells.len()
+            );
+        }
+        if !db.cell_doors.is_empty() {
+            missions_with_doors += 1;
+        }
+    }
+
+    assert!(
+        missions_with_doors >= 15,
+        "expected most missions to have a parsed cell-door table, got {missions_with_doors}"
+    );
+}

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -506,6 +506,7 @@ mod tests {
             cells,
             vertices,
             links,
+            cell_doors: Vec::new(),
         }
     }
 

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -85,6 +85,10 @@ pub struct PathfindingService {
     /// Outgoing link indices for each cell, so A* expansion is O(degree)
     /// instead of a scan over every link in the mission.
     links_by_cell: Vec<Vec<u32>>,
+    /// Below-door cell -> the mission object id of the door that gates it
+    /// (from the AIPATH cell-door table). Lets an AI look up which door
+    /// blocks a cell on its route.
+    cell_to_door: std::collections::HashMap<u32, i32>,
     queries: AtomicU64,
     stressed_retries: AtomicU64,
     no_route: AtomicU64,
@@ -99,13 +103,59 @@ impl PathfindingService {
                 links.push(idx as u32);
             }
         }
+        let cell_to_door = path_database
+            .cell_doors
+            .iter()
+            .map(|cd| (cd.cell, cd.door))
+            .collect();
         Self {
             path_database,
             links_by_cell,
+            cell_to_door,
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
             no_route: AtomicU64::new(0),
         }
+    }
+
+    /// Doors that gate `cell` itself or any cell directly reachable from it -
+    /// i.e. the doors an AI standing in `cell` is about to walk into. Each
+    /// entry is `(door object id, the door cell's center)`; deduplicated by
+    /// door. A short breadth-first reach lets an AI notice (and open) a door
+    /// before it walks its body into the closed leaf and stalls. Empty when
+    /// the mission has no door data.
+    pub fn doors_near_cell(&self, cell: u32) -> Vec<(i32, Vector3<f32>)> {
+        if self.cell_to_door.is_empty() {
+            return Vec::new();
+        }
+        // Breadth-first over the walk graph out to a few hops
+        const DOOR_LOOKAHEAD_HOPS: u32 = 3;
+        let mut out = Vec::new();
+        let mut seen_doors = std::collections::HashSet::new();
+        let mut visited = std::collections::HashSet::from([cell]);
+        let mut frontier = vec![cell];
+        for _ in 0..=DOOR_LOOKAHEAD_HOPS {
+            let mut next = Vec::new();
+            for c in frontier {
+                if let Some(&door) = self.cell_to_door.get(&c) {
+                    if seen_doors.insert(door) {
+                        if let Some(pc) = self.path_database.cells.get(c as usize) {
+                            out.push((door, pc.center));
+                        }
+                    }
+                }
+                if let Some(links) = self.links_by_cell.get(c as usize) {
+                    for &idx in links {
+                        let to = self.path_database.links[idx as usize].to_cell;
+                        if visited.insert(to) {
+                            next.push(to);
+                        }
+                    }
+                }
+            }
+            frontier = next;
+        }
+        out
     }
 
     /// Snapshot of the monotonic query counters
@@ -449,7 +499,7 @@ fn closest_point_on_segment(
 mod tests {
     use super::*;
     use cgmath::vec3;
-    use dark::mission::path_database::{PathCell, PathCellLink};
+    use dark::mission::path_database::{CellDoor, PathCell, PathCellLink};
 
     /// Three unit-square cells in a row along X: 0 -> 1 -> 2.
     /// The 1 -> 2 link is gated by STRESSED; everything else is plain WALK.
@@ -512,6 +562,27 @@ mod tests {
 
     fn service(db: PathDatabase) -> PathfindingService {
         PathfindingService::new(Arc::new(db))
+    }
+
+    #[test]
+    fn doors_near_cell_finds_the_gating_door_within_reach() {
+        // Cells 0 -> 1 -> 2 in a row; cell 2 is a below-door cell gated by
+        // door object 99.
+        let mut db = three_cell_db(PathCellFlags::empty());
+        db.cells[2].flags = PathCellFlags::BELOW_DOOR;
+        db.cell_doors.push(CellDoor { cell: 2, door: 99 });
+        let service = service(db);
+
+        // From cell 0 the door is two hops away - within the lookahead
+        assert_eq!(service.doors_near_cell(0), vec![(99, vec3(5.0, 0.0, 1.0))]);
+        // Standing in the door cell itself also reports it
+        assert_eq!(service.doors_near_cell(2), vec![(99, vec3(5.0, 0.0, 1.0))]);
+    }
+
+    #[test]
+    fn doors_near_cell_empty_without_door_data() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        assert!(service.doors_near_cell(0).is_empty());
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::HashSet};
 
-use cgmath::{Deg, MetricSpace, Quaternion, Rotation3, vec3, vec4};
+use cgmath::{Deg, EuclideanSpace, MetricSpace, Quaternion, Rotation3, vec3, vec4};
 use dark::{
     SCALE_FACTOR,
     motion::{MotionFlags, MotionQueryItem},
@@ -9,10 +9,10 @@ use dark::{
     },
 };
 use rand;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    mission::PlayerInfo,
+    mission::{GlobalPathfinding, GlobalTemplateIdMap, PlayerInfo},
     physics::{InternalCollisionGroups, PhysicsWorld},
     scripts::script_util,
     time::Time,
@@ -29,6 +29,22 @@ use super::{
 // Default timing constants for monsters (in seconds)
 const DEFAULT_ESCALATE_SECONDS: f32 = 1.5;
 const DEFAULT_DECAY_SECONDS: f32 = 3.0;
+
+/// How close (XZ) a pursuing AI must be to a door on its route to interact
+/// with it - generous enough to open it while approaching, not so wide it
+/// opens doors it merely passes near (12 Dark feet).
+const DOOR_INTERACT_RANGE: f32 = 12.0 / SCALE_FACTOR;
+/// Minimum cosine between the AI's heading and the direction to the door,
+/// applied only beyond `DOOR_FACING_RANGE` - a door the AI is nearly on top
+/// of gets opened regardless of facing (its center may be behind the AI once
+/// it's in the doorway), but a distant door must be roughly ahead so the AI
+/// doesn't open ones off to the side while passing.
+const DOOR_FACING_MIN_DOT: f32 = 0.2;
+const DOOR_FACING_RANGE: f32 = 5.0 / SCALE_FACTOR;
+/// Seconds between door interactions per AI, so a closed door isn't spammed
+/// with open requests while it swings (and a locked-door give-up doesn't
+/// re-fire every frame).
+const DOOR_INTERACT_COOLDOWN: f32 = 2.0;
 
 /// Configuration for monster alertness behavior
 #[derive(Clone)]
@@ -70,6 +86,8 @@ pub struct AnimatedMonsterAI {
     /// the script's knowledge exactly (including forgetting) without
     /// per-frame effect churn
     published_awareness: Option<(cgmath::Vector3<f32>, bool)>,
+    /// Throttle between door interactions (open / locked-door give-up)
+    door_cooldown: f32,
 }
 
 impl AnimatedMonsterAI {
@@ -88,6 +106,7 @@ impl AnimatedMonsterAI {
             published_behavior: None,
             last_known_player_pos: None,
             published_awareness: None,
+            door_cooldown: 0.0,
         }
     }
 
@@ -107,6 +126,7 @@ impl AnimatedMonsterAI {
             published_behavior: None,
             last_known_player_pos: None,
             published_awareness: None,
+            door_cooldown: 0.0,
         }
     }
 
@@ -381,6 +401,99 @@ impl AnimatedMonsterAI {
             Effect::NoEffect
         }
     }
+
+    /// While pursuing, open the (unlocked) door gating the AI's route so it
+    /// can follow the player through, or give up at a locked one. The graph
+    /// treats doors as passable, so the AI paths straight at a closed door
+    /// and its body is blocked - this is what actually gets it through.
+    fn handle_doors(
+        &mut self,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+        time: &Time,
+    ) -> Effect {
+        self.door_cooldown = (self.door_cooldown - time.elapsed.as_secs_f32()).max(0.0);
+        if self.door_cooldown > 0.0 {
+            return Effect::NoEffect;
+        }
+        // Only actively-pursuing behaviors bother with doors
+        if !matches!(self.current_behavior.borrow().name(), "Chase" | "Search") {
+            return Effect::NoEffect;
+        }
+
+        let Some(service) = world
+            .borrow::<UniqueView<GlobalPathfinding>>()
+            .ok()
+            .and_then(|g| g.0.clone())
+        else {
+            return Effect::NoEffect;
+        };
+        let (position, forward) = get_position_and_forward(world, entity_id);
+        let pos = position.to_vec();
+        let Some(cell) = service.cell_from_position(pos) else {
+            return Effect::NoEffect;
+        };
+        let doors = service.doors_near_cell(cell);
+        if doors.is_empty() {
+            return Effect::NoEffect;
+        }
+        let Ok(id_map) = world.borrow::<UniqueView<GlobalTemplateIdMap>>() else {
+            return Effect::NoEffect;
+        };
+
+        for (door_obj, door_center) in doors {
+            let (dx, dz) = (door_center.x - pos.x, door_center.z - pos.z);
+            let dist = (dx * dx + dz * dz).sqrt();
+            if dist > DOOR_INTERACT_RANGE || dist < 1e-3 {
+                continue;
+            }
+            // Beyond arm's reach, only open a door roughly ahead (not one off
+            // to the side we're merely passing); nearer ones we open anyway,
+            // since the doorway centre can be behind us once we're in it.
+            if dist > DOOR_FACING_RANGE {
+                let fwd_len = (forward.x * forward.x + forward.z * forward.z).sqrt();
+                if fwd_len < 1e-3
+                    || (forward.x * dx + forward.z * dz) / (fwd_len * dist) < DOOR_FACING_MIN_DOT
+                {
+                    continue;
+                }
+            }
+            let Some(door_ent) = id_map.0.get(&door_obj).map(|w| w.0) else {
+                continue;
+            };
+            // Only act on a door that's actually closed (skip open / opening
+            // ones, and non-door objects)
+            if script_util::door_is_closed(world, door_ent) != Some(true) {
+                continue;
+            }
+
+            self.door_cooldown = DOOR_INTERACT_COOLDOWN;
+            if script_util::is_entity_locked(world, door_ent) {
+                // Can't follow through a locked door: show frustration and
+                // give up the pursuit (drop to a wander), so the player can't
+                // lure the AI into off-limits areas. Forget the last-known
+                // position so it doesn't immediately re-path to the door.
+                self.last_known_player_pos = None;
+                self.alertness.visible_time = 0.0;
+                let downgrade = self.force_alertness(AIAlertLevel::Low, world, physics, entity_id);
+                let thwarted = Effect::QueueAnimationBySchema {
+                    entity_id,
+                    motion_queries: vec![vec![MotionQueryItem::new("thwarted")]],
+                    selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
+                };
+                return Effect::combine(vec![downgrade, thwarted]);
+            }
+            // Unlocked: open it and keep chasing through
+            return Effect::Send {
+                msg: Message {
+                    to: door_ent,
+                    payload: MessagePayload::TurnOn { from: entity_id },
+                },
+            };
+        }
+        Effect::NoEffect
+    }
 }
 
 impl Script for AnimatedMonsterAI {
@@ -614,6 +727,9 @@ impl Script for AnimatedMonsterAI {
 
         let behavior_publish_effect = self.publish_behavior(entity_id);
 
+        // Open a door blocking the pursuit (or give up at a locked one)
+        let door_effect = self.handle_doors(world, physics, entity_id, time);
+
         Effect::combine(vec![
             alertness_effect,
             awareness_effect,
@@ -624,6 +740,7 @@ impl Script for AnimatedMonsterAI {
             alertness_debug_effect,
             fov_debug_effect,
             behavior_publish_effect,
+            door_effect,
         ])
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -41,10 +41,17 @@ const DOOR_INTERACT_RANGE: f32 = 12.0 / SCALE_FACTOR;
 /// doesn't open ones off to the side while passing.
 const DOOR_FACING_MIN_DOT: f32 = 0.2;
 const DOOR_FACING_RANGE: f32 = 5.0 / SCALE_FACTOR;
-/// Seconds between door interactions per AI, so a closed door isn't spammed
-/// with open requests while it swings (and a locked-door give-up doesn't
-/// re-fire every frame).
+/// How often a pursuing AI polls for a blocking door. The scan (a linear
+/// cell lookup plus a small graph BFS) runs at this rate, not every frame.
+const DOOR_POLL_INTERVAL: f32 = 0.3;
+/// After opening a door, wait this long before interacting again - long
+/// enough that the door has left its closed position, so TurnOn (and its
+/// sound) isn't re-sent while it swings.
 const DOOR_INTERACT_COOLDOWN: f32 = 2.0;
+/// After giving up at a locked door, wait this long before re-frustrating -
+/// bounds the "thwarted" gesture for an AI whose alert cap keeps it in a
+/// pursuing state even after the give-up's alertness drop.
+const DOOR_GIVEUP_COOLDOWN: f32 = 8.0;
 
 /// Configuration for monster alertness behavior
 #[derive(Clone)]
@@ -417,10 +424,16 @@ impl AnimatedMonsterAI {
         if self.door_cooldown > 0.0 {
             return Effect::NoEffect;
         }
-        // Only actively-pursuing behaviors bother with doors
+        // Only actively-pursuing behaviors bother with doors (cheap check
+        // left off the cooldown so a state change is noticed promptly)
         if !matches!(self.current_behavior.borrow().name(), "Chase" | "Search") {
             return Effect::NoEffect;
         }
+        // The scan below (cell_from_position is O(cells) + a graph BFS) runs
+        // at a few Hz, not every frame - arm the poll cooldown up front,
+        // regardless of whether a door is found. The act paths override it
+        // with a longer value.
+        self.door_cooldown = DOOR_POLL_INTERVAL;
 
         let Some(service) = world
             .borrow::<UniqueView<GlobalPathfinding>>()
@@ -468,14 +481,16 @@ impl AnimatedMonsterAI {
                 continue;
             }
 
-            self.door_cooldown = DOOR_INTERACT_COOLDOWN;
             if script_util::is_entity_locked(world, door_ent) {
                 // Can't follow through a locked door: show frustration and
                 // give up the pursuit (drop to a wander), so the player can't
                 // lure the AI into off-limits areas. Forget the last-known
-                // position so it doesn't immediately re-path to the door.
+                // position so it doesn't immediately re-path to the door. The
+                // longer cooldown keeps the "thwarted" gesture from replaying
+                // rapidly for an AI whose alert cap won't let it drop below a
+                // pursuing level.
+                self.door_cooldown = DOOR_GIVEUP_COOLDOWN;
                 self.last_known_player_pos = None;
-                self.alertness.visible_time = 0.0;
                 let downgrade = self.force_alertness(AIAlertLevel::Low, world, physics, entity_id);
                 let thwarted = Effect::QueueAnimationBySchema {
                     entity_id,
@@ -484,7 +499,10 @@ impl AnimatedMonsterAI {
                 };
                 return Effect::combine(vec![downgrade, thwarted]);
             }
-            // Unlocked: open it and keep chasing through
+            // Unlocked: open it and keep chasing through. The longer cooldown
+            // avoids re-sending TurnOn (and replaying the open sound) while
+            // the door is still swinging.
+            self.door_cooldown = DOOR_INTERACT_COOLDOWN;
             return Effect::Send {
                 msg: Message {
                     to: door_ent,

--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -1,8 +1,7 @@
-use dark::properties::PropLocked;
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, UniqueView, View, World};
+use shipyard::{EntityId, World};
 
-use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::physics::PhysicsWorld;
 
 use super::{
     Effect, MessagePayload, Script,
@@ -18,35 +17,7 @@ impl BaseButton {
     }
 
     pub fn is_locked(&self, entity_id: EntityId, world: &World) -> bool {
-        let v_prop_locked = world.borrow::<shipyard::View<PropLocked>>().unwrap();
-        let v_prop_key_dst = world
-            .borrow::<View<dark::properties::PropKeyDst>>()
-            .unwrap();
-
-        let _v_prop_key_src = world
-            .borrow::<View<dark::properties::PropKeySrc>>()
-            .unwrap();
-
-        let quest_bits = world.borrow::<UniqueView<QuestInfo>>().unwrap();
-
-        let maybe_prop_locked = v_prop_locked.get(entity_id);
-
-        if let Ok(prop_locked) = maybe_prop_locked {
-            // We're locked... check if we have a key that can open it!
-            if prop_locked.0 {
-                let maybe_prop_key_dst = v_prop_key_dst.get(entity_id);
-                if let Ok(key_dst) = maybe_prop_key_dst {
-                    let is_unlocked = quest_bits.can_unlock(&key_dst.0);
-                    !is_unlocked
-                } else {
-                    true
-                }
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        super::script_util::is_entity_locked(world, entity_id)
     }
 }
 impl Script for BaseButton {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -23,6 +23,53 @@ pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {
     }
 }
 
+/// Whether an entity is currently locked against the player: it carries
+/// `PropLocked(true)` and either has no key destination or a key/quest gate
+/// the player hasn't satisfied. Shared by buttons and (door-opening) AIs.
+pub fn is_entity_locked(world: &World, entity_id: EntityId) -> bool {
+    let v_locked = world
+        .borrow::<View<dark::properties::PropLocked>>()
+        .unwrap();
+    let Ok(locked) = v_locked.get(entity_id) else {
+        return false;
+    };
+    if !locked.0 {
+        return false;
+    }
+    let v_key_dst = world
+        .borrow::<View<dark::properties::PropKeyDst>>()
+        .unwrap();
+    let quest = world
+        .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
+        .unwrap();
+    match v_key_dst.get(entity_id) {
+        // Locked, and the player lacks the key/quest state to open it
+        Ok(key_dst) => !quest.can_unlock(&key_dst.0),
+        // Locked with no key destination - nothing can unlock it
+        Err(_) => true,
+    }
+}
+
+/// Whether a translating door is nearer its closed endpoint than its open
+/// one (i.e. worth opening). `None` for entities that aren't translating
+/// doors.
+pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
+    use cgmath::InnerSpace;
+    let v_door = world
+        .borrow::<View<dark::properties::PropTranslatingDoor>>()
+        .unwrap();
+    let door = v_door.get(entity_id).ok()?;
+    // StdDoor drives the live transform via SetPosition each frame.
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+    let current = v_transform
+        .get(entity_id)
+        .ok()
+        .map(|t| point3_to_vec3(t.0.transform_point(point3(0.0, 0.0, 0.0))))?;
+    let to_closed = (current - door.base_closed_location).magnitude2();
+    let to_open = (current - door.base_open_location).magnitude2();
+    Some(to_closed <= to_open)
+}
+
 pub fn get_all_links_with_template<TData>(
     world: &World,
     producing_entity_id: EntityId,

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -133,16 +133,23 @@ impl Script for StdDoor {
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
             match msg {
                 MessagePayload::TurnOn { from: _ } => {
-                    //self.current_position = trans_door.base_closed_location;
-                    self.desired_position = trans_door.base_open_location;
-                    self.is_moving = true;
-                    play_environmental_sound(
-                        world,
-                        entity_id,
-                        "statechange",
-                        vec![("openstate", "opening"), ("oldopenstate", "closed")],
-                        self.audio_handle.clone(),
-                    )
+                    // Idempotent: if we're already headed open, ignore repeat
+                    // opens (e.g. several AIs converging on the same door) so
+                    // the opening sound isn't replayed each frame.
+                    if (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001
+                    {
+                        Effect::NoEffect
+                    } else {
+                        self.desired_position = trans_door.base_open_location;
+                        self.is_moving = true;
+                        play_environmental_sound(
+                            world,
+                            entity_id,
+                            "statechange",
+                            vec![("openstate", "opening"), ("oldopenstate", "closed")],
+                            self.audio_handle.clone(),
+                        )
+                    }
                 }
                 MessagePayload::TurnOff { from: _ } => {
                     //self.current_position = trans_door.base_closed_location;

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -198,6 +198,38 @@ fn dump_component_at(db: PathDatabase, at: Vector3<f32>) {
     for (desc, count) in &frontier {
         println!("  {count:>5}  {desc}");
     }
+
+    // How many frontier destinations are below-door cells the door table
+    // maps to a door object? Those become passable when the door opens.
+    let door_cells: std::collections::HashMap<u32, i32> =
+        db.cell_doors.iter().map(|cd| (cd.cell, cd.door)).collect();
+    let mut frontier_door_dests: std::collections::BTreeMap<i32, usize> =
+        std::collections::BTreeMap::new();
+    let mut frontier_blocking_non_door = 0usize;
+    for link in &db.links {
+        if !members.contains(&link.from_cell) || members.contains(&link.to_cell) {
+            continue;
+        }
+        if let Some(&door) = door_cells.get(&link.to_cell) {
+            *frontier_door_dests.entry(door).or_default() += 1;
+        } else if db
+            .cells
+            .get(link.to_cell as usize)
+            .map(|c| c.flags.contains(PathCellFlags::BLOCKING_OBB))
+            .unwrap_or(false)
+        {
+            frontier_blocking_non_door += 1;
+        }
+    }
+    println!(
+        "frontier dests gated by a door: {} (across {} doors); blocking-obb non-door dests: {}",
+        frontier_door_dests.values().sum::<usize>(),
+        frontier_door_dests.len(),
+        frontier_blocking_non_door
+    );
+    for (door, count) in frontier_door_dests.iter().take(8) {
+        println!("    door obj {door}: {count} frontier links");
+    }
 }
 
 fn resolve_missions(mission: Option<String>, all: bool) -> Result<Vec<String>> {
@@ -330,6 +362,26 @@ fn print_stats(mission: &str, db: PathDatabase) {
     }
     println!(
         "audit: links into below-door cells: walkable={door_links_walkable} zero-bits={door_links_dead}"
+    );
+
+    // Door table: below-door cells mapped to their gating door object
+    let unique_doors: std::collections::HashSet<i32> =
+        db.cell_doors.iter().map(|cd| cd.door).collect();
+    let door_cells_also_blocking = db
+        .cell_doors
+        .iter()
+        .filter(|cd| {
+            db.cells
+                .get(cd.cell as usize)
+                .map(|c| c.flags.contains(PathCellFlags::BLOCKING_OBB))
+                .unwrap_or(false)
+        })
+        .count();
+    println!(
+        "door table: {} cell-door entries, {} unique doors, {} of those cells also BLOCKING_OBB",
+        db.cell_doors.len(),
+        unique_doors.len(),
+        door_cells_also_blocking
     );
 
     // Walk-graph connectivity for a plain WALK query. Links are treated as


### PR DESCRIPTION
## Summary

Stacked on #398 (the cell-door parse). Delivers the door behavior: a pursuing AI opens the unlocked door blocking its route so it can follow the player through, and shows frustration then drops the pursuit at a locked one — so players can't lure AIs through locked doors into off-limits areas.

**Why behavioral, not a graph change:** the AIPATH graph already treats doors as passable (matching the original engine's door-optimistic search), so a chasing AI paths *through* a closed door and its body is physically blocked. The fix is to have the AI actually open the door.

### What's here
- **`PathfindingService::doors_near_cell`** (from #398's cell-door table): a short breadth-first reach returns the door object gating any cell within a few hops, so the AI notices a door *before* walking its body into the closed leaf. Unit-tested.
- **`AnimatedMonsterAI::handle_doors`** during Chase/Search: polls (~3 Hz, not every frame) for a close door roughly ahead; resolves it via `GlobalTemplateIdMap`; if closed, either sends `TurnOn` (unlocked) or forces alertness down + plays the **`thwarted`** animation + forgets the last-known position (locked).
- **Shared helpers** in `script_util`: `is_entity_locked` (extracted from `base_button` — buttons and AIs now share one lock check, covering `PropLocked` + key/quest gating) and `door_is_closed`.
- **`StdDoor` `TurnOn` is idempotent** — already-opening doors ignore repeat opens, so several AIs converging on one door don't replay the sound.

### Verification
Manually verified in the debug runtime (medsci1): a pursuing OG-Pipe detects the closed, unlocked doors on its route (obj 1729, obj 154) and opens them, with correct proximity/facing/closed/lock gating. Two `doors_near_cell` unit tests (88 shock2vr tests pass).

A fully-automated behavioral e2e is **blocked by a spawn-tool bug** (#401): `SpawnDebugMonster` places monsters below the floor so they fall; combined with medsci1's isolated start room and entity-id instability, staging a reliable "monster walks through door" scenario isn't currently feasible. A native-monster or door debug-scene e2e is the follow-up once #401 lands.

### Cross-engine review
Both engines: no Critical/High. Fixed the per-frame O(cells) scan (now polled), the locked-door give-up loop for alert-capped AIs, and made `StdDoor` open idempotent.

## Test plan
- [x] `cargo test -p shock2vr` — 88 (incl. 2 new `doors_near_cell` tests)
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime -p bench`
- [x] Manual: OPEN decision fires for real medsci1 doors with correct gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)