### PR TITLE
feat(physics): flat (desktop-style) ladder climbing

### DIFF
--- a/.claude/skills/play-through/walkthroughs/medsci1.md
+++ b/.claude/skills/play-through/walkthroughs/medsci1.md
@@ -1,87 +1,137 @@
-# Walkthrough — medsci1 (MedSci Deck 1)
+# Walkthrough — medsci1 (MedSci Deck 1: Cryo Recovery + Science sector)
 
-First playable deck. This walkthrough exercises the critical-path systems —
-player state, item pickup, objective tracking, and the level transition — with
-warp+teleport navigation.
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+**real critical path** (cross-checked against portforward.com, sshock2.com, and
+powerpyx/Steam code guides, then verified against `medsci1.mis` entity data) —
+use it to play with intent and to judge whether a session genuinely progressed.
+It is **not a script**: observe and react; use the anchors to know where the
+path goes and what *should* happen there.
 
-**Derived from game data** (`cargo dq entities medsci1.mis ...`):
-- The MedSci → Engineering transition is a `TrapTripLevel` tripwire, entity
-  **764** (`sym:Tripwire`), `PropDestLevel("eng1")`, `PropDestLoc(21)`, trigger
-  volume at **(12.684996, -5.635426, -43.591045)**. It fires on
-  `SensorBeginIntersect` — teleporting the player into the volume triggers it.
-- Pickup items exist as world entities (e.g. `20 Nanites`), resolvable at run
-  time by name/template.
-- Quest-bit entities here are mechanism triggers (elevator filters), not
-  narrative objectives; medsci1's objectives are goal-driven, so CP3 demonstrates
-  the quest-bit read/set path rather than asserting a specific mission objective.
+**Positions are runtime-space** (same space as `/v1/player/*`, `/v1/entities`)
+verified against a live runtime. **Resolve entities by name/template at run
+time** (`GET /v1/entities?filter=...`) — never hardcode runtime ids. The
+`template_id` in `/v1/entities` output is the stable handle listed below.
 
-**External cross-check:** the intended path on MedSci-1 is wake → arm yourself →
-work through the deck → take the transition toward Engineering. The checkpoints
-below abstract that into verifiable states.
+## Deck structure
 
-Resolve item/trigger runtime ids at run time (`entities.list({filter})` /
-`entities.byTemplate`) rather than trusting the ids above — they are stable but
-the query is self-documenting and robust to data changes.
+Two floors: **lower** (y ≈ −4…−8: spawn cryo bay, cryo-recovery block, upgrade
+hub) and **upper** (y ≈ 0…1: most of the Science sector — elevator lobby,
+chemical storeroom, turret area, bulkheads). Vertical traversal is by **ladders
+and small lift platforms**, not stairs.
 
----
+Three exits (live `/v1/transitions`):
 
-### CP1 — Spawn & load
-- setup: launch the debug runtime on `medsci1.mis`; `step({frames: 5})`.
-- act: none (pure state check).
-- verify:
-  - `info().mission == "medsci1.mis"`
-  - `info().player.hit_points` is non-null and `> 0` (player has a health pool)
-  - `player.position()` is all-finite
-  - `entities.list({limit:1}).total_count > 0` (world instantiated)
-- capture: screenshot `cp1-spawn.png`
-- on-fail: mission won't load / no player / no entities → `[functionality]`
-  (level load or entity instantiation). A null health pool → `[gameplay]` or
-  `[debug_runtime]` depending on whether the player truly has no `PropHitPoints`.
+| exit | entity | position | leads to |
+| --- | --- | --- | --- |
+| Medical bulkhead (north) | `Bulk_On_Button` tmpl 1009 | (43.9, 0.0, −76.4) | medsci2 loc 100 |
+| Medical bulkhead (south) | `Bulk_On_Button` tmpl 1103 | (45.5, 0.0, −15.6) | medsci2 loc 300 |
+| **Maintenance conduit (the level exit)** | `Tripwire` tmpl 764 (TrapTripLevel) | (12.7, −5.6, −43.6) | **eng1** loc 21 |
 
-### CP2 — Acquire an item (pickup)
-- setup: `const item = entities.list({filter:"*Nanites*", limit:50}).entities[0]`
-  (fall back to `*Wrench*` if none). Assert one was found.
-- act: `player.give(item.id)`.
-- verify:
-  - the give call succeeds
-  - `player.inventory()` contains an item with `entity_id == item.id` and
-    `location == "inventory"`
-- capture: screenshot `cp2-inventory.png` (open inventory if the HUD supports it)
-- on-fail: give rejects a valid pickup → `[gameplay]` (frob eligibility) or
-  `[debug_runtime]` (give lever). Item doesn't appear in inventory →
-  `[debug_runtime]` (inventory read) or `[gameplay]` (Contains link).
+The deck's **main elevator is inoperative** (Master Elevator Button tmpl 1041 at
+(0.4, 0, −40.4), Double Elevator Doors ~(0.8, 0.2, −42)) — it is NOT the exit.
+The story objective chain: cryo escape → Science sector → **medsci2 round trip**
+(Grassi → Watts, who has code 12451) → back → maintenance conduit → Engineering.
 
