### PR TITLE
feat(debug): level-transition (warp) endpoint for automated testing

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -34,6 +34,13 @@ pub enum RuntimeCommand {
     /// Move the player to a position
     MovePlayer(Vector3<f32>),
 
+    /// Transition to another level (warp), at an optional spawn-marker id.
+    TransitionLevel {
+        level_file: String,
+        loc: Option<i32>,
+        reply: oneshot::Sender<TransitionLevelResult>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 
@@ -310,6 +317,16 @@ pub struct CommandResult {
     pub success: bool,
     pub message: String,
     pub data: Option<serde_json::Value>,
+}
+
+/// Result of a level transition (warp) request
+#[derive(Debug, Serialize)]
+pub struct TransitionLevelResult {
+    pub success: bool,
+    /// The scene name after the transition (e.g. "eng1.mis"). With the loading
+    /// screen enabled this may still be the previous level until updates run.
+    pub mission: String,
+    pub message: String,
 }
 
 /// Current status of the interactive pathfinding test system

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -274,6 +274,10 @@ async fn start_http_server(
         )
         .route("/v1/player/position", get(get_player_position))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
+        .route(
+            "/v1/control/transition-level",
+            axum::routing::post(transition_level),
+        )
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -314,6 +318,7 @@ async fn start_http_server(
     info!("  POST /v1/entities/{{id}}/message - Inject a script message (damage/frob/signal)");
     info!("  GET  /v1/player/position  - Get current player position");
     info!("  POST /v1/player/teleport  - Teleport player to coordinates");
+    info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
@@ -854,6 +859,37 @@ fn process_command(
                 }
             } else {
                 tracing::error!("No debuggable scene available for player movement");
+            }
+        }
+        RuntimeCommand::TransitionLevel {
+            level_file,
+            loc,
+            reply,
+        } => {
+            tracing::info!("Transitioning level to {} (loc {:?})", level_file, loc);
+            game.transition_level(level_file.clone(), loc);
+            // Report the ACTUAL post-switch scene rather than assuming success.
+            // Without the loading_screen feature the switch is synchronous and
+            // scene_name() is already the target; with it the switch is deferred
+            // (scene_name() is still "loading"/the old level), so success stays
+            // false until the caller steps far enough for it to complete.
+            let mission = game.scene_name().to_string();
+            let success = mission == level_file;
+            let message = if success {
+                format!("Transitioned to {}", mission)
+            } else {
+                format!(
+                    "Transition to {} queued (current scene: {})",
+                    level_file, mission
+                )
+            };
+            let result = commands::TransitionLevelResult {
+                success,
+                mission,
+                message,
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send transition result - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -1827,6 +1863,80 @@ async fn teleport_player(
         })),
         Err(_) => {
             tracing::error!("Failed to receive player position after teleport - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request structure for a level transition (warp)
+#[derive(serde::Deserialize)]
+struct TransitionLevelRequest {
+    /// Target mission - with or without the ".mis" suffix (e.g. "eng1" or "eng1.mis").
+    level: String,
+    /// Optional spawn-marker id (`PropStartLoc`); omit for the map default spawn.
+    #[serde(default)]
+    loc: Option<i32>,
+}
+
+/// HTTP handler for transitioning to another level (warp). Lets a tester jump
+/// directly to any mission in isolation instead of reaching an in-game trigger.
+async fn transition_level(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<TransitionLevelRequest>,
+) -> Result<Json<commands::TransitionLevelResult>, (StatusCode, String)> {
+    // Normalize to a bare mission filename (e.g. "eng1.mis"), then validate it
+    // BEFORE dispatching. The load path does `File::open(...).unwrap()`, so a
+    // missing/typo'd name would panic the game-loop thread and brick the runtime
+    // for every later command - the opposite of a resilient tester lever. (A
+    // structurally-corrupt but present mission - e.g. the known shodan.mis load
+    // crash, #267 - can still panic during parse; that is a pre-existing engine
+    // limitation, not introduced here.)
+    let level = request.level.trim();
+    if level.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "level must not be empty".to_string(),
+        ));
+    }
+    if level.contains('/') || level.contains('\\') || level.contains("..") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("level must be a bare mission name, got '{}'", level),
+        ));
+    }
+    let level_file = if level.to_ascii_lowercase().ends_with(".mis") {
+        level.to_string()
+    } else {
+        format!("{}.mis", level)
+    };
+    let resolved = shock2vr::resource_path(&level_file);
+    if !std::path::Path::new(&resolved).exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "mission '{}' not found (looked at {})",
+                level_file, resolved
+            ),
+        ));
+    }
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::TransitionLevel {
+            level_file,
+            loc: request.loc,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send TransitionLevel command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive transition result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -509,6 +509,25 @@ impl Game {
         self.active_game_scene.scene_name()
     }
 
+    /// Trigger a level transition programmatically (debug/testing lever).
+    ///
+    /// Mirrors what an in-game `TrapTripLevel` trigger emits when the player
+    /// enters its volume: switch to `level_file` at spawn `loc` (a `PropStartLoc`
+    /// marker id, or the map default when `None`). `level_file` should be the
+    /// mission filename (e.g. "eng1.mis"). This lets an automated tester warp to
+    /// any level in isolation instead of having to physically reach each
+    /// transition trigger. With the `loading_screen` feature enabled the switch
+    /// is deferred (the outgoing scene renders the loading screen first), so
+    /// `scene_name()` only reflects the new level after subsequent updates;
+    /// otherwise it is synchronous and observable immediately.
+    pub fn transition_level(&mut self, level_file: String, loc: Option<i32>) {
+        self.handle_global_effect(GlobalEffect::TransitionLevel {
+            level_file,
+            loc,
+            entities_to_trigger: vec![],
+        });
+    }
+
     /// Get access to the debug scene interface if available
     ///
     /// Returns a reference to the current scene as a DebuggableScene trait object

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -16,6 +16,7 @@ import type {
   StepResult,
   StepSpec,
   TeleportResult,
+  TransitionLevelResult,
   WaitForOptions,
 } from "./types.js";
 
@@ -210,6 +211,23 @@ export class Game {
 
   async raycast(request: RayCastRequest): Promise<RayCastResult> {
     return this.client.post<RayCastResult>("/v1/physics/raycast", request);
+  }
+
+  /**
+   * Warp to another level (as if an in-game transition trigger fired), letting
+   * a tester jump directly to any mission in isolation. `level` may omit the
+   * ".mis" suffix; `loc` is an optional spawn-marker id (map default if omitted).
+   * Without the loading_screen feature the switch is synchronous and info()
+   * reflects the new mission immediately.
+   */
+  async transitionLevel(
+    level: string,
+    loc?: number,
+  ): Promise<TransitionLevelResult> {
+    return this.client.post<TransitionLevelResult>(
+      "/v1/control/transition-level",
+      { level, loc },
+    );
   }
 
   /**

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -203,6 +203,13 @@ export interface TeleportResult {
   new_position: Vec3;
 }
 
+export interface TransitionLevelResult {
+  success: boolean;
+  /** Scene name after the transition, e.g. "eng1.mis". */
+  mission: string;
+  message: string;
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/test/transition-level.e2e.test.ts
+++ b/tools/shock2-sdk/test/transition-level.e2e.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the level-transition (warp) endpoint. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before POST /v1/control/transition-level existed, warping
+// levels from HTTP was impossible - a tester could only reach a transition by
+// physically entering an in-game trigger volume. This asserts a direct warp
+// swaps the active mission and leaves the player live in the new level.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "transition-level warps between missions and keeps the player live",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8099),
+    });
+
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "should start in medsci1",
+    );
+
+    // Warp to another deck. Without the loading_screen feature the switch is
+    // synchronous, so info() reflects the new mission immediately.
+    const result = await game.transitionLevel("eng1");
+    assert.equal(result.success, true);
+    assert.equal(result.mission, "eng1.mis", "warp result reports new mission");
+    assert.equal(
+      (await game.info()).mission,
+      "eng1.mis",
+      "active mission should now be eng1",
+    );
+
+    // The new level is live: step it and confirm the player has a finite
+    // position (a broken transition would leave no player / a crashed runtime).
+    await game.step({ frames: 30 });
+    const pos = await game.player.position();
+    assert.ok(
+      Number.isFinite(pos.x) && Number.isFinite(pos.y) && Number.isFinite(pos.z),
+      `player should have a finite position in eng1, got ${JSON.stringify(pos)}`,
+    );
+
+    // A second consecutive warp (with an explicit spawn marker) also works -
+    // guards against the scene handle going stale after the first switch.
+    const second = await game.transitionLevel("hydro1.mis", 1);
+    assert.equal(second.mission, "hydro1.mis");
+    assert.equal((await game.info()).mission, "hydro1.mis");
+
+    // A bad warp must be rejected WITHOUT crashing the game-loop thread (the
+    // load path does File::open(..).unwrap(), so an unvalidated bad name would
+    // brick the runtime for every later command). Assert it errors and the
+    // runtime is still live and unchanged afterward.
+    await assert.rejects(
+      game.transitionLevel("this_level_does_not_exist"),
+      /not found|status 404/,
+      "warp to a nonexistent level should error, not crash",
+    );
+    assert.equal(
+      (await game.info()).mission,
+      "hydro1.mis",
+      "runtime should stay live and on hydro1 after a rejected warp",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Adds **`POST /v1/control/transition-level {level, loc?}`** to the debug runtime — a lever to warp directly to any mission in isolation. This is the first enabling capability for an automated "game tester" play-through harness: you can't test a level end-to-end without being able to change levels.

## Background (what I verified)

Level transitions **already work** in the debug runtime — I confirmed that teleporting the player into a `TrapTripLevel` trigger volume warps `medsci1 → eng1` (fresh level load + eng1's music in the log, runtime survives). What was missing was a clean HTTP way to *trigger* one without knowing a trigger volume's coordinates. This PR exposes that as a direct endpoint, reusing the exact `GlobalEffect::TransitionLevel` path a real in-game trigger emits.

## Changes

- **shock2vr** — `Game::transition_level(level_file, loc)`: a public wrapper over the existing private `handle_global_effect(TransitionLevel)` path.
- **debug_runtime** — route + `RuntimeCommand::TransitionLevel` + `TransitionLevelResult`. The handler **validates the level name before dispatching** (trim, reject empty/path-like, case-insensitive `.mis`, existence check under `Data/`), so a typo'd warp returns `400`/`404` instead of hitting `File::open(..).unwrap()` and **panicking the game-loop thread / bricking the runtime**. `success` reflects the *actual* post-switch scene (correct under the deferred `loading_screen` path too, where it stays `false` until the switch completes).
- **SDK** — `game.transitionLevel(level, loc?)` + `TransitionLevelResult` type.
- **e2e (negative-first)** — warps `medsci1 → eng1 → hydro1` with the player staying live across two consecutive switches, and asserts a **bad warp errors without crashing** the runtime.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; SDK `tsc` clean.
- `SHOCK2_E2E=1 node --test dist/test/transition-level.e2e.test.js` passes (incl. the negative case).
- Live: two consecutive warps, player at a finite position after stepping the new level.

## Cross-engine review (xreview)

Two adversarial reviewers (Claude + Codex) **agreed** on all findings; addressed:
- **High (agreed):** a bad/nonexistent mission name panicked the game-loop thread via `File::open(..).unwrap()`, bricking the runtime. Fixed with pre-dispatch validation + existence check; proven by the negative e2e case.
- **Medium (agreed):** `success` was hardcoded `true` and `mission` read too early under `loading_screen` (would report `"loading"`). Now derived from the actual post-switch scene.
- **Low (agreed):** normalization was case-sensitive and didn't trim / reject empty/path input. Fixed.

## Context

This is **PR 1 of 3** enabling endpoints for the play-through harness (next: `GET /v1/quests` for objective verification, `GET /v1/player/inventory`). Branches off `main`; independent of the open collider-diagnostics PR #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
