### PR TITLE
fix(animation): parse zero-quaternion joint tracks as identity, not NaN

### DIFF
--- a/dark/src/motion/motion_clip.rs
+++ b/dark/src/motion/motion_clip.rs
@@ -70,3 +70,106 @@ impl MotionClip {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::motion::MotionComponent;
+
+    /// Serialize a minimal 2-track .mc payload: a root position track and one
+    /// joint rotation track built from `quat_wxzy` (the on-disk w,-x,z,y
+    /// order), repeated for every frame.
+    fn clip_bytes(num_frames: u32, quat_wxzy: [f32; 4]) -> Vec<u8> {
+        let num_joints = 2u32;
+        let header_len = 4 + 4 * num_joints;
+        let root_len = num_frames * 12;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&num_joints.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&(header_len + root_len).to_le_bytes());
+        for _ in 0..num_frames {
+            for c in [0.0f32; 3] {
+                bytes.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        for _ in 0..num_frames {
+            for c in quat_wxzy {
+                bytes.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        bytes
+    }
+
+    fn mps_motion(num_frames: u32) -> MpsMotion {
+        MpsMotion {
+            motion_type: 0,
+            motion_components: (0..2)
+                .map(|joint_id| MotionComponent {
+                    motion_type: 0,
+                    joint_id,
+                    handle: 0,
+                })
+                .collect(),
+            motion_flags: Vec::new(),
+            sig: 0,
+            frame_count: num_frames as f32,
+            frame_rate: 30,
+            mot_num: 0,
+            name: "test".to_owned(),
+        }
+    }
+
+    /// 23 of the 613 stock motion clips (e.g. bh114009, humwalks, humalert)
+    /// carry an all-zero quaternion track for joints the clip doesn't
+    /// animate. Inverting that zero quaternion divides by zero and floods the
+    /// track - and every pose blended from it - with NaN (issue #508: NaN
+    /// joint transforms fed kinematic hitboxes, poisoning the physics
+    /// broad-phase). A zero quaternion must parse as the identity rotation,
+    /// exactly like the original engine's unnormalized quat->matrix
+    /// conversion treats it.
+    #[test]
+    fn zero_quaternion_track_parses_as_identity_not_nan() {
+        let bytes = clip_bytes(3, [0.0, 0.0, 0.0, 0.0]);
+        let mps = mps_motion(3);
+        let clip = MotionClip::read(&mut Cursor::new(bytes), &mps);
+
+        for (joint, frames) in clip.animation.iter().enumerate() {
+            for (frame, m) in frames.iter().enumerate() {
+                let cells: &[f32; 16] = m.as_ref();
+                assert!(
+                    cells.iter().all(|c| c.is_finite()),
+                    "joint {joint} frame {frame} must stay finite, got {m:?}"
+                );
+                assert_eq!(
+                    *m,
+                    Matrix4::identity(),
+                    "an unanimated (zero-quaternion) track must pose as identity"
+                );
+            }
+        }
+    }
+
+    /// A genuine unit-quaternion track must be untouched by the zero-quat
+    /// guard: 90 degrees about +y on disk still comes out as 90 degrees about
+    /// +y (inverted per the engine's handedness fixup, like every clip since).
+    #[test]
+    fn unit_quaternion_track_still_parses_as_its_rotation() {
+        let half = std::f32::consts::FRAC_1_SQRT_2;
+        // On-disk order is (w, -x, z, y): a +y rotation stores its y in the
+        // final slot.
+        let bytes = clip_bytes(1, [half, 0.0, 0.0, half]);
+        let mps = mps_motion(1);
+        let clip = MotionClip::read(&mut Cursor::new(bytes), &mps);
+
+        let m = clip.animation[1][0];
+        let cells: &[f32; 16] = m.as_ref();
+        assert!(cells.iter().all(|c| c.is_finite()));
+        // invert() of a +90deg yaw is a -90deg yaw: x axis maps to +z.
+        assert!(
+            (m.x.z - 1.0).abs() < 1e-5 && (m.x.x).abs() < 1e-5,
+            "expected a yaw rotation, got {m:?}"
+        );
+    }
+}

--- a/dark/src/ss2_common.rs
+++ b/dark/src/ss2_common.rs
@@ -73,6 +73,15 @@ pub fn read_quat<T: io::Read>(reader: &mut T) -> Quaternion<f32> {
         v: vec3(-neg_x, y, z),
         s: w,
     };
+    // An all-zero quaternion marks an unanimated joint track in shipped
+    // motion data (23 of 613 stock clips have one, e.g. bh114009, humwalks).
+    // `invert()` divides by the zero magnitude and turns the whole track into
+    // NaN, which poisons every downstream pose (issue #508). The original
+    // engine's unnormalized quat->matrix conversion reads a zero quaternion
+    // as the identity rotation, so do the same.
+    if q.magnitude2() <= f32::EPSILON {
+        return Quaternion::new(1.0, 0.0, 0.0, 0.0);
+    }
     q.invert()
 }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3039,6 +3039,13 @@ impl MissionCore {
                         "bh114001", // action
                         "BH413001", // combat
                         "BH212oo8", // reach
+                        // Regression pose (#508): this stock idle gesture is
+                        // one of 23 clips whose unanimated joints are stored
+                        // as all-zero quaternions; it used to parse to NaN
+                        // joint matrices and poison the hitbox kinematic
+                        // bodies. Cycling to it must pose (bind rotation on
+                        // those joints) without a single non-finite value.
+                        "bh114009", // idle gesture with zero-quat joint tracks
                     ];
                     let clip_name =
                         DEBUG_POSE_CLIPS[self.debug_pose_index as usize % DEBUG_POSE_CLIPS.len()];

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -408,6 +408,11 @@ pub struct PhysicsWorld {
     // Sensor Intersection List
     player_sensor_intersections: HashSet<EntityId>,
 
+    // Entities already reported by report_nonfinite_rigid_body_state, so a
+    // body fed bad state every frame (e.g. NaN animation joints driving a
+    // kinematic hitbox) is reported once instead of every frame.
+    reported_nonfinite_entities: HashSet<Option<EntityId>>,
+
     // Collision Events
     events: PhysicsEvents,
 }
@@ -1142,6 +1147,8 @@ impl PhysicsWorld {
 
             player_sensor_intersections: HashSet::new(),
 
+            reported_nonfinite_entities: HashSet::new(),
+
             events: PhysicsEvents::new(),
         }
     }
@@ -1192,11 +1199,88 @@ impl PhysicsWorld {
         debug_renderer.render()
     }
 
+    /// Report (once per entity, ERROR level) any rigid body whose state went
+    /// non-finite before it reaches the broad-phase. Detection only - no
+    /// state is mutated.
+    ///
+    /// A NaN velocity integrates into a NaN pose, which puts a NaN collider
+    /// AABB into the broad-phase BVH. parry's binned rebuild
+    /// (`bvh_binned_build.rs`) bins leaves by their AABB centers, and a NaN
+    /// center silently truncates the computed centroid range (NaN drops the
+    /// accumulated min/max), so valid leaves land outside it and the bin
+    /// index goes out of bounds - possibly many frames later, whenever the
+    /// incremental optimizer happens to rebuild the poisoned subtree
+    /// (issue #506; upstream: dimforge/rapier#961, still unfixed as of parry
+    /// 0.29). The creation-time size sanitizers above can't catch this: the
+    /// state goes bad at *runtime* (e.g. NaN animation joints driving a
+    /// kinematic hitbox, #508). This report names the exact entity and the
+    /// offending field(s) at the first bad frame, so the parry crash that
+    /// follows a few frames later is fully attributed; the fix belongs at
+    /// the producer's source, not here.
+    fn report_nonfinite_rigid_body_state(&mut self) {
+        fn finite_pose(pose: &Isometry<Real>) -> bool {
+            pose.translation.vector.iter().all(|c| c.is_finite())
+                && pose.rotation.coords.iter().all(|c| c.is_finite())
+        }
+
+        for (_handle, body) in self.rigid_body_set.iter() {
+            if !body.is_enabled() {
+                continue;
+            }
+
+            let linvel_bad = !body.linvel().iter().all(|c| c.is_finite());
+            let angvel_bad = !body.angvel().iter().all(|c| c.is_finite());
+            let pose_bad = !finite_pose(body.position());
+            let next_pose_bad = body.is_kinematic() && !finite_pose(body.next_position());
+
+            if !(linvel_bad || angvel_bad || pose_bad || next_pose_bad) {
+                continue;
+            }
+
+            let entity_id = body
+                .colliders()
+                .first()
+                .and_then(|c| self.collider_set.get(*c))
+                .and_then(|c| EntityId::from_inner(c.user_data as u64));
+            // A body fed bad state every frame (e.g. NaN animation joints
+            // driving a kinematic hitbox) is only reported once.
+            if !self.reported_nonfinite_entities.insert(entity_id) {
+                continue;
+            }
+
+            let mut bad_fields = Vec::new();
+            if linvel_bad {
+                bad_fields.push(format!("linvel {:?}", body.linvel()));
+            }
+            if angvel_bad {
+                bad_fields.push(format!("angvel {:?}", body.angvel()));
+            }
+            if pose_bad {
+                bad_fields.push(format!("pose {:?}", body.position()));
+            }
+            if next_pose_bad {
+                bad_fields.push(format!("next kinematic pose {:?}", body.next_position()));
+            }
+            tracing::error!(
+                "[physics] entity {:?} ({:?} body at {:?}): non-finite rigid-body state: {} - this poisons the broad-phase BVH and will panic parry's binned rebuild within a few frames (#506; reported once per entity)",
+                entity_id,
+                body.body_type(),
+                body.translation(),
+                bad_fields.join(", "),
+            );
+        }
+    }
+
     pub fn update(
         &mut self,
         desired_movement: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        // Attribute any non-finite body state to its entity before the step
+        // consumes it (see report_nonfinite_rigid_body_state) - by the time
+        // parry panics, the culprit is already named in the log.
+        self.report_nonfinite_rigid_body_state();
+
         /* Run the game loop, stepping the simulation once per frame. */
         profile!(scope: "physics", level: TRACE, "physics.step", {
             self.physics_pipeline.step(

--- a/tools/shock2-sdk/test/animation-nan-source.e2e.test.ts
+++ b/tools/shock2-sdk/test/animation-nan-source.e2e.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the #508 producer fix: animation clips with all-zero
+// quaternion joint tracks (23 of the 613 stock clips - bh114009, humwalks,
+// humalert, the mbt* maintenance-bot set, ...) used to parse those tracks to
+// all-NaN rotation matrices (`read_quat` inverted a zero quaternion, dividing
+// by zero magnitude). Any creature playing such a clip emitted NaN joint
+// transforms, and the per-joint kinematic hitbox bodies fed those NaN poses
+// to rapier every frame - poisoning the broad-phase BVH and panicking parry's
+// binned rebuild a few frames later (#506; upstream dimforge/rapier#961).
+//
+// The fix parses a zero quaternion as the identity rotation (bind pose for
+// the unanimated joint - the original engine's unnormalized quat->matrix
+// conversion behaves identically), so the NaN never exists.
+//
+// The test forces the exact organic producer deterministically: the
+// DebugHitboxCyclePose action queues named pose clips on every creature, and
+// its playlist ends with bh114009 (the clip caught producing NaN hitbox poses
+// live on station.mis). Playing it through must produce zero non-finite
+// rigid-body reports (#507's detection layer is the tripwire - it mutates
+// nothing, so any NaN reaching physics is reported) and leave every physics
+// body finite. Unfixed, this fails within seconds: the detector fires for
+// each hitbox of every posed creature, and the parry panic can kill stepping
+// outright.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station.mis: posing creatures with a zero-quat-track clip stays finite (#508)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8344),
+    });
+    await game.step({ frames: 30 }); // settle
+
+    const nonfiniteReports = () =>
+      game.logs().filter((l) => l.includes("non-finite rigid-body state"));
+    assert.equal(
+      nonfiniteReports().length,
+      0,
+      "no non-finite report should fire before the poisoned clip plays",
+    );
+
+    // A creature to observe the pose cycle on (entity ids are not stable
+    // across runs, so discover one by name each launch).
+    const entitiesRes = await fetch(`${game.baseUrl}/v1/entities?filter=DROID`);
+    const { entities } = (await entitiesRes.json()) as {
+      entities: { id: number }[];
+    };
+    assert.ok(entities.length > 0, "station.mis should have droid creatures");
+    const droidId = entities[0].id;
+    const animationClips = async (): Promise<string[]> => {
+      const res = await fetch(
+        `${game.baseUrl}/v1/entities/${droidId}/animation`,
+      );
+      const state = (await res.json()) as {
+        clip: string | null;
+        queue: { name: string | null }[];
+        last_clip: string | null;
+      } | null;
+      if (!state) return [];
+      return [
+        state.clip,
+        state.last_clip,
+        ...state.queue.map((q) => q.name),
+      ].filter((c): c is string => typeof c === "string");
+    };
+
+    // Cycle the pose playlist to its final entry, bh114009 (the playlist is
+    // deterministic: one advance per trigger, starting at index 0). The
+    // regression clip must actually reach the creature's animation queue.
+    let sawRegressionClip = false;
+    for (let i = 0; i < 7; i++) {
+      await game.input.trigger("DebugHitboxCyclePose");
+      await game.step({ frames: 2 });
+      const clips = await animationClips();
+      if (clips.some((c) => c.toLowerCase().includes("bh114009"))) {
+        sawRegressionClip = true;
+      }
+    }
+    assert.ok(
+      sawRegressionClip,
+      "cycling the full pose playlist should queue bh114009 on the droid",
+    );
+
+    // Play the clip through (98 frames at 30fps + 500ms blend-in) while the
+    // hitbox bodies track the posed joints every frame. Unfixed, stepping
+    // dies here (parry panic) or the detector fires below.
+    for (let chunk = 0; chunk < 5; chunk++) {
+      const stepped = await game.step({ frames: 60 });
+      assert.equal(
+        stepped.frames_advanced,
+        60,
+        `step chunk ${chunk} should advance (a failure means the physics ` +
+          `thread died - see #506 / parry bvh_binned_build panic)`,
+      );
+    }
+
+    assert.equal(
+      nonfiniteReports().length,
+      0,
+      `the zero-quat clip must not produce any non-finite rigid-body state, ` +
+        `got:\n${nonfiniteReports().slice(0, 5).join("\n")}`,
+    );
+
+    // Belt and braces: every physics body (hitboxes included) is still
+    // finite. (serde_json writes NaN/inf as null, so non-finite components
+    // fail Number.isFinite here.)
+    const { bodies } = await game.physics.bodies({ limit: 2000 });
+    const bad = bodies.filter(
+      (b) =>
+        ![
+          ...b.position,
+          ...b.rotation,
+          ...b.velocity,
+          ...b.angular_velocity,
+        ].every((c) => Number.isFinite(c)),
+    );
+    assert.equal(
+      bad.length,
+      0,
+      `all bodies must stay finite, got ${bad.length} bad (first: ${JSON.stringify(bad[0])})`,
+    );
+  },
+);
+
+// The scenario that killed 5/5 campaign sessions before the stack (#506):
+// plain walking around station.mis's start room while nearby NPCs animate.
+// With the producer fixed there is nothing left to poison the BVH - the walk
+// must survive with zero non-finite reports.
+test(
+  "station.mis: walking the start room survives with zero non-finite reports (#506)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8344) + 1,
+    });
+    await game.step({ frames: 30 });
+
+    // The corridor from the start room toward the Mission Postings door is
+    // covered by overlapping tripwire sensors and room boundaries around
+    // (67..69, -4.6, 17.5) - the area the crashing campaign sessions walked.
+    const waypoints = [
+      { x: 68.5, y: -4.3, z: 24.0 }, // outside, start-room side
+      { x: 68.5, y: -4.3, z: 12.0 }, // outside, Mission Postings side
+    ];
+    for (let pass = 0; pass < 4; pass++) {
+      for (const wp of waypoints) {
+        await game.player.teleport(wp);
+        await game.step({ frames: 30 });
+      }
+      // Also walk through under locomotion (exit-by-walking is how the
+      // campaign hit it, and it exercises the character controller path).
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      await game.step({ frames: 90 });
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      const stepped = await game.step({ frames: 30 });
+      assert.equal(stepped.frames_advanced, 30, `pass ${pass} should survive`);
+    }
+
+    const reports = game
+      .logs()
+      .filter((l) => l.includes("non-finite rigid-body state"));
+    assert.equal(
+      reports.length,
+      0,
+      `walking must not produce non-finite body state, got:\n${reports
+        .slice(0, 5)
+        .join("\n")}`,
+    );
+    const info = await game.info();
+    assert.equal(info.mission, "station.mis");
+  },
+);

