### PR TITLE
feat(physics): detect and attribute non-finite rigid-body state before the broad-phase

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -408,6 +408,11 @@ pub struct PhysicsWorld {
     // Sensor Intersection List
     player_sensor_intersections: HashSet<EntityId>,
 
+    // Entities already reported by report_nonfinite_rigid_body_state, so a
+    // body fed bad state every frame (e.g. NaN animation joints driving a
+    // kinematic hitbox) is reported once instead of every frame.
+    reported_nonfinite_entities: HashSet<Option<EntityId>>,
+
     // Collision Events
     events: PhysicsEvents,
 }
@@ -1142,6 +1147,8 @@ impl PhysicsWorld {
 
             player_sensor_intersections: HashSet::new(),
 
+            reported_nonfinite_entities: HashSet::new(),
+
             events: PhysicsEvents::new(),
         }
     }
@@ -1192,11 +1199,88 @@ impl PhysicsWorld {
         debug_renderer.render()
     }
 
+    /// Report (once per entity, ERROR level) any rigid body whose state went
+    /// non-finite before it reaches the broad-phase. Detection only - no
+    /// state is mutated.
+    ///
+    /// A NaN velocity integrates into a NaN pose, which puts a NaN collider
+    /// AABB into the broad-phase BVH. parry's binned rebuild
+    /// (`bvh_binned_build.rs`) bins leaves by their AABB centers, and a NaN
+    /// center silently truncates the computed centroid range (NaN drops the
+    /// accumulated min/max), so valid leaves land outside it and the bin
+    /// index goes out of bounds - possibly many frames later, whenever the
+    /// incremental optimizer happens to rebuild the poisoned subtree
+    /// (issue #506; upstream: dimforge/rapier#961, still unfixed as of parry
+    /// 0.29). The creation-time size sanitizers above can't catch this: the
+    /// state goes bad at *runtime* (e.g. NaN animation joints driving a
+    /// kinematic hitbox, #508). This report names the exact entity and the
+    /// offending field(s) at the first bad frame, so the parry crash that
+    /// follows a few frames later is fully attributed; the fix belongs at
+    /// the producer's source, not here.
+    fn report_nonfinite_rigid_body_state(&mut self) {
+        fn finite_pose(pose: &Isometry<Real>) -> bool {
+            pose.translation.vector.iter().all(|c| c.is_finite())
+                && pose.rotation.coords.iter().all(|c| c.is_finite())
+        }
+
+        for (_handle, body) in self.rigid_body_set.iter() {
+            if !body.is_enabled() {
+                continue;
+            }
+
+            let linvel_bad = !body.linvel().iter().all(|c| c.is_finite());
+            let angvel_bad = !body.angvel().iter().all(|c| c.is_finite());
+            let pose_bad = !finite_pose(body.position());
+            let next_pose_bad = body.is_kinematic() && !finite_pose(body.next_position());
+
+            if !(linvel_bad || angvel_bad || pose_bad || next_pose_bad) {
+                continue;
+            }
+
+            let entity_id = body
+                .colliders()
+                .first()
+                .and_then(|c| self.collider_set.get(*c))
+                .and_then(|c| EntityId::from_inner(c.user_data as u64));
+            // A body fed bad state every frame (e.g. NaN animation joints
+            // driving a kinematic hitbox) is only reported once.
+            if !self.reported_nonfinite_entities.insert(entity_id) {
+                continue;
+            }
+
+            let mut bad_fields = Vec::new();
+            if linvel_bad {
+                bad_fields.push(format!("linvel {:?}", body.linvel()));
+            }
+            if angvel_bad {
+                bad_fields.push(format!("angvel {:?}", body.angvel()));
+            }
+            if pose_bad {
+                bad_fields.push(format!("pose {:?}", body.position()));
+            }
+            if next_pose_bad {
+                bad_fields.push(format!("next kinematic pose {:?}", body.next_position()));
+            }
+            tracing::error!(
+                "[physics] entity {:?} ({:?} body at {:?}): non-finite rigid-body state: {} - this poisons the broad-phase BVH and will panic parry's binned rebuild within a few frames (#506; reported once per entity)",
+                entity_id,
+                body.body_type(),
+                body.translation(),
+                bad_fields.join(", "),
+            );
+        }
+    }
+
     pub fn update(
         &mut self,
         desired_movement: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        // Attribute any non-finite body state to its entity before the step
+        // consumes it (see report_nonfinite_rigid_body_state) - by the time
+        // parry panics, the culprit is already named in the log.
+        self.report_nonfinite_rigid_body_state();
+
         /* Run the game loop, stepping the simulation once per frame. */
         profile!(scope: "physics", level: TRACE, "physics.step", {
             self.physics_pipeline.step(

--- a/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
+++ b/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the non-finite body-state DETECTION layer (#506).
+//
+// A rigid body whose velocity goes non-finite integrates into a non-finite
+// pose, which puts a NaN AABB into rapier's broad-phase BVH - and parry's
+// binned rebuild (bvh_binned_build.rs) then panics with "index out of
+// bounds" a few frames later, killing the main thread mid-walk (5/5
+// campaign crashes; upstream: dimforge/rapier#961, unfixed as of parry
+// 0.29).
+//
+// This layer does NOT prevent that crash - it attributes it:
+// PhysicsWorld::report_nonfinite_rigid_body_state logs an ERROR naming the
+// exact entity and offending field(s) at the first bad frame, once per
+// entity, without mutating any state. The producer-side fix (NaN animation
+// joints driving kinematic hitboxes) is #508.
+//
+// The poison is injected through the real debug surface: two opposite
+// overflow-to-infinity impulses on one dynamic body (inf + -inf = NaN
+// linvel). The test steps a single frame - enough for one update to run the
+// reporter, and safely before the (still-inevitable) parry panic, which
+// needs the poisoned pose to reach a broad-phase rebuild - then asserts the
+// report fired and the body state was left untouched (still non-finite).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station.mis: non-finite body state is attributed to its entity in the log (#506)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8340),
+    });
+    await game.step({ frames: 30 }); // settle
+
+    // Baseline: the organic #508 producer (NaN hitbox poses) may already
+    // have reported at load, but a *velocity* report can only come from our
+    // poison below.
+    const linvelReports = () =>
+      game
+        .logs()
+        .filter(
+          (l) => l.includes("non-finite rigid-body state") && l.includes("linvel"),
+        );
+    assert.equal(
+      linvelReports().length,
+      0,
+      "no non-finite velocity report should fire before the poison",
+    );
+
+    // Poison every dynamic body (ids are not stable across runs, so discover
+    // them each launch). Animated creatures have their velocity overwritten
+    // by animation locomotion each frame, which would silently clear the
+    // poison - but non-animated items (e.g. the starter pickups) keep it.
+    // 1e300 overflows f32 to +inf; the pair sums to NaN in the body's linvel.
+    const { bodies } = await game.physics.bodies({ limit: 500 });
+    const dynamics = bodies.filter((b) => b.body_type === "dynamic");
+    assert.ok(dynamics.length > 0, "station.mis should have dynamic bodies");
+    for (const body of dynamics) {
+      for (const x of [1e300, -1e300]) {
+        const res = await fetch(
+          `${game.baseUrl}/v1/physics/bodies/${body.body_id}/impulse`,
+          { method: "POST", body: JSON.stringify({ impulse: [x, 0, 0] }) },
+        );
+        const result = (await res.json()) as { success: boolean };
+        assert.ok(result.success, `impulse ${x} on body ${body.body_id} should apply`);
+      }
+    }
+
+    // One frame: the reporter runs at the top of the physics update.
+    await game.step({ frames: 1 });
+
+    // The report names the poisoned entity and the offending field. The log
+    // line is written by the game thread; the SDK reads it off a pipe, so
+    // poll briefly rather than racing the flush.
+    await game.waitFor(() => linvelReports().length > 0, {
+      timeoutMs: 5_000,
+      description: "a non-finite state report naming linvel",
+    });
+    const reports = linvelReports();
+    assert.ok(
+      reports.some((l) => l.includes("ERROR")),
+      `the report should be ERROR level, got: ${reports[0]}`,
+    );
+
+    // Detection only - the poisoned state must NOT have been repaired: at
+    // least one poisoned body (a non-animated one) must still be non-finite.
+    // (serde_json serializes NaN/inf as null, so a non-finite component
+    // surfaces as a non-finite/null entry here.)
+    const after = await game.physics.bodies({ limit: 500 });
+    const poisonedIds = new Set(dynamics.map((b) => b.body_id));
+    const stillBad = after.bodies.filter(
+      (b) =>
+        poisonedIds.has(b.body_id) &&
+        ![...b.velocity, ...b.position].every((c) => Number.isFinite(c)),
+    );
+    assert.ok(
+      stillBad.length > 0,
+      "detection must not mutate state - at least one poisoned body should still be non-finite",
+    );
+  },
+);


### PR DESCRIPTION
## Problem (#506)

Walking around earth.mis / station.mis killed the runtime 5/5 with:

```
thread 'main' panicked at parry3d-0.25.3/src/partitioning/bvh/bvh_binned_build.rs:58:28:
index out of bounds: the len is 8 but the index is N   // N seen: 8, 9, 24, usize::MAX
```

Backtrace (reproduced in-game with `RUST_BACKTRACE=1`):

```
rebuild_range_binned  (parry3d 0.25.3 bvh_binned_build.rs:58)
  <- Bvh::optimize_incremental
  <- rapier3d BroadPhaseBvh::update
  <- PhysicsPipeline::step
  <- shock2vr PhysicsWorld::update
```

## Root cause

A single **non-finite rigid-body state at runtime** (NaN velocity, or a NaN kinematic
target pose) puts a NaN collider AABB into the broad-phase BVH. parry's binned rebuild
bins leaves by AABB center; a NaN center silently truncates the min/max fold that
computes the centroid range, so *valid* leaves land outside the range and the computed
bin index goes out of bounds - possibly many frames after the poisoning, whenever the
incremental optimizer happens to rebuild the poisoned subtree (which is why the crash
looked nondeterministic and correlated loosely with tripwire exits: those were just the
loudest log lines in the fatal frame).

- The creation-time sanitizers (`sanitize_collider_size` / `_radius`) only guard collider
  **sizes at creation** - runtime state corruption bypasses them, and the current-AABB
  audit (`/v1/physics/colliders/validate`) reports clean because the *current* pose is
  finite while the poisoned *leaf* persists in the tree.
- **Observed organic producer**: creature **hitboxes** - kinematic bodies driven by
  animation joint transforms that go NaN when motion queries fail - fed all-NaN kinematic
  target poses to physics *every frame* (~2,500 occurrences in 100 s across ~10 hitbox
  bodies of nearby NPCs/droids). Producer-side fix: #508.
- **Upstream**: dimforge/rapier#961 (open, 2026-07-16; same signature on parry 0.25/0.28,
  unfixed on parry master as of 0.29) - a parry upgrade alone cannot fix it. Verified
  with a 60-line standalone rapier 0.31 program: one NaN `linvel` on one of 50 bodies ->
  the exact panic ~40 frames later.

