### PR TITLE
fix(ai): replace, don't stack, clips on AI behavior changes

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -405,9 +405,15 @@ impl AnimatedMonsterAI {
         self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
         let is_locomotion = self.current_behavior.borrow().is_locomotion();
         let selection_strategy = self.next_selection(is_locomotion);
+        // Play (replace), never queue, on a behavior change: queueing pushes
+        // the new clip on top and leaves the interrupted clip behind it, and
+        // every later clip completion then exposes that stale entry at frame 0
+        // for one tick (a visible pose flash + zero-velocity hiccup each walk
+        // stride) before the completion handler re-queues. Same applies to the
+        // other behavior-change sites below.
         Effect::combine(vec![
             alertness::sync_alertness_effect(entity_id, &self.alertness),
-            Effect::QueueAnimationBySchema {
+            Effect::PlayAnimationBySchema {
                 entity_id,
                 motion_queries: vec![self.current_behavior.borrow().animation()],
                 selection_strategy,
@@ -565,7 +571,7 @@ impl AnimatedMonsterAI {
                 self.door_cooldown = DOOR_GIVEUP_COOLDOWN;
                 self.last_known_player_pos = None;
                 let downgrade = self.force_alertness(AIAlertLevel::Low, world, physics, entity_id);
-                let thwarted = Effect::QueueAnimationBySchema {
+                let thwarted = Effect::PlayAnimationBySchema {
                     entity_id,
                     motion_queries: vec![vec![MotionQueryItem::new("thwarted")]],
                     selection_strategy: dark::motion::MotionQuerySelectionStrategy::Random,
@@ -747,7 +753,7 @@ impl Script for AnimatedMonsterAI {
                         self.current_behavior = behavior;
                         let is_locomotion = self.current_behavior.borrow().is_locomotion();
                         let selection_strategy = self.next_selection(is_locomotion);
-                        Effect::QueueAnimationBySchema {
+                        Effect::PlayAnimationBySchema {
                             entity_id,
                             motion_queries: vec![self.current_behavior.borrow().animation()],
                             selection_strategy,
@@ -794,7 +800,7 @@ impl Script for AnimatedMonsterAI {
                 )));
                 let is_locomotion = self.current_behavior.borrow().is_locomotion();
                 let selection_strategy = self.next_selection(is_locomotion);
-                return Effect::QueueAnimationBySchema {
+                return Effect::PlayAnimationBySchema {
                     entity_id,
                     motion_queries: vec![self.current_behavior.borrow().animation()],
                     selection_strategy,
@@ -824,7 +830,7 @@ impl Script for AnimatedMonsterAI {
                 self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
                 let is_locomotion = self.current_behavior.borrow().is_locomotion();
                 let selection_strategy = self.next_selection(is_locomotion);
-                Effect::QueueAnimationBySchema {
+                Effect::PlayAnimationBySchema {
                     entity_id,
                     motion_queries: vec![self.current_behavior.borrow().animation()],
                     selection_strategy,
@@ -966,7 +972,7 @@ impl Script for AnimatedMonsterAI {
                     )));
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();
                     let selection_strategy = self.next_selection(is_locomotion);
-                    Effect::QueueAnimationBySchema {
+                    Effect::PlayAnimationBySchema {
                         entity_id,
                         motion_queries: vec![self.current_behavior.borrow().animation()],
                         selection_strategy,
@@ -1018,7 +1024,7 @@ impl Script for AnimatedMonsterAI {
                     )));
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();
                     let selection_strategy = self.next_selection(is_locomotion);
-                    Effect::QueueAnimationBySchema {
+                    Effect::PlayAnimationBySchema {
                         entity_id,
                         motion_queries: vec![self.current_behavior.borrow().animation()],
                         selection_strategy,
@@ -1056,7 +1062,7 @@ impl Script for AnimatedMonsterAI {
                     // only when there are none, retry through the
                     // combat-context level (verified across creature types
                     // with `cargo dq motion`).
-                    Effect::QueueAnimationBySchema {
+                    Effect::PlayAnimationBySchema {
                         entity_id,
                         motion_queries: vec![
                             vec![MotionQueryItem::new("receivewound")],

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -384,7 +384,11 @@ impl AnimatedMonsterAI {
         }
     }
 
-    fn force_alertness(
+    /// Set the alertness level and swap to the matching behavior WITHOUT
+    /// starting that behavior's animation - for callers that immediately play
+    /// a different clip over it (the thwarted gesture); the completion
+    /// handler starts the behavior's clip when that clip finishes.
+    fn force_alertness_state(
         &mut self,
         level: AIAlertLevel,
         world: &World,
@@ -403,16 +407,29 @@ impl AnimatedMonsterAI {
         self.alertness.hidden_time = 0.0;
 
         self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
+        alertness::sync_alertness_effect(entity_id, &self.alertness)
+    }
+
+    fn force_alertness(
+        &mut self,
+        level: AIAlertLevel,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+    ) -> Effect {
+        let sync_effect = self.force_alertness_state(level, world, physics, entity_id);
         let is_locomotion = self.current_behavior.borrow().is_locomotion();
         let selection_strategy = self.next_selection(is_locomotion);
         // Play (replace), never queue, on a behavior change: queueing pushes
         // the new clip on top and leaves the interrupted clip behind it, and
         // every later clip completion then exposes that stale entry at frame 0
         // for one tick (a visible pose flash + zero-velocity hiccup each walk
-        // stride) before the completion handler re-queues. Same applies to the
-        // other behavior-change sites below.
+        // stride) before the completion handler re-queues. The other
+        // behavior-change sites below Play for the same reason (the wound
+        // reaction runs on an already-empty queue and Plays only for the
+        // smoother minimum crossfade).
         Effect::combine(vec![
-            alertness::sync_alertness_effect(entity_id, &self.alertness),
+            sync_effect,
             Effect::PlayAnimationBySchema {
                 entity_id,
                 motion_queries: vec![self.current_behavior.borrow().animation()],
@@ -570,7 +587,12 @@ impl AnimatedMonsterAI {
                 // pursuing level.
                 self.door_cooldown = DOOR_GIVEUP_COOLDOWN;
                 self.last_known_player_pos = None;
-                let downgrade = self.force_alertness(AIAlertLevel::Low, world, physics, entity_id);
+                // State-only downgrade: the thwarted gesture replaces the
+                // queue this frame (a second Play here would blend from an
+                // unseen frame-0 pose and waste a clip load); the completion
+                // handler starts the Low behavior's clip after the gesture.
+                let downgrade =
+                    self.force_alertness_state(AIAlertLevel::Low, world, physics, entity_id);
                 let thwarted = Effect::PlayAnimationBySchema {
                     entity_id,
                     motion_queries: vec![vec![MotionQueryItem::new("thwarted")]],


### PR DESCRIPTION
## Summary

Fix #1 of the animation-smoothness stack (stacked on #463, which added the measurement harness this PR is validated with).

Every AI behavior change (alertness shift, scripted sequence start, wound reaction, sequence handback, thwarted gesture) queued its animation **on top** of the playing clip, leaving the interrupted clip in the `AnimationPlayer` queue forever. Every subsequent clip completion popped to that stale entry and posed it **at frame 0 for one tick** — a wrong-pose flash plus a zero-velocity hiccup at every walk-cycle seam, 3–5×/second on a pipe hybrid's short stride clips. This was the dominant cause of the jerky monster walk.

Behavior changes now use `PlayAnimationBySchema` (replace queue + crossfade from the interrupted pose) — the semantics `enter_death` already used. `initialize` and the completion-driven re-queue keep queue semantics: the queue is empty at those points, and that path is what legitimately advances walk cycles and idle rotations.

## Measured impact (medsci1 pipe hybrid, `npm run anim-smoothness`, deterministic fixed 60 Hz)

| walking | before | after |
|---|---|---|
| seam spikes above threshold | 25/10 s, in adjacent-frame pairs | **0** |
| max single-frame joint displacement | **2.83** world units | **0.75** |
| max-joint Δp p95 | 1.08 | 0.49 |
| mean max-joint jerk | 0.86 | 0.56 |
| locomotion (net / path) | 4.60 / 5.23 | 4.66 / 5.24 — unchanged |

Idle metrics are bit-identical before/after, as expected (idle transitions flow through the untouched completion handler). The remaining seam delta (0.75 vs mid-clip 0.13) is the un-blended stride restart — the next two PRs in the stack (universal seam blend, phase carry-over).

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean, `cargo fmt`
- Before/after smoothness capture (above); walker path identical so AI behavior is unaffected
- Full SDK e2e suite + cross-engine review: running, results to follow in comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

Pipe hybrid (`OG-Pipe`, medsci1) alerted and running toward the camera — captured headlessly on both builds via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep; base ref `feat/animation-state-endpoint` vs this branch).

![before/after real-time](https://gist.githubusercontent.com/tommy-xr/63199fadb17f94b828aa66948d98eec0/raw/hybrid-walk-realtime.gif)

<sub>Real-time (screenshot every 4 sim frames, 15 fps). The flash lasts a single 60 Hz tick, so this sampling only catches some of them — the ¼-speed capture below shows every tick.</sub>

![before/after quarter speed](https://gist.githubusercontent.com/tommy-xr/63199fadb17f94b828aa66948d98eec0/raw/hybrid-walk-slowmo.gif)

<sub>Per-sim-frame capture played at ¼ speed. BEFORE: the walk visibly snaps to a wrong pose for one tick at stride seams (stale queued clips — the queue grows to `[ogsrunr, ogsrunr, ogsidle1]` under repeated alerts). AFTER: same seams, no snap, queue stays empty. Metric (`npm run anim-smoothness`, walking phase): 25 clip-switch pose spikes / 10 s (max 2.83) before → 0 after.</sub>

### The seam, frame by frame

![seam frames](https://gist.githubusercontent.com/tommy-xr/63199fadb17f94b828aa66948d98eec0/raw/hybrid-seam-frames.png)

<sub>Sim ticks 58–61 around a stride seam: BEFORE flashes the stale clip's pose at t=60 (root-relative max-joint jump 1.30 vs ~0.15 mid-clip); AFTER continues the stride smoothly.</sub>
