### PR TITLE
feat(career): station tour rewards + player stat model (Fixes #453)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -307,6 +307,14 @@ pub struct PropSignalType(pub String);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropStartLoc(pub i32);
 
+/// `P$CharGenRo` - the character-generation "row"/tour index (4-byte int) on
+/// the station recruit deck's training-tour markers. `station.mis` objs
+/// 125/126/127 carry 0/1/2, selecting which of a training year's three tours
+/// the player completed; `ChooseMission` uses it (with the current career +
+/// year) to look up the tour reward. See `shock2vr::player_stats`.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropCharGenRo(pub i32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropHasRefs(pub bool);
 
@@ -1519,6 +1527,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$StartLoc",
             |reader, _len| read_i32(reader),
             PropStartLoc,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$CharGenRo",
+            |reader, _len| read_i32(reader),
+            PropCharGenRo,
             accumulator::latest,
         ),
         define_prop(

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -622,6 +622,11 @@ pub struct PlayerInfo {
     /// The gamesys names of the active sustained psi powers (e.g. "Inviso"),
     /// in activation order; empty when none. See `shock2vr::PlayerStateSnapshot`.
     pub active_psi_powers: Vec<String>,
+    /// The player's persistent character sheet (primary stats, trained skills,
+    /// mastered psi disciplines), accumulated from career + station training
+    /// tours. `null` when the scene has no player. See
+    /// `shock2vr::player_stats::PlayerStats`.
+    pub stats: Option<shock2vr::player_stats::PlayerStats>,
 }
 
 /// Input state snapshot

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1843,6 +1843,7 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                     .as_ref()
                     .map(|s| s.active_psi_powers.clone())
                     .unwrap_or_default(),
+                stats: state.as_ref().and_then(|s| s.stats.clone()),
             }
         },
         entity_count,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -10,7 +10,7 @@ pub mod scenes;
 pub mod teleport;
 pub mod time;
 
-mod career;
+pub mod career;
 mod creature;
 mod flat_player_controller;
 mod gui;
@@ -22,6 +22,7 @@ pub mod palette;
 pub mod pathfinding;
 pub mod paths;
 mod physics;
+pub mod player_stats;
 mod psi;
 mod quest_info;
 mod runtime_props;
@@ -243,6 +244,10 @@ pub struct PlayerStateSnapshot {
     /// The gamesys names of the currently active sustained psi powers (e.g.
     /// "Inviso"), in activation order. Empty when none are active.
     pub active_psi_powers: Vec<String>,
+    /// The player's persistent character sheet (primary stats, skills, mastered
+    /// psi disciplines), accumulated from career + training tours. `None` when
+    /// the scene has no `QuestInfo` (e.g. a menu). See `crate::player_stats`.
+    pub stats: Option<crate::player_stats::PlayerStats>,
 }
 
 impl Game {
@@ -324,6 +329,10 @@ impl Game {
                 .borrow::<UniqueView<crate::psi::ActivePsiPowers>>()
                 .map(|active| active.0.iter().map(|p| p.name.clone()).collect())
                 .unwrap_or_default(),
+            stats: world
+                .borrow::<UniqueView<QuestInfo>>()
+                .ok()
+                .map(|q| q.player_stats().clone()),
         })
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2727,6 +2727,22 @@ impl MissionCore {
                     );
                 }
 
