### PR TITLE
feat(ui): Tab metagame mode with inventory strip

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -43,6 +43,14 @@ the `play-through` manager triages and delegates fixes.
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 
+**Tab opens the inventory UI in flat mode.** `POST /v1/input/action
+{action:"ToggleUseMode"}` enters the original's metagame "use" mode: `/v1/ui`
+flips to `mode:"use"` and its `strip` lists the carried items as labeled,
+clickable elements (top-docked INVBACK grid). Drive it headlessly like any
+panel: `pointer.position` at an element's `screen_rect` center, `pointer.pressed`
+1→0 (click a carried weapon to wield it). Movement keys still work in use mode;
+trigger the action again to return to shooter mode.
+
 **Container loot lives in containers, not in the world.** Items with an
 incoming `Contains` link (corpse/crate loot) have no world presence — they
 never lie on the floor at their editor coordinates, and `/v1/player/give`

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -459,12 +459,16 @@ pub struct QuestBitsResult {
 }
 
 /// Flat-mode UI state snapshot (`GET /v1/ui`): "shooter" or "use", plus the
-/// open MFD panel (entity binding + labeled clickable elements with canvas
-/// and normalized-screen rects). See projects/flat-ui.md.
+/// open MFD panel and the use-mode inventory strip (entity binding + labeled
+/// clickable elements with canvas and normalized-screen rects). See
+/// projects/flat-ui.md.
 #[derive(Debug, Serialize)]
 pub struct UiStateResult {
     pub mode: String,
     pub active_panel: Option<shock2vr::game_scene::DebugUiPanel>,
+    /// The top-docked inventory strip (Tab metagame mode); `Some` exactly in
+    /// "use" mode.
+    pub strip: Option<shock2vr::game_scene::DebugUiPanel>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -337,7 +337,9 @@ async fn start_http_server(
     info!(
         "  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}"
     );
-    info!("  GET  /v1/ui               - Flat-mode UI state (mode: shooter/use)");
+    info!(
+        "  GET  /v1/ui               - Flat-mode UI state (mode: shooter/use, MFD panel, inventory strip)"
+    );
     info!("  GET  /v1/quests           - Snapshot quest bits (objective flags)");
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
@@ -1016,11 +1018,13 @@ fn process_command(
                     commands::UiStateResult {
                         mode: ui.mode,
                         active_panel: ui.active_panel,
+                        strip: ui.strip,
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
                     mode: "shooter".to_string(),
                     active_panel: None,
+                    strip: None,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -343,6 +343,9 @@ pub struct DebugInventoryItem {
 pub struct DebugUiState {
     pub mode: String,
     pub active_panel: Option<DebugUiPanel>,
+    /// The top-docked inventory strip (Tab metagame mode): the player's
+    /// carried items as labeled elements. `Some` exactly in "use" mode.
+    pub strip: Option<DebugUiPanel>,
 }
 
 /// The open flat-mode MFD panel: which entity it is bound to and its element
@@ -543,13 +546,15 @@ pub trait DebuggableScene {
         Vec::new()
     }
 
-    /// The flat-mode UI state (`GET /v1/ui`): current mode ("shooter"/"use")
-    /// and the open MFD panel, if any. Default: shooter, no panel (scenes
-    /// without a flat metagame UI).
+    /// The flat-mode UI state (`GET /v1/ui`): current mode ("shooter"/"use"),
+    /// the open MFD panel, and the use-mode inventory strip, if any.
+    /// Default: shooter, no panel, no strip (scenes without a flat metagame
+    /// UI).
     fn ui_state(&self) -> DebugUiState {
         DebugUiState {
             mode: "shooter".to_string(),
             active_panel: None,
+            strip: None,
         }
     }
 

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -95,8 +95,11 @@ const OVERLOAD_METER: Rect = Rect::new(
 
 /// Build the flat HUD as a resolution-independent canvas for the given player
 /// stat fractions and (optional) wielded-weapon ammo. Pure (no asset/GL
-/// access), so it is unit-testable.
+/// access), so it is unit-testable. `crosshair` is false in use mode - the
+/// original turns the crosshair overlay off while the cursor is up
+/// (`ShockOverlayMouseMode`, projects/flat-ui.md §2.1).
 pub(crate) fn build_flat_hud_canvas(
+    crosshair: bool,
     health_fraction: f32,
     psi_fraction: f32,
     psi_charge: Option<RuntimePropPsiCharge>,
@@ -107,8 +110,10 @@ pub(crate) fn build_flat_hud_canvas(
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
 
+    if crosshair {
+        canvas.image(CROSSHAIR, "CROSSHAI.PCX");
+    }
     canvas
-        .image(CROSSHAIR, "CROSSHAI.PCX")
         // Bio-monitor backdrop first; the bars + numbers render on top of it.
         .image(METERS_BACKDROP, "BIO.PCX")
         .bar(HEALTH_BAR, "HPBAR.PCX", health_fraction)
@@ -214,8 +219,10 @@ pub(crate) fn create_flat_hud(
     asset_cache: &mut AssetCache,
     world: &World,
     screen_size: cgmath::Vector2<f32>,
+    crosshair: bool,
 ) -> Vec<SceneObject> {
     let canvas = build_flat_hud_canvas(
+        crosshair,
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_psi_charge(world),
@@ -235,14 +242,14 @@ mod tests {
     #[test]
     fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
         // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
-        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, None, None, None);
+        let canvas = build_flat_hud_canvas(true, 1.0, 0.75, None, None, None, None, None);
         assert_eq!(canvas.element_count(), 6);
     }
 
     #[test]
     fn wielding_a_weapon_adds_the_ammo_gauge() {
         // ...plus the ammo backdrop + count when a clip is present.
-        let canvas = build_flat_hud_canvas(1.0, 0.75, None, None, Some(12), None, None);
+        let canvas = build_flat_hud_canvas(true, 1.0, 0.75, None, None, Some(12), None, None);
         assert_eq!(canvas.element_count(), 8);
     }
 
@@ -250,6 +257,7 @@ mod tests {
     fn ammo_type_adds_icon_and_label() {
         // ...plus the ammo-type icon + label when a type is selected.
         let canvas = build_flat_hud_canvas(
+            true,
             1.0,
             0.75,
             None,
@@ -266,6 +274,7 @@ mod tests {
         // Base 6 + gauge backdrop + tier badge + tier count + name = 10;
         // the clip readout is suppressed even though the amp has ammo=0.
         let canvas = build_flat_hud_canvas(
+            true,
             1.0,
             0.75,
             None,
@@ -289,8 +298,17 @@ mod tests {
     }
 
     #[test]
+    fn use_mode_hides_the_crosshair() {
+        // The original turns the crosshair overlay off while the cursor is
+        // up (ShockOverlayMouseMode) - one fewer element than shooter mode.
+        let shooter = build_flat_hud_canvas(true, 1.0, 0.75, None, None, None, None, None);
+        let use_mode = build_flat_hud_canvas(false, 1.0, 0.75, None, None, None, None, None);
+        assert_eq!(use_mode.element_count(), shooter.element_count() - 1);
+    }
+
+    #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(2.0, -1.0, None, None, None, None, None);
+        let _ = build_flat_hud_canvas(true, 2.0, -1.0, None, None, None, None, None);
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -42,6 +42,11 @@ const CANVAS_SIZE: Vector2<f32> = Vector2::new(640.0, 480.0);
 /// The right slot `(450, 124)` is reserved for later character panels.
 const LEFT_MFD_ANCHOR: Vector2<f32> = Vector2::new(2.0, 124.0);
 
+/// The top-docked inventory strip anchor (`shkinv.cpp`: `INV_X = 2`,
+/// `INV_Y = 0`, `inv_rect = 636x121` - horizontally centered on the 640
+/// canvas, flush with the top edge).
+const STRIP_ANCHOR: Vector2<f32> = Vector2::new(2.0, 0.0);
+
 /// Walk-away auto-close distance (world units; dark units / SCALE_FACTOR).
 /// ~10 feet - past normal frob range, so a panel opened up close survives
 /// small repositioning but closes when the player leaves the object.
@@ -67,6 +72,10 @@ pub struct FlatUiHost {
     /// Latest `SetUI` components for the active panel (normalized panel
     /// coordinates, as `GuiScript` emits them).
     components: Vec<GuiComponentRenderInfo>,
+    /// Tab metagame ("use") mode: the top-docked inventory strip, bound to
+    /// the player's `internal_inventory` entity. `Some` exactly while flat
+    /// use mode is on (projects/flat-ui.md §5.2, PR 4).
+    strip: Option<StripSlot>,
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -76,12 +85,23 @@ pub struct FlatUiHost {
     screen_size: Vector2<f32>,
 }
 
+/// The inventory strip's slot state - the same stash-latest-`SetUI` shape as
+/// the MFD panel slot, docked at [`STRIP_ANCHOR`] instead of the left MFD.
+struct StripSlot {
+    entity: EntityId,
+    /// Strip size in panel-local pixels (from `SetUI.world_size`); `None`
+    /// until the first `SetUI` after entering use mode.
+    size_px: Option<Vector2<f32>>,
+    components: Vec<GuiComponentRenderInfo>,
+}
+
 impl FlatUiHost {
     pub fn new() -> FlatUiHost {
         FlatUiHost {
             active_panel: None,
             panel_size_px: None,
             components: Vec::new(),
+            strip: None,
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -91,6 +111,24 @@ impl FlatUiHost {
 
     pub fn active_panel(&self) -> Option<EntityId> {
         self.active_panel
+    }
+
+    /// The entity whose inventory the top-docked strip shows, while use mode
+    /// is on.
+    pub fn strip_entity(&self) -> Option<EntityId> {
+        self.strip.as_ref().map(|s| s.entity)
+    }
+
+    /// Enter/leave Tab metagame mode: bind (or drop) the top-docked
+    /// inventory strip. `Some(entity)` is the player's `internal_inventory`
+    /// entity, whose `GuiScript` already emits `SetUI` every frame - the
+    /// strip just stashes and re-anchors it.
+    pub fn set_strip(&mut self, entity: Option<EntityId>) {
+        self.strip = entity.map(|entity| StripSlot {
+            entity,
+            size_px: None,
+            components: Vec::new(),
+        });
     }
 
     /// Bind the MFD to `entity` (the original's `gOverlayObj`). Opening a
@@ -116,18 +154,27 @@ impl FlatUiHost {
     }
 
     /// Observe an `Effect::SetUI`: stash the component list if it belongs to
-    /// the active panel (the VR world-quad path is untouched by this).
+    /// the active panel or the inventory strip (the VR world-quad path is
+    /// untouched by this).
     pub fn on_set_ui(
         &mut self,
         parent_entity: EntityId,
         world_size: Vector2<f32>,
         components: &[GuiComponentRenderInfo],
     ) {
+        // `SetUI.world_size` is `screen_size_in_pixels * GUI_PIXEL_TO_WORLD_SIZE`.
+        let size_px = world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
+        if let Some(strip) = self.strip.as_mut() {
+            if strip.entity == parent_entity {
+                strip.size_px = Some(size_px);
+                strip.components = components.to_vec();
+                return;
+            }
+        }
         if self.active_panel != Some(parent_entity) {
             return;
         }
-        // `SetUI.world_size` is `screen_size_in_pixels * GUI_PIXEL_TO_WORLD_SIZE`.
-        self.panel_size_px = Some(world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE);
+        self.panel_size_px = Some(size_px);
         self.components = components.to_vec();
     }
 
@@ -145,43 +192,52 @@ impl FlatUiHost {
         self.panel_size_px.map(panel_canvas_rect)
     }
 
+    /// The inventory strip's top-docked rect on the 640x480 canvas (None
+    /// outside use mode / until its first `SetUI` arrives).
+    fn strip_rect(&self) -> Option<Rect> {
+        self.strip
+            .as_ref()
+            .and_then(|s| s.size_px)
+            .map(strip_canvas_rect)
+    }
+
     /// Per-frame pointer processing while in flat presentation. Maps the
     /// normalized pointer to panel-local coordinates and returns the
-    /// `GUIHover` message to dispatch to the panel entity; handles the close
-    /// gestures (close button, LMB on the bare view, walk-away, entity gone).
+    /// `GUIHover` message to dispatch to the strip or panel entity; handles
+    /// the close gestures (close button, LMB on the bare view, walk-away,
+    /// entity gone). A bare-view click closes the MFD panel but never the
+    /// strip - use mode is left by Tab (projects/flat-ui.md §5.2).
     pub fn update(&mut self, world: &World, pointer: Option<Pointer2D>) -> Vec<Message> {
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
 
-        let Some(panel) = self.active_panel else {
-            self.cursor_canvas = None;
-            return Vec::new();
-        };
-
-        // The bound object is gone (destroyed / level state changed).
-        let alive = world
-            .borrow::<EntitiesView>()
-            .map(|entities| entities.is_alive(panel))
-            .unwrap_or(false);
-        if !alive {
-            self.close();
-            return Vec::new();
+        // MFD-slot auto-close: the bound object is gone (destroyed / level
+        // state changed), or the player walked away from it (the original's
+        // per-overlay `distance` check). The strip is bound to the player's
+        // own inventory entity - neither applies.
+        if let Some(panel) = self.active_panel {
+            let alive = world
+                .borrow::<EntitiesView>()
+                .map(|entities| entities.is_alive(panel))
+                .unwrap_or(false);
+            let too_far = alive
+                && (|| {
+                    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+                    let v_pos = world
+                        .borrow::<View<dark::properties::PropPosition>>()
+                        .ok()?;
+                    let pos = v_pos.get(panel).ok()?;
+                    Some((pos.position - player.pos).magnitude() > PANEL_AUTO_CLOSE_DISTANCE)
+                })()
+                .unwrap_or(false);
+            if !alive || too_far {
+                self.close();
+            }
         }
 
-        // Walk-away auto-close (the original's per-overlay `distance` check
-        // against the bound object).
-        let too_far = (|| {
-            let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
-            let v_pos = world
-                .borrow::<View<dark::properties::PropPosition>>()
-                .ok()?;
-            let pos = v_pos.get(panel).ok()?;
-            Some((pos.position - player.pos).magnitude() > PANEL_AUTO_CLOSE_DISTANCE)
-        })()
-        .unwrap_or(false);
-        if too_far {
-            self.close();
+        if self.active_panel.is_none() && self.strip.is_none() {
+            self.cursor_canvas = None;
             return Vec::new();
         }
 
@@ -210,6 +266,22 @@ impl FlatUiHost {
             return Vec::new();
         };
 
+        // The strip's top-docked rect is disjoint from the MFD slot (y 0-121
+        // vs 124+); route the hover to whichever contains the pointer.
+        if let Some(strip) = &self.strip {
+            if let Some(rect) = strip.size_px.map(strip_canvas_rect) {
+                if rect.contains(canvas_pos) {
+                    self.hover_close = false;
+                    return vec![gui_hover(strip.entity, rect, canvas_pos, pointer.pressed)];
+                }
+            }
+        }
+
+        let Some(panel) = self.active_panel else {
+            // Use mode with no MFD open: a bare-view click has nothing to
+            // close (Tab leaves use mode).
+            return Vec::new();
+        };
         let Some(rect) = self.panel_rect() else {
             // Panel opened this frame; no SetUI yet - nothing to hit-test.
             return Vec::new();
@@ -225,24 +297,7 @@ impl FlatUiHost {
         }
 
         if rect.contains(canvas_pos) {
-            // Forward as GUIHover in panel-local normalized coordinates -
-            // the same message the VR hand ray produces, so `GuiScript`'s
-            // hit-test/edge-detection runs unchanged. LMB maps to the
-            // right-hand trigger; flat has no grab gesture yet.
-            let local = point2(
-                (canvas_pos.x - rect.x) / rect.w,
-                (canvas_pos.y - rect.y) / rect.h,
-            );
-            vec![Message {
-                to: panel,
-                payload: MessagePayload::GUIHover {
-                    held_entity_id: None,
-                    screen_coordinates: local,
-                    is_triggered: pointer.pressed,
-                    is_grabbing: false,
-                    hand: Handedness::Right,
-                },
-            }]
+            vec![gui_hover(panel, rect, canvas_pos, pointer.pressed)]
         } else {
             // LMB on the bare 3D view closes the panels (manual p.7).
             if pressed_edge {
@@ -252,44 +307,34 @@ impl FlatUiHost {
         }
     }
 
-    /// Render the active panel + cursor as screen-space overlay objects on
-    /// the shared 640x480 canvas (drawn after the flat HUD).
+    /// Render the inventory strip + active panel + cursor as screen-space
+    /// overlay objects on the shared 640x480 canvas (drawn after the flat
+    /// HUD).
     pub fn render(
         &self,
         asset_cache: &mut AssetCache,
         screen_size: Vector2<f32>,
     ) -> Vec<SceneObject> {
-        let Some(rect) = self.panel_rect() else {
+        let strip_rect = self.strip_rect();
+        let panel_rect = self.panel_rect();
+        if strip_rect.is_none() && panel_rect.is_none() {
             return Vec::new();
-        };
-        let mut canvas = UiCanvas::new(CANVAS_SIZE);
-        for component in &self.components {
-            if is_gui_cursor(component) {
-                // GuiScript appends its own panel-local cursor image for the
-                // VR quads; the host draws the real screen cursor instead.
-                continue;
-            }
-            let r = component_canvas_rect(component, rect);
-            match component {
-                // The original MFD art is opaque on screen; the render-info
-                // alpha is a VR world-quad translucency, deliberately not
-                // applied here.
-                GuiComponentRenderInfo::Image { texture, .. } => {
-                    canvas.image(r, texture);
-                }
-                GuiComponentRenderInfo::Text { text, font, .. } => {
-                    canvas.text(r, text, font, r.h, HAlign::Left, VAlign::Top);
-                }
-            }
         }
-        canvas.image(
-            close_button_canvas_rect(rect),
-            if self.hover_close {
-                "closeon.pcx"
-            } else {
-                "closeoff.pcx"
-            },
-        );
+        let mut canvas = UiCanvas::new(CANVAS_SIZE);
+        if let (Some(strip), Some(rect)) = (self.strip.as_ref(), strip_rect) {
+            draw_components(&mut canvas, &strip.components, rect);
+        }
+        if let Some(rect) = panel_rect {
+            draw_components(&mut canvas, &self.components, rect);
+            canvas.image(
+                close_button_canvas_rect(rect),
+                if self.hover_close {
+                    "closeon.pcx"
+                } else {
+                    "closeoff.pcx"
+                },
+            );
+        }
         if let Some(cursor) = self.cursor_canvas {
             canvas.image(
                 Rect::new(cursor.x, cursor.y, CURSOR_SIZE.x, CURSOR_SIZE.y),
@@ -308,17 +353,50 @@ impl FlatUiHost {
         let Some(rect) = self.panel_rect() else {
             return Vec::new();
         };
-        let to_screen = |r: Rect| {
-            let s = crate::ui::canvas_rect_to_screen(
-                r,
-                CANVAS_SIZE,
-                self.screen_size,
-                ScaleMode::PreserveAspect,
-            );
-            [s.x, s.y, s.w, s.h]
-        };
+        let mut out = self.elements_for(world, &self.components, rect);
+        // The host-drawn close button is clickable too.
+        let close = close_button_canvas_rect(rect);
+        out.push(crate::game_scene::DebugUiElement {
+            kind: "button".to_string(),
+            texture: Some("closeoff.pcx".to_string()),
+            text: None,
+            label: Some("close".to_string()),
+            entity_id: None,
+            rect: [close.x, close.y, close.w, close.h],
+            screen_rect: self.to_screen_rect(close),
+        });
+        out
+    }
+
+    /// Introspection snapshot of the inventory strip's elements for
+    /// `GET /v1/ui` (`strip`) - the same element contract as `debug_elements`
+    /// (carried items label as their name + entity id). Empty outside use
+    /// mode. The strip has no close element: use mode is left by Tab.
+    pub fn strip_debug_elements(&self, world: &World) -> Vec<crate::game_scene::DebugUiElement> {
+        match (self.strip.as_ref(), self.strip_rect()) {
+            (Some(strip), Some(rect)) => self.elements_for(world, &strip.components, rect),
+            _ => Vec::new(),
+        }
+    }
+
+    fn to_screen_rect(&self, r: Rect) -> [f32; 4] {
+        let s = crate::ui::canvas_rect_to_screen(
+            r,
+            CANVAS_SIZE,
+            self.screen_size,
+            ScaleMode::PreserveAspect,
+        );
+        [s.x, s.y, s.w, s.h]
+    }
+
+    fn elements_for(
+        &self,
+        world: &World,
+        components: &[GuiComponentRenderInfo],
+        rect: Rect,
+    ) -> Vec<crate::game_scene::DebugUiElement> {
         let mut out = Vec::new();
-        for component in &self.components {
+        for component in components {
             if is_gui_cursor(component) {
                 continue;
             }
@@ -356,20 +434,9 @@ impl FlatUiHost {
                 label,
                 entity_id,
                 rect: [r.x, r.y, r.w, r.h],
-                screen_rect: to_screen(r),
+                screen_rect: self.to_screen_rect(r),
             });
         }
-        // The host-drawn close button is clickable too.
-        let close = close_button_canvas_rect(rect);
-        out.push(crate::game_scene::DebugUiElement {
-            kind: "button".to_string(),
-            texture: Some("closeoff.pcx".to_string()),
-            text: None,
-            label: Some("close".to_string()),
-            entity_id: None,
-            rect: [close.x, close.y, close.w, close.h],
-            screen_rect: to_screen(close),
-        });
         out
     }
 }
@@ -389,6 +456,61 @@ fn panel_canvas_rect(panel_size_px: Vector2<f32>) -> Rect {
         panel_size_px.x,
         panel_size_px.y,
     )
+}
+
+/// The inventory strip's rect on the canvas: panel-local pixels docked at
+/// the original top-of-screen inventory anchor.
+fn strip_canvas_rect(strip_size_px: Vector2<f32>) -> Rect {
+    Rect::new(
+        STRIP_ANCHOR.x,
+        STRIP_ANCHOR.y,
+        strip_size_px.x,
+        strip_size_px.y,
+    )
+}
+
+/// A `GUIHover` for `to`, in panel-local normalized coordinates - the same
+/// message the VR hand ray produces, so `GuiScript`'s hit-test/edge-detection
+/// runs unchanged. LMB maps to the right-hand trigger; flat has no grab
+/// gesture yet.
+fn gui_hover(to: EntityId, rect: Rect, canvas_pos: Vector2<f32>, pressed: bool) -> Message {
+    let local = point2(
+        (canvas_pos.x - rect.x) / rect.w,
+        (canvas_pos.y - rect.y) / rect.h,
+    );
+    Message {
+        to,
+        payload: MessagePayload::GUIHover {
+            held_entity_id: None,
+            screen_coordinates: local,
+            is_triggered: pressed,
+            is_grabbing: false,
+            hand: Handedness::Right,
+        },
+    }
+}
+
+/// Draw one slot's `SetUI` components into its canvas rect.
+fn draw_components(canvas: &mut UiCanvas, components: &[GuiComponentRenderInfo], rect: Rect) {
+    for component in components {
+        if is_gui_cursor(component) {
+            // GuiScript appends its own panel-local cursor image for the
+            // VR quads; the host draws the real screen cursor instead.
+            continue;
+        }
+        let r = component_canvas_rect(component, rect);
+        match component {
+            // The original MFD art is opaque on screen; the render-info
+            // alpha is a VR world-quad translucency, deliberately not
+            // applied here.
+            GuiComponentRenderInfo::Image { texture, .. } => {
+                canvas.image(r, texture);
+            }
+            GuiComponentRenderInfo::Text { text, font, .. } => {
+                canvas.text(r, text, font, r.h, HAlign::Left, VAlign::Top);
+            }
+        }
+    }
 }
 
 /// Map one `SetUI` component (normalized panel coordinates) to canvas pixels.
@@ -606,6 +728,173 @@ mod tests {
             .expect("the item element should carry its entity id");
         assert_eq!(el.kind, "button");
         assert_eq!(el.label.as_deref(), Some("Psi Amp"));
+    }
+
+    #[test]
+    fn strip_docks_at_the_top_of_the_canvas() {
+        // The inventory strip: 635x120 (invback) at the original inv_rect
+        // anchor (shkinv.cpp INV_X=2, INV_Y=0) - flush with the canvas top.
+        let rect = strip_canvas_rect(vec2(635.0, 120.0));
+        assert_eq!(rect, Rect::new(2.0, 0.0, 635.0, 120.0));
+        // It fits on the canvas and clears the left-MFD slot below (y 124+).
+        assert!(rect.x + rect.w <= CANVAS_SIZE.x);
+        assert!(rect.y + rect.h < LEFT_MFD_ANCHOR.y);
+    }
+
+    /// Hover routing with both slots live: the strip gets the pointer when
+    /// it is over the top dock, the panel when it is over the MFD slot.
+    #[test]
+    fn hover_routes_to_strip_or_panel_by_position() {
+        let mut world = World::new();
+        let inventory = world.add_entity(());
+        let panel = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.open(panel);
+        host.on_set_ui(
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+        host.on_set_ui(
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+
+        // Canvas (320, 60) - the middle of the strip - is normalized
+        // (0.5, 0.125) at the default 640x480 screen size.
+        let over_strip = Pointer2D {
+            position: vec2(0.5, 0.125),
+            pressed: false,
+        };
+        let msgs = host.update(&world, Some(over_strip));
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].to, inventory, "top dock hover goes to the strip");
+
+        // Canvas (96, 272) - the middle of the left MFD - is (0.15, ~0.567).
+        let over_panel = Pointer2D {
+            position: vec2(96.0 / 640.0, 272.0 / 480.0),
+            pressed: false,
+        };
+        let msgs = host.update(&world, Some(over_panel));
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].to, panel, "MFD slot hover goes to the panel");
+    }
+
+    /// A bare-view click in use mode closes the MFD panel (manual p.7) but
+    /// never the strip - use mode is left by Tab.
+    #[test]
+    fn bare_view_click_closes_the_panel_but_keeps_the_strip() {
+        let mut world = World::new();
+        let inventory = world.add_entity(());
+        let panel = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.open(panel);
+        host.on_set_ui(
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+        host.on_set_ui(
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+        // Release first (open() swallows the held button), then click on the
+        // bare view (bottom-right of the canvas, outside both slots).
+        let bare = vec2(0.9, 0.9);
+        host.update(
+            &world,
+            Some(Pointer2D {
+                position: bare,
+                pressed: false,
+            }),
+        );
+        host.update(
+            &world,
+            Some(Pointer2D {
+                position: bare,
+                pressed: true,
+            }),
+        );
+        assert!(host.active_panel().is_none(), "bare-view click closes the panel");
+        assert_eq!(
+            host.strip_entity(),
+            Some(inventory),
+            "the strip survives a bare-view click"
+        );
+
+        // With no panel open, another bare-view click is a no-op.
+        host.update(
+            &world,
+            Some(Pointer2D {
+                position: bare,
+                pressed: false,
+            }),
+        );
+        host.update(
+            &world,
+            Some(Pointer2D {
+                position: bare,
+                pressed: true,
+            }),
+        );
+        assert_eq!(host.strip_entity(), Some(inventory));
+    }
+
+    /// The strip's /v1/ui elements carry the carried items' names + ids -
+    /// the same contract as panel elements - and leaving use mode drops them.
+    #[test]
+    fn strip_elements_label_carried_items() {
+        let mut world = World::new();
+        let wrench = world.add_entity(dark::properties::PropSymName("Wrench".to_owned()));
+        let inventory = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.on_set_ui(
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[
+                GuiComponentRenderInfo::Image {
+                    position: vec2(0.0, 0.0),
+                    size: vec2(1.0, 1.0),
+                    texture: "invback.pcx".to_owned(),
+                    alpha: 0.5,
+                    interactive: false,
+                    entity: None,
+                },
+                GuiComponentRenderInfo::Image {
+                    position: vec2(4.0 / 635.0, 18.0 / 120.0),
+                    size: vec2(35.0 / 635.0, 32.0 / 120.0),
+                    texture: "icn_wrench.pcx".to_owned(),
+                    alpha: 0.5,
+                    interactive: true,
+                    entity: Some(wrench),
+                },
+            ],
+        );
+        let elements = host.strip_debug_elements(&world);
+        // The backdrop is anchored at the canvas top.
+        let backdrop = elements
+            .iter()
+            .find(|e| e.texture.as_deref() == Some("invback.pcx"))
+            .expect("strip should expose the INVBACK backdrop");
+        assert_eq!(backdrop.rect[1], 0.0, "the strip is top-docked");
+        let item = elements
+            .iter()
+            .find(|e| e.entity_id == Some(wrench.inner() as i32))
+            .expect("the carried item should be a strip element");
+        assert_eq!(item.kind, "button");
+        assert_eq!(item.label.as_deref(), Some("Wrench"));
+        // No close element - the strip is closed by Tab, not a click.
+        assert!(elements.iter().all(|e| e.label.as_deref() != Some("close")));
+
+        // Leaving use mode drops the strip and its elements.
+        host.set_strip(None);
+        assert!(host.strip_entity().is_none());
+        assert!(host.strip_debug_elements(&world).is_empty());
     }
 
     #[test]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -819,7 +819,10 @@ mod tests {
                 pressed: true,
             }),
         );
-        assert!(host.active_panel().is_none(), "bare-view click closes the panel");
+        assert!(
+            host.active_panel().is_none(),
+            "bare-view click closes the panel"
+        );
         assert_eq!(
             host.strip_entity(),
             Some(inventory),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2281,6 +2281,12 @@ impl MissionCore {
                     hand,
                     current_parent_id: _,
                 } => {
+                    // What's held before the grab, so anything the grab
+                    // displaces (the flat wield swaps the viewmodel out) can
+                    // be holstered back into the backpack below. VR grabs
+                    // into an occupied hand no-op, so no displacement there.
+                    let held_before = self.interaction.held_entities();
+
                     let grab_effects = self.interaction.grab(&self.world, entity_id, hand);
                     self.process_virtual_hand_effects(asset_cache, grab_effects);
 
@@ -2306,6 +2312,31 @@ impl MissionCore {
 
                                 !is_link_to_entity
                             })
+                        }
+                    }
+
+                    // Holster anything the grab displaced (a weapon the flat
+                    // wield swapped out) back into the player's backpack -
+                    // the original returns it to the inventory grid, not the
+                    // floor at the viewmodel position.
+                    let held_after = self.interaction.held_entities();
+                    let displaced =
+                        [held_before.0, held_before.1]
+                            .into_iter()
+                            .flatten()
+                            .find(|prev| {
+                                *prev != entity_id
+                                    && held_after.0 != Some(*prev)
+                                    && held_after.1 != Some(*prev)
+                            });
+                    if let Some(prev) = displaced {
+                        let inventory_entity = self
+                            .world
+                            .borrow::<UniqueView<PlayerInfo>>()
+                            .map(|player| player.inventory_entity_id)
+                            .ok();
+                        if let Some(inventory_entity) = inventory_entity {
+                            self.drop_entity_into_container(inventory_entity, prev);
                         }
                     }
                 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2087,6 +2087,19 @@ impl MissionCore {
                     // Flat-presentation only: VR has no cursor mode to toggle.
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_use_mode = !self.flat_use_mode;
+                        // Use mode shows the player's backpack as the
+                        // top-docked inventory strip: bind the strip to the
+                        // `internal_inventory` entity (whose GuiScript
+                        // already emits SetUI every frame).
+                        let strip_entity = if self.flat_use_mode {
+                            self.world
+                                .borrow::<UniqueView<PlayerInfo>>()
+                                .ok()
+                                .map(|player| player.inventory_entity_id)
+                        } else {
+                            None
+                        };
+                        self.flat_ui.set_strip(strip_entity);
                     }
                 }
 
@@ -3271,6 +3284,10 @@ impl MissionCore {
                 asset_cache,
                 &self.world,
                 screen_size,
+                // The crosshair is a shooter-mode overlay; use mode replaces
+                // it with the cursor (the original's ShockOverlayMouseMode
+                // turns kOverlayCrosshair off while the cursor is up).
+                !self.flat_use_mode,
             ));
 
             // Flat MFD panel (keypad, container, ...) + cursor, drawn over
@@ -4601,7 +4618,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn ui_state(&self) -> crate::game_scene::DebugUiState {
-        let active_panel = self.flat_ui.active_panel().map(|entity| {
+        let panel_identity = |entity: shipyard::EntityId| {
             let name = self
                 .world
                 .borrow::<View<dark::properties::PropSymName>>()
@@ -4613,11 +4630,26 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 .ok()
                 .and_then(|v| v.get(entity).ok().map(|t| t.template_id))
                 .unwrap_or(0);
+            (name, template_id)
+        };
+        let active_panel = self.flat_ui.active_panel().map(|entity| {
+            let (name, template_id) = panel_identity(entity);
             crate::game_scene::DebugUiPanel {
                 entity_id: entity.inner() as i32,
                 template_id,
                 name,
                 elements: self.flat_ui.debug_elements(&self.world),
+            }
+        });
+        // The top-docked inventory strip (Tab metagame mode), same element
+        // contract as the MFD panel.
+        let strip = self.flat_ui.strip_entity().map(|entity| {
+            let (name, template_id) = panel_identity(entity);
+            crate::game_scene::DebugUiPanel {
+                entity_id: entity.inner() as i32,
+                template_id,
+                name,
+                elements: self.flat_ui.strip_debug_elements(&self.world),
             }
         });
         crate::game_scene::DebugUiState {
@@ -4627,6 +4659,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 "shooter".to_string()
             },
             active_panel,
+            strip,
         }
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -207,15 +207,42 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                     current_parent_id: None,
                 },
             ),
-            ContainerGuiMsg::Frob(ent) => (
-                state.clone(),
-                Effect::Send {
-                    msg: Message {
-                        payload: MessagePayload::Frob,
-                        to: *ent,
-                    },
-                },
-            ),
+            // Wield-or-use (backpack click): a carried weapon - gun
+            // (PropPlayerGun) or melee (PropLimbModel) - is wielded through
+            // `GrabEntity` (flat: the first-person viewmodel wield path,
+            // which also restores world refs and clears the Contains link;
+            // VR: a grab into the hand). Anything else gets its own Frob
+            // (use) action, e.g. a hypo consumes.
+            ContainerGuiMsg::Frob(ent) => {
+                let is_weapon = world
+                    .borrow::<View<dark::properties::PropPlayerGun>>()
+                    .map(|v| v.get(*ent).is_ok())
+                    .unwrap_or(false)
+                    || world
+                        .borrow::<View<dark::properties::PropLimbModel>>()
+                        .map(|v| v.get(*ent).is_ok())
+                        .unwrap_or(false);
+                if is_weapon {
+                    (
+                        state.clone(),
+                        Effect::GrabEntity {
+                            entity_id: *ent,
+                            hand: crate::vr_config::Handedness::Right,
+                            current_parent_id: None,
+                        },
+                    )
+                } else {
+                    (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    )
+                }
+            }
             // Transfer the clicked item's `Contains` link to the player's
             // backpack - the same `DropEntityInfo` path used when a VR hand
             // feeds an item into a container (drop_entity_into_container).
@@ -356,6 +383,51 @@ mod tests {
             "taking a non-grabbable entity must be a no-op, got {:?}",
             effect
         );
+    }
+
+    /// Clicking a carried WEAPON in the backpack strip wields it: gun
+    /// (PropPlayerGun) and melee (PropLimbModel) items route through
+    /// `Effect::GrabEntity` (the flat grab path wields; it also restores
+    /// world refs and clears the Contains link, so the strip updates live).
+    #[test]
+    fn backpack_click_on_a_weapon_wields_it() {
+        let (mut world, container, _item, _inventory) = loot_world();
+        let gui = ContainerGui::inv_container();
+
+        let wrench = world.add_entity((
+            PropObjIcon("icn_wrench".to_owned()),
+            dark::properties::PropLimbModel("atek_h".to_owned()),
+        ));
+        let pistol = world.add_entity((
+            PropObjIcon("icn_pist".to_owned()),
+            dark::properties::PropPlayerGun {
+                flags: 0,
+                hand_model: "pis_h".to_owned(),
+                icon_file: String::new(),
+                model_offset: vec3(0.0, 0.0, 0.0),
+                fire_offset: vec3(0.0, 0.0, 0.0),
+                heading: 0,
+                reload_pitch: 0,
+                reload_rate: 0,
+                gun_type: 0,
+            },
+        ));
+        for weapon in [wrench, pistol] {
+            let (_state, effect) = gui.handle_msg(
+                container,
+                &world,
+                &ContainerGuiState {},
+                &ContainerGuiMsg::Frob(weapon),
+            );
+            assert!(
+                matches!(
+                    effect,
+                    Effect::GrabEntity { entity_id, .. } if entity_id == weapon
+                ),
+                "clicking a carried weapon should wield it via GrabEntity, got {:?}",
+                effect
+            );
+        }
     }
 
     /// The player's own backpack keeps the original click semantics (use the

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -304,6 +304,12 @@ export interface UiState {
   mode: "shooter" | "use";
   /** The open MFD panel, or null when none is open. */
   active_panel: UiPanel | null;
+  /**
+   * The top-docked inventory strip (Tab metagame mode): the player's carried
+   * items as labeled, clickable elements. Present only in "use" mode; null in
+   * shooter mode.
+   */
+  strip: UiPanel | null;
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
@@ -32,6 +32,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (mission id 990)
+const CORPSE_PSI_AMP = 219; // Male Corpse 1 -> Contains -> Psi Amp (mission id 1407)
 
 test(
   "Tab metagame mode renders the carried inventory in the top-docked strip",
@@ -210,6 +211,59 @@ test(
       "non-wielded items stay in the strip",
     );
     await game.screenshot("strip-after-wield.png");
+
+    // --- Wield swap: the displaced weapon returns to the strip, not the
+    // floor (the original returns it to the grid). Loot the Psi Amp (a
+    // PropPlayerGun weapon) from corpse 219, wield it, and check the Wrench
+    // is holstered back into the backpack with no world presence. ---
+    const ampCorpses = await game.entities.byTemplate(CORPSE_PSI_AMP);
+    assert.equal(ampCorpses.length, 1, "expected exactly one Male Corpse 1 (219)");
+    const ampCorpse = ampCorpses[0];
+    await teleportVerified(game, {
+      x: ampCorpse.position[0] + 1.0,
+      y: ampCorpse.position[1] + 0.5,
+      z: ampCorpse.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(ampCorpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const ampPanel = (await game.ui.state()).active_panel;
+    assert.ok(ampPanel, "frobbing corpse 219 should open its loot panel");
+    const ampLoot = ampPanel.elements.find(
+      (e) => e.kind === "button" && e.label === "Psi Amp",
+    );
+    assert.ok(ampLoot, "corpse 219's loot panel should list the Psi Amp");
+    await clickElement(ampLoot);
+    const ampStrip = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.label === "Psi Amp",
+    );
+    assert.ok(ampStrip, "the taken Psi Amp should appear in the strip");
+    await clickElement(ampStrip);
+
+    const afterSwap = await game.player.inventory();
+    const amp = afterSwap.items.find((i) => i.name === "Psi Amp");
+    assert.equal(amp?.location, "left_hand", "the Psi Amp should now be wielded");
+    const holsteredWrench = afterSwap.items.find((i) => i.name === "Wrench");
+    assert.ok(
+      holsteredWrench,
+      `the displaced Wrench must stay carried, not drop into the world ` +
+        `(got ${JSON.stringify(afterSwap.items)})`,
+    );
+    assert.equal(
+      holsteredWrench.location,
+      "inventory",
+      "the displaced Wrench is holstered back into the backpack",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: holsteredWrench.entity_id })).bodies.length,
+      0,
+      "the holstered Wrench has no world presence",
+    );
+    // ...and it re-appears in the strip grid.
+    const stripAfterSwap = (await game.ui.state()).strip;
+    assert.ok(
+      stripAfterSwap?.elements.some((e) => e.label === "Wrench"),
+      "the displaced Wrench returns to the strip grid",
+    );
 
     // --- Tab again -> shooter restored, strip gone ---
     await game.input.trigger("ToggleUseMode");

--- a/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for the Tab metagame ("use") mode inventory strip
+// (projects/flat-ui.md §5.2 / §6 PR 4):
+//
+//  1. Tab (`ToggleUseMode`) flips /v1/ui mode to "use" AND renders the
+//     player's actual carried inventory in the top-docked strip
+//     (`internal_inventory`'s ContainerGui, original 636x121 INVBACK anchored
+//     top-centered - shkinv.cpp INV_X=2/INV_Y=0).
+//  2. /v1/ui exposes the strip's elements with item labels + entity ids -
+//     the same introspection contract as MFD panels.
+//  3. Movement keys keep working in use mode (only mouse-look is
+//     surrendered - manual p.7).
+//  4. Clicking a carried weapon in the strip wields it (the flat grab/wield
+//     path), and the strip updates live (the wielded item leaves the grid).
+//  5. Frobbed MFD panels (loot) coexist with the strip in use mode.
+//  6. Tab again restores shooter mode: strip + elements gone.
+//
+// Item acquisition is honest where it matters: the Wrench is looted from MS
+// Male Corpse 1177 via the PR 3 loot panel (the authored first MedSci
+// interaction); the Nanites use the debug give lever as test setup.
+//
+// Negative-first: on main, Tab already flips /v1/ui mode to "use" (the PR 1
+// mode flag) but NO inventory strip exists - `strip` is absent/null and no
+// carried-item elements appear anywhere. The KEY assertion ("use mode
+// exposes a strip listing the carried Wrench") fails on main.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (mission id 990)
+
+test(
+  "Tab metagame mode renders the carried inventory in the top-docked strip",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8133),
+    });
+    await game.step({ frames: 5 });
+
+    const clickElement = async (el: UiElement) => {
+      const [x, y, w, h] = el.screen_rect;
+      const center: [number, number] = [x + w / 2, y + h / 2];
+      await game.input.set("pointer.position", center);
+      await game.step({ frames: 2 }); // hover registers (edge detection needs a prior unpressed frame)
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+
+    // --- Setup: give the player a couple of items ---
+    // Nanites via the debug give lever (plain test setup)...
+    const { entities: nanites } = await game.entities.list({
+      filter: "*Nanites*",
+      limit: 10,
+    });
+    assert.ok(nanites[0], "expected a Nanites pickup in medsci1");
+    await game.player.give(nanites[0].id);
+
+    // ...and the Wrench looted honestly through the PR 3 loot MFD.
+    const corpses = await game.entities.byTemplate(CORPSE_WRENCH);
+    assert.equal(corpses.length, 1, "expected exactly one MS Male Corpse (1177)");
+    const corpse = corpses[0];
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const lootPanel = (await game.ui.state()).active_panel;
+    assert.ok(lootPanel, "frobbing corpse 1177 should open its loot panel");
+    const wrenchLoot = lootPanel.elements.find(
+      (e) => e.kind === "button" && e.label === "Wrench",
+    );
+    assert.ok(wrenchLoot, "loot panel should list the Wrench");
+    await clickElement(wrenchLoot);
+    const carried = await game.player.inventory();
+    const wrench = carried.items.find((i) => i.name === "Wrench");
+    assert.ok(wrench, `looting should put the Wrench in the backpack (got ${JSON.stringify(carried.items)})`);
+    // Close the loot panel (host close button) so the strip test starts clean.
+    const closeBtn = (await game.ui.state()).active_panel?.elements.find(
+      (e) => e.label === "close",
+    );
+    assert.ok(closeBtn, "loot panel should expose the host close button");
+    await clickElement(closeBtn);
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "the loot panel should close before the strip test",
+    );
+
+    // --- Shooter baseline: no strip ---
+    const shooter = await game.ui.state();
+    assert.equal(shooter.mode, "shooter");
+    assert.ok(!shooter.strip, "shooter mode must not expose an inventory strip");
+    await game.screenshot("strip-shooter-before.png");
+
+    // --- KEY: Tab -> use mode with the carried items visible in the strip ---
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    const use = await game.ui.state();
+    assert.equal(use.mode, "use", "Tab should flip /v1/ui mode to use");
+    assert.ok(
+      use.strip,
+      `use mode must expose the top-docked inventory strip (got ${JSON.stringify(use)})`,
+    );
+    const stripWrench = use.strip.elements.find(
+      (e) => e.kind === "button" && e.label === "Wrench",
+    );
+    assert.ok(
+      stripWrench,
+      `the strip must list the carried Wrench ` +
+        `(got ${JSON.stringify(use.strip.elements)})`,
+    );
+    assert.equal(
+      stripWrench.entity_id,
+      wrench.entity_id,
+      "the strip's Wrench element should carry the item's entity id",
+    );
+    const stripNanites = use.strip.elements.find(
+      (e) => e.kind === "button" && (e.label ?? "").includes("Nanite"),
+    );
+    assert.ok(
+      stripNanites,
+      `the strip must list the carried Nanites (got ${JSON.stringify(use.strip.elements)})`,
+    );
+    // The strip is top-docked: the INVBACK backdrop sits at the canvas top
+    // (shkinv.cpp: INV_Y = 0, horizontally centered).
+    const backdrop = use.strip.elements.find((e) =>
+      (e.texture ?? "").toLowerCase().includes("invback"),
+    );
+    assert.ok(backdrop, "the strip should draw the INVBACK backdrop");
+    assert.equal(backdrop.rect[1], 0, "the strip is anchored at the canvas top");
+    await game.screenshot("strip-use-mode.png");
+
+    // --- Movement keys keep working in use mode ---
+    const posBefore = await game.player.position();
+    await game.input.set("right_hand.thumbstick", [0.0, 1.0]);
+    await game.step({ frames: 30 });
+    await game.input.set("right_hand.thumbstick", [0.0, 0.0]);
+    const posAfter = await game.player.position();
+    const moved = Math.hypot(posAfter.x - posBefore.x, posAfter.z - posBefore.z);
+    assert.ok(
+      moved > 0.1,
+      `locomotion must keep working in use mode (moved ${moved.toFixed(3)})`,
+    );
+
+    // --- Frobbed panels coexist with the strip in use mode ---
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const withPanel = await game.ui.state();
+    assert.ok(
+      withPanel.active_panel,
+      "a frobbed loot panel should open while in use mode",
+    );
+    assert.ok(
+      withPanel.strip,
+      "the inventory strip should stay up alongside an open MFD panel",
+    );
+    await game.screenshot("strip-with-panel.png");
+    const closeBtn2 = withPanel.active_panel.elements.find((e) => e.label === "close");
+    assert.ok(closeBtn2, "the coexisting panel keeps its close button");
+    await clickElement(closeBtn2);
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "closing the panel leaves use mode (and the strip) active",
+    );
+    assert.ok((await game.ui.state()).strip, "the strip survives the panel closing");
+
+    // --- Clicking the carried Wrench in the strip wields it ---
+    const stripNow = (await game.ui.state()).strip;
+    assert.ok(stripNow, "strip still present before the wield click");
+    const wrenchEl = stripNow.elements.find(
+      (e) => e.kind === "button" && e.label === "Wrench",
+    );
+    assert.ok(wrenchEl, "the Wrench is still in the strip before wielding");
+    await clickElement(wrenchEl);
+    const afterWield = await game.player.inventory();
+    const wieldedWrench = afterWield.items.find((i) => i.name === "Wrench");
+    assert.ok(wieldedWrench, "the wielded Wrench is still carried");
+    assert.equal(
+      wieldedWrench.location,
+      "left_hand",
+      "clicking a carried weapon in the strip should wield it (flat reports the viewmodel as left hand)",
+    );
+    // ...and the strip updates live: the wielded item left the grid.
+    const stripAfterWield = (await game.ui.state()).strip;
+    assert.ok(stripAfterWield, "strip stays up after wielding");
+    assert.ok(
+      !stripAfterWield.elements.some((e) => e.label === "Wrench"),
+      "the wielded Wrench should leave the strip grid",
+    );
+    // The Nanites stay put.
+    assert.ok(
+      stripAfterWield.elements.some((e) => (e.label ?? "").includes("Nanite")),
+      "non-wielded items stay in the strip",
+    );
+    await game.screenshot("strip-after-wield.png");
+
+    // --- Tab again -> shooter restored, strip gone ---
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const restored = await game.ui.state();
+    assert.equal(restored.mode, "shooter", "Tab again should restore shooter mode");
+    assert.ok(!restored.strip, "leaving use mode must drop the strip");
+    await game.screenshot("strip-shooter-after.png");
+  },
+);


### PR DESCRIPTION
# feat(ui): Tab metagame mode with inventory strip

PR 4 of the flat metagame UI plan (`projects/flat-ui.md` §5.2 / §6) — Tab now enters the original's **metagame ("use") mode** in flat presentation: cursor up, mouse-look surrendered, and the player's **actual carried inventory rendered in the original top-docked INVBACK strip**. Builds directly on the PR 1-3 machinery (#441 / #444 / #449): the strip is `internal_inventory`'s existing `ContainerGui`, re-presented by the `FlatUiHost` — no new GUI logic, one new anchor.

## Demo

![Tab inventory strip demo](https://gist.githubusercontent.com/tommy-xr/9310e002a47bd417c5701d7cbfb5e310/raw/demo.gif)

<sub>Tab enters use mode: the top-docked INVBACK strip shows the real carried inventory (Wrench + Nanites); clicking the Wrench wields it and it leaves the grid; Tab returns to shooter mode. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Inventory strip still](https://gist.githubusercontent.com/tommy-xr/9310e002a47bd417c5701d7cbfb5e310/raw/strip-still.png)

## What's in

- **Use mode is real** — `ToggleUseMode` (Tab on desktop; HTTP/SDK-triggerable) binds the **top-docked inventory strip** to the player's `internal_inventory` entity. Its `GuiScript` already emits `SetUI` every frame, so the host just stashes and re-anchors the components; the strip updates **live** as items are gained/lost. Anchor pinned from the Dark source (`shkinv.cpp`: `INV_X = 2`, `INV_Y = 0`, `inv_rect` 636×121 — horizontally centered, flush with the canvas top).
- **Cursor + mouse-look** — the cursor now lives whenever *either* slot (strip or MFD) is active; `wants_pointer()` already covered use mode (PR 1), so the desktop runtime surrenders mouse-look while movement keys keep working (manual p.7 semantics). The **crosshair hides in use mode** (the original's `ShockOverlayMouseMode` turns `kOverlayCrosshair` off while the cursor is up).
- **Interaction (tier landed)** — hover + click routing to strip items through the same `GUIHover` contract as panels; **clicking a carried weapon wields it**: `ContainerGui`'s backpack click becomes wield-or-use — a gun (`PropPlayerGun`) or melee weapon (`PropLimbModel`) routes through `Effect::GrabEntity` (flat: the first-person wield path, which also restores world refs and clears the `Contains` link so the strip updates live); anything else keeps its own `Frob` (use) action. **Wield swaps holster**: a weapon displaced by a strip wield returns to the backpack grid (the original's behavior), not the floor.
- **Panels coexist** — a frobbed loot/keypad MFD opens alongside the strip (disjoint canvas rects: strip y 0-121, left MFD y 124+); a bare-view click closes the MFD but never the strip (use mode is left by Tab).
- **INVBACK equip paperdoll** — art-only stub per the design: the weapon/armor/implant equip chrome is baked into `INVBACK.PCX` and renders with the strip backdrop; the slots are non-functional (wiring equip is its own follow-up).
- **`GET /v1/ui`** — gains a `strip` field with the same element contract as panels (carried items labeled by name + entity id, canvas + normalized-screen rects), mirrored through the debug runtime and the SDK `UiState` type.
- **playtest skill** — documents Tab/`ToggleUseMode` and how to drive the strip headlessly (pointer channels + `/v1/ui` rects).

## Deferred (explicitly, per the design's "as capacity allows")

- **Cursor-is-the-item lift/place/swap + drag-into-world throw** (§1.5) — the full `SCM_DRAGOBJ` model (cursor becomes the icon, `drag_obj` blocks mode exit, drop-outside throws) is its own state machine across host + gui + effects; deferred to PR 4.5 rather than bolted on here.
- **ALT-split and CTRL-query** — explicitly out of scope per the design.
- **RMB as a distinct button** — the flat pointer is single-button (`pointer.pressed`); LMB click = wield-or-use covers the useful semantics until a second button channel exists.
- **BIOFULL/AMMOFULL expanded readouts** — PR 5.

## VR preservation (design §5.4)

`Gui` trait, `ContainerGui` grids, `GuiScript` state machine, and the `GUIHover` contract are untouched; the strip is pure flat presentation (`FlatUiHost` + `Effect::ToggleUseMode`, both no-ops in VR). One shared-behavior delta: clicking (trigger) a **weapon** in the VR backpack panel (behind `--experimental gui`) now grabs it into the hand instead of sending it a no-op `Frob` — consistent with "use a weapon = wield it".

## Verification

- **Negative-first e2e** `tools/shock2-sdk/test/inventory-strip.e2e.test.ts`: run against unmodified main, the KEY assertion fails (`use mode must expose the top-docked inventory strip (got {"mode":"use","active_panel":null})`). With this branch it passes end-to-end: give Nanites + **loot the Wrench honestly** from corpse 1177 via the PR 3 loot MFD → Tab → strip lists both items with labels/ids → locomotion still works in use mode → loot panel coexists with the strip → click Wrench → wielded (`left_hand`) + leaves the grid live → Tab → shooter restored, strip gone.
- Negative-first unit test for wield-or-use (`backpack_click_on_a_weapon_wields_it` failed with `Effect::Send{Frob}` pre-change); strip layout/routing unit tests (`strip_docks_at_the_top_of_the_canvas`, `hover_routes_to_strip_or_panel_by_position`, `bare_view_click_closes_the_panel_but_keeps_the_strip`, `strip_elements_label_carried_items`, `use_mode_hides_the_crosshair`).
- `cargo test -p shock2vr`: 119 passed.
- e2e suites: inventory-strip, keypad, container-loot, flat-ui-plumbing, climbing, flat-hud, give-item, inventory, vr-held-model, weapon-ammo all green; `missions.e2e` **23/23**.
- `cargo fmt` + `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- **Cross-engine review** (xreview: Claude Opus subagent + Codex CLI, both given the rendered screenshots): Claude found no Critical/High and verified all four visual states; Codex raised one High — a strip wield-swap dropped the displaced weapon into the world — **fixed** (holster-to-backpack in the `GrabEntity` handler, with a negative-first e2e swap section) and re-validated. Claude's Low notes: the VR backpack weapon-click delta is called out above; an MFD panel surviving Tab-out is pre-existing PR 2/3 panel lifecycle (panels are mode-independent by design until the exclusion-list PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

