### PR TITLE
feat(debug): save/load over the debug runtime HTTP API (frontier persistence)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -48,6 +48,18 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<TransitionLevelResult>,
     },
 
+    /// Save the current game to a named save file (frontier persistence).
+    SaveGame {
+        file: String,
+        reply: oneshot::Sender<SaveLoadResult>,
+    },
+
+    /// Load a previously-saved game, restoring mission/player/quests/items.
+    LoadGame {
+        file: String,
+        reply: oneshot::Sender<SaveLoadResult>,
+    },
+
     /// Snapshot the quest bits (objective flags) the game has set.
     GetQuestBits {
         reply: oneshot::Sender<QuestBitsResult>,
@@ -390,6 +402,18 @@ pub struct MoveResult {
     pub distance_moved: f32,
     /// The distance the move was allowed to attempt: `min(target distance, 5.0)`.
     pub requested_distance: f32,
+}
+
+/// Result of a save-to-file or load-from-file request.
+#[derive(Debug, Serialize)]
+pub struct SaveLoadResult {
+    pub success: bool,
+    /// The bare save name (no extension) that was saved/loaded.
+    pub file: String,
+    /// The active scene name after the operation (e.g. "medsci1.mis"). After a
+    /// load this is the restored mission; after a save it is the scene saved.
+    pub mission: String,
+    pub message: String,
 }
 
 /// Result of a level transition (warp) request

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -333,7 +333,9 @@ async fn start_http_server(
     info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
     info!("  POST /v1/save             - Save the game to a named file {{file}}");
-    info!("  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}");
+    info!(
+        "  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}"
+    );
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
@@ -991,7 +993,10 @@ fn process_command(
                     tracing::error!("Load of '{}' panicked (caught to keep runtime alive)", file);
                     commands::SaveLoadResult {
                         success: false,
-                        message: format!("Failed to load '{}' - corrupt or incompatible save", file),
+                        message: format!(
+                            "Failed to load '{}' - corrupt or incompatible save",
+                            file
+                        ),
                         file,
                         mission: String::new(),
                     }
@@ -2225,7 +2230,10 @@ struct SaveLoadRequest {
 fn validate_save_name(file: &str) -> Result<String, (StatusCode, String)> {
     let file = file.trim();
     if file.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "file must not be empty".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "file must not be empty".to_string(),
+        ));
     }
     if file.contains('/') || file.contains('\\') || file.contains("..") {
         return Err((

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -282,6 +282,8 @@ async fn start_http_server(
             "/v1/control/transition-level",
             axum::routing::post(transition_level),
         )
+        .route("/v1/save", axum::routing::post(save_game))
+        .route("/v1/load", axum::routing::post(load_game))
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
         .route("/v1/player/inventory", get(get_player_inventory))
@@ -330,6 +332,8 @@ async fn start_http_server(
     info!("  POST /v1/player/teleport  - Teleport player to coordinates (raw, unbounded)");
     info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
+    info!("  POST /v1/save             - Save the game to a named file {{file}}");
+    info!("  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}");
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
@@ -932,6 +936,69 @@ fn process_command(
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send transition result - receiver dropped");
+            }
+        }
+        RuntimeCommand::SaveGame { file, reply } => {
+            tracing::info!("Saving game to '{}'", file);
+            // The underlying save path unwraps on I/O errors and on scenes that
+            // lack a player/quest state (e.g. a debug scene). Contain a panic
+            // here so a failed save returns an error instead of unwinding out of
+            // the game-loop thread and bricking the runtime for every later
+            // command. A save is `&self`, so a caught panic leaves state intact.
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                game.save_game(file.clone())
+            }));
+            let result = match outcome {
+                Ok(mission) => commands::SaveLoadResult {
+                    success: true,
+                    message: format!("Saved '{}' ({})", file, mission),
+                    file,
+                    mission,
+                },
+                Err(_) => {
+                    tracing::error!("Save of '{}' panicked (caught to keep runtime alive)", file);
+                    commands::SaveLoadResult {
+                        success: false,
+                        message: format!("Failed to save '{}' (see runtime log)", file),
+                        file,
+                        mission: String::new(),
+                    }
+                }
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send save result - receiver dropped");
+            }
+        }
+        RuntimeCommand::LoadGame { file, reply } => {
+            tracing::info!("Loading game from '{}'", file);
+            // Existence is pre-checked in the handler, but a file that exists yet
+            // is truncated / not UTF-8 / an incompatible save schema still panics
+            // inside SaveData::read. Contain it so a corrupt save returns an error
+            // rather than bricking the game-loop thread. load_from_file only swaps
+            // `active_game_scene` as its final step (after all fallible reads), so
+            // a caught panic leaves the previously-active scene intact.
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                game.load_game(file.clone())
+            }));
+            let result = match outcome {
+                Ok(mission) => commands::SaveLoadResult {
+                    success: true,
+                    message: format!("Loaded '{}' ({})", file, mission),
+                    file,
+                    mission,
+                },
+                Err(_) => {
+                    tracing::error!("Load of '{}' panicked (caught to keep runtime alive)", file);
+                    commands::SaveLoadResult {
+                        success: false,
+                        message: format!("Failed to load '{}' - corrupt or incompatible save", file),
+                        file,
+                        mission: String::new(),
+                    }
+                }
+            };
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send load result - receiver dropped");
             }
         }
         RuntimeCommand::GetQuestBits { reply } => {
@@ -2138,6 +2205,114 @@ async fn transition_level(
         Ok(result) => Ok(Json(result)),
         Err(_) => {
             tracing::error!("Failed to receive transition result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request body for a save or load request. `file` is a bare save name.
+#[derive(serde::Deserialize)]
+struct SaveLoadRequest {
+    /// Bare save name (no extension / path separators), e.g. "frontier".
+    file: String,
+}
+
+/// Validate a bare save name before it reaches the game loop / filesystem.
+///
+/// The save/load path builds an on-disk path from this name, so a name with a
+/// path separator or `..` could escape the saves directory. Reject those (and
+/// empties) with a 400 up front rather than trusting the caller.
+fn validate_save_name(file: &str) -> Result<String, (StatusCode, String)> {
+    let file = file.trim();
+    if file.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "file must not be empty".to_string()));
+    }
+    if file.contains('/') || file.contains('\\') || file.contains("..") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("file must be a bare save name, got '{}'", file),
+        ));
+    }
+    Ok(file.to_string())
+}
+
+/// HTTP handler for saving the current game to a named file. Persists a
+/// "frontier" save that a later runtime launch can reload to resume - the core
+/// of the automated play-through loop's cross-launch resume.
+async fn save_game(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<SaveLoadRequest>,
+) -> Result<Json<commands::SaveLoadResult>, (StatusCode, String)> {
+    let file = validate_save_name(&request.file)?;
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::SaveGame {
+            file,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send SaveGame command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(result) if result.success => Ok(Json(result)),
+        // The save path unwrapped (I/O error, or a scene without player state);
+        // the game loop caught it and stayed alive, so surface a 500 here.
+        Ok(result) => Err((StatusCode::INTERNAL_SERVER_ERROR, result.message)),
+        Err(_) => {
+            tracing::error!("Failed to receive save result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler for loading a named save, restoring the active mission, player
+/// position/rotation, quest bits, and held items. Works cross-launch (a fresh
+/// runtime started on any mission can load a frontier save and resume).
+async fn load_game(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<SaveLoadRequest>,
+) -> Result<Json<commands::SaveLoadResult>, (StatusCode, String)> {
+    let file = validate_save_name(&request.file)?;
+
+    // The load path does `File::open(...).unwrap()`, so a missing save would
+    // panic the game-loop thread and brick the runtime for every later command.
+    // Reject a nonexistent save up front with 404 instead.
+    let resolved = shock2vr::save_file_path(&file);
+    if !resolved.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "save '{}' not found (looked at {})",
+                file,
+                resolved.display()
+            ),
+        ));
+    }
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::LoadGame {
+            file,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send LoadGame command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+
+    match reply_rx.await {
+        Ok(result) if result.success => Ok(Json(result)),
+        // The save existed but was corrupt / schema-incompatible: the game loop
+        // caught the panic and kept the previous scene, so surface a 500 rather
+        // than a misleading success.
+        Ok(result) => Err((StatusCode::INTERNAL_SERVER_ERROR, result.message)),
+        Err(_) => {
+            tracing::error!("Failed to receive load result - sender dropped");
             Err(game_loop_unavailable())
         }
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -90,6 +90,17 @@ pub fn resource_path(str: &str) -> String {
     paths::data_root().join(str).to_string_lossy().into_owned()
 }
 
+/// Resolve a bare save name to its on-disk `.sav` path under `<data_root>/saves`.
+///
+/// `name` is expected to be a bare name (no extension / path separators - the
+/// caller validates that at the edge). Named saves live in a stable directory
+/// keyed off the data root so a save written in one runtime launch can be
+/// reloaded in a later launch (frontier persistence for automated play-through
+/// loops).
+pub fn save_file_path(name: &str) -> std::path::PathBuf {
+    paths::data_root().join("saves").join(format!("{name}.sav"))
+}
+
 /// How the game is presented and controlled.
 ///
 /// `Vr` is the existing head/hands interaction model (forearm HUD panels,
@@ -527,6 +538,37 @@ impl Game {
             loc,
             entities_to_trigger: vec![],
         });
+    }
+
+    /// Save the current game to a named save file under `<data_root>/saves`.
+    ///
+    /// `file` is a bare name (no extension / path separators - validate at the
+    /// edge); it resolves to `<data_root>/saves/<file>.sav`. This is the same
+    /// serialization an in-game quicksave performs (`GlobalEffect::Save`) -
+    /// active mission, player position/rotation, quest bits, and held items.
+    /// Returns the scene name that was saved so the caller can report it.
+    pub fn save_game(&mut self, file: String) -> String {
+        let path = save_file_path(&file);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        self.handle_global_effect(GlobalEffect::Save {
+            file_name: path.to_string_lossy().into_owned(),
+        });
+        self.scene_name().to_string()
+    }
+
+    /// Load a previously-saved game from `<data_root>/saves/<file>.sav`,
+    /// restoring the active mission, player position/rotation, quest bits, and
+    /// held items. The switch is synchronous (no loading-screen deferral), so
+    /// the returned scene name already reflects the restored mission. The caller
+    /// must ensure the file exists - the load path panics on a missing file.
+    pub fn load_game(&mut self, file: String) -> String {
+        let path = save_file_path(&file);
+        self.handle_global_effect(GlobalEffect::Load {
+            file_name: path.to_string_lossy().into_owned(),
+        });
+        self.scene_name().to_string()
     }
 
     /// Get access to the debug scene interface if available

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -19,6 +19,7 @@ import type {
   MoveResult,
   TeleportResult,
   TransitionLevelResult,
+  SaveLoadResult,
   QuestBitsResult,
   QuestBitValue,
   PlayerInventoryResult,
@@ -315,6 +316,26 @@ export class Game {
       "/v1/control/transition-level",
       { level, loc },
     );
+  }
+
+  /**
+   * Save the current game to a named file (a bare name, no extension / path
+   * separators - e.g. "frontier"). Persists the active mission, player
+   * position/rotation, quest bits, and held items. The save survives across
+   * runtime relaunches, so a later `load(file)` in a fresh session resumes it.
+   */
+  async save(file: string): Promise<SaveLoadResult> {
+    return this.client.post<SaveLoadResult>("/v1/save", { file });
+  }
+
+  /**
+   * Load a previously-saved game by name, restoring the active mission, player
+   * position/rotation, quest bits, and held items. The restore is synchronous,
+   * so info() reflects the loaded mission immediately. Rejects (404) if no save
+   * with that name exists.
+   */
+  async load(file: string): Promise<SaveLoadResult> {
+    return this.client.post<SaveLoadResult>("/v1/load", { file });
   }
 
   /**

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -226,6 +226,15 @@ export interface TransitionLevelResult {
   message: string;
 }
 
+export interface SaveLoadResult {
+  success: boolean;
+  /** Bare save name (no extension) that was saved/loaded. */
+  file: string;
+  /** Active scene after the operation, e.g. "medsci1.mis". */
+  mission: string;
+  message: string;
+}
+
 /** The 3-state value of a quest bit (objective flag). */
 export type QuestBitValue = "unknown" | "incomplete" | "complete";
 

