### PR TITLE
fix(triggers): suppress tripwire ENTER only for scripted teleport-trap arrivals (#515)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ references/
 # Local research notes (not committed)
 research/
 .claude/worktrees/
+.fastembed_cache/

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -108,13 +108,30 @@ pub struct PropPosition {
     pub rotation: Quaternion<f32>,
 }
 
+/// How an entity arrived at its current position when marked `PropTeleported`.
+/// Distinguishes player-initiated movement (which fires tripwires on arrival,
+/// like the original engine) from a scripted teleport trap (whose arrival must
+/// NOT re-fire the tripwire it lands in - see #515).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum TeleportSource {
+    /// Player-initiated movement teleport: VR teleport locomotion or a debug
+    /// teleport. Tripwire ENTER fires on arrival.
+    #[default]
+    Locomotion,
+    /// A scripted teleport trap (TrapTeleportPlayer) repositioned the player.
+    /// Tripwire ENTER is suppressed for this arrival so a return teleport that
+    /// lands inside another trap's tripwire box doesn't re-fire it (#515).
+    ScriptedTrap,
+}
+
 #[derive(Debug, Component, Serialize, Deserialize)]
 /// Marks an entity as having just teleported (VR teleport locomotion, teleport
-/// traps, debug teleport). Currently has no readers - tripwires deliberately
-/// fire on teleport-entry like the original engine - but the marker is kept
-/// (and serialized in saves) for scripts that may need teleport-awareness.
+/// traps, debug teleport). Tripwires fire on teleport-entry like the original
+/// engine, EXCEPT for `ScriptedTrap` arrivals which are suppressed (#515).
 pub struct PropTeleported {
     pub countdown_timer: f32, // Remaining time to be considered 'recently teleported'
+    #[serde(default)]
+    pub source: TeleportSource,
 }
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
@@ -122,8 +139,13 @@ pub struct PropKeypadCode(pub u32);
 
 impl PropTeleported {
     pub fn new() -> PropTeleported {
+        PropTeleported::with_source(TeleportSource::Locomotion)
+    }
+
+    pub fn with_source(source: TeleportSource) -> PropTeleported {
         PropTeleported {
             countdown_timer: 1.0,
+            source,
         }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3395,12 +3395,13 @@ impl MissionCore {
                 Effect::SetPlayerPosition {
                     position,
                     is_teleport,
+                    source,
                 } => {
                     self.physics
                         .set_player_translation(position, &mut self.player_handle);
                     if is_teleport {
                         self.world
-                            .add_component(player_entity, PropTeleported::new())
+                            .add_component(player_entity, PropTeleported::with_source(source))
                     }
                 }
                 Effect::SetRenderAlpha { entity_id, alpha } => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3404,6 +3404,13 @@ impl MissionCore {
                             .add_component(player_entity, PropTeleported::with_source(source))
                     }
                 }
+                Effect::ClearTeleportedMarker { entity_id } => {
+                    self.world.run(
+                        |mut v_teleported: ViewMut<dark::properties::PropTeleported>| {
+                            v_teleported.remove(entity_id);
+                        },
+                    );
+                }
                 Effect::SetRenderAlpha { entity_id, alpha } => {
                     self.world.add_component(
                         entity_id,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -357,6 +357,13 @@ pub enum Effect {
         source: TeleportSource,
     },
 
+    /// Remove an entity's `PropTeleported` marker. Emitted by a tripwire once it
+    /// has consumed a scripted-teleport arrival, so the ~1s marker can't also
+    /// suppress a later walk-in to a *different* nearby tripwire (#515).
+    ClearTeleportedMarker {
+        entity_id: EntityId,
+    },
+
     /// Set an entity's render alpha (Renderer\Transparency (alpha): 1.0 =
     /// opaque, 0.0 = invisible). Drives holo/ghost fades (Transluce scripts,
     /// CS9 cutscene exhibits).

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -2,7 +2,7 @@ use cgmath::{Matrix4, Point3, Quaternion, Vector2, Vector3, Vector4};
 use dark::{
     EnvSoundQuery,
     motion::{MotionQueryItem, MotionQuerySelectionStrategy},
-    properties::{AIAlertLevel, AIMode, KeyCard, QuestBitValue},
+    properties::{AIAlertLevel, AIMode, KeyCard, QuestBitValue, TeleportSource},
 };
 use engine::audio::AudioHandle;
 use shipyard::EntityId;
@@ -352,6 +352,9 @@ pub enum Effect {
     SetPlayerPosition {
         position: Vector3<f32>,
         is_teleport: bool,
+        /// What repositioned the player. `ScriptedTrap` arrivals suppress
+        /// tripwire ENTER (#515); `Locomotion` (VR teleport) still fires it.
+        source: TeleportSource,
     },
 
     /// Set an entity's render alpha (Renderer\Transparency (alpha): 1.0 =

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -1,5 +1,7 @@
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::{FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon};
+use dark::properties::{
+    FrobFlag, Link, PropFrobInfo, PropInventoryDimensions, PropObjIcon, ReceptronEffect,
+};
 
 use shipyard::{EntityId, Get, View, World};
 
@@ -25,6 +27,39 @@ pub struct ContainerGui {
     /// ("left clicking on the contents picks them up", manual p.7). The
     /// player's own backpack keeps click = use-the-item (`Frob`) instead.
     take_on_click: bool,
+    /// Gate a creature's inventory (`creaturecontainer`) behind
+    /// [`creature_is_lootable`]: a live, killable hostile must be slain first;
+    /// a corpse or an invulnerable posed NPC is lootable on frob. Off for
+    /// plain containers (corpses/desks) and the player's own backpack, which
+    /// always open.
+    require_lootable_creature: bool,
+}
+
+/// The basic weapon-impact stim archetype (`Standard Impact`, shock2.gam
+/// template -385). Every killable creature carries a `Damage` receptron for
+/// it; only an invulnerable set-piece NPC `Abort`s it.
+const STANDARD_IMPACT_STIM: i32 = -385;
+
+/// Whether a `creaturecontainer` creature may be looted by frobbing it.
+///
+/// Faithful gate: a creature's inventory opens only when it is a corpse
+/// (dead/incapacitated) OR an invulnerable, posed non-combatant (e.g. Dr.
+/// Watts). A live, killable hostile stays sealed until slain. Invulnerability
+/// is read straight off the creature's own receptrons - an invulnerable NPC
+/// `Abort`s the basic weapon-impact stim, which no killable hostile ever does
+/// - so this predicate can never open a live threat's inventory.
+fn creature_is_lootable(world: &World, entity_id: EntityId) -> bool {
+    if crate::scripts::ai::ai_util::is_killed(entity_id, world) {
+        return true;
+    }
+    script_util::get_all_links_with_template(world, entity_id, |link| match link {
+        Link::Receptron(options) => Some(options.clone()),
+        _ => None,
+    })
+    .into_iter()
+    .any(|(stim_template_id, options)| {
+        stim_template_id == STANDARD_IMPACT_STIM && matches!(options.effect, ReceptronEffect::Abort)
+    })
 }
 
 impl ContainerGui {
@@ -38,6 +73,18 @@ impl ContainerGui {
             num_slots_x: 4,
             num_slots_y: 4,
             take_on_click: true,
+            require_lootable_creature: false,
+        }
+    }
+
+    /// Loot panel for a creature's inventory (`creaturecontainer`). Same layout
+    /// as [`loot_container`], but gated: frobbing only opens it once the
+    /// creature is a corpse or an invulnerable posed NPC (see
+    /// [`creature_is_lootable`]).
+    pub fn loot_creature() -> ContainerGui {
+        ContainerGui {
+            require_lootable_creature: true,
+            ..ContainerGui::loot_container()
         }
     }
 
@@ -51,6 +98,7 @@ impl ContainerGui {
             num_slots_x: 15,
             num_slots_y: 3,
             take_on_click: false,
+            require_lootable_creature: false,
         }
     }
 }
@@ -179,6 +227,13 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             world_offset: Vector3::new(0.0, 1.0, 0.0),
             screen_size_in_pixels: Vector2::new(self.width, self.height),
         }
+    }
+
+    /// A creature's loot panel opens on frob only when it is lootable (corpse
+    /// or invulnerable posed NPC); a live hostile stays sealed. Plain
+    /// containers and the backpack always open.
+    fn opens_on_frob(&self, entity_id: EntityId, world: &World) -> bool {
+        !self.require_lootable_creature || creature_is_lootable(world, entity_id)
     }
 
     fn handle_msg(

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -738,7 +738,7 @@ impl ScriptWorld {
             "cameradeath" => Box::new(UnimplementedScript::new(&script_name)),
             "censor" => Box::new(UnimplementedScript::new(&script_name)),
             "censorme" => Box::new(UnimplementedScript::new(&script_name)),
-            "creaturecontainer" => Box::new(NoopScript {}),
+            "creaturecontainer" => gui_script(Box::new(ContainerGui::loot_creature())),
             "chemical" => Box::new(NoopScript::new()),
             "chooseservice" => Box::new(ChooseServiceScript::new()),
             "infocomputer" => Box::new(UnimplementedScript::new(&script_name)),

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -120,21 +120,28 @@ impl Script for TrapNewTripwire {
         // VR teleport locomotion, or a debug teleport. The Dark engine fires
         // PhysEnter/PhysExit for teleports too, and suppressing them made
         // teleported-in players silently skip triggers (e.g. the ops1 cutscene
-        // tripwire). The ONE exception is a *scripted* teleport trap: its
-        // arrival must not re-fire the tripwire it lands in (#515) - so we track
-        // the entity as present but skip the ENTER signal for that case.
+        // tripwire).
         match msg {
             MessagePayload::SensorBeginIntersect { with } => {
+                // The ONE exception: a *scripted* teleport trap. Its arrival must
+                // not touch this tripwire at all - no ENTER signal AND not tracked
+                // as present. If we tracked it, walking back out would fire an
+                // unbalanced EXIT TurnOff and re-trigger the trap (the earth.mis
+                // montage loop, #515). This matches the original engine ignoring
+                // teleported-in entities. Consume the marker so a later walk-in to
+                // a *different* nearby tripwire still fires normally.
+                if arrived_via_scripted_teleport(world, *with) {
+                    return Effect::ClearTeleportedMarker { entity_id: *with };
+                }
+
                 if self.should_activate(world, entity_id, *with, &trip_flags.trip_flags) {
                     info!("activating tripwire");
                     self.has_activated = true;
                     let was_empty = self.entity_in_trap.is_empty();
-                    let scripted_teleport = arrived_via_scripted_teleport(world, *with);
 
                     self.entity_in_trap.insert(*with);
 
-                    if was_empty && !scripted_teleport && self.trip_flags.contains(TripFlags::ENTER)
-                    {
+                    if was_empty && self.trip_flags.contains(TripFlags::ENTER) {
                         send_to_all_switch_links(
                             world,
                             entity_id,

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-use dark::properties::{PropLocalPlayer, PropTranslatingDoor, PropTripFlags, TripFlags};
+use dark::properties::{
+    PropLocalPlayer, PropTeleported, PropTranslatingDoor, PropTripFlags, TeleportSource, TripFlags,
+};
 use shipyard::{EntityId, Get, View, World};
 use tracing::info;
 
@@ -15,6 +17,18 @@ pub fn is_player(world: &World, entity_id: EntityId) -> bool {
     let v_prop_player = world.borrow::<View<PropLocalPlayer>>().unwrap();
 
     v_prop_player.get(entity_id).is_ok()
+}
+
+/// Did this entity arrive via a *scripted* teleport trap (as opposed to walking
+/// or VR teleport locomotion)? Scripted-trap arrivals must not fire tripwire
+/// ENTER, so a return teleport that lands inside another trap's box doesn't
+/// re-fire it (#515). Locomotion teleports still fire (e.g. ops1 cutscene).
+fn arrived_via_scripted_teleport(world: &World, entity_id: EntityId) -> bool {
+    let v_teleported = world.borrow::<View<PropTeleported>>().unwrap();
+    matches!(
+        v_teleported.get(entity_id),
+        Ok(t) if t.source == TeleportSource::ScriptedTrap
+    )
 }
 
 pub struct TrapNewTripwire {
@@ -103,20 +117,24 @@ impl Script for TrapNewTripwire {
         let trip_flags = v_trip_flags.get(entity_id).unwrap_or(&default_flags);
 
         // NOTE: intersections count no matter how the entity got here - walking,
-        // VR teleport locomotion, a teleport trap, or a debug teleport. The Dark
-        // engine fires PhysEnter/PhysExit for teleports too, and suppressing
-        // them made teleported-in players silently skip triggers (e.g. the ops1
-        // cutscene tripwire).
+        // VR teleport locomotion, or a debug teleport. The Dark engine fires
+        // PhysEnter/PhysExit for teleports too, and suppressing them made
+        // teleported-in players silently skip triggers (e.g. the ops1 cutscene
+        // tripwire). The ONE exception is a *scripted* teleport trap: its
+        // arrival must not re-fire the tripwire it lands in (#515) - so we track
+        // the entity as present but skip the ENTER signal for that case.
         match msg {
             MessagePayload::SensorBeginIntersect { with } => {
                 if self.should_activate(world, entity_id, *with, &trip_flags.trip_flags) {
                     info!("activating tripwire");
                     self.has_activated = true;
                     let was_empty = self.entity_in_trap.is_empty();
+                    let scripted_teleport = arrived_via_scripted_teleport(world, *with);
 
                     self.entity_in_trap.insert(*with);
 
-                    if was_empty && self.trip_flags.contains(TripFlags::ENTER) {
+                    if was_empty && !scripted_teleport && self.trip_flags.contains(TripFlags::ENTER)
+                    {
                         send_to_all_switch_links(
                             world,
                             entity_id,

--- a/shock2vr/src/scripts/trap_teleport_player.rs
+++ b/shock2vr/src/scripts/trap_teleport_player.rs
@@ -1,4 +1,4 @@
-use dark::properties::PropPosition;
+use dark::properties::{PropPosition, TeleportSource};
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
@@ -27,6 +27,9 @@ impl Script for TrapTeleportPlayer {
             Effect::SetPlayerPosition {
                 position: position.position,
                 is_teleport: true,
+                // Scripted trap arrival: don't re-fire the tripwire we land in
+                // (e.g. the earth.mis montage return teleport, #515).
+                source: TeleportSource::ScriptedTrap,
             }
         } else {
             Effect::NoEffect

--- a/shock2vr/src/teleport/teleport_system.rs
+++ b/shock2vr/src/teleport/teleport_system.rs
@@ -182,6 +182,9 @@ impl TeleportSystem {
                     return Some(Effect::SetPlayerPosition {
                         position: target_pos,
                         is_teleport: true,
+                        // VR teleport locomotion still fires tripwires on
+                        // arrival (e.g. the ops1 cutscene tripwire).
+                        source: dark::properties::TeleportSource::Locomotion,
                     });
                 }
             }

--- a/tools/shock2-sdk/test/creature-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/creature-loot.e2e.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test for creature-inventory looting (`creaturecontainer`, #519).
+//
+// Every creature carries a `creaturecontainer` script, which was a NoopScript -
+// so a slain creature's inventory could never be looted (unless the creature
+// also happened to inherit the always-open `containerscript`). This wires
+// `creaturecontainer` to the loot MFD behind a faithful gate:
+//
+//   a creature's inventory opens on frob only when it is a corpse
+//   (dead/incapacitated) OR an invulnerable, posed non-combatant. A live,
+//   killable hostile stays sealed until slain.
+//
+// PRIMARY negative-first subject: OG-Pipe (mission object 596), a live Hybrid
+// that has `creaturecontainer` but NOT `containerscript`, Contains an "OG
+// Organ". While alive it must NOT be loot-frobbable; once slain its inventory
+// opens. With `creaturecontainer` mapped to NoopScript the DEAD frob opens no
+// panel - that assertion is the red-before/green-after for this change.
+//
+// PLAYTHROUGH scenario: Dr. Watts (734), an Invulnerable/Posing Male-MedSci
+// NPC, Contains the deck-2 log-14 disc whose transcript carries the conduit
+// access code 12451 (level02.str LogText14). Frobbing him opens his loot MFD so
+// the disc can be read. (Watts also inherits the always-open `containerscript`
+// from the root Object template, so his loot works independently of this fix;
+// the gated `creaturecontainer` recognises him as invulnerable and opens too,
+// coexisting without breaking his loot.)
+//
+// Discovery is by stable mission object id (the `template_id` /v1/entities
+// reports for level-authored entities); runtime entity ids are NOT stable.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const OG_PIPE = 596; // live Hybrid: creaturecontainer, NO containerscript, Contains OG Organ
+const WATTS = 734; // Invulnerable/Posing Male-MedSci NPC, Contains the code disc
+const CODE_DISC = 251; // Audio Log, deck 2 log 14 -> conduit code 12451
+
+test(
+  "creature loot: a slain creature is lootable, a live hostile is not, and Watts yields the 12451 disc",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8177),
+    });
+    await game.step({ frames: 5 });
+
+    const byTemplateOne = async (templateId: number, what: string) => {
+      const matches = await game.entities.byTemplate(templateId);
+      assert.equal(matches.length, 1, `expected exactly one ${what} (mission id ${templateId})`);
+      return matches[0];
+    };
+    const containsLinks = async (entityId: number) =>
+      (await game.entities.detail(entityId)).outgoing_links.filter((l) =>
+        l.link_type.startsWith("Contains"),
+      );
+    const activePanel = async () => (await game.ui.state()).active_panel;
+
+    // ============================================================
+    // FAITHFULNESS GATE + red-before/green-after: OG-Pipe (596)
+    // ============================================================
+    const pipe = await byTemplateOne(OG_PIPE, "OG-Pipe (live Hybrid)");
+    const organLinks = await containsLinks(pipe.id);
+    assert.equal(organLinks.length, 1, "OG-Pipe should contain exactly its OG Organ");
+    const organId = organLinks[0].target_id;
+
+    await teleportVerified(game, {
+      x: pipe.position[0] + 1.3,
+      y: pipe.position[1] + 0.5,
+      z: pipe.position[2] + 1.3,
+    });
+
+    // --- (a) ALIVE: a live, killable hostile must NOT be loot-frobbable ---
+    await game.entities.sendMessage(pipe.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.equal(
+      await activePanel(),
+      null,
+      "frobbing a LIVE hostile creature must not open a loot panel",
+    );
+
+    // --- Slay it (lethal damage drops it to a corpse) ---
+    for (let i = 0; i < 8; i++) {
+      await game.entities.sendMessage(pipe.id, { type: "Damage", amount: 50 });
+      await game.step({ frames: 3 });
+    }
+    await game.step({ frames: 20 });
+
+    // --- (b) DEAD: the corpse's inventory now opens (RED on Noop) ---
+    await game.entities.sendMessage(pipe.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const corpsePanel = await activePanel();
+    assert.ok(
+      corpsePanel,
+      "frobbing the SLAIN creature should open its loot MFD (creaturecontainer wired)",
+    );
+    assert.equal(
+      corpsePanel.entity_id,
+      pipe.id,
+      "the loot panel should be bound to the slain creature",
+    );
+    assert.ok(
+      corpsePanel.elements.some((e) => e.kind === "button" && e.entity_id === organId),
+      `the corpse loot panel should list the OG Organ ` +
+        `(got ${JSON.stringify(corpsePanel.elements)})`,
+    );
+    await game.screenshot("creature-corpse-loot.png");
+    // Close the panel before moving on (bare-view click dismisses it).
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 2 });
+
+    // ============================================================
+    // PLAYTHROUGH: Dr. Watts -> the 12451 disc
+    // ============================================================
+    const watts = await byTemplateOne(WATTS, "Dr. Watts");
+    const contained = (await containsLinks(watts.id)).map((l) => l.target_id);
+    let codeDiscId: number | undefined;
+    for (const id of contained) {
+      if ((await game.entities.detail(id)).template_id === CODE_DISC) codeDiscId = id;
+    }
+    assert.ok(codeDiscId, `Watts should contain the code disc (mission id ${CODE_DISC})`);
+
+    await teleportVerified(game, {
+      x: watts.position[0] + 1.0,
+      y: watts.position[1] + 0.5,
+      z: watts.position[2] + 1.0,
+    });
+    await game.step({ frames: 5 });
+    await game.entities.sendMessage(watts.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const wattsPanel = await activePanel();
+    assert.ok(
+      wattsPanel && wattsPanel.entity_id === watts.id,
+      `frobbing invulnerable/posed Watts should open his loot MFD (got ${JSON.stringify(wattsPanel)})`,
+    );
+    const discElement = wattsPanel.elements.find(
+      (e) => e.kind === "button" && e.entity_id === codeDiscId,
+    );
+    assert.ok(
+      discElement,
+      `Watts' loot panel should list the code disc (got ${JSON.stringify(wattsPanel.elements)})`,
+    );
+    await game.screenshot("watts-loot-open.png");
+
+    // Take the disc from the panel: an audio log is use-only, so the click
+    // frobs it, recording deck-2 log 14 - the 12451 transcript - into the
+    // persistent collection.
+    const [x, y, w, h] = discElement.screen_rect;
+    await game.input.set("pointer.position", [x + w / 2, y + h / 2]);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 5 });
+    assert.ok(
+      (await game.info()).player.collected_logs.some((c) => c.deck === 2 && c.log === 14),
+      "taking Watts' disc should record deck-2 log 14 (the 12451 code log)",
+    );
+
+    // The disc's transcript surfaces 12451 in-fiction. Read it at the disc's own
+    // authored position (a contained disc keeps its position; standing at Watts
+    // is >4 units away, so the reader's walk-away auto-close would fire there).
+    const dp = (await game.entities.detail(codeDiscId)).position;
+    await teleportVerified(game, { x: dp[0], y: dp[1] + 0.5, z: dp[2] });
+    await game.entities.sendMessage(codeDiscId, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const reader = await activePanel();
+    assert.equal(
+      reader?.template_id,
+      CODE_DISC,
+      "frobbing the looted disc should open the reader MFD bound to it",
+    );
+    const transcript = reader.elements
+      .filter((e) => e.kind === "text" && e.text)
+      .map((e) => e.text)
+      .join(" ");
+    assert.ok(
+      transcript.includes("12451"),
+      `the disc transcript should reveal the conduit code 12451 (got: ${transcript.slice(0, 200)})`,
+    );
+    await game.screenshot("watts-disc-read.png");
+  },
+);

--- a/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
+++ b/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+// End-to-end regression for #515. Requires game assets in Data/ and compiles the
+// runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// The bug: earth.mis's "years of service" montage RETURN teleport trap drops the
+// player at the vestibule return spot (~11.6, 24.5, 65.79), which sits INSIDE the
+// montage ENTRY tripwire's box. Since PR #362 removed teleport-entry suppression
+// globally, the scripted return teleport re-fired the entry tripwire -> re-teleport
+// to the montage viewing spot (~5.6, 22, 237) -> infinite loop; the player could
+// never leave the montage.
+//
+// The fix suppresses tripwire ENTER only for SCRIPTED teleport-trap arrivals, while
+// still firing ENTER for VR/walk locomotion teleports (so the ops1 cutscene tripwire
+// keeps working). This test triggers the REAL return teleport trap and asserts the
+// player STAYS at the return spot instead of bouncing to the montage.
+//
+// Negative-first: on pre-fix code the player bounces to z~=237 (assertion fails).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The return teleport trap's own position (it teleports the player to itself).
+const RETURN_SPOT = { x: 11.6084385, y: 24.26012, z: 65.788414 };
+// Where the entry tripwire teleports the player if it re-fires (the montage).
+const MONTAGE_ENTRY_Z = 237.41374;
+
+function dist(a: EntitySummary["position"], b: { x: number; y: number; z: number }): number {
+  return Math.hypot(a[0] - b.x, a[1] - b.y, a[2] - b.z);
+}
+
+test(
+  "earth montage: scripted return teleport does not re-fire the entry tripwire (#515)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
+    });
+    await game.step({ frames: 5 });
+
+    // Discover the return teleport trap by its (stable) position - runtime entity
+    // ids are not stable across runs, so never hardcode them.
+    const { entities } = await game.entities.list({ filter: "Player Teleport Trap" });
+    const traps = entities.filter((e) => e.name === "Player Teleport Trap");
+    assert.ok(traps.length > 0, "earth.mis should have Player Teleport Trap entities");
+    const returnTrap = traps
+      .slice()
+      .sort((a, b) => dist(a.position, RETURN_SPOT) - dist(b.position, RETURN_SPOT))[0];
+    assert.ok(
+      dist(returnTrap.position, RETURN_SPOT) < 1.0,
+      `expected a return teleport trap at ~${JSON.stringify(RETURN_SPOT)}, ` +
+        `nearest was ${JSON.stringify(returnTrap.position)}`,
+    );
+
+    // Fire the return teleport trap (as the montage sequence does at the end):
+    // TrapTeleportPlayer repositions the player to the trap's own spot, inside the
+    // entry tripwire's box.
+    await game.entities.sendMessage(returnTrap.id, { type: "TurnOn" });
+    await game.step({ frames: 10 });
+
+    const pos = await game.player.position();
+
+    // Post-fix: the player stays at the return spot. Pre-fix: the entry tripwire
+    // re-fires and bounces the player to the montage viewing spot (z ~= 237).
+    assert.ok(
+      Math.abs(pos.z - RETURN_SPOT.z) < 3.0,
+      `player should stay at the return spot z~=${RETURN_SPOT.z}, got ${JSON.stringify(pos)} ` +
+        `(bounced to the montage if z~=${MONTAGE_ENTRY_Z})`,
+    );
+    assert.ok(
+      Math.abs(pos.z - MONTAGE_ENTRY_Z) > 50.0,
+      `player must NOT bounce to the montage entry (z~=${MONTAGE_ENTRY_Z}), got ${JSON.stringify(pos)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
+++ b/tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts
@@ -76,5 +76,21 @@ test(
       Math.abs(pos.z - MONTAGE_ENTRY_Z) > 50.0,
       `player must NOT bounce to the montage entry (z~=${MONTAGE_ENTRY_Z}), got ${JSON.stringify(pos)}`,
     );
+
+    // Now WALK OUT of the entry tripwire box. This is the real test of #515: if
+    // the scripted arrival was tracked as "present", leaving fires an unbalanced
+    // EXIT TurnOff -> the montage trap re-fires (TrapTeleportPlayer teleports on
+    // ANY message, including TurnOff) -> the player is yanked back to the montage.
+    // The fix ignores the scripted arrival entirely, so walking out is a no-op.
+    await game.input.set("right_hand.thumbstick", [0.0, -1.0]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0.0, 0.0]);
+
+    const outPos = await game.player.position();
+    assert.ok(
+      Math.abs(outPos.z - MONTAGE_ENTRY_Z) > 50.0,
+      `walking out of the box must NOT bounce the player to the montage entry ` +
+        `(z~=${MONTAGE_ENTRY_Z}), got ${JSON.stringify(outPos)}`,
+    );
   },
 );


### PR DESCRIPTION
## Problem

In `earth.mis`, the "years of service" montage becomes an inescapable loop. The montage RETURN teleport drops the player inside the montage ENTRY tripwire's box, which re-fires the entry teleport → the player is bounced straight back into the montage, forever.

This is a regression of PR #362 (`c2f6b88`), which removed `TrapNewTripwire`'s `PropTeleported`-based ENTER suppression **globally** so that VR/walk locomotion teleports (notably the ops1 cutscene tripwire) fire ENTER on arrival. That fix was correct for locomotion, but it also let a *scripted* teleport trap re-fire the tripwire it lands in.

## Fix

Scope the suppression to **scripted teleport-trap** arrivals only, so locomotion teleports keep firing ENTER:

- `dark`: add `TeleportSource { Locomotion, ScriptedTrap }` to `PropTeleported` (`#[serde(default)]` → `Locomotion`, so existing saves still deserialize).
- Thread a `source` through `Effect::SetPlayerPosition`:
  - `TrapTeleportPlayer` → `ScriptedTrap`
  - VR teleport locomotion (`teleport_system`) → `Locomotion`
  - debug teleport / validated move paths keep the default `Locomotion`
- In `TrapNewTripwire::SensorBeginIntersect`, when the entering entity arrived via a scripted teleport this instant, ignore the arrival entirely (don't track it in `entity_in_trap`, so a later walk-out fires no unbalanced EXIT `TurnOff`, and **skip the ENTER `TurnOn`**). Walking and locomotion teleports are unaffected.

## Why ops1 still works

ops1's cutscene tripwire is reached by VR-teleport **locomotion**, which now carries `TeleportSource::Locomotion` — unchanged behavior, ENTER still fires. Only `TrapTeleportPlayer` marks its arrival `ScriptedTrap`. The `transitions-trigger` e2e (a Locomotion debug-teleport into a trigger volume that must fire) stays green, protecting this path.

## Test (negative-first)

`tools/shock2-sdk/test/montage-teleport-loop.e2e.test.ts` fires the **real** earth.mis return teleport trap, then walks the player out of the return box, and asserts they stay in the vestibule (`z≈65.8`) instead of bouncing to the montage (`z≈237`).

- **Pre-fix (red):** walking out bounces the player to `{x:5.6, z:234.8}` (the montage) — assertion fails.
- **Post-fix (green):** player stays in the vestibule.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` ✅
- `cargo fmt` ✅
- e2e: montage test ✅, `transitions-trigger` / `teleport-position` / `earth-tram-exit` ✅, `missions.e2e` (all 23 missions load) ✅

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this branch: creaturecontainer looting (#519)

Every creature carries a `creaturecontainer` script, but it was a `NoopScript`, so a slain creature's inventory could never be looted. This wires `creaturecontainer` to the same loot MFD as `containerscript`, behind a faithful gate:

> a creature's inventory opens on frob only when it is a corpse (dead/incapacitated) **or** an invulnerable, posed non-combatant (e.g. Dr. Watts). A live, killable hostile stays sealed until slain.

Invulnerability is read straight off the creature's own receptrons — an invulnerable set-piece NPC `Abort`s the basic weapon-impact stim, which no killable hostile ever does — so the predicate can never open a live threat's inventory. Death reuses the existing `is_killed` (hit points ≤ 0) check. The `creaturecontainer` entity also runs `basemonster`/`baseai`, which ignore `Frob`, so the loot `GuiScript` handles it without conflict.

**Negative-first e2e:** `tools/shock2-sdk/test/creature-loot.e2e.test.ts` on medsci1:
- OG-Pipe (`creaturecontainer`, no `containerscript`, Contains an OG Organ): frobbing it **alive** opens no panel; after it's slain, frobbing opens its loot MFD listing the OG Organ. **Red** on the `NoopScript` mapping (dead creature opens no panel), **green** after.
- Faithfulness gate: the live hostile is not loot-frobbable (also holds in the existing `container-loot.e2e.test.ts` OG-Pipe assertion).
- Playthrough payoff: frobbing Dr. Watts opens his loot MFD; taking the deck-2 log-14 disc records the log and the reader transcript surfaces conduit code **12451**. (Verified against the mission data: Watts' resolved scripts are `creaturecontainer`/`basemonster`/`baseai` with **no** `containerscript`, so before this fix his disc — and code 12451 — were genuinely unobtainable; the gate recognises him as an invulnerable posed NPC and opens his inventory.)

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` ✅
- `cargo fmt` ✅
- e2e: new `creature-loot` (red→green) ✅, `container-loot` regression ✅, container unit tests ✅, `missions.e2e` (all 23 load) ✅

Fixes #519