### PR TITLE
feat(ai): gunfire alerts nearby AIs (sound awareness)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1368,6 +1368,35 @@ impl MissionCore {
         );
     }
 
+    /// Propagate a noise (Effect::RaiseNoise): every creature within `radius`
+    /// of `origin` hears it and gets a HeardNoise message, so it can alert and
+    /// investigate the source. A plain Euclidean radius - walls don't
+    /// attenuate it yet (a path-distance model is a follow-up).
+    fn raise_noise(&mut self, origin: Vector3<f32>, radius: f32) {
+        let heard: Vec<EntityId> = {
+            let v_creature = self
+                .world
+                .borrow::<View<dark::properties::PropCreature>>()
+                .unwrap();
+            let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
+            (&v_creature, &v_transform)
+                .iter()
+                .with_id()
+                .filter_map(|(entity_id, (_creature, transform))| {
+                    let pos = transform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+                    let distance = (crate::util::point3_to_vec3(pos) - origin).magnitude();
+                    (distance < radius).then_some(entity_id)
+                })
+                .collect()
+        };
+        for entity_id in heard {
+            self.script_world.dispatch(Message {
+                to: entity_id,
+                payload: MessagePayload::HeardNoise { origin },
+            });
+        }
+    }
+
     pub fn create_entity_by_template_name(
         &mut self,
         asset_cache: &mut AssetCache,
@@ -1812,6 +1841,10 @@ impl MissionCore {
                     stim_template_id,
                 } => {
                     self.radius_blast(center, radius, intensity, stim_template_id);
+                }
+
+                Effect::RaiseNoise { origin, radius } => {
+                    self.raise_noise(origin, radius);
                 }
 
                 Effect::ReloadWeapon => {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -326,6 +326,51 @@ impl AnimatedMonsterAI {
     /// Force alertness to `level` (clamped by the alert cap), reset the
     /// visibility timers, and swap in the canonical behavior for the
     /// resulting level. Callers must check the AI is alive first.
+    /// React to a stimulus that locates the player at `origin` - a hit taken,
+    /// or a noise heard. Refreshes the last-known position (so a searching or
+    /// chasing AI turns toward the fresh cue) and escalates toward Moderate
+    /// (chase) when not already alerted. No-op for a dead AI or one mid
+    /// scripted sequence (which `force_alertness` would otherwise preempt).
+    fn alert_to_position(
+        &mut self,
+        origin: cgmath::Vector3<f32>,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+    ) -> Effect {
+        // No config = an AI that doesn't process alertness at all (e.g. an
+        // apparition replay - see build_config); it must never notice the
+        // player, so a hit or a noise leaves it be.
+        let Some(config) = self.config.as_ref() else {
+            return Effect::NoEffect;
+        };
+        if self.is_dead
+            || is_killed(entity_id, world)
+            || self.current_behavior.borrow().scripted_state() == ScriptedState::Running
+        {
+            return Effect::NoEffect;
+        }
+        // Refresh even when already alerted - the cue reveals where the
+        // player is now, redirecting a stale chase or a search.
+        self.last_known_player_pos = Some(origin);
+
+        let cap = config.alert_cap.clone();
+        // Only force when the clamped target actually raises the level (so a
+        // capped AI isn't reset / re-animated), or when a search should
+        // re-aggro toward the fresh cue.
+        let target = alertness::clamp_level(AIAlertLevel::Moderate, &cap);
+        let escalates = matches!(
+            self.alertness.current_level,
+            AIAlertLevel::Lowest | AIAlertLevel::Low
+        ) && target != self.alertness.current_level;
+        let searching = self.current_behavior.borrow().name() == "Search";
+        if escalates || searching {
+            self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
+        } else {
+            Effect::NoEffect
+        }
+    }
+
     fn force_alertness(
         &mut self,
         level: AIAlertLevel,
@@ -856,41 +901,14 @@ impl Script for AnimatedMonsterAI {
                 let lethal = hit_points(entity_id, world)
                     .map(|hp| hp - amount.round() as i32 <= 0)
                     .unwrap_or(false);
-                let cap = self
-                    .config
-                    .as_ref()
-                    .map(|c| c.alert_cap.clone())
-                    .unwrap_or_else(default_alert_cap);
-                // Respect alert caps: only force when the (clamped) target
-                // actually raises the level, so a capped AI isn't reset -
-                // and doesn't restart its animation - on every hit
-                let target = alertness::clamp_level(AIAlertLevel::Moderate, &cap);
-                let escalates = matches!(
-                    self.alertness.current_level,
-                    AIAlertLevel::Lowest | AIAlertLevel::Low
-                ) && target != self.alertness.current_level;
-                // A searching AI that takes a hit re-aggros too: the shot
-                // reveals the attacker even without line of sight (the dead
-                // case already returned above)
-                let searching = self.current_behavior.borrow().name() == "Search";
-                // A running scripted sequence isn't preempted by nonlethal
-                // damage (force_alertness replaces the behavior); consistent
-                // with the alertness protection in update().
-                let running_sequence =
-                    self.current_behavior.borrow().scripted_state() == ScriptedState::Running;
-                let alert_effect = if !lethal && !running_sequence {
-                    // Any surviving hit reveals the attacker's position -
-                    // refresh the last-known even when already alerted, so
-                    // an AI chasing a stale sighting turns toward where the
-                    // shot actually came from (the dead case returned above)
-                    if let Ok(player) = world.borrow::<shipyard::UniqueView<PlayerInfo>>() {
-                        self.last_known_player_pos = Some(player.pos);
-                    }
-                    if escalates || searching {
-                        self.force_alertness(AIAlertLevel::Moderate, world, physics, entity_id)
-                    } else {
-                        Effect::NoEffect
-                    }
+                // A surviving hit alerts the AI to the attacker (the player):
+                // a shot reveals the player's position even with no line of
+                // sight. A killing blow doesn't - it goes straight to death.
+                let alert_effect = if lethal {
+                    Effect::NoEffect
+                } else if let Ok(player) = world.borrow::<shipyard::UniqueView<PlayerInfo>>() {
+                    let origin = player.pos;
+                    self.alert_to_position(origin, world, physics, entity_id)
                 } else {
                     Effect::NoEffect
                 };
@@ -903,6 +921,12 @@ impl Script for AnimatedMonsterAI {
                     Effect::NoEffect
                 };
                 Effect::combine(vec![hit_points_effect, alert_effect, death_effect])
+            }
+            MessagePayload::HeardNoise { origin } => {
+                // A gunshot (or other noise) draws the AI to investigate its
+                // source, even with no line of sight - same alert path as
+                // taking a hit, minus the damage.
+                self.alert_to_position(*origin, world, physics, entity_id)
             }
             MessagePayload::TurnOn { from: _ } => {
                 // Dead AIs stay dead - a corpse can still be a SwitchLink

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -158,6 +158,15 @@ pub enum Effect {
         stim_template_id: i32,
     },
 
+    /// A noise (gunfire, etc.) at `origin`: every creature within `radius`
+    /// hears it, escalates alertness, and investigates the source - so
+    /// firing a weapon draws nearby AIs even with no line of sight. A plain
+    /// Euclidean radius for now (walls don't attenuate it yet).
+    RaiseNoise {
+        origin: Vector3<f32>,
+        radius: f32,
+    },
+
     ChangeModel {
         entity_id: EntityId,
         model_name: String,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -167,6 +167,12 @@ pub enum MessagePayload {
         amount: f32,
     }, // damage the entity
 
+    // The entity heard a noise (gunfire, etc.) at this position - an AI
+    // alerts and investigates the source, without the noise being an attack.
+    HeardNoise {
+        origin: Vector3<f32>,
+    },
+
     // AI Signal
     Signal {
         name: String,

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -29,6 +29,17 @@ const MELEE_RANGE: f32 = 1.2;
 /// Damage dealt by a flat melee hit. TODO: derive from the weapon's `Melee Typ`.
 const MELEE_DAMAGE: f32 = 6.0;
 
+/// How far a gunshot carries to alert AIs (50 Dark feet). One value for all
+/// guns for now; per-weapon loudness is a follow-up.
+const GUNSHOT_NOISE_RADIUS: f32 = 50.0 / SCALE_FACTOR;
+
+/// The weapon entity's current world position (from its live transform).
+fn weapon_world_position(world: &World, entity_id: EntityId) -> Option<cgmath::Vector3<f32>> {
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().ok()?;
+    let transform = v_transform.get(entity_id).ok()?;
+    Some(transform.0.transform_point(point3(0.0, 0.0, 0.0)).to_vec())
+}
+
 use super::{
     Effect, Message, MessagePayload, Script,
     script_util::{
@@ -153,6 +164,10 @@ impl Script for WeaponScript {
                     AudioHandle::new(),
                 );
 
+                // Only a real gunshot (a fired projectile) raises noise - a
+                // projectile-less weapon that falls through the melee gate
+                // must not emit a phantom gunshot.
+                let is_gunshot = maybe_projectile.is_some();
                 let projectile_effect = Effect::Multiple(
                     maybe_projectile
                         .into_iter()
@@ -186,6 +201,18 @@ impl Script for WeaponScript {
                         entity_id,
                         delta: -1,
                     });
+                }
+                // A gunshot is loud: nearby AIs hear it and investigate the
+                // shooter, even without line of sight. The noise comes from
+                // the weapon (in the player's hands), so its position stands
+                // in for the shooter's.
+                if is_gunshot {
+                    if let Some(origin) = weapon_world_position(world, entity_id) {
+                        effects.push(Effect::RaiseNoise {
+                            origin,
+                            radius: GUNSHOT_NOISE_RADIUS,
+                        });
+                    }
                 }
                 Effect::Multiple(effects)
             }

--- a/tools/shock2-sdk/test/sound-awareness.e2e.test.ts
+++ b/tools/shock2-sdk/test/sound-awareness.e2e.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+test(
+  "firing a weapon alerts a nearby AI that never saw the player",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Wield a pistol (spawns and auto-wields in front of the empty-handed
+    // player), then spawn a monster - both appear along the player's aim.
+    const start = await game.player.position();
+    await game.input.trigger("SpawnDebugItem");
+    await game.step({ frames: 10 });
+
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+    const m = monster.position;
+
+    // Step to the side of the monster (perpendicular to the spawn axis) so a
+    // shot fired straight ahead MISSES it - the alert must come from the
+    // gunshot noise, not a bullet hit. Stay close enough to be in earshot.
+    const fx = m[0] - start.x;
+    const fz = m[2] - start.z;
+    const flen = Math.hypot(fx, fz) || 1;
+    const px = fz / flen; // perpendicular in XZ
+    const pz = -fx / flen;
+    await game.player.teleport({
+      x: m[0] + px * 5,
+      y: start.y,
+      z: m[2] + pz * 5,
+    });
+    await game.step({ frames: 5 });
+
+    // Force it unaware and confirm it stays that way for a couple of frames.
+    // Escalation by sight needs ~1.5s of continuous visibility, so within a
+    // few frames the only thing that can jump it to a combat level is the
+    // gunshot noise - the negative case (no noise raised) leaves it Lowest.
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "Lowest",
+    });
+    await game.step({ frames: 3 });
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(
+      aiProp(detail, "AIAlertness"),
+      "Lowest",
+      "monster should be unaware right before the shot",
+    );
+
+    // Fire the pistol. The gunshot noise reaches the nearby monster.
+    await fireOnce(game);
+    await game.step({ frames: 5 });
+    detail = await game.entities.detail(monster.id);
+    assert.equal(
+      aiProp(detail, "AIAlertness"),
+      "Moderate",
+      `the gunshot should alert the monster to Moderate within a few frames (too fast for sight); got ${aiProp(detail, "AIAlertness")}`,
+    );
+    // It investigates toward the shot (the player's position).
+    assert.ok(
+      aiProp(detail, "AILastKnown") !== undefined,
+      "a noise-alerted monster should have a last-known position to investigate",
+    );
+  },
+);


### PR DESCRIPTION
## What

Firing a weapon now draws AIs that never saw the player. A gunshot is loud, but previously AIs only alerted on **sight** or on **taking a hit** — so the player could fire freely one room away from an unaware enemy and it would never react.

This is item 2 of the AI follow-up sequence (doors → **sound awareness** → patrol routes).

## How

- **`Effect::RaiseNoise { origin, radius }`** — emitted by `weapon_script` on a *live shot* (gated on an actual fired projectile, so a projectile-less/VR-melee fall-through can't emit a phantom gunshot), from the weapon's world position (in the player's hands).
- **`mission_core::raise_noise`** — mirrors the explosion `radius_blast`: enumerate creatures within the radius (plain Euclidean; walls don't attenuate yet) and dispatch a `HeardNoise` message to each.
- **`MessagePayload::HeardNoise { origin }`** — the AI escalates alertness and sets its last-known position to the noise source, so it investigates/chases toward the shot — the same alert path as taking a hit, minus the damage.
- **`AnimatedMonsterAI::alert_to_position`** — extracted helper shared by the `Damage` and `HeardNoise` handlers (refresh last-known + escalate toward Moderate, respecting alert caps, dead/killed AIs, and running scripted sequences). Config-less AIs (e.g. apparition replays) never process alertness, so they ignore both hits and noise.

Gunshot radius is a single value for all guns (50 Dark feet) for now; per-weapon loudness and wall attenuation are follow-ups.

## Testing

- New e2e `tools/shock2-sdk/test/sound-awareness.e2e.test.ts`: spawns a pistol + monster, teleports the player **perpendicular** to the spawn axis so a shot fired straight ahead **misses** the monster, forces it `Lowest`, fires, and asserts it jumps to `Moderate` with a last-known position — within a few frames (too fast for sight escalation, which needs ~1.5s of continuous visibility). Verified negative: with the noise emit disabled the monster stays `Lowest`.
- `cargo test -p shock2vr` (88 passing), `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime`.

## Review

Cross-engine `/xreview` (Claude + Codex): no Critical/High. Codex caught a Medium — apparition (no-config) AIs could be woken by noise/damage — fixed by making `alert_to_position` a no-op when there's no config, consistent with how `update()` skips alertness for those AIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)