### PR TITLE
fix(ai): eliminate mid-route freezes (whiskers, corner insets, stall recovery) - Fixes #481

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -724,6 +724,15 @@ pub struct DebugAiPathEntry {
     pub outcome: String,
     /// Waypoints of the computed route (empty for Failed)
     pub waypoints: Vec<[f32; 3]>,
+    /// Index of the waypoint the steering is CURRENTLY following (its live
+    /// path may lag the latest computed route above)
+    pub live_next_waypoint: Option<usize>,
+    /// Length of the live path being followed
+    pub live_path_len: Option<usize>,
+    /// World position currently steered toward
+    pub live_target: Option<[f32; 3]>,
+    /// Seconds without progress toward the current waypoint
+    pub live_stall_seconds: Option<f32>,
 }
 
 /// Snapshot of the pathfinding service's monotonic query counters.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -717,10 +717,32 @@ impl MissionCore {
         }
 
         let nav_bridges = game_options.experimental_features.contains("nav_bridges");
+        // Vet each synthesized island crossing against the static level
+        // geometry: a torso-height ray between the two cell centers must be
+        // clear, so bridges can't route AIs into railings or thin walls
+        // (which left them stalling at the seam forever - issue #481).
+        let bridge_validator = |from: cgmath::Vector3<f32>, to: cgmath::Vector3<f32>| -> bool {
+            let delta = to - from;
+            let distance = delta.magnitude();
+            if distance <= f32::EPSILON {
+                return true;
+            }
+            physics
+                .ray_cast2(
+                    Point3::new(from.x, from.y, from.z),
+                    delta / distance,
+                    distance,
+                    crate::physics::InternalCollisionGroups::WORLD,
+                    None,
+                    true,
+                )
+                .is_none()
+        };
         let pathfinding_service = abstract_mission.path_database.as_ref().map(|db| {
             Arc::new(PathfindingService::with_nav_options(
                 Arc::new(db.clone()),
                 nav_bridges,
+                Some(&bridge_validator),
             ))
         });
         // Steering strategies path through this unique; MissionCore keeps its
@@ -5556,11 +5578,18 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         service
             .ai_paths()
             .into_iter()
