### PR TITLE
feat(render): stretchy-vertex skinning for creature meshes

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -60,13 +60,14 @@ impl AnimatedModel {
     }
 
     fn to_animated_scene_objects(&self, player: &AnimationPlayer) -> Vec<SceneObject> {
-        let skinning_data = player.get_transforms(&self.skeleton);
+        let pose = player.get_transforms(&self.skeleton);
+        let palette = Skeleton::expand_skinning_palette(&pose, &self.skeleton);
 
         self.scene_objects
             .iter()
             .map(|m| {
                 let mut new_obj = m.clone();
-                new_obj.set_skinning_data(skinning_data);
+                new_obj.set_skinning_palette(palette);
                 new_obj
             })
             .collect::<Vec<SceneObject>>()
@@ -82,14 +83,17 @@ impl AnimatedModel {
             }),
             &rpds::HashTrieMap::new(),
         );
-        let new_data = animated_skeleton.get_transforms();
+        let new_data = Skeleton::expand_skinning_palette(
+            &animated_skeleton.get_transforms(),
+            &animated_skeleton,
+        );
 
         let new_scene_objects = self
             .scene_objects
             .iter()
             .map(|m| {
                 let mut new_obj = m.clone();
-                new_obj.set_skinning_data(new_data);
+                new_obj.set_skinning_palette(new_data);
                 new_obj
             })
             .collect::<Vec<SceneObject>>();

