### PR TITLE
fix(debug): resolve entity ids for recycled slots in debug endpoints

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -39,7 +39,7 @@ use shock2vr::{
 
 // Property imports for state queries
 use dark::properties::{PropModelName, PropPosition, PropSymName, PropTemplateId};
-use shipyard::{EntityId, Get, IntoIter, IntoWithId, View};
+use shipyard::{Get, IntoIter, IntoWithId, View};
 
 // Screen dimensions for the debug window
 const SCR_WIDTH: u32 = 800;
@@ -1126,15 +1126,15 @@ fn process_command(
             }
         }
         RuntimeCommand::GiveItem { entity_id, reply } => {
-            // The list/detail endpoints expose `EntityId::inner() as i32`;
-            // `from_inner` is the exact inverse (see SendEntityMessage).
-            let result = match (
-                EntityId::from_inner(entity_id as u64),
-                game.debug_scene_mut(),
-            ) {
-                (Some(eid), Some(scene)) => scene.give_item(eid),
-                (None, _) => Err(format!("invalid entity id {}", entity_id)),
-                (_, None) => Err("no debuggable scene available".to_string()),
+            // Client-supplied ids are `EntityId::inner() as i32` (generation
+            // bits truncated); resolve against the live entities to recover
+            // the full id (see SendEntityMessage).
+            let result = match game.debug_scene_mut() {
+                Some(scene) => match scene.resolve_entity_id(entity_id) {
+                    Some(eid) => scene.give_item(eid),
+                    None => Err(format!("invalid entity id {}", entity_id)),
+                },
+                None => Err("no debuggable scene available".to_string()),
             };
             if reply.send(result).is_err() {
                 tracing::warn!("Failed to send give-item result - receiver dropped");
@@ -1278,11 +1278,11 @@ fn process_command(
         }
         RuntimeCommand::EntityDetail { id, reply } => {
             let result = if let Some(debug_scene) = game.debug_scene() {
-                // `id` is `EntityId::inner() as i32` (= index + 1) from the list
-                // endpoint; `from_inner` is its exact inverse. Using
-                // `new_from_index_and_gen(id, 0)` here resolved the wrong entity.
-                let entity_id = EntityId::from_inner(id as u64);
-                entity_id
+                // `id` is `EntityId::inner() as i32` from the list endpoint,
+                // which drops the generation bits - resolve against the live
+                // entities to recover the full id (see SendEntityMessage).
+                debug_scene
+                    .resolve_entity_id(id)
                     .and_then(|entity_id| debug_scene.entity_detail(entity_id))
                     .map(|detail| EntityDetailResult {
                         entity_id: detail.entity_id,
@@ -1329,7 +1329,8 @@ fn process_command(
         RuntimeCommand::AnimationState { id, reply } => {
             let result = game.debug_scene().and_then(|debug_scene| {
                 // Same id space as /v1/entities (`EntityId::inner() as i32`).
-                EntityId::from_inner(id as u64)
+                debug_scene
+                    .resolve_entity_id(id)
                     .and_then(|entity_id| debug_scene.animation_state(entity_id))
             });
 
@@ -1338,30 +1339,32 @@ fn process_command(
             }
         }
         RuntimeCommand::SendEntityMessage { id, message, reply } => {
-            // The list/detail endpoints expose `EntityId::inner() as i32`, which
-            // for a live entity is `index + 1`. `from_inner` is the exact
-            // inverse; `new_from_index_and_gen(id, 0)` would double the +1 and
-            // resolve the wrong entity.
-            let entity_id = EntityId::from_inner(id as u64);
-            let result = match (entity_id, game.debug_scene_mut()) {
-                (Some(entity_id), Some(debug_scene)) => {
-                    let queued = debug_scene.send_entity_message(entity_id, message);
-                    CommandResult {
-                        success: queued,
-                        message: if queued {
-                            format!("Message queued for entity {}", id)
-                        } else {
-                            format!("Entity {} not found or not alive", id)
-                        },
-                        data: None,
+            // The list/detail endpoints expose `EntityId::inner() as i32`,
+            // which truncates the generation bits: `from_inner(id as u64)`
+            // would rebuild a generation-0 handle that is stale for any
+            // recycled slot (issue #484). Resolve against the live entities
+            // instead, which recovers the full id by index.
+            let result = match game.debug_scene_mut() {
+                Some(debug_scene) => match debug_scene.resolve_entity_id(id) {
+                    Some(entity_id) => {
+                        let queued = debug_scene.send_entity_message(entity_id, message);
+                        CommandResult {
+                            success: queued,
+                            message: if queued {
+                                format!("Message queued for entity {}", id)
+                            } else {
+                                format!("Entity {} not found or not alive", id)
+                            },
+                            data: None,
+                        }
                     }
-                }
-                (None, _) => CommandResult {
-                    success: false,
-                    message: format!("Invalid entity id {}", id),
-                    data: None,
+                    None => CommandResult {
+                        success: false,
+                        message: format!("Entity {} not found or not alive", id),
+                        data: None,
+                    },
                 },
-                (_, None) => CommandResult {
+                None => CommandResult {
                     success: false,
                     message: "No debuggable scene available".to_string(),
                     data: None,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -482,6 +482,19 @@ pub trait DebuggableScene {
     /// Vector of entity summaries sorted by distance from player
     fn list_entities(&self, limit: Option<usize>, filter: Option<&str>) -> Vec<DebugEntitySummary>;
 
+    /// Resolve a client-facing entity id back to the live `EntityId`.
+    ///
+    /// The entity endpoints expose ids as `EntityId::inner() as i32`, which
+    /// keeps only the low 32 bits of the index part (the low 48 bits hold
+    /// `index + 1`; the top 16 hold the generation). Reconstructing via
+    /// `EntityId::from_inner(id as u64)` therefore yields a generation-0
+    /// handle that is stale for any recycled slot. This looks up the live
+    /// entity whose truncated id matches instead.
+    ///
+    /// # Returns
+    /// The live `EntityId`, or None if no live entity matches
+    fn resolve_entity_id(&self, id: i32) -> Option<EntityId>;
+
     /// Get detailed information about a specific entity
     ///
     /// Returns comprehensive entity information including properties, links,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5176,6 +5176,15 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         })
     }
 
+    fn resolve_entity_id(&self, id: i32) -> Option<EntityId> {
+        use shipyard::EntitiesView;
+
+        self.world
+            .borrow::<EntitiesView>()
+            .ok()
+            .and_then(|entities| entities.iter().find(|e| e.inner() as i32 == id))
+    }
+
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
         use crate::game_scene::{DebugEntityDetail, DebugLinkInfo, DebugPropertyInfo};
         use shipyard::*;

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -291,6 +291,10 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.list_entities(limit, filter)
     }
 
+    fn resolve_entity_id(&self, id: i32) -> Option<EntityId> {
+        self.mission_core.resolve_entity_id(id)
+    }
+
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
         self.mission_core.entity_detail(id)
     }

--- a/tools/shock2-sdk/test/entity-recycled-slot.e2e.test.ts
+++ b/tools/shock2-sdk/test/entity-recycled-slot.e2e.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Regression test for #484: the entity endpoints expose ids as
+// `EntityId::inner() as i32`, which drops shipyard's generation bits. The
+// handlers used to rebuild the id as a generation-0 handle, so any entity
+// living in a recycled slot (generation > 0) could not be messaged or
+// inspected. Mission load itself already recycles slots, so a freshly
+// spawned monster lands in a generation > 0 slot straight away - on the
+// broken build the FIRST sendMessage below fails with "not found or not
+// alive". The kill/respawn cycle exercises the same path again across an
+// explicit slot free (with --experimental ragdoll the killing blow removes
+// the original entity), and the ragdoll count proves each message reached
+// its monster.
+test(
+  "entities in recycled slots can be messaged and inspected",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
+      experimental: ["ragdoll"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    // `known` tracks live ids only - a spawn may reuse a killed monster's
+    // slot, so killed ids must diff as new again.
+    const known = new Set(
+      (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities.map(
+        (e) => e.id,
+      ),
+    );
+    const spawnMonster = async () => {
+      await game.input.trigger("SpawnDebugMonster");
+      await game.step({ frames: 30 });
+      const listed = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+      const monster = listed.entities.find(
+        (e) => e.name === "OG-Pipe" && !known.has(e.id),
+      );
+      assert.ok(
+        monster,
+        `expected a newly spawned OG-Pipe, got ${JSON.stringify(listed.entities.map((e) => e.id))}`,
+      );
+      known.add(monster.id);
+      return monster;
+    };
+
+    // Kill the monster and wait until its entity is gone: under
+    // --experimental ragdoll the killing blow hands the corpse off to a
+    // dedicated ragdoll entity and removes the original, freeing its slot.
+    const killMonster = async (id: number) => {
+      await game.entities.sendMessage(id, { type: "Damage", amount: 1000 });
+      for (let i = 0; i < 20; i++) {
+        await game.step({ frames: 15 });
+        const listed = await game.entities.list({
+          filter: "OG-Pipe",
+          limit: 50,
+        });
+        if (!listed.entities.some((e) => e.id === id)) {
+          known.delete(id);
+          return;
+        }
+      }
+      assert.fail(`monster ${id} was never removed after the killing blow`);
+    };
+
+    for (let round = 1; round <= 2; round++) {
+      const monster = await spawnMonster();
+
+      // Detail must resolve the same id the list endpoint handed out.
+      const detail = await game.entities.detail(monster.id);
+      assert.equal(detail.name, "OG-Pipe", `round ${round}: detail lookup`);
+
+      // The kill message must reach THIS monster: its entity disappears
+      // (checked inside killMonster) and exactly one new ragdoll appears.
+      const ragdollsBefore = (await game.physics.ragdolls()).ragdolls.length;
+      await killMonster(monster.id);
+      assert.equal(
+        (await game.physics.ragdolls()).ragdolls.length,
+        ragdollsBefore + 1,
+        `round ${round}: killing blow should hand off to a new ragdoll`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
Fixes #484.

## Problem

The debug runtime's entity endpoints expose ids as `EntityId::inner() as i32`, which keeps only the low 32 bits of shipyard's index part and drops the generation (top 16 bits). The handlers rebuilt the id with `EntityId::from_inner(id as u64)`, producing a **generation-0 handle** that fails aliveness and component lookups for any entity living in a recycled slot. Mission load itself already recycles slots, so even the *first* `SpawnDebugMonster` spawn frequently could not be messaged (`Entity N not found or not alive`) or inspected (`detail` returns null) — the failure mode that forced the PR-visuals agent to restart the runtime per capture attempt.

## Fix

- New `DebuggableScene::resolve_entity_id(id: i32) -> Option<EntityId>`: scans live entities (`EntitiesView::iter()`) for the one whose truncated id matches, recovering the full generation-carrying handle. Implemented in `MissionCore`, delegated from `Mission`.
- Used in all four handlers that accepted client-supplied entity ids: `SendEntityMessage`, `EntityDetail`, `AnimationState`, `GiveItem`. No other endpoint reconstructs ids from client input (audited).

Known tradeoff (inherent to the truncated wire id, unchanged by this PR): a *stale* id held across a slot free/reuse resolves to the slot's new occupant. The debug API docs already mandate discovering entities by name/template per run, so this stays acceptable for a localhost debug surface.

## Verification

- New SDK e2e `entity-recycled-slot.e2e.test.ts`: spawn → `detail` → kill via `Damage` message across an explicit slot free (`--experimental ragdoll` removes the original entity), two rounds, asserting each killing blow hands off to a new ragdoll. **Fails on main** (`Entity N not found or not alive` / null detail), **passes with the fix** — verified in both directions by stashing the fix.
- Full SDK e2e suite: 109/110 pass. The one failure, `alertness-churn.e2e.test.ts`, is an unrelated pre-existing flake — it also fails intermittently standalone (2 of 3 runs) and touches AI route progress, not entity-id resolution; will be filed separately.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; clippy introduces no new warnings.
- Cross-engine adversarial review (Claude + Codex): no Critical/High findings; both independently confirmed no remaining `from_inner`-on-client-id sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)