### PR TITLE
fix(save): restore loaded corpses without replay

### DIFF
--- a/dark/src/motion/animation_player.rs
+++ b/dark/src/motion/animation_player.rs
@@ -103,6 +103,26 @@ impl AnimationPlayer {
             cancel_root_motion: false,
         }
     }
+
+    /// Hold `animation_clip` on its final frame without ever playing it.
+    ///
+    /// This is the same state a one-shot reaches after its queue drains, but
+    /// constructed directly for restored static poses. Because the playback
+    /// queue is empty, [`Self::update`] emits no motion flags, completion or
+    /// direction events, and no root velocity.
+    pub fn from_completed_animation(animation_clip: Rc<AnimationClip>) -> AnimationPlayer {
+        AnimationPlayer {
+            animation: immutable::List::new(),
+            additional_joint_transforms: immutable::HashTrieMap::new(),
+            last_animation: Some(animation_clip),
+            current_frame: 0,
+            remaining_time: 0.0,
+            blend_state: None,
+            rotation_pos: 0.0,
+            cancel_root_motion: false,
+        }
+    }
+
     pub fn queue_animation(
         player: &AnimationPlayer,
         animation: Rc<AnimationClip>,
@@ -484,6 +504,10 @@ impl AnimationPlayer {
                     elapsed: blend.elapsed,
                 }),
         }
