### PR TITLE
feat(debug): player-inventory read endpoint for automated testing

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -53,6 +53,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Result<(), String>>,
     },
 
+    /// Snapshot the player's carried inventory.
+    GetPlayerInventory {
+        reply: oneshot::Sender<PlayerInventoryResult>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 
@@ -355,6 +360,22 @@ pub struct QuestBitEntry {
 #[derive(Debug, Serialize)]
 pub struct QuestBitsResult {
     pub quests: Vec<QuestBitEntry>,
+    pub count: usize,
+}
+
+/// A single carried item.
+#[derive(Debug, Serialize)]
+pub struct InventoryItemEntry {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    /// "inventory" (backpack), "left_hand", or "right_hand".
+    pub location: String,
+}
+
+/// Snapshot of the player's carried inventory.
+#[derive(Debug, Serialize)]
+pub struct PlayerInventoryResult {
+    pub items: Vec<InventoryItemEntry>,
     pub count: usize,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -280,6 +280,7 @@ async fn start_http_server(
         )
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
+        .route("/v1/player/inventory", get(get_player_inventory))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -323,6 +324,7 @@ async fn start_http_server(
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
+    info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
@@ -926,6 +928,29 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send set-quest-bit result - receiver dropped");
+            }
+        }
+        RuntimeCommand::GetPlayerInventory { reply } => {
+            let items: Vec<commands::InventoryItemEntry> = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .player_inventory()
+                        .into_iter()
+                        .map(|i| commands::InventoryItemEntry {
+                            entity_id: i.entity_id,
+                            name: i.name,
+                            location: i.location,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let result = commands::PlayerInventoryResult {
+                count: items.len(),
+                items,
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send player inventory - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -2034,6 +2059,28 @@ async fn set_quest_bit(
         Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
         Err(_) => {
             tracing::error!("Failed to receive set-quest-bit result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler for snapshotting the player's carried inventory. An empty list
+/// means the player is carrying nothing (or the scene has no player).
+async fn get_player_inventory(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<commands::PlayerInventoryResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GetPlayerInventory { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send GetPlayerInventory command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive player inventory - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -310,6 +310,15 @@ pub struct DebugQuestBit {
     pub bits: u32,
 }
 
+/// A single item the player carries: its entity id, name (if any), and where
+/// it is held - "inventory" (backpack), "left_hand", or "right_hand".
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugInventoryItem {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    pub location: String,
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -428,6 +437,12 @@ pub trait DebuggableScene {
     /// `value` is "unknown", "incomplete", or "complete". Default: unsupported.
     fn set_quest_bit(&mut self, _name: &str, _value: &str) -> Result<(), String> {
         Err("scene does not support quest bits".to_string())
+    }
+
+    /// The items the player is carrying (backpack contents plus the hand-held
+    /// items), for verifying pickups. Empty when the scene has no player.
+    fn player_inventory(&self) -> Vec<DebugInventoryItem> {
+        Vec::new()
     }
 
     /// Get current input context state

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4361,6 +4361,95 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         Ok(())
     }
 
+    fn player_inventory(&self) -> Vec<crate::game_scene::DebugInventoryItem> {
+        // Carried items, matching what the save system persists as "held"
+        // (save_load::get_held_items): each hand-held entity plus everything
+        // nested under it, and the backpack entity's contents - all following
+        // `Contains` links to depth 2. A `seen` set dedups items that appear in
+        // more than one place, with hands taking precedence over the backpack.
+        let (inventory_entity, left_hand, right_hand) = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            (
+                player.inventory_entity_id,
+                player.left_hand_entity_id,
+                player.right_hand_entity_id,
+            )
+        };
+
+        // Recursively collect `Contains` descendants of `root`, tagging each
+        // unique entity with the location it is carried through. Nested
+        // immutable `View<Links>` borrows are fine (mirrors get_held_items).
+        fn collect(
+            world: &shipyard::World,
+            entity: shipyard::EntityId,
+            depth: u32,
+            location: &str,
+            seen: &mut std::collections::HashSet<shipyard::EntityId>,
+            out: &mut Vec<(shipyard::EntityId, String)>,
+        ) {
+            if depth == 0 {
+                return;
+            }
+            crate::scripts::script_util::for_each_link(world, entity, &mut |link| {
+                if matches!(link.link, dark::properties::Link::Contains(_)) {
+                    if let Some(to_ent_id) = link.to_entity_id {
+                        let child = to_ent_id.0;
+                        if seen.insert(child) {
+                            out.push((child, location.to_string()));
+                            collect(world, child, depth - 1, location, seen, out);
+                        }
+                    }
+                }
+            });
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let mut collected: Vec<(shipyard::EntityId, String)> = Vec::new();
+
+        // Hands first (so a held item is attributed to its hand, not the
+        // backpack): the hand entity itself is carried, plus its contents.
+        for (hand, location) in [(left_hand, "left_hand"), (right_hand, "right_hand")] {
+            if let Some(h) = hand {
+                if seen.insert(h) {
+                    collected.push((h, location.to_string()));
+                }
+                collect(&self.world, h, 2, location, &mut seen, &mut collected);
+            }
+        }
+        // Backpack: the inventory entity's contents (the container entity itself
+        // is not an item, so seed `seen` with it and only collect its children).
+        seen.insert(inventory_entity);
+        collect(
+            &self.world,
+            inventory_entity,
+            2,
+            "inventory",
+            &mut seen,
+            &mut collected,
+        );
+
+        let names = self.entity_names_by_inner();
+        let mut items: Vec<_> = collected
+            .into_iter()
+            .map(|(eid, location)| {
+                let id = eid.inner() as i32;
+                crate::game_scene::DebugInventoryItem {
+                    entity_id: id,
+                    name: names.get(&id).cloned(),
+                    location,
+                }
+            })
+            .collect();
+        // Stable ordering for deterministic snapshots.
+        items.sort_by(|a, b| {
+            a.location
+                .cmp(&b.location)
+                .then(a.name.cmp(&b.name))
+                .then(a.entity_id.cmp(&b.entity_id))
+        });
+        items
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -337,6 +337,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.set_quest_bit(name, value)
     }
 
+    fn player_inventory(&self) -> Vec<crate::game_scene::DebugInventoryItem> {
+        self.mission_core.player_inventory()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -19,6 +19,7 @@ import type {
   TransitionLevelResult,
   QuestBitsResult,
   QuestBitValue,
+  PlayerInventoryResult,
   WaitForOptions,
 } from "./types.js";
 
@@ -51,6 +52,11 @@ export class PlayerApi {
 
   async teleport(position: Position): Promise<TeleportResult> {
     return this.client.post<TeleportResult>("/v1/player/teleport", position);
+  }
+
+  /** The items the player is carrying (backpack + hand-held), for verifying pickups. */
+  async inventory(): Promise<PlayerInventoryResult> {
+    return this.client.get<PlayerInventoryResult>("/v1/player/inventory");
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -226,6 +226,20 @@ export interface QuestBitsResult {
   count: number;
 }
 
+/** Where a carried item is held. */
+export type InventoryLocation = "inventory" | "left_hand" | "right_hand";
+
+export interface InventoryItem {
+  entity_id: number;
+  name: string | null;
+  location: InventoryLocation;
+}
+
+export interface PlayerInventoryResult {
+  items: InventoryItem[];
+  count: number;
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/test/inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory.e2e.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the player-inventory endpoint. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before GET /v1/player/inventory existed, the player's carried
+// items were internal (Contains links) and unreadable from HTTP - a tester
+// could not verify "did the player pick up / hold item X?". The debug_psi scene
+// auto-equips the Psi Amp into a hand, giving a deterministic carried item.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "inventory: reports carried items with name and location",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102),
+    });
+    // Let the scene auto-equip the amp.
+    await game.step({ frames: 20 });
+
+    const { items, count } = await game.player.inventory();
+    assert.equal(count, items.length, "count should match items length");
+
+    const amp = items.find((i) => i.name === "Psi Amp");
+    assert.ok(amp, `expected a held 'Psi Amp', got ${JSON.stringify(items)}`);
+    assert.ok(
+      amp.location === "left_hand" || amp.location === "right_hand",
+      `the amp should be hand-held, got location '${amp.location}'`,
+    );
+    assert.ok(
+      Number.isInteger(amp.entity_id),
+      "each item should carry its entity id",
+    );
+  },
+);
+
+test(
+  "inventory: empty when the player carries nothing",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8102) + 1,
+    });
+    await game.step({ frames: 10 });
+
+    // The player starts medsci1 empty-handed; the endpoint returns an empty
+    // (not errored) snapshot - a real reading, distinct from "unsupported".
+    const { items, count } = await game.player.inventory();
+    assert.equal(count, 0, `expected empty inventory, got ${JSON.stringify(items)}`);
+  },
+);


### PR DESCRIPTION
## Summary

Exposes the player's **carried inventory** over HTTP so an automated tester can verify pickups. Carried items were internal (`Contains` links) and unreadable from outside.

**PR 3 of 3** enabling endpoints for the play-through harness. Stacked on #414 (quest bits).

## Changes

- **shock2vr** — `DebuggableScene::player_inventory()` → `DebugInventoryItem { entity_id, name, location }`, overridden by `MissionCore` and **forwarded by `Mission → mission_core`**. It walks `Contains` links to **depth 2** from each hand-held entity and from the backpack (inventory) entity — matching the save system's notion of "held" (`save_load::get_held_items`) — deduping via a seen-set (hands take precedence over the backpack) and tagging each item with where it's carried (`inventory` / `left_hand` / `right_hand`).
- **debug_runtime** — `GET /v1/player/inventory` + `RuntimeCommand::GetPlayerInventory`.
- **SDK** — `game.player.inventory()` + types.
- **e2e** — `debug_psi`'s auto-equipped **Psi Amp** shows as a hand item; `medsci1` is empty (a real empty reading, distinct from "unsupported").

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; SDK `tsc` clean; both e2e tests pass.
- Live: `debug_psi` → `{entity_id:4, name:"Psi Amp", location:"left_hand"}`; `medsci1` → empty.
- Notably the endpoint reads `PlayerInfo.left_hand_entity_id` directly, so it's *more* accurate than `/v1/info`'s `wielded_entity_id` (which read `None` in `debug_psi`) — a discrepancy the harness would surface.

## Cross-engine review (xreview)

Both reviewers **converged**: the initial depth-1 walk was incomplete vs the save system's depth-2 (nested items like ammo-in-a-held-weapon / container contents were missed → false negatives for "did I pick up X"), plus a dedup gap (an item both backpack-linked and hand-held would list twice). Fixed with a proper recursive depth-2 walk + seen-set dedup (hands precedence), and the doc comment corrected. Forwarding verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
