### PR TITLE
feat(ui): elevator panel fidelity - labels, floor gating, current-floor (flat UI 6a)

### DIFF
--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -36,6 +36,12 @@ where
         /// a loot panel), carried through to the render info so debug
         /// introspection (`GET /v1/ui`) can label the element semantically.
         entity: Option<EntityId>,
+        /// An explicit semantic label for this button (e.g. an elevator floor
+        /// name), carried through to the render info so `GET /v1/ui` can report
+        /// what the button *means* - the generic labeling mechanism panels use
+        /// when their art name is not self-describing (unlike the keypad's
+        /// `key<c>.pcx` digits). `None` falls back to entity/art-derived labels.
+        label: Option<String>,
     },
     Text {
         position: Vector2<f32>,
@@ -75,6 +81,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
                 ..
             } => Self::Button {
                 alpha,
@@ -85,6 +92,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
             },
             Self::Text {
                 alpha,
@@ -124,6 +132,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
                 ..
             } => Self::Button {
                 alpha,
@@ -134,6 +143,7 @@ where
                 hover,
                 on_grab,
                 entity,
+                label,
             },
             Self::Text {
                 position,
@@ -161,6 +171,7 @@ where
                 hover,
                 alpha,
                 entity,
+                label,
                 ..
             } => GuiComponent::Button {
                 alpha,
@@ -171,6 +182,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
             },
             Self::Image {
                 alpha,
@@ -223,6 +235,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
                 ..
             } => Self::Button {
                 position,
@@ -233,6 +246,7 @@ where
                 hover,
                 alpha,
                 entity,
+                label,
             },
             Self::Text {
                 position,
@@ -273,6 +287,7 @@ where
                 on_click,
                 on_grab,
                 entity,
+                label,
                 ..
             } => Self::Button {
                 alpha,
@@ -283,6 +298,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
             },
             Self::Text {
                 position,
@@ -323,6 +339,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
                 ..
             } => Self::Button {
                 alpha,
@@ -333,6 +350,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                label,
             },
             Self::Text { .. } => self,
         }
@@ -349,6 +367,7 @@ where
                 on_click,
                 on_grab,
                 hover,
+                label,
                 ..
             } => Self::Button {
                 alpha,
@@ -359,6 +378,38 @@ where
                 on_grab,
                 hover,
                 entity: Some(new_entity),
+                label,
+            },
+            other => other,
+        }
+    }
+
+    /// Give a `Button` an explicit semantic label (no-op for other component
+    /// kinds) - surfaced by `GET /v1/ui` so clients click the button by meaning
+    /// (e.g. an elevator floor name) rather than by art name. See
+    /// `GuiComponent::Button::label`.
+    pub fn with_label(self, new_label: &str) -> GuiComponent<TEvent> {
+        match self {
+            Self::Button {
+                alpha,
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                entity,
+                ..
+            } => Self::Button {
+                alpha,
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                entity,
+                label: Some(new_label.to_owned()),
             },
             other => other,
         }
@@ -384,6 +435,7 @@ pub fn button<TMsg: Clone>(on_click: TMsg) -> GuiComponent<TMsg> {
         hover: ButtonHoverBehavior::None,
         alpha: 0.5,
         entity: None,
+        label: None,
     }
 }
 
@@ -397,6 +449,7 @@ pub fn grabbable<TMsg: Clone>(on_left_grab: TMsg, on_right_grab: TMsg) -> GuiCom
         hover: ButtonHoverBehavior::None,
         alpha: 0.5,
         entity: None,
+        label: None,
     }
 }
 
