### PR TITLE
fix(station): advance training-year counter monotonically (deploy to medsci1)

### DIFF
--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -16,17 +16,19 @@ impl ChooseMissionScript {
     fn get_current_year(world: &World) -> u32 {
         let quest_info = world.borrow::<UniqueView<QuestInfo>>().unwrap();
 
-        // Check for training year quest bits (training_year_1, training_year_2, etc.)
+        // The HIGHEST completed training year (default 1 when none set), so each
+        // trigger advances the counter monotonically. Returning the *lowest*
+        // completed bit made it stick: once training_year_2 and _3 were both set
+        // it always returned 2 -> new_year 3 < 4, re-looping station.mis forever
+        // and never reaching the year-4 deploy-to-medsci1 branch.
+        let mut highest = 1;
         for year in 1..=4 {
             let quest_bit_name = format!("training_year_{}", year);
-            let quest_bit_value = quest_info.read_quest_bit_value(&quest_bit_name);
-            if quest_bit_value == QuestBitValue::COMPLETE {
-                return year;
+            if quest_info.read_quest_bit_value(&quest_bit_name) == QuestBitValue::COMPLETE {
+                highest = year;
             }
         }
-
-        // If no training year quest bits are set, default to year 1
-        1
+        highest
     }
 
     fn set_training_year(year: u32) -> Effect {

--- a/tools/shock2-sdk/test/station-career.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career.e2e.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the station training-year progression. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: ChooseMissionScript::get_current_year returned the LOWEST
+// completed training_year_N bit, so once years 2 and 3 were both set it computed
+// year 3 forever (< 4), re-looping station.mis and NEVER reaching the year-4
+// deploy-to-medsci1 branch - the intro was uncompletable. This fires the
+// training trigger repeatedly and asserts it deploys to medsci1 within a few
+// tours (it looped indefinitely before the fix).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station: training rounds advance and deploy to medsci1",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+    });
+    await game.step({ frames: 10 });
+
+    // Fire the ChooseMission trigger (the transition whose destination is
+    // medsci1); station reloads between tours, so re-find it each time.
+    let mission = (await game.info()).mission;
+    for (let fire = 0; fire < 6 && mission === "station.mis"; fire++) {
+      const trigger = (await game.transitions()).transitions.find((t) =>
+        t.dest_level.toLowerCase().includes("medsci1"),
+      );
+      assert.ok(trigger, "station should expose a ChooseMission trigger to medsci1");
+      // TurnOn is a valid debug message; the SDK's typed union predates it.
+      await game.entities.sendMessage(trigger.entity_id, {
+        type: "TurnOn",
+      } as unknown as Parameters<typeof game.entities.sendMessage>[1]);
+      await game.step({ frames: 20 });
+      mission = (await game.info()).mission;
+    }
+
+    assert.equal(
+      mission.toLowerCase(),
+      "medsci1.mis",
+      `training should deploy to medsci1 (looped forever before the fix); ended at ${mission}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #423. `ChooseMissionScript::get_current_year` returned the *lowest* completed `training_year_N` bit, so once years 2+3 were set it computed year 3 forever and re-looped station.mis — the intro never reached the year-4 deploy-to-medsci1 branch. Now returns the *highest* completed year so the counter advances (2→3→4). Surfaced by the play-through intro playtest; verified live (3 tours → MedSci1) + negative-first e2e (`station-career.e2e.test.ts`). Career branching + skill trainers remain unimplemented (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)