### PR TITLE
docs(skill): play-through automated game-tester harness

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: play-through
+description: >-
+  Play a mission end-to-end as an automated game tester, following a per-mission
+  checkpoint walkthrough via the headless debug runtime (SDK / HTTP - no window,
+  deterministic fixed-timestep). For each checkpoint it sets up state (warp,
+  teleport, give item, set quest bit), acts, then VERIFIES the outcome
+  (mission name, objective bits, inventory, player health/position) and captures
+  a screenshot. Every failure is a surfaced gap - classified [debug_runtime] /
+  [gameplay] / [functionality] - filed as a GitHub issue AND handed to a fix
+  sub-agent in parallel, with the fix PR linked back to the issue. Use to smoke
+  the critical path of a level, surface technical breakage, and march toward a
+  fully playable end-to-end game. Invoke with a mission name (default: medsci1).
+---
+
+# play-through — automated game-tester harness
+
+Drive a mission through a **checkpoint walkthrough** and verify each stage works,
+using the debug runtime headlessly (fixed 60 Hz stepping, no manual clicking).
+The goal is not to "win" the game with AI — it is to **exercise the critical path
+and surface every technical gap**, then drive those gaps to a fix.
+
+## Context discipline (important)
+
+A full run drives many HTTP calls and reads screenshots (image tokens), and each
+gap spawns fix work. Keep the **main context** for the run report and the
+checkpoint verdicts. **Delegate the heavy parts to sub-agents:**
+
+- The per-mission **execution** (launch runtime → step through checkpoints →
+  collect verdicts + screenshots) — one `general-purpose` sub-agent that returns
+  a structured checkpoint result table, not the raw HTTP/image traffic.
+- Each **gap fix** — its own sub-agent (see "On a gap"), run in parallel.
+
+## The toolkit (what the harness drives)
+
+All via the debug runtime — raw `curl` for one-offs, the **TypeScript SDK**
+(`tools/shock2-sdk`, `GameServer.launch`) for multi-step runs (preferred; it
+handles launch/readiness/shutdown). Capabilities the checkpoints rely on:
+
+| Need | Lever |
+| --- | --- |
+| Load / warp levels | `game.transitionLevel(level, loc?)` · `POST /v1/control/transition-level` |
+| Move the player | `game.player.teleport({x,y,z})` (warp) · `POST /v1/control/input` (drive — future) |
+| Give an item (pickup) | `game.player.give(entityId)` → lands in inventory |
+| Find an item's runtime id | `game.entities.byTemplate(id)` · `game.entities.list({filter})` |
+| Verify objective | `game.quests.get(name)` / `.list()` / `.set(name, value)` |
+| Verify inventory | `game.player.inventory()` |
+| Verify player state | `game.info()` → `player.hit_points`, `wielded_entity_id`, position |
+| Trigger a switch/frob | `game.entities.sendMessage(id, {type:"TurnOn"|"Frob"|...})` |
+| Discrete actions | `game.input.trigger("CycleWeapon"|...)` |
+| Capture | `game.screenshot(file)` |
+| Step (deterministic) | `game.step({frames})` — blocks until run; 60 Hz fixed |
+
+## Walkthrough format
+
+Each mission has a checkpoint file at `walkthroughs/<mission>.md` (see
+`walkthroughs/medsci1.md`). A checkpoint is: **setup → act → verify**, each with
+machine-checkable assertions. Checkpoints **derive from game data** (query the
+mission with `cargo dq` for triggers, items, quest bits, positions) and are
+**cross-checked against an external SS2 walkthrough** for the intended path.
+Prefer resolving runtime ids **at run time** (`entities.list` / `byTemplate`)
+over hardcoding — ids are stable per mission but the query is self-documenting.
+
+A checkpoint entry:
+
+```
+### CP<n> — <title>
+- setup:  <warp/teleport/give/step to reach the state under test>
+- act:    <the interaction being tested (frob, give, move, trigger), or none>
+- verify: <assertions — each must be machine-checkable and cite the lever>
+- capture: screenshot cp<n>.png
+- on-fail: <hint for classifying the gap if verify fails>
+```
+
+## The loop
+
+For each checkpoint, in order:
+
+1. **Setup** — reach the state under test (teleport to the area / warp to the
+   level / give a prerequisite item). Warp+teleport is the current navigation
+   model; driving the player (thumbstick) is a planned upgrade — see below.
+2. **Act** — perform the interaction the checkpoint tests (or nothing, for a
+   pure state check).
+3. **Step** — advance enough frames for the effect to land (transitions are
+   synchronous; scripts/animation need a few frames).
+4. **Verify** — evaluate every assertion. A checkpoint **passes** only if all
+   pass. Record PASS/FAIL + the actual values.
+5. **Capture** — screenshot for the report (and before/after when useful).
+6. On FAIL → **surface the gap** (next section). Then continue to later
+   checkpoints where possible (a failed checkpoint doesn't have to abort the
+   run — note which later checkpoints it blocks).
+
+## On a gap (failure)
+
+Classify, then **both** record and fix — in parallel:
+
+**Classify** the failure:
+- `[debug_runtime]` — the harness can't observe/control something it needs (a
+  missing endpoint/field). *Fix = add the capability to the debug runtime.*
+- `[gameplay]` — a trigger/script/objective behaves wrong (transition doesn't
+  fire, item can't be picked up, objective never completes). *Fix = the
+  script/mission logic.*
+- `[functionality]` — a crash, an asset that won't load, a mission that won't
+  step. *Fix = the underlying bug.*
+
+**Record** — file a GitHub issue (`gh issue create`) with: the classification
+label, the mission + checkpoint, the exact repro (lever + args + step count),
+expected vs actual, and any log excerpt. Keep issues deduplicated (search open
+issues first).
+
+**Fix** — spawn a `general-purpose` sub-agent (run gaps in parallel) to fix the
+root cause. Give it the issue number, the repro, and the relevant subsystem
+pointer (CLAUDE.md "Iterating on Visual Features" + the file map). It should:
+follow the repo's incremental-change + `/xreview` + negative-first-test
+discipline, open a PR, and **link the PR to the issue** (`Fixes #<n>`). When it
+returns, **re-run the failed checkpoint** to confirm green.
+
+Do not silently truncate: if a gap blocks later checkpoints, say so in the report.
+
+## Navigation: warp+teleport now, driving later
+
+The current model **teleports** to each checkpoint area and **warps** between
+levels — fast, deterministic, and focused on verifying that content/objectives/
+items work rather than locomotion. Structure walkthroughs so a later upgrade can
+**drive the player** (thumbstick `POST /v1/control/input` + step) over the same
+routes to additionally exercise navmesh/collision/locomotion: keep each
+checkpoint's target as a world position (drivable) rather than an opaque warp, so
+"drive to CP" can replace "teleport to CP" without rewriting the walkthrough.
+Only pursue driving once warp+teleport runs green end-to-end.
+
+## Report
+
+End with a single **run report**:
+
+- A checkpoint table: `CP | title | PASS/FAIL | actual vs expected`.
+- Screenshots (embed the key ones / the failing ones).
+- The gap list: each with classification, the issue number, and the fix PR (or
+  "fix in progress").
+- A one-line verdict: `<n>/<m> checkpoints green; <k> gaps (<filed>/<fixed>)`.
+
+## Running it
+
+```bash
+cd tools/shock2-sdk && npm run build   # first time / after SDK changes
+```
+
+Author the run as an SDK scenario driven by the walkthrough (launch → loop →
+report), or drive `curl` for a quick pass. The debug runtime is deterministic
+(fixed-timestep stepping, `/v1/step` blocks until run, `/v1/screenshot` captures
+the fully-rendered frame), so a plain `step` then `verify` needs no sleeps or
+retries. Always `POST /v1/shutdown` (or let the SDK's `await using` do it) when
+done so the runtime never lingers.
+```

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -66,20 +66,49 @@ intent, not at random.
 
 ## 3-4. Triage & fix
 
-Classify each validated finding: `[gameplay]` (broken interaction/objective) ·
-`[visual]` (rendering) · `[functionality]` (crash / won't load). **Blockers first**
-(they gate progress). File a GitHub issue (classification, mission, repro: exact
-levers + step count, expected vs actual, the screenshot), spawn a fix sub-agent
-(issue # + repro + subsystem pointer; it follows the repo's incremental +
-`/xreview` + negative-first-test discipline, opens a PR `Fixes #n`, re-validates).
-Non-blockers: log them, keep playing past them.
+Classify each validated finding two ways:
+- **Domain:** `[gameplay]` (broken interaction/objective) · `[visual]` (rendering)
+  · `[functionality]` (crash / won't load).
+- **Kind — this matters as much as the domain, because this is a *partial* port:**
+  - **bug** — broken logic in something that's implemented (an off-by-one, a wrong
+    comparator, a crash). Targeted fix.
+  - **feature gap** — a system that is **stubbed / unimplemented** (a script wired
+    to nothing, a `// TODO: Fully implement`, a `UnimplementedScript`, an
+    unparsed property). **Most blockers here are this kind.** The "fix" is a real
+    feature, and it must be **faithful**, not a shim.
+
+**Blockers first** (they gate progress). File a GitHub issue (domain + kind,
+mission, repro: exact levers + step count, expected vs actual, the screenshot).
+
+**Fixing a feature gap — faithfulness is required:**
+- The fix agent must **investigate the original System Shock 2 behavior AND the
+  engine's existing partial wiring** (the relevant scripts, properties, links,
+  `TODO`s, the actual mission entities via `cargo dq`) *before* implementing.
+- Implement it **through the game's own entities/scripts/flow** — do NOT bolt on
+  a debug-only shim (a new keybinding, a hardcoded shortcut, a fake trigger) as
+  the real mechanism. Debug levers are for *testing* the fix, never the fix.
+- Expect a **larger PR**; that's fine. A faithful partial implementation with a
+  clear "deferred" note beats a shim that looks done.
+- **The review checks faithfulness explicitly:** on the fix PR (via `/xreview`
+  and your own read), ask "does this use the real in-world flow, or does it fake
+  the mechanism?" — reject shims. (This is how #426 was caught: it made careers
+  differ via F-key debug actions instead of wiring the station career choice.)
+
+For a plain **bug**, a targeted fix + negative-first test is enough. Either way the
+fix agent follows the repo's incremental + `/xreview` + negative-first-test
+discipline, opens a PR `Fixes #n`, and re-validates. Non-blockers: log them, keep
+playing past them.
 
 ## 5. Replay & frontier
 
