### PR TITLE
feat(career): drive career choice from the real earth.mis flow (follow-up to #426)

### DIFF
--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -73,21 +73,6 @@ impl DesktopInputMapper {
                 modifier: Modifier::Alt,
                 action: InputAction::QuickLoad,
             },
-            Binding {
-                key: Key::F1,
-                modifier: Modifier::None,
-                action: InputAction::SelectCareerMarine,
-            },
-            Binding {
-                key: Key::F2,
-                modifier: Modifier::None,
-                action: InputAction::SelectCareerNavy,
-            },
-            Binding {
-                key: Key::F3,
-                modifier: Modifier::None,
-                action: InputAction::SelectCareerOsa,
-            },
         ];
 
         Self {

--- a/shock2vr/src/career.rs
+++ b/shock2vr/src/career.rs
@@ -1,17 +1,18 @@
 //! Player career branching for the station recruit deck.
 //!
-//! System Shock 2 opens on the recruitment station, where the player picks one
-//! of three service branches - Marine (combat), Navy (tech), or OSA (psi) - and
-//! deploys to the Von Braun (MedSci 1) with a career-appropriate build. The
-//! branch is chosen via `P$Service` (see `ChooseServiceScript`) or the debug
-//! `SelectCareer*` input actions, registered as a persisted quest bit so it
-//! survives the level transition, then applied to the player on deployment.
+//! System Shock 2 opens on the recruitment intro (`earth.mis`), where the player
+//! picks one of three service branches - Marine (combat), Navy (tech), or OSA
+//! (psi) - by walking through the matching career door, then rides through the
+//! recruit station and deploys to the Von Braun (MedSci 1) with a career-
+//! appropriate build. Choosing a branch fires that door's `ChooseServiceScript`
+//! marker (which carries a `P$Service` value), registering the career as a
+//! persisted quest bit so it survives every level transition, then it is applied
+//! to the player on each mission load.
 //!
 //! The per-career attribute table here is a faithful-in-spirit starting point,
 //! not the exact retail OS-unit numbers: it emphasises each branch (Marines are
 //! tanky, OSA are psionic) so the three careers arrive observably different.
-//! A full skill/stat/cyber-module system - and wiring the in-world station
-//! debrief UI to `ChooseServiceScript` - is deferred (issue #424).
+//! A full skill/stat/cyber-module system is deferred (issue #424).
 
 use dark::properties::QuestBitValue;
 

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -54,15 +54,6 @@ pub enum InputAction {
     /// Force every monster back to Lowest alertness (idle). Same caveats as
     /// DebugAlertAll.
     DebugCalmAll,
-
-    /// Enlist in the Marine (combat) service branch at the station recruit
-    /// deck. Registers the career (persisted quest bit) so it applies on the
-    /// next deployment. Mutually exclusive with the other two.
-    SelectCareerMarine,
-    /// Enlist in the Navy (tech) service branch. See `SelectCareerMarine`.
-    SelectCareerNavy,
-    /// Enlist in the OSA (psi) service branch. See `SelectCareerMarine`.
-    SelectCareerOsa,
 }
 
 impl InputAction {
@@ -84,9 +75,6 @@ impl InputAction {
             InputAction::DebugReloadLevel,
             InputAction::DebugAlertAll,
             InputAction::DebugCalmAll,
-            InputAction::SelectCareerMarine,
-            InputAction::SelectCareerNavy,
-            InputAction::SelectCareerOsa,
         ]
     }
 
@@ -106,9 +94,6 @@ impl InputAction {
             InputAction::DebugReloadLevel => "DebugReloadLevel",
             InputAction::DebugAlertAll => "DebugAlertAll",
             InputAction::DebugCalmAll => "DebugCalmAll",
-            InputAction::SelectCareerMarine => "SelectCareerMarine",
-            InputAction::SelectCareerNavy => "SelectCareerNavy",
-            InputAction::SelectCareerOsa => "SelectCareerOsa",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -90,16 +90,6 @@ impl ActionDispatcher {
                 level: AIAlertLevel::Lowest,
             });
         }
