### PR TITLE
feat(ui): BIOFULL/AMMOFULL expanded readouts in use mode (flat UI 5)

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -472,6 +472,9 @@ pub struct UiStateResult {
     /// The item held on the cursor mid-drag (cursor-is-the-item); `Some`
     /// between a lift and the place/throw that clears it.
     pub cursor: Option<shock2vr::game_scene::DebugUiCursor>,
+    /// The AMMOFULL ammo-cycle button (use mode + multi-ammo weapon); `Some`
+    /// when shown. Click it to cycle the wielded weapon's ammo type.
+    pub ammo_cycle: Option<shock2vr::game_scene::DebugUiElement>,
 }
 
 /// A single carried item.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1022,6 +1022,7 @@ fn process_command(
                         active_panel: ui.active_panel,
                         strip: ui.strip,
                         cursor: ui.cursor,
+                        ammo_cycle: ui.ammo_cycle,
                     }
                 })
                 .unwrap_or(commands::UiStateResult {
@@ -1029,6 +1030,7 @@ fn process_command(
                     active_panel: None,
                     strip: None,
                     cursor: None,
+                    ammo_cycle: None,
                 });
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send ui state - receiver dropped");

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -349,6 +349,9 @@ pub struct DebugUiState {
     /// The item held on the cursor mid-drag (the original's "cursor IS the
     /// item", §2.4). `Some` between a lift and the place/throw that clears it.
     pub cursor: Option<DebugUiCursor>,
+    /// The AMMOFULL ammo-cycle button (use mode + multi-ammo weapon wielded);
+    /// clicking it cycles the wielded weapon's ammo type. `None` otherwise.
+    pub ammo_cycle: Option<DebugUiElement>,
 }
 
 /// The item currently riding the cursor (a lifted inventory item): its runtime
@@ -568,6 +571,7 @@ pub trait DebuggableScene {
             active_panel: None,
             strip: None,
             cursor: None,
+            ammo_cycle: None,
         }
     }
 

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -281,7 +281,8 @@ pub(crate) fn create_flat_hud(
         get_wielded_ammo(world),
         get_wielded_ammo_icon(world),
         get_wielded_ammo_type(world),
-        can_cycle_wielded_ammo(world),
+        // The same predicate the pointer hit-test uses, so drawn == clickable.
+        ammo_cycle_button_visible(world, use_mode),
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
@@ -300,6 +301,20 @@ pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
         return false;
     };
     crate::scripts::script_util::ordered_projectile_links(world, weapon).len() >= 2
+}
+
+/// The single source of truth for whether the AMMOFULL ammo-cycle button is
+/// shown/active this frame - used for BOTH rendering (via `create_flat_hud`'s
+/// `can_cycle_ammo`) and pointer hit-testing (`mission_core`), so the drawn and
+/// clickable regions never diverge. Requires use mode, a wielded gun with a
+/// clip (`get_wielded_ammo`), 2+ ammo types, and no psi-amp display (which
+/// replaces the ammo section - `build_flat_hud_canvas`'s psi-power early
+/// return).
+pub(crate) fn ammo_cycle_button_visible(world: &World, use_mode: bool) -> bool {
+    use_mode
+        && get_wielded_psi_power(world).is_none()
+        && get_wielded_ammo(world).is_some()
+        && can_cycle_wielded_ammo(world)
 }
 
 #[cfg(test)]

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -61,6 +61,27 @@ const AMMO_Y: f32 = 414.0;
 const AMMO_W: f32 = 94.0;
 const AMMO_H: f32 = 64.0;
 const AMMO_GAUGE: Rect = Rect::new(AMMO_X, AMMO_Y, AMMO_W, AMMO_H);
