### PR TITLE
feat(ui): flat keypad MFD on frob (Fixes #435)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -458,12 +458,13 @@ pub struct QuestBitsResult {
     pub count: usize,
 }
 
-/// Flat-mode UI state snapshot (`GET /v1/ui`): "shooter" or "use".
-/// Panel/element introspection is added with the flat UI host
-/// (see projects/flat-ui.md).
+/// Flat-mode UI state snapshot (`GET /v1/ui`): "shooter" or "use", plus the
+/// open MFD panel (entity binding + labeled clickable elements with canvas
+/// and normalized-screen rects). See projects/flat-ui.md.
 #[derive(Debug, Serialize)]
 pub struct UiStateResult {
     pub mode: String,
+    pub active_panel: Option<shock2vr::game_scene::DebugUiPanel>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1013,10 +1013,14 @@ fn process_command(
                 .debug_scene()
                 .map(|scene| {
                     let ui = scene.ui_state();
-                    commands::UiStateResult { mode: ui.mode }
+                    commands::UiStateResult {
+                        mode: ui.mode,
+                        active_panel: ui.active_panel,
+                    }
                 })
                 .unwrap_or(commands::UiStateResult {
                     mode: "shooter".to_string(),
+                    active_panel: None,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -342,7 +342,10 @@ pub fn main() {
         // mouse button - or shift+left-click, which is easier on a trackpad -
         // uses/frobs/picks up. (The flat controller reads the right-hand trigger
         // + squeeze.)
-        if !args.vr {
+        // While a 2D cursor UI is up (e.g. an MFD panel), mouse buttons drive
+        // the cursor (`input_context.pointer`), not fire/frob - the original
+        // surrenders the mouse to the metagame the same way.
+        if !args.vr && !wants_pointer {
             let pressed = |b| window.get_mouse_button(b) == Action::Press;
             let shift = window.get_key(Key::LeftShift) == Action::Press
                 || window.get_key(Key::RightShift) == Action::Press;

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -303,6 +303,10 @@ pub fn main() {
     // Tracks whether the OS cursor is currently visible (Normal) vs captured
     // for mouse-look (Disabled). The window starts with the cursor disabled.
     let mut cursor_visible = false;
+    // A mouse button still held when a cursor UI closes (e.g. LMB-closing an
+    // MFD panel) must not fire the weapon on the next frame - swallow the
+    // held press until every button is released.
+    let mut suppress_mouse_until_release = false;
     let mut action_state = InputActionState::new();
 
     let _mode = Mode::Gameplay;
@@ -324,6 +328,22 @@ pub fn main() {
             } else {
                 glfw::CursorMode::Disabled
             });
+            if wants_pointer {
+                // The captured (Disabled) cursor position is a virtual,
+                // unbounded accumulator - garbage as a screen pointer. Start
+                // the visible cursor centered and sync the tracked position
+                // so the first CursorPos event doesn't produce a huge delta.
+                let (cx, cy) = (SCR_WIDTH as f64 / 2.0, SCR_HEIGHT as f64 / 2.0);
+                window.set_cursor_pos(cx, cy);
+                camera_context.mouse_position = Some(MousePosition {
+                    x: cx as f32,
+                    y: cy as f32,
+                });
+            } else {
+                // Re-capturing: forget the pointer position so the next
+                // mouse-look delta starts fresh instead of jumping.
+                camera_context.mouse_position = None;
+            }
             cursor_visible = wants_pointer;
         }
 
@@ -344,19 +364,28 @@ pub fn main() {
         // + squeeze.)
         // While a 2D cursor UI is up (e.g. an MFD panel), mouse buttons drive
         // the cursor (`input_context.pointer`), not fire/frob - the original
-        // surrenders the mouse to the metagame the same way.
-        if !args.vr && !wants_pointer {
+        // surrenders the mouse to the metagame the same way. A button still
+        // held when the UI closes stays swallowed until released.
+        if !args.vr {
             let pressed = |b| window.get_mouse_button(b) == Action::Press;
-            let shift = window.get_key(Key::LeftShift) == Action::Press
-                || window.get_key(Key::RightShift) == Action::Press;
-            let lmb = pressed(MouseButton::Button1);
-            input_context.right_hand.trigger_value = if lmb && !shift { 1.0 } else { 0.0 };
-            input_context.right_hand.squeeze_value =
-                if pressed(MouseButton::Button2) || (lmb && shift) {
-                    1.0
-                } else {
-                    0.0
-                };
+            let any_mouse = pressed(MouseButton::Button1) || pressed(MouseButton::Button2);
+            if wants_pointer {
+                suppress_mouse_until_release = true;
+            } else if !any_mouse {
+                suppress_mouse_until_release = false;
+            }
+            if !wants_pointer && !suppress_mouse_until_release {
+                let shift = window.get_key(Key::LeftShift) == Action::Press
+                    || window.get_key(Key::RightShift) == Action::Press;
+                let lmb = pressed(MouseButton::Button1);
+                input_context.right_hand.trigger_value = if lmb && !shift { 1.0 } else { 0.0 };
+                input_context.right_hand.squeeze_value =
+                    if pressed(MouseButton::Button2) || (lmb && shift) {
+                        1.0
+                    } else {
+                        0.0
+                    };
+            }
         }
 
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
@@ -532,6 +561,13 @@ fn process_events(
             }
             _ => {}
         }
+    }
+
+    // While a 2D cursor UI is up, mouse motion moves the cursor, not the
+    // camera/hands - the original surrenders mouse-look to the metagame.
+    if wants_pointer {
+        rot_yaw = 0.0;
+        rot_pitch = 0.0;
     }
 
     if window.get_key(Key::E) == Action::Press {

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -336,11 +336,45 @@ pub struct DebugInventoryItem {
 
 /// Snapshot of the flat-mode UI state for debug introspection (`GET /v1/ui`).
 /// `mode` is "shooter" (mouse-look, no cursor) or "use" (cursor-driven
-/// metagame UI, the original game's Tab mode). Panel/element introspection
-/// arrives with the flat UI host (see `projects/flat-ui.md`).
+/// metagame UI, the original game's Tab mode). `active_panel` is the
+/// object-bound MFD panel opened by frobbing a GUI-bearing entity (keypad,
+/// container, ...), with its clickable elements - see `projects/flat-ui.md`.
 #[derive(Debug, Serialize, Clone)]
 pub struct DebugUiState {
     pub mode: String,
+    pub active_panel: Option<DebugUiPanel>,
+}
+
+/// The open flat-mode MFD panel: which entity it is bound to and its element
+/// list, so clients can click real widgets instead of hardcoding pixels.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiPanel {
+    /// Runtime entity id of the bound object (NOT stable across runs).
+    pub entity_id: i32,
+    /// The bound object's `PropTemplateId` - stable across runs (the
+    /// mission-file object id for level-authored entities). 0 if absent.
+    pub template_id: i32,
+    pub name: Option<String>,
+    pub elements: Vec<DebugUiElement>,
+}
+
+/// One drawn element of the active panel. `label` gives clickable elements a
+/// semantic identity (keypad digits "0"-"9", "clear", the host "close"
+/// button) so tests can click by meaning; `rect` is on the 640x480 virtual
+/// canvas and `screen_rect` is the same rect in normalized `[0,1]` screen
+/// coordinates (letterbox-corrected) - feed its center straight to the
+/// `pointer.position` input channel.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiElement {
+    /// "button" (clickable), "image", or "text".
+    pub kind: String,
+    pub texture: Option<String>,
+    pub text: Option<String>,
+    pub label: Option<String>,
+    /// Canvas-space rect `[x, y, w, h]` (640x480 virtual canvas).
+    pub rect: [f32; 4],
+    /// Normalized screen-space rect `[x, y, w, h]`.
+    pub screen_rect: [f32; 4],
 }
 
 /// A level-transition trigger (a `TrapTripLevel` tripwire / bulkhead): where it
@@ -506,11 +540,13 @@ pub trait DebuggableScene {
         Vec::new()
     }
 
-    /// The flat-mode UI state (`GET /v1/ui`): current mode ("shooter"/"use").
-    /// Default: shooter (scenes without a flat metagame UI).
+    /// The flat-mode UI state (`GET /v1/ui`): current mode ("shooter"/"use")
+    /// and the open MFD panel, if any. Default: shooter, no panel (scenes
+    /// without a flat metagame UI).
     fn ui_state(&self) -> DebugUiState {
         DebugUiState {
             mode: "shooter".to_string(),
+            active_panel: None,
         }
     }
 

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -373,6 +373,11 @@ pub enum GuiComponentRenderInfo {
         size: Vector2<f32>,
         texture: String,
         alpha: f32,
+        /// Whether the source component reacts to clicks (a `Button`, as
+        /// opposed to a plain `Image`). Purely informational - used by the
+        /// debug UI introspection (`GET /v1/ui`) to distinguish clickable
+        /// elements; the VR quad renderer ignores it.
+        interactive: bool,
     },
     Text {
         position: Vector2<f32>,
@@ -405,6 +410,7 @@ impl GuiComponentRenderInfo {
                 size,
                 texture,
                 alpha,
+                ..
             } => {
                 let texture: Rc<dyn TextureTrait> =
                     asset_cache.get(&TEXTURE_IMPORTER, texture).clone();
@@ -496,6 +502,7 @@ where
                 size: vec2(size.x / screen_size.x, size.y / screen_size.y),
                 texture: texture.clone(),
                 alpha: *alpha,
+                interactive: false,
             },
             GuiComponent::Button {
                 position,
@@ -503,7 +510,8 @@ where
                 texture,
                 hover,
                 alpha,
-                ..
+                on_click,
+                on_grab,
             } => {
                 let is_hovered = is_in_bounds(position, size, screen_space_cursor);
 
@@ -524,6 +532,7 @@ where
                     size,
                     texture,
                     alpha: *alpha,
+                    interactive: on_click.is_some() || on_grab.is_some(),
                 }
             }
         }

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -96,6 +96,10 @@ where
                 parent_entity_id: entity_id,
                 dropped_entity_id: *entity,
             },
+            // Frobbing a GUI-bearing entity opens its panel as a flat-mode MFD
+            // (the original's frob-script -> overlay flow). VR ignores the
+            // effect - its panels are world quads driven by `Hover` instead.
+            MessagePayload::Frob => Effect::OpenPanel { entity: entity_id },
             MessagePayload::GUIHover {
                 held_entity_id,
                 screen_coordinates,

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -1,0 +1,424 @@
+//! Flat-mode MFD panel host (projects/flat-ui.md §5.2, PR 2).
+//!
+//! The flat presentation of the shared `Gui` layer: where VR shows every
+//! panel as an always-on world quad (`GuiManager` + `ProxyGuiScript`), the
+//! original flat game *opens* an object-bound MFD overlay on frob and drives
+//! it with the mouse cursor. This host holds that flat-only state:
+//!
+//! - **Open**: `Effect::OpenPanel { entity }` (emitted by `GuiScript` on
+//!   Frob) binds the panel to one world object - the original's single
+//!   `gOverlayObj` binding.
+//! - **Render**: the panel's `Effect::SetUI` component list is intercepted
+//!   and drawn onto the shared 640x480 [`UiCanvas`] at the original left-MFD
+//!   anchor `(2, 124)` (shkmfddm.h), after the flat HUD, plus a host-drawn
+//!   close button and the `CURSOR.PCX` pointer.
+//! - **Input**: each frame the normalized 2D pointer is mapped through
+//!   [`pointer_to_canvas`] into panel-local normalized coordinates and sent
+//!   to the panel entity as `MessagePayload::GUIHover` - the exact contract
+//!   the VR hand ray synthesizes (`virtual_hand.rs` / `ProxyGuiScript`), so
+//!   every existing panel (keypad, container, elevator, ...) works unchanged.
+//! - **Close**: the host close button, LMB on the bare 3D view (the
+//!   original's exit gesture), or walking away from the bound object (the
+//!   original's per-overlay `distance` auto-close).
+
+use cgmath::{InnerSpace, Vector2, point2};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+use shipyard::{EntitiesView, EntityId, Get, UniqueView, View, World};
+
+use crate::{
+    gui::GuiComponentRenderInfo,
+    input_context::Pointer2D,
+    mission::PlayerInfo,
+    scripts::{Message, MessagePayload},
+    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+    vr_config::Handedness,
+};
+
+/// The shared 640x480 virtual canvas the flat HUD renders on.
+const CANVAS_SIZE: Vector2<f32> = Vector2::new(640.0, 480.0);
+
+/// The original left MFD slot anchor for world-object panels (keypad,
+/// container, ...) on the 640x480 canvas (`shkmfddm.h`: `(2, 124, 188x300)`).
+/// The right slot `(450, 124)` is reserved for later character panels.
+const LEFT_MFD_ANCHOR: Vector2<f32> = Vector2::new(2.0, 124.0);
+
+/// Walk-away auto-close distance (world units; dark units / SCALE_FACTOR).
+/// ~10 feet - past normal frob range, so a panel opened up close survives
+/// small repositioning but closes when the player leaves the object.
+const PANEL_AUTO_CLOSE_DISTANCE: f32 = 4.0;
+
+/// Host-drawn close button, panel-local: the original keypad overlay's
+/// CloseOff/CloseOn gadget at (163, 8, 20x21) in the 188-wide panel,
+/// generalized to hug the panel's top-right corner.
+const CLOSE_BUTTON_SIZE: Vector2<f32> = Vector2::new(20.0, 21.0);
+const CLOSE_BUTTON_MARGIN: Vector2<f32> = Vector2::new(25.0, 8.0);
+
+/// `CURSOR.PCX` native size.
+const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
+
+/// Flat-mode MFD panel state: which world object (if any) has its panel
+/// open, the panel's latest components (from `Effect::SetUI`), and the
+/// cursor/pointer bookkeeping needed to render and hit-test them.
+pub struct FlatUiHost {
+    active_panel: Option<EntityId>,
+    /// Panel size in panel-local pixels (from `SetUI.world_size`); `None`
+    /// until the panel's first `SetUI` arrives (the frame after opening).
+    panel_size_px: Option<Vector2<f32>>,
+    /// Latest `SetUI` components for the active panel (normalized panel
+    /// coordinates, as `GuiScript` emits them).
+    components: Vec<GuiComponentRenderInfo>,
+    /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
+    cursor_canvas: Option<Vector2<f32>>,
+    hover_close: bool,
+    last_pointer_pressed: bool,
+    /// Last known render-target size, for pointer->canvas letterbox mapping
+    /// (updated every rendered frame; 4:3 default until the first render).
+    screen_size: Vector2<f32>,
+}
+
+impl FlatUiHost {
+    pub fn new() -> FlatUiHost {
+        FlatUiHost {
+            active_panel: None,
+            panel_size_px: None,
+            components: Vec::new(),
+            cursor_canvas: None,
+            hover_close: false,
+            last_pointer_pressed: false,
+            screen_size: CANVAS_SIZE,
+        }
+    }
+
+    pub fn active_panel(&self) -> Option<EntityId> {
+        self.active_panel
+    }
+
+    /// Bind the MFD to `entity` (the original's `gOverlayObj`). Opening a
+    /// second panel replaces the first - one panel per (left) slot.
+    pub fn open(&mut self, entity: EntityId) {
+        if self.active_panel != Some(entity) {
+            self.components.clear();
+            self.panel_size_px = None;
+        }
+        self.active_panel = Some(entity);
+    }
+
+    pub fn close(&mut self) {
+        self.active_panel = None;
+        self.panel_size_px = None;
+        self.components.clear();
+        self.hover_close = false;
+    }
+
+    /// Observe an `Effect::SetUI`: stash the component list if it belongs to
+    /// the active panel (the VR world-quad path is untouched by this).
+    pub fn on_set_ui(
+        &mut self,
+        parent_entity: EntityId,
+        world_size: Vector2<f32>,
+        components: &[GuiComponentRenderInfo],
+    ) {
+        if self.active_panel != Some(parent_entity) {
+            return;
+        }
+        // `SetUI.world_size` is `screen_size_in_pixels * GUI_PIXEL_TO_WORLD_SIZE`.
+        self.panel_size_px = Some(world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE);
+        self.components = components.to_vec();
+    }
+
+    /// The render-target size, for the pointer->canvas letterbox mapping.
+    /// Called from the flat render path each frame.
+    pub fn set_screen_size(&mut self, screen_size: Vector2<f32>) {
+        if screen_size.x > 0.0 && screen_size.y > 0.0 {
+            self.screen_size = screen_size;
+        }
+    }
+
+    /// The active panel's rect on the 640x480 canvas (None until its first
+    /// `SetUI` arrives).
+    fn panel_rect(&self) -> Option<Rect> {
+        self.panel_size_px.map(panel_canvas_rect)
+    }
+
+    /// Per-frame pointer processing while in flat presentation. Maps the
+    /// normalized pointer to panel-local coordinates and returns the
+    /// `GUIHover` message to dispatch to the panel entity; handles the close
+    /// gestures (close button, LMB on the bare view, walk-away, entity gone).
+    pub fn update(&mut self, world: &World, pointer: Option<Pointer2D>) -> Vec<Message> {
+        let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
+        let pressed_edge = pressed && !self.last_pointer_pressed;
+        self.last_pointer_pressed = pressed;
+
+        let Some(panel) = self.active_panel else {
+            self.cursor_canvas = None;
+            return Vec::new();
+        };
+
+        // The bound object is gone (destroyed / level state changed).
+        let alive = world
+            .borrow::<EntitiesView>()
+            .map(|entities| entities.is_alive(panel))
+            .unwrap_or(false);
+        if !alive {
+            self.close();
+            return Vec::new();
+        }
+
+        // Walk-away auto-close (the original's per-overlay `distance` check
+        // against the bound object).
+        let too_far = (|| {
+            let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+            let v_pos = world
+                .borrow::<View<dark::properties::PropPosition>>()
+                .ok()?;
+            let pos = v_pos.get(panel).ok()?;
+            Some((pos.position - player.pos).magnitude() > PANEL_AUTO_CLOSE_DISTANCE)
+        })()
+        .unwrap_or(false);
+        if too_far {
+            self.close();
+            return Vec::new();
+        }
+
+        let Some(pointer) = pointer else {
+            self.cursor_canvas = None;
+            return Vec::new();
+        };
+        let canvas_pos = pointer_to_canvas(
+            CANVAS_SIZE,
+            pointer.position,
+            self.screen_size,
+            ScaleMode::PreserveAspect,
+        );
+        self.cursor_canvas = canvas_pos;
+
+        let Some(canvas_pos) = canvas_pos else {
+            // Pointer in the letterbox bars - fully outside the canvas; a
+            // click there is a click on the bare view.
+            if pressed_edge {
+                self.close();
+            }
+            return Vec::new();
+        };
+
+        let Some(rect) = self.panel_rect() else {
+            // Panel opened this frame; no SetUI yet - nothing to hit-test.
+            return Vec::new();
+        };
+
+        // Host-drawn close button (the shared guis have no close component -
+        // VR panels never close).
+        let close_rect = close_button_canvas_rect(rect);
+        self.hover_close = close_rect.contains(canvas_pos);
+        if pressed_edge && self.hover_close {
+            self.close();
+            return Vec::new();
+        }
+
+        if rect.contains(canvas_pos) {
+            // Forward as GUIHover in panel-local normalized coordinates -
+            // the same message the VR hand ray produces, so `GuiScript`'s
+            // hit-test/edge-detection runs unchanged. LMB maps to the
+            // right-hand trigger; flat has no grab gesture yet.
+            let local = point2(
+                (canvas_pos.x - rect.x) / rect.w,
+                (canvas_pos.y - rect.y) / rect.h,
+            );
+            vec![Message {
+                to: panel,
+                payload: MessagePayload::GUIHover {
+                    held_entity_id: None,
+                    screen_coordinates: local,
+                    is_triggered: pointer.pressed,
+                    is_grabbing: false,
+                    hand: Handedness::Right,
+                },
+            }]
+        } else {
+            // LMB on the bare 3D view closes the panels (manual p.7).
+            if pressed_edge {
+                self.close();
+            }
+            Vec::new()
+        }
+    }
+
+    /// Render the active panel + cursor as screen-space overlay objects on
+    /// the shared 640x480 canvas (drawn after the flat HUD).
+    pub fn render(
+        &self,
+        asset_cache: &mut AssetCache,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        let Some(rect) = self.panel_rect() else {
+            return Vec::new();
+        };
+        let mut canvas = UiCanvas::new(CANVAS_SIZE);
+        for component in &self.components {
+            if is_gui_cursor(component) {
+                // GuiScript appends its own panel-local cursor image for the
+                // VR quads; the host draws the real screen cursor instead.
+                continue;
+            }
+            let r = component_canvas_rect(component, rect);
+            match component {
+                // The original MFD art is opaque on screen; the render-info
+                // alpha is a VR world-quad translucency, deliberately not
+                // applied here.
+                GuiComponentRenderInfo::Image { texture, .. } => {
+                    canvas.image(r, texture);
+                }
+                GuiComponentRenderInfo::Text { text, font, .. } => {
+                    canvas.text(r, text, font, r.h, HAlign::Left, VAlign::Top);
+                }
+            }
+        }
+        canvas.image(
+            close_button_canvas_rect(rect),
+            if self.hover_close {
+                "closeon.pcx"
+            } else {
+                "closeoff.pcx"
+            },
+        );
+        if let Some(cursor) = self.cursor_canvas {
+            canvas.image(
+                Rect::new(cursor.x, cursor.y, CURSOR_SIZE.x, CURSOR_SIZE.y),
+                "cursor.pcx",
+            );
+        }
+        canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
+    }
+}
+
+impl Default for FlatUiHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The active panel's rect on the canvas: panel-local pixels anchored at the
+/// original left-MFD slot.
+fn panel_canvas_rect(panel_size_px: Vector2<f32>) -> Rect {
+    Rect::new(
+        LEFT_MFD_ANCHOR.x,
+        LEFT_MFD_ANCHOR.y,
+        panel_size_px.x,
+        panel_size_px.y,
+    )
+}
+
+/// Map one `SetUI` component (normalized panel coordinates) to canvas pixels.
+fn component_canvas_rect(info: &GuiComponentRenderInfo, panel: Rect) -> Rect {
+    let position = info.position();
+    let size = info.size();
+    // Text render-info positions carry a negated y (a VR world-quad
+    // convention baked into `GuiComponent::to_render_info`); undo it here.
+    let y = match info {
+        GuiComponentRenderInfo::Text { .. } => -position.y,
+        _ => position.y,
+    };
+    Rect::new(
+        panel.x + position.x * panel.w,
+        panel.y + y * panel.h,
+        size.x * panel.w,
+        size.y * panel.h,
+    )
+}
+
+/// Host-drawn close button: top-right corner of the panel (the original
+/// keypad overlay's CloseOff gadget position).
+fn close_button_canvas_rect(panel: Rect) -> Rect {
+    Rect::new(
+        panel.x + panel.w - CLOSE_BUTTON_MARGIN.x,
+        panel.y + CLOSE_BUTTON_MARGIN.y,
+        CLOSE_BUTTON_SIZE.x,
+        CLOSE_BUTTON_SIZE.y,
+    )
+}
+
+/// `GuiScript` appends a panel-local `cursor.pcx` image for the VR quads;
+/// the flat host draws its own screen-space cursor instead.
+fn is_gui_cursor(info: &GuiComponentRenderInfo) -> bool {
+    matches!(
+        info,
+        GuiComponentRenderInfo::Image { texture, .. } if texture.eq_ignore_ascii_case("cursor.pcx")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::vec2;
+
+    #[test]
+    fn panel_anchors_at_the_original_left_mfd_slot() {
+        // Keypad panel: 188x296 at (2, 124) - the shkmfddm.h left MFD rect.
+        let rect = panel_canvas_rect(vec2(188.0, 296.0));
+        assert_eq!(rect, Rect::new(2.0, 124.0, 188.0, 296.0));
+        // It fits on the 640x480 canvas.
+        assert!(rect.y + rect.h <= CANVAS_SIZE.y);
+    }
+
+    #[test]
+    fn image_components_map_into_the_panel_rect() {
+        // The keypad's digit "1" button: panel-local (15, 42, 45x60) is
+        // emitted normalized by 188x296; it must land at the anchor + the
+        // same panel-local pixels.
+        let panel = panel_canvas_rect(vec2(188.0, 296.0));
+        let info = GuiComponentRenderInfo::Image {
+            position: vec2(15.0 / 188.0, 42.0 / 296.0),
+            size: vec2(45.0 / 188.0, 60.0 / 296.0),
+            texture: "key10.pcx".to_owned(),
+            alpha: 0.5,
+        };
+        let r = component_canvas_rect(&info, panel);
+        assert!((r.x - 17.0).abs() < 1e-3);
+        assert!((r.y - 166.0).abs() < 1e-3);
+        assert!((r.w - 45.0).abs() < 1e-3);
+        assert!((r.h - 60.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn text_components_undo_the_negated_y_convention() {
+        // to_render_info negates text y for the VR quad; canvas mapping must
+        // put a panel-local y=20 text at panel top + 20, not above the panel.
+        let panel = panel_canvas_rect(vec2(188.0, 296.0));
+        let info = GuiComponentRenderInfo::Text {
+            position: vec2(10.0 / 188.0, -20.0 / 296.0),
+            size: vec2(30.0 / 188.0, 16.0 / 296.0),
+            font: "mainfont.fon".to_owned(),
+            text: "451".to_owned(),
+            alpha: 1.0,
+        };
+        let r = component_canvas_rect(&info, panel);
+        assert!((r.y - (124.0 + 20.0)).abs() < 1e-3);
+    }
+
+    #[test]
+    fn close_button_hugs_the_top_right_corner() {
+        // Matches the original keypad overlay's CloseOff rect (163, 8, 20x21)
+        // for the 188-wide panel.
+        let panel = panel_canvas_rect(vec2(188.0, 296.0));
+        let r = close_button_canvas_rect(panel);
+        assert_eq!(r, Rect::new(2.0 + 163.0, 124.0 + 8.0, 20.0, 21.0));
+    }
+
+    #[test]
+    fn gui_cursor_component_is_recognized() {
+        let cursor = GuiComponentRenderInfo::Image {
+            position: vec2(0.1, 0.1),
+            size: vec2(0.05, 0.05),
+            texture: "cursor.pcx".to_owned(),
+            alpha: 0.5,
+        };
+        assert!(is_gui_cursor(&cursor));
+        let backdrop = GuiComponentRenderInfo::Image {
+            position: vec2(0.0, 0.0),
+            size: vec2(1.0, 1.0),
+            texture: "keypad2.pcx".to_owned(),
+            alpha: 0.5,
+        };
+        assert!(!is_gui_cursor(&backdrop));
+    }
+}

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -289,6 +289,69 @@ impl FlatUiHost {
         }
         canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
     }
+
+    /// Introspection snapshot of the active panel's elements for `GET /v1/ui`:
+    /// canvas + normalized-screen rects and semantic labels, so clients click
+    /// widgets by meaning instead of hardcoded pixels.
+    pub fn debug_elements(&self) -> Vec<crate::game_scene::DebugUiElement> {
+        let Some(rect) = self.panel_rect() else {
+            return Vec::new();
+        };
+        let to_screen = |r: Rect| {
+            let s = crate::ui::canvas_rect_to_screen(
+                r,
+                CANVAS_SIZE,
+                self.screen_size,
+                ScaleMode::PreserveAspect,
+            );
+            [s.x, s.y, s.w, s.h]
+        };
+        let mut out = Vec::new();
+        for component in &self.components {
+            if is_gui_cursor(component) {
+                continue;
+            }
+            let r = component_canvas_rect(component, rect);
+            let (kind, texture, text, label) = match component {
+                GuiComponentRenderInfo::Image {
+                    texture,
+                    interactive,
+                    ..
+                } => (
+                    if *interactive { "button" } else { "image" },
+                    Some(texture.clone()),
+                    None,
+                    if *interactive {
+                        semantic_label(texture)
+                    } else {
+                        None
+                    },
+                ),
+                GuiComponentRenderInfo::Text { text, .. } => {
+                    ("text", None, Some(text.clone()), None)
+                }
+            };
+            out.push(crate::game_scene::DebugUiElement {
+                kind: kind.to_string(),
+                texture,
+                text,
+                label,
+                rect: [r.x, r.y, r.w, r.h],
+                screen_rect: to_screen(r),
+            });
+        }
+        // The host-drawn close button is clickable too.
+        let close = close_button_canvas_rect(rect);
+        out.push(crate::game_scene::DebugUiElement {
+            kind: "button".to_string(),
+            texture: Some("closeoff.pcx".to_string()),
+            text: None,
+            label: Some("close".to_string()),
+            rect: [close.x, close.y, close.w, close.h],
+            screen_rect: to_screen(close),
+        });
+        out
+    }
 }
 
 impl Default for FlatUiHost {
@@ -337,6 +400,25 @@ fn close_button_canvas_rect(panel: Rect) -> Rect {
     )
 }
 
+/// Semantic label for a clickable element, derived from its art name. The
+/// keypad's digit buttons use the `key<c><0|1>.pcx` convention (`c` = the
+/// digit, `n` = clear; the trailing 0/1 is the normal/hover art state), so
+/// both art states of a digit label identically.
+fn semantic_label(texture: &str) -> Option<String> {
+    let t = texture.to_ascii_lowercase();
+    let rest = t.strip_prefix("key")?.strip_suffix(".pcx")?;
+    let mut chars = rest.chars();
+    let (c, state) = (chars.next()?, chars.next()?);
+    if chars.next().is_some() || !matches!(state, '0' | '1') {
+        return None;
+    }
+    match c {
+        '0'..='9' => Some(c.to_string()),
+        'n' => Some("clear".to_string()),
+        _ => None,
+    }
+}
+
 /// `GuiScript` appends a panel-local `cursor.pcx` image for the VR quads;
 /// the flat host draws its own screen-space cursor instead.
 fn is_gui_cursor(info: &GuiComponentRenderInfo) -> bool {
@@ -371,6 +453,7 @@ mod tests {
             size: vec2(45.0 / 188.0, 60.0 / 296.0),
             texture: "key10.pcx".to_owned(),
             alpha: 0.5,
+            interactive: true,
         };
         let r = component_canvas_rect(&info, panel);
         assert!((r.x - 17.0).abs() < 1e-3);
@@ -411,6 +494,7 @@ mod tests {
             size: vec2(0.05, 0.05),
             texture: "cursor.pcx".to_owned(),
             alpha: 0.5,
+            interactive: false,
         };
         assert!(is_gui_cursor(&cursor));
         let backdrop = GuiComponentRenderInfo::Image {
@@ -418,7 +502,21 @@ mod tests {
             size: vec2(1.0, 1.0),
             texture: "keypad2.pcx".to_owned(),
             alpha: 0.5,
+            interactive: false,
         };
         assert!(!is_gui_cursor(&backdrop));
+    }
+
+    #[test]
+    fn semantic_labels_identify_keypad_digits() {
+        // Both art states of a digit button label as the digit.
+        assert_eq!(semantic_label("key40.pcx"), Some("4".to_string()));
+        assert_eq!(semantic_label("key41.pcx"), Some("4".to_string()));
+        assert_eq!(semantic_label("key00.pcx"), Some("0".to_string()));
+        // The clear key (keyn0/keyn1).
+        assert_eq!(semantic_label("keyn1.pcx"), Some("clear".to_string()));
+        // Non-widget art with a "key" prefix must NOT label.
+        assert_eq!(semantic_label("keypad2.pcx"), None);
+        assert_eq!(semantic_label("crosshai.pcx"), None);
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -101,6 +101,11 @@ impl FlatUiHost {
             self.panel_size_px = None;
         }
         self.active_panel = Some(entity);
+        // A button still held at open (e.g. the shift+LMB frob that opened
+        // the panel on desktop) must not read as a fresh press-edge next
+        // frame - it would instantly close the panel as a bare-view click.
+        // Require a release to be observed first.
+        self.last_pointer_pressed = true;
     }
 
     pub fn close(&mut self) {
@@ -182,6 +187,7 @@ impl FlatUiHost {
 
         let Some(pointer) = pointer else {
             self.cursor_canvas = None;
+            self.hover_close = false;
             return Vec::new();
         };
         let canvas_pos = pointer_to_canvas(
@@ -191,6 +197,9 @@ impl FlatUiHost {
             ScaleMode::PreserveAspect,
         );
         self.cursor_canvas = canvas_pos;
+        if canvas_pos.is_none() {
+            self.hover_close = false;
+        }
 
         let Some(canvas_pos) = canvas_pos else {
             // Pointer in the letterbox bars - fully outside the canvas; a
@@ -505,6 +514,44 @@ mod tests {
             interactive: false,
         };
         assert!(!is_gui_cursor(&backdrop));
+    }
+
+    #[test]
+    fn held_button_at_open_does_not_close_the_panel() {
+        // The (shift+)LMB frob that opened the panel is typically still held
+        // on the next frame - it must be swallowed, not treated as a fresh
+        // bare-view click that instantly closes the panel.
+        let mut world = World::new();
+        let panel = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.open(panel);
+        host.on_set_ui(
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+        let bare_view_pressed = Pointer2D {
+            position: vec2(0.9, 0.9),
+            pressed: true,
+        };
+        host.update(&world, Some(bare_view_pressed));
+        assert!(
+            host.active_panel().is_some(),
+            "a button held since before open must not close the panel"
+        );
+        // After a release, a fresh bare-view click DOES close it.
+        host.update(
+            &world,
+            Some(Pointer2D {
+                position: vec2(0.9, 0.9),
+                pressed: false,
+            }),
+        );
+        host.update(&world, Some(bare_view_pressed));
+        assert!(
+            host.active_panel().is_none(),
+            "a fresh click on the bare 3D view should close the panel"
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4484,12 +4484,32 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn ui_state(&self) -> crate::game_scene::DebugUiState {
+        let active_panel = self.flat_ui.active_panel().map(|entity| {
+            let name = self
+                .world
+                .borrow::<View<dark::properties::PropSymName>>()
+                .ok()
+                .and_then(|v| v.get(entity).ok().map(|s| s.0.clone()));
+            let template_id = self
+                .world
+                .borrow::<View<dark::properties::PropTemplateId>>()
+                .ok()
+                .and_then(|v| v.get(entity).ok().map(|t| t.template_id))
+                .unwrap_or(0);
+            crate::game_scene::DebugUiPanel {
+                entity_id: entity.inner() as i32,
+                template_id,
+                name,
+                elements: self.flat_ui.debug_elements(),
+            }
+        });
         crate::game_scene::DebugUiState {
             mode: if self.flat_use_mode {
                 "use".to_string()
             } else {
                 "shooter".to_string()
             },
+            active_panel,
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -266,6 +266,11 @@ pub struct MissionCore {
     /// (Tab). Mode tracking only for now - the cursor + panel presentation
     /// land with the flat UI host (see `projects/flat-ui.md`). Ignored in VR.
     pub flat_use_mode: bool,
+
+    /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
+    /// canvas rendering, and the pointer -> GUIHover input mapping. Inert in
+    /// VR (nothing opens a panel there). See `projects/flat-ui.md` §5.2.
+    pub flat_ui: crate::mission::flat_ui_host::FlatUiHost,
 }
 
 pub struct GlobalContext {
@@ -695,6 +700,7 @@ impl MissionCore {
             debug_weapon_index: 0,
             flat_melee_anim: None,
             flat_use_mode: false,
+            flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
         }
     }
 
@@ -925,6 +931,16 @@ impl MissionCore {
         // now-current transform, so they track a moving parent rather than their
         // spawn pose. Runs after physics sync so parents' transforms are current.
         self.update_attached_entities();
+
+        // Flat-mode MFD panel input: map the 2D pointer onto the active panel
+        // and drive it through the same GUIHover contract the VR hand ray
+        // uses. Dispatched before the script update so hovers/clicks are
+        // processed this frame.
+        if game_options.presentation_mode == crate::PresentationMode::Flat {
+            for msg in self.flat_ui.update(&self.world, input_context.pointer) {
+                self.script_world.dispatch(msg);
+            }
+        }
 
         // Update scripts
         let mut script_effects = profile!(
@@ -1972,6 +1988,15 @@ impl MissionCore {
                     }
                 }
 
+                Effect::OpenPanel { entity } => {
+                    // Flat-presentation only: bind the MFD panel to the
+                    // frobbed object (the original's frob-script -> overlay
+                    // flow). VR ignores it - panels are world quads there.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        self.flat_ui.open(entity);
+                    }
+                }
+
                 Effect::CyclePsiPower => {
                     let powers = self.world.borrow::<UniqueView<GlobalPsiPowers>>().unwrap();
                     let known = self
@@ -2267,6 +2292,15 @@ impl MissionCore {
                     world_size,
                     components,
                 } => {
+                    // Flat presentation: the active panel's components are
+                    // drawn by the FlatUiHost onto the screen-space canvas.
+                    // Deliberately NOT behind `--experimental gui` - the flat
+                    // MFD is the #435 fix; only the VR world-quad path below
+                    // keeps its gating (projects/flat-ui.md §7).
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        self.flat_ui
+                            .on_set_ui(parent_entity, world_size, &components);
+                    }
                     if game_options.experimental_features.contains("gui") {
                         self.gui.update_ui(
                             &mut self.world,
@@ -3136,6 +3170,12 @@ impl MissionCore {
                 &self.world,
                 screen_size,
             ));
+
+            // Flat MFD panel (keypad, container, ...) + cursor, drawn over
+            // the HUD. Also records the render-target size the pointer ->
+            // canvas mapping needs.
+            self.flat_ui.set_screen_size(screen_size);
+            ret.extend(self.flat_ui.render(asset_cache, screen_size));
         }
 
         ret
@@ -3513,6 +3553,14 @@ impl MissionCore {
     /// Returns a vector of SpotLight objects positioned at the player's hands
     pub fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight> {
         self.interaction.hand_spotlights(options)
+    }
+
+    /// Whether the runtime should show a 2D cursor instead of captured
+    /// mouse-look: an MFD panel is open, or Tab "use" mode is active
+    /// (projects/flat-ui.md §5.2). Both are flat-only states, so this is
+    /// inherently false in VR.
+    pub fn wants_pointer(&self) -> bool {
+        self.flat_ui.active_panel().is_some() || self.flat_use_mode
     }
 
     /// Apply the effects produced by an interaction controller (the VR hands or
@@ -4832,5 +4880,9 @@ impl crate::game_scene::GameScene for MissionCore {
 
     fn queue_entity_trigger(&mut self, entity_name: String) {
         self.queue_entity_trigger(entity_name);
+    }
+
+    fn wants_pointer(&self) -> bool {
+        self.wants_pointer()
     }
 }

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -3,6 +3,7 @@ use std::{fs::File, io::BufReader};
 
 use tracing::info;
 pub mod entity_populator;
+pub mod flat_ui_host;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;
@@ -238,6 +239,10 @@ impl crate::game_scene::GameScene for Mission {
 
     fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight> {
         self.mission_core.get_hand_spotlights(options)
+    }
+
+    fn wants_pointer(&self) -> bool {
+        self.mission_core.wants_pointer()
     }
 
     fn world(&self) -> &World {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -97,6 +97,14 @@ pub enum Effect {
     /// See `projects/flat-ui.md`.
     ToggleUseMode,
 
+    /// Open the flat-mode MFD panel bound to `entity` - emitted by `GuiScript`
+    /// when its entity is frobbed, mirroring the original engine where the
+    /// frob script opens the overlay (`cShockGameSrv::Keypad`). Ignored in VR,
+    /// where panels are always-on world quads. See `projects/flat-ui.md` §5.2.
+    OpenPanel {
+        entity: EntityId,
+    },
+
     /// Select the player's next *trained* psi power (advances
     /// `PsiPowerSelection` through the `GlobalPsiPowers` registry, wrapping,
     /// skipping powers not in `PlayerPsiKnownPowers`).

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -118,6 +118,26 @@ pub fn pointer_to_canvas(
     }
 }
 
+/// Map a canvas-pixel rect to normalized screen coordinates (`[0,1]` per
+/// axis, origin top-left) for a `canvas_size` canvas shown on `screen_size`
+/// under `mode` - the rect analogue (and inverse) of [`pointer_to_canvas`].
+/// Lets clients (e.g. the debug runtime's `GET /v1/ui`) aim a normalized
+/// pointer at a canvas rect without re-deriving the letterbox math.
+pub fn canvas_rect_to_screen(
+    rect: Rect,
+    canvas_size: Vector2<f32>,
+    screen_size: Vector2<f32>,
+    mode: ScaleMode,
+) -> Rect {
+    let (scale, offset) = fit(canvas_size, screen_size, mode);
+    Rect::new(
+        (rect.x * scale.x + offset.x) / screen_size.x,
+        (rect.y * scale.y + offset.y) / screen_size.y,
+        rect.w * scale.x / screen_size.x,
+        rect.h * scale.y / screen_size.y,
+    )
+}
+
 enum UiElement {
     Image {
         rect: Rect,
@@ -349,6 +369,29 @@ mod tests {
         // A point inside the left pillarbox bar is outside the canvas.
         let in_bar = pointer_to_canvas(canvas, vec2(0.1, 0.5), screen, ScaleMode::PreserveAspect);
         assert_eq!(in_bar, None);
+    }
+
+    #[test]
+    fn canvas_rect_to_screen_letterboxes_and_roundtrips() {
+        // 640x480 canvas pillarboxed on a 1280x480 screen: scale 1, 320px bars.
+        let canvas = vec2(640.0, 480.0);
+        let screen = vec2(1280.0, 480.0);
+        let r = canvas_rect_to_screen(
+            Rect::new(0.0, 0.0, 640.0, 480.0),
+            canvas,
+            screen,
+            ScaleMode::PreserveAspect,
+        );
+        assert_eq!(r, Rect::new(0.25, 0.0, 0.5, 1.0));
+
+        // Roundtrip: the normalized center of a mapped rect points back at the
+        // canvas rect's center through pointer_to_canvas.
+        let target = Rect::new(17.0, 166.0, 45.0, 60.0);
+        let mapped = canvas_rect_to_screen(target, canvas, screen, ScaleMode::PreserveAspect);
+        let back = pointer_to_canvas(canvas, mapped.center(), screen, ScaleMode::PreserveAspect)
+            .expect("center should land inside the canvas");
+        assert!((back.x - target.center().x).abs() < 1e-3);
+        assert!((back.y - target.center().y).abs() < 1e-3);
     }
 
     #[test]

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -231,7 +231,13 @@ export class QuestsApi {
 export class UiApi {
   constructor(private readonly client: HttpClient) {}
 
-  /** Current UI snapshot: mode is "shooter" or "use" (Tab metagame mode). */
+  /**
+   * Current UI snapshot: mode is "shooter" or "use" (Tab metagame mode), and
+   * the open MFD panel (frob a keypad/container to open one) with its
+   * labeled, clickable elements. Click an element by setting the
+   * `pointer.position` channel to the center of its `screen_rect`, then
+   * pulsing `pointer.pressed`.
+   */
   async state(): Promise<UiState> {
     return this.client.get<UiState>("/v1/ui");
   }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -266,9 +266,41 @@ export interface PlayerInventoryResult {
   count: number;
 }
 
+/**
+ * One drawn element of the active flat-mode MFD panel. `label` gives
+ * clickable elements a semantic identity (keypad digits "0"-"9", "clear",
+ * the host "close" button); `rect` is on the 640x480 virtual canvas and
+ * `screen_rect` is the same rect in normalized [0,1] screen coordinates
+ * (letterbox-corrected) - feed its center straight to the `pointer.position`
+ * input channel.
+ */
+export interface UiElement {
+  /** "button" (clickable), "image", or "text". */
+  kind: "button" | "image" | "text";
+  texture: string | null;
+  text: string | null;
+  label: string | null;
+  /** Canvas-space rect [x, y, w, h] (640x480 virtual canvas). */
+  rect: [number, number, number, number];
+  /** Normalized screen-space rect [x, y, w, h]. */
+  screen_rect: [number, number, number, number];
+}
+
+/** The open flat-mode MFD panel (opened by frobbing a GUI-bearing entity). */
+export interface UiPanel {
+  /** Runtime entity id of the bound object (NOT stable across runs). */
+  entity_id: number;
+  /** Stable template id (mission-file object id for level entities). */
+  template_id: number;
+  name: string | null;
+  elements: UiElement[];
+}
+
 /** Flat-mode UI snapshot (GET /v1/ui). */
 export interface UiState {
   mode: "shooter" | "use";
+  /** The open MFD panel, or null when none is open. */
+  active_panel: UiPanel | null;
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/test/keypad.e2e.test.ts
+++ b/tools/shock2-sdk/test/keypad.e2e.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for the flat-mode keypad MFD (projects/flat-ui.md PR 2,
+// resolves #435): frobbing a keypad in flat presentation opens its MFD panel
+// (drawn at the original left-MFD anchor on the 640x480 canvas), the panel's
+// digit buttons are clickable via the pointer channels, entering the code
+// sends TurnOn over the keypad's SwitchLink, and the linked door opens.
+//
+// Entity discovery is by TEMPLATE ID + LINK TOPOLOGY at run time (runtime
+// entity ids are NOT stable across launches; the `template_id` reported by
+// /v1/entities IS stable - for level-authored entities it is the mission-file
+// object id): the cryo-exit keypad is the medsci1 "Keypad" with template_id
+// 1681 (archetype -258) whose SwitchLink targets "Sci Med Door" (mission id
+// 1739, archetype -206). The code (45100) is authored in the mission data
+// (PropKeypadCode) - the test never enters it through any side channel, it
+// clicks the on-screen digits.
+//
+// Negative-first: on main (pre flat-UI host) the Frob reaches KeyPadGui's
+// GuiScript but falls through to NoEffect - /v1/ui reports no active panel,
+// so the "panel opened" assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "flat keypad MFD: frob opens panel, clicking 45100 opens the door",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8118),
+    });
+    await game.step({ frames: 5 });
+
+    const uiState = () => game.ui.state();
+
+    // --- Discover the cryo-exit keypad + its door by name/template/links ---
+    const keypads = (await game.entities.list({ filter: "Keypad", limit: 50 }))
+      .entities;
+    assert.ok(keypads.length > 0, "medsci1 should contain Keypad entities");
+
+    let keypadId: number | undefined;
+    let doorId: number | undefined;
+    for (const candidate of keypads) {
+      if (candidate.template_id !== 1681) continue; // stable mission id
+      const detail = await game.entities.detail(candidate.id);
+      const doorLink = detail.outgoing_links.find(
+        (l) =>
+          l.link_type.toLowerCase().includes("switch") &&
+          l.target_name.includes("Sci Med Door"),
+      );
+      if (doorLink) {
+        keypadId = candidate.id;
+        doorId = doorLink.target_id;
+        break;
+      }
+    }
+    assert.ok(
+      keypadId !== undefined && doorId !== undefined,
+      "should find the keypad (mission id 1681) SwitchLinked to 'Sci Med Door'",
+    );
+
+    const keypad = await game.entities.detail(keypadId);
+    const doorBefore = await game.entities.detail(doorId);
+
+    // --- Get the player next to the keypad (test setup; teleport is fine) ---
+    const [kx, ky, kz] = keypad.position;
+    await teleportVerified(game, { x: kx + 1.0, y: ky + 0.5, z: kz + 1.0 });
+    await game.step({ frames: 10 });
+
+    // Sanity: no panel is open before the frob.
+    const before = await uiState();
+    assert.ok(
+      !before.active_panel,
+      "no panel should be active before frobbing the keypad",
+    );
+    await game.screenshot("keypad-before-frob.png");
+
+    // --- Frob the keypad: the panel must open (THE #435 fix) ---
+    await game.entities.sendMessage(keypadId, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const opened = await uiState();
+    assert.ok(
+      opened.active_panel,
+      `frobbing the keypad should open its MFD panel (got ${JSON.stringify(opened)})`,
+    );
+    assert.equal(
+      opened.active_panel.entity_id,
+      keypadId,
+      "the active panel should be bound to the keypad entity",
+    );
+    assert.equal(
+      opened.active_panel.template_id,
+      1681,
+      "the active panel should report the keypad's stable template id",
+    );
+
+    // The panel must expose semantically-labeled digit buttons so clients can
+    // click digits without hardcoded pixels.
+    const digitButton = (d: string) => {
+      const el = opened.active_panel!.elements.find(
+        (e) => e.kind === "button" && e.label === d,
+      );
+      assert.ok(el, `panel should expose a button labeled "${d}"`);
+      return el;
+    };
+    for (const d of ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "clear"]) {
+      digitButton(d);
+    }
+    // Redundant visual check: the panel visibly appears.
+    await game.screenshot("keypad-panel-open.png");
+
+    // --- Click 4-5-1-0-0 via the pointer channels ---
+    // Rects come from /v1/ui in normalized screen space (letterbox-corrected),
+    // so the click point is just the rect center.
+    const clickElement = async (el: UiElement) => {
+      const [x, y, w, h] = el.screen_rect;
+      const center: [number, number] = [x + w / 2, y + h / 2];
+      await game.input.set("pointer.position", center);
+      await game.step({ frames: 2 }); // hover registers (edge detection needs a prior unpressed frame)
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+
+    for (const d of ["4", "5", "1", "0", "0"]) {
+      // Re-read the panel each click (hover swaps button textures; rects are
+      // stable but re-reading keeps the loop honest about live state).
+      const state = await uiState();
+      assert.ok(state.active_panel, `panel should stay open while typing ${d}`);
+      const el = state.active_panel.elements.find(
+        (e) => e.kind === "button" && e.label === d,
+      );
+      assert.ok(el, `panel should expose digit "${d}"`);
+      await clickElement(el);
+    }
+    await game.screenshot("keypad-code-entered.png");
+
+    // --- The SwitchLinked door must open (TranslatingDoor slides ~2.4 units) ---
+    await game.step({ frames: 120 }); // ~2s for the door to travel
+    const doorAfter = await game.entities.detail(doorId);
+    const moved = Math.hypot(
+      doorAfter.position[0] - doorBefore.position[0],
+      doorAfter.position[1] - doorBefore.position[1],
+      doorAfter.position[2] - doorBefore.position[2],
+    );
+    assert.ok(
+      moved > 1.0,
+      `entering 45100 should open the Sci Med Door (door moved ${moved.toFixed(2)} units; ` +
+        `before=${doorBefore.position}, after=${doorAfter.position})`,
+    );
+    await game.screenshot("keypad-door-open.png");
+
+    // --- Close behaviors ---
+    // LMB on the bare 3D view (outside the panel) closes it.
+    const stillOpen = await uiState();
+    assert.ok(stillOpen.active_panel, "panel should still be open after success");
+    await game.input.set("pointer.position", [0.9, 0.9]);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 2 });
+    const afterBareClick = await uiState();
+    assert.ok(
+      !afterBareClick.active_panel,
+      "LMB on the bare 3D view should close the panel",
+    );
+
+    // Walk-away auto-close: reopen, then teleport far from the keypad.
+    await game.entities.sendMessage(keypadId, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.ok((await uiState()).active_panel, "panel should reopen on frob");
+    await game.player.teleport({ x: kx + 20, y: ky + 0.5, z: kz + 20 });
+    await game.step({ frames: 5 });
+    const afterWalkAway = await uiState();
+    assert.ok(
+      !afterWalkAway.active_panel,
+      "walking away from the keypad should auto-close its panel",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #435.

PR 2 of the flat metagame UI plan (`projects/flat-ui.md` §6): frobbing a keypad in flat presentation now opens its **MFD panel** at the original left-MFD anchor with a mouse cursor, digits are clickable, and entering the code fires the keypad's SwitchLink — the medsci1 cryo-exit keypad (mission id 1681, code 45100) opens the Sci Med Door (1739), unblocking the play-through.

## Demo

![Flat-mode keypad MFD panel demo](https://gist.githubusercontent.com/tommy-xr/99ad87166dfcb4ea12784225ea4bf799/raw/keypad-demo.gif)

<sub>Frobbing the medsci1 cryo-exit keypad opens the 2D keypad MFD panel (original SS2 art); mouse-clicking 4-5-1-0-0 fills the readout and the SwitchLinked "Sci Med Door" slides open. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Keypad panel still - cursor over a digit, readout mid-entry](https://gist.githubusercontent.com/tommy-xr/99ad87166dfcb4ea12784225ea4bf799/raw/keypad-still.png)

## What's in here

Following the design's §5.2 sketch — **reuse the shared `Gui` layer wholesale, add only a flat presentation + input source**:

- **`GuiScript` `Frob` → new `Effect::OpenPanel { entity }`** — "what is a panel" stays in the script, mirroring the original engine where the frob script opens the overlay (`cShockGameSrv::Keypad` → `ShockOverlayChangeObj`). VR ignores the effect.
- **`FlatUiHost`** (`shock2vr/src/mission/flat_ui_host.rs`) — flat-only state on `MissionCore`:
  - *Open*: `OpenPanel` binds the MFD to one world object (the original's single `gOverlayObj` binding); opening a second panel replaces the first.
  - *Render*: the active panel's `Effect::SetUI` components are intercepted and drawn onto the shared 640×480 `UiCanvas` at the original left-MFD anchor **(2, 124)** (`shkmfddm.h`), after the flat HUD, plus a host-drawn close button (the original `CloseOff/On` gadget rect, 163,8,20×21) and `CURSOR.PCX` at the pointer. **This flat path is ungated** — it is the #435 fix; the VR world-quad path keeps its `--experimental gui` gating unchanged (design §7).
  - *Input*: each frame `InputContext::pointer` maps through `pointer_to_canvas` (letterbox-corrected) → panel-local normalized coords → `MessagePayload::GUIHover` to the panel entity — the exact contract the VR hand ray synthesizes (`virtual_hand.rs` / `ProxyGuiScript`), so `KeyPadGui` runs **unchanged**.
  - *Close*: the close button, **LMB on the bare 3D view** (the original's exit gesture, manual p.7), **walk-away auto-close** (per-overlay `distance` semantics, ~10 ft), or the bound entity dying.
- **`GET /v1/ui`** now reports the active panel: bound entity (runtime id + stable `template_id` + name) and its element list with **semantic labels** (keypad digits `"0"`–`"9"`, `"clear"`, `"close"`), 640×480 canvas rects, **and normalized screen-space rects** (letterbox-corrected via new `ui::canvas_rect_to_screen`) — clients aim `pointer.position` at a `screen_rect` center directly. SDK `UiState`/`UiPanel`/`UiElement` types added.
- **Desktop runtime**: `Mission::wants_pointer()` (panel open or Tab use-mode) flips the OS cursor, and while the cursor is up the mouse buttons drive the pointer instead of fire/frob.

## VR preservation (design §5.4)

Shared code touched, with VR behavior unchanged:
- `GuiScript`: the new `Frob` arm returns `OpenPanel`, which VR's `mission_core` explicitly ignores (previously `Frob` fell through to `NoEffect`). `GUIHover`/`SetUI` handling untouched.
- `Effect::SetUI` routing: flat *observes* the components; the VR `GuiManager` world-quad path (and its `--experimental gui` gate) is byte-for-byte the same code path.
- `GuiComponentRenderInfo::Image` gains an informational `interactive: bool` (Button vs Image); the VR quad renderer ignores it.
- `KeyPadGui` itself: **untouched**.

## Verification trail

- **Negative-first e2e** (`tools/shock2-sdk/test/keypad.e2e.test.ts`): run against unmodified `main` first — failed at exactly the intended assertion (frob → `/v1/ui` `{"mode":"shooter"}`, no panel). After the change, the full scenario passes: discover keypad by stable `template_id` 1681 + SwitchLink topology (no hardcoded runtime ids), teleport near, Frob → panel with labeled digit buttons (+ screenshot diff), click 4-5-1-0-0 via `pointer.position`/`pointer.pressed` on `/v1/ui` `screen_rect` centers, assert door 1739 translates open >1 unit, then assert LMB-on-bare-view close and walk-away auto-close.
- Unit tests: MFD anchor/rect math (incl. the text negated-y render-info convention), close-button rect, `semantic_label` (both art states of a digit; `keypad2.pcx` must NOT label), `canvas_rect_to_screen` letterbox + roundtrip. `cargo test -p shock2vr --lib`: 105 passed.
- Regression e2e: `flat-ui-plumbing`, `climbing`, `flat-hud` — pass; `missions.e2e` (23 mission loads) — pass.
- SDK `npm test` (unit) — pass. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean. `cargo fmt` applied.

- **Cross-engine review** (`/xreview`: Claude subagent + Codex CLI, both fed the media): no VR regression found by either engine; the agreed findings (held-press at open must not bare-view-close the panel; desktop pointer hygiene: cursor re-centering, mouse-look freeze in cursor mode, held-button swallow on close so closing can't fire the weapon; sticky close-button hover) are fixed in the follow-up commit, negative-first unit-tested where applicable, and re-validated (keypad + plumbing e2e green, 106 unit tests).

## Divergences / deferrals (noted per design §7)

- **Keypad check timing fidelity**: the original defers the code check until exactly 5 digits (`KeypadButton`, `shkkeypd.cpp`); shock2quest's `KeyPadGui` checks per press. Functionally equivalent for entering a correct code; **deliberately not reworked here** — follow-up per design §7. Same for wrong-code feedback and success auto-close (unverified in §1.4; panel stays open on success today).
- **Close button is host-drawn**, not a `Gui` component: the shared guis have no close widget (VR panels never close), so the host draws/hits the original `CloseOff/On` rect itself. If a later panel ships its own close component it will simply work via `GUIHover`.
- **Other GuiScript panels open on frob now too** (container/elevator/replicator/GamePig — the `Frob` arm is on the shared `GuiScript`): rendering/hover works generically, but only the keypad's interaction flow is exercised and tested here; loot-taking and containment-at-creation are PR 3.
- **Semantic labels** are derived from the `key<c><0|1>.pcx` art-name convention (both art states label identically); other panels' widgets currently report kind/texture/rects without labels.
- One MFD slot (left) only; the right slot + per-slot exclusion arrive with the first character panel (design §7).
- Flat panel elements draw opaque (the render-info `alpha` is a VR world-quad translucency; the original MFD art is opaque on screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
