### PR TITLE
Fix reserve ammo accounting on reload

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -392,6 +392,9 @@ pub enum Link {
     AIRangedWeapon,
     AIWatchObj(AIWatchOptions),
     Contains(u32),
+    /// From a projectile archetype to the compatible inventory-ammo archetype
+    /// (e.g. Standard Bullet -> Standard Clip).
+    Clip,
     Corpse(CorpseOptions),
     Flinderize(FlinderizeOptions),
     GunFlash(GunFlashOptions),
@@ -972,6 +975,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_link("L$Teleport", |_| Link::Teleport),
         define_link("L$TPathInit", |_| Link::TPathInit),
         define_link("L$AIPatrol", |_| Link::AIPatrol),
+        define_link("L$Clip", |_| Link::Clip),
         define_link("L$Miss Span", |_| Link::MissSpang),
         //define_link("L$TPath", |_| Link::TPath),
         //define_link("L$TPathNext", |_| Link::TPath),

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -361,8 +361,9 @@ pub struct DebugUiState {
     /// The item held on the cursor mid-drag (the original's "cursor IS the
     /// item", §2.4). `Some` between a lift and the place/throw that clears it.
     pub cursor: Option<DebugUiCursor>,
-    /// The AMMOFULL ammo-cycle button (use mode + multi-ammo weapon wielded);
-    /// clicking it cycles the wielded weapon's ammo type. `None` otherwise.
+    /// The AMMOFULL ammo-cycle button (use mode + empty multi-ammo weapon
+    /// wielded); clicking it cycles the wielded weapon's ammo type. `None`
+    /// otherwise.
     pub ammo_cycle: Option<DebugUiElement>,
 }
 

--- a/shock2vr/src/hud/flat_hud.rs
+++ b/shock2vr/src/hud/flat_hud.rs
@@ -278,8 +278,8 @@ pub(crate) fn create_flat_hud(
     canvas.render_screen_space(asset_cache, screen_size, ScaleMode::PreserveAspect)
 }
 
-/// Whether the wielded weapon has 2+ selectable ammo types (so the AMMOFULL
-/// cycle button is meaningful). Mirrors `cycle_ammo`'s `count < 2` guard.
+/// Whether the wielded weapon may cycle ammo (empty, with 2+ selectable
+/// projectile types). Uses the same predicate as `cycle_ammo`.
 pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
     let Some(player) = world
         .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
@@ -290,16 +290,15 @@ pub(crate) fn can_cycle_wielded_ammo(world: &World) -> bool {
     let Some(weapon) = player.left_hand_entity_id else {
         return false;
     };
-    crate::scripts::script_util::ordered_projectile_links(world, weapon).len() >= 2
+    crate::scripts::script_util::can_cycle_ammo(world, weapon)
 }
 
 /// The single source of truth for whether the AMMOFULL ammo-cycle button is
 /// shown/active this frame - used for BOTH rendering (via `create_flat_hud`'s
 /// `can_cycle_ammo`) and pointer hit-testing (`mission_core`), so the drawn and
 /// clickable regions never diverge. Requires use mode, a wielded gun with a
-/// clip (`get_wielded_ammo`), 2+ ammo types, and no psi-amp display (which
-/// replaces the ammo section - `build_flat_hud_canvas`'s psi-power early
-/// return).
+/// empty clip, 2+ ammo types, and no psi-amp display (which replaces the ammo
+/// section - `build_flat_hud_canvas`'s psi-power early return).
 pub(crate) fn ammo_cycle_button_visible(world: &World, use_mode: bool) -> bool {
     use_mode
         && get_wielded_psi_power(world).is_none()
@@ -391,9 +390,9 @@ mod tests {
             true,
         );
         assert_eq!(shooter.element_count(), 8);
-        // Use mode (crosshair off) with a multi-ammo weapon: the same readouts
-        // (expanded backdrops swap in place, same element count) PLUS the
-        // AMMOFULL cycle button = 8 - 1 (crosshair) + 1 (cycle) = 8.
+        // Use mode (crosshair off) with an empty multi-ammo weapon: the same
+        // readouts (expanded backdrops swap in place, same element count) PLUS
+        // the AMMOFULL cycle button = 8 - 1 (crosshair) + 1 (cycle) = 8.
         let use_mode = build_flat_hud_canvas(
             false,
             true,
@@ -401,7 +400,7 @@ mod tests {
             0.75,
             None,
             None,
-            Some(12),
+            Some(0),
             None,
             None,
             true,
@@ -415,7 +414,7 @@ mod tests {
             0.75,
             None,
             None,
-            Some(12),
+            Some(0),
             None,
             None,
             false,

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -36,9 +36,9 @@ pub enum InputAction {
     /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
     /// testing.
     CycleWeapon,
-    /// Cycle the wielded weapon's ammo type (its next Projectile link).
+    /// Cycle an empty wielded weapon's ammo type (its next Projectile link).
     CycleAmmo,
-    /// Reload the wielded weapon: refill its clip to capacity.
+    /// Reload the wielded weapon from compatible backpack reserve.
     Reload,
     /// Select the next psi power (used when firing the psi amp).
     CyclePsiPower,

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -80,8 +80,8 @@ const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
 pub enum FlatUiDragAction {
     Throw(EntityId),
     Wield(EntityId),
-    /// Cycle the wielded weapon's ammo type (the AMMOFULL cycle button was
-    /// clicked). Not tied to a cursor item - the caller maps it to
+    /// Cycle the empty wielded weapon's ammo type (the AMMOFULL cycle button
+    /// was clicked). Not tied to a cursor item - the caller maps it to
     /// `Effect::CycleAmmo`, which acts on the wielded weapon.
     CycleAmmo,
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -434,6 +434,9 @@ impl MissionCore {
         world.add_unique(GlobalPresentationMode(game_options.presentation_mode));
         let template_class_tags = create_template_class_tag_map(&entity_info_rc);
         world.add_unique(GlobalTemplateClassTags(template_class_tags));
+        world.add_unique(
+            crate::mission::reload::GlobalProjectileClips::from_entity_info(&entity_info_rc),
+        );
         // Reuse the obj-icons already hydrated into the template metadata above
         // (keyed by template id) rather than rescanning every template.
         let template_obj_icons: HashMap<i32, String> = template_name_to_template_id
@@ -3976,15 +3979,16 @@ impl MissionCore {
         }
     }
 
-    /// Begin a reload on `weapon`: refill its clip to capacity and start the
-    /// reload animation (a `RuntimePropReloading` on the weapon). SS2's
+    /// Begin a reload on `weapon`: consume compatible backpack reserve to refill
+    /// its clip and start the reload animation (a `RuntimePropReloading` on the
+    /// weapon). SS2's
     /// first-person reload tilts the gun down to a peak angle, holds while the
     /// clip is swapped, then raises it back up; the peak angle and pitch speed
     /// come from the weapon's own data (`PropPlayerGun`'s reload pitch/rate, as
     /// 16-bit angle units where 65536 = 360 deg) and the hold from its reload
     /// time (`PropBaseGunDesc.reload_time_ms`). No-op for non-guns (no
-    /// `PropBaseGunDesc`) and while a reload is already in progress. Reserve ammo
-    /// is unlimited for now (no inventory ammo model yet).
+    /// `PropBaseGunDesc`), while a reload is already in progress, or when no
+    /// compatible reserve rounds are available.
     fn begin_reload(&mut self, weapon: EntityId) {
         // Sensible fallbacks used only when a gun has no PropPlayerGun at all, so
         // the reload is still visible.
@@ -4037,16 +4041,17 @@ impl MissionCore {
         };
         let leg = peak_deg.abs() / rate; // tilt-down (and tilt-up) duration
 
-        // Refill now: firing is gated for the whole reload, so the exact moment
-        // the clip refills is not observable.
-        {
-            let mut v_gun_state = self
-                .world
-                .borrow::<ViewMut<dark::properties::PropGunState>>()
-                .unwrap();
-            if let Ok(gun_state) = (&mut v_gun_state).get(weapon) {
-                gun_state.ammo = clip.max(0);
-            }
+        // Consume the selected projectile's authored Clip type from the
+        // backpack. Multiple small stacks may contribute to one magazine.
+        let reload = crate::mission::reload::load_from_reserve(&self.world, weapon, clip);
+        if reload.rounds_loaded == 0 {
+            return;
+        }
+        for item in reload.depleted_items {
+            self.interaction.on_entity_destroyed(item);
+            self.flat_ui.on_entity_destroyed(item);
+            self.remove_incoming_contains_links(item);
+            self.remove_entity(item);
         }
 
         self.world.add_component(
@@ -4062,13 +4067,15 @@ impl MissionCore {
     }
 
     /// Cycle `weapon` to its next ammo type (next `Projectile` link). No-op when
-    /// the weapon has fewer than two projectile links.
+    /// the weapon has fewer than two projectile links or still has loaded
+    /// rounds; until magazine-unload semantics exist, requiring an empty gun
+    /// prevents standard rounds from turning into AP/HE rounds for free.
     fn cycle_ammo(&mut self, weapon: EntityId) {
+        if !crate::scripts::script_util::can_cycle_ammo(&self.world, weapon) {
+            return;
+        }
         let count =
             crate::scripts::script_util::ordered_projectile_links(&self.world, weapon).len();
-        if count < 2 {
-            return; // single ammo type (or melee) - nothing to cycle
-        }
         let current = self
             .world
             .borrow::<View<RuntimePropSelectedAmmo>>()

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -7,6 +7,7 @@ pub mod flat_ui_host;
 pub mod mission_core;
 pub mod pathfinding_debug;
 pub mod pathfinding_test;
+mod reload;
 pub mod spatial_query;
 mod spawn_location;
 pub mod stim_response;

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -1,0 +1,400 @@
+use std::collections::HashMap;
+
+use dark::{
+    properties::{Link, Links, PropGunState, PropStackCount, PropTemplateId},
+    ss2_entity_info::{self, SystemShock2EntityInfo},
+};
+use shipyard::{EntityId, Get, Unique, UniqueView, View, ViewMut, World};
+
+/// Projectile archetype -> compatible ammo-clip archetypes, authored by the
+/// Dark engine's `Clip` relation.
+#[derive(Unique, Clone, Default)]
+pub(crate) struct GlobalProjectileClips(pub HashMap<i32, Vec<i32>>);
+
+impl GlobalProjectileClips {
+    pub fn from_entity_info(entity_info: &SystemShock2EntityInfo) -> Self {
+        let hierarchy = ss2_entity_info::get_hierarchy(entity_info);
+        let mut projectile_clips = HashMap::new();
+
+        // Relations inherit just like properties. Build the effective Clip
+        // relation for every archetype so a concrete projectile child can use a
+        // relation authored on its family archetype.
+        for template_id in entity_info.entity_to_properties.keys() {
+            let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, template_id);
+            ancestors.push(*template_id);
+            let mut compatible_clips = Vec::new();
+            for ancestor in ancestors {
+                let Some(links) = entity_info.template_to_links.get(&ancestor) else {
+                    continue;
+                };
+                for clip in links
+                    .to_links
+                    .iter()
+                    .filter(|link| matches!(link.link, Link::Clip))
+                {
+                    if !compatible_clips.contains(&clip.to_template_id) {
+                        compatible_clips.push(clip.to_template_id);
+                    }
+                }
+            }
+            if !compatible_clips.is_empty() {
+                projectile_clips.insert(*template_id, compatible_clips);
+            }
+        }
+
+        Self(projectile_clips)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReloadOutcome {
+    pub rounds_loaded: i32,
+    pub depleted_items: Vec<EntityId>,
+}
+
+/// Move matching reserve rounds from the backpack into `weapon`.
+///
+pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) -> ReloadOutcome {
+    let current_ammo = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.ammo));
+    let Some(current_ammo) = current_ammo else {
+        return ReloadOutcome::default();
+    };
+    let mut rounds_needed = (capacity.max(0) - current_ammo.max(0)).max(0);
+    if rounds_needed == 0 {
+        return ReloadOutcome::default();
+    }
+
+    let projectiles = crate::scripts::script_util::ordered_projectile_links(world, weapon);
+    if projectiles.is_empty() {
+        return ReloadOutcome::default();
+    }
+    let selected = world
+        .borrow::<View<crate::runtime_props::RuntimePropSelectedAmmo>>()
+        .ok()
+        .and_then(|selected| selected.get(weapon).ok().map(|selected| selected.0))
+        .unwrap_or(0);
+    let projectile_template = projectiles[selected % projectiles.len()].0;
+    let compatible_clip_templates = world
+        .borrow::<UniqueView<GlobalProjectileClips>>()
+        .ok()
+        .and_then(|clips| clips.0.get(&projectile_template).cloned());
+    let Some(compatible_clip_templates) = compatible_clip_templates else {
+        return ReloadOutcome::default();
+    };
+
+    let inventory = match world.borrow::<UniqueView<crate::mission::PlayerInfo>>() {
+        Ok(player) => player.inventory_entity_id,
+        Err(_) => return ReloadOutcome::default(),
+    };
+    let reserve_items: Vec<EntityId> = {
+        let Ok(links) = world.borrow::<View<Links>>() else {
+            return ReloadOutcome::default();
+        };
+        let Ok(inventory_links) = links.get(inventory) else {
+            return ReloadOutcome::default();
+        };
+        inventory_links
+            .to_links
+            .iter()
+            .filter(|link| matches!(link.link, Link::Contains(_)))
+            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+            .collect()
+    };
+
+    let matching_reserve: Vec<EntityId> = {
+        let Ok((templates, stacks, hierarchy)) = world.borrow::<(
+            View<PropTemplateId>,
+            View<PropStackCount>,
+            UniqueView<crate::mission::GlobalTemplateHierarchy>,
+        )>() else {
+            return ReloadOutcome::default();
+        };
+        reserve_items
+            .into_iter()
+            .filter(|item| {
+                let Ok(template) = templates.get(*item) else {
+                    return false;
+                };
+                let compatible = compatible_clip_templates.iter().any(|clip_template| {
+                    hierarchy.is_or_descends_from(template.template_id, *clip_template)
+                });
+                compatible && stacks.get(*item).is_ok_and(|stack| stack.0 > 0)
+            })
+            .collect()
+    };
+
+    let mut outcome = ReloadOutcome::default();
+    {
+        let Ok(mut stacks) = world.borrow::<ViewMut<PropStackCount>>() else {
+            return outcome;
+        };
+        for item in matching_reserve {
+            if rounds_needed == 0 {
+                break;
+            }
+            let Ok(stack) = (&mut stacks).get(item) else {
+                continue;
+            };
+            let consumed = stack.0.min(rounds_needed).max(0);
+            stack.0 -= consumed;
+            rounds_needed -= consumed;
+            outcome.rounds_loaded += consumed;
+            if stack.0 == 0 {
+                outcome.depleted_items.push(item);
+            }
+        }
+    }
+
+    if outcome.rounds_loaded > 0 {
+        let mut states = world.borrow::<ViewMut<PropGunState>>().unwrap();
+        if let Ok(state) = (&mut states).get(weapon) {
+            state.ammo = (state.ammo.max(0) + outcome.rounds_loaded).min(capacity.max(0));
+        }
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        mission::{GlobalTemplateHierarchy, PlayerInfo},
+        runtime_props::RuntimePropSelectedAmmo,
+    };
+    use cgmath::{Quaternion, Vector3};
+    use dark::properties::{
+        Link, Links, ProjectileOptions, PropStackCount, PropTemplateId, ToLink, WrappedEntityId,
+    };
+    use shipyard::View;
+
+    const PISTOL: i32 = -17;
+    const STD_PROJECTILE: i32 = -362;
+    const ASSAULT_STD_PROJECTILE: i32 = -2253;
+    const HE_PROJECTILE: i32 = -33;
+    const PRISM_PROJECTILE: i32 = -232;
+    const STD_CLIP: i32 = -31;
+    const SMALL_STD_CLIP: i32 = -1358;
+    const EARTH_SMALL_STD_CLIP: i32 = 247;
+    const HE_CLIP: i32 = -32;
+    const SMALL_PRISM: i32 = -41;
+    const LARGE_PRISM: i32 = -44;
+
+    struct Fixture {
+        world: World,
+        weapon: EntityId,
+        inventory: EntityId,
+    }
+
+    impl Fixture {
+        fn new(ammo: i32, selected: usize) -> Self {
+            let mut world = World::new();
+            let player = world.add_entity(());
+            let inventory = world.add_entity((Links::empty(),));
+            let weapon = world.add_entity((
+                PropTemplateId {
+                    template_id: PISTOL,
+                },
+                PropGunState {
+                    ammo,
+                    condition: 1.0,
+                    setting: 0,
+                    modification: 0,
+                    silence_value: 0.0,
+                },
+                RuntimePropSelectedAmmo(selected),
+                Links {
+                    to_links: vec![
+                        ToLink {
+                            link: Link::Projectile(ProjectileOptions {
+                                order: 0,
+                                setting: 0,
+                            }),
+                            to_entity_id: None,
+                            to_template_id: STD_PROJECTILE,
+                        },
+                        ToLink {
+                            link: Link::Projectile(ProjectileOptions {
+                                order: 1,
+                                setting: 0,
+                            }),
+                            to_entity_id: None,
+                            to_template_id: HE_PROJECTILE,
+                        },
+                    ],
+                },
+            ));
+            world.add_unique(PlayerInfo {
+                pos: Vector3::new(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                entity_id: player,
+                left_hand_entity_id: Some(weapon),
+                right_hand_entity_id: None,
+                inventory_entity_id: inventory,
+            });
+            world.add_unique(GlobalProjectileClips(HashMap::from([
+                (STD_PROJECTILE, vec![STD_CLIP, SMALL_STD_CLIP]),
+                (ASSAULT_STD_PROJECTILE, vec![SMALL_STD_CLIP, STD_CLIP]),
+                (HE_PROJECTILE, vec![HE_CLIP]),
+                (PRISM_PROJECTILE, vec![SMALL_PRISM, LARGE_PRISM]),
+            ])));
+            world.add_unique(GlobalTemplateHierarchy(HashMap::from([
+                (SMALL_STD_CLIP, vec![STD_CLIP]),
+                (EARTH_SMALL_STD_CLIP, vec![SMALL_STD_CLIP]),
+            ])));
+            Self {
+                world,
+                weapon,
+                inventory,
+            }
+        }
+
+        fn reserve(&mut self, template_id: i32, rounds: i32) -> EntityId {
+            let item = self
+                .world
+                .add_entity((PropTemplateId { template_id }, PropStackCount(rounds)));
+            let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
+            (&mut links)
+                .get(self.inventory)
+                .unwrap()
+                .to_links
+                .push(ToLink {
+                    link: Link::Contains(0),
+                    to_entity_id: Some(WrappedEntityId(item)),
+                    to_template_id: template_id,
+                });
+            item
+        }
+
+        fn set_standard_projectile(&mut self, template_id: i32) {
+            let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
+            let weapon_links = (&mut links).get(self.weapon).unwrap();
+            weapon_links
+                .to_links
+                .iter_mut()
+                .find(|link| {
+                    matches!(
+                        link.link,
+                        Link::Projectile(ProjectileOptions { order: 0, .. })
+                    )
+                })
+                .unwrap()
+                .to_template_id = template_id;
+        }
+
+        fn ammo(&self) -> i32 {
+            self.world
+                .borrow::<View<PropGunState>>()
+                .unwrap()
+                .get(self.weapon)
+                .unwrap()
+                .ammo
+        }
+
+        fn rounds(&self, item: EntityId) -> i32 {
+            self.world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(item)
+                .unwrap()
+                .0
+        }
+    }
+
+    #[test]
+    fn reload_with_no_reserve_does_not_mint_rounds() {
+        let fixture = Fixture::new(0, 0);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 0);
+        assert_eq!(outcome, ReloadOutcome::default());
+    }
+
+    #[test]
+    fn reload_consumes_exact_reserve_across_real_small_clip_stacks() {
+        let mut fixture = Fixture::new(0, 0);
+        let first = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+        let second = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(first), 0);
+        assert_eq!(fixture.rounds(second), 0);
+        assert_eq!(outcome.rounds_loaded, 12);
+        assert_eq!(outcome.depleted_items, vec![first, second]);
+    }
+
+    #[test]
+    fn reload_accepts_every_authored_assault_standard_clip_target() {
+        let mut fixture = Fixture::new(0, 0);
+        fixture.set_standard_projectile(ASSAULT_STD_PROJECTILE);
+        let small = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+        let regular = fixture.reserve(STD_CLIP, 6);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(small), 0);
+        assert_eq!(fixture.rounds(regular), 0);
+        assert_eq!(outcome.rounds_loaded, 12);
+        assert_eq!(outcome.depleted_items, vec![small, regular]);
+    }
+
+    #[test]
+    fn reload_accepts_sibling_small_and_large_prism_targets() {
+        let mut fixture = Fixture::new(0, 0);
+        fixture.set_standard_projectile(PRISM_PROJECTILE);
+        let small = fixture.reserve(SMALL_PRISM, 10);
+        let large = fixture.reserve(LARGE_PRISM, 20);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 30);
+
+        assert_eq!(fixture.ammo(), 30);
+        assert_eq!(fixture.rounds(small), 0);
+        assert_eq!(fixture.rounds(large), 0);
+        assert_eq!(outcome.rounds_loaded, 30);
+        assert_eq!(outcome.depleted_items, vec![small, large]);
+    }
+
+    #[test]
+    fn partial_reload_consumes_only_missing_rounds() {
+        let mut fixture = Fixture::new(7, 0);
+        let reserve = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 12);
+        assert_eq!(fixture.rounds(reserve), 1);
+        assert_eq!(outcome.rounds_loaded, 5);
+        assert!(outcome.depleted_items.is_empty());
+    }
+
+    #[test]
+    fn mismatched_selected_ammo_does_not_consume_reserve() {
+        let mut fixture = Fixture::new(0, 1);
+        let standard = fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 0);
+        assert_eq!(fixture.rounds(standard), 6);
+        assert_eq!(outcome, ReloadOutcome::default());
+    }
+
+    #[test]
+    fn repeated_reload_cannot_reuse_depleted_reserve() {
+        let mut fixture = Fixture::new(0, 0);
+        fixture.reserve(EARTH_SMALL_STD_CLIP, 6);
+
+        let first = load_from_reserve(&fixture.world, fixture.weapon, 12);
+        let second = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 6);
+        assert_eq!(first.rounds_loaded, 6);
+        assert_eq!(second, ReloadOutcome::default());
+    }
+}

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -114,7 +114,8 @@ pub struct RuntimePropAttachment {
 //
 // Like all runtime props this is not serialized: a save taken mid-reload loads
 // with the reload already "finished" (no tilt, firing allowed). That is benign -
-// `begin_reload` refills the clip up front, so there is no ammo inconsistency.
+// `begin_reload` transfers reserve rounds up front, so there is no ammo
+// inconsistency.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropReloading {
     pub elapsed: f32,
@@ -166,12 +167,11 @@ impl RuntimePropReloading {
 // one. Absent = index 0 (the first/default link). Ignored for weapons with no
 // Projectile links (melee).
 //
-// Scope notes (deliberate simplifications for now):
-// - Not serialized (like all runtime props), so the selection resets to the
-//   first link across save/load and level transitions.
-// - All ammo types share one clip (`PropGunState.ammo`); switching type does not
-//   switch loaded rounds. Per-ammo-type counts need an inventory-ammo model we
-//   don't have yet, so this behaves like a fire-mode selector for now.
+// This runtime component is explicitly persisted by EntitySaveData (including
+// held items) so loaded alternate-ammo magazines retain their identity across
+// save/load and level transitions. Ammo type can only be changed while
+// PropGunState.ammo is empty; reload reserve is then selected through the
+// authored projectile -> Clip relation.
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropSelectedAmmo(pub usize);
 

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -5,7 +5,7 @@ use engine::game_log;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 
-use crate::runtime_props::RuntimePropDeathPose;
+use crate::runtime_props::{RuntimePropDeathPose, RuntimePropSelectedAmmo};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EntitySaveData {
@@ -21,6 +21,11 @@ pub struct EntitySaveData {
     /// the field and load with no generated terminal poses.
     #[serde(default)]
     pub death_poses: HashMap<u64, RuntimePropDeathPose>,
+    /// Selected projectile-link index for weapons whose ammo type has been
+    /// changed. Persisted separately because runtime components are not part of
+    /// the Dark property registry.
+    #[serde(default)]
+    pub selected_ammo: HashMap<u64 /* entity id */, usize>,
 }
 
 impl EntitySaveData {
@@ -31,6 +36,7 @@ impl EntitySaveData {
             properties: HashMap::new(),
             links: HashMap::new(),
             death_poses: HashMap::new(),
+            selected_ammo: HashMap::new(),
         }
     }
     pub fn instantiate(
@@ -80,6 +86,12 @@ impl EntitySaveData {
                 world.add_component(*new_entity_id, links);
             }
         }
+        for (old_entity_id, selected_ammo) in &self.selected_ammo {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, RuntimePropSelectedAmmo(*selected_ammo));
+            }
+        }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
     }
 }
@@ -124,5 +136,33 @@ mod tests {
         let poses = loaded_world.borrow::<View<RuntimePropDeathPose>>().unwrap();
         assert_eq!(poses.get(new_entity).unwrap().0, "resolved_death");
         assert!(poses.get(old_entity).is_err());
+    }
+
+    #[test]
+    fn instantiate_restores_selected_ammo_on_the_remapped_entity() {
+        let old_entity = EntityId::new_from_index_and_gen(7, 3);
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(old_entity.inner());
+        data.selected_ammo.insert(old_entity.inner(), 2);
+        let mut world = World::new();
+
+        let (_, entity_map) = data.instantiate(&mut world);
+
+        let new_entity = entity_map[&old_entity];
+        let selected = world.borrow::<View<RuntimePropSelectedAmmo>>().unwrap();
+        assert_eq!(selected.get(new_entity).unwrap().0, 2);
+    }
+
+    #[test]
+    fn selected_ammo_defaults_empty_for_older_saves() {
+        let data: EntitySaveData = serde_json::from_value(serde_json::json!({
+            "all_entities": [],
+            "template_id_to_entity_id": {},
+            "properties": {},
+            "links": {}
+        }))
+        .unwrap();
+
+        assert!(data.selected_ammo.is_empty());
     }
 }

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     creature::RuntimePropHitBox,
     gui::GuiPropProxyEntity,
     mission::{GlobalTemplateIdMap, PlayerInfo},
-    runtime_props::{RuntimePropDeathPose, RuntimePropDoNotSerialize},
+    runtime_props::{RuntimePropDeathPose, RuntimePropDoNotSerialize, RuntimePropSelectedAmmo},
     scripts::script_util,
     util::partition_map,
 };
