### PR TITLE
feat(debug): give-item lever (headless pickup into inventory)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -58,6 +58,12 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<PlayerInventoryResult>,
     },
 
+    /// Put an existing world entity into the player's inventory (headless pickup).
+    GiveItem {
+        entity_id: i32,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -281,6 +281,7 @@ async fn start_http_server(
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
         .route("/v1/player/inventory", get(get_player_inventory))
+        .route("/v1/player/give", axum::routing::post(give_item))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -326,6 +327,7 @@ async fn start_http_server(
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
+    info!("  POST /v1/player/give      - Put an existing entity in the inventory {{entity_id}}");
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
@@ -952,6 +954,21 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send player inventory - receiver dropped");
+            }
+        }
+        RuntimeCommand::GiveItem { entity_id, reply } => {
+            // The list/detail endpoints expose `EntityId::inner() as i32`;
+            // `from_inner` is the exact inverse (see SendEntityMessage).
+            let result = match (
+                EntityId::from_inner(entity_id as u64),
+                game.debug_scene_mut(),
+            ) {
+                (Some(eid), Some(scene)) => scene.give_item(eid),
+                (None, _) => Err(format!("invalid entity id {}", entity_id)),
+                (_, None) => Err("no debuggable scene available".to_string()),
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send give-item result - receiver dropped");
             }
         }
         RuntimeCommand::GetPlayerPosition(reply) => {
@@ -2088,6 +2105,44 @@ async fn set_quest_bit(
         Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
         Err(_) => {
             tracing::error!("Failed to receive set-quest-bit result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request body for giving an item to the player.
+#[derive(serde::Deserialize)]
+struct GiveItemRequest {
+    /// Runtime entity id of an existing world item (as listed by /v1/entities).
+    entity_id: i32,
+}
+
+/// HTTP handler for putting an existing world entity into the player's
+/// inventory - a headless "pick up" for tests.
+async fn give_item(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<GiveItemRequest>,
+) -> Result<Json<commands::CommandResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GiveItem {
+            entity_id: request.entity_id,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send GiveItem command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(Ok(())) => Ok(Json(commands::CommandResult {
+            success: true,
+            message: format!("Gave entity {} to the player", request.entity_id),
+            data: None,
+        })),
+        Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
+        Err(_) => {
+            tracing::error!("Failed to receive give-item result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -467,6 +467,14 @@ pub trait DebuggableScene {
         Vec::new()
     }
 
+    /// Put an existing world entity into the player's inventory (a headless
+    /// "pick up" for testing). Models a pickup - the item lands in the backpack;
+    /// wielding is a separate, presentation-specific concern. Default:
+    /// unsupported.
+    fn give_item(&mut self, _entity_id: EntityId) -> Result<(), String> {
+        Err("scene does not support giving items".to_string())
+    }
+
     /// Get current input context state
     ///
     /// Returns the current input state including head rotation, hand positions,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1434,6 +1434,49 @@ impl MissionCore {
         self.id_to_physics.remove(&entity_id);
     }
 
+    /// Move `dropped_entity_id` into `container_entity_id` (e.g. the player's
+    /// inventory): drop any prior `Contains` links to it, add a fresh one from
+    /// the container, mark it referenced, and remove it from the physical world.
+    /// Returns false if the container entity has no `Links` (so nothing was
+    /// added). Shared by the `DropEntityInfo` effect and the debug give lever.
+    pub fn drop_entity_into_container(
+        &mut self,
+        container_entity_id: EntityId,
+        dropped_entity_id: EntityId,
+    ) -> bool {
+        let mut was_able_to_drop = false;
+        {
+            // First, remove any existing contains links for the dropped entity..
+            let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
+
+            for (id, links) in (&mut v_links).iter().with_id() {
+                links.to_links.retain(|link| {
+                    let is_link_to_entity = matches!(link.link, Link::Contains(_))
+                        && link.to_entity_id.is_some()
+                        && link.to_entity_id.unwrap().0 == dropped_entity_id;
+
+                    !is_link_to_entity
+                });
+
+                // If it is the container, we'll add the link!
+                if id == container_entity_id {
+                    links.to_links.push(ToLink {
+                        link: Link::Contains(0),
+                        to_entity_id: Some(dark::properties::WrappedEntityId(dropped_entity_id)),
+                        to_template_id: 0, // todo?
+                    });
+                    was_able_to_drop = true;
+                }
+            }
+        }
+        if was_able_to_drop {
+            self.world
+                .add_component(dropped_entity_id, PropHasRefs(false));
+            self.make_un_physical(dropped_entity_id);
+        }
+        was_able_to_drop
+    }
+
     pub fn make_physical(&mut self, entity_id: EntityId) {
         let current_entity = self.id_to_physics.get(&entity_id);
         if current_entity.is_some() {
@@ -2043,38 +2086,7 @@ impl MissionCore {
                     parent_entity_id,
                     dropped_entity_id,
                 } => {
-                    let mut was_able_to_drop = false;
-                    {
-                        // First, remove any existing contains links for the dropped entity..
-                        let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
-
-                        for (id, links) in (&mut v_links).iter().with_id() {
-                            links.to_links.retain(|link| {
-                                let is_link_to_entity = matches!(link.link, Link::Contains(_))
-                                    && link.to_entity_id.is_some()
-                                    && link.to_entity_id.unwrap().0 == dropped_entity_id;
-
-                                !is_link_to_entity
-                            });
-
-                            // If it is the parent, we'll add the link!
-                            if id == parent_entity_id {
-                                links.to_links.push(ToLink {
-                                    link: Link::Contains(0),
-                                    to_entity_id: Some(dark::properties::WrappedEntityId(
-                                        dropped_entity_id,
-                                    )),
-                                    to_template_id: 0, // todo?
-                                });
-                                was_able_to_drop = true;
-                            }
-                        }
-                    }
-                    if was_able_to_drop {
-                        self.world
-                            .add_component(dropped_entity_id, PropHasRefs(false));
-                        self.make_un_physical(dropped_entity_id);
-                    }
+                    self.drop_entity_into_container(parent_entity_id, dropped_entity_id);
                 }
 
                 Effect::GrabEntity {
@@ -4488,6 +4500,36 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 .then(a.entity_id.cmp(&b.entity_id))
         });
         items
+    }
+
+    fn give_item(&mut self, entity_id: shipyard::EntityId) -> Result<(), String> {
+        use shipyard::EntitiesView;
+        let is_alive = self
+            .world
+            .borrow::<EntitiesView>()
+            .map(|entities| entities.is_alive(entity_id))
+            .unwrap_or(false);
+        if !is_alive {
+            return Err(format!("entity {:?} is not alive", entity_id));
+        }
+
+        // Only genuine pickup items may be given - the same eligibility rule the
+        // real grab path uses. This rejects doors, creatures, the player, the
+        // inventory container itself, etc., which reparenting into the inventory
+        // (dropping their links + unphysicalizing them) would corrupt.
+        if !crate::virtual_hand::can_grab_item(&self.world, entity_id) {
+            return Err(format!("entity {:?} is not a pickup item", entity_id));
+        }
+
+        let inventory_entity = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            player.inventory_entity_id
+        };
+        if self.drop_entity_into_container(inventory_entity, entity_id) {
+            Ok(())
+        } else {
+            Err("could not add item to inventory (no inventory container)".to_string())
+        }
     }
 
     fn get_input_state(&self) -> crate::input_context::InputContext {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -345,6 +345,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.player_inventory()
     }
 
+    fn give_item(&mut self, entity_id: shipyard::EntityId) -> Result<(), String> {
+        self.mission_core.give_item(entity_id)
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -4,6 +4,7 @@ import type {
   DebugEntityMessage,
   EntityDetailResult,
   EntityListResult,
+  EntitySummary,
   FrameSnapshot,
   InputAction,
   PathfindingStats,
@@ -58,6 +59,18 @@ export class PlayerApi {
   async inventory(): Promise<PlayerInventoryResult> {
     return this.client.get<PlayerInventoryResult>("/v1/player/inventory");
   }
+
+  /**
+   * Put an existing world entity into the player's inventory - a headless
+   * "pick up" for tests. `entityId` is a runtime id (see entities.list /
+   * entities.byTemplate). Throws (400) if the entity is not alive. The item
+   * lands in the backpack; wielding is a separate, presentation-specific step.
+   */
+  async give(entityId: number): Promise<CommandResult> {
+    return this.client.post<CommandResult>("/v1/player/give", {
+      entity_id: entityId,
+    });
+  }
 }
 
 /** Entity listing and inspection. */
@@ -74,6 +87,18 @@ export class EntitiesApi {
 
   async detail(id: number): Promise<EntityDetailResult> {
     return this.client.get<EntityDetailResult>(`/v1/entities/${id}`);
+  }
+
+  /**
+   * Runtime entities instantiated from a given template id (the negative ids
+   * from dark_query / gamesys). Maps template -> runtime id, e.g. to find the
+   * wrench in a level before giving it to the player. Lists ALL entities (no
+   * limit, so nothing is truncated by the distance-sorted cap) and filters by
+   * template.
+   */
+  async byTemplate(templateId: number): Promise<EntitySummary[]> {
+    const { entities } = await this.list();
+    return entities.filter((e) => e.template_id === templateId);
   }
 
   /**

--- a/tools/shock2-sdk/test/give-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/give-item.e2e.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the give-item (headless pickup) lever. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before POST /v1/player/give existed, there was no headless
+// way to get an existing world item into the player's inventory (pickup runs
+// through the GUI/grab flow). This gives a world item to the player and asserts
+// it lands in the backpack, verifiable via /v1/player/inventory.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "give puts an existing world item into the player's inventory",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
+    });
+    await game.step({ frames: 5 });
+
+    // Find a pickup item in the level (a nanite stack) by name.
+    const { entities } = await game.entities.list({
+      filter: "*Nanites*",
+      limit: 50,
+    });
+    const item = entities[0];
+    assert.ok(item, "expected to find a Nanites pickup in medsci1");
+
+    // It should not be carried yet.
+    const before = await game.player.inventory();
+    assert.ok(
+      !before.items.some((i) => i.entity_id === item.id),
+      "item should not start in the inventory",
+    );
+
+    // Give it, then confirm it's now in the backpack.
+    const result = await game.player.give(item.id);
+    assert.equal(result.success, true);
+
+    const after = await game.player.inventory();
+    const carried = after.items.find((i) => i.entity_id === item.id);
+    assert.ok(carried, `item ${item.id} should be carried after give`);
+    assert.equal(
+      carried.location,
+      "inventory",
+      "a given item lands in the backpack, not a hand",
+    );
+
+    // A bad id is rejected without crashing the runtime.
+    await assert.rejects(
+      game.player.give(999_999),
+      /status 400|not alive|invalid entity/,
+      "giving a nonexistent entity should error",
+    );
+
+    // A non-pickup entity (a door) is rejected too - give only accepts genuine
+    // pickup items, so it can't reparent structural entities into the backpack.
+    const doors = await game.entities.list({ filter: "*Door*", limit: 50 });
+    const door = doors.entities[0];
+    if (door) {
+      await assert.rejects(
+        game.player.give(door.id),
+        /status 400|not a pickup/,
+        "giving a non-pickup entity (door) should error",
+      );
+    }
+    assert.ok(
+      (await game.player.inventory()).items.some((i) => i.entity_id === item.id),
+      "runtime should stay live and keep the item after a rejected give",
+    );
+
+    // byTemplate maps template -> runtime id: the item we found is an instance
+    // of its own template.
+    const sameTemplate = await game.entities.byTemplate(item.template_id);
+    assert.ok(
+      sameTemplate.some((e) => e.id === item.id),
+      "byTemplate should include the item among its template's instances",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Adds **`POST /v1/player/give { entity_id }`** — a headless "pick up" lever that puts an existing world item into the player's inventory, without the interactive GUI/grab flow. The last enabling capability the play-through harness needs (set up "player has item X" / verify pickups).

## Design

Per discussion: **give = into the backpack** (models a pickup, verifiable via `/v1/player/inventory`). Wielding is intentionally out of scope — it's a separate, presentation-specific concern (VR physical grab vs flat auto-wield), and holding e.g. nanites in a hand is nonsensical. Items are identified by **runtime id** (from `entities.list` / the new `entities.byTemplate`).

## Changes

- **shock2vr** — extracted a shared `drop_entity_into_container` helper from the existing `Effect::DropEntityInfo` handler (which now just calls it — **behavior unchanged**, verified by both reviewers). Added a `give_item` override that only accepts genuine pickup items (reuses `can_grab_item`, the real grab path's eligibility), so it can't reparent a door / creature / the player / the inventory container and corrupt their links.
- **debug_runtime** — `RuntimeCommand::GiveItem` + route; invalid or non-pickup entity → `400`.
- **SDK** — `game.player.give(entityId)` + `entities.byTemplate(templateId)` (the template→runtime lookup; lists **all** entities so the distance-sorted cap can't truncate a match).
- **e2e (negative-first)** — give a Nanites pickup → lands in `inventory`; a bad id **and** a non-pickup door are both rejected without crashing; `byTemplate` maps template → runtime.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; SDK `tsc` clean; e2e passes.
- Live: give entity 258 ("20 Nanites") in medsci1 → `{location:"inventory"}`; bogus id → 400; door → 400.

## Cross-engine review (xreview)

Both engines **verified the `DropEntityInfo` refactor is behaviorally identical** (the load-bearing concern). Both **agreed** on two fixes, applied:
- **give_item validation** (Codex High / Claude Low): alive-only check could reparent structural entities → now gated on `can_grab_item` pickup-eligibility (proven by the door-rejection e2e case).
- **byTemplate truncation** (both Medium): distance-sorted cap could miss a far match (medsci1 has ~2042 entities) → now lists without a limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
