### PR TITLE
fix(fx): bullet-hole decal spawns with the spang and lingers its authored 10s

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1727,9 +1727,20 @@ impl MissionCore {
                         .unwrap_or_default()
                 }));
             }
+            // Exclude the host template AND its ancestors: both lookups walk
+            // the whole ancestor chain, so a link authored on an ancestor
+            // would otherwise be walked back from the other end (spawning a
+            // spurious duplicate of the host's ancestor archetype).
+            let excluded: Vec<i32> = exclude_template
+                .map(|t| {
+                    let mut excluded = ss2_entity_info::get_ancestors(hierarchy, &t);
+                    excluded.push(t);
+                    excluded
+                })
+                .unwrap_or_default();
             riders
                 .into_iter()
-                .filter(|t| Some(*t) != exclude_template)
+                .filter(|t| !excluded.contains(t))
                 .collect()
         };
         for particle_template in riders {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -41,8 +41,9 @@ use dark::{
         PropFrameAnimState, PropHasRefs, PropLimbModel, PropLocalPlayer, PropModelName,
         PropMotionActorTags, PropParticleGroup, PropParticleLaunchInfo, PropPhysDimensions,
         PropPhysInitialVelocity, PropPhysState, PropPhysType, PropPlayerGun, PropPosition,
-        PropRenderType, PropScripts, PropTeleported, PropTripFlags, PropertyDefinition, RenderType,
-        ToLink, TripFlags, WrappedEntityId,
+        PropRenderType, PropScripts, PropTeleported, PropTripFlags, PropTweqDeleteConfig,
+        PropTweqDeleteState, PropertyDefinition, RenderType, ToLink, TripFlags, TweqAnimationState,
+        WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -241,6 +242,7 @@ pub struct MissionCore {
     /// creation instantiates these attached (projectile trails, psi bolt
     /// visuals).
     template_to_particle_riders: HashMap<i32, Vec<(i32, dark::properties::ParticleAttachOptions)>>,
+    template_to_particle_attachees: HashMap<i32, Vec<i32>>,
     interaction: Box<dyn PlayerInteraction>,
     pub visibility_engine: Box<dyn VisibilityEngine>,
     pub teleport_system: TeleportSystem,
@@ -640,6 +642,15 @@ impl MissionCore {
             i32,
             Vec<(i32, dark::properties::ParticleAttachOptions)>,
         > = HashMap::new();
+        // Forward map: particle archetype -> the archetypes its own
+        // ParticleAttachement links point AT. Normally the attach target
+        // exists first and the reverse map above spawns the particle riding
+        // it (trails riding projectiles), but a transient impact FX is the
+        // root of its own creation - nothing else ever creates its attach
+        // target. The shipped data has exactly one such pair (the bullet
+        // spang's ParticleAttachement to the "Bullet Hit" decal), and the
+        // decal only appears if the spang's creation brings it along.
+        let mut template_to_particle_attachees: HashMap<i32, Vec<i32>> = HashMap::new();
         for (src_template, links) in &entity_info_rc.template_to_links {
             if *src_template >= 0 {
                 continue;
@@ -651,6 +662,10 @@ impl MissionCore {
                             .entry(link.to_template_id)
                             .or_default()
                             .push((*src_template, *opts));
+                        template_to_particle_attachees
+                            .entry(*src_template)
+                            .or_default()
+                            .push(link.to_template_id);
                     }
                 }
             }
@@ -671,6 +686,7 @@ impl MissionCore {
             level_name: mission,
             entity_info: entity_info_rc.clone(),
             template_to_particle_riders,
+            template_to_particle_attachees,
             script_world,
             id_to_model,
             id_to_animation_player,
@@ -1617,6 +1633,7 @@ impl MissionCore {
             root_transform,
             additional_options,
             0,
+            None,
         )
     }
 
@@ -1630,6 +1647,12 @@ impl MissionCore {
         root_transform: Matrix4<f32>,
         additional_options: CreateEntityOptions,
         rider_depth: u32,
+        // The template of the entity this creation is attached to, if it was
+        // itself spawned off a ParticleAttachement link. The link that caused
+        // this creation must not be walked again from the other end (a trail
+        // riding a projectile must not re-instantiate the projectile; a decal
+        // brought along by a spang must not host a second spang).
+        exclude_template: Option<i32>,
     ) -> EntityCreationInfo {
         let transient_fx = additional_options.transient_fx;
         let created_entity = {
@@ -1672,21 +1695,44 @@ impl MissionCore {
         if rider_depth >= MAX_RIDER_DEPTH {
             return info;
         }
-        let riders: Vec<(i32, dark::properties::ParticleAttachOptions)> = {
+        let riders: Vec<i32> = {
             let hierarchy = ss2_entity_info::get_hierarchy(&self.entity_info);
             let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, &template_id);
             ancestors.push(template_id);
-            ancestors
-                .into_iter()
+            let mut riders: Vec<i32> = ancestors
+                .iter()
                 .flat_map(|t| {
                     self.template_to_particle_riders
-                        .get(&t)
-                        .cloned()
+                        .get(t)
+                        .map(|riders| {
+                            riders
+                                .iter()
+                                .map(|(rider, _opts)| *rider)
+                                .collect::<Vec<_>>()
+                        })
                         .unwrap_or_default()
                 })
+                .collect();
+            // A transient impact FX is the root of its own creation, so the
+            // archetypes its own ParticleAttachement links point at (the
+            // bullet spang's "Bullet Hit" decal) don't exist yet - bring them
+            // along too. Only for transient FX: a live projectile's outgoing
+            // link is cosmetic authoring for OTHER hosts (the player Fusion
+            // Shot's link to the droid variant) and must not spawn here.
+            if transient_fx {
+                riders.extend(ancestors.iter().flat_map(|t| {
+                    self.template_to_particle_attachees
+                        .get(t)
+                        .cloned()
+                        .unwrap_or_default()
+                }));
+            }
+            riders
+                .into_iter()
+                .filter(|t| Some(*t) != exclude_template)
                 .collect()
         };
-        for (particle_template, _attach_options) in riders {
+        for particle_template in riders {
             // vhot/joint offsets are not applied yet - the particle rides the
             // host origin (attach type "object" covers the shipped projectile
             // trails).
@@ -1702,6 +1748,7 @@ impl MissionCore {
                     ..CreateEntityOptions::default()
                 },
                 rider_depth + 1,
+                Some(template_id),
             );
             // Riders are pure visuals: strip any physics the template brought
             // (some riders are full projectile archetypes - e.g. the droid
@@ -1777,30 +1824,57 @@ impl MissionCore {
     pub fn remove_entity(&mut self, entity_id: EntityId) {
         // Entities riding this one (attached particle trails/FX) die with it -
         // otherwise a projectile's trail would linger at its last transform
-        // forever after the projectile is destroyed. The transitive closure is
-        // collected iteratively with a visited set so mission-authored
-        // attachment cycles can't recurse forever.
+        // forever after the projectile is destroyed. Exception: a rider with
+        // its own running delete tweq manages its own lifetime (e.g. the
+        // "Bullet Hit" decal riding a bullet spang is authored to linger 10s,
+        // long past the spang's ~0.8s burst) - it is detached instead, frozen
+        // at its current transform, and its tweq destroys it at the authored
+        // time. The transitive closure is collected iteratively with a visited
+        // set so mission-authored attachment cycles can't recurse forever.
         let mut to_remove: Vec<EntityId> = vec![entity_id];
+        let mut to_detach: Vec<EntityId> = Vec::new();
         let mut visited: HashSet<EntityId> = HashSet::from([entity_id]);
         let mut frontier = vec![entity_id];
         while let Some(parent) = frontier.pop() {
-            let children: Vec<EntityId> = match self
-                .world
-                .borrow::<View<crate::runtime_props::RuntimePropAttachment>>()
-            {
-                Ok(v_attach) => v_attach
+            let children: Vec<(EntityId, bool)> = match self.world.borrow::<(
+                View<crate::runtime_props::RuntimePropAttachment>,
+                View<PropTweqDeleteConfig>,
+                View<PropTweqDeleteState>,
+            )>() {
+                Ok((v_attach, v_delete_config, v_delete_state)) => v_attach
                     .iter()
                     .with_id()
                     .filter(|(id, a)| a.parent == parent && !visited.contains(id))
-                    .map(|(id, _)| id)
+                    .map(|(id, _)| {
+                        // Only a *running* delete tweq counts - a config whose
+                        // state is off would never fire, and the rider would
+                        // leak forever if spared from the cascade.
+                        let self_expiring = v_delete_config.contains(id)
+                            && (&v_delete_state)
+                                .get(id)
+                                .map(|s| s.animation_state.contains(TweqAnimationState::ON))
+                                .unwrap_or(false);
+                        (id, self_expiring)
+                    })
                     .collect(),
                 Err(_) => Vec::new(),
             };
-            for child in children {
+            for (child, self_expiring) in children {
                 visited.insert(child);
-                to_remove.push(child);
-                frontier.push(child);
+                if self_expiring {
+                    to_detach.push(child);
+                } else {
+                    to_remove.push(child);
+                    frontier.push(child);
+                }
             }
+        }
+        // Cut the attachment on survivors so they stop tracking the (about to
+        // be deleted) host and hold their last transform. Their own riders
+        // stay attached to them and die with them when the tweq fires.
+        for id in to_detach {
+            self.world
+                .remove::<(crate::runtime_props::RuntimePropAttachment,)>(id);
         }
         // Children first, host last (reverse discovery order).
         for id in to_remove.into_iter().rev() {

--- a/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
+++ b/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the bullet-hole decal's lifetime (#447): the
+// "Bullet Hit" sprite rides the "Standard Terr Spang" a wall hit spawns, and
+// carries its own authored 10s delete tweq. It must NOT die with the spang
+// when the spang's ~0.8s particle burst expires - the remove_entity rider
+// cascade detaches self-expiring riders instead of deleting them - and it
+// must still be destroyed by its own tweq at the authored time (no leak).
+//
+// Riders WITHOUT a delete tweq must still die with their host - that side is
+// covered by projectile-trail.e2e.test.ts (the laser bolt's trail).
+//
+// Fires the pistol at a wall from medsci1's spawn (the default facing looks
+// at a wall), following blood-spang.e2e.test.ts.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "bullet-hole decal outlives its spang and expires on its own delete tweq",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
+    });
+
+    const bulletHoles = async () =>
+      (await game.entities.list({ filter: "Bullet", limit: 50 })).entities.filter(
+        (e) => e.name === "Bullet Hit",
+      );
+
+    // Wield the pistol (first CycleWeapon roster entry).
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    // Sanity: no decals before the shot.
+    assert.equal(
+      (await bulletHoles()).length,
+      0,
+      "no Bullet Hit entities should exist before the shot",
+    );
+
+    // Fire at the wall the default facing (yaw 0) looks at.
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 5 });
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    // (a) The wall hit spawned the terrain spang's authored decal rider.
+    const justAfter = await bulletHoles();
+    assert.equal(
+      justAfter.length,
+      1,
+      `a wall hit should spawn one Bullet Hit decal (got ${justAfter.length})`,
+    );
+
+    // (b) 2s later the spang's one-shot burst has expired and the spang is
+    // destroyed - but the decal manages its own lifetime (10s delete tweq)
+    // and must survive the host's rider cascade.
+    await game.step({ frames: 120 });
+    const spangs = (await game.entities.list({ filter: "Spang", limit: 50 }))
+      .entities;
+    assert.equal(
+      spangs.length,
+      0,
+      `the spang should expire with its burst (still present: ${spangs
+        .map((e) => e.name)
+        .join(", ")})`,
+    );
+    const afterSpang = await bulletHoles();
+    assert.equal(
+      afterSpang.length,
+      1,
+      "the Bullet Hit decal should outlive the spang burst (authored 10s lifetime)",
+    );
+
+    // (c) ...and past its authored 10s, its own delete tweq destroys it -
+    // detached decals must not leak. ~2.2s have elapsed since the shot; run
+    // well past the 10s mark.
+    await game.step({ frames: 600 }); // +10s => ~12.2s since the shot
+    const afterTweq = await bulletHoles();
+    assert.equal(
+      afterTweq.length,
+      0,
+      "the Bullet Hit decal should be destroyed by its own delete tweq",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
+++ b/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
@@ -30,7 +30,7 @@ test(
     });
 
     const bulletHoles = async () =>
-      (await game.entities.list({ filter: "Bullet", limit: 50 })).entities.filter(
+      (await game.entities.list({ filter: "Bullet Hit", limit: 50 })).entities.filter(
         (e) => e.name === "Bullet Hit",
       );
 


### PR DESCRIPTION
Fixes #447.

## What

A pistol shot into a wall is authored to leave a lingering bullet-hole decal: `Standard Terr Spang` (-364) carries a `ParticleAttachement` link to `Bullet Hit` (-3544), a `bullhit` sprite with a 10-second `TweqDelete` (state authored ON). Two things kept that from happening:

1. **The decal was never instantiated.** Rider instantiation walks links *into* the created template (particle sources riding a created host — trails riding projectiles, matching observed original-game behavior), but the spang's link points *out* of it: the spang is the particle and the decal is its attach target, and nothing else ever creates that target. A gamesys audit of all 112 `ParticleAttachement` links shows the spang→decal pair is the **only** one whose target needs to be brought along by the particle's own creation.
2. **Even if spawned, it died ~9s early.** `remove_entity`'s rider cascade deleted everything riding the host when the spang's ~0.8s burst expired, so the decal could never use its authored 10s lifetime.

## How

- **Forward attachees for transient FX** (`mission_core.rs`): a new `template_to_particle_attachees` map (src → outgoing `ParticleAttachement` archetype targets). Transient-FX creations also spawn those targets as riders. Restricted to `transient_fx` so a live projectile's cosmetic links (e.g. the player Fusion Shot's link to the droid variant) don't spawn extra visuals.
- **Exclude guard**: the rider recursion passes the host's template down, and a rider skips any attachment (either direction) whose template is the host's template *or one of its ancestors* — the link that caused a creation is never walked back from the other end (a trail must not re-instantiate its projectile; the decal must not host a second spang).
- **Detach instead of cascade-delete** (`remove_entity`): a rider with its own *running* delete tweq (`PropTweqDeleteConfig` + `PropTweqDeleteState` ON — the exact pair `run_tweq` fires on, so no leak is possible) is detached (its `RuntimePropAttachment` removed, freezing it at its last transform) instead of deleted. Its own tweq then destroys it at the authored time. Riders without a running delete tweq still cascade-delete exactly as before.
- Serialization: the decal keeps the rider path's `RuntimePropDoNotSerialize`, so a save during its 10s window simply loads without it (same as the spang itself) — no orphaned-on-load hazard.

## Verification

- New e2e test `tools/shock2-sdk/test/bullet-hole.e2e.test.ts`: fires the pistol at a wall from medsci1 spawn and asserts (a) one `Bullet Hit` entity right after the shot, (b) at +2s the spang is gone but the decal survives, (c) past the 10s tweq the decal is destroyed.
- **Negative-tested both halves** before landing them: without the instantiation, (a) fails (`got 0` — the decal never exists); with instantiation but without the detach, (b) fails (the decal dies with the spang).
- Full SDK e2e suite under the shared lock: **78/79 pass**; the one failure (`motion-query-tags`, `fetch failed`) is a transient connection flake on the shared machine — it passes when re-run in isolation, and the suite log contains no runtime panic. Targeted re-run after review fixes: bullet-hole, blood-spang, projectile-trail, save-load all green.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt` applied.
- Cross-engine review (`/xreview`): Claude reviewer found no Critical/High issues; its Medium finding (exclude guard blind to inheritance) is fixed in the second commit. Codex CLI was unavailable (usage limit) and was skipped per the skill's failure policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Demo

![bullet-hole decal lingers after a wall shot](https://gist.githubusercontent.com/tommy-xr/1d61af1bc58e6ed50bc8356791f7c74c/raw/bullet-hole-decal.gif)

<sub>Pistol shot into a medsci1 wall: the "Standard Terr Spang" spark burst (~0.8s) now brings along the "Bullet Hit" wall decal, which stays on the wall after the sparks end. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). The decal is the small grey ring at the crosshair (the wall here is nearly black, so the zoomed insets below make it easier to see).</sub>

![decal persists at t+2s, expired at t+12s](https://gist.githubusercontent.com/tommy-xr/1d61af1bc58e6ed50bc8356791f7c74c/raw/decal-persist-expire.png)

<sub>Left: ~2s after the shot — the spang burst entity is gone but the decal persists (before this fix the wall would be bare here). Right: ~12s after the shot — the decal's authored 10s `TweqDelete` has fired and the wall is bare again. Entity lifecycle verified over HTTP: `Bullet Hit` present at +2.25s with `Spang` gone, both gone at +12.3s.</sub>