+    }
+
+    pub fn is_queue_empty(&self) -> bool {
+        self.animation.is_empty()
     }
 
     pub fn get_transforms(&self, skeleton: &Skeleton) -> [Matrix4<f32>; 40] {
@@ -925,6 +949,30 @@ mod tests {
         let (player, _, _, _) = AnimationPlayer::update(&player, Duration::from_millis(300));
         let player = AnimationPlayer::queue_animation(&player, clip_with_root_motion());
         assert!(player.snapshot().blend.is_none());
+    }
+
+    #[test]
+    fn completed_animation_constructor_holds_without_events_or_motion() {
+        let mut clip = (*clip_with_root_motion()).clone();
+        clip.name = Some("death_pose".to_owned());
+        let player = AnimationPlayer::from_completed_animation(Rc::new(clip));
+
+        let snapshot = player.snapshot();
+        assert!(snapshot.queue.is_empty());
+        assert_eq!(snapshot.last_clip.as_deref(), Some("death_pose"));
+
+        for duration in [
+            Duration::from_millis(16),
+            Duration::from_secs(1),
+            Duration::from_secs(30),
+        ] {
+            let (next, flags, events, velocity) = AnimationPlayer::update(&player, duration);
+            assert!(flags.is_empty());
+            assert!(events.is_empty());
+            assert_eq!(velocity, vec3(0.0, 0.0, 0.0));
+            assert!(next.snapshot().queue.is_empty());
+            assert_eq!(next.snapshot().last_clip.as_deref(), Some("death_pose"));
+        }
     }
 
     #[test]

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -262,6 +262,7 @@ pub struct PhysicsBodySummary {
     pub collision_groups: Vec<String>,
     pub is_sensor: bool,
     pub is_enabled: bool,
+    pub is_sleeping: bool,
 }
 
 /// Per-ragdoll quality/settle metrics

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1411,6 +1411,7 @@ fn process_command(
                             collision_groups: b.collision_groups,
                             is_sensor: b.is_sensor,
                             is_enabled: b.is_enabled,
+                            is_sleeping: b.is_sleeping,
                         })
                         .collect(),
                 };

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -251,6 +251,7 @@ pub struct DebugPhysicsBodySummary {
     pub collision_groups: Vec<String>,
     pub is_sensor: bool,
     pub is_enabled: bool,
+    pub is_sleeping: bool,
 }
 
 /// Detailed information about a physics body for debug inspection

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -408,6 +408,7 @@ fn create_model(
         v_prop_position,
         v_prop_model,
         v_creature_pose,
+        v_death_pose,
         _v_hasrefs,
         _v_rendertype,
         v_scale,
@@ -418,6 +419,7 @@ fn create_model(
             View<PropPosition>,
             View<PropModelName>,
             View<PropCreaturePose>,
+            View<RuntimePropDeathPose>,
             View<PropHasRefs>,
             View<PropRenderType>,
             View<PropScale>,
@@ -457,9 +459,19 @@ fn create_model(
 
         let transform = translation * rotation * scale;
 
-        // TODO: Handle creature pose
+        // Runtime-generated terminal death poses are separate from authored
+        // P$CretPose data, so mission-placed corpse decorations retain their
+        // historical frame-1 bake and physics behavior.
         let (model, animation_player) = {
-            if let Ok(creature_pose) = v_creature_pose.get(entity_id) {
+            if let Ok(death_pose) = v_death_pose.get(entity_id) {
+                let animation_clip =
+                    asset_cache.get(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", death_pose.0));
+                let transformed_model = Model::transform(model_ref, transform);
+                (
+                    transformed_model,
+                    Some(AnimationPlayer::from_completed_animation(animation_clip)),
+                )
+            } else if let Ok(creature_pose) = v_creature_pose.get(entity_id) {
                 // let motion_db = { asset_cache.get(&MOTIONDB_IMPORTER, "motiondb.bin".to_owned()) };
                 // TODO: We can only handle motion name props at the moment..
                 if creature_pose.pose_type.contains(PoseType::MOTION_NAME) {
@@ -688,6 +700,7 @@ pub fn create_physics_representation(
         v_hud_select,
         v_creature,
         v_creature_pose,
+        v_death_pose,
     ) = world
         .borrow::<(
             View<PropPosition>,
@@ -698,6 +711,7 @@ pub fn create_physics_representation(
             View<PropHUDSelect>,
             View<PropCreature>,
             View<PropCreaturePose>,
+            View<RuntimePropDeathPose>,
         )>()
         .unwrap();
     let default_size = 0.5 / SCALE_FACTOR;
@@ -724,6 +738,38 @@ pub fn create_physics_representation(
     } else {
         DynamicPhysicsOptions::default()
     };
+
+    // A restored generated death pose is a completed, resting corpse. Its
+    // serialized P$Position is already the live Rapier body position:
+    // applying the normal creature spawn lift again would raise it by
+    // SCALE_FACTOR/6 (0.4167 world units) and make it visibly settle after
+    // every load. Preserve the live creature's dynamic capsule geometry and
+    // material, place it at the exact saved transform, then start it asleep.
+    // Contacts and impulses can still wake/push it.
+    if v_death_pose.get(entity_id).is_ok() {
+        if let (Ok(pos), Ok(creature_type)) = (v_pos.get(entity_id), v_creature.get(entity_id)) {
+            let creature_def = get_creature_definition(creature_type.0).unwrap();
+            let bbox = creature_def.bounding_size;
+            let radius = bbox.x.max(bbox.z) / 2.0;
+            let creature_shape = PhysicsShape::Capsule {
+                height: radius.max(bbox.y - radius * 2.0),
+                radius,
+            };
+            let rigid_body_handle = physics.add_dynamic(
+                entity_id,
+                pos.position,
+                pos.rotation,
+                vec3(0.0, -creature_def.physics_offset_height, 0.0),
+                creature_shape,
+                CollisionGroup::entity(),
+                false,
+                dynamics_options,
+            );
+            physics.set_enabled_rotations(entity_id, false, false, false);
+            physics.sleep_body(rigid_body_handle);
+            return Some(rigid_body_handle);
+        }
+    }
 
     // Frobbable item, let's see what we can do...
     if let (Ok(pos), Ok(frob_info)) = (v_pos.get(entity_id), v_frob_info.get(entity_id)) {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -38,12 +38,12 @@ use dark::{
     properties::{
         AmbientSoundFlags, Link, LinkDefinition, LinkDefinitionWithData, Links, PhysicsModelType,
         PropAIAlertness, PropAIMode, PropAmbientHacked, PropClassTag, PropCreature,
-        PropFrameAnimState, PropHasRefs, PropLimbModel, PropLocalPlayer, PropModelName,
-        PropMotionActorTags, PropParticleGroup, PropParticleLaunchInfo, PropPhysDimensions,
-        PropPhysInitialVelocity, PropPhysState, PropPhysType, PropPlayerGun, PropPosition,
-        PropRenderType, PropScripts, PropTeleported, PropTripFlags, PropTweqDeleteConfig,
-        PropTweqDeleteState, PropertyDefinition, RenderType, ToLink, TripFlags, TweqAnimationState,
-        WrappedEntityId,
+        PropFrameAnimState, PropHasRefs, PropHitPoints, PropLimbModel, PropLocalPlayer,
+        PropModelName, PropMotionActorTags, PropParticleGroup, PropParticleLaunchInfo,
+        PropPhysDimensions, PropPhysInitialVelocity, PropPhysState, PropPhysType, PropPlayerGun,
+        PropPosition, PropRenderType, PropScripts, PropTeleported, PropTripFlags,
+        PropTweqDeleteConfig, PropTweqDeleteState, PropertyDefinition, RenderType, ToLink,
+        TripFlags, TweqAnimationState, WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -81,9 +81,9 @@ use crate::{
     physics::{self, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
-        RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDoNotSerialize,
-        RuntimePropFlatAim, RuntimePropJointTransforms, RuntimePropReloading,
-        RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
+        RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
+        RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -1483,6 +1483,11 @@ impl MissionCore {
         selection_strategy: MotionQuerySelectionStrategy,
         apply: fn(&AnimationPlayer, Rc<AnimationClip>) -> AnimationPlayer,
     ) {
+        let is_death_query = motion_queries
+            .iter()
+            .flatten()
+            .any(|item| item.tag_name() == "crumple");
+        let mut resolved_death_pose = None;
         let maybe_player = self.id_to_animation_player.get_mut(&entity_id);
         if let Some(player) = maybe_player {
             let v_creature_type = self.world.borrow::<View<PropCreature>>().unwrap();
@@ -1531,6 +1536,20 @@ impl MissionCore {
                     if let Some(clip) = maybe_clip {
                         self.failed_animation_queries.remove(&entity_id);
                         *player = apply(player, clip);
+
+                        // The motion query is random, so its resolved clip name
+                        // is the only durable identity of the corpse pose.
+                        // EntitySaveData explicitly persists this generated
+                        // runtime fact separately from authored P$CretPose.
+                        let is_killed = self
+                            .world
+                            .borrow::<View<PropHitPoints>>()
+                            .ok()
+                            .and_then(|view| view.get(entity_id).ok().map(|hp| hp.hit_points <= 0))
+                            .unwrap_or(false);
+                        if is_death_query && is_killed {
+                            resolved_death_pose = Some(next_animation);
+                        }
                     } else {
                         // Report completion just like the query-miss branch
                         // below, so anything waiting on this animation
@@ -1573,6 +1592,11 @@ impl MissionCore {
                     }
                 }
             }
+        }
+
+        if let Some(motion_or_tag_name) = resolved_death_pose {
+            self.world
+                .add_component(entity_id, RuntimePropDeathPose(motion_or_tag_name));
         }
     }
 
@@ -1682,7 +1706,20 @@ impl MissionCore {
                     adj_velocity.y,
                     adj_velocity.z * scale,
                 );
-                self.physics.set_velocity(*id, scaled);
+                // A restored terminal death player has no queued motion, but
+                // even writing zero velocity wakes its deliberately sleeping
+                // dynamic corpse body. Leave physics ownership untouched:
+                // it stays stable at rest and remains wakeable by contact or
+                // an impulse.
+                let holds_terminal_death_pose = player.is_queue_empty()
+                    && self
+                        .world
+                        .borrow::<View<RuntimePropDeathPose>>()
+                        .unwrap()
+                        .contains(*id);
+                if !holds_terminal_death_pose {
+                    self.physics.set_velocity(*id, scaled);
+                }
             }
 
             if !flags.is_empty() {
@@ -5637,6 +5674,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     collision_groups: info.collision_groups,
                     is_sensor: info.is_sensor,
                     is_enabled: info.is_enabled,
+                    is_sleeping: info.is_sleeping,
                 }
             })
             .collect();

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1835,6 +1835,14 @@ impl PhysicsWorld {
         }
     }
 
+    /// Put a dynamic body to sleep at its current transform. Contact or an
+    /// explicit impulse can still wake it.
+    pub fn sleep_body(&mut self, handle: RigidBodyHandle) {
+        if let Some(body) = self.rigid_body_set.get_mut(handle) {
+            body.sleep();
+        }
+    }
+
     /// Raise a body's angular sleep threshold so residual solver noise (e.g. a
     /// ragdoll extremity buzzing against the floor) still counts as "at rest".
     /// One awake body keeps its whole jointed island awake, so without this a
@@ -2472,6 +2480,34 @@ mod tests {
         for _ in 0..frames {
             world.update(Vector3::new(0.0, 0.0, 0.0), player);
         }
+    }
+
+    #[test]
+    fn sleeping_dynamic_body_stays_dynamic_and_wakes_on_impulse() {
+        let mut world = PhysicsWorld::new();
+        let handle = world.add_dynamic(
+            EntityId::from_inner(1).unwrap(),
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Capsule {
+                height: 1.0,
+                radius: 0.5,
+            },
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+
+        world.sleep_body(handle);
+        let sleeping = world.debug_body_info(handle, &world.rigid_body_set[handle]);
+        assert_eq!(sleeping.body_type, "dynamic");
+        assert!(sleeping.is_sleeping);
+
+        world.apply_impulse(handle, vec3(1.0, 0.0, 0.0));
+        let woken = world.debug_body_info(handle, &world.rigid_body_set[handle]);
+        assert_eq!(woken.body_type, "dynamic");
+        assert!(!woken.is_sleeping);
     }
 
     /// A higher-elasticity object must rebound higher than a low-elasticity one

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -9,6 +9,7 @@
  */
 use cgmath::{Matrix4, Point3, Vector3};
 use dark::ss2_bin_obj_loader::Vhot;
+use serde::{Deserialize, Serialize};
 use shipyard::Component;
 
 // RuntimePropGazeAmount - track how much the player is gazing at a prop
@@ -47,6 +48,22 @@ pub struct RuntimePropLocomotionScale(pub f32);
 
 #[derive(Component)]
 pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
+
+/// Exact resolved death clip used to reconstruct a killed creature's
+/// terminal pose.
+///
+/// Runtime properties are normally rebuilt rather than saved, but this one
+/// is explicitly persisted by `EntitySaveData`: random motion-schema
+/// resolution cannot be repeated on load without risking a different corpse
+/// pose. Keeping it separate from Dark's authored `P$CretPose` also leaves
+/// mission-placed corpse decorations untouched.
+///
+/// The marker is attached when the random crumple query resolves. A save
+/// taken during that crumple therefore resumes at the already-selected
+/// clip's canonical final pose without replaying events. Saves created before
+/// this marker existed cannot recover which random clip had been selected.
+#[derive(Component, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimePropDeathPose(pub String);
 
 #[derive(Component)]
 pub struct RuntimePropSpawnTimeInSeconds(pub f32);

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -5,6 +5,8 @@ use engine::game_log;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 
+use crate::runtime_props::RuntimePropDeathPose;
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EntitySaveData {
     pub all_entities: Vec<u64>,
@@ -12,6 +14,13 @@ pub struct EntitySaveData {
     pub properties:
         HashMap<String /* prop name */, HashMap<u64 /*entity id*/, serde_json::Value>>,
     pub links: HashMap<u64 /*entity_id */, serde_json::Value>,
+    /// Resolved generated death motions keyed by the pre-save entity ID.
+    ///
+    /// This is separate from authored `P$CretPose` data so mission-placed
+    /// corpse decorations retain their existing semantics. Older saves omit
+    /// the field and load with no generated terminal poses.
+    #[serde(default)]
+    pub death_poses: HashMap<u64, RuntimePropDeathPose>,
 }
 
 impl EntitySaveData {
@@ -21,6 +30,7 @@ impl EntitySaveData {
             template_id_to_entity_id: HashMap::new(),
             properties: HashMap::new(),
             links: HashMap::new(),
+            death_poses: HashMap::new(),
         }
     }
     pub fn instantiate(
@@ -54,6 +64,13 @@ impl EntitySaveData {
             }
         }
 
+        for (old_entity_id, death_pose) in &self.death_poses {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, death_pose.clone());
+            }
+        }
+
         // Now, we need to hydrate the links
 
         for (old_entity_id, link) in &self.links {
@@ -64,5 +81,48 @@ impl EntitySaveData {
             }
         }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shipyard::{Get, View};
+
+    #[test]
+    fn legacy_save_without_death_poses_defaults_to_empty() {
+        let save: EntitySaveData = serde_json::from_str(
+            r#"{
+                "all_entities": [],
+                "template_id_to_entity_id": {},
+                "properties": {},
+                "links": {}
+            }"#,
+        )
+        .unwrap();
+
+        assert!(save.death_poses.is_empty());
+    }
+
+    #[test]
+    fn instantiate_remaps_death_pose_to_the_new_entity_id() {
+        let mut source_world = World::new();
+        let old_entity = source_world.add_entity(());
+        let mut save = EntitySaveData::empty();
+        save.all_entities.push(old_entity.inner());
+        save.death_poses.insert(
+            old_entity.inner(),
+            RuntimePropDeathPose("resolved_death".to_owned()),
+        );
+
+        let mut loaded_world = World::new();
+        let _sentinel = loaded_world.add_entity(());
+        let (_, old_to_new) = save.instantiate(&mut loaded_world);
+        let new_entity = old_to_new[&old_entity];
+
+        assert_ne!(new_entity, old_entity);
+        let poses = loaded_world.borrow::<View<RuntimePropDeathPose>>().unwrap();
+        assert_eq!(poses.get(new_entity).unwrap().0, "resolved_death");
+        assert!(poses.get(old_entity).is_err());
     }
 }

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     creature::RuntimePropHitBox,
     gui::GuiPropProxyEntity,
     mission::{GlobalTemplateIdMap, PlayerInfo},
-    runtime_props::RuntimePropDoNotSerialize,
+    runtime_props::{RuntimePropDeathPose, RuntimePropDoNotSerialize},
     scripts::script_util,
     util::partition_map,
 };
@@ -139,11 +139,26 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         }
     }
 
+    let v_death_poses = world.borrow::<View<RuntimePropDeathPose>>().unwrap();
+    let mut world_death_poses = HashMap::new();
+    let mut held_death_poses = HashMap::new();
+    for (entity_id, death_pose) in v_death_poses.iter().with_id() {
+        if entities_to_filter.contains(&entity_id.inner()) {
+            continue;
+        }
+        if held_entities.contains(&entity_id.inner()) {
+            held_death_poses.insert(entity_id.inner(), death_pose.clone());
+        } else {
+            world_death_poses.insert(entity_id.inner(), death_pose.clone());
+        }
+    }
+
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
         links: world_serialized_links,
         all_entities: all_world_entities,
+        death_poses: world_death_poses,
     };
 
     let held_entity_data = EntitySaveData {
@@ -151,6 +166,7 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         template_id_to_entity_id: HashMap::new(),
         links: held_serialized_links,
         properties: held_serialized_properties,
+        death_poses: held_death_poses,
     };
 
     let held_metadata = HeldItemSaveData {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1360,6 +1360,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn killed_monster_initializes_inert_without_replaying_death_effects() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            dark::properties::PropHitPoints { hit_points: 0 },
+            crate::runtime_props::RuntimePropTransform(cgmath::Matrix4::from_scale(1.0)),
+        ));
+        let mut monster = AnimatedMonsterAI::new();
+
+        let effects = Effect::flatten(vec![monster.initialize(entity_id, &world)]);
+
+        assert!(monster.is_dead);
+        assert!(monster.handoff_emitted);
+        assert_eq!(monster.current_behavior.borrow().name(), "Dead");
+        assert!(effects.iter().all(|effect| !matches!(
+            effect,
+            Effect::QueueAnimationBySchema { .. }
+                | Effect::PlayAnimationBySchema { .. }
+                | Effect::PlaySpeech { .. }
+                | Effect::SpawnCorpseRagdoll { .. }
+        )));
+    }
+
+    #[test]
     fn locomotion_scale_full_speed_when_facing_travel_direction() {
         assert_eq!(locomotion_scale_for_heading_error(Deg(0.0)), 1.0);
     }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -681,6 +681,19 @@ impl Script for AnimatedMonsterAI {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         self.current_heading = current_yaw(entity_id, world);
 
+        // Save/load rebuilds scripts after restoring serialized hit points. A
+        // killed monster must start in its inert state: queueing the fresh
+        // script's idle clip would stand the corpse up, then its completion
+        // would enter the normal death path and replay the crumple + speech.
+        if is_killed(entity_id, world) {
+            self.current_behavior = Box::new(RefCell::new(DeadBehavior {}));
+            self.is_dead = true;
+            // This corpse did not enter death in this runtime, so it must not
+            // run the timed animated-crumple -> ragdoll handoff either.
+            self.handoff_emitted = true;
+            return self.publish_behavior(entity_id);
+        }
+
         // Load alertness configuration from entity properties
         self.config = Self::build_config(world, entity_id);
 
@@ -717,10 +730,10 @@ impl Script for AnimatedMonsterAI {
         // behavior so introspection shows "Dead", and release a sensor the
         // ray was intersecting at death so its end-intersect isn't stranded.
         if self.is_dead || is_killed(entity_id, world) {
-            // The handoff timer runs only through the real death flow
-            // (enter_death -> is_dead): a corpse recreated by save/load has
-            // is_killed true but is_dead false, and must stay an animated
-            // corpse rather than ragdoll-ify from whatever pose it loaded in.
+            // A corpse recreated by save/load also latches is_dead so stale
+            // animation completions stay inert, but initialize() pre-marks
+            // its handoff as emitted: it must not ragdoll-ify from whatever
+            // pose the save restored.
             if self.is_dead {
                 self.death_elapsed += time.elapsed.as_secs_f32();
             }

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -213,6 +213,7 @@ export interface PhysicsBodySummary {
   collision_groups: string[];
   is_sensor: boolean;
   is_enabled: boolean;
+  is_sleeping: boolean;
 }
 
 export interface PhysicsBodyListResult {

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -99,5 +99,79 @@ test(
       drift < 0.5,
       `corpse moved ${drift.toFixed(2)} units after death`,
     );
+
+    // Save/load rebuilds scripts rather than serializing their internal
+    // behavior state. Rediscover the corpse after load by its stable template
+    // plus saved position: runtime entity IDs are assigned afresh.
+    const savedCorpse = detail;
+    const saveName = `monster_death_e2e_${Date.now()}`;
+    await game.save(saveName);
+    await game.load(saveName);
+
+    const loadedMonsters = await game.entities.list({
+      filter: "OG-Pipe",
+      limit: 50,
+    });
+    const loadedCorpse = loadedMonsters.entities
+      .filter(
+        (entity) =>
+          entity.name === monster.name &&
+          entity.template_id === monster.template_id,
+      )
+      .map((entity) => ({
+        entity,
+        distance: Math.hypot(
+          entity.position[0] - savedCorpse.position[0],
+          entity.position[1] - savedCorpse.position[1],
+          entity.position[2] - savedCorpse.position[2],
+        ),
+      }))
+      .sort((a, b) => a.distance - b.distance)[0];
+    assert.ok(
+      loadedCorpse && loadedCorpse.distance < 1.0,
+      `expected the saved corpse near ${JSON.stringify(savedCorpse.position)}, got ${JSON.stringify(loadedMonsters.entities)}`,
+    );
+
+    // A loaded corpse must be inert immediately. Sample through the old idle
+    // clip's completion window as well: before the fix initialize() queued an
+    // idle, then AnimationCompleted replayed the death clip and death speech.
+    const loadedStates: Array<{
+      frame: number;
+      behavior: string | undefined;
+      clip: string | null;
+      clipFrame: number;
+      lastClip: string | null;
+      queuedClips: Array<string | null>;
+    }> = [];
+    for (let frame = 0; frame <= 120; frame += 30) {
+      if (frame > 0) {
+        await game.step({ frames: 30 });
+      }
+      const loadedDetail = await game.entities.detail(loadedCorpse.entity.id);
+      const animation = await game.entities.animation(loadedCorpse.entity.id);
+      assert.ok(animation, "loaded OG-Pipe should have an animation player");
+      loadedStates.push({
+        frame,
+        behavior: aiProp(loadedDetail, "AIBehavior"),
+        clip: animation.clip,
+        clipFrame: animation.frame,
+        lastClip: animation.last_clip,
+        queuedClips: animation.queue.map((entry) => entry.name),
+      });
+    }
+
+    const initialPlayback = loadedStates[0];
+    assert.ok(initialPlayback, "expected at least one loaded animation sample");
+    assert.ok(
+      loadedStates.every(
+        (state) =>
+          state.behavior === "Dead" &&
+          state.clip === initialPlayback.clip &&
+          state.clipFrame === initialPlayback.clipFrame &&
+          state.lastClip === initialPlayback.lastClip &&
+          state.queuedClips.length === 0,
+      ),
+      `loaded corpse replayed animation or left Dead behavior: ${JSON.stringify(loadedStates)}`,
+    );
   },
 );

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -14,6 +14,36 @@ function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
 }
 
+function distance3(a: [number, number, number], b: [number, number, number]) {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function maxJointDistance(
+  a: Array<[number, number, number]>,
+  b: Array<[number, number, number]>,
+) {
+  assert.equal(a.length, b.length, "saved and loaded joint counts should match");
+  return Math.max(...a.map((joint, index) => distance3(joint, b[index]!)));
+}
+
+async function spawnOgPipe(game: GameServer) {
+  // Identify the debug spawn by diffing the entity list: medsci1 has native
+  // OG-Pipes too, and runtime entity IDs are not stable across launches.
+  const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+  const known = new Set(preSpawn.entities.map((entity) => entity.id));
+  await game.input.trigger("SpawnDebugMonster");
+  await game.step({ frames: 30 });
+  const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+  const monster = postSpawn.entities.find(
+    (entity) => entity.name === "OG-Pipe" && !known.has(entity.id),
+  );
+  assert.ok(
+    monster,
+    `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((entity) => entity.id))}`,
+  );
+  return monster;
+}
+
 test(
   "a killed monster dies and stays dead",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -25,20 +55,7 @@ test(
 
     await game.step({ frames: 10 });
 
-    // Spawn a monster in front of the player, identifying it by diffing the
-    // entity list across the spawn (medsci1 has native OG-Pipes too).
-    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
-    const known = new Set(preSpawn.entities.map((e) => e.id));
-    await game.input.trigger("SpawnDebugMonster");
-    await game.step({ frames: 30 });
-    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
-    const monster = postSpawn.entities.find(
-      (e) => e.name === "OG-Pipe" && !known.has(e.id),
-    );
-    assert.ok(
-      monster,
-      `expected a newly spawned OG-Pipe, got ${JSON.stringify(postSpawn.entities.map((e) => e.id))}`,
-    );
+    const monster = await spawnOgPipe(game);
 
     // Alert it first so the post-death alertness machinery has both paths to
     // fire (escalation while the player is visible, decay afterwards) - the
@@ -99,12 +116,68 @@ test(
       drift < 0.5,
       `corpse moved ${drift.toFixed(2)} units after death`,
     );
+  },
+);
+
+test(
+  "a loaded corpse does not replay its death",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
+    });
+
+    await game.step({ frames: 10 });
+    const monster = await spawnOgPipe(game);
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+
+    // Death clips are randomly resolved and have different durations. Advance
+    // fixed-size simulation chunks until whichever clip was chosen has
+    // genuinely drained, rather than assuming a particular frame count.
+    let savedAnimation:
+      | Awaited<ReturnType<typeof game.entities.animation>>
+      | undefined;
+    let savedBody:
+      | Awaited<ReturnType<typeof game.physics.bodies>>["bodies"][number]
+      | undefined;
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      await game.step({ frames: 30 });
+      const animation = await game.entities.animation(monster.id);
+      const bodies = await game.physics.bodies({ entityId: monster.id });
+      assert.equal(bodies.bodies.length, 1, "OG-Pipe should own one capsule body");
+      const body = bodies.bodies[0];
+      if (
+        animation?.clip === null &&
+        animation.last_clip &&
+        animation.queue.length === 0 &&
+        body?.is_sleeping
+      ) {
+        savedAnimation = animation;
+        savedBody = body;
+        break;
+      }
+    }
+    assert.ok(
+      savedAnimation,
+      "death animation should reach a settled terminal pose within 1800 frames",
+    );
+    assert.ok(savedBody, "terminal corpse body should be sleeping");
+    assert.equal(savedBody.body_type, "dynamic");
+    const savedCorpse = await game.entities.detail(monster.id);
+    assert.equal(aiProp(savedCorpse, "AIBehavior"), "Dead");
+    assert.equal(savedAnimation.clip, null, "death animation should be complete");
+    assert.ok(savedAnimation.last_clip, "death should leave a terminal pose");
+    assert.deepEqual(savedAnimation.queue, []);
+    assert.ok(savedAnimation.joints.length > 0, "saved corpse should be posed");
 
     // Save/load rebuilds scripts rather than serializing their internal
     // behavior state. Rediscover the corpse after load by its stable template
     // plus saved position: runtime entity IDs are assigned afresh.
-    const savedCorpse = detail;
-    const saveName = `monster_death_e2e_${Date.now()}`;
+    const saveName = `monster_reload_e2e_${Date.now()}`;
     await game.save(saveName);
     await game.load(saveName);
 
@@ -120,21 +193,18 @@ test(
       )
       .map((entity) => ({
         entity,
-        distance: Math.hypot(
-          entity.position[0] - savedCorpse.position[0],
-          entity.position[1] - savedCorpse.position[1],
-          entity.position[2] - savedCorpse.position[2],
-        ),
+        distance: distance3(entity.position, savedCorpse.position),
       }))
       .sort((a, b) => a.distance - b.distance)[0];
     assert.ok(
-      loadedCorpse && loadedCorpse.distance < 1.0,
+      loadedCorpse && loadedCorpse.distance < 0.02,
       `expected the saved corpse near ${JSON.stringify(savedCorpse.position)}, got ${JSON.stringify(loadedMonsters.entities)}`,
     );
 
-    // A loaded corpse must be inert immediately. Sample through the old idle
-    // clip's completion window as well: before the fix initialize() queued an
-    // idle, then AnimationCompleted replayed the death clip and death speech.
+    // A loaded corpse must hold the exact saved terminal death pose and body
+    // position immediately. Sample irregular frames through the old idle
+    // completion window: before the fix initialize() queued idle, then
+    // AnimationCompleted replayed the death clip and death speech.
     const loadedStates: Array<{
       frame: number;
       behavior: string | undefined;
@@ -142,14 +212,27 @@ test(
       clipFrame: number;
       lastClip: string | null;
       queuedClips: Array<string | null>;
+      bodyType: "dynamic" | "static" | "kinematic";
+      bodySleeping: boolean;
+      bodyVelocity: number;
+      bodyMass: number | null;
+      collisionGroups: string[];
+      positionError: number;
+      poseError: number;
     }> = [];
-    for (let frame = 0; frame <= 120; frame += 30) {
-      if (frame > 0) {
-        await game.step({ frames: 30 });
+    let previousFrame = 0;
+    for (const frame of [0, 17, 53, 97, 151]) {
+      if (frame > previousFrame) {
+        await game.step({ frames: frame - previousFrame });
       }
       const loadedDetail = await game.entities.detail(loadedCorpse.entity.id);
       const animation = await game.entities.animation(loadedCorpse.entity.id);
       assert.ok(animation, "loaded OG-Pipe should have an animation player");
+      const bodies = await game.physics.bodies({
+        entityId: loadedCorpse.entity.id,
+      });
+      assert.equal(bodies.bodies.length, 1, "loaded corpse should retain one body");
+      const body = bodies.bodies[0]!;
       loadedStates.push({
         frame,
         behavior: aiProp(loadedDetail, "AIBehavior"),
@@ -157,7 +240,15 @@ test(
         clipFrame: animation.frame,
         lastClip: animation.last_clip,
         queuedClips: animation.queue.map((entry) => entry.name),
+        bodyType: body.body_type,
+        bodySleeping: body.is_sleeping,
+        bodyVelocity: Math.hypot(...body.velocity),
+        bodyMass: body.mass,
+        collisionGroups: body.collision_groups,
+        positionError: distance3(loadedDetail.position, savedCorpse.position),
+        poseError: maxJointDistance(animation.joints, savedAnimation.joints),
       });
+      previousFrame = frame;
     }
 
     const initialPlayback = loadedStates[0];
@@ -166,12 +257,20 @@ test(
       loadedStates.every(
         (state) =>
           state.behavior === "Dead" &&
-          state.clip === initialPlayback.clip &&
+          state.clip === null &&
           state.clipFrame === initialPlayback.clipFrame &&
-          state.lastClip === initialPlayback.lastClip &&
-          state.queuedClips.length === 0,
+          state.lastClip === savedAnimation.last_clip &&
+          state.queuedClips.length === 0 &&
+          state.bodyType === savedBody.body_type &&
+          state.bodySleeping &&
+          state.bodyVelocity < 0.0001 &&
+          state.bodyMass === savedBody.mass &&
+          JSON.stringify(state.collisionGroups) ===
+            JSON.stringify(savedBody.collision_groups) &&
+          state.positionError < 0.02 &&
+          state.poseError < 0.02,
       ),
-      `loaded corpse replayed animation or left Dead behavior: ${JSON.stringify(loadedStates)}`,
+      `loaded corpse changed behavior, pose, or position: ${JSON.stringify(loadedStates)}`,
     );
   },
 );


### PR DESCRIPTION
Fixes #370
Fixes #525

## Root cause

Save/load restores serialized hit points but rebuilds `AnimatedMonsterAI` from a fresh `IdleBehavior`. A killed creature therefore queued idle on load; that clip's completion entered the normal death path again, replaying a new crumple animation and death effects.

The first state-machine fix exposed the second half of the bug: saves discarded the randomly resolved terminal death clip, and creature construction reapplied its normal spawn lift. The corpse became inert but rendered in its bind pose and initially jumped `0.4167` world units.

## Fix

- Initialize killed monsters directly in `DeadBehavior`, latch stale completions inert, and pre-mark the ragdoll handoff emitted.
- Record the exact resolved random crumple clip only after it loads successfully, in a generated `RuntimePropDeathPose` kept separate from authored `P$CretPose`.
- Persist that marker with serde compatibility, held/world filtering, and entity-ID remapping.
- Rebuild the animation player directly in its completed state: terminal frame visible, empty playback queue, and no root velocity, flags, completion events, or direction events.
- Restore the same dynamic creature capsule, offset, material options, collision group, and rotation locks at the exact saved transform; start it asleep but still contact/impulse-wakeable.
- Avoid the zero-velocity animation write that would wake a terminal corpse every frame.
- Extend debug physics telemetry with sleep state and add unit plus real-runtime coverage for AI effects, pose, placement, and dynamic-body parity.

Mission-authored corpse decorations retain their existing `P$CretPose` rendering and physics path.

## Negative-first evidence

Against unmodified `main`, the loaded corpse began in `Idle` with `ogsidle1`, then re-entered `Dead` with a freshly selected death clip.

Against the earlier state-only commit (`63e1b9d`), the enhanced exact-pose test isolated the remaining defect:

```text
saved position: [-37.26784, -4.301141, 18.092224]
loaded position: [-37.26784, -3.884474, 18.092224]
pose error at frames [0,17,53,97,151]:
[4.108497, 3.887181, 3.878644, 3.878339, 3.878339]
position error:
[0.416667, 0.017114, 0.000592, 0.0000004, 0.0000004]
```

That run was already `Dead` with no active/queued clip, proving the large joint error was the bind/T-pose rather than replay. The final scenario holds pose and position error below `0.02` at every sample while preserving the same dynamic, sleeping, zero-velocity body mass and collision groups.

## Visual verification

![Loaded corpse before and after](https://gist.githubusercontent.com/tommy-xr/85ca531db2257219c79c9c319eba1faa/raw/e3c7fcfbda45d10c068640b216e323a5b58de17c/pr526-dead-monster-reload-terminal-pose-v2.gif)

![Frame 120 comparison](https://gist.githubusercontent.com/tommy-xr/85ca531db2257219c79c9c319eba1faa/raw/e3c7fcfbda45d10c068640b216e323a5b58de17c/pr526-dead-monster-reload-compare-v2.png)

<sub>Both sides load the same final-created settled-corpse save with the same camera and fixed-step sequence. Base `7fa7fa3` queues `ogsidle1` and then replays a fresh `ogpdiefw`; `b419a1a` remains `Dead` with `clip=null`, `last_clip=ogpdie2`, an empty queue, and the genuine prone terminal pose. All 81 final frames were inspected; none contains a bind/T-pose.</sub>

## Compatibility boundaries

- A save taken mid-crumple records the clip that was already randomly resolved, then loads at that clip's canonical terminal frame without replaying events or root motion. It does not resume the in-progress blend/frame.
- Saves created before this patch contain no resolved random clip identity, so they cannot reconstruct the exact historical corpse pose. They still receive the inert `DeadBehavior` initialization.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr --lib` — 194 passed
- `RUSTFLAGS="-D warnings" cargo test -p dark completed_animation_constructor_holds_without_events_or_motion` — passed
- `cd tools/shock2-sdk && npm test` — 14 passed, 107 e2e tests skipped as expected
- Focused loaded-corpse e2e — passed
- Full Node 22 SDK e2e suite — 121/121 passed, 0 skipped, no reruns
- Cross-engine adversarial review with the exact media attached — Claude Opus and Codex both returned **SHIP** with 0 Critical/High findings