### PR TITLE
fix(physics): sanitize ball collider radius — zero-radius sphere panicked the BVH broad-phase

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -430,6 +430,32 @@ fn sanitize_collider_size(entity_id: EntityId, context: &str, size: Vector3<f32>
     out
 }
 
+/// Scalar variant of [`sanitize_collider_size`] for ball colliders. A zero
+/// radius (e.g. medsci1's "Lift 1 Walls": a dynamic SPHERE with radius 0)
+/// yields a point AABB, and rapier 0.31's BVH broad-phase build panics on
+/// zero/non-finite AABBs (parry `bvh_binned_build` "index out of bounds") -
+/// the crash is nondeterministic because it depends on the bin layout around
+/// the degenerate AABB.
+fn sanitize_collider_radius(entity_id: EntityId, context: &str, radius: f32) -> f32 {
+    const MIN_RADIUS: f32 = 0.005;
+    const MAX_RADIUS: f32 = 5.0e3;
+    let out = if radius.is_finite() && radius > 0.0 {
+        radius.clamp(MIN_RADIUS, MAX_RADIUS)
+    } else {
+        MIN_RADIUS
+    };
+    if out != radius {
+        tracing::warn!(
+            "[physics] {} entity {:?}: invalid collider radius {} -> clamped to {}",
+            context,
+            entity_id,
+            radius,
+            out
+        );
+    }
+    out
+}
+
 impl PhysicsWorld {
     pub fn add_level_geometry(&mut self, entity_id: EntityId, level: &SystemShock2Level) {
         /* Create the ground. */
@@ -897,7 +923,8 @@ impl PhysicsWorld {
                     .build()
             }
             PhysicsShape::Sphere(size) => {
-                ColliderBuilder::ball(size)
+                let radius = sanitize_collider_radius(entity_id, "add_dynamic", size);
+                ColliderBuilder::ball(radius)
                     //.rotation(vector!(angles.0, angles.1, angles.2))
                     //.rotation(vector!(facing.z, facing.x, facing.y))
                     .translation(vec_to_nvec(offset))


### PR DESCRIPTION
## Summary

medsci1's "Lift 1 Walls" registers a **dynamic SPHERE collider with radius 0** (mass 0.0). `add_dynamic`'s ball arm had no size sanitize (the cuboid arm clamps, the capsule arm asserts, the sphere arm did neither), so it produced a point AABB — and rapier 0.31's BVH broad-phase build panics on zero AABBs (parry `bvh_binned_build` "index out of bounds: the len is 8 but the index is 18446744073709551615"), nondeterministically depending on the bin layout around the degenerate box.

This was the intermittent medsci1 game-thread crash that killed most `ragdoll-death` e2e runs while stabilizing the death-handoff work (~5-in-6 in some batches). Root-cause chain and evidence in #479.

**Fix**: `sanitize_collider_radius` (scalar sibling of `sanitize_collider_size`) clamps ball radii into [0.005, 5e3] at the `add_dynamic` boundary, with the same warn-on-clamp logging.

**Verified**: `GET /v1/physics/colliders/validate` on medsci1 now reports **0 issues** (was 1: the point AABB), the clamp warn fires for the offending entity at load, and the ragdoll-death e2e crash mode is gone (see follow-up PR for the reliability runs).

Whether a lift wall should really be a tiny dynamic ball at all remains tracked in #479 — this PR closes the crash class only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)