### PR TITLE
feat(dark): parse AI patrol data (AI_Patrol property + AIPatrol links)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -329,6 +329,11 @@ pub struct PropLocalPlayer {}
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropHUDSelect(pub bool);
 
+/// "AI_Patrol": when true, the AI patrols a route of patrol-point objects
+/// chained by `Link::AIPatrol`, walking point to point while idle.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropAIPatrol(pub bool);
+
 //  This is a backlink to the template ID from the ss2 map file
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTemplateId {
@@ -370,6 +375,10 @@ pub enum Link {
     ParticleAttachement(ParticleAttachOptions),
     TPathInit,
     TPath(TPathData),
+    /// From a patrol-point object to the next patrol point on its route. An AI
+    /// with `PropAIPatrol(true)` walks this chain of points while idle. The
+    /// link carries no data (a bare "go to the next point" edge).
+    AIPatrol,
     /// Names a destination object for scripted teleports (CS9 eggs/rumblers,
     /// TrapTeleport family, TrapDestroyTeleport's destroy target).
     Teleport,
@@ -898,6 +907,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_link("L$SwitchLin", |_| Link::SwitchLink),
         define_link("L$Teleport", |_| Link::Teleport),
         define_link("L$TPathInit", |_| Link::TPathInit),
+        define_link("L$AIPatrol", |_| Link::AIPatrol),
         define_link("L$Miss Span", |_| Link::MissSpang),
         //define_link("L$TPath", |_| Link::TPath),
         //define_link("L$TPathNext", |_| Link::TPath),
@@ -1008,6 +1018,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop("P$AI_Mode", PropAIMode::read, identity, accumulator::latest),
+        define_prop(
+            "P$AI_Patrol",
+            |reader, _len| read_bool(reader),
+            PropAIPatrol,
+            accumulator::latest,
+        ),
         define_prop(
             "P$AI_SigRsp",
             PropAISignalResponse::read,

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -16,7 +16,9 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use dark::mission::PathDatabase;
+use dark::properties::{self, Link};
 use dark::ss2_chunk_file_reader;
+use dark::ss2_entity_info::{self, SystemShock2EntityInfo};
 
 /// Locate the `Data/` directory, or `None` when assets aren't available.
 ///
@@ -47,6 +49,40 @@ fn load_path_database(data: &Path, mission: &str) -> Option<PathDatabase> {
     let mut reader = BufReader::new(file);
     let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
     PathDatabase::read(&toc, &mut reader)
+}
+
+/// Parse a mission's entity info (properties + links) directly from its own
+/// chunks, without merging the gamesys. Enough to assert on mission-local
+/// properties and links (patrol data lives in the mission file).
+fn load_mission_entity_info(data: &Path, mission: &str) -> SystemShock2EntityInfo {
+    let file = File::open(data.join(mission)).expect("mission file should open");
+    let mut reader = BufReader::new(file);
+    let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+    let (props, links, links_with_data) = properties::get();
+    ss2_entity_info::new(&toc, &links, &links_with_data, &props, &mut reader)
+}
+
+/// Count `Link::AIPatrol` edges across all of a mission's parsed links.
+fn count_aipatrol_links(info: &SystemShock2EntityInfo) -> usize {
+    info.template_to_links
+        .values()
+        .flat_map(|tl| &tl.to_links)
+        .filter(|l| matches!(l.link, Link::AIPatrol))
+        .count()
+}
+
+/// Count entities flagged as patrollers (`PropAIPatrol(true)`). Properties are
+/// trait objects with no downcast, so match on the `Debug` form - the same
+/// rendering `dark_query` shows.
+fn count_patrolling_entities(info: &SystemShock2EntityInfo) -> usize {
+    info.entity_to_properties
+        .values()
+        .filter(|props| {
+            props
+                .iter()
+                .any(|p| format!("{p:?}").contains("PropAIPatrol(true)"))
+        })
+        .count()
 }
 
 /// Every `.mis` filename in `data`.
@@ -149,4 +185,32 @@ fn shodan_v34_aipath_loads_without_door_data() {
             "v3.4 tail must not be parsed until its layout is verified"
         );
     }
+}
+
+#[test]
+fn eng1_patrol_data_parses() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let info = load_mission_entity_info(&data, "eng1.mis");
+
+    // eng1 has a substantial patrol network (a ~1.1KB L$AIPatrol chunk). The
+    // link registration must turn those edges into typed Link::AIPatrol rather
+    // than leaving them in the unparsed bucket.
+    assert!(
+        !info.unparsed_links.contains_key("L$AIPatrol"),
+        "L$AIPatrol should be a registered (parsed) link, not unparsed"
+    );
+    // 81 route edges and 17 flagged patrollers is eng1's known, stable set; a
+    // regression in the link/property parse shifts these counts.
+    let patrol_links = count_aipatrol_links(&info);
+    assert_eq!(
+        patrol_links, 81,
+        "eng1 parsed AIPatrol route-link count changed"
+    );
+
+    // ...and the AIs flagged to walk it (P$AI_Patrol = true).
+    let patrollers = count_patrolling_entities(&info);
+    assert_eq!(patrollers, 17, "eng1 PropAIPatrol(true) AI count changed");
 }

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -385,6 +385,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
+                Link::AIPatrol => "AIPatrol".to_string(),
                 Link::Teleport => "Teleport".to_string(),
                 Link::StimSource(_) => "StimSource".to_string(),
                 Link::Receptron(_) => "Receptron".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -595,6 +595,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
