### PR TITLE
feat(gameplay): crouch shrinks the player collider

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -361,6 +361,9 @@ pub struct InputState {
     /// 2D screen pointer (flat-mode cursor); `None` until a pointer channel
     /// is set. Position is normalized [0,1] per axis, origin top-left.
     pub pointer: Option<InputPointer>,
+    /// Crouch REQUEST (the `crouch` channel), not the resulting collider
+    /// state - standing up is refused while there is no headroom.
+    pub crouch: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -391,6 +394,7 @@ impl Default for InputState {
             left_hand: InputHand::default(),
             right_hand: InputHand::default(),
             pointer: None,
+            crouch: false,
         }
     }
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -732,10 +732,11 @@ fn run_game_blocking(
             time: actual_game_time, // Use accumulated game time, not real time
             camera_offset: pawn_offset,
             camera_rotation: pawn_rotation,
-            // Standing eye height, shared with desktop and the flat controller
-            // via shock2vr::PLAYER_EYE_HEIGHT, so the debug-runtime camera sits
-            // at the same height as desktop and shots land on the crosshair.
-            head_offset: vec3(0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0),
+            // Crouch-aware eye height, shared with desktop and the flat
+            // controller via Game::player_eye_height, so the debug-runtime
+            // camera sits at the same height as desktop and shots land on the
+            // crosshair.
+            head_offset: vec3(0.0, game.player_eye_height() / SCALE_FACTOR, 0.0),
             // Same head rotation fed to game.update, so the rendered view and the
             // flat viewmodel agree. Controllable via `/v1/control/input` head.look.
             head_rotation: current_input.head.rotation,
@@ -1627,6 +1628,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
         },
         left_hand: hand(&input.left_hand),
         right_hand: hand(&input.right_hand),
+        crouch: input.crouch,
     }
 }
 
@@ -1651,7 +1653,8 @@ fn input_channels_help() -> &'static str {
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
-     {left,right}_hand.rotation [x,y,z,w]; \
+     {left,right}_hand.rotation [x,y,z,w], \
+     crouch 0|1 (stand-up refused without headroom); \
      locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
      left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
 }
@@ -1787,6 +1790,19 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
                     pressed: false,
                 });
             pointer.pressed = pressed;