@@ -426,6 +479,10 @@ pub enum GuiComponentRenderInfo {
         /// a loot panel), if any. Purely informational - used by `GET /v1/ui`
         /// to label the element with the item's name and entity id.
         entity: Option<EntityId>,
+        /// An explicit semantic label from the source `Button` (e.g. an
+        /// elevator floor name), if any. Purely informational - used by
+        /// `GET /v1/ui`; takes precedence over entity/art-derived labels.
+        label: Option<String>,
     },
     Text {
         position: Vector2<f32>,
@@ -552,6 +609,7 @@ where
                 alpha: *alpha,
                 interactive: false,
                 entity: None,
+                label: None,
             },
             GuiComponent::Button {
                 position,
@@ -562,6 +620,7 @@ where
                 on_click,
                 on_grab,
                 entity,
+                label,
             } => {
                 let is_hovered = is_in_bounds(position, size, screen_space_cursor);
 
@@ -584,6 +643,7 @@ where
                     alpha: *alpha,
                     interactive: on_click.is_some() || on_grab.is_some(),
                     entity: *entity,
+                    label: label.clone(),
                 }
             }
         }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -632,21 +632,27 @@ impl FlatUiHost {
                     texture,
                     interactive,
                     entity,
+                    label,
                     ..
                 } => (
                     if *interactive { "button" } else { "image" },
                     Some(texture.clone()),
                     None,
-                    if let Some(entity) = entity {
-                        // Fall back to the art-derived label for entity-bound
-                        // items with no symbolic name, so every loot element
-                        // stays clickable by meaning.
-                        entity_label(world, *entity).or_else(|| semantic_label(texture))
-                    } else if *interactive {
-                        semantic_label(texture)
-                    } else {
-                        None
-                    },
+                    // Label precedence: an explicit panel-supplied label (e.g.
+                    // an elevator floor name) wins, then the bound entity's
+                    // symbolic name (loot items), then the art-derived fallback
+                    // for clickables (keypad digits). This keeps every
+                    // interactive element addressable by meaning in `/v1/ui`.
+                    label
+                        .clone()
+                        .or_else(|| (*entity).and_then(|e| entity_label(world, e)))
+                        .or_else(|| {
+                            if *interactive {
+                                semantic_label(texture)
+                            } else {
+                                None
+                            }
+                        }),
                     entity.map(|e| e.inner() as i32),
                 ),
                 GuiComponentRenderInfo::Text { text, .. } => {
@@ -862,6 +868,7 @@ mod tests {
             alpha: 0.5,
             interactive: true,
             entity: None,
+            label: None,
         };
         let r = component_canvas_rect(&info, panel);
         assert!((r.x - 17.0).abs() < 1e-3);
@@ -904,6 +911,7 @@ mod tests {
             alpha: 0.5,
             interactive: false,
             entity: None,
+            label: None,
         };
         assert!(is_gui_cursor(&cursor));
         let backdrop = GuiComponentRenderInfo::Image {
@@ -913,6 +921,7 @@ mod tests {
             alpha: 0.5,
             interactive: false,
             entity: None,
+            label: None,
         };
         assert!(!is_gui_cursor(&backdrop));
     }
@@ -975,6 +984,7 @@ mod tests {
                 alpha: 0.5,
                 interactive: true,
                 entity: Some(item),
+                label: None,
             }],
         );
         let elements = host.debug_elements(&world);
@@ -1123,6 +1133,7 @@ mod tests {
                     alpha: 0.5,
                     interactive: false,
                     entity: None,
+                    label: None,
                 },
                 GuiComponentRenderInfo::Image {
                     position: vec2(4.0 / 635.0, 18.0 / 120.0),
@@ -1131,6 +1142,7 @@ mod tests {
                     alpha: 0.5,
                     interactive: true,
                     entity: Some(wrench),
+                    label: None,
                 },
             ],
         );