--- a/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
+++ b/tools/shock2-sdk/test/nonfinite-body-report.e2e.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the non-finite body-state DETECTION layer (#506).
+//
+// A rigid body whose velocity goes non-finite integrates into a non-finite
+// pose, which puts a NaN AABB into rapier's broad-phase BVH - and parry's
+// binned rebuild (bvh_binned_build.rs) then panics with "index out of
+// bounds" a few frames later, killing the main thread mid-walk (5/5
+// campaign crashes; upstream: dimforge/rapier#961, unfixed as of parry
+// 0.29).
+//
+// This layer does NOT prevent that crash - it attributes it:
+// PhysicsWorld::report_nonfinite_rigid_body_state logs an ERROR naming the
+// exact entity and offending field(s) at the first bad frame, once per
+// entity, without mutating any state. The producer-side fix (NaN animation
+// joints driving kinematic hitboxes) is #508.
+//
+// The poison is injected through the real debug surface: two opposite
+// overflow-to-infinity impulses on one dynamic body (inf + -inf = NaN
+// linvel). The test steps a single frame - enough for one update to run the
+// reporter, and safely before the (still-inevitable) parry panic, which
+// needs the poisoned pose to reach a broad-phase rebuild - then asserts the
+// report fired and the body state was left untouched (still non-finite).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station.mis: non-finite body state is attributed to its entity in the log (#506)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8340),
+    });
+    await game.step({ frames: 30 }); // settle
+
+    // Baseline: the organic #508 producer (NaN hitbox poses) may already
+    // have reported at load, but a *velocity* report can only come from our
+    // poison below.
+    const linvelReports = () =>
+      game
+        .logs()
+        .filter(
+          (l) => l.includes("non-finite rigid-body state") && l.includes("linvel"),
+        );
+    assert.equal(
+      linvelReports().length,
+      0,
+      "no non-finite velocity report should fire before the poison",
+    );
+
+    // Poison every dynamic body (ids are not stable across runs, so discover
+    // them each launch). Animated creatures have their velocity overwritten
+    // by animation locomotion each frame, which would silently clear the
+    // poison - but non-animated items (e.g. the starter pickups) keep it.
+    // 1e300 overflows f32 to +inf; the pair sums to NaN in the body's linvel.
+    const { bodies } = await game.physics.bodies({ limit: 500 });
+    const dynamics = bodies.filter((b) => b.body_type === "dynamic");
+    assert.ok(dynamics.length > 0, "station.mis should have dynamic bodies");
+    for (const body of dynamics) {
+      for (const x of [1e300, -1e300]) {
+        const res = await fetch(
+          `${game.baseUrl}/v1/physics/bodies/${body.body_id}/impulse`,
+          { method: "POST", body: JSON.stringify({ impulse: [x, 0, 0] }) },
+        );
+        const result = (await res.json()) as { success: boolean };
+        assert.ok(result.success, `impulse ${x} on body ${body.body_id} should apply`);
+      }
+    }
+
+    // One frame: the reporter runs at the top of the physics update.
+    await game.step({ frames: 1 });
+
+    // The report names the poisoned entity and the offending field. The log
+    // line is written by the game thread; the SDK reads it off a pipe, so
+    // poll briefly rather than racing the flush.
+    await game.waitFor(() => linvelReports().length > 0, {
+      timeoutMs: 5_000,
+      description: "a non-finite state report naming linvel",
+    });
+    const reports = linvelReports();
+    assert.ok(
+      reports.some((l) => l.includes("ERROR")),
+      `the report should be ERROR level, got: ${reports[0]}`,
+    );
+
+    // Detection only - the poisoned state must NOT have been repaired: at
+    // least one poisoned body (a non-animated one) must still be non-finite.
+    // (serde_json serializes NaN/inf as null, so a non-finite component
+    // surfaces as a non-finite/null entry here.)
+    const after = await game.physics.bodies({ limit: 500 });
+    const poisonedIds = new Set(dynamics.map((b) => b.body_id));
+    const stillBad = after.bodies.filter(
+      (b) =>
+        poisonedIds.has(b.body_id) &&
+        ![...b.velocity, ...b.position].every((c) => Number.isFinite(c)),
+    );
+    assert.ok(
+      stillBad.length > 0,
+      "detection must not mutate state - at least one poisoned body should still be non-finite",
+    );
+  },
+);


