### PR TITLE
fix: show stack counts in world labels

### DIFF
--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -2,12 +2,19 @@ use cgmath::{Matrix4, Vector2, point2, vec2, vec3};
 use collision::{Aabb2, Aabb3};
 use dark::{
     importers::{FONT_IMPORTER, TEXTURE_IMPORTER},
-    properties::{PropHitPoints, PropObjName, PropTemplateId},
+    properties::{PropHitPoints, PropObjName, PropStackCount, PropTemplateId},
 };
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
+
+fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
+    match stack_count {
+        Some(count) => item_name.replace("%d", &count.to_string()),
+        None => item_name.to_owned(),
+    }
+}
 
 pub fn draw_item_name(
     asset_cache: &mut AssetCache,
@@ -41,6 +48,14 @@ pub fn draw_item_name(
         return vec![];
     }
 
+    let stack_count = world
+        .borrow::<View<PropStackCount>>()
+        .unwrap()
+        .get(entity_id)
+        .map(|stack| stack.0)
+        .ok();
+    let item_name = format_stack_aware_item_name(&prop_obj_short_name.0, stack_count);
+
     let aabb = maybe_bbox.unwrap();
     let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
     let extents = project_aabb3(&aabb, view, projection, screen_size);
@@ -54,13 +69,13 @@ pub fn draw_item_name(
     let text_content = if debug_show_ids {
         format!(
             "{} | {} (Tem {}| Ent {})",
-            prop_obj_short_name.0,
+            item_name,
             &maybe_hitpoints,
             prop_template_id.template_id,
             entity_id.inner(),
         )
     } else {
-        format!("{} | {}", prop_obj_short_name.0, &maybe_hitpoints,)
+        format!("{} | {}", item_name, &maybe_hitpoints,)
     };
 
     let text_obj_0_0 = SceneObject::screen_space_text(
@@ -73,6 +88,35 @@ pub fn draw_item_name(
     );
 
     vec![text_obj_0_0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_stack_aware_item_name;
+
+    #[test]
+    fn stack_count_replaces_object_name_decimal_placeholder() {
+        assert_eq!(
+            format_stack_aware_item_name(r#"Nanites: "%d nanites.""#, Some(250)),
+            r#"Nanites: "250 nanites.""#,
+        );
+    }
+
+    #[test]
+    fn object_name_without_decimal_placeholder_is_unchanged() {
+        assert_eq!(
+            format_stack_aware_item_name("Maintenance Tool", Some(12)),
+            "Maintenance Tool",
+        );
+    }
+
+    #[test]
+    fn decimal_placeholder_is_preserved_without_a_stack_count() {
+        assert_eq!(
+            format_stack_aware_item_name(r#"Nanites: "%d nanites.""#, None),
+            r#"Nanites: "%d nanites.""#,
+        );
+    }
 }
 
 pub fn draw_item_outline(

--- a/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
+++ b/tools/shock2-sdk/test/nanite-stack-label.e2e.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function stackCount(properties: { name: string; value: string }[]): number | undefined {
+  const stack = properties.find((property) => property.name === "StackCount");
+  return stack === undefined ? undefined : Number(stack.value);
+}
+
+test(
+  "Earth nanite world-label visual smoke preserves the authored stack",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8193),
+    });
+    await game.step({ frames: 5 });
+
+    // Earth mission object 257 is the Technical Training nanite supply.
+    const pile = (await game.entities.list()).entities.find(
+      (entity) => entity.template_id === 257,
+    );
+    assert.ok(pile, "expected Earth mission object 257 (Big Nanite Pile)");
+
+    const before = await game.entities.detail(pile.id);
+    assert.equal(stackCount(before.properties), 250);
+
+    // The fresh Earth spawn faces opposite the Technical lesson. Stage two
+    // units west of the pile and turn the head 270 degrees; twenty degrees down
+    // centers the physical nanite canister against a clear wall.
+    // Do not squeeze: highlighting renders the label without picking it up.
+    const [x, y, z] = before.position;
+    await game.player.teleport({ x: x - 2.0, y: y - 1.2, z });
+    await game.input.set("head.look", [270, 20]);
+    await game.step({ frames: 2 });
+
+    // This is a real-mission render smoke and artifact capture, not a
+    // pixel/OCR assertion. The negative-first semantic assertion that `%d`
+    // becomes `250` lives in item_outline.rs, beside the formatter used here.
+    const shot = await game.screenshot("earth-nanite-stack-label.png");
+    assert.deepEqual(shot.resolution, [800, 600]);
+    assert.ok(shot.size_bytes > 10_000);
+
+    const after = await game.entities.detail(pile.id);
+    assert.equal(
+      stackCount(after.properties),
+      250,
+      "rendering the stack-aware label must not alter pickup quantity",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #540

## Summary

- resolve `%d` placeholders in world-object labels from the entity's authored `StackCount`
- leave ordinary labels unchanged and preserve placeholders when an entity has no stack count
- add a real `earth.mis` SDK scenario covering the 250-nanite Technical Training pile and proving label rendering does not consume the stack

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr hud::item_outline::tests -- --nocapture`
- `SHOCK2_E2E=1 SHOCK2_E2E_PORT=8994 node --test dist/test/nanite-stack-label.e2e.test.js`
- `npm test` (Node 22: 14 passed, 113 skipped)
- `cargo fmt --all -- --check`
- `git diff --check`

## Review

- Concrete Codex review identified that the Earth SDK scenario's original name
  overstated its assertions. The test is now explicitly a real-mission visual
  smoke/non-consumption check; the negative-first `%d` → `250` regression
  assertion remains in the Rust formatter unit test.
- A fresh isolated Codex review of amended head `e2cf28e` reported no findings.
- The required Claude Opus CLI review could not run in this environment:
  `Not logged in · Please run /login`. No Anthropic credential was available,
  so the independent fallback was a second ephemeral Codex review at high
  reasoning effort.

## Visual verification

Both loops use the same fresh Earth save, discovered mission object
`template_id=257`, camera placement, and fixed-timestep request sequence. The
entity's `StackCount` remained `250` before and after each capture.

| Exact base (`be38d04`) | Fixed (`e2cf28e`) |
| --- | --- |
| ![Exact base labels the 250-nanite stack as zero](https://gist.githubusercontent.com/tommy-xr/40e9abaeefc53d187373a480302b805c/raw/3fec95486ce10ec730cf816ef69140eac3370152/base-clean.gif) | ![Fixed build labels the stack as 250 nanites](https://gist.githubusercontent.com/tommy-xr/40e9abaeefc53d187373a480302b805c/raw/3fec95486ce10ec730cf816ef69140eac3370152/fixed-clean.gif) |

![Before and after with enlarged world-label detail](https://gist.githubusercontent.com/tommy-xr/40e9abaeefc53d187373a480302b805c/raw/3fec95486ce10ec730cf816ef69140eac3370152/before-after.png)

<details>
<summary>Fixed full-resolution still</summary>

![Fixed full-resolution Earth nanite stack label](https://gist.githubusercontent.com/tommy-xr/40e9abaeefc53d187373a480302b805c/raw/3fec95486ce10ec730cf816ef69140eac3370152/fixed-still.png)

</details>
