### PR TITLE
fix(debug): teleport confirmation reports the actual new position

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4192,9 +4192,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         self.physics
             .set_player_translation(position, &mut self.player_handle);
 
-        // Get the player entity and add the PropTeleported component
+        // Keep PlayerInfo.pos consistent with the body immediately. It otherwise
+        // only re-syncs from the physics body on the next update(), so a query
+        // right after a teleport - notably the teleport endpoint's own
+        // confirmation read - would report the stale pre-teleport position.
         let player_entity = {
-            let player_info = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            let mut player_info = self.world.borrow::<UniqueViewMut<PlayerInfo>>().unwrap();
+            player_info.pos = position;
             player_info.entity_id
         };
 

--- a/tools/shock2-sdk/test/teleport-position.e2e.test.ts
+++ b/tools/shock2-sdk/test/teleport-position.e2e.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the teleport confirmation position. Requires game assets
+// in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: teleport_player set the physics body but not PlayerInfo.pos,
+// which only re-synced on the next update(). So the teleport endpoint's own
+// confirmation read reported the STALE pre-teleport position (~the spawn point)
+// even though the teleport itself worked. This asserts the reported position
+// matches the request, with no intervening step.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "teleport reports the actual new position immediately",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
+    });
+    await game.step({ frames: 2 });
+
+    const target = { x: 5, y: 1, z: 5 };
+    const result = await game.player.teleport(target);
+    assert.equal(result.success, true);
+
+    // The confirmation position must reflect the teleport, not the stale spawn.
+    const [x, y, z] = result.new_position;
+    assert.ok(
+      Math.abs(x - target.x) < 0.01 &&
+        Math.abs(y - target.y) < 0.01 &&
+        Math.abs(z - target.z) < 0.01,
+      `teleport should report the new position ~${JSON.stringify(target)}, got [${x}, ${y}, ${z}]`,
+    );
+
+    // And a follow-up query agrees.
+    const pos = await game.player.position();
+    assert.ok(
+      Math.abs(pos.x - target.x) < 0.01 &&
+        Math.abs(pos.y - target.y) < 0.01 &&
+        Math.abs(pos.z - target.z) < 0.01,
+      `player position should be ~${JSON.stringify(target)}, got ${JSON.stringify(pos)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Fixes the debug runtime's teleport endpoint so its `new_position` reflects the **actual** teleported position, not the stale spawn point.

## Bug

`POST /v1/player/teleport` reported a `new_position` that didn't match the request — e.g. teleporting to `(5,1,5)` returned `~(0, 1.43, 0)`. The teleport itself *worked* (a subsequent `/v1/player/position` read `(5,1,5)`), but the endpoint's own confirmation read was wrong.

Root cause: `teleport_player` set the physics body via `set_player_translation`, but left `PlayerInfo.pos` untouched. That unique only re-syncs from the body on the next `update()`, so the confirmation read (which reads `PlayerInfo.pos`) saw the pre-teleport value.

## Fix

Update `PlayerInfo.pos` to the teleport target immediately in `teleport_player`, keeping the unique consistent with the body (the next `update()` re-syncs to the same value).

## Verification

- Live: teleport to `(5,1,5)` now returns `new_position: [5.0, 1.0, 5.0]`.
- e2e (negative-first): `teleport-position.e2e.test.ts` asserts the reported position matches the request with no intervening step — the stale read failed this before the fix.

Surfaced while exercising the debug runtime for the play-through harness. (A sibling investigation into a suspected `/v1/info` `wielded` discrepancy turned out to be a false alarm — on clean re-test it matches the held item.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