@@ -1175,6 +1187,7 @@ mod tests {
             alpha: 0.5,
             interactive: true,
             entity: Some(entity),
+            label: None,
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -579,6 +579,10 @@ impl MissionCore {
 
         world.add_unique(quest_info);
 
+        // Preload the elevator floor labels (MISC.STR) + current mission so the
+        // AssetCache-less ElevatorGui can label/gate floors at draw time.
+        world.add_unique(crate::scripts::ElevatorContext::load(asset_cache, &mission));
+
         world.add_unique(EffectQueue {
             effects: Vec::new(),
         });

--- a/shock2vr/src/scripts/gui/elevator.rs
+++ b/shock2vr/src/scripts/gui/elevator.rs
@@ -1,12 +1,96 @@
 use cgmath::{Vector2, Vector3, vec2};
 
-use shipyard::{EntityId, World};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{EntityId, Unique, UniqueView, World};
 
-use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::gui::{ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::quest_info::QuestInfo;
 
 use crate::gui;
 
 use crate::scripts::Effect;
+
+/// The five main-tram elevator stops, decoded from the gamesys `Elev` file-var
+/// (`Eng1, medsci1, Hydro2, ops2, Rec1` - projects/flat-ui-panels.md §2.1),
+/// index 0 = deck 1. Kept as a verified hardcode with this citation; the
+/// gamesys param reader that would source it lands with the trainer PR (§7.1
+/// PR C2). Deck 6 (the Rec<->Command tram) is a separate elevator, never on
+/// this 5-floor panel.
+const ELEVATOR_STOPS: [&str; 5] = [
+    "eng1.mis",
+    "medsci1.mis",
+    "hydro2.mis",
+    "ops2.mis",
+    "rec1.mis",
+];
+
+/// English fallbacks for the MISC.STR `ElevLevel<n>` floor labels, used when a
+/// data install lacks the string table (verbatim from retail MISC.STR).
+const FALLBACK_FLOOR_LABELS: [&str; 5] = [
+    "Engineering (1)",
+    "Med / Sci (2)",
+    "Hydroponics (3)",
+    "Operations (4)",
+    "Recreational (5)",
+];
+
+/// English fallback for MISC.STR `ElevBlocked`.
+const FALLBACK_BLOCKED_LABEL: &str = "Error!  Shaft inaccessible!";
+
+/// Preloaded elevator-panel data, stored as a world `Unique` because
+/// `Gui::get_components` has no `AssetCache` to read MISC.STR from at draw
+/// time. Populated once at mission load (`MissionCore::load`).
+#[derive(Unique, Clone, Debug)]
+pub struct ElevatorContext {
+    /// Current mission basename (e.g. "medsci1.mis"), to light the current
+    /// floor's button (force-lit + inert, matching the original).
+    pub current_level: String,
+    /// MISC.STR `ElevLevel1..5` floor labels (index 0 = deck 1 = Engineering).
+    pub floor_labels: [String; 5],
+    /// MISC.STR `ElevBlocked` ("Error!  Shaft inaccessible!").
+    pub blocked_label: String,
+}
+
+impl ElevatorContext {
+    /// Read the elevator floor strings from MISC.STR (falling back to the
+    /// verified English defaults when absent) and record the current mission.
+    pub fn load(asset_cache: &mut AssetCache, current_level: &str) -> ElevatorContext {
+        let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "misc.str");
+        let lookup = |key: &str, fallback: &str| -> String {
+            strings
+                .as_ref()
+                .and_then(|s| s.get(&key.to_ascii_lowercase()).cloned())
+                .unwrap_or_else(|| fallback.to_owned())
+        };
+        let floor_labels = std::array::from_fn(|i| {
+            lookup(&format!("ElevLevel{}", i + 1), FALLBACK_FLOOR_LABELS[i])
+        });
+        let blocked_label = lookup("ElevBlocked", FALLBACK_BLOCKED_LABEL);
+        ElevatorContext {
+            current_level: current_level.to_owned(),
+            floor_labels,
+            blocked_label,
+        }
+    }
+}
+
+/// Whether a floor (`deck` 1..=5) is reachable given the `ElevState` quest bit
+/// (raw value). The original gates the panel on `ElevState`: 0 = no power,
+/// 1 = partial ("worm goo") lockout, 2 = fully accessible
+/// (projects/flat-ui-panels.md §2.1).
+///
+/// We deliberately treat the **unset/0 default as fully accessible** rather
+/// than "no power": the shipped, hands-on-verified behavior is an ungated
+/// elevator, and shipping ungated is "strictly more playable" (doc §7.3 #2).
+/// Only an explicit partial-lockout value (`INCOMPLETE`, raw 1) gates - it
+/// seals deck 1 (Engineering), leaving decks >= 2 reachable, matching the
+/// original's "only buttons >= deck 2 work" rule.
+fn is_floor_available(elev_state: u32, deck: usize) -> bool {
+    match elev_state {
+        1 => deck >= 2,
+        _ => true,
+    }
+}
 
 pub struct ElevatorGui;
 
@@ -23,7 +107,7 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
         &self,
         _cursor: &Option<GuiCursor>,
         _entity_id: EntityId,
-        _world: &World,
+        world: &World,
         _state: &ElevatorGuiState,
     ) -> Vec<GuiComponent<ElevatorGuiMsg>> {
         let button_height = 54.0;
@@ -32,13 +116,31 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
         let button_width = 142.0;
         let button_padding = 4.0;
 
-        let stops = vec![
-            ("rec1.mis", "elev50.pcx", "elev51.pcx", "5: Recreation"),
-            ("ops2.mis", "elev40.pcx", "elev41.pcx", "4: Operations"),
-            ("hydro2.mis", "elev30.pcx", "elev31.pcx", "3: Hydropondics"),
-            ("medsci1.mis", "elev20.pcx", "elev21.pcx", "2: Med/Sci"),
-            ("eng1.mis", "elev10.pcx", "elev11.pcx", "1: Engineering"),
-        ];
+        // Floor labels + the current mission come from the preloaded context
+        // (MISC.STR is unreachable here - no AssetCache). Missing context (e.g.
+        // a debug scene that never loads it) falls back to the English labels.
+        let (floor_labels, blocked_label, current_level) = world
+            .borrow::<UniqueView<ElevatorContext>>()
+            .map(|ctx| {
+                (
+                    ctx.floor_labels.clone(),
+                    ctx.blocked_label.clone(),
+                    ctx.current_level.clone(),
+                )
+            })
+            .unwrap_or_else(|_| {
+                (
+                    FALLBACK_FLOOR_LABELS.map(|s| s.to_owned()),
+                    FALLBACK_BLOCKED_LABEL.to_owned(),
+                    String::new(),
+                )
+            });
+
+        // ElevState quest bit (raw): 1 = partial lockout, else accessible.
+        let elev_state = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|q| q.read_quest_bit_value("ElevState").bits())
+            .unwrap_or(0);
 
         let mut components: Vec<GuiComponent<ElevatorGuiMsg>> = vec![
             gui::image("elev.pcx")
@@ -46,23 +148,52 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
                 .with_size(vec2(188.0, 296.0)),
         ];
 
-        for (i, (level, up_texture, _down_texture, label)) in stops.iter().enumerate() {
-            let button_y = initial_padding_y + (button_height + button_padding) * i as f32;
+        // Top button = deck 5, bottom = deck 1 (the original's index-inverted
+        // layout). Row 0 is the topmost button.
+        for (row, deck) in (1..=5usize).rev().enumerate() {
+            let floor_index = deck - 1;
+            let level = ELEVATOR_STOPS[floor_index];
+            let label = &floor_labels[floor_index];
+            let up_texture = format!("elev{deck}0.pcx");
+            let on_texture = format!("elev{deck}1.pcx");
+
+            let button_y = initial_padding_y + (button_height + button_padding) * row as f32;
             let button_x = initial_padding_x;
+            let position = vec2(button_x, button_y);
+            let size = vec2(button_width, button_height);
 
-            components.push(
-                gui::button(ElevatorGuiMsg::ButtonPressed((*level).to_owned()))
-                    .with_position(vec2(button_x, button_y))
-                    .with_size(vec2(button_width, button_height))
-                    .with_image(up_texture), //.with_hover_texture((*down_texture).to_owned()),
-            );
+            let is_current = level.eq_ignore_ascii_case(&current_level);
+            let available = is_floor_available(elev_state, deck);
 
-            components.push(
-                gui::text(label.to_owned())
-                    .with_position(vec2(button_x + 60.0, button_y + 30.0))
-                    .with_size(vec2(100.0, 20.0))
-                    .with_alpha(0.7),
-            );
+            if is_current {
+                // Current floor: force the lit bitmap and make it inert (no
+                // transition) - you can't ride to the deck you're on.
+                components.push(
+                    gui::image(&on_texture)
+                        .with_position(position)
+                        .with_size(size),
+                );
+                components.push(floor_text(label, position));
+            } else if available {
+                components.push(
+                    gui::button(ElevatorGuiMsg::ButtonPressed(level.to_owned()))
+                        .with_position(position)
+                        .with_size(size)
+                        .with_image(&up_texture)
+                        .with_hover(ButtonHoverBehavior::Texture(on_texture.clone()))
+                        .with_label(label),
+                );
+                components.push(floor_text(label, position));
+            } else {
+                // Blocked by the partial-power lockout: inert, showing the
+                // ElevBlocked message in place of the floor name.
+                components.push(
+                    gui::image(&up_texture)
+                        .with_position(position)
+                        .with_size(size),
+                );
+                components.push(floor_text(&blocked_label, position));
+            }
         }
 
         components
@@ -91,6 +222,41 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
                     entities_to_trigger: vec![],
                 }),
             ),
