### PR TITLE
feat(sound): material-tagged collision sounds on weapon impacts

### DIFF
--- a/dark/src/gamesys/env_sound_query.rs
+++ b/dark/src/gamesys/env_sound_query.rs
@@ -44,6 +44,14 @@ impl EnvSoundQuery {
         }
     }
 
+    /// The (tag, value) pairs of this query, e.g. for logging/introspection.
+    pub fn tag_values(&self) -> Vec<(String, String)> {
+        self.items
+            .iter()
+            .map(|item| (item.tag.clone(), item.value.clone()))
+            .collect()
+    }
+
     /// Convert an environmental sound query to a tag query, given the relevant name maps
     pub(crate) fn to_tag_query(&self, tag_map: &NameMap, value_map: &NameMap) -> TagQuery {
         let mut tag_query_items = Vec::new();

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -309,6 +309,7 @@ async fn start_http_server(
             axum::routing::post(trigger_input_action),
         )
         .route("/v1/input/actions", get(list_input_actions))
+        .route("/v1/audio/recent", get(get_recent_audio))
         .route("/v1/screenshot", axum::routing::post(take_screenshot))
         .with_state(command_tx);
 
@@ -350,6 +351,7 @@ async fn start_http_server(
         "  POST /v1/input/action     - Trigger a discrete input action (e.g. PathfindingTestCycle)"
     );
     info!("  GET  /v1/input/actions    - List available input actions");
+    info!("  GET  /v1/audio/recent     - Recently played environmental sounds (sample + tags)");
     info!("  POST /v1/screenshot       - Capture the current framebuffer");
     info!("");
     info!("Test with: curl http://{}/v1/health", addr);
@@ -3139,6 +3141,14 @@ async fn trigger_input_action(
 async fn list_input_actions() -> Json<Value> {
     let actions: Vec<&str> = InputAction::all().iter().map(|a| a.as_str()).collect();
     Json(serde_json::json!({ "actions": actions }))
+}
+
+/// HTTP handler for the recently played environmental sounds (resolved schema
+/// sample + query tags + position). This is the only headless way to observe
+/// audio, e.g. asserting a bullet impact played a material-tagged collision
+/// schema. Reads a process-wide log, so no game-loop round-trip is needed.
+async fn get_recent_audio() -> Json<Value> {
+    Json(serde_json::json!({ "sounds": shock2vr::audio_log::recent() }))
 }
 
 /// Wait for shutdown signal (Ctrl+C)

--- a/shock2vr/src/audio_log.rs
+++ b/shock2vr/src/audio_log.rs
@@ -1,0 +1,45 @@
+//! Ring buffer of recently played environmental sounds, so headless tooling
+//! (the debug runtime's `GET /v1/audio/recent`) can verify that a sound schema
+//! was actually resolved and played - there is no other way to observe audio
+//! without speakers.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+const MAX_ENTRIES: usize = 64;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PlayedEnvSound {
+    /// Monotonically increasing id, so callers can diff "new since last poll".
+    pub sequence: u64,
+    /// Resolved sample name (e.g. "bulmet2"), without extension.
+    pub sample: String,
+    /// The schema query's (tag, value) pairs (e.g. event=collision, material=metal).
+    pub tags: Vec<(String, String)>,
+    pub position: [f32; 3],
+}
+
+static RECENT: Mutex<(u64, VecDeque<PlayedEnvSound>)> = Mutex::new((0, VecDeque::new()));
+
+/// Record a successfully resolved + played environmental sound.
+pub fn record(sample: &str, tags: Vec<(String, String)>, position: [f32; 3]) {
+    let mut guard = RECENT.lock().unwrap();
+    let (next_sequence, entries) = &mut *guard;
+    *next_sequence += 1;
+    entries.push_back(PlayedEnvSound {
+        sequence: *next_sequence,
+        sample: sample.to_owned(),
+        tags,
+        position,
+    });
+    if entries.len() > MAX_ENTRIES {
+        entries.pop_front();
+    }
+}
+
+/// The most recent played sounds, oldest first.
+pub fn recent() -> Vec<PlayedEnvSound> {
+    RECENT.lock().unwrap().1.iter().cloned().collect()
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audio_log;
 pub mod game_scene;
 pub mod hand_pose;
 pub mod input;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4072,6 +4072,13 @@ fn play_environmental_sound(
             "Playing clip: {} handle: {:?} position: {:?}",
             audio_file, &audio_handle, position
         );
+        // Log the resolved play so headless tooling (debug runtime
+        // /v1/audio/recent) can assert a schema actually played.
+        crate::audio_log::record(
+            &audio_file,
+            query.tag_values(),
+            [position.x, position.y, position.z],
+        );
         engine::audio::play_spatial_audio(audio_context, position, audio_handle, None, audio_clip);
     }
 }

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation3, SquareMatrix, vec3};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Matrix4, Quaternion, Rotation3, SquareMatrix, vec3};
 use dark::properties::{CollisionType, PropCollisionType};
 use shipyard::{EntityId, Get, View, World};
 
