### PR TITLE
feat(ui): container loot - containment at creation + loot MFD (Fixes #433)

### DIFF
--- a/.claude/skills/play-through/walkthroughs/medsci1.md
+++ b/.claude/skills/play-through/walkthroughs/medsci1.md
@@ -36,7 +36,7 @@ The story objective chain: cryo escape → Science sector → **medsci2 round tr
 
 | Item / code | Where | Unlocks |
 | --- | --- | --- |
-| Wrench (tmpl 990) @ (−38.1, −5.9, 29.8) | cryo bay floor near spawn | smash debris blocking the first ladder; melee |
+| Wrench (tmpl 990) | **inside** MS Male Corpse (tmpl 1177) @ (−37.3, −5.5, 31.8), cryo bay near spawn — frob the corpse, click the Wrench in the loot panel (`/v1/ui`) | smash debris blocking the first ladder; melee |
 | **Code 45100** | audio log (Amanpour) on first corpse past the card door | cryo-recovery exit door (keypad tmpl 1681 @ (−26.5, 0.2, −12.7)) |
 | Cryo Card (tmpl 1050) @ (−24.3, 0.0, −1.4) | upper walkway after the first ladder | first card-reader door |
 | Power cell #1: Dead Power Cell tmpl 1767 @ (−13.8, −6.5, −34.3) | near jammed door; charge at Recharging Station tmpl 125 @ (−15.8, −6.0, −27.9) | Aux Power receptor tmpl 1766 @ (−13.1, −5.8, −33.1) → jammed cryo-escape door. (Spare Wrench tmpl 1707 @ (−18.5, −6.7, −29.3) here.) |
@@ -49,7 +49,9 @@ The story objective chain: cryo escape → Science sector → **medsci2 round tr
 
 ### Phase A — Cryo Recovery escape (lower floor, around spawn)
 1. **Wake** at (−35, −4.6, 17.9); Polito radios that the section is breached.
-2. **Take the Wrench** (tmpl 990, (−38.1, −5.9, 29.8)) from the bay floor.
+2. **Loot the Wrench** (tmpl 990) from the MS Male Corpse (tmpl 1177,
+   (−37.3, −5.5, 31.8)): frob the corpse → its loot MFD opens → click the
+   Wrench element. Contained loot is never world-placed on the floor.
 3. **Smash the debris and climb the ladder** behind the fallen Air Duct (tmpl
    402, (−41.6, −3.9, 17.9)); ladder rungs `Rick Ladder` stacked at
    (−41.3, −5.8…−2.0, 16.5) → up to the walkway (y ≈ 0). *(A second required

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -37,10 +37,19 @@ the `play-through` manager triages and delegates fixes.
 | `GET /v1/entities/:id` (props, links) | `{left_hand.thumbstick:[turn,0]}` + step (look around) |
 | `GET /v1/info` (health, pos, wielded, psi) | `POST /v1/entities/:id/message {type:"Frob"\|"Damage"\|"TurnOn"}` |
 | `GET /v1/player/inventory` · `GET /v1/quests` | `POST /v1/player/give {entity_id}` (pick up) |
+| `GET /v1/ui` (open MFD panel + labeled, clickable elements) | **loot a corpse/container**: Frob it → `/v1/ui` panel → `pointer.position` center of the item's `screen_rect`, `pointer.pressed` 1→0 |
 | `GET /v1/transitions` (exits: dest + position) | follow an exit: **move** up to a **tripwire** volume; **Frob** a bulkhead **button** |
 
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
+
+**Container loot lives in containers, not in the world.** Items with an
+incoming `Contains` link (corpse/crate loot) have no world presence — they
+never lie on the floor at their editor coordinates, and `/v1/player/give`
+can't honestly reach them. Loot them the way a player does: get close, Frob
+the container, then click the item by its `label` in the `/v1/ui` panel — it
+lands in `/v1/player/inventory` (a living AI's container stays closed until
+it's dead).
 
 **Navigate with `/v1/player/move`, not raw teleport.** It advances the player at
 most ~5 units toward the target and **shapecasts the player collider**, so it

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -360,10 +360,10 @@ pub struct DebugUiPanel {
 
 /// One drawn element of the active panel. `label` gives clickable elements a
 /// semantic identity (keypad digits "0"-"9", "clear", the host "close"
-/// button) so tests can click by meaning; `rect` is on the 640x480 virtual
-/// canvas and `screen_rect` is the same rect in normalized `[0,1]` screen
-/// coordinates (letterbox-corrected) - feed its center straight to the
-/// `pointer.position` input channel.
+/// button, a loot item's name like "Psi Amp") so tests can click by meaning;
+/// `rect` is on the 640x480 virtual canvas and `screen_rect` is the same rect
+/// in normalized `[0,1]` screen coordinates (letterbox-corrected) - feed its
+/// center straight to the `pointer.position` input channel.
 #[derive(Debug, Serialize, Clone)]
 pub struct DebugUiElement {
     /// "button" (clickable), "image", or "text".
@@ -371,6 +371,9 @@ pub struct DebugUiElement {
     pub texture: Option<String>,
     pub text: Option<String>,
     pub label: Option<String>,
+    /// For entity-bound elements (loot-panel items): the item's runtime
+    /// entity id (NOT stable across runs).
+    pub entity_id: Option<i32>,
     /// Canvas-space rect `[x, y, w, h]` (640x480 virtual canvas).
     pub rect: [f32; 4],
     /// Normalized screen-space rect `[x, y, w, h]`.

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -337,12 +337,6 @@ where
             Self::Text { .. } => self,
         }
     }
-}
-
-impl<TEvent> GuiComponent<TEvent>
-where
-    TEvent: Clone,
-{
     /// Tag a `Button` with the world entity it stands for (no-op for other
     /// component kinds) - see `GuiComponent::Button::entity`.
     pub fn with_entity(self, new_entity: EntityId) -> GuiComponent<TEvent> {

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -32,6 +32,10 @@ where
         on_grab: Option<(TEvent, TEvent)>,
         hover: ButtonHoverBehavior,
         alpha: f32,
+        /// The world entity this button stands for (e.g. a contained item in
+        /// a loot panel), carried through to the render info so debug
+        /// introspection (`GET /v1/ui`) can label the element semantically.
+        entity: Option<EntityId>,
     },
     Text {
         position: Vector2<f32>,
@@ -70,6 +74,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
                 ..
             } => Self::Button {
                 alpha,
@@ -79,6 +84,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
             },
             Self::Text {
                 alpha,
@@ -117,6 +123,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
                 ..
             } => Self::Button {
                 alpha,
@@ -126,6 +133,7 @@ where
                 on_click,
                 hover,
                 on_grab,
+                entity,
             },
             Self::Text {
                 position,
@@ -152,6 +160,7 @@ where
                 on_grab,
                 hover,
                 alpha,
+                entity,
                 ..
             } => GuiComponent::Button {
                 alpha,
@@ -161,6 +170,7 @@ where
                 on_click: Some(click_event),
                 on_grab,
                 hover,
+                entity,
             },
             Self::Image {
                 alpha,
@@ -212,6 +222,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
                 ..
             } => Self::Button {
                 position,
@@ -221,6 +232,7 @@ where
                 on_grab,
                 hover,
                 alpha,
+                entity,
             },
             Self::Text {
                 position,
@@ -260,6 +272,7 @@ where
                 texture,
                 on_click,
                 on_grab,
+                entity,
                 ..
             } => Self::Button {
                 alpha,
@@ -269,6 +282,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
             },
             Self::Text {
                 position,
@@ -308,6 +322,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
                 ..
             } => Self::Button {
                 alpha,
@@ -317,8 +332,41 @@ where
                 on_click,
                 on_grab,
                 hover,
+                entity,
             },
             Self::Text { .. } => self,
+        }
+    }
+}
+
+impl<TEvent> GuiComponent<TEvent>
+where
+    TEvent: Clone,
+{
+    /// Tag a `Button` with the world entity it stands for (no-op for other
+    /// component kinds) - see `GuiComponent::Button::entity`.
+    pub fn with_entity(self, new_entity: EntityId) -> GuiComponent<TEvent> {
+        match self {
+            Self::Button {
+                alpha,
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                ..
+            } => Self::Button {
+                alpha,
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                entity: Some(new_entity),
+            },
+            other => other,
         }
     }
 }
@@ -341,6 +389,7 @@ pub fn button<TMsg: Clone>(on_click: TMsg) -> GuiComponent<TMsg> {
         on_grab: None,
         hover: ButtonHoverBehavior::None,
         alpha: 0.5,
+        entity: None,
     }
 }
 
