### PR TITLE
refactor(physics): capsule player controller with explicit step probe — delete the two-pass move hack

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -846,7 +846,6 @@ pub fn create_physics_representation(
             v_phys_type.get(entity_id),
         ) {
             let qrotation = pos.rotation;
-            let _offset_rotation = qrotation.rotate_vector(dimensions.offset0);
 
             let mut is_sensor = false;
             let scale_factor = v_scale

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -22,10 +22,24 @@ use physics_events::*;
 
 use self::debug_render_pipeline::DebugRenderer;
 
-const MOVEMENT_STEP_SIZE: f32 = 20.0;
+/// Player capsule dimensions (SS2 ft): total height and radius. Kept at the
+/// old cuboid's footprint (4.8 tall, 1.6 wide) - resizing toward the original
+/// engine's 6.0 x 2.4 player is deferred until crouch can shrink the collider.
+const PLAYER_HEIGHT: f32 = 4.8;
+const PLAYER_RADIUS: f32 = 0.8;
+
+/// Gap (SS2 ft) the character controller keeps between the player collider
+/// and world geometry (`KinematicCharacterController::offset`).
+const PLAYER_CONTACT_OFFSET: f32 = 0.1;
+
+/// Maximum ledge height (SS2 ft) the player steps up automatically, and how
+/// far below their feet the ground is snapped to when walking down. 2 ft is
+/// the original engine's step-probe height, so stairs climb and descend
+/// without a jump.
+const PLAYER_STEP_HEIGHT: f32 = 2.0;
 
 /// Horizontal reach (world units) for ladder detection: the player grips a
-/// climbable surface when their collider, inflated by this much on x/z,
+/// climbable surface when their collider, inflated by this much radially,
 /// overlaps it. Standing flush against a ladder leaves a small gap between the
 /// collider and the rungs, so the un-inflated shapes never intersect.
 const CLIMB_REACH: f32 = 1.0 / SCALE_FACTOR;
@@ -64,6 +78,84 @@ fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<
         into
     };
     Some(desired_h - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
+}
+
+/// Step-up probe (the original engine's stair-climbing approach: probe up,
+/// forward, then down from the blocked position). Called when the player's
+/// horizontal movement was mostly blocked; returns the extra translation that
+/// hops the player onto a stair-sized ledge ahead, or `None` when there is no
+/// steppable ledge (a full wall, no headroom, or a too-tall/too-steep step).
+///
+/// This exists because rapier's built-in autostep never fires against a step
+/// with a capsule: the step's top edge contacts the bottom sphere above its
+/// center, which parry classifies as a ceiling-ish hit, not a wall.
+///
+/// `pos` is the collider pose after the blocked move; `desired` the movement
+/// input for the frame; `applied` the translation the move actually achieved.
+/// The probe (all casts collision-checked, so the result is a valid pose):
+/// 1. headroom: the capsule must fit `PLAYER_STEP_HEIGHT` straight up;
+/// 2. clearance: at that height it must fit forward far enough to plant the
+///    capsule axis past the riser face (radius + contact gaps) - otherwise
+///    the overhanging capsule gets pulled back down by snap-to-ground;
+/// 3. tread: dropping back down must land on a walkable (mostly-horizontal)
+///    surface above the starting feet - the landing defines the step height.
+fn try_step_up(
+    queries: &QueryPipeline,
+    shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    desired: Vector<Real>,
+    applied: Vector<Real>,
+) -> Option<Vector<Real>> {
+    let desired_h = vector![desired.x, 0.0, desired.z];
+    let desired_norm = desired_h.norm();
+    if desired_norm < 1.0e-6 {
+        return None;
+    }
+    let dir = desired_h / desired_norm;
+    // Not blocked: the move achieved most of the desired horizontal distance.
+    if applied.dot(&dir) > 0.5 * desired_norm {
+        return None;
+    }
+
+    let step_height = PLAYER_STEP_HEIGHT / SCALE_FACTOR;
+    let contact_offset = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    // Far enough forward that the capsule axis (its lowest point) stands on
+    // the tread: the gap to the riser (~contact offset), the capsule radius,
+    // and a contact offset of margin on top.
+    let forward = PLAYER_RADIUS / SCALE_FACTOR + 2.0 * contact_offset;
+    let cast = |from: &Isometry<Real>, dir: Vector<Real>, max_dist: f32| {
+        queries.cast_shape(
+            from,
+            &dir,
+            shape,
+            rapier3d::parry::query::ShapeCastOptions {
+                max_time_of_impact: max_dist,
+                target_distance: contact_offset,
+                stop_at_penetration: false,
+                compute_impact_geometry_on_penetration: true,
+            },
+        )
+    };
+
+    // 1) Headroom directly above.
+    if cast(pos, Vector::y(), step_height).is_some() {
+        return None;
+    }
+    // 2) Forward clearance at the lifted height.
+    let lifted = Translation::from(Vector::y() * step_height) * pos;
+    if cast(&lifted, dir, forward).is_some() {
+        return None;
+    }
+    // 3) Drop onto the tread.
+    let planted = Translation::from(dir * forward) * lifted;
+    let (_, hit) = cast(&planted, -Vector::y(), step_height)?;
+    let lift = step_height - hit.time_of_impact;
+    // Too small to matter (the rounded capsule bottom slides over it anyway),
+    // or a downward/steep landing normal (not a tread).
+    if lift < 0.05 / SCALE_FACTOR || hit.normal1.y < 0.7 {
+        return None;
+    }
+    Some(Vector::y() * lift + dir * forward)
 }
 
 /// Maximum distance (world units) a single validated player move may advance.
