### PR TITLE
[gameplay] Store flat nonweapon pickups in backpack

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -23,7 +23,7 @@ use crate::{
     runtime_props::RuntimePropReloading,
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
-    virtual_hand::{VirtualHandEffect, can_grab_item},
+    virtual_hand::{VirtualHandEffect, can_grab_item, is_wieldable_weapon},
 };
 
 /// Fallback viewmodel framing offset (look space: +x right, +y up, -z forward),
@@ -113,6 +113,16 @@ impl FlatPlayerController {
         self.last_fire_pressed = false;
         effects.push(VirtualHandEffect::HoldItem { entity_id });
         effects
+    }
+
+    /// Apply the original flat pickup split: weapons become the first-person
+    /// viewmodel, while ordinary loot goes straight into the backpack.
+    fn pick_up(&mut self, world: &World, entity_id: EntityId) -> Vec<VirtualHandEffect> {
+        if is_wieldable_weapon(world, entity_id) {
+            self.wield(entity_id)
+        } else {
+            vec![VirtualHandEffect::StoreItem { entity_id }]
+        }
     }
 
     /// Per-frame update. Returns the effects to apply plus the entity currently
@@ -238,8 +248,9 @@ impl FlatPlayerController {
         if use_pressed && !self.last_use_pressed {
             if let Some(target) = highlighted {
                 if can_grab_item(world, target) {
-                    // A pickup-able object (e.g. a weapon): wield it.
-                    effects.extend(self.wield(target));
+                    // Weapons become the flat viewmodel; ordinary loot goes
+                    // into the backpack without displacing that viewmodel.
+                    effects.extend(self.pick_up(world, target));
                 } else {
                     // Otherwise interact with it.
                     effects.push(out_message(target, MessagePayload::Frob));
@@ -271,4 +282,66 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
         .borrow::<View<PropFrobInfo>>()
         .map(|v| v.get(entity_id).is_ok())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::PropPlayerGun;
+
+    fn pistol() -> PropPlayerGun {
+        PropPlayerGun {
+            flags: 0,
+            hand_model: "atek_h".to_owned(),
+            icon_file: String::new(),
+            model_offset: vec3(0.0, 0.0, 0.0),
+            fire_offset: vec3(0.0, 0.0, 0.0),
+            heading: 0,
+            reload_pitch: 0,
+            reload_rate: 0,
+            gun_type: 0,
+        }
+    }
+
+    #[test]
+    fn world_use_of_nonweapon_stores_it_without_displacing_wielded_weapon() {
+        let mut world = World::new();
+        let pistol = world.add_entity(pistol());
+        let ammo = world.add_entity(());
+        let mut controller = FlatPlayerController::new();
+        controller.wield(pistol);
+
+        let effects = controller.pick_up(&world, ammo);
+
+        assert_eq!(
+            controller.wielded_entity(),
+            Some(pistol),
+            "ordinary loot must not replace the wielded weapon"
+        );
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::StoreItem { entity_id }] if *entity_id == ammo
+            ),
+            "ordinary loot should be sent to the backpack"
+        );
+    }
+
+    #[test]
+    fn world_use_of_weapon_still_wields_it() {
+        let mut world = World::new();
+        let weapon = world.add_entity(pistol());
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, weapon);
+
+        assert_eq!(controller.wielded_entity(), Some(weapon));
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::HoldItem { entity_id }] if *entity_id == weapon
+            ),
+            "weapon pickup should preserve flat auto-wield"
+        );
+    }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4717,6 +4717,16 @@ impl MissionCore {
                         to: entity_id,
                     });
                 }
