### PR TITLE
feat(ui): O/S upgrade trait panel - one-time perk selection (flat UI 6f)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3470,9 +3470,13 @@ impl MissionCore {
                                     .award_cyber_modules(NATURALLY_ABLE_MODULES);
                             }
                             TRAIT_TANK => {
-                                // "+5 MAXIMUM hit points" (Trait8): the live
-                                // grant raises only the ceiling; current HP is
-                                // untouched (loads reset current = max anyway).
+                                // Tank (Trait8): the original raises the
+                                // ceiling AND current HP by the bonus (buying
+                                // at 25/30 yields 30/35), clamped to the new
+                                // max. Loads re-derive both from the trait
+                                // list (current HP is not persisted - it
+                                // re-seeds from template + career + traits),
+                                // so the live grant cannot double-apply.
                                 drop(quests);
                                 let player_entity = self
                                     .world
@@ -3480,9 +3484,21 @@ impl MissionCore {
                                     .unwrap()
                                     .entity_id;
                                 self.world.run(
-                                    |mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
-                                        if let Ok(max) = (&mut v_max).get(player_entity) {
-                                            max.hit_points += TANK_HP_BONUS as u32;
+                                    |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
+                                     mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
+                                        let new_max = (&mut v_max)
+                                            .get(player_entity)
+                                            .map(|max| {
+                                                max.hit_points += TANK_HP_BONUS as u32;
+                                                max.hit_points
+                                            })
+                                            .ok();
+                                        if let Ok(hp) = (&mut v_hp).get(player_entity) {
+                                            hp.hit_points += TANK_HP_BONUS;
+                                            if let Some(new_max) = new_max {
+                                                hp.hit_points =
+                                                    hp.hit_points.min(new_max as i32);
+                                            }
                                         }
                                     },
                                 );

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -498,6 +498,29 @@ impl MissionCore {
             info!("Applied {:?} career loadout to player", career);
         }
 
+        // O/S trait bonuses re-derive on every load, like the career loadout
+        // (the player entity is rebuilt each mission load; the traits
+        // themselves persist on the character sheet in QuestInfo). Applied
+        // after the career block so Tank adds on top of the career pool.
+        if quest_info
+            .player_stats()
+            .has_os_trait(crate::scripts::gui::TRAIT_TANK)
+        {
+            use crate::scripts::gui::TANK_HP_BONUS;
+            world.run(
+                |mut v_hp: ViewMut<dark::properties::PropHitPoints>,
+                 mut v_max_hp: ViewMut<dark::properties::PropMaxHitPoints>| {
+                    if let Ok(hp) = (&mut v_hp).get(player_entity) {
+                        hp.hit_points += TANK_HP_BONUS;
+                    }
+                    if let Ok(max_hp) = (&mut v_max_hp).get(player_entity) {
+                        max_hp.hit_points += TANK_HP_BONUS as u32;
+                    }
+                },
+            );
+            info!("Applied Tank O/S trait: +{} max hit points", TANK_HP_BONUS);
+        }
+
         world.add_unique(psi_powers);
         world.add_unique(psi_selection);
         world.add_unique(known_powers);
@@ -682,6 +705,7 @@ impl MissionCore {
         // Preload the elevator floor labels (MISC.STR) + current mission so the
         // AssetCache-less ElevatorGui can label/gate floors at draw time.
         world.add_unique(crate::scripts::ElevatorContext::load(asset_cache, &mission));
+        world.add_unique(crate::scripts::gui::TraitsContext::load(asset_cache));
 
         world.add_unique(EffectQueue {
             effects: Vec::new(),
@@ -3403,6 +3427,76 @@ impl MissionCore {
                         }
                     } else {
                         warn!("TrainerPurchase dropped: gamesys has no cost tables");
+                    }
+                }
+
+                Effect::AcquireOsTrait { trait_id, machine } => {
+                    use crate::scripts::gui::{
+                        NATURALLY_ABLE_MODULES, TANK_HP_BONUS, TRAIT_NATURALLY_ABLE, TRAIT_TANK,
+                        live_effect_note, trait_name, used_bit_name,
+                    };
+                    // The machine's stable mission object id keys its used bit.
+                    let machine_template_id = self
+                        .world
+                        .borrow::<View<dark::properties::PropTemplateId>>()
+                        .ok()
+                        .and_then(|v| v.get(machine).ok().map(|t| t.template_id));
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    // Without a stable machine id the used state could never
+                    // be recorded - refuse rather than vend repeatably.
+                    let Some(machine_id) = machine_template_id else {
+                        warn!("O/S trait {} refused: machine has no template id", trait_id);
+                        continue;
+                    };
+                    let used = quests
+                        .read_quest_bit_value(&used_bit_name(machine_id))
+                        .bits()
+                        != 0;
+                    if used {
+                        info!("O/S trait {} refused: machine already used", trait_id);
+                    } else if !quests.player_stats_mut().add_os_trait(trait_id) {
+                        info!("O/S trait {} refused: owned or slots full", trait_id);
+                    } else {
+                        quests.set_quest_bit_value(
+                            &used_bit_name(machine_id),
+                            dark::properties::QuestBitValue::COMPLETE,
+                        );
+                        // Live effects for the implemented subset; the rest
+                        // are storage-only (their consumers don't exist yet).
+                        match trait_id {
+                            TRAIT_NATURALLY_ABLE => {
+                                quests
+                                    .player_stats_mut()
+                                    .award_cyber_modules(NATURALLY_ABLE_MODULES);
+                            }
+                            TRAIT_TANK => {
+                                // "+5 MAXIMUM hit points" (Trait8): the live
+                                // grant raises only the ceiling; current HP is
+                                // untouched (loads reset current = max anyway).
+                                drop(quests);
+                                let player_entity = self
+                                    .world
+                                    .borrow::<UniqueView<PlayerInfo>>()
+                                    .unwrap()
+                                    .entity_id;
+                                self.world.run(
+                                    |mut v_max: ViewMut<dark::properties::PropMaxHitPoints>| {
+                                        if let Ok(max) = (&mut v_max).get(player_entity) {
+                                            max.hit_points += TANK_HP_BONUS as u32;
+                                        }
+                                    },
+                                );
+                            }
+                            _ => {}
+                        }
+                        info!(
+                            "O/S trait acquired: {} ({}){}",
+                            trait_id,
+                            trait_name(trait_id),
+                            live_effect_note(trait_id)
+                                .map(|n| format!(" - {}", n))
+                                .unwrap_or_default()
+                        );
                     }
                 }
 

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -134,8 +134,8 @@ pub struct PlayerStats {
     /// purchases are deferred (see `scripts::gui::trainer`).
     #[serde(default)]
     pub psi_tier: i32,
-    /// O/S upgrade traits acquired at trait machines, by retail trait id
-    /// (1..=16, `shktrcst.h` enum order = `TRAITS.STR` `Trait1..16`), in
+    /// O/S upgrade traits acquired at trait machines, by the original game's
+    /// trait id (1..=16, the shipped `TRAITS.STR` `Trait1..16` order), in
     /// acquisition order. At most [`OS_TRAIT_SLOTS`]: the whole game has
     /// exactly four machines and each is single-use. See
     /// `scripts::gui::traits` for names and which traits have live effects.

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -134,7 +134,17 @@ pub struct PlayerStats {
     /// purchases are deferred (see `scripts::gui::trainer`).
     #[serde(default)]
     pub psi_tier: i32,
+    /// O/S upgrade traits acquired at trait machines, by retail trait id
+    /// (1..=16, `shktrcst.h` enum order = `TRAITS.STR` `Trait1..16`), in
+    /// acquisition order. At most [`OS_TRAIT_SLOTS`]: the whole game has
+    /// exactly four machines and each is single-use. See
+    /// `scripts::gui::traits` for names and which traits have live effects.
+    #[serde(default)]
+    pub os_traits: Vec<u8>,
 }
+
+/// The player has four O/S trait slots (one per single-use machine in the game).
+pub const OS_TRAIT_SLOTS: usize = 4;
 
 impl Default for PlayerStats {
     fn default() -> PlayerStats {
@@ -152,6 +162,7 @@ impl Default for PlayerStats {
             granted_years: BTreeSet::new(),
             cyber_modules: 0,
             psi_tier: 0,
+            os_traits: Vec::new(),
         }
     }
 }
@@ -220,6 +231,25 @@ impl PlayerStats {
     /// Raise a trainable skill by one level (a trainer purchase).
     pub fn raise_skill(&mut self, skill: Skill) {
         *self.skills.get_mut(skill) += 1;
+    }
+
+    /// Whether an O/S trait (retail id 1..=16) is owned.
+    pub fn has_os_trait(&self, trait_id: u8) -> bool {
+        self.os_traits.contains(&trait_id)
+    }
+
+    /// Acquire an O/S trait. Returns `false` (unchanged) if the id is out of
+    /// the retail 1..=16 range, already owned, or all [`OS_TRAIT_SLOTS`]
+    /// slots are taken.
+    pub fn add_os_trait(&mut self, trait_id: u8) -> bool {
+        if !(1..=16).contains(&trait_id)
+            || self.has_os_trait(trait_id)
+            || self.os_traits.len() >= OS_TRAIT_SLOTS
+        {
+            return false;
+        }
+        self.os_traits.push(trait_id);
+        true
     }
 
     fn stat_mut(&mut self, stat: Stat) -> &mut i32 {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -401,6 +401,17 @@ pub enum Effect {
         target: crate::scripts::gui::TrainerTarget,
     },
 
+    /// Acquire an O/S upgrade trait at a trait machine: atomically validate
+    /// (machine unused, trait not owned, a free slot), record the trait on the
+    /// persistent character sheet, mark the machine used (a quest bit keyed by
+    /// its stable mission object id), and apply the trait's live effect where
+    /// implemented (Tank, Naturally Able). Emitted by `TraitGui`; purchases
+    /// are free, per the original.
+    AcquireOsTrait {
+        trait_id: u8,
+        machine: EntityId,
+    },
+
     SetAIProperty {
         entity_id: EntityId,
         update: AIPropertyUpdate,

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -6,6 +6,7 @@ mod map;
 mod media;
 mod replicator;
 mod trainer;
+mod traits;
 
 pub use container::*;
 pub use elevator::*;
@@ -15,3 +16,4 @@ pub use map::*;
 pub use media::*;
 pub use replicator::*;
 pub use trainer::*;
+pub use traits::*;

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -51,9 +51,10 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
 pub const TRAIT_TANK: u8 = 8;
 
-/// Tank: "+5 maximum hit points" (TRAITS.STR Trait8). Applied live on
-/// purchase and re-derived on every mission load (the player entity is
-/// rebuilt each load).
+/// Tank: "+5 maximum hit points" (TRAITS.STR Trait8). The original raises the
+/// ceiling AND current HP by the bonus on purchase (buying at 25/30 yields
+/// 30/35); the live grant does the same, and both re-derive on every mission
+/// load (the player entity is rebuilt each load).
 pub const TANK_HP_BONUS: i32 = 5;
 
 /// Naturally Able: "One-time bonus of 8 Cyber Enhancement Units" (Trait6).
@@ -104,14 +105,24 @@ fn machine_used(world: &World, machine: EntityId) -> bool {
         .unwrap_or(false)
 }
 
-/// Preloaded `TRAITS.STR` descriptions (`Trait1..16`), added as a world unique
-/// at mission load so the (`AssetCache`-less) `TraitGui` can show the hovered
-/// trait's description - the `ElevatorContext` pattern.
+/// English fallbacks for the MISC.STR trait-panel strings (verbatim from the
+/// shipped table), used when a data install lacks it.
+const FALLBACK_HEADER_LABEL: &str = "Choose one upgrade.";
+const FALLBACK_USED_LABEL: &str = "Your OS has already been upgraded at this unit.";
+
+/// Preloaded trait-panel strings (`TRAITS.STR` descriptions plus the MISC.STR
+/// header / used-machine lines), added as a world unique at mission load so
+/// the (`AssetCache`-less) `TraitGui` can show them - the `ElevatorContext`
+/// pattern.
 #[derive(shipyard::Unique)]
 pub struct TraitsContext {
     /// `Trait1..16` description strings; index 0 = trait id 1. Falls back to
     /// the bare trait name when TRAITS.STR is absent.
     pub descriptions: [String; 16],
+    /// MISC.STR `TraitHeader` ("Choose one upgrade."), drawn atop the panel.
+    pub header_label: String,
+    /// MISC.STR `TraitMachineUsed`, the used-machine refusal.
+    pub used_label: String,
 }
 
 impl TraitsContext {
@@ -124,14 +135,35 @@ impl TraitsContext {
                 .and_then(|s| s.get(&key).cloned())
                 .unwrap_or_else(|| trait_name((i + 1) as u8).to_owned())
         });
-        TraitsContext { descriptions }
+        let misc = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "misc.str");
+        let misc_lookup = |key: &str, fallback: &str| -> String {
+            misc.as_ref()
+                .and_then(|s| s.get(key).cloned())
+                .unwrap_or_else(|| fallback.to_owned())
+        };
+        TraitsContext {
+            descriptions,
+            header_label: misc_lookup("traitheader", FALLBACK_HEADER_LABEL),
+            used_label: misc_lookup("traitmachineused", FALLBACK_USED_LABEL),
+        }
     }
 }
 
-// Panel layout on the 188x296 backdrop (shktrait.cpp): owned-slots row at
-// (15,35) in 35x34 cells; 4x4 selection matrix in (15,76)-(152,209), icons
-// TRAIT01..16 at 34x32, `which = col + row*4 + 1`; description text below
-// from (15,214).
+/// The used-machine refusal line (MISC.STR `TraitMachineUsed`), from the
+/// preloaded context (fallback for scenes that never load it).
+fn used_label(world: &World) -> String {
+    world
+        .borrow::<UniqueView<TraitsContext>>()
+        .map(|ctx| ctx.used_label.clone())
+        .unwrap_or_else(|_| FALLBACK_USED_LABEL.to_owned())
+}
+
+// Panel layout on the 188x296 backdrop: header text at (17,14); owned-slots
+// row at (15,35) in 35x34 cells; 4x4 selection matrix in (15,76)-(152,209),
+// icons TRAIT01..16 at 34x32, `which = col + row*4 + 1`; description text
+// below from (15,214).
+const HEADER_X: f32 = 17.0;
+const HEADER_Y: f32 = 14.0;
 const OWNED_X: f32 = 15.0;
 const OWNED_Y: f32 = 35.0;
 const OWNED_PITCH: f32 = 35.0;
@@ -197,10 +229,18 @@ impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
         world: &World,
         state: &TraitGuiState,
     ) -> Vec<GuiComponent<TraitGuiMsg>> {
+        let header = world
+            .borrow::<UniqueView<TraitsContext>>()
+            .map(|ctx| ctx.header_label.clone())
+            .unwrap_or_else(|_| FALLBACK_HEADER_LABEL.to_owned());
         let mut components: Vec<GuiComponent<TraitGuiMsg>> = vec![
             gui::image("traits.pcx")
                 .with_position(vec2(0.0, 0.0))
                 .with_size(vec2(188.0, 296.0)),
+            // Panel header (MISC.STR TraitHeader), as in the original.
+            gui::text(&header)
+                .with_position(vec2(HEADER_X, HEADER_Y))
+                .with_size(vec2(160.0, 12.0)),
         ];
 
         let owned: Vec<u8> = world
@@ -242,10 +282,14 @@ impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
         // hovered description there).
         let mut lines: Vec<String> = Vec::new();
         if machine_used(world, entity_id) {
-            lines.push("This upgrade unit has been used.".to_owned());
+            lines.push(used_label(world));
         }
         if let Some(message) = &state.message {
-            lines.push(message.clone());
+            // A used-machine refusal repeats the standing used line - skip
+            // the duplicate.
+            if !lines.contains(message) {
+                lines.push(message.clone());
+            }
         }
         if let Some(hovered) = cursor.as_ref().and_then(|c| hovered_trait(c.position)) {
             let description = world
@@ -298,7 +342,7 @@ impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
             if machine_template_id(world, entity_id).is_none() {
                 Some("This upgrade unit is not responding.".to_string())
             } else if machine_used(world, entity_id) {
-                Some("This upgrade unit has already been used.".to_string())
+                Some(used_label(world))
             } else if stats.has_os_trait(*trait_id) {
                 Some(format!("{} is already installed.", trait_name(*trait_id)))
             } else if stats.os_traits.len() >= OS_TRAIT_SLOTS {

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -1,0 +1,411 @@
+//! O/S upgrade machine MFD panel (projects/flat-ui-panels.md §4).
+//!
+//! The retail overlay (`shktrait.cpp`, `kOverlayBuyTraits 20`): one pick from
+//! all 16 traits on a 4x4 icon matrix, an owned-slots row (up to 4 - the whole
+//! game has exactly four machines), a description of the hovered trait from
+//! `TRAITS.STR`, no confirmation step, and **purchases are free**. On buy the
+//! machine becomes single-use ("Used").
+//!
+//! Ours mirrors that: traits are stored on the character sheet
+//! (`PlayerStats::os_traits`, persisted via `QuestInfo`), the per-machine used
+//! flag is a quest bit keyed by the machine's stable mission object id (also
+//! `QuestInfo`, so it survives save/load and deck re-entry), and
+//! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
+//! implemented for the subset with existing consumers (Tank, Naturally Able -
+//! see [`live_effect_note`]); everything else is storage-only for now, listed
+//! per-trait in the PR.
+
+use cgmath::{Vector2, Vector3, vec2};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+use crate::gui::{Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::player_stats::OS_TRAIT_SLOTS;
+use crate::quest_info::QuestInfo;
+use crate::scripts::Effect;
+
+use crate::gui;
+
+/// The 16 O/S traits, by retail id (`shktrcst.h` enum order = `TRAITS.STR`
+/// `Trait1..16` order, verified against the shipped strings).
+pub const OS_TRAITS: [(u8, &str); 16] = [
+    (1, "Strong Metabolism"),
+    (2, "Pharmo-Friendly"),
+    (3, "Pack-Rat"),
+    (4, "Speedy"),
+    (5, "Sharpshooter"),
+    (6, "Naturally Able"),
+    (7, "Cybernetically Enhanced"),
+    (8, "Tank"),
+    (9, "Lethal Weapon"),
+    (10, "Security Expert"),
+    (11, "Smasher"),
+    (12, "Cyber-Assimilation"),
+    (13, "Replicator Expert"),
+    (14, "Power Psi"),
+    (15, "Tinker"),
+    (16, "Spatially Aware"),
+];
+
+/// Retail trait ids with live gameplay effects here (see the effect handler).
+pub const TRAIT_NATURALLY_ABLE: u8 = 6;
+pub const TRAIT_TANK: u8 = 8;
+
+/// Tank: "+5 maximum hit points" (TRAITS.STR Trait8). Applied live on
+/// purchase and re-derived on every mission load (the player entity is
+/// rebuilt each load).
+pub const TANK_HP_BONUS: i32 = 5;
+
+/// Naturally Able: "One-time bonus of 8 Cyber Enhancement Units" (Trait6).
+pub const NATURALLY_ABLE_MODULES: i32 = 8;
+
+/// Display name of a trait id, or "?" for an out-of-range id.
+pub fn trait_name(trait_id: u8) -> &'static str {
+    OS_TRAITS
+        .iter()
+        .find(|(id, _)| *id == trait_id)
+        .map(|(_, name)| *name)
+        .unwrap_or("?")
+}
+
+/// The quest bit marking a machine as used, keyed by the machine's stable
+/// mission object id (for a concrete level object, `PropTemplateId` holds the
+/// object's own positive mission id - NOT the shared archetype id - so each
+/// machine keys its own bit). Lives in `QuestInfo`, so it survives save/load
+/// and deck re-entry - the durable equivalent of the original machine script
+/// remembering a "Used" message.
+///
+/// Note: the bit space is game-global while object ids are per-mission; the
+/// four shipped machines have distinct ids (medsci2 133, rec3 153, rick3 511,
+/// hydro2 879), so no cross-lock is possible with retail data.
+pub fn used_bit_name(machine_template_id: i32) -> String {
+    format!("trait_machine_used_{}", machine_template_id)
+}
+
+/// The machine's stable mission object id (`PropTemplateId`), if any. A
+/// machine without one cannot record a used state, so it must not vend.
+fn machine_template_id(world: &World, machine: EntityId) -> Option<i32> {
+    world
+        .borrow::<View<dark::properties::PropTemplateId>>()
+        .ok()
+        .and_then(|v| v.get(machine).ok().map(|t| t.template_id))
+}
+
+/// Whether the machine bound to this panel has already vended (its used bit
+/// is set). Machines without a stable id read as unused here (the display
+/// path); the pick path refuses them outright.
+fn machine_used(world: &World, machine: EntityId) -> bool {
+    let Some(template_id) = machine_template_id(world, machine) else {
+        return false;
+    };
+    world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|q| q.read_quest_bit_value(&used_bit_name(template_id)).bits() != 0)
+        .unwrap_or(false)
+}
+
+/// Preloaded `TRAITS.STR` descriptions (`Trait1..16`), added as a world unique
+/// at mission load so the (`AssetCache`-less) `TraitGui` can show the hovered
+/// trait's description - the `ElevatorContext` pattern.
+#[derive(shipyard::Unique)]
+pub struct TraitsContext {
+    /// `Trait1..16` description strings; index 0 = trait id 1. Falls back to
+    /// the bare trait name when TRAITS.STR is absent.
+    pub descriptions: [String; 16],
+}
+
+impl TraitsContext {
+    pub fn load(asset_cache: &mut AssetCache) -> TraitsContext {
+        let strings = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, "traits.str");
+        let descriptions = std::array::from_fn(|i| {
+            let key = format!("trait{}", i + 1);
+            strings
+                .as_ref()
+                .and_then(|s| s.get(&key).cloned())
+                .unwrap_or_else(|| trait_name((i + 1) as u8).to_owned())
+        });
+        TraitsContext { descriptions }
+    }
+}
+
+// Panel layout on the 188x296 backdrop (shktrait.cpp): owned-slots row at
+// (15,35) in 35x34 cells; 4x4 selection matrix in (15,76)-(152,209), icons
+// TRAIT01..16 at 34x32, `which = col + row*4 + 1`; description text below
+// from (15,214).
+const OWNED_X: f32 = 15.0;
+const OWNED_Y: f32 = 35.0;
+const OWNED_PITCH: f32 = 35.0;
+const CELL_W: f32 = 34.0;
+const CELL_H: f32 = 32.0;
+const MATRIX_X: f32 = 15.0;
+const MATRIX_Y: f32 = 76.0;
+const MATRIX_PITCH_X: f32 = 34.5;
+const MATRIX_PITCH_Y: f32 = 33.5;
+const DESC_X: f32 = 15.0;
+const DESC_Y: f32 = 214.0;
+/// Bottom of the description area ((15,214)-(174,264) in the original).
+const DESC_Y_MAX: f32 = 264.0;
+/// Crude wrap width for the ~160px description column with the engine font.
+const DESC_CHARS_PER_LINE: usize = 34;
+
+/// Greedy word-wrap: split `text` into lines of at most `width` characters
+/// (long single words get their own over-long line rather than splitting).
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current = word.to_string();
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = word.to_string();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+/// The trait icon art (`TRAIT01.PCX`..`TRAIT16.PCX`; `TRAIT00.PCX` is the
+/// empty-slot art).
+fn trait_icon(trait_id: u8) -> String {
+    format!("trait{:02}.pcx", trait_id)
+}
+
+pub struct TraitGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct TraitGuiState {
+    /// Feedback line (acquired / refusal), shown in the description area.
+    message: Option<String>,
+}
+
+#[derive(Clone)]
+pub enum TraitGuiMsg {
+    Pick(u8),
+}
+
+impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
+    fn get_components(
+        &self,
+        cursor: &Option<GuiCursor>,
+        entity_id: EntityId,
+        world: &World,
+        state: &TraitGuiState,
+    ) -> Vec<GuiComponent<TraitGuiMsg>> {
+        let mut components: Vec<GuiComponent<TraitGuiMsg>> = vec![
+            gui::image("traits.pcx")
+                .with_position(vec2(0.0, 0.0))
+                .with_size(vec2(188.0, 296.0)),
+        ];
+
+        let owned: Vec<u8> = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|q| q.player_stats().os_traits.clone())
+            .unwrap_or_default();
+
+        // Owned-slots row: acquired trait icons, empty-slot art for the rest.
+        for slot in 0..OS_TRAIT_SLOTS {
+            let icon = owned
+                .get(slot)
+                .map(|id| trait_icon(*id))
+                .unwrap_or_else(|| "trait00.pcx".to_owned());
+            components.push(
+                gui::image(&icon)
+                    .with_position(vec2(OWNED_X + OWNED_PITCH * slot as f32, OWNED_Y))
+                    .with_size(vec2(CELL_W, CELL_H)),
+            );
+        }
+
+        // 4x4 selection matrix: which = col + row*4 + 1.
+        for (idx, (trait_id, name)) in OS_TRAITS.iter().enumerate() {
+            let col = idx % 4;
+            let row = idx / 4;
+            components.push(
+                gui::button(TraitGuiMsg::Pick(*trait_id))
+                    .with_position(vec2(
+                        MATRIX_X + MATRIX_PITCH_X * col as f32,
+                        MATRIX_Y + MATRIX_PITCH_Y * row as f32,
+                    ))
+                    .with_size(vec2(CELL_W, CELL_H))
+                    .with_image(&trait_icon(*trait_id))
+                    .with_label(name),
+            );
+        }
+
+        // Description area: the machine's used state, then purchase feedback,
+        // then the hovered trait's TRAITS.STR text (the original shows the
+        // hovered description there).
+        let mut lines: Vec<String> = Vec::new();
+        if machine_used(world, entity_id) {
+            lines.push("This upgrade unit has been used.".to_owned());
+        }
+        if let Some(message) = &state.message {
+            lines.push(message.clone());
+        }
+        if let Some(hovered) = cursor.as_ref().and_then(|c| hovered_trait(c.position)) {
+            let description = world
+                .borrow::<UniqueView<TraitsContext>>()
+                .map(|ctx| ctx.descriptions[(hovered - 1) as usize].clone())
+                .unwrap_or_else(|_| trait_name(hovered).to_owned());
+            lines.push(description);
+        }
+        // Word-wrap into the description box (the engine text path draws a
+        // single unwrapped line; sentence-length TRAITS.STR text would run
+        // off the 188px panel).
+        let mut y = DESC_Y;
+        'lines: for line in &lines {
+            for wrapped in wrap_text(line, DESC_CHARS_PER_LINE) {
+                if y > DESC_Y_MAX {
+                    break 'lines;
+                }
+                components.push(
+                    gui::text(&wrapped)
+                        .with_position(vec2(DESC_X, y))
+                        .with_size(vec2(160.0, 12.0)),
+                );
+                y += 12.0;
+            }
+        }
+
+        components
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -0.2),
+            screen_size_in_pixels: Vector2::new(188.0, 296.0),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        _state: &TraitGuiState,
+        msg: &TraitGuiMsg,
+    ) -> (TraitGuiState, Effect) {
+        let TraitGuiMsg::Pick(trait_id) = msg;
+        // Pre-validate for immediate feedback; the effect handler re-validates
+        // and applies atomically (handle_msg must not mutate).
+        let refusal = {
+            let quests = world.borrow::<UniqueView<QuestInfo>>().unwrap();
+            let stats = quests.player_stats();
+            if machine_template_id(world, entity_id).is_none() {
+                Some("This upgrade unit is not responding.".to_string())
+            } else if machine_used(world, entity_id) {
+                Some("This upgrade unit has already been used.".to_string())
+            } else if stats.has_os_trait(*trait_id) {
+                Some(format!("{} is already installed.", trait_name(*trait_id)))
+            } else if stats.os_traits.len() >= OS_TRAIT_SLOTS {
+                Some("All O/S upgrade slots are full.".to_string())
+            } else {
+                None
+            }
+        };
+        match refusal {
+            Some(message) => (
+                TraitGuiState {
+                    message: Some(message),
+                },
+                Effect::NoEffect,
+            ),
+            None => (
+                TraitGuiState {
+                    message: Some(format!("{} installed.", trait_name(*trait_id))),
+                },
+                Effect::AcquireOsTrait {
+                    trait_id: *trait_id,
+                    machine: entity_id,
+                },
+            ),
+        }
+    }
+}
+
+/// The trait id under a panel-pixel cursor position, if it is over a matrix
+/// cell.
+fn hovered_trait(cursor: cgmath::Point2<f32>) -> Option<u8> {
+    for (idx, (trait_id, _)) in OS_TRAITS.iter().enumerate() {
+        let col = idx % 4;
+        let row = idx / 4;
+        let x = MATRIX_X + MATRIX_PITCH_X * col as f32;
+        let y = MATRIX_Y + MATRIX_PITCH_Y * row as f32;
+        if cursor.x >= x && cursor.x <= x + CELL_W && cursor.y >= y && cursor.y <= y + CELL_H {
+            return Some(*trait_id);
+        }
+    }
+    None
+}
+
+/// One-line note of a trait's live effect, if implemented (for logs).
+pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
+    match trait_id {
+        TRAIT_TANK => Some("+5 max hit points"),
+        TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::point2;
+
+    #[test]
+    fn sixteen_traits_in_retail_order() {
+        assert_eq!(OS_TRAITS.len(), 16);
+        // Spot checks against TRAITS.STR (Trait4 Speedy, Trait8 Tank, Trait16
+        // Spatially Aware).
+        assert_eq!(trait_name(4), "Speedy");
+        assert_eq!(trait_name(8), "Tank");
+        assert_eq!(trait_name(16), "Spatially Aware");
+        // Ids are exactly 1..=16 in order (which = col + row*4 + 1).
+        for (idx, (id, _)) in OS_TRAITS.iter().enumerate() {
+            assert_eq!(*id as usize, idx + 1);
+        }
+    }
+
+    #[test]
+    fn matrix_hit_test_maps_cells_to_ids() {
+        // Center of cell (col 0, row 0) = trait 1; (col 3, row 3) = trait 16.
+        assert_eq!(
+            hovered_trait(point2(MATRIX_X + 1.0, MATRIX_Y + 1.0)),
+            Some(1)
+        );
+        assert_eq!(
+            hovered_trait(point2(
+                MATRIX_X + MATRIX_PITCH_X * 3.0 + 5.0,
+                MATRIX_Y + MATRIX_PITCH_Y * 3.0 + 5.0
+            )),
+            Some(16)
+        );
+        // Off the matrix: no hover.
+        assert_eq!(hovered_trait(point2(5.0, 5.0)), None);
+        assert_eq!(hovered_trait(point2(100.0, 280.0)), None);
+    }
+
+    #[test]
+    fn used_bit_is_keyed_by_stable_mission_id() {
+        assert_eq!(used_bit_name(133), "trait_machine_used_133");
+    }
+
+    #[test]
+    fn descriptions_word_wrap_to_the_panel_column() {
+        let lines = wrap_text(
+            "Tank: Increases maximum hit points by 5.",
+            DESC_CHARS_PER_LINE,
+        );
+        assert!(lines.len() >= 2, "sentence text wraps to multiple lines");
+        assert!(lines.iter().all(|l| l.len() <= DESC_CHARS_PER_LINE));
+        // The full text survives the wrap.
+        assert_eq!(lines.join(" "), "Tank: Increases maximum hit points by 5.");
+        // Degenerate inputs.
+        assert!(wrap_text("", 10).is_empty());
+        assert_eq!(wrap_text("word", 10), vec!["word".to_string()]);
+    }
+}

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -1,10 +1,10 @@
 //! O/S upgrade machine MFD panel (projects/flat-ui-panels.md §4).
 //!