-        if state.just_triggered(InputAction::SelectCareerMarine) {
-            effects.extend(crate::career::Career::Marine.select_effects());
-        }
-        if state.just_triggered(InputAction::SelectCareerNavy) {
-            effects.extend(crate::career::Career::Navy.select_effects());
-        }
-        if state.just_triggered(InputAction::SelectCareerOsa) {
-            effects.extend(crate::career::Career::Osa.select_effects());
-        }
-
         effects
     }
 }

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -1,20 +1,24 @@
-use dark::properties::{PropService, QuestBitValue};
+use dark::properties::{PropDestLevel, PropDestLoc, PropService};
 use shipyard::{EntityId, Get, View, World};
+use tracing::info;
 
 use crate::career::Career;
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, GlobalEffect, MessagePayload, Script};
 
-/// The station recruit-deck script that records which service branch
-/// (Marine/Navy/OSA) the player enlisted in and deploys them to MedSci 1.
+/// Records the service branch (Marine/Navy/OSA) the player enlisted in on the
+/// recruitment intro (`earth.mis`), then sends them on to the recruit station.
 ///
-/// The branch comes from the entity's `P$Service` value; it is registered as a
-/// persisted career quest bit (so it applies to the player on deployment - see
-/// `crate::career`) and the year-1 training quest bit is completed. Attaching
-/// this script to the in-world station debrief UI is still deferred (issue
-/// #424); the `SelectCareer*` input actions drive the same registration
-/// meanwhile.
+/// The three career-choice markers in `earth.mis` (`SendToMarines` and its two
+/// unnamed siblings) carry this script plus a `P$Service` value (0 = Marine,
+/// 1 = Navy, 2 = OSA) and a `P$DestLevel`/`P$DestLoc` transition target. A
+/// tripwire `TurnOn`s the marker matching the branch the player walked into; on
+/// that message this script persists the chosen career as a quest bit - so the
+/// career loadout applies to the player on every subsequent mission load (see
+/// `crate::career` + `MissionCore::load`) - and then transitions to the marker's
+/// own destination (the station recruit deck). The three branches are mutually
+/// exclusive: selecting one clears the others.
 pub struct ChooseServiceScript {}
 impl ChooseServiceScript {
     pub fn new() -> ChooseServiceScript {
@@ -32,27 +36,29 @@ impl Script for ChooseServiceScript {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                // Read the enlisted branch from this entity's P$Service value.
                 let v_service = world.borrow::<View<PropService>>().unwrap();
                 let service = v_service.get(entity_id).map(|s| s.0).unwrap_or(0);
                 let career = Career::from_service(service);
+                info!(
+                    "Recruitment: enlisted in {:?} (service {})",
+                    career, service
+                );
 
                 let mut effects = career.select_effects();
-                effects.push(Effect::SetQuestBit {
-                    quest_bit_name: "training_year_1".to_string(),
-                    quest_bit_value: QuestBitValue::COMPLETE,
-                });
-                // TODO(#424): fully wire the in-world station debrief sequence.
-                effects.push(Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                    level_file: "medsci1.mis".to_owned(),
-                    loc: None,
-                    entities_to_trigger: vec!["DEBRIEF1-DOOR".to_string()],
-                }));
-                effects.push(super::script_util::send_to_all_switch_links_and_self(
-                    world,
-                    entity_id,
-                    MessagePayload::TurnOn { from: entity_id },
-                ));
+
+                // Continue to this marker's own destination (the recruit
+                // station); the marker with no destination just records the
+                // career. A missing dest loc uses the level's default spawn.
+                let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
+                if let Ok(dest_level) = v_dest_level.get(entity_id) {
+                    let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
+                    let dest_loc = v_dest_loc.get(entity_id).ok().map(|l| l.0);
+                    effects.push(Effect::GlobalEffect(GlobalEffect::TransitionLevel {
+                        level_file: format!("{}.mis", dest_level.0),
+                        loc: dest_loc,
+                        entities_to_trigger: vec![],
+                    }));
+                }
 
                 Effect::Multiple(effects)
             }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -9,9 +9,6 @@ export type InputAction =
   | "CycleAmmo"
   | "Reload"
   | "CyclePsiPower"