--- a/tools/shock2-sdk/test/save-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/save-load.e2e.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { GameServer, HttpError, findRepoRoot } from "../src/index.js";
+import type { Position } from "../src/types.js";
+
+// End-to-end test for the save-to-file / load-from-file endpoints. Requires game
+// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: before POST /v1/save + /v1/load existed, there was no way to
+// persist a game from HTTP and resume it in a later runtime launch. The whole
+// point is cross-launch resume for the automated play-through loop (a "frontier"
+// save reloaded after a relaunch). This test proves exactly that: it saves in
+// one runtime process, shuts it down, launches a FRESH process on a DIFFERENT
+// mission, loads the save, and asserts the active mission + player position are
+// restored - which is impossible without the endpoints (the save call 404s).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8101);
+
+function distance(a: Position, b: Position): number {
+  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+// Locate the on-disk .sav for a freshly-saved name by scanning the candidate
+// saves dirs (mirrors shock2vr::save_file_path = <data_root>/saves/<name>.sav;
+// data_root is DARK_ASSET_PATH or a ./Data search relative to the repo root).
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((d): d is string => Boolean(d));
+  for (const root of roots) {
+    const p = join(root, "saves", `${saveName}.sav`);
+    if (existsSync(p)) return p;
+  }
+  return undefined;
+}
+
+test(
+  "save then load in a fresh runtime restores mission and player position",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Use a unique save name per run so stale files from a prior run can't mask
+    // a regression (a real save must be written this run for load to succeed).
+    const saveName = `frontier_e2e_${Date.now()}`;
+    let savedPos: Position;
+
+    // --- Session 1: start in medsci1, move away from spawn, save. ---
+    {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: basePort,
+      });
+
+      await game.step({ frames: 2 });
+      assert.equal(
+        (await game.info()).mission,
+        "medsci1.mis",
+        "should start in medsci1",
+      );
+
+      // Walk forward so the saved position is distinct from the default spawn -
+      // this makes the position-restore assertion meaningful (not a coincidence
+      // of both sessions spawning at the same place).
+      const spawnPos = await game.player.position();
+      await game.input.set("right_hand.thumbstick", [0.0, 1.0]);
+      await game.step({ frames: 90 });
+      await game.input.set("right_hand.thumbstick", [0.0, 0.0]);
+      await game.step({ frames: 5 });
+
+      savedPos = await game.player.position();
+      assert.ok(
+        distance(savedPos, spawnPos) > 0.5,
+        `player should have moved from spawn before saving (spawn=${JSON.stringify(spawnPos)}, saved=${JSON.stringify(savedPos)})`,
+      );
+
+      const saveResult = await game.save(saveName);
+      assert.equal(saveResult.success, true, "save should report success");
+      assert.equal(saveResult.mission, "medsci1.mis");
+    }
+
+    // --- Session 2: a FRESH process on a DIFFERENT mission, then load. ---
+    {
+      await using game = await GameServer.launch({
+        mission: "eng1.mis",
+        port: basePort + 1,
+      });
+
+      await game.step({ frames: 2 });
+      assert.equal(
+        (await game.info()).mission,
+        "eng1.mis",
+        "fresh session should start on the different mission (eng1)",
+      );
+
+      const loadResult = await game.load(saveName);
+      assert.equal(loadResult.success, true, "load should report success");
+      assert.equal(
+        loadResult.mission,
+        "medsci1.mis",
+        "load result should report the restored mission",
+      );
+
+      // The load is synchronous, so info() reflects the restored mission right
+      // away (no step needed to settle the scene swap).
+      assert.equal(
+        (await game.info()).mission,
+        "medsci1.mis",
+        "active mission should be the loaded medsci1 (cross-launch resume)",
+      );
+
+      const loadedPos = await game.player.position();
+      assert.ok(
+        distance(loadedPos, savedPos) < 1.0,
+        `restored player position should match the saved one (saved=${JSON.stringify(savedPos)}, loaded=${JSON.stringify(loadedPos)})`,
+      );
+
+      // Bad names must be rejected with a 400 (not crash the game-loop thread):
+      // the save/load path builds a filesystem path from the name, so an empty
+      // or path-like name has to be refused at the edge.
+      await assert.rejects(
+        game.save(""),
+        (err: unknown) =>
+          err instanceof HttpError && err.status === 400,
+        "empty save name should be a 400",
+      );
+      await assert.rejects(
+        game.load("../escape"),
+        (err: unknown) =>
+          err instanceof HttpError && err.status === 400,
+        "path-like save name should be a 400",
+      );
+      // Loading a save that does not exist must 404, not panic the runtime.
+      await assert.rejects(
+        game.load(`nonexistent_${Date.now()}`),
+        (err: unknown) =>
+          err instanceof HttpError && err.status === 404,
+        "loading a missing save should be a 404",
+      );
+
+      // Runtime is still live after the rejected calls.
+      assert.equal(
+        (await game.info()).mission,
+        "medsci1.mis",
+        "runtime should stay live and on medsci1 after rejected save/load calls",
+      );
+    }
+  },
+);
+
+test(
+  "loading a corrupt save returns 500 without bricking the runtime",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // A frontier save persists across code changes, so an existing-but-corrupt
+    // or schema-incompatible .sav is a real hazard: the load path unwraps while
+    // parsing. The runtime must catch that and return an error, NOT unwind out
+    // of the game-loop thread (which would hang every later command). Negative-
+    // first: without the catch this load hangs/bricks and the liveness check
+    // below times out.
+    const saveName = `corrupt_e2e_${Date.now()}`;
+
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 2 });
+
+    // Write a valid save so the file exists (and to locate the saves dir), then
+    // overwrite it with garbage that is not a valid SaveData payload.
+    await game.save(saveName);
+    const savePath = findSavePath(saveName);
+    assert.ok(savePath, `should be able to locate the saved file for ${saveName}`);
+    writeFileSync(savePath, "this is not a valid save file");
+
+    await assert.rejects(
+      game.load(saveName),
+      (err: unknown) => err instanceof HttpError && err.status === 500,
+      "loading a corrupt save should be a 500, not a hang/crash",
+    );
+
+    // The decisive check: the runtime is still responsive and on the original
+    // mission (the failed load left the previous scene intact).
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "runtime should stay live on medsci1 after a failed load",
+    );
+  },
+);