-//! The retail overlay (`shktrait.cpp`, `kOverlayBuyTraits 20`): one pick from
-//! all 16 traits on a 4x4 icon matrix, an owned-slots row (up to 4 - the whole
-//! game has exactly four machines), a description of the hovered trait from
-//! `TRAITS.STR`, no confirmation step, and **purchases are free**. On buy the
-//! machine becomes single-use ("Used").
+//! The original game's O/S upgrade overlay: one pick from all 16 traits on a
+//! 4x4 icon matrix, an owned-slots row (up to 4 - the whole game has exactly
+//! four machines), a description of the hovered trait from `TRAITS.STR`, no
+//! confirmation step, and **purchases are free**. On buy the machine becomes
+//! single-use ("Used").
 //!
 //! Ours mirrors that: traits are stored on the character sheet
 //! (`PlayerStats::os_traits`, persisted via `QuestInfo`), the per-machine used
@@ -26,8 +26,8 @@ use crate::scripts::Effect;
 
 use crate::gui;
 
-/// The 16 O/S traits, by retail id (`shktrcst.h` enum order = `TRAITS.STR`
-/// `Trait1..16` order, verified against the shipped strings).
+/// The 16 O/S traits, by the original game's trait id (matching the shipped
+/// `TRAITS.STR` `Trait1..16` order, verified against those strings).
 pub const OS_TRAITS: [(u8, &str); 16] = [
     (1, "Strong Metabolism"),
     (2, "Pharmo-Friendly"),

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -85,7 +85,7 @@ use self::choose_service::ChooseServiceScript;
 pub use self::gui::ElevatorContext;
 use self::gui::{
     ContainerGui, ElevatorGui, GamePigGui, KeyPadGui, MapGui, MediaGui, ReplicatorGui, TrainerGui,
-    TrainerMode,
+    TrainerMode, TraitGui,
 };
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::psi_amp_script::PsiAmpScript;
@@ -659,7 +659,7 @@ impl ScriptWorld {
             "psitrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Psi))),
             "techtrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Tech))),
             "statstrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Stats))),
-            "traitmachine" => Box::new(NoopScript::new()),
+            "traitmachine" => gui_script(Box::new(TraitGui)),
 
             // medsci2
             // Keycard in watt's office

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -323,6 +323,9 @@ export interface PlayerStats {
   cyber_modules: number;
   /** Highest psi tier unlocked at a psi trainer (0..=5, sequential). */
   psi_tier: number;
+  /** O/S upgrade traits acquired at trait machines, by retail trait id
+   * (1..=16, TRAITS.STR order), in acquisition order; at most 4. */
+  os_traits: number[];
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for the O/S upgrade (trait) machine MFD (flat UI 6f / PR C3).
+// Opt-in (SHOCK2_E2E=1); requires game assets in Data/.
+//
+// The trait machine offers a one-time pick from all 16 O/S traits (free, per
+// the original). The pick is stored on the persistent character sheet, the
+// machine becomes single-use (a quest bit keyed by its stable mission object
+// id), and implemented trait effects apply (Tank: +5 max HP, live and
+// re-derived across loads).
+//
+// Negative-first: on the C2 base, `traitmachine` is a NoopScript - frobbing
+// medsci2's Trait Machine (mission id 133) opens nothing, so the "panel
+// opened" assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8171);
+
+/** Find the level's Trait Machine by stable mission object id. */
+async function findMachine(game: GameServer, missionId: number) {
+  const entities = (await game.entities.list({ filter: "Trait Machine" })).entities;
+  const machine = entities.find((e) => e.template_id === missionId);
+  assert.ok(machine, `the level should contain Trait Machine (mission id ${missionId})`);
+  return machine;
+}
+
+/** Teleport next to an entity, probing a few offsets for stable footing
+ * (some machines sit next to pits; a bad offset leaves the player falling
+ * out of the panel's walk-away radius). */
+async function standNear(game: GameServer, id: number) {
+  const detail = await game.entities.detail(id);
+  const [x, y, z] = detail.position;
+  for (const [dx, dz] of [
+    [0, 1.2],
+    [0, -1.2],
+    [1.2, 0],
+    [-1.2, 0],
+  ]) {
+    await teleportVerified(game, { x: x + dx, y: y + 0.5, z: z + dz });
+    await game.step({ frames: 30 });
+    const p = (await game.info()).player.position;
+    const dist = Math.hypot(p[0] - x, p[1] - y, p[2] - z);
+    if (dist < 3.0) return;
+  }
+  assert.fail("could not find stable footing near the trait machine");
+}
+
+async function clickElement(game: GameServer, el: UiElement) {
+  const [x, y, w, h] = el.screen_rect;
+  await game.input.set("pointer.position", [x + w / 2, y + h / 2]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+const traitButton = (label: string, els: UiElement[]) => {
+  const el = els.find((e) => e.kind === "button" && e.label === label);
+  assert.ok(el, `panel should expose a trait button labeled "${label}"`);
+  return el;
+};
+
+test(
+  "O/S trait machine: one-time pick, stored persistently, machine single-use",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `os_traits_e2e_${Date.now()}`;
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    const stats = async () => {
+      const s = (await game.info()).player.stats;
+      assert.ok(s, "player should have a character sheet");
+      return s;
+    };
+    assert.deepEqual((await stats()).os_traits, [], "fresh character has no O/S traits");
+    const hpBefore = (await game.info()).player.max_hit_points;
+    assert.ok(hpBefore != null, "player has a hit-point pool");
+
+    // --- Frob the medsci2 machine: the panel must open (fails on the C2
+    // base, where traitmachine is a NoopScript). ---
+    const machine = await findMachine(game, 133);
+    await standNear(game, machine.id);
+    assert.ok(!(await game.ui.state()).active_panel, "no panel before the frob");
+    await game.entities.sendMessage(machine.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const opened = await game.ui.state();
+    assert.ok(opened.active_panel, "frobbing the Trait Machine should open its panel");
+    await game.screenshot("traits-panel-open.png");
+
+    // --- All 16 traits are labeled, clickable buttons. ---
+    const els = opened.active_panel.elements;
+    for (const name of [
+      "Strong Metabolism", "Pharmo-Friendly", "Pack-Rat", "Speedy",
+      "Sharpshooter", "Naturally Able", "Cybernetically Enhanced", "Tank",
+      "Lethal Weapon", "Security Expert", "Smasher", "Cyber-Assimilation",
+      "Replicator Expert", "Power Psi", "Tinker", "Spatially Aware",
+    ]) {
+      traitButton(name, els);
+    }
+
+    // --- Pick Tank: stored + live +5 max HP. ---
+    await clickElement(game, traitButton("Tank", els));
+    await game.step({ frames: 3 });
+    const afterPick = await stats();
+    assert.deepEqual(afterPick.os_traits, [8], "Tank (trait 8) is recorded");
+    const hpAfter = (await game.info()).player.max_hit_points;
+    assert.equal(hpAfter, (hpBefore as number) + 5, "Tank grants +5 max HP live");
+    await game.screenshot("traits-after-pick.png");
+
+    // --- The machine is now single-use: a second pick refuses. ---
+    const refreshed = await game.ui.state();
+    assert.ok(refreshed.active_panel, "panel stays open after the pick");
+    await clickElement(game, traitButton("Speedy", refreshed.active_panel.elements));
+    await game.step({ frames: 3 });
+    assert.deepEqual(
+      (await stats()).os_traits,
+      [8],
+      "the used machine must refuse a second trait",
+    );
+    const refusalUi = await game.ui.state();
+    assert.ok(
+      refusalUi.active_panel!.elements.some(
+        (e) => e.kind === "text" && e.text?.includes("used"),
+      ),
+      "the panel shows the machine-used message",
+    );
+
+    // --- Used state + trait survive save/load. ---
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+    assert.deepEqual((await stats()).os_traits, [8], "trait survives save/load");
+    assert.equal(
+      (await game.info()).player.max_hit_points,
+      (hpBefore as number) + 5,
+      "Tank max-HP bonus re-derives after load",
+    );
+    const machine2 = await findMachine(game, 133);
+    await standNear(game, machine2.id);
+    await game.entities.sendMessage(machine2.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const reopened = await game.ui.state();
+    assert.ok(reopened.active_panel, "the used machine still opens its panel");
+    await clickElement(game, traitButton("Speedy", reopened.active_panel.elements));
+    await game.step({ frames: 3 });
+    assert.deepEqual(
+      (await stats()).os_traits,
+      [8],
+      "the used machine refuses after save/load too",
+    );
+
+    // --- A different machine still works: hydro2's Trait Machine (mission
+    // id 879) vends a second trait, and traits accumulate. ---
+    await game.transitionLevel("hydro2.mis");
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).mission, "hydro2.mis");
+    assert.deepEqual((await stats()).os_traits, [8], "trait survives the transition");
+
+    const hydroMachine = await findMachine(game, 879);
+    await standNear(game, hydroMachine.id);
+    await game.entities.sendMessage(hydroMachine.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const hydroPanel = await game.ui.state();
+    assert.ok(hydroPanel.active_panel, "the second machine opens its panel");
+    const modulesBefore = (await stats()).cyber_modules;
+    await clickElement(
+      game,
+      traitButton("Naturally Able", hydroPanel.active_panel.elements),
+    );
+    await game.step({ frames: 3 });
+    const finalStats = await stats();
+    assert.deepEqual(
+      finalStats.os_traits,
+      [8, 6],
+      "the second machine vends a second trait",
+    );
+    assert.equal(
+      finalStats.cyber_modules,
+      modulesBefore + 8,
+      "Naturally Able grants its one-time +8 cyber modules",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -11,8 +11,9 @@ import { teleportVerified } from "./helpers/teleport.js";
 // The trait machine offers a one-time pick from all 16 O/S traits (free, per
 // the original). The pick is stored on the persistent character sheet, the
 // machine becomes single-use (a quest bit keyed by its stable mission object
-// id), and implemented trait effects apply (Tank: +5 max HP, live and
-// re-derived across loads).
+// id), and implemented trait effects apply (Tank: +5 max AND current HP -
+// original behavior: buying at 25/30 yields 30/35 - live and re-derived
+// across loads).
 //
 // Negative-first: on the C2 base, `traitmachine` is a NoopScript - frobbing
 // medsci2's Trait Machine (mission id 133) opens nothing, so the "panel
@@ -82,8 +83,10 @@ test(
       return s;
     };
     assert.deepEqual((await stats()).os_traits, [], "fresh character has no O/S traits");
-    const hpBefore = (await game.info()).player.max_hit_points;
+    const before = (await game.info()).player;
+    const hpBefore = before.max_hit_points;
     assert.ok(hpBefore != null, "player has a hit-point pool");
+    assert.equal(before.hit_points, hpBefore, "the player starts at full health");
 
     // --- Frob the medsci2 machine: the panel must open (fails on the C2
     // base, where traitmachine is a NoopScript). ---
@@ -107,13 +110,26 @@ test(
       traitButton(name, els);
     }
 
-    // --- Pick Tank: stored + live +5 max HP. ---
+    // --- Pick Tank: stored + live +5 max AND current HP (the original
+    // raises both - buying wounded at 25/30 yields 30/35). The player can't
+    // be wounded headlessly (it has no scripts, so a debug Damage message is
+    // dropped), but the current-HP grant is still observable at full health:
+    // ceiling-only would leave 30/35, the original behavior yields 35/35. ---
     await clickElement(game, traitButton("Tank", els));
     await game.step({ frames: 3 });
     const afterPick = await stats();
     assert.deepEqual(afterPick.os_traits, [8], "Tank (trait 8) is recorded");
-    const hpAfter = (await game.info()).player.max_hit_points;
-    assert.equal(hpAfter, (hpBefore as number) + 5, "Tank grants +5 max HP live");
+    const hpAfter = (await game.info()).player;
+    assert.equal(
+      hpAfter.max_hit_points,
+      (hpBefore as number) + 5,
+      "Tank grants +5 max HP live",
+    );
+    assert.equal(
+      hpAfter.hit_points,
+      (hpBefore as number) + 5,
+      "Tank also grants +5 current HP live (original behavior; not left at the old max)",
+    );
     await game.screenshot("traits-after-pick.png");
 
     // --- The machine is now single-use: a second pick refuses. ---
@@ -129,9 +145,9 @@ test(
     const refusalUi = await game.ui.state();
     assert.ok(
       refusalUi.active_panel!.elements.some(
-        (e) => e.kind === "text" && e.text?.includes("used"),
+        (e) => e.kind === "text" && e.text?.includes("already been upgraded"),
       ),
-      "the panel shows the machine-used message",
+      "the panel shows the shipped machine-used message (MISC.STR TraitMachineUsed)",
     );
 
     // --- Used state + trait survive save/load. ---
@@ -139,10 +155,18 @@ test(
     await game.load(saveName);
     await game.step({ frames: 5 });
     assert.deepEqual((await stats()).os_traits, [8], "trait survives save/load");
+    const hpLoaded = (await game.info()).player;
     assert.equal(
-      (await game.info()).player.max_hit_points,
+      hpLoaded.max_hit_points,
       (hpBefore as number) + 5,
-      "Tank max-HP bonus re-derives after load",
+      "Tank max-HP bonus re-derives after load (not doubled)",
+    );
+    // Current HP is not persisted: it re-seeds to the (trait-adjusted) max on
+    // load, so the live +5 current-HP grant cannot double-apply.
+    assert.equal(
+      hpLoaded.hit_points,
+      hpLoaded.max_hit_points,
+      "current HP re-seeds to max on load (live grant does not double)",
     );
     const machine2 = await findMachine(game, 133);
     await standNear(game, machine2.id);


### PR DESCRIPTION
## Summary

The trait machines (`traitmachine`, previously a `NoopScript`) now open the original game's O/S upgrade MFD: a 4×4 matrix of all **16 traits**, an owned-slots row (max 4 — one per machine in the game), hovered-trait descriptions from `TRAITS.STR`, and a free, no-confirmation pick. Test machines: medsci2 mission id **133**, hydro2 **879**, rec3 **153**, rick3 **511**. Third PR of the C-track — **stacked on #470** (trainer panel); merge that first.

![O/S trait panel demo](https://gist.githubusercontent.com/tommy-xr/6132faf052b3a28a39521f11f02f97ed/raw/traits-demo.gif)

<sub>Frobbing the medsci2 Trait Machine opens the O/S-UP MFD; hovering Tank/Speedy updates the word-wrapped description; picking Tank fills the first owned slot ("Tank installed.", max HP +5), and a second pick is refused. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). A wandering hybrid lands a hit mid-GIF — background action, unrelated to the panel. (Captured before the review fixes below; the refusal line is now the shipped `TraitMachineUsed` string and the panel draws the "Choose one upgrade." header.)</sub>

![O/S trait panel still](https://gist.githubusercontent.com/tommy-xr/6132faf052b3a28a39521f11f02f97ed/raw/traits-panel.png)

## What changed

- **`TraitGui`** (`shock2vr/src/scripts/gui/traits.rs`): TRAITS.PCX backdrop, `MISC.STR TraitHeader` ("Choose one upgrade.") at (17,14), owned-slots row at (15,35) (TRAIT00 empty-slot art), 4×4 selection matrix from (15,76) with `TRAIT01..16.PCX` icon buttons carrying semantic labels (`which = col + row*4 + 1`, original order verified against the shipped `TRAITS.STR`), hovered-trait descriptions (a `TraitsContext` unique preloads `TRAITS.STR` + the MISC.STR panel strings at mission load — the `ElevatorContext` pattern) word-wrapped into the (15,214)–(174,264) description area.
- **Storage**: `PlayerStats::os_traits` (original ids 1..=16, acquisition order, cap 4, id-validated) — persists via `QuestInfo` like the rest of the character sheet.
- **Single-use**: a quest bit keyed by the machine's **stable mission object id** (`PropTemplateId`), so the used state survives save/load and deck re-entry. A machine without a stable id refuses to vend (fail-closed) rather than vending repeatably. A used machine shows the shipped `MISC.STR TraitMachineUsed` line ("Your OS has already been upgraded at this unit.").
- **`Effect::AcquireOsTrait`**: atomic validate (machine unused, trait unowned, free slot) → record → mark used → live effect. Purchases are **free**, per the original.

## Trait effects: live vs storage-only

**Live now** (existing consumers):
- **Tank** (8): +5 max HP **and** +5 current HP (clamped to the new max) — the original raises both, so buying wounded at 25/30 yields 30/35. Applied live on pick and re-derived on every mission load beside the career loadout (the player entity is rebuilt each load; current HP is not persisted, so the live grant cannot double-apply).
- **Naturally Able** (6): one-time +8 cyber modules (the C1 currency).

**Storage-only, effects deferred** (recorded on the sheet; each pending its consumer):
- **Speedy** (4) — needs a locomotion speed-scale hook (flat + VR); deliberately not hand-rolled into movement code here.
- **Sharpshooter** (5) / **Lethal Weapon** (9) — need ranged/melee damage-formula hooks (35% actual for both per the original engine; Sharpshooter's 15% label is the original's bugged string).
- **Spatially Aware** (16) — needs the map/automap panel (track B, PR B2).
- **Pack-Rat** (3) — inventory grid is fixed 15×3 today.
- **Cybernetically Enhanced** (7) — implant slots not modeled.
- **Replicator Expert** (13) / **Tinker** (15) — nanites don't exist yet.
- **Strong Metabolism** (1), **Pharmo-Friendly** (2), **Security Expert** (10), **Smasher** (11), **Cyber-Assimilation** (12), **Power Psi** (14) — no radiation/hypo-scaling/security-hack/overhand-melee/robot-salvage/burnout-immunity hooks yet.

## Review fixes

From an adversarial review verified against original game behavior and the shipped data:

- **Tank grants current HP too** (was ceiling-only): the original shifts current HP by the same +5 it adds to the ceiling — buying at 25/30 now yields 30/35, not 25/35. Clamped to the new max; idempotent across save/load because current HP is not persisted (it re-seeds from template + career + traits on every load). The e2e asserts the live +5 current HP (at full health: 35/35, where ceiling-only left 30/35 — the player can't be wounded headlessly, it has no scripts to receive a debug Damage message) and that a save/load round-trip doesn't double it.
- **Shipped used-machine string** (was an invented one): the used-machine refusal (both the standing panel line and the pick refusal) is now `MISC.STR TraitMachineUsed` — "Your OS has already been upgraded at this unit." — with the shipped text as the English fallback. Other refusal lines with no shipped counterpart (slots full, unresponsive machine) remain minimal invented strings.
- **Missing panel header**: the panel now draws `MISC.STR TraitHeader` ("Choose one upgrade.") at (17,14), like the original.

## Deviations from the original

- **Used machine still opens a clickable matrix, then refuses** — deliberate adaptation. The original blanks the matrix after purchase and shows the used-string instead of a working panel; ours opens the full panel, shows the shipped used-line in the description area, and refuses any pick. Same net behavior (a used machine never vends), friendlier introspection.
- Known cosmetic follow-ups: the owned row shows empty-slot art in every free slot (vs the original's single next-slot marker semantics); matrix pitch is 34.5/33.5 (vs the original's 35/34); owned-slot icons don't show hover descriptions.

## Verification

- **e2e** `os-traits.e2e.test.ts` (negative-first): on the C2 base, frobbing machine 133 does nothing (`NoopScript`) — the panel assert fails. After: panel with 16 labeled trait buttons; picking **Tank** stores trait 8 and grants +5 max **and** +5 current HP live (35/35, not the ceiling-only 30/35); the machine refuses a second pick with the shipped used-string (and still refuses after save/load, with the max-HP bonus re-derived — not doubled — and current HP re-seeded to max, not double-granted); the trait survives a medsci2→hydro2 transition; **hydro2's machine still vends** a second trait; **Naturally Able** grants its +8 modules. (The review fixes were themselves landed negative-first: the pre-fix assertions fail against the shipped string/HP behavior.)
- Unit: original-order/id-mapping, matrix hit-test, used-bit keying, word-wrap; full `cargo test -p dark -p shock2vr` green.
- Missions **23/23**; 12-test flat-UI/station battery green (keypad, trainer, cyber-modules, elevator, inventory, station-flow); SDK unit green; `RUSTFLAGS="-D warnings"` clean on all 3 crates.
- xreview (Claude + Codex): fixes applied — description word-wrap (engine text draws one unwrapped line), machines without a stable id fail closed, `add_os_trait` validates the 1..=16 range.

## Notes

- Per-machine "used" via quest bit is the doc's sanctioned alternative to a serialized runtime prop (`projects/flat-ui-panels.md` §4.3) — it rides existing persistence with zero new plumbing.
- A systemic font-sizing/text-layout fix is being investigated separately; no font changes here. Layout geometry follows the research doc's rects (header (17,14), owned row (15,35), matrix (15,76)–(152,209), description (15,214)–(174,264)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
