### PR TITLE
fix(debug_runtime): report the real template id, not the entity id

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3907,6 +3907,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
              v_transform: View<crate::runtime_props::RuntimePropTransform>,
              v_sym_name: View<dark::properties::PropSymName>,
              v_scripts: View<dark::properties::PropScripts>,
+             v_template_id: View<dark::properties::PropTemplateId>,
              v_links: View<dark::properties::Links>| {
                 for (entity_id, pos) in v_pos.iter().with_id() {
                     let name = v_sym_name
@@ -3944,8 +3945,14 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         .map(|links| links.to_links.len())
                         .unwrap_or(0);
 
-                    // Get template ID from entity ID (negative for templates, positive for instances)
-                    let template_id = entity_id.inner() as i32;
+                    // The template this instance was created from (a negative
+                    // gamesys/mission template id). Unlike the runtime entity
+                    // id, this is stable across runs. 0 if the entity has no
+                    // template backlink.
+                    let template_id = v_template_id
+                        .get(entity_id)
+                        .map(|t| t.template_id)
+                        .unwrap_or(0);
 
                     entities.push(DebugEntitySummary {
                         id: entity_id.inner() as i32,
@@ -3988,6 +3995,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
              v_alertness: View<PropAIAlertness>,
              v_ai_behavior: View<RuntimePropAIBehavior>,
              v_awareness: View<crate::runtime_props::RuntimePropAITargetAwareness>,
+             v_template_id: View<dark::properties::PropTemplateId>,
              v_links: View<dark::properties::Links>| {
                 let position = v_pos.get(id).ok()?;
                 let rotation_array = [
@@ -4002,7 +4010,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .map(|s| s.0.clone())
                     .unwrap_or_else(|_| format!("Entity_{}", id.inner()));
 
-                let template_id = id.inner() as i32;
+                // The stable template backlink (negative id), not the per-run
+                // entity id. 0 if the entity has no template.
+                let template_id = v_template_id.get(id).map(|t| t.template_id).unwrap_or(0);
 
                 // Build properties list
                 let mut properties = Vec::new();


### PR DESCRIPTION
## Problem

`list_entities` and `entity_detail` (`mission_core.rs`) both set `template_id = entity_id.inner()` — a placeholder that just echoed the runtime entity id, despite the field name and a comment claiming it was the template. So `/v1/entities` and `/v1/entities/:id` never actually exposed a template, and (as documented in #411) runtime entity ids are reassigned every launch — leaving no stable handle over HTTP.

## Fix

Read the real `PropTemplateId` backlink instead (0 when an entity has none).

## Verified

`template_id` is now **stable across runs** while entity ids are not. Two fresh eng1 launches, the three native Blue Monkeys:

| run | (entity_id, template_id) |
| --- | --- |
| A | (168, 809), (281, 781), (1228, 164) |
| B | (513, 164), (1173, 781), (1238, 809) |

Same template set `{164, 781, 809}` both runs; entity ids differ. `entity_detail` agrees with `list_entities` (id 1228 → tid 164). The template ids also match `dark_query`'s id space (that Blue Monkey is entity 164 in `cargo dq`), so the field now bridges the offline query tool and the live runtime — automation can identify an entity by a stable template rather than only by name.

No consumer relied on the old placeholder (the SDK only declares the type; no test asserts its value). `cargo test -p shock2vr` green.

Follow-up to #411 (which documented the instability); I'll update that doc's "template_id is a placeholder" caveat once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)