### PR TITLE
feat(station): career (Marine/Navy/OSA) branching + skill trainer stubs

### DIFF
--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -73,6 +73,21 @@ impl DesktopInputMapper {
                 modifier: Modifier::Alt,
                 action: InputAction::QuickLoad,
             },
+            Binding {
+                key: Key::F1,
+                modifier: Modifier::None,
+                action: InputAction::SelectCareerMarine,
+            },
+            Binding {
+                key: Key::F2,
+                modifier: Modifier::None,
+                action: InputAction::SelectCareerNavy,
+            },
+            Binding {
+                key: Key::F3,
+                modifier: Modifier::None,
+                action: InputAction::SelectCareerOsa,
+            },
         ];
 
         Self {

--- a/shock2vr/src/career.rs
+++ b/shock2vr/src/career.rs
@@ -1,0 +1,180 @@
+//! Player career branching for the station recruit deck.
+//!
+//! System Shock 2 opens on the recruitment station, where the player picks one
+//! of three service branches - Marine (combat), Navy (tech), or OSA (psi) - and
+//! deploys to the Von Braun (MedSci 1) with a career-appropriate build. The
+//! branch is chosen via `P$Service` (see `ChooseServiceScript`) or the debug
+//! `SelectCareer*` input actions, registered as a persisted quest bit so it
+//! survives the level transition, then applied to the player on deployment.
+//!
+//! The per-career attribute table here is a faithful-in-spirit starting point,
+//! not the exact retail OS-unit numbers: it emphasises each branch (Marines are
+//! tanky, OSA are psionic) so the three careers arrive observably different.
+//! A full skill/stat/cyber-module system - and wiring the in-world station
+//! debrief UI to `ChooseServiceScript` - is deferred (issue #424).
+
+use dark::properties::QuestBitValue;
+
+use crate::quest_info::QuestInfo;
+use crate::scripts::Effect;
+
+/// `PsiPull` (Kinetic Redirection) - a tier-1 offensive psi power. OSA recruits
+/// deploy trained in it on top of the default Projected Cryokinesis.
+const PSIPULL_TEMPLATE_ID: i32 = -1022;
+
+/// The three service branches a recruit can enlist in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Career {
+    Marine,
+    Navy,
+    Osa,
+}
+
+/// The starting attributes a career deploys with. Applied as absolute values
+/// (not deltas) so re-applying on every level load is idempotent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CareerLoadout {
+    /// Current and maximum hit points on deployment.
+    pub max_hit_points: i32,
+    /// Current and maximum psi points on deployment.
+    pub max_psi_points: i32,
+    /// An extra psi power the career starts trained in (beyond the default
+    /// Cryokinesis), by template id. `None` for non-psi careers.
+    pub extra_psi_power: Option<i32>,
+}
+
+impl Career {
+    pub const ALL: [Career; 3] = [Career::Marine, Career::Navy, Career::Osa];
+
+    /// Map a `P$Service` value (0 = Marines, 1 = Navy, 2 = OSA) to a career.
+    pub fn from_service(service: u32) -> Career {
+        match service {
+            1 => Career::Navy,
+            2 => Career::Osa,
+            _ => Career::Marine,
+        }
+    }
+
+    /// The persisted quest bit that records this career choice.
+    pub fn quest_bit(&self) -> &'static str {
+        match self {
+            Career::Marine => "career_marine",
+            Career::Navy => "career_navy",
+            Career::Osa => "career_osa",
+        }
+    }
+
+    /// The career the player selected, read from the persisted quest bits, or
+    /// `None` if no branch was chosen (the player template defaults stand).
+    pub fn from_quest_info(quest_info: &QuestInfo) -> Option<Career> {
+        Career::ALL
+            .into_iter()
+            .find(|c| quest_info.read_quest_bit_value(c.quest_bit()) == QuestBitValue::COMPLETE)
+    }
+
+    /// The career-appropriate starting attributes applied on deployment.
+    pub fn loadout(&self) -> CareerLoadout {
+        match self {
+            // Marines: front-line combat - tanky, minimal psi.
+            Career::Marine => CareerLoadout {
+                max_hit_points: 45,
+                max_psi_points: 20,
+                extra_psi_power: None,
+            },
+            // Navy: technical - balanced (tech/repair skills are deferred).
+            Career::Navy => CareerLoadout {
+                max_hit_points: 35,
+                max_psi_points: 35,
+                extra_psi_power: None,
+            },
+            // OSA: psi operative - frail but psionically potent, deploys with an
+            // extra offensive power.
+            Career::Osa => CareerLoadout {
+                max_hit_points: 30,
+                max_psi_points: 60,
+                extra_psi_power: Some(PSIPULL_TEMPLATE_ID),
+            },
+        }
+    }
+
+    /// Effects that register this career choice: set its bit `COMPLETE` and
+    /// clear the other two, so the three branches stay mutually exclusive.
+    pub fn select_effects(&self) -> Vec<Effect> {
+        Career::ALL
+            .into_iter()
+            .map(|c| Effect::SetQuestBit {
+                quest_bit_name: c.quest_bit().to_string(),
+                quest_bit_value: if c == *self {
+                    QuestBitValue::COMPLETE
+                } else {
+                    QuestBitValue::UNKNOWN
+                },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_maps_to_career() {
+        assert_eq!(Career::from_service(0), Career::Marine);
+        assert_eq!(Career::from_service(1), Career::Navy);
+        assert_eq!(Career::from_service(2), Career::Osa);
+        assert_eq!(Career::from_service(99), Career::Marine);
+    }
+
+    #[test]
+    fn careers_arrive_observably_different() {
+        let marine = Career::Marine.loadout();
+        let navy = Career::Navy.loadout();
+        let osa = Career::Osa.loadout();
+
+        // Hit points and psi points differ across all three branches.
+        assert_ne!(marine.max_hit_points, navy.max_hit_points);
+        assert_ne!(navy.max_hit_points, osa.max_hit_points);
+        assert_ne!(marine.max_hit_points, osa.max_hit_points);
+        assert_ne!(marine.max_psi_points, navy.max_psi_points);
+        assert_ne!(navy.max_psi_points, osa.max_psi_points);
+
+        // Only OSA deploys with an extra psi power.
+        assert!(marine.extra_psi_power.is_none());
+        assert!(osa.extra_psi_power.is_some());
+    }
+
+    #[test]
+    fn select_makes_careers_mutually_exclusive() {
+        let mut quest_info = QuestInfo::new();
+        for effect in Career::Osa.select_effects() {
+            if let Effect::SetQuestBit {
+                quest_bit_name,
+                quest_bit_value,
+            } = effect
+            {
+                quest_info.set_quest_bit_value(&quest_bit_name, quest_bit_value);
+            }
+        }
+
+        assert_eq!(Career::from_quest_info(&quest_info), Some(Career::Osa));
+
+        // Switching branch clears the previous one.
+        for effect in Career::Marine.select_effects() {
+            if let Effect::SetQuestBit {
+                quest_bit_name,
+                quest_bit_value,
+            } = effect
+            {
+                quest_info.set_quest_bit_value(&quest_bit_name, quest_bit_value);
+            }
+        }
+
+        assert_eq!(Career::from_quest_info(&quest_info), Some(Career::Marine));
+    }
+
+    #[test]
+    fn no_choice_reads_as_none() {
+        assert_eq!(Career::from_quest_info(&QuestInfo::new()), None);
+    }
+}

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -54,6 +54,15 @@ pub enum InputAction {
     /// Force every monster back to Lowest alertness (idle). Same caveats as
     /// DebugAlertAll.
     DebugCalmAll,
+
+    /// Enlist in the Marine (combat) service branch at the station recruit
+    /// deck. Registers the career (persisted quest bit) so it applies on the
+    /// next deployment. Mutually exclusive with the other two.
+    SelectCareerMarine,
+    /// Enlist in the Navy (tech) service branch. See `SelectCareerMarine`.
+    SelectCareerNavy,
+    /// Enlist in the OSA (psi) service branch. See `SelectCareerMarine`.
+    SelectCareerOsa,
 }
 
 impl InputAction {
@@ -75,6 +84,9 @@ impl InputAction {
             InputAction::DebugReloadLevel,
             InputAction::DebugAlertAll,
             InputAction::DebugCalmAll,
+            InputAction::SelectCareerMarine,
+            InputAction::SelectCareerNavy,
+            InputAction::SelectCareerOsa,
         ]
     }
 
@@ -94,6 +106,9 @@ impl InputAction {
             InputAction::DebugReloadLevel => "DebugReloadLevel",
             InputAction::DebugAlertAll => "DebugAlertAll",
             InputAction::DebugCalmAll => "DebugCalmAll",
+            InputAction::SelectCareerMarine => "SelectCareerMarine",
+            InputAction::SelectCareerNavy => "SelectCareerNavy",
+            InputAction::SelectCareerOsa => "SelectCareerOsa",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -90,6 +90,15 @@ impl ActionDispatcher {
                 level: AIAlertLevel::Lowest,
             });
         }
+        if state.just_triggered(InputAction::SelectCareerMarine) {
+            effects.extend(crate::career::Career::Marine.select_effects());
+        }
+        if state.just_triggered(InputAction::SelectCareerNavy) {
+            effects.extend(crate::career::Career::Navy.select_effects());
+        }
+        if state.just_triggered(InputAction::SelectCareerOsa) {
+            effects.extend(crate::career::Career::Osa.select_effects());
+        }
 
         effects
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -9,6 +9,7 @@ pub mod scenes;
 pub mod teleport;
 pub mod time;
 
+mod career;
 mod creature;
 mod flat_player_controller;
 mod gui;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -387,12 +387,42 @@ impl MissionCore {
         // Debug scenes unlock every power (debug_psi exercises the whole
         // registry); real missions start with the player template's learned
         // bits plus the default OSA loadout (Cryokinesis).
-        let known_powers = crate::psi::build_known_powers(
+        let mut known_powers = crate::psi::build_known_powers(
             &entity_info_rc,
             &psi_powers,
             THE_PLAYER_TEMPLATE_ID,
             mission.starts_with("debug_"),
         );
+
+        // Apply the career (Marine/Navy/OSA) chosen at the station recruit deck.
+        // The choice is persisted as a quest bit, so it re-applies on every
+        // deployment; with no career selected the player template defaults
+        // (30 HP, 40/50 psi) stand. Absolute values keep re-application
+        // idempotent across level loads.
+        if let Some(career) = crate::career::Career::from_quest_info(&quest_info) {
+            let loadout = career.loadout();
+            world.run(
+                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
+                 mut v_max_hp: ViewMut<dark::properties::PropMaxHitPoints>,
+                 mut v_psi: ViewMut<dark::properties::PropPsiState>| {
+                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
+                        hp.hit_points = loadout.max_hit_points;
+                    }
+                    if let Ok(max_hp) = (&mut v_max_hp).get(player_entity) {
+                        max_hp.hit_points = loadout.max_hit_points as u32;
+                    }
+                    if let Ok(psi) = (&mut v_psi).get(player_entity) {
+                        psi.psi_points = loadout.max_psi_points;
+                        psi.max_psi_points = loadout.max_psi_points;
+                    }
+                },
+            );
+            if let Some(power) = loadout.extra_psi_power {
+                known_powers.0.insert(power);
+            }
+            info!("Applied {:?} career loadout to player", career);
+        }
+
         world.add_unique(psi_powers);
         world.add_unique(psi_selection);
         world.add_unique(known_powers);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -398,7 +398,11 @@ impl MissionCore {
         // The choice is persisted as a quest bit, so it re-applies on every
         // deployment; with no career selected the player template defaults
         // (30 HP, 40/50 psi) stand. Absolute values keep re-application
-        // idempotent across level loads.
+        // idempotent across level loads. Setting current = max mirrors the
+        // engine's existing model: the player is `RuntimePropDoNotSerialize` and
+        // its HP/psi are re-seeded from the template on every load (there is no
+        // current-HP persistence yet), so this only changes the values arrived
+        // with, not whether a reset happens.
         if let Some(career) = crate::career::Career::from_quest_info(&quest_info) {
             let loadout = career.loadout();
             world.run(

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -16,17 +16,19 @@ impl ChooseMissionScript {
     fn get_current_year(world: &World) -> u32 {
         let quest_info = world.borrow::<UniqueView<QuestInfo>>().unwrap();
 
-        // Check for training year quest bits (training_year_1, training_year_2, etc.)
+        // The HIGHEST completed training year (default 1 when none set), so each
+        // trigger advances the counter monotonically. Returning the *lowest*
+        // completed bit made it stick: once training_year_2 and _3 were both set
+        // it always returned 2 -> new_year 3 < 4, re-looping station.mis forever
+        // and never reaching the year-4 deploy-to-medsci1 branch.
+        let mut highest = 1;
         for year in 1..=4 {
             let quest_bit_name = format!("training_year_{}", year);
-            let quest_bit_value = quest_info.read_quest_bit_value(&quest_bit_name);
-            if quest_bit_value == QuestBitValue::COMPLETE {
-                return year;
+            if quest_info.read_quest_bit_value(&quest_bit_name) == QuestBitValue::COMPLETE {
+                highest = year;
             }
         }
-
-        // If no training year quest bits are set, default to year 1
-        1
+        highest
     }
 
     fn set_training_year(year: u32) -> Effect {

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -1,10 +1,20 @@
 use dark::properties::{PropService, QuestBitValue};
 use shipyard::{EntityId, Get, View, World};
 
+use crate::career::Career;
 use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
+/// The station recruit-deck script that records which service branch
+/// (Marine/Navy/OSA) the player enlisted in and deploys them to MedSci 1.
+///
+/// The branch comes from the entity's `P$Service` value; it is registered as a
+/// persisted career quest bit (so it applies to the player on deployment - see
+/// `crate::career`) and the year-1 training quest bit is completed. Attaching
+/// this script to the in-world station debrief UI is still deferred (issue
+/// #424); the `SelectCareer*` input actions drive the same registration
+/// meanwhile.
 pub struct ChooseServiceScript {}
 impl ChooseServiceScript {
     pub fn new() -> ChooseServiceScript {
@@ -22,45 +32,29 @@ impl Script for ChooseServiceScript {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                // Get the service type from the P$Service property
+                // Read the enlisted branch from this entity's P$Service value.
                 let v_service = world.borrow::<View<PropService>>().unwrap();
                 let service = v_service.get(entity_id).map(|s| s.0).unwrap_or(0);
+                let career = Career::from_service(service);
 
-                // Determine which entities to trigger based on service type
-                let mut entities_to_trigger = vec!["DEBRIEF1-DOOR".to_string()]; // Always trigger DEBRIEF1-DOOR
+                let mut effects = career.select_effects();
+                effects.push(Effect::SetQuestBit {
+                    quest_bit_name: "training_year_1".to_string(),
+                    quest_bit_value: QuestBitValue::COMPLETE,
+                });
+                // TODO(#424): fully wire the in-world station debrief sequence.
+                effects.push(Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
+                    level_file: "medsci1.mis".to_owned(),
+                    loc: None,
+                    entities_to_trigger: vec!["DEBRIEF1-DOOR".to_string()],
+                }));
+                effects.push(super::script_util::send_to_all_switch_links_and_self(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                ));
 
-                let start_entity = match service {
-                    0 => "START_01".to_string(), // Marines
-                    1 => "START_11".to_string(), // Navy
-                    2 => "START_21".to_string(), // OSA
-                    _ => "START_01".to_string(), // Unknown service type, default to Marines
-                };
-                entities_to_trigger.push(start_entity);
-
-                Effect::Multiple(vec![
-                    // Updat quest bit
-                    Effect::SetQuestBit {
-                        quest_bit_name: "training_year_1".to_string(),
-                        quest_bit_value: QuestBitValue::COMPLETE,
-                    },
-                    // TODO: Fully implement station.msi
-                    Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                        level_file: "medsci1.mis".to_owned(),
-                        loc: None,
-                        entities_to_trigger,
-                    }),
-                    // Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                    //     level_file: "station.mis".to_owned(),
-                    //     loc: None,
-                    //     entities_to_trigger,
-                    // }),
-                    // Also trigger switch links in the current mission
-                    super::script_util::send_to_all_switch_links_and_self(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    ),
-                ])
+                Effect::Multiple(effects)
             }
             _ => Effect::NoEffect,
         }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -588,9 +588,7 @@ impl ScriptWorld {
             "shotgunmodify" => Box::new(NoopScript::new()),
             "energyweapon" => Box::new(NoopScript::new()),
             "grenademodify" => Box::new(NoopScript::new()),
-            "weapontrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
-                skill_trainer::TrainerKind::Weapon,
-            )),
+            "weapontrainer" => Box::new(skill_trainer::SkillTrainerScript::new("weapontrainer")),
             "wrench" => Box::new(CompositeScript::new(vec![
                 Box::new(MeleeWeapon::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
@@ -630,15 +628,9 @@ impl ScriptWorld {
             "triggerdestroy" => Box::new(NoopScript::new()),
 
             // skill point machines
-            "psitrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
-                skill_trainer::TrainerKind::Psi,
-            )),
-            "techtrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
-                skill_trainer::TrainerKind::Tech,
-            )),
-            "statstrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
-                skill_trainer::TrainerKind::Stats,
-            )),
+            "psitrainer" => Box::new(skill_trainer::SkillTrainerScript::new("psitrainer")),
+            "techtrainer" => Box::new(skill_trainer::SkillTrainerScript::new("techtrainer")),
+            "statstrainer" => Box::new(skill_trainer::SkillTrainerScript::new("statstrainer")),
             "traitmachine" => Box::new(NoopScript::new()),
 
             // medsci2

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -33,6 +33,7 @@ mod psi_amp_script;
 mod room_trigger;
 pub mod script_util;
 mod setup_initial_debrief;
+mod skill_trainer;
 mod std_door;
 mod tool_consumable;
 mod transluce;
@@ -587,7 +588,9 @@ impl ScriptWorld {
             "shotgunmodify" => Box::new(NoopScript::new()),
             "energyweapon" => Box::new(NoopScript::new()),
             "grenademodify" => Box::new(NoopScript::new()),
-            "weapontrainer" => Box::new(UnimplementedScript::new(&script_name)),
+            "weapontrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
+                skill_trainer::TrainerKind::Weapon,
+            )),
             "wrench" => Box::new(CompositeScript::new(vec![
                 Box::new(MeleeWeapon::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
@@ -627,9 +630,15 @@ impl ScriptWorld {
             "triggerdestroy" => Box::new(NoopScript::new()),
 
             // skill point machines
-            "psitrainer" => Box::new(UnimplementedScript::new(&script_name)),
-            "techtrainer" => Box::new(UnimplementedScript::new(&script_name)),
-            "statstrainer" => Box::new(UnimplementedScript::new(&script_name)),
+            "psitrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
+                skill_trainer::TrainerKind::Psi,
+            )),
+            "techtrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
+                skill_trainer::TrainerKind::Tech,
+            )),
+            "statstrainer" => Box::new(skill_trainer::SkillTrainerScript::new(
+                skill_trainer::TrainerKind::Stats,
+            )),
             "traitmachine" => Box::new(NoopScript::new()),
 
             // medsci2

--- a/shock2vr/src/scripts/skill_trainer.rs
+++ b/shock2vr/src/scripts/skill_trainer.rs
@@ -2,13 +2,12 @@
 //!
 //! The retail game gates these behind cyber modules and a full skill/stat
 //! economy (weapon proficiencies, tech/repair/hack skills, STR/END/AGI/CYB
-//! stats). That economy does not exist yet (issue #424), so only the psi
-//! trainer - which has a real system to hook into (`crate::psi`) - does
-//! something: on frob it trains the player in a psi power. Granting a power is
-//! idempotent (it unions into the known-power set), so a repeat frob is a
-//! harmless no-op. The weapon/tech/stats trainers log and no-op until their
-//! backing systems land, replacing the previous `UnimplementedScript` warning
-//! spam with an intentional, named placeholder.
+//! stats, trained psi powers). None of that economy exists yet - and learned
+//! psi powers aren't even persisted across level loads (`PlayerPsiKnownPowers`
+//! is rebuilt from the player template each load) - so a trainer can't yet
+//! grant anything durable or costed. Rather than vend free, non-persistent
+//! upgrades, this replaces the previous `UnimplementedScript` warning spam with
+//! an intentional, named no-op placeholder until those systems land (#424).
 
 use shipyard::{EntityId, World};
 use tracing::info;
@@ -17,25 +16,14 @@ use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
-/// `PsiHeal` (Cerebro-Stimulated Regeneration) - the tier-2 power the psi
-/// trainer teaches.
-const PSIHEAL_TEMPLATE_ID: i32 = -1017;
-
-#[derive(Debug, Clone, Copy)]
-pub enum TrainerKind {
-    Weapon,
-    Psi,
-    Tech,
-    Stats,
-}
-
 pub struct SkillTrainerScript {
-    kind: TrainerKind,
+    /// The trainer's script name (e.g. "psitrainer"), for the frob log.
+    name: &'static str,
 }
 
 impl SkillTrainerScript {
-    pub fn new(kind: TrainerKind) -> SkillTrainerScript {
-        SkillTrainerScript { kind }
+    pub fn new(name: &'static str) -> SkillTrainerScript {
+        SkillTrainerScript { name }
     }
 }
 
@@ -47,20 +35,12 @@ impl Script for SkillTrainerScript {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        match msg {
-            MessagePayload::Frob => match self.kind {
-                TrainerKind::Psi => Effect::GrantPsiPower {
-                    template_id: PSIHEAL_TEMPLATE_ID,
-                },
-                TrainerKind::Weapon | TrainerKind::Tech | TrainerKind::Stats => {
-                    info!(
-                        "{:?} skill trainer frobbed - no skill/stat system yet (#424)",
-                        self.kind
-                    );
-                    Effect::NoEffect
-                }
-            },
-            _ => Effect::NoEffect,
+        if let MessagePayload::Frob = msg {
+            info!(
+                "'{}' skill trainer frobbed - no skill/stat economy yet (#424)",
+                self.name
+            );
         }
+        Effect::NoEffect
     }
 }

--- a/shock2vr/src/scripts/skill_trainer.rs
+++ b/shock2vr/src/scripts/skill_trainer.rs
@@ -1,0 +1,66 @@
+//! Skill-training machines from the station recruit deck and the decks beyond.
+//!
+//! The retail game gates these behind cyber modules and a full skill/stat
+//! economy (weapon proficiencies, tech/repair/hack skills, STR/END/AGI/CYB
+//! stats). That economy does not exist yet (issue #424), so only the psi
+//! trainer - which has a real system to hook into (`crate::psi`) - does
+//! something: on frob it trains the player in a psi power. Granting a power is
+//! idempotent (it unions into the known-power set), so a repeat frob is a
+//! harmless no-op. The weapon/tech/stats trainers log and no-op until their
+//! backing systems land, replacing the previous `UnimplementedScript` warning
+//! spam with an intentional, named placeholder.
+
+use shipyard::{EntityId, World};
+use tracing::info;
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// `PsiHeal` (Cerebro-Stimulated Regeneration) - the tier-2 power the psi
+/// trainer teaches.
+const PSIHEAL_TEMPLATE_ID: i32 = -1017;
+
+#[derive(Debug, Clone, Copy)]
+pub enum TrainerKind {
+    Weapon,
+    Psi,
+    Tech,
+    Stats,
+}
+
+pub struct SkillTrainerScript {
+    kind: TrainerKind,
+}
+
+impl SkillTrainerScript {
+    pub fn new(kind: TrainerKind) -> SkillTrainerScript {
+        SkillTrainerScript { kind }
+    }
+}
+
+impl Script for SkillTrainerScript {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob => match self.kind {
+                TrainerKind::Psi => Effect::GrantPsiPower {
+                    template_id: PSIHEAL_TEMPLATE_ID,
+                },
+                TrainerKind::Weapon | TrainerKind::Tech | TrainerKind::Stats => {
+                    info!(
+                        "{:?} skill trainer frobbed - no skill/stat system yet (#424)",
+                        self.kind
+                    );
+                    Effect::NoEffect
+                }
+            },
+            _ => Effect::NoEffect,
+        }
+    }
+}

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -9,6 +9,9 @@ export type InputAction =
   | "CycleAmmo"
   | "Reload"
   | "CyclePsiPower"
+  | "SelectCareerMarine"
+  | "SelectCareerNavy"
+  | "SelectCareerOsa"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 

--- a/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for station career (Marine/Navy/OSA) branching. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before this change, choosing a service branch did nothing -
+// there were no SelectCareer* actions and no career loadout, so all three tours
+// deployed to medsci1 with the identical default player-template attributes
+// (30 HP, 40/50 psi). The asserts that the three careers arrive with *different*
+// hit points and psi points would all fail (every value would be 30/40).
+//
+// After the change, the career is registered (persisted quest bit) and applied
+// on deployment, so Marines arrive tanky (45 HP / 20 psi), Navy balanced
+// (35 / 35), and OSA psionic (30 / 60).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+/** Select a career at the station, deploy to medsci1, and read the arrival
+ * attributes. transitionLevel() reloads medsci1, so the loadout (which applies
+ * on mission load from the persisted career bit) re-applies each time. */
+async function deployWithCareer(
+  game: GameServer,
+  action: string,
+): Promise<{ maxHp: number; maxPsi: number }> {
+  await game.input.trigger(action);
+  await game.step({ frames: 2 });
+  await game.transitionLevel("medsci1.mis");
+  await game.step({ frames: 3 });
+  const player = (await game.info()).player;
+  assert.notEqual(
+    player.max_hit_points,
+    null,
+    `${action}: player should have a hit-point pool after deployment`,
+  );
+  assert.notEqual(
+    player.max_psi_points,
+    null,
+    `${action}: player should have a psi pool after deployment`,
+  );
+  return {
+    maxHp: player.max_hit_points as number,
+    maxPsi: player.max_psi_points as number,
+  };
+}
+
+test(
+  "station: careers deploy to medsci1 with distinct attributes",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8117),
+    });
+    await game.step({ frames: 10 });
+
+    const marine = await deployWithCareer(game, "SelectCareerMarine");
+    const navy = await deployWithCareer(game, "SelectCareerNavy");
+    const osa = await deployWithCareer(game, "SelectCareerOsa");
+
+    // Hit points differ across all three branches (Marines tankiest, OSA least).
+    assert.notEqual(marine.maxHp, navy.maxHp, "Marine vs Navy HP should differ");
+    assert.notEqual(navy.maxHp, osa.maxHp, "Navy vs OSA HP should differ");
+    assert.notEqual(marine.maxHp, osa.maxHp, "Marine vs OSA HP should differ");
+    assert.ok(
+      marine.maxHp > osa.maxHp,
+      `Marines should be tankier than OSA (got ${marine.maxHp} vs ${osa.maxHp})`,
+    );
+
+    // Psi points differ too (OSA the strongest psion, Marines the weakest).
+    assert.notEqual(marine.maxPsi, navy.maxPsi, "Marine vs Navy psi should differ");
+    assert.notEqual(navy.maxPsi, osa.maxPsi, "Navy vs OSA psi should differ");
+    assert.ok(
+      osa.maxPsi > marine.maxPsi,
+      `OSA should out-psi Marines (got ${osa.maxPsi} vs ${marine.maxPsi})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/station-career.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career.e2e.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the station training-year progression. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: ChooseMissionScript::get_current_year returned the LOWEST
+// completed training_year_N bit, so once years 2 and 3 were both set it computed
+// year 3 forever (< 4), re-looping station.mis and NEVER reaching the year-4
+// deploy-to-medsci1 branch - the intro was uncompletable. This fires the
+// training trigger repeatedly and asserts it deploys to medsci1 within a few
+// tours (it looped indefinitely before the fix).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station: training rounds advance and deploy to medsci1",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+    });
+    await game.step({ frames: 10 });
+
+    // Fire the ChooseMission trigger (the transition whose destination is
+    // medsci1); station reloads between tours, so re-find it each time.
+    let mission = (await game.info()).mission;
+    for (let fire = 0; fire < 6 && mission === "station.mis"; fire++) {
+      const trigger = (await game.transitions()).transitions.find((t) =>
+        t.dest_level.toLowerCase().includes("medsci1"),
+      );
+      assert.ok(trigger, "station should expose a ChooseMission trigger to medsci1");
+      // TurnOn is a valid debug message; the SDK's typed union predates it.
+      await game.entities.sendMessage(trigger.entity_id, {
+        type: "TurnOn",
+      } as unknown as Parameters<typeof game.entities.sendMessage>[1]);
+      await game.step({ frames: 20 });
+      mission = (await game.info()).mission;
+    }
+
+    assert.equal(
+      mission.toLowerCase(),
+      "medsci1.mis",
+      `training should deploy to medsci1 (looped forever before the fix); ended at ${mission}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #424

## Problem
The station recruit-deck intro had no working career branching: all three tours
(Marine/Navy/OSA) deployed the player to the same MedSci1 marker with the
**default** attributes (30/30 HP, 40/50 psi, empty inventory). `ChooseServiceScript`
never registered a career, and the four skill trainers were `UnimplementedScript`
no-ops.

## Original wiring (investigation)
- Station career selection is SS2's "character creation via gameplay": the recruit
  deck runs a training-year loop (`ChooseMissionScript`, wired to markers 125/126/127,
  all → MedSci1 / loc 2502) and per-year service branches (`START_01/11/21` →
  `GO-MARINES/NAVY/OSA`). The chosen build is encoded on the deploy markers via an
  (unparsed) `P$CharGenRo` "CharGen Room" property.
- `PropService` (0=Marine, 1=Navy, 2=OSA) is what `ChooseServiceScript` reads.
- Player HP/psi are **not** persisted: the player is `RuntimePropDoNotSerialize` and
  re-hydrated from the player template (-384) on **every** mission load. `QuestInfo`
  (quest bits) and held items/inventory **do** persist across transitions. So the only
  faithful place to apply a career build is on load, derived from a persisted bit.
- Nothing on the MedSci1 side reads the service today.

## What this implements
A coherent, tested slice of career branching:

- **`career` module** — the branch→loadout table, quest-bit persistence, and
  mutually-exclusive selection effects. Marines arrive tanky (45 HP / 20 psi), Navy
  balanced (35/35), OSA psionic (30/60 + an extra tier-1 psi power). Values are a
  faithful-in-spirit approximation, not the exact retail OS-unit numbers.
- **Applied on deployment** in `MissionCore::load` from the persisted career bit —
  idempotent (absolute values), survives level transitions, re-applies every load.
- **Selection**: `SelectCareer{Marine,Navy,Osa}` input actions (HTTP `/v1/input/action`
  + desktop F1/F2/F3), and `ChooseServiceScript` now registers the career from
  `P$Service` before deploying.
- **Skill trainers**: the four `UnimplementedScript` no-ops become a single named
  `SkillTrainerScript` placeholder (see Deferred).

### Observable result (debug runtime, verified live)
| Career | max HP | max psi |
| --- | --- | --- |
| Marine | 45 | 20 |
| Navy | 35 | 35 |
| OSA | 30 | 60 |

## Test (negative-first)
`tools/shock2-sdk/test/station-career-attributes.e2e.test.ts` selects each career at
the station, deploys to MedSci1, and asserts the three arrive with distinct HP and
psi. Confirmed it **fails** before the change (with the loadout neutralized, all
careers deploy identical 30/40 → "Marine vs Navy HP should differ") and **passes**
after. Plus `career` unit tests. The full `missions.e2e.test.ts` (all 23 missions
load) and the existing year-loop `station-career.e2e.test.ts` still pass.

## Review
Ran `/xreview` (Claude + Codex). No Critical/High defect in the core; both confirmed
persistence/idempotency are correct. Acted on the convergent finding: the initial psi
trainer's Frob-grant was a game-wide free-power vend **and** ineffective (learned
powers aren't serialized), so it's now a documented no-op stub like the others.

## Deferred (#424)
- Full skill/stat/cyber-module economy and functional trainers (+ psi-power
  persistence) — trainers are named no-op placeholders for now.
- Wiring the in-world station debrief UI to `ChooseServiceScript` (no station entity
  carries the `chooseservice` script in the mission data; the `SelectCareer*` actions
  drive selection meanwhile).
- Career-specific starting gear/inventory grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)