@@ -9,7 +9,7 @@ use crate::{
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
 
-use super::{Effect, Message, MessagePayload, Script};
+use super::{Effect, Message, MessagePayload, Script, script_util::play_impact_sound};
 
 // Script to handle collision type
 pub struct InternalCollisionType {
@@ -78,6 +78,8 @@ impl Script for InternalCollisionType {
                 };
                 let mut effects = vec![initial_effect, damage_effect];
 
+                let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+
                 // Impact effect, from the projectile's authored spang links
                 // (HitSpang matched by victim class, MissSpang fallback) -
                 // the same selection as the fast (raycast) projectile path.
@@ -91,8 +93,6 @@ impl Script for InternalCollisionType {
                     && let Some(template_id) = choose_impact_spang(world, entity_id, *with)
                 {
                     self.spang_spawned = true;
-                    let position =
-                        get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
                     // The physics collision event carries no contact normal,
                     // and spang orientation is minor cosmetics, so
                     // approximate the impact facing with the reversed
@@ -115,6 +115,22 @@ impl Script for InternalCollisionType {
                             ..CreateEntityOptions::default()
                         },
                     });
+                }
+
+                // Impact sound (material-tagged collision schema), unless the
+                // collision type opts out. FULL_COLLISION_SOUND needs no
+                // special handling: impact sounds always play at full volume
+                // here (no velocity scaling).
+                if !self
+                    .collision_flags
+                    .contains(CollisionType::NO_COLLISION_SOUND)
+                {
+                    effects.push(play_impact_sound(
+                        world,
+                        entity_id,
+                        *with,
+                        position.to_vec(),
+                    ));
                 }
 
                 Effect::Multiple(effects)

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -1,5 +1,6 @@
 use cgmath::{
-    Deg, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3, vec3, vec4,
+    Deg, EuclideanSpace, InnerSpace, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, Vector3,
+    vec3, vec4,
 };
 use dark::SCALE_FACTOR;
 
@@ -10,7 +11,11 @@ use crate::{
     mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
     runtime_props::RuntimePropTransform,
-    scripts::{Message, ai::ai_util::does_entity_have_hitboxes, script_util::choose_impact_spang},
+    scripts::{
+        Message,
+        ai::ai_util::does_entity_have_hitboxes,
+        script_util::{choose_impact_spang, play_impact_sound},
+    },
     time::Time,
     util::{get_position_from_transform, get_rotation_from_forward_vector},
 };
@@ -79,6 +84,9 @@ impl Script for InternalFastProjectileScript {
                     lines: vec![(start_point, hit_point, color)],
                 },
                 Effect::DestroyEntity { entity_id },
+                // Impact sound: the projectile's collision schema, tagged with
+                // the material of what was hit (flesh thud vs metal clang).
+                play_impact_sound(world, entity_id, hit_entity_id, hit_point.to_vec()),
             ];
 
             // Impact effect, from the projectile's authored spang links

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -1,8 +1,10 @@
-use shipyard::{EntityId, World};
+use cgmath::{EuclideanSpace, vec3};
+use dark::properties::{CollisionType, PropCollisionType};
+use shipyard::{EntityId, Get, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{physics::PhysicsWorld, util::get_position_from_transform};
 
-use super::{Effect, Message, MessagePayload, Script};
+use super::{Effect, Message, MessagePayload, Script, script_util::play_impact_sound};
 
 // Script to handle collision type
 pub struct MeleeWeapon {}
@@ -16,18 +18,36 @@ impl MeleeWeapon {
 impl Script for MeleeWeapon {
     fn handle_message(
         &mut self,
-        _entity_id: EntityId,
-        _world: &World,
+        entity_id: EntityId,
+        world: &World,
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => Effect::Send {
-                msg: Message {
-                    to: *with,
-                    payload: MessagePayload::Damage { amount: 1.0 },
-                },
-            },
+            MessagePayload::Collided { with } => {
+                let damage_effect = Effect::Send {
+                    msg: Message {
+                        to: *with,
+                        payload: MessagePayload::Damage { amount: 1.0 },
+                    },
+                };
+                // Impact sound: the weapon's collision schema (weapontype
+                // class tag + hit material - wrench on metal clangs, on a
+                // creature thuds), unless its collision type opts out.
+                let no_sound = world
+                    .borrow::<View<PropCollisionType>>()
+                    .ok()
+                    .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
+                    .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
+                let sound_effect = if no_sound {
+                    Effect::NoEffect
+                } else {
+                    let position =
+                        get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+                    play_impact_sound(world, entity_id, *with, position.to_vec())
+                };
+                Effect::Multiple(vec![damage_effect, sound_effect])
+            }
             _ => Effect::NoEffect,
         }
     }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -1,13 +1,15 @@
 use crate::mission::entity_creator::initialize_entity_with_props;
 use crate::mission::mission_core::GlobalTemplateHierarchy;
-use crate::util::resolve_proxy_entity;
-use crate::{runtime_props::RuntimePropTransform, util::point3_to_vec3};
-use cgmath::{Transform, point3};
+use crate::{
+    runtime_props::RuntimePropTransform,
+    util::{point3_to_vec3, resolve_proxy_entity},
+};
+use cgmath::{Transform, Vector3, point3};
 use dark::{
     EnvSoundQuery,
     properties::{
-        Link, Links, ProjectileOptions, PropClassTag, PropGunState, PropSymName, PropTemplateId,
-        PropTweqModelConfig, ToLink,
+        Link, Links, ProjectileOptions, PropClassTag, PropGunState, PropMaterial, PropSymName,
+        PropTemplateId, PropTweqModelConfig, ToLink,
     },
     ss2_entity_info::SystemShock2EntityInfo,
 };
@@ -347,6 +349,64 @@ pub fn play_environmental_sound(
             audio_handle,
             query,
             position: point3_to_vec3(position),
+        }
+    } else {
+        Effect::NoEffect
+    }
+}
+
+/// Material tag used for impact-schema lookups when the hit surface has no
+/// resolvable material. World geometry has no per-texture material lookup in
+/// the port yet, so terrain hits (and entities without material tags) all
+/// sound like the ship's metal bulkheads.
+const DEFAULT_IMPACT_MATERIAL: &str = "metal";
+
+/// The collision-schema material tag ("fleshtarget", "metal", ...) for
+/// whatever was hit: the victim's inherited `PropMaterial` (a tag string like
+/// "Material FleshTarget", authored via archetypes such as `MatFlesh`),
+/// falling back to the default for world hits / untagged entities. Hitbox
+/// proxies resolve to their parent creature.
+fn get_impact_material(world: &World, hit_entity_id: EntityId) -> String {
+    let victim = resolve_proxy_entity(world, hit_entity_id);
+    world
+        .borrow::<View<PropMaterial>>()
+        .ok()
+        .and_then(|v_material| {
+            let raw = &v_material.get(victim).ok()?.0;
+            // "Material FleshTarget" -> "fleshtarget"
+            let mut tokens = raw.split_whitespace();
+            while let Some(token) = tokens.next() {
+                if token.eq_ignore_ascii_case("material") {
+                    return tokens.next().map(|value| value.to_ascii_lowercase());
+                }
+            }
+            None
+        })
+        .unwrap_or_else(|| DEFAULT_IMPACT_MATERIAL.to_owned())
+}
+
+/// Impact/collision sound for `entity_id` (a projectile or melee weapon)
+/// hitting `hit_entity_id`, played at the impact point. The schema query is
+/// the entity's class tags (ammotype for bullets, weapontype for melee) plus
+/// event=collision and the hit surface's material - e.g. a pistol bullet on a
+/// wall resolves (event=collision, ammotype=std, material=metal) -> `bulmet*`,
+/// on a hybrid (event=collision, ammotype=std, material=fleshtarget) ->
+/// `bulftar*`.
+pub fn play_impact_sound(
+    world: &World,
+    entity_id: EntityId,
+    hit_entity_id: EntityId,
+    position: Vector3<f32>,
+) -> Effect {
+    let material = get_impact_material(world, hit_entity_id);
+    let maybe_query =
+        get_environmental_sound_query(world, entity_id, "collision", vec![("material", &material)]);
+
+    if let Some(query) = maybe_query {
+        Effect::PlayEnvironmentalSound {
+            audio_handle: AudioHandle::new(),
+            query,
+            position,
         }
     } else {
         Effect::NoEffect

--- a/tools/dark_query/examples/dump_tags.rs
+++ b/tools/dark_query/examples/dump_tags.rs
@@ -1,0 +1,25 @@
+// Dump the environmental-sound schema's tag and value name maps - the
+// vocabulary usable in `cargo dq sound +tag:value` queries (e.g. tag
+// "material" with values "flesh"/"metal"/"plasticrete"). Run with:
+//   cargo run -p dark_query --example dump_tags
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() {
+    let (properties, links, links_with_data) = dark::properties::get();
+    let data_root = shock2vr::paths::data_root();
+    let gam_path = data_root.join("shock2.gam");
+    let game_file = File::open(&gam_path).unwrap();
+    let mut game_reader = BufReader::new(game_file);
+    let gamesys = dark::gamesys::read(&mut game_reader, &links, &links_with_data, &properties);
+
+    let db = gamesys.speech_db();
+    println!("== TAGS ({}):", db.tag_map.count());
+    for (i, name) in db.tag_map.entries() {
+        println!("  {i}: {name}");
+    }
+    println!("== VALUES ({}):", db.value_map.count());
+    for (i, name) in db.value_map.entries() {
+        println!("  {i}: {name}");
+    }
+}

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -62,6 +62,10 @@ await game.waitFor(
 // Screenshots and physics
 await game.screenshot("test.png");
 await game.raycast({ start: [0, 0, 0], end: [10, 0, 0] });
+
+// Recently played environmental sounds (resolved schema sample + query tags) -
+// the headless way to assert audio, e.g. weapon impact sounds.
+const { sounds } = await game.audio.recent();
 ```
 
 To attach to a runtime you started yourself (`cargo dbgr -- --mission ... --port 8080`):

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -22,6 +22,7 @@ import type {
   SaveLoadResult,
   QuestBitsResult,
   QuestBitValue,
+  RecentAudioResult,
   UiState,
   PlayerInventoryResult,
   TransitionsResult,
@@ -243,6 +244,21 @@ export class UiApi {
   }
 }
 
+/** Played-sound introspection (there is no other headless way to observe audio). */
+export class AudioApi {
+  constructor(private readonly client: HttpClient) {}
+
+  /**
+   * The most recently played environmental sounds (oldest first): resolved
+   * schema sample, query tags, and world position. Snapshot the last
+   * `sequence` before an action, then filter for higher sequences to find
+   * the sounds that action played.
+   */
+  async recent(): Promise<RecentAudioResult> {
+    return this.client.get<RecentAudioResult>("/v1/audio/recent");
+  }
+}
+
 /** Pathfinding service telemetry (distinct from the interactive test). */
 export class PathfindingApi {
   constructor(private readonly client: HttpClient) {}
@@ -274,6 +290,7 @@ export class Game {
   readonly physics: PhysicsApi;
   readonly quests: QuestsApi;
   readonly ui: UiApi;
+  readonly audio: AudioApi;
 
   constructor(protected readonly client: HttpClient) {
     this.player = new PlayerApi(client);
@@ -284,6 +301,7 @@ export class Game {
     this.physics = new PhysicsApi(client);
     this.quests = new QuestsApi(client);
     this.ui = new UiApi(client);
+    this.audio = new AudioApi(client);
   }
 
   get baseUrl(): string {

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { HttpClient, HttpError } from "./client.js";
 export {
+  AudioApi,
   CommandError,
   EntitiesApi,
   Game,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -320,6 +320,21 @@ export interface TransitionsResult {
   count: number;
 }
 
+/** One resolved-and-played environmental sound (GET /v1/audio/recent). */
+export interface PlayedSound {
+  /** Monotonically increasing id - diff against a snapshot to find new plays. */
+  sequence: number;
+  /** Resolved schema sample name without extension (e.g. "bulmet2"). */
+  sample: string;
+  /** The schema query's (tag, value) pairs (e.g. ["event", "collision"]). */
+  tags: [string, string][];
+  position: [number, number, number];
+}
+
+export interface RecentAudioResult {
+  sounds: PlayedSound[];
+}
+
 export interface WaitForOptions {
   /** Total time to wait in milliseconds (default 10_000). */
   timeoutMs?: number;

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PlayedSound } from "../src/types.js";
+
+// End-to-end test for weapon impact sounds: a bullet hit plays the
+// material-tagged collision schema (event=collision + the projectile's
+// ammotype class tag + the hit surface's material), observed via the debug
+// runtime's played-sound log (GET /v1/audio/recent) - the only headless way
+// to see audio.
+//
+// - Creature hit: the victim's inherited PropMaterial ("Material FleshTarget"
+//   via the Hybrids archetype) -> (event=collision, ammotype=std,
+//   material=fleshtarget) -> a bulftar* flesh thud.
+// - Terrain hit: a metal-family clang (bulmet*), distinct from the flesh
+//   thud. The surface ahead of spawn is an entity carrying PropMaterial
+//   "Material MetalBig"; bare world geometry (no per-texture material lookup
+//   in the port yet) falls back to the default material, also metal.
+//
+// Aiming/ordering mirrors blood-spang.e2e.test.ts: target medsci1's corridor
+// OG-Pipe hybrid (near [-21.4, -4.7, 14.9], found by name + anchor since
+// entity ids shuffle per launch) and shoot it FIRST, while it is still calm
+// and stationary - gunfire noise alerts it and a moving target breaks a
+// position-snapshot aim. The wall shot is safe to take second from spawn.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
+
+function tagValue(sound: PlayedSound, tag: string): string | undefined {
+  return sound.tags.find(([t]) => t === tag)?.[1];
+}
+
+function collisionSoundsSince(sounds: PlayedSound[], sequence: number): PlayedSound[] {
+  return sounds.filter(
+    (s) => s.sequence > sequence && tagValue(s, "event") === "collision",
+  );
+}
+
+function describe(sounds: PlayedSound[]): string {
+  return JSON.stringify(
+    sounds.map((s) => ({ sample: s.sample, tags: s.tags })),
+  );
+}
+
+test(
+  "bullet impacts play material-tagged collision schemas (flesh vs terrain)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
+    });
+
+    // Wield the pistol (first CycleWeapon roster entry).
+    await game.step({ frames: 5 });
+    await game.input.trigger("CycleWeapon");
+    await game.step({ frames: 5 });
+
+    const spawn = (await game.info()).player.position;
+
+    // Shot 1 - creature, while it is still calm and stationary (no gunfire
+    // noise has been raised yet). Find the corridor OG-Pipe by name +
+    // position anchor (entity ids are not stable across launches).
+    const anchor = { x: -21.4, y: -4.7, z: 14.9 };
+    const ogs = (await game.entities.list({ filter: "OG", limit: 10 })).entities.filter(
+      (e) => e.name === "OG-Pipe",
+    );
+    const og = ogs.find(
+      (e) =>
+        Math.hypot(
+          e.position[0] - anchor.x,
+          e.position[1] - anchor.y,
+          e.position[2] - anchor.z,
+        ) < 3.0,
+    );
+    assert.ok(og, `expected the corridor OG-Pipe near the anchor (got: ${JSON.stringify(ogs.map((e) => e.position))})`);
+
+    // Stand ~4.5 units south (+z) of it, then aim at its chest from the live
+    // positions. Empirical debug-runtime look mapping: yaw 0 faces -x, yaw 90
+    // faces -z (yaw = atan2(-dz, -dx)); positive pitch aims down.
+    await game.player.teleport({
+      x: og.position[0],
+      y: og.position[1] + 0.8,
+      z: og.position[2] + 4.5,
+    });
+    await game.step({ frames: 15 }); // settle on the floor
+
+    const player = (await game.info()).player;
+    const target = (await game.entities.detail(og.id)).position;
+    const eye = [
+      player.position[0],
+      player.position[1] + PLAYER_EYE_HEIGHT_WORLD,
+      player.position[2],
+    ];
+    const d = [
+      target[0] - eye[0],
+      target[1] + 0.7 - eye[1], // chest height above the entity origin
+      target[2] - eye[2],
+    ];
+    const yawDeg = (Math.atan2(-d[2], -d[0]) * 180) / Math.PI;
+    const pitchDeg =
+      (Math.atan2(-d[1], Math.hypot(d[0], d[2])) * 180) / Math.PI;
+
+    const beforeCreature =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+
+    await game.input.set("head.look", [yawDeg, pitchDeg]);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    const afterCreature = collisionSoundsSince(
+      (await game.audio.recent()).sounds,
+      beforeCreature,
+    );
+    assert.ok(
+      afterCreature.length > 0,
+      "a creature hit should play a collision-schema impact sound",
+    );
+    // ...tagged with the victim's material (flesh thud, not a generic clang).
+    assert.ok(
+      afterCreature.some((s) => tagValue(s, "material") === "fleshtarget"),
+      `the creature impact should resolve material=fleshtarget (got: ${describe(afterCreature)})`,
+    );
+    // ...at the victim, not at the shooter.
+    assert.ok(
+      afterCreature.some(
+        (s) =>
+          Math.hypot(
+            s.position[0] - target[0],
+            s.position[1] - (target[1] + 0.7),
+            s.position[2] - target[2],
+          ) < 2.0,
+      ),
+      `the impact sound should play near the victim (victim at ${JSON.stringify(target)}, sounds at ${JSON.stringify(afterCreature.map((s) => s.position))})`,
+    );
+
+    // Shot 2 - terrain, from back at spawn (the shot hybrid is alerted and
+    // closing in, but a wall can't walk out of the aim): the default facing
+    // (yaw 0) looks at a wall.
+    await game.player.teleport({ x: spawn[0], y: spawn[1], z: spawn[2] });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 5 });
+
+    const beforeTerrain =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+
+    await game.input.set("right_hand.trigger", 1.0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0.0);
+    await game.step({ frames: 1 });
+
+    const afterTerrain = collisionSoundsSince(
+      (await game.audio.recent()).sounds,
+      beforeTerrain,
+    );
+    assert.ok(
+      afterTerrain.length > 0,
+      "a wall hit should play a collision-schema impact sound",
+    );
+    // A metal-family material (metalbig from the surface entity's
+    // PropMaterial, or the default metal for bare world geometry) - a clang,
+    // distinct from the creature shot's flesh thud.
+    assert.ok(
+      afterTerrain.some((s) => tagValue(s, "material")?.startsWith("metal")),
+      `the terrain impact should resolve a metal-family material (got: ${describe(afterTerrain)})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #446

## Root cause

Weapon *fire* resolves a sound through the environmental sound-schema path (`play_environmental_sound` with ammotype/weaponmode tags), but **impacts played nothing on any path**: fast raycast projectiles spawned only the visual spang, slow physical projectiles just slew/destroyed themselves, and melee gave no feedback beyond damage. The schema database already contains the impact sounds — they're tagged `(event=collision, ammotype/weapontype=<class tag>, material=<surface>)`, e.g. a standard bullet on flesh resolves `bulftar*` (thud) and on metal `bulmet*` (clang) — the game just never queried them. `PropCollisionType`'s sound flags were parsed but never read.

## What changed

- **`script_util::play_impact_sound`** — shared helper: builds the collision-schema query from the impacting entity's class tags (`ammotype` for projectiles, `weapontype` for melee) plus `event=collision` and the hit surface's material, played at the impact point.
  - Entity hits resolve the victim's inherited `PropMaterial` (authored via archetypes like `MatFlesh` / the Hybrids' `Material FleshTarget`); hitbox proxies resolve to their parent creature.
  - World hits (and untagged entities) fall back to a **default material: metal** — the port has no per-texture terrain-material lookup yet (deliberately not built here; on a metal ship it's the right default).
- **Fast raycast projectiles** (`internal_fast_projectile.rs`): play the impact sound at the raycast hit point.
- **Slow physical projectiles** (`internal_collision_type.rs`): play it on the `Collided` impact path, honoring `NO_COLLISION_SOUND`. `FULL_COLLISION_SOUND` needs no special handling — impact sounds here always play at full volume (no velocity scaling), and non-impact (bounce) collision sounds stay out of scope.
- **Melee** (`melee_weapon.rs`): dropped out naturally from the same helper — melee collision schemas key off the weapon's `weapontype` class tag (wrench on metal: `hmetmet*`, on a creature: `hwrefle*`), also honoring `NO_COLLISION_SOUND`.

### Headless verifiability (new introspection surface)

Audio playback was previously unobservable without speakers. Successful environmental-sound plays (resolved sample + query tags + position) now land in a small ring buffer (`shock2vr::audio_log`, 64 entries) exposed as:

- `GET /v1/audio/recent` on the debug runtime
- `game.audio.recent()` in the TypeScript SDK

## Deliberately left out

- **Per-texture terrain materials**: world hits use a single default material (metal). A real texture→material database is a separate feature.
- **Velocity-scaled bounce sounds** for plain physical (BOUNCE) objects — this PR only covers weapon impacts; generic prop-collision audio is untouched.

## Verification

- **Negative-first e2e** (`tools/shock2-sdk/test/impact-sounds.e2e.test.ts`): fires the pistol at the medsci1 corridor hybrid (calm, shot first per #442/#448 ordering) and at a wall, asserting via `/v1/audio/recent` that a collision-schema sound played with `material=fleshtarget` for the creature and a metal-family material for the wall, at the impact position. Verified to **fail** without the gameplay change ("a creature hit should play a collision-schema impact sound") and pass with it.
- `impact-sounds` + `blood-spang` + `weapon-ammo` e2e: 3/3 PASS
- **Full e2e suite** (`SHOCK2_E2E=1 npm run test:e2e`): **79/79 PASS**
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query --examples`: clean; `cargo fmt` applied.
- Cross-engine review (`/xreview`; Codex was over its usage limit, so Claude reviewer only): no Critical/High findings. Accepted Lows, deliberately not "fixed": the two flag-gate call sites stay un-deduplicated (they read flags from different sources, and #450 is concurrently editing one of the files); a SLAY_ON_IMPACT projectile could in theory also play a `death` schema on the same hit, but no impact projectile has one in the data; the audio log persists across in-process level reloads (safe for the sequence-diff pattern the SDK documents).

Also adds a `dump_tags` example to `dark_query` that lists the env-sound schema tag/value vocabulary (the values usable in `cargo dq sound +tag:value`), which is how the collision-schema tag shape was discovered.

## Merge note (sibling PRs)

#450 (issue #445) also touches `internal_collision_type.rs` and `script_util.rs` in a parallel worktree. This PR's edits there are deliberately tight and additive (one new `sound_effect` arm inside the existing `Collided` impact branch; one appended helper in `script_util.rs`), so whichever lands second should need at most a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
