### PR TITLE
Animation observability: state endpoint + smoothness metrics + baseline

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -29,6 +29,33 @@ struct BlendState {
     elapsed: f32,
 }
 
+/// Read-only snapshot of an `AnimationPlayer`'s playback state, for debug
+/// introspection (the debug runtime's animation endpoint).
+pub struct AnimationPlayerSnapshot {
+    /// Queued clips, head (currently playing) first.
+    pub queue: Vec<AnimationQueueEntry>,
+    /// Clip whose final frame poses the skeleton once the queue drains.
+    pub last_clip: Option<String>,
+    /// Current frame within the head clip.
+    pub current_frame: u32,
+    /// Sub-frame time carried toward the next frame advance (seconds).
+    pub remaining_time: f32,
+    pub blend: Option<AnimationBlendSnapshot>,
+}
+
+pub struct AnimationQueueEntry {
+    pub name: Option<String>,
+    pub num_frames: u32,
+    pub looping: bool,
+}
+
+pub struct AnimationBlendSnapshot {
+    pub from_clip: Option<String>,
+    pub from_frame: f32,
+    pub duration: f32,
+    pub elapsed: f32,
+}
+
 #[derive(Clone)]
 pub struct AnimationPlayer {
     animation: immutable::List<(Rc<AnimationClip>, AnimationFlags)>,
@@ -341,6 +368,35 @@ impl AnimationPlayer {
                     velocity,
                 )
             }
+        }
+    }
+
+    pub fn snapshot(&self) -> AnimationPlayerSnapshot {
+        AnimationPlayerSnapshot {
+            queue: self
+                .animation
+                .iter()
+                .map(|(clip, flags)| AnimationQueueEntry {
+                    name: clip.name.clone(),
+                    num_frames: clip.num_frames,
+                    looping: matches!(flags, AnimationFlags::Loop),
+                })
+                .collect(),
+            last_clip: self
+                .last_animation
+                .as_ref()
+                .and_then(|clip| clip.name.clone()),
+            current_frame: self.current_frame,
+            remaining_time: self.remaining_time,
+            blend: self
+                .blend_state
+                .as_ref()
+                .map(|blend| AnimationBlendSnapshot {
+                    from_clip: blend.from_clip.name.clone(),
+                    from_frame: blend.from_frame,
+                    duration: blend.duration,
+                    elapsed: blend.elapsed,
+                }),
         }
     }
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -125,6 +125,12 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Option<EntityDetailResult>>,
     },
 