+        }
+    }
+}
+
+/// The floor-name text drawn inside a button (`TEXT_X 60` from the original,
+/// projects/flat-ui-panels.md §2.1).
+fn floor_text(label: &str, button_position: Vector2<f32>) -> GuiComponent<ElevatorGuiMsg> {
+    gui::text(label)
+        .with_position(vec2(button_position.x + 60.0, button_position.y + 30.0))
+        .with_size(vec2(100.0, 20.0))
+        .with_alpha(0.7)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_and_full_power_unlock_every_floor() {
+        // Unset (0) and fully-powered (COMPLETE, 2) leave every deck reachable -
+        // the shipped playable behavior.
+        for state in [0u32, 2] {
+            for deck in 1..=5 {
+                assert!(is_floor_available(state, deck), "state {state} deck {deck}");
+            }
+        }
+    }
+
+    #[test]
+    fn partial_lockout_seals_only_engineering() {
+        // INCOMPLETE (1) is the "worm goo" partial lockout: deck 1 sealed,
+        // decks >= 2 reachable.
+        assert!(!is_floor_available(1, 1));
+        for deck in 2..=5 {
+            assert!(is_floor_available(1, deck), "deck {deck} should stay open");
         }
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -80,6 +80,10 @@ use crate::gui::gui_script;
 
 use self::choose_mission::ChooseMissionScript;
 use self::choose_service::ChooseServiceScript;
+/// Preloaded elevator floor labels (from MISC.STR) + current mission, added as
+/// a world unique at mission load so the (`AssetCache`-less) `ElevatorGui` can
+/// read them at draw time.
+pub use self::gui::ElevatorContext;
 use self::gui::{ContainerGui, ElevatorGui, GamePigGui, KeyPadGui, ReplicatorGui};
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::psi_amp_script::PsiAmpScript;

--- a/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiState } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for the flat-mode elevator MFD (projects/flat-ui-panels.md
+// §2, PR A - "flat UI 6a"): frobbing the medsci1 Master Elevator Button opens
+// ElevatorGui in the left MFD, whose floor buttons are now semantically
+// labeled from MISC.STR (`ElevLevel<n>`), the current deck is lit + inert, and
+// floors gate on the `ElevState` quest bit. Clicking an available floor
+// transitions the game to that mission (marker StartLoc 22).
+//
+// Entity discovery is by NAME at run time (runtime entity ids are NOT stable
+// across launches): the "Master Elevator Button" (medsci1 mission id 1041,
+// script ElevatorButton). The floor labels/decks are global data (the gamesys
+// `Elev` file-var), so the button carries no floor links.
+//
+// Negative-first: on main the floor buttons render with `label: null` (the
+// host only knew the keypad's art-derived labels), so the "button labeled
+// 'Engineering (1)'" assertion fails; the fix adds the generic button-label
+// field + MISC.STR floor names.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The five floor labels ElevatorGui reads from MISC.STR (deck 1..5). Med / Sci
+// (deck 2) is the current floor in medsci1 - lit + inert, never a button.
+const ENGINEERING = "Engineering (1)";
+const OPERATIONS = "Operations (4)";
+
+const floorButton = (state: UiState, label: string): UiElement | undefined =>
+  state.active_panel?.elements.find(
+    (e) => e.kind === "button" && e.label === label,
+  );
+
+test(
+  "flat elevator MFD: labeled floors, current-floor inert, ElevState gating, click transitions",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8163),
+    });
+    await game.step({ frames: 5 });
+
+    const uiState = () => game.ui.state();
+
+    // --- Discover the Master Elevator Button by name ---
+    const buttons = (
+      await game.entities.list({ filter: "Master Elevator Button", limit: 20 })
+    ).entities;
+    assert.ok(
+      buttons.length > 0,
+      "medsci1 should contain a 'Master Elevator Button'",
+    );
+    const buttonId = buttons[0].id;
+    const button = await game.entities.detail(buttonId);
+
+    // --- Get the player next to the button (within the 4u auto-close radius) ---
+    const [bx, by, bz] = button.position;
+    await teleportVerified(game, { x: bx + 1.0, y: by + 0.5, z: bz + 1.0 });
+    await game.step({ frames: 10 });
+
+    const before = await uiState();
+    assert.ok(
+      !before.active_panel,
+      "no panel should be active before frobbing the elevator button",
+    );
+    await game.screenshot("elevator-before-frob.png");
+
+    // --- Frob: the elevator panel must open, bound to the button ---
+    await game.entities.sendMessage(buttonId, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const opened = await uiState();
+    assert.ok(
+      opened.active_panel,
+      `frobbing the elevator button should open its MFD panel (got ${JSON.stringify(opened)})`,
+    );
+    assert.equal(
+      opened.active_panel.entity_id,
+      buttonId,
+      "the active panel should be bound to the elevator button entity",
+    );
+
+    // --- Floor buttons must be semantically labeled (THE fix; negative on main) ---
+    assert.ok(
+      floorButton(opened, ENGINEERING),
+      `panel should expose a floor button labeled "${ENGINEERING}" (on main labels are null)`,
+    );
+    assert.ok(
+      floorButton(opened, OPERATIONS),
+      `panel should expose a floor button labeled "${OPERATIONS}"`,
+    );
+    // The current deck (Med / Sci, deck 2) is lit + inert - never a clickable
+    // button.
+    assert.ok(
+      !floorButton(opened, "Med / Sci (2)"),
+      "the current floor should be inert (not a clickable button)",
+    );
+    await game.screenshot("elevator-panel-open.png");
+
+    // --- Gating: ElevState = INCOMPLETE seals deck 1 (Engineering) ---
+    await game.quests.set("ElevState", "incomplete");
+    await game.step({ frames: 5 });
+    const gated = await uiState();
+    assert.ok(gated.active_panel, "panel should stay open across the gate change");
+    assert.ok(
+      !floorButton(gated, ENGINEERING),
+      "with ElevState=incomplete, Engineering (deck 1) must be sealed (no button)",
+    );
+    assert.ok(
+      floorButton(gated, OPERATIONS),
+      "with ElevState=incomplete, decks >= 2 (e.g. Operations) stay available",
+    );
+    await game.screenshot("elevator-panel-gated.png");
+
+    // --- Ungate and click Engineering: the game transitions to eng1.mis ---
+    await game.quests.set("ElevState", "unknown");
+    await game.step({ frames: 5 });
+    const ungated = await uiState();
+    const engineering = floorButton(ungated, ENGINEERING);
+    assert.ok(
+      engineering,
+      "ungating should restore the Engineering floor button",
+    );
+
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "should still be on medsci1 before clicking a floor",
+    );
+
+    const [rx, ry, rw, rh] = engineering.screen_rect;
+    await game.input.set("pointer.position", [rx + rw / 2, ry + rh / 2]);
+    await game.step({ frames: 2 }); // hover (edge detection needs a prior unpressed frame)
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).mission,
+      "eng1.mis",
+      "clicking the Engineering floor should transition to eng1.mis",
+    );
+    await game.screenshot("elevator-arrived-eng1.png");
+  },
+);