+
+// Use-mode expanded readouts (flat UI 5). Anchors pinned from the Dark source:
+//  - BIOFULL (shkmeter.cpp): `meters_rect = {{2,414},{262,478}}` - the bio
+//    panel stays at (2,414); only the backdrop art widens 128->260 (BIO.PCX is
+//    the left crop of BIOFULL.PCX, so the bars/numbers land identically). The
+//    right half is baked research/query/map + nanite/cyber chrome (art stub).
+//  - AMMOFULL (shkammov.cpp): use ("mouse") mode expands the ammo panel LEFT by
+//    `AMMO_MODE_DX = 166` (AMMOBACK 94 -> AMMOFULL 260), UL = (378,414); the
+//    ammo-type CYCLE button is `cycle_rect = {{186,15},{198,56}}` panel-local
+//    (art ammoarw0/1), i.e. canvas (564,429,12,41). The round count/icon stay
+//    in the panel's right gauge (the AMMOBACK footprint), so their compact
+//    offsets are reused.
+const METERS_FULL_W: f32 = 260.0;
+const AMMO_FULL_MODE_DX: f32 = 166.0;
+const AMMO_FULL_X: f32 = AMMO_X - AMMO_FULL_MODE_DX; // 378
+const AMMO_FULL_GAUGE: Rect = Rect::new(AMMO_FULL_X, AMMO_Y, METERS_FULL_W, AMMO_H);
+/// The AMMOFULL ammo-type cycle button (`shkammov.cpp` cycle_rect, ammoarw
+/// art). Clicking it cycles the wielded weapon's ammo type. Exposed so the
+/// flat pointer host can hit-test the same rect it is drawn at.
+pub(crate) const AMMO_CYCLE_BUTTON: Rect =
+    Rect::new(AMMO_FULL_X + 186.0, AMMO_Y + 15.0, 12.0, 41.0);
 const AMMO_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 22.0, AMMO_W, 20.0); // centered over the gauge
 const AMMO_TEXT_SIZE: f32 = 18.0;
 // Selected ammo-type indicator: the projectile's object icon (P$ObjIcon) just
