### PR TITLE
feat(ragdoll): graduate the multibody rig — sleep on settle, default rig, full joint diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,10 +444,12 @@ The project supports experimental flags for gating in-progress features during d
 - **`ragdoll`**: spawn a physics ragdoll on creature death (`SlayEntity`) instead of
   just removing the entity. Without it, death is unchanged.
 
-- **`ragdoll_multibody`**: make ragdolls use reduced-coordinate (multibody) joints
-  anchored at the limb articulation points — limbs can't separate (no hip gap), but
-  the rig is experimental (extremities can jitter on floor contact). Without it,
-  ragdolls use the stable impulse-joint rig. See `projects/ragdoll-settling-followup.md`.
+- **`ragdoll_impulse`**: make ragdolls fall back to the legacy impulse-joint rig
+  (heavier core, soft locked translation — settles but the hip visibly sags/separates
+  under load). Without it, ragdolls use the default reduced-coordinate (multibody)
+  rig — joints anchored at the limb articulation points, so limbs structurally can't
+  separate — with raised sleep thresholds so the settled corpse goes fully still
+  (and wakes again on contact/impulse). See `projects/ragdoll-settling-followup.md`.
 
 - **`loading_screen`**: show the animated loading screen during level transitions
   (`GlobalEffect::TransitionLevel` / `TestReload`) instead of switching instantly. The

--- a/projects/ragdoll-settling-followup.md
+++ b/projects/ragdoll-settling-followup.md
@@ -116,6 +116,9 @@ the impulse rig kept as the stable default:
   otherwise it uses the impulse rig (parent-origin anchor, heavy core, soft
   translation). Routing verified: default → 19 impulse joints; multibody flag → 0
   impulse joints, bodies stay connected (~1.6 m extent).
+  **2026-07-16 update: multibody is now the DEFAULT rig** (it settles and sleeps —
+  see the graduation notes below); the flag is retired and replaced by
+  `--experimental ragdoll_impulse`, which falls back to the legacy impulse rig.
 
 **What the multibody fixes:** translation is structurally not a DOF, so limbs
 **cannot separate** — the hip gap is gone, and we can finally anchor at the true
@@ -179,9 +182,11 @@ frames so forward-kinematics reproduces the spawn pose (no snap), parent-before-
 insertion (insert is order-robust given per-child dedup), body-creation dedup, joints
 auto-removed with bodies. `PhysicsWorld::create_multibody_joint` →
 `multibody_joint_set.insert`. **Remaining:** the floor-contact jitter (step 0) — until
-that's solved this stays experimental, and `/v1/physics/joints` + the `--debug-physics`
-anchor viz still iterate only the **impulse** set (extend to the multibody set for
-multibody diagnostics).
+that's solved this stays experimental. *(2026-07-16: both resolved — the jitter no
+longer reproduces, ragdoll bodies get a raised angular sleep threshold so the island
+sleeps, multibody is the default rig, and `/v1/physics/joints` + the `--debug-physics`
+anchor viz now cover the multibody set too, with a `joint_type` field. A new
+`POST /v1/physics/bodies/:id/impulse` debug endpoint pokes/wakes bodies headlessly.)*
 
 ### 2. Fallback if multibody proves too unstable — accept gap + auto-sleep
 Keep the stable soft impulse joints, stop fighting the residual ~9 cm hip gap, and add

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -158,9 +158,17 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<RagdollMetricsResult>,
     },
 
-    /// List impulse joints with anchor separation + applied impulse
+    /// List impulse + multibody joints with anchor separation + applied impulse
     ListPhysicsJoints {
         reply: oneshot::Sender<PhysicsJointsResult>,
+    },
+
+    /// Apply a world-space impulse to a dynamic physics body (waking it) -
+    /// e.g. poke a settled ragdoll to verify it wakes and reacts.
+    ApplyBodyImpulse {
+        body_id: u32,
+        impulse: [f32; 3],
+        reply: oneshot::Sender<CommandResult>,
     },
 
     /// Audit collider AABBs for malformed geometry (NaN/degenerate/extreme)
@@ -270,7 +278,7 @@ pub struct RagdollMetricsEntry {
     pub max_drift: f32,
 }
 