-### CP3 — Objective tracking (quest-bit path)
-- setup: none.
-- act: `quests.set("medsci.playthrough.cp3", "complete")`.
-- verify:
-  - `quests.get("medsci.playthrough.cp3") == "complete"`
-  - `quests.list()` includes it; resetting it to `"unknown"` removes it
-- capture: none.
-- on-fail: quest read/set disagree → `[debug_runtime]` (quest endpoint). (When a
-  real medsci1 objective bit is identified, replace this with: perform the
-  objective action, then assert the game-set bit flips — a `[gameplay]` check.)
+## Codes & required items
 
-### CP4 — Level transition (MedSci → Engineering)
-- setup: `player.teleport({x:12.684996, y:-5.635426, z:-43.591045})` — into the
-  entity-764 tripwire volume.
-- act: `step({frames: 15})` to let `SensorBeginIntersect` fire.
-- verify:
-  - `info().mission == "eng1.mis"` (the transition fired and eng1 loaded)
-  - after `step({frames: 30})`, `player.position()` is all-finite (player is
-    live in the new level)
-- capture: screenshot `cp4-eng1.png`
-- on-fail: mission stays `medsci1.mis` → `[gameplay]` (tripwire/`TrapTripLevel`
-  didn't fire) — cross-check by warping directly (`transitionLevel("eng1", 21)`);
-  if the direct warp works but the trigger doesn't, it's the trigger. Runtime
-  crashes on transition → `[functionality]` (level load, e.g. the known
-  shodan.mis loader crash class).
+| Item / code | Where | Unlocks |
+| --- | --- | --- |
+| Wrench (tmpl 990) @ (−38.1, −5.9, 29.8) | cryo bay floor near spawn | smash debris blocking the first ladder; melee |
+| **Code 45100** | audio log (Amanpour) on first corpse past the card door | cryo-recovery exit door (keypad tmpl 1681 @ (−26.5, 0.2, −12.7)) |
+| Cryo Card (tmpl 1050) @ (−24.3, 0.0, −1.4) | upper walkway after the first ladder | first card-reader door |
+| Power cell #1: Dead Power Cell tmpl 1767 @ (−13.8, −6.5, −34.3) | near jammed door; charge at Recharging Station tmpl 125 @ (−15.8, −6.0, −27.9) | Aux Power receptor tmpl 1766 @ (−13.1, −5.8, −33.1) → jammed cryo-escape door. (Spare Wrench tmpl 1707 @ (−18.5, −6.7, −29.3) here.) |
+| Science Card (tmpl 338) @ (−16.6, 1.2, −68.9) | corpse near the "ghost" (upgrade-hub exit) | card door into the Science sector proper |
+| Power cell #2: Dead Power Cell tmpl 1186 @ (29.8, −1.1, −75.7) | reception near the "MED" sign (Polito points it out) | Aux Power receptor tmpl 1128 @ (32.1, 0.9, −76.8) → powers the **north Medical bulkhead** (→ medsci2) |
+| **Code 12451** | Watts' audio log, R&D — **in medsci2** | maintenance conduit keypad tmpl 809 @ (6.3, 0.4, −47.4) → the eng1 exit |
+| Optional: code 00000 (cryo closet, BrawnBoost); code 98383 (sub-armory, medsci2 side) | | |
 
----
+## Critical path (granular)
 
-## Notes for future (driving the player)
+### Phase A — Cryo Recovery escape (lower floor, around spawn)
+1. **Wake** at (−35, −4.6, 17.9); Polito radios that the section is breached.
+2. **Take the Wrench** (tmpl 990, (−38.1, −5.9, 29.8)) from the bay floor.
+3. **Smash the debris and climb the ladder** behind the fallen Air Duct (tmpl
+   402, (−41.6, −3.9, 17.9)); ladder rungs `Rick Ladder` stacked at
+   (−41.3, −5.8…−2.0, 16.5) → up to the walkway (y ≈ 0). *(A second required
+   ladder stack sits at (−17.5, −6.0…−2.0, 14.5).)*
+4. **Pick up the Cryo Card** (tmpl 1050, (−24.3, 0.0, −1.4)); use it on the
+   card-reader door.
+5. **First corpse: audio log with code 45100**; enter it on **keypad tmpl 1681**
+   (−26.5, 0.2, −12.7) to open the cryo-recovery exit door.
+6. **Air-shaft crawl** section (low-clearance passage), leads down toward the
+   jammed-door area.
+7. **Power cell puzzle #1**: take Dead Power Cell (tmpl 1767), charge it at the
+   Recharging Station (tmpl 125), insert into Aux Power (tmpl 1766) — the
+   jammed door opens.
+8. **Cyber-upgrade hub**: Polito awards modules; 4 upgrade stations. (Optional:
+   cryo closet keypad 00000 nearby.)
+9. **Ride the lift up** out of the lower level (Elevator Path pair tmpl 262/263:
+   (−27.6, −7.9, −54.5) → (−27.6, −1.7, −54.5)).
+10. **Take the Science Card** (tmpl 338, (−16.6, 1.2, −68.9)) from the corpse
+    near the "ghost"; it opens the card door out.
+11. **First combat: 2 hybrids** past that door. Then a second platform ride up
+    to the elevator lobby.
 
-CP targets are world positions, so a later upgrade can replace "teleport to CP"
-with "drive to CP" (thumbstick + step) to additionally exercise navmesh,
-collision, and locomotion over the same route — do this only once the
-warp+teleport run is green end-to-end.
+### Phase B — Science sector → Medical bulkhead (upper floor)
+12. **Elevator lobby** (~(0.4, 0, −40)): pressing the elevator button triggers
+    Polito's "elevator is inoperative" objective chain. The **maintenance
+    conduit door** (keypad tmpl 809, (6.3, 0.4, −47.4); "To Maintenence Shaft"
+    sign tmpl 1281 at (5.4, −1.6, −49.1)) is here but **locked — code 12451 not
+    known yet**. Security cameras (5 on the deck) start appearing.
+13. **Power cell #2**: scripted explosion near the "MED" sign; take Dead Power
+    Cell (tmpl 1186, (29.8, −1.1, −75.7)) from reception.
+14. Pass the Xerxes computer room / bio-reconstruction room (optional: activate
+    the Quantum Bio-Reconstruction machine; pistol near the info kiosk).
+15. **Turret gauntlet**: catwalk over a room with 2 Slug Turrets (turrets in
+    data: tmpl 610 (3.2, −5.2, −14.0), tmpl 611 (−4.7, −5.3, −6.1), tmpl 1015
+    (18.8, −0.4, 9.5)). Recharge the power cell at a Recharging Station
+    (tmpl 506 (−6.8, −4.0, −13.1) or tmpl 273 (10.5, −2.8, 33.0)).
+16. **Insert the charged cell into Aux Power tmpl 1128** (32.1, 0.9, −76.8) →
+    the north Medical bulkhead powers up; hit `Bulk_On_Button` tmpl 1009 →
+    **level transition to medsci2**.
+
+### Phase C — medsci2 excursion (required; separate walkthrough)
+17. Medical sector → Grassi's corpse (Crew access card) → Crew Quarters →
+    Watts' office (R&D card) → **Watts' audio log with code 12451** → return
+    through the bulkhead to medsci1.
+
+### Phase D — Exit to Engineering
+18. Back at the conduit: **enter 12451 on keypad tmpl 809** — door opens (the
+    keypad SwitchLinks the door + an Experience Trap: cyber-module award).
+19. **Climb DOWN the shaft ladder** (`Rick Ladder 16` tmpl 1140 at
+    (12.6, −5.6, −42.7)) — one Blue Monkey may be around the conduit.
+20. At the bottom, the **Tripwire (tmpl 764) fires → eng1.mis** (loc 21, near
+    Engineering Control). medsci1 done.
+
+## Required non-walk mechanics — engine watch-points
+
+Pure walk + frob does **NOT** finish this level. Each of these is required and
+is a potential feature-gap finding for the play-through loop — test them
+honestly (report a blocker rather than teleporting past):
+
+1. **Ladder climbing** (steps 3, 19) — ladders have `PropPhysAttr.climbable: 27`;
+   as of 2026-07 climbing is **unimplemented** in shock2vr (`projects/climbing.md`
+   is a plan). Expected FIRST blocker of an honest run.
+2. **Breakable debris** (step 3) — wrench-smash to clear the ladder approach.
+3. **Air-shaft crawl** (step 6) — low-clearance traversal (crouch).
+4. **Power-cell carry + insert** (steps 7, 16) — pick up, recharge, socket into
+   an Aux Power receptor.
+5. **Lift platform rides** (steps 9, 11) — moving-terrain elevators
+   (`Elevator Path` pairs; the path DB shows `moving_terrain` cells).
+6. **Keypad code entry** (steps 5, 18) — 45100 / 12451 via the keypad UI.
+7. **Bulkhead round trip to medsci2 and back** (steps 16–17) — cross-mission
+   state (inventory + quest bits must survive both transitions).
+
+Also known: the AIPATH walk-graph does NOT connect spawn → exit (verified with
+`cargo bn path show`, even with permissive movement bits) — consistent with the
+ladder/lift/crawl legs above splitting the walk components. Any future
+"navigate by pathfinding" upgrade must handle those seams.
+
+## Sources
+
+- portforward.com SS2 walkthrough (Science / Crew-Quarters / Medical pages)
+- sshock2.com full walkthrough (deck split, codes/cards)
+- powerpyx + Steam access-code guides (codes 45100 / 00000 / 12451 / 98383)
+- `cargo dq entities medsci1.mis ...` + live debug-runtime entity dump
+  (2026-07-09) for positions/ids; tripwire + keypad SwitchLinks verified in
+  mission data.

--- a/.claude/skills/play-through/walkthroughs/medsci1.md
+++ b/.claude/skills/play-through/walkthroughs/medsci1.md
@@ -109,9 +109,11 @@ Pure walk + frob does **NOT** finish this level. Each of these is required and
 is a potential feature-gap finding for the play-through loop — test them
 honestly (report a blocker rather than teleporting past):
 
-1. **Ladder climbing** (steps 3, 19) — ladders have `PropPhysAttr.climbable: 27`;
-   as of 2026-07 climbing is **unimplemented** in shock2vr (`projects/climbing.md`
-   is a plan). Expected FIRST blocker of an honest run.
+1. **Ladder climbing** (steps 3, 19) — ladders have `PropPhysAttr.climbable: 27`.
+   Flat (desktop-style) climbing is implemented as of 2026-07: push toward the
+   ladder to ascend, look down + push to descend. Known gaps: entering a
+   descent from the top lip is untested (the grip needs horizontal overlap),
+   and VR grip-climbing is still unimplemented (`projects/climbing.md`).
 2. **Breakable debris** (step 3) — wrench-smash to clear the ladder approach.
 3. **Air-shaft crawl** (step 6) — low-clearance traversal (crouch).
 4. **Power-cell carry + insert** (steps 7, 16) — pick up, recharge, socket into

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -867,6 +867,18 @@ pub fn create_physics_representation(
                 }
             };
 