@@ -92,6 +92,7 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
     let entities_to_filter = get_entities_to_filter_out(world);
 
     let v_links = world.borrow::<View<Links>>().unwrap();
+    let v_selected_ammo = world.borrow::<View<RuntimePropSelectedAmmo>>().unwrap();
     let v_entities = world.borrow::<EntitiesView>().unwrap();
 
     let (all_properties, _, _) = dark::properties::get::<File>();
@@ -153,12 +154,23 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         }
     }
 
+    let raw_selected_ammo: HashMap<u64, usize> = v_selected_ammo
+        .iter()
+        .with_id()
+        .filter(|(entity_id, _)| !entities_to_filter.contains(&entity_id.inner()))
+        .map(|(entity_id, selected)| (entity_id.inner(), selected.0))
+        .collect();
+    let (held_selected_ammo, world_selected_ammo) = partition_map(raw_selected_ammo, |entity_id| {
+        held_entities.contains(entity_id)
+    });
+
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
         links: world_serialized_links,
         all_entities: all_world_entities,
         death_poses: world_death_poses,
+        selected_ammo: world_selected_ammo,
     };
 
     let held_entity_data = EntitySaveData {
@@ -167,6 +179,7 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         links: held_serialized_links,
         properties: held_serialized_properties,
         death_poses: held_death_poses,
+        selected_ammo: held_selected_ammo,
     };
 
     let held_metadata = HeldItemSaveData {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -100,7 +100,7 @@ pub enum Effect {
 
     /// Cycle the player's wielded weapon to its next ammo type (the next
     /// `Projectile` link). No-op when no weapon is wielded or it has fewer than
-    /// two projectile links.
+    /// two projectile links, or while its magazine still has loaded rounds.
     CycleAmmo,
 
     /// Toggle the flat-mode "use" (metagame) mode - cursor-driven UI over the
@@ -187,10 +187,10 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
-    /// Reload the player's wielded weapon: refill its clip (`PropGunState.ammo`)
-    /// to the magazine capacity (`PropBaseGunDesc.clip`). No-op when no weapon is
-    /// wielded or it has no gun state / clip. (Reserve ammo is unlimited for now -
-    /// there is no inventory ammo model yet.)
+    /// Reload the player's wielded weapon from compatible backpack reserve,
+    /// up to its magazine capacity (`PropBaseGunDesc.clip`). No-op when no
+    /// weapon is wielded, it has no gun state / clip, or no matching reserve is
+    /// carried.
     ReloadWeapon,
 
     ApplyForce {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -113,6 +113,18 @@ pub fn ordered_projectile_links(world: &World, weapon: EntityId) -> Vec<(i32, Pr
     links
 }
 
+/// Whether `weapon` may select a different projectile type. Until magazine
+/// unload semantics exist, a gun must be empty so loaded rounds cannot be
+/// converted to a different ammo type for free.
+pub fn can_cycle_ammo(world: &World, weapon: EntityId) -> bool {
+    let is_empty = world
+        .borrow::<View<PropGunState>>()
+        .ok()
+        .and_then(|states| states.get(weapon).ok().map(|state| state.ammo <= 0))
+        .unwrap_or(false);
+    is_empty && ordered_projectile_links(world, weapon).len() >= 2
+}
+
 pub fn get_first_link_with_template_and_data<TData: Clone>(
     world: &World,
     producing_entity_id: EntityId,

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -377,6 +377,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::Corpse(_) => "Corpse".to_string(),
                 Link::AIProjectile(_) => "AIProjectile".to_string(),
                 Link::AIRangedWeapon => "AIRangedWeapon".to_string(),
+                Link::Clip => "Clip".to_string(),
                 Link::GunFlash(_) => "GunFlash".to_string(),
                 Link::LandingPoint => "LandingPoint".to_string(),
                 Link::Replicator => "Replicator".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -587,6 +587,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::Corpse(_) => "Corpse".to_string(),
         dark::properties::Link::AIProjectile(_) => "AIProjectile".to_string(),
         dark::properties::Link::AIRangedWeapon => "AIRangedWeapon".to_string(),
+        dark::properties::Link::Clip => "Clip".to_string(),
         dark::properties::Link::GunFlash(_) => "GunFlash".to_string(),
         dark::properties::Link::LandingPoint => "LandingPoint".to_string(),
         dark::properties::Link::Replicator => "Replicator".to_string(),

--- a/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
+++ b/tools/shock2-sdk/test/bio-ammo-full.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end test for the BIOFULL/AMMOFULL expanded readouts in use mode
 // (flat UI 5, projects/flat-ui.md §1.2 / §6 PR 5):
@@ -9,8 +10,9 @@ import { GameServer } from "../src/index.js";
 //   - Entering use mode (Tab) expands the compact bottom readouts: BIO.PCX ->
 //     BIOFULL.PCX (bottom-left) and AMMOBACK -> AMMOFULL.PCX (bottom-right).
 //   - With a gun that has 2+ ammo types wielded, AMMOFULL shows an ammo-type
-//     CYCLE button, exposed via /v1/ui `ammo_cycle`. Clicking it cycles the
-//     wielded weapon's ammo type (Effect::CycleAmmo).
+//     CYCLE button while the magazine is empty, exposed via /v1/ui
+//     `ammo_cycle`. Clicking it cycles the wielded weapon's ammo type
+//     (Effect::CycleAmmo).
 //   - Shooter mode keeps the compact readouts (no ammo_cycle element).
 //
 // Negative-first: on the base branch (flat UI 4.5) there is no AMMOFULL cycle
@@ -20,8 +22,14 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // The Pistol (gamesys template -17) has 3 ammo types (Standard / HE / AP).
 
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "weapon should expose an Ammo property");
+  return Number(p.value);
+}
+
 test(
-  "use mode exposes AMMOFULL ammo-cycle, which cycles the wielded ammo type",
+  "use mode exposes AMMOFULL ammo-cycle for an empty multi-ammo weapon",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -69,7 +77,23 @@ test(
       `the Pistol should be wielded with an ammo type (got ${JSON.stringify(wielded.player)})`,
     );
 
-    // --- KEY: use mode exposes the AMMOFULL ammo-cycle button ---
+    // Loaded rounds have an established projectile identity, so drain the
+    // magazine before asking the UI to expose its ammo-type cycle control.
+    const loaded = ammoOf(await game.entities.detail(pistol.id));
+    if (loaded > 0) {
+      assert.ok(
+        !(await game.ui.state()).ammo_cycle,
+        "loaded magazine must not expose a conversion control",
+      );
+      await game.input.trigger("ToggleUseMode");
+      await game.step({ frames: 5 });
+      for (let i = 0; i < loaded; i++) await fireOnce(game);
+      assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0);
+      await game.input.trigger("ToggleUseMode");
+      await game.step({ frames: 5 });
+    }
+
+    // --- KEY: use mode exposes the AMMOFULL ammo-cycle button when empty ---
     const use = await game.ui.state();
     assert.equal(use.mode, "use");
     assert.ok(

--- a/tools/shock2-sdk/test/helpers/earth-weapons.ts
+++ b/tools/shock2-sdk/test/helpers/earth-weapons.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+import type { EntitySummary } from "../../src/types.js";
+import { earthWorldUse } from "./earth-world-use.js";
+
+export interface EarthWeaponsPickup {
+  pistol: EntitySummary;
+  clips: EntitySummary[];
+}
+
+/** Pick up the authored Earth Weapons Training pistol and small standard clips
+ * through the normal flat crosshair + squeeze path. Runtime ids are discovered
+ * each launch; the positive template ids are the stable mission object ids. */
+export async function pickupEarthWeapons(
+  game: GameServer,
+  clipCount: number,
+): Promise<EarthWeaponsPickup> {
+  const entities = (await game.entities.list()).entities;
+  const pistol = entities.find(
+    (entity) => entity.template_id === 246 && entity.name === "Pistol",
+  );
+  const clips = entities
+    .filter(
+      (entity) =>
+        entity.template_id >= 247 &&
+        entity.template_id <= 251 &&
+        entity.name.includes("Standard Clip"),
+    )
+    .sort((a, b) => a.template_id - b.template_id)
+    .slice(0, clipCount);
+  assert.ok(pistol, "expected Earth Weapons Training pistol 246");
+  assert.equal(clips.length, clipCount, `expected ${clipCount} Earth small standard clips`);
+
+  await earthWorldUse(game, pistol);
+  assert.equal(
+    (await game.info()).player.wielded_entity_id,
+    pistol.id,
+    "normal world-use should wield the Earth pistol",
+  );
+  for (const clip of clips) {
+    await earthWorldUse(game, clip);
+  }
+
+  return { pistol, clips };
+}

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end regression test for ammo-type cycling (InputAction::CycleAmmo). The
 // pistol carries three Projectile links (std / he / ap); cycling advances the
@@ -15,8 +16,14 @@ async function ammoType(game: GameServer): Promise<string | null> {
   return (await game.info()).player.wielded_ammo_type;
 }
 
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "weapon should expose an Ammo property");
+  return Number(p.value);
+}
+
 test(
-  "cycling advances the wielded weapon's ammo type and wraps",
+  "cycling requires an empty magazine, then advances and wraps",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -32,8 +39,20 @@ test(
     await game.input.trigger("CycleWeapon");
     await game.step({ frames: 5 });
     assert.equal(await ammoType(game), "std", "pistol starts on its first ammo type");
+    const pistolId = (await game.info()).player.wielded_entity_id;
+    assert.ok(pistolId !== null, "pistol should be wielded");
 
-    // Cycle through all three and wrap back.
+    // A loaded magazine has an established projectile identity. Cycling it
+    // would otherwise turn standard rounds into AP/HE for free.
+    const loaded = ammoOf(await game.entities.detail(pistolId));
+    assert.ok(loaded > 0, "debug pistol starts loaded");
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal(await ammoType(game), "std", "loaded pistol cannot change ammo type");
+    for (let i = 0; i < loaded; i++) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "pistol is empty");
+
+    // Once empty, cycle through all three and wrap back.
     const sequence: string[] = [];
     for (let i = 0; i < 3; i++) {
       await game.input.trigger("CycleAmmo");

--- a/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload-animation.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { pickupEarthWeapons } from "./helpers/earth-weapons.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // End-to-end regression test for the reload ANIMATION + fire gate. The wielded
@@ -24,20 +25,25 @@ test(
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
-      mission: "debug_weapons",
+      mission: "earth.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8098),
     });
 
-    await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
-    await game.step({ frames: 5 });
+    await game.step({ frames: 30 });
+    const { pistol, clips } = await pickupEarthWeapons(game, 3);
+    const pistolId = pistol.id;
+    assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "Earth pistol starts empty");
 
-    const pistolId = (await game.entities.list({ limit: 60 })).entities.find(
-      (e) => e.name === "Pistol",
-    )?.id;
-    assert.ok(pistolId !== undefined, "pistol should be wielded");
-
+    // Seed a full magazine from two authored reserve clips, then wait for that
+    // reload to finish before testing the next reload's animation.
+    await game.input.trigger("Reload");
+    await game.step({ frames: 140 });
     const clip = ammoOf(await game.entities.detail(pistolId));
+    assert.equal(clip, 12, "two small clips filled the pistol");
+    assert.ok(
+      (await game.player.inventory()).items.some((item) => item.entity_id === clips[2].id),
+      "third reserve clip remains for the animated partial reload",
+    );
 
     // Not reloading at rest.
     let snap = (await game.info()).player;

--- a/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-reload.e2e.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { pickupEarthWeapons } from "./helpers/earth-weapons.js";
 import { fireOnce } from "./helpers/weapon.js";
 
-// End-to-end regression test for weapon reload (InputAction::Reload): firing
-// drains the clip, and a Reload refills it to the magazine capacity
-// (PropBaseGunDesc.clip). Uses the debug_weapons scene + the pistol (12 rounds).
+// End-to-end regression for authored reserve accounting: the real Earth
+// Weapons Training pistol reloads only from normally-picked-up Small Standard
+// Clips, destroying exhausted stacks and retaining a partial remainder.
 //
 // Opt-in (compiles the runtime + needs Data/ assets):
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
@@ -18,61 +19,139 @@ function ammoOf(detail: { properties: { name: string; value: string }[] }): numb
   return Number(p.value);
 }
 