+            Ok(())
+        }
+        // Crouch request: like the desktop LeftControl hold. The ACTUAL state
+        // can lag (standing up is refused without headroom); observe it via
+        // the player's body y (the collider center drops when crouched).
+        "crouch" => {
+            input.crouch = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
             Ok(())
         }
         _ => Err(format!(

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -347,7 +347,7 @@ pub fn main() {
             cursor_visible = wants_pointer;
         }
 
-        let (mut input_context, input_state) = process_events(
+        let mut input_context = process_events(
             &mut window,
             &mut camera_context,
             &mut hand_context,
@@ -411,11 +411,10 @@ pub fn main() {
 
         let (mut scene, pawn_offset, pawn_rotation) = profile!("game.render", game.render());
 
-        let head_height = if input_state.is_crouching {
-            1.5
-        } else {
-            shock2vr::PLAYER_EYE_HEIGHT
-        };
+        // Crouch-aware, and reflects the ACTUAL collider state (standing up
+        // is refused without headroom), so the camera can't rise through a
+        // ceiling the body still crouches under.
+        let head_height = game.player_eye_height();
         let render_context = engine::EngineRenderContext {
             time: glfw.get_time() as f32,
             camera_offset: pawn_offset,
@@ -493,17 +492,6 @@ fn parse_mission(mission: &str) -> (String, SpawnLocation) {
     return (mission.to_owned(), spawn_location);
 }
 
-struct InputState {
-    is_crouching: bool,
-}
-impl InputState {
-    pub fn new() -> Self {
-        Self {
-            is_crouching: false,
-        }
-    }
-}
-
 // NOTE: not the same version as in common.rs!
 fn process_events(
     //audio: &mut AudioContext,
@@ -515,7 +503,7 @@ fn process_events(
     input_mapper: &mut DesktopInputMapper,
     action_state: &mut InputActionState,
     wants_pointer: bool,
-) -> (InputContext, InputState) {
+) -> InputContext {
     let _speed = 20.0;
     let head_rot_speed = 10.0;
 
@@ -695,12 +683,11 @@ fn process_events(
         }
     }
 
-    let mut input_state = InputState::new();
-    input_state.is_crouching = window.get_key(Key::LeftControl) == Action::Press;
+    input_context.crouch = window.get_key(Key::LeftControl) == Action::Press;
 
     // Discrete actions (spawn, save/load, inventory, pathfinding test) are
     // handled by the mapper, which edge-detects key presses.
     input_mapper.poll(window, action_state);
 
-    (input_context, input_state)
+    input_context
 }

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -41,11 +41,6 @@ const VIEWMODEL_OFFSET: Vector3<f32> = vec3(2.0, -2.5, -5.0);
 /// "Arm Ang Offset" is zero, so the arm root takes the camera rotation
 /// directly.
 const MELEE_VIEWMODEL_OFFSET: Vector3<f32> = vec3(0.6, -2.4, 0.2);
-/// Camera (eye) height above the player's feet, in SS2 units before the
-/// world-scale divide. Shared with the runtimes' render-camera `head_offset` via
-/// `crate::PLAYER_EYE_HEIGHT` so the shot/viewmodel origin coincides with the
-/// rendered eye - otherwise horizontal shots land above/below the crosshair.
-const HEAD_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT;
 
 /// Base yaw applied to every first-person gun model before its per-weapon
 /// `PropPlayerGun.heading`. The pistol (`atek_h`, heading 0) renders correctly
@@ -128,13 +123,14 @@ impl FlatPlayerController {
         player_pos: Vector3<f32>,
         player_rotation: Quaternion<f32>,
         head_rotation: Quaternion<f32>,
+        eye_height: f32,
         world: &World,
         physics: &PhysicsWorld,
     ) -> (Vec<VirtualHandEffect>, Option<EntityId>) {
         let mut effects = Vec::new();
 
         let look = player_rotation * head_rotation;
-        let camera_pos = player_pos + vec3(0.0, HEAD_HEIGHT / SCALE_FACTOR, 0.0);
+        let camera_pos = player_pos + vec3(0.0, eye_height / SCALE_FACTOR, 0.0);
 
         // Crosshair raycast: the frobbable entity under the reticle (resolving
         // hitbox proxies to their parent, and ignoring the weapon we hold).

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -91,6 +91,13 @@ pub trait GameScene {
         false
     }
 
+    /// Whether the player's collider is currently crouched (the *actual*
+    /// physics state - stand-up can be refused for lack of headroom). Drives
+    /// the crouch-aware camera height; non-mission scenes have no player.
+    fn player_is_crouched(&self) -> bool {
+        false
+    }
+
     /// Get lighting information for VR enhancement
     fn get_hand_spotlights(&self, options: &GameOptions) -> Vec<SpotLight>;
 

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -18,6 +18,12 @@ pub struct InputContext {
     // interaction is hand/pointer-ray based. Populated by flat runtimes when a
     // scene wants a cursor (e.g. menus).
     pub pointer: Option<Pointer2D>,
+
+    // Flat-runtime crouch request (desktop key / debug-runtime channel). The
+    // *actual* crouch state can lag this: standing up is refused while there
+    // is no headroom. VR leaves this false - physically crouching moves the
+    // HMD instead.
+    pub crouch: bool,
 }
 
 impl InputContext {
@@ -28,6 +34,7 @@ impl InputContext {
             left_hand: Hand::default(),
             right_hand: Hand::default(),
             pointer: None,
+            crouch: false,
         }
     }
 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -37,6 +37,9 @@ pub struct InteractionContext<'a> {
     pub player_pos: Vector3<f32>,
     pub player_rotation: Quaternion<f32>,
     pub head_rotation: Quaternion<f32>,
+    /// Eye height above `player_pos` in SS2 units - crouch-aware, so the flat
+    /// controller's shot/viewmodel origin follows the actual camera.
+    pub eye_height: f32,
 }
 
 /// How the player interacts with the world. The effects returned by `update`
@@ -276,6 +279,7 @@ impl PlayerInteraction for FlatInteraction {
             ctx.player_pos,
             ctx.player_rotation,
             ctx.head_rotation,
+            ctx.eye_height,
             ctx.world,
             ctx.physics,
         );

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -44,9 +44,29 @@ pub use mission::visibility_engine::CullingInfo;
 /// runtime's render camera (`head_offset`) AND the flat controller's
 /// shot/viewmodel origin, so the rendered view and where shots come from stay
 /// consistent - if these drift, shots no longer line up with the crosshair and
-/// the debug runtime renders at a different height than desktop. Desktop crouch
-/// lowers the camera separately.
+/// the debug runtime renders at a different height than desktop. Crouch swaps
+/// this for [`PLAYER_CROUCH_EYE_HEIGHT`] - flat runtimes should use
+/// [`Game::player_eye_height`] rather than reading the constants directly.
 pub const PLAYER_EYE_HEIGHT: f32 = 4.0;
+
+/// Crouched eye height above the (crouched) body position, in SS2 units.
+/// The crouched capsule is 2.8 ft tall with its center 1.4 ft above the feet;
+/// +1.2 puts the eye at 2.6 ft above the feet - ~90% of crouched body height
+/// like the original engine's crouch, and inside the capsule so the camera
+/// cannot poke through a low ceiling the collider clears.
+pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
+
+/// The single mapping from crouch state to eye height. The render camera and
+/// the flat controller's shot/viewmodel origin must both go through this (or
+/// [`Game::player_eye_height`], which wraps it) so shots stay on the
+/// crosshair.
+pub fn player_eye_height_for(crouched: bool) -> f32 {
+    if crouched {
+        PLAYER_CROUCH_EYE_HEIGHT
+    } else {
+        PLAYER_EYE_HEIGHT
+    }
+}
 
 use std::{
     collections::{HashMap, HashSet},
@@ -908,13 +928,21 @@ impl Game {
     fn load_from_file(&mut self, file_name: String) {
         let mut file = OpenOptions::new().read(true).open(file_name).unwrap();
         let save_data = SaveData::read(&mut file);
-        let (mission, level_map) = Self::load_from_save_data(
+        let was_crouched = save_data.global_data.is_crouched;
+        let (mut mission, level_map) = Self::load_from_save_data(
             save_data,
             &mut self.asset_cache,
             &mut self.audio_context,
             &self.global_context,
             &self.options,
         );
+        // The saved position is the standing-equivalent center (see
+        // GlobalData) and the player was created standing there; re-applying
+        // the crouch drops the capsule back into the saved crouched pose
+        // (e.g. inside a crawlspace the standing capsule wouldn't fit).
+        if was_crouched {
+            mission.mission_core.restore_saved_crouch();
+        }
         self.active_game_scene = Box::new(mission);
         self.mission_to_save_data = level_map;
     }
@@ -951,6 +979,16 @@ impl Game {
             (player_info.pos, player_info.rotation)
         };
 
+        // Normalize the saved center to standing height (see GlobalData): the
+        // live position of a crouched player is the LOWERED collider center,
+        // and load always creates a standing capsule first.
+        let is_crouched = self.active_game_scene.player_is_crouched();
+        let position = if is_crouched {
+            position + vec3(0.0, physics::player_crouch_center_shift(), 0.0)
+        } else {
+            position
+        };
+
         let quest_info = self
             .active_game_scene
             .world()
@@ -964,6 +1002,7 @@ impl Game {
             rotation,
             quest_info,
             active_mission: self.active_game_scene.scene_name().to_string(),
+            is_crouched,
         };
 
         SaveData {
@@ -1001,6 +1040,14 @@ impl Game {
                         .unwrap();
                     (player_info.pos, player_info.rotation)
                 };
+                // As with saves, respawn a crouched player at the
+                // standing-equivalent center (the reload creates a standing
+                // capsule; held crouch input re-applies on the next step).
+                let position = if self.active_game_scene.player_is_crouched() {
+                    position + vec3(0.0, physics::player_crouch_center_shift(), 0.0)
+                } else {
+                    position
+                };
                 let level_name = self.active_game_scene.scene_name().to_string();
                 let spawn_loc = SpawnLocation::PositionRotation(position, rotation);
                 if self.loading_screen_enabled() {
@@ -1018,6 +1065,15 @@ impl Game {
     /// Get hand spotlights for enhanced lighting when experimental flag is enabled
     pub fn get_hand_spotlights(&self) -> Vec<engine::scene::light::SpotLight> {
         self.active_game_scene.get_hand_spotlights(&self.options)
+    }
+
+    /// Eye (render camera) height above the pawn position returned by
+    /// [`Game::render`], in SS2 units - crouch-aware, reflecting the player's
+    /// *actual* collider state (stand-up can be refused for lack of headroom).
+    /// Flat runtimes should use this for their camera `head_offset` so the
+    /// view matches the flat controller's shot origin.
+    pub fn player_eye_height(&self) -> f32 {
+        player_eye_height_for(self.active_game_scene.player_is_crouched())
     }
 
     pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1079,6 +1079,11 @@ impl MissionCore {
                 Vec::new(),
             )
         } else {
+            // Apply the crouch request before moving: swaps the capsule size
+            // feet-planted; standing up is refused without headroom (the
+            // actual state is read back via `player_is_crouched`).
+            self.physics
+                .set_player_crouch(input_context.crouch, &mut self.player_handle);
             profile!(
                 "shock2.update.physics",
                 self.physics.update(
@@ -1215,6 +1220,7 @@ impl MissionCore {
             player_pos,
             player_rotation: player_rot,
             head_rotation: input_context.head.rotation,
+            eye_height: crate::player_eye_height_for(self.player_handle.is_crouched()),
         });
         self.process_virtual_hand_effects(asset_cache, interaction_msgs);
 
@@ -4552,6 +4558,21 @@ impl MissionCore {
     /// inherently false in VR.
     pub fn wants_pointer(&self) -> bool {
         self.flat_ui.active_panel().is_some() || self.flat_use_mode
+    }
+
+    /// Actual crouch state of the player collider (stand-up can be refused
+    /// for lack of headroom, so this can lag the crouch input).
+    pub fn player_is_crouched(&self) -> bool {
+        self.player_handle.is_crouched()
+    }
+
+    /// Re-apply a crouch recorded in save data. The save stores the
+    /// standing-equivalent center and the player is created standing there;
+    /// this drops the capsule back into the saved crouched pose before the
+    /// first step (a standing capsule may not even fit, e.g. mid-crawlspace).
+    pub fn restore_saved_crouch(&mut self) {
+        self.physics
+            .set_player_crouch(true, &mut self.player_handle);
     }
 
     /// Apply the effects produced by an interaction controller (the VR hands or

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -245,6 +245,10 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.wants_pointer()
     }
 
+    fn player_is_crouched(&self) -> bool {
+        self.mission_core.player_is_crouched()
+    }
+
     fn world(&self) -> &World {
         &self.mission_core.world
     }

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -29,6 +29,32 @@ use self::debug_render_pipeline::DebugRenderer;
 const PLAYER_HEIGHT: f32 = 4.8;
 const PLAYER_RADIUS: f32 = 0.8;
 
+/// Crouched capsule height (SS2 ft). The original engine's crouched COLLISION
+/// profile (a stack of two 1.2 ft spheres, body-bottom -1.8 to head-top +1.0
+/// around the object origin) is ~2.8 ft tall - its taller "crouch height" is
+/// only the camera. The authored crawl routes are built for that: the MedSci
+/// air shaft behind keypad 45100 chokes to ~3.1 ft between its floor grate
+/// and entrance lip, which a 2.8 ft capsule plus the 0.1 ft contact offset
+/// clears with margin while 3.0+ scrapes.
+const PLAYER_CROUCH_HEIGHT: f32 = 2.8;
+
+/// Margin (SS2 ft) for the stand-up headroom test capsule: its radius is
+/// shrunk by this and its pose lifted by it, keeping the test top exactly at
+/// the standing crown while floating the test bottom off the floor. Without
+/// it, grazing contacts (the floor rest gap, walls the crouched capsule
+/// already touches) would falsely refuse standing; anything the lateral
+/// shrink lets through is well inside the controller's contact offset and
+/// resolves over the next frames.
+const PLAYER_STAND_TEST_MARGIN: f32 = 0.05;
+
+/// How far (world units) the collider CENTER sits below its standing height
+/// while crouched (the feet stay planted while the capsule shrinks). Save
+/// code uses this to store a standing-equivalent center so a game saved
+/// while crouched doesn't reload a standing capsule embedded in the floor.
+pub fn player_crouch_center_shift() -> f32 {
+    (PLAYER_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR
+}
+
 /// Gap (SS2 ft) the character controller keeps between the player collider
 /// and world geometry (`KinematicCharacterController::offset`).
 const PLAYER_CONTACT_OFFSET: f32 = 0.1;
@@ -379,6 +405,19 @@ pub struct PlayerHandle {
     // Player
     controller: KinematicCharacterController,
     character_handle: RigidBodyHandle,
+    // Whether the collider is currently the crouched capsule. Mutated only by
+    // `PhysicsWorld::set_player_crouch`, which keeps the shape and this flag
+    // in sync.
+    is_crouched: bool,
+}
+
+impl PlayerHandle {
+    /// Whether the player collider is currently the crouched capsule. This is
+    /// the *actual* state (stand-up can be refused for lack of headroom), not
+    /// the requested input.
+    pub fn is_crouched(&self) -> bool {
+        self.is_crouched
+    }
 }
 
 pub struct PhysicsWorld {
@@ -1091,7 +1130,91 @@ impl PhysicsWorld {
         PlayerHandle {
             controller,
             character_handle,
+            is_crouched: false,
         }
+    }
+
+    /// Set the player's crouch state, resizing the capsule with the feet
+    /// planted (the body translation is the collider center, so half the
+    /// height difference is added/removed from it). Standing up is refused
+    /// while there is not enough headroom for the standing capsule; the
+    /// returned bool is the *resulting* crouch state.
+    pub fn set_player_crouch(
+        &mut self,
+        want_crouch: bool,
+        player_handle: &mut PlayerHandle,
+    ) -> bool {
+        if want_crouch == player_handle.is_crouched {
+            return player_handle.is_crouched;
+        }
+
+        let character_handle = player_handle.character_handle;
+        let collider_handle = self.rigid_body_set[character_handle].colliders()[0];
+        // Feet-planted center shift between the two capsule sizes.
+        let center_shift = (PLAYER_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR;
+
+        if want_crouch {
+            let crouched = SharedShape::capsule_y(
+                (PLAYER_CROUCH_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+                PLAYER_RADIUS / SCALE_FACTOR,
+            );
+            self.collider_set[collider_handle].set_shape(crouched);
+            let body = &mut self.rigid_body_set[character_handle];
+            let mut translation = *body.translation();
+            translation.y -= center_shift;
+            body.set_translation(translation, true);
+            player_handle.is_crouched = true;
+        } else {
+            // Headroom check: intersect a test capsule at the feet-planted
+            // standing pose against the same groups the movement casts use.
+            // The test capsule keeps the full segment but shrinks the radius
+            // by the margin and is lifted by the margin, so its TOP sits
+            // exactly at the standing crown (a ceiling lower than standing
+            // height always blocks) while its BOTTOM floats 2x the margin
+            // above the standing feet (the floor/steps the player rests on
+            // never falsely block).
+            let standing_pos = Translation::from(
+                Vector::y() * (center_shift + PLAYER_STAND_TEST_MARGIN / SCALE_FACTOR),
+            ) * self.rigid_body_set[character_handle].position();
+            let test_shape = Capsule::new_y(
+                (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+                (PLAYER_RADIUS - PLAYER_STAND_TEST_MARGIN) / SCALE_FACTOR,
+            );
+            let filter = QueryFilter::new()
+                .groups(InteractionGroups::new(
+                    InternalCollisionGroups::PLAYER.bits.into(),
+                    InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+                    Default::default(),
+                ))
+                .exclude_rigid_body(character_handle)
+                .exclude_sensors();
+            let dispatcher = self.narrow_phase.query_dispatcher();
+            let queries = self.broad_phase.as_query_pipeline(
+                dispatcher,
+                &self.rigid_body_set,
+                &self.collider_set,
+                filter,
+            );
+            let blocked = queries
+                .intersect_shape(standing_pos, &test_shape)
+                .next()
+                .is_some();
+
+            if !blocked {
+                let standing = SharedShape::capsule_y(
+                    (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+                    PLAYER_RADIUS / SCALE_FACTOR,
+                );
+                self.collider_set[collider_handle].set_shape(standing);
+                let body = &mut self.rigid_body_set[character_handle];
+                let mut translation = *body.translation();
+                translation.y += center_shift;
+                body.set_translation(translation, true);
+                player_handle.is_crouched = false;
+            }
+        }
+
+        player_handle.is_crouched
     }
 
     pub fn new() -> PhysicsWorld {

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -34,9 +34,17 @@ impl SaveData {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct GlobalData {
+    /// Player collider center, normalized to STANDING height: a game saved
+    /// while crouched stores `center + crouch shift` (plus `is_crouched`),
+    /// so load always creates the standing capsule here - never one embedded
+    /// in the floor - and then re-applies the crouch.
     pub position: Vector3<f32>,
     pub rotation: Quaternion<f32>,
     pub quest_info: QuestInfo,
     pub held_items: HeldItemSaveData,
     pub active_mission: String,
+    /// Whether the player was crouched at save time. Defaults false for
+    /// saves that predate crouch.
+    #[serde(default)]
+    pub is_crouched: bool,
 }

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -260,6 +260,10 @@ impl GameScene for DebugScene {
         self.core.queue_entity_trigger(entity_name)
     }
 
+    fn player_is_crouched(&self) -> bool {
+        self.core.player_is_crouched()
+    }
+
     fn as_debuggable(&self) -> Option<&dyn crate::game_scene::DebuggableScene> {
         Some(&self.core)
     }
@@ -470,6 +474,10 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
 
     fn queue_entity_trigger(&mut self, entity_name: String) {
         self.core.queue_entity_trigger(entity_name)
+    }
+
+    fn player_is_crouched(&self) -> bool {
+        self.core.player_is_crouched()
     }
 
     fn as_debuggable(&self) -> Option<&dyn crate::game_scene::DebuggableScene> {

--- a/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Regression test for #502: crouch must shrink the player collider, not just
+// the camera. The MedSci critical path proves it end-to-end - behind the
+// keypad-45100 door (template 1739) the corridor is collapsed and the
+// authored route is a low air duct whose entrance grate leaves ~3.1 ft of
+// clearance: the standing 4.8 ft capsule cannot enter, a crouched one can,
+// and standing up under the grate must be refused for lack of headroom.
+//
+// Waypoints were mapped against the live level (raycast probes): the duct
+// runs west along z~=-16.7..-17.1 at floor y=-1.6; a "Broken Railing" prop
+// intrudes from the south, so the crawl line hugs the north side.
+test(
+  "crouch shrinks the collider: MedSci air shaft is crouch-only",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8116),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    await game.step({ frames: 10 });
+
+    // Bounded, collision-validated walk toward a target: repeat single moves
+    // until blocked or arrived (each move is clamped, so several are needed).
+    const walk = async (target: { x: number; y: number; z: number }) => {
+      let last;
+      for (let i = 0; i < 25; i++) {
+        last = await game.player.moveTo(target);
+        await game.step({ frames: 3 });
+        if (last.blocked || last.distance_moved < 0.01) break;
+      }
+      return last!;
+    };
+
+    // Open the cryo-exit door (stable template id; runtime ids change per
+    // launch). TurnOn is what the keypad sends over its SwitchLink - the
+    // keypad MFD flow itself is covered by keypad.e2e.test.ts.
+    const [door] = await game.entities.byTemplate(1739);
+    assert.ok(door, "medsci1 should contain the keypad door (template 1739)");
+    await game.entities.sendMessage(door.id, { type: "TurnOn" });
+    await game.step({ frames: 120 });
+
+    // Walk the authored route: through the doorway to the collapsed-corridor
+    // threshold in front of the duct.
+    await teleportVerified(game, { x: -25.5, y: 0.7, z: -11.7 });
+    await game.step({ frames: 10 });
+    for (const wp of [
+      { x: -24.8, y: 0.7, z: -13.1 },
+      { x: -24.0, y: 0.7, z: -14.6 },
+      { x: -23.2, y: 0.7, z: -16.1 },
+      { x: -22.4, y: 0.7, z: -17.6 },
+    ]) {
+      await walk(wp);
+    }
+
+    // STANDING: the duct entrance grate must reject the 4.8 ft capsule. The
+    // player can drop into the duct mouth but not pass the grate at x=-24.0.
+    await walk({ x: -27.0, y: -0.9, z: -16.9 });
+    const standing = await game.player.position();
+    assert.ok(
+      standing.x > -24.0,
+      `standing player must not pass the duct grate (reached x=${standing.x.toFixed(2)})`,
+    );
+
+    // CROUCH: the capsule shrinks feet-planted (center y drops), and the
+    // duct becomes traversable - crawl west past the grate and the duct's
+    // authored tripwire (x=-29.6) to its far half.
+    const beforeCrouch = await game.player.position();
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 10 });
+    const crouched = await game.player.position();
+    assert.ok(
+      beforeCrouch.y - crouched.y > 0.2,
+      `crouching must lower the collider center (y ${beforeCrouch.y.toFixed(2)} -> ${crouched.y.toFixed(2)})`,
+    );
+
+    for (const wp of [
+      { x: -24.05, y: -0.9, z: -16.9 },
+      { x: -25.5, y: -0.9, z: -16.7 },
+      { x: -28.0, y: -0.9, z: -16.7 },
+      { x: -31.0, y: -0.9, z: -16.9 },
+    ]) {
+      await walk(wp);
+    }
+    const deep = await game.player.position();
+    assert.ok(
+      deep.x < -30.0,
+      `crouched player must crawl through the duct (reached x=${deep.x.toFixed(2)})`,
+    );
+
+    // SAVE/LOAD while crouched: the save must normalize the lowered center
+    // and restore the crouched capsule, not reload a standing capsule
+    // embedded in the duct (regression guard for the crouch-save edge).
+    const preSave = await game.player.position();
+    await game.input.trigger("QuickSave");
+    await game.step({ frames: 30 });
+    await game.input.trigger("QuickLoad");
+    await game.step({ frames: 30 });
+    const loaded = await game.player.position();
+    assert.ok(
+      Math.abs(loaded.y - preSave.y) < 0.2,
+      `crouched save must reload in the crouched pose (y ${preSave.y.toFixed(2)} -> ${loaded.y.toFixed(2)})`,
+    );
+
+    // STAND-UP REFUSAL: crawl back under the entrance grate (~3.1 ft of
+    // headroom) and release crouch - the collider must stay crouched.
+    for (const wp of [
+      { x: -28.0, y: -0.9, z: -16.7 },
+      { x: -25.5, y: -0.9, z: -16.7 },
+      { x: -24.05, y: -0.9, z: -16.9 },
+    ]) {
+      await walk(wp);
+    }
+    const underGrate = await game.player.position();
+    await game.input.set("crouch", 0);
+    await game.step({ frames: 20 });
+    const afterRelease = await game.player.position();
+    assert.ok(
+      Math.abs(afterRelease.y - underGrate.y) < 0.2,
+      `stand-up under the grate must be refused (y ${underGrate.y.toFixed(2)} -> ${afterRelease.y.toFixed(2)}; standing would be +0.40)`,
+    );
+
+    // Crawl back out of the duct mouth. Sample the crouched height AFTER
+    // exiting (the climb out of the duct raises y on its own), then release
+    // crouch - only the actual stand should produce the remaining rise.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+    await walk({ x: -22.4, y: -0.9, z: -17.3 });
+    await walk({ x: -22.4, y: 0.5, z: -18.5 });
+    const preStand = await game.player.position();
+    await game.input.set("crouch", 0);
+    await game.step({ frames: 20 });
+    const stood = await game.player.position();
+    assert.ok(
+      stood.y - preStand.y > 0.25,
+      `player must stand once clear of the duct (y ${preStand.y.toFixed(2)} -> ${stood.y.toFixed(2)}; standing center is +0.40)`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #502.

Crouch was camera-only: desktop LeftControl lowered the render eye but the 4.8 ft physics capsule never changed, so authored crouch-only routes — the MedSci air shaft behind the keypad-45100 door, which chokes to ~3.1 ft under its entrance grate — were impassable, and the debug runtime couldn't express crouching at all.

## What changed

- **`PhysicsWorld::set_player_crouch`** swaps the capsule between 4.8 ft and **2.8 ft feet-planted** (body translation = collider center, so half the height delta shifts it). 2.8 ft matches the original engine's crouched two-sphere *collision* profile (body-bottom −1.8 to head-top +1.0 ≈ 2.8 ft — its taller "crouch height" is only the camera), which the authored crawlspaces are built for: 3.2/3.0 ft capsules measurably scrape the MedSci grate.
- **Stand-up is refused without headroom**: a test capsule whose top sits exactly at the standing crown (radius shrunk + pose lifted by a 0.05 ft margin so the floor and grazing walls can't falsely block) must fit at the feet-planted standing pose first.
- **`InputContext.crouch`** carries the request: desktop maps LeftControl; the debug runtime adds a `crouch` 0|1 channel on `POST /v1/control/input` (reported by GET). VR is deliberately unchanged — #512 tracks deriving crouch from HMD height.
- **Eye height follows the actual collider state** through one shared mapping (`player_eye_height_for`): render camera (desktop + debug runtime) and the flat controller's shot/viewmodel origin, so crouched shots stay on the crosshair and the camera can't rise through a ceiling the body still crouches under.
- **Save/load**: saves store the standing-equivalent center plus `is_crouched` (`serde(default)` keeps old saves loading) and load re-applies the crouch after `create_player` — a game saved mid-crawlspace no longer reloads a standing capsule embedded in the floor. `TestReload` normalizes the same way.
- All movement paths (walk/gravity, ladder grip, step-up probe, validated moves, sensor overlap) read the live collider shape, so they follow the crouched capsule with no special-casing.

## Visuals

Crouch-crawl through the MedSci air shaft (approach → blocked standing → camera drops on crouch → crawl through the grated duct):

![crouch crawl](https://gist.githubusercontent.com/tommy-xr/833a195670ddec11440bf30ec07f0371/raw/crouch-crawl.gif)

| Duct entrance (standing, blocked) | Inside the duct (crouched) |
| --- | --- |
| ![entrance](https://gist.githubusercontent.com/tommy-xr/833a195670ddec11440bf30ec07f0371/raw/still-duct-entrance.png) | ![inside](https://gist.githubusercontent.com/tommy-xr/833a195670ddec11440bf30ec07f0371/raw/still-crouched-inside.png) |

## Verification

- New SDK e2e **`crouch-shaft.e2e.test.ts`** walks the real MedSci route end-to-end: standing blocked at the duct grate; crouch drops the collider center and the duct becomes traversable (past its authored tripwire); crouched quicksave/quickload restores the crouched pose; stand-up refused under the grate; stands again once clear. **Fails on main** (no crouch channel), passes here — verified both directions by stashing.
- Full SDK e2e suite on this branch: **110/111**. The one failure is `entity-recycled-slot.e2e.test.ts` — the regression test for #484, whose fix is PR #509 and not on this branch; it passes once both merge. (`alertness-churn` passed this run; its intermittent failure is tracked in #510.)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; clippy introduces no new warnings; `cargo fmt` applied.
- Cross-engine adversarial review (Claude + Codex) ran on the pre-fix diff; all findings addressed: the save/load-while-crouched regression (now fixed + e2e-guarded), exact-crown stand-test geometry, strengthened final test assertion, eye-height mapping dedup. Known accepted edges, per review: a crouch/stand cycle under a sensor volume re-fires its begin/end intersections (script-side once-only guards apply), and the stand-up headroom test reads the previous step's broad phase, so a door closing into the stand-up space in that exact frame could be missed one frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)