### PR TITLE
fix(mission): StartLoc marker without LandingPoint link spawns at the marker, not origin (Fixes #454)

### DIFF
--- a/shock2vr/src/mission/spawn_location.rs
+++ b/shock2vr/src/mission/spawn_location.rs
@@ -38,32 +38,50 @@ impl SpawnLocation {
             Self::Marker(loc) => {
                 world.run(
                     |v_position: View<PropPosition>, v_start_loc: View<PropStartLoc>| {
-                        let mut spawn_entity_id = None;
-                        let mut closest_delta = u32::MAX;
+                        // The best StartLoc marker that links to a LandingPoint (the
+                        // intended path when the retail data provides one).
+                        let mut landing_spawn_entity_id = None;
+                        let mut landing_delta = u32::MAX;
+                        // Fallback: the best StartLoc marker's OWN position. Some
+                        // retail StartLoc markers have NO LandingPoint link at all
+                        // (e.g. station.mis obj 132 "Starting_Location", the
+                        // post-career recruit-deck spawn at loc 2501). Without this
+                        // fallback such markers resolve to the world origin - see #454.
+                        let mut marker_spawn: Option<(Vector3<f32>, Quaternion<f32>)> = None;
+                        let mut marker_delta = u32::MAX;
                         for (entity_id, start_loc) in (&v_start_loc).iter().with_id() {
                             // HACK: Find the location that matches the best...
                             // aka, why is the eng dest loc 21 but the medsci 12??
                             // Ideally, this should be an exact match, but not sure why the spawn points are off in some cases...
                             let diff = start_loc.0.abs_diff(*loc);
 
-                            // Only consider points that actually are linked to landing points...
+                            if diff < marker_delta {
+                                if let Ok(marker_pos) = v_position.get(entity_id) {
+                                    marker_delta = diff;
+                                    marker_spawn = Some((marker_pos.position, marker_pos.rotation));
+                                }
+                            }
+
+                            // Prefer markers that actually link to a landing point.
                             let all_links =
                                 get_all_links_of_type(world, entity_id, Link::LandingPoint);
 
-                            if diff < closest_delta && !all_links.is_empty() {
-                                closest_delta = diff;
-                                spawn_entity_id =
+                            if diff < landing_delta && !all_links.is_empty() {
+                                landing_delta = diff;
+                                landing_spawn_entity_id =
                                     get_first_link_of_type(world, entity_id, Link::LandingPoint);
                             }
                         }
 
-                        match spawn_entity_id {
-                            None => (),
-                            Some(entity_id) => {
-                                let spawn_pos = v_position.get(entity_id).unwrap();
-                                start_pos = spawn_pos.position;
-                                start_rotation = spawn_pos.rotation;
-                            }
+                        // Landing-point link wins when present; otherwise fall back to
+                        // the matched marker's own position (never the world origin).
+                        if let Some(entity_id) = landing_spawn_entity_id {
+                            let spawn_pos = v_position.get(entity_id).unwrap();
+                            start_pos = spawn_pos.position;
+                            start_rotation = spawn_pos.rotation;
+                        } else if let Some((pos, rot)) = marker_spawn {
+                            start_pos = pos;
+                            start_rotation = rot;
                         }
                     },
                 );
@@ -81,5 +99,73 @@ impl SpawnLocation {
             }
         };
         (start_pos, start_rotation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{Links, ToLink};
+
+    fn quat_identity() -> Quaternion<f32> {
+        Quaternion {
+            v: Vector3::zero(),
+            s: 1.0,
+        }
+    }
+
+    fn position(pos: Vector3<f32>) -> PropPosition {
+        PropPosition {
+            position: pos,
+            cell: 0,
+            rotation: quat_identity(),
+        }
+    }
+
+    /// A StartLoc marker with NO LandingPoint link must spawn at the marker's
+    /// own position, not the world origin (regression test for #454).
+    #[test]
+    fn marker_without_landing_point_falls_back_to_marker_position() {
+        let mut world = World::new();
+        let marker_pos = Vector3::new(81.78, -3.6, 16.54);
+        world.add_entity((PropStartLoc(2501), position(marker_pos)));
+
+        let (start_pos, _) = SpawnLocation::Marker(2501).calculate_start_position(
+            &world,
+            &SystemShock2EntityInfo::empty(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(start_pos, marker_pos);
+    }
+
+    /// When a StartLoc marker DOES link to a LandingPoint, that linked point's
+    /// position wins over the marker's own position.
+    #[test]
+    fn marker_with_landing_point_prefers_linked_position() {
+        let mut world = World::new();
+        let marker_pos = Vector3::new(1.0, 0.0, 1.0);
+        let landing_pos = Vector3::new(50.0, 5.0, 60.0);
+
+        let landing_entity = world.add_entity((position(landing_pos),));
+        world.add_entity((
+            PropStartLoc(2501),
+            position(marker_pos),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(landing_entity)),
+                    link: Link::LandingPoint,
+                }],
+            },
+        ));
+
+        let (start_pos, _) = SpawnLocation::Marker(2501).calculate_start_position(
+            &world,
+            &SystemShock2EntityInfo::empty(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(start_pos, landing_pos);
     }
 }

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -25,9 +25,9 @@ import type { Vec3 } from "../src/types.js";
 // underlying issue is fixed:
 //   * #453 - training tours grant NO stat changes. We assert hp/psi are
 //     UNCHANGED across the tours; flip to "increases" when #453 lands.
-//   * #454 - post-career station arrival spawns at world origin (0,-0.87,0)
-//     instead of the designed recruit-deck spot (81.78,-3.6,16.54). We assert
-//     the buggy origin; flip to the designed spot when #454 lands.
+//   * #454 (FIXED) - post-career station arrival now spawns at the designed
+//     recruit-deck spot (81.78,-3.6,16.54) rather than the world origin. We
+//     assert the designed spot (within ~3 units, allowing physics settle).
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // Stable mission-data world positions (dark_query). These are the TRIPWIRE
@@ -53,8 +53,11 @@ const CAREER_DOORS = {
 // one real tour tripwire exercises the whole tripwire->marker->bit path.
 const TOUR_TRIP: Vec3 = [-22.6, -5.6, 8.0];
 
-const CAREER_SPAWN_BUG: Vec3 = [0.0, -0.87, 0.0]; // #454
-const near = (a: number, b: number) => Math.abs(a - b) < 0.05;
+// #454: the designed post-career recruit-deck spawn (station.mis marker obj 132,
+// PropStartLoc 2501, whose own PropPosition is used now that it has no
+// LandingPoint link). Allow ~3 units of slack for the physics settle after spawn.
+const CAREER_SPAWN_DESIGNED: Vec3 = [81.78026, -3.6, 16.539234];
+const CAREER_SPAWN_TOLERANCE = 3.0;
 
 async function teleportTo(game: GameServer, [x, y, z]: Vec3): Promise<void> {
   await game.player.teleport({ x, y, z });
@@ -99,17 +102,21 @@ test(
     // Marine loadout applied on the station load.
     assert.equal(info.player.max_hit_points, 45, "Marine deploys with 45 max HP");
     assert.equal(info.player.max_psi_points, 20, "Marine deploys with 20 max psi");
-    // #454: post-career arrival currently spawns at world origin, not the
-    // designed recruit-deck spot (81.78,-3.6,16.54). Flip this to the designed
-    // spot when #454 is fixed.
+    // #454 (fixed): post-career arrival lands at the designed recruit-deck spot
+    // (the StartLoc marker's own position), not the world origin.
     const arrival = info.player.position;
+    const spawnDelta = Math.hypot(
+      arrival[0] - CAREER_SPAWN_DESIGNED[0],
+      arrival[1] - CAREER_SPAWN_DESIGNED[1],
+      arrival[2] - CAREER_SPAWN_DESIGNED[2],
+    );
     assert.ok(
-      near(arrival[0], CAREER_SPAWN_BUG[0]) &&
-        near(arrival[1], CAREER_SPAWN_BUG[1]) &&
-        near(arrival[2], CAREER_SPAWN_BUG[2]),
-      `#454: post-career arrival should be at the buggy origin ${JSON.stringify(
-        CAREER_SPAWN_BUG,
-      )}, got ${JSON.stringify(arrival)}`,
+      spawnDelta < CAREER_SPAWN_TOLERANCE,
+      `#454: post-career arrival should be near the designed spot ${JSON.stringify(
+        CAREER_SPAWN_DESIGNED,
+      )} (within ${CAREER_SPAWN_TOLERANCE}u), got ${JSON.stringify(
+        arrival,
+      )} (delta ${spawnDelta.toFixed(2)}u)`,
     );
 
     // Step 2: tours 1 and 2 each set exactly the next training_year bit and loop


### PR DESCRIPTION
## Problem

After choosing a career on `earth.mis`, `ChooseService` transitions to `station.mis` with `loc: 2501`. The matching StartLoc marker (`station.mis` obj **132**, `Starting_Location`, `PropStartLoc(2501)`) has **no LandingPoint link**, and `SpawnLocation::Marker` only accepted StartLoc markers **with** a LandingPoint link — silently falling back to the world origin. The player landed at **(0, -0.87, 0)** instead of the designed recruit-deck spot **(81.78, -3.6, 16.54)** (~83 units away).

## Fix

`shock2vr/src/mission/spawn_location.rs`: when the matched StartLoc marker has no LandingPoint link, fall back to the **marker's own `PropPosition`** (never the world origin). The LandingPoint-link path stays preferred when present, so every mission that already resolves via a linked landing point is unchanged — the two trackers (`landing_delta` / `marker_delta`) are independent and the final select unconditionally prefers landing when available.

A code comment documents the retail-data reality (some StartLoc markers ship with no LandingPoint link).

## Testing

- **Negative-first (e2e):** flipped the `#454` characterization assertion in `station-flow.e2e.test.ts` to the designed spawn (within ~3u, allowing physics settle). It **fails on `main`** (`got [0,-0.87,0], delta 83.48u`) and **passes with the fix** (arrival `(81.78, -4.17, 16.54)`).
- **Unit tests:** two on `spawn_location.rs` — marker-without-LandingPoint falls back to the marker's own position; marker-with-LandingPoint prefers the linked position.
- Suites green: `station-flow` (2/2) + `station-career*` (2/2); `missions.e2e` **23/23**; `cargo test -p shock2vr` (121 passed); `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`.
- Cross-engine adversarial review (Claude + Codex): **no findings**.

## Reachability note (report-only, per the issue)

From the fixed spawn, the player is on valid walkable floor and advances freely on foot toward the tour-door area, then a **straight-line** `/v1/player/move` is geometry-blocked at x≈68 (a wall). Full reachability to the tour doors requires door/corridor navigation a straight shapecast can't resolve — this is expected map geometry, not a spawn defect. Not fixed here (out of scope).

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)