### PR TITLE
feat(ui): cursor-is-the-item inventory drag + throw (flat UI 4.5)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -469,6 +469,9 @@ pub struct UiStateResult {
     /// The top-docked inventory strip (Tab metagame mode); `Some` exactly in
     /// "use" mode.
     pub strip: Option<shock2vr::game_scene::DebugUiPanel>,
+    /// The item held on the cursor mid-drag (cursor-is-the-item); `Some`
+    /// between a lift and the place/throw that clears it.
+    pub cursor: Option<shock2vr::game_scene::DebugUiCursor>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1021,12 +1021,14 @@ fn process_command(
                         mode: ui.mode,
                         active_panel: ui.active_panel,
                         strip: ui.strip,
+                        cursor: ui.cursor,
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
                     mode: "shooter".to_string(),
                     active_panel: None,
                     strip: None,
+                    cursor: None,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -346,6 +346,18 @@ pub struct DebugUiState {
     /// The top-docked inventory strip (Tab metagame mode): the player's
     /// carried items as labeled elements. `Some` exactly in "use" mode.
     pub strip: Option<DebugUiPanel>,
+    /// The item held on the cursor mid-drag (the original's "cursor IS the
+    /// item", §2.4). `Some` between a lift and the place/throw that clears it.
+    pub cursor: Option<DebugUiCursor>,
+}
+
+/// The item currently riding the cursor (a lifted inventory item): its runtime
+/// entity id and symbolic name, so tests can assert lift/place/throw state.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugUiCursor {
+    /// Runtime entity id of the held item (NOT stable across runs).
+    pub entity_id: i32,
+    pub label: Option<String>,
 }
 
 /// The open flat-mode MFD panel: which entity it is bound to and its element
@@ -555,6 +567,7 @@ pub trait DebuggableScene {
             mode: "shooter".to_string(),
             active_panel: None,
             strip: None,
+            cursor: None,
         }
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -67,15 +67,33 @@ const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
 
 /// A host-side action produced by the cursor-is-the-item drag (§1.5/§2.4),
-/// applied by `mission_core` because it touches links/physics: **Lift**
-/// removes the item from its container (the strip slot empties), **Place**
-/// returns it to the player's backpack, **Throw** gives it world presence
-/// with an impulse along the view ray.
+/// applied by `mission_core` because it touches links/physics/effects:
+/// **Lift** removes the item from its container (the strip slot empties),
+/// **Place** returns it to the player's backpack, **Throw** gives it world
+/// presence with an impulse along the view ray, **Wield** equips/uses it (a
+/// double-click, routed through the same effect as a backpack click).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlatUiDragAction {
     Lift(EntityId),
     Place(EntityId),
     Throw(EntityId),
+    Wield(EntityId),
+}
+
+/// Double-click window (frames at 60Hz) and radius (canvas px) for the
+/// wield gesture: a second press on the just-lifted item's slot within this
+/// window/radius wields it instead of placing (the original equips from the
+/// inventory; with a single flat pointer button a double-click is the
+/// faithful mapping - projects/flat-ui.md §1.5).
+const DOUBLE_CLICK_WINDOW_FRAMES: u32 = 20;
+const DOUBLE_CLICK_RADIUS: f32 = 24.0;
+
+/// The just-lifted item and where/when it was lifted, so a quick second click
+/// on the same slot reads as a double-click (wield) rather than a place.
+struct LiftMark {
+    entity: EntityId,
+    canvas_pos: Vector2<f32>,
+    frames_left: u32,
 }
 
 /// The item currently riding the cursor (the original's `drag_obj`): the
