### PR TITLE
fix(anim): engage authored blends from a drained queue, cosine easing

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -104,19 +104,40 @@ impl AnimationPlayer {
             .animation
             .push_front((animation.clone(), AnimationFlags::PlayOnce));
 
-        let blend_state = if let Some((current_clip, flags)) = player.animation.first() {
-            let duration = animation.blend_length.as_secs_f32();
-            if duration > 0.0 {
-                Some(BlendState {
-                    from_clip: current_clip.clone(),
-                    from_frame: player.current_frame as f32,
-                    from_looping: matches!(flags, AnimationFlags::Loop),
-                    duration,
-                    elapsed: 0.0,
+        // Fade from the playing clip, or - when the queue already drained (the
+        // normal case for AI clips, whose completion handler queues the next
+        // clip one tick after the previous one finished) - from the frozen
+        // last-frame pose that get_transforms has been showing. Without the
+        // fallback a clip's authored blend_length only ever applied to
+        // interruptions, so e.g. idle cycling (500ms authored) hard-popped.
+        let duration = animation.blend_length.as_secs_f32();
+        let blend_from = player
+            .animation
+            .first()
+            .map(|(clip, flags)| {
+                (
+                    clip.clone(),
+                    player.current_frame as f32,
+                    matches!(flags, AnimationFlags::Loop),
+                )
+            })
+            .or_else(|| {
+                player.last_animation.as_ref().map(|clip| {
+                    (
+                        clip.clone(),
+                        clip.num_frames.saturating_sub(1) as f32,
+                        false,
+                    )
                 })
-            } else {
-                None
-            }
+            });
+        let blend_state = if duration > 0.0 {
+            blend_from.map(|(from_clip, from_frame, from_looping)| BlendState {
+                from_clip,
+                from_frame,
+                from_looping,
+                duration,
+                elapsed: 0.0,
+            })
         } else {
             None
         };
@@ -435,7 +456,11 @@ impl AnimationPlayer {
 
         if let Some(blend) = &self.blend_state {
             if blend.duration > f32::EPSILON && blend.elapsed < blend.duration {
-                let alpha = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
+                // Raised-cosine ease-in/ease-out rather than linear - a linear
+                // ramp starts and stops the correction abruptly, which reads
+                // as two small hitches bracketing the fade.
+                let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
+                let alpha = (1.0 - (std::f32::consts::PI * t).cos()) / 2.0;
                 let frame = if blend.from_clip.num_frames > 0 {
                     (blend.from_frame.floor() as u32) % blend.from_clip.num_frames
                 } else {
@@ -628,6 +653,41 @@ mod tests {
             "final frame should keep the stride rate, not drop to zero: {:?}",
             clip.root_velocity_at(2)
         );
+    }
+
+    #[test]
+    fn queued_clip_blends_from_drained_queues_last_pose() {
+        // Complete a clip so the queue drains and last_animation holds the
+        // final pose (the normal state when the AI's completion handler
+        // queues the next clip one tick later).
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+        let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(300));
+        assert!(player.snapshot().queue.is_empty());
+        assert!(player.snapshot().last_clip.is_none()); // clip is unnamed
+        assert!(player.last_animation.is_some());
+
+        // A clip with an authored blend must fade from that last pose...
+        let mut blending_clip = (*clip_with_root_motion()).clone();
+        blending_clip.blend_length = Duration::from_millis(500);
+        let player = AnimationPlayer::queue_animation(&player, Rc::new(blending_clip));
+        let blend = player.snapshot().blend.expect(
+            "authored blend_length must engage from the drained queue's last pose, not only on interruptions",
+        );
+        assert!((blend.duration - 0.5).abs() < 1e-6);
+        // ...from the final frame of the completed clip.
+        assert!((blend.from_frame - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn zero_blend_clip_still_hard_cuts() {
+        // Stride clips author blend_length 0 (the pose lines up by design);
+        // they must not acquire a synthetic fade.
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+        let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(300));
+        let player = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
+        assert!(player.snapshot().blend.is_none());
     }
 
     #[test]

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -111,33 +111,16 @@ impl AnimationPlayer {
         // fallback a clip's authored blend_length only ever applied to
         // interruptions, so e.g. idle cycling (500ms authored) hard-popped.
         let duration = animation.blend_length.as_secs_f32();
-        let blend_from = player
-            .animation
-            .first()
-            .map(|(clip, flags)| {
-                (
-                    clip.clone(),
-                    player.current_frame as f32,
-                    matches!(flags, AnimationFlags::Loop),
-                )
-            })
-            .or_else(|| {
-                player.last_animation.as_ref().map(|clip| {
-                    (
-                        clip.clone(),
-                        clip.num_frames.saturating_sub(1) as f32,
-                        false,
-                    )
+        let blend_state = if duration > f32::EPSILON {
+            player
+                .blend_from()
+                .map(|(from_clip, from_frame, from_looping)| BlendState {
+                    from_clip,
+                    from_frame,
+                    from_looping,
+                    duration,
+                    elapsed: 0.0,
                 })
-            });
-        let blend_state = if duration > 0.0 {
-            blend_from.map(|(from_clip, from_frame, from_looping)| BlendState {
-                from_clip,
-                from_frame,
-                from_looping,
-                duration,
-                elapsed: 0.0,
-            })
         } else {
             None
         };
@@ -153,6 +136,30 @@ impl AnimationPlayer {
         }
     }
 
+    /// The pose a new clip should cross-fade from: the playing queue head at
+    /// its current frame, or - when the queue already drained - the frozen
+    /// final frame of `last_animation` (what `get_transforms` is showing).
+    fn blend_from(&self) -> Option<(Rc<AnimationClip>, f32, bool)> {
+        self.animation
+            .first()
+            .map(|(clip, flags)| {
+                (
+                    clip.clone(),
+                    self.current_frame as f32,
+                    matches!(flags, AnimationFlags::Loop),
+                )
+            })
+            .or_else(|| {
+                self.last_animation.as_ref().map(|clip| {
+                    (
+                        clip.clone(),
+                        clip.num_frames.saturating_sub(1) as f32,
+                        false,
+                    )
+                })
+            })
+    }
+
     /// Play `animation` immediately, replacing the whole queue (unlike
     /// `queue_animation`, which pushes on top and lets interrupted clips
     /// resume later). Cross-fades from the interrupted pose over the clip's
@@ -164,40 +171,21 @@ impl AnimationPlayer {
     ) -> AnimationPlayer {
         const MIN_INTERRUPT_BLEND_SECS: f32 = 0.15;
 
-        // Fade from the playing clip's current pose, or from the frozen
-        // last-frame pose when the queue already drained. Known limit: an
-        // interrupt landing mid-blend fades from the head clip's pure pose,
-        // not the blended one on screen - a small pop proportional to how
-        // fresh the interrupted blend was.
-        let blend_from = player
-            .animation
-            .first()
-            .map(|(clip, flags)| {
-                (
-                    clip.clone(),
-                    player.current_frame as f32,
-                    matches!(flags, AnimationFlags::Loop),
-                )
-            })
-            .or_else(|| {
-                player.last_animation.as_ref().map(|clip| {
-                    (
-                        clip.clone(),
-                        clip.num_frames.saturating_sub(1) as f32,
-                        false,
-                    )
-                })
+        // Known limit: an interrupt landing mid-blend fades from the head
+        // clip's pure pose, not the blended one on screen - a small pop
+        // proportional to how fresh the interrupted blend was.
+        let blend_state = player
+            .blend_from()
+            .map(|(from_clip, from_frame, from_looping)| BlendState {
+                from_clip,
+                from_frame,
+                from_looping,
+                duration: animation
+                    .blend_length
+                    .as_secs_f32()
+                    .max(MIN_INTERRUPT_BLEND_SECS),
+                elapsed: 0.0,
             });
-        let blend_state = blend_from.map(|(from_clip, from_frame, from_looping)| BlendState {
-            from_clip,
-            from_frame,
-            from_looping,
-            duration: animation
-                .blend_length
-                .as_secs_f32()
-                .max(MIN_INTERRUPT_BLEND_SECS),
-            elapsed: 0.0,
-        });
 
         AnimationPlayer {
             additional_joint_transforms: player.additional_joint_transforms.clone(),


### PR DESCRIPTION
## Summary

Fix #2 of the animation-smoothness stack (stacked on #464). Two changes in `AnimationPlayer`:

1. **Authored blends now engage at normal clip seams.** `queue_animation` only blended when it interrupted a *playing* clip — but AI clips virtually never interrupt: the completion handler queues the next clip one tick after the previous finishes, so the queue is drained and the authored `blend_length` was silently skipped. It now falls back to blending from `last_animation`'s final frame (the exact pose `get_transforms` was showing), the same fallback `play_animation` already had. Idle clips author 500 ms blends that never ran — every idle clip change hard-popped up to 1.5 world units.
2. **Raised-cosine blend easing** instead of linear (ease-in/ease-out) — a linear ramp starts and stops the pose correction abruptly, which reads as two small hitches bracketing the fade. Applies to interrupt blends too.

Deliberately **not** added: a synthetic minimum blend for zero-blend clips. Stride clips (`ogsrunl`/`ogsrunr`) author 0 ms by design — left/right strides line up pose-for-pose — and the reference behavior also hard-cuts same-schema strides. The measurement confirms walking is unaffected; its remaining seam delta is a phase-reset timing hiccup (next PR in the stack).

## Measured impact (medsci1 pipe hybrid, `npm run anim-smoothness`, deterministic fixed 60 Hz)

| idle | before | after |
|---|---|---|
| clip-cycle pops | 4 per 10 s, max **1.50** units | **0** — max frame delta 0.163 |
| mean max-joint jerk | 0.130 | 0.108 |

Walking metrics unchanged (max 0.7515 identical), as intended.

## Validation

- Two new unit tests: authored blend engages from a drained queue (fails without the fix); zero-blend clips still hard-cut. 25/25 `dark` lib tests pass.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean, `cargo fmt`
- Full e2e + cross-engine review + visuals: running, results to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

BEFORE (`origin/main`) vs AFTER (this PR), medsci1 idle pipe hybrid, captured headlessly via the debug runtime (deterministic fixed 60 Hz; identical clip-change frames on both builds). Watch the right arm at the `ogsidle4`→`oggidle1` seam (~8.2 s in): BEFORE snaps the pose in a single frame (measured 1.50-unit max-joint jump); AFTER cross-fades over 500 ms (max 0.16).

**Slow-motion (~7×) of the worst seam** — the single-frame snap is unmistakable on the left, smooth on the right:

![seam-blend slow-motion before/after](https://gist.githubusercontent.com/tommy-xr/ec747256770cdbe24dffb70b5493675e/raw/seam_blend_slowmo.gif)

**Real-time** (covers two idle transitions, ~5.5 s) — the BEFORE snap reads as a quick jerk, AFTER is continuous:

![seam-blend real-time before/after](https://gist.githubusercontent.com/tommy-xr/ec747256770cdbe24dffb70b5493675e/raw/seam_blend_realtime.gif)

**Still, same sim frame mid-transition** — BEFORE has already hard-snapped the arm/knife up; AFTER is mid cross-fade:

![seam-blend still before/after](https://gist.githubusercontent.com/tommy-xr/ec747256770cdbe24dffb70b5493675e/raw/seam_blend_still.png)

<sub>Verified over HTTP: on AFTER, `GET /v1/entities/:id/animation` reports `blend != null` (duration 0.5 s) at every idle clip change; on `origin/main` the same field is `null` — the authored blend never engaged.</sub>
