### PR TITLE
Implement Earth training inventory vaporization

### DIFF
--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -230,6 +230,45 @@ impl FlatUiHost {
         self.cursor_item.take().map(|c| c.entity)
     }
 
+    /// Drop every host-side reference to a destroyed entity immediately.
+    /// Normally `update` notices a dead panel on the next frame, but a cursor
+    /// item and its double-click mark are pure host state and otherwise retain
+    /// a recycled `EntityId`. The destruction effect pipeline calls this before
+    /// deleting the world entity.
+    pub fn on_entity_destroyed(&mut self, entity: EntityId) {
+        if self.active_panel == Some(entity) {
+            self.close();
+        }
+        if self
+            .strip
+            .as_ref()
+            .is_some_and(|strip| strip.entity == entity)
+        {
+            self.strip = None;
+        }
+        self.components
+            .retain(|component| component_entity(component) != Some(entity));
+        if let Some(strip) = self.strip.as_mut() {
+            strip
+                .components
+                .retain(|component| component_entity(component) != Some(entity));
+        }
+        if self
+            .cursor_item
+            .as_ref()
+            .is_some_and(|item| item.entity == entity)
+        {
+            self.cursor_item = None;
+        }
+        if self
+            .last_lift
+            .as_ref()
+            .is_some_and(|mark| mark.entity == entity)
+        {
+            self.last_lift = None;
+        }
+    }
+
     /// Enter/leave Tab metagame mode: bind (or drop) the top-docked
     /// inventory strip. `Some(entity)` is the player's `internal_inventory`
     /// entity, whose `GuiScript` already emits `SetUI` every frame - the
