### PR TITLE
fix(ai): fall back to authored idle stand motions

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -490,7 +490,7 @@ impl AnimatedMonsterAI {
             sync_effect,
             Effect::PlayAnimationBySchema {
                 entity_id,
-                motion_queries: vec![self.current_behavior.borrow().animation()],
+                motion_queries: self.current_behavior.borrow().animation_queries(),
                 selection_strategy,
             },
         ])
@@ -697,7 +697,7 @@ impl Script for AnimatedMonsterAI {
         let selection_strategy = self.next_selection(is_locomotion);
         let animation_effect = Effect::QueueAnimationBySchema {
             entity_id,
-            motion_queries: vec![self.current_behavior.borrow().animation()],
+            motion_queries: self.current_behavior.borrow().animation_queries(),
             selection_strategy,
         };
 
@@ -871,7 +871,7 @@ impl Script for AnimatedMonsterAI {
                         let selection_strategy = self.next_selection(is_locomotion);
                         Effect::PlayAnimationBySchema {
                             entity_id,
-                            motion_queries: vec![self.current_behavior.borrow().animation()],
+                            motion_queries: self.current_behavior.borrow().animation_queries(),
                             selection_strategy,
                         }
                     } else {
@@ -918,7 +918,7 @@ impl Script for AnimatedMonsterAI {
                 let selection_strategy = self.next_selection(is_locomotion);
                 return Effect::PlayAnimationBySchema {
                     entity_id,
-                    motion_queries: vec![self.current_behavior.borrow().animation()],
+                    motion_queries: self.current_behavior.borrow().animation_queries(),
                     selection_strategy,
                 };
             }
@@ -948,7 +948,7 @@ impl Script for AnimatedMonsterAI {
                 let selection_strategy = self.next_selection(is_locomotion);
                 Effect::PlayAnimationBySchema {
                     entity_id,
-                    motion_queries: vec![self.current_behavior.borrow().animation()],
+                    motion_queries: self.current_behavior.borrow().animation_queries(),
                     selection_strategy,
                 }
             } else {
@@ -1093,7 +1093,7 @@ impl Script for AnimatedMonsterAI {
                     let selection_strategy = self.next_selection(is_locomotion);
                     Effect::PlayAnimationBySchema {
                         entity_id,
-                        motion_queries: vec![self.current_behavior.borrow().animation()],
+                        motion_queries: self.current_behavior.borrow().animation_queries(),
                         selection_strategy,
                     }
                 } else {
@@ -1145,7 +1145,7 @@ impl Script for AnimatedMonsterAI {
                     let selection_strategy = self.next_selection(is_locomotion);
                     Effect::PlayAnimationBySchema {
                         entity_id,
-                        motion_queries: vec![self.current_behavior.borrow().animation()],
+                        motion_queries: self.current_behavior.borrow().animation_queries(),
                         selection_strategy,
                     }
                 } else {
@@ -1229,10 +1229,13 @@ impl Script for AnimatedMonsterAI {
                     //self.current_behavior = Rc::new(IdleBehavior);
                     let is_locomotion = self.current_behavior.borrow().is_locomotion();
                     let selection_strategy = self.next_selection(is_locomotion);
-                    let motion_query_items = self.current_behavior.borrow().animation();
+                    let motion_queries = self.current_behavior.borrow().animation_queries();
 
                     // Check if this is an attack animation and play attack sound
-                    let attack_sound_effect = if is_attack_animation(&motion_query_items) {
+                    let attack_sound_effect = if motion_queries
+                        .iter()
+                        .any(|query| is_attack_animation(query))
+                    {
                         if let Some(voice_index) =
                             crate::scripts::speech_util::resolve_entity_voice_index(
                                 world, entity_id,
@@ -1253,7 +1256,7 @@ impl Script for AnimatedMonsterAI {
 
                     let queue_animation_effect = Effect::QueueAnimationBySchema {
                         entity_id,
-                        motion_queries: vec![motion_query_items],
+                        motion_queries,
                         selection_strategy,
                         //tag: "idlegesture".to_owned(),
                         // motion_query_items: vec![

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -50,6 +50,11 @@ pub trait Behavior {
         vec![]
     }
 
+    /// Motion schema queries to try in priority order for this behavior.
+    fn animation_queries(&self) -> Vec<Vec<MotionQueryItem>> {
+        vec![self.animation()]
+    }
+
     ///
     /// turn_speed
     ///

--- a/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
@@ -11,6 +11,30 @@ impl Behavior for IdleBehavior {
 
     fn animation(self: &IdleBehavior) -> Vec<MotionQueryItem> {
         vec![MotionQueryItem::new("idlegesture")]
-        //vec![MotionQueryItem::new("stand")]
+    }
+
+    fn animation_queries(&self) -> Vec<Vec<MotionQueryItem>> {
+        vec![self.animation(), vec![MotionQueryItem::new("stand")]]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_prefers_gesture_then_stand() {
+        let queries = IdleBehavior.animation_queries();
+        let tags = queries
+            .iter()
+            .map(|query| {
+                query
+                    .iter()
+                    .map(MotionQueryItem::tag_name)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(tags, vec![vec!["idlegesture"], vec!["stand"]]);
     }
 }

--- a/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
+++ b/tools/shock2-sdk/test/motion-query-tags.e2e.test.ts
@@ -24,6 +24,38 @@ function failedQueries(logs: string[], tag: string): string[] {
 }
 
 test(
+  "idle droid falls back to an authored stand motion",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8106),
+    });
+
+    await game.step({ frames: 10 });
+
+    const maintenance = await game.entities.list({
+      filter: "Maintenance",
+      limit: 10,
+    });
+    const droid = maintenance.entities.find((entity) => entity.name === "Maintenance");
+    assert.ok(droid, "expected the medsci1 maintenance droid");
+
+    const animation = await game.entities.animation(droid.id);
+    assert.ok(animation, "maintenance droid should have an animation player");
+    assert.ok(
+      ["mbtstd", "mbtfake1", "mbtfake2"].includes(animation.clip ?? ""),
+      `expected an authored droid stand clip, got ${animation.clip}`,
+    );
+    assert.deepEqual(
+      failedQueries(game.logs(), "idlegesture"),
+      [],
+      "idle droid query should resolve without entering the failure loop",
+    );
+  },
+);
+
+test(
   "wound and death motion queries resolve (hybrid wound, human death)",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {


### PR DESCRIPTION
Fixes #382

## Summary

- add a behavior-level ordered motion-query list that defaults to each behavior's existing single query
- keep `idlegesture` as the preferred idle schema and retry with authored `stand` only when it has no match
- pass behavior alternatives through every AI animation start/requeue path, reusing the existing first-match-wins schema resolver
- add unit and debug-runtime regressions for the query order and the native `medsci1` Maintenance droid

This is data-driven rather than creature-specific: humans and other creatures with authored `idlegesture` clips keep selecting them, while droids (and any other creature without one) can use their authored stand set.

## Negative-first evidence

At base `7fa7fa3bd57e36834b717ca9c0b463018a00ccec`, with only the regression scaffold present and before the idle override/call-site implementation:

```text
$ RUSTFLAGS="-D warnings" cargo test -p shock2vr idle_prefers_gesture_then_stand -- --nocapture

assertion `left == right` failed
  left: [["idlegesture"]]
 right: [["idlegesture"], ["stand"]]

test result: FAILED. 0 passed; 1 failed
```

After the implementation, the same test passes. The runtime regression also discovers the mission entity by name on every launch, verifies its current clip is one of `mbtstd` / `mbtfake1` / `mbtfake2`, and verifies no `idlegesture` query warning is emitted.

Motion database checks independently pin the data:

```text
cargo dq motion 2 +idlegesture +droid +maintenance
No animations found

cargo dq motion 2 +stand +droid +maintenance
mbtstd, mbtfake1, mbtfake2

cargo dq motion 0 +idlegesture +human --limit 5
29 matching animations
```

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` — 191 passed, 0 failed
- Node 22 `npm test` in `tools/shock2-sdk` — 121 discovered; 14 fast tests passed, 107 e2e-gated tests skipped
- Node 22 focused `motion-query-tags.e2e.test.ts` — 2/2 passed
- Node 22 full `npm run test:e2e` — 121/121 passed, 0 failed/skipped/cancelled (25m10s)

## Visual evidence

![Maintenance droid authored idle animation](https://gist.githubusercontent.com/tommy-xr/45a96bbc901cbb440c83e505570081da/raw/maintenance-idle-fallback-pr.gif)

<sub>The idle Maintenance droid now advances through authored stand motions (`mbtfake1` → `mbtfake2` → `mbtstd`) instead of remaining frozen. Captured headlessly with deterministic fixed-timestep stepping.</sub>

### Before → after

![Maintenance droid before and after](https://gist.githubusercontent.com/tommy-xr/45a96bbc901cbb440c83e505570081da/raw/maintenance-idle-before-after.png)

Before and after used separate runtime binaries (base `7fa7fa3` versus this change), independently discovered runtime entity IDs, and the same teleport/look/step sequence. Baseline stayed at `clip=null`, frame 0 across both samples; after advanced from `mbtfake1` frame 40 to frame 70. Hosted media and telemetry: [gist](https://gist.github.com/tommy-xr/45a96bbc901cbb440c83e505570081da).

## Review

xreview scope was `origin/main` plus the exact four-file change and all visual artifacts.

- Codex reviewer: no findings; visual and code paths verified; `VERDICT: SHIP`
- independent fallback reviewer: Critical 0, High 0, Medium 0, Low 0; visual motion and first-match behavior verified; `VERDICT: SHIP`
- synthesis: **SHIP — 0 agreed Critical/High findings**
- duplication evidence: 3,080 functions indexed; no actionable semantic duplication signal

The configured Claude Opus CLI was attempted for the second engine but was not authenticated in this environment (`loggedIn: false`), so the required second pass used an independent read-only reviewer agent instead. The token-clone subprocess was also unavailable; the semantic duplication pass completed.