+    /// Get animation playback state + posed skeleton for an entity
+    AnimationState {
+        id: i32,
+        reply: oneshot::Sender<Option<shock2vr::game_scene::DebugAnimationState>>,
+    },
+
     /// Inject a script message into a specific entity (damage, frob, signal)
     SendEntityMessage {
         id: i32,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -272,6 +272,7 @@ async fn start_http_server(
             "/v1/entities/:id/message",
             axum::routing::post(send_entity_message),
         )
+        .route("/v1/entities/:id/animation", get(get_animation_state))
         .route("/v1/player/position", get(get_player_position))
         .route("/v1/player/teleport", axum::routing::post(teleport_player))
         .route(
@@ -329,6 +330,9 @@ async fn start_http_server(
     info!("  GET  /v1/entities         - List entities with optional limit and filter");
     info!("  GET  /v1/entities/{{id}}    - Get detailed entity information");
     info!("  POST /v1/entities/{{id}}/message - Inject a script message (damage/frob/signal)");
+    info!(
+        "  GET  /v1/entities/{{id}}/animation - Animation playback state + posed skeleton (world-space joints)"
+    );
     info!("  GET  /v1/player/position  - Get current player position");
     info!("  POST /v1/player/teleport  - Teleport player to coordinates (raw, unbounded)");
     info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
@@ -1302,6 +1306,17 @@ fn process_command(
                 tracing::warn!("Failed to send entity detail - receiver dropped");
             }
         }
+        RuntimeCommand::AnimationState { id, reply } => {
+            let result = game.debug_scene().and_then(|debug_scene| {
+                // Same id space as /v1/entities (`EntityId::inner() as i32`).
+                EntityId::from_inner(id as u64)
+                    .and_then(|entity_id| debug_scene.animation_state(entity_id))
+            });
+
+            if let Err(_) = reply.send(result) {
+                tracing::warn!("Failed to send animation state - receiver dropped");
+            }
+        }
         RuntimeCommand::SendEntityMessage { id, message, reply } => {
             // The list/detail endpoints expose `EntityId::inner() as i32`, which
             // for a live entity is `index + 1`. `from_inner` is the exact
@@ -2046,6 +2061,30 @@ async fn get_entity_detail(
         Ok(result) => Json(result),
         Err(_) => {
             tracing::error!("Failed to receive entity detail - sender dropped");
+            Json(None)
+        }
+    }
+}
+
+/// Get animation playback state + world-space posed skeleton for an entity
+async fn get_animation_state(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Path(id): Path<i32>,
+) -> Json<Option<shock2vr::game_scene::DebugAnimationState>> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if let Err(_) = command_tx.send(RuntimeCommand::AnimationState {
+        id,
+        reply: reply_tx,
+    }) {
+        tracing::error!("Failed to send AnimationState command - game loop receiver dropped");
+        return Json(None);
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive animation state - sender dropped");
             Json(None)
         }
     }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -383,6 +383,51 @@ pub struct DebugUiElement {
     pub screen_rect: [f32; 4],
 }
 
+/// Animation playback state + posed skeleton for one entity, sampled at the
+/// current frame. Joint positions are world-space, so stepping the simulation
+/// and diffing successive snapshots measures pose continuity directly (a
+/// single-frame spike across many joints = a seam pop).
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugAnimationState {
+    pub entity_id: i32,
+    /// Currently playing clip (queue head), `None` when the queue is empty.
+    pub clip: Option<String>,
+    pub frame: u32,
+    pub num_frames: u32,
+    pub looping: bool,
+    /// Sub-frame time carried toward the next frame advance (seconds).
+    pub remaining_time: f32,
+    /// Clips queued behind the head, in play order.
+    pub queue: Vec<DebugAnimationQueueEntry>,
+    /// Clip whose final frame poses the skeleton while the queue is empty.
+    pub last_clip: Option<String>,
+    pub blend: Option<DebugAnimationBlend>,
+    /// Entity world position / rotation (the pose the joints are composed with).
+    pub position: [f32; 3],
+    pub rotation: [f32; 4], // quaternion [x, y, z, w]
+    /// World-space joint positions (fixed 40-slot skeleton; unused slots track
+    /// the entity transform).
+    pub joints: Vec<[f32; 3]>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugAnimationQueueEntry {
+    pub name: Option<String>,
+    pub num_frames: u32,
+    pub looping: bool,
+}
+
+/// An in-flight crossfade from a previous clip's pose.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugAnimationBlend {
+    pub from_clip: Option<String>,
+    pub from_frame: f32,
+    pub duration: f32,
+    pub elapsed: f32,
+    /// Blend progress 0..1 (0 = fully the old pose).
+    pub alpha: f32,
+}
+
 /// A level-transition trigger (a `TrapTripLevel` tripwire / bulkhead): where it
 /// leads (`dest_level` + optional spawn `dest_loc`) and its world `position`, so
 /// a tester can teleport into its volume and let the real trigger fire the
@@ -429,6 +474,12 @@ pub trait DebuggableScene {
     /// # Returns
     /// Detailed entity information, or None if entity doesn't exist
     fn entity_detail(&self, id: EntityId) -> Option<DebugEntityDetail>;
+
+    /// Animation playback state + world-space posed skeleton for an entity
+    ///
+    /// Returns None when the entity has no animation player (non-animated
+    /// entities). See [`DebugAnimationState`].
+    fn animation_state(&self, id: EntityId) -> Option<DebugAnimationState>;
 
     /// Perform a physics raycast for debugging
     ///

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4260,17 +4260,14 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
         let transform = transform.unwrap_or_else(Matrix4::identity);
         let position = [transform.w.x, transform.w.y, transform.w.z];
-        let rotation_mat = Matrix3::new(
-            transform.x.x,
-            transform.x.y,
-            transform.x.z,
-            transform.y.x,
-            transform.y.y,
-            transform.y.z,
-            transform.z.x,
-            transform.z.y,
-            transform.z.z,
-        );
+        // The transform is translation * rotation * scale (PropScale, possibly
+        // non-uniform), so the basis columns must be normalized before the
+        // quaternion conversion - Quaternion::from assumes an orthonormal
+        // matrix and returns a different rotation for a scaled one.
+        let basis_x = vec3(transform.x.x, transform.x.y, transform.x.z).normalize();
+        let basis_y = vec3(transform.y.x, transform.y.y, transform.y.z).normalize();
+        let basis_z = vec3(transform.z.x, transform.z.y, transform.z.z).normalize();
+        let rotation_mat = Matrix3::from_cols(basis_x, basis_y, basis_z);
         let rotation_quat = Quaternion::from(rotation_mat).normalize();
         let rotation = [
             rotation_quat.v.x,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -9,8 +9,8 @@ use std::{
 
 use cgmath::{EuclideanSpace, Zero};
 use cgmath::{
-    InnerSpace, Matrix4, Point3, Quaternion, Rotation, Rotation3, SquareMatrix, Transform, Vector2,
-    Vector3, num_traits::ToPrimitive, vec3,
+    InnerSpace, Matrix3, Matrix4, Point3, Quaternion, Rotation, Rotation3, SquareMatrix, Transform,
+    Vector2, Vector3, num_traits::ToPrimitive, vec3,
 };
 
 use crate::SpawnLocation;
@@ -4238,6 +4238,97 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         }
 
         entities
+    }
+
+    fn animation_state(&self, id: EntityId) -> Option<crate::game_scene::DebugAnimationState> {
+        use crate::game_scene::{
+            DebugAnimationBlend, DebugAnimationQueueEntry, DebugAnimationState,
+        };
+        use shipyard::*;
+
+        let snapshot = self.id_to_animation_player.get(&id)?.snapshot();
+
+        let (transform, joint_transforms) = self.world.run(
+            |v_transform: View<crate::runtime_props::RuntimePropTransform>,
+             v_joints: View<crate::runtime_props::RuntimePropJointTransforms>| {
+                (
+                    v_transform.get(id).ok().map(|t| t.0),
+                    v_joints.get(id).ok().map(|j| j.0),
+                )
+            },
+        );
+
+        let transform = transform.unwrap_or_else(Matrix4::identity);
+        let position = [transform.w.x, transform.w.y, transform.w.z];
+        let rotation_mat = Matrix3::new(
+            transform.x.x,
+            transform.x.y,
+            transform.x.z,
+            transform.y.x,
+            transform.y.y,
+            transform.y.z,
+            transform.z.x,
+            transform.z.y,
+            transform.z.z,
+        );
+        let rotation_quat = Quaternion::from(rotation_mat).normalize();
+        let rotation = [
+            rotation_quat.v.x,
+            rotation_quat.v.y,
+            rotation_quat.v.z,
+            rotation_quat.s,
+        ];
+
+        let joints = joint_transforms
+            .map(|joint_transforms| {
+                joint_transforms
+                    .iter()
+                    .map(|joint| {
+                        let world = transform * joint;
+                        [world.w.x, world.w.y, world.w.z]
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut queue = snapshot.queue;
+        let head = if queue.is_empty() {
+            None
+        } else {
+            Some(queue.remove(0))
+        };
+
+        Some(DebugAnimationState {
+            entity_id: id.inner() as i32,
+            clip: head.as_ref().and_then(|entry| entry.name.clone()),
+            frame: snapshot.current_frame,
+            num_frames: head.as_ref().map(|entry| entry.num_frames).unwrap_or(0),
+            looping: head.as_ref().map(|entry| entry.looping).unwrap_or(false),
+            remaining_time: snapshot.remaining_time,
+            queue: queue
+                .into_iter()
+                .map(|entry| DebugAnimationQueueEntry {
+                    name: entry.name,
+                    num_frames: entry.num_frames,
+                    looping: entry.looping,
+                })
+                .collect(),
+            last_clip: snapshot.last_clip,
+            blend: snapshot.blend.map(|blend| DebugAnimationBlend {
+                from_clip: blend.from_clip,
+                from_frame: blend.from_frame,
+                duration: blend.duration,
+                elapsed: blend.elapsed,
+                alpha: if blend.duration > f32::EPSILON {
+                    (blend.elapsed / blend.duration).clamp(0.0, 1.0)
+                } else {
+                    1.0
+                },
+            }),
+            position,
+            rotation,
+            joints,
+        })
     }
 
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -295,6 +295,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.entity_detail(id)
     }
 
+    fn animation_state(&self, id: EntityId) -> Option<crate::game_scene::DebugAnimationState> {
+        self.mission_core.animation_state(id)
+    }
+
     fn raycast(
         &self,
         start: cgmath::Point3<f32>,

--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
     "test:e2e": "tsc && SHOCK2_E2E=1 node --test --test-concurrency=1 \"dist/test/*.test.js\"",
-    "test:e2e:reliability": "tsc && node scripts/reliability.mjs"
+    "test:e2e:reliability": "tsc && node scripts/reliability.mjs",
+    "anim-smoothness": "tsc && node dist/scripts/anim-smoothness.js"
   },
   "engines": {
     "node": ">=20"

--- a/tools/shock2-sdk/scripts/anim-smoothness.ts
+++ b/tools/shock2-sdk/scripts/anim-smoothness.ts
@@ -1,0 +1,321 @@
+/**
+ * Capture an animation-smoothness baseline for the pipe hybrid (OG-Pipe) in
+ * medsci1: sample GET /v1/entities/:id/animation once per stepped frame for
+ * an IDLE phase and a WALKING phase (alertness forced High so the AI
+ * locomotes), run the smoothness metrics over both, write a JSON report, and
+ * print a summary table.
+ *
+ *   npm run anim-smoothness [-- /path/to/report.json]
+ *
+ * Default report path: <repo>/projects/animation-smoothness-baseline.json.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { findRepoRoot, GameServer } from "../src/index.js";
+import type { Game } from "../src/index.js";
+import { analyzePhase, type PhaseReport } from "../src/anim-metrics.js";
+import type { AnimationState, EntitySummary, Vec3 } from "../src/types.js";
+
+const PORT = 8095;
+const MISSION = "medsci1.mis";
+const CAPTURE_FRAMES = 600; // 10 s at the fixed 60 Hz step rate
+const FPS = 60;
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/**
+ * Find the pipe hybrids by NAME - runtime entity ids are NOT stable across
+ * launches, so identity must come from the name (or template_id). Returns
+ * the OG-Pipes that actually have an animation player, nearest first.
+ */
+async function findPipeHybrids(game: Game): Promise<EntitySummary[]> {
+  const { entities } = await game.entities.list({ filter: "OG-Pipe", limit: 20 });
+  const animated: EntitySummary[] = [];
+  for (const entity of entities) {
+    if (entity.name !== "OG-Pipe") continue;
+    const anim = await game.entities.animation(entity.id);
+    if (anim && anim.joints.length > 0) animated.push(entity);
+  }
+  if (animated.length === 0) {
+    throw new Error(
+      `No animated OG-Pipe found in ${MISSION} (candidates: ${JSON.stringify(
+        entities.map((e) => ({ id: e.id, name: e.name })),
+      )})`,
+    );
+  }
+  return animated;
+}
+
+/** Step one frame at a time and record the animation state after each step. */
+async function captureSamples(
+  game: Game,
+  entityId: number,
+  frames: number,
+  label: string,
+): Promise<AnimationState[]> {
+  const samples: AnimationState[] = [];
+  for (let i = 0; i < frames; i++) {
+    await game.step({ frames: 1 });
+    const sample = await game.entities.animation(entityId);
+    if (!sample) {
+      throw new Error(
+        `${label}: animation state became null at sample ${i} (entity ${entityId} despawned?)`,
+      );
+    }
+    samples.push(sample);
+    if ((i + 1) % 120 === 0) {
+      console.error(`  ${label}: ${i + 1}/${frames} frames (clip: ${sample.clip})`);
+    }
+  }
+  return samples;
+}
+
+/**
+ * Keep the player out of melee range during the walking capture so the
+ * hybrid keeps locomoting instead of switching to attack clips. moveTo is a
+ * collision-valid hop, so this never puts the player inside geometry.
+ */
+async function keepPlayerAway(game: Game, creaturePos: Vec3): Promise<void> {
+  const player = await game.player.position();
+  const playerPos: Vec3 = [player.x, player.y, player.z];
+  const dist = distance(playerPos, creaturePos);
+  if (dist >= 12) return;
+  const dx = playerPos[0] - creaturePos[0];
+  const dz = playerPos[2] - creaturePos[2];
+  const len = Math.hypot(dx, dz) || 1;
+  await game.player.moveTo({
+    x: player.x + (dx / len) * 4.5,
+    y: player.y,
+    z: player.z + (dz / len) * 4.5,
+  });
+}
+
+interface WalkingCapture {
+  samples: AnimationState[];
+  /** Entity moved meaningfully during the capture. */
+  locomotionConfirmed: boolean;
+  /** A locomotion clip (ogsrun / walk) was observed. */
+  sawLocomotionClip: boolean;
+  netDisplacement: number;
+  totalPathLength: number;
+}
+
+/**
+ * Force alertness on each candidate in turn and pick the first that actually
+ * locomotes (some OG-Pipes get stuck on geometry and run in place - still
+ * valid for pose metrics, but locomotion metrics need real movement).
+ */
+async function selectWalker(
+  game: Game,
+  candidates: EntitySummary[],
+): Promise<EntitySummary> {
+  for (const candidate of candidates) {
+    await game.entities.sendMessage(candidate.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    const before = (await game.entities.animation(candidate.id))!.position;
+    let moved = 0;
+    for (let i = 0; i < 10 && moved <= 2; i++) {
+      await game.step({ frames: 30 });
+      const state = (await game.entities.animation(candidate.id))!;
+      moved = distance(state.position, before);
+      await keepPlayerAway(game, state.position);
+    }
+    console.error(
+      `  candidate ${candidate.id} (distance ${candidate.distance.toFixed(1)}): moved ${moved.toFixed(2)} units during warmup`,
+    );
+    if (moved > 2) return candidate;
+  }
+  console.error(
+    "WARNING: no OG-Pipe locomoted during warmup - using the nearest one (pose metrics still valid, locomotion metrics are not).",
+  );
+  return candidates[0];
+}
+
+async function captureWalking(
+  game: Game,
+  entityId: number,
+): Promise<WalkingCapture> {
+  let sawLocomotionClip = false;
+  const samples: AnimationState[] = [];
+  for (let i = 0; i < CAPTURE_FRAMES; i++) {
+    await game.step({ frames: 1 });
+    const sample = await game.entities.animation(entityId);
+    if (!sample) {
+      throw new Error(`walking: animation state became null at sample ${i}`);
+    }
+    samples.push(sample);
+    if (sample.clip && /run|walk/i.test(sample.clip)) sawLocomotionClip = true;
+    if (i % 60 === 59) {
+      // Re-assert alertness (it decays) and keep out of melee range.
+      await game.entities.sendMessage(entityId, {
+        type: "SetAlertness",
+        level: "High",
+      });
+      await keepPlayerAway(game, sample.position);
+    }
+    if ((i + 1) % 120 === 0) {
+      console.error(`  walking: ${i + 1}/${CAPTURE_FRAMES} frames (clip: ${sample.clip})`);
+    }
+  }
+
+  let totalPathLength = 0;
+  for (let i = 1; i < samples.length; i++) {
+    totalPathLength += distance(samples[i].position, samples[i - 1].position);
+  }
+  const netDisplacement = distance(
+    samples[samples.length - 1].position,
+    samples[0].position,
+  );
+
+  return {
+    samples,
+    locomotionConfirmed: netDisplacement > 2 || totalPathLength > 5,
+    sawLocomotionClip,
+    netDisplacement,
+    totalPathLength,
+  };
+}
+
+function fmt(value: number): string {
+  return value.toFixed(4);
+}
+
+function printPhaseSummary(name: string, report: PhaseReport): void {
+  console.log(`\n=== ${name} (${report.sampleCount} samples, ${report.durationSeconds.toFixed(1)}s) ===`);
+  console.log(
+    `  clips: ${Object.entries(report.clipFrames)
+      .map(([clip, frames]) => `${clip}=${frames}f`)
+      .join(", ")}`,
+  );
+  console.log(`  clip changes: ${report.clipChangeCount}, loop resets: ${report.loopResetCount}`);
+  console.log(`  spike threshold (root-relative max-joint dp): ${fmt(report.spikeThreshold)}`);
+  console.log(
+    `  spikes: ${report.spikes.length} (${report.spikesPerSecond.toFixed(2)}/s)` +
+      ` - clip-switch=${report.spikeKinds["clip-switch"]},` +
+      ` loop-seam=${report.spikeKinds["loop-seam"]},` +
+      ` mid-clip=${report.spikeKinds["mid-clip"]},` +
+      ` max magnitude=${fmt(report.maxSpikeMagnitude)}`,
+  );
+  console.log("  per-frame max-joint |dp|      p50      p95      max     mean");
+  console.log(
+    `    root-relative          ${fmt(report.localMaxDelta.p50)}  ${fmt(report.localMaxDelta.p95)}  ${fmt(report.localMaxDelta.max)}  ${fmt(report.localMaxDelta.mean)}`,
+  );
+  console.log(
+    `    world                  ${fmt(report.worldMaxDelta.p50)}  ${fmt(report.worldMaxDelta.p95)}  ${fmt(report.worldMaxDelta.max)}  ${fmt(report.worldMaxDelta.mean)}`,
+  );
+  console.log(
+    `  mean max-joint jerk: local=${fmt(report.localMeanMaxJerk)} world=${fmt(report.worldMeanMaxJerk)}`,
+  );
+  console.log(
+    `  entity |dp| p50/p95/max: ${fmt(report.entityDelta.p50)}/${fmt(report.entityDelta.p95)}/${fmt(report.entityDelta.max)}` +
+      `  entity accel p95/max: ${fmt(report.entityAccel.p95)}/${fmt(report.entityAccel.max)}`,
+  );
+  const top = [...report.spikes]
+    .sort((a, b) => b.magnitude - a.magnitude)
+    .slice(0, 8);
+  if (top.length > 0) {
+    console.log("  top spikes (frame, kind, magnitude, clip transition):");
+    for (const spike of top) {
+      console.log(
+        `    #${spike.index}  ${spike.kind.padEnd(11)} ${fmt(spike.magnitude)}  ${spike.prevClip ?? "(none)"} -> ${spike.clip ?? "(none)"}@${spike.clipFrame}${spike.blending ? " [blending]" : ""}`,
+      );
+    }
+  }
+}
+
+/** Round all numbers deeply so the JSON report stays readable and compact. */
+function roundDeep(value: unknown): unknown {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value : Number(value.toFixed(5));
+  }
+  if (Array.isArray(value)) return value.map(roundDeep);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        roundDeep(v),
+      ]),
+    );
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const repoRoot = findRepoRoot(import.meta.dirname);
+  if (!repoRoot) throw new Error("Could not locate the cargo workspace root");
+  const outPath =
+    process.argv[2] ??
+    path.join(repoRoot, "projects", "animation-smoothness-baseline.json");
+
+  console.error(`Launching debug runtime (${MISSION}, port ${PORT})...`);
+  await using game = await GameServer.launch({ mission: MISSION, port: PORT });
+
+  // Let the mission settle before measuring.
+  await game.step({ frames: 60 });
+
+  const candidates = await findPipeHybrids(game);
+  const target = candidates[0];
+  console.error(
+    `Idle target: ${target.name} (runtime id ${target.id}, template ${target.template_id}, distance ${target.distance.toFixed(1)}; ${candidates.length} animated OG-Pipes total)`,
+  );
+
+  console.error("Capturing IDLE phase...");
+  const idleSamples = await captureSamples(game, target.id, CAPTURE_FRAMES, "idle");
+  const idle = analyzePhase(idleSamples, { fps: FPS });
+
+  console.error("Forcing alertness and selecting a walker...");
+  const walker = await selectWalker(game, candidates);
+  console.error(`Walking target: runtime id ${walker.id}`);
+  const walkingCapture = await captureWalking(game, walker.id);
+  const walking = analyzePhase(walkingCapture.samples, { fps: FPS });
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    mission: MISSION,
+    entity: {
+      name: target.name,
+      template_id: target.template_id,
+      // Runtime ids are not stable across launches; recorded for traceability only.
+      idle_runtime_id: target.id,
+      walking_runtime_id: walker.id,
+      walking_template_id: walker.template_id,
+    },
+    captureFrames: CAPTURE_FRAMES,
+    fps: FPS,
+    phases: {
+      idle,
+      walking: {
+        ...walking,
+        locomotion: {
+          confirmed: walkingCapture.locomotionConfirmed,
+          sawLocomotionClip: walkingCapture.sawLocomotionClip,
+          netDisplacement: walkingCapture.netDisplacement,
+          totalPathLength: walkingCapture.totalPathLength,
+        },
+      },
+    },
+  };
+
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, JSON.stringify(roundDeep(report), null, 2));
+
+  printPhaseSummary("IDLE", idle);
+  printPhaseSummary("WALKING", walking);
+  console.log(
+    `\nwalking locomotion: confirmed=${walkingCapture.locomotionConfirmed}` +
+      ` sawLocomotionClip=${walkingCapture.sawLocomotionClip}` +
+      ` net=${walkingCapture.netDisplacement.toFixed(2)} path=${walkingCapture.totalPathLength.toFixed(2)}`,
+  );
+  console.log(`\nReport written to ${outPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/shock2-sdk/scripts/anim-smoothness.ts
+++ b/tools/shock2-sdk/scripts/anim-smoothness.ts
@@ -269,6 +269,22 @@ async function main(): Promise<void> {
   const idleSamples = await captureSamples(game, target.id, CAPTURE_FRAMES, "idle");
   const idle = analyzePhase(idleSamples, { fps: FPS });
 
+  // The "idle" label is only honest if the AI stayed idle - it could have
+  // spotted the player and gone into locomotion/attack clips mid-capture.
+  const nonIdleClips = [
+    ...new Set(
+      idleSamples
+        .map((s) => s.clip)
+        .filter((clip): clip is string => clip !== null && !/idle/i.test(clip)),
+    ),
+  ];
+  const idleConfirmed = nonIdleClips.length === 0;
+  if (!idleConfirmed) {
+    console.error(
+      `WARNING: idle capture contains non-idle clips (${nonIdleClips.join(", ")}) - the AI was not idle; idle metrics are suspect.`,
+    );
+  }
+
   console.error("Forcing alertness and selecting a walker...");
   const walker = await selectWalker(game, candidates);
   console.error(`Walking target: runtime id ${walker.id}`);
@@ -289,7 +305,11 @@ async function main(): Promise<void> {
     captureFrames: CAPTURE_FRAMES,
     fps: FPS,
     phases: {
-      idle,
+      idle: {
+        ...idle,
+        idleConfirmed,
+        nonIdleClips,
+      },
       walking: {
         ...walking,
         locomotion: {

--- a/tools/shock2-sdk/src/anim-metrics.ts
+++ b/tools/shock2-sdk/src/anim-metrics.ts
@@ -13,6 +13,13 @@
  * exceeds a threshold are flagged as spikes and attributed to the clip
  * timeline: `clip-switch` (clip name changed), `loop-seam` (same clip
  * restarted), or `mid-clip`.
+ *
+ * Caveats: joints are the endpoint's fixed 40-slot skeleton, so unused slots
+ * (which track the entity transform, i.e. zero local motion) dilute the MEAN
+ * stats on sparse skeletons - max-based metrics and spike detection are
+ * unaffected. Root-relative space removes translation/rotation but not the
+ * entity's (constant) scale, so cross-entity comparisons of absolute
+ * magnitudes assume similar scales.
  */
 
 import type { AnimationState, Quat, Vec3 } from "./types.js";
@@ -272,9 +279,11 @@ function percentile(sorted: number[], p: number): number {
 
 /**
  * Spike threshold over the root-relative max-joint-displacement series:
- * mean + sigma * std computed over the values at or below p95 (so the seam
- * pops being hunted cannot inflate the threshold past themselves), floored
- * at `minSpike`.
+ * median + sigma * MAD (scaled to sigma-equivalent units), floored at
+ * `minSpike`. Median/MAD stay anchored to the typical frame even when seam
+ * pops occupy a large share of frames (a walk cycle seaming every ~15 frames
+ * with a two-frame pop is ~13% of samples - enough to inflate a trimmed-mean
+ * threshold past the very pops being hunted).
  */
 export function spikeThreshold(
   values: number[],
@@ -283,20 +292,20 @@ export function spikeThreshold(
 ): number {
   if (values.length === 0) return minSpike;
   const sorted = [...values].sort((a, b) => a - b);
-  const p95 = percentile(sorted, 0.95);
-  const trimmed = values.filter((v) => v <= p95);
-  const mean = trimmed.reduce((acc, v) => acc + v, 0) / trimmed.length;
-  const std = Math.sqrt(
-    trimmed.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) /
-      trimmed.length,
-  );
-  return Math.max(minSpike, mean + sigma * std);
+  const median = percentile(sorted, 0.5);
+  const deviations = values.map((v) => Math.abs(v - median)).sort((a, b) => a - b);
+  // 1.4826 scales MAD to the standard deviation of a normal distribution.
+  const mad = 1.4826 * percentile(deviations, 0.5);
+  return Math.max(minSpike, median + sigma * mad);
 }
 
 /**
- * Classify a spike at metric index `i` by the clip timeline. The pose can
- * update one sample after the queue-head bookkeeping changes (60 Hz sampling
- * of 30 fps clips), so the previous metric's transition also counts.
+ * Classify a spike at metric index `i` by the clip timeline. Seam pops span
+ * TWO adjacent frames (observed in baseline data): the pose jumps to a wrong
+ * pose on the transition frame, then jumps back to the new clip's pose on the
+ * next - so a spike one frame after a transition is still seam-caused and the
+ * previous metric's transition also counts. Tradeoff: a genuine mid-clip pop
+ * landing right after an unrelated transition is over-attributed to the seam.
  */
 function classifySpike(metrics: FrameMetric[], i: number): SpikeKind {
   const here = metrics[i];

--- a/tools/shock2-sdk/src/anim-metrics.ts
+++ b/tools/shock2-sdk/src/anim-metrics.ts
@@ -1,0 +1,382 @@
+/**
+ * Animation smoothness metrics over a sequence of per-frame AnimationState
+ * samples (GET /v1/entities/:id/animation, one sample per stepped frame).
+ *
+ * Two spaces are analyzed:
+ * - world: raw world-space joint positions (includes locomotion), and
+ * - local: root-relative joints (joint minus entity position, rotated by the
+ *   inverse entity rotation) - isolates pose pops from locomotion.
+ *
+ * Per-frame metrics are first/second/third differences of joint positions
+ * (displacement / accel / jerk), plus the entity-position second difference
+ * (locomotion smoothness). Frames whose root-relative max-joint displacement
+ * exceeds a threshold are flagged as spikes and attributed to the clip
+ * timeline: `clip-switch` (clip name changed), `loop-seam` (same clip
+ * restarted), or `mid-clip`.
+ */
+
+import type { AnimationState, Quat, Vec3 } from "./types.js";
+
+function sub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function magnitude(a: Vec3): number {
+  return Math.hypot(a[0], a[1], a[2]);
+}
+
+/** Rotate `v` by the inverse (conjugate) of the unit quaternion `q` = [x,y,z,w]. */
+export function rotateByInverse(v: Vec3, q: Quat): Vec3 {
+  // Conjugate of q, then v' = v + 2w(u x v) + 2(u x (u x v)) with u = q.xyz.
+  const ux = -q[0];
+  const uy = -q[1];
+  const uz = -q[2];
+  const w = q[3];
+  const cx = uy * v[2] - uz * v[1];
+  const cy = uz * v[0] - ux * v[2];
+  const cz = ux * v[1] - uy * v[0];
+  const ccx = uy * cz - uz * cy;
+  const ccy = uz * cx - ux * cz;
+  const ccz = ux * cy - uy * cx;
+  return [
+    v[0] + 2 * (w * cx + ccx),
+    v[1] + 2 * (w * cy + ccy),
+    v[2] + 2 * (w * cz + ccz),
+  ];
+}
+
+/** Joints expressed in the entity's local (root-relative) frame. */
+export function rootRelativeJoints(sample: AnimationState): Vec3[] {
+  return sample.joints.map((joint) =>
+    rotateByInverse(sub(joint, sample.position), sample.rotation),
+  );
+}
+
+/** Differences between sample `index` and the preceding sample(s). */
+export interface FrameMetric {
+  /** Sample index the metric belongs to (delta from sample index-1). */
+  index: number;
+  clip: string | null;
+  clipFrame: number;
+  /** Clip name differs from the previous sample. */
+  clipChanged: boolean;
+  /** Same clip, but the frame index moved backwards (loop restart). */
+  loopReset: boolean;
+  /** A crossfade blend was active at this sample. */
+  blending: boolean;
+  worldMaxDelta: number;
+  worldMeanDelta: number;
+  localMaxDelta: number;
+  localMeanDelta: number;
+  /** Max per-joint second difference |p[t] - 2p[t-1] + p[t-2]| (0 until index 2). */
+  worldMaxAccel: number;
+  localMaxAccel: number;
+  /** Max per-joint third difference (0 until index 3). */
+  worldMaxJerk: number;
+  localMaxJerk: number;
+  /** Entity-position first difference (locomotion speed per frame). */
+  entityDelta: number;
+  /** Entity-position second difference (locomotion smoothness). */
+  entityAccel: number;
+}
+
+export type SpikeKind = "clip-switch" | "loop-seam" | "mid-clip";
+
+export interface SpikeInfo {
+  index: number;
+  kind: SpikeKind;
+  /** Root-relative max-joint displacement at this frame. */
+  magnitude: number;
+  worldMagnitude: number;
+  clip: string | null;
+  prevClip: string | null;
+  clipFrame: number;
+  blending: boolean;
+}
+
+export interface SeriesStats {
+  mean: number;
+  p50: number;
+  p95: number;
+  max: number;
+}
+
+export interface AnalyzeOptions {
+  /** Sigma multiplier for the spike threshold (default 5). */
+  sigma?: number;
+  /** Absolute floor for the spike threshold, world units (default 0.1). */
+  minSpike?: number;
+  /** Simulation rate the samples were captured at (default 60). */
+  fps?: number;
+}
+
+export interface PhaseReport {
+  sampleCount: number;
+  durationSeconds: number;
+  /** Threshold applied to the root-relative max-joint-displacement series. */
+  spikeThreshold: number;
+  spikes: SpikeInfo[];
+  spikesPerSecond: number;
+  maxSpikeMagnitude: number;
+  spikeKinds: Record<SpikeKind, number>;
+  clipChangeCount: number;
+  loopResetCount: number;
+  /** Frames spent per clip name across the capture. */
+  clipFrames: Record<string, number>;
+  localMaxDelta: SeriesStats;
+  worldMaxDelta: SeriesStats;
+  /** Mean over frames of the max per-joint jerk magnitude. */
+  localMeanMaxJerk: number;
+  worldMeanMaxJerk: number;
+  entityDelta: SeriesStats;
+  entityAccel: SeriesStats;
+  frames: FrameMetric[];
+}
+
+export function computeFrameMetrics(samples: AnimationState[]): FrameMetric[] {
+  const world = samples.map((s) => s.joints);
+  const local = samples.map(rootRelativeJoints);
+  const metrics: FrameMetric[] = [];
+
+  for (let t = 1; t < samples.length; t++) {
+    const jointCount = Math.min(world[t].length, world[t - 1].length);
+    let worldMaxDelta = 0;
+    let worldSumDelta = 0;
+    let localMaxDelta = 0;
+    let localSumDelta = 0;
+    let worldMaxAccel = 0;
+    let localMaxAccel = 0;
+    let worldMaxJerk = 0;
+    let localMaxJerk = 0;
+
+    for (let j = 0; j < jointCount; j++) {
+      const wd = magnitude(sub(world[t][j], world[t - 1][j]));
+      const ld = magnitude(sub(local[t][j], local[t - 1][j]));
+      worldMaxDelta = Math.max(worldMaxDelta, wd);
+      localMaxDelta = Math.max(localMaxDelta, ld);
+      worldSumDelta += wd;
+      localSumDelta += ld;
+
+      if (t >= 2 && j < world[t - 2].length) {
+        worldMaxAccel = Math.max(
+          worldMaxAccel,
+          magnitude(secondDiff(world, t, j)),
+        );
+        localMaxAccel = Math.max(
+          localMaxAccel,
+          magnitude(secondDiff(local, t, j)),
+        );
+        if (t >= 3 && j < world[t - 3].length) {
+          worldMaxJerk = Math.max(
+            worldMaxJerk,
+            magnitude(thirdDiff(world, t, j)),
+          );
+          localMaxJerk = Math.max(
+            localMaxJerk,
+            magnitude(thirdDiff(local, t, j)),
+          );
+        }
+      }
+    }
+
+    const entityDelta = magnitude(
+      sub(samples[t].position, samples[t - 1].position),
+    );
+    const entityAccel =
+      t >= 2
+        ? magnitude([
+            samples[t].position[0] -
+              2 * samples[t - 1].position[0] +
+              samples[t - 2].position[0],
+            samples[t].position[1] -
+              2 * samples[t - 1].position[1] +
+              samples[t - 2].position[1],
+            samples[t].position[2] -
+              2 * samples[t - 1].position[2] +
+              samples[t - 2].position[2],
+          ])
+        : 0;
+
+    const clipChanged = samples[t].clip !== samples[t - 1].clip;
+    const loopReset = !clipChanged && samples[t].frame < samples[t - 1].frame;
+
+    metrics.push({
+      index: t,
+      clip: samples[t].clip,
+      clipFrame: samples[t].frame,
+      clipChanged,
+      loopReset,
+      blending: samples[t].blend !== null,
+      worldMaxDelta,
+      worldMeanDelta: jointCount > 0 ? worldSumDelta / jointCount : 0,
+      localMaxDelta,
+      localMeanDelta: jointCount > 0 ? localSumDelta / jointCount : 0,
+      worldMaxAccel,
+      localMaxAccel,
+      worldMaxJerk,
+      localMaxJerk,
+      entityDelta,
+      entityAccel,
+    });
+  }
+
+  return metrics;
+}
+
+function secondDiff(series: Vec3[][], t: number, j: number): Vec3 {
+  return [
+    series[t][j][0] - 2 * series[t - 1][j][0] + series[t - 2][j][0],
+    series[t][j][1] - 2 * series[t - 1][j][1] + series[t - 2][j][1],
+    series[t][j][2] - 2 * series[t - 1][j][2] + series[t - 2][j][2],
+  ];
+}
+
+function thirdDiff(series: Vec3[][], t: number, j: number): Vec3 {
+  return [
+    series[t][j][0] -
+      3 * series[t - 1][j][0] +
+      3 * series[t - 2][j][0] -
+      series[t - 3][j][0],
+    series[t][j][1] -
+      3 * series[t - 1][j][1] +
+      3 * series[t - 2][j][1] -
+      series[t - 3][j][1],
+    series[t][j][2] -
+      3 * series[t - 1][j][2] +
+      3 * series[t - 2][j][2] -
+      series[t - 3][j][2],
+  ];
+}
+
+function seriesStats(values: number[]): SeriesStats {
+  if (values.length === 0) {
+    return { mean: 0, p50: 0, p95: 0, max: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mean = values.reduce((acc, v) => acc + v, 0) / values.length;
+  return {
+    mean,
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    max: sorted[sorted.length - 1],
+  };
+}
+
+/** `sorted` must be ascending. */
+function percentile(sorted: number[], p: number): number {
+  const pos = (sorted.length - 1) * p;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+/**
+ * Spike threshold over the root-relative max-joint-displacement series:
+ * mean + sigma * std computed over the values at or below p95 (so the seam
+ * pops being hunted cannot inflate the threshold past themselves), floored
+ * at `minSpike`.
+ */
+export function spikeThreshold(
+  values: number[],
+  sigma: number,
+  minSpike: number,
+): number {
+  if (values.length === 0) return minSpike;
+  const sorted = [...values].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 0.95);
+  const trimmed = values.filter((v) => v <= p95);
+  const mean = trimmed.reduce((acc, v) => acc + v, 0) / trimmed.length;
+  const std = Math.sqrt(
+    trimmed.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) /
+      trimmed.length,
+  );
+  return Math.max(minSpike, mean + sigma * std);
+}
+
+/**
+ * Classify a spike at metric index `i` by the clip timeline. The pose can
+ * update one sample after the queue-head bookkeeping changes (60 Hz sampling
+ * of 30 fps clips), so the previous metric's transition also counts.
+ */
+function classifySpike(metrics: FrameMetric[], i: number): SpikeKind {
+  const here = metrics[i];
+  const prev = i > 0 ? metrics[i - 1] : undefined;
+  if (here.clipChanged || prev?.clipChanged) return "clip-switch";
+  if (here.loopReset || prev?.loopReset) return "loop-seam";
+  return "mid-clip";
+}
+
+export function analyzePhase(
+  samples: AnimationState[],
+  options?: AnalyzeOptions,
+): PhaseReport {
+  const sigma = options?.sigma ?? 5;
+  const minSpike = options?.minSpike ?? 0.1;
+  const fps = options?.fps ?? 60;
+
+  const metrics = computeFrameMetrics(samples);
+  const localSeries = metrics.map((m) => m.localMaxDelta);
+  const threshold = spikeThreshold(localSeries, sigma, minSpike);
+
+  const spikes: SpikeInfo[] = [];
+  for (let i = 0; i < metrics.length; i++) {
+    const m = metrics[i];
+    if (m.localMaxDelta <= threshold) continue;
+    spikes.push({
+      index: m.index,
+      kind: classifySpike(metrics, i),
+      magnitude: m.localMaxDelta,
+      worldMagnitude: m.worldMaxDelta,
+      clip: m.clip,
+      prevClip: samples[m.index - 1].clip,
+      clipFrame: m.clipFrame,
+      blending: m.blending,
+    });
+  }
+
+  const spikeKinds: Record<SpikeKind, number> = {
+    "clip-switch": 0,
+    "loop-seam": 0,
+    "mid-clip": 0,
+  };
+  for (const spike of spikes) spikeKinds[spike.kind]++;
+
+  const clipFrames: Record<string, number> = {};
+  for (const sample of samples) {
+    const name = sample.clip ?? "(none)";
+    clipFrames[name] = (clipFrames[name] ?? 0) + 1;
+  }
+
+  const durationSeconds = Math.max(samples.length - 1, 0) / fps;
+  const jerkFrames = metrics.filter((m) => m.index >= 3);
+
+  return {
+    sampleCount: samples.length,
+    durationSeconds,
+    spikeThreshold: threshold,
+    spikes,
+    spikesPerSecond: durationSeconds > 0 ? spikes.length / durationSeconds : 0,
+    maxSpikeMagnitude: spikes.reduce((acc, s) => Math.max(acc, s.magnitude), 0),
+    spikeKinds,
+    clipChangeCount: metrics.filter((m) => m.clipChanged).length,
+    loopResetCount: metrics.filter((m) => m.loopReset).length,
+    clipFrames,
+    localMaxDelta: seriesStats(localSeries),
+    worldMaxDelta: seriesStats(metrics.map((m) => m.worldMaxDelta)),
+    localMeanMaxJerk:
+      jerkFrames.length > 0
+        ? jerkFrames.reduce((acc, m) => acc + m.localMaxJerk, 0) /
+          jerkFrames.length
+        : 0,
+    worldMeanMaxJerk:
+      jerkFrames.length > 0
+        ? jerkFrames.reduce((acc, m) => acc + m.worldMaxJerk, 0) /
+          jerkFrames.length
+        : 0,
+    entityDelta: seriesStats(metrics.map((m) => m.entityDelta)),
+    entityAccel: seriesStats(
+      metrics.filter((m) => m.index >= 2).map((m) => m.entityAccel),
+    ),
+    frames: metrics,
+  };
+}

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from "./client.js";
 import type {
+  AnimationState,
   CommandResult,
   DebugEntityMessage,
   EntityDetailResult,
@@ -119,6 +120,19 @@ export class EntitiesApi {
   async byTemplate(templateId: number): Promise<EntitySummary[]> {
     const { entities } = await this.list();
     return entities.filter((e) => e.template_id === templateId);
+  }
+
+  /**
+   * Animation playback state + world-space posed skeleton for an entity:
+   * current clip / frame, queued clips, in-flight blend, and the 40
+   * world-space joint positions. Returns null when the entity has no
+   * animation player. Sample once per stepped frame to quantify pose
+   * smoothness (see src/anim-metrics.ts).
+   */
+  async animation(id: number): Promise<AnimationState | null> {
+    return this.client.get<AnimationState | null>(
+      `/v1/entities/${id}/animation`,
+    );
   }
 
   /**

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -9,4 +9,5 @@ export {
   UiApi,
 } from "./game.js";
 export { findRepoRoot, GameServer, type LaunchOptions } from "./server.js";
+export * from "./anim-metrics.js";
 export type * from "./types.js";

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -106,6 +106,55 @@ export interface EntityDetailResult {
   incoming_links: LinkInfo[];
 }
 
+/** A clip queued behind the currently-playing head clip. */
+export interface AnimationQueueEntry {
+  name: string | null;
+  num_frames: number;
+  looping: boolean;
+}
+
+/** An in-flight crossfade from a previous clip's pose. */
+export interface AnimationBlend {
+  from_clip: string | null;
+  from_frame: number;
+  /** Total blend duration (seconds). */
+  duration: number;
+  /** Time elapsed into the blend (seconds). */
+  elapsed: number;
+  /** Blend progress 0..1 (0 = fully the old pose). */
+  alpha: number;
+}
+
+/**
+ * Animation playback state + world-space posed skeleton for one entity, as
+ * reported by GET /v1/entities/:id/animation (null when the entity has no
+ * animation player).
+ */
+export interface AnimationState {
+  entity_id: number;
+  /** Currently playing clip (queue head), null when the queue is empty. */
+  clip: string | null;
+  /** Current frame within the head clip. */
+  frame: number;
+  num_frames: number;
+  looping: boolean;
+  /** Sub-frame time carried toward the next frame advance (seconds). */
+  remaining_time: number;
+  /** Clips queued behind the head, in play order. */
+  queue: AnimationQueueEntry[];
+  /** Clip whose final frame poses the skeleton while the queue is empty. */
+  last_clip: string | null;
+  blend: AnimationBlend | null;
+  /** Entity world position / rotation (the pose the joints are composed with). */
+  position: Vec3;
+  rotation: Quat;
+  /**
+   * World-space joint positions (fixed 40-slot skeleton; unused slots track
+   * the entity transform).
+   */
+  joints: Vec3[];
+}
+
 export interface ScreenshotResult {
   filename: string;
   full_path: string;

--- a/tools/shock2-sdk/test/anim-metrics.test.ts
+++ b/tools/shock2-sdk/test/anim-metrics.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  analyzePhase,
+  computeFrameMetrics,
+  rootRelativeJoints,
+  rotateByInverse,
+  spikeThreshold,
+} from "../src/anim-metrics.js";
+import type { AnimationState, Quat, Vec3 } from "../src/types.js";
+
+function makeSample(overrides: Partial<AnimationState>): AnimationState {
+  return {
+    entity_id: 1,
+    clip: "ogsidle1",
+    frame: 0,
+    num_frames: 44,
+    looping: false,
+    remaining_time: 0,
+    queue: [],
+    last_clip: null,
+    blend: null,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0, 1],
+    joints: [[0, 0, 0]],
+    ...overrides,
+  };
+}
+
+test("rotateByInverse undoes a 90-degree yaw", () => {
+  const halfSqrt2 = Math.SQRT1_2;
+  // 90 degrees about +Y: rotates +X to -Z. The inverse maps -Z back to +X.
+  const q: Quat = [0, halfSqrt2, 0, halfSqrt2];
+  const result = rotateByInverse([0, 0, -1], q);
+  assert.ok(Math.abs(result[0] - 1) < 1e-6, `x: ${result[0]}`);
+  assert.ok(Math.abs(result[1]) < 1e-6, `y: ${result[1]}`);
+  assert.ok(Math.abs(result[2]) < 1e-6, `z: ${result[2]}`);
+});
+
+test("rootRelativeJoints removes translation and rotation", () => {
+  const halfSqrt2 = Math.SQRT1_2;
+  const localOffset: Vec3 = [1, 2, 0];
+  // Entity at [10, 0, 5], yawed 90 degrees: the local +X offset lands at -Z in
+  // world space.
+  const sample = makeSample({
+    position: [10, 0, 5],
+    rotation: [0, halfSqrt2, 0, halfSqrt2],
+    joints: [[10, 2, 5 - 1]],
+  });
+  const [joint] = rootRelativeJoints(sample);
+  for (let axis = 0; axis < 3; axis++) {
+    assert.ok(
+      Math.abs(joint[axis] - localOffset[axis]) < 1e-5,
+      `axis ${axis}: ${joint[axis]} != ${localOffset[axis]}`,
+    );
+  }
+});
+
+test("root-relative metrics isolate pose pops from locomotion", () => {
+  // Entity glides +X at 0.1/frame with a rigid pose: world deltas are pure
+  // locomotion, local deltas are ~0.
+  const samples = Array.from({ length: 10 }, (_, t) =>
+    makeSample({
+      frame: t,
+      position: [t * 0.1, 0, 0],
+      joints: [
+        [t * 0.1, 1, 0],
+        [t * 0.1 + 0.5, 1.5, 0],
+      ],
+    }),
+  );
+  const metrics = computeFrameMetrics(samples);
+  for (const m of metrics) {
+    assert.ok(Math.abs(m.worldMaxDelta - 0.1) < 1e-6, `world ${m.worldMaxDelta}`);
+    assert.ok(m.localMaxDelta < 1e-6, `local ${m.localMaxDelta}`);
+    assert.ok(Math.abs(m.entityDelta - 0.1) < 1e-6);
+    assert.ok(m.entityAccel < 1e-6);
+  }
+});
+
+test("spikes at a clip change are classified clip-switch", () => {
+  const samples: AnimationState[] = [];
+  for (let t = 0; t < 40; t++) {
+    const changed = t >= 20;
+    samples.push(
+      makeSample({
+        clip: changed ? "ogsrunl" : "ogsidle1",
+        frame: changed ? t - 20 : t,
+        // Small continuous drift, then a 1-unit pop exactly at the switch.
+        joints: [[t * 0.01 + (changed ? 1 : 0), 1, 0]],
+      }),
+    );
+  }
+  const report = analyzePhase(samples, { minSpike: 0.1 });
+  assert.equal(report.clipChangeCount, 1);
+  assert.equal(report.spikes.length, 1);
+  assert.equal(report.spikes[0].kind, "clip-switch");
+  assert.equal(report.spikes[0].index, 20);
+  assert.ok(Math.abs(report.spikes[0].magnitude - 1) < 0.02);
+  assert.equal(report.spikes[0].prevClip, "ogsidle1");
+  assert.equal(report.spikes[0].clip, "ogsrunl");
+});
+
+test("spikes at a frame reset of the same clip are classified loop-seam", () => {
+  const samples: AnimationState[] = [];
+  for (let t = 0; t < 40; t++) {
+    const frame = t % 20; // clip restarts at t=20 without a name change
+    samples.push(
+      makeSample({
+        clip: "ogsrunl",
+        frame,
+        joints: [[frame * 0.01 + (t === 20 ? 0.8 : 0), 1, 0]],
+      }),
+    );
+  }
+  const report = analyzePhase(samples, { minSpike: 0.1 });
+  assert.equal(report.loopResetCount, 1);
+  // The pop enters at the reset and leaves the next frame; both deltas are
+  // attributed to the reset (a pose update can trail the queue bookkeeping
+  // by one sample).
+  assert.equal(report.spikes.length, 2);
+  for (const spike of report.spikes) {
+    assert.equal(spike.kind, "loop-seam");
+  }
+});
+
+test("mid-clip spikes are classified mid-clip", () => {
+  const samples = Array.from({ length: 40 }, (_, t) =>
+    makeSample({
+      frame: t,
+      num_frames: 100,
+      joints: [[t * 0.01 + (t === 25 ? 0.7 : 0), 1, 0]],
+    }),
+  );
+  const report = analyzePhase(samples, { minSpike: 0.1 });
+  assert.equal(report.spikes.length, 2, "the pop enters and leaves (two deltas)");
+  for (const spike of report.spikes) {
+    assert.equal(spike.kind, "mid-clip");
+  }
+});
+
+test("spikeThreshold is robust to the spikes themselves and floored", () => {
+  // Alternating 0 / 0.1 stride (30fps clips sampled at 60Hz) with 1.0 pops.
+  const values: number[] = [];
+  for (let t = 0; t < 100; t++) values.push(t % 2 === 0 ? 0 : 0.1);
+  values[15] = 1.0;
+  values[45] = 1.0;
+  const threshold = spikeThreshold(values, 5, 0.1);
+  assert.ok(threshold < 1.0, `threshold ${threshold} should not swallow the pops`);
+  assert.ok(threshold >= 0.1, "floored at minSpike");
+
+  // All-zero series: MAD and std collapse, floor wins.
+  assert.equal(spikeThreshold(new Array(50).fill(0), 5, 0.1), 0.1);
+});
+
+test("analyzePhase summary stats and rates", () => {
+  const samples = Array.from({ length: 61 }, (_, t) =>
+    makeSample({ frame: t, num_frames: 100, joints: [[t * 0.05, 1, 0]] }),
+  );
+  const report = analyzePhase(samples, { fps: 60 });
+  assert.equal(report.sampleCount, 61);
+  assert.ok(Math.abs(report.durationSeconds - 1) < 1e-9);
+  assert.equal(report.spikes.length, 0);
+  assert.ok(Math.abs(report.localMaxDelta.p50 - 0.05) < 1e-6);
+  assert.ok(Math.abs(report.localMaxDelta.max - 0.05) < 1e-6);
+  assert.equal(report.clipFrames["ogsidle1"], 61);
+});

--- a/tools/shock2-sdk/test/anim-metrics.test.ts
+++ b/tools/shock2-sdk/test/anim-metrics.test.ts
@@ -152,6 +152,19 @@ test("spikeThreshold is robust to the spikes themselves and floored", () => {
 
   // All-zero series: MAD and std collapse, floor wins.
   assert.equal(spikeThreshold(new Array(50).fill(0), 5, 0.1), 0.1);
+
+  // Seam pops on ~13% of frames (two-frame pop every 15 frames, the pipe
+  // hybrid stride rate) must not inflate the threshold past the pops - this
+  // is where a trimmed-mean threshold failed on the real baseline.
+  const strided: number[] = [];
+  for (let t = 0; t < 600; t++) {
+    strided.push(t % 15 <= 1 ? 2.0 : t % 2 === 0 ? 0 : 0.13);
+  }
+  const stridedThreshold = spikeThreshold(strided, 5, 0.1);
+  assert.ok(
+    stridedThreshold < 2.0,
+    `threshold ${stridedThreshold} must catch pops at 13% frame share`,
+  );
 });
 
 test("analyzePhase summary stats and rates", () => {

--- a/tools/shock2-sdk/tsconfig.json
+++ b/tools/shock2-sdk/tsconfig.json
@@ -12,5 +12,5 @@
     "rootDir": ".",
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

First slice of the animation-smoothness stack (goal: smooth creature animation; the pipe-hybrid walk is visibly jerky). This PR adds the **measurement harness** so every subsequent fix lands with exact before/after numbers:

- **`GET /v1/entities/:id/animation`** (debug runtime): the entity's `AnimationPlayer` state — head clip/frame/queue/`last_clip`, in-flight blend (with alpha) — plus the 40 world-space joint positions from `RuntimePropJointTransforms`. Works for missions and debug scenes (implemented on `MissionCore`).
- **SDK**: `game.entities.animation(id)` typed accessor; `src/anim-metrics.ts` computes per-frame joint displacement/accel/jerk in world and root-relative space, detects spikes (median+MAD threshold), and attributes each to `clip-switch` / `loop-seam` / `mid-clip`.
- **`npm run anim-smoothness`**: captures an idle + walking baseline on the medsci1 pipe hybrid (walker selection verifies actual locomotion; idle phase verifies it stayed idle) and writes a JSON report.

## Baseline captured (medsci1 OG-Pipe, 600 frames/phase at fixed 60 Hz)

| | idle | walking (locomotion confirmed) |
|---|---|---|
| clip changes / 10 s | 4 | 40 |
| seam spikes | 4, up to **1.50** units | 25 above auto threshold, max **2.83** units |
| max-joint Δp p50 / p95 | 0.002 / 0.118 | 0.133 / 1.083 |

Every spike is at a clip seam (`clip frame 0`, `blending: false`), in adjacent-frame **pairs** — the pose jumps to a stale pose and snaps back next frame, ~20× normal frame-to-frame motion. This confirms the diagnosis driving the upcoming fixes (stale-clip flash at completion, no seam blend, phase reset). Spike magnitudes are bit-identical across capture runs (fixed timestep), so fix validation is exact.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; `cargo fmt`
- `npm test` green (incl. 9 new anim-metrics unit tests)
- Missions e2e: 23/23 missions load (`missions.e2e.test.ts`)
- Endpoint exercised live; two baseline captures end-to-end
- Cross-engine adversarial review (Claude + Codex): the one agreed High (entity scale corrupting the rotation quaternion → root-relative metric space) is fixed, plus a robust MAD spike threshold (the trimmed-mean version provably under-counted seams on real data) and an idle-phase guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)