-  | "SelectCareerMarine"
-  | "SelectCareerNavy"
-  | "SelectCareerOsa"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 
@@ -64,7 +61,10 @@ export type DebugEntityMessage =
   | { type: "Damage"; amount: number }
   | { type: "Frob" }
   | { type: "Signal"; name: string }
-  | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" };
+  | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" }
+  // Switch-link activate/deactivate - what a tripwire/button sends to its targets.
+  | { type: "TurnOn" }
+  | { type: "TurnOff" };
 
 export interface EntitySummary {
   id: number;

--- a/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-career-attributes.e2e.test.ts
@@ -2,45 +2,98 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
 
-// End-to-end test for station career (Marine/Navy/OSA) branching. Requires game
-// assets in Data/ and compiles the runtime on first run, so it is opt-in:
+// End-to-end test for career (Marine/Navy/OSA) branching. Requires game assets
+// in Data/ and compiles the runtime on first run, so it is opt-in:
 //
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 //
-// Negative-first: before this change, choosing a service branch did nothing -
-// there were no SelectCareer* actions and no career loadout, so all three tours
-// deployed to medsci1 with the identical default player-template attributes
-// (30 HP, 40/50 psi). The asserts that the three careers arrive with *different*
-// hit points and psi points would all fail (every value would be 30/40).
+// The career is chosen by *playing the recruitment intro* (earth.mis): three
+// ChooseService markers there carry a P$Service value (0=Marine, 1=Navy, 2=OSA)
+// and a transition to the recruit station. TurnOn'ing one (as its tripwire does
+// when the player walks through that career door) persists the chosen career as
+// a quest bit and ships the player to the station; the career loadout is then
+// applied to the player on every subsequent mission load. Marines arrive tanky
+// (45 HP / 20 psi), Navy balanced (35 / 35), OSA psionic (30 / 60).
 //
-// After the change, the career is registered (persisted quest bit) and applied
-// on deployment, so Marines arrive tanky (45 HP / 20 psi), Navy balanced
-// (35 / 35), and OSA psionic (30 / 60).
+// Negative-first: with the loadout neutralized (or the career never registered),
+// all three branches deploy with the identical default player-template
+// attributes (30 HP, 40/50 psi) and the "should differ" asserts fail. The test
+// also guards that selection is the *station flow*, not the removed debug
+// SelectCareer* input actions.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-/** Select a career at the station, deploy to medsci1, and read the arrival
- * attributes. transitionLevel() reloads medsci1, so the loadout (which applies
- * on mission load from the persisted career bit) re-applies each time. */
-async function deployWithCareer(
-  game: GameServer,
-  action: string,
+// The ChooseService career markers in earth.mis, keyed by their P$Service value,
+// located by their (stable) mission-data world positions. Runtime entity ids are
+// not stable across runs and two of the three markers are unnamed, so position
+// is the reliable handle.
+const MARKERS: Record<string, { service: number; pos: Vec3 }> = {
+  marine: { service: 0, pos: [-5.199172, 24.0, 68.71187] },
+  navy: { service: 1, pos: [-1.8059494, 24.0, 84.12585] },
+  osa: { service: 2, pos: [16.933895, 24.0, 83.833176] },
+};
+
+function dist2(a: Vec3, b: Vec3): number {
+  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2;
+}
+
+/**
+ * Play one career: launch the recruitment intro, TurnOn the branch's
+ * ChooseService marker (the real career-choice entity), confirm it ships the
+ * player to the recruit station, deploy on to medsci1, and read the arrival
+ * attributes. A fresh launch per career keeps the runs independent (and avoids a
+ * pre-existing earth.mis reload issue).
+ */
+async function playCareer(
+  branch: keyof typeof MARKERS,
+  port: number,
 ): Promise<{ maxHp: number; maxPsi: number }> {
-  await game.input.trigger(action);
-  await game.step({ frames: 2 });
+  await using game = await GameServer.launch({ mission: "earth.mis", port });
+  await game.step({ frames: 5 });
+
+  // Guard: selection must go through station's own entities, not the removed
+  // debug SelectCareer* actions.
+  const actions = await game.input.actions();
+  assert.ok(
+    !actions.some((a) => a.startsWith("SelectCareer")),
+    "career selection must not be driven by debug SelectCareer* actions",
+  );
+
+  const { pos } = MARKERS[branch];
+  const { entities } = await game.entities.list({ limit: 5000 });
+  const candidates = entities.filter((e) => e.position && e.position.every((v) => v != null));
+  const marker = candidates.reduce((best, e) =>
+    dist2(e.position, pos) < dist2(best.position, pos) ? e : best,
+  );
+  assert.ok(
+    dist2(marker.position, pos) < 0.01,
+    `${branch}: found a marker at ${JSON.stringify(marker.position)} (wanted ${JSON.stringify(pos)})`,
+  );
+  // Confirm the position lookup actually hit a ChooseService marker (the real
+  // career-choice entity), not just some unrelated entity nearby.
+  const detail = await game.entities.detail(marker.id);
+  assert.ok(
+    detail.properties.some((p) => p.name === "Scripts" && p.value.includes("ChooseService")),
+    `${branch}: marker ${marker.id} should carry the ChooseService script`,
+  );
+
+  await game.entities.sendMessage(marker.id, { type: "TurnOn" });
+  await game.step({ frames: 3 });
+  // The marker's own transition ships the player to the recruit station.
+  assert.equal(
+    (await game.info()).mission,
+    "station.mis",
+    `${branch}: choosing a career should transition to the recruit station`,
+  );
+
+  // Deploy on to medsci1 (reloading re-applies the loadout from the persisted
+  // career bit on mission load).
   await game.transitionLevel("medsci1.mis");
   await game.step({ frames: 3 });
   const player = (await game.info()).player;
-  assert.notEqual(
-    player.max_hit_points,
-    null,
-    `${action}: player should have a hit-point pool after deployment`,
-  );
-  assert.notEqual(
-    player.max_psi_points,
-    null,
-    `${action}: player should have a psi pool after deployment`,
-  );
+  assert.notEqual(player.max_hit_points, null, `${branch}: player should have a hit-point pool`);
+  assert.notEqual(player.max_psi_points, null, `${branch}: player should have a psi pool`);
   return {
     maxHp: player.max_hit_points as number,
     maxPsi: player.max_psi_points as number,
@@ -48,18 +101,13 @@ async function deployWithCareer(
 }
 
 test(
-  "station: careers deploy to medsci1 with distinct attributes",
+  "career: branches chosen at the recruitment intro deploy with distinct attributes",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await GameServer.launch({
-      mission: "station.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8117),
-    });
-    await game.step({ frames: 10 });
-
-    const marine = await deployWithCareer(game, "SelectCareerMarine");
-    const navy = await deployWithCareer(game, "SelectCareerNavy");
-    const osa = await deployWithCareer(game, "SelectCareerOsa");
+    const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8117);
+    const marine = await playCareer("marine", basePort);
+    const navy = await playCareer("navy", basePort + 1);
+    const osa = await playCareer("osa", basePort + 2);
 
     // Hit points differ across all three branches (Marines tankiest, OSA least).
     assert.notEqual(marine.maxHp, navy.maxHp, "Marine vs Navy HP should differ");


### PR DESCRIPTION
Follow-up to **#426** (which merged while this rework was in flight, so it could not be updated in place). #426 shipped Marine/Navy/OSA career branching but used debug `SelectCareer*` input actions (desktop F1/F2/F3) as the selection mechanism, on the assumption that no mission entity wired the choice. It does — this PR replaces the debug shortcut with the game's own flow.

## The real flow (verified from mission data)
The recruitment intro **`earth.mis`** has three markers that already carry the `ChooseService` script plus:
- `P$Service` — 0 = Marine, 1 = Navy, 2 = OSA
- `P$DestLevel="station"` / `P$DestLoc=2501` — a transition to the recruit station's canonical start (`Starting_Location`, `PropStartLoc 2501`)

Each is `TurnOn`'d by a tripwire when the player walks through that career door. (`ChooseServiceScript` was already registered and attached to these entities in the mission data — the original code just hardcoded a medsci1 jump with a `// TODO: Fully implement station.msi`.) No other mission carries `S$ChooseService`.

The station year loop (`ChooseMissionScript`) then advances the three training years and deploys to MedSci1; the persisted career bit is applied to the player on that load. Player HP/psi aren't serialized (the player is re-hydrated from its template each load), so re-applying from a persisted bit is the correct mechanism — that part of #426 is kept unchanged.

## Changes
- **`ChooseServiceScript`**: on `TurnOn`, read `P$Service`, persist the mutually-exclusive career quest bit, and transition to the marker's own `P$DestLevel`/`P$DestLoc` (the station). Removed the hardcoded medsci1 shortcut, the `START_xx`/`DEBRIEF1-DOOR` triggers, and the redundant `training_year_1` set (the year loop owns progression and defaults to year 1).
- **Removed** the `SelectCareer{Marine,Navy,Osa}` debug input actions, their dispatcher wiring, the desktop F1/F2/F3 bindings, and the SDK action types.
- **Kept** the on-load loadout application from the persisted bit.
- Added `TurnOn`/`TurnOff` to the SDK `DebugEntityMessage` type.

### Observable result (verified live in the debug runtime)
`earth.mis` → TurnOn a career marker → transitions to `station.mis` → deploy to `medsci1.mis`:

| Career | max HP | max psi |
| --- | --- | --- |
| Marine | 45 | 20 |
| Navy | 35 | 35 |
| OSA | 30 | 60 |

## Test (negative-first)
`tools/shock2-sdk/test/station-career-attributes.e2e.test.ts` now selects a career by `TurnOn`'ing the **real earth.mis ChooseService marker** (located by its stable world position — runtime ids aren't stable and two of the three markers are unnamed; also asserts the matched entity actually carries the `ChooseService` script), asserts the choice transitions to the station, deploys to medsci1, and asserts the three branches arrive with distinct HP/psi. It also guards that the removed `SelectCareer*` actions are gone. Confirmed it **fails** when career persistence is neutralized (all three deploy at the default 30/40 → "Marine vs Navy HP should differ").

`station-career.e2e.test.ts` (year loop) and `missions.e2e.test.ts` (all 23 missions load) still pass; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` is clean.

## Review
Ran `/xreview` (Claude subagent + Codex) twice. The one High raised (Codex: career could "stall" at the station with an empty `entities_to_trigger`) was not corroborated — the Claude reviewer traced the entities (all three markers have 0 links, so the old switch-link/DEBRIEF propagation was a no-op) and the transition lands at the station's own start loc 2501, from which the independently-tested year loop advances. Codex itself noted it could not scan the `.mis` data. Acted on the convergent Low finding by asserting the position-matched entity is a genuine `ChooseService` marker.

## Deferred
- Full skill/stat/cyber-module economy and functional trainers (#424) — the trainer stubs land in #426.
- The e2e deploys from station to medsci1 via a direct `transitionLevel` rather than walking the full 3-year `ChooseMission` loop (that path is covered by `station-career.e2e.test.ts`; looping the reloads in one test would be flaky).
- Pre-existing: transitioning **to** `earth.mis` (reloading it) panics in property parsing (`dark/src/properties/mod.rs:1933`); a fresh load is fine, so the test uses a fresh launch per career.

🤖 Generated with [Claude Code](https://claude.com/claude-code)