### PR TITLE
fix(gameplay): recharge energy weapons at stations

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2646,6 +2646,20 @@ impl MissionCore {
                     }
                 }
 
+                Effect::RechargeAmmo {
+                    entity_id,
+                    capacity,
+                } => {
+                    let mut v_gun_state = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropGunState>>()
+                        .unwrap();
+
+                    if let Ok(gun_state) = (&mut v_gun_state).get(entity_id) {
+                        crate::scripts::effect::recharge_ammo_to_capacity(gun_state, capacity);
+                    }
+                }
+
                 Effect::RadiusBlast {
                     center,
                     radius,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -2,7 +2,7 @@ use cgmath::{Matrix4, Point3, Quaternion, Vector2, Vector3, Vector4};
 use dark::{
     EnvSoundQuery,
     motion::{MotionQueryItem, MotionQuerySelectionStrategy},
-    properties::{AIAlertLevel, AIMode, KeyCard, QuestBitValue, TeleportSource},
+    properties::{AIAlertLevel, AIMode, KeyCard, PropGunState, QuestBitValue, TeleportSource},
 };
 use engine::audio::AudioHandle;
 use shipyard::EntityId;
@@ -88,6 +88,14 @@ pub enum Effect {
     AdjustAmmo {
         entity_id: EntityId,
         delta: i32,
+    },
+
+    /// Raise an energy weapon's charge to at least its authored capacity.
+    /// Applied against the live gun state so duplicate recharge messages in one
+    /// tick remain idempotent. No-op for entities without a gun state.
+    RechargeAmmo {
+        entity_id: EntityId,
+        capacity: i32,
     },
 
     /// Cycle the player's wielded weapon to its next ammo type (the next
@@ -493,6 +501,50 @@ pub enum Effect {
     /// Advance every creature to its next animation pose. Debug-only, used by the
     /// `debug_hitbox` scene to inspect per-joint hitbox/ragdoll fit across poses.
     DebugCycleHitboxPose,
+}
+
+pub(crate) fn recharge_ammo_to_capacity(gun_state: &mut PropGunState, capacity: i32) {
+    gun_state.ammo = gun_state.ammo.max(capacity.max(0));
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::PropGunState;
+
+    use super::recharge_ammo_to_capacity;
+
+    fn gun_state(ammo: i32) -> PropGunState {
+        PropGunState {
+            ammo,
+            condition: 0.75,
+            setting: 1,
+            modification: 2,
+            silence_value: 0.25,
+        }
+    }
+
+    #[test]
+    fn duplicate_same_tick_recharges_are_idempotent_and_preserve_other_state() {
+        let mut state = gun_state(0);
+
+        recharge_ammo_to_capacity(&mut state, 100);
+        recharge_ammo_to_capacity(&mut state, 100);
+
+        assert_eq!(state.ammo, 100);
+        assert_eq!(state.condition, 0.75);
+        assert_eq!(state.setting, 1);
+        assert_eq!(state.modification, 2);
+        assert_eq!(state.silence_value, 0.25);
+    }
+
+    #[test]
+    fn recharge_does_not_reduce_over_capacity_charge() {
+        let mut state = gun_state(125);
+
+        recharge_ammo_to_capacity(&mut state, 100);
+
+        assert_eq!(state.ammo, 125);
+    }
 }
 
 impl Effect {

--- a/shock2vr/src/scripts/energy_station.rs
+++ b/shock2vr/src/scripts/energy_station.rs
@@ -43,9 +43,8 @@ impl Script for EnergyStation {
             // item the player carries at once (there is no
             // hold-one-item-near-the-station step - that is VR-only, handled by
             // Hover/Collided above). Each item self-handles Recharge, so only
-            // responders react - today that is the dead power cell. Energy-weapon
-            // recharge would be a separate follow-up, once those gain a Recharge
-            // handler; the mechanism here is already general.
+            // responders react - dead power cells replace themselves with charged
+            // cells, while energy weapons replenish their internal charge.
             MessagePayload::Frob => do_recharge_all(world, entity_id),
             _ => Effect::NoEffect,
         }

--- a/shock2vr/src/scripts/energy_weapon.rs
+++ b/shock2vr/src/scripts/energy_weapon.rs
@@ -1,0 +1,167 @@
+use dark::properties::{PropBaseGunDesc, PropGunState};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// Recharges an energy weapon's internal charge to its authored capacity.
+///
+/// Recharging is deliberately monotonic: a full or over-capacity weapon is
+/// left alone. The resulting [`Effect::RechargeAmmo`] changes only
+/// [`PropGunState::ammo`], preserving the weapon's condition, setting,
+/// modification, selected ammo, and inventory/held state. Capacity is applied
+/// against the live state so duplicate messages in one tick stay idempotent.
+pub struct EnergyWeapon;
+
+impl EnergyWeapon {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for EnergyWeapon {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Recharge) {
+            return Effect::NoEffect;
+        }
+
+        let v_gun_desc = world.borrow::<View<PropBaseGunDesc>>().unwrap();
+        let v_gun_state = world.borrow::<View<PropGunState>>().unwrap();
+        let (Ok(gun_desc), Ok(gun_state)) = (v_gun_desc.get(entity_id), v_gun_state.get(entity_id))
+        else {
+            return Effect::NoEffect;
+        };
+        let capacity = gun_desc.clip.max(0);
+
+        if gun_state.ammo >= capacity {
+            Effect::NoEffect
+        } else {
+            Effect::RechargeAmmo {
+                entity_id,
+                capacity,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropBaseGunDesc, PropGunState};
+    use shipyard::{Get, View, ViewMut, World};
+
+    use crate::{physics::PhysicsWorld, scripts::effect::recharge_ammo_to_capacity};
+
+    use super::{Effect, EnergyWeapon, MessagePayload, Script};
+
+    fn gun_desc(clip: i32) -> PropBaseGunDesc {
+        PropBaseGunDesc {
+            burst: 1,
+            clip,
+            spray: 1,
+            stim_modifier: 1.0,
+            burst_interval_ms: 0,
+            shot_interval_ms: 0,
+            ammo_usage: 1,
+            speed_modifier: 1.0,
+            reload_time_ms: 0,
+        }
+    }
+
+    fn gun_state(ammo: i32) -> PropGunState {
+        PropGunState {
+            ammo,
+            condition: 0.75,
+            setting: 1,
+            modification: 2,
+            silence_value: 0.25,
+        }
+    }
+
+    fn recharge(world: &World, weapon: shipyard::EntityId) -> Effect {
+        EnergyWeapon::new().handle_message(
+            weapon,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Recharge,
+        )
+    }
+
+    #[test]
+    fn recharge_refills_to_authored_capacity_without_mutating_other_state() {
+        let mut world = World::new();
+        let weapon = world.add_entity((gun_desc(100), gun_state(37)));
+
+        match recharge(&world, weapon) {
+            Effect::RechargeAmmo {
+                entity_id,
+                capacity,
+            } => {
+                assert_eq!(entity_id, weapon);
+                assert_eq!(capacity, 100);
+            }
+            other => panic!("expected recharge ammo adjustment, got {other:?}"),
+        }
+
+        let states = world.borrow::<View<PropGunState>>().unwrap();
+        let state = states.get(weapon).unwrap();
+        assert_eq!(state.ammo, 37, "the effect pipeline owns ammo mutation");
+        assert_eq!(state.condition, 0.75);
+        assert_eq!(state.setting, 1);
+        assert_eq!(state.modification, 2);
+        assert_eq!(state.silence_value, 0.25);
+    }
+
+    #[test]
+    fn recharge_at_capacity_is_idempotent() {
+        let mut world = World::new();
+        let weapon = world.add_entity((gun_desc(100), gun_state(100)));
+
+        assert!(matches!(recharge(&world, weapon), Effect::NoEffect));
+    }
+
+    #[test]
+    fn recharge_does_not_reduce_over_capacity_charge() {
+        let mut world = World::new();
+        let weapon = world.add_entity((gun_desc(100), gun_state(125)));
+
+        assert!(matches!(recharge(&world, weapon), Effect::NoEffect));
+    }
+
+    #[test]
+    fn duplicate_same_tick_recharges_apply_idempotently() {
+        let mut world = World::new();
+        let weapon = world.add_entity((gun_desc(100), gun_state(0)));
+        // Script messages in one update all inspect the same pre-effect world.
+        let effects = [recharge(&world, weapon), recharge(&world, weapon)];
+
+        for effect in effects {
+            let Effect::RechargeAmmo {
+                entity_id,
+                capacity,
+            } = effect
+            else {
+                panic!("expected recharge effect");
+            };
+            let mut states = world.borrow::<ViewMut<PropGunState>>().unwrap();
+            recharge_ammo_to_capacity((&mut states).get(entity_id).unwrap(), capacity);
+        }
+
+        let states = world.borrow::<View<PropGunState>>().unwrap();
+        assert_eq!(states.get(weapon).unwrap().ammo, 100);
+    }
+
+    #[test]
+    fn recharge_ignores_entities_without_gun_properties() {
+        let mut world = World::new();
+        let unrelated = world.add_entity(());
+
+        assert!(matches!(recharge(&world, unrelated), Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -15,6 +15,7 @@ mod cs9;
 mod dead_power_cell;
 mod destroy_all_by_name;
 mod energy_station;
+mod energy_weapon;
 mod exp_cookie;
 mod frob_qb;
 pub mod gui;
@@ -103,6 +104,7 @@ use self::{
     dead_power_cell::DeadPowerCell,
     destroy_all_by_name::DestroyAllByName,
     energy_station::EnergyStation,
+    energy_weapon::EnergyWeapon,
     exp_cookie::ExpCookie,
     frob_qb::FrobQB,
     internal_collision_type::InternalCollisionType,
@@ -621,7 +623,7 @@ impl ScriptWorld {
             "riflemodify" => Box::new(NoopScript::new()),
             "stasismodify" => Box::new(NoopScript::new()),
             "shotgunmodify" => Box::new(NoopScript::new()),
-            "energyweapon" => Box::new(NoopScript::new()),
+            "energyweapon" => Box::new(EnergyWeapon::new()),
             "grenademodify" => Box::new(NoopScript::new()),
             "weapontrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Weapons))),
             "wrench" => Box::new(CompositeScript::new(vec![

--- a/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
+++ b/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { rotateByInverse } from "../src/anim-metrics.js";
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// Earth Weapons Training's authored energy-weapon lesson:
+//   1. Pick up the empty Laser Pistol with the normal reticle + use input.
+//   2. Frob the real Recharging Station through the same input path.
+//   3. Observe the station's activation sound and the laser charging to its
+//      authored BaseGunDesc capacity.
+//   4. Fire the charged laser through the normal trigger path.
+//
+// Runtime entity ids vary per launch, so the two mission objects are resolved
+// by their stable mission-file object ids (exposed as `template_id`). Teleport
+// is used only to stage the player beside each object; pickup and station
+// activation are real reticle/squeeze interactions. In particular, this test
+// does not use debug give, Reload, AdjustAmmo, or direct Recharge/Frob messages.
+//
+// Negative-first: before #531, EnergyWeapon was a NoopScript. The station
+// activated and played audio, but the laser stayed at charge 0, so the
+// capacity assertion failed and the real trigger remained a dry fire.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const LASER_PISTOL_OBJECT = 253;
+const RECHARGING_STATION_OBJECT = 258;
+const LASER_AUTHORED_CAPACITY = 100;
+const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
+
+function ammoOf(detail: {
+  properties: { name: string; value: string }[];
+}): number {
+  const ammo = detail.properties.find((property) => property.name === "Ammo");
+  assert.ok(ammo, "laser should expose its GunState ammo/charge");
+  return Number(ammo.value);
+}
+
+async function aimAt(
+  game: GameServer,
+  [targetX, targetY, targetZ]: Vec3,
+): Promise<void> {
+  const player = (await game.info()).player;
+  const worldDelta: Vec3 = [
+    targetX - player.position[0],
+    targetY - (player.position[1] + PLAYER_EYE_HEIGHT_WORLD),
+    targetZ - player.position[2],
+  ];
+  // `head.look` is pawn-local, while mission spawn markers may rotate the
+  // pawn. Convert the desired world-space aim into that local frame first.
+  const [dx, dy, dz] = rotateByInverse(worldDelta, player.rotation);
+  const yawDeg = (Math.atan2(-dz, -dx) * 180) / Math.PI;
+  const pitchDeg =
+    (Math.atan2(-dy, Math.hypot(dx, dz)) * 180) / Math.PI;
+
+  await game.input.set("head.look", [yawDeg, pitchDeg]);
+  await game.step({ frames: 3 });
+}
+
+async function pulseUse(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.squeeze", 1.0);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.squeeze", 0.0);
+  await game.step({ frames: 2 });
+}
+
+test(
+  "earth.mis: the authored station recharges the normally acquired Laser Pistol",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8174),
+    });
+    await game.step({ frames: 5 });
+
+    const laser = (await game.entities.byTemplate(LASER_PISTOL_OBJECT))[0];
+    assert.ok(laser, "expected Earth Laser Pistol object 253");
+    const station = (
+      await game.entities.byTemplate(RECHARGING_STATION_OBJECT)
+    )[0];
+    assert.ok(station, "expected Earth Recharging Station object 258");
+
+    const laserBefore = await game.entities.detail(laser.id);
+    assert.equal(ammoOf(laserBefore), 0, "Earth laser should begin uncharged");
+    const capacity = LASER_AUTHORED_CAPACITY;
+
+    // Stand beside the laser, point the reticle at its live position, and use
+    // it normally. Flat pickup wields the weapon in the player's left slot.
+    await game.player.teleport({
+      x: laser.position[0] + 3.0,
+      y: laser.position[1] + 0.5,
+      z: laser.position[2],
+    });
+    await game.step({ frames: 15 });
+    const liveLaserPosition = (await game.entities.detail(laser.id)).position;
+    await aimAt(game, liveLaserPosition);
+    await pulseUse(game);
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      laser.id,
+      "normal reticle/use pickup should wield the authored laser",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) =>
+          item.entity_id === laser.id &&
+          item.name === "Laser Pistol" &&
+          item.location === "left_hand",
+      ),
+      "the normally picked-up laser should be carried",
+    );
+
+    // A real trigger pull at zero must be a dry fire before the lesson.
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(laser.id)),
+      0,
+      "uncharged laser should remain dry",
+    );
+
+    // Stand beside the station and frob it with the same normal reticle/use
+    // path. Snapshot audio first so the assertion proves this activation.
+    await game.player.teleport({
+      x: station.position[0] + 3.0,
+      y: station.position[1] + 0.5,
+      z: station.position[2],
+    });
+    await game.step({ frames: 15 });
+    const liveStationPosition = (await game.entities.detail(station.id)).position;
+    await aimAt(game, [
+      liveStationPosition[0],
+      liveStationPosition[1] + 1.5,
+      liveStationPosition[2],
+    ]);
+    const audioBefore =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await pulseUse(game);
+    await game.step({ frames: 10 });
+
+    const activationSounds = (await game.audio.recent()).sounds.filter(
+      (sound) =>
+        sound.sequence > audioBefore &&
+        sound.tags.some(
+          ([tag, value]) => tag === "event" && value === "activate",
+        ),
+    );
+    assert.ok(
+      activationSounds.some(
+        (sound) =>
+          Math.hypot(
+            sound.position[0] - liveStationPosition[0],
+            sound.position[1] - liveStationPosition[1],
+            sound.position[2] - liveStationPosition[2],
+          ) < 0.1,
+      ),
+      "normal station Frob should play its positional activation sound",
+    );
+    assert.equal(
+      ammoOf(await game.entities.detail(laser.id)),
+      capacity,
+      "station should charge the carried laser to authored capacity",
+    );
+
+    // Repeating the authored interaction at full charge is idempotent.
+    await pulseUse(game);
+    await game.step({ frames: 10 });
+    assert.equal(
+      ammoOf(await game.entities.detail(laser.id)),
+      capacity,
+      "a second station Frob should not exceed authored capacity",
+    );
+
+    // The charged weapon now fires normally and consumes charge.
+    await fireOnce(game);
+    const afterShot = ammoOf(await game.entities.detail(laser.id));
+    assert.ok(
+      afterShot >= 0 && afterShot < capacity,
+      `a real laser shot should consume charge (${capacity} -> ${afterShot})`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- implement the authored `EnergyWeapon` recharge response instead of mapping it to a no-op
- refill energy charge to `BaseGunDesc.clip` through an apply-time, idempotent effect
- preserve over-capacity charge and every non-ammo gun-state field
- cover duplicate same-tick recharge messages and the complete Earth training interaction

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr energy_weapon -- --nocapture` — 5 passed
- `cargo test -p shock2vr duplicate_same_tick_recharges_are_idempotent_and_preserve_other_state -- --nocapture` — passed
- `npm test` — 121 total, 14 passed, 107 opt-in E2E skipped
- targeted Earth E2E — normal pickup, dry fire, station frob, repeat frob, and real shot passed
- mission load E2E — 23/23 missions passed
- final cross-engine review with refreshed media — no findings

## Visual verification

![Earth Laser Pistol recharge demo](https://gist.githubusercontent.com/tommy-xr/4d313c26abc8c1fc2bae6749db506108/raw/4ec6384e6cae032f55f5c972be281b0c201b8058/energy-recharge-demo.gif)

<sub>Earth Weapons Training: the normally acquired empty Laser Pistol charges from 0 to 100 at the authored Recharging Station, then a real trigger shot consumes one charge. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Earth Laser Pistol recharge before and after](https://gist.githubusercontent.com/tommy-xr/4d313c26abc8c1fc2bae6749db506108/raw/fbddd0c0d991c8e6b7bd91bbcbbbde299f128cf6/energy-recharge-before-after.png)

### Firing verification

![Charged Laser Pistol firing](https://gist.githubusercontent.com/tommy-xr/4d313c26abc8c1fc2bae6749db506108/raw/3cab7c2d5f98c031107e3938fd1bd918b3420f50/energy-recharge-shot.png)

Fixes #531