--- a/dark/src/ss2_bin_ai_loader.rs
+++ b/dark/src/ss2_bin_ai_loader.rs
@@ -14,7 +14,7 @@ use engine::{
     scene::{SceneObject, VertexPositionTextureSkinnedNormal},
     texture::{AnimatedTexture, TextureTrait},
 };
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::{
     SCALE_FACTOR,
@@ -29,6 +29,11 @@ use crate::{
     util::load_multiple_textures_for_model,
 };
 
+/// Number of base joint slots in the skinning palette; stretchy frames for
+/// joint `j` live at palette slot `MAX_JOINTS + j` (see
+/// `ss2_skeleton::expand_skinning_palette`).
+pub const MAX_JOINTS: usize = 40;
+
 #[derive(Clone)]
 pub struct SystemShock2AIMesh {
     // pub header: BinHeader,
@@ -40,6 +45,10 @@ pub struct SystemShock2AIMesh {
 
     pub joints: Vec<AIJointInfo>,
     pub joint_map: Vec<AIJointMapEntry>,
+    /// One weight per vertex of each stretchy segment (indexed by
+    /// `AIJointInfo::weight_index + local vertex index`); rigid segments
+    /// consume none. 0 = follow the joint's parent frame, 1 = the joint.
+    pub weights: Vec<f32>,
 }
 
 impl SystemShock2AIMesh {
@@ -231,9 +240,16 @@ pub fn read<T: Read + Seek>(
         uvs,
         vertices,
         normals,
+        weights,
     }
 }
 
+/// A segment: a run of mesh geometry bound to one joint. Non-stretchy
+/// segments follow their joint rigidly; a stretchy segment is the blend
+/// region between `joint`'s parent and `joint`, with one per-vertex weight
+/// (see `to_vertices`). Validated field-by-field against creature meshes
+/// (byte-level dump of GRUNT_P.BIN: 29 segments in stretchy/rigid pairs,
+/// stretchy vertex counts exactly matching the header weight count).
 #[derive(Debug, Clone)]
 pub struct AIJointMapEntry {
     pub joint: i8,
@@ -241,29 +257,26 @@ pub struct AIJointMapEntry {
     num_of_material_segments: i8,
     #[allow(dead_code)]
     map_start: i8,
-    // en1: i8, // what is this for?
-    // jother: i8,
-    // en2: i8,
-    // rotation: Vector3<f32>,
+    /// The segment blends between `joint`'s parent and `joint`; its vertices
+    /// carry weights (0 = parent-frame, 1 = joint-frame).
+    pub stretchy: bool,
 }
 
 pub fn read_joint_map_entry<T: Read + Seek>(reader: &mut T) -> AIJointMapEntry {
-    // Not convinced this is a 100% accurate, should revisit?
     let _bbox = read_i32(reader);
     let joint = read_i8(reader);
     let num_of_material_segments = read_i8(reader);
     let map_start = read_i8(reader);
-    let _en2 = read_i8(reader);
-    let _rotation = read_vec3(reader);
+    let flags = read_i8(reader);
+    // The remaining 12 bytes are the segment's own geometry ranges, unused:
+    // vertex/polygon ranges come from the material-segment table below.
+    let _data_chunk = read_vec3(reader);
 
     AIJointMapEntry {
         joint,
         num_of_material_segments,
         map_start,
-        // en1,
-        // jother,
-        // en2,
-        // rotation,
+        stretchy: (flags & 0x1) != 0,
     }
 }
 
@@ -365,7 +378,8 @@ pub struct AIJointInfo {
     start_poly: i16,
     num_vertices: i16,
     start_vertex: i16,
-    #[allow(dead_code)]
+    /// Start of this run's weights in the mesh weight array; only meaningful
+    /// when the owning segment is stretchy (garbage for rigid runs).
     weight_index: u16,
     #[allow(dead_code)]
     flag: i16,
@@ -479,8 +493,8 @@ pub fn to_scene_objects(
         ));
 
         let mut scene_object = engine::scene::scene_object::SceneObject::create(material, geometry);
-        let skinning_data = skeleton.get_transforms();
-        scene_object.set_skinning_data(skinning_data);
+        let skinning_data = Skeleton::expand_skinning_palette(&skeleton.get_transforms(), skeleton);
+        scene_object.set_skinning_palette(skinning_data);
         scene_objects.push(scene_object);
     }
 
@@ -504,19 +518,40 @@ pub fn to_vertices(
     let joints = &mesh.joints;
     let joint_map = &mesh.joint_map;
 
-    // Create a map of vertex index -> joint
-    let mut vertex_to_weights: HashMap<u16, JointId> = HashMap::new();
+    // Map each vertex to its joint binding: rigid vertices follow one joint;
+    // vertices of a stretchy segment blend between the joint's parent frame
+    // and the joint by their authored weight (see the palette layout in
+    // `ss2_skeleton::expand_skinning_palette`: slot `40 + j` is joint j's
+    // parent-oriented frame).
+    let mut vertex_to_weights: HashMap<u16, (JointId, Option<f32>)> = HashMap::new();
 
     for joint in joints {
         let start_vertex = joint.start_vertex as u16;
         let end_vertex = start_vertex + (joint.num_vertices as u16);
 
-        // TODO: Incorporate weights
-        // let weight = weights[joint.weight_index];
-
-        let joint_id = joint_map[joint.mapper_id as usize].joint as JointId;
-        for i in start_vertex..end_vertex {
-            vertex_to_weights.insert(i, joint_id);
+        let segment = &joint_map[joint.mapper_id as usize];
+        if segment.joint < 0 || (segment.joint as usize) >= MAX_JOINTS {
+            // An out-of-range joint would index garbage in the bone palette;
+            // bind rigidly to the root instead so the part stays attached.
+            warn!(
+                "AI mesh segment {} has out-of-range joint {}; binding to root",
+                joint.mapper_id, segment.joint
+            );
+            for i in start_vertex..end_vertex {
+                vertex_to_weights.insert(i, (0, None));
+            }
+            continue;
+        }
+        let joint_id = segment.joint as JointId;
+        for (local_idx, i) in (start_vertex..end_vertex).enumerate() {
+            let stretch_weight = if segment.stretchy {
+                mesh.weights
+                    .get(joint.weight_index as usize + local_idx)
+                    .copied()
+            } else {
+                None
+            };
+            vertex_to_weights.insert(i, (joint_id, stretch_weight));
         }
     }
 
@@ -532,21 +567,21 @@ pub fn to_vertices(
             let v1 = vertices[tri.vert_index1 as usize];
             let v2 = vertices[tri.vert_index2 as usize];
 
-            let j1 = vertex_to_weights.get(&tri.vert_index0).unwrap();
-            let j2 = vertex_to_weights.get(&tri.vert_index1).unwrap();
-            let j3 = vertex_to_weights.get(&tri.vert_index2).unwrap();
+            let (j1, w1) = *vertex_to_weights.get(&tri.vert_index0).unwrap();
+            let (j2, w2) = *vertex_to_weights.get(&tri.vert_index1).unwrap();
+            let (j3, w3) = *vertex_to_weights.get(&tri.vert_index2).unwrap();
 
-            add_vertex_to_hitbox(&mut joint_to_hitbox, *j1, v0);
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j1, v1);
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j1, v2);
+            add_vertex_to_hitbox(&mut joint_to_hitbox, j1, v0);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j1, v1);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j1, v2);
 
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j2, v0);
-            add_vertex_to_hitbox(&mut joint_to_hitbox, *j2, v1);
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j2, v2);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j2, v0);
+            add_vertex_to_hitbox(&mut joint_to_hitbox, j2, v1);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j2, v2);
 
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j3, v0);
-            // add_vertex_to_hitbox(&mut joint_to_hitbox, *j3, v1);
-            add_vertex_to_hitbox(&mut joint_to_hitbox, *j3, v2);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j3, v0);
+            // add_vertex_to_hitbox(&mut joint_to_hitbox, j3, v1);
+            add_vertex_to_hitbox(&mut joint_to_hitbox, j3, v2);
 
             // let xform0 = skeleton.global_transform(j1);
             // let xform1 = skeleton.global_transform(j2);
@@ -561,29 +596,9 @@ pub fn to_vertices(
             let normal1 = uvs[tri.vert_index1 as usize].normal;
             let normal2 = uvs[tri.vert_index2 as usize].normal;
 
-            // For now, use simple single-bone weighting (1.0 for primary bone, 0.0 for others)
-            // TODO: Implement proper multi-bone weighting from AI mesh weight data
-            verts.push(build_vertex(
-                v0,
-                uv0,
-                normal0,
-                [*j1, 0, 0, 0],
-                [1.0, 0.0, 0.0, 0.0],
-            ));
-            verts.push(build_vertex(
-                v1,
-                uv1,
-                normal1,
-                [*j2, 0, 0, 0],
-                [1.0, 0.0, 0.0, 0.0],
-            ));
-            verts.push(build_vertex(
-                v2,
-                uv2,
-                normal2,
-                [*j3, 0, 0, 0],
-                [1.0, 0.0, 0.0, 0.0],
-            ));
+            verts.push(build_vertex(v0, uv0, normal0, skin_binding(j1, w1)));
+            verts.push(build_vertex(v1, uv1, normal1, skin_binding(j2, w2)));
+            verts.push(build_vertex(v2, uv2, normal2, skin_binding(j3, w3)));
         }
         material_to_verts.push((name.to_owned(), verts));
     }