+function stackOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "StackCount");
+  assert.ok(p, "reserve clip should expose a StackCount property");
+  return Number(p.value);
+}
+
 test(
-  "reload refills the wielded clip to capacity",
+  "earth reload consumes matching reserve entities and partial stacks",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
-      mission: "debug_weapons",
+      mission: "earth.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8097),
     });
 
-    // debug_weapons starts unarmed; CycleWeapon spawns + wields the pistol.
-    await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
-    await game.step({ frames: 5 });
+    await game.step({ frames: 30 });
+    let { pistol, clips } = await pickupEarthWeapons(game, 3);
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0, "Earth pistol starts empty");
+    for (const clip of clips) {
+      assert.equal(stackOf(await game.entities.detail(clip.id)), 6, "authored small clip has 6");
+    }
 
-    const pistolId = (await game.entities.list({ limit: 60 })).entities.find(
-      (e) => e.name === "Pistol",
-    )?.id;
-    assert.ok(pistolId !== undefined, "pistol should be wielded");
+    // The selected ammo type controls compatibility. AP is selected here, so
+    // carrying only standard clips must neither consume reserve nor mint ammo.
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_ammo_type, "ap");
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 0);
+    assert.equal((await game.info()).player.reloading, false);
+    for (const clip of clips) {
+      assert.equal(
+        stackOf(await game.entities.detail(clip.id)),
+        6,
+        "mismatched standard reserve remains untouched",
+      );
+    }
 
