### PR TITLE
fix(spawn): drop SpawnDebugMonster spawns to the floor (#401)

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3751,10 +3751,39 @@ impl MissionCore {
                         (vec3_to_point3(player.pos), player.rotation * head_rotation)
                     };
                     let forward = rot * vec3(0.0, 2.5 / SCALE_FACTOR, -10.0 / SCALE_FACTOR);
+                    let target = pos + forward;
+                    // Drop-to-floor: the naive forward offset can land inside or
+                    // below the level geometry (e.g. on pitched-down aim), which
+                    // drops the spawn out of the world. Cast straight down onto
+                    // the floor at the target's XZ and rest the monster there.
+                    // The ray starts a fixed height above the PLAYER's floor
+                    // (`pos.y`), not above the naive target - a pitched target
+                    // can land below the floor, and a ray starting there would
+                    // miss the floor above it. If no floor is found within range,
+                    // fall back to the player's own position (known-good ground)
+                    // rather than the naive target - the naive point is exactly
+                    // the below-floor case this fixes, so it must not be the
+                    // fallback.
+                    let ray_start = Point3::new(target.x, pos.y + 2.0, target.z);
+                    let spawn_pos = match self.physics.ray_cast2(
+                        ray_start,
+                        vec3(0.0, -1.0, 0.0),
+                        20.0,
+                        crate::physics::InternalCollisionGroups::WORLD,
+                        None,
+                        true,
+                    ) {
+                        Some(hit) => Point3::new(
+                            hit.hit_point.x,
+                            hit.hit_point.y + 0.1,
+                            hit.hit_point.z,
+                        ),
+                        None => pos,
+                    };
                     let info = self.create_entity_with_position(
                         asset_cache,
                         template_id,
-                        pos + forward,
+                        spawn_pos,
                         rot,
                         Matrix4::identity(),
                         CreateEntityOptions::default(),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3773,11 +3773,9 @@ impl MissionCore {
                         None,
                         true,
                     ) {
-                        Some(hit) => Point3::new(
-                            hit.hit_point.x,
-                            hit.hit_point.y + 0.1,
-                            hit.hit_point.z,
-                        ),
+                        Some(hit) => {
+                            Point3::new(hit.hit_point.x, hit.hit_point.y + 0.1, hit.hit_point.z)
+                        }
                         None => pos,
                     };
                     let info = self.create_entity_with_position(

--- a/tools/shock2-sdk/test/spawn-drop-to-floor.e2e.test.ts
+++ b/tools/shock2-sdk/test/spawn-drop-to-floor.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Regression for #401: SpawnDebugMonster used to place the spawn at a naive
+// forward offset with NO drop-to-floor raycast. On pitched-down aim the offset
+// lands inside/below the level geometry, so the monster is created below the
+// floor and falls out of the world (body y plummeting from ~floor level to
+// tens-negative). The fix casts straight down onto the floor at the target's
+// XZ and rests the monster there.
+test(
+  "SpawnDebugMonster drops the spawn to the floor even on pitched-down aim",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    await game.step({ frames: 10 });
+
+    // Floor reference: the player stands on it, so its y is ~the floor height
+    // where the monster should come to rest.
+    const floorY = (await game.player.position()).y;
+
+    // Aim steeply DOWN into the floor. At this pitch the naive forward offset
+    // (up + forward, then rotated by the head) tips several units below the
+    // floor - the exact case that used to spawn the monster below the world.
+    // (Empirically on medsci1: floor ~ -5, naive spawn ~ -8.3, then plummeting
+    // to ~ -200 within a few seconds. The fixed path rests it at ~ -4.)
+    await game.input.set("head.look", [0, 80]);
+    await game.step({ frames: 2 });
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(
+      monster,
+      `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((e) => e.id))}`,
+    );
+
+    // Read the spawned body's y right after spawn...
+    async function bodyY(): Promise<number> {
+      const { bodies } = await game.physics.bodies({ entityId: monster!.id });
+      assert.ok(bodies.length > 0, "spawned monster should own a physics body");
+      // The creature capsule is the lowest body; take the min y across bodies.
+      return Math.min(...bodies.map((b) => b.position[1]));
+    }
+    const initialY = await bodyY();
+
+    // ...and after letting physics run for ~2s. If the monster spawned below
+    // the floor it keeps falling into the void; if it rests on the floor it
+    // stays put.
+    await game.step({ frames: 120 });
+    const finalY = await bodyY();
+
+    // It must not have plummeted out of the world. Pre-fix, finalY reaches
+    // tens-negative (the issue records y ~ -5 -> -135, observed ~ -200 here);
+    // the drop-to-floor spawn keeps it within a couple of units of the floor it
+    // was placed on.
+    assert.ok(
+      finalY > floorY - 2.0,
+      `monster fell through the floor: floorY=${floorY.toFixed(2)}, ` +
+        `initialY=${initialY.toFixed(2)}, finalY=${finalY.toFixed(2)}`,
+    );
+    // And it did not spawn below the floor to begin with (pre-fix ~ -8.3).
+    assert.ok(
+      initialY > floorY - 2.0,
+      `monster spawned below the floor: floorY=${floorY.toFixed(2)}, ` +
+        `initialY=${initialY.toFixed(2)}`,
+    );
+  },
+);


### PR DESCRIPTION
## The bug (Fixes #401)

Triggering the `SpawnDebugMonster` input action spawned the monster below the floor. `Effect::SpawnInFrontOfPlayer` (`shock2vr/src/mission/mission_core.rs`) placed the monster at a naive forward offset — `pos + rot * vec3(0, 2.5/SCALE, -10/SCALE)` — with **no drop-to-floor raycast**. On pitched-down aim the offset tips several units below the floor, so the monster is created inside/below the level trimesh and falls out of the world.

Observed on `medsci1.mis` (floor ≈ -5): the naive spawn lands at y ≈ -8.3 and plummets to ≈ -200 within a few seconds.

## The fix

Cast a ray straight **down** onto the floor at the target's XZ (against `InternalCollisionGroups::WORLD`) and rest the monster on the hit point (+0.1 epsilon):

- The ray starts a fixed height above the **player's** floor (`pos.y + 2.0`), *not* above the naive target — a pitched target can land below the floor, and a ray starting there would miss the floor above it.
- If no floor is hit within 20 units, fall back to the **player's own position** (known-good ground) rather than the naive below-floor point (which is exactly the case being fixed).

The change is scoped to the `SpawnInFrontOfPlayer` arm only. The visually-identical offset in the `DebugCycleWeapon` arm is intentionally left unchanged — it force-*wields* the created entity (viewmodel), so its spawn position is irrelevant.

## Verification (red → green)

New SDK e2e regression test `tools/shock2-sdk/test/spawn-drop-to-floor.e2e.test.ts`: pitches the aim down (`head.look [0, 80]`), spawns the debug monster, and asserts its physics body rests near the floor rather than plummeting.

**Red (pre-fix runtime):**
```
not ok 1 - SpawnDebugMonster drops the spawn to the floor even on pitched-down aim
  error: 'monster fell through the floor: floorY=-5.00, initialY=-9.44, finalY=-38.33'
```

**Green (with fix):**
```
ok 1 - SpawnDebugMonster drops the spawn to the floor even on pitched-down aim
# pass 1  # fail 0
```

Command: `cd tools/shock2-sdk && SHOCK2_E2E=1 node --test dist/test/spawn-drop-to-floor.e2e.test.js`

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` — clean.
- `missions.e2e.test.ts` — all 23 missions load.
- Full SDK e2e suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visuals

![spawn-drop-to-floor demo](https://gist.githubusercontent.com/tommy-xr/17020b6c3921e81a0d9a3ae8eba5a82c/raw/demo.gif)

<sub>Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep): aim pitched steeply down, `SpawnDebugMonster` triggered, then stepped forward — the hybrid rests standing on the floor.</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/17020b6c3921e81a0d9a3ae8eba5a82c/raw/beforeafter.png)

<sub>Same deterministic input sequence run against `main` (before) and this branch (after). Before: the spawned monster has fallen through the floor and is gone. After: it rests standing on the floor in front of the player.</sub>