+                Effect::GrantTourReward { career, year, tour } => {
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let applied = quests
+                        .player_stats_mut()
+                        .apply_tour_reward(career, year, tour);
+                    if applied {
+                        info!(
+                            "Applied training-tour reward ({:?} year {} tour {}): {:?}",
+                            career,
+                            year,
+                            tour,
+                            quests.player_stats()
+                        );
+                    }
+                }
+
                 Effect::SetAIProperty { entity_id, update } => {
                     // The AI may have been destroyed earlier in this same
                     // effect batch (e.g. a scripted sequence whose final

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -1,0 +1,427 @@
+//! Player stat / skill model and the station training-tour reward table.
+//!
+//! System Shock 2's character is created by the earth->station recruit flow:
+//! the player picks a service branch (`career.rs`) and then completes three
+//! training tours - one per training "year" - on the recruit deck. Each tour
+//! grants stats/skills/psi-disciplines hardcoded by (career, year, tour). The
+//! retail engine keyed those grants by service+year+tour and stored them in
+//! code; the shipped `res/strings/CHARGEN.STR` (`Mission1..Mission27`) is the
+//! faithful *display* spec for the same grants. This module mirrors those 27
+//! grants as a Rust table ([`tour_reward`]) - the numbers are authored here
+//! (retail did the same); the STR strings are only used for the debrief text
+//! lookup ([`TourReward::text_key`]), never parsed for the numbers.
+//!
+//! [`PlayerStats`] is the persistent character sheet. It is stored inside
+//! [`crate::quest_info::QuestInfo`] (the same struct that carries career/quest
+//! bits), so it rides the existing persistence path for free: it survives level
+//! transitions (`QuestInfo` is threaded through `Game::save_active_scene` ->
+//! `load_mission_into_scene`) and save/load (`QuestInfo` is embedded in
+//! `SaveData::global_data`). This mirrors how hp/psi "persist": those are
+//! re-derived from the persisted career quest bits on every mission load
+//! (`mission_core.rs`); stats are the same idea but accumulate across tours.
+//!
+//! Deferred (storage + grants only, per issue #453): career-specific stat
+//! baselines (all careers start from the uniform [`PlayerStats::default`]
+//! baseline for now), and *derived gameplay effects* - Endurance->maxHP scaling
+//! and wiring the granted psi disciplines into `crate::psi` known powers. Those
+//! are noted here so a follow-up can pick them up.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::career::Career;
+
+/// The five primary character statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stat {
+    Strength,
+    Endurance,
+    Agility,
+    PsionicAbility,
+    CyberAffinity,
+}
+
+/// The nine trainable skills (weapon proficiencies + tech skills).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Skill {
+    StandardWeapons,
+    EnergyWeapons,
+    HeavyWeapons,
+    ExoticWeapons,
+    Hack,
+    Repair,
+    Modify,
+    Maintenance,
+    Research,
+}
+
+/// The trainable skill levels. Skills start untrained (0) and are raised by
+/// training tours. Named fields (rather than a map) keep the serialized shape
+/// explicit and stable for the debug-runtime / SDK introspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillLevels {
+    pub standard_weapons: i32,
+    pub energy_weapons: i32,
+    pub heavy_weapons: i32,
+    pub exotic_weapons: i32,
+    pub hack: i32,
+    pub repair: i32,
+    pub modify: i32,
+    pub maintenance: i32,
+    pub research: i32,
+}
+
+impl SkillLevels {
+    const fn zero() -> SkillLevels {
+        SkillLevels {
+            standard_weapons: 0,
+            energy_weapons: 0,
+            heavy_weapons: 0,
+            exotic_weapons: 0,
+            hack: 0,
+            repair: 0,
+            modify: 0,
+            maintenance: 0,
+            research: 0,
+        }
+    }
+
+    fn get_mut(&mut self, skill: Skill) -> &mut i32 {
+        match skill {
+            Skill::StandardWeapons => &mut self.standard_weapons,
+            Skill::EnergyWeapons => &mut self.energy_weapons,
+            Skill::HeavyWeapons => &mut self.heavy_weapons,
+            Skill::ExoticWeapons => &mut self.exotic_weapons,
+            Skill::Hack => &mut self.hack,
+            Skill::Repair => &mut self.repair,
+            Skill::Modify => &mut self.modify,
+            Skill::Maintenance => &mut self.maintenance,
+            Skill::Research => &mut self.research,
+        }
+    }
+}
+
+/// The player's persistent character sheet: primary stats, trained skills, and
+/// mastered psi disciplines, plus the set of training years already granted
+/// (so a tour reward applies exactly once per year even if a tour marker
+/// re-fires). Serialized as part of `QuestInfo`; see the module docs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlayerStats {
+    pub strength: i32,
+    pub endurance: i32,
+    pub agility: i32,
+    pub psionic_ability: i32,
+    pub cyber_affinity: i32,
+    pub skills: SkillLevels,
+    /// Psi disciplines mastered via OSA training tours, by display name (e.g.
+    /// "Cryokinesis"). Storage only for now; wiring these into the active psi
+    /// power set is a deferred derived effect (see module docs).
+    pub psi_disciplines: Vec<String>,
+    /// Training years (1..=3) whose tour reward has already been applied.
+    pub granted_years: BTreeSet<u32>,
+}
+
+impl Default for PlayerStats {
+    fn default() -> PlayerStats {
+        // Baseline: every primary stat starts at the retail floor of 1, skills
+        // untrained. Career-specific baselines are deferred (module docs), so
+        // all careers currently share this baseline and diverge via their tours.
+        PlayerStats {
+            strength: 1,
+            endurance: 1,
+            agility: 1,
+            psionic_ability: 1,
+            cyber_affinity: 1,
+            skills: SkillLevels::zero(),
+            psi_disciplines: Vec::new(),
+            granted_years: BTreeSet::new(),
+        }
+    }
+}
+
+impl PlayerStats {
+    pub fn new() -> PlayerStats {
+        PlayerStats::default()
+    }
+
+    fn stat_mut(&mut self, stat: Stat) -> &mut i32 {
+        match stat {
+            Stat::Strength => &mut self.strength,
+            Stat::Endurance => &mut self.endurance,
+            Stat::Agility => &mut self.agility,
+            Stat::PsionicAbility => &mut self.psionic_ability,
+            Stat::CyberAffinity => &mut self.cyber_affinity,
+        }
+    }
+
+    /// Apply a (career, year, tour) training-tour reward, once per training
+    /// year. Returns `true` if a reward was applied, `false` if this year was
+    /// already granted or no reward exists for the key.
+    pub fn apply_tour_reward(&mut self, career: Career, year: u32, tour: u32) -> bool {
+        if self.granted_years.contains(&year) {
+            return false;
+        }
+        let Some(reward) = tour_reward(career, year, tour) else {
+            return false;
+        };
+        for (stat, amount) in reward.stats {
+            *self.stat_mut(*stat) += *amount;
+        }
+        for (skill, amount) in reward.skills {
+            *self.skills.get_mut(*skill) += *amount;
+        }
+        for discipline in reward.psi_disciplines {
+            self.psi_disciplines.push((*discipline).to_string());
+        }
+        self.granted_years.insert(year);
+        true
+    }
+}
+
+/// One training-tour reward: the grants plus the `CHARGEN.STR` key of its
+/// debrief text (so a future UI can show the "You've gained..." message).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TourReward {
+    /// The `res/strings/CHARGEN.STR` key for this tour's debrief text
+    /// (`Mission1..Mission27`). Display only; the grants below are authoritative.
+    pub text_key: &'static str,
+    pub stats: &'static [(Stat, i32)],
+    pub skills: &'static [(Skill, i32)],
+    /// Mastered psi disciplines, by display name (OSA year-1/3 tours).
+    pub psi_disciplines: &'static [&'static str],
+}
+
+const fn reward(
+    text_key: &'static str,
+    stats: &'static [(Stat, i32)],
+    skills: &'static [(Skill, i32)],
+    psi_disciplines: &'static [&'static str],
+) -> TourReward {
+    TourReward {
+        text_key,
+        stats,
+        skills,
+        psi_disciplines,
+    }
+}
+
+use Skill::*;
+use Stat::*;
+
+/// The 27 training-tour rewards, indexed `[career][year-1][tour]`. Career order
+/// (Marine, Navy, OSA) matches `Career::from_service` (0/1/2) and the
+/// CHARGEN.STR block order (`Mission1..9` Marine, `10..18` Navy, `19..27` OSA).
+/// Each entry is annotated with its `MissionN` string.
+#[rustfmt::skip]
+static REWARDS: [[[TourReward; 3]; 3]; 3] = [
+    // ===== Marine (career 0) =====
+    [
+        // Year 1
+        [
+            reward("Mission1", &[(Strength, 2)], &[], &[]),   // +2 Strength
+            reward("Mission2", &[(Endurance, 2)], &[], &[]),  // +2 Endurance
+            reward("Mission3", &[(Agility, 2)], &[], &[]),    // +2 Agility
+        ],
+        // Year 2
+        [
+            reward("Mission4", &[(CyberAffinity, 1)], &[(EnergyWeapons, 1)], &[]), // +1 Energy Weapons, +1 Cyber Affinity
+            reward("Mission5", &[(CyberAffinity, 1)], &[(HeavyWeapons, 1)], &[]),  // +1 Heavy Weapons, +1 Cyber Affinity
+            reward("Mission6", &[], &[(StandardWeapons, 2)], &[]),                 // +2 Standard Weapons
+        ],
+        // Year 3
+        [
+            reward("Mission7", &[], &[(Maintenance, 1)], &[]), // +1 Maintenance
+            reward("Mission8", &[], &[(Modify, 1)], &[]),      // +1 Modify
+            reward("Mission9", &[], &[(Repair, 1)], &[]),      // +1 Repair
+        ],
+    ],
+    // ===== Navy (career 1) =====
+    [
+        // Year 1
+        [
+            reward("Mission10", &[(Strength, 1)], &[(Hack, 1)], &[]),   // +1 Hack, +1 Strength
+            reward("Mission11", &[(Strength, 1)], &[(Repair, 1)], &[]), // +1 Repair, +1 Strength
+            reward("Mission12", &[(Strength, 1)], &[(Modify, 1)], &[]), // +1 Modify, +1 Strength
+        ],
+        // Year 2
+        [
+            reward("Mission13", &[(CyberAffinity, 2)], &[], &[]),          // +2 Cyber Affinity
+            reward("Mission14", &[], &[(Maintenance, 1)], &[]),            // +1 Maintenance
+            reward("Mission15", &[], &[(StandardWeapons, 2)], &[]),        // +2 Standard Weapons
+        ],
+        // Year 3
+        [
+            reward("Mission16", &[], &[(Research, 1)], &[]),  // +1 Research
+            reward("Mission17", &[(Endurance, 2)], &[], &[]), // +2 Endurance
+            reward("Mission18", &[(Agility, 2)], &[], &[]),   // +2 Agility
+        ],
+    ],
+    // ===== OSA (career 2) =====
+    [
+        // Year 1 - psi disciplines (each also unlocks Tier 2 access in retail)
+        [
+            reward("Mission19", &[], &[], &["Cryokinesis", "Psychogenic Cyber Affinity"]), // mastered Cryokinesis + Psychogenic Cyber Affinity
+            reward("Mission20", &[], &[], &["Cryokinesis", "Kinetic Redirection"]),        // mastered Cryokinesis + Kinetic Redirection
+            reward("Mission21", &[], &[], &["Cryokinesis", "Psycho-reflective Screen"]),   // mastered Cryokinesis + Psycho-reflective Screen
+        ],
+        // Year 2
+        [
+            reward("Mission22", &[(PsionicAbility, 2)], &[], &[]), // +2 Psionic Ability
+            reward("Mission23", &[], &[(Research, 1)], &[]),       // +1 Research
+            reward("Mission24", &[(Endurance, 2)], &[], &[]),      // +2 Endurance
+        ],
+        // Year 3 - +1 STR/+1 AGI/+1 CYB plus a mastered psi discipline
+        [
+            reward("Mission25", &[(Strength, 1), (Agility, 1), (CyberAffinity, 1)], &[], &["Psychogenic Agility"]),      // + Psychogenic Agility
+            reward("Mission26", &[(Strength, 1), (Agility, 1), (CyberAffinity, 1)], &[], &["Neuro-Reflex Dampening"]),   // + Neuro-Reflex Dampening
+            reward("Mission27", &[(Strength, 1), (Agility, 1), (CyberAffinity, 1)], &[], &["Remote Electron Tampering"]), // + Remote Electron Tampering
+        ],
+    ],
+];
+
+/// Career index into [`REWARDS`], matching `Career::from_service` (0/1/2) and
+/// the CHARGEN.STR block order.
+fn career_index(career: Career) -> usize {
+    match career {
+        Career::Marine => 0,
+        Career::Navy => 1,
+        Career::Osa => 2,
+    }
+}
+
+/// The reward for completing tour `tour` (0..=2) of training year `year`
+/// (1..=3) for the given career, or `None` if the indices are out of range.
+pub fn tour_reward(career: Career, year: u32, tour: u32) -> Option<&'static TourReward> {
+    if year < 1 || year > 3 || tour > 2 {
+        return None;
+    }
+    Some(&REWARDS[career_index(career)][(year - 1) as usize][tour as usize])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_is_fully_populated_with_unique_text_keys() {
+        let mut keys = BTreeSet::new();
+        for career in Career::ALL {
+            for year in 1..=3 {
+                for tour in 0..=2 {
+                    let r = tour_reward(career, year, tour).unwrap_or_else(|| {
+                        panic!("missing reward {:?} y{} t{}", career, year, tour)
+                    });
+                    assert!(keys.insert(r.text_key), "duplicate text key {}", r.text_key);
+                    // Every entry grants something (stats, skills, or disciplines).
+                    let total = r.stats.len() + r.skills.len() + r.psi_disciplines.len();
+                    assert!(total > 0, "empty reward for {}", r.text_key);
+                }
+            }
+        }
+        assert_eq!(keys.len(), 27, "expected all 27 MissionN keys");
+        // Keys should be exactly Mission1..=Mission27.
+        for n in 1..=27 {
+            assert!(keys.contains(format!("Mission{}", n).as_str()));
+        }
+    }
+
+    #[test]
+    fn out_of_range_returns_none() {
+        assert!(tour_reward(Career::Marine, 0, 0).is_none());
+        assert!(tour_reward(Career::Marine, 4, 0).is_none());
+        assert!(tour_reward(Career::Marine, 1, 3).is_none());
+    }
+
+    #[test]
+    fn spot_check_exact_grants() {
+        // Marine Y1 T0 (Mission1): +2 Strength.
+        let r = tour_reward(Career::Marine, 1, 0).unwrap();
+        assert_eq!(r.text_key, "Mission1");
+        assert_eq!(r.stats, &[(Stat::Strength, 2)]);
+
+        // Marine Y2 T0 (Mission4): +1 Energy Weapons, +1 Cyber Affinity.
+        let r = tour_reward(Career::Marine, 2, 0).unwrap();
+        assert_eq!(r.text_key, "Mission4");
+        assert_eq!(r.stats, &[(Stat::CyberAffinity, 1)]);
+        assert_eq!(r.skills, &[(Skill::EnergyWeapons, 1)]);
+
+        // Marine Y3 T0 (Mission7): +1 Maintenance.
+        let r = tour_reward(Career::Marine, 3, 0).unwrap();
+        assert_eq!(r.text_key, "Mission7");
+        assert_eq!(r.skills, &[(Skill::Maintenance, 1)]);
+
+        // Navy Y1 T0 (Mission10): +1 Hack, +1 Strength.
+        let r = tour_reward(Career::Navy, 1, 0).unwrap();
+        assert_eq!(r.text_key, "Mission10");
+        assert_eq!(r.stats, &[(Stat::Strength, 1)]);
+        assert_eq!(r.skills, &[(Skill::Hack, 1)]);
+
+        // OSA Y1 T1 (Mission20): Cryokinesis + Kinetic Redirection.
+        let r = tour_reward(Career::Osa, 1, 1).unwrap();
+        assert_eq!(r.text_key, "Mission20");
+        assert_eq!(r.psi_disciplines, &["Cryokinesis", "Kinetic Redirection"]);
+
+        // OSA Y3 T2 (Mission27): +1 STR/+1 AGI/+1 CYB + Remote Electron Tampering.
+        let r = tour_reward(Career::Osa, 3, 2).unwrap();
+        assert_eq!(r.text_key, "Mission27");
+        assert_eq!(
+            r.stats,
+            &[
+                (Stat::Strength, 1),
+                (Stat::Agility, 1),
+                (Stat::CyberAffinity, 1)
+            ]
+        );
+        assert_eq!(r.psi_disciplines, &["Remote Electron Tampering"]);
+    }
+
+    #[test]
+    fn apply_marine_tour0_chain_accumulates() {
+        // The Marine chain the station-flow e2e walks: tour 0 of each year.
+        let mut stats = PlayerStats::new();
+        let base_str = stats.strength;
+        let base_cyb = stats.cyber_affinity;
+
+        assert!(stats.apply_tour_reward(Career::Marine, 1, 0)); // +2 STR
+        assert_eq!(stats.strength, base_str + 2);
+
+        assert!(stats.apply_tour_reward(Career::Marine, 2, 0)); // +1 EnergyWeapons, +1 CYB
+        assert_eq!(stats.skills.energy_weapons, 1);
+        assert_eq!(stats.cyber_affinity, base_cyb + 1);
+
+        assert!(stats.apply_tour_reward(Career::Marine, 3, 0)); // +1 Maintenance
+        assert_eq!(stats.skills.maintenance, 1);
+
+        assert_eq!(stats.granted_years, BTreeSet::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn tour_reward_applies_once_per_year() {
+        let mut stats = PlayerStats::new();
+        assert!(stats.apply_tour_reward(Career::Marine, 1, 0)); // +2 STR
+        assert_eq!(stats.strength, 3);
+        // Re-firing the same year (even a different tour) is a no-op.
+        assert!(!stats.apply_tour_reward(Career::Marine, 1, 1));
+        assert!(!stats.apply_tour_reward(Career::Marine, 1, 0));
+        assert_eq!(stats.strength, 3);
+    }
+
+    #[test]
+    fn stats_round_trip_through_serde() {
+        let mut stats = PlayerStats::new();
+        stats.apply_tour_reward(Career::Osa, 1, 0);
+        stats.apply_tour_reward(Career::Osa, 3, 0);
+        let json = serde_json::to_string(&stats).unwrap();
+        let back: PlayerStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(stats, back);
+        assert_eq!(
+            back.psi_disciplines,
+            vec![
+                "Cryokinesis".to_string(),
+                "Psychogenic Cyber Affinity".to_string(),
+                "Psychogenic Agility".to_string()
+            ]
+        );
+    }
+}

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -259,7 +259,13 @@ static REWARDS: [[[TourReward; 3]; 3]; 3] = [
     ],
     // ===== OSA (career 2) =====
     [
-        // Year 1 - psi disciplines (each also unlocks Tier 2 access in retail)
+        // Year 1 - psi disciplines. Each Mission19-21 string also grants
+        // "Level Two Psi disciplines" (Tier 2 access) on top of the two named
+        // powers. That tier unlock is intentionally NOT stored here: it is a psi
+        // capability gate with no reader until the deferred psi-discipline
+        // gameplay wiring lands (see module docs) - representing it now would be
+        // storage with no consumer. Only the two named mastered powers are
+        // recorded, which is what the character sheet surfaces today.
         [
             reward("Mission19", &[], &[], &["Cryokinesis", "Psychogenic Cyber Affinity"]), // mastered Cryokinesis + Psychogenic Cyber Affinity
             reward("Mission20", &[], &[], &["Cryokinesis", "Kinetic Redirection"]),        // mastered Cryokinesis + Kinetic Redirection

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -9,11 +9,19 @@ use dark::properties::{KeyCard, QuestBitValue};
 use serde::{Deserialize, Serialize};
 use shipyard::Unique;
 
+use crate::player_stats::PlayerStats;
+
 #[derive(Deserialize, Serialize, Unique, Clone, Debug)]
 pub struct QuestInfo {
     quest_bit_values: HashMap<String, QuestBitValue>,
     played_emails: HashSet<String>,
     key_cards: Vec<KeyCard>,
+    /// The player's persistent character sheet (primary stats, skills, mastered
+    /// psi disciplines). Lives here so it survives level transitions and
+    /// save/load on the same path as the career/quest bits. `#[serde(default)]`
+    /// keeps older save files (written before this field existed) loadable.
+    #[serde(default)]
+    player_stats: PlayerStats,
 }
 
 impl QuestInfo {
@@ -22,7 +30,19 @@ impl QuestInfo {
             quest_bit_values: HashMap::new(),
             played_emails: HashSet::new(),
             key_cards: Vec::new(),
+            player_stats: PlayerStats::new(),
         }
+    }
+
+    /// The player's persistent character sheet.
+    pub fn player_stats(&self) -> &PlayerStats {
+        &self.player_stats
+    }
+
+    /// Mutable access to the player's character sheet (e.g. to apply a training
+    /// tour reward).
+    pub fn player_stats_mut(&mut self) -> &mut PlayerStats {
+        &mut self.player_stats
     }
 
     pub fn add_key_card(&mut self, key_card: KeyCard) {

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -1,8 +1,8 @@
-use dark::properties::{PropDestLevel, PropDestLoc, QuestBitValue};
+use dark::properties::{PropCharGenRo, PropDestLevel, PropDestLoc, QuestBitValue};
 use shipyard::{EntityId, Get, UniqueView, View, World};
 use tracing::info;
 
-use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
+use crate::{career::Career, physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{Effect, MessagePayload, Script};
 
@@ -38,6 +38,34 @@ impl ChooseMissionScript {
             quest_bit_value: QuestBitValue::COMPLETE,
         }
     }
+
+    /// The reward effect for completing this tour: the current career (from the
+    /// persisted career bit) + the training year being completed (`current_year`,
+    /// 1..=3) + the tour index `P$CharGenRo` carried by the tour marker
+    /// (`entity_id`). `Effect::NoEffect` when no career is set or the marker
+    /// lacks a tour index. The grant is applied at most once per training year
+    /// (see `PlayerStats::apply_tour_reward`).
+    fn grant_reward_effect(world: &World, entity_id: EntityId, current_year: u32) -> Effect {
+        let career = {
+            let quest_info = world.borrow::<UniqueView<QuestInfo>>().unwrap();
+            Career::from_quest_info(&quest_info)
+        };
+        let Some(career) = career else {
+            return Effect::NoEffect;
+        };
+        let tour = world
+            .borrow::<View<PropCharGenRo>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|c| c.0));
+        let Some(tour) = tour else {
+            return Effect::NoEffect;
+        };
+        Effect::GrantTourReward {
+            career,
+            year: current_year,
+            tour: tour.max(0) as u32,
+        }
+    }
 }
 
 impl Script for ChooseMissionScript {
@@ -50,22 +78,34 @@ impl Script for ChooseMissionScript {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                // Get current training year and increment it
+                // Get current training year and increment it. `current_year` is
+                // the year the player just completed (1..=3): the first tour
+                // fires with no `training_year_*` bit set (current 1 -> new 2),
+                // the second with `_2` set (current 2 -> new 3), the third with
+                // `_2`+`_3` (current 3 -> new 4 = deploy). NB: `training_year_1`
+                // is never authored - the counter starts at `_2`.
                 let current_year = Self::get_current_year(world);
                 let new_year = current_year + 1;
 
                 // Create effect to set the new year quest bit
                 let set_year_effect = Self::set_training_year(new_year);
 
+                // Grant this tour's stat/skill reward for (career, completed
+                // year, tour index). Applies at most once per training year.
+                let grant_effect = Self::grant_reward_effect(world, entity_id, current_year);
+
                 if new_year < 4 {
                     info!(
                         "ChooseMission: Handling year {} (< 4), returning to station.mis",
                         new_year
                     );
-                    // For years 1, 2, 3: only teleport to PropDestLoc (stay in current mission)
+                    // For years 1, 2: loop back to station.mis for the next tour.
+                    // The transition uses the level's default spawn (loc: None);
+                    // the marker's PropDestLoc is only used on the final deploy.
 
                     Effect::Multiple(vec![
                         set_year_effect,
+                        grant_effect,
                         Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
                             level_file: "station.mis".to_string(),
                             loc: None,
@@ -85,6 +125,7 @@ impl Script for ChooseMissionScript {
 
                     Effect::Multiple(vec![
                         set_year_effect,
+                        grant_effect,
                         Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
                             level_file,
                             loc: dest_loc,

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -53,17 +53,21 @@ impl ChooseMissionScript {
         let Some(career) = career else {
             return Effect::NoEffect;
         };
+        // A malformed (negative) tour index is rejected rather than clamped to
+        // tour 0, so bad data grants nothing instead of the wrong reward
+        // (`tour_reward` validates the 0..=2 range on the u32).
         let tour = world
             .borrow::<View<PropCharGenRo>>()
             .ok()
-            .and_then(|v| v.get(entity_id).ok().map(|c| c.0));
+            .and_then(|v| v.get(entity_id).ok().map(|c| c.0))
+            .and_then(|raw| u32::try_from(raw).ok());
         let Some(tour) = tour else {
             return Effect::NoEffect;
         };
         Effect::GrantTourReward {
             career,
             year: current_year,
-            tour: tour.max(0) as u32,
+            tour,
         }
     }
 }

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -12,8 +12,14 @@ use super::{Effect, GlobalEffect, MessagePayload, Script};
 ///
 /// The three career-choice markers in `earth.mis` (`SendToMarines` and its two
 /// unnamed siblings) carry this script plus a `P$Service` value (0 = Marine,
-/// 1 = Navy, 2 = OSA) and a `P$DestLevel`/`P$DestLoc` transition target. A
-/// tripwire `TurnOn`s the marker matching the branch the player walked into; on
+/// 1 = Navy, 2 = OSA) and a `P$DestLevel`/`P$DestLoc` transition target.
+///
+/// NB retail data misnomer: `earth.mis` obj 609 is *named* `SendToMarines` but
+/// carries `P$Service = 1` (= Navy), verified against `MISC.STR` + the banner
+/// geometry. The engine follows `P$Service`, not the name, so this marker
+/// correctly enlists the player in the Navy - do not "fix" the name.
+///
+/// A tripwire `TurnOn`s the marker matching the branch the player walked into; on
 /// that message this script persists the chosen career as a quest bit - so the
 /// career loadout applies to the player on every subsequent mission load (see
 /// `crate::career` + `MissionCore::load`) - and then transitions to the marker's

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -342,6 +342,15 @@ pub enum Effect {
         quest_bit_value: QuestBitValue,
     },
 
+    /// Apply the training-tour reward for `(career, year, tour)` to the player's
+    /// persistent stats (in `QuestInfo`). Applied at most once per training
+    /// year. Emitted by `ChooseMissionScript` on tour completion.
+    GrantTourReward {
+        career: crate::career::Career,
+        year: u32,
+        tour: u32,
+    },
+
     SetAIProperty {
         entity_id: EntityId,
         update: AIPropertyUpdate,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -189,6 +189,38 @@ export interface PlayerSnapshot {
   /** The gamesys names of the active sustained psi powers (e.g. "Inviso"),
    * in activation order; empty when none. */
   active_psi_powers: string[];
+  /** The player's persistent character sheet (primary stats, trained skills,
+   * mastered psi disciplines), accumulated from career + station training
+   * tours; null when the scene has no player. */
+  stats: PlayerStats | null;
+}
+
+/** Trainable skill levels (weapon proficiencies + tech skills). */
+export interface SkillLevels {
+  standard_weapons: number;
+  energy_weapons: number;
+  heavy_weapons: number;
+  exotic_weapons: number;
+  hack: number;
+  repair: number;
+  modify: number;
+  maintenance: number;
+  research: number;
+}
+
+/** The player's persistent character sheet. Primary stats start at a baseline
+ * of 1 and skills at 0; station training tours raise them per the (career,
+ * year, tour) reward table. `psi_disciplines` lists OSA-mastered disciplines by
+ * display name; `granted_years` records which training years were applied. */
+export interface PlayerStats {
+  strength: number;
+  endurance: number;
+  agility: number;
+  psionic_ability: number;
+  cyber_affinity: number;
+  skills: SkillLevels;
+  psi_disciplines: string[];
+  granted_years: number[];
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -21,13 +21,20 @@ import type { Vec3 } from "../src/types.js";
 // characterization test: it must PASS on `main` and encodes the flow as a
 // permanent regression net.
 //
-// Two assertions deliberately pin CURRENT (buggy) behavior so they FLIP when the
-// underlying issue is fixed:
-//   * #453 - training tours grant NO stat changes. We assert hp/psi are
-//     UNCHANGED across the tours; flip to "increases" when #453 lands.
-//   * #454 (FIXED) - post-career station arrival now spawns at the designed
-//     recruit-deck spot (81.78,-3.6,16.54) rather than the world origin. We
-//     assert the designed spot (within ~3 units, allowing physics settle).
+// #453 (LANDED): training tours now grant stats/skills per the (career, year,
+// tour) reward table mirroring CHARGEN.STR. This test's Marine chain fires tour
+// marker 125 (P$CharGenRo = tour 0) once per year, so it applies the tour-0
+// grant of each Marine year: Y1 Mission1 (+2 STR), Y2 Mission4 (+1 Energy
+// Weapons, +1 Cyber Affinity), Y3 Mission7 (+1 Maintenance). We assert each
+// grant as it lands and the cumulative sheet surviving the deploy to MedSci1
+// (and a save/load round-trip mid-flow). These assertions read
+// `info.player.stats`, which did not exist before #453 - the pre-#453 runtime
+// reports no stats and applies no grants, so they fail on `main` (negative).
+//
+// #454 (FIXED): post-career station arrival spawns at the designed
+// recruit-deck spot (81.78,-3.6,16.54) - the StartLoc marker's own position -
+// rather than the world origin. We assert the designed spot (within ~3 units,
+// allowing physics settle).
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // Stable mission-data world positions (dark_query). These are the TRIPWIRE
@@ -102,6 +109,19 @@ test(
     // Marine loadout applied on the station load.
     assert.equal(info.player.max_hit_points, 45, "Marine deploys with 45 max HP");
     assert.equal(info.player.max_psi_points, 20, "Marine deploys with 20 max psi");
+
+    // #453: the persistent character sheet exists and starts at baseline (no
+    // tours completed yet). On `main` this field is absent, so `base` is
+    // null/undefined and every assertion below fails (the negative).
+    const base = info.player.stats;
+    assert.ok(base, "#453: player.stats should be present at station arrival");
+    assert.deepEqual(
+      base.granted_years,
+      [],
+      "#453: no training-year rewards applied before any tour",
+    );
+    const baseStr = base.strength;
+    const baseCyb = base.cyber_affinity;
     // #454 (fixed): post-career arrival lands at the designed recruit-deck spot
     // (the StartLoc marker's own position), not the world origin.
     const arrival = info.player.position;
@@ -119,32 +139,61 @@ test(
       )} (delta ${spawnDelta.toFixed(2)}u)`,
     );
 
-    // Step 2: tours 1 and 2 each set exactly the next training_year bit and loop
-    // back to station.mis. hp/psi must NOT change (#453).
-    const tours: { expected: string[] }[] = [
-      { expected: ["training_year_2"] },
-      { expected: ["training_year_2", "training_year_3"] },
-    ];
-    for (const [i, tour] of tours.entries()) {
-      await teleportTo(game, TOUR_TRIP);
-      await game.step({ frames: 20 });
-      info = await game.info();
-      assert.equal(
-        info.mission.toLowerCase(),
-        "station.mis",
-        `tour ${i + 1} (year < 4) should loop back to station.mis`,
-      );
-      assert.deepEqual(
-        await completeTrainingYears(game),
-        tour.expected,
-        `tour ${i + 1} should set exactly ${JSON.stringify(tour.expected)}`,
-      );
-      // #453: tours grant no stats today. Flip to an increase when #453 is fixed.
-      assert.equal(info.player.max_hit_points, 45, `#453: tour ${i + 1} must not change max HP`);
-      assert.equal(info.player.max_psi_points, 20, `#453: tour ${i + 1} must not change max psi`);
-    }
+    // Step 2: tours 1 and 2 each set exactly the next training_year bit, loop
+    // back to station.mis, and grant the tour-0 reward for that Marine year
+    // (#453). hp/psi are unchanged by these grants (they touch STR/skills), so
+    // the loadout stays 45/20 - the observable change is now in player.stats.
+    await teleportTo(game, TOUR_TRIP);
+    await game.step({ frames: 20 });
+    info = await game.info();
+    assert.equal(info.mission.toLowerCase(), "station.mis", "tour 1 (year < 4) should loop back to station.mis");
+    assert.deepEqual(
+      await completeTrainingYears(game),
+      ["training_year_2"],
+      "tour 1 should set exactly training_year_2",
+    );
+    // #453 Marine Y1 T0 (Mission1): +2 Strength.
+    assert.ok(info.player.stats, "player.stats present after tour 1");
+    assert.equal(info.player.stats.strength, baseStr + 2, "#453: tour 1 grants +2 Strength (Mission1)");
+    assert.deepEqual(info.player.stats.granted_years, [1], "tour 1 records year 1 granted");
+    assert.equal(info.player.max_hit_points, 45, "tour 1 leaves max HP unchanged (grant is STR)");
+    assert.equal(info.player.max_psi_points, 20, "tour 1 leaves max psi unchanged");
 
-    // Step 3: the third tour advances to year 4 and deploys to MedSci1.
+    await teleportTo(game, TOUR_TRIP);
+    await game.step({ frames: 20 });
+    info = await game.info();
+    assert.equal(info.mission.toLowerCase(), "station.mis", "tour 2 (year < 4) should loop back to station.mis");
+    assert.deepEqual(
+      await completeTrainingYears(game),
+      ["training_year_2", "training_year_3"],
+      "tour 2 should set training_year_2 + training_year_3",
+    );
+    // #453 Marine Y2 T0 (Mission4): +1 Energy Weapons, +1 Cyber Affinity.
+    assert.ok(info.player.stats, "player.stats present after tour 2");
+    assert.equal(info.player.stats.strength, baseStr + 2, "STR from tour 1 carries into tour 2");
+    assert.equal(info.player.stats.skills.energy_weapons, 1, "#453: tour 2 grants +1 Energy Weapons (Mission4)");
+    assert.equal(info.player.stats.cyber_affinity, baseCyb + 1, "#453: tour 2 grants +1 Cyber Affinity (Mission4)");
+    assert.deepEqual(info.player.stats.granted_years, [1, 2], "tour 2 records years 1+2 granted");
+
+    // Save/load leg: persist mid-flow (after year 2) and reload in the same
+    // runtime; the accumulated stats must survive the round-trip byte-for-byte.
+    const statsBeforeSave = info.player.stats;
+    const saveName = `station_flow_453_${Date.now()}`;
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+    info = await game.info();
+    assert.equal(info.mission.toLowerCase(), "station.mis", "load restores station.mis");
+    assert.ok(info.player.stats, "player.stats present after load");
+    assert.deepEqual(
+      info.player.stats,
+      statsBeforeSave,
+      "#453: the character sheet survives save/load unchanged",
+    );
+
+    // Step 3: the third tour advances to year 4, grants the Marine Y3 T0 reward
+    // (Mission7: +1 Maintenance), and deploys to MedSci1 - stats survive the
+    // level transition.
     await teleportTo(game, TOUR_TRIP);
     await game.step({ frames: 20 });
     info = await game.info();
@@ -158,10 +207,17 @@ test(
       ["training_year_2", "training_year_3", "training_year_4"],
       "all three training years should be complete after deploying",
     );
-    // Career and loadout survive the whole chain unchanged (#453 keeps stats flat).
+    // Career and loadout survive the whole chain.
     assert.equal(await game.quests.get("career_marine"), "complete", "Marine career should survive deploy");
     assert.equal(info.player.max_hit_points, 45, "Marine max HP should survive deploy");
     assert.equal(info.player.max_psi_points, 20, "Marine max psi should survive deploy");
+    // #453: the cumulative Marine tour-0 sheet survives the deploy into MedSci1.
+    assert.ok(info.player.stats, "player.stats present at MedSci1");
+    assert.equal(info.player.stats.strength, baseStr + 2, "cumulative +2 STR at MedSci1 (Mission1)");
+    assert.equal(info.player.stats.cyber_affinity, baseCyb + 1, "cumulative +1 Cyber Affinity at MedSci1 (Mission4)");
+    assert.equal(info.player.stats.skills.energy_weapons, 1, "cumulative +1 Energy Weapons at MedSci1 (Mission4)");
+    assert.equal(info.player.stats.skills.maintenance, 1, "#453: tour 3 grants +1 Maintenance (Mission7)");
+    assert.deepEqual(info.player.stats.granted_years, [1, 2, 3], "all three years granted at MedSci1");
     assert.ok(
       info.player.position.every(Number.isFinite),
       `deploy position should be finite, got ${JSON.stringify(info.player.position)}`,


### PR DESCRIPTION
## What & why

Fixes #453. Before this, choosing a station training tour did **nothing** to the character: stats were identical before/after every tour, and `SkillTrainerScript` was a named no-op — no player stat/skill storage existed anywhere (only hp/psi). This lands the character-creation reward system: the nine tour choices across three training years now accumulate into a persistent stat/skill sheet, faithful to retail's hardcoded `(service, year, tour)` grants.

## What it does

- **Parse `P$CharGenRo`** (`dark`): station tour markers (objs 125/126/127) carry this 4-byte int tour index (0/1/2), previously unparsed. New `PropCharGenRo(i32)`.
- **Reward table** (`shock2vr/src/player_stats.rs`): a 27-entry `[career][year-1][tour]` table mirroring `CHARGEN.STR` `Mission1..27` exactly. Numbers are **authored in Rust** (retail did the same; the STR is display text — not regex'd at runtime); each entry is annotated with its `MissionN` key, and `TourReward::text_key` carries the key so a future debrief UI can show the "You've gained…" message.
- **Player stat/skill model**: `PlayerStats` — STR/END/AGI/PSI/CYB, nine skills (Standard/Energy/Heavy/Exotic Weapons, Hack/Repair/Modify/Maintenance/Research), mastered psi disciplines, and `granted_years`.
- **ChooseMission applies the grant** for `(current career, completed year, P$CharGenRo tour)` on each tour's `TurnOn`, **once per training year** (gated on `granted_years`).
- **Introspection**: `PlayerStats` surfaced on the debug runtime `/v1/info` player block + SDK `PlayerSnapshot.stats` types.
- **D5 nits folded in**: fixed the stale `choose_mission` comment (years 1/2 loop with `loc: None`, not a `PropDestLoc` teleport; `training_year_1` is never authored); documented that `earth.mis` obj 609 `SendToMarines` carries `Service=1` (Navy) — a retail data misnomer, engine mapping is correct.

## Design decisions

- **Where stats live & how they persist:** `PlayerStats` is a field of `QuestInfo`. That's the crux — `QuestInfo` is already threaded across level transitions (`save_active_scene → load_mission_into_scene`) and embedded in `SaveData::global_data`, so the sheet rides the **existing** persistence path for free and survives both level transitions **and** save/load. This mirrors how hp/psi "persist" today: they're re-derived from persisted career quest bits on each load (`mission_core.rs`); stats are the same idea but accumulate. `#[serde(default)]` keeps pre-existing saves loadable.
- **Grant as an Effect:** `ChooseMission` emits `Effect::GrantTourReward{career,year,tour}`, applied before the level-transition effect so the grant is committed to `QuestInfo` before the outgoing scene serializes.
- **Baseline:** all primary stats start at the retail floor of 1, skills at 0 (uniform across careers for now).

## Deferred (explicit)

- **END→maxHP scaling** — does not drop out naturally (maxHP is set from career-loadout absolutes on every load), so deferred rather than half-wired.
- **Wiring granted psi disciplines into the active power set** (`crate::psi`) — storage + grant names only for now.
- **Career-specific stat baselines** and **OSA year-1 "Tier Two access"** — the latter is a psi capability gate with no reader until the psi-discipline wiring lands.

## Verification

- Unit: reward-table (all 27 populated, unique `MissionN` keys, exact-grant spot checks, out-of-range → `None`), once-per-year gating, serde round-trip, Marine tour-0 chain accumulation.
- `cargo fmt` clean; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark` clean; `cargo test -p shock2vr -p dark` green (125 + 5).
- e2e (SDK): **station-flow** (flipped — see below), station-career, station-career-attributes, save-load, all **23/23 missions load**, SDK `npm test`.
- **Negative-first evidence:** the flipped station-flow assertions read `info.player.stats` and the granted values. With the grant neutralized (rebuild), the Marine chain fails at `#453: tour 1 grants +2 Strength (Mission1)` — *expected 3, actual 1*; the sibling Navy/OSA test still passes. Restoring the grant makes both pass. The test also adds a save/load leg (save after year 2, load, assert the sheet round-trips unchanged) and asserts the cumulative sheet survives the deploy into MedSci1.

## The 27-grant grid (career × year × tour → grant)

| Career | Year | Tour 0 | Tour 1 | Tour 2 |
|---|---|---|---|---|
| **Marine** | 1 | +2 STR (M1) | +2 END (M2) | +2 AGI (M3) |
| | 2 | +1 EnergyWpn +1 CYB (M4) | +1 HeavyWpn +1 CYB (M5) | +2 StdWpn (M6) |
| | 3 | +1 Maintenance (M7) | +1 Modify (M8) | +1 Repair (M9) |
| **Navy** | 1 | +1 Hack +1 STR (M10) | +1 Repair +1 STR (M11) | +1 Modify +1 STR (M12) |
| | 2 | +2 CYB (M13) | +1 Maintenance (M14) | +2 StdWpn (M15) |
| | 3 | +1 Research (M16) | +2 END (M17) | +2 AGI (M18) |
| **OSA** | 1 | psi: Cryokinesis + Psychogenic Cyber Affinity (M19) | psi: Cryokinesis + Kinetic Redirection (M20) | psi: Cryokinesis + Psycho-reflective Screen (M21) |
| | 2 | +2 PSI (M22) | +1 Research (M23) | +2 END (M24) |
| | 3 | +1 STR/+1 AGI/+1 CYB + Psychogenic Agility (M25) | +1 STR/+1 AGI/+1 CYB + Neuro-Reflex Dampening (M26) | +1 STR/+1 AGI/+1 CYB + Remote Electron Tampering (M27) |

## Review

Ran cross-engine adversarial review (`/xreview`): both engines found **no Critical/High**. Verified all 27 entries against `CHARGEN.STR`. Applied the agreed Low fix (reject negative tour index via `u32::try_from` rather than clamp to 0); kept `text_key` (issue-mandated text lookup); documented the OSA tier-2 access as a conscious deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