### PR DESCRIPTION
## What

Exposes the game's save-to-file / load-from-file over the debug runtime's HTTP API, so an automated play-through loop can persist a **frontier** save and reload it to resume **across runtime relaunches**.

Two endpoints, mirroring the existing `/v1/control/transition-level` pattern (public `Game` wrapper + `RuntimeCommand` + route + async handler):

- `POST /v1/save { file }` — save the current game to a named save file.
- `POST /v1/load { file }` — load a previously-saved game (restores active mission, player position/rotation, quest bits, held items).

## Cross-launch resume use case

The play-through loop plays a session, advances a frontier, then relaunches the runtime to continue. Persisting/reloading a named save is how the frontier survives a relaunch. `file` is a bare name (e.g. `"frontier"`); it resolves to `<data_root>/saves/<name>.sav` — a stable location keyed off the data root, so a save written in one launch is found by a later launch (verified: save in a `medsci1` process, then `load("frontier")` in a fresh process started on `eng1` restores `medsci1` at the saved position).

## Wiring

- **`shock2vr/src/lib.rs`**: `Game::save_game` / `load_game` (thin wrappers over the existing `GlobalEffect::Save`/`Load` path) return the resulting `scene_name()`; new `save_file_path(name)` resolves the bare name under `<data_root>/saves`.
- **`runtimes/debug_runtime`**: `RuntimeCommand::SaveGame`/`LoadGame` + `SaveLoadResult`, routes `POST /v1/save` + `POST /v1/load`, async handlers.
- **`tools/shock2-sdk`**: `game.save(file)` / `game.load(file)` + `SaveLoadResult` type.

