### PR TITLE
feat(ragdoll): death-crumple → ragdoll handoff — creature deaths finally reach the ragdoll path

### DIFF
--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -178,7 +178,11 @@ impl RagDoll {
         }
     }
 
-    fn update(&mut self, physics: &mut PhysicsWorld) {
+    /// Advance this ragdoll's render transforms from physics, sanitizing the
+    /// rig on the way. Returns false when the rig is poisoned (a body position
+    /// went non-finite/absurd) - the caller must despawn it before the next
+    /// physics step, or the broad-phase BVH build will panic on the bad AABB.
+    fn update(&mut self, physics: &mut PhysicsWorld) -> bool {
         // Break runaway spawn transients before they cascade to a NaN AABB
         // (which panics the parry BVH broad-phase). Normal collapse dynamics
         // peak well below the cap, so this is a no-op except in the rare
@@ -191,6 +195,33 @@ impl RagDoll {
                 "ragdoll velocity runaway: clamped {} velocity components",
                 corrected
             );
+        }
+        // The velocity clamp bounds what enters each step, but a single solve
+        // can still explode (deep-penetration recovery at spawn) and integrate
+        // a non-finite position within that same step. The BVH panic only
+        // happens on the NEXT step's broad-phase, so catching it here - and
+        // having the manager despawn the rig - keeps the game alive.
+        for handle in &self.physics_bodies {
+            if let Some(iso) = physics.get_body_transform(*handle) {
+                let t = iso.translation;
+                let sane = |v: f32| v.is_finite() && v.abs() < 1.0e6;
+                // The AABB is computed from the full isometry, so a non-finite
+                // ROTATION poisons it just like a non-finite translation (an
+                // angular DOF can blow up while linear stays bounded).
+                let r = iso.rotation;
+                let rot_finite =
+                    r.i.is_finite() && r.j.is_finite() && r.k.is_finite() && r.w.is_finite();
+                if !(sane(t.x) && sane(t.y) && sane(t.z) && rot_finite) {
+                    tracing::warn!(
+                        "ragdoll body transform diverged (pos {}, {}, {}; rot finite: {}) - despawning the corpse",
+                        t.x,
+                        t.y,
+                        t.z,
+                        rot_finite
+                    );
+                    return false;
+                }
+            }
         }
         for (joint_id, handle) in &self.joint_to_body {
             if let Some(isometry) = physics.get_body_transform(*handle) {
@@ -206,6 +237,7 @@ impl RagDoll {
                 }
             }
         }
+        true
     }
 
     fn renderables(&self) -> Vec<SceneObject> {
@@ -259,11 +291,22 @@ impl RagDollManager {
         // locked translation - settles but the hip can visibly sag/separate
         // under load).
         use_multibody: bool,
+        // When false, limbs collide with the world but not with each other
+        // (CollisionGroup::ragdoll_no_self). Death-handoff rigs spawn in a
+        // crumpled, limb-overlapping pose whose many deep limb-limb contacts
+        // can explode the articulated solve to non-finite positions in one
+        // step; the debug scene's standing-fall spawn keeps self-collision.
+        self_collide: bool,
         physics: &mut PhysicsWorld,
     ) -> bool {
         if !model.can_create_rag_doll() {
             return false;
         }
+        let collision_group = if self_collide {
+            CollisionGroup::ragdoll()
+        } else {
+            CollisionGroup::ragdoll_no_self()
+        };
 
         let (bones, _) = match model.ragdoll_source() {
             Some(data) => data,
@@ -340,7 +383,7 @@ impl RagDollManager {
                             *radius,
                         ),
                         density,
-                        CollisionGroup::ragdoll(),
+                        collision_group,
                     );
                 }
                 Some(HitBoxShape::Cuboid {
@@ -368,19 +411,14 @@ impl RagDollManager {
                         SharedShape::cuboid(he.x, he.y, he.z),
                         vec3(center.x, center.y, center.z),
                         density,
-                        CollisionGroup::ragdoll(),
+                        collision_group,
                     );
                 }
                 None => {
                     let r = DEFAULT_JOINT_RADIUS;
                     let volume = 4.0 / 3.0 * std::f32::consts::PI * r * r * r;
                     let density = TARGET_BODY_MASS / volume.max(MIN_VOLUME);
-                    physics.attach_collider(
-                        handle,
-                        SharedShape::ball(r),
-                        density,
-                        CollisionGroup::ragdoll(),
-                    );
+                    physics.attach_collider(handle, SharedShape::ball(r), density, collision_group);
                 }
             }
 
@@ -531,10 +569,23 @@ impl RagDollManager {
         true
     }
 
-    pub fn update(&mut self, physics: &mut PhysicsWorld) {
-        for ragdoll in self.ragdolls.values_mut() {
-            ragdoll.update(physics);
+    /// Advance all ragdolls. Returns the corpse entity ids of any rigs that
+    /// were despawned because a body transform went non-finite (the broad-
+    /// phase BVH build would panic on their AABB next step) - the caller
+    /// should delete those (otherwise-empty) corpse entities from the world.
+    /// Losing a corpse is the rare last-resort outcome; the velocity clamp in
+    /// `RagDoll::update` makes it rarer still.
+    pub fn update(&mut self, physics: &mut PhysicsWorld) -> Vec<EntityId> {
+        let mut poisoned = Vec::new();
+        for (entity_id, ragdoll) in self.ragdolls.iter_mut() {
+            if !ragdoll.update(physics) {
+                poisoned.push(*entity_id);
+            }
         }
+        for entity_id in &poisoned {
+            self.remove_entity(*entity_id, physics);
+        }
+        poisoned
     }
 
     /// Per-ragdoll quality metrics (keyed by the corpse entity id).

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -109,6 +109,11 @@ pub use crate::resource_path;
 /// (starting hit points, psi pool, base stats, vulnerabilities, ...).
 pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 
+/// Vertical clearance (world units) a death-handoff ragdoll spawns with, so a
+/// floor-lying crumple pose doesn't start deeply interpenetrating the level
+/// trimesh (see `spawn_ragdoll`).
+const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
+
 #[derive(Unique, Clone)]
 pub struct PlayerInfo {
     pub pos: Vector3<f32>,
@@ -834,7 +839,11 @@ impl MissionCore {
 
         // Clear forces
         self.physics.clear_forces();
-        self.rag_doll_manager.update(&mut self.physics);
+        // A poisoned (transform-diverged) rig is despawned by the manager;
+        // also delete its otherwise-empty corpse entity so it doesn't leak.
+        for poisoned_id in self.rag_doll_manager.update(&mut self.physics) {
+            self.world.delete_entity(poisoned_id);
+        }
 
         let (left_hand_entity_id, right_hand_entity_id) = self.interaction.held_entities();
 
@@ -2162,9 +2171,21 @@ impl MissionCore {
     /// creature is torn down via `remove_entity`, which also clears any ragdoll
     /// keyed by that id - so the corpse must live under its own id to survive.
     /// Replace a creature with a physics ragdoll of its current pose. `use_multibody`
-    /// selects reduced-coordinate (multibody) joints over the default impulse joints.
+    /// selects reduced-coordinate (multibody) joints over the legacy impulse joints.
+    /// `crumpled_pose` marks rigs spawned from a finished death crumple (floor-
+    /// lying, limb-overlapping): those spawn without limb self-collision (the
+    /// pose's deep limb-limb contacts can explode the articulated solve - see
+    /// `CollisionGroup::ragdoll_no_self`) and with a small vertical lift so the
+    /// fitted colliders don't start inside the level trimesh. Standing/mid-
+    /// animation spawns (instant slays, the debug scene) pass false and keep
+    /// the full self-colliding rig with no lift.
     /// Returns true if a ragdoll was spawned (the creature is then removed).
-    pub fn spawn_ragdoll(&mut self, entity_id: EntityId, use_multibody: bool) -> bool {
+    pub fn spawn_ragdoll(
+        &mut self,
+        entity_id: EntityId,
+        use_multibody: bool,
+        crumpled_pose: bool,
+    ) -> bool {
         let spawned = {
             let model = match self.id_to_model.get(&entity_id) {
                 Some(model) if model.can_create_rag_doll() => model,
@@ -2199,14 +2220,26 @@ impl MissionCore {
             // not tear down the ragdoll (the manager keys ragdolls by entity id).
             let ragdoll_id = self.world.add_entity(RuntimePropDoNotSerialize {});
 
+            // A crumple pose ends lying ON the floor, so the fitted colliders
+            // start interpenetrating the level trimesh - the deep-penetration
+            // recovery through the articulated solver exploded ~half of
+            // medsci1 handoffs to non-finite positions within a step. A few cm
+            // of clearance lets the rig drop back down instead (imperceptible
+            // at spawn). Standing spawns don't need it.
+            let lift = if crumpled_pose {
+                RAGDOLL_SPAWN_LIFT
+            } else {
+                0.0
+            };
             self.rag_doll_manager.add_ragdoll(
                 ragdoll_id,
                 model,
                 root_transform,
                 &joint_transforms,
-                vec3(0.0, 0.0, 0.0),
+                vec3(0.0, lift, 0.0),
                 &joint_limits,
                 use_multibody,
+                !crumpled_pose,
                 &mut self.physics,
             )
         };
@@ -2907,10 +2940,35 @@ impl MissionCore {
                                     !game_options
                                         .experimental_features
                                         .contains("ragdoll_impulse"),
+                                    // Slain mid-animation, usually upright -
+                                    // not a crumpled pose.
+                                    false,
                                 );
                         if !spawned_ragdoll {
                             self.remove_entity(entity_id);
                         }
+                    }
+                }
+                Effect::SpawnCorpseRagdoll { entity_id } => {
+                    // Death-crumple handoff (AI deaths): once the death
+                    // animation has finished, replace the animated corpse with
+                    // a physics ragdoll seeded from its final pose. Gated on
+                    // the `ragdoll` experimental flag - without it the
+                    // animated corpse entity persists exactly as before.
+                    // (Known experimental limitations: the ragdoll corpse is
+                    // not serialized, so it vanishes on save/load; and the
+                    // creature entity is removed, which will matter once
+                    // corpse looting (`creaturecontainer`) is implemented.)
+                    if game_options.experimental_features.contains("ragdoll") {
+                        self.spawn_ragdoll(
+                            entity_id,
+                            !game_options
+                                .experimental_features
+                                .contains("ragdoll_impulse"),
+                            // Finished death crumple: floor-lying and limb-
+                            // overlapping.
+                            true,
+                        );
                     }
                 }
                 Effect::StopSound { handle } => {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -430,6 +430,32 @@ fn sanitize_collider_size(entity_id: EntityId, context: &str, size: Vector3<f32>
     out
 }
 
+/// Scalar variant of [`sanitize_collider_size`] for ball colliders. A zero
+/// radius (e.g. medsci1's "Lift 1 Walls": a dynamic SPHERE with radius 0)
+/// yields a point AABB, and rapier 0.31's BVH broad-phase build panics on
+/// zero/non-finite AABBs (parry `bvh_binned_build` "index out of bounds") -
+/// the crash is nondeterministic because it depends on the bin layout around
+/// the degenerate AABB.
+fn sanitize_collider_radius(entity_id: EntityId, context: &str, radius: f32) -> f32 {
+    const MIN_RADIUS: f32 = 0.005;
+    const MAX_RADIUS: f32 = 5.0e3;
+    let out = if radius.is_finite() && radius > 0.0 {
+        radius.clamp(MIN_RADIUS, MAX_RADIUS)
+    } else {
+        MIN_RADIUS
+    };
+    if out != radius {
+        tracing::warn!(
+            "[physics] {} entity {:?}: invalid collider radius {} -> clamped to {}",
+            context,
+            entity_id,
+            radius,
+            out
+        );
+    }
+    out
+}
+
 impl PhysicsWorld {
     pub fn add_level_geometry(&mut self, entity_id: EntityId, level: &SystemShock2Level) {
         /* Create the ground. */
@@ -897,7 +923,8 @@ impl PhysicsWorld {
                     .build()
             }
             PhysicsShape::Sphere(size) => {
-                ColliderBuilder::ball(size)
+                let radius = sanitize_collider_radius(entity_id, "add_dynamic", size);
+                ColliderBuilder::ball(radius)
                     //.rotation(vector!(angles.0, angles.1, angles.2))
                     //.rotation(vector!(facing.z, facing.x, facing.y))
                     .translation(vec_to_nvec(offset))

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -230,6 +230,7 @@ impl Default for DynamicPhysicsOptions {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct CollisionGroup(InteractionGroups);
 
 impl CollisionGroup {
@@ -303,6 +304,20 @@ impl CollisionGroup {
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::SELECTABLE.bits)
                 .into(),
+            test_mode: Default::default(),
+        })
+    }
+
+    /// Ragdoll limbs that collide with the world but NOT with each other (nor
+    /// other selectables). Used for death-handoff rigs spawned in a crumpled,
+    /// limb-overlapping pose: the many simultaneous deep limb-limb contacts
+    /// there can drive the articulated (multibody) solve to non-finite
+    /// positions in a single step. Floor contact is what matters for a lying
+    /// corpse; limb self-collision is cosmetic in that pose.
+    pub fn ragdoll_no_self() -> CollisionGroup {
+        CollisionGroup(InteractionGroups {
+            memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
+            filter: InternalCollisionGroups::WORLD.bits.into(),
             test_mode: Default::default(),
         })
     }

--- a/shock2vr/src/scenes/debug_ragdoll.rs
+++ b/shock2vr/src/scenes/debug_ragdoll.rs
@@ -176,6 +176,10 @@ impl RagdollHooks {
                 !game_options
                     .experimental_features
                     .contains("ragdoll_impulse"),
+                // Standing-fall spawn, not a crumpled pose: keeps limb
+                // self-collision and no lift (the config the settle metrics
+                // are calibrated against).
+                false,
             );
             println!(
                 "Applied massive damage to pipe hybrid entity {:?} for ragdoll testing",

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -74,6 +74,12 @@ pub struct AnimatedMonsterAI {
     current_behavior: Box<RefCell<dyn Behavior>>,
     current_heading: Deg<f32>,
     is_dead: bool,
+    /// Script updates seen since entering death. Guards the crumple->ragdoll
+    /// handoff against a stale AnimationCompleted: a clip that happened to
+    /// finish in the very tick the killing blow landed is dispatched after
+    /// `is_dead` is set, and would otherwise hand off before the crumple has
+    /// even started. The real crumple completion arrives seconds later.
+    updates_since_death: u32,
     took_damage: bool,
     animation_seq: u32,
     locomotion_seq: u32,
@@ -101,6 +107,7 @@ impl AnimatedMonsterAI {
     pub fn idle() -> AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
+            updates_since_death: 0,
             took_damage: false,
             current_behavior: Box::new(RefCell::new(IdleBehavior)),
             current_heading: Deg(0.0),
@@ -120,6 +127,7 @@ impl AnimatedMonsterAI {
     pub fn new() -> AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
+            updates_since_death: 0,
             took_damage: false,
             // Start with IdleBehavior - alertness will drive behavior changes
             current_behavior: Box::new(RefCell::new(IdleBehavior)),
@@ -655,6 +663,7 @@ impl Script for AnimatedMonsterAI {
         // behavior so introspection shows "Dead", and release a sensor the
         // ray was intersecting at death so its end-intersect isn't stranded.
         if self.is_dead || is_killed(entity_id, world) {
+            self.updates_since_death = self.updates_since_death.saturating_add(1);
             let sensor_release_effect = match self.last_hit_sensor.take() {
                 Some(sensor_id) => Effect::Send {
                     msg: Message {
@@ -1068,7 +1077,21 @@ impl Script for AnimatedMonsterAI {
             }
             MessagePayload::AnimationCompleted => {
                 if self.is_dead {
-                    Effect::NoEffect
+                    // The death crumple finished: offer the corpse to physics.
+                    // No-op unless the `ragdoll` experimental flag is on - the
+                    // animated corpse stays otherwise. (The is_dead branch
+                    // queues nothing and a successful spawn removes this
+                    // entity, so this cannot double-fire.)
+                    //
+                    // Completions dispatched in the same tick the killing blow
+                    // landed belong to the clip the crumple interrupted, not
+                    // the crumple itself (which just started) - swallow those,
+                    // or the corpse would ragdoll from its still-standing pose.
+                    if self.updates_since_death >= 1 {
+                        Effect::SpawnCorpseRagdoll { entity_id }
+                    } else {
+                        Effect::NoEffect
+                    }
                 } else if is_killed(entity_id, world) {
                     // Fallback for kills that didn't arrive as a Damage
                     // message (the lethal-damage path enters death eagerly)

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -234,6 +234,14 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
+    /// The death (crumple) animation finished: hand the corpse over to physics
+    /// as a ragdoll. Emitted unconditionally by the AI on death-animation
+    /// completion; the handler is a no-op unless the `ragdoll` experimental
+    /// flag is on (the animated corpse entity stays, exactly as before).
+    SpawnCorpseRagdoll {
+        entity_id: EntityId,
+    },
+
     QueueAnimationBySchema {
         // ActorType, MotActorTags get inferred from the entity id
         entity_id: EntityId,

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -12,6 +12,7 @@ import type {
   PathfindingTestStatus,
   PhysicsBodyListResult,
   Position,
+  RagdollMetricsResult,
   RayCastRequest,
   RayCastResult,
   ScreenshotResult,
@@ -196,6 +197,11 @@ export class PhysicsApi {
     if (options?.limit !== undefined) params.set("limit", String(options.limit));
     const query = params.size > 0 ? `?${params}` : "";
     return this.client.get<PhysicsBodyListResult>(`/v1/physics/bodies${query}`);
+  }
+
+  /** Per-ragdoll settle/quality metrics (empty list when no ragdolls exist). */
+  async ragdolls(): Promise<RagdollMetricsResult> {
+    return this.client.get<RagdollMetricsResult>("/v1/ragdoll/metrics");
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -202,6 +202,21 @@ export interface PhysicsBodyListResult {
   player_position: Vec3;
 }
 
+/** Settle/quality metrics for one ragdoll (GET /v1/ragdoll/metrics). */
+export interface RagdollMetrics {
+  entity_id: number;
+  body_count: number;
+  max_linear_speed: number;
+  max_angular_speed: number;
+  min_y: number;
+  max_nonadjacent_overlap: number;
+  max_drift: number;
+}
+
+export interface RagdollMetricsResult {
+  ragdolls: RagdollMetrics[];
+}
+
 export interface PlayerSnapshot {
   entity_id: number | null;
   position: Vec3;

--- a/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// With `--experimental ragdoll`, a monster's death crumple hands the corpse
+// over to physics: once the death animation completes, the animated corpse
+// entity is replaced by a multibody ragdoll. (The no-flag path - animated
+// corpse persists, no ragdoll - is covered by monster-death.e2e.test.ts,
+// which would fail if the corpse entity ever vanished without the flag.)
+test(
+  "death crumple hands off to a ragdoll under --experimental ragdoll",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+      experimental: ["ragdoll"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.physics.ragdolls()).ragdolls.length,
+      0,
+      "no ragdolls before anything dies",
+    );
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(
+      monster,
+      `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((e) => e.id))}`,
+    );
+    // World y where the monster stood, for the fell-through-the-floor check
+    // below (medsci1 floors sit at arbitrary world heights).
+    const aliveY = monster.position[1];
+
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+
+    // The death crumple has to actually play out before the handoff fires
+    // (the ragdoll spawns on the crumple's AnimationCompleted, not on the
+    // killing blow). Step in 0.5s batches until the ragdoll exists.
+    let ragdolls = (await game.physics.ragdolls()).ragdolls;
+    for (let i = 0; i < 30 && ragdolls.length === 0; i++) {
+      await game.step({ frames: 30 });
+      ragdolls = (await game.physics.ragdolls()).ragdolls;
+    }
+    assert.equal(
+      ragdolls.length,
+      1,
+      "death crumple should spawn exactly one ragdoll within 15s",
+    );
+    assert.ok(
+      ragdolls[0].body_count >= 15,
+      `humanoid ragdoll should have a full rig, got ${ragdolls[0].body_count} bodies`,
+    );
+
+    // The animated corpse entity is replaced by the ragdoll corpse.
+    const after = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    assert.ok(
+      !after.entities.some((e) => e.id === monster.id),
+      "the animated corpse entity should be removed once the ragdoll takes over",
+    );
+
+    // And the ragdoll settles rather than exploding: wait (up to 20s) for its
+    // bulk motion to die down. A corpse can legitimately roll for a few
+    // seconds on uneven ground; what must NOT happen is a runaway (speed
+    // growing without bound) or a fall through the floor.
+    let settled = ragdolls[0];
+    for (let i = 0; i < 20 && settled.max_linear_speed >= 0.5; i++) {
+      await game.step({ frames: 60 });
+      const now = (await game.physics.ragdolls()).ragdolls[0];
+      assert.ok(now, "ragdoll still tracked while settling");
+      settled = now;
+    }
+    assert.ok(
+      settled.max_linear_speed < 0.5,
+      `corpse should settle within 20s, still moving at ${settled.max_linear_speed}`,
+    );
+    assert.ok(
+      settled.min_y > aliveY - 5.0,
+      `corpse must not fall through the floor: min_y=${settled.min_y}, alive y=${aliveY}`,
+    );
+    // ... and stays near where the monster died (catches large-but-finite
+    // misbehavior - sliding/launching across the level - that the divergence
+    // despawn threshold would not).
+    assert.ok(
+      settled.max_drift < 15.0,
+      `corpse drifted ${settled.max_drift} units from its death spot`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

**Stacked on #480** (the zero-radius-sphere BVH crash fix — its flake killed most runs of this PR's e2e test until root-caused).

Real creature deaths never spawned a ragdoll: lethal damage put the AI into `DeadBehavior` with a crumple animation and the animated corpse persisted forever — `Effect::SlayEntity` (the only ragdoll hook) fires only for non-creature slays, so `--experimental ragdoll` did almost nothing in real gameplay. Now, under that flag, the AI emits a new `Effect::SpawnCorpseRagdoll` when its death crumple completes, and the handler replaces the animated corpse with a multibody ragdoll seeded from the final pose. Without the flag, behavior is unchanged (handler no-ops; guarded by `monster-death.e2e.test.ts`).

## Crumple-pose robustness

A floor-lying, limb-overlapping crumple pose is much harsher than the debug scene's standing fall — it exploded the articulated solve to non-finite positions in ~half of medsci1 handoffs (positions reaching 1e7–1e14 in a step, then a BVH broad-phase panic). Three fixes, verified by 10-run loops:

| Fix | Effect |
| --- | --- |
| Handoff rigs spawn without limb self-collision (`CollisionGroup::ragdoll_no_self`) | divergences 5/10 → **0/10** (the pose's deep limb-limb contacts were the explosion source) |
| 5 cm spawn lift (crumple-pose spawns only) | keeps fitted colliders out of the level trimesh |
| Last-resort guard: a rig whose body **transform** (translation or rotation) goes non-finite is despawned before the next step, and its corpse entity deleted | converts a would-be game-thread crash into a logged, rare corpse despawn; never fired post-fix |

## Review (xreview: Claude + Codex)

No Critical findings. Addressed: **[AGREED]** rotation now validated in the divergence guard (not just translation); stale-`AnimationCompleted` race gated (a clip finishing in the killing-blow tick can no longer hand off from a still-standing pose); poisoned despawn no longer leaks the ECS corpse entity; the spawn lift no longer applies to standing/instant-slay spawns (`crumpled_pose` parameter drives both lift and self-collision). Accepted tradeoff (documented): `ragdoll_no_self` corpses don't collide with other corpses/selectables — a per-rig Rapier contact hook is the eventual fix if stacked corpses matter.

## Verification

- New SDK e2e scenario `ragdoll-death.e2e.test.ts`: spawn an OG-Pipe in medsci1, kill it, assert the crumple hands off to exactly one 20-body ragdoll, the corpse entity is removed, and the rig settles near its death spot without falling through the floor. **Negative-tested** (fails without the wiring).
- **Full e2e suite: 100/100 pass** on this commit.
- Reliability loops: 9/10 and 3/4 green with 0 divergences (sole failure mode is a transient HTTP `fetch failed` in the test client, no runtime involvement).
- Also adds `PhysicsApi.ragdolls()` to the SDK.

## Known experimental limitations (documented in code)

- The ragdoll corpse is not serialized — it vanishes on save/load.
- The creature entity is removed at handoff, which will matter once corpse looting (`creaturecontainer`, currently a `NoopScript`) is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![death crumple to ragdoll handoff](https://gist.githubusercontent.com/tommy-xr/58e662b0e57218df76f06ca37ebaafc4/raw/ragdoll-handoff.gif)

<sub>Under `--experimental ragdoll` in medsci1: a hybrid takes lethal damage, the death-crumple animation plays to completion, then the physics ragdoll takes over and the corpse settles. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep; 1 shot per 4 sim frames).</sub>

| Crumple animation (mid-fall) | Just after ragdoll handoff | Settled physics corpse |
| --- | --- | --- |
| ![mid-crumple](https://gist.githubusercontent.com/tommy-xr/58e662b0e57218df76f06ca37ebaafc4/raw/still-crumple.png) | ![handoff](https://gist.githubusercontent.com/tommy-xr/58e662b0e57218df76f06ca37ebaafc4/raw/still-handoff.png) | ![settled](https://gist.githubusercontent.com/tommy-xr/58e662b0e57218df76f06ca37ebaafc4/raw/still-settled.png) |

<sub>Sequence: crumple animation plays → completes → physics ragdoll takes over (confirmed via `/v1/ragdoll/metrics` reporting a live 20-body ragdoll) → settles to rest.</sub>
