### PR TITLE
feat(debug): quest-bit (objective) read/set endpoints

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -41,6 +41,18 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<TransitionLevelResult>,
     },
 
+    /// Snapshot the quest bits (objective flags) the game has set.
+    GetQuestBits {
+        reply: oneshot::Sender<QuestBitsResult>,
+    },
+
+    /// Set a quest bit (objective flag) - for test setup / skipping ahead.
+    SetQuestBit {
+        name: String,
+        value: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 
@@ -351,6 +363,23 @@ pub struct TransitionLevelResult {
     /// screen enabled this may still be the previous level until updates run.
     pub mission: String,
     pub message: String,
+}
+
+/// A single quest bit (objective flag) and its 3-state value.
+#[derive(Debug, Serialize)]
+pub struct QuestBitEntry {
+    pub name: String,
+    /// "unknown", "incomplete", or "complete" (a projection of `bits`).
+    pub value: String,
+    /// The exact raw flag value (scripts compare quest bits by raw value).
+    pub bits: u32,
+}
+
+/// Snapshot of all quest bits the game has set.
+#[derive(Debug, Serialize)]
+pub struct QuestBitsResult {
+    pub quests: Vec<QuestBitEntry>,
+    pub count: usize,
 }
 
 /// Current status of the interactive pathfinding test system

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -53,6 +53,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Result<(), String>>,
     },
 
