### PR TITLE
feat(input): flat-UI plumbing — pointer channels, ToggleUseMode, GET /v1/ui

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -60,6 +60,11 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<SaveLoadResult>,
     },
 
+    /// Snapshot the flat-mode UI state (mode: shooter/use).
+    GetUiState {
+        reply: oneshot::Sender<UiStateResult>,
+    },
+
     /// Snapshot the quest bits (objective flags) the game has set.
     GetQuestBits {
         reply: oneshot::Sender<QuestBitsResult>,
@@ -334,6 +339,15 @@ pub struct InputState {
     pub head: InputHead,
     pub left_hand: InputHand,
     pub right_hand: InputHand,
+    /// 2D screen pointer (flat-mode cursor); `None` until a pointer channel
+    /// is set. Position is normalized [0,1] per axis, origin top-left.
+    pub pointer: Option<InputPointer>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InputPointer {
+    pub position: [f32; 2],
+    pub pressed: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -357,6 +371,7 @@ impl Default for InputState {
             head: InputHead::default(),
             left_hand: InputHand::default(),
             right_hand: InputHand::default(),
+            pointer: None,
         }
     }
 }
@@ -441,6 +456,14 @@ pub struct QuestBitEntry {
 pub struct QuestBitsResult {
     pub quests: Vec<QuestBitEntry>,
     pub count: usize,
+}
+
+/// Flat-mode UI state snapshot (`GET /v1/ui`): "shooter" or "use".
+/// Panel/element introspection is added with the flat UI host
+/// (see projects/flat-ui.md).
+#[derive(Debug, Serialize)]
+pub struct UiStateResult {
+    pub mode: String,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -284,6 +284,7 @@ async fn start_http_server(
         )
         .route("/v1/save", axum::routing::post(save_game))
         .route("/v1/load", axum::routing::post(load_game))
+        .route("/v1/ui", get(get_ui_state))
         .route("/v1/quests", get(get_quest_bits))
         .route("/v1/quests/:name", axum::routing::post(set_quest_bit))
         .route("/v1/player/inventory", get(get_player_inventory))
@@ -336,6 +337,7 @@ async fn start_http_server(
     info!(
         "  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}"
     );
+    info!("  GET  /v1/ui               - Flat-mode UI state (mode: shooter/use)");
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
@@ -1006,6 +1008,20 @@ fn process_command(
                 tracing::warn!("Failed to send load result - receiver dropped");
             }
         }
+        RuntimeCommand::GetUiState { reply } => {
+            let result = game
+                .debug_scene()
+                .map(|scene| {
+                    let ui = scene.ui_state();
+                    commands::UiStateResult { mode: ui.mode }
+                })
+                .unwrap_or(commands::UiStateResult {
+                    mode: "shooter".to_string(),
+                });
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send ui state - receiver dropped");
+            }
+        }
         RuntimeCommand::GetQuestBits { reply } => {
             let quests: Vec<commands::QuestBitEntry> = game
                 .debug_scene()
@@ -1525,6 +1541,10 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
         }
     }
     commands::InputState {
+        pointer: input.pointer.map(|p| commands::InputPointer {
+            position: [p.position.x, p.position.y],
+            pressed: p.pressed,
+        }),
         head: commands::InputHead {
             rotation: [
                 input.head.rotation.v.x,
@@ -1555,6 +1575,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// stick does what) since that is the game's convention, not guessable.
 fn input_channels_help() -> &'static str {
     "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
+     pointer.position [x,y] (normalized, origin top-left), pointer.pressed 0|1, \
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
@@ -1648,6 +1669,31 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         "head.look" => {
             let yp = arr(channel, value, 2)?;
             input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
+            Ok(())
+        }
+        // Flat-mode 2D pointer (cursor). Position is normalized [0,1] per
+        // axis, origin top-left; setting either channel materializes the
+        // pointer (it is `None` until first set).
+        "pointer.position" => {
+            let xy = arr(channel, value, 2)?;
+            let pointer = input
+                .pointer
+                .get_or_insert(shock2vr::input_context::Pointer2D {
+                    position: cgmath::vec2(0.0, 0.0),
+                    pressed: false,
+                });
+            pointer.position = cgmath::vec2(xy[0], xy[1]);
+            Ok(())
+        }
+        "pointer.pressed" => {
+            let pressed = num(channel, value)? != 0.0;
+            let pointer = input
+                .pointer
+                .get_or_insert(shock2vr::input_context::Pointer2D {
+                    position: cgmath::vec2(0.0, 0.0),
+                    pressed: false,
+                });
+            pointer.pressed = pressed;
             Ok(())
         }
         _ => Err(format!(
@@ -2335,6 +2381,23 @@ struct SetQuestBitRequest {
 
 /// HTTP handler for snapshotting quest bits (objective flags). An empty list
 /// means the level has set no quest bits yet (all objectives read as unknown).
+async fn get_ui_state(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+) -> Result<Json<commands::UiStateResult>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::GetUiState { reply: reply_tx })
+        .is_err()
+    {
+        tracing::error!("Failed to send GetUiState command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(result) => Ok(Json(result)),
+        Err(_) => Err(game_loop_unavailable()),
+    }
+}
+
 async fn get_quest_bits(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
 ) -> Result<Json<commands::QuestBitsResult>, (StatusCode, String)> {

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1575,7 +1575,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// stick does what) since that is the game's convention, not guessable.
 fn input_channels_help() -> &'static str {
     "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
-     pointer.position [x,y] (normalized, origin top-left), pointer.pressed 0|1, \
+     pointer.position [x,y] in [0,1] (origin top-left; null clears), pointer.pressed 0|1, \
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
@@ -1673,9 +1673,24 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         }
         // Flat-mode 2D pointer (cursor). Position is normalized [0,1] per
         // axis, origin top-left; setting either channel materializes the
-        // pointer (it is `None` until first set).
+        // pointer (it is `None` until first set). `pointer.position: null`
+        // clears the pointer back to `None` (scenes branch on Some/None, so
+        // the cleared state must be reachable for testing).
         "pointer.position" => {
+            if value.is_null() {
+                input.pointer = None;
+                return Ok(());
+            }
             let xy = arr(channel, value, 2)?;
+            if !(xy[0].is_finite() && xy[1].is_finite())
+                || !(0.0..=1.0).contains(&xy[0])
+                || !(0.0..=1.0).contains(&xy[1])
+            {
+                return Err(format!(
+                    "channel '{channel}' expects normalized coordinates in [0,1], got [{}, {}]",
+                    xy[0], xy[1]
+                ));
+            }
             let pointer = input
                 .pointer
                 .get_or_insert(shock2vr::input_context::Pointer2D {
@@ -1686,7 +1701,13 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
             Ok(())
         }
         "pointer.pressed" => {
-            let pressed = num(channel, value)? != 0.0;
+            let pressed = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
             let pointer = input
                 .pointer
                 .get_or_insert(shock2vr::input_context::Pointer2D {

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -73,6 +73,11 @@ impl DesktopInputMapper {
                 modifier: Modifier::Alt,
                 action: InputAction::QuickLoad,
             },
+            Binding {
+                key: Key::Tab,
+                modifier: Modifier::None,
+                action: InputAction::ToggleUseMode,
+            },
         ];
 
         Self {

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -2,7 +2,9 @@ use glfw::{Action, Key, Window};
 use shock2vr::input::{InputAction, InputActionState};
 use std::collections::HashSet;
 
-/// Whether a binding requires the Alt modifier to be held.
+/// Modifier requirement for a binding. `None` requires Alt NOT held (so a
+/// plain-key binding doesn't also fire during a system chord like Alt+Tab);
+/// `Alt` requires it held.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Modifier {
     None,
@@ -94,7 +96,7 @@ impl DesktopInputMapper {
 
         for binding in &self.bindings {
             let modifier_satisfied = match binding.modifier {
-                Modifier::None => true,
+                Modifier::None => !is_alt_pressed,
                 Modifier::Alt => is_alt_pressed,
             };
             let is_down = modifier_satisfied && window.get_key(binding.key) == Action::Press;

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -334,6 +334,15 @@ pub struct DebugInventoryItem {
     pub location: String,
 }
 
+/// Snapshot of the flat-mode UI state for debug introspection (`GET /v1/ui`).
+/// `mode` is "shooter" (mouse-look, no cursor) or "use" (cursor-driven
+/// metagame UI, the original game's Tab mode). Panel/element introspection
+/// arrives with the flat UI host (see `projects/flat-ui.md`).
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiState {
+    pub mode: String,
+}
+
 /// A level-transition trigger (a `TrapTripLevel` tripwire / bulkhead): where it
 /// leads (`dest_level` + optional spawn `dest_loc`) and its world `position`, so
 /// a tester can teleport into its volume and let the real trigger fire the
@@ -495,6 +504,14 @@ pub trait DebuggableScene {
     /// items), for verifying pickups. Empty when the scene has no player.
     fn player_inventory(&self) -> Vec<DebugInventoryItem> {
         Vec::new()
+    }
+
+    /// The flat-mode UI state (`GET /v1/ui`): current mode ("shooter"/"use").
+    /// Default: shooter (scenes without a flat metagame UI).
+    fn ui_state(&self) -> DebugUiState {
+        DebugUiState {
+            mode: "shooter".to_string(),
+        }
     }
 
     /// Put an existing world entity into the player's inventory (a headless

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -54,6 +54,11 @@ pub enum InputAction {
     /// Force every monster back to Lowest alertness (idle). Same caveats as
     /// DebugAlertAll.
     DebugCalmAll,
+
+    /// Toggle the flat-mode "use" (metagame) mode: cursor-driven UI over the
+    /// 3D view, as the original game does on Tab. Shooter mode is restored on
+    /// a second toggle. No-op in VR. See `projects/flat-ui.md`.
+    ToggleUseMode,
 }
 
 impl InputAction {
@@ -75,6 +80,7 @@ impl InputAction {
             InputAction::DebugReloadLevel,
             InputAction::DebugAlertAll,
             InputAction::DebugCalmAll,
+            InputAction::ToggleUseMode,
         ]
     }
 
@@ -94,6 +100,7 @@ impl InputAction {
             InputAction::DebugReloadLevel => "DebugReloadLevel",
             InputAction::DebugAlertAll => "DebugAlertAll",
             InputAction::DebugCalmAll => "DebugCalmAll",
+            InputAction::ToggleUseMode => "ToggleUseMode",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -90,6 +90,9 @@ impl ActionDispatcher {
                 level: AIAlertLevel::Lowest,
             });
         }
+        if state.just_triggered(InputAction::ToggleUseMode) {
+            effects.push(Effect::ToggleUseMode);
+        }
         effects
     }
 }
@@ -168,6 +171,15 @@ mod tests {
                 level: AIAlertLevel::Lowest
             }
         ));
+    }
+
+    #[test]
+    fn toggle_use_mode_maps_to_toggle_effect() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::ToggleUseMode);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(matches!(effects[0], Effect::ToggleUseMode));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1966,7 +1966,10 @@ impl MissionCore {
                 }
 
                 Effect::ToggleUseMode => {
-                    self.flat_use_mode = !self.flat_use_mode;
+                    // Flat-presentation only: VR has no cursor mode to toggle.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        self.flat_use_mode = !self.flat_use_mode;
+                    }
                 }
 
                 Effect::CyclePsiPower => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -261,6 +261,11 @@ pub struct MissionCore {
     /// entity and its motion player (loops the player-melee idle; a swing is
     /// queued on attack and auto-returns to idle). `None` for guns / no weapon.
     flat_melee_anim: Option<(EntityId, AnimationPlayer)>,
+
+    /// Flat-mode "use" (metagame) mode, toggled by `Effect::ToggleUseMode`
+    /// (Tab). Mode tracking only for now - the cursor + panel presentation
+    /// land with the flat UI host (see `projects/flat-ui.md`). Ignored in VR.
+    pub flat_use_mode: bool,
 }
 
 pub struct GlobalContext {
@@ -689,6 +694,7 @@ impl MissionCore {
             debug_pose_index: 0,
             debug_weapon_index: 0,
             flat_melee_anim: None,
+            flat_use_mode: false,
         }
     }
 
@@ -1957,6 +1963,10 @@ impl MissionCore {
                     if let Some(weapon) = wielded {
                         self.cycle_ammo(weapon);
                     }
+                }
+
+                Effect::ToggleUseMode => {
+                    self.flat_use_mode = !self.flat_use_mode;
                 }
 
                 Effect::CyclePsiPower => {
@@ -4420,6 +4430,16 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 }
             })
             .collect()
+    }
+
+    fn ui_state(&self) -> crate::game_scene::DebugUiState {
+        crate::game_scene::DebugUiState {
+            mode: if self.flat_use_mode {
+                "use".to_string()
+            } else {
+                "shooter".to_string()
+            },
+        }
     }
 
     fn quest_bits(&self) -> Vec<crate::game_scene::DebugQuestBit> {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -341,6 +341,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.quest_bits()
     }
 
+    fn ui_state(&self) -> crate::game_scene::DebugUiState {
+        self.mission_core.ui_state()
+    }
+
     fn set_quest_bit(&mut self, name: &str, value: &str) -> Result<(), String> {
         self.mission_core.set_quest_bit(name, value)
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -90,6 +90,13 @@ pub enum Effect {
     /// two projectile links.
     CycleAmmo,
 
+    /// Toggle the flat-mode "use" (metagame) mode - cursor-driven UI over the
+    /// 3D view, as the original game does on Tab. Currently only tracks the
+    /// mode (introspectable via the debug runtime's `GET /v1/ui`); the cursor
+    /// and panel presentation land with the flat UI host. No-op in VR.
+    /// See `projects/flat-ui.md`.
+    ToggleUseMode,
+
     /// Select the player's next *trained* psi power (advances
     /// `PsiPowerSelection` through the `GlobalPsiPowers` registry, wrapping,
     /// skipping powers not in `PlayerPsiKnownPowers`).

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -22,6 +22,7 @@ import type {
   SaveLoadResult,
   QuestBitsResult,
   QuestBitValue,
+  UiState,
   PlayerInventoryResult,
   TransitionsResult,
   WaitForOptions,
@@ -226,6 +227,16 @@ export class QuestsApi {
   }
 }
 
+/** Flat-mode UI state introspection (GET /v1/ui). */
+export class UiApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /** Current UI snapshot: mode is "shooter" or "use" (Tab metagame mode). */
+  async state(): Promise<UiState> {
+    return this.client.get<UiState>("/v1/ui");
+  }
+}
+
 /** Pathfinding service telemetry (distinct from the interactive test). */
 export class PathfindingApi {
   constructor(private readonly client: HttpClient) {}
@@ -256,6 +267,7 @@ export class Game {
   readonly pathfinding: PathfindingApi;
   readonly physics: PhysicsApi;
   readonly quests: QuestsApi;
+  readonly ui: UiApi;
 
   constructor(protected readonly client: HttpClient) {
     this.player = new PlayerApi(client);
@@ -265,6 +277,7 @@ export class Game {
     this.pathfinding = new PathfindingApi(client);
     this.physics = new PhysicsApi(client);
     this.quests = new QuestsApi(client);
+    this.ui = new UiApi(client);
   }
 
   get baseUrl(): string {

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -6,6 +6,7 @@ export {
   InputApi,
   PathfindingTestApi,
   PlayerApi,
+  UiApi,
 } from "./game.js";
 export { findRepoRoot, GameServer, type LaunchOptions } from "./server.js";
 export type * from "./types.js";

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -9,6 +9,7 @@ export type InputAction =
   | "CycleAmmo"
   | "Reload"
   | "CyclePsiPower"
+  | "ToggleUseMode"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 
@@ -265,9 +266,9 @@ export interface PlayerInventoryResult {
   count: number;
 }
 
-/** Flat-mode UI snapshot (GET /v1/ui). Mode: "shooter" | "use". */
+/** Flat-mode UI snapshot (GET /v1/ui). */
 export interface UiState {
-  mode: string;
+  mode: "shooter" | "use";
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -265,6 +265,11 @@ export interface PlayerInventoryResult {
   count: number;
 }
 
+/** Flat-mode UI snapshot (GET /v1/ui). Mode: "shooter" | "use". */
+export interface UiState {
+  mode: string;
+}
+
 export interface TransitionEntry {
   entity_id: number;
   name: string | null;

--- a/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the flat-UI plumbing (projects/flat-ui.md PR 1):
+// - GET /v1/ui reports the flat UI mode ("shooter" by default)
+// - InputAction::ToggleUseMode flips it to "use" and back (the original
+//   game's Tab metagame mode - mode tracking only at this stage)
+// - the pointer.position / pointer.pressed input channels are accepted and
+//   echoed by GET /v1/control/input (the cursor input the flat panels will
+//   consume)
+//
+// Negative-first: before this plumbing, /v1/ui 404s and the pointer channels
+// are rejected as unknown.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "flat UI plumbing: /v1/ui mode toggle + pointer channels",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8111),
+    });
+    await game.step({ frames: 2 });
+
+    // Default mode is shooter.
+    const initial = await game.ui.state();
+    assert.equal(initial.mode, "shooter", "flat UI should start in shooter mode");
+
+    // Tab (ToggleUseMode) flips to use mode...
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 2 });
+    const afterToggle = await game.ui.state();
+    assert.equal(afterToggle.mode, "use", "ToggleUseMode should enter use mode");
+
+    // ...and back to shooter.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 2 });
+    const afterSecondToggle = await game.ui.state();
+    assert.equal(
+      afterSecondToggle.mode,
+      "shooter",
+      "a second ToggleUseMode should restore shooter mode",
+    );
+
+    // Pointer channels are accepted and echoed.
+    await game.input.set("pointer.position", [0.5, 0.25]);
+    await game.input.set("pointer.pressed", 1);
+    const echoed = (await (
+      await fetch(`${game.baseUrl}/v1/control/input`)
+    ).json()) as {
+      pointer: { position: [number, number]; pressed: boolean } | null;
+    };
+    assert.ok(echoed.pointer, "pointer state should be echoed once set");
+    assert.deepEqual(echoed.pointer.position, [0.5, 0.25]);
+    assert.equal(echoed.pointer.pressed, true);
+
+    await game.input.set("pointer.pressed", 0);
+    const released = (await (
+      await fetch(`${game.baseUrl}/v1/control/input`)
+    ).json()) as { pointer: { pressed: boolean } | null };
+    assert.equal(released.pointer?.pressed, false);
+  },
+);

--- a/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-ui-plumbing.e2e.test.ts
@@ -21,7 +21,7 @@ test(
   async () => {
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8111),
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
     });
     await game.step({ frames: 2 });
 
@@ -62,5 +62,25 @@ test(
       await fetch(`${game.baseUrl}/v1/control/input`)
     ).json()) as { pointer: { pressed: boolean } | null };
     assert.equal(released.pointer?.pressed, false);
+
+    // Invalid values are rejected with a 400 (not silently accepted).
+    for (const [channel, value] of [
+      ["pointer.position", [1.5, 0.5]],
+      ["pointer.position", [Number.NaN, 0.5]],
+      ["pointer.pressed", 0.5],
+    ] as const) {
+      const res = await fetch(`${game.baseUrl}/v1/control/input`, {
+        method: "POST",
+        body: JSON.stringify({ channel, value }),
+      });
+      assert.equal(res.status, 400, `${channel}=${value} should be rejected`);
+    }
+
+    // `pointer.position: null` clears the pointer back to None.
+    await game.input.set("pointer.position", null);
+    const cleared = (await (
+      await fetch(`${game.baseUrl}/v1/control/input`)
+    ).json()) as { pointer: unknown };
+    assert.equal(cleared.pointer, null, "null position should clear the pointer");
   },
 );