-Track the **frontier**: furthest level + position + quest/inventory state reached.
-Replay resumes there (`transitionLevel(level, loc)` + `teleport`; `QuickLoad`
-only within a live session) so
-each iteration starts at the edge of the known-good region and pushes further.
+Track the **frontier**: the furthest state reached. The robust, faithful way to
+persist and resume it is the game's **own save format** (it stores exactly this:
+active mission, player position/rotation, quest bits, held items) — at the edge
+of known-good, `POST /v1/save {file:"frontier"}`; each replay (a fresh runtime
+launch, since fixes rebuild the binary) resumes with `POST /v1/load
+{file:"frontier"}`. That survives relaunches, which `QuickLoad` (same-session
+only) and manual `transitionLevel`+`teleport` do not. Each iteration starts at
+the frontier and pushes further.
 
 ## Report (aggregate, self-contained)
 

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -77,7 +77,8 @@ Non-blockers: log them, keep playing past them.
 ## 5. Replay & frontier
 
 Track the **frontier**: furthest level + position + quest/inventory state reached.
-Replay resumes there (`transitionLevel(level, loc)` + `teleport`/`QuickLoad`) so
+Replay resumes there (`transitionLevel(level, loc)` + `teleport`; `QuickLoad`
+only within a live session) so
 each iteration starts at the edge of the known-good region and pushes further.
 
 ## Report (aggregate, self-contained)

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -1,114 +1,108 @@
 ---
 name: play-through
 description: >-