@@ -107,6 +125,9 @@ pub struct FlatUiHost {
     /// The item lifted onto the cursor (the original's "cursor IS the item"
     /// drag, §2.4). `Some` between a lift and the place/throw that clears it.
     cursor_item: Option<CursorItem>,
+    /// The most recent lift, for double-click (wield) detection. Counts down
+    /// each frame and clears when the window elapses.
+    last_lift: Option<LiftMark>,
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -134,6 +155,7 @@ impl FlatUiHost {
             components: Vec::new(),
             strip: None,
             cursor_item: None,
+            last_lift: None,
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -166,6 +188,7 @@ impl FlatUiHost {
     /// the metagame while `drag_obj` is set, so Tab-out re-homes the item
     /// rather than losing it (projects/flat-ui.md §1.5).
     pub fn take_cursor_item(&mut self) -> Option<EntityId> {
+        self.last_lift = None;
         self.cursor_item.take().map(|c| c.entity)
     }
 
@@ -269,6 +292,14 @@ impl FlatUiHost {
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
 
+        // Age out the double-click window since the last lift.
+        if let Some(mark) = self.last_lift.as_mut() {
+            match mark.frames_left.checked_sub(1) {
+                Some(remaining) => mark.frames_left = remaining,
+                None => self.last_lift = None,
+            }
+        }
+
         // MFD-slot auto-close: the bound object is gone (destroyed / level
         // state changed), or the player walked away from it (the original's
         // per-overlay `distance` check). The strip is bound to the player's
@@ -349,12 +380,27 @@ impl FlatUiHost {
                 return (Vec::new(), Vec::new());
             }
             if over_strip {
-                let held = self.cursor_item.take().unwrap();
-                let mut actions = vec![FlatUiDragAction::Place(held.entity)];
+                let held = self.cursor_item.as_ref().unwrap().entity;
+                // Double-click on the just-lifted item's slot wields it (the
+                // second press of a quick same-spot double-click) rather than
+                // placing - the faithful single-button equip gesture.
+                if self.is_double_click(held, canvas_pos) {
+                    self.cursor_item = None;
+                    self.last_lift = None;
+                    return (Vec::new(), vec![FlatUiDragAction::Wield(held)]);
+                }
+                self.cursor_item = None;
+                self.last_lift = None;
+                let mut actions = vec![FlatUiDragAction::Place(held)];
                 // Dropping onto an occupied slot swaps: the occupant lifts.
                 if let Some(target) = self.strip_item_at(canvas_pos) {
-                    if target != held.entity {
+                    if target != held {
                         self.cursor_item = Some(make_cursor_item(world, target));
+                        self.last_lift = Some(LiftMark {
+                            entity: target,
+                            canvas_pos,
+                            frames_left: DOUBLE_CLICK_WINDOW_FRAMES,
+                        });
                         actions.push(FlatUiDragAction::Lift(target));
                     }
                 }
@@ -366,6 +412,7 @@ impl FlatUiHost {
             }
             // Bare 3D view: throw the held item along the view ray.
             let held = self.cursor_item.take().unwrap();
+            self.last_lift = None;
             return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
         }
 
@@ -376,6 +423,11 @@ impl FlatUiHost {
             if pressed_edge {
                 if let Some(item) = self.strip_item_at(canvas_pos) {
                     self.cursor_item = Some(make_cursor_item(world, item));
+                    self.last_lift = Some(LiftMark {
+                        entity: item,
+                        canvas_pos,
+                        frames_left: DOUBLE_CLICK_WINDOW_FRAMES,
+                    });
                     return (Vec::new(), vec![FlatUiDragAction::Lift(item)]);
                 }
                 return (Vec::new(), Vec::new());
@@ -416,6 +468,17 @@ impl FlatUiHost {
             }
             (Vec::new(), Vec::new())
         }
+    }
+
+    /// Whether a press on `held`'s slot at `canvas_pos` is the second click of
+    /// a double-click on the item just lifted (same entity, within the window
+    /// and radius of the lift) - the wield gesture.
+    fn is_double_click(&self, held: EntityId, canvas_pos: Vector2<f32>) -> bool {
+        self.last_lift.as_ref().is_some_and(|mark| {
+            mark.entity == held
+                && mark.frames_left > 0
+                && (mark.canvas_pos - canvas_pos).magnitude() <= DOUBLE_CLICK_RADIUS
+        })
     }
 
     /// The interactive strip item whose canvas rect contains `canvas_pos`
@@ -1171,6 +1234,18 @@ mod tests {
             .cursor_debug()
             .expect("the swapped-in Pistol is on the cursor");
         assert_eq!(cursor.entity_id, pistol.inner() as i32);
+    }
+
+    #[test]
+    fn double_click_on_a_strip_item_wields_it() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        // First click lifts onto the cursor...
+        let first = press_edge(&mut host, &world, (23.5, 34.0));
+        assert_eq!(first, vec![FlatUiDragAction::Lift(wrench)]);
+        // ...a quick second click on the same slot wields it (double-click).
+        let second = press_edge(&mut host, &world, (23.5, 34.0));
+        assert_eq!(second, vec![FlatUiDragAction::Wield(wrench)]);
+        assert!(host.cursor_debug().is_none(), "wielding clears the cursor");
     }
 
     #[test]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -67,15 +67,17 @@ const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
 
 /// A host-side action produced by the cursor-is-the-item drag (§1.5/§2.4),
-/// applied by `mission_core` because it touches links/physics/effects:
-/// **Lift** removes the item from its container (the strip slot empties),
-/// **Place** returns it to the player's backpack, **Throw** gives it world
-/// presence with an impulse along the view ray, **Wield** equips/uses it (a
-/// double-click, routed through the same effect as a backpack click).
+/// applied by `mission_core` because it touches physics/effects.
+///
+/// Lift/place/swap are *not* here: a lifted item **stays in the backpack
+/// container** (the host just hides it from the strip while it rides the
+/// cursor), so it is always reachable and serializes correctly on
+/// save/transition. Only committing the drag reaches the world: **Throw**
+/// detaches it and gives it world presence with an impulse along the view ray;
+/// **Wield** equips/uses it (a double-click) via the same effect as a backpack
+/// click, acting on the still-contained item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlatUiDragAction {
-    Lift(EntityId),
-    Place(EntityId),
     Throw(EntityId),
     Wield(EntityId),
 }
@@ -389,22 +391,22 @@ impl FlatUiHost {
                     self.last_lift = None;
                     return (Vec::new(), vec![FlatUiDragAction::Wield(held)]);
                 }
-                self.cursor_item = None;
+                // Place (or swap): the held item stays in the backpack the
+                // whole time, so placing is just dropping it off the cursor.
+                // Dropping onto another item swaps by lifting that occupant.
                 self.last_lift = None;
-                let mut actions = vec![FlatUiDragAction::Place(held)];
-                // Dropping onto an occupied slot swaps: the occupant lifts.
-                if let Some(target) = self.strip_item_at(canvas_pos) {
-                    if target != held {
+                match self.strip_item_at(canvas_pos) {
+                    Some(target) if target != held => {
                         self.cursor_item = Some(make_cursor_item(world, target));
                         self.last_lift = Some(LiftMark {
                             entity: target,
                             canvas_pos,
                             frames_left: DOUBLE_CLICK_WINDOW_FRAMES,
                         });
-                        actions.push(FlatUiDragAction::Lift(target));
                     }
+                    _ => self.cursor_item = None,
                 }
-                return (Vec::new(), actions);
+                return (Vec::new(), Vec::new());
             }
             if over_panel {
                 // Escape hatch: a click on an open MFD keeps the held item.
@@ -416,8 +418,10 @@ impl FlatUiHost {
             return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
         }
 
-        // --- Empty cursor over the strip: LMB on an item lifts it (host-
-        // handled, no GuiScript routing); hover highlights via GUIHover. ---
+        // --- Empty cursor over the strip: LMB on an item lifts it onto the
+        // cursor (the item stays in the backpack - the host just hides it from
+        // the strip - so nothing reaches the world). Hover highlights via
+        // GUIHover. ---
         if over_strip {
             self.hover_close = false;
             if pressed_edge {
@@ -428,7 +432,7 @@ impl FlatUiHost {
                         canvas_pos,
                         frames_left: DOUBLE_CLICK_WINDOW_FRAMES,
                     });
-                    return (Vec::new(), vec![FlatUiDragAction::Lift(item)]);
+                    return (Vec::new(), Vec::new());
                 }
                 return (Vec::new(), Vec::new());
             }
@@ -481,18 +485,26 @@ impl FlatUiHost {
         })
     }
 
+    /// The entity currently hidden from the strip because it is on the cursor.
+    fn held_entity(&self) -> Option<EntityId> {
+        self.cursor_item.as_ref().map(|c| c.entity)
+    }
+
     /// The interactive strip item whose canvas rect contains `canvas_pos`
     /// (loot/backpack item buttons carry their entity), for lift/swap
-    /// hit-testing.
+    /// hit-testing. The item on the cursor is hidden, so it never hit-tests.
     fn strip_item_at(&self, canvas_pos: Vector2<f32>) -> Option<EntityId> {
         let strip = self.strip.as_ref()?;
         let rect = strip.size_px.map(strip_canvas_rect)?;
+        let held = self.held_entity();
         strip.components.iter().find_map(|c| match c {
             GuiComponentRenderInfo::Image {
                 interactive: true,
                 entity: Some(entity),
                 ..
-            } if component_canvas_rect(c, rect).contains(canvas_pos) => Some(*entity),
+            } if Some(*entity) != held && component_canvas_rect(c, rect).contains(canvas_pos) => {
+                Some(*entity)
+            }
             _ => None,
         })
     }
@@ -512,10 +524,12 @@ impl FlatUiHost {
         }
         let mut canvas = UiCanvas::new(CANVAS_SIZE);
         if let (Some(strip), Some(rect)) = (self.strip.as_ref(), strip_rect) {
-            draw_components(&mut canvas, &strip.components, rect);
+            // Hide the item riding the cursor from the strip grid (it is drawn
+            // as the cursor instead).
+            draw_components(&mut canvas, &strip.components, rect, self.held_entity());
         }
         if let Some(rect) = panel_rect {
-            draw_components(&mut canvas, &self.components, rect);
+            draw_components(&mut canvas, &self.components, rect, None);
             canvas.image(
                 close_button_canvas_rect(rect),
                 if self.hover_close {
@@ -552,7 +566,7 @@ impl FlatUiHost {
         let Some(rect) = self.panel_rect() else {
             return Vec::new();
         };
-        let mut out = self.elements_for(world, &self.components, rect);
+        let mut out = self.elements_for(world, &self.components, rect, None);
         // The host-drawn close button is clickable too.
         let close = close_button_canvas_rect(rect);
         out.push(crate::game_scene::DebugUiElement {
@@ -573,7 +587,10 @@ impl FlatUiHost {
     /// mode. The strip has no close element: use mode is left by Tab.
     pub fn strip_debug_elements(&self, world: &World) -> Vec<crate::game_scene::DebugUiElement> {
         match (self.strip.as_ref(), self.strip_rect()) {
-            (Some(strip), Some(rect)) => self.elements_for(world, &strip.components, rect),
+            // Hide the item on the cursor: it left the grid for the drag.
+            (Some(strip), Some(rect)) => {
+                self.elements_for(world, &strip.components, rect, self.held_entity())
+            }
             _ => Vec::new(),
         }
     }
@@ -593,11 +610,21 @@ impl FlatUiHost {
         world: &World,
         components: &[GuiComponentRenderInfo],
         rect: Rect,
+        hide: Option<EntityId>,
     ) -> Vec<crate::game_scene::DebugUiElement> {
         let mut out = Vec::new();
         for component in components {
             if is_gui_cursor(component) {
                 continue;
+            }
+            if let GuiComponentRenderInfo::Image {
+                entity: Some(entity),
+                ..
+            } = component
+            {
+                if Some(*entity) == hide {
+                    continue;
+                }
             }
             let r = component_canvas_rect(component, rect);
             let (kind, texture, text, label, entity_id) = match component {
@@ -689,13 +716,29 @@ fn gui_hover(to: EntityId, rect: Rect, canvas_pos: Vector2<f32>, pressed: bool) 
     }
 }
 
-/// Draw one slot's `SetUI` components into its canvas rect.
-fn draw_components(canvas: &mut UiCanvas, components: &[GuiComponentRenderInfo], rect: Rect) {
+/// Draw one slot's `SetUI` components into its canvas rect. `hide` is the
+/// entity riding the cursor (if any) - its component is skipped so it does not
+/// also render in the grid.
+fn draw_components(
+    canvas: &mut UiCanvas,
+    components: &[GuiComponentRenderInfo],
+    rect: Rect,
+    hide: Option<EntityId>,
+) {
     for component in components {
         if is_gui_cursor(component) {
             // GuiScript appends its own panel-local cursor image for the
             // VR quads; the host draws the real screen cursor instead.
             continue;
+        }
+        if let GuiComponentRenderInfo::Image {
+            entity: Some(entity),
+            ..
+        } = component
+        {
+            if Some(*entity) == hide {
+                continue;
+            }
         }
         let r = component_canvas_rect(component, rect);
         match component {
@@ -1181,21 +1224,34 @@ mod tests {
     fn lmb_on_a_strip_item_lifts_it_onto_the_cursor() {
         let (world, mut host, wrench, _inv) = drag_world();
         // Slot 0 center on the canvas: (2 + 4 + 17.5, 18 + 16) = (23.5, 34).
+        // Lifting is host-internal (the item stays in the backpack) - no
+        // world action is emitted.
         let actions = press_edge(&mut host, &world, (23.5, 34.0));
-        assert_eq!(actions, vec![FlatUiDragAction::Lift(wrench)]);
+        assert!(actions.is_empty(), "lifting emits no world action");
         let cursor = host.cursor_debug().expect("the item is on the cursor");
         assert_eq!(cursor.entity_id, wrench.inner() as i32);
         assert_eq!(cursor.label.as_deref(), Some("Wrench"));
+        // The lifted item is hidden from the strip grid and its hit-testing.
+        assert!(
+            host.strip_debug_elements(&world)
+                .iter()
+                .all(|e| e.entity_id != Some(wrench.inner() as i32)),
+            "the lifted item leaves the strip grid",
+        );
+        assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), None);
     }
 
     #[test]
     fn placing_over_the_strip_returns_the_item_and_clears_the_cursor() {
         let (world, mut host, wrench, _inv) = drag_world();
         press_edge(&mut host, &world, (23.5, 34.0)); // lift
-        // An empty strip cell (far from slot 0) places it back.
+        // An empty strip cell (far from slot 0) places it back: cursor clears,
+        // no world action (the item never left the backpack).
         let actions = press_edge(&mut host, &world, (400.0, 60.0));
-        assert_eq!(actions, vec![FlatUiDragAction::Place(wrench)]);
+        assert!(actions.is_empty(), "placing emits no world action");
         assert!(host.cursor_debug().is_none(), "placing clears the cursor");
+        // The item is visible in the strip again.
+        assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), Some(wrench));
     }
 
     #[test]
@@ -1222,26 +1278,26 @@ mod tests {
         );
         press_edge(&mut host, &world, (23.5, 34.0)); // lift the Wrench
         // Drop onto slot 1 (Pistol): center (2 + 4 + 35 + 17.5, 34) = (58.5, 34).
+        // Swapping is host-internal - the Pistol lifts onto the cursor, the
+        // Wrench returns to the grid; no world action.
         let actions = press_edge(&mut host, &world, (58.5, 34.0));
-        assert_eq!(
-            actions,
-            vec![
-                FlatUiDragAction::Place(wrench),
-                FlatUiDragAction::Lift(pistol),
-            ],
-        );
+        assert!(actions.is_empty(), "swapping emits no world action");
         let cursor = host
             .cursor_debug()
             .expect("the swapped-in Pistol is on the cursor");
         assert_eq!(cursor.entity_id, pistol.inner() as i32);
+        // The Pistol is now hidden and the Wrench visible again.
+        assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), Some(wrench));
+        assert_eq!(host.strip_item_at(vec2(58.5, 34.0)), None);
     }
 
     #[test]
     fn double_click_on_a_strip_item_wields_it() {
         let (world, mut host, wrench, _inv) = drag_world();
-        // First click lifts onto the cursor...
+        // First click lifts onto the cursor (no world action)...
         let first = press_edge(&mut host, &world, (23.5, 34.0));
-        assert_eq!(first, vec![FlatUiDragAction::Lift(wrench)]);
+        assert!(first.is_empty());
+        assert!(host.cursor_debug().is_some());
         // ...a quick second click on the same slot wields it (double-click).
         let second = press_edge(&mut host, &world, (23.5, 34.0));
         assert_eq!(second, vec![FlatUiDragAction::Wield(wrench)]);

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -61,6 +61,34 @@ const CLOSE_BUTTON_MARGIN: Vector2<f32> = Vector2::new(25.0, 8.0);
 /// `CURSOR.PCX` native size.
 const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 
+/// Size of the item icon drawn when the cursor "is" a lifted item (the
+/// original replaces the arrow with the object's `objicon` art). One
+/// inventory slot (35x32, matching `ContainerGui`'s slot pixels).
+const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
+
+/// A host-side action produced by the cursor-is-the-item drag (§1.5/§2.4),
+/// applied by `mission_core` because it touches links/physics: **Lift**
+/// removes the item from its container (the strip slot empties), **Place**
+/// returns it to the player's backpack, **Throw** gives it world presence
+/// with an impulse along the view ray.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlatUiDragAction {
+    Lift(EntityId),
+    Place(EntityId),
+    Throw(EntityId),
+}
+
+/// The item currently riding the cursor (the original's `drag_obj`): the
+/// cursor renders this item's icon instead of the arrow, and the item has no
+/// container link and no world presence until placed or thrown.
+struct CursorItem {
+    entity: EntityId,
+    /// `objicon` art (`"<icon>.pcx"`) drawn as the cursor, if the item has one.
+    icon: Option<String>,
+    /// The item's symbolic name, for `/v1/ui` `cursor.label`.
+    label: Option<String>,
+}
+
 /// Flat-mode MFD panel state: which world object (if any) has its panel
 /// open, the panel's latest components (from `Effect::SetUI`), and the
 /// cursor/pointer bookkeeping needed to render and hit-test them.
@@ -76,6 +104,9 @@ pub struct FlatUiHost {
     /// the player's `internal_inventory` entity. `Some` exactly while flat
     /// use mode is on (projects/flat-ui.md §5.2, PR 4).
     strip: Option<StripSlot>,
+    /// The item lifted onto the cursor (the original's "cursor IS the item"
+    /// drag, §2.4). `Some` between a lift and the place/throw that clears it.
+    cursor_item: Option<CursorItem>,
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -102,6 +133,7 @@ impl FlatUiHost {
             panel_size_px: None,
             components: Vec::new(),
             strip: None,
+            cursor_item: None,
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -117,6 +149,24 @@ impl FlatUiHost {
     /// is on.
     pub fn strip_entity(&self) -> Option<EntityId> {
         self.strip.as_ref().map(|s| s.entity)
+    }
+
+    /// The item currently held on the cursor mid-drag (for `/v1/ui` `cursor`).
+    pub fn cursor_debug(&self) -> Option<crate::game_scene::DebugUiCursor> {
+        self.cursor_item
+            .as_ref()
+            .map(|c| crate::game_scene::DebugUiCursor {
+                entity_id: c.entity.inner() as i32,
+                label: c.label.clone(),
+            })
+    }
+
+    /// Take the item off the cursor (clearing it), returning its entity id.
+    /// The caller returns it to the backpack - the original refuses to leave
+    /// the metagame while `drag_obj` is set, so Tab-out re-homes the item
+    /// rather than losing it (projects/flat-ui.md §1.5).
+    pub fn take_cursor_item(&mut self) -> Option<EntityId> {
+        self.cursor_item.take().map(|c| c.entity)
     }
 
     /// Enter/leave Tab metagame mode: bind (or drop) the top-docked
@@ -201,13 +251,20 @@ impl FlatUiHost {
             .map(strip_canvas_rect)
     }
 
-    /// Per-frame pointer processing while in flat presentation. Maps the
-    /// normalized pointer to panel-local coordinates and returns the
-    /// `GUIHover` message to dispatch to the strip or panel entity; handles
-    /// the close gestures (close button, LMB on the bare view, walk-away,
-    /// entity gone). A bare-view click closes the MFD panel but never the
-    /// strip - use mode is left by Tab (projects/flat-ui.md §5.2).
-    pub fn update(&mut self, world: &World, pointer: Option<Pointer2D>) -> Vec<Message> {
+    /// Per-frame pointer processing while in flat presentation. Returns the
+    /// `GUIHover` messages to dispatch to the strip/panel entity plus any
+    /// cursor-drag [`FlatUiDragAction`]s (lift/place/throw) for the caller to
+    /// apply. Handles the close gestures (close button, LMB on the bare view,
+    /// walk-away, entity gone) and the cursor-is-the-item drag (§1.5/§2.4):
+    /// LMB on a strip item lifts it onto the cursor, LMB on another slot
+    /// places/swaps, LMB on the bare view throws it into the world. A
+    /// bare-view click closes the MFD panel but never the strip - use mode is
+    /// left by Tab (projects/flat-ui.md §5.2).
+    pub fn update(
+        &mut self,
+        world: &World,
+        pointer: Option<Pointer2D>,
+    ) -> (Vec<Message>, Vec<FlatUiDragAction>) {
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
@@ -238,13 +295,13 @@ impl FlatUiHost {
 
         if self.active_panel.is_none() && self.strip.is_none() {
             self.cursor_canvas = None;
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
 
         let Some(pointer) = pointer else {
             self.cursor_canvas = None;
             self.hover_close = false;
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         };
         let canvas_pos = pointer_to_canvas(
             CANVAS_SIZE,
@@ -257,34 +314,85 @@ impl FlatUiHost {
             self.hover_close = false;
         }
 
+        // A press fully outside the canvas (letterbox bars) is a bare-view
+        // click: throw a held item, else close the panel.
         let Some(canvas_pos) = canvas_pos else {
-            // Pointer in the letterbox bars - fully outside the canvas; a
-            // click there is a click on the bare view.
             if pressed_edge {
+                if let Some(held) = self.cursor_item.take() {
+                    return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
+                }
                 self.close();
             }
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         };
 
-        // The strip's top-docked rect is disjoint from the MFD slot (y 0-121
-        // vs 124+); route the hover to whichever contains the pointer.
-        if let Some(strip) = &self.strip {
-            if let Some(rect) = strip.size_px.map(strip_canvas_rect) {
-                if rect.contains(canvas_pos) {
-                    self.hover_close = false;
-                    return vec![gui_hover(strip.entity, rect, canvas_pos, pointer.pressed)];
-                }
+        let strip_rect = self
+            .strip
+            .as_ref()
+            .and_then(|s| s.size_px)
+            .map(strip_canvas_rect);
+        let over_strip = strip_rect.map(|r| r.contains(canvas_pos)).unwrap_or(false);
+        let panel_rect = self.panel_rect();
+        // The close button hugs the panel's corner but sits just outside the
+        // panel rect; treat both as "over the panel" so a held item is never
+        // thrown from there.
+        let over_panel = panel_rect
+            .map(|r| r.contains(canvas_pos) || close_button_canvas_rect(r).contains(canvas_pos))
+            .unwrap_or(false);
+
+        // --- Cursor-is-the-item drag: while an item rides the cursor, LMB
+        // places/swaps/throws it and never routes to a GuiScript (protecting
+        // the held item - the original blocks losing `drag_obj`). ---
+        if self.cursor_item.is_some() {
+            self.hover_close = false;
+            if !pressed_edge {
+                return (Vec::new(), Vec::new());
             }
+            if over_strip {
+                let held = self.cursor_item.take().unwrap();
+                let mut actions = vec![FlatUiDragAction::Place(held.entity)];
+                // Dropping onto an occupied slot swaps: the occupant lifts.
+                if let Some(target) = self.strip_item_at(canvas_pos) {
+                    if target != held.entity {
+                        self.cursor_item = Some(make_cursor_item(world, target));
+                        actions.push(FlatUiDragAction::Lift(target));
+                    }
+                }
+                return (Vec::new(), actions);
+            }
+            if over_panel {
+                // Escape hatch: a click on an open MFD keeps the held item.
+                return (Vec::new(), Vec::new());
+            }
+            // Bare 3D view: throw the held item along the view ray.
+            let held = self.cursor_item.take().unwrap();
+            return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
+        }
+
+        // --- Empty cursor over the strip: LMB on an item lifts it (host-
+        // handled, no GuiScript routing); hover highlights via GUIHover. ---
+        if over_strip {
+            self.hover_close = false;
+            if pressed_edge {
+                if let Some(item) = self.strip_item_at(canvas_pos) {
+                    self.cursor_item = Some(make_cursor_item(world, item));
+                    return (Vec::new(), vec![FlatUiDragAction::Lift(item)]);
+                }
+                return (Vec::new(), Vec::new());
+            }
+            let rect = strip_rect.unwrap();
+            let entity = self.strip.as_ref().unwrap().entity;
+            return (vec![gui_hover(entity, rect, canvas_pos, false)], Vec::new());
         }
 
         let Some(panel) = self.active_panel else {
             // Use mode with no MFD open: a bare-view click has nothing to
             // close (Tab leaves use mode).
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         };
-        let Some(rect) = self.panel_rect() else {
+        let Some(rect) = panel_rect else {
             // Panel opened this frame; no SetUI yet - nothing to hit-test.
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         };
 
         // Host-drawn close button (the shared guis have no close component -
@@ -293,18 +401,37 @@ impl FlatUiHost {
         self.hover_close = close_rect.contains(canvas_pos);
         if pressed_edge && self.hover_close {
             self.close();
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
 
         if rect.contains(canvas_pos) {
-            vec![gui_hover(panel, rect, canvas_pos, pointer.pressed)]
+            (
+                vec![gui_hover(panel, rect, canvas_pos, pointer.pressed)],
+                Vec::new(),
+            )
         } else {
             // LMB on the bare 3D view closes the panels (manual p.7).
             if pressed_edge {
                 self.close();
             }
-            Vec::new()
+            (Vec::new(), Vec::new())
         }
+    }
+
+    /// The interactive strip item whose canvas rect contains `canvas_pos`
+    /// (loot/backpack item buttons carry their entity), for lift/swap
+    /// hit-testing.
+    fn strip_item_at(&self, canvas_pos: Vector2<f32>) -> Option<EntityId> {
+        let strip = self.strip.as_ref()?;
+        let rect = strip.size_px.map(strip_canvas_rect)?;
+        strip.components.iter().find_map(|c| match c {
+            GuiComponentRenderInfo::Image {
+                interactive: true,
+                entity: Some(entity),
+                ..
+            } if component_canvas_rect(c, rect).contains(canvas_pos) => Some(*entity),
+            _ => None,
+        })
     }
 
     /// Render the inventory strip + active panel + cursor as screen-space
@@ -336,10 +463,19 @@ impl FlatUiHost {
             );
         }
         if let Some(cursor) = self.cursor_canvas {
-            canvas.image(
-                Rect::new(cursor.x, cursor.y, CURSOR_SIZE.x, CURSOR_SIZE.y),
-                "cursor.pcx",
-            );
+            // The cursor IS the lifted item: draw its icon in place of the
+            // arrow (the original's `SCM_DRAGOBJ`, §2.4). Fall back to the
+            // arrow when the held item has no icon or nothing is held.
+            match self.cursor_item.as_ref().and_then(|c| c.icon.as_deref()) {
+                Some(icon) => canvas.image(
+                    Rect::new(cursor.x, cursor.y, CURSOR_ITEM_SIZE.x, CURSOR_ITEM_SIZE.y),
+                    icon,
+                ),
+                None => canvas.image(
+                    Rect::new(cursor.x, cursor.y, CURSOR_SIZE.x, CURSOR_SIZE.y),
+                    "cursor.pcx",
+                ),
+            };
         }
         canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
     }
@@ -540,6 +676,20 @@ fn close_button_canvas_rect(panel: Rect) -> Rect {
         CLOSE_BUTTON_SIZE.x,
         CLOSE_BUTTON_SIZE.y,
     )
+}
+
+/// Resolve a lifted item's cursor art (`objicon`) and label (`SymName`) for
+/// the cursor-is-the-item drag.
+fn make_cursor_item(world: &World, entity: EntityId) -> CursorItem {
+    let icon = world
+        .borrow::<View<dark::properties::PropObjIcon>>()
+        .ok()
+        .and_then(|v| v.get(entity).ok().map(|i| format!("{}.pcx", i.0)));
+    CursorItem {
+        entity,
+        icon,
+        label: entity_label(world, entity),
+    }
 }
 
 /// Semantic label for an entity-bound element (a loot-panel item): the
@@ -768,7 +918,7 @@ mod tests {
             position: vec2(0.5, 0.125),
             pressed: false,
         };
-        let msgs = host.update(&world, Some(over_strip));
+        let (msgs, _) = host.update(&world, Some(over_strip));
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].to, inventory, "top dock hover goes to the strip");
 
@@ -777,7 +927,7 @@ mod tests {
             position: vec2(96.0 / 640.0, 272.0 / 480.0),
             pressed: false,
         };
-        let msgs = host.update(&world, Some(over_panel));
+        let (msgs, _) = host.update(&world, Some(over_panel));
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].to, panel, "MFD slot hover goes to the panel");
     }
@@ -898,6 +1048,156 @@ mod tests {
         host.set_strip(None);
         assert!(host.strip_entity().is_none());
         assert!(host.strip_debug_elements(&world).is_empty());
+    }
+
+    // --- Cursor-is-the-item drag (§1.5/§2.4) ---
+
+    /// Normalized pointer position that lands on canvas `(cx, cy)` at the
+    /// default 640x480 screen size (no letterbox, so canvas = norm * size).
+    fn norm(cx: f32, cy: f32) -> cgmath::Vector2<f32> {
+        vec2(cx / 640.0, cy / 480.0)
+    }
+
+    fn strip_item(entity: EntityId, slot_x: usize) -> GuiComponentRenderInfo {
+        // ContainerGui strip slots: 4px inset, 35px slot pitch, 32px tall
+        // (container.rs inv_container), emitted normalized by 635x120.
+        let x = 4.0 + 35.0 * slot_x as f32;
+        GuiComponentRenderInfo::Image {
+            position: vec2(x / 635.0, 18.0 / 120.0),
+            size: vec2(35.0 / 635.0, 32.0 / 120.0),
+            texture: "icn_x.pcx".to_owned(),
+            alpha: 0.5,
+            interactive: true,
+            entity: Some(entity),
+        }
+    }
+
+    fn press_edge(
+        host: &mut FlatUiHost,
+        world: &World,
+        canvas: (f32, f32),
+    ) -> Vec<FlatUiDragAction> {
+        // An unpressed frame first so the press is a rising edge.
+        host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: false,
+            }),
+        );
+        let (_msgs, actions) = host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: true,
+            }),
+        );
+        actions
+    }
+
+    /// A world+host with the strip showing `Wrench` in slot 0 (icon + name so
+    /// the cursor can render/label it).
+    fn drag_world() -> (World, FlatUiHost, EntityId, EntityId) {
+        let mut world = World::new();
+        let wrench = world.add_entity((
+            dark::properties::PropObjIcon("icn_wrench".to_owned()),
+            dark::properties::PropSymName("Wrench".to_owned()),
+        ));
+        let inventory = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+        host.on_set_ui(
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(wrench, 0)],
+        );
+        (world, host, wrench, inventory)
+    }
+
+    #[test]
+    fn lmb_on_a_strip_item_lifts_it_onto_the_cursor() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        // Slot 0 center on the canvas: (2 + 4 + 17.5, 18 + 16) = (23.5, 34).
+        let actions = press_edge(&mut host, &world, (23.5, 34.0));
+        assert_eq!(actions, vec![FlatUiDragAction::Lift(wrench)]);
+        let cursor = host.cursor_debug().expect("the item is on the cursor");
+        assert_eq!(cursor.entity_id, wrench.inner() as i32);
+        assert_eq!(cursor.label.as_deref(), Some("Wrench"));
+    }
+
+    #[test]
+    fn placing_over_the_strip_returns_the_item_and_clears_the_cursor() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift
+        // An empty strip cell (far from slot 0) places it back.
+        let actions = press_edge(&mut host, &world, (400.0, 60.0));
+        assert_eq!(actions, vec![FlatUiDragAction::Place(wrench)]);
+        assert!(host.cursor_debug().is_none(), "placing clears the cursor");
+    }
+
+    #[test]
+    fn clicking_the_bare_view_while_holding_throws_the_item() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift
+        // Below the strip (y > 121), no panel open: the bare 3D view.
+        let actions = press_edge(&mut host, &world, (320.0, 300.0));
+        assert_eq!(actions, vec![FlatUiDragAction::Throw(wrench)]);
+        assert!(host.cursor_debug().is_none(), "throwing clears the cursor");
+    }
+
+    #[test]
+    fn dropping_onto_an_occupied_slot_swaps() {
+        let (mut world, mut host, wrench, inventory) = drag_world();
+        let pistol = world.add_entity((
+            dark::properties::PropObjIcon("icn_pist".to_owned()),
+            dark::properties::PropSymName("Pistol".to_owned()),
+        ));
+        host.on_set_ui(
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(wrench, 0), strip_item(pistol, 1)],
+        );
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift the Wrench
+        // Drop onto slot 1 (Pistol): center (2 + 4 + 35 + 17.5, 34) = (58.5, 34).
+        let actions = press_edge(&mut host, &world, (58.5, 34.0));
+        assert_eq!(
+            actions,
+            vec![
+                FlatUiDragAction::Place(wrench),
+                FlatUiDragAction::Lift(pistol),
+            ],
+        );
+        let cursor = host
+            .cursor_debug()
+            .expect("the swapped-in Pistol is on the cursor");
+        assert_eq!(cursor.entity_id, pistol.inner() as i32);
+    }
+
+    #[test]
+    fn clicking_a_panel_while_holding_keeps_the_item() {
+        let (mut world, mut host, wrench, _inv) = drag_world();
+        let panel = world.add_entity(());
+        host.open(panel);
+        host.on_set_ui(
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[],
+        );
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift the Wrench
+        assert!(host.cursor_debug().is_some());
+        // Click inside the left-MFD panel (canvas ~ (96, 272)): the held item
+        // is protected (escape hatch), no drag action, cursor unchanged.
+        let actions = press_edge(&mut host, &world, (96.0, 272.0));
+        assert!(
+            actions.is_empty(),
+            "a panel click while holding does nothing"
+        );
+        assert_eq!(
+            host.cursor_debug().map(|c| c.entity_id),
+            Some(wrench.inner() as i32),
+            "the item stays on the cursor",
+        );
+        assert_eq!(host.active_panel(), Some(panel), "the panel stays open");
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -960,8 +960,12 @@ impl MissionCore {
         // uses. Dispatched before the script update so hovers/clicks are
         // processed this frame.
         if game_options.presentation_mode == crate::PresentationMode::Flat {
-            for msg in self.flat_ui.update(&self.world, input_context.pointer) {
+            let (messages, drag_actions) = self.flat_ui.update(&self.world, input_context.pointer);
+            for msg in messages {
                 self.script_world.dispatch(msg);
+            }
+            for action in drag_actions {
+                self.apply_flat_drag_action(action);
             }
         }
 
@@ -1586,6 +1590,88 @@ impl MissionCore {
         }
     }
 
+    /// Apply a cursor-is-the-item drag action from the `FlatUiHost` (§1.5/§2.4).
+    /// These touch container links and physics, so the host emits them and the
+    /// mission applies them here.
+    fn apply_flat_drag_action(&mut self, action: crate::mission::flat_ui_host::FlatUiDragAction) {
+        use crate::mission::flat_ui_host::FlatUiDragAction;
+        match action {
+            // Lifting onto the cursor empties the item's slot: drop its
+            // container link. It stays alive and non-physical (still in the
+            // backpack, just off-grid) until placed or thrown.
+            FlatUiDragAction::Lift(entity_id) => self.detach_from_containers(entity_id),
+            // Placing returns the item to the player's backpack (first free
+            // slot) - the same `Contains`-relink path as looting.
+            FlatUiDragAction::Place(entity_id) => {
+                let inventory = self
+                    .world
+                    .borrow::<UniqueView<PlayerInfo>>()
+                    .ok()
+                    .map(|player| player.inventory_entity_id);
+                if let Some(inventory) = inventory {
+                    self.drop_entity_into_container(inventory, entity_id);
+                }
+            }
+            FlatUiDragAction::Throw(entity_id) => self.throw_entity_into_world(entity_id),
+        }
+    }
+
+    /// Remove every incoming `Contains` link to `entity_id` (take it out of
+    /// whatever container holds it) without giving it world presence - the
+    /// "lift onto the cursor" half of the drag.
+    fn detach_from_containers(&mut self, entity_id: EntityId) {
+        let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
+        for links in (&mut v_links).iter() {
+            links.to_links.retain(|link| {
+                !(matches!(link.link, Link::Contains(_))
+                    && link.to_entity_id.map(|w| w.0) == Some(entity_id))
+            });
+        }
+    }
+
+    /// Throw a cursor-held item into the world: detach it from any container,
+    /// give it physics presence just ahead of the camera, and shove it along
+    /// the flat view ray (the original's `ShockInterfaceClick` -> `ThrowObj`,
+    /// §2.4).
+    fn throw_entity_into_world(&mut self, entity_id: EntityId) {
+        /// How far ahead of the camera the item materializes (world units).
+        const THROW_SPAWN_DISTANCE: f32 = 0.5;
+        /// Launch speed along the view ray (world units/sec).
+        const THROW_SPEED: f32 = 6.0;
+
+        // Origin + direction: the flat aim ray (camera + view forward), with a
+        // player-facing fallback (flat_aim_ray is None only outside flat mode).
+        let (origin, forward) = self.interaction.flat_aim_ray().unwrap_or_else(|| {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            let forward = player.rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+            (
+                Point3::new(player.pos.x, player.pos.y, player.pos.z),
+                forward,
+            )
+        });
+
+        self.detach_from_containers(entity_id);
+        let throw_pos = vec3(
+            origin.x + forward.x * THROW_SPAWN_DISTANCE,
+            origin.y + forward.y * THROW_SPAWN_DISTANCE,
+            origin.z + forward.z * THROW_SPAWN_DISTANCE,
+        );
+        self.make_physical(entity_id);
+        self.set_entity_position_rotation(
+            entity_id,
+            throw_pos,
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 1.0),
+        );
+        self.physics.set_velocity(entity_id, forward * THROW_SPEED);
+        // A thrown item is a normal referenced world object again.
+        self.world.add_component(entity_id, PropHasRefs(true));
+        self.script_world.dispatch(Message {
+            payload: MessagePayload::Drop,
+            to: entity_id,
+        });
+    }
+
     pub fn set_entity_position_rotation(
         &mut self,
         entity_id: EntityId,
@@ -2091,11 +2177,24 @@ impl MissionCore {
                         // top-docked inventory strip: bind the strip to the
                         // `internal_inventory` entity (whose GuiScript
                         // already emits SetUI every frame).
+                        let inventory_entity = self
+                            .world
+                            .borrow::<UniqueView<PlayerInfo>>()
+                            .ok()
+                            .map(|player| player.inventory_entity_id);
+                        // Leaving use mode with an item on the cursor must not
+                        // lose it: return it to the backpack (the original
+                        // refuses to exit the metagame while `drag_obj` is
+                        // set - projects/flat-ui.md §1.5).
+                        if !self.flat_use_mode {
+                            if let (Some(item), Some(inventory)) =
+                                (self.flat_ui.take_cursor_item(), inventory_entity)
+                            {
+                                self.drop_entity_into_container(inventory, item);
+                            }
+                        }
                         let strip_entity = if self.flat_use_mode {
-                            self.world
-                                .borrow::<UniqueView<PlayerInfo>>()
-                                .ok()
-                                .map(|player| player.inventory_entity_id)
+                            inventory_entity
                         } else {
                             None
                         };
@@ -4698,6 +4797,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             },
             active_panel,
             strip,
+            cursor: self.flat_ui.cursor_debug(),
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1592,58 +1592,28 @@ impl MissionCore {
     }
 
     /// Apply a cursor-is-the-item drag action from the `FlatUiHost` (§1.5/§2.4).
-    /// Lift/Place/Throw touch container links and physics and are applied
-    /// directly; Wield produces the same effect a backpack click does (wield a
-    /// weapon, use anything else) and is returned for the normal effect
-    /// pipeline to process (it needs `asset_cache` for the grab).
+    /// Lift/place/swap never reach here: a lifted item stays in the backpack
+    /// container (the host just hides it from the strip), so only committing
+    /// the drag touches the world. `Throw` detaches + launches; `Wield`
+    /// produces the same effect a backpack click does (returned for the normal
+    /// effect pipeline, which has `asset_cache` for the grab).
     fn apply_flat_drag_action(
         &mut self,
         action: crate::mission::flat_ui_host::FlatUiDragAction,
     ) -> Vec<Effect> {
         use crate::mission::flat_ui_host::FlatUiDragAction;
         match action {
-            // Lifting onto the cursor empties the item's slot: drop its
-            // container link. It stays alive and non-physical (still in the
-            // backpack, just off-grid) until placed or thrown.
-            FlatUiDragAction::Lift(entity_id) => {
-                self.detach_from_containers(entity_id);
-                Vec::new()
-            }
-            // Placing returns the item to the player's backpack (first free
-            // slot) - the same `Contains`-relink path as looting.
-            FlatUiDragAction::Place(entity_id) => {
-                let inventory = self
-                    .world
-                    .borrow::<UniqueView<PlayerInfo>>()
-                    .ok()
-                    .map(|player| player.inventory_entity_id);
-                if let Some(inventory) = inventory {
-                    self.drop_entity_into_container(inventory, entity_id);
-                }
-                Vec::new()
-            }
             FlatUiDragAction::Throw(entity_id) => {
                 self.throw_entity_into_world(entity_id);
                 Vec::new()
             }
-            // Double-click = equip/use: a weapon (gun or melee) wields via
-            // `GrabEntity` (which holsters any displaced weapon back to the
-            // grid), anything else gets a `Frob` (use) - identical to the
-            // ContainerGui backpack click, so the wield path is shared, not
-            // duplicated. The item was lifted onto the cursor, so it is
-            // already detached from the backpack.
+            // Double-click = equip/use, acting on the still-contained item -
+            // identical to the ContainerGui backpack click (shared weapon test,
+            // shared effects): a weapon (gun or melee) wields via `GrabEntity`
+            // (which also clears its Contains link and holsters any displaced
+            // weapon back to the grid), anything else gets a `Frob` (use).
             FlatUiDragAction::Wield(entity_id) => {
-                let is_weapon = self
-                    .world
-                    .borrow::<View<dark::properties::PropPlayerGun>>()
-                    .map(|v| v.get(entity_id).is_ok())
-                    .unwrap_or(false)
-                    || self
-                        .world
-                        .borrow::<View<PropLimbModel>>()
-                        .map(|v| v.get(entity_id).is_ok())
-                        .unwrap_or(false);
-                if is_weapon {
+                if crate::virtual_hand::is_wieldable_weapon(&self.world, entity_id) {
                     vec![Effect::GrabEntity {
                         entity_id,
                         hand: crate::vr_config::Handedness::Right,
@@ -1662,8 +1632,7 @@ impl MissionCore {
     }
 
     /// Remove every incoming `Contains` link to `entity_id` (take it out of
-    /// whatever container holds it) without giving it world presence - the
-    /// "lift onto the cursor" half of the drag.
+    /// whatever container holds it) without giving it world presence.
     fn detach_from_containers(&mut self, entity_id: EntityId) {
         let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
         for links in (&mut v_links).iter() {
@@ -1674,26 +1643,32 @@ impl MissionCore {
         }
     }
 
-    /// Throw a cursor-held item into the world: detach it from any container,
-    /// give it physics presence just ahead of the camera, and shove it along
-    /// the flat view ray (the original's `ShockInterfaceClick` -> `ThrowObj`,
-    /// §2.4).
+    /// Throw a cursor-held item into the world: give it physics presence just
+    /// ahead of the camera and shove it along the flat view ray (the original's
+    /// `ShockInterfaceClick` -> `ThrowObj`, §2.4). The item is still in the
+    /// backpack when this runs; it is only detached once a physics body is
+    /// confirmed, so an aborted throw (no view ray, or a modelless item with no
+    /// physics representation) leaves it in the backpack rather than lost or
+    /// frozen mid-air.
     fn throw_entity_into_world(&mut self, entity_id: EntityId) {
         /// How far ahead of the camera the item materializes (world units).
         const THROW_SPAWN_DISTANCE: f32 = 0.5;
         /// Launch speed along the view ray (world units/sec).
         const THROW_SPEED: f32 = 6.0;
 
-        // Origin + direction: the flat aim ray (camera + view forward), with a
-        // player-facing fallback (flat_aim_ray is None only outside flat mode).
-        let (origin, forward) = self.interaction.flat_aim_ray().unwrap_or_else(|| {
-            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-            let forward = player.rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-            (
-                Point3::new(player.pos.x, player.pos.y, player.pos.z),
-                forward,
-            )
-        });
+        // Origin + direction: the flat aim ray (camera + view forward). Only
+        // set in flat presentation; without it, leave the item in the backpack.
+        let Some((origin, forward)) = self.interaction.flat_aim_ray() else {
+            return;
+        };
+
+        self.make_physical(entity_id);
+        if self.id_to_physics.get(&entity_id).is_none() {
+            // No physics representation (e.g. a modelless item): don't strand a
+            // static object in the air - leave it in the backpack (it reappears
+            // in the strip once the cursor cleared).
+            return;
+        }
 
         self.detach_from_containers(entity_id);
         let throw_pos = vec3(
@@ -1701,7 +1676,6 @@ impl MissionCore {
             origin.y + forward.y * THROW_SPAWN_DISTANCE,
             origin.z + forward.z * THROW_SPAWN_DISTANCE,
         );
-        self.make_physical(entity_id);
         self.set_entity_position_rotation(
             entity_id,
             throw_pos,
@@ -2222,24 +2196,20 @@ impl MissionCore {
                         // top-docked inventory strip: bind the strip to the
                         // `internal_inventory` entity (whose GuiScript
                         // already emits SetUI every frame).
-                        let inventory_entity = self
-                            .world
-                            .borrow::<UniqueView<PlayerInfo>>()
-                            .ok()
-                            .map(|player| player.inventory_entity_id);
-                        // Leaving use mode with an item on the cursor must not
-                        // lose it: return it to the backpack (the original
-                        // refuses to exit the metagame while `drag_obj` is
-                        // set - projects/flat-ui.md §1.5).
+                        // Leaving use mode drops any item on the cursor. It was
+                        // never removed from the backpack (the host only hid it
+                        // from the strip), so clearing the cursor is enough -
+                        // the item is already reachable there (projects/flat-ui.md
+                        // §1.5). This also means a save/transition mid-drag
+                        // serializes it correctly, with no orphan.
                         if !self.flat_use_mode {
-                            if let (Some(item), Some(inventory)) =
-                                (self.flat_ui.take_cursor_item(), inventory_entity)
-                            {
-                                self.drop_entity_into_container(inventory, item);
-                            }
+                            self.flat_ui.take_cursor_item();
                         }
                         let strip_entity = if self.flat_use_mode {
-                            inventory_entity
+                            self.world
+                                .borrow::<UniqueView<PlayerInfo>>()
+                                .ok()
+                                .map(|player| player.inventory_entity_id)
                         } else {
                             None
                         };

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -965,7 +965,8 @@ impl MissionCore {
                 self.script_world.dispatch(msg);
             }
             for action in drag_actions {
-                self.apply_flat_drag_action(action);
+                let drag_effects = self.apply_flat_drag_action(action);
+                effects.extend(drag_effects);
             }
         }
 
@@ -1591,15 +1592,23 @@ impl MissionCore {
     }
 
     /// Apply a cursor-is-the-item drag action from the `FlatUiHost` (§1.5/§2.4).
-    /// These touch container links and physics, so the host emits them and the
-    /// mission applies them here.
-    fn apply_flat_drag_action(&mut self, action: crate::mission::flat_ui_host::FlatUiDragAction) {
+    /// Lift/Place/Throw touch container links and physics and are applied
+    /// directly; Wield produces the same effect a backpack click does (wield a
+    /// weapon, use anything else) and is returned for the normal effect
+    /// pipeline to process (it needs `asset_cache` for the grab).
+    fn apply_flat_drag_action(
+        &mut self,
+        action: crate::mission::flat_ui_host::FlatUiDragAction,
+    ) -> Vec<Effect> {
         use crate::mission::flat_ui_host::FlatUiDragAction;
         match action {
             // Lifting onto the cursor empties the item's slot: drop its
             // container link. It stays alive and non-physical (still in the
             // backpack, just off-grid) until placed or thrown.
-            FlatUiDragAction::Lift(entity_id) => self.detach_from_containers(entity_id),
+            FlatUiDragAction::Lift(entity_id) => {
+                self.detach_from_containers(entity_id);
+                Vec::new()
+            }
             // Placing returns the item to the player's backpack (first free
             // slot) - the same `Contains`-relink path as looting.
             FlatUiDragAction::Place(entity_id) => {
@@ -1611,8 +1620,44 @@ impl MissionCore {
                 if let Some(inventory) = inventory {
                     self.drop_entity_into_container(inventory, entity_id);
                 }
+                Vec::new()
             }
-            FlatUiDragAction::Throw(entity_id) => self.throw_entity_into_world(entity_id),
+            FlatUiDragAction::Throw(entity_id) => {
+                self.throw_entity_into_world(entity_id);
+                Vec::new()
+            }
+            // Double-click = equip/use: a weapon (gun or melee) wields via
+            // `GrabEntity` (which holsters any displaced weapon back to the
+            // grid), anything else gets a `Frob` (use) - identical to the
+            // ContainerGui backpack click, so the wield path is shared, not
+            // duplicated. The item was lifted onto the cursor, so it is
+            // already detached from the backpack.
+            FlatUiDragAction::Wield(entity_id) => {
+                let is_weapon = self
+                    .world
+                    .borrow::<View<dark::properties::PropPlayerGun>>()
+                    .map(|v| v.get(entity_id).is_ok())
+                    .unwrap_or(false)
+                    || self
+                        .world
+                        .borrow::<View<PropLimbModel>>()
+                        .map(|v| v.get(entity_id).is_ok())
+                        .unwrap_or(false);
+                if is_weapon {
+                    vec![Effect::GrabEntity {
+                        entity_id,
+                        hand: crate::vr_config::Handedness::Right,
+                        current_parent_id: None,
+                    }]
+                } else {
+                    vec![Effect::Send {
+                        msg: Message {
+                            payload: MessagePayload::Frob,
+                            to: entity_id,
+                        },
+                    }]
+                }
+            }
         }
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -214,14 +214,7 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // VR: a grab into the hand). Anything else gets its own Frob
             // (use) action, e.g. a hypo consumes.
             ContainerGuiMsg::Frob(ent) => {
-                let is_weapon = world
-                    .borrow::<View<dark::properties::PropPlayerGun>>()
-                    .map(|v| v.get(*ent).is_ok())
-                    .unwrap_or(false)
-                    || world
-                        .borrow::<View<dark::properties::PropLimbModel>>()
-                        .map(|v| v.get(*ent).is_ok())
-                        .unwrap_or(false);
+                let is_weapon = crate::virtual_hand::is_wieldable_weapon(world, *ent);
                 if is_weapon {
                     (
                         state.clone(),

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -507,6 +507,21 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
+/// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
+/// a melee arm (`PropLimbModel`). Clicking one in the backpack/strip wields it
+/// (`Effect::GrabEntity`) instead of using it; shared by `ContainerGui` and the
+/// flat cursor-drag wield so the two can't drift.
+pub(crate) fn is_wieldable_weapon(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropPlayerGun>>()
+        .map(|v| v.get(entity_id).is_ok())
+        .unwrap_or(false)
+        || world
+            .borrow::<View<dark::properties::PropLimbModel>>()
+            .map(|v| v.get(entity_id).is_ok())
+            .unwrap_or(false)
+}
+
 ///
 /// In the case where we hit an entity that is 'proxied' (like, a hitbox that points to a parent),
 /// resolve to the parent entity.

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -299,6 +299,18 @@ export interface UiPanel {
   elements: UiElement[];
 }
 
+/**
+ * The item currently held on the cursor (the original's "cursor IS the item"
+ * drag model, §2.4): lifting a strip item puts it here and empties its slot;
+ * placing/throwing clears it. `null` when the cursor is empty.
+ */
+export interface UiCursor {
+  /** Runtime entity id of the held item (NOT stable across runs). */
+  entity_id: number;
+  /** The item's symbolic name (e.g. "Wrench"), if any. */
+  label: string | null;
+}
+
 /** Flat-mode UI snapshot (GET /v1/ui). */
 export interface UiState {
   mode: "shooter" | "use";
@@ -310,6 +322,8 @@ export interface UiState {
    * shooter mode.
    */
   strip: UiPanel | null;
+  /** The item held on the cursor mid-drag, or null when the cursor is empty. */
+  cursor: UiCursor | null;
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiState } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for the cursor-is-the-item inventory drag (flat UI 4.5,
+// projects/flat-ui.md §1.5 / §2.4 / §5.2):
+//
+//   - LMB on a strip item LIFTS it onto the cursor (the cursor becomes the
+//     item; the slot empties). /v1/ui exposes the held item (`cursor`).
+//   - LMB on another slot PLACES it back into the grid.
+//   - LMB on the bare 3D view THROWS the held item into the world (it gains
+//     physics presence near the player).
+//   - Escape hatch: Tab-out with an item on the cursor returns it to the
+//     backpack rather than losing it.
+//
+// Negative-first: on unmodified main the strip click WIELDS the item (the
+// interim PR 4 behavior) - there is no cursor-held state, so `/v1/ui.cursor`
+// is absent and the KEY assertion ("clicking a strip item lifts it onto the
+// cursor") fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (mission id 990)
+const CORPSE_PSI_AMP = 219; // Male Corpse 1 -> Contains -> Psi Amp (mission id 1407)
+
+test(
+  "cursor-is-the-item: lift, place, and throw a strip item",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8156),
+    });
+    await game.step({ frames: 5 });
+
+    const setPointer = async (screen: [number, number], pressed: 0 | 1) => {
+      await game.input.set("pointer.position", screen);
+      await game.input.set("pointer.pressed", pressed);
+    };
+    const center = (el: UiElement): [number, number] => {
+      const [x, y, w, h] = el.screen_rect;
+      return [x + w / 2, y + h / 2];
+    };
+    // A discrete click at a screen point: hover (an unpressed frame so the
+    // press is an edge), press, release.
+    const clickAt = async (screen: [number, number]) => {
+      await setPointer(screen, 0);
+      await game.step({ frames: 2 });
+      await setPointer(screen, 1);
+      await game.step({ frames: 2 });
+      await setPointer(screen, 0);
+      await game.step({ frames: 2 });
+    };
+    const clickElement = (el: UiElement) => clickAt(center(el));
+
+    // Loot an item honestly through a PR-3 loot MFD (frob corpse -> take).
+    const lootFromCorpse = async (template: number, itemName: string) => {
+      const corpses = await game.entities.byTemplate(template);
+      assert.equal(corpses.length, 1, `expected exactly one corpse ${template}`);
+      const corpse = corpses[0];
+      await teleportVerified(game, {
+        x: corpse.position[0] + 1.0,
+        y: corpse.position[1] + 0.5,
+        z: corpse.position[2] + 1.0,
+      });
+      await game.entities.sendMessage(corpse.id, { type: "Frob" });
+      await game.step({ frames: 5 });
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, `frobbing corpse ${template} should open its loot panel`);
+      const loot = panel.elements.find(
+        (e) => e.kind === "button" && e.label === itemName,
+      );
+      assert.ok(loot, `loot panel should list ${itemName}`);
+      await clickElement(loot);
+      // Close the loot panel (bare-view click) so the next step starts clean.
+      const close = (await game.ui.state()).active_panel?.elements.find(
+        (e) => e.label === "close",
+      );
+      if (close) await clickElement(close);
+    };
+
+    const stripItem = (ui: UiState, name: string): UiElement | undefined =>
+      ui.strip?.elements.find((e) => e.kind === "button" && e.label === name);
+
+    // --- Setup: two grabbable items in the backpack ---
+    await lootFromCorpse(CORPSE_WRENCH, "Wrench");
+    await lootFromCorpse(CORPSE_PSI_AMP, "Psi Amp");
+    const carried = await game.player.inventory();
+    const wrench = carried.items.find((i) => i.name === "Wrench");
+    const amp = carried.items.find((i) => i.name === "Psi Amp");
+    assert.ok(wrench && amp, `both items should be carried (got ${JSON.stringify(carried.items)})`);
+
+    // --- Tab into use mode; strip lists both items ---
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    let ui = await game.ui.state();
+    assert.equal(ui.mode, "use");
+    assert.ok(stripItem(ui, "Wrench"), "strip should list the Wrench");
+    assert.ok(stripItem(ui, "Psi Amp"), "strip should list the Psi Amp");
+    assert.ok(!ui.cursor, "nothing is on the cursor before lifting");
+    const stripBackdrop = ui.strip!.elements.find((e) =>
+      (e.texture ?? "").toLowerCase().includes("invback"),
+    )!;
+    await game.screenshot("drag-before-lift.png");
+
+    // --- KEY: LMB on the Wrench LIFTS it onto the cursor ---
+    const wrenchEl = stripItem(ui, "Wrench")!;
+    await clickElement(wrenchEl);
+    ui = await game.ui.state();
+    assert.ok(
+      ui.cursor,
+      `lifting a strip item must put it on the cursor (got ${JSON.stringify(ui)})`,
+    );
+    assert.equal(ui.cursor.entity_id, wrench!.entity_id, "the cursor holds the Wrench entity");
+    assert.equal(ui.cursor.label, "Wrench", "the cursor is labeled with the item");
+    assert.ok(!stripItem(ui, "Wrench"), "the lifted Wrench leaves the strip grid");
+    assert.ok(stripItem(ui, "Psi Amp"), "the Psi Amp stays in the strip");
+    await game.screenshot("drag-lifted.png");
+
+    // --- PLACE it back: LMB on an empty strip cell (backdrop center) ---
+    await clickAt(center(stripBackdrop));
+    ui = await game.ui.state();
+    assert.ok(!ui.cursor, "placing clears the cursor");
+    assert.ok(stripItem(ui, "Wrench"), "the placed Wrench returns to the strip grid");
+    await game.screenshot("drag-placed.png");
+
+    // --- LIFT again, then THROW into the bare 3D view ---
+    await clickElement(stripItem(ui, "Wrench")!);
+    ui = await game.ui.state();
+    assert.equal(ui.cursor?.entity_id, wrench!.entity_id, "the Wrench is on the cursor again");
+
+    const playerBefore = await game.player.position();
+    // A point below the top-docked strip (y > 121 canvas) and clear of the
+    // bottom HUD readouts: dead center-ish of the 3D view.
+    await clickAt([0.5, 0.6]);
+    ui = await game.ui.state();
+    assert.ok(!ui.cursor, "throwing clears the cursor");
+    assert.ok(!stripItem(ui, "Wrench"), "the thrown Wrench is gone from the strip");
+    const afterThrow = await game.player.inventory();
+    assert.ok(
+      !afterThrow.items.some((i) => i.name === "Wrench"),
+      "the thrown Wrench is no longer carried",
+    );
+    // The thrown item gained world presence near the player.
+    const bodies = await game.physics.bodies({ entityId: wrench!.entity_id });
+    assert.ok(
+      bodies.bodies.length > 0,
+      `the thrown Wrench should have a physics body (got ${JSON.stringify(bodies.bodies)})`,
+    );
+    const p = bodies.bodies[0].position;
+    assert.ok(
+      Number.isFinite(p[0]) && Number.isFinite(p[1]) && Number.isFinite(p[2]),
+      `the thrown Wrench body position must be finite (got ${JSON.stringify(p)})`,
+    );
+    const dist = Math.hypot(
+      p[0] - playerBefore.x,
+      p[1] - playerBefore.y,
+      p[2] - playerBefore.z,
+    );
+    assert.ok(dist < 10, `the thrown Wrench should land near the player (dist ${dist.toFixed(2)})`);
+    await game.screenshot("drag-thrown.png");
+
+    // --- Escape hatch: lift the Psi Amp, then Tab-out returns it ---
+    await clickElement(stripItem(await game.ui.state(), "Psi Amp")!);
+    ui = await game.ui.state();
+    assert.equal(ui.cursor?.entity_id, amp!.entity_id, "the Psi Amp is on the cursor");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    ui = await game.ui.state();
+    assert.equal(ui.mode, "shooter", "Tab-out returns to shooter mode");
+    assert.ok(!ui.cursor, "leaving use mode clears the cursor");
+    const finalInv = await game.player.inventory();
+    assert.ok(
+      finalInv.items.some((i) => i.name === "Psi Amp"),
+      `Tab-out with an item on the cursor must return it to the backpack ` +
+        `(got ${JSON.stringify(finalInv.items)})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -26,7 +26,7 @@ const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (mission id 
 const CORPSE_PSI_AMP = 219; // Male Corpse 1 -> Contains -> Psi Amp (mission id 1407)
 
 test(
-  "cursor-is-the-item: lift, place, and throw a strip item",
+  "cursor-is-the-item: lift, place, wield (double-click), and throw a strip item",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -105,18 +105,25 @@ test(
     )!;
     await game.screenshot("drag-before-lift.png");
 
-    // --- KEY: LMB on the Wrench LIFTS it onto the cursor ---
+    // --- KEY: a single LMB on the Wrench LIFTS it onto the cursor (it does
+    // NOT wield - that is the double-click, tested below) ---
     const wrenchEl = stripItem(ui, "Wrench")!;
     await clickElement(wrenchEl);
     ui = await game.ui.state();
     assert.ok(
       ui.cursor,
-      `lifting a strip item must put it on the cursor (got ${JSON.stringify(ui)})`,
+      `a single click on a strip item must lift it onto the cursor (got ${JSON.stringify(ui)})`,
     );
     assert.equal(ui.cursor.entity_id, wrench!.entity_id, "the cursor holds the Wrench entity");
     assert.equal(ui.cursor.label, "Wrench", "the cursor is labeled with the item");
     assert.ok(!stripItem(ui, "Wrench"), "the lifted Wrench leaves the strip grid");
     assert.ok(stripItem(ui, "Psi Amp"), "the Psi Amp stays in the strip");
+    // A single click lifts, it must NOT wield: no item is in hand.
+    const liftedInv = await game.player.inventory();
+    assert.ok(
+      !liftedInv.items.some((i) => i.location === "left_hand" || i.location === "right_hand"),
+      `a single click must not wield (got ${JSON.stringify(liftedInv.items)})`,
+    );
     await game.screenshot("drag-lifted.png");
 
     // --- PLACE it back: LMB on an empty strip cell (backdrop center) ---
@@ -126,56 +133,78 @@ test(
     assert.ok(stripItem(ui, "Wrench"), "the placed Wrench returns to the strip grid");
     await game.screenshot("drag-placed.png");
 
-    // --- LIFT again, then THROW into the bare 3D view ---
+    // --- Escape hatch: lift the Wrench, Tab-out returns it, then re-enter ---
     await clickElement(stripItem(ui, "Wrench")!);
-    ui = await game.ui.state();
-    assert.equal(ui.cursor?.entity_id, wrench!.entity_id, "the Wrench is on the cursor again");
+    assert.equal(
+      (await game.ui.state()).cursor?.entity_id,
+      wrench!.entity_id,
+      "the Wrench is on the cursor",
+    );
+    await game.input.trigger("ToggleUseMode"); // Tab-out
+    await game.step({ frames: 5 });
+    let shooter = await game.ui.state();
+    assert.equal(shooter.mode, "shooter", "Tab-out returns to shooter mode");
+    assert.ok(!shooter.cursor, "leaving use mode clears the cursor");
+    const returned = await game.player.inventory();
+    const returnedWrench = returned.items.find((i) => i.name === "Wrench");
+    assert.ok(
+      returnedWrench && returnedWrench.location === "inventory",
+      `Tab-out with an item on the cursor must return it to the backpack ` +
+        `(got ${JSON.stringify(returned.items)})`,
+    );
+    await game.input.trigger("ToggleUseMode"); // Tab back in
+    await game.step({ frames: 5 });
 
+    // --- WIELD: a DOUBLE-click on the Wrench equips it (single=lift,
+    // double=wield - the faithful single-button mapping) ---
+    const wrenchEl2 = stripItem(await game.ui.state(), "Wrench")!;
+    await clickElement(wrenchEl2); // first click lifts...
+    await clickElement(wrenchEl2); // ...quick second click on the same slot wields
+    ui = await game.ui.state();
+    assert.ok(!ui.cursor, "wielding clears the cursor");
+    const afterWield = await game.player.inventory();
+    const wieldedWrench = afterWield.items.find((i) => i.name === "Wrench");
+    assert.equal(
+      wieldedWrench?.location,
+      "left_hand",
+      `double-clicking a carried weapon should wield it (got ${JSON.stringify(afterWield.items)})`,
+    );
+    assert.ok(!stripItem(ui, "Wrench"), "the wielded Wrench leaves the strip grid");
+    await game.screenshot("drag-wielded.png");
+
+    // --- THROW: lift the Psi Amp, then LMB on the bare 3D view throws it ---
+    await clickElement(stripItem(await game.ui.state(), "Psi Amp")!);
+    ui = await game.ui.state();
+    assert.equal(ui.cursor?.entity_id, amp!.entity_id, "the Psi Amp is on the cursor");
     const playerBefore = await game.player.position();
     // A point below the top-docked strip (y > 121 canvas) and clear of the
     // bottom HUD readouts: dead center-ish of the 3D view.
     await clickAt([0.5, 0.6]);
     ui = await game.ui.state();
     assert.ok(!ui.cursor, "throwing clears the cursor");
-    assert.ok(!stripItem(ui, "Wrench"), "the thrown Wrench is gone from the strip");
+    assert.ok(!stripItem(ui, "Psi Amp"), "the thrown Psi Amp is gone from the strip");
     const afterThrow = await game.player.inventory();
     assert.ok(
-      !afterThrow.items.some((i) => i.name === "Wrench"),
-      "the thrown Wrench is no longer carried",
+      !afterThrow.items.some((i) => i.name === "Psi Amp"),
+      "the thrown Psi Amp is no longer carried",
     );
     // The thrown item gained world presence near the player.
-    const bodies = await game.physics.bodies({ entityId: wrench!.entity_id });
+    const bodies = await game.physics.bodies({ entityId: amp!.entity_id });
     assert.ok(
       bodies.bodies.length > 0,
-      `the thrown Wrench should have a physics body (got ${JSON.stringify(bodies.bodies)})`,
+      `the thrown Psi Amp should have a physics body (got ${JSON.stringify(bodies.bodies)})`,
     );
     const p = bodies.bodies[0].position;
     assert.ok(
       Number.isFinite(p[0]) && Number.isFinite(p[1]) && Number.isFinite(p[2]),
-      `the thrown Wrench body position must be finite (got ${JSON.stringify(p)})`,
+      `the thrown Psi Amp body position must be finite (got ${JSON.stringify(p)})`,
     );
     const dist = Math.hypot(
       p[0] - playerBefore.x,
       p[1] - playerBefore.y,
       p[2] - playerBefore.z,
     );
-    assert.ok(dist < 10, `the thrown Wrench should land near the player (dist ${dist.toFixed(2)})`);
+    assert.ok(dist < 10, `the thrown Psi Amp should land near the player (dist ${dist.toFixed(2)})`);
     await game.screenshot("drag-thrown.png");
-
-    // --- Escape hatch: lift the Psi Amp, then Tab-out returns it ---
-    await clickElement(stripItem(await game.ui.state(), "Psi Amp")!);
-    ui = await game.ui.state();
-    assert.equal(ui.cursor?.entity_id, amp!.entity_id, "the Psi Amp is on the cursor");
-    await game.input.trigger("ToggleUseMode");
-    await game.step({ frames: 5 });
-    ui = await game.ui.state();
-    assert.equal(ui.mode, "shooter", "Tab-out returns to shooter mode");
-    assert.ok(!ui.cursor, "leaving use mode clears the cursor");
-    const finalInv = await game.player.inventory();
-    assert.ok(
-      finalInv.items.some((i) => i.name === "Psi Amp"),
-      `Tab-out with an item on the cursor must return it to the backpack ` +
-        `(got ${JSON.stringify(finalInv.items)})`,
-    );
   },
 );

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -208,3 +208,52 @@ test(
     await game.screenshot("drag-thrown.png");
   },
 );
+
+// A lifted item must not be lost if the game is saved/reloaded mid-drag: the
+// cursor-held item stays in the backpack container (the strip just hides it),
+// so it serializes as a normal carried item. Regression for the xreview
+// finding that detaching on lift orphaned the item on any non-Tab exit.
+test(
+  "a lifted item survives a mid-drag save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8158),
+    });
+    await game.step({ frames: 5 });
+
+    // Give the player a carried item (source doesn't matter here).
+    const { entities: nanites } = await game.entities.list({ filter: "*Nanites*", limit: 10 });
+    assert.ok(nanites[0], "expected a Nanites pickup in medsci1");
+    await game.player.give(nanites[0].id);
+
+    // Tab into use mode and lift the item onto the cursor.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const el = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && (e.label ?? "").includes("Nanite"),
+    );
+    assert.ok(el, "the Nanites should be in the strip");
+    const [x, y, w, h] = el.screen_rect;
+    await game.input.set("pointer.position", [x + w / 2, y + h / 2]);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 2 });
+    const lifted = await game.ui.state();
+    assert.ok(lifted.cursor, "the item is on the cursor before saving");
+
+    // Save and reload mid-drag; the item must still be carried.
+    const saveName = `flat-ui-drag-save-${Date.now()}`;
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+    const restored = await game.player.inventory();
+    assert.ok(
+      restored.items.some((i) => (i.name ?? "").includes("Nanite")),
+      `the lifted item must survive a save/load mid-drag (got ${JSON.stringify(restored.items)})`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
@@ -32,7 +32,6 @@ import { teleportVerified } from "./helpers/teleport.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const CORPSE_WRENCH = 1177; // MS Male Corpse -> Contains -> Wrench (mission id 990)
-const CORPSE_PSI_AMP = 219; // Male Corpse 1 -> Contains -> Psi Amp (mission id 1407)
 
 test(
   "Tab metagame mode renders the carried inventory in the top-docked strip",
@@ -182,88 +181,11 @@ test(
     );
     assert.ok((await game.ui.state()).strip, "the strip survives the panel closing");
 
-    // --- Clicking the carried Wrench in the strip wields it ---
-    const stripNow = (await game.ui.state()).strip;
-    assert.ok(stripNow, "strip still present before the wield click");
-    const wrenchEl = stripNow.elements.find(
-      (e) => e.kind === "button" && e.label === "Wrench",
-    );
-    assert.ok(wrenchEl, "the Wrench is still in the strip before wielding");
-    await clickElement(wrenchEl);
-    const afterWield = await game.player.inventory();
-    const wieldedWrench = afterWield.items.find((i) => i.name === "Wrench");
-    assert.ok(wieldedWrench, "the wielded Wrench is still carried");
-    assert.equal(
-      wieldedWrench.location,
-      "left_hand",
-      "clicking a carried weapon in the strip should wield it (flat reports the viewmodel as left hand)",
-    );
-    // ...and the strip updates live: the wielded item left the grid.
-    const stripAfterWield = (await game.ui.state()).strip;
-    assert.ok(stripAfterWield, "strip stays up after wielding");
-    assert.ok(
-      !stripAfterWield.elements.some((e) => e.label === "Wrench"),
-      "the wielded Wrench should leave the strip grid",
-    );
-    // The Nanites stay put.
-    assert.ok(
-      stripAfterWield.elements.some((e) => (e.label ?? "").includes("Nanite")),
-      "non-wielded items stay in the strip",
-    );
-    await game.screenshot("strip-after-wield.png");
-
-    // --- Wield swap: the displaced weapon returns to the strip, not the
-    // floor (the original returns it to the grid). Loot the Psi Amp (a
-    // PropPlayerGun weapon) from corpse 219, wield it, and check the Wrench
-    // is holstered back into the backpack with no world presence. ---
-    const ampCorpses = await game.entities.byTemplate(CORPSE_PSI_AMP);
-    assert.equal(ampCorpses.length, 1, "expected exactly one Male Corpse 1 (219)");
-    const ampCorpse = ampCorpses[0];
-    await teleportVerified(game, {
-      x: ampCorpse.position[0] + 1.0,
-      y: ampCorpse.position[1] + 0.5,
-      z: ampCorpse.position[2] + 1.0,
-    });
-    await game.entities.sendMessage(ampCorpse.id, { type: "Frob" });
-    await game.step({ frames: 5 });
-    const ampPanel = (await game.ui.state()).active_panel;
-    assert.ok(ampPanel, "frobbing corpse 219 should open its loot panel");
-    const ampLoot = ampPanel.elements.find(
-      (e) => e.kind === "button" && e.label === "Psi Amp",
-    );
-    assert.ok(ampLoot, "corpse 219's loot panel should list the Psi Amp");
-    await clickElement(ampLoot);
-    const ampStrip = (await game.ui.state()).strip?.elements.find(
-      (e) => e.kind === "button" && e.label === "Psi Amp",
-    );
-    assert.ok(ampStrip, "the taken Psi Amp should appear in the strip");
-    await clickElement(ampStrip);
-
-    const afterSwap = await game.player.inventory();
-    const amp = afterSwap.items.find((i) => i.name === "Psi Amp");
-    assert.equal(amp?.location, "left_hand", "the Psi Amp should now be wielded");
-    const holsteredWrench = afterSwap.items.find((i) => i.name === "Wrench");
-    assert.ok(
-      holsteredWrench,
-      `the displaced Wrench must stay carried, not drop into the world ` +
-        `(got ${JSON.stringify(afterSwap.items)})`,
-    );
-    assert.equal(
-      holsteredWrench.location,
-      "inventory",
-      "the displaced Wrench is holstered back into the backpack",
-    );
-    assert.equal(
-      (await game.physics.bodies({ entityId: holsteredWrench.entity_id })).bodies.length,
-      0,
-      "the holstered Wrench has no world presence",
-    );
-    // ...and it re-appears in the strip grid.
-    const stripAfterSwap = (await game.ui.state()).strip;
-    assert.ok(
-      stripAfterSwap?.elements.some((e) => e.label === "Wrench"),
-      "the displaced Wrench returns to the strip grid",
-    );
+    // NOTE: strip item interaction (lift onto the cursor / place / throw) is
+    // the cursor-is-the-item drag, covered end-to-end by
+    // inventory-drag.e2e.test.ts (flat UI 4.5). This test stays focused on the
+    // strip rendering the carried inventory, coexisting with a panel, and Tab
+    // toggling the mode.
 
     // --- Tab again -> shooter restored, strip gone ---
     await game.input.trigger("ToggleUseMode");


### PR DESCRIPTION
## Demo

![cursor-is-the-item flat inventory drag](https://gist.githubusercontent.com/tommy-xr/e325c23d5e4c5c8335aa24c4c2854c98/raw/drag-demo.gif)

<sub>Flat "use" mode (Tab): a single click **lifts** a strip item onto the cursor (the cursor *becomes* the item, the slot empties), the icon **follows the cursor** across the 3D view, and a click on the bare view **throws** it into the world. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

**Cursor-as-item (lifted, mid-move):**

![lifted item on the cursor](https://gist.githubusercontent.com/tommy-xr/e325c23d5e4c5c8335aa24c4c2854c98/raw/drag-still.png)

---

PR 4.5 of the flat metagame UI plan (`projects/flat-ui.md` §1.5 / §2.4 / §5.2) — the deferred **cursor-is-the-item drag** from PR 4 (#456). In flat "use" mode (Tab), the mouse cursor now *becomes* the item you're moving, faithfully to the original's `SCM_DRAGOBJ` model.

## What's in

- **Lift / place / swap** — a single LMB on a top-docked inventory-strip item **lifts it onto the cursor** (the cursor renders the item's `objicon`; the slot empties). LMB on an empty slot **places** it; LMB on another item **swaps**. The lifted item **stays in the backpack container** the whole time — the host just hides it from the strip — so it is always reachable and serializes correctly (see Review).
- **Throw into the world** — LMB on the bare 3D view **throws** the held item: it gains physics presence just ahead of the camera and an impulse along the flat view ray (the original's `ShockInterfaceClick → ThrowObj`).
- **Wield / use (double-click)** — a quick double-click on a strip item **equips/uses** it — the faithful single-button mapping of the original's equip-from-inventory. Wield reuses the exact backpack-click effect (`GrabEntity` for a weapon — which holsters any displaced weapon back to the grid — `Frob`/use otherwise), so no wield logic is duplicated. **Single click = lift, double-click = wield.**
- **Escape hatch** — Tab-out (or a save/level transition) with an item on the cursor never loses it: because the item stays in the backpack, it's already reachable; the cursor just clears.
- **`GET /v1/ui`** gains a `cursor` field (held item entity id + label) so tests assert lift state; mirrored in the SDK `UiState` type.

This supersedes PR 4's interim "click wields" for the strip (a single flat pointer button can't be both lift and use); `inventory-strip.e2e` is trimmed of its wield assertions, which move — with lift/place/throw — to the new `inventory-drag.e2e`.

## VR preservation (design §5.4)

The `Gui` trait, `ContainerGui`, `GuiScript`, and the `GUIHover` contract are untouched. The drag is pure flat presentation (`FlatUiHost` cursor state + two `FlatUiDragAction`s, both no-ops in VR). `is_wieldable_weapon` is extracted and now shared by `ContainerGui` and the flat wield (were copy-pasted).

## Verification

- **Negative-first e2e** `tools/shock2-sdk/test/inventory-drag.e2e.test.ts`: on unmodified main a strip click wields (no cursor state), so the KEY assertion "a single click lifts the item onto the cursor" fails. On this branch it passes end-to-end: loot Wrench + Psi Amp → Tab → **single-click Wrench lifts it** (cursor holds it, slot empties, not wielded) → place back → escape hatch (Tab-out returns it) → **double-click wields** (left_hand) → **lift + bare-view click throws** the Psi Amp into the world (finite physics body near the player). Plus a **save/load regression** test: a lifted item survives a mid-drag save/reload.
- Unit tests on the `FlatUiHost` drag state machine (lift/place/swap/throw/double-click-wield, panel-click-keeps-item) — `cargo test -p shock2vr`: **125 passed**.
- e2e suites: inventory-drag, inventory-strip, keypad, container-loot, flat-ui-plumbing, climbing all green; `missions.e2e` **23/23**.
- `cargo fmt` + `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; SDK `npm test` green.

## Cross-engine review (xreview)

Claude Opus subagent + Codex CLI, both adversarial. **Agreed top finding**: detaching the item's `Contains` link on lift orphaned it on any non-Tab exit from use mode (save / level transition serialize only hands + backpack). Codex added a second High: double-clicking a non-weapon `Frob`'d a detached item into an unreachable orphan. **Both fixed at the root** by keeping the lifted item in the backpack container (hidden from the strip) — see the follow-up commit. Also applied: throw no longer unwraps the aim ray and guards on a real physics body (no floating static item / panic); shared `is_wieldable_weapon` (was duplicated). Remaining Medium (frame-based double-click window) is documented — the game runs at a fixed 60 Hz step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