+    /// Snapshot the player's carried inventory.
+    GetPlayerInventory {
+        reply: oneshot::Sender<PlayerInventoryResult>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 
@@ -379,6 +384,22 @@ pub struct QuestBitEntry {
 #[derive(Debug, Serialize)]
 pub struct QuestBitsResult {
     pub quests: Vec<QuestBitEntry>,
+    pub count: usize,
+}
+
+/// A single carried item.
+#[derive(Debug, Serialize)]
+pub struct InventoryItemEntry {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    /// "inventory" (backpack), "left_hand", or "right_hand".
+    pub location: String,
+}
+
+/// Snapshot of the player's carried inventory.
+#[derive(Debug, Serialize)]
+pub struct PlayerInventoryResult {
+    pub items: Vec<InventoryItemEntry>,
     pub count: usize,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -280,6 +280,7 @@ async fn start_http_server(
         )
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
+        .route("/v1/player/inventory", get(get_player_inventory))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -324,6 +325,7 @@ async fn start_http_server(
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
+    info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
@@ -927,6 +929,29 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send set-quest-bit result - receiver dropped");
+            }
+        }
+        RuntimeCommand::GetPlayerInventory { reply } => {
+            let items: Vec<commands::InventoryItemEntry> = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .player_inventory()
+                        .into_iter()
+                        .map(|i| commands::InventoryItemEntry {
+                            entity_id: i.entity_id,
+                            name: i.name,
+                            location: i.location,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let result = commands::PlayerInventoryResult {
+                count: items.len(),
+                items,
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send player inventory - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -2063,6 +2088,28 @@ async fn set_quest_bit(
         Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
         Err(_) => {
             tracing::error!("Failed to receive set-quest-bit result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler for snapshotting the player's carried inventory. An empty list
+/// means the player is carrying nothing (or the scene has no player).
+async fn get_player_inventory(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<commands::PlayerInventoryResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GetPlayerInventory { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send GetPlayerInventory command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive player inventory - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -278,6 +278,8 @@ async fn start_http_server(
             "/v1/control/transition-level",
             axum::routing::post(transition_level),
         )
+        .route("/v1/quests", get(get_quest_bits))
+        .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -320,6 +322,8 @@ async fn start_http_server(
     info!("  GET  /v1/player/position  - Get current player position");
     info!("  POST /v1/player/teleport  - Teleport player to coordinates");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
+    info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
+    info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
@@ -891,6 +895,38 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send transition result - receiver dropped");
+            }
+        }
+        RuntimeCommand::GetQuestBits { reply } => {
+            let quests: Vec<commands::QuestBitEntry> = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .quest_bits()
+                        .into_iter()
+                        .map(|q| commands::QuestBitEntry {
+                            name: q.name,
+                            value: q.value,
+                            bits: q.bits,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let result = commands::QuestBitsResult {
+                count: quests.len(),
+                quests,
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send quest bits - receiver dropped");
+            }
+        }
+        RuntimeCommand::SetQuestBit { name, value, reply } => {
+            let result = match game.debug_scene_mut() {
+                Some(scene) => scene.set_quest_bit(&name, &value),
+                None => Err("no debuggable scene available".to_string()),
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send set-quest-bit result - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -1966,6 +2002,67 @@ async fn transition_level(
         Ok(result) => Ok(Json(result)),
         Err(_) => {
             tracing::error!("Failed to receive transition result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request body for setting a quest bit.
+#[derive(serde::Deserialize)]
+struct SetQuestBitRequest {
+    /// "unknown", "incomplete", or "complete".
+    value: String,
+}
+
+/// HTTP handler for snapshotting quest bits (objective flags). An empty list
+/// means the level has set no quest bits yet (all objectives read as unknown).
+async fn get_quest_bits(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<commands::QuestBitsResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GetQuestBits { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send GetQuestBits command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive quest bits - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler for setting a quest bit (test setup / skipping ahead).
+async fn set_quest_bit(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Path(name): Path<String>,
+    LenientJson(request): LenientJson<SetQuestBitRequest>,
+) -> Result<Json<commands::CommandResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::SetQuestBit {
+            name: name.clone(),
+            value: request.value.clone(),
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send SetQuestBit command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(Ok(())) => Ok(Json(commands::CommandResult {
+            success: true,
+            message: format!("Set quest bit '{}' to '{}'", name, request.value),
+            data: None,
+        })),
+        Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
+        Err(_) => {
+            tracing::error!("Failed to receive set-quest-bit result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -325,6 +325,15 @@ pub struct DebugQuestBit {
     pub bits: u32,
 }
 
+/// A single item the player carries: its entity id, name (if any), and where
+/// it is held - "inventory" (backpack), "left_hand", or "right_hand".
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugInventoryItem {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    pub location: String,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -450,6 +459,12 @@ pub trait DebuggableScene {
     /// `value` is "unknown", "incomplete", or "complete". Default: unsupported.
     fn set_quest_bit(&mut self, _name: &str, _value: &str) -> Result<(), String> {
         Err("scene does not support quest bits".to_string())
+    }
+
+    /// The items the player is carrying (backpack contents plus the hand-held
+    /// items), for verifying pickups. Empty when the scene has no player.
+    fn player_inventory(&self) -> Vec<DebugInventoryItem> {
+        Vec::new()
     }
 
     /// Get current input context state

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -313,6 +313,18 @@ pub struct DebugColliderIssue {
     pub is_sensor: bool,
 }
 
+/// A single quest bit (objective flag): its name, a friendly 3-state `value`
+/// ("unknown"/"incomplete"/"complete"), and the exact raw `bits`. `value` is a
+/// projection (COMPLETE takes precedence), so a rare combined flag (e.g.
+/// INCOMPLETE|COMPLETE = 3) reads as "complete" - use `bits` when the exact
+/// value matters, since scripts compare quest bits by raw value.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugQuestBit {
+    pub name: String,
+    pub value: String,
+    pub bits: u32,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -426,6 +438,18 @@ pub trait DebuggableScene {
     /// diagnose physics-query misbehavior (bad raycasts, parry3d overflow).
     fn audit_colliders(&self) -> Vec<DebugColliderIssue> {
         Vec::new()
+    }
+
+    /// Snapshot of quest bits (objective flags) the game has set, for verifying
+    /// mission progress. Empty when the scene has no quest state.
+    fn quest_bits(&self) -> Vec<DebugQuestBit> {
+        Vec::new()
+    }
+
+    /// Set a quest bit (objective flag) - for test setup / skipping ahead.
+    /// `value` is "unknown", "incomplete", or "complete". Default: unsupported.
+    fn set_quest_bit(&mut self, _name: &str, _value: &str) -> Result<(), String> {
+        Err("scene does not support quest bits".to_string())
     }
 
     /// Get current input context state

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4401,6 +4401,95 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         Ok(())
     }
 
+    fn player_inventory(&self) -> Vec<crate::game_scene::DebugInventoryItem> {
+        // Carried items, matching what the save system persists as "held"
+        // (save_load::get_held_items): each hand-held entity plus everything
+        // nested under it, and the backpack entity's contents - all following
+        // `Contains` links to depth 2. A `seen` set dedups items that appear in
+        // more than one place, with hands taking precedence over the backpack.
+        let (inventory_entity, left_hand, right_hand) = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            (
+                player.inventory_entity_id,
+                player.left_hand_entity_id,
+                player.right_hand_entity_id,
+            )
+        };
+
+        // Recursively collect `Contains` descendants of `root`, tagging each
+        // unique entity with the location it is carried through. Nested
+        // immutable `View<Links>` borrows are fine (mirrors get_held_items).
+        fn collect(
+            world: &shipyard::World,
+            entity: shipyard::EntityId,
+            depth: u32,
+            location: &str,
+            seen: &mut std::collections::HashSet<shipyard::EntityId>,
+            out: &mut Vec<(shipyard::EntityId, String)>,
+        ) {
+            if depth == 0 {
+                return;
+            }
+            crate::scripts::script_util::for_each_link(world, entity, &mut |link| {
+                if matches!(link.link, dark::properties::Link::Contains(_)) {
+                    if let Some(to_ent_id) = link.to_entity_id {
+                        let child = to_ent_id.0;
+                        if seen.insert(child) {
+                            out.push((child, location.to_string()));
+                            collect(world, child, depth - 1, location, seen, out);
+                        }
+                    }
+                }
+            });
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let mut collected: Vec<(shipyard::EntityId, String)> = Vec::new();
+
+        // Hands first (so a held item is attributed to its hand, not the
+        // backpack): the hand entity itself is carried, plus its contents.
+        for (hand, location) in [(left_hand, "left_hand"), (right_hand, "right_hand")] {
+            if let Some(h) = hand {
+                if seen.insert(h) {
+                    collected.push((h, location.to_string()));
+                }
+                collect(&self.world, h, 2, location, &mut seen, &mut collected);
+            }
+        }
+        // Backpack: the inventory entity's contents (the container entity itself
+        // is not an item, so seed `seen` with it and only collect its children).
+        seen.insert(inventory_entity);
+        collect(
+            &self.world,
+            inventory_entity,
+            2,
+            "inventory",
+            &mut seen,
+            &mut collected,
+        );
+
+        let names = self.entity_names_by_inner();
+        let mut items: Vec<_> = collected
+            .into_iter()
+            .map(|(eid, location)| {
+                let id = eid.inner() as i32;
+                crate::game_scene::DebugInventoryItem {
+                    entity_id: id,
+                    name: names.get(&id).cloned(),
+                    location,
+                }
+            })
+            .collect();
+        // Stable ordering for deterministic snapshots.
+        items.sort_by(|a, b| {
+            a.location
+                .cmp(&b.location)
+                .then(a.name.cmp(&b.name))
+                .then(a.entity_id.cmp(&b.entity_id))
+        });
+        items
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4351,6 +4351,56 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .collect()
     }
 
+    fn quest_bits(&self) -> Vec<crate::game_scene::DebugQuestBit> {
+        use dark::properties::QuestBitValue;
+        let quests = self.world.borrow::<UniqueView<QuestInfo>>().unwrap();
+        let mut bits: Vec<_> = quests
+            .quest_bits()
+            .into_iter()
+            .map(|(name, value)| crate::game_scene::DebugQuestBit {
+                name,
+                // COMPLETE wins over INCOMPLETE if both bits are somehow set;
+                // `bits` preserves the exact value for callers that need it.
+                value: if value.contains(QuestBitValue::COMPLETE) {
+                    "complete"
+                } else if value.contains(QuestBitValue::INCOMPLETE) {
+                    "incomplete"
+                } else {
+                    "unknown"
+                }
+                .to_string(),
+                bits: value.bits(),
+            })
+            .collect();
+        // Stable ordering (HashMap iteration is not deterministic).
+        bits.sort_by(|a, b| a.name.cmp(&b.name));
+        bits
+    }
+
+    fn set_quest_bit(&mut self, name: &str, value: &str) -> Result<(), String> {
+        use dark::properties::QuestBitValue;
+        let quest_value = match value.to_ascii_lowercase().as_str() {
+            "unknown" => QuestBitValue::UNKNOWN,
+            "incomplete" => QuestBitValue::INCOMPLETE,
+            "complete" => QuestBitValue::COMPLETE,
+            other => {
+                return Err(format!(
+                    "invalid quest value '{}' (expected unknown/incomplete/complete)",
+                    other
+                ));
+            }
+        };
+        let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+        // Setting "unknown" resets the bit to its pristine (absent) state so it
+        // doesn't linger in quest_bits() as a touched-but-unknown entry.
+        if quest_value == QuestBitValue::UNKNOWN {
+            quests.clear_quest_bit_value(name);
+        } else {
+            quests.set_quest_bit_value(name, quest_value);
+        }
+        Ok(())
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -341,6 +341,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.set_quest_bit(name, value)
     }
 
+    fn player_inventory(&self) -> Vec<crate::game_scene::DebugInventoryItem> {
+        self.mission_core.player_inventory()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -333,6 +333,14 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.audit_colliders()
     }
 
+    fn quest_bits(&self) -> Vec<crate::game_scene::DebugQuestBit> {
+        self.mission_core.quest_bits()
+    }
+
+    fn set_quest_bit(&mut self, name: &str, value: &str) -> Result<(), String> {
+        self.mission_core.set_quest_bit(name, value)
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -46,6 +46,25 @@ impl QuestInfo {
             .insert(quest_name.to_ascii_lowercase(), quest_value);
     }
 
+    /// Remove a quest bit, resetting it to the pristine `UNKNOWN` state (absent
+    /// from the map, so it no longer appears in `quest_bits()`). Reads still
+    /// return `UNKNOWN`, same as a never-set bit. Used by debug tooling to reset
+    /// an objective; game scripts use `set_quest_bit_value` directly.
+    pub fn clear_quest_bit_value(&mut self, quest_name: &str) {
+        self.quest_bit_values
+            .remove(&quest_name.to_ascii_lowercase());
+    }
+
+    /// All quest bits the game has touched, as `(name, value)` pairs. Bits never
+    /// referenced are absent (they read as `UNKNOWN`). Used by debug tooling to
+    /// snapshot objective progress. Order is unspecified (HashMap iteration).
+    pub fn quest_bits(&self) -> Vec<(String, QuestBitValue)> {
+        self.quest_bit_values
+            .iter()
+            .map(|(name, value)| (name.clone(), *value))
+            .collect()
+    }
+
     pub fn has_played_email(&self, email: &str) -> bool {
         self.played_emails.contains(email)
     }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -19,6 +19,7 @@ import type {
   TransitionLevelResult,
   QuestBitsResult,
   QuestBitValue,
+  PlayerInventoryResult,
   WaitForOptions,
 } from "./types.js";
 
@@ -51,6 +52,11 @@ export class PlayerApi {
 
   async teleport(position: Position): Promise<TeleportResult> {
     return this.client.post<TeleportResult>("/v1/player/teleport", position);
+  }
+
+  /** The items the player is carrying (backpack + hand-held), for verifying pickups. */
+  async inventory(): Promise<PlayerInventoryResult> {
+    return this.client.get<PlayerInventoryResult>("/v1/player/inventory");
   }
 }
 

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -17,6 +17,8 @@ import type {
   StepSpec,
   TeleportResult,
   TransitionLevelResult,
+  QuestBitsResult,
+  QuestBitValue,
   WaitForOptions,
 } from "./types.js";
 
@@ -149,6 +151,31 @@ export class PathfindingTestApi {
   }
 }
 
+/** Quest bits (objective flags): read progress, or set for test setup. */
+export class QuestsApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /** Snapshot every quest bit the game has set. Bits never touched are absent (they read as "unknown"). */
+  async list(): Promise<QuestBitsResult> {
+    return this.client.get<QuestBitsResult>("/v1/quests");
+  }
+
+  /** Value of a single quest bit by name ("unknown" if the game hasn't set it). */
+  async get(name: string): Promise<QuestBitValue> {
+    const { quests } = await this.list();
+    const lower = name.toLowerCase();
+    return quests.find((q) => q.name === lower)?.value ?? "unknown";
+  }
+
+  /** Set a quest bit (test setup / skipping ahead). Throws on an invalid value. */
+  async set(name: string, value: QuestBitValue): Promise<CommandResult> {
+    return this.client.post<CommandResult>(
+      `/v1/quests/${encodeURIComponent(name)}`,
+      { value },
+    );
+  }
+}
+
 /** Pathfinding service telemetry (distinct from the interactive test). */
 export class PathfindingApi {
   constructor(private readonly client: HttpClient) {}
@@ -178,6 +205,7 @@ export class Game {
   readonly pathfindingTest: PathfindingTestApi;
   readonly pathfinding: PathfindingApi;
   readonly physics: PhysicsApi;
+  readonly quests: QuestsApi;
 
   constructor(protected readonly client: HttpClient) {
     this.player = new PlayerApi(client);
@@ -186,6 +214,7 @@ export class Game {
     this.pathfindingTest = new PathfindingTestApi(client);
     this.pathfinding = new PathfindingApi(client);
     this.physics = new PhysicsApi(client);
+    this.quests = new QuestsApi(client);
   }
 
   get baseUrl(): string {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -210,6 +210,22 @@ export interface TransitionLevelResult {
   message: string;
 }
 
+/** The 3-state value of a quest bit (objective flag). */
+export type QuestBitValue = "unknown" | "incomplete" | "complete";
+
+export interface QuestBitEntry {
+  name: string;
+  /** Friendly 3-state projection of `bits` (COMPLETE takes precedence). */
+  value: QuestBitValue;
+  /** Exact raw flag value; use when the precise value matters (scripts compare by raw value). */
+  bits: number;
+}
+
+export interface QuestBitsResult {
+  quests: QuestBitEntry[];
+  count: number;
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -226,6 +226,20 @@ export interface QuestBitsResult {
   count: number;
 }
 
+/** Where a carried item is held. */
+export type InventoryLocation = "inventory" | "left_hand" | "right_hand";
+
+export interface InventoryItem {
+  entity_id: number;
+  name: string | null;
+  location: InventoryLocation;
+}
+
+export interface PlayerInventoryResult {
+  items: InventoryItem[];
+  count: number;
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/test/inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory.e2e.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the player-inventory endpoint. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before GET /v1/player/inventory existed, the player's carried
+// items were internal (Contains links) and unreadable from HTTP - a tester
+// could not verify "did the player pick up / hold item X?". The debug_psi scene
+// auto-equips the Psi Amp into a hand, giving a deterministic carried item.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "inventory: reports carried items with name and location",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
+    });
+    // Let the scene auto-equip the amp.
+    await game.step({ frames: 20 });
+
+    const { items, count } = await game.player.inventory();
+    assert.equal(count, items.length, "count should match items length");
+
+    const amp = items.find((i) => i.name === "Psi Amp");
+    assert.ok(amp, `expected a held 'Psi Amp', got ${JSON.stringify(items)}`);
+    assert.ok(
+      amp.location === "left_hand" || amp.location === "right_hand",
+      `the amp should be hand-held, got location '${amp.location}'`,
+    );
+    assert.ok(
+      Number.isInteger(amp.entity_id),
+      "each item should carry its entity id",
+    );
+  },
+);
+
+test(
+  "inventory: empty when the player carries nothing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102) + 1,
+    });
+    await game.step({ frames: 10 });
+
+    // The player starts medsci1 empty-handed; the endpoint returns an empty
+    // (not errored) snapshot - a real reading, distinct from "unsupported".
+    const { items, count } = await game.player.inventory();
+    assert.equal(count, 0, `expected empty inventory, got ${JSON.stringify(items)}`);
+  },
+);

--- a/tools/shock2-sdk/test/quests.e2e.test.ts
+++ b/tools/shock2-sdk/test/quests.e2e.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the quest-bit (objective flag) endpoints. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before GET/POST /v1/quests existed, objective state was
+// internal to the script system and unreadable from HTTP - a tester could not
+// verify "did objective X complete?". This asserts the read/set round-trip and
+// the unknown default that back checkpoint verification.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "quests: read/set round-trip, unknown default, and value validation",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8101),
+    });
+    await game.step({ frames: 5 });
+
+    // A bit the game hasn't set reads as "unknown", and isn't in the list.
+    assert.equal(
+      await game.quests.get("some.unset.objective"),
+      "unknown",
+      "an unset quest bit should read as unknown",
+    );
+
+    // Set a bit and read it straight back (the primary verification path).
+    await game.quests.set("harness.objective", "complete");
+    assert.equal(
+      await game.quests.get("harness.objective"),
+      "complete",
+      "a set quest bit should read back its value",
+    );
+
+    // Names are case-insensitive (stored lowercased), matching QuestInfo.
+    await game.quests.set("MixedCaseObjective", "incomplete");
+    assert.equal(await game.quests.get("mixedcaseobjective"), "incomplete");
+
+    const { quests, count } = await game.quests.list();
+    assert.equal(count, quests.length);
+    const objective = quests.find((q) => q.name === "harness.objective");
+    assert.ok(objective, "list should include the set objective");
+    assert.equal(objective.value, "complete");
+    // The raw bits are exposed losslessly (COMPLETE = 2); scripts compare by raw value.
+    assert.equal(objective.bits, 2, "complete objective should have raw bits 2");
+    assert.equal(
+      quests.find((q) => q.name === "mixedcaseobjective")?.bits,
+      1,
+      "incomplete objective should have raw bits 1",
+    );
+
+    // An invalid value is rejected (not silently stored), and doesn't crash the
+    // runtime - a following read still works.
+    await assert.rejects(
+      // deliberately bad value; cast around the typed API
+      game.quests.set("x", "bogus" as never),
+      /status 400|invalid quest value/,
+      "an invalid quest value should be rejected",
+    );
+    assert.equal(
+      await game.quests.get("harness.objective"),
+      "complete",
+      "runtime should stay live after a rejected set",
+    );
+
+    // Setting a bit back to "unknown" resets it (removed from the list), so it
+    // doesn't linger as a touched-but-unknown entry.
+    await game.quests.set("harness.objective", "unknown");
+    assert.equal(await game.quests.get("harness.objective"), "unknown");
+    const after = await game.quests.list();
+    assert.ok(
+      !after.quests.some((q) => q.name === "harness.objective"),
+      "a bit reset to unknown should not appear in the list",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Exposes the game's **quest-bit (objective flag) state** over HTTP — the *"did objective X complete?"* signal the play-through harness needs for machine-checkable checkpoints. Quest bits were internal to the script system and unreadable from outside.

**PR 2 of 3** enabling endpoints. Stacked on #413 (level-transition warp).

## Changes

- **shock2vr** — `QuestInfo::quest_bits()` (snapshot) + `clear_quest_bit_value()` (reset). `DebuggableScene` gains `quest_bits()` / `set_quest_bit()`, overridden by `MissionCore` over the `QuestInfo` unique and **forwarded by `Mission → mission_core`**.
- **debug_runtime** — `GET /v1/quests` (snapshot) + `POST /v1/quests/:name {value}`.
  - Each entry carries the friendly 3-state `value` (`unknown`/`incomplete`/`complete`) **and** the raw `bits`. Scripts compare quest bits by exact raw value (`choose_mission.rs` does `== QuestBitValue::COMPLETE`; others use `.bits()`), so the string is a lossy projection (COMPLETE wins over a rare combined flag) while `bits` stays exact.
  - Invalid values return `400`. Setting `"unknown"` **resets** the bit (removed from the snapshot) rather than leaving a touched-but-unknown entry.
- **SDK** — `game.quests.list()` / `get(name)` / `set(name, value)` + types.
- **e2e (negative-first)** — read/set round-trip, unknown default, raw `bits`, reset-to-unknown, and `400` on an invalid value *without crashing the runtime*.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; SDK `tsc` clean.
- `SHOCK2_E2E=1 node --test dist/test/quests.e2e.test.js` passes.
- Live: set→read round-trip, case-insensitive keys, invalid value → 400, reset removes the entry.

## Cross-engine review (xreview)

Both reviewers **agreed** the `Mission → mission_core` forwarding is present for *both* methods (a sibling PR shipped a forwarding gap — verified not repeated here) and the bitflags→string mapping correctly avoids the empty-`UNKNOWN` `contains()` trap. Addressed:
- **Medium (Codex):** the string round-trip was lossy for a raw combined flag (`INCOMPLETE|COMPLETE` = 3 → 2), and scripts compare by raw value. Fixed by exposing raw `bits` alongside the string (lossless read).
- **Low (agreed):** setting `"unknown"` stored a zero-entry that lingered in the list. Now resets the bit (removed), scoped to the debug path — the shared script-facing `set_quest_bit_value` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
