### PR TITLE
feat(anim): fractional-frame interpolation + phase carry across seams

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -80,6 +80,7 @@ impl AnimatedModel {
                 animation_clip: &animation_clip,
                 frame,
                 fraction: 0.0,
+                wrap: false,
                 cancel_root_motion: false,
             }),
             &rpds::HashTrieMap::new(),

--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -79,6 +79,7 @@ impl AnimatedModel {
             Some(AnimationInfo {
                 animation_clip: &animation_clip,
                 frame,
+                fraction: 0.0,
                 cancel_root_motion: false,
             }),
             &rpds::HashTrieMap::new(),

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -147,9 +147,18 @@ impl AnimationPlayer {
         self.animation
             .first()
             .map(|(clip, flags)| {
+                // Fade from the pose actually on screen - the whole frame
+                // plus the sub-frame remainder - not the integer keyframe
+                // behind it (which would start the fade with a backward pop).
+                let time_per_frame = clip.time_per_frame.as_secs_f32();
+                let fraction = if time_per_frame > f32::EPSILON {
+                    (self.remaining_time / time_per_frame).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
                 (
                     clip.clone(),
-                    self.current_frame as f32,
+                    self.current_frame as f32 + fraction,
                     matches!(flags, AnimationFlags::Loop),
                 )
             })
@@ -336,16 +345,15 @@ impl AnimationPlayer {
                     AnimationFlags::PlayOnce => {
                         let last_animation = player.animation.first().map(|m| m.0.clone());
                         let animation = player.animation.drop_first().unwrap_or_default();
-                        // Carry the time we overshot past the final frame into
-                        // the next clip (whole overshot frames plus the
-                        // sub-frame remainder). Zeroing it here phase-reset
-                        // the cadence at every seam: with the AI re-queueing
-                        // the next clip one tick after completion, the final
-                        // pose was held an extra tick per clip - a rhythmic
-                        // hitch at stride rate on short locomotion clips.
-                        let overshoot = (next_frame - current_clip.num_frames) as f32
-                            * time_per_frame
-                            + remaining_duration;
+                        // Carry the sub-frame remainder past the final frame
+                        // into the next clip - zeroing it phase-reset the
+                        // cadence at every seam. Whole overshot frames (a
+                        // large dt hitch landing on a completion) are
+                        // deliberately dropped: carrying more than one frame
+                        // would leave the new clip's logical time ahead of
+                        // its rendered pose. The advance loop already leaves
+                        // remaining_duration < time_per_frame.
+                        let overshoot = remaining_duration;
                         (
                             AnimationPlayer {
                                 additional_joint_transforms: player
@@ -429,8 +437,8 @@ impl AnimationPlayer {
         let maybe_current_clip = self
             .animation
             .first()
-            .map(|m| (m.0.clone(), false))
-            .or_else(|| self.last_animation.clone().map(|m| (m, true)));
+            .map(|m| (m.0.clone(), matches!(m.1, AnimationFlags::Loop), false))
+            .or_else(|| self.last_animation.clone().map(|m| (m, false, true)));
 
         // If there is no animation, we still may need to apply joint transforms (ie, for camera or turret)
         if maybe_current_clip.is_none() {
@@ -439,7 +447,7 @@ impl AnimationPlayer {
             return animated_skeleton.get_transforms();
         }
 
-        let (rc_animation_clip, is_last_anim) = maybe_current_clip.unwrap();
+        let (rc_animation_clip, is_looping, is_last_anim) = maybe_current_clip.unwrap();
         let current_clip = rc_animation_clip.as_ref();
 
         // Sub-frame position: the whole frame plus the accumulated remainder
@@ -462,6 +470,7 @@ impl AnimationPlayer {
             skeleton,
             current_clip,
             current_frame,
+            is_looping,
             &self.additional_joint_transforms,
             self.cancel_root_motion,
         );
@@ -473,18 +482,16 @@ impl AnimationPlayer {
                 // as two small hitches bracketing the fade.
                 let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
                 let alpha = (1.0 - (std::f32::consts::PI * t).cos()) / 2.0;
-                // Keep the fractional from-position (the from-pose advances
-                // smoothly during the fade), normalized into the clip.
-                let frame = if blend.from_clip.num_frames > 0 {
-                    blend.from_frame % blend.from_clip.num_frames as f32
-                } else {
-                    0.0
-                };
+                // update() keeps from_frame in range (loops wrap, one-shots
+                // clamp), and the fractional position advances smoothly
+                // during the fade.
+                let frame = blend.from_frame;
 
                 let from_transforms = Self::compute_transforms_for_clip(
                     skeleton,
                     &blend.from_clip,
                     frame,
+                    blend.from_looping,
                     &self.additional_joint_transforms,
                     self.cancel_root_motion,
                 );
@@ -501,6 +508,7 @@ impl AnimationPlayer {
         skeleton: &Skeleton,
         clip: &AnimationClip,
         frame: f32,
+        wrap: bool,
         additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
         cancel_root_motion: bool,
     ) -> [Matrix4<f32>; 40] {
@@ -510,6 +518,7 @@ impl AnimationPlayer {
                 animation_clip: clip,
                 frame: frame as u32,
                 fraction: frame.fract(),
+                wrap,
                 cancel_root_motion,
             }),
             additional_joint_transforms,
@@ -696,6 +705,24 @@ mod tests {
         // crosses the 0.1s frame boundary exactly one frame in.
         let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(60));
         assert_eq!(player.snapshot().current_frame, 1);
+    }
+
+    #[test]
+    fn blend_starts_from_the_fractional_displayed_pose() {
+        // Advance half a frame (tpf 100ms, dt 50ms): the screen shows frame
+        // 0.5. A blend must fade from that pose, not integer frame 0.
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+        let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(50));
+        let mut blending_clip = (*clip_with_root_motion()).clone();
+        blending_clip.blend_length = Duration::from_millis(500);
+        let player = AnimationPlayer::queue_animation(&player, Rc::new(blending_clip));
+        let blend = player.snapshot().blend.expect("blend engages");
+        assert!(
+            (blend.from_frame - 0.5).abs() < 1e-4,
+            "from-pose must be the displayed fractional frame, got {}",
+            blend.from_frame
+        );
     }
 
     #[test]

--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -130,7 +130,11 @@ impl AnimationPlayer {
             animation: new_animation,
             last_animation: None,
             current_frame: 0,
-            remaining_time: 0.0,
+            // Preserve the sub-frame playback remainder (including the
+            // overshoot carried across the previous clip's completion) so a
+            // queued continuation keeps the clip cadence instead of
+            // restarting the frame clock at every seam.
+            remaining_time: player.remaining_time,
             blend_state,
             cancel_root_motion: player.cancel_root_motion,
         }
@@ -332,6 +336,16 @@ impl AnimationPlayer {
                     AnimationFlags::PlayOnce => {
                         let last_animation = player.animation.first().map(|m| m.0.clone());
                         let animation = player.animation.drop_first().unwrap_or_default();
+                        // Carry the time we overshot past the final frame into
+                        // the next clip (whole overshot frames plus the
+                        // sub-frame remainder). Zeroing it here phase-reset
+                        // the cadence at every seam: with the AI re-queueing
+                        // the next clip one tick after completion, the final
+                        // pose was held an extra tick per clip - a rhythmic
+                        // hitch at stride rate on short locomotion clips.
+                        let overshoot = (next_frame - current_clip.num_frames) as f32
+                            * time_per_frame
+                            + remaining_duration;
                         (
                             AnimationPlayer {
                                 additional_joint_transforms: player
@@ -340,7 +354,7 @@ impl AnimationPlayer {
                                 animation,
                                 last_animation,
                                 current_frame: 0,
-                                remaining_time: 0.0,
+                                remaining_time: overshoot,
                                 blend_state,
                                 cancel_root_motion: player.cancel_root_motion,
                             },
@@ -428,10 +442,20 @@ impl AnimationPlayer {
         let (rc_animation_clip, is_last_anim) = maybe_current_clip.unwrap();
         let current_clip = rc_animation_clip.as_ref();
 
+        // Sub-frame position: the whole frame plus the accumulated remainder
+        // toward the next one, so 60Hz+ playback of 30fps clips interpolates
+        // between keyframes instead of holding each for two ticks. A drained
+        // queue holds the final keyframe exactly.
         let current_frame = if is_last_anim {
-            current_clip.num_frames - 1
+            (current_clip.num_frames - 1) as f32
         } else {
-            self.current_frame
+            let time_per_frame = current_clip.time_per_frame.as_secs_f32();
+            let fraction = if time_per_frame > f32::EPSILON {
+                (self.remaining_time / time_per_frame).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            self.current_frame as f32 + fraction
         };
 
         let mut animated_transforms = Self::compute_transforms_for_clip(
@@ -449,10 +473,12 @@ impl AnimationPlayer {
                 // as two small hitches bracketing the fade.
                 let t = (blend.elapsed / blend.duration).clamp(0.0, 1.0);
                 let alpha = (1.0 - (std::f32::consts::PI * t).cos()) / 2.0;
+                // Keep the fractional from-position (the from-pose advances
+                // smoothly during the fade), normalized into the clip.
                 let frame = if blend.from_clip.num_frames > 0 {
-                    (blend.from_frame.floor() as u32) % blend.from_clip.num_frames
+                    blend.from_frame % blend.from_clip.num_frames as f32
                 } else {
-                    0
+                    0.0
                 };
 
                 let from_transforms = Self::compute_transforms_for_clip(
@@ -474,7 +500,7 @@ impl AnimationPlayer {
     fn compute_transforms_for_clip(
         skeleton: &Skeleton,
         clip: &AnimationClip,
-        frame: u32,
+        frame: f32,
         additional_joint_transforms: &immutable::HashTrieMap<u32, Matrix4<f32>>,
         cancel_root_motion: bool,
     ) -> [Matrix4<f32>; 40] {
@@ -482,7 +508,8 @@ impl AnimationPlayer {
             skeleton,
             Some(AnimationInfo {
                 animation_clip: clip,
-                frame,
+                frame: frame as u32,
+                fraction: frame.fract(),
                 cancel_root_motion,
             }),
             additional_joint_transforms,
@@ -641,6 +668,34 @@ mod tests {
             "final frame should keep the stride rate, not drop to zero: {:?}",
             clip.root_velocity_at(2)
         );
+    }
+
+    #[test]
+    fn completion_carries_overshoot_and_queueing_preserves_it() {
+        // 3-frame clip at 10fps (0.3s). A 0.35s tick completes it with 0.05s
+        // of overshoot past the final frame.
+        let player =
+            AnimationPlayer::queue_animation(&AnimationPlayer::empty(), clip_with_root_motion());
+        let (player, _, events, _) = AnimationPlayer::update(&player, Duration::from_millis(350));
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnimationEvent::Completed))
+        );
+        let carried = player.snapshot().remaining_time;
+        assert!(
+            (carried - 0.05).abs() < 1e-4,
+            "overshoot must carry across completion (got {carried})"
+        );
+
+        // Queueing the continuation keeps the remainder...
+        let player = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
+        assert!((player.snapshot().remaining_time - 0.05).abs() < 1e-4);
+
+        // ...so the frame clock stays on cadence: 0.05 carried + 0.06 tick
+        // crosses the 0.1s frame boundary exactly one frame in.
+        let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(60));
+        assert_eq!(player.snapshot().current_frame, 1);
     }
 
     #[test]

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -5,7 +5,7 @@ use rpds as immutable;
 use std::collections::HashMap;
 use tracing::warn;
 
-use cgmath::{Deg, Matrix4, Quaternion, SquareMatrix, Vector2, Vector3};
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, SquareMatrix, Vector2, Vector3};
 use engine::{
     assets::asset_cache::AssetCache,
     scene::{
@@ -424,6 +424,12 @@ fn calc_and_cache_global_transform(
 pub struct AnimationInfo<'a> {
     pub animation_clip: &'a AnimationClip,
     pub frame: u32,
+    /// Sub-frame progress toward `frame + 1` (0..1). Poses interpolate
+    /// between the two keyframes (per-joint rotation slerp, translation
+    /// lerp), so playback above the clip's native frame rate advances
+    /// smoothly instead of snapping to whole 30fps keyframes. The final
+    /// keyframe holds (no wrap) - seams are the queue's business.
+    pub fraction: f32,
     /// Cancel the clip's root motion: both the per-frame clip root transform
     /// and the root joint's animation transform are replaced with identity, so
     /// the posed skeleton stays anchored at the model origin and only the
@@ -446,14 +452,23 @@ pub fn animate(
     let root_transform = if let Some(AnimationInfo {
         animation_clip,
         frame,
+        fraction,
         cancel_root_motion,
     }) = animation_info
     {
-        let normalized_frame = frame % animation_clip.num_frames;
+        let normalized_frame = (frame % animation_clip.num_frames) as usize;
+        let sample = |frames: &Vec<Matrix4<f32>>| -> Matrix4<f32> {
+            let current = frames[normalized_frame.min(frames.len() - 1)];
+            if fraction > f32::EPSILON && normalized_frame + 1 < frames.len() {
+                interpolate_transform(&current, &frames[normalized_frame + 1], fraction)
+            } else {
+                current
+            }
+        };
         let animations = &animation_clip.joint_to_frame;
         for key in animations {
             let (joint, frames) = key;
-            animation_transforms.insert(*joint, frames[normalized_frame as usize]);
+            animation_transforms.insert(*joint, sample(frames));
         }
 
         if cancel_root_motion {
@@ -478,7 +493,7 @@ pub fn animate(
         } else if animation_clip.root_transforms.is_empty() {
             Matrix4::identity()
         } else {
-            animation_clip.root_transforms[normalized_frame as usize]
+            sample(&animation_clip.root_transforms)
         }
     } else {
         Matrix4::identity()
@@ -511,6 +526,25 @@ pub fn animate(
 
 fn translation_from_matrix(matrix: &Matrix4<f32>) -> Vector3<f32> {
     matrix.w.truncate()
+}
+
+/// Interpolate between two affine keyframes: rotation by quaternion slerp
+/// (basis columns normalized first - keyframes are rotation+translation, but
+/// stay robust to scale), translation by lerp.
+fn interpolate_transform(a: &Matrix4<f32>, b: &Matrix4<f32>, t: f32) -> Matrix4<f32> {
+    let rot = |m: &Matrix4<f32>| -> Quaternion<f32> {
+        let x = m.x.truncate().normalize();
+        let y = m.y.truncate().normalize();
+        let z = m.z.truncate().normalize();
+        Quaternion::from(cgmath::Matrix3::from_cols(x, y, z)).normalize()
+    };
+    let blended = rot(a).slerp(rot(b), t).normalize();
+    let translation = a.w.truncate() * (1.0 - t) + b.w.truncate() * t;
+    let mut out = Matrix4::from(blended);
+    out.w.x = translation.x;
+    out.w.y = translation.y;
+    out.w.z = translation.z;
+    out
 }
 
 #[cfg(test)]
@@ -603,6 +637,7 @@ mod tests {
             Some(AnimationInfo {
                 animation_clip: &clip,
                 frame: 0,
+                fraction: 0.0,
                 cancel_root_motion: false,
             }),
             &immutable::HashTrieMap::new(),
@@ -616,6 +651,55 @@ mod tests {
     }
 
     #[test]
+    fn animate_interpolates_between_keyframes_at_fractional_positions() {
+        let (skeleton, mut clip) = test_skeleton_and_clip();
+        // Two keyframes for the child joint: translation steps (2,0,0) ->
+        // (4,0,0); rotation identity -> 90 deg yaw. Root static both frames.
+        clip.num_frames = 2;
+        clip.joint_to_frame.insert(
+            0,
+            vec![
+                Matrix4::from_translation(Vector3::new(5.0, 0.0, 0.0)),
+                Matrix4::from_translation(Vector3::new(5.0, 0.0, 0.0)),
+            ],
+        );
+        clip.joint_to_frame.insert(
+            1,
+            vec![
+                Matrix4::from_translation(Vector3::new(2.0, 0.0, 0.0)),
+                Matrix4::from_translation(Vector3::new(4.0, 0.0, 0.0))
+                    * Matrix4::from_angle_y(Deg(90.0)),
+            ],
+        );
+        clip.root_transforms = vec![Matrix4::identity(), Matrix4::identity()];
+
+        let posed = animate(
+            &skeleton,
+            Some(AnimationInfo {
+                animation_clip: &clip,
+                frame: 0,
+                fraction: 0.5,
+                cancel_root_motion: false,
+            }),
+            &immutable::HashTrieMap::new(),
+        );
+        // Joint 1 global = root(5,0,0) * bone local(1,0,0) * anim(interp):
+        // translation lerps to (3,0,0) -> global (9,0,0); rotation slerps to
+        // a 45 deg yaw.
+        let child = posed.get_transforms()[1];
+        assert!(
+            (translation_from_matrix(&child) - Vector3::new(9.0, 0.0, 0.0)).magnitude() < 1e-5,
+            "translation must lerp midway, got {:?}",
+            translation_from_matrix(&child)
+        );
+        let yaw = child.z.x.atan2(child.z.z).to_degrees();
+        assert!(
+            (yaw - 45.0).abs() < 0.5,
+            "rotation must slerp midway (expected 45 deg yaw, got {yaw})"
+        );
+    }
+
+    #[test]
     fn animate_cancel_root_motion_pins_root_and_strips_joint_translations() {
         let (skeleton, clip) = test_skeleton_and_clip();
         let posed = animate(
@@ -623,6 +707,7 @@ mod tests {
             Some(AnimationInfo {
                 animation_clip: &clip,
                 frame: 0,
+                fraction: 0.0,
                 cancel_root_motion: true,
             }),
             &immutable::HashTrieMap::new(),

--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -427,9 +427,12 @@ pub struct AnimationInfo<'a> {
     /// Sub-frame progress toward `frame + 1` (0..1). Poses interpolate
     /// between the two keyframes (per-joint rotation slerp, translation
     /// lerp), so playback above the clip's native frame rate advances
-    /// smoothly instead of snapping to whole 30fps keyframes. The final
-    /// keyframe holds (no wrap) - seams are the queue's business.
+    /// smoothly instead of snapping to whole 30fps keyframes.
     pub fraction: f32,
+    /// Whether the final keyframe interpolates toward frame 0 (looping
+    /// clips). One-shots hold their final keyframe - their seams are the
+    /// queue's business.
+    pub wrap: bool,
     /// Cancel the clip's root motion: both the per-frame clip root transform
     /// and the root joint's animation transform are replaced with identity, so
     /// the posed skeleton stays anchored at the model origin and only the
@@ -453,16 +456,30 @@ pub fn animate(
         animation_clip,
         frame,
         fraction,
+        wrap,
         cancel_root_motion,
     }) = animation_info
     {
         let normalized_frame = (frame % animation_clip.num_frames) as usize;
         let sample = |frames: &Vec<Matrix4<f32>>| -> Matrix4<f32> {
-            let current = frames[normalized_frame.min(frames.len() - 1)];
-            if fraction > f32::EPSILON && normalized_frame + 1 < frames.len() {
-                interpolate_transform(&current, &frames[normalized_frame + 1], fraction)
+            let Some(&current) = frames.get(normalized_frame.min(frames.len().saturating_sub(1)))
+            else {
+                // Empty keyframe track (malformed clip data) - bind pose.
+                return Matrix4::identity();
+            };
+            if fraction <= f32::EPSILON {
+                return current;
+            }
+            let next = if normalized_frame + 1 < frames.len() {
+                Some(normalized_frame + 1)
+            } else if wrap && frames.len() > 1 {
+                Some(0)
             } else {
-                current
+                None
+            };
+            match next {
+                Some(next) => interpolate_transform(&current, &frames[next], fraction),
+                None => current,
             }
         };
         let animations = &animation_clip.joint_to_frame;
@@ -638,6 +655,7 @@ mod tests {
                 animation_clip: &clip,
                 frame: 0,
                 fraction: 0.0,
+                wrap: false,
                 cancel_root_motion: false,
             }),
             &immutable::HashTrieMap::new(),
@@ -679,6 +697,7 @@ mod tests {
                 animation_clip: &clip,
                 frame: 0,
                 fraction: 0.5,
+                wrap: false,
                 cancel_root_motion: false,
             }),
             &immutable::HashTrieMap::new(),
@@ -700,6 +719,50 @@ mod tests {
     }
 
     #[test]
+    fn animate_wraps_interpolation_on_looping_clips() {
+        let (skeleton, mut clip) = test_skeleton_and_clip();
+        // Child joint: (2,0,0) at frame 0, (4,0,0) at frame 1. Sampling the
+        // FINAL frame with fraction 0.5 and wrap on must head back toward
+        // frame 0: lerp((4,0,0), (2,0,0), 0.5) = (3,0,0).
+        clip.num_frames = 2;
+        clip.joint_to_frame
+            .insert(0, vec![Matrix4::identity(), Matrix4::identity()]);
+        clip.joint_to_frame.insert(
+            1,
+            vec![
+                Matrix4::from_translation(Vector3::new(2.0, 0.0, 0.0)),
+                Matrix4::from_translation(Vector3::new(4.0, 0.0, 0.0)),
+            ],
+        );
+        clip.root_transforms = vec![Matrix4::identity(), Matrix4::identity()];
+
+        let sample_child = |wrap: bool| {
+            let posed = animate(
+                &skeleton,
+                Some(AnimationInfo {
+                    animation_clip: &clip,
+                    frame: 1,
+                    fraction: 0.5,
+                    wrap,
+                    cancel_root_motion: false,
+                }),
+                &immutable::HashTrieMap::new(),
+            );
+            translation_from_matrix(&posed.get_transforms()[1])
+        };
+
+        // bone local (1,0,0) + anim translation.
+        assert!(
+            (sample_child(true) - Vector3::new(4.0, 0.0, 0.0)).magnitude() < 1e-5,
+            "looping: final frame interpolates toward frame 0"
+        );
+        assert!(
+            (sample_child(false) - Vector3::new(5.0, 0.0, 0.0)).magnitude() < 1e-5,
+            "one-shot: final frame holds"
+        );
+    }
+
+    #[test]
     fn animate_cancel_root_motion_pins_root_and_strips_joint_translations() {
         let (skeleton, clip) = test_skeleton_and_clip();
         let posed = animate(
@@ -708,6 +771,7 @@ mod tests {
                 animation_clip: &clip,
                 frame: 0,
                 fraction: 0.0,
+                wrap: false,
                 cancel_root_motion: true,
             }),
             &immutable::HashTrieMap::new(),


### PR DESCRIPTION
## Summary

Fixes #3+#4 of the animation-smoothness stack (stacked on #469), both in the playback clock:

1. **Fractional-frame interpolation.** Poses interpolate between adjacent keyframes at the sub-frame position (per-joint rotation slerp, translation lerp, root transform included) instead of snapping to whole 30 fps keyframes. At 60 Hz, every other tick used to repeat the previous pose — a constant sawtooth under all motion. The blend-from pose also advances fractionally during crossfades. (Correcting the record: `research/model-differences.md` claims both engines snap to integer frames; observation of shipped behavior shows sub-frame interpolation — the doc will be updated separately.)
2. **Phase carry across seams.** A completing clip carries its overshoot past the final frame into the next, and re-queues preserve the sub-frame remainder, so the frame clock never phase-resets at a seam. Honest note: **no measurable effect at exactly 60 Hz with these clips** (their durations are whole multiples of the tick) — this matters at 72/90/120 Hz VR refresh rates and prevents cadence drift. Unit-tested either way.

## Measured impact (medsci1 pipe hybrid, deterministic 60 Hz)

| | before (post-#469) | after |
|---|---|---|
| idle mean max-joint jerk | 0.108 | **0.010** |
| idle max frame delta | 0.163 | **0.081** |
| walking mean max-joint jerk | 0.556 | **0.222** |
| walking mid-clip p50 | 0.133 (alternating 0 / 0.27) | 0.154 (uniform every tick) |
| walking stride-seam max | 0.752 | 0.801 |

Versus the original baseline: idle jerk is now **13×** lower, walking jerk **3.9×** lower. The stride seam is now the one dominant residual (0.80 vs 0.15 mid-clip) — the one-tick completion hold plus the hard stride cut. That's a game-loop-ordering follow-up (apply queued animation effects before posing), deliberately out of scope here. The auto-threshold now flags all 40 stride seams because mid-clip variance collapsed — a metric artifact of the improvement, not a regression (absolute seam magnitude ~unchanged).

## Validation

- 27/27 `dark` unit tests, including new: overshoot carry + cadence preservation across a queue seam; slerp-midpoint interpolation (45° at fraction 0.5)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean, `cargo fmt`
- Full e2e + cross-engine review: running, results to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)