### PR TITLE
feat(debug): /v1/transitions endpoint for trigger-based level chaining

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -58,6 +58,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<PlayerInventoryResult>,
     },
 
+    /// List level-transition triggers (dest + position) for trigger-based traversal.
+    ListTransitions {
+        reply: oneshot::Sender<TransitionsResult>,
+    },
+
     /// Put an existing world entity into the player's inventory (headless pickup).
     GiveItem {
         entity_id: i32,
@@ -406,6 +411,24 @@ pub struct InventoryItemEntry {
 #[derive(Debug, Serialize)]
 pub struct PlayerInventoryResult {
     pub items: Vec<InventoryItemEntry>,
+    pub count: usize,
+}
+
+/// A level-transition trigger and where it leads.
+#[derive(Debug, Serialize)]
+pub struct TransitionEntry {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    /// Destination mission (no ".mis" suffix, e.g. "eng1").
+    pub dest_level: String,
+    pub dest_loc: Option<i32>,
+    pub position: [f32; 3],
+}
+
+/// All level-transition triggers in the current scene.
+#[derive(Debug, Serialize)]
+pub struct TransitionsResult {
+    pub transitions: Vec<TransitionEntry>,
     pub count: usize,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -281,6 +281,7 @@ async fn start_http_server(
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
         .route("/v1/player/inventory", get(get_player_inventory))
+        .route("/v1/transitions", get(list_transitions))
         .route("/v1/player/give", axum::routing::post(give_item))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
@@ -954,6 +955,31 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send player inventory - receiver dropped");
+            }
+        }
+        RuntimeCommand::ListTransitions { reply } => {
+            let transitions: Vec<commands::TransitionEntry> = game
+                .debug_scene()
+                .map(|scene| {
+                    scene
+                        .list_transitions()
+                        .into_iter()
+                        .map(|t| commands::TransitionEntry {
+                            entity_id: t.entity_id,
+                            name: t.name,
+                            dest_level: t.dest_level,
+                            dest_loc: t.dest_loc,
+                            position: t.position,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let result = commands::TransitionsResult {
+                count: transitions.len(),
+                transitions,
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send transitions - receiver dropped");
             }
         }
         RuntimeCommand::GiveItem { entity_id, reply } => {
@@ -2165,6 +2191,28 @@ async fn get_player_inventory(
         Ok(result) => Ok(Json(result)),
         Err(_) => {
             tracing::error!("Failed to receive player inventory - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler listing level-transition triggers (dest + position), so a tester
+/// can follow the real triggers between levels instead of warping explicitly.
+async fn list_transitions(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<commands::TransitionsResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::ListTransitions { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send ListTransitions command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive transitions - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -334,6 +334,19 @@ pub struct DebugInventoryItem {
     pub location: String,
 }
 
+/// A level-transition trigger (a `TrapTripLevel` tripwire / bulkhead): where it
+/// leads (`dest_level` + optional spawn `dest_loc`) and its world `position`, so
+/// a tester can teleport into its volume and let the real trigger fire the
+/// transition (rather than warping explicitly).
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugTransition {
+    pub entity_id: i32,
+    pub name: Option<String>,
+    pub dest_level: String,
+    pub dest_loc: Option<i32>,
+    pub position: [f32; 3],
+}
+
 /// Debug scene trait for remote debugging capabilities
 ///
 /// This trait provides debugging and inspection capabilities for game scenes,
@@ -473,6 +486,13 @@ pub trait DebuggableScene {
     /// unsupported.
     fn give_item(&mut self, _entity_id: EntityId) -> Result<(), String> {
         Err("scene does not support giving items".to_string())
+    }
+
+    /// Level-transition triggers in this scene (where each leads + its position),
+    /// so a tester can follow the real triggers between levels instead of warping
+    /// explicitly. Empty when the scene has none.
+    fn list_transitions(&self) -> Vec<DebugTransition> {
+        Vec::new()
     }
 
     /// Get current input context state

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4533,6 +4533,36 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         }
     }
 
+    fn list_transitions(&self) -> Vec<crate::game_scene::DebugTransition> {
+        use dark::properties::{PropDestLevel, PropDestLoc, PropPosition, PropSymName};
+        use shipyard::Get;
+        // `PropDestLevel` is a live component on each transition trigger (the
+        // trigger script reads it the same way), so we can list every trigger
+        // with where it leads and its volume position.
+        self.world.run(
+            |v_dest: View<PropDestLevel>,
+             v_loc: View<PropDestLoc>,
+             v_pos: View<PropPosition>,
+             v_sym: View<PropSymName>| {
+                let mut out = Vec::new();
+                for (id, dest) in v_dest.iter().with_id() {
+                    let position = v_pos
+                        .get(id)
+                        .map(|p| [p.position.x, p.position.y, p.position.z])
+                        .unwrap_or([0.0, 0.0, 0.0]);
+                    out.push(crate::game_scene::DebugTransition {
+                        entity_id: id.inner() as i32,
+                        name: v_sym.get(id).ok().map(|s| s.0.clone()),
+                        dest_level: dest.0.clone(),
+                        dest_loc: v_loc.get(id).ok().map(|l| l.0),
+                        position,
+                    });
+                }
+                out
+            },
+        )
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         // MissionCore doesn't store InputContext directly - it's passed to update()
         // For debugging purposes, return a default state

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -349,6 +349,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.give_item(entity_id)
     }
 
+    fn list_transitions(&self) -> Vec<crate::game_scene::DebugTransition> {
+        self.mission_core.list_transitions()
+    }
+
     fn get_input_state(&self) -> crate::input_context::InputContext {
         self.mission_core.get_input_state()
     }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -21,6 +21,7 @@ import type {
   QuestBitsResult,
   QuestBitValue,
   PlayerInventoryResult,
+  TransitionsResult,
   WaitForOptions,
 } from "./types.js";
 
@@ -271,6 +272,15 @@ export class Game {
 
   async raycast(request: RayCastRequest): Promise<RayCastResult> {
     return this.client.post<RayCastResult>("/v1/physics/raycast", request);
+  }
+
+  /**
+   * Level-transition triggers in the current scene (where each leads + its
+   * position). Teleport into a trigger's position and step to let the real
+   * trigger fire the transition, instead of warping with transitionLevel().
+   */
+  async transitions(): Promise<TransitionsResult> {
+    return this.client.get<TransitionsResult>("/v1/transitions");
   }
 
   /**

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -240,6 +240,20 @@ export interface PlayerInventoryResult {
   count: number;
 }
 
+export interface TransitionEntry {
+  entity_id: number;
+  name: string | null;
+  /** Destination mission (no ".mis" suffix, e.g. "eng1"). */
+  dest_level: string;
+  dest_loc: number | null;
+  position: Vec3;
+}
+
+export interface TransitionsResult {
+  transitions: TransitionEntry[];
+  count: number;
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/test/transitions-trigger.e2e.test.ts
+++ b/tools/shock2-sdk/test/transitions-trigger.e2e.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for trigger-based level chaining. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before GET /v1/transitions, a tester could not discover where
+// a level's transition triggers lead at runtime (DestLevel is an inherited
+// property, invisible in entity-detail), so the only way to change level was the
+// explicit transitionLevel() warp. This discovers the forward trigger, teleports
+// into its volume, and lets the REAL trigger script fire the transition.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "transitions: discover the forward trigger and let it fire the level change",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+    });
+    await game.step({ frames: 5 });
+
+    const { transitions } = await game.transitions();
+    assert.ok(transitions.length > 0, "medsci1 should expose transition triggers");
+
+    // Find the forward trigger to Engineering.
+    const toEng1 = transitions.find((t) => t.dest_level === "eng1");
+    assert.ok(toEng1, `expected a trigger to eng1, got ${JSON.stringify(transitions.map((t) => t.dest_level))}`);
+    assert.ok(
+      toEng1.position.every(Number.isFinite),
+      "the trigger should have a finite volume position",
+    );
+
+    // Teleport into the trigger's volume and step - the real TrapTripLevel
+    // script fires on SensorBeginIntersect (no explicit warp).
+    const [x, y, z] = toEng1.position;
+    await game.player.teleport({ x, y, z });
+    await game.step({ frames: 15 });
+
+    assert.equal(
+      (await game.info()).mission,
+      "eng1.mis",
+      "entering the trigger volume should transition to eng1 via the real trigger",
+    );
+  },
+);


### PR DESCRIPTION
Adds `GET /v1/transitions` — lists each level-transition trigger with its destination (`dest_level`/`dest_loc`) and world position, so the play-through harness can follow the **real triggers** between levels (teleport into the forward trigger's volume → its script fires the transition) instead of warping explicitly. Fixes #421.

Destinations were unreadable at runtime (inherited `DestLevel`); but `PropDestLevel` is a live component (the trigger script reads it the same way), so `list_transitions()` iterates `View<PropDestLevel>`. Forwarded `Mission → mission_core`.

**e2e (negative-first):** discover medsci1's forward trigger to eng1, teleport into its volume, assert the real trigger fires (mission → `eng1.mis`). Verified live: medsci1 → `eng1 via Tripwire @ (12.7,-5.6,-43.6)` + two bulkheads → medsci2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)