@@ -893,8 +985,13 @@ impl PhysicsWorld {
         let player_entity_user_data = player_entity.inner() as u128;
         rigid_body.user_data = player_entity_user_data;
         let character_handle = self.rigid_body_set.insert(rigid_body);
-        let mut collider =
-            ColliderBuilder::cuboid(0.8 / SCALE_FACTOR, 2.4 / SCALE_FACTOR, 0.8 / SCALE_FACTOR);
+        // A capsule with the same footprint as the old cuboid: 4.8 SS2 ft tall,
+        // 1.6 ft wide (the original engine's player is a stack of spheres - a
+        // rounded shape slides cleanly along corners/seams the box snagged on).
+        let mut collider = ColliderBuilder::capsule_y(
+            (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+            PLAYER_RADIUS / SCALE_FACTOR,
+        );
         collider = collider.collision_groups(InteractionGroups::new(
             InternalCollisionGroups::PLAYER.bits.into(),
             InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
@@ -907,9 +1004,15 @@ impl PhysicsWorld {
 
         let mut controller = KinematicCharacterController::default();
 
-        controller.offset = CharacterLength::Absolute(0.1 / SCALE_FACTOR);
-        controller.snap_to_ground = Some(CharacterLength::Absolute(0.1 / SCALE_FACTOR));
-        controller.normal_nudge_factor = 0.1;
+        controller.offset = CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
+        // Walking down stairs stays grounded (snapped onto the next tread)
+        // instead of chaining micro-falls. Stepping UP is handled by an
+        // explicit probe in `move_player` (see `try_step_up`) - rapier's
+        // built-in autostep needs a wall-classified contact, but a capsule
+        // touching a step edge above its bottom-sphere center reads as a
+        // ceiling and never triggers it.
+        controller.snap_to_ground =
+            Some(CharacterLength::Absolute(PLAYER_STEP_HEIGHT / SCALE_FACTOR));
 
         self.entity_id_to_body
             .insert(player_entity, character_handle);
@@ -1062,19 +1165,8 @@ impl PhysicsWorld {
         let character_shape = character_collider.shared_shape().clone();
         let character_pos = *character_collider.position();
 
-        let step_size = Vector::y() * MOVEMENT_STEP_SIZE * self.integration_parameters.dt;
-
-        // We do our player movement in two passes
-        // First: move the player forward and a bit upwards
-        // Second: Drop the player down for gravity
-        // This wasn't necessary until upgrading to rapier v0.19.0 - when we upgraded to that version,
-        // we started to snag on geometry.
-        let movement_with_upward = desired_movement + step_size;
-
         let mut gravity = -0.5 / SCALE_FACTOR;
         gravity *= self.rigid_body_set[player_handle.character_handle].gravity_scale();
-
-        let gravity_movement = Vector::y() * gravity - step_size;
 
         // Filter shared by both movement passes: only collide with the
         // collidable groups as the player, ignore the player body and sensors.
@@ -1106,9 +1198,12 @@ impl PhysicsWorld {
                 &self.collider_set,
                 climb_filter,
             );
-            character_shape.as_cuboid().and_then(|cuboid| {
-                let inflated =
-                    Cuboid::new(cuboid.half_extents + vector![CLIMB_REACH, 0.0, CLIMB_REACH]);
+            character_shape.as_capsule().and_then(|capsule| {
+                let inflated = Capsule::new(
+                    capsule.segment.a,
+                    capsule.segment.b,
+                    capsule.radius + CLIMB_REACH,
+                );
                 // Grip the closest climbable within reach, by contact distance,
                 // and take the contact's *face normal* as the climb direction.
                 // (The collider-center direction is wrong when the player is
@@ -1138,46 +1233,41 @@ impl PhysicsWorld {
             })
         };
 
-        //let mut collisions = vec![];
-        let (mvt1, mvt2) = profile!(scope: "physics", level: TRACE, "physics.move_player", {
-            // HACK: For rapier v0.19.0, our previous strategy of combining the movement + gravity
-            // caused us to snag on physics geometry. In order to counter this, we'll do the movement in two phases
-            // a forward phase to move and then an application of gravity
+        let mvt = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             let queries = self.broad_phase.as_query_pipeline(
                 dispatcher,
                 &self.rigid_body_set,
                 &self.collider_set,
                 movement_filter,
             );
-            // While gripping a ladder the climb vector replaces the walk pass
-            // (no step-up bump needed) and the gravity pass is a no-op.
-            let (first_movement, second_movement) = match climb_movement {
-                Some(climb) => (climb, Vector::zeros()),
-                None => (
-                    movement_with_upward.cast::<Real>(),
-                    gravity_movement.cast::<Real>(),
-                ),
+            // While gripping a ladder the climb vector replaces walking, and
+            // gravity is suppressed for the frame; otherwise walk + gravity in
+            // one pass.
+            let movement = match climb_movement {
+                Some(climb) => climb,
+                None => desired_movement + Vector::y() * gravity,
             };
-            (player_handle.controller.move_shape(
+            let mut mvt = player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &queries,
                 character_shape.as_ref(),
                 &character_pos,
-                first_movement,
+                movement,
                 |_c| (),
-                //|c| collisions.push(c),
-            ),
-
-            // Second pass: Apply gravity and undo our step size
-            player_handle.controller.move_shape(
-                self.integration_parameters.dt,
-                &queries,
-                character_shape.as_ref(),
-                &character_pos,
-                second_movement,
-                |_c| (),
-                //|c| collisions.push(c),
-            ))
+            );
+            // Stairs: if walking was blocked, probe for a step and hop onto it.
+            if climb_movement.is_none() {
+                if let Some(step) = try_step_up(
+                    &queries,
+                    character_shape.as_ref(),
+                    &(Translation::from(mvt.translation) * character_pos),
+                    desired_movement,
+                    mvt.translation,
+                ) {
+                    mvt.translation += step;
+                }
+            }
+            mvt
         });
 
         let mut collision_events = Vec::new();
@@ -1252,9 +1342,7 @@ impl PhysicsWorld {
         let character_body = &mut self.rigid_body_set[player_handle.character_handle];
         let _original_pos = character_body.position().translation.vector;
         let pos = character_body.position();
-        character_body.set_next_kinematic_translation(
-            pos.translation.vector + mvt1.translation + mvt2.translation,
-        );
+        character_body.set_next_kinematic_translation(pos.translation.vector + mvt.translation);
         (collision_events, character_body)
     }
 
@@ -2113,6 +2201,68 @@ mod tests {
         assert!(
             plain_ascent.abs() < 0.5,
             "a plain wall must not be climbable, rose {plain_ascent}"
+        );
+    }
+
+    /// Walking into a stair-sized ledge steps up onto it; a too-tall ledge
+    /// blocks. The step limit is 2 SS2 ft (0.8 wu), the original engine's
+    /// step-probe height - a 1.5 ft riser climbs, a 3 ft ledge doesn't.
+    /// (Negative-first: the old two-pass up-bump stepped at most
+    /// `MOVEMENT_STEP_SIZE * dt` = 0.33 wu per frame, so the 0.6 wu riser
+    /// failed before native autostep.)
+    #[test]
+    fn player_steps_up_stairs_but_not_tall_ledges() {
+        // Height gained after walking +x into a `step_height`-tall platform.
+        let run = |step_height: f32| -> f32 {
+            let mut world = PhysicsWorld::new();
+            // Floor top at y=0 (parentless trimesh, like level geometry).
+            let floor_verts = vec![
+                point![-100.0, 0.0, -100.0],
+                point![100.0, 0.0, -100.0],
+                point![100.0, 0.0, 100.0],
+                point![-100.0, 0.0, 100.0],
+            ];
+            let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+            world.add_collider(
+                EntityId::from_inner(1000).unwrap(),
+                ColliderBuilder::trimesh(floor_verts, floor_tris)
+                    .expect("floor trimesh")
+                    .build(),
+            );
+            let mut player =
+                world.create_player(vec3(-6.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+            // A platform ahead of the player whose top sits at `step_height`.
+            world.add_kinematic(
+                EntityId::from_inner(2001).unwrap(),
+                vec3(-3.0, step_height / 2.0, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(4.0, step_height, 4.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            // Settle onto the floor, then walk into the step.
+            for _ in 0..30 {
+                world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            }
+            let start = world.get_player_translation(&player);
+            for _ in 0..240 {
+                world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
+            }
+            let end = world.get_player_translation(&player);
+            end.y - start.y
+        };
+
+        let riser = run(0.6); // 1.5 SS2 ft - a typical stair riser
+        let ledge = run(1.2); // 3.0 SS2 ft - over the 2 ft step limit
+
+        assert!(
+            riser > 0.5,
+            "a 1.5 ft riser should be stepped up, rose {riser}"
+        );
+        assert!(
+            ledge < 0.1,
+            "a 3 ft ledge must not be auto-stepped, rose {ledge}"
         );
     }
 }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1180,7 +1180,6 @@ impl PhysicsWorld {
         let original_position = *character_body.position();
         let character_user_data = character_body.user_data;
         let character_collider = &self.collider_set[character_body.colliders()[0]];
-        let _character_mass = character_body.mass();
 
         // In rapier 0.31 the `QueryPipeline` is a transient view built from the
         // broad-phase BVH, and it borrows the body/collider sets. Snapshot the
@@ -1376,21 +1375,7 @@ impl PhysicsWorld {
 
         self.player_sensor_intersections = current_sensor_intersections;
 
-        // for collision in &collisions {
-        //     let _collider = &self.collider_set[collision.handle];
-        //     self.controller.solve_character_collision_impulses(
-        //         self.integration_parameters.dt,
-        //         &mut self.rigid_body_set,
-        //         &self.collider_set,
-        //         &self.query_pipeline,
-        //         character_collider.shape(),
-        //         character_mass,
-        //         collision,
-        //         QueryFilter::new().exclude_rigid_body(self.character_handle),
-        //     )
-        // }
         let character_body = &mut self.rigid_body_set[player_handle.character_handle];
-        let _original_pos = character_body.position().translation.vector;
         let pos = character_body.position();
         character_body.set_next_kinematic_translation(pos.translation.vector + mvt.translation);
         (collision_events, character_body)
@@ -2324,10 +2309,10 @@ mod tests {
     /// earth.mis tram floor slab) must make progress. The rotated top-face
     /// normal carries ~1e-6 float error, so tangential movement casts read as
     /// "approaching" and re-hit the resting contact at toi=0 every solver
-    /// iteration - without `normal_nudge_factor` the player freezes in place
-    /// after a frame or two. (Negative-first: fails with the nudge at
-    /// rapier's 1e-4 default; an AXIS-ALIGNED slab passes either way because
-    /// its exact (0,1,0) normal reports no hit for tangential motion.)
+    /// iteration and the player freezes in place after a frame or two.
+    /// (Negative-first: fails without `PLAYER_REST_LIFT`; an AXIS-ALIGNED
+    /// slab passes either way because its exact (0,1,0) normal reports no hit
+    /// for tangential motion.)
     #[test]
     fn player_walks_on_rotated_platform() {
         use cgmath::Rotation3;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -151,8 +151,10 @@ fn try_step_up(
     let (_, hit) = cast(&planted, -Vector::y(), step_height)?;
     let lift = step_height - hit.time_of_impact;
     // Too small to matter (the rounded capsule bottom slides over it anyway),
-    // or a downward/steep landing normal (not a tread).
-    if lift < 0.05 / SCALE_FACTOR || hit.normal1.y < 0.7 {
+    // or a downward/steep landing normal (not a tread). The threshold sits
+    // just above cos(45 deg) so the probe can't hop up slopes the controller's
+    // slope limit (default 45 deg) refuses to walk.
+    if lift < 0.05 / SCALE_FACTOR || hit.normal1.y < 0.72 {
         return None;
     }
     Some(Vector::y() * lift + dir * forward)
@@ -1006,7 +1008,10 @@ impl PhysicsWorld {
 
         controller.offset = CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
         // Walking down stairs stays grounded (snapped onto the next tread)
-        // instead of chaining micro-falls. Stepping UP is handled by an
+        // instead of chaining micro-falls. Deliberate tradeoff: this also
+        // absorbs any intended drop up to the step height (the player glues
+        // to <= 2 ft ledges rather than falling) - revisit when gravity
+        // becomes an integrated velocity. Stepping UP is handled by an
         // explicit probe in `move_player` (see `try_step_up`) - rapier's
         // built-in autostep needs a wall-classified contact, but a capsule
         // touching a step edge above its bottom-sphere center reads as a
@@ -1198,12 +1203,17 @@ impl PhysicsWorld {
                 &self.collider_set,
                 climb_filter,
             );
+            // Broad-phase candidate query: the capsule's bounds inflated by
+            // CLIMB_REACH on x/z only (a cuboid, so the reach stays horizontal
+            // - inflating the capsule radius would also extend the caps
+            // vertically and grip ladders from above/below their ends).
             character_shape.as_capsule().and_then(|capsule| {
-                let inflated = Capsule::new(
-                    capsule.segment.a,
-                    capsule.segment.b,
+                let half_height = capsule.half_height() + capsule.radius;
+                let inflated = Cuboid::new(vector![
                     capsule.radius + CLIMB_REACH,
-                );
+                    half_height,
+                    capsule.radius + CLIMB_REACH
+                ]);
                 // Grip the closest climbable within reach, by contact distance,
                 // and take the contact's *face normal* as the climb direction.
                 // (The collider-center direction is wrong when the player is
@@ -1255,8 +1265,10 @@ impl PhysicsWorld {
                 movement,
                 |_c| (),
             );
-            // Stairs: if walking was blocked, probe for a step and hop onto it.
-            if climb_movement.is_none() {
+            // Stairs: if grounded walking was blocked, probe for a step and
+            // hop onto it. (Grounded-only: an airborne player pressed against
+            // a wall must not ratchet up ledges.)
+            if climb_movement.is_none() && mvt.grounded {
                 if let Some(step) = try_step_up(
                     &queries,
                     character_shape.as_ref(),

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -32,6 +32,21 @@ const PLAYER_RADIUS: f32 = 0.8;
 /// and world geometry (`KinematicCharacterController::offset`).
 const PLAYER_CONTACT_OFFSET: f32 = 0.1;
 
+/// Extra height (SS2 ft) the player is lifted each grounded frame, keeping the
+/// resting gap a hair above `PLAYER_CONTACT_OFFSET`. Load-bearing: movement
+/// casts use `PLAYER_CONTACT_OFFSET` as their target distance, so a capsule
+/// resting at exactly that gap starts every cast already "in contact" with
+/// its own floor. On a yaw-ROTATED support (e.g. the earth.mis tram floor
+/// slab) the rotated top-face normal carries ~1e-6 float error, which makes
+/// even purely tangential walking read as "approaching" - every solver
+/// iteration then re-hits the same contact at toi=0, applies zero
+/// translation, and the player freezes in place. (Axis-aligned floors yield
+/// an exact (0,1,0) normal, where tangential motion reports no hit - which is
+/// why flat test floors work without this.) The next frame's gravity pass
+/// consumes the lift again, so the rest height is stable. Regression-tested
+/// by `player_walks_on_rotated_platform`.
+const PLAYER_REST_LIFT: f32 = 0.01;
+
 /// Maximum ledge height (SS2 ft) the player steps up automatically, and how
 /// far below their feet the ground is snapped to when walking down. 2 ft is
 /// the original engine's step-probe height, so stairs climb and descend
@@ -120,17 +135,21 @@ fn try_step_up(
     let step_height = PLAYER_STEP_HEIGHT / SCALE_FACTOR;
     let contact_offset = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
     // Far enough forward that the capsule axis (its lowest point) stands on
-    // the tread: the gap to the riser (~contact offset), the capsule radius,
-    // and a contact offset of margin on top.
-    let forward = PLAYER_RADIUS / SCALE_FACTOR + 2.0 * contact_offset;
-    let cast = |from: &Isometry<Real>, dir: Vector<Real>, max_dist: f32| {
+    // the tread: the capsule radius, the gap to the riser (which can exceed
+    // the contact offset when the walk stalled early), and margin on top.
+    let forward = PLAYER_RADIUS / SCALE_FACTOR + 4.0 * contact_offset;
+    // `target_distance` counts lateral grazes (e.g. the riser edge the player
+    // is pressed against) as immediate hits, so the clearance casts (up,
+    // forward) use 0; only the landing cast keeps the contact offset so the
+    // player comes to rest at the normal gap above the tread.
+    let cast = |from: &Isometry<Real>, dir: Vector<Real>, max_dist: f32, target: f32| {
         queries.cast_shape(
             from,
             &dir,
             shape,
             rapier3d::parry::query::ShapeCastOptions {
                 max_time_of_impact: max_dist,
-                target_distance: contact_offset,
+                target_distance: target,
                 stop_at_penetration: false,
                 compute_impact_geometry_on_penetration: true,
             },
@@ -138,17 +157,17 @@ fn try_step_up(
     };
 
     // 1) Headroom directly above.
-    if cast(pos, Vector::y(), step_height).is_some() {
+    if cast(pos, Vector::y(), step_height, 0.0).is_some() {
         return None;
     }
     // 2) Forward clearance at the lifted height.
     let lifted = Translation::from(Vector::y() * step_height) * pos;
-    if cast(&lifted, dir, forward).is_some() {
+    if cast(&lifted, dir, forward, 0.0).is_some() {
         return None;
     }
     // 3) Drop onto the tread.
     let planted = Translation::from(dir * forward) * lifted;
-    let (_, hit) = cast(&planted, -Vector::y(), step_height)?;
+    let (_, hit) = cast(&planted, -Vector::y(), step_height, contact_offset)?;
     let lift = step_height - hit.time_of_impact;
     // Too small to matter (the rounded capsule bottom slides over it anyway),
     // or a downward/steep landing normal (not a tread). The threshold sits
@@ -1250,21 +1269,40 @@ impl PhysicsWorld {
                 &self.collider_set,
                 movement_filter,
             );
-            // While gripping a ladder the climb vector replaces walking, and
-            // gravity is suppressed for the frame; otherwise walk + gravity in
-            // one pass.
-            let movement = match climb_movement {
-                Some(climb) => climb,
-                None => desired_movement + Vector::y() * gravity,
+            // Walk and gravity run as separate passes - NOT the old up-bump
+            // hack (there is no artificial upward movement): a combined
+            // walk+gravity cast points into the floor the player rests on,
+            // which degenerates into zero-progress resting contacts (see
+            // `PLAYER_REST_LIFT`). While gripping a ladder the climb vector
+            // replaces both passes.
+            let (walk, apply_gravity) = match climb_movement {
+                Some(climb) => (climb, false),
+                None => (desired_movement, true),
             };
             let mut mvt = player_handle.controller.move_shape(
                 self.integration_parameters.dt,
                 &queries,
                 character_shape.as_ref(),
                 &character_pos,
-                movement,
+                walk,
                 |_c| (),
             );
+            if apply_gravity {
+                let after_walk = Translation::from(mvt.translation) * character_pos;
+                let fall = player_handle.controller.move_shape(
+                    self.integration_parameters.dt,
+                    &queries,
+                    character_shape.as_ref(),
+                    &after_walk,
+                    Vector::y() * gravity,
+                    |_c| (),
+                );
+                mvt.translation += fall.translation;
+                mvt.grounded = fall.grounded;
+                if mvt.grounded {
+                    mvt.translation += Vector::y() * (PLAYER_REST_LIFT / SCALE_FACTOR);
+                }
+            }
             // Stairs: if grounded walking was blocked, probe for a step and
             // hop onto it. (Grounded-only: an airborne player pressed against
             // a wall must not ratchet up ledges.)
@@ -2253,16 +2291,20 @@ mod tests {
                 CollisionGroup::entity(),
                 false,
             );
-            // Settle onto the floor, then walk into the step.
+            // Settle onto the floor, then walk into the step; report the
+            // highest point reached (a successful step-up crosses the platform
+            // and walks off the far side, so the END height is floor level
+            // either way).
             for _ in 0..30 {
                 world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
             }
             let start = world.get_player_translation(&player);
+            let mut max_y = start.y;
             for _ in 0..240 {
                 world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
+                max_y = max_y.max(world.get_player_translation(&player).y);
             }
-            let end = world.get_player_translation(&player);
-            end.y - start.y
+            max_y - start.y
         };
 
         let riser = run(0.6); // 1.5 SS2 ft - a typical stair riser
@@ -2275,6 +2317,47 @@ mod tests {
         assert!(
             ledge < 0.1,
             "a 3 ft ledge must not be auto-stepped, rose {ledge}"
+        );
+    }
+
+    /// Walking along the top of a yaw-ROTATED kinematic cuboid (e.g. the
+    /// earth.mis tram floor slab) must make progress. The rotated top-face
+    /// normal carries ~1e-6 float error, so tangential movement casts read as
+    /// "approaching" and re-hit the resting contact at toi=0 every solver
+    /// iteration - without `normal_nudge_factor` the player freezes in place
+    /// after a frame or two. (Negative-first: fails with the nudge at
+    /// rapier's 1e-4 default; an AXIS-ALIGNED slab passes either way because
+    /// its exact (0,1,0) normal reports no hit for tangential motion.)
+    #[test]
+    fn player_walks_on_rotated_platform() {
+        use cgmath::Rotation3;
+        let mut world = PhysicsWorld::new();
+        // A tram-slab-like platform, yawed 90 degrees: authored 4 wide x 10
+        // long, so after rotation its long axis lies along world x.
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.0, 1.0, 0.0),
+            Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), cgmath::Deg(90.0)),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 0.4, 10.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(-3.0, 3.0, 0.0), EntityId::from_inner(2000).unwrap());
+        // Settle onto the slab, then walk along it.
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        for _ in 0..120 {
+            world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        let walked = end.x - start.x;
+        assert!(
+            walked > 3.0,
+            "walking on a rotated platform should progress ~6 units, moved {walked}"
         );
     }
 }

--- a/tools/shock2-sdk/test/earth-tram-exit.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-tram-exit.e2e.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the earth.mis intro: the player must be able to WALK out
+// of the UNN tram they spawn in, across the station boardwalk, to the base of
+// the recruitment-center gravshafts (the level's first traversal).
+//
+// Negative-first: the player rests on the tram's floor slab - a yaw-ROTATED
+// kinematic cuboid - at exactly the character controller's contact offset.
+// Without the grounded rest lift (see `PLAYER_REST_LIFT` in
+// shock2vr/src/physics/mod.rs), every movement cast re-hits that resting
+// contact at toi=0 (the rotated face normal's ~1e-6 tilt makes tangential
+// walking read as "approaching"), the controller applies zero translation,
+// and the player freezes inside the tram after ~one frame of walking - this
+// walk never gets past the tram doorway (z stays ~-11).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "earth.mis: the player can walk out of the intro tram to the gravshaft base",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8112),
+    });
+    await game.step({ frames: 30 }); // settle onto the tram floor
+
+    const spawn = await game.player.position();
+    assert.ok(
+      spawn.z < -10,
+      `expected to spawn inside the tram (z < -10), got z=${spawn.z}`,
+    );
+
+    // Hold forward: out the tram door, across the boardwalk, until the wall
+    // at the gravshaft base stops the walk (~z=12.4).
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 300 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    const end = await game.player.position();
+    assert.ok(
+      end.z > 10,
+      `walking forward from the tram should reach the gravshaft base ` +
+        `(z > 10), got z=${end.z.toFixed(2)} (frozen inside the tram means ` +
+        `the resting-contact fix regressed - see PLAYER_REST_LIFT)`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

First slice of the character-controller cleanup (full review + plan in `projects/character-controller-review.md`, comparing our controller against the original engine's player physics). This slice replaces the player's collider shape, deletes the legacy movement hacks, and makes step climbing an explicit, documented mechanism — plus fixes a long-standing walking freeze this work uncovered (#457).

### What changed

- **Cuboid → capsule** (same 4.8 × 1.6 ft footprint; resizing toward the original's 6.0 × 2.4 player is deferred until crouch can shrink the collider). The original player is a stack of spheres — a rounded shape slides along the corners the box snagged on.
- **Deleted the two-pass move hack** (`MOVEMENT_STEP_SIZE` up-bump + gravity-undo, a rapier-0.19-era workaround). The up-bump also let the flat-bottomed box **ratchet up thin ledges of any height** — e.g. on `main`, "walking out of the earth.mis tram" actually climbs an invisible barrier and crosses the plaza hovering above the floor.
- **Explicit step probe** (`try_step_up`): when grounded walking is blocked, cast up (headroom) → forward (clearance past the riser) → down (find the tread). Max step = **2 SS2 ft**, matching the original's step probe; `snap_to_ground` at the same distance handles walking *down* stairs. Rapier's built-in autostep can't work here: a capsule touching a step edge above its bottom-sphere center classifies as a ceiling-ish contact, never a wall, so it never fires (verified against rapier 0.31 source + empirically).
- **Deleted `normal_nudge_factor = 0.1`** (1000× rapier's default): proven dead — it never fixed the resting-contact freeze below and broke stair-stepping in single-pass mode. Its historical effect was accidental synergy with the up-bump.
- **Fixed a resting-contact freeze** (#457): the player rests exactly `contact_offset` above its support, so every movement cast starts within the cast's target distance of its own floor. On a **yaw-rotated** cuboid (the earth.mis tram's Moving Terrain floor slab — the 90° quaternion is irrational in f32) the rotated top-face normal carries ~1e-6 tilt, making tangential walking read as "approaching": every solver iteration re-hits the same contact at toi=0 and the player freezes after one frame. Fix: walk and gravity as **separate `move_shape` passes** (standard move-then-fall, no up-bump) + **`PLAYER_REST_LIFT`** (0.01 SS2 ft per grounded frame) keeping the resting gap a hair above the cast target. Axis-aligned floors yield an exact (0,1,0) normal (tangential motion reports no hit), which is why everything else always worked.
- Dead-code cleanup surfaced by the investigation (stale pre-0.31 impulse block, misleading `_offset_rotation` in `entity_creator`).

### Behavior changes to be aware of

- The player can no longer climb arbitrary walls by pushing into them (up-bump ratchet is gone); steps over 2 ft honestly block until jump/mantle land (next slices).
- `snap_to_ground` = 2 ft: walking off ledges ≤ 2 ft snaps down instead of falling — documented tradeoff, revisited when gravity becomes an integrated velocity.
- The player stands at true ground height (the old controller hovered up to one bump above its support).

## Verification

- **Negative-first unit tests** (each fails on the old controller / without its fix):
  - `player_steps_up_stairs_but_not_tall_ledges` — 1.5 ft riser climbs (old max was ~0.8 ft), 3 ft ledge blocks
  - `player_walks_on_rotated_platform` — freezes without `PLAYER_REST_LIFT`
  - `player_climbs_climbable_wall_but_not_plain_wall` — ladder grip unchanged with the capsule
- **New e2e**: `earth-tram-exit.e2e.test.ts` — walks from the earth.mis tram spawn out the door, across the boardwalk, to the gravshaft base (frozen after ~1 frame before the fix)
- **Full SDK e2e suite green (82/82)** on the core capsule commit, including the every-mission load smoke test, real-mission ladder climbing, and validated player moves; final full-suite run on HEAD in flight (will confirm in a comment)
- 121 unit tests, `RUSTFLAGS="-D warnings"` check on shock2vr/desktop_runtime/debug_runtime
- Cross-engine adversarial review (Claude + Codex) — all agreed findings addressed (grounded-gated step probe, horizontal-only climb reach, slope-limit-consistent tread threshold)
- Interactive verification via debug runtime: medsci1 walking/wall-stops/falls, earth.mis tram→gravshaft traversal (the fix for #457 was root-caused with per-cast hit instrumentation, body COM inspection, and an A/B against a main worktree)

## Follow-ups (tracked in `projects/character-controller-review.md`)

1. Gravity as integrated velocity (32 ft/s²) — unlocks jump/mantle/fall damage
2. Jump (14 ft/s) — also needed to enter the earth.mis gravshaft (~3 ft lip)
3. Authentic movement speeds (walk 5.5 / run 11 vs our flat 25 ft/s)
4. Real crouch (collider shrink + speed + fire-ray height)
5. Gravshaft room-gravity lift doesn't fire; tram TPath never runs (separate features)

Fixes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)