### PR TITLE
feat(flat): add real container looting flow

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -334,6 +334,13 @@ pub struct InputState {
     pub head: InputHead,
     pub left_hand: InputHand,
     pub right_hand: InputHand,
+    pub pointer: Option<InputPointer>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InputPointer {
+    pub position: [f32; 2],
+    pub pressed: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -357,6 +364,7 @@ impl Default for InputState {
             head: InputHead::default(),
             left_hand: InputHand::default(),
             right_hand: InputHand::default(),
+            pointer: None,
         }
     }
 }
@@ -567,6 +575,10 @@ pub struct PlayerInfo {
     pub wielded_entity_id: Option<i32>,
     /// The entity held in the right hand (VR), `None` otherwise.
     pub right_hand_entity_id: Option<i32>,
+    /// Current flat crosshair target and open container UI state.
+    pub highlighted_entity_id: Option<i32>,
+    pub active_container_entity_id: Option<i32>,
+    pub active_container_item_ids: Vec<i32>,
     /// Whether the wielded weapon is mid-reload, plus the current viewmodel tilt
     /// (degrees) and reload progress (0..1). See `shock2vr::PlayerStateSnapshot`.
     pub reloading: bool,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1535,6 +1535,10 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
         },
         left_hand: hand(&input.left_hand),
         right_hand: hand(&input.right_hand),
+        pointer: input.pointer.map(|pointer| commands::InputPointer {
+            position: [pointer.position.x, pointer.position.y],
+            pressed: pointer.pressed,
+        }),
     }
 }
 
@@ -1550,6 +1554,8 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
 /// - `{left,right}_hand.thumbstick` : `[x, y]`
+/// - `pointer.position`             : normalized `[x, y]`
+/// - `pointer.pressed`              : boolean or number (0/1)
 /// One line describing every recognized input channel, used in error messages so
 /// a bad request is self-documenting. Includes the locomotion semantics (which
 /// stick does what) since that is the game's convention, not guessable.
@@ -1559,6 +1565,7 @@ fn input_channels_help() -> &'static str {
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
      {left,right}_hand.rotation [x,y,z,w]; \
+     pointer.position [x,y], pointer.pressed <bool or number>; \
      locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
      left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
 }
@@ -1586,6 +1593,38 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         a.iter()
             .map(|e| num(channel, e))
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    if let Some(field) = channel.strip_prefix("pointer.") {
+        let pointer = input
+            .pointer
+            .get_or_insert(shock2vr::input_context::Pointer2D {
+                position: Vector2::new(0.5, 0.5),
+                pressed: false,
+            });
+        return match field {
+            "position" => {
+                let p = arr(channel, value, 2)?;
+                pointer.position = Vector2::new(p[0], p[1]);
+                Ok(())
+            }
+            "pressed" => {
+                pointer.pressed = if let Some(pressed) = value.as_bool() {
+                    pressed
+                } else if let Some(pressed) = value.as_f64() {
+                    pressed > 0.5
+                } else {
+                    return Err(format!(
+                        "channel '{channel}' expects a boolean or number, got {value}"
+                    ));
+                };
+                Ok(())
+            }
+            _ => Err(format!(
+                "unknown input channel '{channel}'; {}",
+                input_channels_help()
+            )),
+        };
     }
 
     // Hand channels: "<left|right>_hand.<field>"
@@ -1741,6 +1780,14 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                 camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
                 right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),
+                highlighted_entity_id: state.as_ref().and_then(|s| s.highlighted_entity_id),
+                active_container_entity_id: state
+                    .as_ref()
+                    .and_then(|s| s.active_container_entity_id),
+                active_container_item_ids: state
+                    .as_ref()
+                    .map(|s| s.active_container_item_ids.clone())
+                    .unwrap_or_default(),
                 reloading: state.as_ref().is_some_and(|s| s.reloading),
                 reload_pitch_deg: state.as_ref().map(|s| s.reload_pitch_deg).unwrap_or(0.0),
                 reload_progress: state.as_ref().map(|s| s.reload_progress).unwrap_or(0.0),

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -9,19 +9,25 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slices 5-6).
 
