### PR TITLE
Fix Station training-year initialization

### DIFF
--- a/shock2vr/src/career.rs
+++ b/shock2vr/src/career.rs
@@ -65,6 +65,19 @@ impl Career {
         }
     }
 
+    /// Stable symbolic name of Station's authored initialization root for this
+    /// service and training year. Destination missions resolve this name only
+    /// after their scripts exist, so runtime entity ids never cross a level
+    /// transition.
+    pub fn station_start_trigger(&self, year: u32) -> String {
+        let service = match self {
+            Career::Marine => 0,
+            Career::Navy => 1,
+            Career::Osa => 2,
+        };
+        format!("START_{}{}", service, year)
+    }
+
     /// The career the player selected, read from the persisted quest bits, or
     /// `None` if no branch was chosen (the player template defaults stand).
     pub fn from_quest_info(quest_info: &QuestInfo) -> Option<Career> {
@@ -125,6 +138,15 @@ mod tests {
         assert_eq!(Career::from_service(1), Career::Navy);
         assert_eq!(Career::from_service(2), Career::Osa);
         assert_eq!(Career::from_service(99), Career::Marine);
+    }
+
+    #[test]
+    fn station_start_roots_match_authored_service_and_year_names() {
+        assert_eq!(Career::Marine.station_start_trigger(1), "START_01");
+        assert_eq!(Career::Marine.station_start_trigger(3), "START_03");
+        assert_eq!(Career::Navy.station_start_trigger(2), "START_12");
+        assert_eq!(Career::Osa.station_start_trigger(1), "START_21");
+        assert_eq!(Career::Osa.station_start_trigger(3), "START_23");
     }
 
     #[test]

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -106,6 +106,12 @@ impl Script for ChooseMissionScript {
                     // For years 1, 2: loop back to station.mis for the next tour.
                     // The transition uses the level's default spawn (loc: None);
                     // the marker's PropDestLoc is only used on the final deploy.
+                    let entities_to_trigger = {
+                        let quest_info = world.borrow::<UniqueView<QuestInfo>>().unwrap();
+                        Career::from_quest_info(&quest_info)
+                            .map(|career| vec![career.station_start_trigger(new_year)])
+                            .unwrap_or_default()
+                    };
 
                     Effect::Multiple(vec![
                         set_year_effect,
@@ -113,7 +119,7 @@ impl Script for ChooseMissionScript {
                         Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
                             level_file: "station.mis".to_string(),
                             loc: None,
-                            entities_to_trigger: vec![],
+                            entities_to_trigger,
                         }),
                     ])
                 } else {

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -62,7 +62,7 @@ impl Script for ChooseServiceScript {
                     effects.push(Effect::GlobalEffect(GlobalEffect::TransitionLevel {
                         level_file: format!("{}.mis", dest_level.0),
                         loc: dest_loc,
-                        entities_to_trigger: vec![],
+                        entities_to_trigger: vec![career.station_start_trigger(1)],
                     }));
                 }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -1,5 +1,5 @@
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::{Link, PropInventoryDimensions, PropObjIcon};
+use dark::properties::{FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon};
 
 use shipyard::{EntityId, Get, View, World};
 
@@ -241,9 +241,33 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // feeds an item into a container (drop_entity_into_container).
             // Guarded by the same grabbability check as the debug give
             // lever: reparenting a non-grabbable entity would corrupt it.
+            // Use-only contained objects (notably corpse audio logs) still
+            // need their normal Frob behavior when clicked; they are consumed
+            // or recorded in place rather than moved into the backpack.
             ContainerGuiMsg::Take(ent) => {
                 if !crate::virtual_hand::can_grab_item(world, *ent) {
-                    return (state.clone(), Effect::NoEffect);
+                    let is_use_only = world
+                        .borrow::<View<PropFrobInfo>>()
+                        .map(|frob| {
+                            frob.get(*ent).is_ok_and(|frob| {
+                                frob.world_action.contains(FrobFlag::SCRIPT)
+                                    || frob.inventory_action.contains(FrobFlag::SCRIPT)
+                            })
+                        })
+                        .unwrap_or(false);
+                    return if is_use_only {
+                        (
+                            state.clone(),
+                            Effect::Send {
+                                msg: Message {
+                                    payload: MessagePayload::Frob,
+                                    to: *ent,
+                                },
+                            },
+                        )
+                    } else {
+                        (state.clone(), Effect::NoEffect)
+                    };
                 }
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
@@ -356,6 +380,60 @@ mod tests {
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
         }
+    }
+
+    /// Use-only objects can be contained too. Audio logs are the critical
+    /// retail case: they deliberately cannot be grabbed, but clicking their
+    /// corpse-loot icon must still run `LogDiscScript`'s normal Frob path.
+    #[test]
+    fn loot_container_click_frobs_a_non_grabbable_item() {
+        let mut world = World::new();
+        let item = world.add_entity((
+            PropObjIcon("disc".to_owned()),
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        let container = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(item)),
+                link: Link::Contains(0),
+            }],
+        });
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let gui = ContainerGui::loot_container();
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "non-grabbable contained objects should be used in place"
+        );
     }
 
     /// A contained entity that is not grabbable (no MOVE/USE_AMMO frob

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -6,7 +6,10 @@ use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
 
