### PR TITLE
fix(physics): stop non-impact collisions from dealing damage

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -96,7 +96,7 @@ use crate::{
     },
     teleport::{TeleportSystem, TeleportUI, TeleportVisualStyle},
     time::Time,
-    util::{get_email_sound_file, has_refs, vec3_to_point3},
+    util::{debug_entity, get_email_sound_file, has_refs, vec3_to_point3},
     virtual_hand::VirtualHandEffect,
     vr_config,
 };
@@ -1791,6 +1791,17 @@ impl MissionCore {
 
                     if let Ok(hit_points) = (&mut v_hit_points).get(entity_id) {
                         hit_points.hit_points += delta;
+                        // Every HP change flows through here (weapon, stim,
+                        // collision damage) - trace it with the resulting
+                        // total so a mysterious death is attributable.
+                        let hp = hit_points.hit_points;
+                        drop(v_hit_points);
+                        tracing::debug!(
+                            "hp: {} {:+} -> {}",
+                            debug_entity(&self.world, entity_id),
+                            delta,
+                            hp
+                        );
                     }
                 }
 

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -38,17 +38,25 @@ impl Script for InternalCollisionType {
     ) -> Effect {
         match msg {
             MessagePayload::Collided { with } => {
-                let initial_effect = {
-                    if self.collision_flags.contains(CollisionType::SLAY_ON_IMPACT) {
-                        Effect::SlayEntity { entity_id }
-                    } else if self
-                        .collision_flags
-                        .contains(CollisionType::DESTROY_ON_IMPACT)
-                    {
-                        Effect::DestroyEntity { entity_id }
-                    } else {
-                        Effect::NoEffect
-                    }
+                // Only impact-payload entities (projectiles / fragile props
+                // flagged to slay or destroy themselves on contact) deal
+                // collision damage. A plain BOUNCE creature must not: any two
+                // creatures with a collision type would otherwise damage each
+                // other 1/frame on contact, killing low-HP crew during
+                // crowded scripted scenes (e.g. the command2 flee cutscene,
+                // where Suarez died bumping the other fleeing actors).
+                let is_impact = self
+                    .collision_flags
+                    .intersects(CollisionType::SLAY_ON_IMPACT | CollisionType::DESTROY_ON_IMPACT);
+                if !is_impact {
+                    return Effect::NoEffect;
+                }
+
+                let initial_effect = if self.collision_flags.contains(CollisionType::SLAY_ON_IMPACT)
+                {
+                    Effect::SlayEntity { entity_id }
+                } else {
+                    Effect::DestroyEntity { entity_id }
                 };
                 let damage_effect = Effect::Send {
                     msg: Message {


### PR DESCRIPTION
While checking the **command2 "Suarez/Siddons flee a rumbler" cutscene**, found it wasn't playing right — the fleeing crewman Suarez died partway through. Root cause was a physics bug affecting all missions.

## The bug
`InternalCollisionType` (attached to every entity with a `PropCollisionType`) sent a flat `Damage { amount: 1.0 }` to whatever it collided with — **unconditionally, on every `Collided` event**, with no collision flag backing it (an ancient stub from #8). So any two entities with a collision type damaged each other ~1/frame on contact. Low-HP crew are lethal here: Suarez (10 HP) collides with the other clustered fleeing actors and dies mid-run, while the 220-HP Humbler shrugs it off.

The damage-event log (added here) is the smoking gun:
```
hp: EId(405) | 1948 | Suarez -1 -> 9
hp: ... Suarez -1 -> 8  ...  -1 -> 1   (then dead)
```

## The fix
Gate collision damage on the impact flags (`SLAY_ON_IMPACT`/`DESTROY_ON_IMPACT`) — only projectiles/fragile props meant to die on contact deal it. Weapons/projectiles/melee already deal their own damage through the weapon/stim system, so nothing legitimate depended on the stub.

Also adds a durable **damage-event breadcrumb**: every HP change logs `hp: <entity> <±delta> -> <total>` at `debug` level (the `AdjustHitPoints` choke point), so future mysterious deaths are attributable to their source.

## Verification
The flee cutscene now plays — the crew escape:

![command2 flee cutscene](https://gist.githubusercontent.com/tommy-xr/0612b477c3b8d5ced218b6ba7cc5333f/raw/command2_flee_full.gif)

<sub>Full scene: Suarez and Siddons flee down the corridor toward the escape door while the Humbler (rumbler) gives chase (~26s, timelapsed). Captured headlessly via the debug runtime.</sub>

Across 8 fresh runs, every run that completed (6/7) ran the scene end-to-end — the crew reach `lovend` and the cleanup destroys the actors, with **zero collision deaths** (previously Suarez died every run). Full e2e: 58/59 (the one failure is the pre-existing flaky ragdoll-drift test, unrelated — this change touches HP, not physics motion).

## Separate finding (not fixed here)
~25% of debug-runtime runs of command2 crash with a `parry3d ray_aabb subtract-with-overflow` panic, from the **player's per-frame aim raycast** (`FlatPlayerController::update` → `PhysicsWorld::ray_cast2`) hitting one of the level's 62 degenerate/thin colliders. It's a **debug-build overflow check** — release wraps silently, so the shipped game shouldn't crash — but it makes the debug runtime unreliable on this level. Filing separately; the fix is likely disabling overflow-checks for the debug-runtime build (to match release) or hardening the collider sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
