### PR TITLE
fix(physics): guard raycasts against degenerate rays + collider audit tooling

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -98,6 +98,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<PhysicsJointsResult>,
     },
 
+    /// Audit collider AABBs for malformed geometry (NaN/degenerate/extreme)
+    AuditColliders {
+        reply: oneshot::Sender<ColliderAuditResult>,
+    },
+
     /// Shutdown the debug runtime gracefully
     Shutdown,
 }
@@ -217,6 +222,25 @@ pub struct PhysicsJointEntry {
     pub separation: f32,
     pub linear_impulse: f32,
     pub angular_impulse: f32,
+}
+
+/// Result of the collider-health audit: colliders with malformed AABBs.
+/// `total_count` is the number of issues; an empty `issues` list means the
+/// level's collider geometry is clean.
+#[derive(Debug, Serialize)]
+pub struct ColliderAuditResult {
+    pub total_count: usize,
+    pub issues: Vec<ColliderIssueEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ColliderIssueEntry {
+    pub entity_id: Option<i32>,
+    pub entity_name: Option<String>,
+    pub kind: String,
+    pub aabb_min: [f32; 3],
+    pub aabb_max: [f32; 3],
+    pub is_sensor: bool,
 }
 
 /// Detailed information about a physics body

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -278,6 +278,7 @@ async fn start_http_server(
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
         .route("/v1/physics/joints", get(list_physics_joints))
+        .route("/v1/physics/colliders/validate", get(audit_colliders))
         .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
         .route("/v1/control/input", get(get_input_state))
         .route("/v1/control/input", axum::routing::post(set_input_channel))
@@ -1176,6 +1177,34 @@ fn process_command(
                 tracing::warn!("Failed to send ragdoll metrics - receiver dropped");
             }
         }
+        RuntimeCommand::AuditColliders { reply } => {
+            let issues: Vec<commands::ColliderIssueEntry> = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .audit_colliders()
+                        .into_iter()
+                        .map(|iss| commands::ColliderIssueEntry {
+                            entity_id: iss.entity_id,
+                            entity_name: iss.entity_name,
+                            kind: iss.kind,
+                            aabb_min: iss.aabb_min,
+                            aabb_max: iss.aabb_max,
+                            is_sensor: iss.is_sensor,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if reply
+                .send(commands::ColliderAuditResult {
+                    total_count: issues.len(),
+                    issues,
+                })
+                .is_err()
+            {
+                tracing::warn!("Failed to send collider audit - receiver dropped");
+            }
+        }
         RuntimeCommand::ListPhysicsJoints { reply } => {
             let joints = game
                 .debug_scene()
@@ -1978,6 +2007,35 @@ async fn list_physics_joints(
         Err(_) => {
             tracing::error!("Failed to receive physics joints - sender dropped");
             Json(commands::PhysicsJointsResult { joints: vec![] })
+        }
+    }
+}
+
+/// HTTP handler for the collider-health audit: reports colliders with
+/// malformed world AABBs (NaN/inf, degenerate, or extreme). An empty `issues`
+/// list means the level's collider geometry is clean.
+async fn audit_colliders(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Json<commands::ColliderAuditResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    let empty = || commands::ColliderAuditResult {
+        total_count: 0,
+        issues: vec![],
+    };
+    if command_tx
+        .send(RuntimeCommand::AuditColliders { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send AuditColliders command - game loop receiver dropped");
+        return Json(empty());
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive collider audit - sender dropped");
+            Json(empty())
         }
     }
 }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -298,6 +298,21 @@ pub struct DebugPhysicsJoint {
     pub angular_impulse: f32,
 }
 
+/// A malformed collider found by the physics audit: an AABB with NaN/inf
+/// bounds, zero/negative extent, or extreme coordinates. Bad AABBs poison
+/// physics queries (garbage raycasts; a debug-build parry3d overflow), so this
+/// is surfaced for any level on demand.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugColliderIssue {
+    pub entity_id: Option<i32>,
+    pub entity_name: Option<String>,
+    /// "non_finite" | "degenerate" | "extreme".
+    pub kind: String,
+    pub aabb_min: [f32; 3],
+    pub aabb_max: [f32; 3],
+    pub is_sensor: bool,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -403,6 +418,13 @@ pub trait DebuggableScene {
     /// Every impulse joint with its anchor separation + applied impulse, for
     /// ragdoll diagnostics. Empty when the scene has no joints.
     fn list_physics_joints(&self) -> Vec<DebugPhysicsJoint> {
+        Vec::new()
+    }
+
+    /// Colliders whose world AABB is malformed (NaN/inf, degenerate, or
+    /// extreme). Empty means the level's collider geometry is clean. Used to
+    /// diagnose physics-query misbehavior (bad raycasts, parry3d overflow).
+    fn audit_colliders(&self) -> Vec<DebugColliderIssue> {
         Vec::new()
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4311,6 +4311,32 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .collect()
     }
 
+    fn audit_colliders(&self) -> Vec<crate::game_scene::DebugColliderIssue> {
+        let issues = self.physics.audit_colliders();
+        if issues.is_empty() {
+            return Vec::new();
+        }
+        // Resolve names via the shared `inner() as i32` map so recycled entities
+        // (generation > 0) match the same truncation the physics side used -
+        // reconstructing an EntityId with `from_inner` would drop the generation
+        // and silently miss those.
+        let names = self.entity_names_by_inner();
+        issues
+            .into_iter()
+            .map(|iss| {
+                let entity_name = iss.entity_id.and_then(|id| names.get(&id).cloned());
+                crate::game_scene::DebugColliderIssue {
+                    entity_id: iss.entity_id,
+                    entity_name,
+                    kind: iss.kind.as_str().to_string(),
+                    aabb_min: iss.aabb_min,
+                    aabb_max: iss.aabb_max,
+                    is_sensor: iss.is_sensor,
+                }
+            })
+            .collect()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -329,6 +329,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.list_physics_joints()
     }
 
+    fn audit_colliders(&self) -> Vec<crate::game_scene::DebugColliderIssue> {
+        self.mission_core.audit_colliders()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -994,7 +994,33 @@ impl PhysicsWorld {
         entity_to_ignore: Option<EntityId>,
         ignore_sensors: bool,
     ) -> Option<RayCastResult> {
-        let direction = direction.normalize();
+        // Guard against degenerate rays. A zero-length direction normalizes to
+        // NaN, and a NaN/zero ray direction sends parry's `clip_aabb_line` down
+        // its `near_side == 0` path (see parry3d clip_aabb_line.rs): when the
+        // ray origin also lies inside a collider AABB it returns face index 0,
+        // and parry's feature math then computes `0u32 - 1`, which panics with
+        // "attempt to subtract with overflow" in debug builds (issue #405) and
+        // silently returns garbage hits in release. Reject such rays here - the
+        // single choke point every raycast funnels through - rather than let a
+        // bad caller crash the whole runtime.
+        // Reject only truly non-normalizable input: an exactly-zero or
+        // non-finite direction (both normalize to NaN) or a non-finite origin. A
+        // tiny-but-nonzero direction still normalizes cleanly, so - unlike a
+        // `< EPSILON` bound - this never rejects legitimate short rays such as
+        // `ray_cast3`'s `end - start`.
+        let norm_sq = direction.magnitude2();
+        if !(start_point.x.is_finite() && start_point.y.is_finite() && start_point.z.is_finite())
+            || !norm_sq.is_finite()
+            || norm_sq == 0.0
+        {
+            tracing::debug!(
+                "ray_cast2: rejecting degenerate ray (origin={:?}, direction={:?})",
+                start_point,
+                direction
+            );
+            return None;
+        }
+        let direction = direction / norm_sq.sqrt();
         let ray = Ray::new(
             point![start_point.x, start_point.y, start_point.z],
             vector![direction.x, direction.y, direction.z],
@@ -1256,6 +1282,54 @@ impl PhysicsWorld {
         Some((min?, max?))
     }
 
+    /// Scan every collider's world AABB for values that break physics queries:
+    /// NaN/infinite bounds, degenerate (zero/negative) extents, or bounds far
+    /// outside any plausible level. A single bad AABB can make raycasts return
+    /// garbage or (in debug builds) panic inside parry3d, so this is the
+    /// first-line check when a level misbehaves. Cheap enough to call on demand
+    /// or per frame while diagnosing.
+    pub fn audit_colliders(&self) -> Vec<ColliderIssue> {
+        const EXTREME: f32 = 1.0e5;
+        let mut issues = Vec::new();
+        for (_handle, collider) in self.collider_set.iter() {
+            let aabb = collider.compute_aabb();
+            let mn = aabb.mins;
+            let mx = aabb.maxs;
+            let finite = mn.x.is_finite()
+                && mn.y.is_finite()
+                && mn.z.is_finite()
+                && mx.x.is_finite()
+                && mx.y.is_finite()
+                && mx.z.is_finite();
+
+            let kind = if !finite {
+                Some(ColliderIssueKind::NonFinite)
+            } else if mx.x <= mn.x || mx.y <= mn.y || mx.z <= mn.z {
+                Some(ColliderIssueKind::Degenerate)
+            } else if [mn.x, mn.y, mn.z, mx.x, mx.y, mx.z]
+                .iter()
+                .any(|c| c.abs() > EXTREME)
+            {
+                Some(ColliderIssueKind::Extreme)
+            } else {
+                None
+            };
+
+            if let Some(kind) = kind {
+                let entity_id =
+                    EntityId::from_inner(collider.user_data as u64).map(|id| id.inner() as i32);
+                issues.push(ColliderIssue {
+                    entity_id,
+                    kind,
+                    aabb_min: [mn.x, mn.y, mn.z],
+                    aabb_max: [mx.x, mx.y, mx.z],
+                    is_sensor: collider.is_sensor(),
+                });
+            }
+        }
+        issues
+    }
+
     /// Enumerate every rigid body in the simulation for debug tooling.
     ///
     /// This iterates the raw Rapier `RigidBodySet` rather than the
@@ -1382,6 +1456,43 @@ pub struct DebugJointInfo {
     pub linear_impulse: f32,
     /// Magnitude of the angular (limit) constraint impulse this step.
     pub angular_impulse: f32,
+}
+
+/// A malformed collider found by [`PhysicsWorld::audit_colliders`]. Bad
+/// collider AABBs feed garbage into the physics queries (parry3d's ray-AABB
+/// math can even integer-overflow on a degenerate box in debug builds), so
+/// this is a data-hygiene check surfaced for any level on demand.
+#[derive(Debug, Clone)]
+pub struct ColliderIssue {
+    /// Owning entity (from `Collider::user_data`), if any.
+    pub entity_id: Option<i32>,
+    /// What's wrong with the collider's world AABB.
+    pub kind: ColliderIssueKind,
+    /// The offending world-space AABB (min, max) - may contain NaN/inf.
+    pub aabb_min: [f32; 3],
+    pub aabb_max: [f32; 3],
+    pub is_sensor: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColliderIssueKind {
+    /// An AABB bound is NaN or infinite - poisons every query it touches.
+    NonFinite,
+    /// Zero (or negative) extent on some axis - a flat/degenerate box.
+    Degenerate,
+    /// Bounds far outside any plausible level extent (|coord| > 1e5) -
+    /// usually an entity that fell out of the world or a bad transform.
+    Extreme,
+}
+
+impl ColliderIssueKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ColliderIssueKind::NonFinite => "non_finite",
+            ColliderIssueKind::Degenerate => "degenerate",
+            ColliderIssueKind::Extreme => "extreme",
+        }
+    }
 }
 
 /// Rapier-free description of a rigid body, for debug tooling / HTTP introspection.
@@ -1522,6 +1633,67 @@ mod tests {
             high_peak > low_peak + 0.1,
             "high-restitution apex {high_peak} should exceed low-restitution apex {low_peak}"
         );
+    }
+
+    /// A degenerate ray (zero-length or non-finite direction) whose origin sits
+    /// inside a collider AABB must return `None`, not panic. (Negative-first:
+    /// without the guard in `ray_cast2`, parry's `clip_aabb_line` returns face
+    /// index 0 for this case and the feature math computes `0u32 - 1`, panicking
+    /// with "attempt to subtract with overflow" in debug builds - issue #405.)
+    #[test]
+    fn degenerate_ray_does_not_panic() {
+        let (mut world, mut player) = world_with_floor();
+        // A dynamic *cuboid* the query pipeline will actually see (static bodies
+        // don't enter the query BVH until they move). The shape must be a cuboid:
+        // parry's face-index overflow is in the ray-vs-box path; a ball uses a
+        // different ray cast and never hits it. AABB ~ [-1, 1, -1] .. [1, 3, 1].
+        world.add_dynamic(
+            EntityId::from_inner(42).unwrap(),
+            vec3(0.0, 2.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(1.0, 1.0, 1.0)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        step(&mut world, &mut player, 1);
+
+        // Origin inside the cuboid's AABB - the exact condition that makes
+        // parry's `clip_aabb_line` return face index 0 for a degenerate ray.
+        let origin = point3(0.0, 2.0, 0.0);
+
+        let zero_dir = world.ray_cast2(
+            origin,
+            Vector3::new(0.0, 0.0, 0.0),
+            100.0,
+            InternalCollisionGroups::ALL_COLLIDABLE,
+            None,
+            false,
+        );
+        assert!(zero_dir.is_none(), "zero-direction ray should return None");
+
+        let nan_dir = world.ray_cast2(
+            origin,
+            Vector3::new(f32::NAN, 0.0, 0.0),
+            100.0,
+            InternalCollisionGroups::ALL_COLLIDABLE,
+            None,
+            false,
+        );
+        assert!(nan_dir.is_none(), "NaN-direction ray should return None");
+
+        // Regression guard: a valid ray must still hit (the check must reject
+        // only degenerate rays, not good ones).
+        let valid = world.ray_cast2(
+            point3(0.0, 5.0, 0.0),
+            Vector3::new(0.0, -1.0, 0.0),
+            100.0,
+            InternalCollisionGroups::ALL_COLLIDABLE,
+            None,
+            false,
+        );
+        assert!(valid.is_some(), "valid downward ray should hit the cuboid");
     }
 
     /// A higher-friction box, given the same initial horizontal velocity on the


### PR DESCRIPTION
## Summary

Fixes the parry3d panic `ray_aabb.rs:62 attempt to subtract with overflow` (#405) and adds durable collider-health diagnostic tooling.

**The crash is a degenerate _ray direction_ (zero-length or NaN), not a malformed collider.** When such a ray's origin lies inside a collider AABB, parry's `clip_aabb_line` takes its `near_side == 0` path (documented for exactly the "dir is zero or NaN" case), returns face index `0`, and the feature math then computes `0u32 - 1`, which underflows. Debug builds panic; **release builds (overflow-checks off) silently return _wrong_ raycast results** — arguably worse.

## Fix (at the source)

`PhysicsWorld::ray_cast2` is the single choke point every raycast funnels through (crosshair aim, weapon fire, AI line-of-sight, AI steering whiskers), so the guard lives there: reject a non-finite origin or a zero/non-finite direction, return `None`, log at `debug!`. One guard protects every caller rather than patching ~5 call sites.

- The `== 0.0` check also catches f32 underflow-to-zero (a subnormal-tiny direction whose squared norm rounds to `0.0` would otherwise `NaN` on normalize).

## Diagnostic tooling

For the complementary failure mode — a *malformed collider* AABB would crash parry the same way — this adds:

- `PhysicsWorld::audit_colliders()`: scans every collider's world AABB for non-finite / degenerate / extreme bounds.
- **`GET /v1/physics/colliders/validate`** on the debug runtime, reporting each issue with entity name + id.

```
curl http://127.0.0.1:8080/v1/physics/colliders/validate
# { "total_count": 0, "issues": [] }   <- clean
```

## Verification

- **Negative-first unit test** `degenerate_ray_does_not_panic`: reproduces the exact `ray_aabb.rs:62` overflow when the guard is removed, passes with it. Covers zero-direction, NaN-direction, and a valid-ray regression guard.
- Ran the command2 flee cutscene through the (now correctly wired) audit — colliders are clean at frame 0 **and across the full 2400-frame cutscene**, confirming the crash is the degenerate ray, not geometry.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; `cargo test -p shock2vr --lib physics::` 3/3 pass.

## Cross-engine review (xreview)

Two adversarial reviewers (Claude + Codex) ran over the change. Findings addressed:
- **High:** `Mission` never forwarded `audit_colliders()` to `MissionCore`, so the endpoint returned the empty default for real missions (a false "clean" reading). Fixed.
- **Agreed Medium:** reject threshold `< EPSILON` wrongly rejected legitimate short rays (`ray_cast3` passes `end - start`) — tightened to `== 0.0`.
- **Agreed:** `warn!` on the raycast hot path could spam per-frame — downgraded to `debug!`.
- **Medium:** name resolution used a `from_inner` round-trip that dropped the generation and missed recycled entities — switched to the existing `entity_names_by_inner()` helper.

## Note

The intermittent command2 crash didn't reproduce in 18 headless runs, so the *exact* offending caller isn't pinned — but the guard defends all of them and the `debug!` log names any future occurrence's origin/direction. The most likely source is AI steering/LOS normalizing a direction from an entity with a momentarily zero/NaN rotation (e.g. `collision_avoidance_steering_strategy.rs:86`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