+                VirtualHandEffect::StoreItem { entity_id } => {
+                    let inventory_entity = self
+                        .world
+                        .borrow::<UniqueView<PlayerInfo>>()
+                        .map(|player| player.inventory_entity_id)
+                        .ok();
+                    if let Some(inventory_entity) = inventory_entity {
+                        self.drop_entity_into_container(inventory_entity, entity_id);
+                    }
+                }
                 VirtualHandEffect::DropItem { entity_id } => {
                     self.make_physical(entity_id);
 

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -62,6 +62,11 @@ pub enum VirtualHandEffect {
     HoldItem {
         entity_id: EntityId,
     },
+    /// Flat-only world pickup of ordinary loot into the player backpack.
+    /// VR preserves its physical hand-grab path and never emits this.
+    StoreItem {
+        entity_id: EntityId,
+    },
     DropItem {
         entity_id: EntityId,
     },

--- a/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "earth: flat world-use stores ammo without displacing the wielded pistol",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
+    });
+    await game.step({ frames: 30 });
+
+    // PropTemplateId is the stable mission-object id for level-authored
+    // entities. Runtime ids are deliberately rediscovered every launch.
+    const entities = (await game.entities.list()).entities;
+    const pistol = entities.find(
+      (entity) => entity.template_id === 246 && entity.name === "Pistol",
+    );
+    const clip = entities.find(
+      (entity) =>
+        entity.template_id === 249 && entity.name.includes("Standard Clip"),
+    );
+    assert.ok(pistol, "expected Earth Weapons Training pistol 246");
+    assert.ok(clip, "expected Earth Weapons Training standard clip 249");
+
+    await earthWorldUse(game, pistol);
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      pistol.id,
+      "normal world-use should auto-wield the pistol",
+    );
+
+    await earthWorldUse(game, clip);
+
+    const player = (await game.info()).player;
+    assert.equal(
+      player.wielded_entity_id,
+      pistol.id,
+      "picking up ammo must retain the wielded pistol",
+    );
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === pistol.id)?.location,
+      "left_hand",
+      `pistol should remain wielded, got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === clip.id)?.location,
+      "inventory",
+      `clip should land in the backpack, got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: clip.id })).bodies.length,
+      0,
+      "a backpack item must no longer have a world physics body",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/helpers/earth-world-use.ts
+++ b/tools/shock2-sdk/test/helpers/earth-world-use.ts
@@ -1,0 +1,46 @@
+import type { GameServer } from "../../src/index.js";
+import type { EntitySummary } from "../../src/types.js";
+
+export interface EarthWorldUseStaging {
+  horizontalOffset: number;
+  verticalOffset: number;
+  pitchDeg: number;
+}
+
+const DEFAULT_STAGING: EarthWorldUseStaging = {
+  horizontalOffset: 0.1,
+  verticalOffset: -1.6,
+  pitchDeg: -63.435,
+};
+
+/**
+ * Aim at and world-use an authored entity through the normal flat crosshair
+ * and squeeze input. Teleporting only stages the camera; acquisition still
+ * flows through the game's real interaction controller.
+ *
+ * The close staging is intentional for Earth training: booth geometry sits
+ * between ordinary standing positions and the display items. The first fixed
+ * step applies 0.2 units of gravity before interaction. Starting 1.6 below
+ * the item's center therefore leaves the camera 0.2 below it; the fixed upward
+ * pitch aims the ray through the center from 0.1 units away.
+ *
+ * This is deliberately Earth-training-specific. Callers targeting different
+ * geometry must provide and document a clear-ray staging configuration.
+ */
+export async function earthWorldUse(
+  game: GameServer,
+  item: EntitySummary,
+  staging: EarthWorldUseStaging = DEFAULT_STAGING,
+): Promise<void> {
+  const [x, y, z] = (await game.entities.detail(item.id)).position;
+  await game.player.teleport({
+    x: x + staging.horizontalOffset,
+    y: y + staging.verticalOffset,
+    z,
+  });
+  await game.input.set("head.look", [0, staging.pitchDeg]);
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 1 });
+}


### PR DESCRIPTION
## Summary

- distinguish flat-mode weapons from inventory items during normal world pickup
- keep guns and melee weapons on the existing wield path
- store nonweapon pickups in the player's backpack through the existing container transfer path
- cover the behavior with focused Rust tests and a real Earth mission E2E scenario

## Visual verification

The first state shows the real Standard Clip pickup target with the pistol equipped. The second captures the original bug. The fixed state comes from the isolated issue branch runtime: the clip is in the backpack while the pistol remains equipped.

![Before, bug, and fixed comparison](https://gist.githubusercontent.com/tommy-xr/76e9da5474bf48b40785ad6ad0026add/raw/flat-pickup-before-after.png)

![Flat pickup interaction evidence](https://gist.githubusercontent.com/tommy-xr/76e9da5474bf48b40785ad6ad0026add/raw/flat-pickup-demo.gif)

## Validation

- `cargo test -p shock2vr flat_player_controller::tests -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test`
- targeted `flat-world-pickup.e2e.test.ts`
- `npm run test:e2e` — 120/121 passed; the unrelated timing-sensitive
  `pathfinding-budget.e2e.test.ts` observed 3 queries instead of its threshold
- isolated rerun of `pathfinding-budget.e2e.test.ts` — 1/1 passed

Fixes #528