+            // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
+            // extra marker membership so player movement can detect contact.
+            let is_climbable = v_phys_attr
+                .get(entity_id)
+                .map(|pa| pa.climbable != 0)
+                .unwrap_or(false);
+            let group = if is_climbable {
+                CollisionGroup::climbable_entity()
+            } else {
+                CollisionGroup::entity()
+            };
+
             let rigid_body_handle = if !immobile && phys_type.phys_type == PhysicsModelType::SPHERE
             {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
@@ -877,7 +889,7 @@ pub fn create_physics_representation(
                     dimensions.offset0,
                     shape,
                     //size,
-                    CollisionGroup::entity(),
+                    group,
                     is_sensor,
                     dynamics_options,
                 )
@@ -888,7 +900,7 @@ pub fn create_physics_representation(
                     qrotation,
                     dimensions.offset0,
                     size,
-                    CollisionGroup::entity(),
+                    group,
                     is_sensor,
                 )
             };

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -869,6 +869,12 @@ pub fn create_physics_representation(
 
             // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
             // extra marker membership so player movement can detect contact.
+            // Simplifications: `climbable` is plausibly a per-face bitmask in
+            // the original engine (27 = the four vertical sides on ladders) -
+            // any non-zero value marks the whole collider climbable here. And
+            // only this (non-frobbable) creation branch checks it: all known
+            // ladders are plain terrain objects; a frobbable climbable would
+            // need the same treatment in the branch above.
             let is_climbable = v_phys_attr
                 .get(entity_id)
                 .map(|pa| pa.climbable != 0)

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -34,17 +34,24 @@ const CLIMB_REACH: f32 = 1.0 / SCALE_FACTOR;
 /// redirected to vertical movement at this scale).
 const CLIMB_SPEED_SCALE: f32 = 0.6;
 
-/// Half-Life-style flat ladder movement: redirect the into-ladder component of
-/// the desired movement to vertical. `toward_ladder` is the horizontal unit
-/// vector from the player to the climbable surface. Returns `None` when the
-/// player is not pushing toward the ladder (no grip - normal walking/gravity
-/// applies). Looking down (a downward-pitched desired movement) descends
-/// instead of ascending, so the same input walks down a shaft ladder.
+/// Half-Life-style flat ladder movement: convert the into-ladder component of
+/// the desired movement into a vertical climb. `toward_ladder` is the
+/// horizontal unit **face normal** from the player toward the climbable
+/// surface (from the contact query - NOT the collider-center direction, which
+/// gains a lateral component whenever the player is off-center and steers the
+/// player sideways off the ladder). Returns `None` when the player is not
+/// pushing toward the ladder (no grip - normal walking/gravity applies).
+/// Looking down (a downward-pitched desired movement) descends instead of
+/// ascending, so the same input walks down a shaft ladder; the sign flip at
+/// the pitch threshold matches classic ladder feel.
 ///
-/// The into-ladder component is removed from the horizontal movement rather
-/// than kept: the character controller only collides with level trimesh (not
-/// entity colliders), so keeping the push would drift the player through the
-/// rung plane and break the grip. Lateral (along-ladder) movement is preserved.
+/// The into-ladder component is removed from the horizontal movement: the
+/// character controller's slope limiting treats a vertical climbable face as
+/// an unclimbable slope and cancels the ascent when the player also pushes
+/// into it (empirically: ascent drops from ~7u to ~0.3u over 240 frames).
+/// Lateral (along-ladder) movement is preserved. The vertical component of
+/// `desired` (head pitch / debug fly channel) is dropped so climb speed
+/// depends only on the into-ladder push.
 fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<Vector<Real>> {
     let desired_h = vector![desired.x, 0.0, desired.z];
     let into = desired_h.dot(&toward_ladder);
@@ -56,7 +63,7 @@ fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<
     } else {
         into
     };
-    Some(desired - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
+    Some(desired_h - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
 }
 
 /// Maximum distance (world units) a single validated player move may advance.
@@ -1102,15 +1109,29 @@ impl PhysicsWorld {
             character_shape.as_cuboid().and_then(|cuboid| {
                 let inflated =
                     Cuboid::new(cuboid.half_extents + vector![CLIMB_REACH, 0.0, CLIMB_REACH]);
-                let player_center = character_pos.translation.vector;
-                // Grip the nearest overlapping climbable (horizontal distance).
+                // Grip the closest climbable within reach, by contact distance,
+                // and take the contact's *face normal* as the climb direction.
+                // (The collider-center direction is wrong when the player is
+                // off-center: its lateral component steers the player sideways
+                // off the ladder - a positive-feedback drift.)
                 let mut nearest: Option<(f32, Vector<Real>)> = None;
                 for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
-                    let delta = collider.position().translation.vector - player_center;
-                    let horizontal = vector![delta.x, 0.0, delta.z];
-                    let distance = horizontal.norm();
-                    if distance > 1e-3 && nearest.is_none_or(|(d, _)| distance < d) {
-                        nearest = Some((distance, horizontal / distance));
+                    let contact = rapier3d::parry::query::contact(
+                        &character_pos,
+                        character_shape.as_ref(),
+                        collider.position(),
+                        collider.shape(),
+                        CLIMB_REACH,
+                    );
+                    if let Ok(Some(contact)) = contact {
+                        // normal1 points from the player toward the climbable.
+                        let toward_h = vector![contact.normal1.x, 0.0, contact.normal1.z];
+                        let toward_norm = toward_h.norm();
+                        // A mostly-vertical normal means the player is on top of
+                        // (or under) the surface - that's standing, not climbing.
+                        if toward_norm > 0.5 && nearest.is_none_or(|(d, _)| contact.dist < d) {
+                            nearest = Some((contact.dist, toward_h / toward_norm));
+                        }
                     }
                 }
                 nearest.and_then(|(_, toward)| climb_redirect(desired_movement, toward))
@@ -2023,9 +2044,15 @@ mod tests {
     /// the player on the floor. (Negative-first: without the CLIMBABLE
     /// detection + redirect in `move_player`, both cases stay at floor height
     /// and the ascent assertion fails.)
+    ///
+    /// Also guards against lateral drift: the player starts OFF-CENTER on the
+    /// wall (z = 0.5 on a 2-wide wall). With a collider-center-based climb
+    /// direction the residual lateral term steers the player sideways along
+    /// the wall while climbing; the contact face normal keeps the climb
+    /// straight (with center-delta the ascent itself also collapses here).
     #[test]
     fn player_climbs_climbable_wall_but_not_plain_wall() {
-        let run = |group: CollisionGroup| -> f32 {
+        let run = |group: CollisionGroup| -> (f32, f32) {
             let mut world = PhysicsWorld::new();
             // Floor top at y=0, built the way the game builds level geometry
             // (a parentless collider): a fixed-BODY floor never enters the
@@ -2044,12 +2071,16 @@ mod tests {
                     .expect("floor trimesh")
                     .build(),
             );
+            // Off-center on the wall's z-extent (see doc comment). The scene
+            // sits at x=-6 so the floor's triangle seam (the x=z diagonal)
+            // stays away from the walk path - crossing the seam produces a
+            // lateral slide artifact unrelated to climbing.
             let mut player =
-                world.create_player(vec3(0.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+                world.create_player(vec3(-6.0, 1.0, 0.5), EntityId::from_inner(2000).unwrap());
             // A tall thin "ladder" wall just +x of the player, feet on the floor.
             world.add_kinematic(
                 EntityId::from_inner(2001).unwrap(),
-                vec3(1.0, 5.0, 0.0),
+                vec3(-5.0, 5.0, 0.0),
                 identity_quat(),
                 Vector3::new(0.0, 0.0, 0.0),
                 vec3(0.2, 10.0, 2.0),
@@ -2060,19 +2091,24 @@ mod tests {
             for _ in 0..30 {
                 world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
             }
-            let start_y = world.get_player_translation(&player).y;
+            let start = world.get_player_translation(&player);
             for _ in 0..240 {
                 world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
             }
-            world.get_player_translation(&player).y - start_y
+            let end = world.get_player_translation(&player);
+            (end.y - start.y, end.z - start.z)
         };
 
-        let climbable_ascent = run(CollisionGroup::climbable_entity());
-        let plain_ascent = run(CollisionGroup::entity());
+        let (climbable_ascent, climbable_drift) = run(CollisionGroup::climbable_entity());
+        let (plain_ascent, _) = run(CollisionGroup::entity());
 
         assert!(
             climbable_ascent > 2.0,
             "pushing into a climbable wall should ascend it, rose {climbable_ascent}"
+        );
+        assert!(
+            climbable_drift.abs() < 0.1,
+            "climbing straight up must not drift sideways, drifted {climbable_drift}"
         );
         assert!(
             plain_ascent.abs() < 0.5,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -24,6 +24,41 @@ use self::debug_render_pipeline::DebugRenderer;
 
 const MOVEMENT_STEP_SIZE: f32 = 20.0;
 
+/// Horizontal reach (world units) for ladder detection: the player grips a
+/// climbable surface when their collider, inflated by this much on x/z,
+/// overlaps it. Standing flush against a ladder leaves a small gap between the
+/// collider and the rungs, so the un-inflated shapes never intersect.
+const CLIMB_REACH: f32 = 1.0 / SCALE_FACTOR;
+
+/// Climb speed as a fraction of walk speed (the into-ladder input component is
+/// redirected to vertical movement at this scale).
+const CLIMB_SPEED_SCALE: f32 = 0.6;
+
+/// Half-Life-style flat ladder movement: redirect the into-ladder component of
+/// the desired movement to vertical. `toward_ladder` is the horizontal unit
+/// vector from the player to the climbable surface. Returns `None` when the
+/// player is not pushing toward the ladder (no grip - normal walking/gravity
+/// applies). Looking down (a downward-pitched desired movement) descends
+/// instead of ascending, so the same input walks down a shaft ladder.
+///
+/// The into-ladder component is removed from the horizontal movement rather
+/// than kept: the character controller only collides with level trimesh (not
+/// entity colliders), so keeping the push would drift the player through the
+/// rung plane and break the grip. Lateral (along-ladder) movement is preserved.
+fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<Vector<Real>> {
+    let desired_h = vector![desired.x, 0.0, desired.z];
+    let into = desired_h.dot(&toward_ladder);
+    if into <= 1e-6 {
+        return None;
+    }
+    let vertical = if desired.y < -0.25 * into {
+        -into
+    } else {
+        into
+    };
+    Some(desired - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
+}
+
 /// Maximum distance (world units) a single validated player move may advance.
 /// A request for a farther target is clamped to this, so an automated tester
 /// navigates in short, collision-checked hops instead of one long teleport.
@@ -43,6 +78,10 @@ bitflags! {
         const UI = 1 << 4;
         const HITBOX = 1 << 5;
         const RAYCAST = 1 << 6;
+        // Marker membership for climbable surfaces (PropPhysAttr.climbable != 0,
+        // e.g. ladders). Nothing filters on it for collision - it exists so the
+        // player movement code can query "am I touching a ladder?" cheaply.
+        const CLIMBABLE = 1 << 7;
         const ALL_COLLIDABLE = Self::WORLD.bits | Self::ENTITY.bits | Self::PLAYER.bits | Self::SELECTABLE.bits;
         const ALL = Self::ALL_COLLIDABLE.bits | Self::UI.bits | Self::HITBOX.bits | Self::RAYCAST.bits;
     }
@@ -94,6 +133,23 @@ impl CollisionGroup {
     pub fn entity() -> CollisionGroup {
         CollisionGroup(InteractionGroups {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
+            filter: (InternalCollisionGroups::WORLD.bits
+                | InternalCollisionGroups::PLAYER.bits
+                | InternalCollisionGroups::SELECTABLE.bits
+                | InternalCollisionGroups::ENTITY.bits)
+                .into(),
+            test_mode: Default::default(),
+        })
+    }
+
+    /// Same collision behavior as `entity()`, plus the `CLIMBABLE` marker
+    /// membership so player movement can detect ladder contact (see
+    /// `PropPhysAttr.climbable`).
+    pub fn climbable_entity() -> CollisionGroup {
+        CollisionGroup(InteractionGroups {
+            memberships: (InternalCollisionGroups::ENTITY.bits
+                | InternalCollisionGroups::CLIMBABLE.bits)
+                .into(),
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::PLAYER.bits
                 | InternalCollisionGroups::SELECTABLE.bits
@@ -1025,6 +1081,42 @@ impl PhysicsWorld {
             .exclude_sensors();
         let dispatcher = self.narrow_phase.query_dispatcher();
 
+        // Flat climbing: when the player overlaps a climbable surface (ladder)
+        // and pushes toward it, redirect that input to vertical movement and
+        // suppress the gravity pass for this frame (see `climb_redirect`).
+        let climb_movement = {
+            let climb_filter = QueryFilter::new()
+                .groups(InteractionGroups::new(
+                    InternalCollisionGroups::PLAYER.bits.into(),
+                    InternalCollisionGroups::CLIMBABLE.bits.into(),
+                    Default::default(),
+                ))
+                .exclude_rigid_body(player_handle.character_handle)
+                .exclude_sensors();
+            let queries = self.broad_phase.as_query_pipeline(
+                dispatcher,
+                &self.rigid_body_set,
+                &self.collider_set,
+                climb_filter,
+            );
+            character_shape.as_cuboid().and_then(|cuboid| {
+                let inflated =
+                    Cuboid::new(cuboid.half_extents + vector![CLIMB_REACH, 0.0, CLIMB_REACH]);
+                let player_center = character_pos.translation.vector;
+                // Grip the nearest overlapping climbable (horizontal distance).
+                let mut nearest: Option<(f32, Vector<Real>)> = None;
+                for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
+                    let delta = collider.position().translation.vector - player_center;
+                    let horizontal = vector![delta.x, 0.0, delta.z];
+                    let distance = horizontal.norm();
+                    if distance > 1e-3 && nearest.is_none_or(|(d, _)| distance < d) {
+                        nearest = Some((distance, horizontal / distance));
+                    }
+                }
+                nearest.and_then(|(_, toward)| climb_redirect(desired_movement, toward))
+            })
+        };
+
         //let mut collisions = vec![];
         let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             // HACK: For rapier v0.19.0, our previous strategy of combining the movement + gravity
@@ -1036,12 +1128,21 @@ impl PhysicsWorld {
                 &self.collider_set,
                 movement_filter,
             );
+            // While gripping a ladder the climb vector replaces the walk pass
+            // (no step-up bump needed) and the gravity pass is a no-op.
+            let (first_movement, second_movement) = match climb_movement {
+                Some(climb) => (climb, Vector::zeros()),
+                None => (
+                    movement_with_upward.cast::<Real>(),
+                    gravity_movement.cast::<Real>(),
+                ),
+            };
             (player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &queries,
                 character_shape.as_ref(),
                 &character_pos,
-                movement_with_upward.cast::<Real>(),
+                first_movement,
                 |_c| (),
                 //|c| collisions.push(c),
             ),
@@ -1052,7 +1153,7 @@ impl PhysicsWorld {
                 &queries,
                 character_shape.as_ref(),
                 &character_pos,
-                gravity_movement.cast::<Real>(),
+                second_movement,
                 |_c| (),
                 //|c| collisions.push(c),
             ))
@@ -1683,6 +1784,7 @@ fn collision_group_names(bits: u32) -> Vec<String> {
         (InternalCollisionGroups::UI, "ui"),
         (InternalCollisionGroups::HITBOX, "hitbox"),
         (InternalCollisionGroups::RAYCAST, "raycast"),
+        (InternalCollisionGroups::CLIMBABLE, "climbable"),
     ];
     for (group, name) in candidates {
         if bits & group.bits != 0 {
@@ -1886,6 +1988,95 @@ mod tests {
         assert!(
             slippery_x > grippy_x + 1.0,
             "low-friction box ({slippery_x}) should out-slide high-friction box ({grippy_x})"
+        );
+    }
+
+    // --- Flat ladder climbing (`climb_redirect` + CLIMBABLE detection) ---
+
+    /// Pushing toward the ladder redirects the input to an ascent.
+    #[test]
+    fn climb_redirect_ascends_when_pushing_into_ladder() {
+        let toward = vector![1.0, 0.0, 0.0];
+        let climb = climb_redirect(vector![0.1, 0.0, 0.0], toward).expect("should grip");
+        assert!(climb.y > 0.0, "expected upward redirect, got {climb:?}");
+    }
+
+    /// Pushing away from (or parallel to) the ladder does not grip.
+    #[test]
+    fn climb_redirect_ignores_push_away_or_parallel() {
+        let toward = vector![1.0, 0.0, 0.0];
+        assert!(climb_redirect(vector![-0.1, 0.0, 0.0], toward).is_none());
+        assert!(climb_redirect(vector![0.0, 0.0, 0.1], toward).is_none());
+        assert!(climb_redirect(vector![0.0, 0.0, 0.0], toward).is_none());
+    }
+
+    /// A downward-pitched push (looking down) descends instead of ascending.
+    #[test]
+    fn climb_redirect_descends_when_looking_down() {
+        let toward = vector![1.0, 0.0, 0.0];
+        let climb = climb_redirect(vector![0.1, -0.1, 0.0], toward).expect("should grip");
+        assert!(climb.y < 0.0, "expected downward redirect, got {climb:?}");
+    }
+
+    /// A player standing at the base of a climbable wall who pushes into it
+    /// climbs it; against an identical NON-climbable wall the same input leaves
+    /// the player on the floor. (Negative-first: without the CLIMBABLE
+    /// detection + redirect in `move_player`, both cases stay at floor height
+    /// and the ascent assertion fails.)
+    #[test]
+    fn player_climbs_climbable_wall_but_not_plain_wall() {
+        let run = |group: CollisionGroup| -> f32 {
+            let mut world = PhysicsWorld::new();
+            // Floor top at y=0, built the way the game builds level geometry
+            // (a parentless collider): a fixed-BODY floor never enters the
+            // query BVH the character controller moves against, so the player
+            // would fall straight through it.
+            let floor_verts = vec![
+                point![-100.0, 0.0, -100.0],
+                point![100.0, 0.0, -100.0],
+                point![100.0, 0.0, 100.0],
+                point![-100.0, 0.0, 100.0],
+            ];
+            let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+            world.add_collider(
+                EntityId::from_inner(1000).unwrap(),
+                ColliderBuilder::trimesh(floor_verts, floor_tris)
+                    .expect("floor trimesh")
+                    .build(),
+            );
+            let mut player =
+                world.create_player(vec3(0.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+            // A tall thin "ladder" wall just +x of the player, feet on the floor.
+            world.add_kinematic(
+                EntityId::from_inner(2001).unwrap(),
+                vec3(1.0, 5.0, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.2, 10.0, 2.0),
+                group,
+                false,
+            );
+            // Let the player settle onto the floor, then push into the wall.
+            for _ in 0..30 {
+                world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            }
+            let start_y = world.get_player_translation(&player).y;
+            for _ in 0..240 {
+                world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
+            }
+            world.get_player_translation(&player).y - start_y
+        };
+
+        let climbable_ascent = run(CollisionGroup::climbable_entity());
+        let plain_ascent = run(CollisionGroup::entity());
+
+        assert!(
+            climbable_ascent > 2.0,
+            "pushing into a climbable wall should ascend it, rose {climbable_ascent}"
+        );
+        assert!(
+            plain_ascent.abs() < 0.5,
+            "a plain wall must not be climbable, rose {plain_ascent}"
         );
     }
 }

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for flat (desktop-style) ladder climbing.
+//
+// medsci1's critical path starts with a REQUIRED ladder climb out of the cryo
+// recovery bay (rung entities named "Rick Ladder", PropPhysAttr.climbable=27,
+// stacked at x=-41.3, z=16.5). A player pressing forward into the ladder must
+// ascend it - Half-Life style - instead of being stopped by the ladder's
+// collider.
+//
+// Negative-first: without the climbing implementation the forward input just
+// presses the player against the ladder collider (y stays at floor height), so
+// the ascent assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "flat climbing: pushing into a ladder ascends it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Resolve the cryo-recovery ladder at run time (runtime entity ids are not
+    // stable across launches): cluster the "Rick Ladder" rungs by column and
+    // take the column near (-17.5, 14.5) - the shaft ladder on medsci1's
+    // critical path. (The other cryo-bay column, at (-41.3, 16.5), is fenced
+    // off by the fallen air duct the player is meant to wrench-smash first, so
+    // it can't be walked up to.)
+    const rungs = (await game.entities.list({ filter: "Rick Ladder", limit: 100 }))
+      .entities;
+    assert.ok(rungs.length > 0, "medsci1 should contain Rick Ladder entities");
+
+    const columns = new Map<string, { x: number; z: number; ys: number[] }>();
+    for (const rung of rungs) {
+      const [x, y, z] = rung.position;
+      const key = `${Math.round(x)},${Math.round(z)}`;
+      const col = columns.get(key) ?? { x, z, ys: [] };
+      col.ys.push(y);
+      columns.set(key, col);
+    }
+    const ladder = [...columns.values()].reduce((best, col) => {
+      const d = (c: { x: number; z: number }) =>
+        Math.hypot(c.x - -17.5, c.z - 14.5);
+      return d(col) < d(best) ? col : best;
+    });
+    const ladderTop = Math.max(...ladder.ys);
+
+    // Stand on the bay floor just north (+z) of the ladder plane. The rungs
+    // face +z there (the -z side drops into a deep shaft), and with the debug
+    // runtime's default camera (facing -x) a LEFT strafe moves the player -z,
+    // INTO the ladder face (mapping verified empirically).
+    await game.player.teleport({
+      x: ladder.x,
+      y: -4.5,
+      z: ladder.z + 1.5,
+    });
+    await game.step({ frames: 30 }); // settle onto the floor
+    const before = await game.player.position();
+    assert.ok(
+      before.y < ladderTop,
+      `expected to start below the ladder top (${ladderTop}), got y=${before.y}`,
+    );
+
+    // Press into the ladder and hold.
+    await game.input.set("right_hand.thumbstick", [-1, 0]);
+    await game.step({ frames: 240 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    const after = await game.player.position();
+    const ascent = after.y - before.y;
+    assert.ok(
+      ascent > 2,
+      `pressing into the ladder should climb it (started y=${before.y.toFixed(2)}, ` +
+        `ended y=${after.y.toFixed(2)}, ascent=${ascent.toFixed(2)}; ` +
+        "without climbing the ladder collider just blocks the player)",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Implements Half-Life-style flat ladder climbing — the first honest blocker on medsci1's critical path (the deck starts with a required ladder climb out of the cryo recovery bay, and exits via a ladder descent into the eng1 maintenance conduit; discovered via the play-through loop investigation).

- **`CLIMBABLE` collision-group marker**: entities with `PropPhysAttr.climbable != 0` (ladders — value 27 = four climbable sides) get an extra membership bit. Marker only; collision behavior unchanged.
- **Climb movement** in `PhysicsWorld::move_player`: when the player's (horizontally inflated) collider contacts a climbable and pushes toward it, the into-ladder input component is redirected to a vertical climb (look down + push to descend); the gravity pass is suppressed while gripping; lateral movement along the ladder is preserved.
- The climb direction is the **contact face normal** (parry contact query), not the collider-center direction — the latter drifts the player sideways off the ladder when off-center (caught by adversarial review, regression-tested).
- Works through the existing locomotion inputs — desktop keys and the debug runtime (`/v1/control/input`) get it with no new wiring. VR grip-climbing is a follow-up (`projects/climbing.md`); the marker/detection work is shared.

Also includes a rewrite of the medsci1 play-through walkthrough (real critical path from cross-checked walkthrough sources + runtime-verified entity anchors, with the required non-walk mechanics listed as engine watch-points).

## Demo

![flat ladder climbing demo](https://gist.githubusercontent.com/tommy-xr/90b93feac7be82bfc56b4e5a1bd75200/raw/demo.gif)

<sub>The player walks into the medsci1 cryo-shaft ladder and pushes toward it — the into-ladder input redirects to a vertical climb (first-person view: the camera rises from the bay floor up the shaft ladder). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![ladder base vs risen](https://gist.githubusercontent.com/tommy-xr/90b93feac7be82bfc56b4e5a1bd75200/raw/baserisen.png)

<sub>Stills at the ladder base (player y = -4.97) and after the climb (settled at y = -1.17, +3.8 units) — the RISEN frame shows the ladder rungs at frame right and the upper-shaft light fixture.</sub>

## Verification (negative-first)

- **Unit** (`shock2vr/src/physics/mod.rs` tests): `climb_redirect` cases; headless harness — a player pushing into a climbable wall ascends it (>2u), an identical plain wall does not, and an off-center climb does not drift sideways (fails with the center-delta direction).
- **E2E** (`tools/shock2-sdk/test/climbing.e2e.test.ts`): climbs the real medsci1 cryo-shaft ladder via thumbstick input; failed before the feature (player pinned at the ladder base), passes after — on a rebuild-verified binary.
- **Full SDK e2e suite**: 73/75 pass. The 2 failures are unrelated: `monster-death` is flaky (passes on re-run); `blood-spang` **fails identically on freshly-built `main`** (pre-existing — hybrid hits select `Standard Terr Spang` instead of a blood spang; surfacing separately).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p shock2vr` 97 passed.
- Adversarial review (`/xreview`, single-engine — Codex was rate-limited): all Critical/High findings addressed (face-normal fix); deferred items below.

## Known gaps (deferred, documented in the walkthrough)

- **Descent entry from a top lip** is untested/unsupported: the grip needs horizontal overlap, which a player standing above the topmost rung doesn't have yet. Medsci1's descent (maintenance conduit) is several blockers away on the critical path.
- **Top-out mantle**: leaving the grip at the top relies on normal walk + step-up; may need a mantle assist depending on geometry.
- Discovered while testing (pre-existing, not touched here): the kinematic character controller's behavior differs between trimesh level geometry and entity colliders in the unit-test harness, and `blood-spang` e2e fails on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
