### PR TITLE
fix(debug): entity-list sort panics on NaN distance (total order)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3961,11 +3961,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         );
 
         // Sort by distance from player
-        entities.sort_by(|a, b| {
-            a.distance
-                .partial_cmp(&b.distance)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // `total_cmp` is a genuine total order. `partial_cmp(..).unwrap_or(Equal)`
+        // is NOT: when an entity has a NaN distance (some levels, e.g. earth /
+        // rec2, contain an entity at a non-finite position) the comparator
+        // reports Equal inconsistently, which trips Rust's total-order check and
+        // panics the sort - killing the game thread on the next entity list.
+        entities.sort_by(|a, b| a.distance.total_cmp(&b.distance));
 
         // Apply limit if provided
         if let Some(limit) = limit {

--- a/tools/shock2-sdk/playthrough-sweep.mjs
+++ b/tools/shock2-sdk/playthrough-sweep.mjs
@@ -1,0 +1,151 @@
+// Full-game play-through sweep. For each mission in narrative order: load it,
+// run baseline checkpoints (spawn/health, carried inventory, notable items,
+// transition targets), log richly, and screenshot each checkpoint. Writes a
+// markdown report to /tmp/claude/playthrough/report.md; screenshots land in
+// /tmp/claude/ (the runtime's fixed output dir). Robust per-mission (one crash
+// won't abort the sweep). Report-only: does not file issues / spawn fix-agents.
+import { GameServer } from "./dist/src/index.js";
+import { mkdirSync, writeFileSync, renameSync, existsSync } from "node:fs";
+
+// Narrative order (Data/ has all of these). shodan is last and known to crash
+// on load (#267) - kept in so the sweep records it as a [functionality] gap.
+const MISSIONS = process.env.SWEEP_MISSIONS
+  ? process.env.SWEEP_MISSIONS.split(",")
+  : [
+      "earth", "station",
+      "medsci1", "medsci2",
+      "eng1", "eng2",
+      "hydro1", "hydro2", "hydro3",
+      "ops1", "ops2", "ops3", "ops4",
+      "rec1", "rec2", "rec3",
+      "command1", "command2",
+      "rick1", "rick2", "rick3",
+      "many", "shodan",
+    ];
+
+const ITEM_CATEGORIES = {
+  weapon: /wrench|pistol|shotgun|assault|laser|rifle|grenade|crystal|fusion|worm launcher|stasis/i,
+  ammo: /bullet|shell|nanite|clip|cell|ammo|slug|dart/i,
+  consumable: /hypo|medkit|med patch|patch|booster|kit|drink|snack|juice|chips/i,
+  keycard: /keycard|access card|key card|regen|replicator code|card$/i,
+  log: /log|email|audiolog|data ?log|note/i,
+};
+const SCR = "/tmp/claude";
+const OUT = "/tmp/claude/playthrough";
+mkdirSync(OUT, { recursive: true });
+
+const finite = (p) => [p.x, p.y, p.z].every(Number.isFinite);
+const report = [];
+const summary = [];
+
+async function shot(game, name) {
+  try {
+    await game.screenshot(name);
+    const src = `${SCR}/${name}`;
+    if (existsSync(src)) {
+      renameSync(src, `${OUT}/${name}`);
+      return `![${name}](${name})`;
+    }
+  } catch {}
+  return `(screenshot ${name} unavailable)`;
+}
+
+async function sweepMission(mission, index) {
+  const port = 8140 + index;
+  const lines = [`\n## ${mission}`];
+  let loaded = false;
+  let game;
+  try {
+    game = await GameServer.launch({ mission: `${mission}.mis`, port });
+  } catch (e) {
+    lines.push(`- **LOAD FAILED** — \`${String(e.message).slice(0, 200)}\``);
+    lines.push(`- GAP [functionality]: ${mission} did not launch/become ready.`);
+    summary.push({ mission, loaded: false, gap: "load-failed" });
+    report.push(lines.join("\n"));
+    return;
+  }
+  try {
+    await game.step({ frames: 5 });
+    const info = await game.info();
+    const pos = await game.player.position();
+    loaded = info.mission != null;
+
+    // CP1 — load & player state
+    const hp = info.player.hit_points;
+    lines.push(`### CP1 — Load & player state`);
+    lines.push(`- mission: \`${info.mission}\``);
+    lines.push(`- health: ${hp == null ? "none" : `${hp}/${info.player.max_hit_points}`}`);
+    lines.push(`- psi: ${info.player.psi_points == null ? "none" : `${info.player.psi_points}/${info.player.max_psi_points}`}`);
+    lines.push(`- wielded: ${info.player.wielded_entity_id ?? "none"}`);
+    lines.push(`- position: (${pos.x.toFixed(1)}, ${pos.y.toFixed(1)}, ${pos.z.toFixed(1)}) finite=${finite(pos)}`);
+    lines.push(`- ${await shot(game, `${mission}-cp1-spawn.png`)}`);
+
+    // full entity list (one call), used for items + transitions
+    const all = (await game.entities.list()).entities;
+    lines.push(`- entities: ${all.length}`);
+
+    // CP2 — carried inventory
+    const inv = await game.player.inventory();
+    lines.push(`### CP2 — Carried inventory (${inv.count})`);
+    if (inv.items.length === 0) lines.push(`- (empty)`);
+    for (const it of inv.items)
+      lines.push(`- ${it.name ?? "?"} (#${it.entity_id}) @ ${it.location}`);
+
+    // CP3 — notable items present in the level
+    lines.push(`### CP3 — Notable items in level`);
+    const byCat = {};
+    for (const e of all) {
+      for (const [cat, re] of Object.entries(ITEM_CATEGORIES)) {
+        if (re.test(e.name)) {
+          (byCat[cat] ??= []).push(e);
+          break;
+        }
+      }
+    }
+    for (const [cat, es] of Object.entries(byCat)) {
+      const names = [...new Set(es.map((e) => e.name))].slice(0, 6).join(", ");
+      lines.push(`- **${cat}** (${es.length}): ${names}${es.length > 6 ? " …" : ""}`);
+    }
+    if (Object.keys(byCat).length === 0) lines.push(`- (none matched)`);
+    lines.push(`- ${await shot(game, `${mission}-cp3-items.png`)}`);
+
+    // CP4 — transition triggers present (the exact DestLevel is an inherited
+    // property, which the runtime's entity-detail exposes only as direct props;
+    // resolving it needs dark_query - a surfaced [debug_runtime] gap).
+    lines.push(`### CP4 — Transition triggers`);
+    const triggers = all.filter((e) => /tripwire|bulk_on|levelchange|elevator/i.test(e.name));
+    const names = [...new Set(triggers.map((t) => t.name))].slice(0, 8).join(", ");
+    lines.push(`- ${triggers.length} trigger(s): ${names || "(none)"}`);
+
+    summary.push({ mission, loaded: true, hp, entities: all.length, items: Object.keys(byCat).length, triggers: triggers.length });
+  } catch (e) {
+    lines.push(`- **ERROR during sweep** — \`${String(e.message).slice(0, 200)}\``);
+    summary.push({ mission, loaded, gap: "sweep-error" });
+  } finally {
+    try { await game[Symbol.asyncDispose](); } catch {}
+  }
+  report.push(lines.join("\n"));
+  console.log(`  swept ${mission}: loaded=${loaded}`);
+}
+
+console.log(`Sweeping ${MISSIONS.length} missions...`);
+for (let i = 0; i < MISSIONS.length; i++) {
+  await sweepMission(MISSIONS[i], i);
+}
+
+// Assemble report
+const header = [
+  `# Full-game play-through sweep`,
+  ``,
+  `| mission | loaded | health | entities | item cats | triggers |`,
+  `| --- | --- | --- | --- | --- | --- |`,
+  ...summary.map(
+    (s) =>
+      `| ${s.mission} | ${s.loaded ? "✅" : "❌ " + (s.gap ?? "")} | ${s.hp ?? "-"} | ${s.entities ?? "-"} | ${s.items ?? "-"} | ${s.triggers ?? "-"} |`,
+  ),
+  ``,
+  `Loaded ${summary.filter((s) => s.loaded).length}/${MISSIONS.length} missions.`,
+];
+writeFileSync(`${OUT}/report.md`, header.join("\n") + "\n" + report.join("\n") + "\n");
+console.log(`\nReport: ${OUT}/report.md`);
+console.log(header.join("\n"));

--- a/tools/shock2-sdk/test/entity-list-sort.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-list-sort.e2e.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end regression for the entity-list distance sort. Requires game assets
+// in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: earth.mis (and rec2.mis) contain an entity at a non-finite
+// position, so its `distance` is NaN. list_entities sorted with
+// `partial_cmp(..).unwrap_or(Equal)`, which is not a total order - Rust's sort
+// panicked ("comparison function does not correctly implement a total order"),
+// killing the game thread, so the NEXT request got 503. This asserts listing
+// entities in earth succeeds and the runtime stays live.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "entity list does not panic on a NaN distance (earth.mis)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
+    });
+    await game.step({ frames: 5 });
+
+    // Before the fix this call crashed the game thread mid-sort.
+    const list = await game.entities.list();
+    assert.ok(list.total_count >= 0, "entity list should return");
+
+    // The runtime is still live afterward (a crash would 503 here).
+    const info = await game.info();
+    assert.equal(info.mission, "earth.mis", "runtime should stay live after listing");
+  },
+);


### PR DESCRIPTION
## Summary

Fixes a game-thread crash surfaced by the `play-through` full-game sweep: `earth.mis` and `rec2.mis` crashed the instant the harness listed entities.

Fixes #419.

## Root cause

`MissionCore::list_entities` sorted by distance with `partial_cmp(&b.distance).unwrap_or(Equal)` — **not a total order**. Some levels contain an entity at a non-finite position (NaN distance), so the comparator reports `Equal` inconsistently, and Rust's sort **panics** (`comparison function does not correctly implement a total order`), killing the game thread → the next request 503s.

## Fix

Sort with `f32::total_cmp` — a genuine total order (NaN sorts consistently).

## Verification

- Live: `earth.mis` now lists entities (`Starting_Location`, `Large Tram …`) with 0 panics; the runtime stays live.
- e2e (negative-first): `entity-list-sort.e2e.test.ts` lists entities in earth and asserts the runtime survives (it panicked before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)