### PR DESCRIPTION
Fidelity polish for the flat-mode **elevator MFD** (`projects/flat-ui-panels.md` §2, PR A — "flat UI 6a"), plus the shared **button-label groundwork** the later panel-wave PRs build their `/v1/ui` labels on. This is the track that lands first.

The elevator already worked end-to-end on main (frob the Master Elevator Button → panel opens → click a floor → transition). This PR is the fidelity + labels + durable e2e the design note calls for.

## Shared groundwork (what the other tracks build on)

- Adds an explicit `label: Option<String>` to `GuiComponent::Button` and `GuiComponentRenderInfo::Image`, with a `with_label(&str)` builder.
- `FlatUiHost`'s `/v1/ui` element labeling now resolves in precedence order: **explicit label → bound entity's symbolic name → keypad art-derived fallback**. So any clickable panel element can be addressed by meaning; the keypad's existing digit labels are unchanged.

## Elevator

- **Floor names from `MISC.STR` `ElevLevel<n>`** (were hardcoded, and had a "Hydropondics" typo). Loaded into a new `ElevatorContext` world unique at `MissionCore::load`, because `Gui::get_components` has no `AssetCache` at draw time. Falls back to the verified English strings if the table is absent.
- **Current deck is force-lit and inert** — you can't ride to the floor you're on (medsci1 = Med / Sci, deck 2).
- **`ElevState` quest-bit gating.** An explicit partial-lockout value (`INCOMPLETE`) seals deck 1 (Engineering), leaving decks ≥ 2 open — the original's "worm goo" rule. The **unset default and full-power (`COMPLETE`) leave every floor open**, preserving the shipped, hands-on-verified ungated behavior (design note §7.3 #2: which script sets `ElevState` in real data is unverified, and shipping ungated is strictly more playable — treating the pristine 0 as "no power / all locked" would make the elevator unusable in a normal playthrough since no implemented script sets the bit).
- **Hover art** (`elev<f>1.pcx`) re-enabled on available floor buttons.
- Floor buttons now carry a `/v1/ui` `label` (the floor name), so automation clicks a floor by meaning.