### PR DESCRIPTION
Stacked on #507 (base: `playthrough-fixes-506`). #507 is the detection layer; this PR removes the producer, so nothing non-finite reaches physics in the first place.

## Root cause

**23 of the 613 stock motion clips store the tracks of joints they don't animate as all-zero quaternions** (`bh114009`, `humwalks`, `humalert`, `humdwstr`, the `mbt*` maintenance-bot set, `mdwfrob`, ...). `read_quat` (`dark/src/ss2_common.rs`) called `q.invert()` on every parsed quaternion — conjugate divided by magnitude² — so a zero quaternion divided by zero and the **whole track parsed as all-NaN rotation matrices** at clip load:

```
joint 9 frame 0..97: Matrix4 [[NaN, NaN, NaN, 0.0], [NaN, NaN, NaN, 0.0], [NaN, NaN, NaN, 0.0], [0,0,0,1]]
```

From there the chain reported in #508: any creature playing such a clip emits NaN `RuntimePropJointTransforms` → `hit_boxes.rs` derives NaN kinematic target poses → rapier's broad-phase BVH is poisoned → parry's binned rebuild panics frames later (#506, the 5/5 campaign crash; upstream dimforge/rapier#961).

**Why "failed motion query" was a red herring:** a failed query leaves the previous pose playing and produces no NaN — the live session with 488 `__null_animation__`/prodroid failures (an *intentional* fail-sentinel used by scripted-sequence actions that want no animation) and 592 assault-droid `idlegesture` failures (a content gap) had **zero** non-finite reports. The producer is a **successful** query resolving to a zero-quat clip: in the #507 organic capture, the first NaN report lands 40 ms after `bh114009_.mc` (a human NPC idle gesture pick) loads — the failure spam in the same window was ambient log noise.