-use cgmath::{Deg, Point3, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
+use cgmath::{Deg, Point3, Quaternion, Rotation, Rotation3, Vector2, Vector3, point3, vec2, vec3};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use shipyard::{EntityId, Get, View, World};
 
 use dark::{
     SCALE_FACTOR,
-    properties::{PropFrobInfo, PropLimbModel, PropPlayerGun},
+    properties::{
+        Link, PropFrobInfo, PropInventoryDimensions, PropLimbModel, PropObjIcon, PropObjShortName,
+        PropPlayerGun, PropScripts,
+    },
 };
 
 use crate::{
-    input_context::Hand,
+    input_context::InputContext,
+    inventory::Inventory,
     physics::{InternalCollisionGroups, PhysicsWorld},
     runtime_props::RuntimePropReloading,
-    scripts::{Message, MessagePayload},
+    scripts::{Message, MessagePayload, script_util},
+    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign},
     util::resolve_proxy_entity,
     virtual_hand::{VirtualHandEffect, can_grab_item},
 };
@@ -58,6 +64,23 @@ const VIEWMODEL_BASE_YAW_DEG: f32 = -90.0;
 /// down around the camera, so the carried gun sits lower on screen.
 const GUN_CARRY_PITCH_DEG: f32 = -11.25;
 
