### PR TITLE
fix(ai): deaf AIs ignore noise; stabilize the blood-spang e2e (shoot the calm hybrid first)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -5,6 +5,7 @@ mod prop_ai_alertness;
 mod prop_ai_aware_delay;
 mod prop_ai_camera;
 mod prop_ai_device;
+mod prop_ai_hearing;
 mod prop_ai_mode;
 mod prop_ambient_hacked;
 mod prop_anim_tex;
@@ -41,6 +42,7 @@ pub use prop_ai_alertness::*;
 pub use prop_ai_aware_delay::*;
 pub use prop_ai_camera::*;
 pub use prop_ai_device::*;
+pub use prop_ai_hearing::*;
 pub use prop_ai_mode::*;
 pub use prop_ambient_hacked::*;
 pub use prop_anim_tex::*;
@@ -1028,6 +1030,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$AI_AwrDel2",
             PropAIAwareDelay::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AI_Hearin",
+            PropAIHearing::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_ai_hearing.rs
+++ b/dark/src/properties/prop_ai_hearing.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::{read_bytes, read_u32};
+
+/// AI hearing acuity rating (P$AI_Hearin), 0-5: 0 = deaf (the AI ignores
+/// noises entirely - e.g. the `Deaf` metaproperty sets it), higher values are
+/// progressively more acute. Creatures without the property hear normally.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropAIHearing {
+    pub rating: u32,
+}
+
+impl PropAIHearing {
+    pub fn is_deaf(&self) -> bool {
+        self.rating == 0
+    }
+
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropAIHearing {
+        let rating = read_u32(reader);
+
+        const EXPECTED_SIZE: u32 = 4;
+        if len > EXPECTED_SIZE {
+            let remaining = (len - EXPECTED_SIZE) as usize;
+            read_bytes(reader, remaining);
+        }
+
+        PropAIHearing { rating }
+    }
+}

--- a/dark/src/properties/prop_ai_hearing.rs
+++ b/dark/src/properties/prop_ai_hearing.rs
@@ -8,6 +8,8 @@ use crate::ss2_common::{read_bytes, read_u32};
 /// AI hearing acuity rating (P$AI_Hearin), 0-5: 0 = deaf (the AI ignores
 /// noises entirely - e.g. the `Deaf` metaproperty sets it), higher values are
 /// progressively more acute. Creatures without the property hear normally.