@@ -281,24 +320,41 @@ impl FlatUiHost {
     /// untouched by this).
     pub fn on_set_ui(
         &mut self,
+        world: &World,
         parent_entity: EntityId,
         world_size: Vector2<f32>,
         components: &[GuiComponentRenderInfo],
     ) {
+        let is_strip = self
+            .strip
+            .as_ref()
+            .is_some_and(|strip| strip.entity == parent_entity);
+        if !is_strip && self.active_panel != Some(parent_entity) {
+            return;
+        }
+
+        // SetUI effects are snapshots produced during script update. A
+        // DestroyEntity earlier in the same effect batch can invalidate one
+        // of their entity-bound buttons, so never cache a dead/recycled id.
+        let entities = world.borrow::<EntitiesView>().unwrap();
+        let components: Vec<_> = components
+            .iter()
+            .filter(|component| {
+                component_entity(component).is_none_or(|entity| entities.is_alive(entity))
+            })
+            .cloned()
+            .collect();
+
         // `SetUI.world_size` is `screen_size_in_pixels * GUI_PIXEL_TO_WORLD_SIZE`.
         let size_px = world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
-        if let Some(strip) = self.strip.as_mut() {
-            if strip.entity == parent_entity {
-                strip.size_px = Some(size_px);
-                strip.components = components.to_vec();
-                return;
-            }
-        }
-        if self.active_panel != Some(parent_entity) {
+        if is_strip {
+            let strip = self.strip.as_mut().unwrap();
+            strip.size_px = Some(size_px);
+            strip.components = components;
             return;
         }
         self.panel_size_px = Some(size_px);
-        self.components = components.to_vec();
+        self.components = components;
     }
 
     /// The render-target size, for the pointer->canvas letterbox mapping.
@@ -850,6 +906,13 @@ fn component_canvas_rect(info: &GuiComponentRenderInfo, panel: Rect) -> Rect {
     )
 }
 
+fn component_entity(info: &GuiComponentRenderInfo) -> Option<EntityId> {
+    match info {
+        GuiComponentRenderInfo::Image { entity, .. } => *entity,
+        GuiComponentRenderInfo::Text { .. } => None,
+    }
+}
+
 /// Host-drawn close button: top-right corner of the panel (the original
 /// keypad overlay's CloseOff gadget position).
 fn close_button_canvas_rect(panel: Rect) -> Rect {
@@ -1069,6 +1132,7 @@ mod tests {
         let mut host = FlatUiHost::new();
         host.open(panel);
         host.on_set_ui(
+            &world,
             panel,
             vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],
@@ -1108,6 +1172,7 @@ mod tests {
         let mut host = FlatUiHost::new();
         host.open(panel);
         host.on_set_ui(
+            &world,
             panel,
             vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[GuiComponentRenderInfo::Image {
@@ -1151,11 +1216,13 @@ mod tests {
         host.set_strip(Some(inventory));
         host.open(panel);
         host.on_set_ui(
+            &world,
             inventory,
             vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],
         );
         host.on_set_ui(
+            &world,
             panel,
             vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],
@@ -1192,11 +1259,13 @@ mod tests {
         host.set_strip(Some(inventory));
         host.open(panel);
         host.on_set_ui(
+            &world,
             inventory,
             vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],
         );
         host.on_set_ui(
+            &world,
             panel,
             vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],
@@ -1256,6 +1325,7 @@ mod tests {
         let mut host = FlatUiHost::new();
         host.set_strip(Some(inventory));
         host.on_set_ui(
+            &world,
             inventory,
             vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[
@@ -1359,6 +1429,7 @@ mod tests {
         let mut host = FlatUiHost::new();
         host.set_strip(Some(inventory));
         host.on_set_ui(
+            &world,
             inventory,
             vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[strip_item(wrench, 0)],
@@ -1385,6 +1456,98 @@ mod tests {
             "the lifted item leaves the strip grid",
         );
         assert_eq!(host.strip_item_at(vec2(23.5, 34.0)), None);
+    }
+
+    #[test]
+    fn destroying_a_cursor_item_clears_host_references_immediately() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0));
+        assert!(host.cursor_debug().is_some());
+        assert!(host.last_lift.is_some());
+
+        host.on_entity_destroyed(wrench);
+
+        assert!(host.cursor_debug().is_none());
+        assert!(host.last_lift.is_none());
+    }
+
+    #[test]
+    fn destroying_the_active_panel_closes_it_immediately() {
+        let mut world = World::new();
+        let panel = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.open(panel);
+
+        host.on_entity_destroyed(panel);
+
+        assert!(host.active_panel().is_none());
+    }
+
+    #[test]
+    fn destroying_the_strip_container_clears_its_binding() {
+        let mut world = World::new();
+        let inventory = world.add_entity(());
+        let mut host = FlatUiHost::new();
+        host.set_strip(Some(inventory));
+
+        host.on_entity_destroyed(inventory);
+
+        assert!(host.strip_entity().is_none());
+    }
+
+    #[test]
+    fn destroying_an_item_prunes_cached_panel_and_strip_components() {
+        let (mut world, mut host, wrench, _inventory) = drag_world();
+        let panel = world.add_entity(());
+        host.open(panel);
+        host.on_set_ui(
+            &world,
+            panel,
+            vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(wrench, 0)],
+        );
+        let wrench_id = wrench.inner() as i32;
+        assert!(
+            host.debug_elements(&world)
+                .iter()
+                .any(|element| element.entity_id == Some(wrench_id))
+        );
+        assert!(
+            host.strip_debug_elements(&world)
+                .iter()
+                .any(|element| element.entity_id == Some(wrench_id))
+        );
+
+        host.on_entity_destroyed(wrench);
+
+        assert!(
+            host.debug_elements(&world)
+                .iter()
+                .all(|element| element.entity_id != Some(wrench_id))
+        );
+        assert!(
+            host.strip_debug_elements(&world)
+                .iter()
+                .all(|element| element.entity_id != Some(wrench_id))
+        );
+    }
+
+    #[test]
+    fn stale_set_ui_cannot_restore_an_item_destroyed_earlier_in_the_batch() {
+        let (mut world, mut host, wrench, inventory) = drag_world();
+        world.delete_entity(wrench);
+        host.on_entity_destroyed(wrench);
+
+        // This snapshot was produced before DestroyEntity, but is applied
+        // afterwards in the same effect batch.
+        host.on_set_ui(
+            &world,
+            inventory,
+            vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+            &[strip_item(wrench, 0)],
+        );
+
+        assert!(host.strip_debug_elements(&world).is_empty());
     }
 
     #[test]
@@ -1418,6 +1581,7 @@ mod tests {
             dark::properties::PropSymName("Pistol".to_owned()),
         ));
         host.on_set_ui(
+            &world,
             inventory,
             vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[strip_item(wrench, 0), strip_item(pistol, 1)],
@@ -1490,6 +1654,7 @@ mod tests {
         let panel = world.add_entity(());
         host.open(panel);
         host.on_set_ui(
+            &world,
             panel,
             vec2(188.0, 296.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
             &[],

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3136,7 +3136,7 @@ impl MissionCore {
                     // keeps its gating (projects/flat-ui.md §7).
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui
-                            .on_set_ui(parent_entity, world_size, &components);
+                            .on_set_ui(&self.world, parent_entity, world_size, &components);
                     }
                     if game_options.experimental_features.contains("gui") {
                         self.gui.update_ui(
@@ -3422,6 +3422,20 @@ impl MissionCore {
                 Effect::DestroyEntity { entity_id } => {
                     info!("!!!Destroying entity: {:?}", entity_id);
                     self.interaction.on_entity_destroyed(entity_id);
+                    self.flat_ui.on_entity_destroyed(entity_id);
+                    // `PlayerInfo` mirrors the interaction controller each
+                    // update, but effects later in this same batch may inspect
+                    // it before then. Clear destroyed hand/wield references
+                    // atomically so no system can observe a live player
+                    // pointing at a dead (or recycled) entity.
+                    if let Ok(mut player) = self.world.borrow::<UniqueViewMut<PlayerInfo>>() {
+                        if player.left_hand_entity_id == Some(entity_id) {
+                            player.left_hand_entity_id = None;
+                        }
+                        if player.right_hand_entity_id == Some(entity_id) {
+                            player.right_hand_entity_id = None;
+                        }
+                    }
                     // Only a contained item (no world presence, PropHasRefs
                     // false) can leave a dangling inventory `Contains` link
                     // behind. World-present entities - FX spangs, projectiles,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -61,6 +61,7 @@ mod trigger_multi;
 mod tweq_depressable;
 mod tweqable;
 mod use_sound;
+mod vaporize_inventory;
 mod weapon_script;
 use std::collections::{HashMap, HashSet};
 
@@ -141,6 +142,7 @@ use self::{
     tweq_depressable::TweqDepressable,
     tweqable::Tweqable,
     use_sound::UseSound,
+    vaporize_inventory::VaporizeInventory,
     weapon_script::WeaponScript,
 };
 
@@ -511,7 +513,7 @@ impl ScriptWorld {
             "charmable" => Box::new(NoopScript::new()),
             "transientcorpse" => Box::new(NoopScript::new()),
             "whiteout" => Box::new(NoopScript::new()),
-            "vaporizeinventory" => Box::new(NoopScript::new()),
+            "vaporizeinventory" => Box::new(VaporizeInventory::new()),
 
             // Internal
             "internal_collision_type" => Box::new(InternalCollisionType::new()),

--- a/shock2vr/src/scripts/vaporize_inventory.rs
+++ b/shock2vr/src/scripts/vaporize_inventory.rs
@@ -1,0 +1,123 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
+
+/// Remove every entity the player is carrying when an authored training-exit
+/// trap activates. Earth composes this mission-local script with the inherited
+/// `TrapTeleportPlayer`; returning destruction effects here lets both scripts
+/// run through the normal effect pipeline on the same `TurnOn`.
+pub struct VaporizeInventory;
+
+impl VaporizeInventory {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for VaporizeInventory {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
+        }
+
+        Effect::combine(
+            player_carried_items(world)
+                .into_iter()
+                .map(|entity_id| Effect::DestroyEntity { entity_id })
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::VaporizeInventory;
+
+    fn contains(entity: shipyard::EntityId) -> ToLink {
+        ToLink {
+            to_template_id: 0,
+            to_entity_id: Some(WrappedEntityId(entity)),
+            link: Link::Contains(0),
+        }
+    }
+
+    #[test]
+    fn turn_on_destroys_hands_backpack_and_nested_carried_entities_once() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let nested_equipment = world.add_entity(Links::empty());
+        let left_hand = world.add_entity(Links {
+            to_links: vec![contains(nested_equipment)],
+        });
+        let right_hand = world.add_entity(Links::empty());
+        let backpack_item = world.add_entity(Links::empty());
+        let inventory = world.add_entity(Links {
+            // Duplicate the left hand deliberately: malformed ownership must
+            // not emit two destruction effects for one entity.
+            to_links: vec![contains(backpack_item), contains(left_hand)],
+        });
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: Some(left_hand),
+            right_hand_entity_id: Some(right_hand),
+            inventory_entity_id: inventory,
+        });
+
+        let effect = VaporizeInventory::new().handle_message(
+            player,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: player },
+        );
+        let destroyed: Vec<_> = Effect::flatten(vec![effect])
+            .into_iter()
+            .map(|effect| match effect {
+                Effect::DestroyEntity { entity_id } => entity_id,
+                other => panic!("expected only DestroyEntity, got {other:?}"),
+            })
+            .collect();
+
+        assert_eq!(
+            destroyed,
+            vec![left_hand, nested_equipment, right_hand, backpack_item]
+        );
+        assert!(
+            !destroyed.contains(&inventory),
+            "the backpack container survives"
+        );
+        assert!(!destroyed.contains(&player), "the player survives");
+    }
+
+    #[test]
+    fn unrelated_messages_leave_inventory_untouched() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        let effect = VaporizeInventory::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// Earth training gives the player temporary supplies which must not escape the
+// Basic/Advanced rooms. Each authored exit tripwire SwitchLinks to a
+// Player Teleport Trap with both inherited TrapTeleportPlayer and local
+// VaporizeInventory scripts:
+//
+//   Basic    tripwire 380 -> trap 379
+//   Weapons  tripwire 374 -> trap 371
+//   Tech     tripwire 375 -> trap 372
+//   Psionic  tripwire 376 -> trap 373
+//
+// The primary scenario acquires the real Basic supplies via ordinary gameplay
+// input (crosshair squeeze + container UI), then enters the real exit sensor
+// through a bounded collision-valid move. No debug give, script-message
+// injection, or direct level transition is used.
+//
+// Negative-first: on main VaporizeInventory is a NoopScript. Trap 379 performs
+// its teleport, but Chem #1 and the Juice bottle remain in the backpack, so the
+// empty-inventory assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const BASIC_CRATE = 307;
+const BASIC_CHEM = 242;
+const BASIC_JUICE = 355;
+const BASIC_EXIT_TRIPWIRE = 380;
+const BASIC_EXIT_DESTINATION = 379;
+
+const ADVANCED_EXITS = [
+  { name: "Weapons", tripwire: 374, destination: 371 },
+  { name: "Technical", tripwire: 375, destination: 372 },
+  { name: "Psionic", tripwire: 376, destination: 373 },
+] as const;
+
+async function exactlyOne(
+  game: GameServer,
+  templateId: number,
+  what: string,
+): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(templateId);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one ${what} (mission object ${templateId}), got ${JSON.stringify(matches)}`,
+  );
+  return matches[0];
+}
+
+async function click(game: GameServer, element: UiElement): Promise<void> {
+  const [x, y, width, height] = element.screen_rect;
+  await game.input.set("pointer.position", [x + width / 2, y + height / 2]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+async function squeeze(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 2 });
+}
+
+type Quat = [number, number, number, number];
+
+function multiplyQuat(a: Quat, b: Quat): Quat {
+  const [ax, ay, az, aw] = a;
+  const [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+}
+
+function lookQuat(direction: [number, number, number]): Quat {
+  const length = Math.hypot(...direction);
+  const [bx, by, bz] = direction.map((v) => v / length) as [
+    number,
+    number,
+    number,
+  ];
+  // Shortest-arc quaternion from flat controller local forward (0,0,-1)
+  // to the desired world direction.
+  const dot = -bz;
+  if (dot < -0.999999) {
+    return [0, 1, 0, 0];
+  }
+  const q: Quat = [by, -bx, 0, 1 + dot];
+  const qLength = Math.hypot(...q);
+  return q.map((v) => v / qLength) as Quat;
+}
+
+/**
+ * Stand near an entity, compose a world-space look with the authored player
+ * pawn rotation, and squeeze. Teleport is only spatial setup; acquisition
+ * itself follows the production reticle/Frob/pickup path.
+ */
+async function frobNormally(
+  game: GameServer,
+  target: EntitySummary,
+  didInteract: () => Promise<boolean>,
+  aimOffsetY = 0,
+): Promise<void> {
+  const [tx, ty, tz] = target.position;
+  const aimY = ty + aimOffsetY;
+  // Mission props may sit tight against one wall. Try the four cardinal
+  // approach faces, always using the production crosshair + squeeze path, and
+  // stop as soon as the expected interaction state appears.
+  const stands = [
+    { x: tx - 2.3, y: ty, z: tz },
+    { x: tx + 2.3, y: ty, z: tz },
+    { x: tx, y: ty, z: tz - 2.3 },
+    { x: tx, y: ty, z: tz + 2.3 },
+  ];
+  for (const stand of stands) {
+    await teleportVerified(game, stand);
+    const player = await game.player.position();
+    const pawn = (await game.info()).player.rotation;
+    const eyeY = player.y + 1.6;
+    const dx = tx - player.x;
+    const dz = tz - player.z;
+    const desiredWorldLook = lookQuat([dx, aimY - eyeY, dz]);
+    const inversePawn: Quat = [-pawn[0], -pawn[1], -pawn[2], pawn[3]];
+    const head = multiplyQuat(inversePawn, desiredWorldLook);
+    await game.input.set("head.rotation", head);
+    await game.step({ frames: 3 });
+    await squeeze(game);
+    if (await didInteract()) {
+      return;
+    }
+  }
+  assert.fail(`ordinary crosshair squeeze could not interact with ${target.name}`);
+}
+
+async function acquireBasicItemsNormally(
+  game: GameServer,
+): Promise<{ chemId: number }> {
+  const crate = await exactlyOne(game, BASIC_CRATE, "Basic crate");
+  await frobNormally(
+    game,
+    crate,
+    async () => (await game.ui.state()).active_panel?.entity_id === crate.id,
+    0.7,
+  );
+
+  const opened = await game.ui.state();
+  assert.equal(
+    opened.active_panel?.entity_id,
+    crate.id,
+    `ordinary squeeze should open the Basic crate, got ${JSON.stringify(opened.active_panel)}`,
+  );
+  const chem = opened.active_panel.elements.find(
+    (element) => element.kind === "button" && element.entity_id !== null,
+  );
+  assert.ok(chem, "Basic crate should expose its Fermium item button");
+  const chemDetail = await game.entities.detail(chem.entity_id!);
+  assert.equal(
+    chemDetail.template_id,
+    BASIC_CHEM,
+    "the normally-looted Basic crate item must be authored Chem #1",
+  );
+  await click(game, chem);
+
+  const juice = await exactlyOne(game, BASIC_JUICE, "Basic Juice bottle");
+  await frobNormally(
+    game,
+    juice,
+    async () =>
+      (await game.player.inventory()).items.some((item) => item.entity_id === juice.id),
+  );
+
+  const inventory = await game.player.inventory();
+  assert.deepEqual(
+    inventory.items
+      .map((item) => item.name)
+      .sort(),
+    ["Chem #1", "Juice bottle"],
+    `ordinary interactions should acquire both Basic supplies, got ${JSON.stringify(inventory)}`,
+  );
+  return { chemId: chem.entity_id! };
+}
+
+async function crossRealExit(
+  game: GameServer,
+  tripwireTemplate: number,
+  destinationTemplate: number,
+): Promise<void> {
+  const tripwire = await exactlyOne(game, tripwireTemplate, "training exit tripwire");
+  const destination = await exactlyOne(
+    game,
+    destinationTemplate,
+    "training exit teleport destination",
+  );
+  const [x, y, z] = tripwire.position;
+
+  const [dx, , dz] = destination.position;
+  // Training rooms wall off different faces of their exit sensors. Try each
+  // cardinal approach, starting just outside the sensor and entering through a
+  // bounded collision-valid move. Rapier's real SensorBeginIntersect then
+  // drives the tripwire SwitchLink.
+  const approaches = [
+    { x, y: y + 0.5, z: z - 4 },
+    { x: x - 4, y: y + 0.5, z },
+    { x: x + 4, y: y + 0.5, z },
+    { x, y: y + 0.5, z: z + 4 },
+  ];
+  for (const start of approaches) {
+    // Read the immediate paused position before any frame can generate a
+    // sensor event, then prove that the setup itself did not teleport us.
+    await game.player.teleport(start);
+    const beforeMove = await game.player.position();
+    assert.ok(
+      Math.hypot(beforeMove.x - dx, beforeMove.z - dz) >= 3,
+      "spatial setup must not teleport through the exit",
+    );
+    await game.step({ frames: 3 });
+    const afterSetup = await game.player.position();
+    assert.ok(
+      Math.hypot(afterSetup.x - dx, afterSetup.z - dz) >= 3,
+      "spatial setup must remain outside the exit sensor",
+    );
+    const moved = await game.player.moveTo({ x, y: y + 0.5, z });
+    await game.step({ frames: 12 });
+    const arrived = await game.player.position();
+    if (moved.moved && Math.hypot(arrived.x - dx, arrived.z - dz) < 3) {
+      return;
+    }
+  }
+
+  const arrived = await game.player.position();
+  assert.fail(
+    `tripwire ${tripwireTemplate} should fire its authored teleport to ${destinationTemplate}; ` +
+      `destination=${JSON.stringify(destination.position)} actual=${JSON.stringify(arrived)}`,
+  );
+}
+
+test(
+  "earth Basic exit vaporizes supplies acquired through normal interactions",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+    });
+    await game.step({ frames: 5 });
+
+    const acquired = await acquireBasicItemsNormally(game);
+
+    // Mirror the strict playthrough edge case: lift Chem #1 onto the use-mode
+    // cursor before leaving. It remains a backpack-owned item, but the host has
+    // an additional pure-UI EntityId reference which vaporization must clear.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const strip = (await game.ui.state()).strip;
+    const chemElement = strip?.elements.find(
+      (element) => element.entity_id === acquired.chemId,
+    );
+    assert.ok(chemElement, "use-mode strip should expose the acquired Chem #1");
+    await click(game, chemElement);
+    assert.equal(
+      (await game.ui.state()).cursor?.entity_id,
+      acquired.chemId,
+      "Chem #1 should ride the cursor before crossing the exit",
+    );
+
+    await crossRealExit(game, BASIC_EXIT_TRIPWIRE, BASIC_EXIT_DESTINATION);
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.count,
+      0,
+      `the Basic exit must vaporize every temporary carried item, got ${JSON.stringify(inventory)}`,
+    );
+    // The cleanup is destruction, not merely hiding/removing container links.
+    // Assert by stable mission identity: runtime EntityId slots may be recycled
+    // immediately after deletion, so querying an old numeric id can correctly
+    // resolve to a different newly-created entity.
+    assert.equal((await game.entities.byTemplate(BASIC_CHEM)).length, 0);
+    assert.equal((await game.entities.byTemplate(BASIC_JUICE)).length, 0);
+    const player = (await game.info()).player;
+    assert.equal(player.wielded_entity_id, null);
+    assert.equal(player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.ui.state()).cursor,
+      null,
+      "vaporization must clear the host-side cursor entity reference",
+    );
+  },
+);
+
+for (const advanced of ADVANCED_EXITS) {
+  test(
+    `earth ${advanced.name} exit shares VaporizeInventory cleanup`,
+    { skip: !e2eEnabled, timeout: 600_000 },
+    async () => {
+      await using game = await GameServer.launch({
+        mission: "earth.mis",
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8197),
+      });
+      await game.step({ frames: 5 });
+
+      // Use one genuine world item as compact setup for each Advanced exit.
+      // The primary Basic scenario above proves ordinary acquisition; these
+      // cases isolate the three other authored trap compositions.
+      const juice = await exactlyOne(game, BASIC_JUICE, "control Juice bottle");
+      await game.player.give(juice.id);
+      assert.equal((await game.player.inventory()).count, 1);
+
+      await crossRealExit(game, advanced.tripwire, advanced.destination);
+      assert.equal(
+        (await game.player.inventory()).count,
+        0,
+        `${advanced.name} exit must vaporize the same generic carried-item set`,
+      );
+      assert.equal(
+        (await game.entities.byTemplate(BASIC_JUICE)).length,
+        0,
+        `${advanced.name} exit must destroy the carried entity, not only detach it`,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- implement the authored `VaporizeInventory` script as a generic carried-item cleanup for backpack, held, wielded, and nested equipped items
- clear interaction, player, flat-UI cursor, panel, strip, and cached component references before entity deletion, including stale `SetUI` snapshots later in the same effect batch
- exercise the real Earth Basic, Weapons, Technical, and Psionic exit tripwires and teleport traps

## Verification

- negative-first Earth Basic E2E on `main`: authored teleport succeeded but Chem #1 and Juice remained (`inventory.count = 2`)
- `cargo test -p shock2vr vaporize_inventory -- --nocapture` — 2 passed
- focused flat-UI destruction/stale-`SetUI` regressions — 5 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- SDK fast suite — 14 active passed, 110 E2E skipped as designed
- Earth `VaporizeInventory` E2E — 4/4 exits passed through real sensor → SwitchLink → teleport-trap paths
- mission load smoke — 23/23 missions passed
- dual-engine adversarial re-review after fixes — no findings, ship as-is

## Visual verification

![Earth Basic exit inventory vaporization](https://gist.githubusercontent.com/tommy-xr/8d485d52171bc53c276c2455574253f9/raw/earth-basic-exit-vaporize.gif)

<sub>Earth Basic tripwire 380 → teleport trap 379. Captured headlessly through the debug runtime with the same fixed-step sequence on baseline and fix.</sub>

### Before → after

![Baseline retains training items; fix clears inventory strip and cursor](https://gist.githubusercontent.com/tommy-xr/8d485d52171bc53c276c2455574253f9/raw/earth-basic-exit-vaporize-before-after.png)

Fixes #536
