### PR TITLE
Faithful flat power-cell recharge and insert (#518)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1958,13 +1958,7 @@ impl MissionCore {
             let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
 
             for (id, links) in (&mut v_links).iter().with_id() {
-                links.to_links.retain(|link| {
-                    let is_link_to_entity = matches!(link.link, Link::Contains(_))
-                        && link.to_entity_id.is_some()
-                        && link.to_entity_id.unwrap().0 == dropped_entity_id;
-
-                    !is_link_to_entity
-                });
+                drop_contains_links_to(links, dropped_entity_id);
 
                 // If it is the container, we'll add the link!
                 if id == container_entity_id {
@@ -2019,14 +2013,12 @@ impl MissionCore {
     /// when an entity is destroyed so a consumed/used inventory item (e.g. a
     /// power cell inserted into an aux-power receptor) leaves no dangling link
     /// behind - a stale link would otherwise resolve to whatever entity later
-    /// recycles the slot. A no-op for entities that were never contained.
+    /// recycles the slot. Only invoked for contained items (see the destroy
+    /// path), so the full scan is not run for world-present FX/projectiles.
     fn remove_incoming_contains_links(&mut self, entity_id: EntityId) {
         let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
         for (_id, links) in (&mut v_links).iter().with_id() {
-            links.to_links.retain(|link| {
-                !(matches!(link.link, Link::Contains(_))
-                    && link.to_entity_id.map(|e| e.0) == Some(entity_id))
-            });
+            drop_contains_links_to(links, entity_id);
         }
     }
 
@@ -3430,7 +3422,15 @@ impl MissionCore {
                 Effect::DestroyEntity { entity_id } => {
                     info!("!!!Destroying entity: {:?}", entity_id);
                     self.interaction.on_entity_destroyed(entity_id);
-                    self.remove_incoming_contains_links(entity_id);
+                    // Only a contained item (no world presence, PropHasRefs
+                    // false) can leave a dangling inventory `Contains` link
+                    // behind. World-present entities - FX spangs, projectiles,
+                    // creatures - are never `Contains` targets, so skip the
+                    // full link scan for them (several are destroyed per frame
+                    // in combat).
+                    if !crate::util::has_refs(&self.world, entity_id) {
+                        self.remove_incoming_contains_links(entity_id);
+                    }
                     self.remove_entity(entity_id);
                 }
                 Effect::ResetGravity { entity_id } => {
@@ -4927,6 +4927,15 @@ fn option_to_vec<T>(option: Option<T>) -> Vec<T> {
         None => vec![],
         Some(v) => vec![v],
     }
+}
+
+/// Remove every `Contains` link in `links` that points at `target` - used when
+/// an item leaves a container (moved/dropped into another container, or
+/// destroyed while contained), so no stale `Contains` link is left behind.
+fn drop_contains_links_to(links: &mut Links, target: EntityId) {
+    links.to_links.retain(|link| {
+        !(matches!(link.link, Link::Contains(_)) && link.to_entity_id.map(|e| e.0) == Some(target))
+    });
 }
 
 pub fn make_un_physical2(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1985,6 +1985,51 @@ impl MissionCore {
         was_able_to_drop
     }
 
+    /// When an entity is replaced (e.g. a dead power cell recharged into a live
+    /// one), any container that held the old entity via a `Contains` link should
+    /// keep holding the new one - otherwise the replacement is orphaned in the
+    /// world and the container is left with a dangling link. Rewrites those
+    /// incoming `Contains` links in place (preserving slot ordinal) and makes the
+    /// new entity a proper contained item (un-physical, no refs). Returns whether
+    /// the new entity was placed into a container. VR held items are tracked by
+    /// the hand, not a `Contains` link, so this leaves the VR hold path untouched.
+    fn transfer_containment(&mut self, old_entity_id: EntityId, new_entity_id: EntityId) -> bool {
+        let mut transferred = false;
+        {
+            let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
+            for (_id, links) in (&mut v_links).iter().with_id() {
+                for link in links.to_links.iter_mut() {
+                    if matches!(link.link, Link::Contains(_))
+                        && link.to_entity_id.map(|e| e.0) == Some(old_entity_id)
+                    {
+                        link.to_entity_id = Some(WrappedEntityId(new_entity_id));
+                        transferred = true;
+                    }
+                }
+            }
+        }
+        if transferred {
+            self.world.add_component(new_entity_id, PropHasRefs(false));
+            self.make_un_physical(new_entity_id);
+        }
+        transferred
+    }
+
+    /// Drop any container's `Contains` link that points at `entity_id`. Called
+    /// when an entity is destroyed so a consumed/used inventory item (e.g. a
+    /// power cell inserted into an aux-power receptor) leaves no dangling link
+    /// behind - a stale link would otherwise resolve to whatever entity later
+    /// recycles the slot. A no-op for entities that were never contained.
+    fn remove_incoming_contains_links(&mut self, entity_id: EntityId) {
+        let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
+        for (_id, links) in (&mut v_links).iter().with_id() {
+            links.to_links.retain(|link| {
+                !(matches!(link.link, Link::Contains(_))
+                    && link.to_entity_id.map(|e| e.0) == Some(entity_id))
+            });
+        }
+    }
+
     pub fn make_physical(&mut self, entity_id: EntityId) {
         let current_entity = self.id_to_physics.get(&entity_id);
         if current_entity.is_some() {
@@ -3156,6 +3201,10 @@ impl MissionCore {
                         );
                     }
 
+                    // Keep a contained item (e.g. an inventory power cell
+                    // recharged at a station) in its container after replacement.
+                    self.transfer_containment(entity_id, new_entity_info.entity_id);
+
                     self.remove_entity(entity_id);
                 }
 
@@ -3381,6 +3430,7 @@ impl MissionCore {
                 Effect::DestroyEntity { entity_id } => {
                     info!("!!!Destroying entity: {:?}", entity_id);
                     self.interaction.on_entity_destroyed(entity_id);
+                    self.remove_incoming_contains_links(entity_id);
                     self.remove_entity(entity_id);
                 }
                 Effect::ResetGravity { entity_id } => {

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -3,7 +3,6 @@ use dark::{
     properties::{PropClassTag, PropPosition},
 };
 use engine::audio::AudioHandle;
-use engine::script_log;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
@@ -40,38 +39,54 @@ impl Script for EnergyStation {
                 }
             }
             MessagePayload::Collided { with } => do_recharge(world, entity_id, with),
+            // Flat presentation: frobbing the station recharges every
+            // rechargeable item the player carries at once (there is no
+            // hold-one-item-near-the-station step - that is VR-only, handled by
+            // Hover/Collided above). Each item self-handles Recharge, so only
+            // the ones that respond (dead power cell, energy weapons, ...) react.
+            MessagePayload::Frob => do_recharge_all(world, entity_id),
             _ => Effect::NoEffect,
         }
     }
 }
 
-fn do_recharge(world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
+fn do_recharge_all(world: &World, entity_id: EntityId) -> Effect {
+    let mut effects: Vec<Effect> = super::script_util::player_carried_items(world)
+        .into_iter()
+        .map(|item| Effect::Send {
+            msg: Message {
+                to: item,
+                payload: MessagePayload::Recharge,
+            },
+        })
+        .collect();
+    effects.push(activate_sound(world, entity_id));
+    Effect::combine(effects)
+}
+
+fn activate_sound(world: &World, entity_id: EntityId) -> Effect {
     let v_pos = world.borrow::<View<PropPosition>>().unwrap();
     let v_class_tag = world.borrow::<View<PropClassTag>>().unwrap();
     let mut class_tags = v_class_tag
         .get(entity_id)
         .map(|p| p.class_tags())
         .unwrap_or(vec![]);
-
-    // log_property::<PropClassTag>(world);
-    // panic!();
-    //log_property::<PropDeviceTag>(world);
     let pos = v_pos.get(entity_id).unwrap();
+    let mut query = vec![("event", "activate")];
+    query.append(&mut class_tags);
+    Effect::PlayEnvironmentalSound {
+        audio_handle: AudioHandle::new(),
+        query: EnvSoundQuery::from_tag_values(query),
+        position: pos.position,
+    }
+}
+
+fn do_recharge(world: &World, entity_id: EntityId, with: &EntityId) -> Effect {
     let recharge_effect = Effect::Send {
         msg: Message {
             to: *with,
             payload: MessagePayload::Recharge,
         },
     };
-
-    let mut query = vec![("event", "activate")];
-    query.append(&mut class_tags);
-    script_log!(DEBUG, "Energy station activate query: {:?}", query);
-    let sound_effect = Effect::PlayEnvironmentalSound {
-        audio_handle: AudioHandle::new(),
-        query: EnvSoundQuery::from_tag_values(query),
-        position: pos.position,
-    };
-
-    Effect::combine(vec![recharge_effect, sound_effect])
+    Effect::combine(vec![recharge_effect, activate_sound(world, entity_id)])
 }

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -39,11 +39,13 @@ impl Script for EnergyStation {
                 }
             }
             MessagePayload::Collided { with } => do_recharge(world, entity_id, with),
-            // Flat presentation: frobbing the station recharges every
-            // rechargeable item the player carries at once (there is no
+            // Flat presentation: frobbing the station sends Recharge to every
+            // item the player carries at once (there is no
             // hold-one-item-near-the-station step - that is VR-only, handled by
             // Hover/Collided above). Each item self-handles Recharge, so only
-            // the ones that respond (dead power cell, energy weapons, ...) react.
+            // responders react - today that is the dead power cell. Energy-weapon
+            // recharge would be a separate follow-up, once those gain a Recharge
+            // handler; the mechanism here is already general.
             MessagePayload::Frob => do_recharge_all(world, entity_id),
             _ => Effect::NoEffect,
         }

--- a/shock2vr/src/scripts/obj_consume_button.rs
+++ b/shock2vr/src/scripts/obj_consume_button.rs
@@ -21,30 +21,43 @@ impl Script for ObjConsumeButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
+            // VR: the player holds a specific item against the receptor.
             MessagePayload::ProvideForConsumption { entity } => {
                 if can_consume_entity(world, entity_id, *entity) {
-                    let switch_link_efect = send_to_all_switch_links_and_self(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    let destroy_consumee = Effect::DestroyEntity { entity_id: *entity };
-
-                    let sound_effect = play_environmental_sound(
-                        world,
-                        entity_id,
-                        "activate",
-                        vec![],
-                        AudioHandle::new(),
-                    );
-                    Effect::combine(vec![switch_link_efect, destroy_consumee, sound_effect])
+                    consume(world, entity_id, *entity)
                 } else {
                     Effect::NoEffect
+                }
+            }
+            // Flat: frobbing the receptor consumes the first matching item the
+            // player carries (no hold-item-near-the-receptor step - that is
+            // VR-only, handled above).
+            MessagePayload::Frob => {
+                match super::script_util::player_carried_items(world)
+                    .into_iter()
+                    .find(|item| can_consume_entity(world, entity_id, *item))
+                {
+                    Some(item) => consume(world, entity_id, item),
+                    None => Effect::NoEffect,
                 }
             }
             _ => Effect::NoEffect,
         }
     }
+}
+
+fn consume(world: &World, entity_id: EntityId, entity_to_consume: EntityId) -> Effect {
+    let switch_link_efect = send_to_all_switch_links_and_self(
+        world,
+        entity_id,
+        MessagePayload::TurnOn { from: entity_id },
+    );
+    let destroy_consumee = Effect::DestroyEntity {
+        entity_id: entity_to_consume,
+    };
+    let sound_effect =
+        play_environmental_sound(world, entity_id, "activate", vec![], AudioHandle::new());
+    Effect::combine(vec![switch_link_efect, destroy_consumee, sound_effect])
 }
 
 fn can_consume_entity(world: &World, self_id: EntityId, entity_to_consume_id: EntityId) -> bool {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -270,6 +270,62 @@ pub fn get_first_link_of_type(
     all_links.get(0).copied()
 }
 
+/// Every item the player is currently carrying: each wielded/hand-held entity
+/// plus everything nested under it, and the backpack (inventory) entity's
+/// contents - following `Contains` links to depth 2 (mirrors the item set the
+/// save system and the debug inventory enumerate). The hand/inventory container
+/// entities themselves are excluded; a wielded item *is* its hand entity, so it
+/// is included. Empty when there is no player (e.g. a debug scene without one).
+pub fn player_carried_items(world: &World) -> Vec<EntityId> {
+    let player = match world.borrow::<UniqueView<crate::mission::PlayerInfo>>() {
+        Ok(player) => player,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+
+    // Hands first: the hand entity itself is the wielded item, plus its contents.
+    for hand in [player.left_hand_entity_id, player.right_hand_entity_id]
+        .into_iter()
+        .flatten()
+    {
+        if seen.insert(hand) {
+            out.push(hand);
+        }
+        collect_contained_items(world, hand, 2, &mut seen, &mut out);
+    }
+
+    // Backpack: only the inventory container's contents (the container is not an item).
+    seen.insert(player.inventory_entity_id);
+    collect_contained_items(world, player.inventory_entity_id, 2, &mut seen, &mut out);
+
+    out
+}
+
+fn collect_contained_items(
+    world: &World,
+    entity_id: EntityId,
+    depth: u32,
+    seen: &mut std::collections::HashSet<EntityId>,
+    out: &mut Vec<EntityId>,
+) {
+    if depth == 0 {
+        return;
+    }
+    for_each_link(world, entity_id, &mut |link| {
+        if matches!(link.link, Link::Contains(_)) {
+            if let Some(to_entity_id) = link.to_entity_id {
+                let child = to_entity_id.0;
+                if seen.insert(child) {
+                    out.push(child);
+                    collect_contained_items(world, child, depth - 1, seen, out);
+                }
+            }
+        }
+    });
+}
+
 pub fn get_all_switch_links(world: &World, producing_entity_id: EntityId) -> Vec<EntityId> {
     let links = world.borrow::<View<Links>>().unwrap();
     let mut linked_entities = Vec::new();

--- a/tools/shock2-sdk/test/powercell-recharge.e2e.test.ts
+++ b/tools/shock2-sdk/test/powercell-recharge.e2e.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end coverage for the FLAT-mode power-cell interaction (issue #518).
+//
+// Faithful flat behavior (unlike VR's hold-one-item-near-the-station):
+//   1. Frobbing a Recharging Station recharges EVERY rechargeable item the
+//      player carries at once - turning each Dead Power Cell in the backpack
+//      into a charged Power Cell (in place, so it stays carried).
+//   2. Frobbing the Aux Power receptor consumes a matching Power Cell from the
+//      player's inventory and fires its switch-links (opening its Security Door).
+//
+// A frob is driven here via the Frob message injection, which dispatches the
+// exact same MessagePayload::Frob the flat use-button emits at the reticle
+// target (see the StdDoor door-frob test for the same convention; reticle
+// targeting itself is covered by the campaign play-through).
+//
+// Negative-first: before #518 the EnergyStation script ignored Frob (it only
+// handled the VR Hover/Collided messages), so frobbing the station left every
+// Dead Power Cell dead. Reverting the energy_station.rs Frob arm makes the
+// recharge assertion below fail (the dead cells stay "Dead Power Cell").
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Mission object ids (stable across runs; the debug runtime exposes them as
+// `template_id`) - used to select specific instances without hardcoding the
+// per-run runtime entity ids.
+const SECURITY_DOOR_OBJ = 335; // switch-linked to the Aux Power receptor (obj 1128)
+const RECEPTOR_OBJ = 1128; // Aux Power W/Out Battery, PropConsumeType "power cell"
+
+test(
+  "medsci1.mis: frobbing the Recharging Station recharges all carried cells, and the Aux Power receptor consumes one",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8161),
+    });
+    await game.step({ frames: 5 });
+
+    // --- Stage: give the player both Dead Power Cells in the level. ---
+    const deadCells = (
+      await game.entities.list({ filter: "Dead Power Cell", limit: 20 })
+    ).entities;
+    assert.ok(
+      deadCells.length >= 2,
+      `expected >=2 Dead Power Cells in medsci1, found ${deadCells.length}`,
+    );
+    for (const cell of deadCells) {
+      const res = await game.player.give(cell.id);
+      assert.equal(res.success, true, `give dead cell ${cell.id}`);
+    }
+
+    const before = await game.player.inventory();
+    const deadBefore = before.items.filter((i) => i.name === "Dead Power Cell");
+    assert.equal(
+      deadBefore.length,
+      deadCells.length,
+      "both dead cells should be carried before recharge",
+    );
+
+    // --- Recharge: frob the Recharging Station (recharge-all). ---
+    const station = (
+      await game.entities.list({ filter: "Recharging Station", limit: 10 })
+    ).entities[0];
+    assert.ok(station, "expected a Recharging Station in medsci1");
+
+    await game.entities.sendMessage(station.id, { type: "Frob" });
+    await game.step({ frames: 10 });
+
+    const afterRecharge = await game.player.inventory();
+    // Recharge-all: every Dead Power Cell became a charged Power Cell, and each
+    // stays in the backpack (recharged in place, not orphaned in the world).
+    assert.equal(
+      afterRecharge.items.filter((i) => i.name === "Dead Power Cell").length,
+      0,
+      "no Dead Power Cell should remain after frobbing the station",
+    );
+    assert.equal(
+      afterRecharge.items.filter((i) => i.name === "Power Cell").length,
+      deadCells.length,
+      "every dead cell should now be a charged Power Cell, still carried",
+    );
+
+    // --- Insert: frob the Aux Power receptor, consuming one Power Cell. ---
+    const receptor = (
+      await game.entities.byTemplate(RECEPTOR_OBJ)
+    )[0];
+    assert.ok(receptor, "expected the Aux Power receptor (obj 1128) in medsci1");
+
+    const door = (await game.entities.byTemplate(SECURITY_DOOR_OBJ))[0];
+    assert.ok(door, "expected the receptor's switch-linked Security Door");
+    const doorYBefore = (await game.entities.detail(door.id)).position[1];
+
+    const cellsBeforeInsert = afterRecharge.items.filter(
+      (i) => i.name === "Power Cell",
+    ).length;
+
+    await game.entities.sendMessage(receptor.id, { type: "Frob" });
+    await game.step({ frames: 60 });
+
+    const afterInsert = await game.player.inventory();
+    // One Power Cell was consumed (and left no dangling inventory link behind).
+    assert.equal(
+      afterInsert.items.filter((i) => i.name === "Power Cell").length,
+      cellsBeforeInsert - 1,
+      "frobbing the receptor should consume exactly one Power Cell",
+    );
+
+    // The receptor fired its switch-links: the Security Door slid open.
+    const doorYAfter = (await game.entities.detail(door.id)).position[1];
+    assert.ok(
+      doorYAfter > doorYBefore + 1.0,
+      `receptor should open its Security Door (y ${doorYBefore} -> ${doorYAfter})`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Reimplements the flat-mode power-cell interaction faithfully. In flat System Shock 2, frobbing the **Recharging Station recharges every rechargeable item the player carries at once** (energy weapons / powered gear AND Dead Power Cells) - there is no hold-one-item-near-the-station step; that hold-to-charge interaction is VR-only. This replaces an earlier (reverted) attempt that incorrectly modeled the VR hold semantics from the flat controller.

### Recharge (station)
`EnergyStation` now handles `Frob`: it enumerates the player's carried items - wielded/hand items plus backpack contents, via a new `script_util::player_carried_items` helper - and sends each the existing `Recharge` message. The scope is **general**: no power-cell special-casing. Only items that self-handle `Recharge` react (the Dead Power Cell today, energy weapons/gear later); everything else no-ops.

### Insert (Aux Power receptor)
`ObjConsumeButton` now handles `Frob`: it consumes the first matching item (by `PropConsumeType`) from the player's inventory, firing its switch-links and destroying the cell - the flat counterpart of VR's `ProvideForConsumption`.

### Faithfulness fixes to make the above actually work
- `ReplaceEntity` now transfers container membership to the replacement, so a Dead Power Cell recharged in the backpack becomes a charged Power Cell that **stays carried** instead of being orphaned at the world origin.
- `DestroyEntity` now purges incoming `Contains` links, so a consumed inventory item leaves **no dangling link** (which would otherwise resolve to a recycled slot).

### VR path unchanged
The VR `Hover` / `Collided` / `ProvideForConsumption` handlers are untouched. VR held items are tracked by the hand controller (not a `Contains` link), so the container-transfer/purge leaves them alone. The old flat_player_controller VR-message emission was **not** reintroduced.

## Testing
- New SDK e2e `tools/shock2-sdk/test/powercell-recharge.e2e.test.ts` (medsci1): gives the player both Dead Power Cells, frobs the station and asserts **both** recharge in place (recharge-all), then frobs the Aux Power receptor and asserts one cell is consumed and its switch-linked Security Door opens.
  - Negative-first confirmed: reverting the station's `Frob` arm leaves the cells dead (`2 !== 0`), restored -> green.
- `missions.e2e.test.ts`: all 23 missions load.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; `cargo fmt` applied.

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)