-use super::{Effect, Message, MessagePayload, Script, script_util::play_environmental_sound};
+use super::{
+    Effect, Message, MessagePayload, Script,
+    script_util::{is_entity_locked, play_environmental_sound},
+};
 
 pub struct StdDoor {
     audio_handle: AudioHandle,
@@ -23,6 +26,49 @@ impl StdDoor {
             desired_position: Vector3::zero(),
             is_moving: false,
         }
+    }
+
+    fn target_is_open(&self, trans_door: &PropTranslatingDoor) -> bool {
+        (self.desired_position - trans_door.base_open_location).magnitude2()
+            < (self.desired_position - trans_door.base_closed_location).magnitude2()
+    }
+
+    fn open(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        trans_door: &PropTranslatingDoor,
+    ) -> Effect {
+        if self.target_is_open(trans_door) {
+            return Effect::NoEffect;
+        }
+
+        self.desired_position = trans_door.base_open_location;
+        self.is_moving = true;
+        play_environmental_sound(
+            world,
+            entity_id,
+            "statechange",
+            vec![("openstate", "opening"), ("oldopenstate", "closed")],
+            self.audio_handle.clone(),
+        )
+    }
+
+    fn close(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        trans_door: &PropTranslatingDoor,
+    ) -> Effect {
+        self.desired_position = trans_door.base_closed_location;
+        self.is_moving = true;
+        play_environmental_sound(
+            world,
+            entity_id,
+            "statechange",
+            vec![("openstate", "closing"), ("oldopenstate", "open")],
+            self.audio_handle.clone(),
+        )
     }
 }
 impl Script for StdDoor {
@@ -132,41 +178,156 @@ impl Script for StdDoor {
 
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
             match msg {
+                MessagePayload::Frob => {
+                    // The original StdDoor toggles on player FrobWorldEnd. A
+                    // locked, closed door rejects that player-driven open,
+                    // while scripted TurnOn below deliberately bypasses locks.
+                    if self.target_is_open(trans_door) {
+                        self.close(entity_id, world, trans_door)
+                    } else if is_entity_locked(world, entity_id) {
+                        // SS2's existing locked-control feedback; the player
+                        // still gets a response without changing door state.
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "hackfail".to_owned(),
+                        }
+                    } else {
+                        self.open(entity_id, world, trans_door)
+                    }
+                }
                 MessagePayload::TurnOn { from: _ } => {
                     // Idempotent: if we're already headed open, ignore repeat
                     // opens (e.g. several AIs converging on the same door) so
                     // the opening sound isn't replayed each frame.
-                    if (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001
-                    {
-                        Effect::NoEffect
-                    } else {
-                        self.desired_position = trans_door.base_open_location;
-                        self.is_moving = true;
-                        play_environmental_sound(
-                            world,
-                            entity_id,
-                            "statechange",
-                            vec![("openstate", "opening"), ("oldopenstate", "closed")],
-                            self.audio_handle.clone(),
-                        )
-                    }
+                    self.open(entity_id, world, trans_door)
                 }
                 MessagePayload::TurnOff { from: _ } => {
                     //self.current_position = trans_door.base_closed_location;
-                    self.desired_position = trans_door.base_closed_location;
-                    self.is_moving = true;
-                    play_environmental_sound(
-                        world,
-                        entity_id,
-                        "statechange",
-                        vec![("openstate", "closing"), ("oldopenstate", "open")],
-                        self.audio_handle.clone(),
-                    )
+                    self.close(entity_id, world, trans_door)
                 }
                 _ => Effect::NoEffect,
             }
         } else {
             Effect::NoEffect
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Matrix4, vec3};
+    use dark::properties::{KeyCard, PropClassTag, PropKeyDst, PropLocked};
+
+    use crate::{quest_info::QuestInfo, runtime_props::RuntimePropTransform};
+
+    use super::*;
+
+    fn key_card() -> KeyCard {
+        KeyCard {
+            is_master: false,
+            region_id: 2,
+            lock_id: 7,
+        }
+    }
+
+    fn test_world(locked: bool, has_key: bool) -> (World, EntityId) {
+        let mut world = World::new();
+        let closed = vec3(1.0, 2.0, 3.0);
+        let open = vec3(1.0, 4.0, 3.0);
+        let entity_id = world.add_entity((
+            PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 2.0,
+                speed: 4.0,
+                axis: 1,
+                state: 0,
+                base_closed_location: closed,
+                base_open_location: open,
+                base_location: closed,
+            },
+            PropLocked(locked),
+            PropKeyDst(key_card()),
+            PropClassTag::from_string("doortype scidoor"),
+            RuntimePropTransform(Matrix4::from_translation(closed)),
+        ));
+        let mut quest = QuestInfo::new();
+        if has_key {
+            quest.add_key_card(key_card());
+        }
+        world.add_unique(quest);
+        (world, entity_id)
+    }
+
+    fn initialized_door(entity_id: EntityId, world: &World) -> StdDoor {
+        let mut door = StdDoor::new();
+        door.initialize(entity_id, world);
+        door
+    }
+
+    #[test]
+    fn frob_opens_an_unlocked_closed_door() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn frob_toggles_an_opening_door_back_toward_closed() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 2.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn frob_does_not_open_a_locked_closed_door_without_its_key() {
+        let (world, entity_id) = test_world(true, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 2.0, 3.0));
+        assert!(!door.is_moving);
+    }
+
+    #[test]
+    fn frob_opens_a_locked_door_when_the_player_has_its_key() {
+        let (world, entity_id) = test_world(true, true);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn scripted_turn_on_bypasses_a_player_lock() {
+        let (world, entity_id) = test_world(true, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
     }
 }

--- a/tools/shock2-sdk/test/door-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/door-frob.e2e.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// End-to-end coverage for the StdDoor script/effect/collider path after a Frob
+// is dispatched. Earth mission objects 80/81 have no incoming SwitchLinks, so
+// the StdDoor script itself must toggle. The campaign play-through separately
+// covers normal player targeting and use-button dispatch to this same payload.
+//
+// Negative-first: before #495, MessagePayload::Frob was ignored by StdDoor, so
+// both the entity transform and its kinematic body remained at z=63.38 and the
+// recruitment-center passage stayed physically blocked.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const TARGET: Vec3 = [5.003685, 24.0, 63.38392];
+
+function distanceSquared(entity: EntitySummary, target: Vec3): number {
+  return entity.position.reduce(
+    (sum, component, axis) => sum + (component - target[axis]) ** 2,
+    0,
+  );
+}
+
+test(
+  "earth.mis: StdDoor Frob opens and closes its collider",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8146),
+    });
+    await game.step({ frames: 5 });
+
+    const candidates = (
+      await game.entities.list({ filter: "Interrogation Room", limit: 20 })
+    ).entities;
+    assert.ok(candidates.length >= 2, "expected Earth's Interrogation Room door pair");
+    const door = candidates.reduce((nearest, candidate) =>
+      distanceSquared(candidate, TARGET) < distanceSquared(nearest, TARGET)
+        ? candidate
+        : nearest,
+    );
+    assert.ok(
+      distanceSquared(door, TARGET) < 0.01,
+      `expected recruitment door near ${JSON.stringify(TARGET)}, got ${JSON.stringify(door.position)}`,
+    );
+
+    const before = await game.entities.detail(door.id);
+    const beforeBodies = (await game.physics.bodies({ entityId: door.id })).bodies;
+    assert.equal(beforeBodies.length, 1, "the door should own one kinematic body");
+
+    await game.entities.sendMessage(door.id, { type: "Frob" });
+    await game.step({ frames: 60 });
+
+    const open = await game.entities.detail(door.id);
+    const openBody = (await game.physics.bodies({ entityId: door.id })).bodies[0];
+    assert.ok(
+      open.position[2] > before.position[2] + 1.2,
+      `frob should slide the door open, before=${before.position[2]}, after=${open.position[2]}`,
+    );
+    assert.ok(
+      Math.abs(openBody.position[2] - open.position[2]) < 0.01,
+      "the kinematic collider must follow the opened door transform",
+    );
+
+    await game.entities.sendMessage(door.id, { type: "Frob" });
+    await game.step({ frames: 60 });
+
+    const closed = await game.entities.detail(door.id);
+    const closedBody = (await game.physics.bodies({ entityId: door.id })).bodies[0];
+    assert.ok(
+      Math.abs(closed.position[2] - before.position[2]) < 0.01,
+      `second frob should return the door to closed, got z=${closed.position[2]}`,
+    );
+    assert.ok(
+      Math.abs(closedBody.position[2] - closed.position[2]) < 0.01,
+      "the kinematic collider must follow the closed door transform",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -66,6 +66,39 @@ const TOUR_TRIP: Vec3 = [-22.6, -5.6, 8.0];
 const CAREER_SPAWN_DESIGNED: Vec3 = [81.78026, -3.6, 16.539234];
 const CAREER_SPAWN_TOLERANCE = 3.0;
 
+// START_01's YEAR-1 chain teleports the authored recruiter (mission object
+// 881, exposed as the stable template_id) from its below-map storage position
+// into this exhibit. Checking that exact object guards the destination setup;
+// merely reaching station.mis or its exit tripwire does not.
+const MARINE_YEAR_ONE_RECRUITER_TEMPLATE = 881;
+const MARINE_YEAR_ONE_RECRUITER_POSITION: Vec3 = [15.6, -3.2, 10.4];
+const STAGED_ENTITY_TOLERANCE = 1.0;
+
+async function assertStagedEntity(
+  game: GameServer,
+  filter: string,
+  templateId: number,
+  expected: Vec3,
+  label: string,
+): Promise<void> {
+  const entity = (await game.entities.list({ filter, limit: 20 })).entities.find(
+    (candidate) => candidate.template_id === templateId,
+  );
+  assert.ok(entity, `${label}: expected stable template ${templateId}`);
+  assert.ok(entity.position, `${label}: entity should expose a world position`);
+  const delta = Math.hypot(
+    entity.position[0] - expected[0],
+    entity.position[1] - expected[1],
+    entity.position[2] - expected[2],
+  );
+  assert.ok(
+    delta < STAGED_ENTITY_TOLERANCE,
+    `${label}: expected template ${templateId} near ${JSON.stringify(expected)}, got ${JSON.stringify(
+      entity.position,
+    )} (delta ${delta.toFixed(2)}u)`,
+  );
+}
+
 async function teleportTo(game: GameServer, [x, y, z]: Vec3): Promise<void> {
   await game.player.teleport({ x, y, z });
 }
@@ -139,6 +172,18 @@ test(
       )} (delta ${spawnDelta.toFixed(2)}u)`,
     );
 
+    // #497 (negative-first): loading Station must activate START_01 after the
+    // destination scripts initialize. Before the fix, ChooseService passed an
+    // empty entities_to_trigger list and this recruiter stayed below the map at
+    // y=-26 even though the test could still teleport to the exit tripwire.
+    await assertStagedEntity(
+      game,
+      "MaleRec",
+      MARINE_YEAR_ONE_RECRUITER_TEMPLATE,
+      MARINE_YEAR_ONE_RECRUITER_POSITION,
+      "#497 START_01 recruiter",
+    );
+
     // Step 2: tours 1 and 2 each set exactly the next training_year bit, loop
     // back to station.mis, and grant the tour-0 reward for that Marine year
     // (#453). hp/psi are unchanged by these grants (they touch STR/skills), so
@@ -158,6 +203,13 @@ test(
     assert.deepEqual(info.player.stats.granted_years, [1], "tour 1 records year 1 granted");
     assert.equal(info.player.max_hit_points, 45, "tour 1 leaves max HP unchanged (grant is STR)");
     assert.equal(info.player.max_psi_points, 20, "tour 1 leaves max psi unchanged");
+    await assertStagedEntity(
+      game,
+      "Marines 4",
+      360,
+      [0.012, -1.6, 8.0],
+      "#497 START_02 Marine choice",
+    );
 
     await teleportTo(game, TOUR_TRIP);
     await game.step({ frames: 20 });
@@ -174,6 +226,13 @@ test(
     assert.equal(info.player.stats.skills.energy_weapons, 1, "#453: tour 2 grants +1 Energy Weapons (Mission4)");
     assert.equal(info.player.stats.cyber_affinity, baseCyb + 1, "#453: tour 2 grants +1 Cyber Affinity (Mission4)");
     assert.deepEqual(info.player.stats.granted_years, [1, 2], "tour 2 records years 1+2 granted");
+    await assertStagedEntity(
+      game,
+      "Marines 7",
+      369,
+      [0.012, -1.6, 8.0],
+      "#497 START_03 Marine choice",
+    );
 
     // Save/load leg: persist mid-flow (after year 2) and reload in the same
     // runtime; the accumulated stats must survive the round-trip byte-for-byte.


### PR DESCRIPTION
## Summary

- activate Station's authored `START_<service><year>` root after each destination load
- preserve stable symbolic-name triggering instead of carrying runtime entity IDs across missions
- extend the honest Earth → Station → three tours e2e to verify the year-one recruiter and year-two/year-three Marine choices are actually staged

This PR is stacked on #496 because the play-through first needs the Earth recruitment gateway fix to reach Station normally.

Fixes #497

## Visual verification

![Station recruiter staged](https://gist.githubusercontent.com/tommy-xr/2f15f384c40be0c4725e436fc7f3bcfe/raw/station-recruiter.gif)

<sub>The authored year-one recruiter idles in the tour booth after the Earth → Station transition. Captured headlessly through deterministic fixed-timestep stepping.</sub>

### Before → after

![Empty booth before; year-one recruiter staged after](https://gist.githubusercontent.com/tommy-xr/2f15f384c40be0c4725e436fc7f3bcfe/raw/before-after.png)

## Validation

- `cargo test -p shock2vr` — 189 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test` — 108 tests, 14 passed / 94 opt-in skipped
- focused Station flow e2e — passed (Earth career tripwire, `START_01`, `START_02`, `START_03`, MedSci1 deploy)
- full `npm run test:e2e` — 107/108 passed; unrelated `monster-death` corpse-settling assertion reported 0.75u drift

## Review

- adversarial inline review: no correctness or simplicity findings
- external Codex CLI review unavailable locally because `@openai/codex-darwin-x64` is missing