## Fix

Parse a zero quaternion as the **identity rotation** (`dark/src/ss2_common.rs::read_quat`). This is the original engine's semantics: its unnormalized quat→matrix conversion maps a zero quaternion to the identity matrix, so the joint rests at its bind-pose local rotation ("track not animated"). No downstream repair layers — with #507 rescoped to detection-only, any *future* non-finite producer still reports loudly instead of being masked.

Also appends `bh114009` to the `DebugHitboxCyclePose` playlist as a deterministic regression pose (it's a legitimate biped idle-gesture pose, and the exact clip caught poisoning hitboxes live on station.mis).

## Tests (negative-first)

| Test | Unfixed | Fixed |
| --- | --- | --- |
| `dark` unit: `zero_quaternion_track_parses_as_identity_not_nan` | **fails** — `joint 1 frame 0 must stay finite, got Matrix4 [[NaN, ...` | passes |
| `dark` unit: `unit_quaternion_track_still_parses_as_its_rotation` | passes (guards the refactor) | passes |
| e2e `animation-nan-source`: cycle every station.mis creature to the `bh114009` pose, play it through | **fails in ~12 s** — `POST /v1/step failed with status 503: Game loop unavailable - the game thread may have crashed` (the parry BVH panic, reproduced deterministically) | passes: zero `non-finite rigid-body state` reports, every physics body finite |
| e2e `animation-nan-source`: start-room walk survival (the scenario that killed 5/5 campaign sessions) | passes (organic trigger is a rare idle-gesture pick — hence the campaign's minutes-to-crash latency) | passes with zero non-finite reports |

Data-level verification (real assets): with the fix, `bh114009`/`humwalks`/`humalert`/`mbtback` all parse with **0 degenerate entries**; unfixed, `bh114009` had 294 NaN keyframe matrices (3 joints × 98 frames).

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `cargo test -p dark` (41) / `cargo test -p shock2vr` (190+) — green
- SDK `npm test` — green; `missions.e2e.test.ts` — 23/23 missions load
- `animation-nan-source.e2e.test.ts` — 2/2 on the fixed build (fail-then-pass evidence above)

## Deferred

- The 592× assault-droid `idlegesture` misses (`Tag("idlegesture") + droid + assault`) are a genuine content/tag gap, unrelated to NaN (failures are pose-neutral). Re-query spam is already rate-limited to one per ~0.5 s per entity by the existing `FailedAnimationGuard`.

Fixes #508
Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