## Tests

- **Unit** (`is_floor_available`): default/full-power open every floor; partial lockout seals only Engineering.
- **e2e `elevator-panel.e2e.test.ts`** (negative-first, ports 8163–8165): frob the Master Elevator Button (discovered by name) → `/v1/ui` exposes floor buttons labeled `"Engineering (1)"` etc.; `ElevState=incomplete` seals Engineering (button disappears) while `Operations (4)` stays; ungate + click Engineering → `/v1/info` mission becomes `eng1.mis`.
  - **Negative on main** (fix stashed): the test fails at *"panel should expose a floor button labeled 'Engineering (1)'"* — the panel opens but floor labels are null.
  - **Positive** (fix): green.

## Validation

- `cargo fmt --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr --lib` — 137 passed.
- SDK `npm test` — green. Flat-UI e2es (keypad, flat-ui-plumbing, flat-hud, inventory-strip, inventory-drag, container-loot) — green. `missions.e2e.test.ts` — 23/23 load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Visuals

Flat-mode elevator MFD fidelity: frobbing the medsci1 Master Elevator Button opens `ElevatorGui` in the left MFD with semantically-labeled floor buttons (Recreational [5], Operations [4], Hydroponics [3], Engineering [1]), the current deck **Med / Sci [2]** lit + inert, and clicking a floor transitions the game to that mission.

![elevator MFD flow](https://gist.githubusercontent.com/tommy-xr/bcc0ed2522329a616d45167653758ca7/raw/demo.gif)

<sub>Approach the elevator alcove → frob opens the labeled-floor panel (current deck lit) → click **Engineering [1]** → arrive in eng1. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Panel still (all five decks labeled from MISC.STR, Med / Sci lit as current floor):

![elevator panel still](https://gist.githubusercontent.com/tommy-xr/bcc0ed2522329a616d45167653758ca7/raw/elevator_still.png)
