### PR TITLE
feat(debug): bounded shapecast-validated player move (POST /v1/player/move)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -34,6 +34,13 @@ pub enum RuntimeCommand {
     /// Move the player to a position
     MovePlayer(Vector3<f32>),
 
+    /// Move the player toward a target with a bounded, shape-cast-validated hop
+    /// (won't pass through walls / out of bounds). See `MoveResult`.
+    MovePlayerValidated {
+        target: Vector3<f32>,
+        reply: oneshot::Sender<MoveResult>,
+    },
+
     /// Transition to another level (warp), at an optional spawn-marker id.
     TransitionLevel {
         level_file: String,
@@ -369,6 +376,20 @@ pub struct CommandResult {
     pub success: bool,
     pub message: String,
     pub data: Option<serde_json::Value>,
+}
+
+/// Result of a bounded, shape-cast-validated player move (`/v1/player/move`).
+#[derive(Debug, Serialize)]
+pub struct MoveResult {
+    /// Whether the player position actually changed.
+    pub moved: bool,
+    /// Whether the shape cast hit geometry before the full clamped distance.
+    pub blocked: bool,
+    pub new_position: [f32; 3],
+    /// How far the player actually advanced (world units).
+    pub distance_moved: f32,
+    /// The distance the move was allowed to attempt: `min(target distance, 5.0)`.
+    pub requested_distance: f32,
 }
 
 /// Result of a level transition (warp) request

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -275,6 +275,10 @@ async fn start_http_server(
         .route("/v1/player/position", get(get_player_position))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
         .route(
+            "/v1/player/move",
+            axum::routing::post(move_player_validated),
+        )
+        .route(
             "/v1/control/transition-level",
             axum::routing::post(transition_level),
         )
@@ -323,7 +327,8 @@ async fn start_http_server(
     info!("  GET  /v1/entities/{{id}}    - Get detailed entity information");
     info!("  POST /v1/entities/{{id}}/message - Inject a script message (damage/frob/signal)");
     info!("  GET  /v1/player/position  - Get current player position");
-    info!("  POST /v1/player/teleport  - Teleport player to coordinates");
+    info!("  POST /v1/player/teleport  - Teleport player to coordinates (raw, unbounded)");
+    info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
@@ -869,6 +874,33 @@ fn process_command(
                 }
             } else {
                 tracing::error!("No debuggable scene available for player movement");
+            }
+        }
+        RuntimeCommand::MovePlayerValidated { target, reply } => {
+            tracing::info!("Validated player move toward: {:?}", target);
+            let result = if let Some(debug_scene) = game.debug_scene_mut() {
+                let r = debug_scene.move_player(target);
+                MoveResult {
+                    moved: r.moved,
+                    blocked: r.blocked,
+                    new_position: [r.new_position.x, r.new_position.y, r.new_position.z],
+                    distance_moved: r.distance_moved,
+                    requested_distance: r.requested_distance,
+                }
+            } else {
+                tracing::error!("No debuggable scene available for validated player move");
+                // No scene: report a no-op move at the origin so the HTTP layer
+                // still gets a well-formed response.
+                MoveResult {
+                    moved: false,
+                    blocked: false,
+                    new_position: [0.0, 0.0, 0.0],
+                    distance_moved: 0.0,
+                    requested_distance: 0.0,
+                }
+            };
+            if let Err(_) = reply.send(result) {
+                tracing::warn!("Failed to send validated-move result - receiver dropped");
             }
         }
         RuntimeCommand::TransitionLevel {
@@ -1996,6 +2028,42 @@ async fn teleport_player(
         })),
         Err(_) => {
             tracing::error!("Failed to receive player position after teleport - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request structure for a bounded, collision-validated player move.
+#[derive(serde::Deserialize)]
+struct MoveRequest {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+/// HTTP handler for a bounded, shape-cast-validated player move. Unlike
+/// `/v1/player/teleport`, this clamps the displacement and stops short of any
+/// geometry it hits, so the player can never be pushed through a wall or out of
+/// bounds.
+async fn move_player_validated(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<MoveRequest>,
+) -> Result<Json<MoveResult>, (StatusCode, String)> {
+    let target = Vector3::new(request.x, request.y, request.z);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if let Err(_) = command_tx.send(RuntimeCommand::MovePlayerValidated {
+        target,
+        reply: reply_tx,
+    }) {
+        tracing::error!("Failed to send MovePlayerValidated command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => {
+            tracing::error!("Failed to receive validated-move result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -408,6 +408,23 @@ pub trait DebuggableScene {
     /// Ok(()) on success, or error message if teleportation fails
     fn teleport_player(&mut self, position: Vector3<f32>) -> Result<(), String>;
 
+    /// Move the player toward `target` in a single bounded, collision-validated
+    /// hop.
+    ///
+    /// Unlike [`teleport_player`](Self::teleport_player), which warps the player
+    /// unconditionally, this clamps the displacement to a maximum distance and
+    /// shape-casts the player collider along the way, stopping short of any
+    /// geometry it hits. Intended for automated navigation that must stay inside
+    /// the level (a closed door, for instance, blocks the move).
+    ///
+    /// # Arguments
+    /// * `target` - Desired destination in world coordinates
+    ///
+    /// # Returns
+    /// A [`MoveResult`](crate::physics::MoveResult) describing how far the
+    /// player actually moved and whether it was blocked.
+    fn move_player(&mut self, target: Vector3<f32>) -> crate::physics::MoveResult;
+
     /// Get the current player position for distance calculations
     ///
     /// Returns the player's current world position, used for sorting

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4231,6 +4231,30 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         Ok(())
     }
 
+    fn move_player(&mut self, target: cgmath::Vector3<f32>) -> crate::physics::MoveResult {
+        // Bounded, shape-cast-validated move: physics clamps the displacement
+        // and stops short of any geometry it hits.
+        let result = self
+            .physics
+            .move_player_validated(target, &mut self.player_handle);
+
+        if result.moved {
+            // Keep PlayerInfo.pos consistent with the body immediately (same
+            // reasoning as `teleport_player`), and mark the player teleported so
+            // the render/camera path picks up the new position this frame.
+            let player_entity = {
+                let mut player_info = self.world.borrow::<UniqueViewMut<PlayerInfo>>().unwrap();
+                player_info.pos = result.new_position;
+                player_info.entity_id
+            };
+
+            self.world
+                .add_component(player_entity, PropTeleported::new());
+        }
+
+        result
+    }
+
     fn player_position(&self) -> cgmath::Vector3<f32> {
         // Get player position from PlayerInfo unique component
         self.world

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -303,6 +303,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.teleport_player(position)
     }
 
+    fn move_player(&mut self, target: Vector3<f32>) -> crate::physics::MoveResult {
+        self.mission_core.move_player(target)
+    }
+
     fn player_position(&self) -> Vector3<f32> {
         self.mission_core.player_position()
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -497,20 +497,21 @@ impl PhysicsWorld {
         let delta = target - current;
         let dist = delta.magnitude();
 
-        // Distance we are allowed to attempt this call.
-        let requested_distance = dist.min(MAX_PLAYER_MOVE_DISTANCE);
-
-        // Degenerate request (zero or non-finite): nothing to do.
+        // Degenerate request (zero or non-finite): nothing to do. Guard before
+        // computing `requested_distance` so a NaN target doesn't report a
+        // bogus clamp value (`NaN.min(5.0) == 5.0`).
         if !dist.is_finite() || dist == 0.0 {
             return MoveResult {
                 moved: false,
                 blocked: false,
                 new_position: current,
                 distance_moved: 0.0,
-                requested_distance,
+                requested_distance: 0.0,
             };
         }
 
+        // Distance we are allowed to attempt this call.
+        let requested_distance = dist.min(MAX_PLAYER_MOVE_DISTANCE);
         let dir = delta / dist; // normalized direction
 
         // Snapshot the character shape + pose (cheap Arc clone) before building
@@ -544,9 +545,20 @@ impl PhysicsWorld {
         // Shape-cast the character collider along the (normalized) direction.
         // With a unit velocity the time-of-impact is a distance in world units,
         // mirroring how `ray_cast2` treats `max_toi` as a distance.
+        //
+        // `stop_at_penetration: false` so a start that is already touching /
+        // slightly penetrating geometry (e.g. after a raw `/v1/player/teleport`
+        // dropped the player against a wall) doesn't return `toi == 0` and pin
+        // the player as permanently `blocked` - a move *away* from the contact
+        // (separating velocity) is then discarded at t=0 and proceeds normally,
+        // while a move *into* it still blocks.
         let shape_vel = vector![dir.x, dir.y, dir.z];
-        let options =
-            rapier3d::parry::query::ShapeCastOptions::with_max_time_of_impact(requested_distance);
+        let options = rapier3d::parry::query::ShapeCastOptions {
+            max_time_of_impact: requested_distance,
+            target_distance: 0.0,
+            stop_at_penetration: false,
+            compute_impact_geometry_on_penetration: true,
+        };
 
         let allowed_distance = {
             let queries = self.broad_phase.as_query_pipeline(
@@ -574,6 +586,7 @@ impl PhysicsWorld {
             None => (requested_distance, false),
         };
 
+        // When `distance_moved == 0`, `current + dir * 0` is exactly `current`.
         let new_position = current + dir * distance_moved;
 
         if distance_moved > 0.0 {
@@ -583,11 +596,7 @@ impl PhysicsWorld {
         MoveResult {
             moved: distance_moved > 0.0,
             blocked,
-            new_position: if distance_moved > 0.0 {
-                new_position
-            } else {
-                current
-            },
+            new_position,
             distance_moved,
             requested_distance,
         }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -24,6 +24,16 @@ use self::debug_render_pipeline::DebugRenderer;
 
 const MOVEMENT_STEP_SIZE: f32 = 20.0;
 
+/// Maximum distance (world units) a single validated player move may advance.
+/// A request for a farther target is clamped to this, so an automated tester
+/// navigates in short, collision-checked hops instead of one long teleport.
+pub const MAX_PLAYER_MOVE_DISTANCE: f32 = 5.0;
+
+/// Skin margin (world units) subtracted from the shape-cast time-of-impact so
+/// the player stops just short of the geometry it hit rather than flush against
+/// (or slightly inside) it.
+const PLAYER_MOVE_SKIN_MARGIN: f32 = 0.1;
+
 bitflags! {
     pub struct InternalCollisionGroups: u32 {
         const WORLD = 1 << 0; // 1
@@ -130,6 +140,24 @@ pub struct RayCastResult {
     pub is_sensor: bool,
     // TODO:
     // entity_id
+}
+
+/// Result of a bounded, shape-cast-validated player move (see
+/// [`PhysicsWorld::move_player_validated`]).
+#[derive(Clone, Debug)]
+pub struct MoveResult {
+    /// Whether the player position actually changed.
+    pub moved: bool,
+    /// Whether the shape cast hit geometry before the full clamped distance,
+    /// stopping the move short of the target.
+    pub blocked: bool,
+    /// The player's new world position after the move.
+    pub new_position: Vector3<f32>,
+    /// How far the player actually advanced (world units).
+    pub distance_moved: f32,
+    /// The distance the move was allowed to attempt this call: `min(target
+    /// distance, MAX_PLAYER_MOVE_DISTANCE)`.
+    pub requested_distance: f32,
 }
 
 #[derive(Clone, Debug)]
@@ -449,6 +477,120 @@ impl PhysicsWorld {
             .get(player_handle.character_handle)
             .unwrap();
         nvec_to_cgmath(*character_body.translation())
+    }
+
+    /// Move the player toward `target`, but bounded and collision-validated.
+    ///
+    /// The displacement `target - current` is clamped to at most
+    /// [`MAX_PLAYER_MOVE_DISTANCE`], then the player's character-controller
+    /// collider is shape-cast along that direction. If it hits geometry before
+    /// the clamped distance, the player stops just short of the contact
+    /// (time-of-impact minus [`PLAYER_MOVE_SKIN_MARGIN`], clamped >= 0) and the
+    /// result is marked `blocked`. Unlike `set_player_translation`, this can
+    /// never move the player through a wall or out of bounds.
+    pub fn move_player_validated(
+        &mut self,
+        target: Vector3<f32>,
+        player_handle: &mut PlayerHandle,
+    ) -> MoveResult {
+        let current = self.get_player_translation(player_handle);
+        let delta = target - current;
+        let dist = delta.magnitude();
+
+        // Distance we are allowed to attempt this call.
+        let requested_distance = dist.min(MAX_PLAYER_MOVE_DISTANCE);
+
+        // Degenerate request (zero or non-finite): nothing to do.
+        if !dist.is_finite() || dist == 0.0 {
+            return MoveResult {
+                moved: false,
+                blocked: false,
+                new_position: current,
+                distance_moved: 0.0,
+                requested_distance,
+            };
+        }
+
+        let dir = delta / dist; // normalized direction
+
+        // Snapshot the character shape + pose (cheap Arc clone) before building
+        // the query pipeline, which borrows the body/collider sets. Mirrors the
+        // pattern in `move_player`.
+        //
+        // Cast from the *body* pose, not the collider's cached pose: a kinematic
+        // body's collider position is only re-synced during a physics step, so
+        // after a prior `set_player_translation` (below) with no step in between
+        // - e.g. two `move_player_validated` calls back to back - the collider
+        // pose is stale and would restart the cast from the old spot, letting
+        // the player tunnel through walls. The body's own `position()` updates
+        // immediately. The collider is parented at the body origin (identity
+        // local transform), so the body pose is the collider's true world pose.
+        let character_body = &self.rigid_body_set[player_handle.character_handle];
+        let character_collider = &self.collider_set[character_body.colliders()[0]];
+        let character_shape = character_collider.shared_shape().clone();
+        let character_pos = *character_body.position();
+
+        // Same collision filter the real player movement uses: collide with the
+        // collidable groups, ignore the player's own body and all sensors.
+        let filter = QueryFilter::new()
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::PLAYER.bits.into(),
+                InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+                Default::default(),
+            ))
+            .exclude_rigid_body(player_handle.character_handle)
+            .exclude_sensors();
+
+        // Shape-cast the character collider along the (normalized) direction.
+        // With a unit velocity the time-of-impact is a distance in world units,
+        // mirroring how `ray_cast2` treats `max_toi` as a distance.
+        let shape_vel = vector![dir.x, dir.y, dir.z];
+        let options =
+            rapier3d::parry::query::ShapeCastOptions::with_max_time_of_impact(requested_distance);
+
+        let allowed_distance = {
+            let queries = self.broad_phase.as_query_pipeline(
+                self.narrow_phase.query_dispatcher(),
+                &self.rigid_body_set,
+                &self.collider_set,
+                filter,
+            );
+
+            match queries.cast_shape(
+                &character_pos,
+                &shape_vel,
+                character_shape.as_ref(),
+                options,
+            ) {
+                Some((_handle, hit)) => Some(
+                    (hit.time_of_impact - PLAYER_MOVE_SKIN_MARGIN).clamp(0.0, requested_distance),
+                ),
+                None => None,
+            }
+        };
+
+        let (distance_moved, blocked) = match allowed_distance {
+            Some(d) => (d, true),
+            None => (requested_distance, false),
+        };
+
+        let new_position = current + dir * distance_moved;
+
+        if distance_moved > 0.0 {
+            self.set_player_translation(new_position, player_handle);
+        }
+
+        MoveResult {
+            moved: distance_moved > 0.0,
+            blocked,
+            new_position: if distance_moved > 0.0 {
+                new_position
+            } else {
+                current
+            },
+            distance_moved,
+            requested_distance,
+        }
     }
 
     pub fn get_aabb2(&self, entity_id: EntityId) -> Option<Aabb3<f32>> {

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -16,6 +16,7 @@ import type {
   ScreenshotResult,
   StepResult,
   StepSpec,
+  MoveResult,
   TeleportResult,
   TransitionLevelResult,
   QuestBitsResult,
@@ -54,6 +55,22 @@ export class PlayerApi {
 
   async teleport(position: Position): Promise<TeleportResult> {
     return this.client.post<TeleportResult>("/v1/player/teleport", position);
+  }
+
+  /**
+   * Move the player toward `target` in a single bounded, collision-valid hop.
+   *
+   * The displacement is clamped to at most 5 world units and the player
+   * collider is shape-cast along the way, stopping just short of any geometry
+   * it hits (`blocked: true`). Unlike {@link teleport}, this can never move the
+   * player through a wall or out of bounds - prefer it for exploration. A
+   * closed door blocks the move, so the pattern is: move up to the door (it
+   * trips the tripwire, or Frob it), step until it opens, then move through.
+   *
+   * Named `moveTo` because `move` is awkward as a bare method name.
+   */
+  async moveTo(target: Position): Promise<MoveResult> {
+    return this.client.post<MoveResult>("/v1/player/move", target);
   }
 
   /** The items the player is carrying (backpack + hand-held), for verifying pickups. */

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -203,6 +203,19 @@ export interface TeleportResult {
   new_position: Vec3;
 }
 
+/** Result of a bounded, shape-cast-validated player move (`player.moveTo`). */
+export interface MoveResult {
+  /** Whether the player position actually changed. */
+  moved: boolean;
+  /** Whether the move hit geometry before the full clamped distance. */
+  blocked: boolean;
+  new_position: Vec3;
+  /** How far the player actually advanced (world units). */
+  distance_moved: number;
+  /** The distance the move was allowed to attempt: `min(target distance, 5.0)`. */
+  requested_distance: number;
+}
+
 export interface TransitionLevelResult {
   success: boolean;
   /** Scene name after the transition, e.g. "eng1.mis". */

--- a/tools/shock2-sdk/test/player-move.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-move.e2e.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position, Vec3 } from "../src/index.js";
+
+// End-to-end test for the bounded, shape-cast-validated player move
+// (POST /v1/player/move, game.player.moveTo). Requires game assets in Data/ and
+// compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: a raw teleport (the old /v1/player/teleport behaviour) warps
+// the player unconditionally - straight through a wall and out of bounds. This
+// test drives the player into a wall and asserts the move is CLAMPED and
+// BLOCKED short of the geometry (distance_moved < requested, player stops before
+// the wall). Against a raw teleport these assertions fail: it would report the
+// full requested distance and land the player inside/behind the wall.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const toVec = (p: Position): Vec3 => [p.x, p.y, p.z];
+
+test(
+  "validated player move: clamps + blocks at walls, advances in open space",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+    });
+    await game.step({ frames: 2 });
+
+    const spawn = await game.player.position();
+
+    // Probe the four horizontal axes with a world raycast to find (a) a nearby
+    // wall to move into and (b) an open direction with room for a full hop.
+    const axes: Array<{ name: string; dir: Vec3 }> = [
+      { name: "+x", dir: [1, 0, 0] },
+      { name: "-x", dir: [-1, 0, 0] },
+      { name: "+z", dir: [0, 0, 1] },
+      { name: "-z", dir: [0, 0, -1] },
+    ];
+    const PROBE = 12;
+    const probes = await Promise.all(
+      axes.map(async (a) => {
+        const end: Vec3 = [
+          spawn.x + a.dir[0] * PROBE,
+          spawn.y + a.dir[1] * PROBE,
+          spawn.z + a.dir[2] * PROBE,
+        ];
+        const hit = await game.raycast({
+          start: toVec(spawn),
+          end,
+          collision_groups: ["world"],
+        });
+        // distance-to-wall along the axis (Infinity when the probe finds nothing).
+        const wall =
+          hit.hit && hit.hit_point
+            ? Math.hypot(
+                hit.hit_point[0] - spawn.x,
+                hit.hit_point[1] - spawn.y,
+                hit.hit_point[2] - spawn.z,
+              )
+            : Infinity;
+        return { ...a, wall };
+      }),
+    );
+
+    // Nearest wall = the direction we move INTO; farthest = OPEN direction.
+    const wallAxis = probes.reduce((m, p) => (p.wall < m.wall ? p : m));
+    const openAxis = probes.reduce((m, p) => (p.wall > m.wall ? p : m));
+
+    assert.ok(
+      wallAxis.wall < 2.5,
+      `expected a wall within 2.5u at medsci1 spawn, nearest was ${wallAxis.name} @ ${wallAxis.wall}`,
+    );
+    assert.ok(
+      openAxis.wall > 6,
+      `expected an open axis with >6u clearance, best was ${openAxis.name} @ ${openAxis.wall}`,
+    );
+
+    // --- Wall case: move toward the wall with a far (clamped) target. ---
+    // A raw teleport would land at the full 5u and punch through the wall.
+    const wallTarget: Position = {
+      x: spawn.x + wallAxis.dir[0] * 10,
+      y: spawn.y + wallAxis.dir[1] * 10,
+      z: spawn.z + wallAxis.dir[2] * 10,
+    };
+    const blockedMove = await game.player.moveTo(wallTarget);
+
+    assert.equal(blockedMove.blocked, true, "move into a wall should be blocked");
+    assert.equal(
+      blockedMove.requested_distance,
+      5,
+      "a 10u target should clamp the requested distance to 5",
+    );
+    assert.ok(
+      blockedMove.distance_moved < blockedMove.requested_distance,
+      `blocked move should advance less than requested, got ${blockedMove.distance_moved} of ${blockedMove.requested_distance}`,
+    );
+    // The player must stop SHORT of the wall - its centre never reaches the wall
+    // surface (a raw teleport would sail past it).
+    assert.ok(
+      blockedMove.distance_moved < wallAxis.wall,
+      `player should stop before the wall at ${wallAxis.wall}u, but advanced ${blockedMove.distance_moved}u`,
+    );
+
+    // --- Open-space cases: clamp to target distance, and to the 5u cap. ---
+    // Near target (3u < 5u cap): advances ~3u, not blocked.
+    await game.player.teleport(spawn);
+    await game.step({ frames: 1 });
+    const nearTarget: Position = {
+      x: spawn.x + openAxis.dir[0] * 3,
+      y: spawn.y + openAxis.dir[1] * 3,
+      z: spawn.z + openAxis.dir[2] * 3,
+    };
+    const nearMove = await game.player.moveTo(nearTarget);
+    assert.equal(nearMove.blocked, false, "open-space move should not be blocked");
+    assert.ok(
+      Math.abs(nearMove.distance_moved - 3) < 0.05,
+      `near open move should advance ~3u, got ${nearMove.distance_moved}`,
+    );
+
+    // Far target (10u): clamped to the 5u cap, still clear (open axis has >6u).
+    await game.player.teleport(spawn);
+    await game.step({ frames: 1 });
+    const farTarget: Position = {
+      x: spawn.x + openAxis.dir[0] * 10,
+      y: spawn.y + openAxis.dir[1] * 10,
+      z: spawn.z + openAxis.dir[2] * 10,
+    };
+    const farMove = await game.player.moveTo(farTarget);
+    assert.equal(farMove.blocked, false, "clamped open-space move should not be blocked");
+    assert.ok(
+      Math.abs(farMove.distance_moved - 5) < 0.05,
+      `far open move should advance ~5u (the cap), got ${farMove.distance_moved}`,
+    );
+  },
+);


### PR DESCRIPTION
## What

Adds `POST /v1/player/move { x, y, z }` to the debug runtime: a **bounded, collision-checked** player move so an automated playtester navigates by short, wall-respecting hops instead of teleporting through geometry / out of bounds.

Behavior:
1. Clamp the displacement `target - current` to at most **5.0 units** (`MAX_PLAYER_MOVE_DISTANCE`).
2. Shape-cast the player's kinematic character-controller collider along the (clamped) direction using Rapier 0.31's query pipeline (`broad_phase.as_query_pipeline(...).cast_shape(...)`, the shape-cast analogue of the `cast_ray_and_get_normal` path in `ray_cast2`), excluding the player's own body and sensors.
3. On a hit: stop just short of contact (`time_of_impact - 0.1u` skin margin, clamped `>= 0`), report `blocked: true`. Clear: advance the full clamped distance, `blocked: false`.
4. Update the player the same way teleport does (`set_player_translation` + keep `PlayerInfo.pos` / `PropTeleported` in sync).
5. Returns `{ moved, blocked, new_position, distance_moved, requested_distance }`.

`POST /v1/player/teleport` is **unchanged** (raw, unbounded — for test setup / frontier-resume).

## Door-traversal implication

A **closed door is solid to the shape cast**, so `moveTo` toward a door stops at it (`blocked: true`) rather than clipping through. The intended automated-nav pattern is: **move up to the door → it trips the tripwire (or `Frob` it) → step and wait for it to open → then move through.** This makes headless exploration stay inside the level and respect the same barriers a player does, unlike raw teleport.

## Implementation notes

- Physics API: `PhysicsWorld::move_player_validated(target, &mut PlayerHandle) -> MoveResult` (`shock2vr/src/physics/mod.rs`).
- `DebuggableScene::move_player(target) -> MoveResult` — trait in `game_scene.rs`, real impl in `MissionCore`, **forwarded by `Mission -> mission_core`** (closing the forwarding-gap class of bug).
- `RuntimeCommand::MovePlayerValidated` + result type + route + async handler in `runtimes/debug_runtime` (mirrors `/v1/player/teleport`).
- TS SDK: `game.player.moveTo({ x, y, z })` (`moveTo` since `move` is awkward) + `MoveResult` type.

**Gotcha (load-bearing):** the shape cast starts from the character **body** pose (`character_body.position()`), *not* the collider's cached pose. A kinematic collider's pose only re-syncs on a physics `step()`, so after a prior direct-write move with no intervening step, casting from the stale collider pose restarts from the old spot and **tunnels through walls**. The body's own `position()` updates immediately (the collider is parented at the body origin, identity local transform). This was caught live during verification (constant per-hop advance while "blocked").

- Character capsule dimensions: the player collider is actually a **cuboid** half-extents `(0.32, 0.96, 0.32)` (`0.8/2.4/0.8` ÷ `SCALE_FACTOR` 2.5). Skin margin chosen: **0.1** units.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` — clean.
- Live (`medsci1.mis`): open-space move advances `min(5, target_dist)`; move toward a wall blocks short of it (position stays inside, confirmed via `/v1/screenshot`); hammering a wall never tunnels through.
- **Negative-first e2e** (`tools/shock2-sdk/test/player-move.e2e.test.ts`): drives the player into a wall and asserts the move is clamped + blocked short of it, and open-space moves advance `~min(5, target_dist)`. Confirmed it **fails** with the shapecast bypassed (a raw teleport passes through) and passes with it.
- `missions.e2e.test.ts` — all 23 missions still load.

## Review

Ran `/xreview` (Claude + Codex). Applied the AGREED fix (`stop_at_penetration=false` so a player teleported against a wall can still move away rather than being pinned `blocked`/`distance_moved==0`) plus two minor cleanups (NaN `requested_distance` guard, redundant branch). Re-verified live + e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)