### PR TITLE
feat(career): cyber-module currency - real AwardXP with persistence (flat UI 6d)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -177,6 +177,12 @@ pub struct PropDestLoc(pub i32);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropExp(pub i32);
 
+/// The count of a stackable object (e.g. how many cyber modules an EXP-cookie
+/// pile is worth - the retail engine stores an EXP cookie's module value as its
+/// stack count, `P$StackCoun`). A 4-byte signed int.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropStackCount(pub i32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropLimbModel(pub String);
 
@@ -1142,6 +1148,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$ExP",
             |reader, _len| read_i32(reader),
             PropExp,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$StackCoun",
+            |reader, _len| read_i32(reader),
+            PropStackCount,
             accumulator::latest,
         ),
         define_prop(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2334,7 +2334,14 @@ impl MissionCore {
                 }
 
                 Effect::AwardXP { amount } => {
-                    warn!("!! TODO !!: Award XP {}", amount);
+                    // Cyber modules are the game's upgrade currency (retail's
+                    // "XP"). Persisted on the character sheet inside QuestInfo,
+                    // so the balance survives level transitions + save/load.
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let balance = quests.player_stats_mut().award_cyber_modules(amount);
+                    if amount > 0 {
+                        info!("Awarded {} cyber modules (balance now {})", amount, balance);
+                    }
                 }
 
                 Effect::DrawDebugLines { lines } => {
@@ -4389,6 +4396,16 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 v_hearing.get(id).ok().map(|h| h.rating)
             });
 
+        // Cyber-module award sources (EXP traps carry `PropExp`, EXP-cookie
+        // piles carry a stack count), surfaced so automation can read the exact
+        // award before firing it. Looked up outside the main run (view limit).
+        let exp_value = self
+            .world
+            .run(|v: View<dark::properties::PropExp>| v.get(id).ok().map(|e| e.0));
+        let stack_count = self
+            .world
+            .run(|v: View<dark::properties::PropStackCount>| v.get(id).ok().map(|s| s.0));
+
         self.world.run(
             |v_pos: View<dark::properties::PropPosition>,
              v_sym_name: View<dark::properties::PropSymName>,
@@ -4443,6 +4460,21 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "Scripts".to_string(),
                         value: scripts.scripts.join(", "),
+                    });
+                }
+
+                // Cyber-module award amount (EXP trap `PropExp` / EXP-cookie
+                // stack count), so tests can read the exact award.
+                if let Some(exp) = exp_value {
+                    properties.push(DebugPropertyInfo {
+                        name: "Exp".to_string(),
+                        value: exp.to_string(),
+                    });
+                }
+                if let Some(stack) = stack_count {
+                    properties.push(DebugPropertyInfo {
+                        name: "StackCount".to_string(),
+                        value: stack.to_string(),
                     });
                 }
 

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -120,6 +120,15 @@ pub struct PlayerStats {
     pub psi_disciplines: Vec<String>,
     /// Training years (1..=3) whose tour reward has already been applied.
     pub granted_years: BTreeSet<u32>,
+    /// Cyber modules: the game's upgrade currency. The retail engine stores
+    /// these as the stack count of a hidden "fake cookie" inventory object
+    /// (`kEquipFakeCookies`); the pragmatic equivalent here is a persistent
+    /// counter beside the rest of the character sheet. Awarded by
+    /// `Effect::AwardXP` (quest/`PropExp` traps + `expcookie` pickups) and
+    /// spent at trainer stations. `#[serde(default)]` keeps saves written
+    /// before this field existed loadable (they load with 0 modules).
+    #[serde(default)]
+    pub cyber_modules: i32,
 }
 
 impl Default for PlayerStats {
@@ -136,6 +145,7 @@ impl Default for PlayerStats {
             skills: SkillLevels::zero(),
             psi_disciplines: Vec::new(),
             granted_years: BTreeSet::new(),
+            cyber_modules: 0,
         }
     }
 }