-    const clip = ammoOf(await game.entities.detail(pistolId));
-    assert.ok(clip > 1, `pistol should start with a full clip (got ${clip})`);
+    // Ammo selection is part of a loaded magazine's identity. Save/load must
+    // preserve a non-default selection rather than silently converting it.
+    const saveName = `reload_selected_ammo_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    assert.equal((await game.info()).player.wielded_ammo_type, "ap");
+    const restored = (await game.entities.list()).entities;
+    pistol = restored.find((entity) => entity.template_id === 246 && entity.name === "Pistol")!;
+    clips = restored
+      .filter(
+        (entity) =>
+          entity.template_id >= 247 &&
+          entity.template_id <= 249 &&
+          entity.name.includes("Standard Clip"),
+      )
+      .sort((a, b) => a.template_id - b.template_id);
+    assert.ok(pistol, "saved Earth pistol should be restored");
+    assert.equal(clips.length, 3, "all three saved reserve clips should be restored");
+    assert.equal((await game.info()).player.wielded_entity_id, pistol.id);
 
-    // Drain a few rounds.
-    const shots = 4;
-    for (let i = 0; i < shots; i++) await fireOnce(game);
-    assert.equal(
-      ammoOf(await game.entities.detail(pistolId)),
-      clip - shots,
-      "firing consumes one round per shot",
-    );
+    // Return through HE to standard for the matching-reserve scenarios.
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_ammo_type, "he");
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_ammo_type, "std");
 
-    // Reload: the clip refills to capacity.
+    // One reload fills the 12-round magazine from two real six-round entities.
     await game.input.trigger("Reload");
     await game.step({ frames: 2 });
     assert.equal(
-      ammoOf(await game.entities.detail(pistolId)),
-      clip,
-      "reload refills the clip to capacity",
+      ammoOf(await game.entities.detail(pistol.id)),
+      12,
+      "two six-round reserve entities fill the 12-round pistol",
+    );
+    const afterFull = await game.player.inventory();
+    const liveAfterFull = new Set(
+      (await game.entities.list()).entities.map((entity) => entity.id),
+    );
+    for (const exhausted of clips.slice(0, 2)) {
+      assert.ok(
+        !afterFull.items.some((item) => item.entity_id === exhausted.id),
+        `exhausted reserve ${exhausted.template_id} should leave the backpack`,
+      );
+      assert.ok(
+        !liveAfterFull.has(exhausted.id),
+        `exhausted reserve ${exhausted.template_id} should be destroyed`,
+      );
+    }
+    assert.equal(
+      stackOf(await game.entities.detail(clips[2].id)),
+      6,
+      "reload stops once the magazine is full",
+    );
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "loaded standard rounds cannot be converted to another ammo type",
     );
 
-    // Firing is blocked while the reload animation plays, so let it finish
-    // before draining the clip again.
+    // Let the fire-gating animation finish, then exercise a partial reload.
     await game.step({ frames: 130 });
     assert.equal((await game.info()).player.reloading, false, "reload finished");
-
-    // Drain to empty, then a reload restores a full clip (so an empty weapon is
-    // usable again - the core point of reload).
-    for (let i = 0; i < clip; i++) await fireOnce(game);
-    assert.equal(ammoOf(await game.entities.detail(pistolId)), 0, "clip should be empty");
+    await fireOnce(game);
+    assert.equal(
+      (await game.info()).player.wielded_ammo_type,
+      "std",
+      "the guarded magazine still fires its selected standard projectile",
+    );
+    for (let i = 0; i < 3; i++) await fireOnce(game);
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 8, "four shots consumed");
     await game.input.trigger("Reload");
     await game.step({ frames: 2 });
     assert.equal(
-      ammoOf(await game.entities.detail(pistolId)),
-      clip,
-      "reloading an empty clip restores a full clip",
+      ammoOf(await game.entities.detail(pistol.id)),
+      12,
+      "partial reload restores only the four missing rounds",
     );
+    assert.equal(
+      stackOf(await game.entities.detail(clips[2].id)),
+      2,
+      "partial reload leaves the unused reserve remainder",
+    );
+
+    // A repeated reload at capacity cannot consume or mint anything.
+    await game.step({ frames: 130 });
+    await game.input.trigger("Reload");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.reloading, false, "full gun does not start reload");
+    assert.equal(ammoOf(await game.entities.detail(pistol.id)), 12);
+    assert.equal(stackOf(await game.entities.detail(clips[2].id)), 2);
   },
 );


### PR DESCRIPTION
Fixes #529

## Summary
- consume only matching backpack clip stacks when reloading, including inherited/multiple authored `Clip` targets
- keep selected ammo stable across save/load and prevent cycling a loaded magazine into another ammo type
- cover real Earth pistol/clip pickup, exact and partial reserve consumption, empty reserve, repeated reloads, animation/fire gating, and ammo selection persistence

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- focused Rust reload tests: 7 passed
- save/load selection tests: 2 passed
- SDK unit suite: 121 total, 14 passed / 107 E2E skipped
- affected Earth E2Es: 4 passed
- mission load safety net: 23/23 passed
- full SDK E2E suite was not repeated here because it ran on the stacked prerequisite; targeted gameplay and all-mission loading suites were run on this branch

## Review
- independent adversarial review: no Critical/High/Medium findings
- Codex CLI review: no substantive Critical/High/Medium findings; ship as-is

## Gameplay evidence

![Reserve-ammo reload demo](https://gist.githubusercontent.com/tommy-xr/b79b2d6bdfec9b43f3d496d52cdbdb78/raw/final-reload-consumes-reserve.gif)

<sub>Real Earth pistol 246 and authored clips 247–249, acquired through the normal flat crosshair + squeeze path. Reloading transfers 12 matching rounds, removes two exhausted six-round reserve clips, and runs the authored viewmodel animation. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![Reserve ammo before/after](https://gist.githubusercontent.com/tommy-xr/b79b2d6bdfec9b43f3d496d52cdbdb78/raw/final-before-after-reserve-ammo.png)