### PR DESCRIPTION
**PR 1 of the flat metagame UI plan** (`projects/flat-ui.md`, #440): the headless harness the upcoming panels need. No visible behavior change.

- **`InputAction::ToggleUseMode`** (Tab on desktop) → `Effect::ToggleUseMode`, tracked as a use/shooter mode flag on `MissionCore` — the original game's Tab metagame mode. Gated to flat presentation (no-op in VR); cursor + panel presentation land with the flat UI host (PR 2).
- **`GET /v1/ui`** on the debug runtime reports the mode — the skeleton of the UI introspection endpoint (panel/element rects arrive with the first panel).
- **`pointer.position` / `pointer.pressed` input channels** populate the existing `InputContext::pointer`, validated (finite `[0,1]`; pressed strictly 0|1; `null` position clears), echoed by `GET /v1/control/input`.
- SDK: `game.ui.state()` + `UiState`; `ToggleUseMode` in the action union.
- Desktop mapper: `Modifier::None` bindings no longer fire during Alt chords (Alt+Tab was going to phantom-toggle the mode).

## Verification

- New e2e `flat-ui-plumbing.e2e.test.ts` (negative-first — `/v1/ui` 404s and pointer channels are rejected without this): mode `shooter` → `use` → `shooter` via ToggleUseMode; pointer set/echo; invalid values 400; null-clear.
- `missions.e2e.test.ts`: 23/23 load clean.
- `RUSTFLAGS="-D warnings" cargo check` on shock2vr + both runtimes; `cargo test -p shock2vr` green; SDK unit tests green.
- Cross-engine adversarial review (Claude + Codex): no Critical/High; both Mediums + all Lows addressed in the second commit (VR gating, input validation, Alt-chord fix, SDK typing, port dedup).

**Known/intentional**: `flat_use_mode` resets on level transition or load (fresh `MissionCore`) — nothing consumes the flag yet; the UI host PR makes the cross-load behavior an explicit decision.

Next in the stack: PR 2 — keypad MFD on frob (resolves #435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)