-            .map(|(entity, record)| crate::game_scene::DebugAiPathEntry {
-                entity_id: entity as i32,
-                goal: record.goal.into(),
-                outcome: format!("{:?}", record.outcome),
-                waypoints: record.waypoints.into_iter().map(Into::into).collect(),
+            .map(|(entity, record)| {
+                let live = service.ai_steering(entity);
+                crate::game_scene::DebugAiPathEntry {
+                    entity_id: entity as i32,
+                    goal: record.goal.into(),
+                    outcome: format!("{:?}", record.outcome),
+                    waypoints: record.waypoints.into_iter().map(Into::into).collect(),
+                    live_next_waypoint: live.map(|l| l.next_waypoint),
+                    live_path_len: live.map(|l| l.path_len),
+                    live_target: live.and_then(|l| l.target).map(Into::into),
+                    live_stall_seconds: live.map(|l| l.stall_seconds),
+                }
             })
             .collect()
     }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -18,13 +18,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-/// Taut crossing points keep this distance (1.5 Dark feet) from shared-edge
+/// Taut crossing points keep this distance (3 Dark feet) from shared-edge
 /// endpoints. Endpoints are wall corners: a fully-taut path has zero
-/// clearance there, dragging the AI's body through the corner and leaving
-/// whisker avoidance to fight the path every frame. One fixed radius for all
-/// creatures for now - it also (harmlessly) insets interior subdivision
-/// edges, not just walls.
-const EDGE_CLEARANCE: f32 = 1.5 / SCALE_FACTOR;
+/// clearance there, dragging the AI's body through the corner. 1.5 feet
+/// proved insufficient - it is under the widest creature capsule radius, so
+/// taut routes grazed door frames and the body WEDGED on the corner pushing
+/// full speed into it forever (stall cleared the path, the re-path produced
+/// the identical taut route - issue #481's remaining freeze). One fixed
+/// radius for all creatures for now - it also (harmlessly) insets interior
+/// subdivision edges, not just walls.
+const EDGE_CLEARANCE: f32 = 3.0 / SCALE_FACTOR;
 
 /// A zero-bit link counts as a flat walkable seam when the two cell floors
 /// differ by no more than this (3 Dark feet - covers small steps; genuine
@@ -121,6 +124,21 @@ pub struct AiPathRecord {
     pub outcome: AiPathOutcome,
 }
 
+/// Live path-following state, published by the steering every frame it
+/// runs - shows what the strategy is ACTUALLY following (which can lag or
+/// differ from the latest computed route in `AiPathRecord`)
+#[derive(Debug, Clone, Copy)]
+pub struct AiSteeringDebug {
+    /// Index of the waypoint currently steered toward
+    pub next_waypoint: usize,
+    /// Length of the path being followed (0 = no active path)
+    pub path_len: usize,
+    /// World position currently steered toward (waypoint), if any
+    pub target: Option<Vector3<f32>>,
+    /// Seconds without progress toward the current waypoint
+    pub stall_seconds: f32,
+}
+
 /// Pathfinding service for AI navigation
 ///
 /// Uses AIPATH cells for navigation mesh queries and A* pathfinding.
@@ -150,6 +168,8 @@ pub struct PathfindingService {
     /// Latest path per AI entity (key: EntityId::inner()), recorded by the
     /// path-follow steering so tooling can see what each AI is doing
     ai_paths: std::sync::Mutex<HashMap<u64, AiPathRecord>>,
+    /// Live steering state per AI (what it is actually following right now)
+    ai_steering: std::sync::Mutex<HashMap<u64, AiSteeringDebug>>,
     /// Mission object ids of doors that are currently locked AND closed -
     /// A* refuses links into their below-door cells (the runtime door gate;
     /// closed-but-openable doors stay pathable and are opened on arrival).
@@ -164,13 +184,22 @@ impl PathfindingService {
     /// Create a new pathfinding service with the given path database
     /// (faithful traversal rules; no island bridging)
     pub fn new(path_database: Arc<PathDatabase>) -> Self {
-        Self::with_nav_options(path_database, false)
+        Self::with_nav_options(path_database, false, None)
     }
 
     /// Create a pathfinding service; `bridge_islands` enables the
     /// experimental mesh reconnection (island-crossing links + relaxed
-    /// blocking-cell traversal) for full-map navigation.
-    pub fn with_nav_options(path_database: Arc<PathDatabase>, bridge_islands: bool) -> Self {
+    /// blocking-cell traversal) for full-map navigation. `bridge_validator`
+    /// (when provided) vets each candidate crossing - given the two cell
+    /// centers, return whether the straight walk between them is physically
+    /// clear. Without it bridges are purely geometric and can cross railings
+    /// or thin walls, leaving AIs stalling at a seam physics won't let them
+    /// pass.
+    pub fn with_nav_options(
+        path_database: Arc<PathDatabase>,
+        bridge_islands: bool,
+        bridge_validator: Option<&dyn Fn(Vector3<f32>, Vector3<f32>) -> bool>,
+    ) -> Self {
         let mut links_by_cell = vec![Vec::new(); path_database.cells.len()];
         for (idx, link) in path_database.links.iter().enumerate() {
             if let Some(links) = links_by_cell.get_mut(link.from_cell as usize) {
@@ -184,7 +213,7 @@ impl PathfindingService {
             .collect();
         let mut effective_bits = compute_effective_bits(&path_database);
         let bridge_links = if bridge_islands {
-            compute_bridge_links(&path_database, &effective_bits)
+            compute_bridge_links(&path_database, &effective_bits, bridge_validator)
         } else {
             Vec::new()
         };
@@ -209,6 +238,7 @@ impl PathfindingService {
             bridge_links,
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
+            ai_steering: std::sync::Mutex::new(HashMap::new()),
             locked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
@@ -242,6 +272,22 @@ impl PathfindingService {
         if let Ok(mut paths) = self.ai_paths.lock() {
             paths.insert(entity, record);
         }
+    }
+
+    /// Publish an AI's live steering state (called by path-follow steering
+    /// every frame it runs)
+    pub fn record_ai_steering(&self, entity: u64, debug: AiSteeringDebug) {
+        if let Ok(mut steering) = self.ai_steering.lock() {
+            steering.insert(entity, debug);
+        }
+    }
+
+    /// The live steering state for an entity, if it has published any
+    pub fn ai_steering(&self, entity: u64) -> Option<AiSteeringDebug> {
+        self.ai_steering
+            .lock()
+            .ok()
+            .and_then(|steering| steering.get(&entity).copied())
     }
 
     /// Snapshot of every AI's latest recorded path
@@ -759,7 +805,11 @@ fn is_flat_seam(db: &PathDatabase, link: &PathCellLink) -> bool {
 /// of each other at a walkable slope. Purely geometric - a candidate through
 /// thick geometry is possible but rare at these gates, and steering/stall
 /// handling copes with the odd bad bridge.
-fn compute_bridge_links(db: &PathDatabase, effective_bits: &[MovementBits]) -> Vec<PathCellLink> {
+fn compute_bridge_links(
+    db: &PathDatabase,
+    effective_bits: &[MovementBits],
+    validator: Option<&dyn Fn(Vector3<f32>, Vector3<f32>) -> bool>,
+) -> Vec<PathCellLink> {
     // Union-find over walk-usable links to label islands
     let mut parent: Vec<u32> = (0..db.cells.len() as u32).collect();
     fn find(parent: &mut Vec<u32>, mut a: u32) -> u32 {
@@ -869,10 +919,24 @@ fn compute_bridge_links(db: &PathDatabase, effective_bits: &[MovementBits]) -> V
             .then(x.2.cmp(&y.2))
     });
 
+    /// Cast height above the cell floors: torso level, clearing steps but
+    /// under railings and half-walls a creature can't cross
+    const BRIDGE_PROBE_HEIGHT: f32 = 3.5 / SCALE_FACTOR;
+
+    let mut rejected = 0usize;
     let mut bridges = Vec::new();
     for (_, a_id, b_id) in candidates {
         if find(&mut parent, a_id) == find(&mut parent, b_id) {
             continue;
+        }
+        if let Some(validate) = validator {
+            let lift = Vector3::new(0.0, BRIDGE_PROBE_HEIGHT, 0.0);
+            let from = db.cells[a_id as usize].center + lift;
+            let to = db.cells[b_id as usize].center + lift;
+            if !validate(from, to) {
+                rejected += 1;
+                continue;
+            }
         }
         let root_a = find(&mut parent, a_id);
         parent[root_a as usize] = find(&mut parent, b_id);
@@ -895,6 +959,12 @@ fn compute_bridge_links(db: &PathDatabase, effective_bits: &[MovementBits]) -> V
                 cost,
             });
         }
+    }
+    if rejected > 0 {
+        tracing::info!(
+            "pathfinding: rejected {} island-bridge candidates blocked by geometry",
+            rejected
+        );
     }
     bridges
 }
@@ -1122,7 +1192,7 @@ pub(crate) mod tests {
             "islands must stay separate without nav_bridges"
         );
 
-        let bridged = PathfindingService::with_nav_options(Arc::new(db), true);
+        let bridged = PathfindingService::with_nav_options(Arc::new(db), true, None);
         let path = bridged
             .find_path(vec3(1.0, 0.0, 1.0), vec3(5.0, 0.0, 1.0), MovementBits::WALK)
             .expect("nav_bridges must synthesize a crossing");
@@ -1182,7 +1252,7 @@ pub(crate) mod tests {
             ok_bits: MovementBits::WALK,
             cost: 1,
         });
-        let service = PathfindingService::with_nav_options(Arc::new(db), true);
+        let service = PathfindingService::with_nav_options(Arc::new(db), true, None);
         assert!(
             service
                 .find_path(vec3(1.0, 0.0, 1.0), vec3(5.0, 0.0, 1.0), MovementBits::WALK)
@@ -1199,7 +1269,7 @@ pub(crate) mod tests {
         db.links.truncate(1); // cell 2 becomes an island, bridged below
         db.cells[2].flags = PathCellFlags::BELOW_DOOR;
         db.cell_doors.push(CellDoor { cell: 2, door: 99 });
-        let service = PathfindingService::with_nav_options(Arc::new(db), true);
+        let service = PathfindingService::with_nav_options(Arc::new(db), true, None);
         assert_eq!(service.doors_near_cell(0), vec![(99, vec3(5.0, 0.0, 1.0))]);
     }
 
@@ -1314,7 +1384,10 @@ pub(crate) mod tests {
         // A goal hugging the corridor wall (z near 0) pulls the taut points
         // toward the edge endpoints - wall corners. The crossing points must
         // keep EDGE_CLEARANCE distance from the endpoints so the AI's body
-        // doesn't drag through the corner.
+        // doesn't drag through (or wedge on) the corner. The test edges span
+        // z in [0, 2] - shorter than twice the clearance - so they collapse
+        // to their midpoint, the maximum available clearance.
+        assert!(2.0 < 2.0 * EDGE_CLEARANCE, "test assumes short edges");
         let service = service(three_cell_db(PathCellFlags::empty()));
         let start = vec3(1.0, 0.0, 1.0);
         let goal = vec3(5.0, 0.0, 0.05);
@@ -1322,16 +1395,14 @@ pub(crate) mod tests {
             .find_path(start, goal, MovementBits::WALK | MovementBits::STRESSED)
             .unwrap();
         assert_eq!(path.len(), 4, "start + 2 edge crossings + goal");
-        // Edges span z in [0, 2]; the goal at z=0.05 pulls both crossings to
-        // the inset endpoint, exactly EDGE_CLEARANCE from the z=0 corner
         assert!(
-            (path[1].z - EDGE_CLEARANCE).abs() < 1e-5,
-            "crossing 1 not clamped to the inset endpoint: z = {}",
+            (path[1].z - 1.0).abs() < 1e-5,
+            "crossing 1 not collapsed to the edge midpoint: z = {}",
             path[1].z
         );
         assert!(
-            (path[2].z - EDGE_CLEARANCE).abs() < 1e-5,
-            "crossing 2 not clamped to the inset endpoint: z = {}",
+            (path[2].z - 1.0).abs() < 1e-5,
+            "crossing 2 not collapsed to the edge midpoint: z = {}",
             path[2].z
         );
     }

--- a/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
@@ -24,13 +24,15 @@ impl ChaseBehavior {
     pub fn new() -> ChaseBehavior {
         ChaseBehavior {
             steering_strategy: steering::chained(vec![
+                // Path steering leads: the route already avoids static
+                // geometry (nav-mesh + edge clearance), and letting whisker
+                // avoidance preempt it deadlocks AIs against walls the path
+                // was about to turn away from (issue #481). Avoidance guards
+                // only the direct-chase fallback below.
+                Box::new(PathFollowSteeringStrategy::chase_player()),
                 Box::new(
                     CollisionAvoidanceSteeringStrategy::conservative(), /* conservative so we can focus on the chase */
                 ),
-                // Route to the player through the navigation mesh; falls
-                // through to the direct chase when there is no AIPATH data
-                // or no route.
-                Box::new(PathFollowSteeringStrategy::chase_player()),
                 Box::new(ChasePlayerSteeringStrategy),
             ]),
         }

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -55,10 +55,10 @@ impl PatrolBehavior {
 
     fn steering_to(goal: Vector3<f32>) -> Box<dyn SteeringStrategy> {
         steering::chained(vec![
-            Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
-            // Route to the fixed patrol point via the nav mesh; without AIPATH
-            // data this returns None and the AI just holds its heading.
+            // Path steering leads; whisker avoidance only covers the no-route
+            // case (see chase_behavior for the deadlock this prevents)
             Box::new(PathFollowSteeringStrategy::to_point(goal)),
+            Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
         ])
     }
 

--- a/shock2vr/src/scripts/ai/behavior/search_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/search_behavior.rs
@@ -51,10 +51,11 @@ impl SearchBehavior {
         SearchBehavior {
             goal,
             steering_strategy: steering::chained(vec![
-                Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
-                // Route to the fixed last-known position; without AIPATH
-                // data this returns None and the AI just scans in place
+                // Path steering leads; whisker avoidance only covers the
+                // no-route case (see chase_behavior for the deadlock this
+                // prevents)
                 Box::new(PathFollowSteeringStrategy::to_point(goal)),
+                Box::new(CollisionAvoidanceSteeringStrategy::conservative()),
             ]),
             arrived: false,
             scan_seconds: 0.0,

--- a/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/wander_behavior.rs
@@ -29,11 +29,11 @@ impl WanderBehavior {
     pub fn new() -> WanderBehavior {
         WanderBehavior {
             steering_strategy: steering::chained(vec![
-                Box::new(CollisionAvoidanceSteeringStrategy::comprehensive()),
-                // Roam to random reachable spots; without AIPATH data this
-                // returns None and the AI just walks its current heading
-                // (the previous behavior).
+                // Path steering leads; whisker avoidance only covers the
+                // no-route case (see chase_behavior for the deadlock this
+                // prevents)
                 Box::new(PathFollowSteeringStrategy::wander(WANDER_RADIUS)),
+                Box::new(CollisionAvoidanceSteeringStrategy::comprehensive()),
             ]),
         }
     }

--- a/shock2vr/src/scripts/ai/steering/collision_avoidance_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/collision_avoidance_steering_strategy.rs
@@ -48,13 +48,15 @@ impl SteeringStrategy for CollisionAvoidanceSteeringStrategy {
         entity_id: EntityId,
         _time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
-        // TODO
-        let height = 1.0 / SCALE_FACTOR;
         let whisker_angle = Deg(30.0);
         let target_offset = 8.0 / SCALE_FACTOR;
 
-        let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0))
-            + vec3(0.0, -height, 0.0);
+        // Cast from the body center, NOT below it: a knee-height whisker
+        // looking down a descending staircase hits the lower steps' risers
+        // (vertical faces, so the mostly-vertical-normal filter doesn't
+        // reject them) and treats the descent the route chose as a wall.
+        // Real walls extend above body center and are still seen.
+        let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
 
         let mut debug_lines = vec![];
 
@@ -76,7 +78,12 @@ impl SteeringStrategy for CollisionAvoidanceSteeringStrategy {
                 extra_whisker_distance,
                 Some(Deg(-30.0)),
             ),
-            (rotation, main_whisker_distance, Some(Deg(180.0))),
+            // The main (straight-ahead) whisker deflects along the wall via
+            // the hit normal (below) instead of carrying a fixed mitigation:
+            // a fixed 180 reversal fights the path steering command straight
+            // back at the obstacle, flip-flopping the heading forever while
+            // the AI runs in place (issue #481's freeze).
+            (rotation, main_whisker_distance, None),
             //(rotation, main_whisker_distance, None),
         ];
 
@@ -124,15 +131,19 @@ impl SteeringStrategy for CollisionAvoidanceSteeringStrategy {
                 // dist = distance_to_hit;
 
                 if !is_normal_mostly_vertical && !entity_is_door {
-                    if mitigation.is_none() {
-                        maybe_steering_output = Some(Steering::from_current(
-                            current_heading + self.last_mitigation_direction,
-                        ));
-                    } else {
-                        self.last_mitigation_direction = mitigation.unwrap();
-                        maybe_steering_output = Some(Steering::from_current(
-                            current_heading + mitigation.unwrap(),
-                        ));
+                    match mitigation {
+                        // Main whisker: steer toward the point deflected off
+                        // the obstacle along its surface normal - glancing
+                        // away instead of reversing into a heading war with
+                        // the path steering
+                        None => {
+                            maybe_steering_output = Some(Steering::turn_to_point(position, target));
+                        }
+                        Some(mitigation) => {
+                            self.last_mitigation_direction = mitigation;
+                            maybe_steering_output =
+                                Some(Steering::from_current(current_heading + mitigation));
+                        }
                     }
                 }
                 // }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -30,9 +30,15 @@ pub enum PathTarget {
 
 /// A waypoint counts as reached within this XZ distance (2 Dark feet)
 const WAYPOINT_ADVANCE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
-/// ...and within this height difference (4 Dark feet): feet-vs-cell-floor
-/// offsets are small, a waypoint on the floor above/below is not "reached"
-const WAYPOINT_ADVANCE_HEIGHT: f32 = 4.0 / SCALE_FACTOR;
+/// ...and within this height difference (7 Dark feet). Waypoint heights are
+/// cell-FLOOR heights while an AI's position is its body center, which for
+/// the tall grunt models sits ~4.2 Dark feet above the floor - the previous
+/// 4-foot gate was at that boundary, so physics jitter could leave an AI
+/// permanently "not arrived" at a waypoint it was standing on (running in
+/// place through an endless stall/re-path loop). 7 feet clears the tallest
+/// body-center offset while still rejecting waypoints on a stacked floor
+/// (floor-to-floor separation is 10+ feet).
+const WAYPOINT_ADVANCE_HEIGHT: f32 = 7.0 / SCALE_FACTOR;
 /// Re-path when a moving target strays this far from the path's goal
 const REPATH_TARGET_DRIFT: f32 = 6.0 / SCALE_FACTOR;
 /// Minimum seconds between A* queries per strategy instance (behaviors are
@@ -46,6 +52,13 @@ const REPATH_FAILURE_BACKOFF_SECONDS: f32 = 2.0;
 /// Drop the path when we can't get closer to the current waypoint for this
 /// long (blocked by a prop, another AI, or unreachable geometry)
 const STALL_SECONDS: f32 = 3.0;
+/// After a stall, back out toward the previous waypoint for about this long
+/// before re-pathing. Without the retreat, the fresh route is identical to
+/// the one that just wedged (same start cell, same taut corners), so an AI
+/// pressed against a door frame - or two AIs pressed against each other -
+/// repeated the wedge forever (issue #481). Jittered per stall so mutually
+/// blocking AIs unstick on different frames.
+const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
 
@@ -65,6 +78,8 @@ pub struct PathFollowSteeringStrategy {
     stall_waypoint: usize,
     stall_best: f32,
     stall_seconds: f32,
+    /// Active stall recovery: seconds left, and the point to back out toward
+    recovery: Option<(f32, Vector3<f32>)>,
 }
 
 impl PathFollowSteeringStrategy {
@@ -90,6 +105,7 @@ impl PathFollowSteeringStrategy {
             stall_waypoint: usize::MAX,
             stall_best: f32::INFINITY,
             stall_seconds: 0.0,
+            recovery: None,
         }
     }
 
@@ -135,6 +151,22 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         let position = position_point.to_vec();
 
         self.repath_cooldown = (self.repath_cooldown - time.elapsed.as_secs_f32()).max(0.0);
+
+        // Stall recovery: back out toward the previous waypoint (ground we
+        // know we stood on) so the next route doesn't start from the wedged
+        // pose and reproduce the wedge
+        if let Some((seconds_left, retreat)) = self.recovery {
+            let seconds_left = seconds_left - time.elapsed.as_secs_f32();
+            if seconds_left <= 0.0 || xz_distance(position, retreat) < WAYPOINT_ADVANCE_DISTANCE {
+                self.recovery = None;
+            } else {
+                self.recovery = Some((seconds_left, retreat));
+                return Some((
+                    Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(retreat)),
+                    Effect::NoEffect,
+                ));
+            }
+        }
 
         // Path is exhausted - forget it so we re-path (chase) or pick a new
         // destination (wander)
@@ -255,6 +287,16 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
 
         self.next_waypoint = advance_waypoint(position, &self.path, self.next_waypoint);
 
+        service.record_ai_steering(
+            entity_id.inner(),
+            crate::pathfinding::AiSteeringDebug {
+                next_waypoint: self.next_waypoint,
+                path_len: self.path.len(),
+                target: self.path.get(self.next_waypoint).copied(),
+                stall_seconds: self.stall_seconds,
+            },
+        );
+
         // No route (or none yet) - let the next strategy in the chain steer
         let waypoint = *self.path.get(self.next_waypoint)?;
 
@@ -272,8 +314,25 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         } else {
             self.stall_seconds += time.elapsed.as_secs_f32();
             if self.stall_seconds >= STALL_SECONDS {
+                // Back out toward the previous waypoint (or straight back
+                // when the route began here), then re-path from clear ground
+                let retreat = self
+                    .path
+                    .get(self.next_waypoint.saturating_sub(1))
+                    .copied()
+                    .filter(|p| xz_distance(position, *p) >= WAYPOINT_ADVANCE_DISTANCE)
+                    .unwrap_or_else(|| {
+                        let (_, forward) = ai_util::get_position_and_forward(world, entity_id);
+                        position - forward * 2.0
+                    });
+                let jitter = rand::thread_rng().gen_range(0.8..1.6);
+                self.recovery = Some((STALL_RECOVERY_SECONDS * jitter, retreat));
                 self.clear_path();
-                return None;
+                self.repath_cooldown = STALL_RECOVERY_SECONDS * jitter;
+                return Some((
+                    Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(retreat)),
+                    Effect::NoEffect,
+                ));
             }
         }
 
@@ -371,8 +430,18 @@ mod tests {
 
     #[test]
     fn advance_tolerates_small_height_offsets() {
-        // Feet vs cell-floor offset (well under 4 Dark feet) still reaches
+        // Feet vs cell-floor offset (well under the gate) still reaches
         let path = vec![vec3(0.0, 0.5, 0.0), vec3(10.0, 0.0, 0.0)];
+        assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
+    }
+
+    #[test]
+    fn advance_tolerates_body_center_above_cell_floor() {
+        // Waypoint heights are cell-floor heights; a tall creature's body
+        // center rides ~1.7 units above them. Standing on the waypoint must
+        // count as reached (the freeze in issue #481: it didn't, and the AI
+        // ran in place through an endless stall/re-path loop).
+        let path = vec![vec3(0.0, -1.7, 0.0), vec3(10.0, -1.7, 0.0)];
         assert_eq!(advance_waypoint(vec3(0.0, 0.0, 0.0), &path, 0), 1);
     }
 

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -557,7 +557,7 @@ fn run_bench(
     let links = db.links.len();
     let components = walk_components(&db);
     let t_build = Instant::now();
-    let service = PathfindingService::with_nav_options(Arc::new(db), bridges);
+    let service = PathfindingService::with_nav_options(Arc::new(db), bridges, None);
     let build_ms = t_build.elapsed().as_millis();
     let bridge_links = service.bridge_link_count();
     // Sample start/goal from the largest walk component so queries are

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -29,6 +29,7 @@ import type {
   PlayerInventoryResult,
   TransitionsResult,
   WaitForOptions,
+  AiPathEntry,
 } from "./types.js";
 
 /** Error thrown when the game reports a command failed (success: false). */
@@ -291,6 +292,15 @@ export class PathfindingApi {
    */
   async stats(): Promise<PathfindingStats | null> {
     return this.client.get<PathfindingStats | null>("/v1/pathfinding/stats");
+  }
+
+  /**
+   * The latest route each AI computed: goal, waypoints, and whether the
+   * query found a Full route, a Partial (closest-reachable) route, or
+   * Failed. Empty until an AI has pathed.
+   */
+  async aiPaths(): Promise<AiPathEntry[]> {
+    return this.client.get<AiPathEntry[]>("/v1/ai/paths");
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -42,6 +42,18 @@ export interface CommandResult {
 }
 
 /** Monotonic pathfinding query counters (diff across steps for rates). */
+/** One AI's most recent path query (GET /v1/ai/paths). */
+export interface AiPathEntry {
+  /** EntityId::inner() as i32 - same id space as the entity endpoints. */
+  entity_id: number;
+  /** Where the AI was trying to go. */
+  goal: [number, number, number];
+  /** "Full", "Partial" (closest reachable), or "Failed". */
+  outcome: string;
+  /** Route waypoints (empty for Failed). */
+  waypoints: [number, number, number][];
+}
+
 export interface PathfindingStats {
   queries: number;
   stressed_retries: number;

--- a/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
+++ b/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function dist3(a: [number, number, number], b: [number, number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function distXZ(a: [number, number, number], b: [number, number, number]): number {
+  const dx = a[0] - b[0];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+test(
+  "no AI freezes mid-route after alertness churn (regression: #481)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8105),
+      experimental: ["nav_bridges"],
+    });
+
+    await game.step({ frames: 10 });
+    await game.player.teleport({ x: -14.0, y: 0.5, z: -30.0 });
+    await game.step({ frames: 10 });
+
+    const player = await game.player.position();
+    const playerPos: [number, number, number] = [player.x, player.y, player.z];
+    const hybrids = (await game.entities.list({ filter: "OG-", limit: 20 })).entities.filter(
+      (e) => e.name.startsWith("OG-"),
+    );
+    assert.ok(hybrids.length >= 2, `expected hybrids in medsci1, got ${hybrids.length}`);
+
+    // The #481 repro: alert everyone, let alertness decay (behavior churn:
+    // chase -> search/wander), then pin a chase and run long enough that
+    // routes cross stairs and doorway seams.
+    await game.input.trigger("DebugAlertAll");
+    await game.step({ frames: 630 });
+    await game.input.trigger("DebugForceChase");
+    await game.step({ frames: 1800 });
+
+    // Freeze signature: an AI that is still far (XZ) from the END of its own
+    // current route yet doesn't move, ALONE. Excluded (not this bug):
+    // - parked AT its route end (legitimately waiting at the closest
+    //   reachable point) or with no route at all (sealed rooms - Failed);
+    // - within engagement range of the player (arrived; jostling against
+    //   the player's capsule is combat, not navigation);
+    // - another creature within 2 units (a mutual crowd jam - real but a
+    //   separate, softer issue: crowd separation steering).
+    const before = new Map<number, [number, number, number]>();
+    for (const h of hybrids) {
+      const d = await game.entities.detail(h.id);
+      before.set(h.id, d.position);
+    }
+    await game.step({ frames: 300 }); // 5s observation window
+
+    const routes = new Map(
+      (await game.pathfinding.aiPaths()).map((e) => [e.entity_id, e] as const),
+    );
+    const positions = new Map<number, [number, number, number]>();
+    for (const h of hybrids) {
+      positions.set(h.id, (await game.entities.detail(h.id)).position);
+    }
+    const frozen: string[] = [];
+    for (const h of hybrids) {
+      const p = positions.get(h.id)!;
+      const moved = dist3(p, before.get(h.id)!);
+      const route = routes.get(h.id);
+      if (!route || route.outcome === "Failed" || route.waypoints.length === 0) continue;
+      if (dist3(p, playerPos) < 6.0) continue; // arrived / engaging
+      const jammed = hybrids.some(
+        (o) => o.id !== h.id && dist3(positions.get(o.id)!, p) < 2.0,
+      );
+      if (jammed) continue; // mutual crowd jam - tracked separately
+      const routeEnd = route.waypoints[route.waypoints.length - 1];
+      const remaining = distXZ(p, routeEnd);
+      if (remaining > 3.0 && moved < 0.3) {
+        frozen.push(
+          `${h.id}: ${remaining.toFixed(1)} XZ from its route end, moved ${moved.toFixed(2)} in 5s (${route.outcome} route, ${route.waypoints.length} wps)`,
+        );
+      }
+    }
+    assert.deepEqual(
+      frozen,
+      [],
+      `AIs frozen mid-route after alertness churn:\n  ${frozen.join("\n  ")}`,
+    );
+  },
+);


### PR DESCRIPTION
## Problem

Monsters with valid routes froze permanently mid-route (running in place) under sustained pursuit — capping the convergence numbers in #483's demo. Issue #481.

## Diagnosis

Added live steering introspection (`GET /v1/ai/paths` now reports the waypoint actually being followed, path length, target, stall seconds — plus an SDK wrapper), then interrogated frozen specimens frame-by-frame. Four stacked mechanisms, each individually verified:

1. **Stairs read as walls**: knee-height avoidance whiskers hit descending steps' risers (vertical faces pass the normal filter). → cast from body center.
2. **Avoidance vs path heading war**: the main whisker's fixed +180° mitigation reversed the AI into a perpetual flip-flop against path steering; avoidance also *preempted* the path (first in chain). → deflect along the hit normal, and reorder every chain so path steering leads (the route already avoids static geometry); avoidance guards only the no-route fallback.
3. **Corner wedging**: taut-path corner insets (1.5 dark ft) were under the widest creature capsule radius — routes grazed door frames and the body wedged pushing full-speed into the corner. → EDGE_CLEARANCE 3 ft; waypoint arrival height tolerance 4→7 ft (waypoint heights are cell-floor heights, body centers ride ~4.2 ft above).
4. **Stall loops**: the stall escape re-pathed into the identical wedge. → on stall, back out toward the previous waypoint (jittered ~1s) before re-pathing; also staggers/resolves most mutual crowd jams.

Bonus: island bridges are now **vetted against static geometry** (torso-height ray between cell centers), closing the bridges-through-railings item from #485.

## Verification

- New e2e `alertness-churn.e2e.test.ts` encodes the freeze signature (far from its *own* route end, alone, not moving): **fails on the pre-fix build (3 frozen), passes with the fixes**. Residual mutual crowd jams in sealed dead-end pockets are excluded and tracked as #487.
- Full SDK e2e suite: 102/103 (the one failure, corpse-drift tolerance in monster-death, reproduces on clean `main` — pre-existing flake from the ragdoll momentum work).
- Unit: 157 green, incl. new regression tests for the arrival-height gate and edge-clearance collapse.
- Convergence numbers comparison vs #483 follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)