@@ -603,12 +618,28 @@ fn add_vertex_to_hitbox(
     *entry = entry.grow(point);
 }
 
+/// Bone palette slots + weights for a vertex. Rigid vertices follow their
+/// joint alone; a stretchy vertex blends the joint (weight `w`) with the
+/// joint's parent-oriented frame at palette slot `40 + joint` (weight
+/// `1 - w`) - see `ss2_skeleton::expand_skinning_palette`.
+fn skin_binding(joint: JointId, stretch_weight: Option<f32>) -> ([u32; 4], [f32; 4]) {
+    match stretch_weight {
+        Some(w) => {
+            let w = w.clamp(0.0, 1.0);
+            (
+                [joint, MAX_JOINTS as u32 + joint, 0, 0],
+                [w, 1.0 - w, 0.0, 0.0],
+            )
+        }
+        None => ([joint, 0, 0, 0], [1.0, 0.0, 0.0, 0.0]),
+    }
+}
+
 fn build_vertex(
     vec: Point3<f32>,
     uv: Vector2<f32>,
     normal: Vector3<f32>,
-    bone_indices: [u32; 4],
-    bone_weights: [f32; 4],
+    (bone_indices, bone_weights): ([u32; 4], [f32; 4]),
 ) -> VertexPositionTextureSkinnedNormal {
     VertexPositionTextureSkinnedNormal {
         position: vec.to_vec(),
@@ -616,5 +647,76 @@ fn build_vertex(
         bone_indices,
         bone_weights,
         normal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rigid_vertices_bind_to_a_single_joint() {
+        let (indices, weights) = skin_binding(7, None);
+        assert_eq!(indices, [7, 0, 0, 0]);
+        assert_eq!(weights, [1.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn stretchy_vertices_blend_joint_with_its_parent_frame_slot() {
+        let (indices, weights) = skin_binding(7, Some(0.75));
+        assert_eq!(indices, [7, MAX_JOINTS as u32 + 7, 0, 0]);
+        assert_eq!(weights, [0.75, 0.25, 0.0, 0.0]);
+
+        // Degenerate weights from data are clamped, not propagated.
+        let (_, weights) = skin_binding(3, Some(1.5));
+        assert_eq!(weights, [1.0, 0.0, 0.0, 0.0]);
+    }
+
+    /// Structure-level invariants against a real creature mesh, mirroring the
+    /// byte-level validation this work was built on: every stretchy-segment
+    /// vertex has exactly one weight (the header's weight count), weights are
+    /// sane blend factors, and every segment's joint is in palette range.
+    #[test]
+    fn grunt_mesh_weights_cover_exactly_the_stretchy_vertices() {
+        // Same search the engine's data_root uses, minus the shock2vr
+        // dependency (dark can't depend on it).
+        let path = std::env::var("DARK_ASSET_PATH")
+            .map(std::path::PathBuf::from)
+            .into_iter()
+            .chain(["Data", "../Data", "../../Data"].map(std::path::PathBuf::from))
+            .map(|root| root.join("res/mesh/GRUNT_P.BIN"))
+            .find(|p| p.exists());
+        let Some(path) = path else {
+            eprintln!("skipping: GRUNT_P.BIN not found (no game data present)");
+            return;
+        };
+        let mut file = std::fs::File::open(path).unwrap();
+        let common_header = crate::ss2_bin_header::read(&mut file);
+        let mesh = read(&mut file, &common_header);
+
+        assert!(!mesh.weights.is_empty(), "grunt has stretchy segments");
+        assert!(
+            mesh.weights.iter().all(|w| (0.0..=1.0).contains(w)),
+            "weights are blend factors"
+        );
+
+        let stretchy_verts: usize = mesh
+            .joints
+            .iter()
+            .filter(|smatseg| mesh.joint_map[smatseg.mapper_id as usize].stretchy)
+            .map(|smatseg| smatseg.num_vertices as usize)
+            .sum();
+        assert_eq!(
+            stretchy_verts,
+            mesh.weights.len(),
+            "one weight per stretchy vertex, none for rigid"
+        );
+
+        for segment in &mesh.joint_map {
+            assert!(
+                segment.joint >= 0 && (segment.joint as usize) < MAX_JOINTS,
+                "segment joints stay in palette range"
+            );
+        }
     }
 }

--- a/dark/src/ss2_bin_ai_loader.rs
+++ b/dark/src/ss2_bin_ai_loader.rs
@@ -32,7 +32,7 @@ use crate::{
 /// Number of base joint slots in the skinning palette; stretchy frames for
 /// joint `j` live at palette slot `MAX_JOINTS + j` (see
 /// `ss2_skeleton::expand_skinning_palette`).
-pub const MAX_JOINTS: usize = 40;
+pub const MAX_JOINTS: usize = engine::scene::MAX_SKINNED_JOINTS;
 
 #[derive(Clone)]
 pub struct SystemShock2AIMesh {
@@ -543,11 +543,28 @@ pub fn to_vertices(
             continue;
         }
         let joint_id = segment.joint as JointId;
+        // A stretchy run's weights must fully cover its vertices. A malformed
+        // range falls back to rigid binding LOUDLY - silently degrading would
+        // be indistinguishable from intentionally rigid data.
+        let weight_end = joint.weight_index as usize + joint.num_vertices.max(0) as usize;
+        let stretchy = segment.stretchy
+            && {
+                let in_bounds = weight_end <= mesh.weights.len();
+                if !in_bounds {
+                    warn!(
+                        "AI mesh stretchy run (segment {}, joint {}) weight range {}..{} exceeds weight array ({}); binding rigidly",
+                        joint.mapper_id,
+                        joint_id,
+                        joint.weight_index,
+                        weight_end,
+                        mesh.weights.len()
+                    );
+                }
+                in_bounds
+            };
         for (local_idx, i) in (start_vertex..end_vertex).enumerate() {
-            let stretch_weight = if segment.stretchy {
-                mesh.weights
-                    .get(joint.weight_index as usize + local_idx)
-                    .copied()
+            let stretch_weight = if stretchy {
+                Some(mesh.weights[joint.weight_index as usize + local_idx])
             } else {
                 None
             };

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -8,7 +8,10 @@ use tracing::warn;
 use cgmath::{Deg, Matrix4, Quaternion, SquareMatrix, Vector2, Vector3};
 use engine::{
     assets::asset_cache::AssetCache,
-    scene::{SceneObject, VertexPosition, color_material, cube, lines_mesh},
+    scene::{
+        MAX_SKINNED_JOINTS, SKINNING_PALETTE_SIZE, SceneObject, VertexPosition, color_material,
+        cube, lines_mesh,
+    },
     util,
 };
 
@@ -86,24 +89,22 @@ impl Skeleton {
     /// parent, and empty slots, fall back to the joint's own transform,
     /// which makes any second-bone reference a no-op.
     pub fn expand_skinning_palette(
-        pose: &[Matrix4<f32>; 40],
+        pose: &[Matrix4<f32>; MAX_SKINNED_JOINTS],
         skeleton: &Skeleton,
-    ) -> [Matrix4<f32>; 80] {
-        let mut palette = [Matrix4::identity(); 80];
-        palette[..40].copy_from_slice(pose);
-        for j in 0..40 {
-            palette[40 + j] = pose[j];
-        }
+    ) -> [Matrix4<f32>; SKINNING_PALETTE_SIZE] {
+        let mut palette = [Matrix4::identity(); SKINNING_PALETTE_SIZE];
+        palette[..MAX_SKINNED_JOINTS].copy_from_slice(pose);
+        palette[MAX_SKINNED_JOINTS..].copy_from_slice(pose);
         for bone in skeleton.bones() {
             let j = bone.joint_id as usize;
-            if j >= 40 {
+            if j >= MAX_SKINNED_JOINTS {
                 continue;
             }
             if let Some(parent) = bone.parent_id {
-                if (parent as usize) < 40 {
+                if (parent as usize) < MAX_SKINNED_JOINTS {
                     let mut frame = pose[parent as usize];
                     frame.w = pose[j].w;
-                    palette[40 + j] = frame;
+                    palette[MAX_SKINNED_JOINTS + j] = frame;
                 }
             }
         }

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -76,6 +76,40 @@ impl Skeleton {
         transforms
     }
 
+    /// Expand a posed 40-joint palette to the 80-slot render palette: slot
+    /// `40 + j` holds joint j's "parent frame" - the parent joint's
+    /// orientation anchored at joint j's own position. Stretchy vertices
+    /// blend between joint j (weight `w`) and this frame (weight `1 - w`):
+    /// at `w = 1` they follow the joint exactly, at `w = 0` the parent's
+    /// orientation about the same pivot, so the blend rotates about the
+    /// joint rather than tearing between two pivots. Joints without a
+    /// parent, and empty slots, fall back to the joint's own transform,
+    /// which makes any second-bone reference a no-op.
+    pub fn expand_skinning_palette(
+        pose: &[Matrix4<f32>; 40],
+        skeleton: &Skeleton,
+    ) -> [Matrix4<f32>; 80] {
+        let mut palette = [Matrix4::identity(); 80];
+        palette[..40].copy_from_slice(pose);
+        for j in 0..40 {
+            palette[40 + j] = pose[j];
+        }
+        for bone in skeleton.bones() {
+            let j = bone.joint_id as usize;
+            if j >= 40 {
+                continue;
+            }
+            if let Some(parent) = bone.parent_id {
+                if (parent as usize) < 40 {
+                    let mut frame = pose[parent as usize];
+                    frame.w = pose[j].w;
+                    palette[40 + j] = frame;
+                }
+            }
+        }
+        palette
+    }
+
     pub fn global_transform(&self, joint_id: &JointId) -> Matrix4<f32> {
         let _joint_offset = *joint_id as f32;
 
@@ -524,6 +558,40 @@ mod tests {
             name: None,
         };
         (Skeleton::create_from_bones(bones), clip)
+    }
+
+    #[test]
+    fn expand_skinning_palette_builds_parent_frames() {
+        let (skeleton, _clip) = test_skeleton_and_clip();
+        let mut pose = [Matrix4::identity(); 40];
+        // Root (joint 0): a recognizable rotation + its own translation.
+        pose[0] = Matrix4::from_translation(Vector3::new(5.0, 0.0, 0.0))
+            * Matrix4::from_angle_y(Deg(90.0));
+        // Child (joint 1): identity rotation, distinct translation.
+        pose[1] = Matrix4::from_translation(Vector3::new(6.0, 2.0, 0.0));
+
+        let palette = Skeleton::expand_skinning_palette(&pose, &skeleton);
+
+        // Slots 0..40 are the pose itself.
+        assert_eq!(palette[0], pose[0]);
+        assert_eq!(palette[1], pose[1]);
+
+        // Joint 1's parent frame: the ROOT's orientation anchored at JOINT 1's
+        // position - stretchy weight 0 rotates with the parent about the
+        // child pivot.
+        let frame = palette[41];
+        assert_eq!(
+            translation_from_matrix(&frame),
+            Vector3::new(6.0, 2.0, 0.0),
+            "parent frame must pivot at the child joint"
+        );
+        assert_eq!(frame.x, pose[0].x, "parent frame carries parent basis x");
+        assert_eq!(frame.z, pose[0].z, "parent frame carries parent basis z");
+
+        // Root has no parent; an unused slot has no bone: both fall back to
+        // the joint's own transform so a second-bone reference is a no-op.
+        assert_eq!(palette[40], pose[0]);
+        assert_eq!(palette[45], pose[5]);
     }
 
     #[test]

--- a/engine/src/scene/debug_normal_material.rs
+++ b/engine/src/scene/debug_normal_material.rs
@@ -150,7 +150,8 @@ const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
         uniform mat4 world;
         uniform mat4 view;
         uniform mat4 projection;
-        uniform mat4 bone_matrices[40];
+        // Matches the skinned material's palette (base joints + parent frames).
+        uniform mat4 bone_matrices[80];
 
         out vec3 worldNormal;
 

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -1,6 +1,13 @@
 pub mod scene;
 pub use scene::{LegacyScene, Scene};
 
+/// Number of base joint slots in the skinning palette.
+pub const MAX_SKINNED_JOINTS: usize = 40;
+/// Full skinning-palette size: base joints in `0..MAX_SKINNED_JOINTS`, one
+/// auxiliary "parent frame" per joint in the upper half (blended by stretchy
+/// vertices). The shader-side `bone_matrices` array literals mirror this.
+pub const SKINNING_PALETTE_SIZE: usize = 2 * MAX_SKINNED_JOINTS;
+
 pub mod light;
 pub use light::{Light, LightType, SpotLight};
 

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -36,7 +36,7 @@ pub struct SceneObject {
     pub geometry: Rc<Box<dyn Geometry>>,
     pub transform: Matrix4<f32>,
     pub local_transform: Matrix4<f32>, //hack...
-    pub skinning_data: [Matrix4<f32>; 40],
+    pub skinning_data: [Matrix4<f32>; 80],
     pub depth_write: bool,
     /// When true, the depth buffer is cleared *before* drawing this object, so it
     /// (and anything drawn after it) renders on top of the world while still
@@ -216,7 +216,7 @@ impl SceneObject {
             geometry,
             transform,
             local_transform: Matrix4::identity(),
-            skinning_data: [Matrix4::identity(); 40],
+            skinning_data: [Matrix4::identity(); 80],
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
@@ -312,8 +312,20 @@ impl SceneObject {
         self.local_transform = transform;
     }
 
+    /// Set the 40 joint matrices; the parent-frame slots (40..80) are
+    /// filled with each joint's own transform, so a stretchy second-bone
+    /// reference degrades to the rigid single-bone result. Callers with real
+    /// parent frames use [`set_skinning_palette`](Self::set_skinning_palette).
     pub fn set_skinning_data(&mut self, skinning_data: [Matrix4<f32>; 40]) {
-        self.skinning_data = skinning_data;
+        self.skinning_data[..40].copy_from_slice(&skinning_data);
+        self.skinning_data[40..].copy_from_slice(&skinning_data);
+    }
+
+    /// Set the full 80-slot palette: joint transforms in 0..40, per-joint
+    /// parent frames (parent orientation about the joint's position) in
+    /// 40..80, blended by stretchy vertices.
+    pub fn set_skinning_palette(&mut self, palette: [Matrix4<f32>; 80]) {
+        self.skinning_data = palette;
     }
 
     pub fn get_transform(&self) -> Matrix4<f32> {
@@ -326,7 +338,7 @@ impl SceneObject {
             geometry: Rc::new(geometry),
             transform: Matrix4::identity(),
             local_transform: Matrix4::identity(),
-            skinning_data: [Matrix4::identity(); 40],
+            skinning_data: [Matrix4::identity(); 80],
             depth_write: true,
             clear_depth: false,
             transparency_override: None,

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -36,7 +36,7 @@ pub struct SceneObject {
     pub geometry: Rc<Box<dyn Geometry>>,
     pub transform: Matrix4<f32>,
     pub local_transform: Matrix4<f32>, //hack...
-    pub skinning_data: [Matrix4<f32>; 80],
+    pub skinning_data: [Matrix4<f32>; crate::scene::SKINNING_PALETTE_SIZE],
     pub depth_write: bool,
     /// When true, the depth buffer is cleared *before* drawing this object, so it
     /// (and anything drawn after it) renders on top of the world while still
@@ -216,7 +216,7 @@ impl SceneObject {
             geometry,
             transform,
             local_transform: Matrix4::identity(),
-            skinning_data: [Matrix4::identity(); 80],
+            skinning_data: [Matrix4::identity(); crate::scene::SKINNING_PALETTE_SIZE],
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
@@ -316,15 +316,22 @@ impl SceneObject {
     /// filled with each joint's own transform, so a stretchy second-bone
     /// reference degrades to the rigid single-bone result. Callers with real
     /// parent frames use [`set_skinning_palette`](Self::set_skinning_palette).
-    pub fn set_skinning_data(&mut self, skinning_data: [Matrix4<f32>; 40]) {
-        self.skinning_data[..40].copy_from_slice(&skinning_data);
-        self.skinning_data[40..].copy_from_slice(&skinning_data);
+    pub fn set_skinning_data(
+        &mut self,
+        skinning_data: [Matrix4<f32>; crate::scene::MAX_SKINNED_JOINTS],
+    ) {
+        let half = crate::scene::MAX_SKINNED_JOINTS;
+        self.skinning_data[..half].copy_from_slice(&skinning_data);
+        self.skinning_data[half..].copy_from_slice(&skinning_data);
     }
 
     /// Set the full 80-slot palette: joint transforms in 0..40, per-joint
     /// parent frames (parent orientation about the joint's position) in
     /// 40..80, blended by stretchy vertices.
-    pub fn set_skinning_palette(&mut self, palette: [Matrix4<f32>; 80]) {
+    pub fn set_skinning_palette(
+        &mut self,
+        palette: [Matrix4<f32>; crate::scene::SKINNING_PALETTE_SIZE],
+    ) {
         self.skinning_data = palette;
     }
 
@@ -338,7 +345,7 @@ impl SceneObject {
             geometry: Rc::new(geometry),
             transform: Matrix4::identity(),
             local_transform: Matrix4::identity(),
-            skinning_data: [Matrix4::identity(); 80],
+            skinning_data: [Matrix4::identity(); crate::scene::SKINNING_PALETTE_SIZE],
             depth_write: true,
             clear_depth: false,
             transparency_override: None,

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -26,7 +26,7 @@ const UNIFIED_VERTEX_SHADER_SOURCE: &str = r#"
         uniform mat4 world;
         uniform mat4 view;
         uniform mat4 projection;
-        uniform mat4 bone_matrices[40];
+        uniform mat4 bone_matrices[80];
 
         out vec2 texCoord;
         out vec3 worldPos;
@@ -163,7 +163,7 @@ struct UnifiedUniforms {
     transparency_loc: i32,
 
     // Bone matrices for skeletal animation
-    bone_matrices_locs: [i32; 40],
+    bone_matrices_locs: [i32; 80],
 
     // Spotlight array uniforms (6 spotlights)
     spotlight_pos_loc: [i32; 6],
@@ -224,7 +224,7 @@ impl SkinnedMaterial {
             gl::Uniform1f(uniforms.emissivity_loc, self.emissivity);
 
             // Set bone matrices for skeletal animation
-            for i in 0..40 {
+            for i in 0..80 {
                 let mat = skinning_data[i];
                 gl::UniformMatrix4fv(uniforms.bone_matrices_locs[i], 1, gl::FALSE, mat.as_ptr());
             }
@@ -312,8 +312,8 @@ impl Material for SkinnedMaterial {
                 let shader = crate::shader_program::link(&vertex_shader, &fragment_shader);
 
                 // Get uniform locations for all shader variables
-                let mut bone_matrices_locs = [0i32; 40];
-                for i in 0..40 {
+                let mut bone_matrices_locs = [0i32; 80];
+                for i in 0..80 {
                     let name = format!("bone_matrices[{i}]");
                     let c_str = CString::new(name).unwrap();
                     bone_matrices_locs[i] = gl::GetUniformLocation(shader.gl_id, c_str.as_ptr());

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -1,5 +1,4 @@
 extern crate gl;
-use std::ffi::CString;
 use std::rc::Rc;
 
 use crate::engine::EngineRenderContext;
@@ -26,7 +25,11 @@ const UNIFIED_VERTEX_SHADER_SOURCE: &str = r#"
         uniform mat4 world;
         uniform mat4 view;
         uniform mat4 projection;
-        uniform mat4 bone_matrices[80];
+        // Affine bones packed as 3 vec4 rows each (the mat3x4's columns hold
+        // the matrix rows), so the 80-slot palette costs 240 uniform vectors
+        // and fits the GLES 3.0 guaranteed vertex budget (256); a mat4 array
+        // would need 320. Apply with `vec4(v) * bone_matrices[i]`.
+        uniform mat3x4 bone_matrices[80];
 
         out vec2 texCoord;
         out vec3 worldPos;
@@ -36,29 +39,34 @@ const UNIFIED_VERTEX_SHADER_SOURCE: &str = r#"
             texCoord = inTex;
 
             // Apply weighted bone transformations to position and normal
-            vec4 skinnedPos = vec4(0.0);
+            vec3 skinnedPos = vec3(0.0);
             vec3 skinnedNormal = vec3(0.0);
+            float totalWeight = 0.0;
 
             // Blend up to 4 bones based on weights
             if (bone_weights.x > 0.0) {
-                skinnedPos += bone_weights.x * (bone_matrices[bone_ids.x] * vec4(inPos, 1.0));
-                skinnedNormal += bone_weights.x * (mat3(bone_matrices[bone_ids.x]) * inNormal);
+                skinnedPos += bone_weights.x * (vec4(inPos, 1.0) * bone_matrices[bone_ids.x]);
+                skinnedNormal += bone_weights.x * (vec4(inNormal, 0.0) * bone_matrices[bone_ids.x]);
+                totalWeight += bone_weights.x;
             }
             if (bone_weights.y > 0.0) {
-                skinnedPos += bone_weights.y * (bone_matrices[bone_ids.y] * vec4(inPos, 1.0));
-                skinnedNormal += bone_weights.y * (mat3(bone_matrices[bone_ids.y]) * inNormal);
+                skinnedPos += bone_weights.y * (vec4(inPos, 1.0) * bone_matrices[bone_ids.y]);
+                skinnedNormal += bone_weights.y * (vec4(inNormal, 0.0) * bone_matrices[bone_ids.y]);
+                totalWeight += bone_weights.y;
             }
             if (bone_weights.z > 0.0) {
-                skinnedPos += bone_weights.z * (bone_matrices[bone_ids.z] * vec4(inPos, 1.0));
-                skinnedNormal += bone_weights.z * (mat3(bone_matrices[bone_ids.z]) * inNormal);
+                skinnedPos += bone_weights.z * (vec4(inPos, 1.0) * bone_matrices[bone_ids.z]);
+                skinnedNormal += bone_weights.z * (vec4(inNormal, 0.0) * bone_matrices[bone_ids.z]);
+                totalWeight += bone_weights.z;
             }
             if (bone_weights.w > 0.0) {
-                skinnedPos += bone_weights.w * (bone_matrices[bone_ids.w] * vec4(inPos, 1.0));
-                skinnedNormal += bone_weights.w * (mat3(bone_matrices[bone_ids.w]) * inNormal);
+                skinnedPos += bone_weights.w * (vec4(inPos, 1.0) * bone_matrices[bone_ids.w]);
+                skinnedNormal += bone_weights.w * (vec4(inNormal, 0.0) * bone_matrices[bone_ids.w]);
+                totalWeight += bone_weights.w;
             }
 
             // Fallback to original position if no valid bones
-            vec4 mod_position = (skinnedPos.w > 0.0) ? skinnedPos : vec4(inPos, 1.0);
+            vec4 mod_position = (totalWeight > 0.0) ? vec4(skinnedPos, 1.0) : vec4(inPos, 1.0);
             vec3 mod_normal = (length(skinnedNormal) > 0.0) ? normalize(skinnedNormal) : inNormal;
 
             // Transform to world space
@@ -163,7 +171,7 @@ struct UnifiedUniforms {
     transparency_loc: i32,
 
     // Bone matrices for skeletal animation
-    bone_matrices_locs: [i32; 80],
+    bone_matrices_loc: i32,
 
     // Spotlight array uniforms (6 spotlights)
     spotlight_pos_loc: [i32; 6],
@@ -223,11 +231,28 @@ impl SkinnedMaterial {
             gl::Uniform1f(uniforms.transparency_loc, self.transparency);
             gl::Uniform1f(uniforms.emissivity_loc, self.emissivity);
 
-            // Set bone matrices for skeletal animation
-            for i in 0..80 {
-                let mat = skinning_data[i];
-                gl::UniformMatrix4fv(uniforms.bone_matrices_locs[i], 1, gl::FALSE, mat.as_ptr());
+            // Pack each affine bone as its 3 matrix rows (the shader-side
+            // mat3x4's columns) and upload the whole palette in one call.
+            let mut packed = [0f32; crate::scene::SKINNING_PALETTE_SIZE * 12];
+            for (bone, mat) in skinning_data
+                .iter()
+                .enumerate()
+                .take(crate::scene::SKINNING_PALETTE_SIZE)
+            {
+                let base = bone * 12;
+                for row in 0..3 {
+                    packed[base + row * 4] = mat.x[row];
+                    packed[base + row * 4 + 1] = mat.y[row];
+                    packed[base + row * 4 + 2] = mat.z[row];
+                    packed[base + row * 4 + 3] = mat.w[row];
+                }
             }
+            gl::UniformMatrix3x4fv(
+                uniforms.bone_matrices_loc,
+                crate::scene::SKINNING_PALETTE_SIZE as i32,
+                gl::FALSE,
+                packed.as_ptr(),
+            );
 
             // Set spotlight array uniforms
             for i in 0..6 {
@@ -312,12 +337,8 @@ impl Material for SkinnedMaterial {
                 let shader = crate::shader_program::link(&vertex_shader, &fragment_shader);
 
                 // Get uniform locations for all shader variables
-                let mut bone_matrices_locs = [0i32; 80];
-                for i in 0..80 {
-                    let name = format!("bone_matrices[{i}]");
-                    let c_str = CString::new(name).unwrap();
-                    bone_matrices_locs[i] = gl::GetUniformLocation(shader.gl_id, c_str.as_ptr());
-                }
+                let bone_matrices_loc =
+                    gl::GetUniformLocation(shader.gl_id, c_str!("bone_matrices[0]").as_ptr());
 
                 let uniforms = UnifiedUniforms {
                     // Basic transformation matrices
@@ -339,7 +360,7 @@ impl Material for SkinnedMaterial {
                     ),
 
                     // Bone matrices
-                    bone_matrices_locs,
+                    bone_matrices_loc,
 
                     // Spotlight array uniforms (6 spotlights)
                     spotlight_pos_loc: [


### PR DESCRIPTION
## Summary

Creature (AI) meshes author blend regions between body parts as **stretchy segments** carrying one weight per vertex. Our loader parsed the weights and the stretchy flag but discarded both, binding every vertex rigidly to a single joint — so creature skin cracked and pinched at elbows, knees, shoulders, and neck while animating ("parts of the mesh look incorrectly mapped"). This was a pre-existing, documented gap (`research/model-differences.md` §1).

**Ground truth**: validated the format byte-for-byte against `GRUNT_P.BIN` — 29 segments in stretchy/rigid pairs per joint, and the 110-entry weight array covers *exactly* the vertices of stretchy segments. It also confirmed our rigid binding was already correct (the loader reads the segment table's joint ids directly).

**The fix**:
- Loader keeps the stretchy flag + weights; stretchy vertices emit a two-bone binding: the joint `j` at weight `w`, and palette slot `40 + j` at weight `1 − w`.
- Slot `40 + j` is the joint's **parent frame**: the parent's orientation anchored at the joint's own position (`Skeleton::expand_skinning_palette`). Sharing the pivot means the blend *rotates* about the joint rather than tearing between two pivots; the `w=0`/`w=1` endpoints match the parent/child frames exactly. (The reference behavior slerps the rotation per vertex; a weighted matrix blend with a shared pivot matches it at the endpoints and closely approximates it between — revisit only if extreme flex shows artifacts.)
- `SceneObject`/skinned material grow to an 80-slot palette; the 40-slot setter pads new slots with each joint's own transform, so ragdolls, GLB models, and static-object callers behave identically by construction.
- Out-of-range segment joints (latent i8→u32 cast hazard) now bind to the root with a warning instead of indexing garbage past the palette.

## Validation

- 27/27 `dark` unit tests, including new ones: palette parent-frame construction, rigid/stretchy binding emission (with weight clamping), and structure-level invariants against the real grunt mesh (one weight per stretchy vertex; all joints in palette range)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; `cargo fmt`
- **Missions e2e: 23/23** — every mission loads (the loader touches every creature everywhere)
- In-game render check: hybrid draws fully intact with the 80-slot palette (wiring errors would explode/detach parts)
- Cross-engine review + bent-joint before/after visuals: running, results to follow

Note: the vertex shader's bone palette is now 80 mat4 (320 vec4 uniform components). Quest's Adreno GLES3 exposes far more than this; flagging in case a minimum-spec GLES device ever matters.

## Visuals

MedSci-1 pipe hybrid, idle animation (arm raises the pipe across its body), framed on the upper body from behind. Same deterministic request sequence on both builds (fixed 60 Hz stepping), so every frame is pose-matched — the only difference is vertex skinning.

![stretchy skinning before/after — idle](https://gist.githubusercontent.com/tommy-xr/85f11f90d191b392a140a1df20328fe9/raw/demo.gif)

<sub>Left = base (`main`), right = this branch. Watch the right shoulder/deltoid and the elbow as the arm bends: BEFORE the skin facets and pinches into a hard seam at the joint; AFTER the parent/child bones blend so the surface stays continuous. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`).</sub>

### Before -> after (peak elbow flex)

![shoulder + elbow before/after](https://gist.githubusercontent.com/tommy-xr/85f11f90d191b392a140a1df20328fe9/raw/beforeafter.png)

<sub>Money shot at maximum joint flex: BEFORE (left) shows the faceted deltoid and the hard elbow seam where each vertex rigidly follows one bone; AFTER (right) the shoulder rounds smoothly into the bicep and the elbow crease is continuous. The improvement is a surface detail on a low-poly model — subtlest on straight limbs, most visible at bent shoulders/elbows.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