@@ -353,6 +402,7 @@ pub fn grabbable<TMsg: Clone>(on_left_grab: TMsg, on_right_grab: TMsg) -> GuiCom
         on_grab: Some((on_left_grab, on_right_grab)),
         hover: ButtonHoverBehavior::None,
         alpha: 0.5,
+        entity: None,
     }
 }
 
@@ -378,6 +428,10 @@ pub enum GuiComponentRenderInfo {
         /// debug UI introspection (`GET /v1/ui`) to distinguish clickable
         /// elements; the VR quad renderer ignores it.
         interactive: bool,
+        /// The world entity the source button stands for (a contained item in
+        /// a loot panel), if any. Purely informational - used by `GET /v1/ui`
+        /// to label the element with the item's name and entity id.
+        entity: Option<EntityId>,
     },
     Text {
         position: Vector2<f32>,
@@ -503,6 +557,7 @@ where
                 texture: texture.clone(),
                 alpha: *alpha,
                 interactive: false,
+                entity: None,
             },
             GuiComponent::Button {
                 position,
@@ -512,6 +567,7 @@ where
                 alpha,
                 on_click,
                 on_grab,
+                entity,
             } => {
                 let is_hovered = is_in_bounds(position, size, screen_space_cursor);
 
@@ -533,6 +589,7 @@ where
                     texture,
                     alpha: *alpha,
                     interactive: on_click.is_some() || on_grab.is_some(),
+                    entity: *entity,
                 }
             }
         }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -534,6 +534,33 @@ fn create_bitmap(
     }
 }
 
