### PR TITLE
test(gameplay): verify room gravity (P$RoomGrav) lifts the player through the earth.mis gravshaft

### DIFF
--- a/tools/shock2-sdk/test/gravshaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/gravshaft.e2e.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for room gravity (P$RoomGrav) in earth.mis: the pair of
+// gravshafts under the "TO STREET LEVEL" sign is the only route up from the
+// subway spawn, so this traversal gates the whole game (#504).
+//
+// Data (all through the real flow: P$RoomGrav on the room object -> ROOM_DB
+// sensor -> internal_room_trigger -> SwitchLink -> CoreRoom -> SetGravity on
+// the intersecting player):
+//   - The LEFT shaft (x=9.6)  is room "Up"   (obj 270, negative gravity: lifts)
+//   - The RIGHT shaft (x=12.0) is room "Down" (obj 227, +20% gravity: descent)
+//   - The shaft top             is room "Stop" (obj 228, 0% gravity)
+//
+// This pins the full chain end-to-end: standing at the bottom of the UP shaft
+// must carry the player from the subway floor (y~2) to street level (y~21),
+// while the DOWN shaft must NOT lift (that is the faithful behavior the #504
+// playtest ran into when it tested x=12 and concluded the shafts were dead).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "earth.mis: the up gravshaft lifts the player to street level (#504)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8306),
+    });
+    await game.step({ frames: 30 }); // settle
+
+    // Enter the UP shaft at its base (teleporting into a room volume fires
+    // the same sensor intersect as walking in).
+    await game.player.teleport({ x: 9.6, y: 2.0, z: 14.4 });
+
+    // The ride to street level takes ~6s at the shaft's lift rate; sample the
+    // climb so a failure shows where it stalled.
+    const samples: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      await game.step({ frames: 60 });
+      samples.push((await game.player.position()).y);
+    }
+    const peak = Math.max(...samples);
+    const trace = samples.map((y) => y.toFixed(1)).join(" -> ");
+
+    assert.ok(
+      peak > 18,
+      `the up gravshaft should lift the player from the subway (y~2) to ` +
+        `street level (y>18); got y: ${trace} (no rise means the ` +
+        `P$RoomGrav -> CoreRoom -> SetGravity -> character-controller chain ` +
+        `is broken - see #504)`,
+    );
+
+    // Faithful counterpart: the RIGHT shaft is the DOWN shaft (+20% gravity).
+    // Standing in it must NOT lift the player - a lift here would mean room
+    // gravity data is being misapplied across rooms.
+    await game.player.teleport({ x: 12.0, y: 2.0, z: 14.8 });
+    await game.step({ frames: 360 });
+    const down = await game.player.position();
+    assert.ok(
+      down.y < 5,
+      `the down gravshaft must not lift the player (room "Down" has +20% ` +
+        `gravity), got y=${down.y.toFixed(2)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Issue #504 reported the earth.mis gravshafts as a start-of-game blocker: standing in a shaft at (12.0, 2.0, 14.8) never lifts the player, with a diagnosis that `P$RoomGrav` is lost between the raw chunk and the merged entity DB.

**Neither the diagnosis nor the blocker reproduces on current `main`.** The room-gravity chain already works end-to-end; the playtest was standing in the *descent* shaft. This PR adds the e2e regression test that was missing for this gating traversal, so any future break in the chain is caught.

## What the data actually says

`earth.mis`'s `P$RoomGrav` chunk targets the three concrete room objects directly (decoded from the raw chunk, and confirmed via `cargo dq entities earth.mis 270`):

| Room obj | SymName | Raw value | Runtime gravity |
|---|---|---|---|
| 270 | `Up` (left shaft, x=9.6) | -10 | -0.3 (lifts) |
| 227 | `Down` (right shaft, x=12.0) | +20 | +0.2 (slow descent) |
| 228 | `Stop` (shaft top) | 0 | 0.0 (hover at exit) |

The issue's repro point (12.0, 2.0, 14.8) is the **Down** shaft - staying at y≈2 there is the faithful behavior. The ascent shaft is the **left** one (x=9.6).

## Runtime verification (debug runtime, fixed 60 Hz steps)

Entering the up shaft at (9.6, 2.0, 14.4) — sensor fires `SensorBeginIntersect` → `CoreRoom` applies `SetGravity(-0.3)` to the player's kinematic body → the character controller's gravity pass (which multiplies in `gravity_scale`) lifts the player:

```
y: 3.6 -> 5.4 -> 7.2 -> 9.0 -> 10.8 -> 12.9 -> 14.4 -> 15.1 -> 18.7 -> 21.7 (street level, "Stop" room, hovers)
```

From the top the player walks out and up to the recruitment level (y≈23.4), where the `station.mis` transition markers sit — so earth.mis **can** be started honestly. Walking in from the subway floor (no teleport) behaves identically. Verified across 4 fresh runtime processes (sensor bookkeeping uses `HashSet`s, so cross-process event-order nondeterminism was a concern — no flake observed).

## The test (negative-validated)

`tools/shock2-sdk/test/gravshaft.e2e.test.ts`:
- rides the up shaft and asserts the player rises above y=18 (with a per-second y trace on failure), and
- asserts the down shaft does **not** lift (faithful counterpart — this is the exact confusion that produced #504).

Negative validation: simulating the reported failure (dropping the room's gravity adjustment in `CoreRoom::initialize`) makes the test fail with `y: 2.0 -> 2.0 -> ... -> 2.0` — precisely the issue's symptom — confirming it exercises the real `P$RoomGrav` → room sensor → `CoreRoom` → `SetGravity` → character-controller chain.

## Why the original investigation saw no `PropRoomGravity`

Not reproducible: on clean `main` with the real game data, `cargo dq entities earth.mis 270` shows `PropRoomGravity(Set(-0.3))` and `dq --filter` finds all three rooms. The earlier dq runs most likely resolved the repo's placeholder `Data/` instead of the real assets.

## Validation

- `SHOCK2_E2E=1 node --test dist/test/gravshaft.e2e.test.js` — 3/3 fresh-process passes (plus 1 negative-validation fail-then-pass cycle)
- `SHOCK2_E2E=1 node --test dist/test/missions.e2e.test.js` — all 23 missions load
- `npm test` (SDK unit tests) — pass
- No Rust code changed (test-only PR), so CI's `RUSTFLAGS="-D warnings"` builds are unaffected

Fixes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)