@@ -98,8 +119,10 @@ const OVERLOAD_METER: Rect = Rect::new(
 /// access), so it is unit-testable. `crosshair` is false in use mode - the
 /// original turns the crosshair overlay off while the cursor is up
 /// (`ShockOverlayMouseMode`, projects/flat-ui.md §2.1).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_flat_hud_canvas(
     crosshair: bool,
+    use_mode: bool,
     health_fraction: f32,
     psi_fraction: f32,
     psi_charge: Option<RuntimePropPsiCharge>,
@@ -107,15 +130,34 @@ pub(crate) fn build_flat_hud_canvas(
     ammo: Option<i32>,
     ammo_icon: Option<String>,
     ammo_type: Option<String>,
+    can_cycle_ammo: bool,
 ) -> UiCanvas {
     let mut canvas = UiCanvas::new(vec2(VIRTUAL_W, VIRTUAL_H));
+
+    // Use mode expands the compact bottom readouts in place (flat UI 5): the
+    // bio panel widens to BIOFULL and the ammo gauge to AMMOFULL. The bars,
+    // numbers, and ammo count/icon keep their compact offsets (the FULL art is
+    // a superset with the same crops), so only the backdrops swap.
+    let (meters_backdrop, meters_art) = if use_mode {
+        (
+            Rect::new(METERS_X, METERS_Y, METERS_FULL_W, METERS_H),
+            "BIOFULL.PCX",
+        )
+    } else {
+        (METERS_BACKDROP, "BIO.PCX")
+    };
+    let (ammo_backdrop, ammo_art) = if use_mode {
+        (AMMO_FULL_GAUGE, "AMMOFULL.PCX")
+    } else {
+        (AMMO_GAUGE, "AMMOBACK.PCX")
+    };
 
     if crosshair {
         canvas.image(CROSSHAIR, "CROSSHAI.PCX");
     }
     canvas
         // Bio-monitor backdrop first; the bars + numbers render on top of it.
-        .image(METERS_BACKDROP, "BIO.PCX")
+        .image(meters_backdrop, meters_art)
         .bar(HEALTH_BAR, "HPBAR.PCX", health_fraction)
         .bar(PSI_BAR, "PSIBAR.PCX", psi_fraction);
 
@@ -163,7 +205,7 @@ pub(crate) fn build_flat_hud_canvas(
     // the discipline name.
     if let Some((power_name, tier)) = psi_power {
         canvas
-            .image(AMMO_GAUGE, "AMMOBACK.PCX")
+            .image(ammo_backdrop, ammo_art)
             .image(PSI_TIER_BADGE, &format!("AmPsi{}1.PCX", tier.clamp(1, 5)))
             .text(
                 AMMO_TEXT,
@@ -186,7 +228,7 @@ pub(crate) fn build_flat_hud_canvas(
 
     // Ammo gauge (only when a weapon with a clip is wielded).
     if let Some(rounds) = ammo {
-        canvas.image(AMMO_GAUGE, "AMMOBACK.PCX").text(
+        canvas.image(ammo_backdrop, ammo_art).text(
             AMMO_TEXT,
             &format!("{rounds}"),
             "mainfont.fon",
@@ -209,20 +251,29 @@ pub(crate) fn build_flat_hud_canvas(
                 VAlign::Middle,
             );
         }
+
+        // AMMOFULL ammo-type cycle button (use mode, multi-ammo weapon): the
+        // clickable ammoarw gadget the flat pointer host wires to CycleAmmo.
+        if use_mode && can_cycle_ammo {
+            canvas.image(AMMO_CYCLE_BUTTON, "ammoarw0.pcx");
+        }
     }
 
     canvas
 }
 
-/// Build and render the flat HUD as screen-space scene objects.
+/// Build and render the flat HUD as screen-space scene objects. `use_mode`
+/// (Tab metagame mode) expands the compact readouts to BIOFULL/AMMOFULL.
 pub(crate) fn create_flat_hud(
     asset_cache: &mut AssetCache,
     world: &World,
     screen_size: cgmath::Vector2<f32>,
     crosshair: bool,
+    use_mode: bool,
 ) -> Vec<SceneObject> {
     let canvas = build_flat_hud_canvas(
         crosshair,
+        use_mode,
         get_health_percentage(world),
         get_psi_percentage(world),
         get_wielded_psi_charge(world),
@@ -230,9 +281,25 @@ pub(crate) fn create_flat_hud(
         get_wielded_ammo(world),
         get_wielded_ammo_icon(world),
         get_wielded_ammo_type(world),
+        can_cycle_wielded_ammo(world),
     );
     // Keep the crosshair square and bars undistorted on non-4:3 windows.
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
+}
+
+/// Whether the wielded weapon has 2+ selectable ammo types (so the AMMOFULL
+/// cycle button is meaningful). Mirrors `cycle_ammo`'s `count < 2` guard.
+pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
+    let Some(player) = world
+        .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
+        .ok()
+    else {
+        return false;
+    };
+    let Some(weapon) = player.left_hand_entity_id else {
+        return false;
+    };
+    crate::scripts::script_util::ordered_projectile_links(world, weapon).len() >= 2
 }
 
 #[cfg(test)]
@@ -242,14 +309,26 @@ mod tests {
     #[test]
     fn canvas_has_crosshair_bio_backdrop_bars_and_readouts() {
         // Crosshair + bio backdrop + 2 bars + 2 stat numbers = 6 (no weapon).
-        let canvas = build_flat_hud_canvas(true, 1.0, 0.75, None, None, None, None, None);
+        let canvas =
+            build_flat_hud_canvas(true, false, 1.0, 0.75, None, None, None, None, None, false);
         assert_eq!(canvas.element_count(), 6);
     }
 
     #[test]
     fn wielding_a_weapon_adds_the_ammo_gauge() {
         // ...plus the ammo backdrop + count when a clip is present.
-        let canvas = build_flat_hud_canvas(true, 1.0, 0.75, None, None, Some(12), None, None);
+        let canvas = build_flat_hud_canvas(
+            true,
+            false,
+            1.0,
+            0.75,
+            None,
+            None,
+            Some(12),
+            None,
+            None,
+            false,
+        );
         assert_eq!(canvas.element_count(), 8);
     }
 
@@ -258,6 +337,7 @@ mod tests {
         // ...plus the ammo-type icon + label when a type is selected.
         let canvas = build_flat_hud_canvas(
             true,
+            false,
             1.0,
             0.75,
             None,
@@ -265,6 +345,7 @@ mod tests {
             Some(12),
             Some("STD_I.PCX".to_string()),
             Some("std".to_string()),
+            false,
         );
         assert_eq!(canvas.element_count(), 10);
     }
@@ -275,6 +356,7 @@ mod tests {
         // the clip readout is suppressed even though the amp has ammo=0.
         let canvas = build_flat_hud_canvas(
             true,
+            false,
             1.0,
             0.75,
             None,
@@ -282,8 +364,66 @@ mod tests {
             Some(0),
             None,
             None,
+            false,
         );
         assert_eq!(canvas.element_count(), 10);
+    }
+
+    #[test]
+    fn use_mode_expands_readouts_and_adds_the_ammo_cycle_button() {
+        // Shooter with a multi-ammo weapon: crosshair + bio + 2 bars + 2
+        // numbers + ammo backdrop + count = 8; NO cycle button.
+        let shooter = build_flat_hud_canvas(
+            true,
+            false,
+            1.0,
+            0.75,
+            None,
+            None,
+            Some(12),
+            None,
+            None,
+            true,
+        );
+        assert_eq!(shooter.element_count(), 8);
+        // Use mode (crosshair off) with a multi-ammo weapon: the same readouts
+        // (expanded backdrops swap in place, same element count) PLUS the
+        // AMMOFULL cycle button = 8 - 1 (crosshair) + 1 (cycle) = 8.
+        let use_mode = build_flat_hud_canvas(
+            false,
+            true,
+            1.0,
+            0.75,
+            None,
+            None,
+            Some(12),
+            None,
+            None,
+            true,
+        );
+        assert_eq!(use_mode.element_count(), 8);
+        // The cycle button only appears when the weapon can actually cycle.
+        let single_ammo = build_flat_hud_canvas(
+            false,
+            true,
+            1.0,
+            0.75,
+            None,
+            None,
+            Some(12),
+            None,
+            None,
+            false,
+        );
+        assert_eq!(single_ammo.element_count(), 7);
+    }
+
+    #[test]
+    fn ammo_cycle_button_sits_in_the_ammofull_panel() {
+        // The cycle button (shkammov.cpp cycle_rect) is inside the expanded
+        // AMMOFULL gauge and left of the compact AMMOBACK footprint.
+        assert!(AMMO_FULL_GAUGE.x <= AMMO_CYCLE_BUTTON.x);
+        assert!(AMMO_CYCLE_BUTTON.x + AMMO_CYCLE_BUTTON.w <= AMMO_FULL_GAUGE.x + AMMO_FULL_GAUGE.w);
     }
 
     #[test]
@@ -301,14 +441,16 @@ mod tests {
     fn use_mode_hides_the_crosshair() {
         // The original turns the crosshair overlay off while the cursor is
         // up (ShockOverlayMouseMode) - one fewer element than shooter mode.
-        let shooter = build_flat_hud_canvas(true, 1.0, 0.75, None, None, None, None, None);
-        let use_mode = build_flat_hud_canvas(false, 1.0, 0.75, None, None, None, None, None);
+        let shooter =
+            build_flat_hud_canvas(true, false, 1.0, 0.75, None, None, None, None, None, false);
+        let use_mode =
+            build_flat_hud_canvas(false, false, 1.0, 0.75, None, None, None, None, None, false);
         assert_eq!(use_mode.element_count(), shooter.element_count() - 1);
     }
 
     #[test]
     fn out_of_range_fractions_do_not_panic() {
         // Fills are clamped inside `UiCanvas::bar`.
-        let _ = build_flat_hud_canvas(true, 2.0, -1.0, None, None, None, None, None);
+        let _ = build_flat_hud_canvas(true, false, 2.0, -1.0, None, None, None, None, None, false);
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -80,6 +80,10 @@ const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
 pub enum FlatUiDragAction {
     Throw(EntityId),
     Wield(EntityId),
+    /// Cycle the wielded weapon's ammo type (the AMMOFULL cycle button was
+    /// clicked). Not tied to a cursor item - the caller maps it to
+    /// `Effect::CycleAmmo`, which acts on the wielded weapon.
+    CycleAmmo,
 }
 
 /// Double-click window (frames at 60Hz) and radius (canvas px) for the
@@ -130,6 +134,10 @@ pub struct FlatUiHost {
     /// The most recent lift, for double-click (wield) detection. Counts down
     /// each frame and clears when the window elapses.
     last_lift: Option<LiftMark>,
+    /// The AMMOFULL ammo-cycle button rect on the 640x480 canvas, set each
+    /// frame by the mission when use mode has a multi-ammo weapon wielded
+    /// (flat UI 5); `None` otherwise. Clicking it emits `CycleAmmo`.
+    ammo_cycle_rect: Option<Rect>,
     /// Pointer position on the 640x480 canvas (None: no pointer / letterbox).
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
@@ -158,6 +166,7 @@ impl FlatUiHost {
             strip: None,
             cursor_item: None,
             last_lift: None,
+            ammo_cycle_rect: None,
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
@@ -182,6 +191,28 @@ impl FlatUiHost {
             .map(|c| crate::game_scene::DebugUiCursor {
                 entity_id: c.entity.inner() as i32,
                 label: c.label.clone(),
+            })
+    }
+
+    /// Set (or clear) the AMMOFULL ammo-cycle button's canvas rect for this
+    /// frame. The mission passes `Some(rect)` only in use mode with a
+    /// multi-ammo weapon wielded, matching what the flat HUD draws.
+    pub fn set_ammo_cycle_button(&mut self, rect: Option<Rect>) {
+        self.ammo_cycle_rect = rect;
+    }
+
+    /// The ammo-cycle button as a `/v1/ui` element (so tests click it by
+    /// meaning), or `None` when it is not shown.
+    pub fn ammo_cycle_debug(&self) -> Option<crate::game_scene::DebugUiElement> {
+        self.ammo_cycle_rect
+            .map(|r| crate::game_scene::DebugUiElement {
+                kind: "button".to_string(),
+                texture: Some("ammoarw0.pcx".to_string()),
+                text: None,
+                label: Some("cycle_ammo".to_string()),
+                entity_id: None,
+                rect: [r.x, r.y, r.w, r.h],
+                screen_rect: self.to_screen_rect(r),
             })
     }
 
@@ -416,6 +447,18 @@ impl FlatUiHost {
             let held = self.cursor_item.take().unwrap();
             self.last_lift = None;
             return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
+        }
+
+        // --- AMMOFULL ammo-cycle button (use mode, multi-ammo weapon): a
+        // click cycles the wielded ammo type. Checked with an empty cursor
+        // only (mid-drag, a bottom-right click is a throw), before strip/panel
+        // routing since the button is disjoint from both. ---
+        if pressed_edge {
+            if let Some(rect) = self.ammo_cycle_rect {
+                if rect.contains(canvas_pos) {
+                    return (Vec::new(), vec![FlatUiDragAction::CycleAmmo]);
+                }
+            }
         }
 
         // --- Empty cursor over the strip: LMB on an item lifts it onto the
@@ -1289,6 +1332,26 @@ mod tests {
         // The Pistol is now hidden and the Wrench visible again.
         assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), Some(wrench));
         assert_eq!(host.strip_item_at(vec2(58.5, 34.0)), None);
+    }
+
+    #[test]
+    fn clicking_the_ammo_cycle_button_emits_cycle_ammo() {
+        let (world, mut host, _wrench, _inv) = drag_world();
+        // The AMMOFULL cycle button lives at canvas (564,429,12,41).
+        host.set_ammo_cycle_button(Some(Rect::new(564.0, 429.0, 12.0, 41.0)));
+        // A click on its center (570, 449) cycles the ammo.
+        let actions = press_edge(&mut host, &world, (570.0, 449.0));
+        assert_eq!(actions, vec![FlatUiDragAction::CycleAmmo]);
+        // The /v1/ui element is exposed with a clickable label.
+        let el = host.ammo_cycle_debug().expect("the button is exposed");
+        assert_eq!(el.label.as_deref(), Some("cycle_ammo"));
+        assert_eq!(el.kind, "button");
+        // A click elsewhere in the bare view does not cycle.
+        let actions = press_edge(&mut host, &world, (300.0, 300.0));
+        assert!(actions.is_empty());
+        // Cleared when not shown.
+        host.set_ammo_cycle_button(None);
+        assert!(host.ammo_cycle_debug().is_none());
     }
 
     #[test]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -403,6 +403,10 @@ impl FlatUiHost {
         let over_panel = panel_rect
             .map(|r| r.contains(canvas_pos) || close_button_canvas_rect(r).contains(canvas_pos))
             .unwrap_or(false);
+        let over_ammo = self
+            .ammo_cycle_rect
+            .map(|r| r.contains(canvas_pos))
+            .unwrap_or(false);
 
         // --- Cursor-is-the-item drag: while an item rides the cursor, LMB
         // places/swaps/throws it and never routes to a GuiScript (protecting
@@ -439,8 +443,10 @@ impl FlatUiHost {
                 }
                 return (Vec::new(), Vec::new());
             }
-            if over_panel {
-                // Escape hatch: a click on an open MFD keeps the held item.
+            if over_panel || over_ammo {
+                // Escape hatch: a click on an open MFD or the AMMOFULL cycle
+                // button keeps the held item (a visible button must not throw
+                // the item you're carrying).
                 return (Vec::new(), Vec::new());
             }
             // Bare 3D view: throw the held item along the view ray.
@@ -1352,6 +1358,20 @@ mod tests {
         // Cleared when not shown.
         host.set_ammo_cycle_button(None);
         assert!(host.ammo_cycle_debug().is_none());
+    }
+
+    #[test]
+    fn clicking_the_ammo_button_while_holding_keeps_the_item() {
+        // A visible button must not throw the item you're carrying: clicking
+        // the ammo-cycle button mid-drag protects the held item (no throw, no
+        // cycle) rather than treating it as a bare-view throw.
+        let (world, mut host, _wrench, _inv) = drag_world();
+        host.set_ammo_cycle_button(Some(Rect::new(564.0, 429.0, 12.0, 41.0)));
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift the Wrench
+        assert!(host.cursor_debug().is_some());
+        let actions = press_edge(&mut host, &world, (570.0, 449.0)); // click the ammo button
+        assert!(actions.is_empty(), "the click neither throws nor cycles");
+        assert!(host.cursor_debug().is_some(), "the held item is protected");
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -961,9 +961,10 @@ impl MissionCore {
         // processed this frame.
         if game_options.presentation_mode == crate::PresentationMode::Flat {
             // Expose the AMMOFULL ammo-cycle button for hit-testing exactly when
-            // the flat HUD draws it (use mode + a multi-ammo weapon wielded).
+            // the flat HUD draws it (the shared visibility predicate, so the
+            // clickable rect never diverges from the rendered button).
             let ammo_button =
-                if self.flat_use_mode && crate::hud::can_cycle_wielded_ammo(&self.world) {
+                if crate::hud::ammo_cycle_button_visible(&self.world, self.flat_use_mode) {
                     Some(crate::hud::AMMO_CYCLE_BUTTON)
                 } else {
                     None

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -960,6 +960,16 @@ impl MissionCore {
         // uses. Dispatched before the script update so hovers/clicks are
         // processed this frame.
         if game_options.presentation_mode == crate::PresentationMode::Flat {
+            // Expose the AMMOFULL ammo-cycle button for hit-testing exactly when
+            // the flat HUD draws it (use mode + a multi-ammo weapon wielded).
+            let ammo_button =
+                if self.flat_use_mode && crate::hud::can_cycle_wielded_ammo(&self.world) {
+                    Some(crate::hud::AMMO_CYCLE_BUTTON)
+                } else {
+                    None
+                };
+            self.flat_ui.set_ammo_cycle_button(ammo_button);
+
             let (messages, drag_actions) = self.flat_ui.update(&self.world, input_context.pointer);
             for msg in messages {
                 self.script_world.dispatch(msg);
@@ -1607,6 +1617,9 @@ impl MissionCore {
                 self.throw_entity_into_world(entity_id);
                 Vec::new()
             }
+            // The AMMOFULL cycle button: advance the wielded weapon's ammo type
+            // via the same effect as the CycleAmmo key/action.
+            FlatUiDragAction::CycleAmmo => vec![Effect::CycleAmmo],
             // Double-click = equip/use, acting on the still-contained item -
             // identical to the ContainerGui backpack click (shared weapon test,
             // shared effects): a weapon (gun or melee) wields via `GrabEntity`
@@ -3449,6 +3462,8 @@ impl MissionCore {
                 // it with the cursor (the original's ShockOverlayMouseMode
                 // turns kOverlayCrosshair off while the cursor is up).
                 !self.flat_use_mode,
+                // Use mode expands the compact readouts to BIOFULL/AMMOFULL.
+                self.flat_use_mode,
             ));
 
             // Flat MFD panel (keypad, container, ...) + cursor, drawn over
@@ -4829,6 +4844,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             active_panel,
             strip,
             cursor: self.flat_ui.cursor_debug(),
+            ammo_cycle: self.flat_ui.ammo_cycle_debug(),
         }
     }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -356,6 +356,13 @@ export interface UiState {
   strip: UiPanel | null;
   /** The item held on the cursor mid-drag, or null when the cursor is empty. */
   cursor: UiCursor | null;
+  /**
+   * The AMMOFULL ammo-type cycle button, exposed only in use mode when a gun
+   * with 2+ ammo types is wielded (the expanded weapon panel, flat UI 5).
+   * Click its `screen_rect` center to cycle the wielded weapon's ammo type
+   * (Effect::CycleAmmo). null in shooter mode / unarmed / single-ammo weapons.
+   */
+  ammo_cycle: UiElement | null;
 }
 
 export interface TransitionEntry {

--- a/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
+++ b/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the BIOFULL/AMMOFULL expanded readouts in use mode
+// (flat UI 5, projects/flat-ui.md §1.2 / §6 PR 5):
+//
+//   - Entering use mode (Tab) expands the compact bottom readouts: BIO.PCX ->
+//     BIOFULL.PCX (bottom-left) and AMMOBACK -> AMMOFULL.PCX (bottom-right).
+//   - With a gun that has 2+ ammo types wielded, AMMOFULL shows an ammo-type
+//     CYCLE button, exposed via /v1/ui `ammo_cycle`. Clicking it cycles the
+//     wielded weapon's ammo type (Effect::CycleAmmo).
+//   - Shooter mode keeps the compact readouts (no ammo_cycle element).
+//
+// Negative-first: on the base branch (flat UI 4.5) there is no AMMOFULL cycle
+// button and /v1/ui has no `ammo_cycle` field, so the KEY assertion ("use mode
+// exposes the ammo-cycle button with a gun wielded") fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The Pistol (gamesys template -17) has 3 ammo types (Standard / HE / AP).
+
+test(
+  "use mode exposes AMMOFULL ammo-cycle, which cycles the wielded ammo type",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8159),
+    });
+    await game.step({ frames: 5 });
+
+    const clickScreen = async (rect: [number, number, number, number]) => {
+      const [x, y, w, h] = rect;
+      await game.input.set("pointer.position", [x + w / 2, y + h / 2]);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+
+    // --- Setup: give the player a Pistol and wield it ---
+    const { entities: pistols } = await game.entities.list({ filter: "Pistol", limit: 20 });
+    const pistol = pistols.find((e) => (e.name ?? "") === "Pistol");
+    assert.ok(pistol, `expected a Pistol in medsci1 (got ${JSON.stringify(pistols.map((e) => e.name))})`);
+    await game.player.give(pistol.id);
+
+    // Shooter baseline: no ammo_cycle element (compact readouts).
+    const shooter = await game.ui.state();
+    assert.equal(shooter.mode, "shooter");
+    assert.ok(!shooter.ammo_cycle, "shooter mode must not expose the ammo-cycle button");
+    await game.screenshot("ammo-shooter-compact.png");
+
+    // Tab into use mode and wield the Pistol from the strip (double-click).
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const pistolEl = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.label === "Pistol",
+    );
+    assert.ok(pistolEl, "the Pistol should be in the strip");
+    await clickScreen(pistolEl.screen_rect); // first click lifts...
+    await clickScreen(pistolEl.screen_rect); // ...double-click wields
+    await game.step({ frames: 5 });
+
+    const wielded = await game.info();
+    assert.ok(
+      wielded.player.wielded_ammo_type,
+      `the Pistol should be wielded with an ammo type (got ${JSON.stringify(wielded.player)})`,
+    );
+
+    // --- KEY: use mode exposes the AMMOFULL ammo-cycle button ---
+    const use = await game.ui.state();
+    assert.equal(use.mode, "use");
+    assert.ok(
+      use.ammo_cycle,
+      `use mode with a multi-ammo gun must expose the ammo-cycle button (got ${JSON.stringify(use)})`,
+    );
+    await game.screenshot("ammo-use-expanded.png");
+
+    // --- Clicking the ammo-cycle button cycles the wielded ammo type ---
+    const before = (await game.info()).player.wielded_ammo_type;
+    await clickScreen(use.ammo_cycle.screen_rect);
+    await game.step({ frames: 3 });
+    const after = (await game.info()).player.wielded_ammo_type;
+    assert.notEqual(
+      after,
+      before,
+      `clicking the ammo-cycle button should change the wielded ammo type (${before} -> ${after})`,
+    );
+    await game.screenshot("ammo-use-cycled.png");
+
+    // --- Tab back to shooter: compact readouts, no ammo_cycle ---
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const restored = await game.ui.state();
+    assert.equal(restored.mode, "shooter");
+    assert.ok(!restored.ammo_cycle, "leaving use mode drops the ammo-cycle button");
+    await game.screenshot("ammo-shooter-after.png");
+  },
+);


### PR DESCRIPTION
## Demo

In Tab **use** mode the compact bottom readouts expand in place — BIO→**BIOFULL** (left) and AMMOBACK→**AMMOFULL** (right, with the green ammo-cycle arrow). Clicking the arrow cycles the wielded Pistol's ammo type (**STD → AP → HE → …**).

![ammo-type cycle in AMMOFULL](https://gist.githubusercontent.com/tommy-xr/56385cd3bba782bc290b4817777bd07b/raw/ammo_cycle.gif)

<sub>Give + wield a Pistol, Tab into use mode, then click the AMMOFULL cycle arrow. `/v1/info` `wielded_ammo_type` steps `std → ap → he → std` across clicks. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Expanded readouts (use mode)

![AMMOFULL expanded readout](https://gist.githubusercontent.com/tommy-xr/56385cd3bba782bc290b4817777bd07b/raw/ammofull_still.png)

### Compact → expanded

![compact vs expanded bottom HUD](https://gist.githubusercontent.com/tommy-xr/56385cd3bba782bc290b4817777bd07b/raw/compact_vs_expanded.png)

---

PR 5 of the flat metagame UI plan (`projects/flat-ui.md` §1.2 / §6). **Stacked on #461 (flat UI 4.5)** — base branch `feat/flat-ui-4-5`.

In Tab "use" mode, the compact bottom HUD readouts now expand in place to their original FULL variants, and the expanded ammo panel gets a working ammo-type cycle button. Shooter mode keeps the compact readouts exactly as before.

## What's in

- **BIOFULL** (bottom-left) — `BIO.PCX → BIOFULL.PCX`: the bio panel widens 128→260 at the same `(2,414)` anchor. Because `BIO.PCX` is the left crop of `BIOFULL.PCX`, the health/psi bars and numbers land identically; the right half is the baked research/query/map + nanite/cyber chrome (art-only, like PR 4's INVBACK equip stub).
- **AMMOFULL** (bottom-right) — `AMMOBACK → AMMOFULL.PCX`: the ammo panel expands **left** by 166px to `(378,414)` `260×64`, with the round count/icon staying in the panel's right gauge (the AMMOBACK footprint).
- **Ammo-type cycle button** — the AMMOFULL cycle arrow (`ammoarw` art at canvas `(564,429,12,41)`) is drawn when a multi-ammo weapon is wielded and **wired to `Effect::CycleAmmo`** — clicking it advances the wielded weapon's ammo type. The original AMMOFULL uses a single cycle arrow (not per-type direct-select), so this is the faithful mechanism (reuses the existing `CycleAmmo` machinery unchanged).
- **`GET /v1/ui`** gains an `ammo_cycle` element (canvas + normalized-screen rects, label `"cycle_ammo"`) so tests click it by meaning; mirrored in the SDK `UiState` type.

## Anchor provenance (pinned from the Dark source)

All coordinates are cited in the constants, from the 2010 leak mirror (`dima424658/darkengine`):
- **BIOFULL** — `shkmeter.cpp`: `meters_rect = {{2,414},{262,478}}` (260×64); `gHndBio → gHndBioFull`, no mode offset (the panel stays at (2,414), only the art widens). Bars/numbers at `HP_X=8/HP_Y=18`, `HPTEXT_X=92`, `PSI_Y=41` — which the existing flat HUD already matched.
- **AMMOFULL** — `shkammov.cpp`: use ("mouse") mode expands the panel left by `AMMO_MODE_DX=166` (AMMOBACK 94 → AMMOFULL 260); the cycle button is `cycle_rect = {{186,15},{198,56}}` panel-local → canvas `(564,429,12,41)`.

## VR preservation (design §5.4)

Flat-only: the changes live in `flat_hud` (the screen-space HUD builder, unbuilt in VR) and `FlatUiHost` (one new clickable rect). The `Gui` layer, `ContainerGui`, and the VR forearm HUD are untouched.

## Verification

- **Negative-first e2e** `tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts`: on the base branch, use mode with a wielded gun exposes no `ammo_cycle` element, so the KEY assertion fails. On this branch it passes: give + **wield a Pistol** (3 ammo types, via PR 4.5's double-click) → `/v1/ui` exposes the `ammo_cycle` button in use mode → clicking it **changes `/v1/info` `wielded_ammo_type`** → Tab back to shooter drops the button. Screenshots capture compact vs expanded readouts.
- Unit tests on the canvas builder (use-mode element counts, cycle-button placement) and the hit-test (`clicking_the_ammo_cycle_button_emits_cycle_ammo`, `clicking_the_ammo_button_while_holding_keeps_the_item`) — `cargo test -p shock2vr`: **129 passed**.
- e2e suites: bio-ammo-full, inventory-drag, inventory-strip, keypad, container-loot, flat-ui-plumbing, climbing, flat-hud all green; `missions.e2e` **23/23**.
- `cargo fmt` + `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; SDK `npm test` green.

## Cross-engine review (xreview)

Claude Opus subagent + Codex CLI. **Both agreed** on one finding: the button's DRAW condition (use mode + a wielded gun **with a clip** + 2+ ammo types + no psi display) didn't match the HIT-TEST condition (only use mode + 2+ ammo types), so a clip-less multi-ammo weapon (e.g. an unlimited debug gun) would get an invisible-but-clickable hotspot. **Fixed** with a single shared predicate `ammo_cycle_button_visible` used by both render and hit-test (also removes the duplicated condition Claude flagged). Codex also flagged that clicking the visible button while carrying a cursor item threw the item — **fixed** (the ammo button now protects the held item) with a regression test. Remaining Low (a one-frame visibility lag on the Tab-toggle frame, shared with the strip/cursor) accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