## Robustness (reject/contain before the panic)

The underlying save/load path `.unwrap()`s, so the endpoints defend the game-loop thread:

- **Name validation** at the edge: empty / `/` / `\` / `..` are rejected with **400**; a load of a missing save is rejected with **404** — before dispatch, so a bad name can't reach the filesystem.
- **`catch_unwind`** at the game-loop boundary: an I/O failure, or an existing-but-corrupt/schema-incompatible `.sav`, returns **HTTP 500** instead of unwinding out of and bricking the game-loop thread. A failed load leaves the previously-active scene intact. (Added after cross-engine review flagged that an existence check alone still panics on a corrupt file — a real hazard for frontier saves that outlive a code change.)

## Tests (negative-first, SDK e2e, gated behind `SHOCK2_E2E=1`)

`tools/shock2-sdk/test/save-load.e2e.test.ts`:
1. Save in one runtime process, shut it down, launch a **fresh** process on a **different** mission, load — assert mission + player position restored (cross-launch resume). Also asserts empty/path-like names → 400 and a missing save → 404, and the runtime stays live afterward.
2. Plant a corrupt `.sav`, load it — assert **500** and that the runtime is still responsive on the original mission (validates the `catch_unwind` fix).

Both pass. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` and `npm test` (SDK units) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)