+const CONTAINER_CANVAS_SIZE: Vector2<f32> = vec2(640.0, 480.0);
+const CONTAINER_PANEL: Rect = Rect::new(226.0, 92.0, 188.0, 296.0);
+const CONTAINER_INVENTORY_OFFSET: Vector2<f32> = vec2(241.0, 252.0);
+const CONTAINER_SLOT_SIZE: Vector2<f32> = vec2(35.0, 32.0);
+
+#[derive(Clone, Copy, Debug)]
+struct FlatContainerItem {
+    entity_id: EntityId,
+    rect: Rect,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FlatContainerState {
+    entity_id: EntityId,
+    hovered_item: Option<EntityId>,
+}
+
 pub struct FlatPlayerController {
     wielded_entity: Option<EntityId>,
     last_fire_pressed: bool,
@@ -65,6 +88,8 @@ pub struct FlatPlayerController {
     /// Camera/crosshair fire ray (world space) from the last `update`, so the
     /// firing path can spawn projectiles along the crosshair (camera-origin aim).
     last_aim: Option<(Point3<f32>, Vector3<f32>)>,
+    active_container: Option<FlatContainerState>,
+    last_pointer_pressed: bool,
 }
 
 impl FlatPlayerController {
@@ -74,6 +99,8 @@ impl FlatPlayerController {
             last_fire_pressed: false,
             last_use_pressed: false,
             last_aim: None,
+            active_container: None,
+            last_pointer_pressed: false,
         }
     }
 
@@ -88,6 +115,21 @@ impl FlatPlayerController {
     /// The camera/crosshair fire ray (origin, forward) from the last `update`.
     pub fn aim_ray(&self) -> Option<(Point3<f32>, Vector3<f32>)> {
         self.last_aim
+    }
+
+    pub fn active_container(&self) -> Option<EntityId> {
+        self.active_container.map(|state| state.entity_id)
+    }
+
+    pub fn active_container_items(&self, world: &World) -> Vec<EntityId> {
+        self.active_container
+            .map(|state| {
+                container_items(world, state.entity_id)
+                    .into_iter()
+                    .map(|item| item.entity_id)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Stop wielding `entity_id` if it was the held weapon (e.g. it was
@@ -124,7 +166,7 @@ impl FlatPlayerController {
     /// under the crosshair (for highlight rendering), if any.
     pub fn update(
         &mut self,
-        input: &Hand,
+        input_context: &InputContext,
         player_pos: Vector3<f32>,
         player_rotation: Quaternion<f32>,
         head_rotation: Quaternion<f32>,
@@ -132,6 +174,52 @@ impl FlatPlayerController {
         physics: &PhysicsWorld,
     ) -> (Vec<VirtualHandEffect>, Option<EntityId>) {
         let mut effects = Vec::new();
+        let input = &input_context.right_hand;
+
+        // While a flat container is open the pointer owns interaction. A new
+        // squeeze edge toggles it closed; a pointer click takes exactly the
+        // chosen item through the normal wield/HoldItem path.
+        if let Some(mut container) = self.active_container {
+            let use_pressed = input.squeeze_value > 0.5;
+            if use_pressed && !self.last_use_pressed {
+                self.active_container = None;
+                self.last_pointer_pressed = false;
+            } else {
+                let pointer = input_context.pointer;
+                let canvas_pointer = pointer.map(|p| {
+                    vec2(
+                        p.position.x * CONTAINER_CANVAS_SIZE.x,
+                        p.position.y * CONTAINER_CANVAS_SIZE.y,
+                    )
+                });
+                let items = container_items(world, container.entity_id);
+                container.hovered_item = canvas_pointer.and_then(|position| {
+                    items
+                        .iter()
+                        .find(|item| item.rect.contains(position))
+                        .map(|item| item.entity_id)
+                });
+                let pointer_pressed = pointer.is_some_and(|p| p.pressed);
+                if pointer_pressed && !self.last_pointer_pressed {
+                    if let Some(item) = container.hovered_item {
+                        effects.extend(self.wield(item));
+                    }
+                }
+                self.last_pointer_pressed = pointer_pressed;
+                self.active_container = Some(container);
+            }
+            self.last_use_pressed = use_pressed;
+            effects.extend(self.update_wielded_viewmodel(
+                input.trigger_value,
+                player_pos,
+                player_rotation,
+                head_rotation,
+                world,
+                false,
+            ));
+            return (effects, None);
+        }
+        self.last_pointer_pressed = false;
 
         let look = player_rotation * head_rotation;
         let camera_pos = player_pos + vec3(0.0, HEAD_HEIGHT / SCALE_FACTOR, 0.0);
@@ -154,88 +242,14 @@ impl FlatPlayerController {
             .map(|e| resolve_proxy_entity(world, e))
             .filter(|e| Some(*e) != self.wielded_entity && is_frobbable(world, *e));
 
-        // Place the viewmodel + fire on the trigger edge.
-        if let Some(entity_id) = self.wielded_entity {
-            // First-person framing: guns place at their authored per-weapon
-            // `PropPlayerGun.model_offset` (plus the carry pitch below); melee
-            // arms anchor at the authored PlayerMelee arm offset; anything
-            // else falls back to `VIEWMODEL_OFFSET`. This intentionally
-            // ignores the VR hand-model table, which is keyed inconsistently
-            // and drops per-weapon heading. The first-person `hand_model`
-            // meshes all share one orientation, corrected by a single base
-            // yaw. NB: PropPlayerGun.heading is NOT the FP model's rotation -
-            // applying it over-rotates exactly by its value (the
-            // shotgun/assault 90deg, the psi-amp 180deg), so it is
-            // deliberately not used here.
-            let is_melee = world
-                .borrow::<View<PropLimbModel>>()
-                .map(|v| v.get(entity_id).is_ok())
-                .unwrap_or(false);
-            // Authored offsets are in Dark camera axes (x back, y left, z up);
-            // look space is (+x right, +y up, -z forward), so the conversion
-            // is `vec3(-o.y, o.z, o.x)` (`MELEE_VIEWMODEL_OFFSET` is stored
-            // pre-converted).
-            let gun_offset = world
-                .borrow::<View<PropPlayerGun>>()
-                .ok()
-                .and_then(|v| v.get(entity_id).ok().map(|g| g.model_offset));
-            let offset = if is_melee {
-                MELEE_VIEWMODEL_OFFSET
-            } else if let Some(mo) = gun_offset {
-                vec3(-mo.y, mo.z, mo.x)
-            } else {
-                VIEWMODEL_OFFSET
-            };
-            // Melee arms take the camera rotation directly (camSynch semantics:
-            // root = ang offset * camera rotation, and the authored ang offset
-            // is zero); the gun meshes share one orientation corrected by a
-            // single base yaw, plus a pitch (which also swings the framing
-            // offset down around the camera - the gun pivots around the EYE,
-            // not around its own origin, matching the original's pitch
-            // mechanism). At rest the pitch is the carry angle; a reload ramps
-            // it from there to the weapon's authored peak and back, so the gun
-            // dips out of view instead of spinning in place and exposing the
-            // FP mesh's open rear.
-            let (rotation, position) = if is_melee {
-                (
-                    look * Quaternion::from_angle_y(Deg(180.0)),
-                    camera_pos + look.rotate_vector(offset / SCALE_FACTOR),
-                )
-            } else {
-                let pitch_deg = match world
-                    .borrow::<View<RuntimePropReloading>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().copied())
-                {
-                    Some(r) if r.peak_deg.abs() > f32::EPSILON => {
-                        let frac = r.pitch_deg() / r.peak_deg; // ramp 0..1..0
-                        GUN_CARRY_PITCH_DEG + (r.peak_deg - GUN_CARRY_PITCH_DEG) * frac
-                    }
-                    _ => GUN_CARRY_PITCH_DEG,
-                };
-                let pitch = Quaternion::from_angle_x(Deg(pitch_deg));
-                (
-                    look * pitch * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG)),
-                    camera_pos + (look * pitch).rotate_vector(offset / SCALE_FACTOR),
-                )
-            };
-            effects.push(VirtualHandEffect::SetPositionRotation {
-                entity_id,
-                position,
-                rotation,
-                scale: vec3(1.0, 1.0, 1.0),
-            });
-
-            let fire_pressed = input.trigger_value > 0.5;
-            if fire_pressed && !self.last_fire_pressed {
-                effects.push(out_message(entity_id, MessagePayload::TriggerPull));
-            } else if !fire_pressed && self.last_fire_pressed {
-                effects.push(out_message(entity_id, MessagePayload::TriggerRelease));
-            }
-            self.last_fire_pressed = fire_pressed;
-        } else {
-            self.last_fire_pressed = false;
-        }
+        effects.extend(self.update_wielded_viewmodel(
+            input.trigger_value,
+            player_pos,
+            player_rotation,
+            head_rotation,
+            world,
+            true,
+        ));
 
         // Use / frob / pickup on the use-button (squeeze) rising edge.
         let use_pressed = input.squeeze_value > 0.5;
@@ -247,12 +261,149 @@ impl FlatPlayerController {
                 } else {
                     // Otherwise interact with it.
                     effects.push(out_message(target, MessagePayload::Frob));
+                    if is_container(world, target) {
+                        self.active_container = Some(FlatContainerState {
+                            entity_id: target,
+                            hovered_item: None,
+                        });
+                    }
                 }
             }
         }
         self.last_use_pressed = use_pressed;
 
         (effects, highlighted)
+    }
+
+    fn update_wielded_viewmodel(
+        &mut self,
+        trigger_value: f32,
+        player_pos: Vector3<f32>,
+        player_rotation: Quaternion<f32>,
+        head_rotation: Quaternion<f32>,
+        world: &World,
+        allow_fire: bool,
+    ) -> Vec<VirtualHandEffect> {
+        let Some(entity_id) = self.wielded_entity else {
+            self.last_fire_pressed = false;
+            return Vec::new();
+        };
+
+        let look = player_rotation * head_rotation;
+        let camera_pos = player_pos + vec3(0.0, HEAD_HEIGHT / SCALE_FACTOR, 0.0);
+        // First-person framing: guns place at their authored per-weapon
+        // `PropPlayerGun.model_offset`; melee arms use the authored PlayerMelee
+        // anchor; anything else falls back to `VIEWMODEL_OFFSET`.
+        let is_melee = world
+            .borrow::<View<PropLimbModel>>()
+            .map(|v| v.get(entity_id).is_ok())
+            .unwrap_or(false);
+        let gun_offset = world
+            .borrow::<View<PropPlayerGun>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|g| g.model_offset));
+        let offset = if is_melee {
+            MELEE_VIEWMODEL_OFFSET
+        } else if let Some(mo) = gun_offset {
+            vec3(-mo.y, mo.z, mo.x)
+        } else {
+            VIEWMODEL_OFFSET
+        };
+        let (rotation, position) = if is_melee {
+            (
+                look * Quaternion::from_angle_y(Deg(180.0)),
+                camera_pos + look.rotate_vector(offset / SCALE_FACTOR),
+            )
+        } else {
+            let pitch_deg = match world
+                .borrow::<View<RuntimePropReloading>>()
+                .ok()
+                .and_then(|v| v.get(entity_id).ok().copied())
+            {
+                Some(r) if r.peak_deg.abs() > f32::EPSILON => {
+                    let frac = r.pitch_deg() / r.peak_deg;
+                    GUN_CARRY_PITCH_DEG + (r.peak_deg - GUN_CARRY_PITCH_DEG) * frac
+                }
+                _ => GUN_CARRY_PITCH_DEG,
+            };
+            let pitch = Quaternion::from_angle_x(Deg(pitch_deg));
+            (
+                look * pitch * Quaternion::from_angle_y(Deg(VIEWMODEL_BASE_YAW_DEG)),
+                camera_pos + (look * pitch).rotate_vector(offset / SCALE_FACTOR),
+            )
+        };
+        let mut effects = vec![VirtualHandEffect::SetPositionRotation {
+            entity_id,
+            position,
+            rotation,
+            scale: vec3(1.0, 1.0, 1.0),
+        }];
+
+        if allow_fire {
+            let fire_pressed = trigger_value > 0.5;
+            if fire_pressed && !self.last_fire_pressed {
+                effects.push(out_message(entity_id, MessagePayload::TriggerPull));
+            } else if !fire_pressed && self.last_fire_pressed {
+                effects.push(out_message(entity_id, MessagePayload::TriggerRelease));
+            }
+            self.last_fire_pressed = fire_pressed;
+        } else {
+            self.last_fire_pressed = false;
+        }
+        effects
+    }
+
+    pub fn render_container_ui(
+        &self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        let Some(state) = self.active_container else {
+            return Vec::new();
+        };
+
+        let mut canvas = UiCanvas::new(CONTAINER_CANVAS_SIZE);
+        canvas.image(CONTAINER_PANEL, "contain.pcx");
+        let title = world
+            .borrow::<View<PropObjShortName>>()
+            .ok()
+            .and_then(|names| names.get(state.entity_id).ok().map(|name| name.0.clone()))
+            .unwrap_or_else(|| "CONTAINER".to_string());
+        canvas.text(
+            Rect::new(238.0, 106.0, 164.0, 24.0),
+            &title,
+            "mainfont.fon",
+            16.0,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+
+        let icons = world.borrow::<View<PropObjIcon>>().unwrap();
+        for item in container_items(world, state.entity_id) {
+            if let Ok(icon) = icons.get(item.entity_id) {
+                canvas.image(item.rect, &format!("{}.pcx", icon.0));
+            }
+            if state.hovered_item == Some(item.entity_id) {
+                canvas.text(
+                    Rect::new(item.rect.x - 14.0, item.rect.y, 12.0, item.rect.h),
+                    ">",
+                    "mainfont.fon",
+                    16.0,
+                    HAlign::Center,
+                    VAlign::Middle,
+                );
+            }
+        }
+        canvas.text(
+            Rect::new(238.0, 354.0, 164.0, 22.0),
+            "CLICK ITEM  |  USE TO CLOSE",
+            "mainfont.fon",
+            9.0,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+        canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
     }
 }
 
@@ -275,4 +426,51 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
         .borrow::<View<PropFrobInfo>>()
         .map(|v| v.get(entity_id).is_ok())
         .unwrap_or(false)
+}
+
+fn is_container(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropScripts>>()
+        .map(|scripts| {
+            scripts.get(entity_id).is_ok_and(|scripts| {
+                // CreatureContainer belongs to living monsters too; exposing
+                // it here would allow looting AI before death. Concrete loot
+                // containers and spawned corpses inherit ContainerScript.
+                scripts
+                    .scripts
+                    .iter()
+                    .any(|name| name.eq_ignore_ascii_case("containerscript"))
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn container_items(world: &World, entity_id: EntityId) -> Vec<FlatContainerItem> {
+    let mut links = script_util::get_all_links_with_data(world, entity_id, |link| match link {
+        Link::Contains(ordinal) => Some(*ordinal),
+        _ => None,
+    });
+    links.sort_by_key(|(_, ordinal)| *ordinal);
+
+    let dimensions = world.borrow::<View<PropInventoryDimensions>>().unwrap();
+    let mut inventory = Inventory::new(4, 4);
+    for (item, _) in links {
+        let (width, height) = dimensions
+            .get(item)
+            .map(|dims| (dims.width as usize, dims.height as usize))
+            .unwrap_or((1, 1));
+        inventory.insert_first_available(item, width, height);
+    }
+    inventory
+        .all_items()
+        .map(|item| FlatContainerItem {
+            entity_id: item.entity,
+            rect: Rect::new(
+                CONTAINER_INVENTORY_OFFSET.x + CONTAINER_SLOT_SIZE.x * item.x as f32,
+                CONTAINER_INVENTORY_OFFSET.y + CONTAINER_SLOT_SIZE.y * item.y as f32,
+                CONTAINER_SLOT_SIZE.x * item.width as f32,
+                CONTAINER_SLOT_SIZE.y * item.height as f32,
+            ),
+        })
+        .collect()
 }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -91,6 +91,15 @@ pub trait GameScene {
         false
     }
 
+    /// Flat interaction state exposed read-only for debug tooling.
+    fn highlighted_entity(&self) -> Option<EntityId> {
+        None
+    }
+
+    fn active_container(&self) -> Option<(EntityId, Vec<EntityId>)> {
+        None
+    }
+
     /// Get lighting information for VR enhancement
     fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight>;
 

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -10,7 +10,7 @@
 
 use std::cell::RefCell;
 
-use cgmath::{InnerSpace, Point3, Quaternion, Vector3, Vector4};
+use cgmath::{InnerSpace, Point3, Quaternion, Vector2, Vector3, Vector4};
 use engine::{
     assets::asset_cache::AssetCache,
     scene::{SceneObject, light::SpotLight},
@@ -52,6 +52,16 @@ pub trait PlayerInteraction {
     /// Entities under the reticle/hands, for the hover-highlight overlay.
     fn highlighted_entities(&self) -> Vec<EntityId>;
 
+    /// The open flat container and its currently-visible contents. Empty for
+    /// VR and while no container UI is active.
+    fn active_container(&self) -> Option<EntityId> {
+        None
+    }
+
+    fn active_container_items(&self, _world: &World) -> Vec<EntityId> {
+        Vec::new()
+    }
+
     /// The first-person viewmodel entity (drawn on top); `None` for VR.
     fn viewmodel_entity(&self) -> Option<EntityId> {
         None
@@ -61,6 +71,15 @@ pub trait PlayerInteraction {
     /// panels). Flat draws nothing here; its weapon is drawn from
     /// `viewmodel_entity`.
     fn render(&self, _asset_cache: &mut AssetCache, _world: &World) -> Vec<SceneObject> {
+        Vec::new()
+    }
+
+    fn render_flat_ui(
+        &self,
+        _asset_cache: &mut AssetCache,
+        _world: &World,
+        _screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
         Vec::new()
     }
 
@@ -272,7 +291,7 @@ impl Default for FlatInteraction {
 impl PlayerInteraction for FlatInteraction {
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
         let (msgs, highlighted) = self.controller.update(
-            &ctx.input.right_hand,
+            ctx.input,
             ctx.player_pos,
             ctx.player_rotation,
             ctx.head_rotation,
@@ -289,6 +308,24 @@ impl PlayerInteraction for FlatInteraction {
 
     fn highlighted_entities(&self) -> Vec<EntityId> {
         self.highlighted.into_iter().collect()
+    }
+
+    fn active_container(&self) -> Option<EntityId> {
+        self.controller.active_container()
+    }
+
+    fn active_container_items(&self, world: &World) -> Vec<EntityId> {
+        self.controller.active_container_items(world)
+    }
+
+    fn render_flat_ui(
+        &self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        self.controller
+            .render_container_ui(asset_cache, world, screen_size)
     }
 
     fn viewmodel_entity(&self) -> Option<EntityId> {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -211,6 +211,11 @@ pub struct PlayerStateSnapshot {
     pub rotation: [f32; 4],
     pub wielded_entity_id: Option<i32>,
     pub right_hand_entity_id: Option<i32>,
+    /// Flat crosshair target and open container state. These are read-only
+    /// observability for headless player-input tests.
+    pub highlighted_entity_id: Option<i32>,
+    pub active_container_entity_id: Option<i32>,
+    pub active_container_item_ids: Vec<i32>,
     /// Whether the wielded weapon is mid-reload, and (if so) the current
     /// reload RAMP angle in degrees (0 -> authored peak -> 0) and the reload
     /// progress (0..1). When not reloading: `false`, `0.0`, `0.0`. Lets tooling
@@ -251,6 +256,20 @@ impl Game {
     pub fn player_state(&self) -> Option<PlayerStateSnapshot> {
         use crate::mission::mission_core::PlayerInfo;
         use crate::runtime_props::RuntimePropReloading;
+        let highlighted_entity_id = self
+            .active_game_scene
+            .highlighted_entity()
+            .map(|entity| entity.inner() as i32);
+        let (active_container_entity_id, active_container_item_ids) = self
+            .active_game_scene
+            .active_container()
+            .map(|(container, items)| {
+                (
+                    Some(container.inner() as i32),
+                    items.into_iter().map(|item| item.inner() as i32).collect(),
+                )
+            })
+            .unwrap_or((None, Vec::new()));
         let world = self.world();
         let info = world.borrow::<shipyard::UniqueView<PlayerInfo>>().ok()?;
         let reload = info.left_hand_entity_id.and_then(|weapon| {
@@ -273,6 +292,9 @@ impl Game {
             ],
             wielded_entity_id: info.left_hand_entity_id.map(|e| e.inner() as i32),
             right_hand_entity_id: info.right_hand_entity_id.map(|e| e.inner() as i32),
+            highlighted_entity_id,
+            active_container_entity_id,
+            active_container_item_ids,
             reloading: reload.is_some(),
             reload_pitch_deg: reload.map(|(p, _)| p).unwrap_or(0.0),
             reload_progress: reload.map(|(_, p)| p).unwrap_or(0.0),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3123,6 +3123,10 @@ impl MissionCore {
                 &self.world,
                 screen_size,
             ));
+            ret.extend(
+                self.interaction
+                    .render_flat_ui(asset_cache, &self.world, screen_size),
+            );
         }
 
         ret
@@ -3502,6 +3506,18 @@ impl MissionCore {
         self.interaction.hand_spotlights(options)
     }
 
+    pub fn highlighted_entity(&self) -> Option<EntityId> {
+        self.interaction.highlighted_entities().into_iter().next()
+    }
+
+    pub fn active_container(&self) -> Option<EntityId> {
+        self.interaction.active_container()
+    }
+
+    pub fn active_container_items(&self) -> Vec<EntityId> {
+        self.interaction.active_container_items(&self.world)
+    }
+
     /// Apply the effects produced by an interaction controller (the VR hands or
     /// the flat first-person controller). Shared so both presentations go
     /// through one path.
@@ -3547,6 +3563,17 @@ impl MissionCore {
                 }
                 VirtualHandEffect::HoldItem { entity_id } => {
                     self.make_un_physical(entity_id);
+                    // Once an item is held, it no longer belongs to a world
+                    // container. Flat pointer selection reaches this same
+                    // shared path as ordinary direct pickup/wield.
+                    let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
+                    for entity_links in (&mut links).iter() {
+                        entity_links.to_links.retain(|link| {
+                            !matches!(link.link, Link::Contains(_))
+                                || link.to_entity_id.map(|to| to.0) != Some(entity_id)
+                        });
+                    }
+                    drop(links);
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::Hold,
                         to: entity_id,

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -236,6 +236,20 @@ impl crate::game_scene::GameScene for Mission {
         )
     }
 
+    fn wants_pointer(&self) -> bool {
+        self.mission_core.active_container().is_some()
+    }
+
+    fn highlighted_entity(&self) -> Option<EntityId> {
+        self.mission_core.highlighted_entity()
+    }
+
+    fn active_container(&self) -> Option<(EntityId, Vec<EntityId>)> {
+        self.mission_core
+            .active_container()
+            .map(|entity_id| (entity_id, self.mission_core.active_container_items()))
+    }
+
     fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight> {
         self.mission_core.get_hand_spotlights(options)
     }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -162,6 +162,10 @@ export interface PlayerSnapshot {
   wielded_entity_id: number | null;
   /** The entity held in the right hand (VR); null otherwise. */
   right_hand_entity_id: number | null;
+  /** Flat crosshair target plus the currently-open container and its live items. */
+  highlighted_entity_id: number | null;
+  active_container_entity_id: number | null;
+  active_container_item_ids: number[];
   /** Whether the wielded weapon is mid-reload, plus the current viewmodel tilt
    * (degrees) and reload progress (0..1). false/0/0 when not reloading. */
   reloading: boolean;

--- a/tools/shock2-sdk/test/flat-container.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-container.e2e.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Negative-first coverage for #433. The authored first MedSci interaction is
+// corpse 1177 -> Contains -> wrench 990. Follow the real AIPATH bend with
+// bounded, collision-valid moves, then use the same flat input channels as the
+// desktop runtime. No give-item or remote-Frob shortcut is involved.
+test(
+  "flat container: opens the starting MedSci corpse and takes its wrench",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8117),
+    });
+    await game.step({ frames: 5 });
+
+    const corpses = await game.entities.byTemplate(1177);
+    assert.equal(corpses.length, 1, "expected authored corpse 1177");
+    const corpse = corpses[0];
+    const corpseDetail = await game.entities.detail(corpse.id);
+    const wrenchLink = corpseDetail.outgoing_links.find(
+      (link) => link.link_type.startsWith("Contains") && link.target_name.includes("Wrench"),
+    );
+    assert.ok(
+      wrenchLink,
+      `corpse should initially contain the authored wrench: ${JSON.stringify(corpseDetail.outgoing_links)}`,
+    );
+
+    // Preserve the player's live origin Y while following the AIPATH X/Z
+    // waypoints around the cryo partition.
+    const y = (await game.player.position()).y;
+    for (const [x, z] of [
+      [-36.5, 21.7],
+      [-37.1, 25.9],
+      [-39.5, 26.5],
+      [-39.5, 26.7],
+      [-38.3, 27.1],
+      [-37.7, 28.9],
+      [-37.7, 30.5],
+      [-37.4, 31.2],
+    ]) {
+      const moved = await game.player.moveTo({ x, y, z });
+      assert.equal(moved.blocked, false, `authored route blocked at ${x},${z}`);
+      await game.step({ frames: 2 });
+    }
+
+    // Aim at the body's center, then use/frob on the normal squeeze edge.
+    const player = await game.player.position();
+    const playerSnapshot = (await game.info()).player;
+    const corpseBodies = await game.physics.bodies({ entityId: corpse.id });
+    const dx = corpse.position[0] - player.x;
+    const dz = corpse.position[2] - player.z;
+    const cameraY = player.y + 4.5 / 2.5;
+    const dy = corpse.position[1] - cameraY;
+    // head.look's authored desktop convention describes the camera position
+    // around the origin (yaw=0 renders toward -X), so aim uses the inverse of
+    // the target direction.
+    const yaw = Math.atan2(-dz, -dx) * (180 / Math.PI);
+    const pitch = Math.atan2(-dy, Math.hypot(dx, dz)) * (180 / Math.PI);
+    // The authored creature pose shifts the visible torso away from the
+    // object's position marker, so converge on it through the same read-only
+    // highlighted-entity signal a headless player sees.
+    let aimed = false;
+    const seenHighlights = new Set<number | null>();
+    for (const pitchOffset of [-60, -45, -30, -15, 0, 15]) {
+      for (const yawOffset of [0, -10, 10, -20, 20]) {
+        await game.input.set("head.look", [yaw + yawOffset, pitch + pitchOffset]);
+        await game.step({ frames: 1 });
+        const highlighted = (await game.info()).player.highlighted_entity_id;
+        seenHighlights.add(highlighted);
+        if (highlighted === corpse.id) {
+          aimed = true;
+          break;
+        }
+      }
+      if (aimed) break;
+    }
+    assert.ok(
+      aimed,
+      `normal head look should highlight corpse ${corpse.id}; saw ${JSON.stringify([...seenHighlights])}, target=${JSON.stringify(corpse.position)}, player=${JSON.stringify(player)}, rotation=${JSON.stringify(playerSnapshot.rotation)}, bodies=${JSON.stringify(corpseBodies.bodies)}`,
+    );
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 1 });
+
+    const opened = await game.info();
+    assert.equal(opened.player.active_container_entity_id, corpse.id);
+    assert.deepEqual(opened.player.active_container_item_ids, [wrenchLink.target_id]);
+
+    // Click the wrench's first 4x4 container slot in the screen-space panel.
+    await game.input.set("pointer.position", [0.4, 0.55]);
+    await game.input.set("pointer.pressed", 1.0);
+    await game.step({ frames: 1 });
+    await game.input.set("pointer.pressed", 0.0);
+    await game.step({ frames: 1 });
+
+    const inventory = await game.player.inventory();
+    assert.ok(
+      inventory.items.some((item) => item.entity_id === wrenchLink.target_id),
+      `expected real input to take wrench; got ${JSON.stringify(inventory.items)}`,
+    );
+
+    const afterCorpse = await game.entities.detail(corpse.id);
+    assert.ok(
+      !afterCorpse.outgoing_links.some(
+        (link) =>
+          link.link_type.startsWith("Contains") && link.target_id === wrenchLink.target_id,
+      ),
+      "taking the wrench should remove the live Contains link",
+    );
+
+    // Normal use toggles the open container closed.
+    await game.input.set("right_hand.squeeze", 1.0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 0.0);
+    await game.step({ frames: 1 });
+    assert.equal((await game.info()).player.active_container_entity_id, null);
+  },
+);


### PR DESCRIPTION
## Summary

- add a real flatscreen container interaction state driven by normal frob/use and pointer input
- render the opened container and its live `Contains` contents in screen space, transfer the specifically clicked item through the shared wield/Hold path, and keep `Contains` links accurate
- expose read-only highlighted entity and active container/item state through `/v1/info`, plus pointer channels through the debug runtime
- cover the authored MedSci corpse -> wrench route with a negative-first SDK e2e scenario

Fixes #433

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (93 passed)
- `cd tools/shock2-sdk && npm test` (6 passed, 69 opt-in skipped)
- focused `flat-container.e2e.test.ts` (passed)
- full SDK e2e: 73/75 passed, including the new container scenario and all mission-load tests
  - `blood-spang.e2e.test.ts` fails identically on local `main` (no new blood spang)
  - `monster-death.e2e.test.ts` intermittently reported 0.75 units of corpse movement; it passed in the immediate local `main` baseline replay
- xreview: no remaining Critical/High/Medium findings after restricting looting to `ContainerScript` (living `CreatureContainer` AI stays closed)

## Visual verification

![Flat-screen container looting demo](https://gist.githubusercontent.com/tommy-xr/1badb8a61e0f63f5d56a3420912238c4/raw/flat-container-demo.gif)

<sub>Opens the authored MedSci corpse, selects and transfers its wrench through normal flat-screen pointer input, then closes the container with normal use input. Captured headlessly through the deterministic debug runtime.</sub>

![Flat-screen container with selected wrench](https://gist.githubusercontent.com/tommy-xr/1badb8a61e0f63f5d56a3420912238c4/raw/flat-container-selected.png)

![Transferred wrench with container still open](https://gist.githubusercontent.com/tommy-xr/1badb8a61e0f63f5d56a3420912238c4/raw/flat-container-transferred.png)

![Container closed with wrench wielded](https://gist.githubusercontent.com/tommy-xr/1badb8a61e0f63f5d56a3420912238c4/raw/flat-container-closed.png)