-/// Impulse joint diagnostics (ragdoll constraint health).
+/// Joint diagnostics (ragdoll constraint health), impulse + multibody.
 #[derive(Debug, Serialize)]
 pub struct PhysicsJointsResult {
     pub joints: Vec<PhysicsJointEntry>,
@@ -280,6 +288,8 @@ pub struct PhysicsJointsResult {
 pub struct PhysicsJointEntry {
     pub body1_id: u32,
     pub body2_id: u32,
+    /// `"impulse"` or `"multibody"` - which joint set this came from.
+    pub joint_type: String,
     pub bone1: Option<u32>,
     pub bone2: Option<u32>,
     pub anchor1: [f32; 3],

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -295,6 +295,10 @@ async fn start_http_server(
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
         .route("/v1/physics/joints", get(list_physics_joints))
+        .route(
+            "/v1/physics/bodies/:id/impulse",
+            axum::routing::post(apply_body_impulse),
+        )
         .route("/v1/physics/colliders/validate", get(audit_colliders))
         .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
         .route("/v1/control/input", get(get_input_state))
@@ -1504,6 +1508,7 @@ fn process_command(
                         .map(|j| commands::PhysicsJointEntry {
                             body1_id: j.body1_id,
                             body2_id: j.body2_id,
+                            joint_type: j.joint_type,
                             bone1: j.bone1,
                             bone2: j.bone2,
                             anchor1: j.anchor1,
@@ -1517,6 +1522,34 @@ fn process_command(
                 .unwrap_or_default();
             if let Err(_) = reply.send(commands::PhysicsJointsResult { joints }) {
                 tracing::warn!("Failed to send physics joints - receiver dropped");
+            }
+        }
+        RuntimeCommand::ApplyBodyImpulse {
+            body_id,
+            impulse,
+            reply,
+        } => {
+            let result = match game.debug_scene_mut() {
+                Some(debug_scene) => {
+                    let applied = debug_scene.apply_body_impulse(body_id, impulse);
+                    CommandResult {
+                        success: applied,
+                        message: if applied {
+                            format!("Impulse applied to body {}", body_id)
+                        } else {
+                            format!("No dynamic body with id {}", body_id)
+                        },
+                        data: None,
+                    }
+                }
+                None => CommandResult {
+                    success: false,
+                    message: "Current scene is not debuggable".to_string(),
+                    data: None,
+                },
+            };
+            if let Err(_) = reply.send(result) {
+                tracing::warn!("Failed to send impulse result - receiver dropped");
             }
         }
         RuntimeCommand::GetInput(reply) => {
@@ -2100,6 +2133,48 @@ async fn get_animation_state(
 /// Inject a script message (damage, frob, signal) into a specific entity.
 ///
 /// Body is a tagged `DebugEntityMessage`, e.g. `{"type":"Damage","amount":1.0}`.
+/// Request body for POST /v1/physics/bodies/:id/impulse.
+#[derive(serde::Deserialize)]
+struct BodyImpulseRequest {
+    /// World-space impulse vector (mass * velocity change).
+    impulse: [f32; 3],
+}
+
+/// HTTP handler: apply a world-space impulse to a dynamic physics body,
+/// waking it if asleep. Lets tests poke a settled/sleeping ragdoll headlessly.
+async fn apply_body_impulse(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Path(id): Path<u32>,
+    LenientJson(request): LenientJson<BodyImpulseRequest>,
+) -> Json<CommandResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    if let Err(_) = command_tx.send(RuntimeCommand::ApplyBodyImpulse {
+        body_id: id,
+        impulse: request.impulse,
+        reply: reply_tx,
+    }) {
+        tracing::error!("Failed to send ApplyBodyImpulse command - game loop receiver dropped");
+        return Json(CommandResult {
+            success: false,
+            message: "Game loop unavailable".to_string(),
+            data: None,
+        });
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive impulse result - sender dropped");
+            Json(CommandResult {
+                success: false,
+                message: "No response from game loop".to_string(),
+                data: None,
+            })
+        }
+    }
+}
+
 async fn send_entity_message(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
     Path(id): Path<i32>,

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -44,6 +44,15 @@ const MIN_VOLUME: f32 = 1e-4;
 /// measured from the bind/rest pose. Keeps the rig from folding/twisting through
 /// itself. Per-bone limit profiles (hinge knees, cone shoulders) are a follow-up.
 const JOINT_CONE_LIMIT: f32 = 1.05;
+/// Sleep thresholds for ragdoll bodies. A settled extremity can hold a
+/// low-grade contact buzz (~0.5-1 rad/s) that sits above rapier's default
+/// angular threshold (0.5), and one awake body keeps the whole jointed island
+/// awake - so the corpse never sleeps and the buzz never stops. Raising the
+/// angular threshold lets the island sleep once bulk motion is done (rapier
+/// needs the entire island below thresholds for ~2s); sleep zeroes the buzz,
+/// and contact or an applied impulse wakes the corpse (it stays pokeable).
+const SLEEP_LINEAR_THRESHOLD: f32 = 0.4; // rapier default
+const SLEEP_ANGULAR_THRESHOLD: f32 = 1.5;
 
 /// Quality/settle metrics for one ragdoll, for the verification harness.
 #[derive(Clone, Debug)]
@@ -222,11 +231,12 @@ impl RagDollManager {
         joint_transforms: &[Matrix4<f32>; 40],
         root_offset: Vector3<f32>,
         joint_limits: &HashMap<u32, JointLimit>,
-        // When true, use reduced-coordinate (multibody) joints anchored at the
-        // articulation point: limbs can't separate (no hip gap), but the rig is
-        // experimental (extremities can jitter on floor contact). When false, the
-        // stable impulse-joint rig (heavier core, soft locked translation - settles
-        // but the hip can visibly sag/separate under load).
+        // When true (the default rig), use reduced-coordinate (multibody) joints
+        // anchored at the articulation point: limbs structurally can't separate
+        // (no hip gap) and the rig settles. When false (the legacy
+        // `ragdoll_impulse` fallback), the impulse-joint rig (heavier core, soft
+        // locked translation - settles but the hip can visibly sag/separate
+        // under load).
         use_multibody: bool,
         physics: &mut PhysicsWorld,
     ) -> bool {
@@ -286,6 +296,11 @@ impl RagDollManager {
 
             let handle = physics.create_dynamic_body(isometry, Some(entity_id));
             physics.set_body_damping(handle, LINEAR_DAMPING, ANGULAR_DAMPING);
+            physics.set_body_sleep_thresholds(
+                handle,
+                SLEEP_LINEAR_THRESHOLD,
+                SLEEP_ANGULAR_THRESHOLD,
+            );
             spawn_positions.insert(handle, pos_vec);
 
             // Build the collider from the joint's fitted shape. Density is chosen

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -55,6 +55,12 @@ const JOINT_CONE_LIMIT: f32 = 1.05;
 /// to ~1.5 rad/s for 2s could hard-stop - lower toward 1.0 if that's ever
 /// visible.
 const SLEEP_ANGULAR_THRESHOLD: f32 = 1.5;
+/// Hard cap on ragdoll body velocities (per generalized-DOF component for the
+/// multibody rig; linvel/angvel norms for free bodies). Healthy collapse
+/// dynamics peak around 7-20; the cap only engages when a spawn transient
+/// enters runaway feedback (which otherwise ends in a NaN AABB and a parry
+/// BVH panic). Applied once per frame in `RagDoll::update`.
+const MAX_BODY_SPEED: f32 = 30.0;
 
 /// Quality/settle metrics for one ragdoll, for the verification harness.
 #[derive(Clone, Debug)]
@@ -172,7 +178,20 @@ impl RagDoll {
         }
     }
 
-    fn update(&mut self, physics: &PhysicsWorld) {
+    fn update(&mut self, physics: &mut PhysicsWorld) {
+        // Break runaway spawn transients before they cascade to a NaN AABB
+        // (which panics the parry BVH broad-phase). Normal collapse dynamics
+        // peak well below the cap, so this is a no-op except in the rare
+        // diverging run.
+        let corrected = physics.sanitize_ragdoll_bodies(&self.physics_bodies, MAX_BODY_SPEED);
+        if corrected > 0 {
+            // Common during the spawn transient (several frames per death),
+            // so debug rather than warn.
+            tracing::debug!(
+                "ragdoll velocity runaway: clamped {} velocity components",
+                corrected
+            );
+        }
         for (joint_id, handle) in &self.joint_to_body {
             if let Some(isometry) = physics.get_body_transform(*handle) {
                 let world = matrix_from_isometry(isometry);
@@ -512,7 +531,7 @@ impl RagDollManager {
         true
     }
 
-    pub fn update(&mut self, physics: &PhysicsWorld) {
+    pub fn update(&mut self, physics: &mut PhysicsWorld) {
         for ragdoll in self.ragdolls.values_mut() {
             ragdoll.update(physics);
         }

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -44,14 +44,16 @@ const MIN_VOLUME: f32 = 1e-4;
 /// measured from the bind/rest pose. Keeps the rig from folding/twisting through
 /// itself. Per-bone limit profiles (hinge knees, cone shoulders) are a follow-up.
 const JOINT_CONE_LIMIT: f32 = 1.05;
-/// Sleep thresholds for ragdoll bodies. A settled extremity can hold a
-/// low-grade contact buzz (~0.5-1 rad/s) that sits above rapier's default
-/// angular threshold (0.5), and one awake body keeps the whole jointed island
-/// awake - so the corpse never sleeps and the buzz never stops. Raising the
-/// angular threshold lets the island sleep once bulk motion is done (rapier
-/// needs the entire island below thresholds for ~2s); sleep zeroes the buzz,
-/// and contact or an applied impulse wakes the corpse (it stays pokeable).
-const SLEEP_LINEAR_THRESHOLD: f32 = 0.4; // rapier default
+/// Angular sleep threshold for ragdoll bodies (rad/s). A settled extremity can
+/// hold a low-grade contact buzz (~0.5-1 rad/s) that sits above rapier's
+/// default angular threshold (0.5), and one awake body keeps the whole jointed
+/// island awake - so the corpse never sleeps and the buzz never stops. Raising
+/// it lets the island sleep once bulk motion is done (rapier needs the entire
+/// island below thresholds for ~2s continuously, so a corpse in real motion
+/// won't freeze); sleep zeroes the buzz, and contact or an applied impulse
+/// wakes the corpse (it stays pokeable). Tradeoff: a limb rotating alone at up
+/// to ~1.5 rad/s for 2s could hard-stop - lower toward 1.0 if that's ever
+/// visible.
 const SLEEP_ANGULAR_THRESHOLD: f32 = 1.5;
 
 /// Quality/settle metrics for one ragdoll, for the verification harness.
@@ -296,11 +298,7 @@ impl RagDollManager {
 
             let handle = physics.create_dynamic_body(isometry, Some(entity_id));
             physics.set_body_damping(handle, LINEAR_DAMPING, ANGULAR_DAMPING);
-            physics.set_body_sleep_thresholds(
-                handle,
-                SLEEP_LINEAR_THRESHOLD,
-                SLEEP_ANGULAR_THRESHOLD,
-            );
+            physics.set_body_angular_sleep_threshold(handle, SLEEP_ANGULAR_THRESHOLD);
             spawn_positions.insert(handle, pos_vec);
 
             // Build the collider from the joint's fitted shape. Density is chosen

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -282,18 +282,22 @@ pub struct DebugRagdollMetrics {
     pub max_drift: f32,
 }
 
-/// One impulse joint's state, for ragdoll diagnostics. `separation` and the
-/// impulses staying non-zero at rest mean the constraint can't be satisfied.
+/// One joint's state, for ragdoll diagnostics. `separation` and the impulses
+/// staying non-zero at rest mean the constraint can't be satisfied.
 #[derive(Debug, Serialize, Clone)]
 pub struct DebugPhysicsJoint {
     pub body1_id: u32,
     pub body2_id: u32,
+    /// `"impulse"` or `"multibody"` - which joint set this came from.
+    pub joint_type: String,
     /// Skeleton joint id each body represents, if it's a ragdoll body.
     pub bone1: Option<u32>,
     pub bone2: Option<u32>,
     pub anchor1: [f32; 3],
     pub anchor2: [f32; 3],
     pub separation: f32,
+    /// Constraint impulses this step. Rapier does not expose these for
+    /// multibody links, so they read 0 there.
     pub linear_impulse: f32,
     pub angular_impulse: f32,
 }
@@ -581,10 +585,18 @@ pub trait DebuggableScene {
         Vec::new()
     }
 
-    /// Every impulse joint with its anchor separation + applied impulse, for
-    /// ragdoll diagnostics. Empty when the scene has no joints.
+    /// Every impulse + multibody joint with its anchor separation (+ applied
+    /// impulse for impulse joints), for ragdoll diagnostics. Empty when the
+    /// scene has no joints.
     fn list_physics_joints(&self) -> Vec<DebugPhysicsJoint> {
         Vec::new()
+    }
+
+    /// Apply a world-space impulse to a dynamic physics body by `body_id`
+    /// (waking it if asleep). Debug hook for poking ragdolls headlessly - e.g.
+    /// verify a sleeping corpse wakes on impact. False = no such dynamic body.
+    fn apply_body_impulse(&mut self, _body_id: u32, _impulse: [f32; 3]) -> bool {
+        false
     }
 
     /// Colliders whose world AABB is malformed (NaN/inf, degenerate, or

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2896,17 +2896,17 @@ impl MissionCore {
 
                         // With the `ragdoll` experimental flag, replace the slain
                         // creature with a physics ragdoll of its death pose (the
-                        // spawn removes the creature itself). `ragdoll_multibody`
-                        // selects the experimental reduced-coordinate joints. Without
-                        // the flag (or for non-ragdoll-able entities), fall back to
-                        // the plain removal.
+                        // spawn removes the creature itself). The reduced-coordinate
+                        // multibody rig is the default; `ragdoll_impulse` falls back
+                        // to the legacy impulse-joint rig. Without the flag (or for
+                        // non-ragdoll-able entities), fall back to the plain removal.
                         let spawned_ragdoll =
                             game_options.experimental_features.contains("ragdoll")
                                 && self.spawn_ragdoll(
                                     entity_id,
-                                    game_options
+                                    !game_options
                                         .experimental_features
-                                        .contains("ragdoll_multibody"),
+                                        .contains("ragdoll_impulse"),
                                 );
                         if !spawned_ragdoll {
                             self.remove_entity(entity_id);
@@ -4996,6 +4996,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 bone2: body_to_bone.get(&j.body2_id).copied(),
                 body1_id: j.body1_id,
                 body2_id: j.body2_id,
+                joint_type: j.joint_type.to_string(),
                 anchor1: j.anchor1,
                 anchor2: j.anchor2,
                 separation: j.separation,
@@ -5003,6 +5004,11 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 angular_impulse: j.angular_impulse,
             })
             .collect()
+    }
+
+    fn apply_body_impulse(&mut self, body_id: u32, impulse: [f32; 3]) -> bool {
+        self.physics
+            .apply_body_impulse(body_id, vec3(impulse[0], impulse[1], impulse[2]))
     }
 
     fn audit_colliders(&self) -> Vec<crate::game_scene::DebugColliderIssue> {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -834,7 +834,7 @@ impl MissionCore {
 
         // Clear forces
         self.physics.clear_forces();
-        self.rag_doll_manager.update(&self.physics);
+        self.rag_doll_manager.update(&mut self.physics);
 
         let (left_hand_entity_id, right_hand_entity_id) = self.interaction.held_entities();
 

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -342,6 +342,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.list_physics_joints()
     }
 
+    fn apply_body_impulse(&mut self, body_id: u32, impulse: [f32; 3]) -> bool {
+        self.mission_core.apply_body_impulse(body_id, impulse)
+    }
+
     fn audit_colliders(&self) -> Vec<crate::game_scene::DebugColliderIssue> {
         self.mission_core.audit_colliders()
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -408,7 +408,11 @@ fn sanitize_collider_size(entity_id: EntityId, context: &str, size: Vector3<f32>
     const MAX_SIZE: f32 = 1.0e4;
     let clamp = |v: f32| -> f32 {
         if v.is_finite() && v > 0.0 {
-            v.min(MAX_SIZE)
+            // Clamp up as well as down: a tiny-but-positive size (e.g. medsci1's
+            // "Lift 1 Walls" wall segment) yields a point-like AABB, and parry's
+            // debug-build ray-AABB test overflows on those (FeatureId::Face(0 - 1))
+            // - any AI vision/ground probe crossing it panics the game thread.
+            v.clamp(MIN_SIZE, MAX_SIZE)
         } else {
             MIN_SIZE
         }
@@ -1444,8 +1448,20 @@ impl PhysicsWorld {
         let binding = |_collider_handle: ColliderHandle, collider: &Collider| {
             let data = collider.user_data;
             let maybe_entity_id = EntityId::from_inner(data as u64);
-
-            maybe_entity_id != entity_to_ignore
+            if maybe_entity_id == entity_to_ignore {
+                return false;
+            }
+            // A degenerate collider (zero-extent / non-finite AABB, e.g.
+            // medsci1's point-sized "Lift 1 Walls") poisons parry's ray-AABB
+            // clip the same way a degenerate ray does: face index 0 ->
+            // `0u32 - 1` overflow panic in debug builds, NaN normals in
+            // release. Skip such colliders - a point can't meaningfully block
+            // a ray, and letting one through crashes AI vision/ground probes.
+            // (`GET /v1/physics/colliders/validate` audits the data root
+            // cause.)
+            let aabb = collider.compute_aabb();
+            aabb.mins.iter().all(|v| v.is_finite())
+                && aabb.extents().iter().all(|e| e.is_finite() && *e > 1.0e-5)
         };
         filter = filter.predicate(&binding);
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -13,6 +13,7 @@ use dark::{SCALE_FACTOR, mission::SystemShock2Level};
 use engine::scene::SceneObject;
 use rapier3d::{
     control::{CharacterLength, KinematicCharacterController},
+    na,
     na::UnitQuaternion,
     prelude::*,
 };
@@ -1581,6 +1582,66 @@ impl PhysicsWorld {
         }
     }
 
+    /// Clamp ragdoll body velocities to finite, bounded magnitudes. The spawn
+    /// transient of a ragdoll can (rarely, and nondeterministically across
+    /// processes) enter a runaway feedback loop - a contact spike begets a
+    /// bigger spike next frame until a position goes non-finite and the parry
+    /// BVH broad-phase panics on the NaN AABB. Clamping once per frame breaks
+    /// the cascade while leaving normal collapse dynamics (peaks well below
+    /// the cap) untouched.
+    ///
+    /// Multibody-linked bodies clamp the owning multibody's generalized (DOF)
+    /// velocities - writing a link body's linvel/angvel would be overwritten
+    /// by the reduced-coordinate readback. Each multibody is clamped once no
+    /// matter how many of its links appear in `handles`. Free bodies clamp
+    /// linvel/angvel directly. Returns the number of corrected values.
+    pub fn sanitize_ragdoll_bodies(&mut self, handles: &[RigidBodyHandle], max_speed: f32) -> u32 {
+        let mut corrected = 0u32;
+        let mut seen_multibodies = Vec::new();
+        for handle in handles {
+            if let Some(link) = self.multibody_joint_set.rigid_body_link(*handle) {
+                let index = link.multibody;
+                if seen_multibodies.contains(&index) {
+                    continue;
+                }
+                seen_multibodies.push(index);
+                if let Some(multibody) = self.multibody_joint_set.get_multibody_mut(index) {
+                    for v in multibody.generalized_velocity_mut().iter_mut() {
+                        if !v.is_finite() {
+                            *v = 0.0;
+                            corrected += 1;
+                        } else if v.abs() > max_speed {
+                            *v = v.clamp(-max_speed, max_speed);
+                            corrected += 1;
+                        }
+                    }
+                }
+            } else if let Some(body) = self.rigid_body_set.get_mut(*handle) {
+                let lin = *body.linvel();
+                let ang = *body.angvel();
+                if !lin.iter().all(|v| v.is_finite()) || lin.norm() > max_speed {
+                    let new_lin = if lin.iter().all(|v| v.is_finite()) {
+                        lin * (max_speed / lin.norm())
+                    } else {
+                        na::zero()
+                    };
+                    body.set_linvel(new_lin, false);
+                    corrected += 1;
+                }
+                if !ang.iter().all(|v| v.is_finite()) || ang.norm() > max_speed {
+                    let new_ang = if ang.iter().all(|v| v.is_finite()) {
+                        ang * (max_speed / ang.norm())
+                    } else {
+                        na::zero()
+                    };
+                    body.set_angvel(new_ang, false);
+                    corrected += 1;
+                }
+            }
+        }
+        corrected
+    }
+
     /// Apply a world-space impulse to a dynamic body by its debug `body_id`
     /// (the rigid body handle index, as reported by [`debug_list_bodies`]),
     /// waking it even for a zero impulse (rapier skips a zero `apply_impulse`
@@ -1588,22 +1649,35 @@ impl PhysicsWorld {
     /// wake). Debug/testing hook - e.g. poke a sleeping ragdoll to verify
     /// wake-on-impulse. Matches by handle index like the other debug-endpoint
     /// lookups (the generation isn't exposed over HTTP), so callers must use
-    /// ids from a fresh body listing. For a multibody link this is a plain
-    /// rigid-body impulse, not a full articulated-dynamics response - fine for
-    /// poking, not physically exact. Returns false if no dynamic body matches.
+    /// ids from a fresh body listing. Returns false if no dynamic body matches.
     pub fn apply_body_impulse(&mut self, body_id: u32, impulse: Vector3<f32>) -> bool {
         let handle = self
             .rigid_body_set
             .iter()
             .find(|(handle, _)| handle.into_raw_parts().0 == body_id)
             .map(|(handle, _)| handle);
-        if let Some(handle) = handle {
-            if let Some(body) = self.rigid_body_set.get_mut(handle) {
-                if body.body_type() == RigidBodyType::Dynamic {
-                    body.wake_up(true);
+        let Some(handle) = handle else {
+            return false;
+        };
+        // A multibody link ignores direct velocity writes: the reduced-
+        // coordinate solver recomputes every link body's velocity from the
+        // joint velocities each step (`Multibody` forward kinematics), so
+        // `apply_impulse` is silently overwritten. Its forward *dynamics* does
+        // read the per-body user-force accumulator, so convert the impulse to
+        // a force over one physics step - `clear_forces` (called right after
+        // each step) makes it impulsive.
+        let is_multibody_link = self.multibody_joint_set.rigid_body_link(handle).is_some();
+        let dt = self.integration_parameters.dt;
+        if let Some(body) = self.rigid_body_set.get_mut(handle) {
+            if body.body_type() == RigidBodyType::Dynamic {
+                body.wake_up(true);
+                if is_multibody_link {
+                    body.add_force(vec_to_nvec(impulse) / dt, true);
+                    self.rigid_bodies_with_forces.push(handle);
+                } else {
                     body.apply_impulse(vec_to_nvec(impulse), true);
-                    return true;
                 }
+                return true;
             }
         }
         false

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1111,24 +1111,35 @@ impl PhysicsWorld {
             &self.narrow_phase,
         );
 
-        // Joint-anchor overlay: each impulse joint constrains a point on the
-        // parent body (anchor1, cyan cross) to coincide with a point on the child
+        // Joint-anchor overlay: each joint constrains a point on the parent
+        // body (anchor1, cyan cross) to coincide with a point on the child
         // body (anchor2, magenta cross). A line connects them - a satisfied joint
         // has overlapping crosses and an invisible line; a sagging/separated joint
-        // (e.g. the hips) shows a visible gap.
-        for (_h, joint) in self.impulse_joint_set.iter() {
-            if let (Some(b1), Some(b2)) = (
-                self.rigid_body_set.get(joint.body1),
-                self.rigid_body_set.get(joint.body2),
-            ) {
-                let a1 = b1.position() * joint.data.local_frame1;
-                let a2 = b2.position() * joint.data.local_frame2;
-                let p1 = Vector3::new(a1.translation.x, a1.translation.y, a1.translation.z);
-                let p2 = Vector3::new(a2.translation.x, a2.translation.y, a2.translation.z);
-                debug_renderer.add_cross(p1, 0.12, Vector3::new(0.0, 0.6, 1.0)); // anchor1 blue
-                debug_renderer.add_cross(p2, 0.12, Vector3::new(1.0, 0.0, 1.0)); // anchor2 magenta
-                debug_renderer.add_line(p1, p2, Vector3::new(1.0, 1.0, 0.0)); // gap (yellow)
-            }
+        // (e.g. the hips) shows a visible gap. Impulse and multibody joints both
+        // draw (multibody anchors should always coincide - translation is not a
+        // DOF there).
+        let impulse_anchors = self
+            .impulse_joint_set
+            .iter()
+            .filter_map(|(_h, joint)| {
+                let b1 = self.rigid_body_set.get(joint.body1)?;
+                let b2 = self.rigid_body_set.get(joint.body2)?;
+                Some((
+                    b1.position() * joint.data.local_frame1,
+                    b2.position() * joint.data.local_frame2,
+                ))
+            })
+            .collect::<Vec<_>>();
+        let multibody_anchors = self
+            .multibody_joint_anchor_pairs()
+            .into_iter()
+            .map(|(_, _, a1, a2)| (a1, a2));
+        for (a1, a2) in impulse_anchors.into_iter().chain(multibody_anchors) {
+            let p1 = Vector3::new(a1.translation.x, a1.translation.y, a1.translation.z);
+            let p2 = Vector3::new(a2.translation.x, a2.translation.y, a2.translation.z);
+            debug_renderer.add_cross(p1, 0.12, Vector3::new(0.0, 0.6, 1.0)); // anchor1 blue
+            debug_renderer.add_cross(p2, 0.12, Vector3::new(1.0, 0.0, 1.0)); // anchor2 magenta
+            debug_renderer.add_line(p1, p2, Vector3::new(1.0, 1.0, 0.0)); // gap (yellow)
         }
 
         debug_renderer.render()
@@ -1558,6 +1569,45 @@ impl PhysicsWorld {
         }
     }
 
+    /// Raise a body's sleep thresholds so residual solver noise (e.g. a ragdoll
+    /// extremity buzzing against the floor) still counts as "at rest". One
+    /// awake body keeps its whole jointed island awake, so without this a
+    /// settled ragdoll never sleeps. Sleeping bodies auto-wake on contact or
+    /// applied force, so the corpse stays interactive.
+    pub fn set_body_sleep_thresholds(
+        &mut self,
+        handle: RigidBodyHandle,
+        normalized_linear: f32,
+        angular: f32,
+    ) {
+        if let Some(body) = self.rigid_body_set.get_mut(handle) {
+            let activation = body.activation_mut();
+            activation.normalized_linear_threshold = normalized_linear;
+            activation.angular_threshold = angular;
+        }
+    }
+
+    /// Apply a world-space impulse to a dynamic body by its debug `body_id`
+    /// (the rigid body handle index, as reported by [`debug_list_bodies`]),
+    /// waking it. Debug/testing hook - e.g. poke a sleeping ragdoll to verify
+    /// wake-on-impulse. Returns false if no dynamic body matches.
+    pub fn apply_body_impulse(&mut self, body_id: u32, impulse: Vector3<f32>) -> bool {
+        let handle = self
+            .rigid_body_set
+            .iter()
+            .find(|(handle, _)| handle.into_raw_parts().0 == body_id)
+            .map(|(handle, _)| handle);
+        if let Some(handle) = handle {
+            if let Some(body) = self.rigid_body_set.get_mut(handle) {
+                if body.body_type() == RigidBodyType::Dynamic {
+                    body.apply_impulse(vec_to_nvec(impulse), true);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Create a static (fixed) rigid body without requiring an EntityId
     /// Returns the handle for use in ragdoll systems
     pub fn create_static_body(
@@ -1753,7 +1803,8 @@ impl PhysicsWorld {
     /// `separation ≈ 0` and a small impulse; a persistent separation/impulse
     /// means the constraint can't be satisfied (the rig fights itself).
     pub fn debug_list_joints(&self) -> Vec<DebugJointInfo> {
-        self.impulse_joint_set
+        let impulse = self
+            .impulse_joint_set
             .iter()
             .filter_map(|(_handle, joint)| {
                 let b1 = self.rigid_body_set.get(joint.body1)?;
@@ -1772,12 +1823,55 @@ impl PhysicsWorld {
                 Some(DebugJointInfo {
                     body1_id: joint.body1.into_raw_parts().0,
                     body2_id: joint.body2.into_raw_parts().0,
+                    joint_type: "impulse",
                     anchor1: [a1.translation.x, a1.translation.y, a1.translation.z],
                     anchor2: [a2.translation.x, a2.translation.y, a2.translation.z],
                     separation,
                     linear_impulse,
                     angular_impulse,
                 })
+            });
+        let multibody = self
+            .multibody_joint_anchor_pairs()
+            .into_iter()
+            .map(|(b1, b2, a1, a2)| DebugJointInfo {
+                body1_id: b1.into_raw_parts().0,
+                body2_id: b2.into_raw_parts().0,
+                joint_type: "multibody",
+                anchor1: [a1.translation.x, a1.translation.y, a1.translation.z],
+                anchor2: [a2.translation.x, a2.translation.y, a2.translation.z],
+                separation: (a1.translation.vector - a2.translation.vector).norm(),
+                linear_impulse: 0.0,
+                angular_impulse: 0.0,
+            });
+        impulse.chain(multibody).collect()
+    }
+
+    /// `(parent body, child body, world anchor on parent, world anchor on child)`
+    /// for every multibody joint. Translation is structurally not a DOF for
+    /// these, so the anchors should always coincide.
+    fn multibody_joint_anchor_pairs(
+        &self,
+    ) -> Vec<(
+        RigidBodyHandle,
+        RigidBodyHandle,
+        Isometry<Real>,
+        Isometry<Real>,
+    )> {
+        self.multibody_joint_set
+            .iter()
+            .filter_map(|(_handle, _link_id, multibody, link)| {
+                let parent = multibody.link(link.parent_id()?)?;
+                let b1_handle = parent.rigid_body_handle();
+                let b2_handle = link.rigid_body_handle();
+                let b1 = self.rigid_body_set.get(b1_handle)?;
+                let b2 = self.rigid_body_set.get(b2_handle)?;
+                Some((
+                    b1_handle,
+                    b2_handle,
+                    b1.position() * link.joint.data.local_frame1,
+                    b2.position() * link.joint.data.local_frame2,
+                ))
             })
             .collect()
     }
@@ -1838,17 +1932,22 @@ impl PhysicsWorld {
     }
 }
 
-/// Rapier-free description of an impulse joint, for ragdoll diagnostics.
+/// Rapier-free description of a joint, for ragdoll diagnostics.
 #[derive(Debug, Clone)]
 pub struct DebugJointInfo {
     pub body1_id: u32,
     pub body2_id: u32,
+    /// `"impulse"` or `"multibody"` - which joint set this came from.
+    pub joint_type: &'static str,
     /// World anchor on each body (should coincide for a satisfied ball joint).
     pub anchor1: [f32; 3],
     pub anchor2: [f32; 3],
     /// Distance between the two anchors - the translation-constraint violation.
+    /// Structurally ~0 for multibody joints (translation is not a DOF there);
+    /// a persistent gap on a multibody joint means the frame setup is wrong.
     pub separation: f32,
     /// Magnitude of the linear (translation) constraint impulse this step.
+    /// Rapier does not expose applied impulses for multibody links, so 0 there.
     pub linear_impulse: f32,
     /// Magnitude of the angular (limit) constraint impulse this step.
     pub angular_impulse: f32,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1569,28 +1569,28 @@ impl PhysicsWorld {
         }
     }
 
-    /// Raise a body's sleep thresholds so residual solver noise (e.g. a ragdoll
-    /// extremity buzzing against the floor) still counts as "at rest". One
-    /// awake body keeps its whole jointed island awake, so without this a
+    /// Raise a body's angular sleep threshold so residual solver noise (e.g. a
+    /// ragdoll extremity buzzing against the floor) still counts as "at rest".
+    /// One awake body keeps its whole jointed island awake, so without this a
     /// settled ragdoll never sleeps. Sleeping bodies auto-wake on contact or
-    /// applied force, so the corpse stays interactive.
-    pub fn set_body_sleep_thresholds(
-        &mut self,
-        handle: RigidBodyHandle,
-        normalized_linear: f32,
-        angular: f32,
-    ) {
+    /// applied force, so the corpse stays interactive. (The linear threshold is
+    /// left at rapier's default - the residual buzz is angular.)
+    pub fn set_body_angular_sleep_threshold(&mut self, handle: RigidBodyHandle, angular: f32) {
         if let Some(body) = self.rigid_body_set.get_mut(handle) {
-            let activation = body.activation_mut();
-            activation.normalized_linear_threshold = normalized_linear;
-            activation.angular_threshold = angular;
+            body.activation_mut().angular_threshold = angular;
         }
     }
 
     /// Apply a world-space impulse to a dynamic body by its debug `body_id`
     /// (the rigid body handle index, as reported by [`debug_list_bodies`]),
-    /// waking it. Debug/testing hook - e.g. poke a sleeping ragdoll to verify
-    /// wake-on-impulse. Returns false if no dynamic body matches.
+    /// waking it even for a zero impulse (rapier skips a zero `apply_impulse`
+    /// entirely, so the wake is explicit - `{"impulse":[0,0,0]}` is a pure
+    /// wake). Debug/testing hook - e.g. poke a sleeping ragdoll to verify
+    /// wake-on-impulse. Matches by handle index like the other debug-endpoint
+    /// lookups (the generation isn't exposed over HTTP), so callers must use
+    /// ids from a fresh body listing. For a multibody link this is a plain
+    /// rigid-body impulse, not a full articulated-dynamics response - fine for
+    /// poking, not physically exact. Returns false if no dynamic body matches.
     pub fn apply_body_impulse(&mut self, body_id: u32, impulse: Vector3<f32>) -> bool {
         let handle = self
             .rigid_body_set
@@ -1600,6 +1600,7 @@ impl PhysicsWorld {
         if let Some(handle) = handle {
             if let Some(body) = self.rigid_body_set.get_mut(handle) {
                 if body.body_type() == RigidBodyType::Dynamic {
+                    body.wake_up(true);
                     body.apply_impulse(vec_to_nvec(impulse), true);
                     return true;
                 }

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -173,9 +173,9 @@ impl RagdollHooks {
             );
             core.spawn_ragdoll(
                 entity_id,
-                game_options
+                !game_options
                     .experimental_features
-                    .contains("ragdoll_multibody"),
+                    .contains("ragdoll_impulse"),
             );
             println!(
                 "Applied massive damage to pipe hybrid entity {:?} for ragdoll testing",


### PR DESCRIPTION
## Summary

The multibody ragdoll rig's June blocker ("extremities won't settle" contact limit-cycle) no longer reproduces on main — most likely fixed as a side effect of #333's collider friction/restitution work (see the re-evaluation in #477). What remained was a ~0.5 rad/s single-extremity buzz that sat above rapier's default angular sleep threshold (0.5 rad/s), and one awake body keeps the whole jointed island awake — so the corpse never slept and the buzz never stopped.

This PR graduates the multibody rig:

- **Raised angular sleep threshold (1.5 rad/s) on ragdoll bodies** — the settled island now sleeps ~6 s after death (velocities zero exactly; the buzz is gone). Contact or an applied impulse wakes the corpse, so it stays fully pokeable (verified). Rapier requires the *entire island* below thresholds for 2 continuous seconds, so a corpse in real motion can't freeze mid-fall.
- **Multibody is now the default rig** (no hip gap possible — translation is structurally not a DOF — and a visibly better settled pose than the impulse rig, which holds a 9.6 cm hip gap at rest). New `--experimental ragdoll_impulse` falls back to the legacy impulse rig.
- **Joint diagnostics cover the multibody set**: `/v1/physics/joints` and the `--debug-physics` anchor overlay now enumerate multibody joints too, with a new `joint_type` field (`"impulse"` / `"multibody"`).
- **New debug endpoint `POST /v1/physics/bodies/:id/impulse`** — apply a world-space impulse to a dynamic body (zero impulse = pure wake), closing part of the ragdoll harness gap noted in `projects/ragdoll.md`. Used here to verify wake-on-poke headlessly.

## Verification (headless, debug_ragdoll, fixed 60 Hz)

| Check | Result |
| --- | --- |
| Default rig routing | 19 multibody joints, 0 impulse; max separation **0.0** |
| `ragdoll_impulse` fallback | 19 impulse joints |
| Settle + sleep | velocities → exactly 0 at t≈6 s; `is_sleeping: true` |
| Wake on poke | impulse → motion resumes (`is_sleeping: false`), re-sleeps ~12 s later |
| Zero-impulse wake | `{"impulse":[0,0,0]}` wakes the body (rapier skips zero impulses, wake is explicit) |
| Settled pose | flat prone corpse (screenshot below), vs the impulse rig's folded-legs-in-air pose |

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean. Cross-engine review (/xreview: Claude + Codex) found no Critical/High issues; both engines' findings addressed in the second commit.

Stacked note: reads best after #477 (the re-evaluation doc); merge order doesn't matter technically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![multibody ragdoll: kill → collapse → settle → sleep → impulse poke](https://gist.githubusercontent.com/tommy-xr/36e1fa3c0af5359b04a4c9adcb07f1a8/raw/ragdoll_demo.gif)

<sub>`debug_ragdoll` with the multibody rig as default: the pipe hybrid is killed, collapses into a ragdoll, settles into a flat prone corpse and falls asleep (`/v1/ragdoll/metrics` reports `max_linear_speed == 0`), then a `POST /v1/physics/bodies/:id/impulse` poke on a thigh body wakes it — it shifts and re-settles to sleep. Settle plays accelerated; collapse and poke are ~real-time. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| Mid-collapse | Settled sleeping corpse |
| --- | --- |
| ![mid-collapse](https://gist.githubusercontent.com/tommy-xr/36e1fa3c0af5359b04a4c9adcb07f1a8/raw/midcollapse.png) | ![settled sleeping corpse](https://gist.githubusercontent.com/tommy-xr/36e1fa3c0af5359b04a4c9adcb07f1a8/raw/settled.png) |