## This PR: detection & attribution only

Per review direction, this layer performs **no band-aid repairs** - it does not prevent
the crash by itself. `PhysicsWorld::report_nonfinite_rigid_body_state` runs immediately
before every physics step and logs an ERROR naming the exact entity and offending state
at the **first bad frame**, once per entity, so the parry crash a few frames later is
fully attributed to its producer:

```
ERROR shock2vr::physics: [physics] entity Some(EId(96.0)) (Dynamic body at [[98.56, -5.97, -46.39]]):
  non-finite rigid-body state: linvel [[NaN, -0.48, -0.015]] - this poisons the broad-phase BVH
  and will panic parry's binned rebuild within a few frames (#506; reported once per entity)
```

Checked fields: `linvel`, `angvel`, `pose`, and (for kinematic bodies) the `next
kinematic pose`. The actual crash is eliminated by fixing the producer (#508, stacked
on this branch); together they close #506.

## Verification

**Negative-first e2e** (`tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts`,
station.mis): poison **every dynamic body**'s velocity to NaN through the real debug
surface (two opposite overflow-to-inf impulses via `/v1/physics/bodies/:id/impulse`;
animated creatures get their velocity overwritten by animation locomotion each frame,
non-animated items keep the poison), step one frame, then assert:
- an ERROR report naming `linvel` fires (polled via `game.logs()`), and
- the poisoned state is **not** mutated (still non-finite afterwards).

Without this change: fails 1/1 (timeout waiting for the report). With it: **5/5** runs
pass.

**Regressions** (final build): `RUSTFLAGS="-D warnings" cargo check -p shock2vr
-p desktop_runtime -p debug_runtime` clean; `missions.e2e` 23/23; SDK unit tests pass;
`cargo fmt` applied.

Part of #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
