### PR TITLE
fix(scripts): slow projectiles spawn their authored impact spangs

### DIFF
--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -1,19 +1,27 @@
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation3, SquareMatrix, vec3};
 use dark::properties::{CollisionType, PropCollisionType};
 use shipyard::{EntityId, Get, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{
+    mission::entity_creator::CreateEntityOptions,
+    physics::PhysicsWorld,
+    scripts::script_util::choose_impact_spang,
+    util::{get_position_from_transform, get_rotation_from_forward_vector},
+};
 
 use super::{Effect, Message, MessagePayload, Script};
 
 // Script to handle collision type
 pub struct InternalCollisionType {
     collision_flags: CollisionType,
+    spang_spawned: bool,
 }
 
 impl InternalCollisionType {
     pub fn new() -> InternalCollisionType {
         InternalCollisionType {
             collision_flags: CollisionType::empty(),
+            spang_spawned: false,
         }
     }
 }
@@ -32,8 +40,8 @@ impl Script for InternalCollisionType {
     fn handle_message(
         &mut self,
         entity_id: EntityId,
-        _world: &World,
-        _physics: &PhysicsWorld,
+        world: &World,
+        physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
@@ -61,10 +69,55 @@ impl Script for InternalCollisionType {
                 let damage_effect = Effect::Send {
                     msg: Message {
                         to: *with,
+                        // TODO: Resolve damage from the projectile's authored
+                        // data - shared follow-up with the fast (raycast)
+                        // projectile path's hardcoded 6.0 in
+                        // internal_fast_projectile.rs.
                         payload: MessagePayload::Damage { amount: 1.0 },
                     },
                 };
-                Effect::Multiple(vec![initial_effect, damage_effect])
+                let mut effects = vec![initial_effect, damage_effect];
+
+                // Impact effect, from the projectile's authored spang links
+                // (HitSpang matched by victim class, MissSpang fallback) -
+                // the same selection as the fast (raycast) projectile path.
+                // This is what makes slow projectiles (laser/fusion bolts,
+                // grenades) show their authored impact FX. At most one spang
+                // per projectile: an impact starting contact with several
+                // colliders at once (a corner, a creature capsule + its
+                // hitbox proxy) queues multiple Collided messages before the
+                // slay/destroy effect lands.
+                if !self.spang_spawned
+                    && let Some(template_id) = choose_impact_spang(world, entity_id, *with)
+                {
+                    self.spang_spawned = true;
+                    let position =
+                        get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+                    // The physics collision event carries no contact normal,
+                    // and spang orientation is minor cosmetics, so
+                    // approximate the impact facing with the reversed
+                    // velocity. This is read post-solve, so it may already be
+                    // deflected by the contact; if the solver stopped the
+                    // projectile outright, fall back to straight up.
+                    let facing = physics
+                        .get_velocity(entity_id)
+                        .filter(|v| v.magnitude2() > 1e-6)
+                        .map(|v| -v.normalize())
+                        .unwrap_or(vec3(0.0, 1.0, 0.0));
+                    effects.push(Effect::CreateEntity {
+                        template_id,
+                        position,
+                        orientation: get_rotation_from_forward_vector(facing)
+                            * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
+                        root_transform: Matrix4::identity(),
+                        options: CreateEntityOptions {
+                            transient_fx: true,
+                            ..CreateEntityOptions::default()
+                        },
+                    });
+                }
+
+                Effect::Multiple(effects)
             }
             _ => Effect::NoEffect,
         }

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -1,25 +1,18 @@
 use cgmath::{
     Deg, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3, vec4,
 };
-use dark::{
-    SCALE_FACTOR,
-    properties::{Link, PropTemplateId},
-};
+use dark::SCALE_FACTOR;
 
-use shipyard::{EntityId, Get, UniqueView, View, World};
+use shipyard::{EntityId, Get, View, World};
 
 use crate::{
     creature::RuntimePropHitBox,
-    mission::{entity_creator::CreateEntityOptions, mission_core::GlobalTemplateHierarchy},
+    mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::RuntimePropTransform,
-    scripts::{
-        Message,
-        ai::ai_util::does_entity_have_hitboxes,
-        script_util::{get_all_links_with_template, get_first_link_with_template_and_data},
-    },
+    scripts::{Message, ai::ai_util::does_entity_have_hitboxes, script_util::choose_impact_spang},
     time::Time,
-    util::{get_position_from_transform, get_rotation_from_forward_vector, resolve_proxy_entity},
+    util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
 
 use super::{Effect, MessagePayload, Script};
@@ -88,28 +81,9 @@ impl Script for InternalFastProjectileScript {
                 Effect::DestroyEntity { entity_id },
             ];
 
-            // Impact effect, from the projectile's authored spang links:
-            // - a creature hit spawns the `HitSpang` whose victim archetype
-            //   class the victim descends from (blood for hybrids/midwives,
-            //   sparks for robots/turrets, ...);
-            // - a world hit spawns the `MissSpang` (terrain spang).
-            // Any entity hit tries the HitSpang match first - not just hitbox
-            // hits, so victims without fitted hitboxes (and catch-all victim
-            // classes like the laser's `Physical`) still spang - and falls
-            // back to the terrain spang when the projectile has no spang
-            // authored for that entity's class.
-            let spang_template = choose_hit_spang(world, entity_id, hit_entity_id).or_else(|| {
-                get_first_link_with_template_and_data(world, entity_id, |link| {
-                    if matches!(link, Link::MissSpang) {
-                        Some(())
-                    } else {
-                        None
-                    }
-                })
-                .map(|(spang_template, ())| spang_template)
-            });
-
-            if let Some(template_id) = spang_template {
+            // Impact effect, from the projectile's authored spang links
+            // (HitSpang matched by victim class, MissSpang fallback).
+            if let Some(template_id) = choose_impact_spang(world, entity_id, hit_entity_id) {
                 effects.push(Effect::CreateEntity {
                     template_id,
                     position: hit_point + hit_normal * SCALE_FACTOR / 25.0,
@@ -146,35 +120,6 @@ impl Script for InternalFastProjectileScript {
     ) -> Effect {
         Effect::NoEffect
     }
-}
-
-/// The spang (impact effect) a projectile spawns on `victim`, from the
-/// projectile's `HitSpang` links: each link targets a victim archetype class
-/// (Hybrids, Robots, ...) and carries the spang template to spawn. Links are
-/// scanned most-derived-projectile-template first (entity links merge
-/// ancestors root-first, so without the reversal a base class's link would
-/// shadow an override authored on a derived projectile); the first link whose
-/// class the victim is or descends from wins. `victim` may be a hitbox proxy
-/// (resolved to its parent creature). `None` when the projectile has no spang
-/// authored for this victim's class.
-fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
-    let victim = resolve_proxy_entity(world, victim);
-    let victim_template = world
-        .borrow::<View<PropTemplateId>>()
-        .ok()
-        .and_then(|v| v.get(victim).ok().map(|t| t.template_id))?;
-    let hierarchy = world.borrow::<UniqueView<GlobalTemplateHierarchy>>().ok()?;
-    get_all_links_with_template(world, projectile, |link| {
-        if let Link::HitSpang(spang_template) = link {
-            Some(*spang_template)
-        } else {
-            None
-        }
-    })
-    .into_iter()
-    .rev()
-    .find(|(victim_class, _)| hierarchy.is_or_descends_from(victim_template, *victim_class))
-    .map(|(_, spang_template)| spang_template)
 }
 
 fn projectile_ray_cast(

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -1,4 +1,6 @@
 use crate::mission::entity_creator::initialize_entity_with_props;
+use crate::mission::mission_core::GlobalTemplateHierarchy;
+use crate::util::resolve_proxy_entity;
 use crate::{runtime_props::RuntimePropTransform, util::point3_to_vec3};
 use cgmath::{Transform, point3};
 use dark::{
@@ -10,7 +12,7 @@ use dark::{
     ss2_entity_info::SystemShock2EntityInfo,
 };
 use engine::audio::AudioHandle;
-use shipyard::{Component, EntityId, Get, IntoIter, IntoWithId, View, World};
+use shipyard::{Component, EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
 use std::collections::HashMap;
 
 use super::{Effect, Message, MessagePayload};
@@ -118,6 +120,61 @@ pub fn get_first_link_with_template_and_data<TData: Clone>(
     all_links
         .get(0)
         .map(|(template_id, data)| (*template_id, data.clone()))
+}
+
+/// The impact effect (spang) a projectile spawns when it hits `victim`, from
+/// the projectile's authored spang links:
+/// - a creature hit spawns the `HitSpang` whose victim archetype class the
+///   victim descends from (blood for hybrids/midwives, sparks for
+///   robots/turrets, ...);
+/// - anything else falls back to the `MissSpang` (terrain spang).
+///
+/// Any victim tries the HitSpang match first - not just hitbox hits, so
+/// victims without fitted hitboxes (and catch-all victim classes like the
+/// laser's `Physical`) still spang - and falls back to the terrain spang when
+/// the projectile has no spang authored for that victim's class. `None` when
+/// the projectile has no spang links at all. Shared by the fast (raycast) and
+/// slow (physics `Collided`) projectile impact paths.
+pub fn choose_impact_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
+    choose_hit_spang(world, projectile, victim).or_else(|| {
+        get_first_link_with_template_and_data(world, projectile, |link| {
+            if matches!(link, Link::MissSpang) {
+                Some(())
+            } else {
+                None
+            }
+        })
+        .map(|(spang_template, ())| spang_template)
+    })
+}
+
+/// The spang (impact effect) a projectile spawns on `victim`, from the
+/// projectile's `HitSpang` links: each link targets a victim archetype class
+/// (Hybrids, Robots, ...) and carries the spang template to spawn. Links are
+/// scanned most-derived-projectile-template first (entity links merge
+/// ancestors root-first, so without the reversal a base class's link would
+/// shadow an override authored on a derived projectile); the first link whose
+/// class the victim is or descends from wins. `victim` may be a hitbox proxy
+/// (resolved to its parent creature). `None` when the projectile has no spang
+/// authored for this victim's class.
+fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
+    let victim = resolve_proxy_entity(world, victim);
+    let victim_template = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|v| v.get(victim).ok().map(|t| t.template_id))?;
+    let hierarchy = world.borrow::<UniqueView<GlobalTemplateHierarchy>>().ok()?;
+    get_all_links_with_template(world, projectile, |link| {
+        if let Link::HitSpang(spang_template) = link {
+            Some(*spang_template)
+        } else {
+            None
+        }
+    })
+    .into_iter()
+    .rev()
+    .find(|(victim_class, _)| hierarchy.is_or_descends_from(victim_template, *victim_class))
+    .map(|(_, spang_template)| spang_template)
 }
 
 pub fn for_each_link(

--- a/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for slow-projectile impact spangs (issue #445): projectiles
+// with an initial velocity <= 80 keep a physics body (no raycast script), so
+// their impacts arrive as physics `Collided` messages. That path must spawn
+// the projectile's authored spang (HitSpang by victim class, MissSpang
+// fallback) just like the fast raycast path does - laser bolts, fusion orbs
+// and grenades all carry authored spang links that were previously dead data.
+//
+// Fires the laser pistol (bolt velocity 40 -> physics path) at the
+// `debug_weapons` backstop wall and asserts the bolt's authored `MissSpang`
+// ("Laser Spang") appears at the wall and then expires with its particles.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "slow projectile impacts spawn the authored spang (laser bolt -> Laser Spang)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
+    });
+
+    // Cycle to the laser pistol (4th roster entry).
+    await game.step({ frames: 5 });
+    for (let i = 0; i < 4; i++) {
+      await game.input.trigger("CycleWeapon");
+      await game.step({ frames: 3 });
+    }
+    await game.step({ frames: 5 });
+
+    // Fire at the wall straight ahead (the scene's backstop at x = -12).
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+
+    // The bolt flies ~0.5s to the wall and the spang burst is short-lived, so
+    // poll in small steps to observe it inside its particle lifetime.
+    let spang;
+    for (let i = 0; i < 12 && !spang; i++) {
+      await game.step({ frames: 10 });
+      const spangs = (await game.entities.list({ filter: "Spang", limit: 50 }))
+        .entities;
+      spang = spangs.find((e) => e.name === "Laser Spang");
+    }
+    assert.ok(
+      spang,
+      "a laser bolt wall hit should spawn its authored MissSpang (Laser Spang)",
+    );
+    // ...at the impact point (the wall face is at x = -11.5; the muzzle is
+    // near x = -1), not wherever the bolt spawned.
+    assert.ok(
+      spang.position[0] < -10,
+      `the spang should spawn at the wall (got ${JSON.stringify(spang.position)})`,
+    );
+
+    // Spangs are one-shot bursts: they expire with their particles instead of
+    // accumulating at every bolt hole.
+    await game.step({ frames: 180 }); // 3s >> the particle lifetime
+    const after = (await game.entities.list({ filter: "Spang", limit: 50 }))
+      .entities;
+    assert.ok(
+      !after.some((e) => e.name === "Laser Spang"),
+      `the spang should expire after its burst (still present: ${after
+        .map((e) => e.name)
+        .join(", ")})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #445

## Root cause

Projectiles whose `PropPhysInitialVelocity` magnitude is <= 80 keep a physics body instead of getting the raycast `InternalFastProjectileScript` (`mission_core::finish_instantiating_entity`). Their impacts therefore arrive as `MessagePayload::Collided` in `InternalCollisionType`, which only slew/destroyed the projectile and sent a flat 1.0 damage — it never looked at the projectile's authored spang links. The `MissSpang`/`HitSpang` links on the whole slow-projectile family (Laser Shot -2474 -> "Laser Spang" -4276, Big Laser Shot -2255, Fusion Shot -232, Big Fusion Shot -3424, the grenade family -3443/-1348/-1350/-1347, Ninja Shot -2824) were dead data: bolts vanished with no impact FX.

## What changed

- **`scripts/script_util.rs`**: the fast path's spang selection (a `HitSpang` matched by the victim's archetype class, `MissSpang` fallback) is extracted verbatim into a shared `choose_impact_spang` helper.
- **`scripts/internal_fast_projectile.rs`**: now calls the shared helper (no behavior change).
- **`scripts/internal_collision_type.rs`**: on an impact `Collided` (SLAY/DESTROY_ON_IMPACT), spawns the chosen spang at the projectile's contact position with `transient_fx: true`, mirroring the fast path's `CreateEntity`. The physics collision event carries no contact normal, so the spang faces the projectile's reversed (post-solve) velocity, falling back to straight up — spang orientation is minor cosmetics, so no normal plumbing. A `spang_spawned` guard keeps a multi-contact impact (corner hit, creature capsule + hitbox proxy) to one spang.

Deliberately left out (per the issue triage):

- **Authored damage resolution**: both paths still hardcode damage (1.0 slow / 6.0 fast); a shared follow-up, cross-referenced in comments at both sites.
- **Grenade explosions**: unaffected — those already work via receptrons; this change is only the impact spang.

## Verification

- New e2e test `tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts`: fires the laser pistol at the `debug_weapons` wall, asserts the authored "Laser Spang" appears at the wall and expires with its particles. **Negative-first**: fails on base (`a laser bolt wall hit should spawn its authored MissSpang`), passes with the fix.
- Full SDK e2e suite under the shared lock: **79/79 pass** (run twice — after the initial fix and again after review-driven hardening).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt`; `cargo test -p dark -p shock2vr` (134 tests) pass.
- Cross-engine review (`/xreview`): Claude reviewer findings addressed (multi-contact spang guard, corrected facing comment, e2e port default); Codex reviewer unavailable (usage limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

![before/after laser bolt wall impact](https://gist.githubusercontent.com/tommy-xr/2c8844f692b8b952f17398a4a81acb96/raw/beforeafter.gif)

<sub>Laser pistol fired at the `debug_weapons` wall, identical deterministic request sequence on base (`1a20002`, left) and this branch (right). On the base ref the bolt reaches the wall and simply vanishes; with the fix the authored "Laser Spang" particle burst spawns at the impact point. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![after: full flight + spang](https://gist.githubusercontent.com/tommy-xr/2c8844f692b8b952f17398a4a81acb96/raw/after.gif)

<sub>Full-frame AFTER capture: bolt flight (~26 frames to the wall) followed by the spang burst dispersing and expiring.</sub>

### Before → after

![before/after still with impact-point zoom](https://gist.githubusercontent.com/tommy-xr/2c8844f692b8b952f17398a4a81acb96/raw/beforeafter.png)

<sub>Still at 38 frames after the trigger pull (spang mid-burst), with a zoom on the impact point. Frame-identical runs (`ImageChops.difference` bbox is `None` pre-fire); the only delta is the spang particles. Still PNG: [spang-still.png](https://gist.githubusercontent.com/tommy-xr/2c8844f692b8b952f17398a4a81acb96/raw/spang-still.png).</sub>