+/// Only deafness is honored so far - nonzero ratings don't yet scale hearing
+/// range.
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropAIHearing {
     pub rating: u32,

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -214,3 +214,47 @@ fn eng1_patrol_data_parses() {
     let patrollers = count_patrolling_entities(&info);
     assert_eq!(patrollers, 17, "eng1 PropAIPatrol(true) AI count changed");
 }
+
+#[test]
+fn medsci1_deaf_metaproperty_delivers_hearing_component() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+
+    // Full pipeline: parse gamesys + mission, merge, and instantiate the
+    // world - the same path the game takes - then assert the AI hearing
+    // property lands on the right entities.
+    let (props, links, links_with_data) = properties::get();
+    let gam_file = File::open(data.join("shock2.gam")).expect("gamesys should open");
+    let mut gam_reader = BufReader::new(gam_file);
+    let gamesys = dark::gamesys::read(&mut gam_reader, &links, &links_with_data, &props);
+
+    let mission_info = load_mission_entity_info(&data, "medsci1.mis");
+    let merged = ss2_entity_info::merge_with_gamesys(&mission_info, &gamesys);
+
+    let mut world = shipyard::World::new();
+    let template_to_entity =
+        merged
+            .initialize_world_with_entities(&mut world, std::collections::HashMap::new(), |_| true);
+
+    // Object 596 is an OG-Pipe hybrid with the `Deaf` metaproperty attached
+    // (hearing rating 0); its sibling OG-Pipes 163 and 1007 hear normally
+    // (no hearing property authored anywhere in their inheritance chain).
+    let v_hearing = world
+        .borrow::<shipyard::View<properties::PropAIHearing>>()
+        .unwrap();
+    let deaf = template_to_entity[&596];
+    let rating = shipyard::Get::get(&v_hearing, deaf)
+        .expect("deaf OG-Pipe (obj 596) should inherit PropAIHearing from the Deaf metaproperty");
+    assert_eq!(rating.rating, 0, "Deaf metaproperty should set rating 0");
+    assert!(rating.is_deaf());
+
+    for id in [163, 1007] {
+        let entity = template_to_entity[&id];
+        assert!(
+            shipyard::Get::get(&v_hearing, entity).is_err(),
+            "OG-Pipe obj {id} should have no authored hearing property"
+        );
+    }
+}

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -244,14 +244,18 @@ fn medsci1_deaf_metaproperty_delivers_hearing_component() {
     let v_hearing = world
         .borrow::<shipyard::View<properties::PropAIHearing>>()
         .unwrap();
-    let deaf = template_to_entity[&596];
+    let deaf = *template_to_entity
+        .get(&596)
+        .expect("medsci1 obj 596 (deaf OG-Pipe) should instantiate");
     let rating = shipyard::Get::get(&v_hearing, deaf)
         .expect("deaf OG-Pipe (obj 596) should inherit PropAIHearing from the Deaf metaproperty");
     assert_eq!(rating.rating, 0, "Deaf metaproperty should set rating 0");
     assert!(rating.is_deaf());
 
     for id in [163, 1007] {
-        let entity = template_to_entity[&id];
+        let entity = *template_to_entity
+            .get(&id)
+            .expect("medsci1 hearing OG-Pipes (obj 163/1007) should instantiate");
         assert!(
             shipyard::Get::get(&v_hearing, entity).is_err(),
             "OG-Pipe obj {id} should have no authored hearing property"

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4046,6 +4046,14 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         use crate::game_scene::{DebugEntityDetail, DebugLinkInfo, DebugPropertyInfo};
         use shipyard::*;
 
+        // Looked up outside the main run: the closure below is at shipyard's
+        // view-count limit.
+        let hearing_rating = self
+            .world
+            .run(|v_hearing: View<dark::properties::PropAIHearing>| {
+                v_hearing.get(id).ok().map(|h| h.rating)
+            });
+
         self.world.run(
             |v_pos: View<dark::properties::PropPosition>,
              v_sym_name: View<dark::properties::PropSymName>,
@@ -4132,6 +4140,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "AIBehavior".to_string(),
                         value: behavior.0.clone(),
+                    });
+                }
+                // Hearing acuity when authored (0 = deaf, ignores noises)
+                if let Some(rating) = hearing_rating {
+                    properties.push(DebugPropertyInfo {
+                        name: "AIHearing".to_string(),
+                        value: rating.to_string(),
                     });
                 }
                 if let Ok(awareness) = v_awareness.get(id) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1411,7 +1411,10 @@ impl MissionCore {
     /// Propagate a noise (Effect::RaiseNoise): every creature within `radius`
     /// of `origin` hears it and gets a HeardNoise message, so it can alert and
     /// investigate the source. A plain Euclidean radius - walls don't
-    /// attenuate it yet (a path-distance model is a follow-up).
+    /// attenuate it yet (a path-distance model is a follow-up). Deaf AIs
+    /// (hearing acuity 0, e.g. the `Deaf` metaproperty on medsci1's
+    /// card-slot-watching OG-Pipe, obj 596 - the corridor hybrids hear
+    /// normally) are filtered out here so no listener has to re-check.
     fn raise_noise(&mut self, origin: Vector3<f32>, radius: f32) {
         let heard: Vec<EntityId> = {
             let v_creature = self
@@ -1419,10 +1422,17 @@ impl MissionCore {
                 .borrow::<View<dark::properties::PropCreature>>()
                 .unwrap();
             let v_transform = self.world.borrow::<View<RuntimePropTransform>>().unwrap();
+            let v_hearing = self
+                .world
+                .borrow::<View<dark::properties::PropAIHearing>>()
+                .unwrap();
             (&v_creature, &v_transform)
                 .iter()
                 .with_id()
                 .filter_map(|(entity_id, (_creature, transform))| {
+                    if v_hearing.get(entity_id).is_ok_and(|h| h.is_deaf()) {
+                        return None;
+                    }
                     let pos = transform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
                     let distance = (crate::util::point3_to_vec3(pos) - origin).magnitude();
                     (distance < radius).then_some(entity_id)

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -5,8 +5,7 @@ use dark::{
     SCALE_FACTOR,
     motion::{MotionFlags, MotionQueryItem},
     properties::{
-        AIAlertLevel, Link, PropAIAlertCap, PropAIAwareDelay, PropAIHearing, PropAISignalResponse,
-        PropPosition,
+        AIAlertLevel, Link, PropAIAlertCap, PropAIAwareDelay, PropAISignalResponse, PropPosition,
     },
 };
 use rand;
@@ -939,17 +938,8 @@ impl Script for AnimatedMonsterAI {
             MessagePayload::HeardNoise { origin } => {
                 // A gunshot (or other noise) draws the AI to investigate its
                 // source, even with no line of sight - same alert path as
-                // taking a hit, minus the damage. A deaf AI (hearing rating 0,
-                // e.g. the `Deaf` metaproperty on medsci1's corridor hybrids)
-                // ignores it.
-                let is_deaf = world
-                    .borrow::<View<PropAIHearing>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().map(|h| h.is_deaf()))
-                    .unwrap_or(false);
-                if is_deaf {
-                    return Effect::NoEffect;
-                }
+                // taking a hit, minus the damage. (Deaf AIs never receive
+                // this message - raise_noise filters them out.)
                 self.alert_to_position(*origin, world, physics, entity_id)
             }
             MessagePayload::TurnOn { from: _ } => {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -5,7 +5,8 @@ use dark::{
     SCALE_FACTOR,
     motion::{MotionFlags, MotionQueryItem},
     properties::{
-        AIAlertLevel, Link, PropAIAlertCap, PropAIAwareDelay, PropAISignalResponse, PropPosition,
+        AIAlertLevel, Link, PropAIAlertCap, PropAIAwareDelay, PropAIHearing, PropAISignalResponse,
+        PropPosition,
     },
 };
 use rand;
@@ -938,7 +939,17 @@ impl Script for AnimatedMonsterAI {
             MessagePayload::HeardNoise { origin } => {
                 // A gunshot (or other noise) draws the AI to investigate its
                 // source, even with no line of sight - same alert path as
-                // taking a hit, minus the damage.
+                // taking a hit, minus the damage. A deaf AI (hearing rating 0,
+                // e.g. the `Deaf` metaproperty on medsci1's corridor hybrids)
+                // ignores it.
+                let is_deaf = world
+                    .borrow::<View<PropAIHearing>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().map(|h| h.is_deaf()))
+                    .unwrap_or(false);
+                if is_deaf {
+                    return Effect::NoEffect;
+                }
                 self.alert_to_position(*origin, world, physics, entity_id)
             }
             MessagePayload::TurnOn { from: _ } => {

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -6,16 +6,25 @@ import { GameServer } from "../src/index.js";
 // End-to-end test for data-driven impact spangs: a projectile spawns the spang
 // its authored links say, not a hardcoded effect.
 //
-// - Terrain hit: the projectile's `MissSpang` link (pistol bullets -> the
-//   "Standard Terr Spang" particle effect).
 // - Creature hit: the `HitSpang` link whose victim archetype class the victim
 //   descends from (pistol bullets + a hybrid -> "Standard Blood Spang").
+// - Terrain hit: the projectile's `MissSpang` link (pistol bullets -> the
+//   "Standard Terr Spang" particle effect).
 //
-// Targets medsci1's stationary corridor OG-Pipe hybrid (near [-21.4, -4.7,
-// 14.9] - found by name + anchor since entity ids shuffle per launch), and
-// aims by computing head.look from the live player/victim positions. Relies
-// on the debug runtime's deterministic stepping (paused = fully frozen, so
-// positions are stable regardless of HTTP timing).
+// Targets medsci1's corridor OG-Pipe hybrid (near [-21.4, -4.7, 14.9] - found
+// by name + anchor since entity ids shuffle per launch), and aims by computing
+// head.look from the live player/victim positions. Relies on the debug
+// runtime's deterministic stepping (paused = fully frozen, so positions are
+// stable regardless of HTTP timing).
+//
+// Shot ORDER matters (#442): the creature shot must come first, while the
+// hybrid is still calm and stationary. Gunfire raises a noise that alerts
+// nearby AIs, and this hybrid hears - a wall shot fired first sends it
+// walking toward the noise, and a position-snapshot aim then grazes over its
+// head (the miss lands on terrain behind it, spawning a second Terr Spang
+// instead of the blood spang). The wall doesn't move, so the terrain shot is
+// safe to take second, from back at spawn where the alerted hybrid can't
+// reach during the test.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
@@ -37,24 +46,10 @@ test(
     await game.input.trigger("CycleWeapon");
     await game.step({ frames: 5 });
 
-    // Shot 1 - terrain: from spawn, the default facing looks at a wall.
-    await game.input.set("right_hand.trigger", 1.0);
-    await game.step({ frames: 2 });
-    await game.input.set("right_hand.trigger", 0.0);
-    await game.step({ frames: 1 });
+    const spawn = (await game.info()).player.position;
 
-    const afterTerrain = (await game.entities.list({ filter: "Spang", limit: 50 }))
-      .entities;
-    assert.ok(
-      afterTerrain.some((e) => e.name === "Standard Terr Spang"),
-      `a wall hit should spawn the authored terrain spang (got: ${afterTerrain
-        .map((e) => e.name)
-        .join(", ")})`,
-    );
-
-    const bloodBefore = afterTerrain.filter((e) => e.name === "Standard Blood Spang").length;
-
-    // Shot 2 - creature. Find the stationary corridor OG-Pipe by name +
+    // Shot 1 - creature, while it is still calm and stationary (no gunfire
+    // noise has been raised yet). Find the corridor OG-Pipe by name +
     // position anchor (entity ids are not stable across launches).
     const anchor = { x: -21.4, y: -4.7, z: 14.9 };
     const ogs = (await game.entities.list({ filter: "OG", limit: 10 })).entities.filter(
@@ -107,8 +102,8 @@ test(
       .entities;
     const bloodSpangs = afterBlood.filter((e) => e.name === "Standard Blood Spang");
     assert.ok(
-      bloodSpangs.length > bloodBefore,
-      `a hybrid hit should spawn a NEW blood spang (got: ${afterBlood
+      bloodSpangs.length > 0,
+      `a hybrid hit should spawn a blood spang (got: ${afterBlood
         .map((e) => e.name)
         .join(", ")})`,
     );
@@ -123,6 +118,26 @@ test(
           ) < 2.0,
       ),
       `the blood spang should spawn near the victim (victim at ${JSON.stringify(target)}, spangs at ${JSON.stringify(bloodSpangs.map((e) => e.position))})`,
+    );
+
+    // Shot 2 - terrain, from back at spawn (the shot hybrid is alerted and
+    // closing in, but a wall can't walk out of the aim): the default facing
+    // (yaw 0) looks at a wall.
+    await game.player.teleport({ x: spawn[0], y: spawn[1], z: spawn[2] });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    const afterTerrain = (await game.entities.list({ filter: "Spang", limit: 50 }))
+      .entities;
+    assert.ok(
+      afterTerrain.some((e) => e.name === "Standard Terr Spang"),
+      `a wall hit should spawn the authored terrain spang (got: ${afterTerrain
+        .map((e) => e.name)
+        .join(", ")})`,
     );
 
     // Spangs are one-shot bursts: they expire with their particles instead of


### PR DESCRIPTION
## What

Fixes #442 — `blood-spang.e2e.test.ts` failing deterministically on main (`a hybrid hit should spawn a NEW blood spang (got: Standard Terr Spang, Standard Terr Spang)`), restoring the full e2e suite to green (**77/77**, was 75/76).

## Root cause (not spang classification)

The spang selection was fine. Probing the failing run over the debug runtime showed the second shot's terrain spang spawning at `(-21.49, -6.30, 12.13)` — **exactly on the aim ray, 8.7 units past the hybrid, on the floor behind it**. The bullet flew over the target's head:

1. #403 made gunfire raise a noise that alerts every creature within 20 world units — with no deafness/hearing check.
2. The test's **first** (wall) shot woke medsci1's corridor OG-Pipe, which walked toward the noise (confirmed: it moves on a noise-only repro with no teleport and no line of sight, `z 14.92 → 16.64` in ~45 frames).
3. The test aims a steep 32°-down ray from a position snapshot taken ~5 frames before the bullet's raycast; as the hybrid closed distance, the fixed ray crept up its body and grazed over its head (hitbox probe at fire time: normal `(0.08, 0.83, 0.55)` — the top of the skull). Miss → `MissSpang` fallback → second Terr Spang.

## Changes

**Game (fidelity):** parse the AI hearing acuity property (`P$AI_Hearin`, previously in the unparsed bucket) — the `Deaf` metaproperty sets it to 0 — and filter deaf AIs out of noise propagation in `raise_noise`, so no `HeardNoise` listener has to re-check. medsci1 authors a genuinely deaf OG-Pipe (obj 596, the card-slot watcher). Only deafness is honored so far; nonzero acuity ratings don't yet scale hearing range (the flat radius + Euclidean model already carries a follow-up note).

**Test hardening:** the *corridor* OG-Pipes (obj 163/1007) hear normally, so investigating a gunshot is correct behavior — the deafness fix alone can't stabilize the test. Reordered the shots: creature first (while calm and stationary — sight-alerting takes ~45+ frames, the shot lands in ~21), then the terrain shot from back at spawn, where the alerted hybrid can't interfere. Walls don't walk away.

**Debug introspection:** `/v1/entities/:id` now reports `AIHearing` when authored.

## Tests

- New `dark` integration test: full parse → gamesys-merge → world-instantiation pipeline on real data; asserts obj 596 gets `PropAIHearing { rating: 0 }` via the metaproperty and obj 163/1007 get none. Verified it fails without the property registration (negative test).
- `blood-spang.e2e.test.ts`: passing 4/4 standalone runs + once in the full suite.
- Full e2e suite: **77/77 pass**. `RUSTFLAGS="-D warnings"` check clean on `shock2vr`, `desktop_runtime`, `debug_runtime`.

## Review

`/xreview` ran on this change (Codex engine unavailable — usage limit — so Claude-only): no Critical/High findings; applied its Medium/Low suggestions (deaf filter hoisted from the AI script into `raise_noise` as a single global invariant, misleading comment about *which* hybrid is deaf corrected, `expect()` messages in the integration test, acuity-scaling limitation documented).

## Spang audit follow-ups (found while here)

Filed from the broader audit of impact-effect handling: #445 (slow projectiles — laser/fusion/grenade — never spawn their authored spangs and deal flat 1.0 collision damage), #446 (impacts are silent: no material collision sounds; melee has no impact feedback at all), #447 (the "Bullet Hit" bullet-hole decal dies with the spang burst instead of its authored 10s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