@@ -143,6 +153,15 @@ impl Default for PlayerStats {
 impl PlayerStats {
     pub fn new() -> PlayerStats {
         PlayerStats::default()
+    }
+
+    /// Award cyber modules (the upgrade currency). Negative or zero amounts are
+    /// ignored - awards only ever add. Returns the new balance.
+    pub fn award_cyber_modules(&mut self, amount: i32) -> i32 {
+        if amount > 0 {
+            self.cyber_modules = self.cyber_modules.saturating_add(amount);
+        }
+        self.cyber_modules
     }
 
     fn stat_mut(&mut self, stat: Stat) -> &mut i32 {
@@ -411,6 +430,31 @@ mod tests {
         assert!(!stats.apply_tour_reward(Career::Marine, 1, 1));
         assert!(!stats.apply_tour_reward(Career::Marine, 1, 0));
         assert_eq!(stats.strength, 3);
+    }
+
+    #[test]
+    fn cyber_modules_award() {
+        let mut stats = PlayerStats::new();
+        assert_eq!(stats.cyber_modules, 0);
+        assert_eq!(stats.award_cyber_modules(4), 4);
+        assert_eq!(stats.award_cyber_modules(3), 7);
+        // Non-positive awards are ignored.
+        assert_eq!(stats.award_cyber_modules(0), 7);
+        assert_eq!(stats.award_cyber_modules(-5), 7);
+    }
+
+    #[test]
+    fn cyber_modules_survive_serde_and_default_for_old_saves() {
+        let mut stats = PlayerStats::new();
+        stats.award_cyber_modules(12);
+        let json = serde_json::to_string(&stats).unwrap();
+        let back: PlayerStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.cyber_modules, 12);
+        // A save written before this field existed (no `cyber_modules` key)
+        // loads with the serde default of 0.
+        let legacy = r#"{"strength":1,"endurance":1,"agility":1,"psionic_ability":1,"cyber_affinity":1,"skills":{"standard_weapons":0,"energy_weapons":0,"heavy_weapons":0,"exotic_weapons":0,"hack":0,"repair":0,"modify":0,"maintenance":0,"research":0},"psi_disciplines":[],"granted_years":[]}"#;
+        let loaded: PlayerStats = serde_json::from_str(legacy).unwrap();
+        assert_eq!(loaded.cyber_modules, 0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/exp_cookie.rs
+++ b/shock2vr/src/scripts/exp_cookie.rs
@@ -1,0 +1,65 @@
+use dark::properties::{PropExp, PropStackCount};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// Cyber-module pickup ("fake cookie" in the retail source - the pickup script
+/// is literally named `expcookie`). Frobbing the module awards its worth of
+/// cyber modules to the player and removes the object from the world, mirroring
+/// [`super::trap_exp_once::TrapEXPOnce`] but driven by a player frob rather than
+/// a trap `TurnOn`.
+///
+/// The award amount is the object's stack count (`P$StackCoun` - the retail
+/// engine stores an EXP-cookie pile's module value as its stack count, e.g. the
+/// "10 EXP" pile has stack count 10), falling back to `P$ExP` for any
+/// cookie authored the trap way.
+pub struct ExpCookie {}
+
+impl ExpCookie {
+    pub fn new() -> ExpCookie {
+        ExpCookie {}
+    }
+}
+
+impl Script for ExpCookie {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob => {
+                let stack = world
+                    .borrow::<View<PropStackCount>>()
+                    .unwrap()
+                    .get(entity_id)
+                    .map(|p| p.0)
+                    .ok();
+                let award_amount = stack
+                    .filter(|&n| n > 0)
+                    .or_else(|| {
+                        world
+                            .borrow::<View<PropExp>>()
+                            .unwrap()
+                            .get(entity_id)
+                            .map(|p| p.0)
+                            .ok()
+                    })
+                    .unwrap_or(0);
+                Effect::Combined {
+                    effects: vec![
+                        Effect::AwardXP {
+                            amount: award_amount,
+                        },
+                        Effect::DestroyEntity { entity_id },
+                    ],
+                }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -15,6 +15,7 @@ mod cs9;
 mod dead_power_cell;
 mod destroy_all_by_name;
 mod energy_station;
+mod exp_cookie;
 mod frob_qb;
 mod gui;
 mod internal_collision_type;
@@ -97,6 +98,7 @@ use self::{
     dead_power_cell::DeadPowerCell,
     destroy_all_by_name::DestroyAllByName,
     energy_station::EnergyStation,
+    exp_cookie::ExpCookie,
     frob_qb::FrobQB,
     internal_collision_type::InternalCollisionType,
     internal_explosion::InternalExplosion,
@@ -600,10 +602,10 @@ impl ScriptWorld {
             "viralmodify" => Box::new(UnimplementedScript::new(&script_name)),
 
             //goodies:
-            "expcookie" => Box::new(UnimplementedScript::new(&script_name)), // cyber modules
+            "expcookie" => Box::new(ExpCookie::new()), // cyber modules
             "medkitscript" => Box::new(UnimplementedScript::new(&script_name)), // cyber modules
             "speedpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
-            "radpatch" => Box::new(UnimplementedScript::new(&script_name)),  // speed boost
+            "radpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
             "autoinstallsoft" => Box::new(UnimplementedScript::new(&script_name)), // auto install software
             "strboost" => Box::new(UnimplementedScript::new(&script_name)),        // strength boost
             "intboost" => Box::new(UnimplementedScript::new(&script_name)),

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -221,6 +221,11 @@ export interface PlayerStats {
   skills: SkillLevels;
   psi_disciplines: string[];
   granted_years: number[];
+  /** Cyber modules: the game's upgrade currency, awarded by quest/`PropExp`
+   * traps and module pickups, spent at trainer stations. Persists across level
+   * transitions and save/load. Defaults to 0 for saves written before the
+   * currency existed. */
+  cyber_modules: number;
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/cyber-modules.e2e.test.ts
+++ b/tools/shock2-sdk/test/cyber-modules.e2e.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+// End-to-end test for the cyber-module currency (flat UI 6d / PR C1). Requires
+// game assets in Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Cyber modules are the game's upgrade currency. Before PR C1, Effect::AwardXP
+// was a `warn!`-and-drop TODO and no balance existed anywhere. This test proves
+// the closed loop: a persistent balance on the character sheet, incremented by
+// the two real award sites (EXP traps via PropExp, EXP-cookie pickups via their
+// stack count), surviving save/load and a level transition.
+//
+// Negative-first: on main, info().stats has no `cyber_modules` field (undefined,
+// so the `=== 0` baseline assert fails) and TurnOn'ing the trap changes nothing.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8169);
+
+/** Read the property `name`'s integer value from an entity's detail, or null. */
+async function propInt(
+  game: GameServer,
+  id: number,
+  name: string,
+): Promise<number | null> {
+  const detail = await game.entities.detail(id);
+  const p = detail.properties.find((p) => p.name === name);
+  return p ? Number(p.value) : null;
+}
+
+/** The player's current cyber-module balance from /v1/info. */
+async function modules(game: GameServer): Promise<number | undefined> {
+  return (await game.info()).player.stats?.cyber_modules;
+}
+
+test(
+  "cyber modules: EXP traps + cookie pickups award a persistent balance",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `cyber_modules_e2e_${Date.now()}`;
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    // Baseline: a fresh character has zero cyber modules. (On main this field
+    // is absent -> undefined, so this assert fails: the negative test.)
+    assert.equal(await modules(game), 0, "fresh character starts with 0 modules");
+
+    // --- Award via an EXP trap (PropExp) ---
+    // Discover an Experience Trap by name (runtime ids are not stable), pick one
+    // that carries a positive PropExp, and read the exact award to assert on.
+    const { entities } = await game.entities.list({ filter: "Experience Trap" });
+    let trap: EntitySummary | undefined;
+    let trapExp = 0;
+    for (const e of entities) {
+      const exp = await propInt(game, e.id, "Exp");
+      if (exp && exp > 0) {
+        trap = e;
+        trapExp = exp;
+        break;
+      }
+    }
+    assert.ok(trap, "medsci1 should have an Experience Trap carrying PropExp");
+
+    await game.entities.sendMessage(trap.id, { type: "TurnOn" });
+    await game.step({ frames: 3 });
+    assert.equal(
+      await modules(game),
+      trapExp,
+      `TurnOn'ing the EXP trap awards its PropExp (${trapExp}) modules`,
+    );
+
+    // --- Award via an EXP-cookie pickup (stack count) ---
+    // Discover an ExpCookie pile carrying a positive stack count (its module
+    // worth). Runtime ids aren't stable, so find it by script + StackCount.
+    const expEntities = (await game.entities.list({ filter: "EXP" })).entities;
+    let cookie: EntitySummary | undefined;
+    let stack = 0;
+    for (const e of expEntities) {
+      const detail = await game.entities.detail(e.id);
+      const isCookie = detail.properties.some(
+        (p) => p.name === "Scripts" && p.value.includes("ExpCookie"),
+      );
+      const sc = detail.properties.find((p) => p.name === "StackCount");
+      if (isCookie && sc && Number(sc.value) > 0) {
+        cookie = e;
+        stack = Number(sc.value);
+        break;
+      }
+    }
+    assert.ok(cookie, "medsci1 should have an ExpCookie pile with a stack count");
+
+    await game.entities.sendMessage(cookie.id, { type: "Frob" });
+    await game.step({ frames: 3 });
+    const afterCookie = await modules(game);
+    assert.equal(
+      afterCookie,
+      trapExp + stack,
+      `frobbing the cookie awards its stack count (${stack}) on top of the trap`,
+    );
+
+    // --- Persists across save/load ---
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 3 });
+    assert.equal(
+      await modules(game),
+      afterCookie,
+      "the module balance survives save/load",
+    );
+
+    // --- Persists across a level transition ---
+    await game.transitionLevel("eng1.mis");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.info()).mission,
+      "eng1.mis",
+      "transition reached eng1",
+    );
+    assert.equal(
+      await modules(game),
+      afterCookie,
+      "the module balance survives a level transition",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Cyber modules are System Shock 2's upgrade currency (retail's "XP"). Before this change `Effect::AwardXP` was a `warn!`-and-drop TODO and no balance existed anywhere in the engine. This PR makes the currency real and persistent — the prerequisite for the trainer (C2) and O/S (C3) panels.

Part of the flat-UI panel wave (`projects/flat-ui-panels.md` §6, PR C1). First of the stacked C-track (C1 → C2 → C3).

## What changed

- **Persistent balance**: `PlayerStats` (inside `QuestInfo`) gains a `cyber_modules: i32` counter, so it rides the existing save/load + level-transition persistence path and is surfaced at `/v1/info` (+ SDK `PlayerStats.cyber_modules`) for free. `#[serde(default)]` keeps pre-existing saves loadable (they load with 0).
- **`Effect::AwardXP`** now increments the balance instead of warning. The existing `TrapEXPOnce` (`PropExp`) award sites — e.g. medsci1's Polito 4-module award — work day one.
- **`P$StackCoun` → `PropStackCount`**: parse the previously-unparsed 4-byte stack-count property, and implement the `expcookie` pickup script (was `UnimplementedScript`): frobbing a module pile awards its stack count (the retail model — an EXP-cookie pile's module worth is its stack count; falls back to `PropExp`) and destroys it.
- **Observability**: surface an entity's award amount (`Exp` / `StackCount`) in `/v1/entities/:id` detail so automation can assert the exact award.

## Verification

- **e2e** `cyber-modules.e2e.test.ts` (negative-first): on main `info().stats` has no `cyber_modules` (baseline assert fails). After: fresh char = 0 modules; TurnOn an EXP trap awards its `PropExp`; frob a cookie awards its stack count; the balance survives save/load **and** a level transition (medsci1 → eng1).
- `cargo test -p dark -p shock2vr` green; `missions.e2e.test.ts` 23/23 (property-parser change is safe); station-flow + save-load e2e green.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
- xreview (Claude + Codex): no Critical/High. Applied fixes: `saturating_add` on award; log guarded to `amount > 0`; deferred the unused `spend_cyber_modules` helper to C2 (its consumer).

## Deferred

- The BIOFULL HUD module counter (nanite/module readout) — introspection-only for now; the on-screen counter lands with the panels that spend modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)