### PR TITLE
feat(ragdoll): killing-blow seeding + near-instant handoff with inherited momentum

### DIFF
--- a/shock2vr/src/creature/hit_box_script.rs
+++ b/shock2vr/src/creature/hit_box_script.rs
@@ -39,10 +39,19 @@ impl Script for HitBoxScript {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Damage { amount } => Effect::Send {
+            MessagePayload::Damage { amount, impact } => Effect::Send {
                 msg: Message {
                     to: self.parent_entity_id,
-                    payload: MessagePayload::Damage { amount: *amount },
+                    // Forward to the owning creature, stamping which skeleton
+                    // joint was struck so a death ragdoll can react at the
+                    // right limb.
+                    payload: MessagePayload::Damage {
+                        amount: *amount,
+                        impact: impact.map(|i| crate::scripts::DamageImpact {
+                            bone: Some(self.hit_box_joint_idx),
+                            ..i
+                        }),
+                    },
                 },
             },
             _ => Effect::NoEffect,

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -296,6 +296,11 @@ impl RagDollManager {
         // locked translation - settles but the hip can visibly sag/separate
         // under load).
         use_multibody: bool,
+        // The dying creature's bulk velocity (root-motion carries the crumple
+        // forward), inherited by the rig so the fall's momentum is continuous
+        // across the handoff. Multibody only (the legacy impulse rig isn't
+        // seeded - body-level writes work there but it's a deprecated path).
+        seed_velocity: Vector3<f32>,
         // When false, limbs collide with the world but not with each other
         // (CollisionGroup::ragdoll_no_self). Death-handoff rigs spawn in a
         // crumpled, limb-overlapping pose whose many deep limb-limb contacts
@@ -556,6 +561,19 @@ impl RagDollManager {
                     let handle = physics.create_impulse_joint(parent_handle, child_handle, joint);
                     joint_handles.push(handle);
                     joint_pairs.push((parent_handle, child_handle));
+                }
+            }
+        }
+
+        // Inherit the dying creature's bulk motion so the crumple's momentum
+        // is continuous across the handoff (mid-fall spawns would otherwise
+        // freeze for an instant). Written into the multibody's generalized
+        // root DOF - body-level set_linvel is clobbered by the readback.
+        if use_multibody && seed_velocity.magnitude2() > 1.0e-8 {
+            if let Some(first) = body_handles.first() {
+                if !physics.set_multibody_root_linvel(*first, seed_velocity) {
+                    // Best-effort momentum; note the miss rather than fail.
+                    tracing::debug!("ragdoll velocity seed not applied (non-finite or no body)");
                 }
             }
         }

--- a/shock2vr/src/creature/rag_doll.rs
+++ b/shock2vr/src/creature/rag_doll.rs
@@ -61,6 +61,11 @@ const SLEEP_ANGULAR_THRESHOLD: f32 = 1.5;
 /// enters runaway feedback (which otherwise ends in a NaN AABB and a parry
 /// BVH panic). Applied once per frame in `RagDoll::update`.
 const MAX_BODY_SPEED: f32 = 30.0;
+/// Impulse magnitude (N*s, bodies are ~1 mass unit each) applied to the struck
+/// limb when a death ragdoll is seeded with the killing blow. Tuned in medsci1
+/// A/B runs: 8.0 gives the struck limb a clearly visible ~2.5 m/s reaction
+/// that propagates through the articulated rig without launching the corpse.
+const KILLING_BLOW_IMPULSE: f32 = 8.0;
 
 /// Quality/settle metrics for one ragdoll, for the verification harness.
 #[derive(Clone, Debug)]
@@ -602,6 +607,42 @@ impl RagDollManager {
             scene.extend(ragdoll.renderables());
         }
         scene
+    }
+
+    /// Seed a just-spawned corpse with its killing blow: shove the struck limb
+    /// (by skeleton joint id when the hitbox reported one, else the body
+    /// nearest the hit point) along the blow's direction. The articulated rig
+    /// propagates the reaction naturally.
+    pub fn apply_impact(
+        &mut self,
+        entity_id: EntityId,
+        impact: &crate::scripts::DamageImpact,
+        physics: &mut PhysicsWorld,
+    ) {
+        let Some(ragdoll) = self.ragdolls.get(&entity_id) else {
+            return;
+        };
+        let by_bone = impact
+            .bone
+            .and_then(|bone| ragdoll.joint_to_body.get(&bone).copied());
+        let handle = by_bone.or_else(|| {
+            // Nearest body to the hit point.
+            ragdoll
+                .physics_bodies
+                .iter()
+                .filter_map(|h| {
+                    physics.get_body_transform(*h).map(|iso| {
+                        let p =
+                            Vector3::new(iso.translation.x, iso.translation.y, iso.translation.z);
+                        (*h, (p - impact.point).magnitude2())
+                    })
+                })
+                .min_by(|a, b| a.1.total_cmp(&b.1))
+                .map(|(h, _)| h)
+        });
+        if let Some(handle) = handle {
+            physics.apply_impulse_to_handle(handle, impact.direction * KILLING_BLOW_IMPULSE);
+        }
     }
 
     pub fn remove_entity(&mut self, entity_id: EntityId, physics: &mut PhysicsWorld) {

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -727,7 +727,16 @@ pub struct DebugPathfindingStats {
 #[serde(tag = "type")]
 pub enum DebugEntityMessage {
     /// Deal `amount` damage (drives `InternalSimpleHealth` / AI health).
-    Damage { amount: f32 },
+    /// `direction` (world-space, need not be normalized) and `point` optionally
+    /// describe the blow so a death ragdoll reacts to it - same data a real
+    /// projectile hit carries. Omitted = directionless damage.
+    Damage {
+        amount: f32,
+        #[serde(default)]
+        direction: Option<[f32; 3]>,
+        #[serde(default)]
+        point: Option<[f32; 3]>,
+    },
     /// Frob (use) the entity.
     Frob,
     /// Send a named AI signal.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2244,6 +2244,13 @@ impl MissionCore {
             } else {
                 0.0
             };
+            // The creature's live capsule velocity IS the crumple's root
+            // motion (animation drives the body through physics velocity), so
+            // it seeds the rig's bulk momentum across the handoff.
+            let seed_velocity = self
+                .physics
+                .get_velocity(entity_id)
+                .unwrap_or_else(Vector3::zero);
             let spawned = self.rag_doll_manager.add_ragdoll(
                 ragdoll_id,
                 model,
@@ -2252,6 +2259,7 @@ impl MissionCore {
                 vec3(0.0, lift, 0.0),
                 &joint_limits,
                 use_multibody,
+                seed_velocity,
                 !crumpled_pose,
                 &mut self.physics,
             );

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -837,8 +837,14 @@ impl MissionCore {
             )
         };
 
-        // Clear forces
-        self.physics.clear_forces();
+        // Clear one-shot forces - but only after a step actually consumed
+        // them. A paused (zero-dt) frame skips physics.update above, and
+        // clearing there would silently erase forces queued between frames
+        // (e.g. a killing-blow impulse on a multibody link, which is applied
+        // as a one-step force) before they ever acted.
+        if !time.elapsed.is_zero() {
+            self.physics.clear_forces();
+        }
         // A poisoned (transform-diverged) rig is despawned by the manager;
         // also delete its otherwise-empty corpse entity so it doesn't leak.
         for poisoned_id in self.rag_doll_manager.update(&mut self.physics) {
@@ -1565,7 +1571,12 @@ impl MissionCore {
                 if amount > 0.0 {
                     self.script_world.dispatch(Message {
                         to: entity_id,
-                        payload: MessagePayload::Damage { amount },
+                        // No impact vector: the blast's physical push is
+                        // applied radially to bodies by radius_blast itself.
+                        payload: MessagePayload::Damage {
+                            amount,
+                            impact: None,
+                        },
                     });
                 }
             }
@@ -2179,17 +2190,19 @@ impl MissionCore {
     /// fitted colliders don't start inside the level trimesh. Standing/mid-
     /// animation spawns (instant slays, the debug scene) pass false and keep
     /// the full self-colliding rig with no lift.
-    /// Returns true if a ragdoll was spawned (the creature is then removed).
+    /// Returns the corpse entity id if a ragdoll was spawned (the creature is
+    /// then removed) - the id keys the ragdoll in `rag_doll_manager` (e.g. for
+    /// `apply_impact`).
     pub fn spawn_ragdoll(
         &mut self,
         entity_id: EntityId,
         use_multibody: bool,
         crumpled_pose: bool,
-    ) -> bool {
-        let spawned = {
+    ) -> Option<EntityId> {
+        let (spawned, ragdoll_id) = {
             let model = match self.id_to_model.get(&entity_id) {
                 Some(model) if model.can_create_rag_doll() => model,
-                _ => return false,
+                _ => return None,
             };
 
             let (root_transform, joint_transforms) = {
@@ -2201,11 +2214,11 @@ impl MissionCore {
 
                 let root_transform = match v_transform.get(entity_id) {
                     Ok(transform) => transform.0,
-                    Err(_) => return false,
+                    Err(_) => return None,
                 };
                 let joint_transforms = match v_joint_transforms.get(entity_id) {
                     Ok(joints) => joints.0,
-                    Err(_) => return false,
+                    Err(_) => return None,
                 };
                 (root_transform, joint_transforms)
             };
@@ -2231,7 +2244,7 @@ impl MissionCore {
             } else {
                 0.0
             };
-            self.rag_doll_manager.add_ragdoll(
+            let spawned = self.rag_doll_manager.add_ragdoll(
                 ragdoll_id,
                 model,
                 root_transform,
@@ -2241,7 +2254,8 @@ impl MissionCore {
                 use_multibody,
                 !crumpled_pose,
                 &mut self.physics,
-            )
+            );
+            (spawned, ragdoll_id)
         };
 
         if spawned {
@@ -2249,8 +2263,10 @@ impl MissionCore {
             // AI scripts, and animated model so only the ragdoll remains.
             self.remove_entity(entity_id);
             println!("Spawned ragdoll and removed creature {:?}", entity_id);
+            Some(ragdoll_id)
+        } else {
+            None
         }
-        spawned
     }
 
     pub fn handle_effects(
@@ -2935,21 +2951,23 @@ impl MissionCore {
                         // non-ragdoll-able entities), fall back to the plain removal.
                         let spawned_ragdoll =
                             game_options.experimental_features.contains("ragdoll")
-                                && self.spawn_ragdoll(
-                                    entity_id,
-                                    !game_options
-                                        .experimental_features
-                                        .contains("ragdoll_impulse"),
-                                    // Slain mid-animation, usually upright -
-                                    // not a crumpled pose.
-                                    false,
-                                );
+                                && self
+                                    .spawn_ragdoll(
+                                        entity_id,
+                                        !game_options
+                                            .experimental_features
+                                            .contains("ragdoll_impulse"),
+                                        // Slain mid-animation, usually upright -
+                                        // not a crumpled pose.
+                                        false,
+                                    )
+                                    .is_some();
                         if !spawned_ragdoll {
                             self.remove_entity(entity_id);
                         }
                     }
                 }
-                Effect::SpawnCorpseRagdoll { entity_id } => {
+                Effect::SpawnCorpseRagdoll { entity_id, impact } => {
                     // Death-crumple handoff (AI deaths): once the death
                     // animation has finished, replace the animated corpse with
                     // a physics ragdoll seeded from its final pose. Gated on
@@ -2960,7 +2978,7 @@ impl MissionCore {
                     // creature entity is removed, which will matter once
                     // corpse looting (`creaturecontainer`) is implemented.)
                     if game_options.experimental_features.contains("ragdoll") {
-                        self.spawn_ragdoll(
+                        let ragdoll_id = self.spawn_ragdoll(
                             entity_id,
                             !game_options
                                 .experimental_features
@@ -2969,6 +2987,17 @@ impl MissionCore {
                             // overlapping.
                             true,
                         );
+                        // Seed the corpse with the killing blow: the struck
+                        // limb gets a shove along the shot's direction, so the
+                        // corpse reacts to HOW it died instead of collapsing
+                        // in place.
+                        if let (Some(ragdoll_id), Some(impact)) = (ragdoll_id, impact) {
+                            self.rag_doll_manager.apply_impact(
+                                ragdoll_id,
+                                &impact,
+                                &mut self.physics,
+                            );
+                        }
                     }
                 }
                 Effect::StopSound { handle } => {
@@ -5411,7 +5440,37 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         }
 
         let payload = match message {
-            DebugEntityMessage::Damage { amount } => MessagePayload::Damage { amount },
+            DebugEntityMessage::Damage {
+                amount,
+                direction,
+                point,
+            } => MessagePayload::Damage {
+                amount,
+                // A directional debug blow mirrors what a projectile hit
+                // carries (point falls back to the victim's position).
+                impact: direction.and_then(|d| {
+                    let d = vec3(d[0], d[1], d[2]);
+                    if d.magnitude2() <= 1.0e-12 {
+                        return None;
+                    }
+                    let point = point.map(|p| vec3(p[0], p[1], p[2])).or_else(|| {
+                        self.world
+                            .borrow::<View<RuntimePropTransform>>()
+                            .ok()
+                            .and_then(|v| {
+                                v.get(id)
+                                    .ok()
+                                    .map(|t| crate::util::get_position_from_matrix(&t.0))
+                            })
+                            .map(|p| vec3(p.x, p.y, p.z))
+                    })?;
+                    Some(crate::scripts::DamageImpact {
+                        direction: d.normalize(),
+                        point,
+                        bone: None,
+                    })
+                }),
+            },
             DebugEntityMessage::Frob => MessagePayload::Frob,
             DebugEntityMessage::Signal { name } => MessagePayload::Signal { name },
             DebugEntityMessage::SetAlertness { level } => MessagePayload::SetAlertness { level },

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1720,6 +1720,54 @@ impl PhysicsWorld {
         self.apply_impulse_to_handle(handle, impulse)
     }
 
+    /// Seed a multibody's free-root velocity with a world-space linear
+    /// velocity (rapier free-joint DOF layout: linear xyz at generalized
+    /// indices 0..3, angular at 3..6 - see `MultibodyJoint::integrate`).
+    /// Body-level `set_linvel` is clobbered by the reduced-coordinate
+    /// readback, so inherited motion (e.g. a dying creature's root-motion
+    /// velocity carrying into its ragdoll) must be written into the
+    /// generalized coordinates. `body` may be any link of the multibody.
+    /// Returns false for non-multibody bodies.
+    pub fn set_multibody_root_linvel(
+        &mut self,
+        body: RigidBodyHandle,
+        linvel: Vector3<f32>,
+    ) -> bool {
+        // Sanitize the seed: it gets a full physics step before the ragdoll's
+        // per-frame velocity clamp sees it, so a non-finite or runaway value
+        // (e.g. a capsule mid-knockback) must not reach the solver verbatim.
+        const MAX_SEED_SPEED: f32 = 30.0;
+        if !(linvel.x.is_finite() && linvel.y.is_finite() && linvel.z.is_finite()) {
+            return false;
+        }
+        let norm = linvel.magnitude();
+        let linvel = if norm > MAX_SEED_SPEED {
+            linvel * (MAX_SEED_SPEED / norm)
+        } else {
+            linvel
+        };
+        let Some(link) = self.multibody_joint_set.rigid_body_link(body) else {
+            // Not articulated (e.g. a one-bone skeleton spawns a lone free
+            // body): a direct write works there.
+            if let Some(rigid_body) = self.rigid_body_set.get_mut(body) {
+                rigid_body.set_linvel(vec_to_nvec(linvel), true);
+                return true;
+            }
+            return false;
+        };
+        let index = link.multibody;
+        if let Some(multibody) = self.multibody_joint_set.get_multibody_mut(index) {
+            let mut generalized = multibody.generalized_velocity_mut();
+            if generalized.len() >= 3 {
+                generalized[0] = linvel.x;
+                generalized[1] = linvel.y;
+                generalized[2] = linvel.z;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Multibody-aware impulse on a body handle, waking it even for a zero
     /// impulse. A multibody link ignores direct velocity writes: the reduced-
     /// coordinate solver recomputes every link body's velocity from the joint

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1717,13 +1717,22 @@ impl PhysicsWorld {
         let Some(handle) = handle else {
             return false;
         };
-        // A multibody link ignores direct velocity writes: the reduced-
-        // coordinate solver recomputes every link body's velocity from the
-        // joint velocities each step (`Multibody` forward kinematics), so
-        // `apply_impulse` is silently overwritten. Its forward *dynamics* does
-        // read the per-body user-force accumulator, so convert the impulse to
-        // a force over one physics step - `clear_forces` (called right after
-        // each step) makes it impulsive.
+        self.apply_impulse_to_handle(handle, impulse)
+    }
+
+    /// Multibody-aware impulse on a body handle, waking it even for a zero
+    /// impulse. A multibody link ignores direct velocity writes: the reduced-
+    /// coordinate solver recomputes every link body's velocity from the joint
+    /// velocities each step (`Multibody` forward kinematics), so
+    /// `apply_impulse` is silently overwritten. Its forward *dynamics* does
+    /// read the per-body user-force accumulator, so convert the impulse to a
+    /// force over one physics step - `clear_forces` (called right after each
+    /// step) makes it impulsive. Free dynamic bodies get a plain impulse.
+    pub fn apply_impulse_to_handle(
+        &mut self,
+        handle: RigidBodyHandle,
+        impulse: Vector3<f32>,
+    ) -> bool {
         let is_multibody_link = self.multibody_joint_set.rigid_body_link(handle).is_some();
         let dt = self.integration_parameters.dt;
         if let Some(body) = self.rigid_body_set.get_mut(handle) {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -80,6 +80,10 @@ pub struct AnimatedMonsterAI {
     /// `is_dead` is set, and would otherwise hand off before the crumple has
     /// even started. The real crumple completion arrives seconds later.
     updates_since_death: u32,
+    /// The blow that killed this creature (direction/point/bone), stashed at
+    /// the lethal Damage so the crumple->ragdoll handoff can seed the corpse's
+    /// physical reaction.
+    death_impact: Option<crate::scripts::DamageImpact>,
     took_damage: bool,
     animation_seq: u32,
     locomotion_seq: u32,
@@ -108,6 +112,7 @@ impl AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
             updates_since_death: 0,
+            death_impact: None,
             took_damage: false,
             current_behavior: Box::new(RefCell::new(IdleBehavior)),
             current_heading: Deg(0.0),
@@ -128,6 +133,7 @@ impl AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
             updates_since_death: 0,
+            death_impact: None,
             took_damage: false,
             // Start with IdleBehavior - alertness will drive behavior changes
             current_behavior: Box::new(RefCell::new(IdleBehavior)),
@@ -925,7 +931,7 @@ impl Script for AnimatedMonsterAI {
                 .handle_message(entity_id, world, physics, msg);
         }
         match msg {
-            MessagePayload::Damage { amount } => {
+            MessagePayload::Damage { amount, impact } => {
                 // Corpses don't bleed: no HP churn, aggro, or replayed death
                 // from shooting a dead monster. The world check also covers a
                 // post-load corpse, whose recreated script has is_dead reset
@@ -966,6 +972,9 @@ impl Script for AnimatedMonsterAI {
                 // interrupts the in-flight clip (cross-fading from its
                 // current pose) instead of waiting for it to complete
                 let death_effect = if lethal {
+                    // Remember how the killing blow landed for the
+                    // crumple->ragdoll handoff.
+                    self.death_impact = *impact;
                     self.enter_death(world, entity_id)
                 } else {
                     Effect::NoEffect
@@ -1088,7 +1097,10 @@ impl Script for AnimatedMonsterAI {
                     // the crumple itself (which just started) - swallow those,
                     // or the corpse would ragdoll from its still-standing pose.
                     if self.updates_since_death >= 1 {
-                        Effect::SpawnCorpseRagdoll { entity_id }
+                        Effect::SpawnCorpseRagdoll {
+                            entity_id,
+                            impact: self.death_impact,
+                        }
                     } else {
                         Effect::NoEffect
                     }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -52,6 +52,15 @@ const DOOR_INTERACT_COOLDOWN: f32 = 2.0;
 /// bounds the "thwarted" gesture for an AI whose alert cap keeps it in a
 /// pursuing state even after the give-up's alertness drop.
 const DOOR_GIVEUP_COOLDOWN: f32 = 8.0;
+/// How far into the death crumple the corpse hands off to physics. Near-
+/// instant (a few frames) so the killing-blow impulse lands AT the kill -
+/// any longer and the reaction reads as delayed. The crumple still starts
+/// (its first frames shape the initial pose and root velocity, both of which
+/// the rig inherits - see spawn_ragdoll), but physics owns the death from
+/// here; the ragdoll spawns from the current pose, so there is no snap.
+/// Raise this to let more of the authored death animation play before
+/// physics takes over (at 0.5 the impulse visibly lags the shot).
+const CRUMPLE_HANDOFF_SECONDS: f32 = 0.05;
 
 /// Configuration for monster alertness behavior
 #[derive(Clone)]
@@ -74,12 +83,12 @@ pub struct AnimatedMonsterAI {
     current_behavior: Box<RefCell<dyn Behavior>>,
     current_heading: Deg<f32>,
     is_dead: bool,
-    /// Script updates seen since entering death. Guards the crumple->ragdoll
-    /// handoff against a stale AnimationCompleted: a clip that happened to
-    /// finish in the very tick the killing blow landed is dispatched after
-    /// `is_dead` is set, and would otherwise hand off before the crumple has
-    /// even started. The real crumple completion arrives seconds later.
-    updates_since_death: u32,
+    /// Seconds of sim time since entering death; drives the timed
+    /// crumple->ragdoll handoff.
+    death_elapsed: f32,
+    /// The handoff effect is emitted exactly once (a failed spawn - e.g. a
+    /// non-ragdollable model - must not re-emit every frame).
+    handoff_emitted: bool,
     /// The blow that killed this creature (direction/point/bone), stashed at
     /// the lethal Damage so the crumple->ragdoll handoff can seed the corpse's
     /// physical reaction.
@@ -111,7 +120,8 @@ impl AnimatedMonsterAI {
     pub fn idle() -> AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
-            updates_since_death: 0,
+            death_elapsed: 0.0,
+            handoff_emitted: false,
             death_impact: None,
             took_damage: false,
             current_behavior: Box::new(RefCell::new(IdleBehavior)),
@@ -132,7 +142,8 @@ impl AnimatedMonsterAI {
     pub fn new() -> AnimatedMonsterAI {
         AnimatedMonsterAI {
             is_dead: false,
-            updates_since_death: 0,
+            death_elapsed: 0.0,
+            handoff_emitted: false,
             death_impact: None,
             took_damage: false,
             // Start with IdleBehavior - alertness will drive behavior changes
@@ -462,6 +473,10 @@ impl AnimatedMonsterAI {
     fn enter_death(&mut self, world: &World, entity_id: EntityId) -> Effect {
         self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
         self.is_dead = true;
+        // Anchor the ragdoll-handoff timer to the crumple's actual start
+        // (kills arriving via the AnimationCompleted fallback enter death
+        // later than they were dealt).
+        self.death_elapsed = 0.0;
 
         let death_sound_effect = if let Some(voice_index) =
             crate::scripts::speech_util::resolve_entity_voice_index(world, entity_id)
@@ -669,7 +684,29 @@ impl Script for AnimatedMonsterAI {
         // behavior so introspection shows "Dead", and release a sensor the
         // ray was intersecting at death so its end-intersect isn't stranded.
         if self.is_dead || is_killed(entity_id, world) {
-            self.updates_since_death = self.updates_since_death.saturating_add(1);
+            // The handoff timer runs only through the real death flow
+            // (enter_death -> is_dead): a corpse recreated by save/load has
+            // is_killed true but is_dead false, and must stay an animated
+            // corpse rather than ragdoll-ify from whatever pose it loaded in.
+            if self.is_dead {
+                self.death_elapsed += time.elapsed.as_secs_f32();
+            }
+            // Near-instant handoff: once the death animation has had a few
+            // frames, offer the corpse to physics (no-op without the
+            // `ragdoll` experimental flag; a successful spawn removes this
+            // entity, so at most one emission ever matters).
+            let handoff_effect = if self.is_dead
+                && !self.handoff_emitted
+                && self.death_elapsed >= CRUMPLE_HANDOFF_SECONDS
+            {
+                self.handoff_emitted = true;
+                Effect::SpawnCorpseRagdoll {
+                    entity_id,
+                    impact: self.death_impact,
+                }
+            } else {
+                Effect::NoEffect
+            };
             let sensor_release_effect = match self.last_hit_sensor.take() {
                 Some(sensor_id) => Effect::Send {
                     msg: Message {
@@ -680,6 +717,7 @@ impl Script for AnimatedMonsterAI {
                 None => Effect::NoEffect,
             };
             return Effect::combine(vec![
+                handoff_effect,
                 sensor_release_effect,
                 self.publish_behavior(entity_id),
             ]);
@@ -1086,24 +1124,11 @@ impl Script for AnimatedMonsterAI {
             }
             MessagePayload::AnimationCompleted => {
                 if self.is_dead {
-                    // The death crumple finished: offer the corpse to physics.
-                    // No-op unless the `ragdoll` experimental flag is on - the
-                    // animated corpse stays otherwise. (The is_dead branch
-                    // queues nothing and a successful spawn removes this
-                    // entity, so this cannot double-fire.)
-                    //
-                    // Completions dispatched in the same tick the killing blow
-                    // landed belong to the clip the crumple interrupted, not
-                    // the crumple itself (which just started) - swallow those,
-                    // or the corpse would ragdoll from its still-standing pose.
-                    if self.updates_since_death >= 1 {
-                        Effect::SpawnCorpseRagdoll {
-                            entity_id,
-                            impact: self.death_impact,
-                        }
-                    } else {
-                        Effect::NoEffect
-                    }
+                    // The crumple->ragdoll handoff is timed from update()
+                    // (CRUMPLE_HANDOFF_SECONDS), not completion-driven - a
+                    // stale completion from the clip the crumple interrupted
+                    // could otherwise hand off from a still-standing pose.
+                    Effect::NoEffect
                 } else if is_killed(entity_id, world) {
                     // Fallback for kills that didn't arrive as a Damage
                     // message (the lethal-damage path enters death eagerly)

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -235,11 +235,14 @@ pub enum Effect {
     },
 
     /// The death (crumple) animation finished: hand the corpse over to physics
-    /// as a ragdoll. Emitted unconditionally by the AI on death-animation
-    /// completion; the handler is a no-op unless the `ragdoll` experimental
-    /// flag is on (the animated corpse entity stays, exactly as before).
+    /// as a ragdoll, optionally seeded with the killing blow (so the corpse
+    /// reacts at the struck limb, in the shot's direction). Emitted
+    /// unconditionally by the AI on death-animation completion; the handler is
+    /// a no-op unless the `ragdoll` experimental flag is on (the animated
+    /// corpse entity stays, exactly as before).
     SpawnCorpseRagdoll {
         entity_id: EntityId,
+        impact: Option<crate::scripts::DamageImpact>,
     },
 
     QueueAnimationBySchema {

--- a/shock2vr/src/scripts/internal_collision_type.rs
+++ b/shock2vr/src/scripts/internal_collision_type.rs
@@ -73,7 +73,10 @@ impl Script for InternalCollisionType {
                         // data - shared follow-up with the fast (raycast)
                         // projectile path's hardcoded 6.0 in
                         // internal_fast_projectile.rs.
-                        payload: MessagePayload::Damage { amount: 1.0 },
+                        payload: MessagePayload::Damage {
+                            amount: 1.0,
+                            impact: None,
+                        },
                     },
                 };
                 let mut effects = vec![initial_effect, damage_effect];

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -77,7 +77,24 @@ impl Script for InternalFastProjectileScript {
                     msg: Message {
                         to: hit_entity_id,
                         // TODO: Properly calculate damage
-                        payload: MessagePayload::Damage { amount: 6.0 },
+                        payload: MessagePayload::Damage {
+                            amount: 6.0,
+                            // The shot's travel direction + hit point seed the
+                            // victim's death-ragdoll reaction. Bone is filled
+                            // in by the hitbox script when a hitbox was struck.
+                            impact: {
+                                let travel = hit_point - start_point;
+                                if travel.magnitude2() > 1.0e-12 {
+                                    Some(crate::scripts::DamageImpact {
+                                        direction: travel.normalize(),
+                                        point: hit_point.to_vec(),
+                                        bone: None,
+                                    })
+                                } else {
+                                    None
+                                }
+                            },
+                        },
                     },
                 },
                 Effect::DrawDebugLines {

--- a/shock2vr/src/scripts/internal_simple_health.rs
+++ b/shock2vr/src/scripts/internal_simple_health.rs
@@ -25,7 +25,7 @@ impl Script for InternalSimpleHealth {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Damage { amount } => {
+            MessagePayload::Damage { amount, impact: _ } => {
                 // Damage amounts are authored as floats but hit points are an
                 // integer pool; round to match the AI damage path
                 // (animated_monster_ai).
@@ -72,7 +72,10 @@ mod tests {
             entity_id,
             world,
             &physics,
-            &MessagePayload::Damage { amount },
+            &MessagePayload::Damage {
+                amount,
+                impact: None,
+            },
         )
     }
 

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -28,7 +28,10 @@ impl Script for MeleeWeapon {
                 let damage_effect = Effect::Send {
                     msg: Message {
                         to: *with,
-                        payload: MessagePayload::Damage { amount: 1.0 },
+                        payload: MessagePayload::Damage {
+                            amount: 1.0,
+                            impact: None,
+                        },
                     },
                 };
                 // Impact sound: the weapon's collision schema (weapontype

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -144,6 +144,21 @@ use self::{
     weapon_script::WeaponScript,
 };
 
+/// World-space description of the blow behind a `Damage` message, for physics
+/// reactions (ragdoll seeding). None when the source has no meaningful
+/// direction (scripted damage, collisions; radius blasts shove bodies
+/// directly).
+#[derive(Clone, Copy, Debug)]
+pub struct DamageImpact {
+    /// Unit direction the blow traveled (attacker toward victim).
+    pub direction: cgmath::Vector3<f32>,
+    /// World-space hit point.
+    pub point: cgmath::Vector3<f32>,
+    /// Skeleton joint id of the hitbox that was struck, when known (filled in
+    /// by HitBoxScript as it forwards damage to its parent creature).
+    pub bone: Option<u32>,
+}
+
 #[derive(Clone, Debug)]
 pub enum MessagePayload {
     Frob,
@@ -172,6 +187,9 @@ pub enum MessagePayload {
     }, // propose to consume this entity
     Damage {
         amount: f32,
+        /// The blow's direction/point/bone, when the source knows them -
+        /// seeds the death ragdoll's reaction.
+        impact: Option<DamageImpact>,
     }, // damage the entity
 
     // The entity heard a noise (gunfire, etc.) at this position - an AI

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -242,6 +242,7 @@ fn melee_swing(
     );
     if let Some(RayCastResult {
         maybe_entity_id: Some(target),
+        hit_point,
         ..
     }) = hit
     {
@@ -251,6 +252,17 @@ fn melee_swing(
                 to: target,
                 payload: MessagePayload::Damage {
                     amount: MELEE_DAMAGE,
+                    // Swing direction + contact point seed the victim's
+                    // death-ragdoll reaction. No bone: melee resolves a hitbox
+                    // proxy to its parent BEFORE sending (so HitBoxScript
+                    // never stamps it) - the ragdoll's nearest-body-to-point
+                    // fallback picks the struck limb from the contact point
+                    // instead.
+                    impact: Some(crate::scripts::DamageImpact {
+                        direction: aim.forward.normalize(),
+                        point: hit_point.to_vec(),
+                        bone: None,
+                    }),
                 },
             },
         });

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -59,7 +59,14 @@ export interface PathfindingTestStatus {
  * Mirrors the engine's `DebugEntityMessage`; the `type` field is the serde tag.
  */
 export type DebugEntityMessage =
-  | { type: "Damage"; amount: number }
+  | {
+      type: "Damage";
+      amount: number;
+      /** Optional world-space blow direction (seeds a death-ragdoll reaction). */
+      direction?: [number, number, number];
+      /** Optional world-space hit point (defaults to the victim's position). */
+      point?: [number, number, number];
+    }
   | { type: "Frob" }
   | { type: "Signal"; name: string }
   | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" }

--- a/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
@@ -108,3 +108,57 @@ test(
     );
   },
 );
+
+// The killing blow seeds the corpse: a directional lethal hit shoves the
+// struck limb along the blow at handoff, so the corpse reacts to HOW it died.
+// (Control measurement: a directionless kill leaves max body vx ~0.1; the
+// seeded kill reaches ~2.5 - threshold 1.0 discriminates cleanly.)
+test(
+  "a directional killing blow seeds the ragdoll's reaction",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+      experimental: ["ragdoll"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    await game.step({ frames: 10 });
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // Kill with a world +X blow (what a projectile hit reports).
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+      direction: [1, 0, 0],
+    });
+
+    let ragdolls = (await game.physics.ragdolls()).ragdolls;
+    for (let i = 0; i < 30 && ragdolls.length === 0; i++) {
+      await game.step({ frames: 30 });
+      ragdolls = (await game.physics.ragdolls()).ragdolls;
+    }
+    assert.equal(ragdolls.length, 1, "crumple should hand off to a ragdoll");
+
+    // Sample body velocities right after the handoff: the struck limb must be
+    // moving along the blow.
+    await game.step({ frames: 3 });
+    const bodies = await game.physics.bodies({
+      entityId: ragdolls[0].entity_id,
+    });
+    const maxVx = Math.max(...bodies.bodies.map((b) => b.velocity[0]));
+    assert.ok(
+      maxVx > 1.0,
+      `struck limb should move along the +X blow, max vx=${maxVx}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
@@ -55,18 +55,16 @@ test(
       amount: 1000,
     });
 
-    // The death crumple has to actually play out before the handoff fires
-    // (the ragdoll spawns on the crumple's AnimationCompleted, not on the
-    // killing blow). Step in 0.5s batches until the ragdoll exists.
-    let ragdolls = (await game.physics.ragdolls()).ragdolls;
-    for (let i = 0; i < 30 && ragdolls.length === 0; i++) {
-      await game.step({ frames: 30 });
-      ragdolls = (await game.physics.ragdolls()).ragdolls;
-    }
+    // The handoff is near-instant (~0.05s into the crumple, so the killing
+    // blow lands AT the kill): half a second after the killing blow the
+    // ragdoll must already exist. This pins the timing contract - the old
+    // completion-driven handoff (~4s later) would fail here.
+    await game.step({ frames: 30 });
+    const ragdolls = (await game.physics.ragdolls()).ragdolls;
     assert.equal(
       ragdolls.length,
       1,
-      "death crumple should spawn exactly one ragdoll within 15s",
+      "the killing blow should hand off to exactly one ragdoll within 0.5s",
     );
     assert.ok(
       ragdolls[0].body_count >= 15,


### PR DESCRIPTION
## Summary

**Stacked on #482.** Two commits that make a death read as one continuous physical event:

**Commit 1 — the killing blow reaches the ragdoll.** `MessagePayload::Damage` gains `impact: Option<DamageImpact>` (unit direction, world hit point, optional skeleton bone). Fast projectiles fill it from their trajectory, the flat melee swing from its aim ray, and `HitBoxScript` stamps the struck bone as it forwards damage to the owning creature. The AI stashes the lethal hit's impact (first blow wins) and passes it through `SpawnCorpseRagdoll`; the struck limb (by bone, else nearest body to the hit point) gets a shove along the blow via the multibody-aware force-conversion path. `DebugEntityMessage::Damage` gains optional serde-default `direction`/`point` so tooling can inject directional blows.

**Commit 2 — the handoff is near-instant.** The corpse hands to physics ~0.05 s after the kill (timed from the AI's update; `CRUMPLE_HANDOFF_SECONDS` is the tuning knob), replacing the completion-driven handoff — at ~4 s the impulse visibly lagged the shot (user feedback), and even a 0.5 s mid-crumple trial still read as delayed. The rig also **inherits the dying creature's bulk velocity**: the capsule's live root-motion velocity is written into the multibody's free-root generalized DOF (linear xyz at indices 0..3 per rapier's free-joint layout — body-level `set_linvel` is clobbered by the reduced-coordinate readback; layout verified against the vendored rapier source by both reviewers).

## Verification

- A/B in medsci1: +X killing blow → corpse max body vx **3.33** four frames after the kill; directionless control → 0.11. Handoff fires at 0.067 s (was ~4 s).
- New e2e assertions pin both contracts: the ragdoll must exist within 0.5 s of the killing blow (the old completion-driven behavior fails this), and the struck limb must move along the blow (threshold 1.0 vs 0.11 control baseline).
- `cargo test -p shock2vr` 143/143; full e2e suite **100/101** (the one failure is the recurring transient client-side `fetch failed`, green in isolation).

## Review (xreview: Claude + Codex, both commits)

**[AGREED]** and fixed: the handoff timer is anchored strictly to the real death flow (`is_dead`, reset in `enter_death`) — previously `is_killed` alone could start it, letting save-loaded corpses or non-Damage kills ragdoll-ify from a non-crumpled pose. Also from review: seed velocity sanitized (non-finite rejected, magnitude capped at 30) since it gets one physics step before the per-frame clamp; one-bone/non-articulated rigs fall back to a direct `set_linvel`; a `#[cfg(test)]` constructor fix that `cargo check` can't see; `clear_forces` gated on a real physics step so paused frames can't erase queued one-step forces. Noted, not fixed: same-tick batched lethal damage falls back to the pre-existing `is_killed` death path (corpse collapses unseeded in that rare case).

## Tradeoff to evaluate in-game

At 0.05 s the authored death animation contributes only the first frames of pose — deaths are physics-owned. If that ends up feeling floppy, the escalation path is per-bone animation/physics compositing (powered-ragdoll); the constant is the cheap knob in the meantime.

## Visuals

![ragdoll killing-blow demo](https://gist.githubusercontent.com/tommy-xr/2077c5b6b812cd89b10b5ccaf3fc7918/raw/ragdoll-killing-blow.gif)

<sub>~Real-time: a +X killing blow lands on a hybrid in medsci1 (`--experimental ragdoll`); the corpse reacts along the shot's direction within 4 frames (~0.05 s) of the kill, collapses, and settles as one continuous physical event. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

| Shot lands (+4 frames) | Shoved mid-collapse | Settled |
| --- | --- | --- |
| ![instant of the shot](https://gist.githubusercontent.com/tommy-xr/2077c5b6b812cd89b10b5ccaf3fc7918/raw/still-1-instant.png) | ![mid-collapse shove](https://gist.githubusercontent.com/tommy-xr/2077c5b6b812cd89b10b5ccaf3fc7918/raw/still-2-midcollapse.png) | ![settled corpse](https://gist.githubusercontent.com/tommy-xr/2077c5b6b812cd89b10b5ccaf3fc7918/raw/still-3-settled.png) |

<sub>Left: 4 sim frames after the kill message the head/torso are already pitching along the blow — no dead-air between shot and reaction. Middle: the rig reels in the blow's direction with inherited momentum. Right: the corpse settles displaced along the shot line.</sub>


🤖 Generated with [Claude Code](https://claude.com/claude-code)