+        dark::properties::Link::AIPatrol => "AIPatrol".to_string(),
         dark::properties::Link::Teleport => "Teleport".to_string(),
         // Include the payload: blast tuning (intensity/radius) is exactly what
         // one inspects these links for.


### PR DESCRIPTION
## What

Parses the two pieces of the System Shock 2 AI **patrol** system in the `dark` crate, so a follow-up can drive idle AIs along authored routes. **No behavior change yet** — nothing consumes the data, so patrolling AIs still just wander. This is PR 1 of 2 (parse → behavior).

The task originally guessed "AIPath/AIGoalLoc links", but the real SS2 mechanism (confirmed against the data + engine reference) is:

- **`PropAIPatrol`** (`P$AI_Patrol`, BOOL) — flags an AI as a patroller.
- **`Link::AIPatrol`** (`L$AIPatrol`, dataless) — chains patrol-point objects, each point linking to the *next* point on the route. The AI finds the nearest point and walks the chain.

## Evidence it's real, well-used data

`dark_query` now renders it. In eng1, "Patrol Path" markers form chains:

```
Entity 477 (sym:Patrol Path)
  Outgoing: AIPatrol -> Entity 478 (sym:Patrol Path)
  Incoming: Entity 476 (sym:Patrol Path) -> AIPatrol
```

Shipping missions use it broadly — **eng1 alone has 81 route edges and 17 flagged patrollers**; hydro2/medsci1/many/rec* are similar. Only earth/ops1 lack it.

## Changes

- `dark/src/properties/mod.rs`: `PropAIPatrol(bool)` + register `P$AI_Patrol`; `Link::AIPatrol` variant + register `L$AIPatrol` as a dataless link (matches the engine's `noDataDesc`).
- `tools/dark_query`: add an `AIPatrol` arm to the two exhaustive `Link` matches so the tool still builds (this was caught by cross-engine review — see below).

## Testing

- New `dark/tests/mission_loading.rs::eng1_patrol_data_parses` — asserts eng1 parses exactly **81** `AIPatrol` links and **17** `PropAIPatrol(true)` entities, and that `L$AIPatrol` is no longer in the unparsed bucket. Negative-verified: reverting the parse makes it fail.
- `cargo test -p dark` green; `RUSTFLAGS="-D warnings" cargo check` on dark/dark_query/shock2vr/debug_runtime.
- All **23 missions still load** via the SDK missions e2e (this change touches core `properties::get()`, which affects live loading).

## Review

Cross-engine `/xreview` (Claude + Codex). Both verified the on-disk chunk names are byte-exact (`P$AI_Patrol`, `L$AIPatrol` — no truncation needed, unlike `L$AIWatchOb`). Codex caught a **High** the other missed: the new `Link::AIPatrol` variant broke two exhaustive `Link` matches in `tools/dark_query` — fixed here (I'd initially missed it because a `2>/dev/null` had hidden the compile error). One **Low** left as-is to avoid scope creep: the empty `LD$AIPatrol` companion chunk still lands in the global `unparsed_link_data` map — cosmetic, identical for every dataless link, no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)