-  Harden the game toward fully-playable end-to-end with a PLAYTEST -> FIX ->
-  REPLAY loop. An agent actually PLAYS a mission via the headless debug runtime -
-  it SEES the world (screenshots it reads) and ACTS with the runtime's tools
-  (move, look, frob, pick up, attack, follow triggers) - and reports what it
-  observes and where it gets stuck. Each blocker/bug is classified
-  ([gameplay]/[visual]/[functionality]), filed as a GitHub issue, and delegated
-  to a fix sub-agent (PR linked to the issue); then the agent REPLAYS from the
-  frontier to get a little further and find the next issue. Repeat. A run builds
-  an HTML timeline report from the playtest (each step: screenshot + note +
-  action + any bug). This is a playtest, NOT a scripted checkpoint runner.
-  Invoke with a mission (default medsci1) and optionally a progress goal.
+  Manager loop that hardens the game toward fully-playable end-to-end. It drives
+  the `playtest` primitive in a PLAYTEST -> REVIEW -> FIX -> REPLAY loop: play one
+  session (agent plays a mission via the debug runtime, emits a data.json),
+  adversarially REVIEW that session against a real walkthrough (did it genuinely
+  progress, were the actions sensible, are the findings real - not artifacts of
+  poking the wrong thing), triage the validated blocker/bugs, file + delegate a
+  fix (PR "Fixes #n"), then REPLAY from the advancing frontier - until a mission
+  (then the game) plays through with no new blocker. Aggregates every session into
+  a self-contained HTML timeline report. Invoke with a mission (default medsci1)
+  and a goal (default: reach the level's exit).
 ---
 
-# play-through — playtest → fix → replay loop
+# play-through — the playtest → review → fix → replay loop
 
-Iteratively drive the game toward **playable end-to-end** by *playing* it. An
-agent plays a mission like a QA tester, surfaces the thing that blocks or breaks,
-we fix it, and the agent replays a little further to find the next thing. The
-value is the agent **noticing** problems organically — not a script asserting
-predefined checks.
+Owns the *loop* that hardens the game to end-to-end playable. The atomic unit is
+the **`playtest`** skill (play one session, emit `data.json`); this manager runs
+it repeatedly, **reviews** each session for validity, fixes what blocks progress,
+and replays a little further — tracking a **frontier** so it never re-plays solved
+ground. Delegate the playtest and each fix to sub-agents (keeps the image-heavy
+work out of the main context); the manager holds the loop state and the report.
 
 ## The loop
 
 ```
-launch/resume at the frontier
-   → PLAYTEST (agent plays toward the goal, observing + acting)
-   → it surfaces an issue (a blocker, or a bug it noticed)
-   → classify + file a GitHub issue + delegate a FIX sub-agent (PR "Fixes #n")
-   → re-validate the fix, then REPLAY from the frontier
-   → gets a little further → finds the next issue
-repeat until the mission (then the game) plays through cleanly
+resume at the frontier (warp/teleport/QuickLoad) — or launch fresh at iteration 0
+  1. PLAYTEST   → invoke `playtest` toward the goal → data.json + screenshots + frontier
+  2. REVIEW     → adversarially judge the session (below). Shallow/invalid → re-play with guidance.
+  3. TRIAGE     → keep only REAL findings; identify the progress BLOCKER.
+  4. FIX        → file issue + delegate fix sub-agent (PR "Fixes #n"); re-validate.
+  5. REPLAY     → resume at the (now advanced) frontier; confirm it gets further.
+repeat until the mission plays through with no new blocker, then advance to the next level
 ```
 
-Each iteration should get **further** than the last. Track a **frontier** (the
-furthest level + position reached, plus quest/inventory state) and resume there
-each replay — via `transitionLevel(level, loc)` to the frontier level and a
-teleport/`QuickLoad`, so you don't replay solved sections every time.
+Each iteration must get **further**. Stop a mission when a full session reaches its
+exit with no new blocker; then chain to the next level and continue. "End-to-end
+with confidence" = every mission in sequence plays through clean on a fresh replay.
 
-## The playtest agent (how it plays)
+## 2. REVIEW — the quality gate (do not skip)
 
-Delegate each playtest to a **`general-purpose` sub-agent** (keeps the image-heavy
-observe loop out of the main context; it returns a playtest log + a frontier +
-the issue to fix). Its brief:
+A playtest can *look* busy without actually **playing** (teleport-and-poke,
+frobbing decorative props, "bugs" that are just the agent doing the wrong thing).
+Before acting on a session, review its `data.json` **adversarially** — spawn a
+reviewer sub-agent (it may read the screenshots and consult a real System Shock 2
+walkthrough for the mission):
 
-> You are a QA playtester for a System Shock 2 port. A debug runtime of
-> `<mission>` runs at `<url>`. **Play toward `<goal>`** (default: reach the
-> level's exit / next level). SEE the world and REACT to it — don't run a script.
-> Loop: screenshot → **Read the PNG** → decide → act → step → observe. Explore,
-> interact (frob doors/terminals, pick up items, fight), and follow the level's
-> real exit. **Report where you get stuck and every bug you notice.** Return: a
-> step-by-step log (each: what you saw in which screenshot, what you did), the
-> **frontier** you reached, and the **blocking issue** (if any) + other bugs,
-> each with a screenshot, severity, and classification.
+- **Did it genuinely progress** toward the goal, or just survey? (moved along the
+  intended path, pursued the objective, tried the real exit — vs jumping between
+  random nearby entities).
+- **Were the actions sensible?** (frobbed *doors / keypads / objective items /
+  usable terminals* — not decorative set-dressing; engaged enemies as a player
+  would, not just debug-damaged them). Flag nonsensical actions.
+- **Coverage vs the walkthrough:** did it do what a player *should* here (get the
+  wrench, find the keycard, deal with the objective, reach the elevator)? Note
+  what it skipped.
+- **Are the findings real** or artifacts? (e.g. "console frob does nothing" may be
+  correct-by-design if that console isn't interactive — not a bug). Keep only
+  validated findings; downgrade or drop the rest.
 
-**Senses & hands** (HTTP; SDK `GameServer` for lifecycle):
+Verdict: was this a valid playtest? If **no** (too shallow, wrong actions), re-run
+`playtest` with the review's specific guidance (and the walkthrough context)
+before triaging. Feed the walkthrough into the *next* playtest so it plays with
+intent, not at random.
 
-| Sense the world | Act on it |
-| --- | --- |
-| `POST /v1/screenshot {filename}` → **Read `/tmp/claude/<file>`** | `POST /v1/player/teleport {x,y,z}` (jump to inspect) |
-| `GET /v1/entities?filter=&limit=` (name/id/pos/distance) | `POST /v1/control/input {right_hand.thumbstick:[strafe,fwd]}` + step (walk) |
-| `GET /v1/entities/:id` (props, links) | `left_hand.thumbstick:[turn,0]` + step (look around) |
-| `GET /v1/info` (health, pos, wielded, psi) | `POST /v1/entities/:id/message {type:"Frob"\|"Damage"\|"TurnOn"}` |
-| `GET /v1/player/inventory` · `GET /v1/quests` | `POST /v1/player/give {entity_id}` (pick up) |
-| `GET /v1/transitions` (where exits lead + position) | follow an exit: teleport into a **tripwire** volume; **Frob** a bulkhead **button** |
+## 3-4. Triage & fix
 
-Note: **tripwires** fire on entry (teleport into the volume); **bulkhead buttons**
-fire on **Frob** (teleporting into a button does nothing). `/v1/transitions`
-gives each trigger's destination + position.
+Classify each validated finding: `[gameplay]` (broken interaction/objective) ·
+`[visual]` (rendering) · `[functionality]` (crash / won't load). **Blockers first**
+(they gate progress). File a GitHub issue (classification, mission, repro: exact
+levers + step count, expected vs actual, the screenshot), spawn a fix sub-agent
+(issue # + repro + subsystem pointer; it follows the repo's incremental +
+`/xreview` + negative-first-test discipline, opens a PR `Fixes #n`, re-validates).
+Non-blockers: log them, keep playing past them.
 
-## On an issue (blocker or bug)
+## 5. Replay & frontier
 
-**Classify:** `[gameplay]` (a broken interaction/objective — door won't open,
-frob does nothing, item can't be taken, trigger won't fire) · `[visual]` (missing
-texture, floating/clipping/z-fighting, T-posed creature, HUD glitch) ·
-`[functionality]` (crash, level won't load/step).
+Track the **frontier**: furthest level + position + quest/inventory state reached.
+Replay resumes there (`transitionLevel(level, loc)` + `teleport`/`QuickLoad`) so
+each iteration starts at the edge of the known-good region and pushes further.
 
-**File + fix (parallel).** File a GitHub issue (classification, mission, repro:
-exact levers + step count, expected vs actual, the screenshot). Spawn a
-`general-purpose` fix sub-agent with the issue # + repro + subsystem pointer; it
-follows the repo's incremental + `/xreview` + negative-first-test discipline,
-opens a PR (`Fixes #n`), and re-validates. Blockers first (they gate progress);
-log non-blocking bugs and keep playing past them when possible.
+## Report (aggregate, self-contained)
 
-**Replay.** After the fix merges (or on the fix branch), replay from the frontier
-and confirm the agent gets further. Note if a fix unblocks new territory.
+Each `playtest` emits a `data.json` next to its screenshots. Render a session (or
+the aggregate) to a **self-contained HTML timeline** — images inlined as base64,
+so it's one portable file:
 
-## The report (built from the playtest)
+```
+node .claude/skills/play-through/render-timeline.mjs <run-dir>/data.json
+# -> <run-dir>/report.html   (open file://... ; renders anywhere)
+```
 
-Assemble an **HTML timeline** from the playtest log — one entry per step with the
-screenshot, a note on what the agent saw, the action it took, and any bug — plus
-the issues filed and their fix PRs, and how far the frontier advanced this
-iteration. Render locally (self-contained HTML, images by relative path) so it's
-viewable without hosting. See `render-timeline.mjs` (reusable across runs); keep
-the per-mission game-data notes in `walkthroughs/<mission>.md` as context for the
-playtest agent (spawn point, exits, notable items — NOT a script to follow).
+`data.json` schema is documented in `render-timeline.mjs` (steps: screenshot +
+what the agent saw + what it did + any bug; plus frontier, bugs with issue/fix
+links, verdict). Keep per-mission game-data notes in `walkthroughs/<mission>.md`
+as context for the playtest + review (spawn, exits, notable items — NOT a script).
 
-## Optional fast first pass
-
-Before the agent digs into a level, a quick load+transition smoke can pre-flag
-dead levels (won't load, no forward trigger). That's a coarse net; the agent
-playtest is where real issues surface. Don't let the first-pass script substitute
-for actually playing.
+Optionally record a **video** of a session — capture frames at a cadence during
+play and stitch with the **`video-capture`** skill (60Hz sim / 4 = real-time
+15fps). Local artifact.
 
 ## Notes
-
-- Deterministic: `/v1/step` blocks until frames run; `/v1/screenshot` captures the
-  fully-rendered frame — no sleeps/retries.
-- Always `POST /v1/shutdown` (or SDK `await using`) when done.
-- Navigation today is teleport + short thumbstick drives; richer real-movement
-  playtesting (full navmesh traversal) is a planned upgrade — keep frontier
-  positions as world coordinates so it drops in later.
+- Delegate playtest + review + each fix to sub-agents; the manager keeps the
+  ledger (frontier, issues→fixes, iteration report).
+- Navigation today is teleport + short thumbstick drives; real-movement
+  playtesting (navmesh traversal) is a planned upgrade — keep frontier positions
+  as world coordinates so it drops in.

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -1,153 +1,114 @@
 ---
 name: play-through
 description: >-
-  Play a mission end-to-end as an automated game tester, following a per-mission
-  checkpoint walkthrough via the headless debug runtime (SDK / HTTP - no window,
-  deterministic fixed-timestep). For each checkpoint it sets up state (warp,
-  teleport, give item, set quest bit), acts, then VERIFIES the outcome
-  (mission name, objective bits, inventory, player health/position) and captures
-  a screenshot. Every failure is a surfaced gap - classified [debug_runtime] /
-  [gameplay] / [functionality] - filed as a GitHub issue AND handed to a fix
-  sub-agent in parallel, with the fix PR linked back to the issue. Use to smoke
-  the critical path of a level, surface technical breakage, and march toward a
-  fully playable end-to-end game. Invoke with a mission name (default: medsci1).
+  Harden the game toward fully-playable end-to-end with a PLAYTEST -> FIX ->
+  REPLAY loop. An agent actually PLAYS a mission via the headless debug runtime -
+  it SEES the world (screenshots it reads) and ACTS with the runtime's tools
+  (move, look, frob, pick up, attack, follow triggers) - and reports what it
+  observes and where it gets stuck. Each blocker/bug is classified
+  ([gameplay]/[visual]/[functionality]), filed as a GitHub issue, and delegated
+  to a fix sub-agent (PR linked to the issue); then the agent REPLAYS from the
+  frontier to get a little further and find the next issue. Repeat. A run builds
+  an HTML timeline report from the playtest (each step: screenshot + note +
+  action + any bug). This is a playtest, NOT a scripted checkpoint runner.
+  Invoke with a mission (default medsci1) and optionally a progress goal.
 ---
 
-# play-through — automated game-tester harness
+# play-through — playtest → fix → replay loop
 
-Drive a mission through a **checkpoint walkthrough** and verify each stage works,
-using the debug runtime headlessly (fixed 60 Hz stepping, no manual clicking).
-The goal is not to "win" the game with AI — it is to **exercise the critical path
-and surface every technical gap**, then drive those gaps to a fix.
-
-## Context discipline (important)
-
-A full run drives many HTTP calls and reads screenshots (image tokens), and each
-gap spawns fix work. Keep the **main context** for the run report and the
-checkpoint verdicts. **Delegate the heavy parts to sub-agents:**
-
-- The per-mission **execution** (launch runtime → step through checkpoints →
-  collect verdicts + screenshots) — one `general-purpose` sub-agent that returns
-  a structured checkpoint result table, not the raw HTTP/image traffic.
-- Each **gap fix** — its own sub-agent (see "On a gap"), run in parallel.
-
-## The toolkit (what the harness drives)
-
-All via the debug runtime — raw `curl` for one-offs, the **TypeScript SDK**
-(`tools/shock2-sdk`, `GameServer.launch`) for multi-step runs (preferred; it
-handles launch/readiness/shutdown). Capabilities the checkpoints rely on:
-
-| Need | Lever |
-| --- | --- |
-| Load / warp levels | `game.transitionLevel(level, loc?)` · `POST /v1/control/transition-level` |
-| Move the player | `game.player.teleport({x,y,z})` (warp) · `POST /v1/control/input` (drive — future) |
-| Give an item (pickup) | `game.player.give(entityId)` → lands in inventory |
-| Find an item's runtime id | `game.entities.byTemplate(id)` · `game.entities.list({filter})` |
-| Verify objective | `game.quests.get(name)` / `.list()` / `.set(name, value)` |
-| Verify inventory | `game.player.inventory()` |
-| Verify player state | `game.info()` → `player.hit_points`, `wielded_entity_id`, position |
-| Trigger a switch/frob | `game.entities.sendMessage(id, {type:"TurnOn"|"Frob"|...})` |
-| Discrete actions | `game.input.trigger("CycleWeapon"|...)` |
-| Capture | `game.screenshot(file)` |
-| Step (deterministic) | `game.step({frames})` — blocks until run; 60 Hz fixed |
-
-## Walkthrough format
-
-Each mission has a checkpoint file at `walkthroughs/<mission>.md` (see
-`walkthroughs/medsci1.md`). A checkpoint is: **setup → act → verify**, each with
-machine-checkable assertions. Checkpoints **derive from game data** (query the
-mission with `cargo dq` for triggers, items, quest bits, positions) and are
-**cross-checked against an external SS2 walkthrough** for the intended path.
-Prefer resolving runtime ids **at run time** (`entities.list` / `byTemplate`)
-over hardcoding — ids are stable per mission but the query is self-documenting.
-
-A checkpoint entry:
-
-```
-### CP<n> — <title>
-- setup:  <warp/teleport/give/step to reach the state under test>
-- act:    <the interaction being tested (frob, give, move, trigger), or none>
-- verify: <assertions — each must be machine-checkable and cite the lever>
-- capture: screenshot cp<n>.png
-- on-fail: <hint for classifying the gap if verify fails>
-```
+Iteratively drive the game toward **playable end-to-end** by *playing* it. An
+agent plays a mission like a QA tester, surfaces the thing that blocks or breaks,
+we fix it, and the agent replays a little further to find the next thing. The
+value is the agent **noticing** problems organically — not a script asserting
+predefined checks.
 
 ## The loop
 
-For each checkpoint, in order:
-
-1. **Setup** — reach the state under test (teleport to the area / warp to the
-   level / give a prerequisite item). Warp+teleport is the current navigation
-   model; driving the player (thumbstick) is a planned upgrade — see below.
-2. **Act** — perform the interaction the checkpoint tests (or nothing, for a
-   pure state check).
-3. **Step** — advance enough frames for the effect to land (transitions are
-   synchronous; scripts/animation need a few frames).
-4. **Verify** — evaluate every assertion. A checkpoint **passes** only if all
-   pass. Record PASS/FAIL + the actual values.
-5. **Capture** — screenshot for the report (and before/after when useful).
-6. On FAIL → **surface the gap** (next section). Then continue to later
-   checkpoints where possible (a failed checkpoint doesn't have to abort the
-   run — note which later checkpoints it blocks).
-
-## On a gap (failure)
-
-Classify, then **both** record and fix — in parallel:
-
-**Classify** the failure:
-- `[debug_runtime]` — the harness can't observe/control something it needs (a
-  missing endpoint/field). *Fix = add the capability to the debug runtime.*
-- `[gameplay]` — a trigger/script/objective behaves wrong (transition doesn't
-  fire, item can't be picked up, objective never completes). *Fix = the
-  script/mission logic.*
-- `[functionality]` — a crash, an asset that won't load, a mission that won't
-  step. *Fix = the underlying bug.*
-
-**Record** — file a GitHub issue (`gh issue create`) with: the classification
-label, the mission + checkpoint, the exact repro (lever + args + step count),
-expected vs actual, and any log excerpt. Keep issues deduplicated (search open
-issues first).
-
-**Fix** — spawn a `general-purpose` sub-agent (run gaps in parallel) to fix the
-root cause. Give it the issue number, the repro, and the relevant subsystem
-pointer (CLAUDE.md "Iterating on Visual Features" + the file map). It should:
-follow the repo's incremental-change + `/xreview` + negative-first-test
-discipline, open a PR, and **link the PR to the issue** (`Fixes #<n>`). When it
-returns, **re-run the failed checkpoint** to confirm green.
-
-Do not silently truncate: if a gap blocks later checkpoints, say so in the report.
-
-## Navigation: warp+teleport now, driving later
-
-The current model **teleports** to each checkpoint area and **warps** between
-levels — fast, deterministic, and focused on verifying that content/objectives/
-items work rather than locomotion. Structure walkthroughs so a later upgrade can
-**drive the player** (thumbstick `POST /v1/control/input` + step) over the same
-routes to additionally exercise navmesh/collision/locomotion: keep each
-checkpoint's target as a world position (drivable) rather than an opaque warp, so
-"drive to CP" can replace "teleport to CP" without rewriting the walkthrough.
-Only pursue driving once warp+teleport runs green end-to-end.
-
-## Report
-
-End with a single **run report**:
-
-- A checkpoint table: `CP | title | PASS/FAIL | actual vs expected`.
-- Screenshots (embed the key ones / the failing ones).
-- The gap list: each with classification, the issue number, and the fix PR (or
-  "fix in progress").
-- A one-line verdict: `<n>/<m> checkpoints green; <k> gaps (<filed>/<fixed>)`.
-
-## Running it
-
-```bash
-cd tools/shock2-sdk && npm run build   # first time / after SDK changes
+```
+launch/resume at the frontier
+   → PLAYTEST (agent plays toward the goal, observing + acting)
+   → it surfaces an issue (a blocker, or a bug it noticed)
+   → classify + file a GitHub issue + delegate a FIX sub-agent (PR "Fixes #n")
+   → re-validate the fix, then REPLAY from the frontier
+   → gets a little further → finds the next issue
+repeat until the mission (then the game) plays through cleanly
 ```
 
-Author the run as an SDK scenario driven by the walkthrough (launch → loop →
-report), or drive `curl` for a quick pass. The debug runtime is deterministic
-(fixed-timestep stepping, `/v1/step` blocks until run, `/v1/screenshot` captures
-the fully-rendered frame), so a plain `step` then `verify` needs no sleeps or
-retries. Always `POST /v1/shutdown` (or let the SDK's `await using` do it) when
-done so the runtime never lingers.
-```
+Each iteration should get **further** than the last. Track a **frontier** (the
+furthest level + position reached, plus quest/inventory state) and resume there
+each replay — via `transitionLevel(level, loc)` to the frontier level and a
+teleport/`QuickLoad`, so you don't replay solved sections every time.
+
+## The playtest agent (how it plays)
+
+Delegate each playtest to a **`general-purpose` sub-agent** (keeps the image-heavy
+observe loop out of the main context; it returns a playtest log + a frontier +
+the issue to fix). Its brief:
+
+> You are a QA playtester for a System Shock 2 port. A debug runtime of
+> `<mission>` runs at `<url>`. **Play toward `<goal>`** (default: reach the
+> level's exit / next level). SEE the world and REACT to it — don't run a script.
+> Loop: screenshot → **Read the PNG** → decide → act → step → observe. Explore,
+> interact (frob doors/terminals, pick up items, fight), and follow the level's
+> real exit. **Report where you get stuck and every bug you notice.** Return: a
+> step-by-step log (each: what you saw in which screenshot, what you did), the
+> **frontier** you reached, and the **blocking issue** (if any) + other bugs,
+> each with a screenshot, severity, and classification.
+
+**Senses & hands** (HTTP; SDK `GameServer` for lifecycle):
+
+| Sense the world | Act on it |
+| --- | --- |
+| `POST /v1/screenshot {filename}` → **Read `/tmp/claude/<file>`** | `POST /v1/player/teleport {x,y,z}` (jump to inspect) |
+| `GET /v1/entities?filter=&limit=` (name/id/pos/distance) | `POST /v1/control/input {right_hand.thumbstick:[strafe,fwd]}` + step (walk) |
+| `GET /v1/entities/:id` (props, links) | `left_hand.thumbstick:[turn,0]` + step (look around) |
+| `GET /v1/info` (health, pos, wielded, psi) | `POST /v1/entities/:id/message {type:"Frob"\|"Damage"\|"TurnOn"}` |
+| `GET /v1/player/inventory` · `GET /v1/quests` | `POST /v1/player/give {entity_id}` (pick up) |
+| `GET /v1/transitions` (where exits lead + position) | follow an exit: teleport into a **tripwire** volume; **Frob** a bulkhead **button** |
+
+Note: **tripwires** fire on entry (teleport into the volume); **bulkhead buttons**
+fire on **Frob** (teleporting into a button does nothing). `/v1/transitions`
+gives each trigger's destination + position.
+
+## On an issue (blocker or bug)
+
+**Classify:** `[gameplay]` (a broken interaction/objective — door won't open,
+frob does nothing, item can't be taken, trigger won't fire) · `[visual]` (missing
+texture, floating/clipping/z-fighting, T-posed creature, HUD glitch) ·
+`[functionality]` (crash, level won't load/step).
+
+**File + fix (parallel).** File a GitHub issue (classification, mission, repro:
+exact levers + step count, expected vs actual, the screenshot). Spawn a
+`general-purpose` fix sub-agent with the issue # + repro + subsystem pointer; it
+follows the repo's incremental + `/xreview` + negative-first-test discipline,
+opens a PR (`Fixes #n`), and re-validates. Blockers first (they gate progress);
+log non-blocking bugs and keep playing past them when possible.
+
+**Replay.** After the fix merges (or on the fix branch), replay from the frontier
+and confirm the agent gets further. Note if a fix unblocks new territory.
+
+## The report (built from the playtest)
+
+Assemble an **HTML timeline** from the playtest log — one entry per step with the
+screenshot, a note on what the agent saw, the action it took, and any bug — plus
+the issues filed and their fix PRs, and how far the frontier advanced this
+iteration. Render locally (self-contained HTML, images by relative path) so it's
+viewable without hosting. See `render-timeline.mjs` (reusable across runs); keep
+the per-mission game-data notes in `walkthroughs/<mission>.md` as context for the
+playtest agent (spawn point, exits, notable items — NOT a script to follow).
+
+## Optional fast first pass
+
+Before the agent digs into a level, a quick load+transition smoke can pre-flag
+dead levels (won't load, no forward trigger). That's a coarse net; the agent
+playtest is where real issues surface. Don't let the first-pass script substitute
+for actually playing.
+
+## Notes
+
+- Deterministic: `/v1/step` blocks until frames run; `/v1/screenshot` captures the
+  fully-rendered frame — no sleeps/retries.
+- Always `POST /v1/shutdown` (or SDK `await using`) when done.
+- Navigation today is teleport + short thumbstick drives; richer real-movement
+  playtesting (full navmesh traversal) is a planned upgrade — keep frontier
+  positions as world coordinates so it drops in later.

--- a/.claude/skills/play-through/render-timeline.mjs
+++ b/.claude/skills/play-through/render-timeline.mjs
@@ -54,7 +54,7 @@ const stepHtml = (s) => `
     <div class="dot"></div>
     <div class="card">
       <div class="hd"><span class="ix">${esc(s.index)}</span><h3>${esc(s.title)}</h3></div>
-      ${embed(s.screenshot) ? `<img loading="lazy" src="${embed(s.screenshot)}" alt="${esc(s.title)}">` : ""}
+      ${embed(s.screenshot) ? `<img loading="lazy" src="${embed(s.screenshot)}" alt="${esc(s.title)}">` : s.screenshot ? `<p class="missing">⚠ missing screenshot: ${esc(s.screenshot)}</p>` : ""}
       ${s.observation ? `<p class="obs"><b>Saw:</b> ${esc(s.observation)}</p>` : ""}
       ${s.action ? `<p class="act"><b>Did:</b> ${esc(s.action)}</p>` : ""}
       ${s.bug ? `<p class="bug">${badge(s.bug.severity)} <b>${esc(s.bug.class)}</b> ${esc(s.bug.detail)}</p>` : ""}
@@ -95,6 +95,7 @@ const html = `<!doctype html><html><head><meta charset="utf-8">
   .obs, .act, .bug { margin:4px 0; font-size:14px; }
   .obs b, .act b { color:#9fa0a8; font-weight:600; }
   .bug { background:#241416; border:1px solid #4a2327; border-radius:7px; padding:7px 9px; }
+  .missing { color:#f5a524; font-size:13px; }
 </style></head><body><div class="wrap">
   <h1>Playtest — ${esc(data.mission)}</h1>
   <p class="sub">goal: <b>${esc(data.goal || "explore & QA")}</b> · frontier: <b>${esc(data.frontier || "-")}</b> · ${esc(data.generated || "")}</p>
@@ -105,7 +106,7 @@ const html = `<!doctype html><html><head><meta charset="utf-8">
   <tbody>${(data.bugs || []).map(bugRow).join("") || `<tr><td colspan="5" class="muted">none</td></tr>`}</tbody></table>
 
   <h2>Timeline (${(data.steps || []).length} steps)</h2>
-  <div class="timeline">${(data.steps || []).map(stepHtml).join("")}</div>
+  <div class="timeline">${(data.steps || []).map(stepHtml).join("") || `<p class="muted">no steps</p>`}</div>
 </div></body></html>`;
 
 const out = join(dir, "report.html");

--- a/.claude/skills/play-through/render-timeline.mjs
+++ b/.claude/skills/play-through/render-timeline.mjs
@@ -46,6 +46,16 @@ function embed(filename) {
 }
 
 const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+// Inline an mp4 session recording (if `data.video` is set) as a base64 data URI.
+function embedVideo(filename) {
+  if (!filename) return "";
+  const p = join(dir, filename);
+  if (!existsSync(p)) return `<p class="missing">⚠ missing video: ${esc(filename)}</p>`;
+  const b64 = readFileSync(p).toString("base64");
+  return `<video controls preload="metadata" src="data:video/mp4;base64,${b64}"></video>`;
+}
+
 const sevColor = { high: "#e5484d", med: "#f5a524", medium: "#f5a524", low: "#8b8d98" };
 const badge = (sev) => `<span class="sev" style="background:${sevColor[String(sev).toLowerCase()] || "#8b8d98"}">${esc(sev)}</span>`;
 
@@ -96,10 +106,12 @@ const html = `<!doctype html><html><head><meta charset="utf-8">
   .obs b, .act b { color:#9fa0a8; font-weight:600; }
   .bug { background:#241416; border:1px solid #4a2327; border-radius:7px; padding:7px 9px; }
   .missing { color:#f5a524; font-size:13px; }
+  video { width:100%; border-radius:10px; border:1px solid #24262c; margin:8px 0 20px; background:#000; }
 </style></head><body><div class="wrap">
   <h1>Playtest — ${esc(data.mission)}</h1>
   <p class="sub">goal: <b>${esc(data.goal || "explore & QA")}</b> · frontier: <b>${esc(data.frontier || "-")}</b> · ${esc(data.generated || "")}</p>
   ${data.verdict ? `<p class="sub">${esc(data.verdict)}</p>` : ""}
+  ${embedVideo(data.video)}
 
   <h2>Issues found (${(data.bugs || []).length})</h2>
   <table><thead><tr><th>Sev</th><th>Class</th><th>Issue</th><th>Shot</th><th>Filed → Fix</th></tr></thead>

--- a/.claude/skills/play-through/render-timeline.mjs
+++ b/.claude/skills/play-through/render-timeline.mjs
@@ -1,0 +1,113 @@
+// Render a playtest run into a self-contained, local HTML timeline.
+//
+//   node render-timeline.mjs <data.json>
+//
+// <data.json> lives in a directory alongside the run's screenshots (referenced
+// by filename). Writes report.html next to it: a vertical timeline where each
+// step shows its screenshot, what the agent observed (the note), the action it
+// took, and any bug it flagged - plus a bug summary and verdict. Open the
+// report.html directly (file://); images load by relative path, no server.
+//
+// data.json shape:
+//   {
+//     "mission": "medsci1", "goal": "...", "generated": "...",
+//     "frontier": "medsci1 @ (x,y,z)",
+//     "steps": [ { "index":1, "title":"...", "screenshot":"pt-01.png",
+//                  "observation":"what the agent saw",
+//                  "action":"what it did",
+//                  "bug": { "severity":"Low", "class":"[visual]", "detail":"..." } | null } ],
+//     "bugs":  [ { "title":"...", "severity":"High|Med|Low", "class":"[gameplay|visual|functionality]",
+//                  "screenshot":"pt-02.png", "detail":"...", "issue":"#123", "fixPr":"#124" } ],
+//     "verdict": "..."
+//   }
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join, extname } from "node:path";
+
+const dataPath = process.argv[2];
+if (!dataPath) { console.error("usage: node render-timeline.mjs <data.json>"); process.exit(1); }
+const data = JSON.parse(readFileSync(dataPath, "utf8"));
+const dir = dirname(dataPath);
+
+// Inline each screenshot as a base64 data URI so report.html is a single,
+// portable, self-contained file (images render even if moved/shared).
+const mime = { ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".gif": "image/gif" };
+const embedCache = new Map();
+function embed(filename) {
+  if (!filename) return null;
+  if (embedCache.has(filename)) return embedCache.get(filename);
+  const p = join(dir, filename);
+  let uri = null;
+  if (existsSync(p)) {
+    const b64 = readFileSync(p).toString("base64");
+    uri = `data:${mime[extname(filename).toLowerCase()] || "image/png"};base64,${b64}`;
+  }
+  embedCache.set(filename, uri);
+  return uri;
+}
+
+const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const sevColor = { high: "#e5484d", med: "#f5a524", medium: "#f5a524", low: "#8b8d98" };
+const badge = (sev) => `<span class="sev" style="background:${sevColor[String(sev).toLowerCase()] || "#8b8d98"}">${esc(sev)}</span>`;
+
+const stepHtml = (s) => `
+  <div class="step${s.bug ? " has-bug" : ""}">
+    <div class="dot"></div>
+    <div class="card">
+      <div class="hd"><span class="ix">${esc(s.index)}</span><h3>${esc(s.title)}</h3></div>
+      ${embed(s.screenshot) ? `<img loading="lazy" src="${embed(s.screenshot)}" alt="${esc(s.title)}">` : ""}
+      ${s.observation ? `<p class="obs"><b>Saw:</b> ${esc(s.observation)}</p>` : ""}
+      ${s.action ? `<p class="act"><b>Did:</b> ${esc(s.action)}</p>` : ""}
+      ${s.bug ? `<p class="bug">${badge(s.bug.severity)} <b>${esc(s.bug.class)}</b> ${esc(s.bug.detail)}</p>` : ""}
+    </div>
+  </div>`;
+
+const bugRow = (b) => `
+  <tr>
+    <td>${badge(b.severity)}</td><td>${esc(b.class)}</td>
+    <td><b>${esc(b.title)}</b><br><span class="muted">${esc(b.detail)}</span></td>
+    <td>${embed(b.screenshot) ? `<img class="thumb" src="${embed(b.screenshot)}" alt="${esc(b.title)}">` : "-"}</td>
+    <td>${b.issue ? esc(b.issue) : "-"}${b.fixPr ? ` → ${esc(b.fixPr)}` : ""}</td>
+  </tr>`;
+
+const html = `<!doctype html><html><head><meta charset="utf-8">
+<title>Playtest — ${esc(data.mission)}</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; background:#0f1012; color:#e8e8ea; font:15px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 28px 20px 80px; }
+  h1 { font-size: 24px; margin: 0 0 4px; }
+  .sub { color:#9fa0a8; margin: 0 0 20px; }
+  .sub b { color:#e8e8ea; }
+  .sev { color:#0f1012; font-weight:700; font-size:11px; padding:1px 7px; border-radius:10px; }
+  table { width:100%; border-collapse:collapse; margin: 8px 0 28px; }
+  th,td { text-align:left; padding:8px 10px; border-bottom:1px solid #24262c; vertical-align:top; font-size:13.5px; }
+  th { color:#9fa0a8; font-weight:600; }
+  .muted { color:#9fa0a8; }
+  .timeline { position:relative; margin-left: 10px; padding-left: 26px; border-left: 2px solid #2a2c33; }
+  .step { position:relative; margin: 0 0 22px; }
+  .dot { position:absolute; left:-35px; top:6px; width:12px; height:12px; border-radius:50%; background:#4c78ff; border:2px solid #0f1012; }
+  .step.has-bug .dot { background:#e5484d; }
+  .card { background:#17181c; border:1px solid #24262c; border-radius:10px; padding:12px 14px; }
+  .hd { display:flex; align-items:center; gap:9px; margin-bottom:6px; }
+  .hd h3 { margin:0; font-size:16px; }
+  .ix { background:#2a2c33; color:#c8c9cf; font-size:12px; font-weight:700; width:22px; height:22px; border-radius:50%; display:grid; place-items:center; }
+  .card img { display:block; width:100%; border-radius:7px; margin:6px 0 8px; border:1px solid #24262c; }
+  .obs, .act, .bug { margin:4px 0; font-size:14px; }
+  .obs b, .act b { color:#9fa0a8; font-weight:600; }
+  .bug { background:#241416; border:1px solid #4a2327; border-radius:7px; padding:7px 9px; }
+</style></head><body><div class="wrap">
+  <h1>Playtest — ${esc(data.mission)}</h1>
+  <p class="sub">goal: <b>${esc(data.goal || "explore & QA")}</b> · frontier: <b>${esc(data.frontier || "-")}</b> · ${esc(data.generated || "")}</p>
+  ${data.verdict ? `<p class="sub">${esc(data.verdict)}</p>` : ""}
+
+  <h2>Issues found (${(data.bugs || []).length})</h2>
+  <table><thead><tr><th>Sev</th><th>Class</th><th>Issue</th><th>Shot</th><th>Filed → Fix</th></tr></thead>
+  <tbody>${(data.bugs || []).map(bugRow).join("") || `<tr><td colspan="5" class="muted">none</td></tr>`}</tbody></table>
+
+  <h2>Timeline (${(data.steps || []).length} steps)</h2>
+  <div class="timeline">${(data.steps || []).map(stepHtml).join("")}</div>
+</div></body></html>`;
+
+const out = join(dir, "report.html");
+writeFileSync(out, html);
+console.log(`wrote ${out}`);

--- a/.claude/skills/play-through/walkthroughs/medsci1.md
+++ b/.claude/skills/play-through/walkthroughs/medsci1.md
@@ -1,0 +1,87 @@
+# Walkthrough — medsci1 (MedSci Deck 1)
+
+First playable deck. This walkthrough exercises the critical-path systems —
+player state, item pickup, objective tracking, and the level transition — with
+warp+teleport navigation.
+
+**Derived from game data** (`cargo dq entities medsci1.mis ...`):
+- The MedSci → Engineering transition is a `TrapTripLevel` tripwire, entity
+  **764** (`sym:Tripwire`), `PropDestLevel("eng1")`, `PropDestLoc(21)`, trigger
+  volume at **(12.684996, -5.635426, -43.591045)**. It fires on
+  `SensorBeginIntersect` — teleporting the player into the volume triggers it.
+- Pickup items exist as world entities (e.g. `20 Nanites`), resolvable at run
+  time by name/template.
+- Quest-bit entities here are mechanism triggers (elevator filters), not
+  narrative objectives; medsci1's objectives are goal-driven, so CP3 demonstrates
+  the quest-bit read/set path rather than asserting a specific mission objective.
+
+**External cross-check:** the intended path on MedSci-1 is wake → arm yourself →
+work through the deck → take the transition toward Engineering. The checkpoints
+below abstract that into verifiable states.
+
+Resolve item/trigger runtime ids at run time (`entities.list({filter})` /
+`entities.byTemplate`) rather than trusting the ids above — they are stable but
+the query is self-documenting and robust to data changes.
+
+---
+
+### CP1 — Spawn & load
+- setup: launch the debug runtime on `medsci1.mis`; `step({frames: 5})`.
+- act: none (pure state check).
+- verify:
+  - `info().mission == "medsci1.mis"`
+  - `info().player.hit_points` is non-null and `> 0` (player has a health pool)
+  - `player.position()` is all-finite
+  - `entities.list({limit:1}).total_count > 0` (world instantiated)
+- capture: screenshot `cp1-spawn.png`
+- on-fail: mission won't load / no player / no entities → `[functionality]`
+  (level load or entity instantiation). A null health pool → `[gameplay]` or
+  `[debug_runtime]` depending on whether the player truly has no `PropHitPoints`.
+
+### CP2 — Acquire an item (pickup)
+- setup: `const item = entities.list({filter:"*Nanites*", limit:50}).entities[0]`
+  (fall back to `*Wrench*` if none). Assert one was found.
+- act: `player.give(item.id)`.
+- verify:
+  - the give call succeeds
+  - `player.inventory()` contains an item with `entity_id == item.id` and
+    `location == "inventory"`
+- capture: screenshot `cp2-inventory.png` (open inventory if the HUD supports it)
+- on-fail: give rejects a valid pickup → `[gameplay]` (frob eligibility) or
+  `[debug_runtime]` (give lever). Item doesn't appear in inventory →
+  `[debug_runtime]` (inventory read) or `[gameplay]` (Contains link).
+
+### CP3 — Objective tracking (quest-bit path)
+- setup: none.
+- act: `quests.set("medsci.playthrough.cp3", "complete")`.
+- verify:
+  - `quests.get("medsci.playthrough.cp3") == "complete"`
+  - `quests.list()` includes it; resetting it to `"unknown"` removes it
+- capture: none.
+- on-fail: quest read/set disagree → `[debug_runtime]` (quest endpoint). (When a
+  real medsci1 objective bit is identified, replace this with: perform the
+  objective action, then assert the game-set bit flips — a `[gameplay]` check.)
+
+### CP4 — Level transition (MedSci → Engineering)
+- setup: `player.teleport({x:12.684996, y:-5.635426, z:-43.591045})` — into the
+  entity-764 tripwire volume.
+- act: `step({frames: 15})` to let `SensorBeginIntersect` fire.
+- verify:
+  - `info().mission == "eng1.mis"` (the transition fired and eng1 loaded)
+  - after `step({frames: 30})`, `player.position()` is all-finite (player is
+    live in the new level)
+- capture: screenshot `cp4-eng1.png`
+- on-fail: mission stays `medsci1.mis` → `[gameplay]` (tripwire/`TrapTripLevel`
+  didn't fire) — cross-check by warping directly (`transitionLevel("eng1", 21)`);
+  if the direct warp works but the trigger doesn't, it's the trigger. Runtime
+  crashes on transition → `[functionality]` (level load, e.g. the known
+  shodan.mis loader crash class).
+
+---
+
+## Notes for future (driving the player)
+
+CP targets are world positions, so a later upgrade can replace "teleport to CP"
+with "drive to CP" (thumbstick + step) to additionally exercise navmesh,
+collision, and locomotion over the same route — do this only once the
+warp+teleport run is green end-to-end.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: playtest
+description: >-
+  Play ONE session of a System Shock 2 mission via the headless debug runtime,
+  as a QA agent. SEE the world (screenshots you read) and ACT with the runtime's
+  tools (move, look, frob, pick up, attack, follow real triggers) toward a goal -
+  observe and react, don't run a script. Emit a structured data.json (per-step
+  screenshot + what you saw + what you did + any bug, plus the frontier reached
+  and the issues found) so the run renders to an HTML timeline and drives the
+  play-through loop. This is the atomic unit; the `play-through` manager runs it
+  in a fix-and-replay loop. Invoke with a mission (default medsci1), a start
+  state (fresh, or resume at a frontier), and a goal.
+---
+
+# playtest — play one session, report structured
+
+Play a mission the way a QA tester would: take in the world, interact, try to
+make progress toward the goal, and **notice** what's broken. Output a structured
+`data.json` + screenshots. You do NOT fix anything here — you observe and report;
+the `play-through` manager triages and delegates fixes.
+
+## Reach the start state
+- **Fresh:** launch the runtime on the mission (SDK `GameServer.launch`, or
+  `cargo dbgr --mission <m>.mis --port <p>`), `step 5` to settle.
+- **Resume at a frontier** (the manager passes one): warp with
+  `POST /v1/control/transition-level {level, loc}` and/or `teleport {x,y,z}` (or
+  `QuickLoad`) to where the last session stalled, so you don't replay solved parts.
+
+## Senses & hands (HTTP; SDK for lifecycle)
+
+| See the world | Act on it |
+| --- | --- |
+| `POST /v1/screenshot {filename}` → **Read `/tmp/claude/<file>`** (do this often) | `POST /v1/player/teleport {x,y,z}` (jump to inspect) |
+| `GET /v1/entities?filter=&limit=` (name/id/pos/distance) | `POST /v1/control/input {right_hand.thumbstick:[strafe,fwd]}` + step (walk) |
+| `GET /v1/entities/:id` (props, links) | `{left_hand.thumbstick:[turn,0]}` + step (look around) |
+| `GET /v1/info` (health, pos, wielded, psi) | `POST /v1/entities/:id/message {type:"Frob"\|"Damage"\|"TurnOn"}` |
+| `GET /v1/player/inventory` · `GET /v1/quests` | `POST /v1/player/give {entity_id}` (pick up) |
+| `GET /v1/transitions` (exits: dest + position) | follow an exit: teleport into a **tripwire** volume; **Frob** a bulkhead **button** |
+
+`/v1/step {frames:N}` after each action so it takes effect (deterministic; no
+sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
+
+## How to play (toward the goal)
+1. Screenshot + **read it**. Describe what you actually see; is it coherent or off?
+2. Explore: look around, list nearby entities, teleport near interesting ones
+   (door, corpse, item, terminal, monster) and screenshot each.
+3. Interact toward progress: pick up items, frob doors/terminals/keypads, fight,
+   and follow the level's real exit toward the goal.
+4. Hunt bugs the whole time: missing/black textures, floating/clipping/z-fighting,
+   T-posed or frozen creatures, doors that won't open, frobs that do nothing,
+   items that can't be taken, HUD glitches, physics weirdness, implausible
+   positions. Anything you'd file as a playtester — especially whatever **blocks
+   progress**.
+
+## Output: `data.json` (drop it next to the screenshots)
+
+Write a `data.json` in the run's output dir (same dir as the `pt-*.png`), in this
+exact shape — the manager renders it with `render-timeline.mjs` and reads the
+frontier/issues to drive the loop:
+
+```json
+{
+  "mission": "medsci1",
+  "goal": "reach the eng1 exit",
+  "generated": "iteration N",
+  "frontier": "medsci1 @ (x,y,z) — reached the locked Sci door",
+  "verdict": "one-line summary of how it went",
+  "steps": [
+    { "index": 1, "title": "Wake in cryo bay", "screenshot": "pt-01.png",
+      "observation": "what you saw", "action": "what you did",
+      "bug": { "severity": "High|Med|Low", "class": "[gameplay|visual|functionality]", "detail": "..." } }
+  ],
+  "bugs": [
+    { "title": "short", "severity": "High", "class": "[gameplay]", "screenshot": "pt-07.png",
+      "detail": "what's wrong + how you triggered it", "blocker": true }
+  ]
+}
+```
+
+- `steps[].bug` is optional (null when the step was clean).
+- Mark the progress **blocker** (`"blocker": true`) — the manager fixes it first.
+- Set `frontier` to the furthest reachable state so the next session resumes there.
+
+Return to the caller: the `data.json` path, the frontier, and the blocker (if any).
+Leave the runtime running only if asked; otherwise `POST /v1/shutdown`.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -32,20 +32,34 @@ the `play-through` manager triages and delegates fixes.
 
 | See the world | Act on it |
 | --- | --- |
-| `POST /v1/screenshot {filename}` → **Read `/tmp/claude/<file>`** (do this often) | `POST /v1/player/teleport {x,y,z}` (jump to inspect) |
+| `POST /v1/screenshot {filename}` → **Read `/tmp/claude/<file>`** (do this often) | **`POST /v1/player/move {x,y,z}`** — navigate (bounded ≤5u hop, collision-checked) |
 | `GET /v1/entities?filter=&limit=` (name/id/pos/distance) | `POST /v1/control/input {right_hand.thumbstick:[strafe,fwd]}` + step (walk) |
 | `GET /v1/entities/:id` (props, links) | `{left_hand.thumbstick:[turn,0]}` + step (look around) |
 | `GET /v1/info` (health, pos, wielded, psi) | `POST /v1/entities/:id/message {type:"Frob"\|"Damage"\|"TurnOn"}` |
 | `GET /v1/player/inventory` · `GET /v1/quests` | `POST /v1/player/give {entity_id}` (pick up) |
-| `GET /v1/transitions` (exits: dest + position) | follow an exit: teleport into a **tripwire** volume; **Frob** a bulkhead **button** |
+| `GET /v1/transitions` (exits: dest + position) | follow an exit: **move** up to a **tripwire** volume; **Frob** a bulkhead **button** |
 
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 
+**Navigate with `/v1/player/move`, not raw teleport.** It advances the player at
+most ~5 units toward the target and **shapecasts the player collider**, so it
+**cannot tunnel through walls or out of bounds** (returns `blocked:true`,
+`distance_moved < requested` when it hits geometry). So you walk to a place in
+short hops, checking screenshots — this is what makes it a real playtest instead
+of warping to arbitrary (often out-of-level) entity coordinates. Raw
+`/v1/player/teleport` is reserved for manager-driven setup/frontier-resume.
+
+**Doors block the shapecast** — you can't move through a closed one. The pattern:
+move up to the door → it trips the tripwire (or `Frob` it) → `step` and wait for
+it to open (re-screenshot) → then `move` through. That's genuine door-by-door
+traversal.
+
 ## How to play (toward the goal)
 1. Screenshot + **read it**. Describe what you actually see; is it coherent or off?
-2. Explore: look around, list nearby entities, teleport near interesting ones
-   (door, corpse, item, terminal, monster) and screenshot each.
+2. Explore: look around, list nearby entities, **move** (bounded hops) toward
+   interesting ones (door, corpse, item, terminal, monster) and screenshot each.
+   If a `move` reports `blocked`, something's in the way — that's real geometry.
 3. Interact toward progress: pick up items, frob doors/terminals/keypads, fight,
    and follow the level's real exit toward the goal.
 4. Hunt bugs the whole time: missing/black textures, floating/clipping/z-fighting,
@@ -82,6 +96,9 @@ frontier/issues to drive the loop:
 - `steps[].bug` is optional (null when the step was clean).
 - Mark the progress **blocker** (`"blocker": true`) — the manager fixes it first.
 - Set `frontier` to the furthest reachable state so the next session resumes there.
+- Optional **session video**: also capture `frame-NNNN.png` every 4 sim-frames
+  during play, stitch with the `video-capture` skill, and set `"video":
+  "session.mp4"` — `render-timeline.mjs` embeds it as a `<video>` in the report.
 
 Return to the caller: the `data.json` path, the frontier, and the blocker (if any).
 Leave the runtime running only if asked; otherwise `POST /v1/shutdown`.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -23,8 +23,10 @@ the `play-through` manager triages and delegates fixes.
 - **Fresh:** launch the runtime on the mission (SDK `GameServer.launch`, or
   `cargo dbgr --mission <m>.mis --port <p>`), `step 5` to settle.
 - **Resume at a frontier** (the manager passes one): warp with
-  `POST /v1/control/transition-level {level, loc}` and/or `teleport {x,y,z}` (or
-  `QuickLoad`) to where the last session stalled, so you don't replay solved parts.
+  `POST /v1/control/transition-level {level, loc}` and/or `teleport {x,y,z}` to
+  where the last session stalled, so you don't replay solved parts. (`QuickLoad`
+  — `POST /v1/input/action {"action":"QuickLoad"}` — only restores a `QuickSave`
+  made earlier in the *same* runtime session, so it's not a cross-launch resume.)
 
 ## Senses & hands (HTTP; SDK for lifecycle)
 

--- a/.claude/skills/video-capture/SKILL.md
+++ b/.claude/skills/video-capture/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: video-capture
+description: >-
+  Record an mp4 video of the headless debug runtime by capturing periodic
+  screenshots and stitching them with ffmpeg. Deterministic fixed-timestep: the
+  sim runs at 60Hz, so capturing a frame every 4 sim-frames yields real-time
+  15fps. Drive movement (turn/walk via /v1/control/input) while capturing for
+  smooth footage - a pan of a scene, a walk down a corridor, or a record of a
+  playtest session. Local artifact (not hosted), so file size is fine. Used
+  standalone to grab a clip, or by the `playtest` / `play-through` skills to
+  record a session.
+---
+
+# video-capture — record an mp4 from the debug runtime
+
+Turn the deterministic step+screenshot loop into a video. The sim is fixed 60Hz,
+so **capture every 4 sim-frames → real-time 15fps** (every 6 → 10fps). Screenshots
+are deterministic (each captures the fully-rendered frame), so no sleeps/retries.
+
+## Capture loop
+
+Against a running runtime (launch it, or reuse a `playtest` session). Make a
+subdir under `/tmp/claude/` (where the runtime writes shots) and capture
+sequential frames while something is moving:
+
+```bash
+mkdir -p /tmp/claude/rec
+# optional: drive smooth motion (a slow turn-in-place pan)
+curl -s -X POST :PORT/v1/control/input -d '{"left_hand.thumbstick":[0.35,0.0]}'
+for n in $(seq -w 1 60); do
+  curl -s -X POST :PORT/v1/step -d '{"frames":4}'                              # 4 -> 15fps
+  curl -s -X POST :PORT/v1/screenshot -d "{\"filename\":\"rec/frame-${n}.png\"}"
+done
+curl -s -X POST :PORT/v1/control/input -d '{"left_hand.thumbstick":[0.0,0.0]}'  # stop
+```
+
+Motion options via `/v1/control/input` (set channel, then step): `left_hand.thumbstick:[turn,0]`
+to look around, `right_hand.thumbstick:[strafe,forward]` to walk. A discrete
+teleport-and-poke session records as a choppier slideshow; continuous motion is
+smooth.
+
+## Assemble
+
+```bash
+node .claude/skills/video-capture/record-video.mjs /tmp/claude/rec        # -> rec/video.mp4 @ 15fps
+node .claude/skills/video-capture/record-video.mjs /tmp/claude/rec out.mp4 15
+```
+
+`record-video.mjs` globs `frame-*.png` and runs ffmpeg (`libx264`, `yuv420p`,
+even-dimension scale). Requires `ffmpeg` on PATH.
+
+## Notes
+- Delegate a long capture to a sub-agent (many screenshots — keep the image
+  traffic out of the main context); it returns the mp4 path.
+- Frame count / fps: N frames at F fps = N/F seconds. 60 frames @ 15fps = 4s.
+- Local-only artifact; embed/host separately only if a PR needs it (see
+  `pr-visuals` for GIF+gist hosting).

--- a/.claude/skills/video-capture/SKILL.md
+++ b/.claude/skills/video-capture/SKILL.md
@@ -24,14 +24,15 @@ subdir under `/tmp/claude/` (where the runtime writes shots) and capture
 sequential frames while something is moving:
 
 ```bash
+BASE=http://127.0.0.1:8080   # the runtime's port
 mkdir -p /tmp/claude/rec
 # optional: drive smooth motion (a slow turn-in-place pan)
-curl -s -X POST :PORT/v1/control/input -d '{"left_hand.thumbstick":[0.35,0.0]}'
+curl -s -X POST $BASE/v1/control/input -d '{"left_hand.thumbstick":[0.35,0.0]}'
 for n in $(seq -w 1 60); do
-  curl -s -X POST :PORT/v1/step -d '{"frames":4}'                              # 4 -> 15fps
-  curl -s -X POST :PORT/v1/screenshot -d "{\"filename\":\"rec/frame-${n}.png\"}"
+  curl -s -X POST $BASE/v1/step -d '{"frames":4}'                              # 4 -> 15fps
+  curl -s -X POST $BASE/v1/screenshot -d "{\"filename\":\"rec/frame-${n}.png\"}"
 done
-curl -s -X POST :PORT/v1/control/input -d '{"left_hand.thumbstick":[0.0,0.0]}'  # stop
+curl -s -X POST $BASE/v1/control/input -d '{"left_hand.thumbstick":[0.0,0.0]}'  # stop
 ```
 
 Motion options via `/v1/control/input` (set channel, then step): `left_hand.thumbstick:[turn,0]`

--- a/.claude/skills/video-capture/record-video.mjs
+++ b/.claude/skills/video-capture/record-video.mjs
@@ -30,15 +30,24 @@ if (frames.length === 0) {
 }
 
 // -vf scale trunc-to-even keeps libx264/yuv420p happy for odd-sized captures.
-execFileSync(
-  "ffmpeg",
-  [
-    "-y", "-framerate", String(fps),
-    "-pattern_type", "glob", "-i", join(dir, "frame-*.png"),
-    "-c:v", "libx264", "-pix_fmt", "yuv420p",
-    "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-    out,
-  ],
-  { stdio: ["ignore", "ignore", "inherit"] },
-);
+try {
+  execFileSync(
+    "ffmpeg",
+    [
+      "-y", "-framerate", String(fps),
+      "-pattern_type", "glob", "-i", join(dir, "frame-*.png"),
+      "-c:v", "libx264", "-pix_fmt", "yuv420p",
+      "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+      out,
+    ],
+    { stdio: ["ignore", "ignore", "inherit"] },
+  );
+} catch (e) {
+  console.error(
+    e.code === "ENOENT"
+      ? "ffmpeg not found on PATH — install ffmpeg (e.g. brew install ffmpeg)."
+      : `ffmpeg failed assembling ${dir}/frame-*.png -> ${out}: ${e.message}`,
+  );
+  process.exit(1);
+}
 console.log(`wrote ${out} (${frames.length} frames @ ${fps}fps)`);

--- a/.claude/skills/video-capture/record-video.mjs
+++ b/.claude/skills/video-capture/record-video.mjs
@@ -1,0 +1,44 @@
+// Assemble a directory of periodic screenshots into a video with ffmpeg.
+//
+//   node record-video.mjs <frameDir> [outFile] [fps=15]
+//
+// Expects sequential frames named frame-0001.png, frame-0002.png, ... in
+// <frameDir> (default out: <frameDir>/video.mp4). Handy for a playtest "video
+// record": during a session, capture a frame every 4 sim-frames (60Hz / 4 =
+// real-time 15fps) -
+//   POST /v1/step {frames:4}; POST /v1/screenshot {filename:"<sub>/frame-0001.png"}
+// (screenshots land under /tmp/claude/) - then run this to stitch them at 15fps.
+// Smooth footage needs continuous motion (drive left/right-stick via
+// /v1/control/input while capturing, e.g. a slow turn/walk); a discrete
+// teleport-and-poke session yields a choppier record.
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = process.argv[2];
+if (!dir || !existsSync(dir)) {
+  console.error("usage: node record-video.mjs <frameDir> [outFile] [fps]");
+  process.exit(1);
+}
+const out = process.argv[3] || join(dir, "video.mp4");
+const fps = process.argv[4] || "15";
+
+const frames = readdirSync(dir).filter((f) => /^frame-\d+\.png$/.test(f));
+if (frames.length === 0) {
+  console.error(`no frame-*.png in ${dir}`);
+  process.exit(1);
+}
+
+// -vf scale trunc-to-even keeps libx264/yuv420p happy for odd-sized captures.
+execFileSync(
+  "ffmpeg",
+  [
+    "-y", "-framerate", String(fps),
+    "-pattern_type", "glob", "-i", join(dir, "frame-*.png"),
+    "-c:v", "libx264", "-pix_fmt", "yuv420p",
+    "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+    out,
+  ],
+  { stdio: ["ignore", "ignore", "inherit"] },
+);
+console.log(`wrote ${out} (${frames.length} frames @ ${fps}fps)`);


### PR DESCRIPTION
## Summary

Adds the **`play-through`** skill — an automated game-tester harness that drives a mission end-to-end through a per-mission checkpoint walkthrough (headless debug runtime, deterministic fixed-timestep) and **verifies** each stage, turning every failure into a surfaced, classified, and fixed gap.

This is the payoff of the debug-runtime levers built for it: level-transition warp (#413), quest read/set + inventory read (#414), give-item (#417), and the teleport-position fix (#416).

## What it does

For each checkpoint: **setup** (warp / teleport / give item / set quest bit) → **act** → **verify** (mission name, objective bits, inventory, player health/position) → **screenshot**. On a failure it classifies the gap — `[debug_runtime]` (missing capability) / `[gameplay]` (broken trigger/script) / `[functionality]` (crash/asset) — **files a GitHub issue AND spawns a fix sub-agent in parallel**, linking the fix PR back to the issue, then re-runs the checkpoint.

## Contents

- **`SKILL.md`** — the loop, the toolkit table (which lever drives what), the gap taxonomy + file-and-fix delegation contract, warp+teleport navigation (with **driving the player** documented as the next upgrade — CP targets are world positions so the route is reusable), and the run-report format. Follows the repo's context-discipline pattern (delegate the heavy execution + each fix to sub-agents).
- **`walkthroughs/medsci1.md`** — the first walkthrough, **derived from game data** (`cargo dq`: the entity-764 MedSci→eng1 tripwire at a known volume, pickup items, the quest-bit path) and **cross-checked against the intended SS2 path**. Four checkpoints exercise spawn/health, item pickup, objective tracking, and the level transition.

## Design decisions (from discussion)

- First mission: **medsci1** (real transition + items + a health pool in one run).
- On a gap: **file issue AND fix-agent**, PR linked to issue.
- Navigation: **warp+teleport now**, driving the player later (once warp+teleport is green end-to-end).
- Checkpoints: **derived from game data**, cross-checked with an external walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)