### PR TITLE
Let players toggle standard doors

### DIFF
--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -6,7 +6,10 @@ use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{Effect, Message, MessagePayload, Script, script_util::play_environmental_sound};
+use super::{
+    Effect, Message, MessagePayload, Script,
+    script_util::{is_entity_locked, play_environmental_sound},
+};
 
 pub struct StdDoor {
     audio_handle: AudioHandle,
@@ -23,6 +26,49 @@ impl StdDoor {
             desired_position: Vector3::zero(),
             is_moving: false,
         }
+    }
+
+    fn target_is_open(&self, trans_door: &PropTranslatingDoor) -> bool {
+        (self.desired_position - trans_door.base_open_location).magnitude2()
+            < (self.desired_position - trans_door.base_closed_location).magnitude2()
+    }
+
+    fn open(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        trans_door: &PropTranslatingDoor,
+    ) -> Effect {
+        if self.target_is_open(trans_door) {
+            return Effect::NoEffect;
+        }
+
+        self.desired_position = trans_door.base_open_location;
+        self.is_moving = true;
+        play_environmental_sound(
+            world,
+            entity_id,
+            "statechange",
+            vec![("openstate", "opening"), ("oldopenstate", "closed")],
+            self.audio_handle.clone(),
+        )
+    }
+
+    fn close(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        trans_door: &PropTranslatingDoor,
+    ) -> Effect {
+        self.desired_position = trans_door.base_closed_location;
+        self.is_moving = true;
+        play_environmental_sound(
+            world,
+            entity_id,
+            "statechange",
+            vec![("openstate", "closing"), ("oldopenstate", "open")],
+            self.audio_handle.clone(),
+        )
     }
 }
 impl Script for StdDoor {
@@ -132,41 +178,156 @@ impl Script for StdDoor {
 
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
             match msg {
+                MessagePayload::Frob => {
+                    // The original StdDoor toggles on player FrobWorldEnd. A
+                    // locked, closed door rejects that player-driven open,
+                    // while scripted TurnOn below deliberately bypasses locks.
+                    if self.target_is_open(trans_door) {
+                        self.close(entity_id, world, trans_door)
+                    } else if is_entity_locked(world, entity_id) {
+                        // SS2's existing locked-control feedback; the player
+                        // still gets a response without changing door state.
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "hackfail".to_owned(),
+                        }
+                    } else {
+                        self.open(entity_id, world, trans_door)
+                    }
+                }
                 MessagePayload::TurnOn { from: _ } => {
                     // Idempotent: if we're already headed open, ignore repeat
                     // opens (e.g. several AIs converging on the same door) so
                     // the opening sound isn't replayed each frame.
-                    if (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001
-                    {
-                        Effect::NoEffect
-                    } else {
-                        self.desired_position = trans_door.base_open_location;
-                        self.is_moving = true;
-                        play_environmental_sound(
-                            world,
-                            entity_id,
-                            "statechange",
-                            vec![("openstate", "opening"), ("oldopenstate", "closed")],
-                            self.audio_handle.clone(),
-                        )
-                    }
+                    self.open(entity_id, world, trans_door)
                 }
                 MessagePayload::TurnOff { from: _ } => {
                     //self.current_position = trans_door.base_closed_location;
-                    self.desired_position = trans_door.base_closed_location;
-                    self.is_moving = true;
-                    play_environmental_sound(
-                        world,
-                        entity_id,
-                        "statechange",
-                        vec![("openstate", "closing"), ("oldopenstate", "open")],
-                        self.audio_handle.clone(),
-                    )
+                    self.close(entity_id, world, trans_door)
                 }
                 _ => Effect::NoEffect,
             }
         } else {
             Effect::NoEffect
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Matrix4, vec3};
+    use dark::properties::{KeyCard, PropClassTag, PropKeyDst, PropLocked};
+
+    use crate::{quest_info::QuestInfo, runtime_props::RuntimePropTransform};
+
+    use super::*;
+
+    fn key_card() -> KeyCard {
+        KeyCard {
+            is_master: false,
+            region_id: 2,
+            lock_id: 7,
+        }
+    }
+
+    fn test_world(locked: bool, has_key: bool) -> (World, EntityId) {
+        let mut world = World::new();
+        let closed = vec3(1.0, 2.0, 3.0);
+        let open = vec3(1.0, 4.0, 3.0);
+        let entity_id = world.add_entity((
+            PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 2.0,
+                speed: 4.0,
+                axis: 1,
+                state: 0,
+                base_closed_location: closed,
+                base_open_location: open,
+                base_location: closed,
+            },
+            PropLocked(locked),
+            PropKeyDst(key_card()),
+            PropClassTag::from_string("doortype scidoor"),
+            RuntimePropTransform(Matrix4::from_translation(closed)),
+        ));
+        let mut quest = QuestInfo::new();
+        if has_key {
+            quest.add_key_card(key_card());
+        }
+        world.add_unique(quest);
+        (world, entity_id)
+    }
+
+    fn initialized_door(entity_id: EntityId, world: &World) -> StdDoor {
+        let mut door = StdDoor::new();
+        door.initialize(entity_id, world);
+        door
+    }
+
+    #[test]
+    fn frob_opens_an_unlocked_closed_door() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn frob_toggles_an_opening_door_back_toward_closed() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 2.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn frob_does_not_open_a_locked_closed_door_without_its_key() {
+        let (world, entity_id) = test_world(true, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 2.0, 3.0));
+        assert!(!door.is_moving);
+    }
+
+    #[test]
+    fn frob_opens_a_locked_door_when_the_player_has_its_key() {
+        let (world, entity_id) = test_world(true, true);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn scripted_turn_on_bypasses_a_player_lock() {
+        let (world, entity_id) = test_world(true, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
     }
 }

--- a/tools/shock2-sdk/test/door-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/door-frob.e2e.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// End-to-end coverage for the StdDoor script/effect/collider path after a Frob
+// is dispatched. Earth mission objects 80/81 have no incoming SwitchLinks, so
+// the StdDoor script itself must toggle. The campaign play-through separately
+// covers normal player targeting and use-button dispatch to this same payload.
+//
+// Negative-first: before #495, MessagePayload::Frob was ignored by StdDoor, so
+// both the entity transform and its kinematic body remained at z=63.38 and the
+// recruitment-center passage stayed physically blocked.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const TARGET: Vec3 = [5.003685, 24.0, 63.38392];
+
+function distanceSquared(entity: EntitySummary, target: Vec3): number {
+  return entity.position.reduce(
+    (sum, component, axis) => sum + (component - target[axis]) ** 2,
+    0,
+  );
+}
+
+test(
+  "earth.mis: StdDoor Frob opens and closes its collider",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8146),
+    });
+    await game.step({ frames: 5 });
+
+    const candidates = (
+      await game.entities.list({ filter: "Interrogation Room", limit: 20 })
+    ).entities;
+    assert.ok(candidates.length >= 2, "expected Earth's Interrogation Room door pair");
+    const door = candidates.reduce((nearest, candidate) =>
+      distanceSquared(candidate, TARGET) < distanceSquared(nearest, TARGET)
+        ? candidate
+        : nearest,
+    );
+    assert.ok(
+      distanceSquared(door, TARGET) < 0.01,
+      `expected recruitment door near ${JSON.stringify(TARGET)}, got ${JSON.stringify(door.position)}`,
+    );
+
+    const before = await game.entities.detail(door.id);
+    const beforeBodies = (await game.physics.bodies({ entityId: door.id })).bodies;
+    assert.equal(beforeBodies.length, 1, "the door should own one kinematic body");
+
+    await game.entities.sendMessage(door.id, { type: "Frob" });
+    await game.step({ frames: 60 });
+
+    const open = await game.entities.detail(door.id);
+    const openBody = (await game.physics.bodies({ entityId: door.id })).bodies[0];
+    assert.ok(
+      open.position[2] > before.position[2] + 1.2,
+      `frob should slide the door open, before=${before.position[2]}, after=${open.position[2]}`,
+    );
+    assert.ok(
+      Math.abs(openBody.position[2] - open.position[2]) < 0.01,
+      "the kinematic collider must follow the opened door transform",
+    );
+
+    await game.entities.sendMessage(door.id, { type: "Frob" });
+    await game.step({ frames: 60 });
+
+    const closed = await game.entities.detail(door.id);
+    const closedBody = (await game.physics.bodies({ entityId: door.id })).bodies[0];
+    assert.ok(
+      Math.abs(closed.position[2] - before.position[2]) < 0.01,
+      `second frob should return the door to closed, got z=${closed.position[2]}`,
+    );
+    assert.ok(
+      Math.abs(closedBody.position[2] - closed.position[2]) < 0.01,
+      "the kinematic collider must follow the closed door transform",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- handle player `Frob` in the general `StdDoor` script, toggling the authored translating-door endpoints
- reject locked player opens through the existing `PropLocked` / `PropKeyDst` / `QuestInfo` resolver while allowing the held key to open the door
- preserve the original scripted-control invariant: `TurnOn` and `TurnOff` bypass player locks
- add negative-first unit coverage plus an Earth mission runtime scenario proving the door transform and kinematic collider open and close together

## Faithfulness

The original standard door script toggles on player `FrobWorldEnd`; only a player-driven open of a locked, closed door is rejected. This implementation follows that behavior through the existing in-world message, script, authored door endpoints, lock/key state, and `SetPosition` effect. It adds no Earth-specific branch, debug action, shortcut, or fake trigger. Earth mission objects 80 and 81 work because they are ordinary unlocked `StdDoor` entities with no controller links.

## Negative-first

Before the implementation, the new tests showed three failures: an unlocked closed door ignored Frob, a keyed locked door ignored Frob, and a second Frob could not reverse an opening target. The locked-without-key control already stayed closed. All five tests now pass, including scripted `TurnOn` bypassing a player lock.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` — 187 passed before the final review-only test addition
- `cargo test -p shock2vr std_door` — 5 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cd tools/shock2-sdk && npm test` — 108 total, 14 passed / 94 opt-in skipped
- `SHOCK2_E2E=1 node --test dist/test/door-frob.e2e.test.js` — passed against `earth.mis`
- full `npm run test:e2e` was attempted; the unrelated `alertness-churn.e2e.test.ts` failed its existing issue #481 assertion before this focused change, while the preceding forced-alertness scenario and following ammo/spang scenarios passed

## Visual verification

![Earth StdDoor player-Frob toggle](https://gist.githubusercontent.com/tommy-xr/23fdeec239552102b0c29a2a4d0381f7/raw/earth-std-door-toggle.gif)

<sub>Earth recruitment gateway object 81 opens and closes through the general `StdDoor` Frob path. Captured headlessly via deterministic fixed-step runtime requests.</sub>

### Before → after

![Base ignores Frob; PR #496 opens the door](https://gist.githubusercontent.com/tommy-xr/23fdeec239552102b0c29a2a4d0381f7/raw/earth-std-door-before-after.png)

Fixes #495
