### PR TITLE
feat(ui): render UI text with the original .FON bitmap fonts

### DIFF
--- a/dark/src/font.rs
+++ b/dark/src/font.rs
@@ -50,6 +50,67 @@ pub struct CharInfo {
     pub width: f32,
 }
 
+/// Pure (no-GL) glyph metrics parsed from a Dark `.FON` file: the header plus
+/// the column table. Separated from [`Font::read`] (which additionally builds a
+/// GL texture atlas) so the byte-level parse is unit-testable headlessly.
+#[derive(Debug, PartialEq)]
+pub struct FontMetrics {
+    pub format: u16,
+    pub first_char: i16,
+    pub last_char: i16,
+    /// Glyph height in pixels (font's native size on the 640x480 canvas).
+    pub height: u16,
+    pub row_width: u16,
+    pub bitmap_offset: u32,
+    /// Column x-positions in the bitmap strip; `columns[i+1] - columns[i]` is
+    /// the pixel width of the `first_char + i` glyph. Has `num_chars + 1`
+    /// entries so the last glyph's width is well-defined.
+    pub columns: Vec<u16>,
+}
+
+impl FontMetrics {
+    /// Number of glyphs described (inclusive `first_char..=last_char`).
+    pub fn num_chars(&self) -> usize {
+        (self.last_char - self.first_char + 1) as usize
+    }
+
+    /// Pixel width of the glyph for `code`, or `None` if out of range.
+    pub fn glyph_width(&self, code: i16) -> Option<u16> {
+        if code < self.first_char || code > self.last_char {
+            return None;
+        }
+        let i = (code - self.first_char) as usize;
+        Some(self.columns[i + 1] - self.columns[i])
+    }
+
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontMetrics {
+        let header = FontHeader::read(reader);
+        assert!(header.palette == 0);
+
+        let num_chars = (header.last_char - header.first_char + 1) as usize;
+        reader
+            .seek(io::SeekFrom::Start(header.width_offset as u64))
+            .unwrap();
+        // The column table has `num_chars + 1` entries: N glyph starts plus the
+        // end column of the last glyph, so every glyph width is a difference of
+        // adjacent entries.
+        let mut columns = Vec::with_capacity(num_chars + 1);
+        for _ in 0..=num_chars {
+            columns.push(read_u16(reader));
+        }
+
+        FontMetrics {
+            format: header.format,
+            first_char: header.first_char,
+            last_char: header.last_char,
+            height: header.num_rows,
+            row_width: header.row_width,
+            bitmap_offset: header.bitmap_offset,
+            columns,
+        }
+    }
+}
+
 impl FontHeader {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontHeader {
         let format = read_u16(reader);
@@ -147,54 +208,42 @@ impl Font {
         // Then rewind and start reading...
         reader.seek(io::SeekFrom::Start(0)).unwrap();
 
-        let header = FontHeader::read(reader);
+        let metrics = FontMetrics::read(reader);
 
-        // Currently, we don't support any palettes
-        assert!(header.palette == 0);
+        info!("Loading font with metrics: {:?}", metrics);
 
-        info!("Loading font with header: {:?}", header);
-
-        let num_chars = header.last_char - header.first_char + 1;
-
-        let mut widths = Vec::new();
-        reader
-            .seek(io::SeekFrom::Start(header.width_offset as u64))
-            .unwrap();
-
-        for _ in 0..num_chars {
-            widths.push(read_u16(reader))
-        }
+        let num_chars = metrics.num_chars();
 
         // Read bitmap data
         reader
-            .seek(io::SeekFrom::Start(header.bitmap_offset as u64))
+            .seek(io::SeekFrom::Start(metrics.bitmap_offset as u64))
             .unwrap();
 
-        let bitmap_size = end_bytes - header.bitmap_offset as u64;
+        let bitmap_size = end_bytes - metrics.bitmap_offset as u64;
         let bitmap = read_bytes(reader, bitmap_size as usize);
 
         let mut char_to_info = HashMap::new();
         let mut texture_packer = TexturePacker::<image::Rgba<u8>>::new_rgba(512, 512);
-        for n in 0..num_chars - 1 {
-            let code = header.first_char + n;
+        for n in 0..num_chars {
+            let code = metrics.first_char + n as i16;
             let ascii = char::from_u32(code as u32).unwrap();
-            let idx = n as usize;
+            let idx = n;
 
-            let column = widths[idx];
-            let width = widths[idx + 1] - widths[idx];
+            let column = metrics.columns[idx];
+            let width = metrics.columns[idx + 1] - metrics.columns[idx];
 
             // Generate the image corresponding to the character:
             let img: ImageBuffer<image::Rgba<u8>, std::vec::Vec<u8>> =
-                image::ImageBuffer::from_fn(width as u32, header.num_rows as u32, |x, y| {
+                image::ImageBuffer::from_fn(width as u32, metrics.height as u32, |x, y| {
                     let adj_x = x + (column as u32);
-                    if header.format == 0 {
+                    if metrics.format == 0 {
                         // This is a little gnarly... what is happening here is that each pixel
                         // is compacted horizontally. Each 'byte' value actually corresponds to 8
                         // pixels - each bit tracking whether the pixel is on or off.
 
                         // First, get the byte-index of the pixel
                         let idx_packed = adj_x / 8;
-                        let byte_index = (y * header.row_width as u32 + idx_packed) as usize;
+                        let byte_index = (y * metrics.row_width as u32 + idx_packed) as usize;
 
                         // This gives us the full byte value
                         let packed_val = bitmap[byte_index];
@@ -211,7 +260,7 @@ impl Font {
                     } else {
                         // If format is not 0, this is easy mode... each byte
                         // just directly corresponds to an alpha value.
-                        let idx = (y * header.row_width as u32 + adj_x) as usize;
+                        let idx = (y * metrics.row_width as u32 + adj_x) as usize;
                         let mut alpha = bitmap[idx];
                         // Not sure why this is necessary... but we get artifacts (random bright pixels) in some fonts w/o this
                         if alpha > 205 {
@@ -243,7 +292,7 @@ impl Font {
         Font {
             texture,
             char_to_info,
-            base_height: header.num_rows as f32,
+            base_height: metrics.height as f32,
         }
     }
 }
@@ -288,6 +337,87 @@ impl engine::Font for Font {
 
 #[cfg(test)]
 mod tests {
+    use super::FontMetrics;
+    use std::io::Cursor;
+
+    /// Build a minimal, valid Dark `.FON` byte buffer for `first..=last` with
+    /// the given `columns` (len == num_chars + 1) and `height`. Mirrors the
+    /// 84-byte header layout `FontHeader::read` expects.
+    fn synth_font(first: i16, last: i16, height: u16, columns: &[u16], format: u16) -> Vec<u8> {
+        let num_chars = (last - first + 1) as usize;
+        assert_eq!(columns.len(), num_chars + 1);
+        let width_offset: u32 = 84;
+        let bitmap_offset: u32 = width_offset + (columns.len() as u32) * 2;
+        let row_width: u16 = *columns.last().unwrap();
+
+        let mut b = vec![0u8; 84];
+        b[0..2].copy_from_slice(&format.to_le_bytes());
+        // b[2] unk, b[3] palette = 0
+        b[0x24..0x26].copy_from_slice(&first.to_le_bytes());
+        b[0x26..0x28].copy_from_slice(&last.to_le_bytes());
+        b[0x48..0x4c].copy_from_slice(&width_offset.to_le_bytes());
+        b[0x4c..0x50].copy_from_slice(&bitmap_offset.to_le_bytes());
+        b[0x50..0x52].copy_from_slice(&row_width.to_le_bytes());
+        b[0x52..0x54].copy_from_slice(&height.to_le_bytes());
+        for c in columns {
+            b.extend_from_slice(&c.to_le_bytes());
+        }
+        b.extend(vec![0u8; (row_width as usize) * (height as usize)]);
+        b
+    }
+
+    #[test]
+    fn font_metrics_parses_glyph_count_widths_and_height() {
+        // Digits '0'..'1' (2 glyphs): '0' spans [0,3)=3px, '1' spans [3,7)=4px.
+        let bytes = synth_font(48, 49, 11, &[0, 3, 7], 0);
+        let m = FontMetrics::read(&mut Cursor::new(bytes));
+
+        assert_eq!(m.num_chars(), 2);
+        assert_eq!(m.height, 11);
+        assert_eq!(m.first_char, 48);
+        assert_eq!(m.last_char, 49);
+        // The column table must carry num_chars + 1 entries so the *last*
+        // glyph's width is defined (the old parser dropped it).
+        assert_eq!(m.columns.len(), 3);
+        assert_eq!(m.glyph_width(48), Some(3));
+        assert_eq!(m.glyph_width(49), Some(4));
+        // Out-of-range codes have no glyph.
+        assert_eq!(m.glyph_width(47), None);
+        assert_eq!(m.glyph_width(50), None);
+    }
+
+    /// Real-font parse guarded by asset availability (game `.FON` files are not
+    /// in the repo, so this no-ops in CI). MAINFONT.FON: char 0..=225, 11px
+    /// tall, mono (format 0).
+    #[test]
+    fn mainfont_metrics_from_real_asset_when_present() {
+        let mut found = None;
+        for root in [
+            std::env::var("DARK_ASSET_PATH").unwrap_or_default(),
+            "../Data".into(),
+            "../../Data".into(),
+        ] {
+            let p = std::path::Path::new(&root).join("res/fonts/MAINFONT.FON");
+            if p.exists() {
+                found = Some(p);
+                break;
+            }
+        }
+        let Some(path) = found else {
+            eprintln!("skipping: MAINFONT.FON asset not found");
+            return;
+        };
+        let bytes = std::fs::read(path).unwrap();
+        let m = FontMetrics::read(&mut Cursor::new(bytes));
+        assert_eq!(m.format, 0);
+        assert_eq!(m.first_char, 0);
+        assert_eq!(m.last_char, 225);
+        assert_eq!(m.height, 11);
+        assert_eq!(m.num_chars(), 226);
+        assert_eq!(m.columns.len(), 227);
+        let w0 = m.glyph_width(b'0' as i16).unwrap();
+        assert!((1..=20).contains(&w0), "digit width {w0} out of range");
+    }
 
     #[test]
     fn test_half_pixel_calculation_formula() {

--- a/dark/src/font.rs
+++ b/dark/src/font.rs
@@ -111,6 +111,26 @@ impl FontMetrics {
     }
 }
 
+/// Alpha for one bitmap byte of an *unpacked* (non-format-0) font.
+///
+/// - Format `0x0001` ("antialias-16", e.g. `METAFONT.FON`): each byte is a
+///   coverage level 0..=15; scale linearly so full coverage (15) is fully
+///   opaque (255). Without this the whole font renders at max alpha 15 -
+///   nearly invisible.
+/// - Other formats (e.g. the `0xCCCC` AA fonts): each byte is used as direct
+///   alpha. The `> 205` clamp works around artifacts (random bright pixels)
+///   seen in some of those fonts; the proper fix is palette/coverage
+///   normalization (see `projects/ui-font-fidelity.md` follow-ups).
+fn unpacked_byte_alpha(format: u16, value: u8) -> u8 {
+    if format == 1 {
+        value.saturating_mul(17)
+    } else if value > 205 {
+        0
+    } else {
+        value
+    }
+}
+
 impl FontHeader {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T) -> FontHeader {
         let format = read_u16(reader);
@@ -258,14 +278,9 @@ impl Font {
 
                         image::Rgba([255, 255, 255, alpha])
                     } else {
-                        // If format is not 0, this is easy mode... each byte
-                        // just directly corresponds to an alpha value.
+                        // Unpacked formats: one byte per pixel.
                         let idx = (y * metrics.row_width as u32 + adj_x) as usize;
-                        let mut alpha = bitmap[idx];
-                        // Not sure why this is necessary... but we get artifacts (random bright pixels) in some fonts w/o this
-                        if alpha > 205 {
-                            alpha = 0;
-                        }
+                        let alpha = unpacked_byte_alpha(metrics.format, bitmap[idx]);
                         image::Rgba([255, 255, 255, alpha])
                     }
                 });
@@ -386,24 +401,29 @@ mod tests {
         assert_eq!(m.glyph_width(50), None);
     }
 
-    /// Real-font parse guarded by asset availability (game `.FON` files are not
-    /// in the repo, so this no-ops in CI). MAINFONT.FON: char 0..=225, 11px
-    /// tall, mono (format 0).
-    #[test]
-    fn mainfont_metrics_from_real_asset_when_present() {
-        let mut found = None;
+    /// Locate a game asset by data-root-relative path (fonts live under both
+    /// `res/fonts/` and `res/intrface/`). Returns `None` when the game data is
+    /// absent (e.g. CI), so real-asset tests can no-op.
+    fn find_asset(rel: &str) -> Option<std::path::PathBuf> {
         for root in [
             std::env::var("DARK_ASSET_PATH").unwrap_or_default(),
             "../Data".into(),
             "../../Data".into(),
         ] {
-            let p = std::path::Path::new(&root).join("res/fonts/MAINFONT.FON");
+            let p = std::path::Path::new(&root).join(rel);
             if p.exists() {
-                found = Some(p);
-                break;
+                return Some(p);
             }
         }
-        let Some(path) = found else {
+        None
+    }
+
+    /// Real-font parse guarded by asset availability (game `.FON` files are not
+    /// in the repo, so this no-ops in CI). MAINFONT.FON: char 0..=225, 11px
+    /// tall, mono (format 0).
+    #[test]
+    fn mainfont_metrics_from_real_asset_when_present() {
+        let Some(path) = find_asset("res/fonts/MAINFONT.FON") else {
             eprintln!("skipping: MAINFONT.FON asset not found");
             return;
         };
@@ -417,6 +437,35 @@ mod tests {
         assert_eq!(m.columns.len(), 227);
         let w0 = m.glyph_width(b'0' as i16).unwrap();
         assert!((1..=20).contains(&w0), "digit width {w0} out of range");
+    }
+
+    /// METAFONT.FON — the original's default GUI style font (main menu et al),
+    /// shipped under `res/intrface/`, format 0x0001 ("antialias-16"): each
+    /// bitmap byte is a 0..=15 coverage level. Asserts the 0..15 -> 0..255
+    /// alpha scaling reaches full opacity; before format-1 support the parser
+    /// treated these bytes as direct alpha (max 15/255 - nearly invisible).
+    #[test]
+    fn metafont_format1_alpha_from_real_asset_when_present() {
+        let Some(path) = find_asset("res/intrface/METAFONT.FON") else {
+            eprintln!("skipping: METAFONT.FON asset not found");
+            return;
+        };
+        let bytes = std::fs::read(path).unwrap();
+        let m = FontMetrics::read(&mut Cursor::new(bytes.clone()));
+        assert_eq!(m.format, 1);
+        assert_eq!(m.height, 20);
+        assert_eq!(m.first_char, 0);
+        assert_eq!(m.last_char, 225);
+
+        let bitmap = &bytes[m.bitmap_offset as usize..];
+        let max_coverage = bitmap.iter().copied().max().unwrap();
+        assert_eq!(max_coverage, 15, "format-1 coverage levels are 0..=15");
+        let max_alpha = bitmap
+            .iter()
+            .map(|&b| super::unpacked_byte_alpha(m.format, b))
+            .max()
+            .unwrap();
+        assert_eq!(max_alpha, 255, "full coverage must decode to full alpha");
     }
 
     #[test]

--- a/engine/src/font.rs
+++ b/engine/src/font.rs
@@ -41,3 +41,55 @@ pub fn measure_text_width(font: &dyn Font, text: &str, font_size: f32) -> f32 {
     }
     width
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::texture::TextureTrait;
+    use std::rc::Rc;
+
+    /// Fixed-metrics stub font: every glyph is `advance` wide at `base_height`.
+    struct StubFont {
+        advance: f32,
+        base_height: f32,
+    }
+
+    impl Font for StubFont {
+        fn get_texture(&self) -> Rc<dyn TextureTrait> {
+            unreachable!("measure_text_width does not touch the texture")
+        }
+        fn get_character_info(&self, _c: char) -> Option<FontCharacterInfo> {
+            Some(FontCharacterInfo {
+                min_uv_x: 0.0,
+                min_uv_y: 0.0,
+                max_uv_x: 0.0,
+                max_uv_y: 0.0,
+                advance: self.advance,
+            })
+        }
+        fn base_height(&self) -> f32 {
+            self.base_height
+        }
+        fn get_half_pixel(&self) -> f32 {
+            0.0
+        }
+    }
+
+    #[test]
+    fn measure_scales_with_font_size_and_counts_gaps() {
+        // base_height 10, advance 4. At native size (10) multiplier = 1:
+        // 3 glyphs => 3*4 advance + 2 inter-glyph gaps of 1 = 14.
+        let f = StubFont {
+            advance: 4.0,
+            base_height: 10.0,
+        };
+        assert_eq!(measure_text_width(&f, "abc", 10.0), 14.0);
+        // Single glyph: no inter-glyph gap.
+        assert_eq!(measure_text_width(&f, "a", 10.0), 4.0);
+        // Empty string: zero width.
+        assert_eq!(measure_text_width(&f, "", 10.0), 0.0);
+        // Doubling font_size doubles both advances and the gaps (multiplier 2):
+        // 3*8 + 2*2 = 28.
+        assert_eq!(measure_text_width(&f, "abc", 20.0), 28.0);
+    }
+}

--- a/engine/src/font.rs
+++ b/engine/src/font.rs
@@ -22,24 +22,15 @@ pub trait Font {
 
 /// Width, in the same units as `font_size`, that
 /// [`SceneObject::screen_space_text`](crate::scene::SceneObject::screen_space_text)
-/// would occupy for `text`. Mirrors that renderer's per-glyph advance + inter-glyph
-/// spacing so callers can align/center text before drawing it.
+/// would occupy for `text`. Mirrors that renderer's layout: the sum of glyph
+/// advances, nothing added between glyphs (side bearings are baked into the
+/// `.FON` glyph cells), so callers can align/center text before drawing it.
 pub fn measure_text_width(font: &dyn Font, text: &str, font_size: f32) -> f32 {
     let multiplier = font_size / font.base_height();
-    let mut width = 0.0;
-    let mut count = 0u32;
-    for c in text.chars() {
-        if let Some(info) = font.get_character_info(c) {
-            width += info.advance * multiplier;
-            count += 1;
-        }
-    }
-    // screen_space_text adds one `multiplier` of spacing after each glyph; only the
-    // gaps between glyphs contribute to visible width.
-    if count > 1 {
-        width += multiplier * (count - 1) as f32;
-    }
-    width
+    text.chars()
+        .filter_map(|c| font.get_character_info(c))
+        .map(|info| info.advance * multiplier)
+        .sum()
 }
 
 #[cfg(test)]
@@ -76,20 +67,21 @@ mod tests {
     }
 
     #[test]
-    fn measure_scales_with_font_size_and_counts_gaps() {
-        // base_height 10, advance 4. At native size (10) multiplier = 1:
-        // 3 glyphs => 3*4 advance + 2 inter-glyph gaps of 1 = 14.
+    fn measure_is_sum_of_advances_with_no_added_spacing() {
+        // The Dark engine's advance is exactly the offset-table column
+        // difference - side bearings are baked into the glyph cells, nothing is
+        // added between glyphs. base_height 10, advance 4, native size
+        // (multiplier = 1): 3 glyphs => 3*4 = 12.
         let f = StubFont {
             advance: 4.0,
             base_height: 10.0,
         };
-        assert_eq!(measure_text_width(&f, "abc", 10.0), 14.0);
-        // Single glyph: no inter-glyph gap.
+        assert_eq!(measure_text_width(&f, "abc", 10.0), 12.0);
+        // Single glyph: its advance.
         assert_eq!(measure_text_width(&f, "a", 10.0), 4.0);
         // Empty string: zero width.
         assert_eq!(measure_text_width(&f, "", 10.0), 0.0);
-        // Doubling font_size doubles both advances and the gaps (multiplier 2):
-        // 3*8 + 2*2 = 28.
-        assert_eq!(measure_text_width(&f, "abc", 20.0), 28.0);
+        // Doubling font_size doubles the advances (multiplier 2): 3*8 = 24.
+        assert_eq!(measure_text_width(&f, "abc", 20.0), 24.0);
     }
 }

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -138,7 +138,10 @@ impl SceneObject {
                 },
             ]);
 
-            x += adj_width + multiplier;
+            // Advance is exactly the `.FON` offset-table column difference -
+            // side bearings are baked into the glyph cells, nothing is added
+            // between glyphs (matches the original engine's layout).
+            x += adj_width;
         }
 
         let mesh = mesh::create(vertices);

--- a/projects/ui-font-fidelity.md
+++ b/projects/ui-font-fidelity.md
@@ -1,0 +1,132 @@
+# UI Font Fidelity (flat UI text sizing)
+
+Status: **in progress** — first slice landed (native-size seam + HUD/menu/panel
+migration). Remaining screens (research/keypad MFDs, log reader, save/load) are
+follow-ups.
+
+## Problem
+
+Font sizing across the whole flat UI reads "way off" from the original System
+Shock 2. The original renders all UI text with **Dark bitmap fonts** (`.FON`) at
+their **native pixel size** on the 640×480 canvas — bitmap fonts are drawn 1:1,
+never scaled. Our flat UI parses and renders the same `.FON` fonts, but every
+call site passed an **ad-hoc font size** larger than the font's native height,
+so text came out ~1.4–1.8× too big and, for panels, wildly oversized.
+
+The most visible symptom is the flat HUD bio-monitor: the health/PSI numbers
+("100"/"80") render so large they nearly overflow the BIO.PCX backdrop.
+
+## What the engine does (the seam)
+
+Text rendering is already centralized and already uses the real fonts:
+
+- **Fonts**: `dark/src/font.rs` parses Dark `.FON` bitmap fonts (both mono
+  `format=0` and anti-aliased `format=0xCCCC`) into a glyph atlas + per-glyph
+  advance/`base_height` (native pixel height). Exposed through the
+  `engine::Font` trait and `dark::importers::FONT_IMPORTER`.
+- **Primitive**: `SceneObject::screen_space_text` (`engine/src/scene/scene_object.rs`)
+  lays out glyphs at `font_size` px; `multiplier = font_size / base_height`.
+- **Canvas**: `shock2vr/src/ui/mod.rs` (`UiCanvas`) describes UI in **640×480
+  canvas pixels**; `render_screen_space` maps canvas→screen (`scale`, letterbox)
+  and draws each `Text` element via `screen_space_text` with
+  `font_size = size * scale.y`. Alignment (`HAlign`/`VAlign`) is resolved here.
+
+So `size` on a canvas `Text` element **is** the glyph pixel height on the
+640×480 canvas. The seam is correct; the callers passed the wrong `size`.
+
+### Fonts and their native heights
+
+Decoded from `res/fonts/*.FON` (header: `format@0`, `first@0x24`, `last@0x26`,
+`width_offset@0x48`, `bitmap_offset@0x4c`, `row_width@0x50`, `num_rows@0x52`):
+
+| Font          | format | native height (px) | notes                        |
+| ------------- | ------ | ------------------ | ---------------------------- |
+| MAINFONT.FON  | 0 mono | **11**             | the general UI/HUD font we use |
+| MAINAA.FON    | 0xCCCC | **12**             | anti-aliased menu font        |
+| BOLDAA.FON    | 0xCCCC | 14                 | (unused today)                |
+| BLUEAA.FON    | 0xCCCC | 20                 | (unused today)                |
+| DIMMED.FON    | 0xCCCC | 12                 | (unused today)                |
+| bignum.fon    | 0 mono | 22                 | big numerics (unused today)   |
+| numfont.fon   | 0xCCCC | 11                 | HUD numerics (unused today)   |
+| keyfont/KEYFONTA | -   | 22                 | (unused today)                |
+
+Only **mainfont.fon** (13 call sites) and **mainaa.fon** (menu) are referenced
+in code today.
+
+## Gap table (element → original vs. ours before the fix)
+
+| Element                    | Font (native px) | Our size (before) | Delta        |
+| -------------------------- | ---------------- | ----------------- | ------------ |
+| Main-menu buttons          | mainaa (12)      | 19                | ~1.6× big    |
+| HUD health/PSI numbers     | mainfont (11)    | 16                | ~1.45× big   |
+| HUD ammo count             | mainfont (11)    | 18                | ~1.6× big    |
+| HUD ammo-type label        | mainfont (11)    | 12                | ~1.1× big    |
+| HUD PSI power name         | mainfont (11)    | 10                | ~0.9× (ok)   |
+| Panel text (elevator, MFD) | mainfont (11)    | **= rect height** (e.g. 20) | ~1.8×, and coupled to the box size — a plain bug |
+
+The panel path was the worst offender: `flat_ui_host` drew `GuiComponent::Text`
+with `size = rect.h` (the component's *bounding-box* height, not a font size), so
+a 20px-tall floor-label box rendered 20px text.
+
+## Root cause
+
+Two independent issues; **(1) dominates**:
+
+1. **Sizing**: UI text was rendered at ad-hoc `size` constants larger than the
+   font's native pixel height. Bitmap fonts must render at native height (1:1)
+   to match the original. This is the "way off across the whole flat UI"
+   complaint.
+2. **AA glyph parsing (minor, deferred)**: the `.FON` parser's anti-aliased
+   branch has `if alpha > 205 { alpha = 0 }`, which *erases* the densest (solid)
+   glyph pixels — AA coverage tops out at ~210, not 255. It hollows AA glyph
+   cores. Barely affects MAINAA (only ~55 px), so the menu still looks fine, but
+   it corrupts fonts like BLUEAA (~1014 px). Only matters once we adopt more AA
+   fonts. **Left as a follow-up** (see below).
+
+## The fix (this PR)
+
+Route the correction through the seam so it generalizes:
+
+- `UiCanvas::text` now treats `size <= 0.0` as a sentinel meaning **render at the
+  font's native `base_height`** (resolved at render time, where the font is
+  loaded). New convenience `UiCanvas::text_native(...)` is the fidelity-correct
+  default.
+- Migrated the three flat-UI text paths to native sizing:
+  - `hud/flat_hud.rs` — all HUD text (`text_native`); removed the ad-hoc size
+    constants.
+  - `scenes/main_menu.rs` — menu labels (`text_native`, mainaa 12px); removed
+    `MENU_FONT_SIZE`.
+  - `mission/flat_ui_host.rs` — `GuiComponent::Text` now renders at native height
+    (vertically centered in the component box) instead of `rect.h`.
+- Because alignment is resolved at the seam (`VAlign`), shrinking to native
+  height **auto-recenters** text within the existing art-derived rects — no
+  per-element position re-tuning needed for the HUD/menu.
+
+### Parser refactor (enables the mandated test)
+
+`dark/src/font.rs` gained `FontMetrics` — the pure, no-GL header+column parse
+(previously inlined in `Font::read`, which also builds a GL atlas and so can't
+run headlessly). `Font::read` now consumes it. This also fixed an off-by-one
+(the old loop read only `num_chars` columns and dropped the last glyph; the
+column table has `num_chars + 1` entries). Unit-tested on a synthetic font and
+on real MAINFONT.FON (asset-guarded so CI, which lacks game assets, skips it).
+
+## Verification
+
+- Unit tests: `FontMetrics` parse (glyph count/widths/height) + `measure_text_width`.
+- Visual before/after: HUD and main menu (see PR). BEFORE shows oversized
+  "100"/"80"; AFTER renders them at native 11px inside the bio-monitor.
+- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p dark -p engine`.
+- SDK missions e2e (all missions still load) + flat-UI e2es (assert labels, not
+  pixels — unaffected).
+
+## Follow-ups (not in this PR)
+
+1. **AA parser fix**: replace the `alpha > 205 → 0` hack with proper coverage
+   normalization (scale 0..~210 → 0..255) so AA glyph cores render solid. Needed
+   before adopting BLUEAA/BOLDAA/numfont.
+2. **Per-font fidelity**: the original uses distinct fonts per element (numfont
+   for HUD numerics, bignum for large counts). We use mainfont everywhere. Once
+   the AA parser is fixed, swap in the correct faces.
+3. **Remaining panels**: verify research/keypad MFDs, the log/email reader, and
+   save/load screens at native height against original references.

--- a/projects/ui-font-fidelity.md
+++ b/projects/ui-font-fidelity.md
@@ -20,10 +20,10 @@ The most visible symptom is the flat HUD bio-monitor: the health/PSI numbers
 
 Text rendering is already centralized and already uses the real fonts:
 
-- **Fonts**: `dark/src/font.rs` parses Dark `.FON` bitmap fonts (both mono
-  `format=0` and anti-aliased `format=0xCCCC`) into a glyph atlas + per-glyph
-  advance/`base_height` (native pixel height). Exposed through the
-  `engine::Font` trait and `dark::importers::FONT_IMPORTER`.
+- **Fonts**: `dark/src/font.rs` parses Dark `.FON` bitmap fonts (mono
+  `format=0`, antialias-16 `format=0x0001`, and anti-aliased `format=0xCCCC`)
+  into a glyph atlas + per-glyph advance/`base_height` (native pixel height).
+  Exposed through the `engine::Font` trait and `dark::importers::FONT_IMPORTER`.
 - **Primitive**: `SceneObject::screen_space_text` (`engine/src/scene/scene_object.rs`)
   lays out glyphs at `font_size` px; `multiplier = font_size / base_height`.
 - **Canvas**: `shock2vr/src/ui/mod.rs` (`UiCanvas`) describes UI in **640×480
@@ -36,33 +36,52 @@ So `size` on a canvas `Text` element **is** the glyph pixel height on the
 
 ### Fonts and their native heights
 
-Decoded from `res/fonts/*.FON` (header: `format@0`, `first@0x24`, `last@0x26`,
-`width_offset@0x48`, `bitmap_offset@0x4c`, `row_width@0x50`, `num_rows@0x52`):
+Decoded from the shipped `.FON` files - `res/fonts/*.FON` plus the interface
+fonts in `res/intrface/` (header: `format@0`, `first@0x24`, `last@0x26`,
+`width_offset@0x48`, `bitmap_offset@0x4c`, `row_width@0x50`, `num_rows@0x52`).
+"Native height" is the full glyph-cell height (`num_rows`), which includes the
+font's internal leading - the visible cap/digit ink is shorter (noted where it
+matters):
 
 | Font          | format | native height (px) | notes                        |
 | ------------- | ------ | ------------------ | ---------------------------- |
-| MAINFONT.FON  | 0 mono | **11**             | the general UI/HUD font we use |
-| MAINAA.FON    | 0xCCCC | **12**             | anti-aliased menu font        |
+| METAFONT.FON  | 0x0001 | **20** (cap ink 10) | the default GUI style font - main menu et al (`res/intrface/`) |
+| MAINFONT.FON  | 0 mono | **11** (digit ink 8) | the general UI/HUD font we use |
+| MAINAA.FON    | 0xCCCC | **12** (digit ink 8) | the AA shock font - the original's HUD/panel face |
 | BOLDAA.FON    | 0xCCCC | 14                 | (unused today)                |
 | BLUEAA.FON    | 0xCCCC | 20                 | (unused today)                |
 | DIMMED.FON    | 0xCCCC | 12                 | (unused today)                |
 | bignum.fon    | 0 mono | 22                 | big numerics (unused today)   |
-| numfont.fon   | 0xCCCC | 11                 | HUD numerics (unused today)   |
+| numfont.fon   | 0xCCCC | 11 (digit ink 11)  | large numerics (unused today) |
 | keyfont/KEYFONTA | -   | 22                 | (unused today)                |
 
-Only **mainfont.fon** (13 call sites) and **mainaa.fon** (menu) are referenced
+Only **mainfont.fon** (13 call sites) and **metafont.fon** (menu) are referenced
 in code today.
+
+Format `0x0001` ("antialias-16", e.g. METAFONT) stores one byte per pixel with
+**coverage levels 0..=15**; the parser scales those linearly to 0..255 alpha
+(15 -> 255). Treating them as direct byte alpha - what the parser did before
+format-1 support - renders the whole font at max alpha 15/255, i.e. nearly
+invisible.
 
 ## Gap table (element → original vs. ours before the fix)
 
 | Element                    | Font (native px) | Our size (before) | Delta        |
 | -------------------------- | ---------------- | ----------------- | ------------ |
-| Main-menu buttons          | mainaa (12)      | 19                | ~1.6× big    |
+| Main-menu buttons          | metafont (20)    | mainaa at 19      | wrong face: ~½ the original's bulk (see below) |
 | HUD health/PSI numbers     | mainfont (11)    | 16                | ~1.45× big   |
 | HUD ammo count             | mainfont (11)    | 18                | ~1.6× big    |
 | HUD ammo-type label        | mainfont (11)    | 12                | ~1.1× big    |
 | HUD PSI power name         | mainfont (11)    | 10                | ~0.9× (ok)   |
 | Panel text (elevator, MFD) | mainfont (11)    | **= rect height** (e.g. 20) | ~1.8×, and coupled to the box size — a plain bug |
+
+**Menu correction (review fix):** the first draft of this table compared the
+menu against the wrong reference face. The original's main menu uses the
+default GUI style font - **METAFONT.FON**, a 20px-cell antialias-16 display
+face (cap ink 10px, 'N' 16px wide, "NEW GAME" = 120 canvas px). `mainaa`
+(12px cell, cap 8px, "NEW GAME" = 63px) at native size is ~half the original's
+bulk. The native-size premise was right; the face was wrong. The menu now
+renders METAFONT via the same `text_native` seam.
 
 The panel path was the worst offender: `flat_ui_host` drew `GuiComponent::Text`
 with `size = rect.h` (the component's *bounding-box* height, not a font size), so
@@ -76,12 +95,13 @@ Two independent issues; **(1) dominates**:
    font's native pixel height. Bitmap fonts must render at native height (1:1)
    to match the original. This is the "way off across the whole flat UI"
    complaint.
-2. **AA glyph parsing (minor, deferred)**: the `.FON` parser's anti-aliased
-   branch has `if alpha > 205 { alpha = 0 }`, which *erases* the densest (solid)
-   glyph pixels — AA coverage tops out at ~210, not 255. It hollows AA glyph
-   cores. Barely affects MAINAA (only ~55 px), so the menu still looks fine, but
-   it corrupts fonts like BLUEAA (~1014 px). Only matters once we adopt more AA
-   fonts. **Left as a follow-up** (see below).
+2. **AA glyph parsing (minor, deferred)**: the `.FON` parser's `0xCCCC` branch
+   has `if alpha > 205 { alpha = 0 }`. Those bytes are *palette-resolved
+   coverage* values, not straight alpha - in MAINAA only 55 of 10452 bitmap
+   bytes exceed 205 (max 209), so the clamp barely shows there, but the proper
+   fix is palette/coverage normalization for the `0xCCCC` fonts (distinct from
+   the format-`0x0001` 0..15 -> 0..255 scaling, which is exact and already
+   implemented). **Left as a follow-up** (see below).
 
 ## The fix (this PR)
 
@@ -94,8 +114,11 @@ Route the correction through the seam so it generalizes:
 - Migrated the three flat-UI text paths to native sizing:
   - `hud/flat_hud.rs` — all HUD text (`text_native`); removed the ad-hoc size
     constants.
-  - `scenes/main_menu.rs` — menu labels (`text_native`, mainaa 12px); removed
-    `MENU_FONT_SIZE`.
+  - `scenes/main_menu.rs` — menu labels (`text_native`); removed
+    `MENU_FONT_SIZE`. Review fixes then switched the face to the original's
+    METAFONT (20px) and replaced the eyeballed button rects with the
+    `MAINR.BIN` layout (`UI_LAYOUT_IMPORTER`, same pattern as the loading
+    screen).
   - `mission/flat_ui_host.rs` — `GuiComponent::Text` now renders at native height
     (vertically centered in the component box) instead of `rect.h`.
 - Because alignment is resolved at the seam (`VAlign`), shrinking to native
@@ -109,7 +132,17 @@ Route the correction through the seam so it generalizes:
 run headlessly). `Font::read` now consumes it. This also fixed an off-by-one
 (the old loop read only `num_chars` columns and dropped the last glyph; the
 column table has `num_chars + 1` entries). Unit-tested on a synthetic font and
-on real MAINFONT.FON (asset-guarded so CI, which lacks game assets, skips it).
+on real MAINFONT.FON / METAFONT.FON (asset-guarded so CI, which lacks game
+assets, skips them).
+
+### Inter-glyph spacing (review fix)
+
+The renderer (`SceneObject::screen_space_text`) and the mirrored
+`measure_text_width` both added **+1px (canvas) of spacing after every glyph**.
+The original's advance is exactly the `.FON` offset-table column difference —
+side bearings are baked into the glyph cells, and the shipped fonts carry no
+extra spacing. Removed; strings tightened ~8-11% and centering (which goes
+through `measure_text_width`) stays consistent by construction.
 
 ## Verification
 
@@ -122,11 +155,15 @@ on real MAINFONT.FON (asset-guarded so CI, which lacks game assets, skips it).
 
 ## Follow-ups (not in this PR)
 
-1. **AA parser fix**: replace the `alpha > 205 → 0` hack with proper coverage
-   normalization (scale 0..~210 → 0..255) so AA glyph cores render solid. Needed
-   before adopting BLUEAA/BOLDAA/numfont.
-2. **Per-font fidelity**: the original uses distinct fonts per element (numfont
-   for HUD numerics, bignum for large counts). We use mainfont everywhere. Once
-   the AA parser is fixed, swap in the correct faces.
+1. **`0xCCCC` AA parser fix**: replace the `alpha > 205 → 0` hack with proper
+   palette/coverage normalization (those bytes are palette-resolved coverage;
+   in MAINAA only 55/10452 exceed 205, max 209). Distinct from the format-
+   `0x0001` 0..15 scaling, which is already exact. Needed before adopting
+   BLUEAA/BOLDAA.
+2. **HUD/panel face swap to mainaa**: the original's HUD/panel text face is
+   **mainaa** (the AA shock font), not numfont. Our current mainfont happens to
+   match mainaa's digit ink height (8px), so HUD *size* is already correct —
+   the follow-up is only the face swap (do it after the `0xCCCC` normalization
+   above so the AA cores render solid). Do not re-touch the HUD sizing path.
 3. **Remaining panels**: verify research/keypad MFDs, the log/email reader, and
    save/load screens at native height against original references.

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -42,7 +42,6 @@ const METERS_H: f32 = 64.0;
 const BAR_W: f32 = 80.0;
 const BAR_H: f32 = 14.0;
 const TEXT_W: f32 = 60.0;
-const TEXT_SIZE: f32 = 16.0;
 
 /// Bio-monitor backdrop (BIO.PCX, 128x64) the bars/numbers sit on, the
 /// health/psi equivalent of the ammo gauge's AMMOBACK frame.
@@ -83,12 +82,10 @@ const AMMO_FULL_GAUGE: Rect = Rect::new(AMMO_FULL_X, AMMO_Y, METERS_FULL_W, AMMO
 pub(crate) const AMMO_CYCLE_BUTTON: Rect =
     Rect::new(AMMO_FULL_X + 186.0, AMMO_Y + 15.0, 12.0, 41.0);
 const AMMO_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 22.0, AMMO_W, 20.0); // centered over the gauge
-const AMMO_TEXT_SIZE: f32 = 18.0;
 // Selected ammo-type indicator: the projectile's object icon (P$ObjIcon) just
 // left of the gauge, with its type label (std/he/ap) below the round count.
 const AMMO_ICON: Rect = Rect::new(AMMO_X - 40.0, AMMO_Y + 16.0, 32.0, 32.0);
 const AMMO_TYPE_TEXT: Rect = Rect::new(AMMO_X, AMMO_Y + 44.0, AMMO_W, 16.0);
-const AMMO_TYPE_TEXT_SIZE: f32 = 12.0;
 
 // Selected psi power display - drawn in the ammo section while the psi amp
 // is wielded (replacing the meaningless clip readout): the tier badge
@@ -98,7 +95,6 @@ const PSI_TIER_BADGE: Rect = Rect::new(AMMO_X - 44.0, AMMO_Y + 22.0, 32.0, 19.0)
 // The discipline names ("Projected Cryokinesis") are long, so the label rect
 // extends left of the gauge and uses a smaller size than the ammo-type label.
 const PSI_POWER_NAME: Rect = Rect::new(AMMO_X - 60.0, AMMO_Y + 44.0, AMMO_W + 60.0, 16.0);
-const PSI_POWER_NAME_SIZE: f32 = 10.0;
 
 // Psi overload meter - drawn center-screen below the crosshair while the psi
 // amp's trigger is held on an overloadable power (and briefly after release,
@@ -164,19 +160,17 @@ pub(crate) fn build_flat_hud_canvas(
     let health_pct = (health_fraction.clamp(0.0, 1.0) * 100.0).round() as i32;
     let psi_pct = (psi_fraction.clamp(0.0, 1.0) * 100.0).round() as i32;
     canvas
-        .text(
+        .text_native(
             HEALTH_TEXT,
             &format!("{health_pct}"),
             "mainfont.fon",
-            TEXT_SIZE,
             HAlign::Left,
             VAlign::Middle,
         )
-        .text(
+        .text_native(
             PSI_TEXT,
             &format!("{psi_pct}"),
             "mainfont.fon",
-            TEXT_SIZE,
             HAlign::Left,
             VAlign::Middle,
         );
@@ -207,19 +201,17 @@ pub(crate) fn build_flat_hud_canvas(
         canvas
             .image(ammo_backdrop, ammo_art)
             .image(PSI_TIER_BADGE, &format!("AmPsi{}1.PCX", tier.clamp(1, 5)))
-            .text(
+            .text_native(
                 AMMO_TEXT,
                 &format!("{tier}"),
                 "mainfont.fon",
-                AMMO_TEXT_SIZE,
                 HAlign::Center,
                 VAlign::Middle,
             )
-            .text(
+            .text_native(
                 PSI_POWER_NAME,
                 &power_name.to_ascii_uppercase(),
                 "mainfont.fon",
-                PSI_POWER_NAME_SIZE,
                 HAlign::Center,
                 VAlign::Middle,
             );
@@ -228,11 +220,10 @@ pub(crate) fn build_flat_hud_canvas(
 
     // Ammo gauge (only when a weapon with a clip is wielded).
     if let Some(rounds) = ammo {
-        canvas.image(ammo_backdrop, ammo_art).text(
+        canvas.image(ammo_backdrop, ammo_art).text_native(
             AMMO_TEXT,
             &format!("{rounds}"),
             "mainfont.fon",
-            AMMO_TEXT_SIZE,
             HAlign::Center,
             VAlign::Middle,
         );
@@ -242,11 +233,10 @@ pub(crate) fn build_flat_hud_canvas(
             canvas.image(AMMO_ICON, &icon);
         }
         if let Some(ammo_type) = ammo_type {
-            canvas.text(
+            canvas.text_native(
                 AMMO_TYPE_TEXT,
                 &ammo_type.to_ascii_uppercase(),
                 "mainfont.fon",
-                AMMO_TYPE_TEXT_SIZE,
                 HAlign::Center,
                 VAlign::Middle,
             );

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -61,14 +61,14 @@ const AMMO_W: f32 = 94.0;
 const AMMO_H: f32 = 64.0;
 const AMMO_GAUGE: Rect = Rect::new(AMMO_X, AMMO_Y, AMMO_W, AMMO_H);
 
-// Use-mode expanded readouts (flat UI 5). Anchors pinned from the Dark source:
-//  - BIOFULL (shkmeter.cpp): `meters_rect = {{2,414},{262,478}}` - the bio
+// Use-mode expanded readouts (flat UI 5). Anchors match the original layout:
+//  - BIOFULL: the original meters rect is {{2,414},{262,478}} - the bio
 //    panel stays at (2,414); only the backdrop art widens 128->260 (BIO.PCX is
 //    the left crop of BIOFULL.PCX, so the bars/numbers land identically). The
 //    right half is baked research/query/map + nanite/cyber chrome (art stub).
-//  - AMMOFULL (shkammov.cpp): use ("mouse") mode expands the ammo panel LEFT by
-//    `AMMO_MODE_DX = 166` (AMMOBACK 94 -> AMMOFULL 260), UL = (378,414); the
-//    ammo-type CYCLE button is `cycle_rect = {{186,15},{198,56}}` panel-local
+//  - AMMOFULL: use ("mouse") mode expands the ammo panel LEFT by
+//    166 (AMMOBACK 94 -> AMMOFULL 260), UL = (378,414); the
+//    ammo-type CYCLE button is {{186,15},{198,56}} panel-local
 //    (art ammoarw0/1), i.e. canvas (564,429,12,41). The round count/icon stay
 //    in the panel's right gauge (the AMMOBACK footprint), so their compact
 //    offsets are reused.
@@ -76,7 +76,7 @@ const METERS_FULL_W: f32 = 260.0;
 const AMMO_FULL_MODE_DX: f32 = 166.0;
 const AMMO_FULL_X: f32 = AMMO_X - AMMO_FULL_MODE_DX; // 378
 const AMMO_FULL_GAUGE: Rect = Rect::new(AMMO_FULL_X, AMMO_Y, METERS_FULL_W, AMMO_H);
-/// The AMMOFULL ammo-type cycle button (`shkammov.cpp` cycle_rect, ammoarw
+/// The AMMOFULL ammo-type cycle button (the original's cycle hotspot, ammoarw
 /// art). Clicking it cycles the wielded weapon's ammo type. Exposed so the
 /// flat pointer host can hit-test the same rect it is drawn at.
 pub(crate) const AMMO_CYCLE_BUTTON: Rect =
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn ammo_cycle_button_sits_in_the_ammofull_panel() {
-        // The cycle button (shkammov.cpp cycle_rect) is inside the expanded
+        // The cycle button (the original's cycle hotspot) is inside the expanded
         // AMMOFULL gauge and left of the compact AMMOBACK footprint.
         assert!(AMMO_FULL_GAUGE.x <= AMMO_CYCLE_BUTTON.x);
         assert!(AMMO_CYCLE_BUTTON.x + AMMO_CYCLE_BUTTON.w <= AMMO_FULL_GAUGE.x + AMMO_FULL_GAUGE.w);

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -822,7 +822,11 @@ fn draw_components(
                 canvas.image(r, texture);
             }
             GuiComponentRenderInfo::Text { text, font, .. } => {
-                canvas.text(r, text, font, r.h, HAlign::Left, VAlign::Top);
+                // Render at the font's native pixel height (the Dark engine
+                // draws its bitmap fonts 1:1), not the component's box height -
+                // the `size` on a GUI text component is its bounding box, not a
+                // font size. Vertically center the native-height text in that box.
+                canvas.text_native(r, text, font, HAlign::Left, VAlign::Middle);
             }
         }
     }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -37,7 +37,6 @@ const NEW_GAME_MISSION: &str = "earth.mis";
 const CANVAS_W: f32 = 640.0;
 const CANVAS_H: f32 = 480.0;
 const MENU_FONT: &str = "mainaa.fon"; // anti-aliased menu font (vs the bitmap mainfont)
-const MENU_FONT_SIZE: f32 = 19.0; // canvas pixels (~0.04 * height)
 /// The 4:3 menu art is letterboxed (not stretched) on non-4:3 windows.
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
@@ -226,11 +225,10 @@ impl GameScene for MainMenuScene {
         for item in MENU_ITEMS {
             let hovered = pointer_canvas.is_some_and(|pp| item.rect.contains(pp));
             canvas
-                .text(
+                .text_native(
                     item.rect,
                     item.label,
                     MENU_FONT,
-                    MENU_FONT_SIZE,
                     HAlign::Center,
                     VAlign::Middle,
                 )

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
 use engine::{
     assets::asset_cache::AssetCache,
     audio::AudioContext,
@@ -36,7 +37,12 @@ const NEW_GAME_MISSION: &str = "earth.mis";
 /// The menu is authored on the original 640x480 `MAIN.PCX` canvas.
 const CANVAS_W: f32 = 640.0;
 const CANVAS_H: f32 = 480.0;
-const MENU_FONT: &str = "mainaa.fon"; // anti-aliased menu font (vs the bitmap mainfont)
+/// The original menu draws its labels with the default GUI style font -
+/// METAFONT.FON (`res/intrface/`), a 20px-cell antialias-16 display face.
+const MENU_FONT: &str = "metafont.fon";
+/// Original widget layout for `MAIN.PCX` - LTRB rects for the six buttons
+/// (top to bottom) plus the corner logo (`UI_LAYOUT_IMPORTER`).
+const LAYOUT_FILE: &str = "MAINR.BIN";
 /// The 4:3 menu art is letterboxed (not stretched) on non-4:3 windows.
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
@@ -49,33 +55,59 @@ enum MenuAction {
 struct MenuItem {
     label: &'static str,
     action: MenuAction,
-    /// Hit/draw rect in canvas pixels, over the MAIN.PCX button.
-    rect: Rect,
+    /// Index of this button's rect in the `MAINR.BIN` layout (six buttons top
+    /// to bottom, then the corner logo).
+    layout_index: usize,
+    /// Hit/draw rect in canvas pixels if the layout file is absent (the decoded
+    /// `MAINR.BIN` values: buttons at x=400, 179x60, 76px vertical pitch).
+    fallback_rect: Rect,
 }
 
 // MAIN.PCX (native 640x480) has a vertical stack of six buttons down the right
-// side; centers (measured from the art's marker rows) are y = 37, 113, 190, 266,
-// 341, 418, each ~76 tall, left edge x ~= 405. New Game = top button, Quit =
-// bottom button. Labels are centered in the button rect.
+// side; New Game = top button, Quit = bottom button. Labels are centered in the
+// button rect.
 const MENU_ITEMS: &[MenuItem] = &[
     MenuItem {
         label: "NEW GAME",
         action: MenuAction::NewGame,
-        rect: Rect::new(405.0, 0.0, 213.0, 76.0),
+        layout_index: 0,
+        fallback_rect: Rect::new(400.0, 20.0, 179.0, 60.0),
     },
     MenuItem {
         label: "QUIT",
         action: MenuAction::Quit,
-        rect: Rect::new(405.0, 380.0, 213.0, 76.0),
+        layout_index: 5,
+        fallback_rect: Rect::new(400.0, 400.0, 179.0, 60.0),
     },
 ];
 
-/// Pure click resolution: on a rising press edge over an item, return its
-/// action. Also returns the new `last_pressed` to track for the next frame.
+/// Resolve each menu item's canvas rect from the `MAINR.BIN` layout (falling
+/// back to the decoded values if it's absent). Parallel to [`MENU_ITEMS`].
+fn menu_rects(layout: Option<&[MapRect]>) -> Vec<Rect> {
+    MENU_ITEMS
+        .iter()
+        .map(
+            |item| match layout.and_then(|rects| rects.get(item.layout_index)) {
+                Some(r) => Rect::new(
+                    r.ul_x as f32,
+                    r.ul_y as f32,
+                    r.width() as f32,
+                    r.height() as f32,
+                ),
+                None => item.fallback_rect,
+            },
+        )
+        .collect()
+}
+
+/// Pure click resolution: on a rising press edge over an item (`rects` is
+/// parallel to [`MENU_ITEMS`]), return its action. Also returns the new
+/// `last_pressed` to track for the next frame.
 fn resolve_click(
     pointer: Option<Pointer2D>,
     last_pressed: bool,
     screen_size: Vector2<f32>,
+    rects: &[Rect],
 ) -> (Option<MenuAction>, bool) {
     match pointer {
         Some(p) => {
@@ -86,8 +118,13 @@ fn resolve_click(
                     screen_size,
                     SCALE_MODE,
                 )
-                .and_then(|c| MENU_ITEMS.iter().find(|it| it.rect.contains(c)))
-                .map(|it| it.action)
+                .and_then(|c| {
+                    MENU_ITEMS
+                        .iter()
+                        .zip(rects)
+                        .find(|(_, rect)| rect.contains(c))
+                })
+                .map(|(it, _)| it.action)
             } else {
                 None
             };
@@ -156,7 +193,7 @@ impl GameScene for MainMenuScene {
         &mut self,
         time: &Time,
         input_context: &InputContext,
-        _asset_cache: &mut AssetCache,
+        asset_cache: &mut AssetCache,
         _game_options: &GameOptions,
         _command_effects: Vec<Effect>,
     ) -> Vec<Effect> {
@@ -164,11 +201,15 @@ impl GameScene for MainMenuScene {
             *world_time = time.clone();
         }
 
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
+
         self.pointer = input_context.pointer;
         let (action, last_pressed) = resolve_click(
             input_context.pointer,
             self.last_pressed,
             self.last_screen_size,
+            &rects,
         );
         self.last_pressed = last_pressed;
 
@@ -214,6 +255,10 @@ impl GameScene for MainMenuScene {
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "MAIN.PCX");
 
         // Clickable items, centered in their button and brighter when hovered.
+        // Button rects come from the original `MAINR.BIN` layout (cached by the
+        // asset cache after the first load).
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
         let pointer_canvas = self.pointer.and_then(|p| {
             pointer_to_canvas(
                 vec2(CANVAS_W, CANVAS_H),
@@ -222,16 +267,10 @@ impl GameScene for MainMenuScene {
                 SCALE_MODE,
             )
         });
-        for item in MENU_ITEMS {
-            let hovered = pointer_canvas.is_some_and(|pp| item.rect.contains(pp));
+        for (item, rect) in MENU_ITEMS.iter().zip(&rects) {
+            let hovered = pointer_canvas.is_some_and(|pp| rect.contains(pp));
             canvas
-                .text_native(
-                    item.rect,
-                    item.label,
-                    MENU_FONT,
-                    HAlign::Center,
-                    VAlign::Middle,
-                )
+                .text_native(*rect, item.label, MENU_FONT, HAlign::Center, VAlign::Middle)
                 .opacity(if hovered { 1.0 } else { 0.6 });
         }
 
@@ -290,36 +329,71 @@ mod tests {
     #[test]
     fn rising_edge_over_new_game_activates_it() {
         // Press edge over the top button (normalized ~ canvas (512, 37)).
-        let (action, last) = resolve_click(pointer_at(0.8, 0.078, true), false, SCREEN);
+        let (action, last) = resolve_click(
+            pointer_at(0.8, 0.078, true),
+            false,
+            SCREEN,
+            &menu_rects(None),
+        );
         assert_eq!(action, Some(MenuAction::NewGame));
         assert!(last);
     }
 
     #[test]
     fn rising_edge_over_quit_activates_it() {
-        let (action, _) = resolve_click(pointer_at(0.8, 0.870, true), false, SCREEN);
+        let (action, _) = resolve_click(
+            pointer_at(0.8, 0.870, true),
+            false,
+            SCREEN,
+            &menu_rects(None),
+        );
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
     #[test]
     fn held_press_does_not_re_activate() {
         // Already pressed last frame -> no new activation even over an item.
-        let (action, last) = resolve_click(pointer_at(0.8, 0.078, true), true, SCREEN);
+        let (action, last) = resolve_click(
+            pointer_at(0.8, 0.078, true),
+            true,
+            SCREEN,
+            &menu_rects(None),
+        );
         assert_eq!(action, None);
         assert!(last);
     }
 
     #[test]
     fn click_outside_items_does_nothing() {
-        let (action, _) = resolve_click(pointer_at(0.05, 0.05, true), false, SCREEN);
+        let (action, _) = resolve_click(
+            pointer_at(0.05, 0.05, true),
+            false,
+            SCREEN,
+            &menu_rects(None),
+        );
         assert_eq!(action, None);
     }
 
     #[test]
     fn no_pointer_means_no_action() {
-        let (action, last) = resolve_click(None, true, SCREEN);
+        let (action, last) = resolve_click(None, true, SCREEN, &menu_rects(None));
         assert_eq!(action, None);
         assert!(!last);
+    }
+
+    #[test]
+    fn menu_rects_prefer_layout_and_fall_back() {
+        // With a layout: New Game = rect 0, Quit = rect 5.
+        let layout: Vec<MapRect> = (0..7)
+            .map(|i| MapRect::new(10, i * 70, 110, i * 70 + 50))
+            .collect();
+        let rects = menu_rects(Some(&layout));
+        assert_eq!(rects[0], Rect::new(10.0, 0.0, 100.0, 50.0));
+        assert_eq!(rects[1], Rect::new(10.0, 350.0, 100.0, 50.0));
+        // Without: the decoded MAINR.BIN fallbacks.
+        let rects = menu_rects(None);
+        assert_eq!(rects[0], Rect::new(400.0, 20.0, 179.0, 60.0));
+        assert_eq!(rects[1], Rect::new(400.0, 400.0, 179.0, 60.0));
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -213,6 +213,10 @@ impl UiCanvas {
         self
     }
 
+    /// Add a text element sized in **canvas pixels** (`size` = cap-to-baseline
+    /// pixel height at the 640x480 canvas scale). Pass `size <= 0.0` to render
+    /// at the font's *native* pixel height (`base_height`); prefer
+    /// [`text_native`](Self::text_native) for that.
     pub fn text(
         &mut self,
         rect: Rect,
@@ -232,6 +236,23 @@ impl UiCanvas {
             opacity: 1.0,
         });
         self
+    }
+
+    /// Add text rendered at the font's **native pixel height** on the 640x480
+    /// canvas - the way the Dark engine draws its bitmap `.FON` fonts (1:1, no
+    /// scaling). This is the fidelity-correct default for UI text; callers only
+    /// pick an explicit [`text`](Self::text) size when the original art
+    /// deliberately scales a font. Height comes from the loaded font's
+    /// `base_height` at render time (the `size <= 0.0` sentinel).
+    pub fn text_native(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        font: &str,
+        h: HAlign,
+        v: VAlign,
+    ) -> &mut Self {
+        self.text(rect, text, font, 0.0, h, v)
     }
 
     /// Render the canvas as a screen-space overlay on `screen_size`, mapped via
@@ -293,7 +314,15 @@ impl UiCanvas {
                     opacity,
                 } => {
                     let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
-                    let font_size = size * scale.y;
+                    // `size <= 0` renders at the font's native pixel height, so
+                    // Dark `.FON` bitmap fonts draw at their authored size (the
+                    // way the original engine does) instead of an ad-hoc scale.
+                    let canvas_size = if *size > 0.0 {
+                        *size
+                    } else {
+                        font_obj.base_height()
+                    };
+                    let font_size = canvas_size * scale.y;
                     let width = measure_text_width(&**font_obj, text, font_size);
 
                     let rx = rect.x * scale.x + offset.x;

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -213,10 +213,11 @@ impl UiCanvas {
         self
     }
 
-    /// Add a text element sized in **canvas pixels** (`size` = cap-to-baseline
-    /// pixel height at the 640x480 canvas scale). Pass `size <= 0.0` to render
-    /// at the font's *native* pixel height (`base_height`); prefer
-    /// [`text_native`](Self::text_native) for that.
+    /// Add a text element sized in **canvas pixels** (`size` = the full
+    /// glyph-cell height at the 640x480 canvas scale - `.FON` cells include the
+    /// font's internal leading, so the visible cap ink is shorter than `size`).
+    /// Pass `size <= 0.0` to render at the font's *native* pixel height
+    /// (`base_height`); prefer [`text_native`](Self::text_native) for that.
     pub fn text(
         &mut self,
         rect: Rect,


### PR DESCRIPTION
## Problem

Font sizing across the whole flat UI read "way off" from the original System Shock 2. The original renders all UI text with **Dark bitmap fonts** (`.FON`) at their **native pixel size** on the 640×480 canvas — bitmap fonts draw 1:1, never scaled. Our flat UI already parses and renders the same `.FON` fonts, but every call site passed an **ad-hoc size larger than the font's native height**, so text came out too big. The clearest symptom: the HUD bio-monitor health/PSI numbers ("100"/"80") render so large they nearly overflow the panel.

### Gap table (before this PR; measured from the shipped `.FON` files)

| Element | Original face (native px) | Ours (before) | Delta |
| --- | --- | --- | --- |
| Main-menu buttons | **metafont (20, cap ink 10)** | mainaa at 19 | wrong face — see review fixes below |
| HUD health/PSI numbers | mainaa (digit ink 8) | mainfont at 16 | ~1.45× big |
| HUD ammo count | mainaa (digit ink 8) | mainfont at 18 | ~1.6× big |
| Panel text (elevator/MFD) | mainaa (digit ink 8) | **= rect height** (~20) | ~1.8×, coupled to box size — a bug |

> **Correction (review):** the first draft of this table compared the menu against the wrong reference face. The original's main menu uses **the original game's default GUI style font** — `METAFONT.FON` (`res/intrface/`), a 20px-cell display face (cap ink 10px, "NEW GAME" = 120 canvas px) — not `mainaa` (12px cell, "NEW GAME" = 63px). The native-size premise and seam were right; the face was wrong. Similarly the original HUD/panel face is `mainaa` (whose digit ink height, 8px, our `mainfont` happens to match — so HUD *size* is correct; the face swap is a follow-up).

## Fix

Route the correction through the existing `UiCanvas` text seam so it generalizes:

- **`UiCanvas`**: `size <= 0.0` now means *render at the font's native `base_height`* (resolved at render time where the font is loaded); new `text_native()` is the fidelity-correct default. Alignment is already resolved at the seam, so native text **auto-recenters** in the art-derived rects — no per-element position re-tuning.
- Migrated the three flat-UI text paths: `flat_hud`, `main_menu`, and `flat_ui_host` panel text (which was using the component's *box height* as the font size — a plain bug).
- **`dark/font`**: extracted a pure, no-GL `FontMetrics` parser so the byte-level parse is unit-testable headlessly; `Font::read` consumes it. This also fixed an off-by-one that dropped the last glyph (the column table has `num_chars + 1` entries).

## Review fixes

1. **Format-`0x0001` (antialias-16) font support** (`dark/src/font.rs`): these fonts store one byte per pixel with coverage levels 0..=15 (verified: METAFONT's bitmap bytes top out at exactly 15); the parser now scales them linearly to 0..255 alpha. Previously any non-packed format was treated as direct byte alpha, which would render METAFONT at max alpha 15/255 — nearly invisible. Asset-guarded unit test on the real METAFONT.FON (format 1, 20px cell, decoded alpha reaches 255).
2. **Main menu renders the original face** (`shock2vr/src/scenes/main_menu.rs`): `metafont.fon` via the same `text_native` seam. Measured from the updated capture: "NEW GAME" = **118.4 canvas px** wide, cap ink **9.6 px** (expected from the font data: 120 px / 10 px; the AA fringe clips ~1px at the threshold). Before (mainaa): 64.8 px / 8 px.
3. **Menu button rects from `MAINR.BIN`** (`UI_LAYOUT_IMPORTER`, same pattern as the loading screen) instead of eyeballed constants: first button (400,20,179,60), 76px pitch, Quit at (400,400). Labels center in the true boxes with no per-element tuning (text centers within ~1 canvas px of the button center in the capture).
4. **Removed the +1px inter-glyph spacing** (`engine/src/scene/scene_object.rs`, `engine/src/font.rs`): the original's advance is exactly the `.FON` offset-table column difference — side bearings are baked into the glyph cells, and the shipped fonts carry no header spacing. Strings tighten ~8–11%; centering goes through the same `measure_text_width` so it stays consistent. The measure unit test was corrected first (failed against the old behavior, passes now).

### Known follow-ups

- **`0xCCCC` AA clamp**: the parser's `alpha > 205 → 0` workaround remains for the `0xCCCC` fonts. Those bytes are palette-resolved coverage values (in MAINAA only 55 of 10452 bitmap bytes exceed 205, max 209), so the eventual fix is palette/coverage normalization — distinct from the exact format-`0x0001` scaling added here. Needed before adopting BLUEAA/BOLDAA.
- **HUD/panel face swap to `mainaa`**: the original's HUD/panel text face is mainaa, not numfont; sizes already match (digit ink 8px), so only the face swap remains (after the `0xCCCC` normalization above). The HUD sizing path is untouched by the review fixes.

See `projects/ui-font-fidelity.md` for the full investigation and `.FON` format notes.

## Verification

- Unit tests: `FontMetrics` parse (synthetic + asset-guarded real MAINFONT.FON and METAFONT.FON — verified they actually run with game data present), format-1 alpha decode, `measure_text_width` (corrected negative-first), menu rect resolution from layout + fallback.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark -p engine` clean; `cargo fmt`.
- `cargo test -p dark -p engine -p shock2vr`: 193 tests pass.
- SDK e2e: `flat-hud`, `flat-ui-plumbing`, `elevator-panel`, `bio-ammo-full` — all pass.

## Before / After

**Flat HUD bio-monitor** — the health/PSI numbers ("100"/"80") shrink from the oversized 16px to native 11px and sit cleanly inside the readout:

![HUD before/after](https://gist.githubusercontent.com/tommy-xr/6944a13a92ba6d9ac62ee51ef0d16803/raw/cmp_hud.png)

**Main menu (review fix)** — left: mainaa at native size (the wrong, half-bulk face, mis-centered in the eyeballed rect); right: METAFONT in the `MAINR.BIN` button rects — "NEW GAME" measures 118.4 canvas px wide, cap ink ~10px, matching the original:

![Menu review-fix before/after](https://gist.githubusercontent.com/tommy-xr/6944a13a92ba6d9ac62ee51ef0d16803/raw/cmp_menu_reviewfix.png)

**Main menu (full frame, after):**

![Menu after](https://gist.githubusercontent.com/tommy-xr/6944a13a92ba6d9ac62ee51ef0d16803/raw/menu_metafont.png)

_Captured headless via the debug runtime (`/v1/step` + `/v1/screenshot`), same deterministic sequence for both refs._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
