### PR TITLE
fix(debug): reject concurrent step requests

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -15,7 +15,7 @@ pub enum RuntimeCommand {
     GetInfo(oneshot::Sender<FrameSnapshot>),
 
     /// Step the simulation forward by frames or time
-    Step(StepSpec, oneshot::Sender<StepResult>),
+    Step(StepSpec, oneshot::Sender<Result<StepResult, StepError>>),
 
     /// Take a screenshot of the current frame
     Screenshot(ScreenshotSpec, oneshot::Sender<ScreenshotResult>),
@@ -191,6 +191,13 @@ pub enum StepSpec {
     Frames { frames: u32 },
     /// Step by duration
     Duration { duration: String }, // Will be parsed with humantime
+}
+
+/// Error returned when a step command cannot be started.
+#[derive(Debug)]
+pub enum StepError {
+    /// Another step request is still advancing the simulation.
+    AlreadyInProgress,
 }
 
 /// Result of stepping the simulation

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -517,7 +517,7 @@ fn run_game_blocking(
     // - `Screenshot` captures after the frame is fully rendered (below), not at
     //   command-receive time (which is before this iteration's render/swap and
     //   would read a stale/blank back buffer -> intermittent black screenshots).
-    let mut pending_step_reply: Option<oneshot::Sender<StepResult>> = None;
+    let mut pending_step_reply: Option<oneshot::Sender<Result<StepResult, StepError>>> = None;
     let mut frames_advanced_this_step = 0u32;
     let mut pending_screenshots: Vec<(ScreenshotSpec, oneshot::Sender<ScreenshotResult>)> =
         Vec::new();
@@ -557,6 +557,14 @@ fn run_game_blocking(
         while let Ok(command) = command_rx.try_recv() {
             match command {
                 RuntimeCommand::Step(step_spec, reply) => {
+                    if pending_step_reply.is_some() {
+                        tracing::warn!(
+                            "Rejected Step command - another step is already in progress"
+                        );
+                        let _ = reply.send(Err(StepError::AlreadyInProgress));
+                        continue;
+                    }
+
                     match step_spec {
                         StepSpec::Frames { frames } => {
                             frames_to_step = frames;
@@ -583,12 +591,12 @@ fn run_game_blocking(
                                     );
                                     // Nothing to step; reply immediately so the
                                     // caller isn't left hanging.
-                                    let _ = reply.send(StepResult {
+                                    let _ = reply.send(Ok(StepResult {
                                         frames_advanced: 0,
                                         time_advanced: 0.0,
                                         new_frame_index: frame_counter,
                                         new_total_time: accumulated_time,
-                                    });
+                                    }));
                                     continue;
                                 }
                             }
@@ -694,12 +702,12 @@ fn run_game_blocking(
                     // frame is rendered later this same loop iteration, so by the
                     // time the HTTP response is observed the frame is up to date.)
                     if let Some(reply) = pending_step_reply.take() {
-                        let _ = reply.send(StepResult {
+                        let _ = reply.send(Ok(StepResult {
                             frames_advanced: frames_advanced_this_step,
                             time_advanced: frames_advanced_this_step as f32 * FIXED_STEP_DT,
                             new_frame_index: frame_counter,
                             new_total_time: accumulated_time,
-                        });
+                        }));
                     }
                 }
             }
@@ -2016,15 +2024,24 @@ async fn step_frame(
     // Send command to game loop
     if let Err(_) = command_tx.send(RuntimeCommand::Step(step_spec, reply_tx)) {
         tracing::error!("Failed to send Step command - game loop receiver dropped");
-        return Err(game_loop_unavailable());
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Game loop command channel closed - the game thread may have stopped (check the debug_runtime process output)".to_string(),
+        ));
     }
 
     // Wait for response
     match reply_rx.await {
-        Ok(result) => Ok(Json(result)),
+        Ok(Ok(result)) => Ok(Json(result)),
+        Ok(Err(StepError::AlreadyInProgress)) => {
+            Err((StatusCode::CONFLICT, "Step already in progress".to_string()))
+        }
         Err(_) => {
-            tracing::error!("Failed to receive step result - sender dropped");
-            Err(game_loop_unavailable())
+            tracing::error!("Game loop dropped Step reply sender before completion");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Game loop dropped the Step reply before completion (check the debug_runtime process output)".to_string(),
+            ))
         }
     }
 }

--- a/tools/shock2-sdk/test/concurrent-step.e2e.test.ts
+++ b/tools/shock2-sdk/test/concurrent-step.e2e.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, HttpError } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "concurrent step is rejected without interrupting the in-flight step",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_minimal",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8115),
+    });
+
+    // Keep the rejection handled from the moment the request is launched:
+    // the buggy runtime drops this reply as soon as the second request arrives.
+    const inFlight = game.step({ frames: 10_000 }).then(
+      (result) => ({ result, error: undefined }),
+      (error: unknown) => ({ result: undefined, error }),
+    );
+
+    await game.waitFor(
+      () =>
+        game
+          .logs()
+          .some((line) => line.includes("Starting step: 10000 frames")),
+      {
+        timeoutMs: 10_000,
+        intervalMs: 1,
+        description: "the 10,000-frame step to start",
+      },
+    );
+
+    await assert.rejects(
+      game.step({ frames: 2 }),
+      (error: unknown) =>
+        error instanceof HttpError &&
+        error.status === 409 &&
+        /step already in progress/i.test(error.body),
+      "the overlapping step should receive a clear conflict response",
+    );
+
+    const first = await inFlight;
+    assert.ifError(first.error);
+    assert.equal(first.result?.frames_advanced, 10_000);
+
+    const later = await game.step({ frames: 2 });
+    assert.equal(later.frames_advanced, 2);
+    assert.equal(
+      later.new_frame_index,
+      first.result!.new_frame_index + 2,
+      "a later step should work after the original request completes",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #358

## Summary

- Reject a second `/v1/step` request with `409 Conflict` while a step is already running.
- Preserve the original request's reply sender and step counters instead of overwriting them.
- Use a typed step result/error path and distinguish command-channel closure from a reply dropped during processing.
- Add a durable SDK e2e regression test covering overlap rejection, full completion of the original 10,000-frame request, and a successful later step.

## Negative-first evidence

With only the new e2e test added on base `7fa7fa3`, the focused Node 22 run failed:

```text
not ok 1 - concurrent step is rejected without interrupting the in-flight step
error: Missing expected rejection: the overlapping step should receive a clear conflict response
code: ERR_ASSERTION
```

The competing 2-frame request incorrectly returned success, reproducing the pending-reply overwrite. After the runtime change, the same test passes and asserts:

- the competing request receives HTTP 409 with `Step already in progress`;
- the original request reports exactly 10,000 frames advanced;
- a later 2-frame request succeeds at the expected next frame index.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `RUSTFLAGS="-D warnings" cargo check -p debug_runtime -p shock2vr`
- `RUSTFLAGS="-D warnings" cargo test -p debug_runtime -p shock2vr` — 190 passed, 0 failed
- Node 22 `npm test` — 121 discovered, 14 passed, 107 e2e skipped, 0 failed
- Node 22 focused concurrent-step e2e — 1 passed, 0 failed
- Node 22 `npm run test:e2e` — 121 passed, 0 failed, 0 skipped

## Review

- Native Codex exact-diff review: no Critical, High, Medium, or Low findings; ship verdict.
- Independent read-only fallback review: no actionable findings; ship verdict.
- Claude Opus review could not run: `claude auth status` reported `"loggedIn": false`, and the invocation failed with `Not logged in · Please run /login`.
- Dupfinder indexed 3,077 functions and found no actionable semantic duplication in the changed functions. Its token-clone backend was unavailable (`jscpd produced no report`), so that limitation is recorded here.

This is not a visual change; no PR visuals are required.
