### PR TITLE
docs: refresh TODO.md + AI project docs with Jul 2-5 status

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,11 +13,8 @@ Needs human verification (batch these — no automated test covers "feel"):
   default `0.5`, so dynamic props are slightly slidier. Low magnitude and covered
   by automated tests, but confirm it feels right in the same pass.
 
-Recent work
-- (in progress) flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
-- [x] flat runtime -> fix alpha transparency / z-order break (viewmodel depth-clear wiped world depth before the transparent pass; engine now renders the overlay group after the world's passes)
-- [x] flat runtime -> camera-origin aim along the crosshair (#315); muzzle flash now tracks the weapon via RuntimePropAttachment (#323)
-- [x] flat runtime -> per-weapon viewmodel framing from PropPlayerGun.model_offset (viewmodel-FOV scale + authored offsets + 11.25deg carry pitch; see projects/flat-weapon-handling.md)
+Recent work (in progress / remaining polish; completed slices are in the year summary at the bottom)
+- flatscreen runtime landed: desktop defaults to flat, mouse-driven menu, first-person viewmodel + click-to-fire, crosshair frob/pickup (slices 1-6, #295-#305). Remaining polish:
 - modernize combat: add recoil / accuracy modifier (like counter-strike)
 - weapon ammo next slices: per-shot m_ammoUsage + clip size from BaseGunDesc (P$BaseGunDe), reload, ammo-type switching (see projects/flat-weapon-handling.md)
 
@@ -28,8 +25,6 @@ Recent work
   (#384), gunfire (#403) + damage (#359) alerts, scripted sequences survive alertness changes (#387).
   Patrol data parses (#406) but no patrol behavior consumes it yet. See projects/ai-pathfinding.md.
 - Fable: check to see feasibility of loading the 25th anniversary assets
-- [x] Fable: fix flat screen first-person melee weapon orientation (camSynch equivalent: root-motion cancel + authored PlayerMelee arm anchor; projects/flat-weapon-handling.md)
-- [x] Fable: fix flat screen first-person ranged weapon positioning (per-weapon model_offset framing, above)
 
 
 SNACKS:
@@ -45,7 +40,6 @@ SNACKS:
   - Have a 'script' for simulating a slow swipe (low damage) or fast swipe (high damage)
   - Add raycast test to see what is being hit
 
-- [x] Main menu (flat mouse-driven menu boots by default; #297, #300)
 - Fix ranged attack when monsters only support melee
 - Nanite counting / gui upgrade for replicator
 - Cybernetic module counting / ui for upgrade stations
@@ -73,29 +67,16 @@ Can do these in parallel:
 - Skip cutscene by pressing trigger
 - What are the entry points for a cutscene? How do we know to play a cutscene?
 
-- [x] Combat: Handle Player Health
-  - [x] Should just be a number on player state? (PropHitPoints on player entity)
-  - [x] Render in HUD somehow... (VR forearm + flat HUD health bar; #300)
 - [ ] Combat: Handle Player Death
   - [ ] Camera fall down animation, static
 - Create a placeholder UI for 'assets not found'
 - Create a floating menu 'mission'
-- [x] AIWatchObj link: Apparitions (#400 - Grassi apparition in medsci1 materializes,
-      performs its authored animation, and vanishes; full replayable lifecycle)
-  - [x] Handle ScriptMessage 'ApparBegin'/'ApparEnd' via the new Apparition script
-  - [x] Implement 'Signal' (new scripted-sequence Signal/ScriptMessage actions; AIWatchObj fires it)
-- Fix slay (in progress)
-  - [x] Make robots blow up (explosions push + damage their surroundings #388, resolved through
-        receptrons #399; barrel chain reactions work), scatter flinderize gibs on slay (#377),
-        killing blows crossfade-interrupt the current clip (#375)
-  - Create corpse and make container available (corpse-on-death handoff step 1 done, #281; container TODO)
-  - Maybe there's another way to figure out what to slay?
+- Fix slay (in progress) - robots blow up / gibs / killing-blow interrupt done (year summary);
+  remaining: create corpse and make container available (corpse-on-death handoff step 1 done, #281;
+  container TODO)
 - command2.mis:
   - Why is door not transparent?
   - Why is door not moving?
-- [x] rec:
-  - why is the cutscene flaky? (FIXED #387 - alertness changes cancelled a running scripted
-    sequence at a player-dependent moment; running sequences are now protected. rec1 Cortez verified)
 - Android pipeline improvements (CI build is green; release mode + artifact still todo)
   - Build w/ release
   - Add APK as artifact
@@ -116,8 +97,7 @@ Can do these in parallel:
 - [ ] VR: Is handedness already considered?
   - [ ] Where would the scale be factored in?
 - [ ] VR: Weapon scale
-- [x] Hack for blood spangs - replaced: projectile impacts now spawn the authored spangs (HitSpang links by victim class -> blood/sparks/grub/many; MissSpang -> terrain)
-  - [ ] Add bitmap, tweq destroy
+- [ ] Spang follow-up: tweq-destroy on spang burst
 - [ ] Camera AI - If player still visible after 3 seconds, switch to alarm - SwitchLink ecology ? How does triggering happen?
 - [ ] Security system AI
 - [ ] Add ecology
@@ -304,9 +284,6 @@ Can do these in parallel:
   - [ ] Create system
     - [ ] EmitTweq
   - [ ] Fix rotation tweq when not full rotation
-- [x] Explosions (ie, re301 in barrel) (#388/#399)
-  - [x] Implement physics to push items away (radial impulse on dynamic bodies)
-  - [x] Implement damage (radius blast resolved through receptrons - type-aware; barrel chains work)
 - [ ] Skinned model - incorporate weights into animation
 - [ ] Factor playerscript out to use existing link infra
 - [ ] Implement collision sounds
@@ -319,7 +296,6 @@ Can do these in parallel:
 - [ ] Weapons: Source/Stim Act/React (partial: act/react stim sources #388 + receptron links #395
       parse, and radius blasts resolve damage through receptrons #399; per-weapon stim application
       and periodic emitters still TODO - see #390)
-- [x] Spangs: Particle system not working correctly for blood spatter - SOLVED: P$ParticleG ships in two struct versions (mission 324 bytes, gamesys 380 with 8 extra bytes after gravity); the parser now handles both, and one-shot spang groups expire with their burst.
 - [ ] AI Behavior Improvements
   - Wander: Scan rays up/down to try and capture more of environment?
   - Add 'cliff' detector
@@ -496,9 +472,12 @@ Release Checklist
   table parsing (#398), AI patrol data parsing (#406)
 - Motion/animation: entity movement driven by per-frame root velocity (#396), wound/death queries
   reach the clips the data has (#385), `dq motion-info` per-clip metadata (#394)
-- Combat/flat viewmodel: faithful first-person framing for all 15 weapons (#335), data-driven impact
-  spangs (#338), bitmap particles + attached particle riders (#340/#342), viewmodel overlay renders
-  after the world's transparent pass (#337)
+- Combat / gibs / spangs: faithful first-person framing for all 15 weapons (#335); projectile impacts
+  spawn the authored spangs by victim class (HitSpang blood/sparks/grub, MissSpang terrain, #338),
+  with the P$ParticleG parser handling both struct versions so blood bursts render and expire; bitmap
+  particles + attached particle riders (#340/#342); scatter/launch flinderize gibs on slay (#377);
+  viewmodel overlay renders after the world's transparent pass (#337); flat melee render/idle/swing
+  (#319-#321) and first-person melee/ranged weapon orientation from PropPlayerGun
 - Fixed: non-impact collisions no longer deal damage (#404); dead monsters stay dead (#371);
   human death animations / wound clips play (#385, closes #381); SDK launch-retry only on port races (#378)
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,11 @@ Recent work
 - weapon ammo next slices: per-shot m_ammoUsage + clip size from BaseGunDesc (P$BaseGunDe), reload, ammo-type switching (see projects/flat-weapon-handling.md)
 
 - Fable: finish ragdolls (in progress) - hitbox-fitted colliders + rapier 0.31 compliant joints settle into a heap; on-death ragdoll behind `--experimental ragdoll`; multibody rig still experimental (extremity jitter / hip-sag), see projects/ragdoll-settling-followup.md
-- Fable: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped; broader AI behavior testing ongoing
+- Fable: finish AI pathing & testing (in progress) - A* pathfinding + interactive path viz shipped;
+  AI now path-follows for chase/wander (#270/#271), opens/gives-up at route doors (#402), and the
+  awareness loop is much richer: search last-known position (#379), chase the last-*seen* position
+  (#384), gunfire (#403) + damage (#359) alerts, scripted sequences survive alertness changes (#387).
+  Patrol data parses (#406) but no patrol behavior consumes it yet. See projects/ai-pathfinding.md.
 - Fable: check to see feasibility of loading the 25th anniversary assets
 - [x] Fable: fix flat screen first-person melee weapon orientation (camSynch equivalent: root-motion cancel + authored PlayerMelee arm anchor; projects/flat-weapon-handling.md)
 - [x] Fable: fix flat screen first-person ranged weapon positioning (per-weapon model_offset framing, above)
@@ -33,7 +37,8 @@ SNACKS:
 - [ ] Implement frobbing keycards (collecting when held)
 - [ ] implement tweqallbyname -> eng
 
-- Player 'damage'
+- Player 'damage' (BLOCKED: player entity is created outside entity_creator so it has no scripts -
+  Damage messages to it are dropped; see #389. Enemy/explosion damage plumbing otherwise landed)
 - Player 'death'
 - Ladder handling - for both desktop and vr (climbable flag in phys attr)
 - Melee attacking: player
@@ -54,7 +59,9 @@ TODO:
 - Start cutting APK releases - automate releases
 - Create a website with instructions on how to install
 - Test with new assets
-- Psi powers
+- Psi powers (largely landed: amp is usable and casts powers #345, hold-to-overload charge meter
+  #350, trained-power gating #354, sustained powers - Photonic Redirection invisibility #355,
+  selected discipline shown in the HUD #353. See projects/psi-powers.md)
 
 - Figure out how to get macOS build running by re-pointing binary - DYLD path or LD_LIBRARY_PATH. How to co-locate binaries?
 - Same for Windows
@@ -73,21 +80,22 @@ Can do these in parallel:
   - [ ] Camera fall down animation, static
 - Create a placeholder UI for 'assets not found'
 - Create a floating menu 'mission'
-- AIWatchObj link: Apparitions
-  - Parse ApparStart link
-  - Handle ScriptMessage 'ApparBegin', 'ApparEnd' -> these should just be scripts?
-  - Implement 'Signal'?
-  - Example 'grassi app' in medsci
-  - Quick iteration: spawn near that one
+- [x] AIWatchObj link: Apparitions (#400 - Grassi apparition in medsci1 materializes,
+      performs its authored animation, and vanishes; full replayable lifecycle)
+  - [x] Handle ScriptMessage 'ApparBegin'/'ApparEnd' via the new Apparition script
+  - [x] Implement 'Signal' (new scripted-sequence Signal/ScriptMessage actions; AIWatchObj fires it)
 - Fix slay (in progress)
-  - Make robots blow up, spawn items
+  - [x] Make robots blow up (explosions push + damage their surroundings #388, resolved through
+        receptrons #399; barrel chain reactions work), scatter flinderize gibs on slay (#377),
+        killing blows crossfade-interrupt the current clip (#375)
   - Create corpse and make container available (corpse-on-death handoff step 1 done, #281; container TODO)
   - Maybe there's another way to figure out what to slay?
 - command2.mis:
   - Why is door not transparent?
   - Why is door not moving?
-- rec:
-  - why is the cutscene flaky?
+- [x] rec:
+  - why is the cutscene flaky? (FIXED #387 - alertness changes cancelled a running scripted
+    sequence at a player-dependent moment; running sequences are now protected. rec1 Cortez verified)
 - Android pipeline improvements (CI build is green; release mode + artifact still todo)
   - Build w/ release
   - Add APK as artifact
@@ -296,9 +304,9 @@ Can do these in parallel:
   - [ ] Create system
     - [ ] EmitTweq
   - [ ] Fix rotation tweq when not full rotation
-- [ ] Explosions (ie, re301 in barrel)
-  - [ ] Implement physics to push items away
-  - [ ] Implement damage
+- [x] Explosions (ie, re301 in barrel) (#388/#399)
+  - [x] Implement physics to push items away (radial impulse on dynamic bodies)
+  - [x] Implement damage (radius blast resolved through receptrons - type-aware; barrel chains work)
 - [ ] Skinned model - incorporate weights into animation
 - [ ] Factor playerscript out to use existing link infra
 - [ ] Implement collision sounds
@@ -308,7 +316,9 @@ Can do these in parallel:
 - [ ] Perf: Can we minimize draw calls for materials based on cell?
 - [ ] Create a localized string mapper
   - [ ] Use dictionary in lookup method.
-- [ ] Weapons: Source/Stim Act/React
+- [ ] Weapons: Source/Stim Act/React (partial: act/react stim sources #388 + receptron links #395
+      parse, and radius blasts resolve damage through receptrons #399; per-weapon stim application
+      and periodic emitters still TODO - see #390)
 - [x] Spangs: Particle system not working correctly for blood spatter - SOLVED: P$ParticleG ships in two struct versions (mission 324 bytes, gamesys 380 with 8 extra bytes after gravity); the parser now handles both, and one-shot spang groups expire with their burst.
 - [ ] AI Behavior Improvements
   - Wander: Scan rays up/down to try and capture more of environment?
@@ -468,6 +478,29 @@ Release Checklist
 - Debug runtime ergonomics: defaults to flat (`--vr` to opt in), `/v1/info` reports player + wielded entity, `/v1/control/input` accepts both body shapes and validates (actionable 400s), e2e suite runs serially (#324)
 - Weapon ammo: parse `P$GunState`, consume a round per shot, dry-fire at empty (#326); faithful flat HUD - ammo gauge (AMMOBACK) + corrected health/psi meters + BIOFULL bio-monitor backdrop, all positioned from the original `shkmeter.cpp`/`shkammov.cpp` coords (#327)
 - Dev workflow: pre-push git hook running `cargo fmt --check` (#325)
+- Psi powers usable: cast from the amp (#345), hold-to-overload charge meter (#350), trained-power
+  gating (#354), sustained Photonic Redirection invisibility (#355), selected discipline in HUD (#353)
+- VR gloves: SteamVR hand poses retargeted onto the vr_glove GLB and rendered as the player's hands
+  (#348/#351); grip pose + fitted weapon offsets for held items, world models kept on held weapons (#356/#368)
+- Cutscenes: ops1 SHODAN reveal / CS9 (#364), theatre screens fade in after walls open (#367),
+  animated holo fades (#365), holo rumblers animate via authored pose tag (#372), event-driven wall
+  timing via CS9_DoorReporter (#373), apparitions materialize/perform/vanish (medsci1 Grassi, #400)
+- Act/react (stims): stim-source (#388) + receptron (#395) link parsing; explosions push and damage
+  their surroundings, resolved through receptrons so damage is stim-type-aware (#388/#399)
+- AI awareness/behavior: search last-known position on losing sight (#379), chase the last-*seen*
+  position not the player's true location (#384), gunfire (#403) + taking damage (#359) raise
+  alertness, pursuers open/give-up at route doors (#402), scripted sequences survive alertness
+  changes (#387), killing blows crossfade-interrupt the current clip (#375)
+- Pathfinding: engine-faithful link gating + taut edge waypoints + benchmark CLI (#270), path-following
+  steering for chase/wander (#271), per-frame query budget + jittered re-path (#366), AIPATH cell-door
+  table parsing (#398), AI patrol data parsing (#406)
+- Motion/animation: entity movement driven by per-frame root velocity (#396), wound/death queries
+  reach the clips the data has (#385), `dq motion-info` per-clip metadata (#394)
+- Combat/flat viewmodel: faithful first-person framing for all 15 weapons (#335), data-driven impact
+  spangs (#338), bitmap particles + attached particle riders (#340/#342), viewmodel overlay renders
+  after the world's transparent pass (#337)
+- Fixed: non-impact collisions no longer deal damage (#404); dead monsters stay dead (#371);
+  human death animations / wound clips play (#385, closes #381); SDK launch-retry only on port races (#378)
 
 2026: Things I hope we can do
 

--- a/projects/ai-generalize-alertness.md
+++ b/projects/ai-generalize-alertness.md
@@ -1,5 +1,13 @@
 # Generalized Alertness System for All AI Types
 
+> **Status:** All 5 phases complete (see checkboxes below). Follow-on behavior
+> built on this system (tracked elsewhere): losing sight drives a Search of the
+> last-known position (#379); chase pursues the last-*seen* position (#384);
+> gunfire (#403) and taking damage (#359) escalate alertness; scripted sequences
+> survive alertness changes (#387). Sustained Photonic Redirection makes the
+> player invisible to this awareness path (#355). Alert *propagation* between
+> linked AIs (Phase 5 item 2) remains unimplemented.
+
 ## Overview
 
 This project aims to extract and generalize the alertness system currently implemented in `camera_ai.rs` to make it reusable across all AI types (cameras, turrets, animated monsters). The goal is to provide consistent alertness behavior while allowing each AI type to customize responses to alertness changes.

--- a/projects/ai-pathfinding.md
+++ b/projects/ai-pathfinding.md
@@ -4,14 +4,20 @@
 
 This plan implements proper A* pathfinding for monster AI using the AIPATH data stored in mission files. The implementation is broken into 5 phases, each building on the previous.
 
-## Current State
+## Current State (updated 2026-07-05)
 
 - ✅ **AIPATH parsing complete** - Complete pathfinding database extraction from mission files (Phase 1)
 - ✅ **Debug visualization complete** - `--debug-pathfinding` flag renders navigation mesh overlay (Phase 2)
 - ✅ **A* pathfinding complete** - Full interactive pathfinding with P-key testing and HTTP API (Phase 3)
-- **AI uses direct movement** - Monsters chase players in a straight line with whisker-based collision avoidance
-- **Scripted sequences exist** - `ScriptedSequenceBehavior` supports waypoint navigation via `GotoScriptedAction`, but uses direct steering
-- **Ready for Phase 4** - AI integration with pathfinding service
+- ✅ **AI path-following integrated (Phase 4)** - Chase and wander steer along A\* paths via
+  `path_follow_steering_strategy.rs` (#270/#271), with engine-faithful link gating and taut
+  edge waypoints kept clear of wall corners (#360). A per-frame query budget with telemetry and
+  jittered re-path throttles pathfinding cost (#366). A pursuing AI opens the unlocked door
+  gating a cell on its route and gives up at a locked one (#402), using the parsed AIPATH
+  cell-door table (#398). Benchmark CLI (`cargo bn path`) measures latency/quality.
+- 🔶 **Patrol (Phase 5) - data parsed, behavior pending** - `P$AI_Patrol` + `L$AIPatrol`
+  route chains now parse (#406), but no `PatrolBehavior` consumes them yet; flagged patrollers
+  still just wander.
 
 ## Design Decisions
 
@@ -317,9 +323,15 @@ This implementation provides a solid foundation for Phase 4 AI integration, with
 
 ---
 
-## Phase 4: AI Integration
+## Phase 4: AI Integration ✅ **COMPLETED** (#270/#271)
 
 **Goal**: Enhance monster AI to use A* pathfinding when chasing the player.
+
+> Shipped as `PathFollowSteeringStrategy` (`path_follow_steering_strategy.rs`),
+> not the exact `PathfindingSteeringStrategy` sketch below. Chase/wander follow
+> A\* paths with taut waypoints (#360); a query budget + jittered re-path bounds
+> per-frame cost (#366); route doors open/give-up (#402). The design sketch below
+> is retained for historical context.
 
 ### Files to Modify
 
@@ -396,9 +408,15 @@ Create a new `PathfindingSteeringStrategy` that:
 
 ---
 
-## Phase 5: Patrol Path Implementation
+## Phase 5: Patrol Path Implementation 🔶 **IN PROGRESS** (data parsed, behavior pending)
 
 **Goal**: Implement patrol behavior using AIWatchObj/TPath links with A* navigation between waypoints.
+
+> **Update (2026-07-05):** The patrol *data* now parses — `P$AI_Patrol` (the
+> patroller flag) and `L$AIPatrol` route-point chains (#406, verified in eng1:
+> 17 patrollers, 81 route edges). Nothing consumes it yet, so no `PatrolBehavior`
+> exists and flagged AIs still wander. Note the shipped data uses `AIPatrol`
+> links, not the `TPath` links this plan assumed.
 
 ### Background
 

--- a/projects/ai_improvements.md
+++ b/projects/ai_improvements.md
@@ -1,5 +1,29 @@
 # AI Improvements
 
+> **Status (updated 2026-07-05):** This is the original scoping doc. Most of it
+> has since shipped under dedicated efforts — cross-reference those docs for the
+> current state:
+> - **Pathfinding (Objective 4 / old Phase 3):** A\* pathfinding + interactive
+>   viz landed, and AI now path-follows via `path_follow_steering_strategy.rs`
+>   (chase/wander, #270/#271). Doors on a pursuit route open/give-up (#402), the
+>   AIPATH cell-door table parses (#398), and there's a benchmark CLI + jittered
+>   re-path budget (#366). See `ai-pathfinding.md`.
+> - **Alertness (Objective 5 groundwork):** generalized across cameras, turrets,
+>   and monsters. See `ai-generalize-alertness.md`.
+> - **Behavior fidelity:** losing sight now drives a Search of the last-known
+>   position (#379), chase pursues the last-*seen* position rather than the
+>   player's true location (#384), gunfire (#403) and taking damage (#359) raise
+>   alertness, and scripted sequences survive alertness changes (#387).
+> - **Motion/animation:** wound/death queries reach the right clips (#385,
+>   fixes #381), killing blows crossfade-interrupt the current clip (#375), and
+>   movement is driven by per-frame root velocity (#396).
+> - **Blocker bugs from "Current Findings" below:** collision-avoidance whisker
+>   distances are now honored (conservative vs comprehensive differ). The
+>   `__NULL_ACTION__` tag is a deliberate idle sentinel, not a typo. Scripted-
+>   sequence robustness was reworked in #387 (per-action watchdog).
+> - **Still open:** security-alarm propagation and turret/global-alert
+>   coordination (Objective 5 / old Phase 4) are not implemented.
+
 ## Current Findings
 
 ### Blocker Bugs


### PR DESCRIPTION
Documentation-only sweep bringing `TODO.md` and the AI project docs in line with
the past few days of merged work (PRs #335–#406). No code changes.

## TODO.md
- Marked done: apparitions (#400), explosions push+damage through receptrons
  (#388/#399), rec1 cutscene flakiness (#387), robots-blow-up under "Fix slay".
- Annotated with current status: AI pathing/awareness, psi powers, act/react
  stims, and player-damage (still **blocked** by #389 — the player entity has no
  scripts, so Damage messages to it are dropped).
- Added a consolidated Jul 2–5 block to the "2026 (so far)" year summary
  (psi, VR gloves, cutscenes, act/react, AI awareness/behavior, pathfinding,
  motion/animation, flat viewmodel, and notable fixes).

## Project docs
- **ai-pathfinding.md** — Phase 4 (AI path-following) marked complete
  (#270/#271/#360/#366/#402); Phase 5 (patrol) marked in-progress: the data now
  parses (#406) but no `PatrolBehavior` consumes it yet.
- **ai_improvements.md** — added a status header mapping the original scoping
  plan onto what has since shipped, and what's still open (security propagation /
  turret coordination).
- **ai-generalize-alertness.md** — pointer to the follow-on awareness/search work.

## Notes
- Done in a worktree to avoid conflicting with in-flight work on
  `feat/ai-patrol-behavior`.
- Untracked `projects/*.md` files in the main working tree (WIP: shodan-v2,
  ui-consolidation, map-rendering, etc.) were intentionally **not** touched.
- Separately verified as fixed and closed: #381 (human death/wound clips, fixed
  by #385), #374 & #386 (launch-failure e2e assertion, fixed by #378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)