+/// Enforce containment at creation (projects/flat-ui.md §5.2/§6 PR 3): an
+/// entity with an incoming `Contains` link lives inside its container's loot
+/// panel and must have NO world presence - no render, no physics - until
+/// taken (`GrabEntity`/`DropEntityInfo` clear or move the link and restore
+/// `PropHasRefs`) or dropped. Mission data usually authors `P$HasRefs=false`
+/// on contained items already (the Dark editor sets it when parenting an
+/// object into a container); this makes the invariant structural instead of
+/// data-dependent. Must run after links are hydrated and before the
+/// instantiation loop: physics creation (`create_entity_core`) and model
+/// rendering both gate on `has_refs`. `PropHasRefs` is a serialized
+/// property, so the state round-trips through save/load.
+pub fn suppress_contained_entity_world_presence(world: &mut World) {
+    use shipyard::IntoIter;
+    let contained: Vec<EntityId> = {
+        let v_links = world.borrow::<View<Links>>().unwrap();
+        v_links
+            .iter()
+            .flat_map(|links| links.to_links.iter())
+            .filter(|link| matches!(link.link, Link::Contains(_)))
+            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+            .collect()
+    };
+    for entity in contained {
+        world.add_component(entity, PropHasRefs(false));
+    }
+}
+
 pub fn initialize_links_for_entity(
     template_id: i32,
     entity_id: EntityId,
@@ -938,5 +965,74 @@ impl Default for CreateEntityOptions {
             attach_to: None,
             transient_fx: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{Links, ToLink};
+
+    fn contains_link(to: EntityId) -> ToLink {
+        ToLink {
+            to_template_id: 0,
+            to_entity_id: Some(WrappedEntityId(to)),
+            link: Link::Contains(0),
+        }
+    }
+
+    fn has_refs_of(world: &World, entity: EntityId) -> Option<bool> {
+        let v = world.borrow::<View<PropHasRefs>>().unwrap();
+        v.get(entity).ok().map(|p| p.0)
+    }
+
+    #[test]
+    fn contained_entities_lose_world_presence() {
+        let mut world = World::new();
+        let loot = world.add_entity(());
+        let world_placed = world.add_entity(());
+        let container = world.add_entity(Links {
+            to_links: vec![contains_link(loot)],
+        });
+
+        suppress_contained_entity_world_presence(&mut world);
+
+        // The Contains target is suppressed; nothing else is touched.
+        assert_eq!(has_refs_of(&world, loot), Some(false));
+        assert_eq!(has_refs_of(&world, world_placed), None);
+        assert_eq!(has_refs_of(&world, container), None);
+    }
+
+    #[test]
+    fn containment_overrides_an_authored_visible_flag() {
+        // A contained item whose data inconsistently says HasRefs(true) (the
+        // invariant is structural, not data-dependent).
+        let mut world = World::new();
+        let loot = world.add_entity(PropHasRefs(true));
+        let _container = world.add_entity(Links {
+            to_links: vec![contains_link(loot)],
+        });
+
+        suppress_contained_entity_world_presence(&mut world);
+
+        assert_eq!(has_refs_of(&world, loot), Some(false));
+    }
+
+    #[test]
+    fn non_contains_links_do_not_suppress() {
+        // Trap/script references (SwitchLink etc.) must not hide entities.
+        let mut world = World::new();
+        let door = world.add_entity(());
+        let _switch = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(door)),
+                link: Link::SwitchLink,
+            }],
+        });
+
+        suppress_contained_entity_world_presence(&mut world);
+
+        assert_eq!(has_refs_of(&world, door), None);
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -334,7 +334,10 @@ impl FlatUiHost {
                     Some(texture.clone()),
                     None,
                     if let Some(entity) = entity {
-                        entity_label(world, *entity)
+                        // Fall back to the art-derived label for entity-bound
+                        // items with no symbolic name, so every loot element
+                        // stays clickable by meaning.
+                        entity_label(world, *entity).or_else(|| semantic_label(texture))
                     } else if *interactive {
                         semantic_label(texture)
                     } else {

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -301,8 +301,10 @@ impl FlatUiHost {
 
     /// Introspection snapshot of the active panel's elements for `GET /v1/ui`:
     /// canvas + normalized-screen rects and semantic labels, so clients click
-    /// widgets by meaning instead of hardcoded pixels.
-    pub fn debug_elements(&self) -> Vec<crate::game_scene::DebugUiElement> {
+    /// widgets by meaning instead of hardcoded pixels. Entity-bound buttons
+    /// (loot-panel items) label as the item's name and carry its entity id;
+    /// other clickables fall back to art-derived labels (keypad digits).
+    pub fn debug_elements(&self, world: &World) -> Vec<crate::game_scene::DebugUiElement> {
         let Some(rect) = self.panel_rect() else {
             return Vec::new();
         };
@@ -321,23 +323,27 @@ impl FlatUiHost {
                 continue;
             }
             let r = component_canvas_rect(component, rect);
-            let (kind, texture, text, label) = match component {
+            let (kind, texture, text, label, entity_id) = match component {
                 GuiComponentRenderInfo::Image {
                     texture,
                     interactive,
+                    entity,
                     ..
                 } => (
                     if *interactive { "button" } else { "image" },
                     Some(texture.clone()),
                     None,
-                    if *interactive {
+                    if let Some(entity) = entity {
+                        entity_label(world, *entity)
+                    } else if *interactive {
                         semantic_label(texture)
                     } else {
                         None
                     },
+                    entity.map(|e| e.inner() as i32),
                 ),
                 GuiComponentRenderInfo::Text { text, .. } => {
-                    ("text", None, Some(text.clone()), None)
+                    ("text", None, Some(text.clone()), None, None)
                 }
             };
             out.push(crate::game_scene::DebugUiElement {
@@ -345,6 +351,7 @@ impl FlatUiHost {
                 texture,
                 text,
                 label,
+                entity_id,
                 rect: [r.x, r.y, r.w, r.h],
                 screen_rect: to_screen(r),
             });
@@ -356,6 +363,7 @@ impl FlatUiHost {
             texture: Some("closeoff.pcx".to_string()),
             text: None,
             label: Some("close".to_string()),
+            entity_id: None,
             rect: [close.x, close.y, close.w, close.h],
             screen_rect: to_screen(close),
         });
@@ -407,6 +415,15 @@ fn close_button_canvas_rect(panel: Rect) -> Rect {
         CLOSE_BUTTON_SIZE.x,
         CLOSE_BUTTON_SIZE.y,
     )
+}
+
+/// Semantic label for an entity-bound element (a loot-panel item): the
+/// entity's symbolic name (the same identity `/v1/entities` reports).
+fn entity_label(world: &World, entity: EntityId) -> Option<String> {
+    world
+        .borrow::<View<dark::properties::PropSymName>>()
+        .ok()
+        .and_then(|v| v.get(entity).ok().map(|name| name.0.clone()))
 }
 
 /// Semantic label for a clickable element, derived from its art name. The
@@ -463,6 +480,7 @@ mod tests {
             texture: "key10.pcx".to_owned(),
             alpha: 0.5,
             interactive: true,
+            entity: None,
         };
         let r = component_canvas_rect(&info, panel);
         assert!((r.x - 17.0).abs() < 1e-3);
@@ -504,6 +522,7 @@ mod tests {
             texture: "cursor.pcx".to_owned(),
             alpha: 0.5,
             interactive: false,
+            entity: None,
         };
         assert!(is_gui_cursor(&cursor));
         let backdrop = GuiComponentRenderInfo::Image {
@@ -512,6 +531,7 @@ mod tests {
             texture: "keypad2.pcx".to_owned(),
             alpha: 0.5,
             interactive: false,
+            entity: None,
         };
         assert!(!is_gui_cursor(&backdrop));
     }
@@ -552,6 +572,37 @@ mod tests {
             host.active_panel().is_none(),
             "a fresh click on the bare 3D view should close the panel"
         );
+    }
+
+    #[test]
+    fn entity_bound_elements_label_with_the_item_name_and_id() {
+        // A loot-panel item button carries its entity; /v1/ui must label it
+        // with the item's symbolic name ("Psi Amp") and its entity id so
+        // tests click loot by meaning.
+        let mut world = World::new();
+        let item = world.add_entity(dark::properties::PropSymName("Psi Amp".to_owned()));
+        let panel = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.open(panel);
+        host.on_set_ui(
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[GuiComponentRenderInfo::Image {
+                position: vec2(15.0 / 188.0, 160.0 / 296.0),
+                size: vec2(35.0 / 188.0, 32.0 / 296.0),
+                texture: "icn_psi.pcx".to_owned(),
+                alpha: 0.5,
+                interactive: true,
+                entity: Some(item),
+            }],
+        );
+        let elements = host.debug_elements(&world);
+        let el = elements
+            .iter()
+            .find(|e| e.entity_id == Some(item.inner() as i32))
+            .expect("the item element should carry its entity id");
+        assert_eq!(el.kind, "button");
+        assert_eq!(el.label.as_deref(), Some("Psi Amp"));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4507,7 +4507,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 entity_id: entity.inner() as i32,
                 template_id,
                 name,
-                elements: self.flat_ui.debug_elements(),
+                elements: self.flat_ui.debug_elements(&self.world),
             }
         });
         crate::game_scene::DebugUiState {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -491,6 +491,13 @@ impl MissionCore {
             &mut entities_to_instantiate,
         );
 
+        // Containment at creation: anything a `Contains` link points at (loot
+        // in corpses/containers, items carried by live AIs, backpack
+        // contents) has no world presence until taken or dropped. Runs before
+        // the instantiation loop below so neither models nor physics bodies
+        // are created for contained items.
+        entity_creator::suppress_contained_entity_world_presence(&mut world);
+
         // Get the set of entities with PropPosition to be materialized
         world.run(
             |v_pos: View<dark::properties::PropPosition>,

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -219,7 +219,12 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // Transfer the clicked item's `Contains` link to the player's
             // backpack - the same `DropEntityInfo` path used when a VR hand
             // feeds an item into a container (drop_entity_into_container).
+            // Guarded by the same grabbability check as the debug give
+            // lever: reparenting a non-grabbable entity would corrupt it.
             ContainerGuiMsg::Take(ent) => {
+                if !crate::virtual_hand::can_grab_item(world, *ent) {
+                    return (state.clone(), Effect::NoEffect);
+                }
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -245,13 +250,21 @@ mod tests {
     use crate::gui::GuiInputInfo;
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
-    use dark::properties::{Links, ToLink, WrappedEntityId};
+    use dark::properties::{FrobFlag, Links, PropFrobInfo, ToLink, WrappedEntityId};
 
-    /// A world with a loot container holding one iconed item, plus the
-    /// player-info unique the Take path resolves the backpack through.
+    /// A world with a loot container holding one iconed, grabbable item,
+    /// plus the player-info unique the Take path resolves the backpack
+    /// through.
     fn loot_world() -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
-        let item = world.add_entity(PropObjIcon("icn_psi".to_owned()));
+        let item = world.add_entity((
+            PropObjIcon("icn_psi".to_owned()),
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
         let container = world.add_entity(Links {
             to_links: vec![ToLink {
                 to_template_id: 0,
@@ -323,6 +336,26 @@ mod tests {
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
         }
+    }
+
+    /// A contained entity that is not grabbable (no MOVE/USE_AMMO frob
+    /// action) must not be reparented - same guard as the debug give lever.
+    #[test]
+    fn take_refuses_a_non_grabbable_entity() {
+        let (mut world, container, _item, _inventory) = loot_world();
+        let stuck = world.add_entity(PropObjIcon("icn_junk".to_owned()));
+        let gui = ContainerGui::loot_container();
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(stuck),
+        );
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "taking a non-grabbable entity must be a no-op, got {:?}",
+            effect
+        );
     }
 
     /// The player's own backpack keeps the original click semantics (use the

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -21,6 +21,10 @@ pub struct ContainerGui {
     inv_offset_y: f32,
     num_slots_x: usize,
     num_slots_y: usize,
+    /// Loot semantics: clicking an item takes it into the player's backpack
+    /// ("left clicking on the contents picks them up", manual p.7). The
+    /// player's own backpack keeps click = use-the-item (`Frob`) instead.
+    take_on_click: bool,
 }
 
 impl ContainerGui {
@@ -33,6 +37,7 @@ impl ContainerGui {
             inv_offset_y: 160.0,
             num_slots_x: 4,
             num_slots_y: 4,
+            take_on_click: true,
         }
     }
 
@@ -45,6 +50,7 @@ impl ContainerGui {
             inv_offset_y: 18.0,
             num_slots_x: 15,
             num_slots_y: 3,
+            take_on_click: false,
         }
     }
 }
@@ -57,6 +63,8 @@ pub enum ContainerGuiMsg {
     GrabbedWithLeftHand(EntityId),
     GrabbedWithRightHand(EntityId),
     Frob(EntityId),
+    /// Take the item out of this container into the player's backpack.
+    Take(EntityId),
 }
 
 impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
@@ -118,12 +126,18 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                 continue;
             }
 
+            let on_click = if self.take_on_click {
+                ContainerGuiMsg::Take(ent)
+            } else {
+                ContainerGuiMsg::Frob(ent)
+            };
             components.push(
                 gui::grabbable(
                     ContainerGuiMsg::GrabbedWithLeftHand(ent),
                     ContainerGuiMsg::GrabbedWithRightHand(ent),
                 )
-                .with_onclick(ContainerGuiMsg::Frob(ent))
+                .with_onclick(on_click)
+                .with_entity(ent)
                 .with_image(&format!("{}.pcx", obj_icon))
                 .with_position(vec2(
                     initial_offset_x + position_x,
@@ -170,7 +184,7 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
     fn handle_msg(
         &self,
         _entity_id: EntityId,
-        _world: &World,
+        world: &World,
         state: &ContainerGuiState,
         msg: &ContainerGuiMsg,
     ) -> (ContainerGuiState, Effect) {
@@ -202,7 +216,137 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     },
                 },
             ),
+            // Transfer the clicked item's `Contains` link to the player's
+            // backpack - the same `DropEntityInfo` path used when a VR hand
+            // feeds an item into a container (drop_entity_into_container).
+            ContainerGuiMsg::Take(ent) => {
+                let inventory_entity = world
+                    .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
+                    .map(|player| player.inventory_entity_id)
+                    .ok();
+                match inventory_entity {
+                    Some(inventory_entity) => (
+                        state.clone(),
+                        Effect::DropEntityInfo {
+                            parent_entity_id: inventory_entity,
+                            dropped_entity_id: *ent,
+                        },
+                    ),
+                    None => (state.clone(), Effect::NoEffect),
+                }
+            }
         }
-        //(state.clone(), Effect::NoEffect)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::GuiInputInfo;
+    use crate::mission::PlayerInfo;
+    use cgmath::{Quaternion, point2, vec3};
+    use dark::properties::{Links, ToLink, WrappedEntityId};
+
+    /// A world with a loot container holding one iconed item, plus the
+    /// player-info unique the Take path resolves the backpack through.
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        let mut world = World::new();
+        let item = world.add_entity(PropObjIcon("icn_psi".to_owned()));
+        let container = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(item)),
+                link: Link::Contains(0),
+            }],
+        });
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, container, item, inventory)
+    }
+
+    fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
+        GuiInputInfo {
+            held_entity_id: None,
+            cursor_position: cursor,
+            is_pressed: pressed,
+            is_grabbed: false,
+            hand: crate::vr_config::Handedness::Right,
+        }
+    }
+
+    /// Clicking a loot-panel item yields `Take`, and `Take` transfers the
+    /// item to the player's backpack through the shared `DropEntityInfo`
+    /// path ("left clicking on the contents picks them up", manual p.7).
+    #[test]
+    fn loot_container_click_takes_the_item_into_the_backpack() {
+        let (world, container, item, inventory) = loot_world();
+        let gui = ContainerGui::loot_container();
+        let components = gui.get_components(&None, container, &world, &ContainerGuiState {});
+
+        // The item button carries its entity for /v1/ui introspection.
+        let item_button = components
+            .iter()
+            .find(|c| matches!(c, GuiComponent::Button { entity, .. } if *entity == Some(item)))
+            .expect("loot panel should expose a button bound to the contained item");
+
+        // Simulate a press edge on the item's slot (first slot at the loot
+        // panel's inventory offset).
+        let (position, size) = match item_button {
+            GuiComponent::Button { position, size, .. } => (*position, *size),
+            _ => unreachable!(),
+        };
+        let center = point2(position.x + size.x / 2.0, position.y + size.y / 2.0);
+        let event = item_button
+            .get_event(&input_at(center, false), &input_at(center, true))
+            .expect("a press edge on the item should produce an event");
+        assert!(
+            matches!(event, ContainerGuiMsg::Take(e) if e == item),
+            "clicking a loot item should Take it"
+        );
+
+        let (_state, effect) = gui.handle_msg(container, &world, &ContainerGuiState {}, &event);
+        match effect {
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } => {
+                assert_eq!(parent_entity_id, inventory);
+                assert_eq!(dropped_entity_id, item);
+            }
+            other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
+        }
+    }
+
+    /// The player's own backpack keeps the original click semantics (use the
+    /// item), NOT take-into-self.
+    #[test]
+    fn backpack_click_frobs_the_item() {
+        let (world, container, item, _inventory) = loot_world();
+        let gui = ContainerGui::inv_container();
+        let components = gui.get_components(&None, container, &world, &ContainerGuiState {});
+        let item_button = components
+            .iter()
+            .find(|c| matches!(c, GuiComponent::Button { entity, .. } if *entity == Some(item)))
+            .expect("backpack should expose a button bound to the carried item");
+        let (position, size) = match item_button {
+            GuiComponent::Button { position, size, .. } => (*position, *size),
+            _ => unreachable!(),
+        };
+        let center = point2(position.x + size.x / 2.0, position.y + size.y / 2.0);
+        let event = item_button
+            .get_event(&input_at(center, false), &input_at(center, true))
+            .expect("a press edge on the item should produce an event");
+        assert!(
+            matches!(event, ContainerGuiMsg::Frob(e) if e == item),
+            "clicking a backpack item should Frob (use) it"
+        );
     }
 }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -280,6 +280,9 @@ export interface UiElement {
   texture: string | null;
   text: string | null;
   label: string | null;
+  /** For loot-panel item buttons: the contained item's runtime entity id
+   * (NOT stable across runs - resolve identity via label / entity lookup). */
+  entity_id: number | null;
   /** Canvas-space rect [x, y, w, h] (640x480 virtual canvas). */
   rect: [number, number, number, number];
   /** Normalized screen-space rect [x, y, w, h]. */

--- a/tools/shock2-sdk/test/container-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/container-loot.e2e.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for container loot (projects/flat-ui.md PR 3, resolves #433;
+// supersedes PR #439, salvaging its interaction semantics and scenario shape):
+//
+//  1. Containment at creation: an entity with an incoming `Contains` link has
+//     NO world presence (no physics body) until taken - it lives inside its
+//     container's loot panel, not double-placed at its authored editor spot.
+//  2. Loot MFD: frobbing a `ContainerScript` container (a corpse) opens its
+//     ContainerGui panel in the flat MFD slot; a living `CreatureContainer`
+//     AI does NOT open a panel (looting the living is not a thing - the rule
+//     salvaged from #439).
+//  3. Take: clicking a contained item in the panel transfers its `Contains`
+//     link to the player backpack; the panel reflects the removal live.
+//  4. /v1/ui semantics: loot elements carry the item's name as `label` and
+//     its runtime `entity_id`, so tests click "Psi Amp" by meaning.
+//  5. Save/load round-trip preserves containment state (contained stays
+//     contained, taken stays taken, world-placed stays world-placed).
+//
+// Entity discovery is by TEMPLATE ID at run time (runtime entity ids are NOT
+// stable across launches; the `template_id` reported by /v1/entities IS
+// stable - the mission-file object id for level-authored entities):
+//   - corpse 219 ("Male Corpse 1") -> Contains -> Psi Amp (mission id 1407)
+//   - corpse 1177 ("MS Male Corpse") -> Contains -> Wrench (mission id 990),
+//     the authored first MedSci interaction (#433 / #439's scenario)
+//   - Cryo Card 1050: NO incoming Contains - the world-placed control item
+//   - OG-Pipe 596: a living CreatureContainer AI (Contains -> OG Organ)
+//
+// Negative-first: on main (pre containment-at-creation) the Psi Amp is
+// instantiated as a physical world prop at its authored position ~2.7 units
+// from the corpse - the "no physics bodies" assertion fails; and the loot
+// panel's elements carry no item name labels - the "Psi Amp element" lookup
+// fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CORPSE_PSI_AMP = 219; // Male Corpse 1 -> Contains -> Psi Amp
+const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (the #433 route)
+const CRYO_CARD = 1050; // world-placed control item (no incoming Contains)
+const LIVING_AI = 596; // OG-Pipe with Contains -> OG Organ (must NOT open)
+
+test(
+  "container loot: contained items have no world presence and are taken via the loot MFD",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8119),
+    });
+    await game.step({ frames: 5 });
+
+    const byTemplateOne = async (templateId: number, what: string) => {
+      const matches = await game.entities.byTemplate(templateId);
+      assert.equal(matches.length, 1, `expected exactly one ${what} (mission id ${templateId})`);
+      return matches[0];
+    };
+    const bodyCount = async (entityId: number) =>
+      (await game.physics.bodies({ entityId })).bodies.length;
+    const containsLinks = async (entityId: number) => {
+      const detail = await game.entities.detail(entityId);
+      return detail.outgoing_links.filter((l) => l.link_type.startsWith("Contains"));
+    };
+    const clickElement = async (el: UiElement) => {
+      const [x, y, w, h] = el.screen_rect;
+      const center: [number, number] = [x + w / 2, y + h / 2];
+      await game.input.set("pointer.position", center);
+      await game.step({ frames: 2 }); // hover registers (edge detection needs a prior unpressed frame)
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+
+    // --- Discover the corpse and its contained Psi Amp ---
+    const corpse = await byTemplateOne(CORPSE_PSI_AMP, "Male Corpse 1");
+    const ampLinks = await containsLinks(corpse.id);
+    assert.equal(ampLinks.length, 1, "corpse 219 should contain exactly the Psi Amp");
+    const ampId = ampLinks[0].target_id;
+    assert.ok(
+      ampLinks[0].target_name.includes("Psi Amp"),
+      `corpse 219's contained item should be the Psi Amp, got ${ampLinks[0].target_name}`,
+    );
+
+    // --- (i) NEGATIVE KEY: contained items are NOT world-placed ---
+    // On main both carry physics bodies at their authored editor positions
+    // (the double-placed-loot bug, design doc §4.6).
+    assert.equal(
+      await bodyCount(ampId),
+      0,
+      "the corpse-contained Psi Amp must have no world presence (no physics body)",
+    );
+    const corpse1177 = await byTemplateOne(CORPSE_WRENCH, "MS Male Corpse");
+    const wrenchLinks = await containsLinks(corpse1177.id);
+    assert.equal(wrenchLinks.length, 1, "corpse 1177 should contain exactly the Wrench");
+    assert.equal(
+      await bodyCount(wrenchLinks[0].target_id),
+      0,
+      "the corpse-contained Wrench must have no world presence (no physics body)",
+    );
+
+    // --- (iv) control: a genuinely world-placed item keeps its presence ---
+    const cryoCard = await byTemplateOne(CRYO_CARD, "Cryo Card");
+    assert.ok(
+      (await bodyCount(cryoCard.id)) > 0,
+      "the world-placed Cryo Card (no incoming Contains) must keep its physics body",
+    );
+
+    // --- living CreatureContainer AI must NOT open a loot panel ---
+    const pipe = await byTemplateOne(LIVING_AI, "OG-Pipe 596");
+    await teleportVerified(game, {
+      x: pipe.position[0] + 1.5,
+      y: pipe.position[1] + 0.5,
+      z: pipe.position[2] + 1.5,
+    });
+    await game.entities.sendMessage(pipe.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "frobbing a living CreatureContainer AI must not open a loot panel",
+    );
+
+    // --- (ii) frob the corpse -> loot MFD opens with a labeled Psi Amp ---
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.step({ frames: 5 });
+    await game.screenshot("loot-before-frob.png");
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const opened = await game.ui.state();
+    assert.ok(
+      opened.active_panel,
+      `frobbing the corpse should open its loot MFD panel (got ${JSON.stringify(opened)})`,
+    );
+    assert.equal(
+      opened.active_panel.entity_id,
+      corpse.id,
+      "the active panel should be bound to the corpse entity",
+    );
+    const ampElement = opened.active_panel.elements.find(
+      (e) => e.kind === "button" && e.label === "Psi Amp",
+    );
+    assert.ok(
+      ampElement,
+      `loot panel should expose a button labeled "Psi Amp" ` +
+        `(got ${JSON.stringify(opened.active_panel.elements)})`,
+    );
+    assert.equal(
+      ampElement.entity_id,
+      ampId,
+      "the Psi Amp element should carry the contained item's entity id",
+    );
+    await game.screenshot("loot-panel-open.png");
+
+    // --- (iii) click the Psi Amp -> it transfers to the player backpack ---
+    await clickElement(ampElement);
+
+    const inventory = await game.player.inventory();
+    assert.ok(
+      inventory.items.some((i) => i.entity_id === ampId),
+      `taking the Psi Amp should put it in the player inventory ` +
+        `(got ${JSON.stringify(inventory.items)})`,
+    );
+    // The corpse's Contains link moved to the backpack...
+    assert.equal(
+      (await containsLinks(corpse.id)).length,
+      0,
+      "taking the Psi Amp should remove the corpse's Contains link",
+    );
+    // ...the panel reflects the removal live...
+    const afterTake = await game.ui.state();
+    assert.ok(afterTake.active_panel, "the loot panel stays open after taking an item");
+    assert.ok(
+      !afterTake.active_panel.elements.some((e) => e.entity_id === ampId),
+      "the taken Psi Amp should disappear from the loot panel",
+    );
+    // ...and the item STILL has no world presence (it is carried, not spilled).
+    assert.equal(
+      await bodyCount(ampId),
+      0,
+      "the taken Psi Amp lives in the backpack, not in the world",
+    );
+    await game.screenshot("loot-taken.png");
+
+    // --- (v) save/load round-trip preserves all three states ---
+    const saveName = `container_loot_e2e_${Date.now()}`;
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+
+    // Taken stays taken: the corpse has no Contains link and the amp is still
+    // in the backpack (runtime ids changed across the load - rediscover).
+    const corpseReloaded = await byTemplateOne(CORPSE_PSI_AMP, "Male Corpse 1 (after load)");
+    assert.equal(
+      (await containsLinks(corpseReloaded.id)).length,
+      0,
+      "after load the corpse must not regain its Contains link",
+    );
+    const inventoryReloaded = await game.player.inventory();
+    const ampCarried = inventoryReloaded.items.find((i) => i.name === "Psi Amp");
+    assert.ok(
+      ampCarried,
+      `after load the taken Psi Amp stays in the inventory ` +
+        `(got ${JSON.stringify(inventoryReloaded.items)})`,
+    );
+    assert.equal(
+      await bodyCount(ampCarried.entity_id),
+      0,
+      "after load the carried Psi Amp still has no world presence",
+    );
+
+    // Contained stays contained: corpse 1177 still holds its Wrench, with no
+    // world presence...
+    const corpse1177Reloaded = await byTemplateOne(CORPSE_WRENCH, "MS Male Corpse (after load)");
+    const wrenchReloaded = await containsLinks(corpse1177Reloaded.id);
+    assert.equal(wrenchReloaded.length, 1, "after load corpse 1177 still contains the Wrench");
+    assert.ok(
+      wrenchReloaded[0].target_name.includes("Wrench"),
+      `corpse 1177's contained item should still be the Wrench, got ${wrenchReloaded[0].target_name}`,
+    );
+    assert.equal(
+      await bodyCount(wrenchReloaded[0].target_id),
+      0,
+      "after load the contained Wrench still has no world presence",
+    );
+    // ...and its loot panel still works from the loaded state.
+    await teleportVerified(game, {
+      x: corpse1177Reloaded.position[0] + 1.0,
+      y: corpse1177Reloaded.position[1] + 0.5,
+      z: corpse1177Reloaded.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(corpse1177Reloaded.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const reloadedPanel = await game.ui.state();
+    assert.ok(
+      reloadedPanel.active_panel &&
+        reloadedPanel.active_panel.elements.some(
+          (e) => e.kind === "button" && e.label === "Wrench",
+        ),
+      `after load, frobbing corpse 1177 should open a loot panel listing the Wrench ` +
+        `(got ${JSON.stringify(reloadedPanel.active_panel)})`,
+    );
+
+    // World-placed stays world-placed.
+    const cryoCardReloaded = await byTemplateOne(CRYO_CARD, "Cryo Card (after load)");
+    assert.ok(
+      (await bodyCount(cryoCardReloaded.id)) > 0,
+      "after load the world-placed Cryo Card keeps its physics body",
+    );
+  },
+);


### PR DESCRIPTION
PR 3 of the flat metagame UI plan (`projects/flat-ui.md` §6). **Supersedes #439, salvaging its interaction semantics and e2e scenario** — especially the rule that looting is restricted to `ContainerScript` containers/corpses while living `CreatureContainer` AIs stay closed, and the authored MedSci corpse → wrench scenario shape.

## What this does

- **Containment at creation (flat AND VR):** any entity targeted by an incoming `Contains` link gets `PropHasRefs(false)` before the instantiation loop (`entity_creator::suppress_contained_entity_world_presence`, called from `MissionCore::new`), so contained loot has **no physics body and no rendered model** until taken or dropped. `PropHasRefs` is a serialized property, so the state round-trips through save/load; trap/script references (`SwitchLink` etc.) are untouched.
- **Loot MFD:** frobbing a `ContainerScript` container/corpse opens its `ContainerGui` panel in the flat MFD slot (via PR 2's generic `Frob → Effect::OpenPanel` path — verified and hardened here). Living `CreatureContainer` AIs route to `NoopScript` and never open (salvaged #439 rule, e2e-asserted).
- **Take:** clicking a contained item yields `ContainerGuiMsg::Take` → `Effect::DropEntityInfo` into the player's backpack — the existing `drop_entity_into_container` transfer path — guarded by the same `can_grab_item` check as the debug give lever. The panel reflects the removal live. The player's own backpack panel keeps click = use (`Frob`); VR grab-to-hand is untouched.
- **`GET /v1/ui` semantics:** loot elements carry the item's name as `label` (e.g. `"Psi Amp"`, falling back to art-derived labels for unnamed items) and its runtime `entity_id`, threaded via a new `GuiComponent::Button::entity` field — tests click loot by meaning, never by pixels.
- **Docs:** the medsci1 walkthrough claimed the starting Wrench lies on the cryo bay floor — it is authored inside the MS Male Corpse (1177 → Contains → 990). Reworded to the real frob → loot-panel flow, and the playtest skill now teaches honest looting via `/v1/ui` + pointer channels.

## VR preservation

The shared `Gui`/`GuiScript` layer is unchanged in shape; VR world-quad panels and grab-to-hand (`on_grab → GrabEntity`) behave as before. The containment pass benefits VR too: contained loot can no longer be double-placed at its authored editor position. `GrabEntity` still restores `PropHasRefs(true)` and strips `Contains` on pickup.

## Verification

- **Negative-first e2e** (`tools/shock2-sdk/test/container-loot.e2e.test.ts`): written first and run against unmodified `main`, where it fails at the loot-panel label assertions (`label: null`, no `entity_id`). Full flow on this branch: corpse 219 → labeled "Psi Amp" element → pointer click → `player_inventory()` + live panel update + `Contains` moved → save/load round-trip (taken stays taken, corpse 1177's Wrench stays contained with no world presence, world-placed Cryo Card 1050 keeps its body) → post-load loot panel works → living OG-Pipe never opens a panel.
- Suites green on this branch: `container-loot` e2e, `keypad` e2e, `flat-ui-plumbing` e2e, `climbing` e2e, **`missions.e2e` 23/23**, `cargo test -p shock2vr` (113), SDK `npm test`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt`.
- Unit tests: containment pass (incl. authored-visible override + SwitchLink non-suppression negatives), loot click → `Take` → `DropEntityInfo`, backpack click stays `Frob`, non-grabbable `Take` refusal, `/v1/ui` entity labels.
- Cross-engine review: Claude reviewer found 0 Critical/High; both actionable Low findings fixed and re-validated. **Codex engine unavailable** during review (usage limit) — single-engine per the xreview failure policy.

## Divergences / deferrals

- **Design-doc premise (§4.6) divergence:** the "double-placed loot" bug does not reproduce on `main` — the mission data itself authors `P$HasRefs(false)` on contained items (verified: medsci1 1407/990/1329) and the engine already gates physics/render on it. The containment pass therefore *enforces the invariant structurally* (data-independent, and it covers any future runtime-created `Contains`) rather than fixing a live double-placement. The negative e2e run against `main` documented this: the physics-presence assertions already passed; the label/take assertions did not.
- **Stackables:** taking ammo/hypos does a raw `Contains` move (no stack merge) — consistent with the pre-existing VR drop-into-container path; flagged for a follow-up.
- **Cursor-carry / drag-and-drop loot semantics** (original's lift-to-cursor) are PR 4 scope; click-to-take matches the manual's "left clicking on the contents picks them up".
- **Containers destroyed before looting:** unchanged behavior (contained entities simply remain contained/unreachable); noted per design §7, not over-engineered here.

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

![Flat container-loot demo](https://gist.githubusercontent.com/tommy-xr/56dd3518b478d92ce4e0d90c916e1101/raw/loot-demo.gif)

<sub>Frob the corpse → its loot MFD opens in the left panel slot → the cursor moves to the Psi Amp and clicks → the item leaves the panel and lands in the player inventory. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Loot MFD panel open](https://gist.githubusercontent.com/tommy-xr/56dd3518b478d92ce4e0d90c916e1101/raw/loot-panel.png)
