### PR TITLE
fix: implement Earth HackDiff training minigame

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -4,7 +4,7 @@ use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
 
 use crate::{
     EnvMap, EnvSoundQuery, SoundSchema, SpeechDB, TagDatabase,
-    gamesys::params::TrainerCostTables,
+    gamesys::params::{HrmParams, TrainerCostTables},
     properties::{LinkDefinition, LinkDefinitionWithData, PropertyDefinition},
     ss2_chunk_file_reader::{self},
     ss2_entity_info::{self, SystemShock2EntityInfo},
@@ -18,6 +18,8 @@ pub struct Gamesys {
     /// Trainer upgrade cost tables (`STATCOST`/`WTECHCOST`/`WSKILLCOST`/
     /// `PSICOST` file-var chunks); `None` if the gamesys lacks them.
     trainer_costs: Option<TrainerCostTables>,
+    /// HRM hacking/repair/modify tuning (`HRM` file-var chunk).
+    hrm_params: Option<HrmParams>,
 }
 
 impl Gamesys {
@@ -63,6 +65,10 @@ impl Gamesys {
     pub fn trainer_costs(&self) -> Option<&TrainerCostTables> {
         self.trainer_costs.as_ref()
     }
+
+    pub fn hrm_params(&self) -> Option<&HrmParams> {
+        self.hrm_params.as_ref()
+    }
 }
 
 pub fn read<T: io::Read + io::Seek>(
@@ -86,6 +92,7 @@ pub fn read<T: io::Read + io::Seek>(
     let env_tag_map = EnvMap::read(&table_of_contents, reader);
     let speech_db = SpeechDB::read(&table_of_contents, reader);
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
+    let hrm_params = HrmParams::read(&table_of_contents, reader);
 
     // Uncomment to output debug info for voices:
     // debug_print_voices(&sound_schema, &speech_db);
@@ -97,5 +104,6 @@ pub fn read<T: io::Read + io::Seek>(
         env_tag_map,
         speech_db,
         trainer_costs,
+        hrm_params,
     }
 }

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -36,6 +36,21 @@ pub struct TrainerCostTables {
     pub psi_cost: [[i32; 8]; 5],
 }
 
+/// Retail `HRM` gamesys file-var (`sHRMParams`): bonuses applied to an
+/// object's `P$HackDiff` base values for the player's relevant tech skill and
+/// Cyber Affinity stat.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HrmParams {
+    pub skill_critical_bonus: i32,
+    pub skill_success_bonus: i32,
+    pub stat_critical_bonus: i32,
+    pub stat_success_bonus: i32,
+    /// Authored `m_statBreak` table for Cyber Affinity 1..=8. Retail exposes
+    /// this data in the editor but `ShockHRMTriggerEffect` does not consult it:
+    /// landing on a failed mine breaks a hack target unconditionally.
+    pub stat_break_chance: [f32; 8],
+}
+
 fn read_table<T: io::Read + io::Seek, const COLS: usize, const ROWS: usize>(
     table_of_contents: &ChunkFileTableOfContents,
     reader: &mut T,
@@ -72,5 +87,43 @@ impl TrainerCostTables {
             weapon_cost: read_table(table_of_contents, reader, "WSKILLCOST")?,
             psi_cost: read_table(table_of_contents, reader, "PSICOST")?,
         })
+    }
+}
+
+impl HrmParams {
+    /// Read the 48-byte `HRM` chunk. Returns `None` for a missing/truncated
+    /// gamesys rather than reading through into the next chunk.
+    pub fn read<T: io::Read + io::Seek>(
+        table_of_contents: &ChunkFileTableOfContents,
+        reader: &mut T,
+    ) -> Option<Self> {
+        let chunk = table_of_contents.get_chunk("HRM".to_owned())?;
+        if chunk.length < 48 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset)).ok()?;
+        let skill_critical_bonus = reader.read_i32::<LittleEndian>().ok()?;
+        let skill_success_bonus = reader.read_i32::<LittleEndian>().ok()?;
+        let stat_critical_bonus = reader.read_i32::<LittleEndian>().ok()?;
+        let stat_success_bonus = reader.read_i32::<LittleEndian>().ok()?;
+        let mut stat_break_chance = [0.0; 8];
+        for chance in &mut stat_break_chance {
+            *chance = reader.read_f32::<LittleEndian>().ok()?;
+        }
+        Some(Self {
+            skill_critical_bonus,
+            skill_success_bonus,
+            stat_critical_bonus,
+            stat_success_bonus,
+            stat_break_chance,
+        })
+    }
+
+    pub fn success_chance(&self, base: i32, skill: i32, stat: i32) -> i32 {
+        (base + skill * self.skill_success_bonus + stat * self.stat_success_bonus).min(85)
+    }
+
+    pub fn mine_count(&self, base: i32, skill: i32, stat: i32) -> i32 {
+        (base - skill * self.skill_critical_bonus - stat * self.stat_critical_bonus).max(0)
     }
 }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -17,6 +17,7 @@ mod prop_frame_anim_config;
 mod prop_frame_anim_state;
 mod prop_frob_info;
 mod prop_gun_state;
+mod prop_hack_diff;
 mod prop_hit_points;
 mod prop_key;
 mod prop_log;
@@ -54,6 +55,7 @@ pub use prop_frame_anim_config::*;
 pub use prop_frame_anim_state::*;
 pub use prop_frob_info::*;
 pub use prop_gun_state::*;
+pub use prop_hack_diff::*;
 pub use prop_hit_points::*;
 pub use prop_key::*;
 pub use prop_log::*;
@@ -1211,6 +1213,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$GunState",
             PropGunState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$HackDiff",
+            PropHackDiff::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_hack_diff.rs
+++ b/dark/src/properties/prop_hack_diff.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+use std::io;
+
+use crate::ss2_common::{read_i32, read_single};
+
+/// Dark's 12-byte `P$HackDiff` / `sTechInfo` record.
+///
+/// `success_chance` and `critical_chance` are the authored base values used by
+/// the HRM board; `cost` is the nanite cost factor (the retail hack operation's
+/// base cost is one, so the factor is also the displayed cost).
+#[derive(Debug, Component, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PropHackDiff {
+    pub success_chance: i32,
+    pub critical_chance: i32,
+    pub cost: f32,
+}
+
+impl PropHackDiff {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 12, "P$HackDiff must be a 12-byte sTechInfo record");
+        Self {
+            success_chance: read_i32(reader),
+            critical_chance: read_i32(reader),
+            cost: read_single(reader),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::PropHackDiff;
+
+    #[test]
+    fn parses_little_endian_tech_info_layout() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&75i32.to_le_bytes());
+        bytes.extend_from_slice(&2i32.to_le_bytes());
+        bytes.extend_from_slice(&15.5f32.to_le_bytes());
+
+        let property = PropHackDiff::read(&mut Cursor::new(bytes), 12);
+        assert_eq!(
+            property,
+            PropHackDiff {
+                success_chance: 75,
+                critical_chance: 2,
+                cost: 15.5,
+            }
+        );
+    }
+}

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -294,3 +294,30 @@ fn gamesys_trainer_cost_tables_match_the_retail_values() {
     assert_eq!(costs.psi_cost[0][1..], [3; 7]);
     assert_eq!(costs.psi_cost[4][1..], [20; 7]);
 }
+
+#[test]
+fn gamesys_hrm_params_match_retail_hacking_tuning() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let file = File::open(data.join("shock2.gam")).expect("shock2.gam should open");
+    let mut reader = BufReader::new(file);
+    let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+    let params = dark::gamesys::HrmParams::read(&toc, &mut reader)
+        .expect("retail shock2.gam carries the 48-byte HRM chunk");
+
+    assert_eq!(params.skill_critical_bonus, 0);
+    assert_eq!(params.skill_success_bonus, 10);
+    assert_eq!(params.stat_critical_bonus, 1);
+    assert_eq!(params.stat_success_bonus, 5);
+    assert_eq!(
+        params.stat_break_chance,
+        [10.0, 14.0, 20.0, 28.0, 38.0, 50.0, 75.0, 95.0]
+    );
+
+    // Earth starts at Hack 0 / Cyber 1. Its object-266 override (50,2)
+    // therefore plays at 55% with one mine, not raw 50% / two mines.
+    assert_eq!(params.success_chance(50, 0, 1), 55);
+    assert_eq!(params.mine_count(2, 0, 1), 1);
+}

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -860,6 +860,16 @@ fn draw_components(
             // VR quads; the host draws the real screen cursor instead.
             continue;
         }
+        // A zero-alpha button is a hit target over art already baked into the
+        // panel backdrop (the HRM board's unlit node boxes). Keep it in input
+        // routing and debug introspection, but do not paint its placeholder
+        // texture over the backdrop.
+        if matches!(
+            component,
+            GuiComponentRenderInfo::Image { alpha, .. } if *alpha <= 0.0
+        ) {
+            continue;
+        }
         if let GuiComponentRenderInfo::Image {
             entity: Some(entity),
             ..

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -230,6 +230,10 @@ pub struct GlobalTemplateHierarchy(pub HashMap<i32, Vec<i32>>);
 #[derive(Unique, Clone)]
 pub struct GlobalTrainerCosts(pub Option<dark::gamesys::TrainerCostTables>);
 
+/// Retail HRM tuning from the gamesys `HRM` chunk, shared with hackable GUIs.
+#[derive(Unique, Clone)]
+pub struct GlobalHrmParams(pub Option<dark::gamesys::HrmParams>);
+
 impl GlobalTemplateHierarchy {
     /// Whether `template_id` is `class_template_id` or inherits from it.
     pub fn is_or_descends_from(&self, template_id: i32, class_template_id: i32) -> bool {
@@ -450,6 +454,7 @@ impl MissionCore {
         world.add_unique(GlobalTrainerCosts(
             game_entity_info.trainer_costs().cloned(),
         ));
+        world.add_unique(GlobalHrmParams(game_entity_info.hrm_params().cloned()));
         let (mut psi_powers, psi_selection) = crate::psi::build_psi_power_registry(&entity_info_rc);
         // Player-facing discipline names come from the psihelp string table;
         // a data install without it just keeps the gamesys symbolic names.
@@ -2672,6 +2677,16 @@ impl MissionCore {
                             delta,
                             hp
                         );
+                    }
+                }
+
+                Effect::AdjustStackCount { entity_id, delta } => {
+                    let mut stacks = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropStackCount>>()
+                        .unwrap();
+                    if let Ok(stack) = (&mut stacks).get(entity_id) {
+                        stack.0 = (stack.0 + delta).max(0);
                     }
                 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -83,6 +83,14 @@ pub enum Effect {
         delta: i32,
     },
 
+    /// Adjust an item's stack count (`P$StackCoun`) by `delta`. The caller is
+    /// responsible for destroying a stack it exhausts; this effect is used by
+    /// authored-currency operations such as the HRM hacking board.
+    AdjustStackCount {
+        entity_id: EntityId,
+        delta: i32,
+    },
+
     /// Adjust a weapon's current clip ammo (`PropGunState.ammo`) by `delta`
     /// (negative to consume). No-op for entities without a gun state.
     AdjustAmmo {

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -1,10 +1,11 @@
 use cgmath::{Vector2, Vector3, vec2};
-use dark::properties::PropKeypadCode;
+use dark::properties::{PropHackDiff, PropKeypadCode, PropTemplateId};
 use engine::audio::AudioHandle;
 
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::gui::{self, ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::{mission::GlobalHrmParams, player_stats::Skill, quest_info::QuestInfo, time::Time};
 
 use crate::scripts::{Effect, MessagePayload, script_util::*};
 
@@ -13,12 +14,207 @@ pub struct KeyPadGui;
 #[derive(Clone, Debug, Default)]
 pub struct KeyPadState {
     current_value: Option<u32>,
+    hack: HackState,
 }
 
 #[derive(Clone)]
 pub enum KeyPadMsg {
     ButtonPressed(u32),
     Clear,
+    StartHack,
+    PlayNode { x: usize, y: usize },
+}
+
+const BOARD_WIDTH: usize = 5;
+const BOARD_HEIGHT: usize = 4;
+const BOARD_X: f32 = 16.0;
+const BOARD_Y: f32 = 48.0;
+const BOARD_DX: f32 = 30.0;
+const BOARD_DY: f32 = 36.0;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum HackPhase {
+    #[default]
+    Unpaid,
+    Playing,
+    Won,
+    Lost,
+    Unwinnable,
+    InsufficientNanites,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum HackNode {
+    #[default]
+    Free,
+    Lit,
+    Burned,
+    Mine,
+    Empty,
+}
+
+#[derive(Clone, Debug)]
+struct HackState {
+    phase: HackPhase,
+    nodes: [HackNode; BOARD_WIDTH * BOARD_HEIGHT],
+    rng_state: u64,
+}
+
+impl Default for HackState {
+    fn default() -> Self {
+        Self {
+            phase: HackPhase::Unpaid,
+            nodes: base_hack_board(),
+            rng_state: 0,
+        }
+    }
+}
+
+const fn board_index(x: usize, y: usize) -> usize {
+    y * BOARD_WIDTH + x
+}
+
+const fn base_hack_board() -> [HackNode; BOARD_WIDTH * BOARD_HEIGHT] {
+    use HackNode::{Empty as E, Free as F};
+    [
+        E, E, F, F, F, //
+        F, F, F, E, F, //
+        F, E, F, F, F, //
+        F, F, F, E, E,
+    ]
+}
+
+fn next_random(rng_state: &mut u64, upper_exclusive: u32) -> u32 {
+    debug_assert!(upper_exclusive > 0);
+    let mut value = if *rng_state == 0 {
+        0x9e37_79b9_7f4a_7c15
+    } else {
+        *rng_state
+    };
+    value ^= value << 13;
+    value ^= value >> 7;
+    value ^= value << 17;
+    *rng_state = value;
+    (value % u64::from(upper_exclusive)) as u32
+}
+
+fn hack_seed(world: &World, entity_id: EntityId) -> u64 {
+    // Simulation time makes ordinary play vary with the moment START is
+    // pressed, while fixed-step replay requests produce the same board. Mix in
+    // the stable authored object id rather than the run-local Shipyard id.
+    let time = world
+        .borrow::<UniqueView<Time>>()
+        .map(|time| time.total.as_nanos() as u64)
+        .unwrap_or_default();
+    let stable_id = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|templates| {
+            templates
+                .get(entity_id)
+                .ok()
+                .map(|template| template.template_id as u64)
+        })
+        .unwrap_or_else(|| entity_id.inner());
+    mix_hack_seed(time, stable_id)
+}
+
+fn mix_hack_seed(time_nanoseconds: u64, stable_id: u64) -> u64 {
+    time_nanoseconds ^ stable_id.rotate_left(17) ^ 0x1ac1_d4b1
+}
+
+fn board_with_mines(
+    mine_count: i32,
+    rng_state: &mut u64,
+) -> [HackNode; BOARD_WIDTH * BOARD_HEIGHT] {
+    let mut nodes = base_hack_board();
+    let mut free: Vec<_> = nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(index, node)| (*node == HackNode::Free).then_some(index))
+        .collect();
+    for _ in 0..mine_count.max(0) as usize {
+        if free.is_empty() {
+            break;
+        }
+        let selected = next_random(rng_state, free.len() as u32) as usize;
+        nodes[free.remove(selected)] = HackNode::Mine;
+    }
+    nodes
+}
+
+fn hack_cost(diff: PropHackDiff) -> i32 {
+    (diff.cost as i32).max(1)
+}
+
+fn outcome_roll(rng_state: &mut u64) -> i32 {
+    next_random(rng_state, 100) as i32
+}
+
+fn roll_succeeds(roll: i32, chance: i32) -> bool {
+    roll < chance
+}
+
+fn effective_hack_values(world: &World, diff: PropHackDiff) -> (i32, i32) {
+    let (skill, stat) = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .ok()
+        .map(|quest| {
+            let stats = quest.player_stats();
+            (stats.skill_level(Skill::Hack), stats.cyber_affinity)
+        })
+        .unwrap_or((0, 0));
+    world
+        .borrow::<UniqueView<GlobalHrmParams>>()
+        .ok()
+        .and_then(|params| params.0.clone())
+        .map(|params| {
+            (
+                params.success_chance(diff.success_chance, skill, stat),
+                params.mine_count(diff.critical_chance, skill, stat),
+            )
+        })
+        .unwrap_or((
+            diff.success_chance.clamp(0, 85),
+            diff.critical_chance.max(0),
+        ))
+}
+
+fn has_connected_three(nodes: &[HackNode; BOARD_WIDTH * BOARD_HEIGHT]) -> bool {
+    (0..BOARD_HEIGHT).any(|y| {
+        (0..=BOARD_WIDTH - 3)
+            .any(|x| (0..3).all(|offset| nodes[board_index(x + offset, y)] == HackNode::Lit))
+    }) || (0..BOARD_WIDTH).any(|x| {
+        (0..=BOARD_HEIGHT - 3)
+            .any(|y| (0..3).all(|offset| nodes[board_index(x, y + offset)] == HackNode::Lit))
+    })
+}
+
+fn board_has_potential_path(nodes: &[HackNode; BOARD_WIDTH * BOARD_HEIGHT]) -> bool {
+    let can_contribute = |node| matches!(node, HackNode::Lit | HackNode::Free | HackNode::Mine);
+    (0..BOARD_HEIGHT).any(|y| {
+        (0..=BOARD_WIDTH - 3)
+            .any(|x| (0..3).all(|offset| can_contribute(nodes[board_index(x + offset, y)])))
+    }) || (0..BOARD_WIDTH).any(|x| {
+        (0..=BOARD_HEIGHT - 3)
+            .any(|y| (0..3).all(|offset| can_contribute(nodes[board_index(x, y + offset)])))
+    })
+}
+
+/// Numeric keypad codes take precedence over the inherited tech difficulty.
+/// Retail numeric keypads inherit from the same archetype as hack-only panels,
+/// so `P$HackDiff` alone does not distinguish the two modes.
+fn hack_diff_for_entity(world: &World, entity_id: EntityId) -> Option<PropHackDiff> {
+    let has_numeric_code = world
+        .borrow::<View<PropKeypadCode>>()
+        .is_ok_and(|view| view.get(entity_id).is_ok());
+    if has_numeric_code {
+        return None;
+    }
+    world
+        .borrow::<View<PropHackDiff>>()
+        .ok()
+        .and_then(|view| view.get(entity_id).ok().copied())
 }
 
 fn get_texture_for_char(char: char) -> String {
@@ -50,6 +246,235 @@ fn draw_number(num: u32) -> Vec<GuiComponent<KeyPadMsg>> {
     ret
 }
 
+fn draw_hack_board(state: &HackState, diff: PropHackDiff) -> Vec<GuiComponent<KeyPadMsg>> {
+    let mut components = vec![
+        gui::image("hack.pcx")
+            .with_position(vec2(0.0, 0.0))
+            .with_size(vec2(188.0, 296.0)),
+    ];
+
+    // Connected bars sit behind their lit endpoints, like retail DrawBoard.
+    for y in 0..BOARD_HEIGHT {
+        for x in 0..BOARD_WIDTH {
+            if state.nodes[board_index(x, y)] != HackNode::Lit {
+                continue;
+            }
+            let position = vec2(BOARD_X + x as f32 * BOARD_DX, BOARD_Y + y as f32 * BOARD_DY);
+            if x + 1 < BOARD_WIDTH && state.nodes[board_index(x + 1, y)] == HackNode::Lit {
+                components.push(
+                    gui::image("hrmbarh.pcx")
+                        .with_position(position)
+                        .with_size(vec2(30.0, 16.0)),
+                );
+            }
+            if y + 1 < BOARD_HEIGHT && state.nodes[board_index(x, y + 1)] == HackNode::Lit {
+                components.push(
+                    gui::image("hrmbarv.pcx")
+                        .with_position(position)
+                        .with_size(vec2(16.0, 36.0)),
+                );
+            }
+        }
+    }
+
+    for y in 0..BOARD_HEIGHT {
+        for x in 0..BOARD_WIDTH {
+            let node = state.nodes[board_index(x, y)];
+            if node == HackNode::Empty {
+                continue;
+            }
+            let position = vec2(BOARD_X + x as f32 * BOARD_DX, BOARD_Y + y as f32 * BOARD_DY);
+            let texture = match node {
+                HackNode::Lit => Some("hrmon.pcx"),
+                HackNode::Burned => Some("hrmburn.pcx"),
+                HackNode::Mine => Some("hrmmine.pcx"),
+                HackNode::Free | HackNode::Empty => None,
+            };
+            if let Some(texture) = texture {
+                components.push(
+                    gui::image(texture)
+                        .with_position(position)
+                        .with_size(vec2(16.0, 16.0)),
+                );
+            }
+            // The unlit node outline is already part of HACK.PCX. This
+            // zero-alpha button supplies a normal 16x16 hit target without
+            // painting a placeholder over that authored art.
+            components.push(
+                gui::button(KeyPadMsg::PlayNode { x, y })
+                    .with_position(position)
+                    .with_size(vec2(16.0, 16.0))
+                    .with_image("hrmpip.pcx")
+                    .with_alpha(0.0)
+                    .with_label(&format!("node-{x}-{y}")),
+            );
+        }
+    }
+
+    let result_texture = match state.phase {
+        HackPhase::Won => Some("winh.pcx"),
+        HackPhase::Lost => Some("loseh.pcx"),
+        HackPhase::Unwinnable => Some("failh.pcx"),
+        HackPhase::InsufficientNanites => Some("payh.pcx"),
+        HackPhase::Unpaid | HackPhase::Playing => None,
+    };
+    if let Some(texture) = result_texture {
+        components.push(
+            gui::image(texture)
+                .with_position(vec2(13.0, 42.0))
+                .with_size(vec2(142.0, 134.0)),
+        );
+    }
+
+    // HACK.PCX already supplies the cyan `COST:` label. Retail draws only the
+    // dynamic numeric value in the 48px slot beginning at x=128, after the
+    // result overlay so WINH/LOSEH/PAYH cannot obscure it.
+    components.push(
+        gui::text(&hack_cost(diff).to_string())
+            .with_position(vec2(147.0, 158.0))
+            .with_size(vec2(29.0, 18.0)),
+    );
+
+    if !matches!(state.phase, HackPhase::Won | HackPhase::Lost) {
+        let (normal, hover, label) =
+            if matches!(state.phase, HackPhase::Playing | HackPhase::Unwinnable) {
+                ("reset0.pcx", "reset1.pcx", "reset-hack")
+            } else {
+                ("start0.pcx", "start1.pcx", "start-hack")
+            };
+        components.push(
+            gui::button(KeyPadMsg::StartHack)
+                .with_position(vec2(157.0, 232.0))
+                .with_size(vec2(20.0, 56.0))
+                .with_image(normal)
+                .with_hover(ButtonHoverBehavior::Texture(hover.to_owned()))
+                .with_label(label),
+        );
+    }
+    components
+}
+
+fn handle_hack_msg(
+    entity_id: EntityId,
+    world: &World,
+    state: &KeyPadState,
+    msg: &KeyPadMsg,
+    diff: PropHackDiff,
+) -> (KeyPadState, Effect) {
+    let mut new_state = state.clone();
+    match msg {
+        KeyPadMsg::StartHack
+            if !matches!(new_state.hack.phase, HackPhase::Won | HackPhase::Lost) =>
+        {
+            let cost = hack_cost(diff);
+            let Some(payment) = spend_player_nanites(world, cost) else {
+                new_state.hack.phase = HackPhase::InsufficientNanites;
+                return (
+                    new_state,
+                    Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        name: "login".to_owned(),
+                    },
+                );
+            };
+            let (_, mine_count) = effective_hack_values(world, diff);
+            let mut rng_state = hack_seed(world, entity_id);
+            tracing::debug!(entity = entity_id.inner(), rng_state, "HRM rng seed");
+            let nodes = board_with_mines(mine_count, &mut rng_state);
+            tracing::debug!(
+                entity = entity_id.inner(),
+                rng_state,
+                "HRM rng initialized after mine placement"
+            );
+            new_state.hack = HackState {
+                phase: HackPhase::Playing,
+                nodes,
+                rng_state,
+            };
+            (
+                new_state,
+                Effect::combine(vec![
+                    payment,
+                    Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        name: "start_hack".to_owned(),
+                    },
+                ]),
+            )
+        }
+        KeyPadMsg::PlayNode { x, y }
+            if *x < BOARD_WIDTH
+                && *y < BOARD_HEIGHT
+                && new_state.hack.phase == HackPhase::Playing =>
+        {
+            let index = board_index(*x, *y);
+            let node = new_state.hack.nodes[index];
+            if !matches!(node, HackNode::Free | HackNode::Mine) {
+                return (
+                    new_state,
+                    Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        name: "login".to_owned(),
+                    },
+                );
+            }
+
+            let was_mine = node == HackNode::Mine;
+            let roll = outcome_roll(&mut new_state.hack.rng_state);
+            tracing::debug!(
+                entity = entity_id.inner(),
+                roll,
+                rng_state = new_state.hack.rng_state,
+                "HRM rng outcome"
+            );
+            let (chance, _) = effective_hack_values(world, diff);
+            if roll_succeeds(roll, chance) {
+                new_state.hack.nodes[index] = HackNode::Lit;
+                if has_connected_three(&new_state.hack.nodes) {
+                    new_state.hack.phase = HackPhase::Won;
+                    return (
+                        new_state,
+                        Effect::combine(vec![
+                            send_to_all_switch_links_and_self(
+                                world,
+                                entity_id,
+                                MessagePayload::TurnOn { from: entity_id },
+                            ),
+                            Effect::PlaySound {
+                                handle: AudioHandle::new(),
+                                name: "hack_success".to_owned(),
+                            },
+                        ]),
+                    );
+                }
+            } else if was_mine {
+                new_state.hack.phase = HackPhase::Lost;
+                return (
+                    new_state,
+                    Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        name: "hack_critical".to_owned(),
+                    },
+                );
+            } else {
+                new_state.hack.nodes[index] = HackNode::Burned;
+                if !board_has_potential_path(&new_state.hack.nodes) {
+                    new_state.hack.phase = HackPhase::Unwinnable;
+                }
+            }
+
+            (
+                new_state,
+                Effect::PlaySound {
+                    handle: AudioHandle::new(),
+                    name: "hacking".to_owned(),
+                },
+            )
+        }
+        _ => (new_state, Effect::NoEffect),
+    }
+}
+
 impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
     fn get_components(
         &self,
@@ -58,6 +483,11 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
         _world: &World,
         _state: &KeyPadState,
     ) -> Vec<GuiComponent<KeyPadMsg>> {
+        let hack_diff = hack_diff_for_entity(_world, _entity_id);
+        if let Some(hack_diff) = hack_diff {
+            return draw_hack_board(&_state.hack, hack_diff);
+        }
+
         let button_width = 45.0;
         let button_height = 60.0;
         let left_margin = 15.0;
@@ -182,6 +612,11 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
         state: &KeyPadState,
         msg: &KeyPadMsg,
     ) -> (KeyPadState, crate::Effect) {
+        let hack_diff = hack_diff_for_entity(world, entity_id);
+        if let Some(hack_diff) = hack_diff {
+            return handle_hack_msg(entity_id, world, state, msg, hack_diff);
+        }
+
         let v_prop_keypad_code = world.borrow::<View<PropKeypadCode>>().unwrap();
         let maybe_keypad_code = v_prop_keypad_code.get(entity_id);
 
@@ -206,11 +641,14 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
                 };
                 KeyPadState {
                     current_value: Some(new_value),
+                    ..state.clone()
                 }
             }
             KeyPadMsg::Clear => KeyPadState {
                 current_value: None,
+                ..state.clone()
             },
+            KeyPadMsg::StartHack | KeyPadMsg::PlayNode { .. } => state.clone(),
         };
 
         // Check if the keypad code matches
@@ -241,5 +679,133 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
             new_state,
             Effect::combine(vec![additional_effect, press_effect]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retail_board_has_authored_holes_and_fourteen_playable_nodes() {
+        let board = base_hack_board();
+        assert_eq!(
+            board.iter().filter(|node| **node == HackNode::Free).count(),
+            14
+        );
+        assert_eq!(board[board_index(0, 0)], HackNode::Empty);
+        assert_eq!(board[board_index(3, 1)], HackNode::Empty);
+        assert_eq!(board[board_index(4, 3)], HackNode::Empty);
+    }
+
+    #[test]
+    fn earth_top_row_requires_all_three_connected_nodes() {
+        let mut board = base_hack_board();
+        board[board_index(2, 0)] = HackNode::Lit;
+        board[board_index(3, 0)] = HackNode::Lit;
+        assert!(!has_connected_three(&board));
+
+        board[board_index(4, 0)] = HackNode::Lit;
+        assert!(has_connected_three(&board));
+    }
+
+    #[test]
+    fn connected_three_also_recognizes_vertical_paths() {
+        let mut board = base_hack_board();
+        for y in 1..=3 {
+            board[board_index(0, y)] = HackNode::Lit;
+        }
+        assert!(has_connected_three(&board));
+    }
+
+    #[test]
+    fn seeded_earth_route_uses_three_genuine_success_rolls() {
+        let earth_effective_chance = 55;
+        let mut rng_state = 7;
+        let board = board_with_mines(1, &mut rng_state);
+        let rolls = (0..3)
+            .map(|_| outcome_roll(&mut rng_state))
+            .collect::<Vec<_>>();
+
+        assert!(
+            [(2, 0), (3, 0), (4, 0)]
+                .into_iter()
+                .all(|(x, y)| board[board_index(x, y)] != HackNode::Mine)
+        );
+        assert!(
+            rolls
+                .iter()
+                .all(|roll| roll_succeeds(*roll, earth_effective_chance)),
+            "seeded route should genuinely pass all three 55% rolls: {rolls:?}"
+        );
+    }
+
+    #[test]
+    fn real_interaction_time_changes_board_randomness() {
+        assert_ne!(
+            mix_hack_seed(1_000_000_000, 266),
+            mix_hack_seed(1_016_666_667, 266)
+        );
+    }
+
+    #[test]
+    fn probability_boundaries_have_exact_outcome_counts() {
+        for chance in [0, 55, 85] {
+            assert_eq!(
+                (0..100).filter(|roll| roll_succeeds(*roll, chance)).count(),
+                chance as usize
+            );
+        }
+    }
+
+    #[test]
+    fn board_is_unwinnable_when_free_nodes_remain_but_no_triple_can_survive() {
+        let mut board = base_hack_board();
+        for (x, y) in [(3, 0), (1, 1), (3, 2), (1, 3), (0, 2), (2, 1), (4, 1)] {
+            board[board_index(x, y)] = HackNode::Burned;
+        }
+
+        assert!(board.contains(&HackNode::Free));
+        assert!(!board_has_potential_path(&board));
+    }
+
+    #[test]
+    fn numeric_keypad_code_takes_precedence_over_inherited_hack_diff() {
+        let mut world = World::new();
+        let numeric_with_inherited_hack_diff = world.add_entity((
+            PropKeypadCode(45100),
+            PropHackDiff {
+                success_chance: 50,
+                critical_chance: 2,
+                cost: 3.0,
+            },
+        ));
+        assert!(
+            hack_diff_for_entity(&world, numeric_with_inherited_hack_diff).is_none(),
+            "an authored numeric code must take precedence over inherited HackDiff"
+        );
+    }
+
+    #[test]
+    fn critical_loss_is_terminal_for_the_live_panel_state() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        let state = KeyPadState {
+            hack: HackState {
+                phase: HackPhase::Lost,
+                ..HackState::default()
+            },
+            ..KeyPadState::default()
+        };
+        let diff = PropHackDiff {
+            success_chance: 50,
+            critical_chance: 1,
+            cost: 3.0,
+        };
+
+        let (after, effect) = handle_hack_msg(entity, &world, &state, &KeyPadMsg::StartHack, diff);
+
+        assert_eq!(after.hack.phase, HackPhase::Lost);
+        assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -315,6 +315,75 @@ pub fn player_carried_items(world: &World) -> Vec<EntityId> {
     out
 }
 
+/// Build the effects that pay `amount` nanites from the player's real carried
+/// stacks. Nanites are identified by their inherited inventory icon
+/// (`nan_ic`), not by a mission/runtime id. Returns `None` without side effects
+/// when the carried total is insufficient.
+pub fn spend_player_nanites(world: &World, amount: i32) -> Option<Effect> {
+    if amount <= 0 {
+        return Some(Effect::NoEffect);
+    }
+
+    let icons = world.borrow::<View<dark::properties::PropObjIcon>>().ok()?;
+    let stacks = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()?;
+    let nanite_stacks: Vec<_> = player_carried_items(world)
+        .into_iter()
+        .filter_map(|entity| {
+            let icon = icons.get(entity).ok()?;
+            let stack = stacks.get(entity).ok()?.0;
+            (icon.0.eq_ignore_ascii_case("nan_ic") && stack > 0).then_some((entity, stack))
+        })
+        .collect();
+
+    let debits = plan_stack_payment(
+        &nanite_stacks
+            .iter()
+            .map(|(_, stack)| *stack)
+            .collect::<Vec<_>>(),
+        amount,
+    )?;
+    let mut effects = Vec::new();
+    for ((entity_id, stack), paid) in nanite_stacks.into_iter().zip(debits) {
+        if paid == 0 {
+            continue;
+        }
+        if paid == stack {
+            effects.push(Effect::DestroyEntity { entity_id });
+        } else {
+            effects.push(Effect::AdjustStackCount {
+                entity_id,
+                delta: -paid,
+            });
+        }
+    }
+    Some(Effect::combine(effects))
+}
+
+/// Plan an atomic payment across ordered stacks. Each returned entry is the
+/// amount debited from the corresponding stack.
+fn plan_stack_payment(stacks: &[i32], amount: i32) -> Option<Vec<i32>> {
+    if amount <= 0 {
+        return Some(vec![0; stacks.len()]);
+    }
+    if stacks.iter().copied().sum::<i32>() < amount {
+        return None;
+    }
+
+    let mut remaining = amount;
+    Some(
+        stacks
+            .iter()
+            .map(|stack| {
+                let paid = remaining.min((*stack).max(0));
+                remaining -= paid;
+                paid
+            })
+            .collect(),
+    )
+}
+
 fn collect_contained_items(
     world: &World,
     entity_id: EntityId,
@@ -573,5 +642,25 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
         }
     } else {
         Effect::NoEffect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_stack_payment;
+
+    #[test]
+    fn stack_payment_is_atomic_when_total_is_insufficient() {
+        assert_eq!(plan_stack_payment(&[1, 1], 3), None);
+    }
+
+    #[test]
+    fn stack_payment_consumes_full_stacks_before_partial_stack() {
+        assert_eq!(plan_stack_payment(&[2, 5, 4], 9), Some(vec![2, 5, 2]));
+    }
+
+    #[test]
+    fn stack_payment_ignores_non_positive_entries() {
+        assert_eq!(plan_stack_payment(&[-1, 0, 5], 3), Some(vec![0, 0, 3]));
     }
 }

--- a/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// Honest Earth Technical Training regression for #539. Runtime entity ids are
+// deliberately never hardcoded: the authored mission-object ids below are
+// stable `template_id` values, and the door is additionally verified through
+// the keypad's SwitchLink.
+//
+// Negative-first evidence (2026-07-23): against integration base be38d04 this
+// fails at "hackable keypad should expose the HRM start button". Physical
+// pickup and physical keypad frob both succeed, but /v1/ui reports only the
+// numeric 0-9/clear keypad because P$HackDiff was unparsed.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const EARTH_NANITES = 257;
+const EARTH_HACKABLE_KEYPAD = 266;
+const EARTH_LINKED_DOOR = 265;
+
+test(
+  "Earth hackable keypad: pay nanites, connect three HRM nodes, open linked door",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8155),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    await game.step({ frames: 5 });
+
+    const [nanites] = await game.entities.byTemplate(EARTH_NANITES);
+    const [keypad] = await game.entities.byTemplate(EARTH_HACKABLE_KEYPAD);
+    const [door] = await game.entities.byTemplate(EARTH_LINKED_DOOR);
+    assert.ok(nanites, "Earth should contain authored nanite pile 257");
+    assert.ok(keypad, "Earth should contain authored keypad 266");
+    assert.ok(door, "Earth should contain authored door 265");
+
+    const keypadDetail = await game.entities.detail(keypad.id);
+    assert.ok(
+      keypadDetail.outgoing_links.some(
+        (link) =>
+          link.link_type.toLowerCase().includes("switch") &&
+          link.target_id === door.id,
+      ),
+      "keypad 266 should SwitchLink to door 265",
+    );
+
+    // Acquire the actual training nanites through the rendered world
+    // interaction path (crosshair ray + right-hand squeeze), not debug give.
+    await earthWorldUse(game, nanites);
+    const inventoryBefore = await game.player.inventory();
+    const carriedNanites = inventoryBefore.items.find(
+      (item) => item.name === "Big Nanite Pile",
+    );
+    assert.ok(
+      carriedNanites,
+      `physical pickup should put Big Nanite Pile in the backpack (got ${JSON.stringify(inventoryBefore.items)})`,
+    );
+    const stackBefore = Number(
+      (await game.entities.detail(carriedNanites.entity_id)).properties.find(
+        (property) => property.name === "StackCount",
+      )?.value,
+    );
+    assert.equal(stackBefore, 250, "the physical Earth pile should carry 250 nanites");
+
+    const doorBefore = await game.entities.detail(door.id);
+
+    // Frob through the same rendered-world input path. A direct debug Frob
+    // message would not prove an ordinary player can reach the feature.
+    const [keypadX, keypadY, keypadZ] = keypadDetail.position;
+    await teleportVerified(game, {
+      x: keypadX - 1.63,
+      y: keypadY - 1,
+      z: keypadZ + 3.25,
+    });
+    // Earth spawns facing the opposite body heading from the accepted manual
+    // route; -154.5deg is the same world ray as that route's +25.5deg head
+    // yaw after its 180deg body turn.
+    await game.input.set("head.look", [-154.5, 10]);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+    await game.step({ frames: 5 });
+
+    const opened = (await game.ui.state()).active_panel;
+    assert.ok(opened, "physical keypad frob should open an MFD panel");
+    assert.equal(opened.template_id, EARTH_HACKABLE_KEYPAD);
+    const start = opened.elements.find(
+      (element) =>
+        element.kind === "button" && element.label === "start-hack",
+    );
+    assert.ok(start, "hackable keypad should expose the HRM start button");
+    assert.ok(
+      opened.elements.some(
+        (element) =>
+          element.texture?.toLowerCase() === "hack.pcx",
+      ),
+      "hackable keypad should render the retail HACK backdrop",
+    );
+    const costText = opened.elements
+      .filter((element) => element.kind === "text")
+      .map((element) => element.text ?? "")
+      .find((text) => /^\d+$/.test(text));
+    assert.ok(
+      costText,
+      "HRM panel should draw its authored numeric cost in HACK.PCX's COST slot",
+    );
+    const cost = Number(costText);
+    assert.ok(cost > 0, `authored nanite cost should be positive (got ${costText})`);
+
+    const clickElement = async (element: UiElement) => {
+      const [x, y, width, height] = element.screen_rect;
+      await game.input.set("pointer.position", [
+        x + width / 2,
+        y + height / 2,
+      ]);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+
+    await clickElement(start);
+    const stackAfterPayment = Number(
+      (await game.entities.detail(carriedNanites.entity_id)).properties.find(
+        (property) => property.name === "StackCount",
+      )?.value,
+    );
+    assert.equal(
+      stackAfterPayment,
+      stackBefore - cost,
+      "starting the board should deduct exactly the authored cost",
+    );
+
+    const doorDisplacement = async () => {
+      const current = await game.entities.detail(door.id);
+      return Math.hypot(
+        current.position[0] - doorBefore.position[0],
+        current.position[1] - doorBefore.position[1],
+        current.position[2] - doorBefore.position[2],
+      );
+    };
+    await game.step({ frames: 12 });
+    assert.ok(
+      (await doorDisplacement()) < 0.05,
+      "paying the nanite cost alone must not open the linked door",
+    );
+
+    // The retail hacking layout's top row has three adjacent playable nodes
+    // at x=2,3,4. The player must click all three; merely paying cannot open
+    // the door.
+    const path = ["node-2-0", "node-3-0", "node-4-0"];
+    for (const [index, label] of path.entries()) {
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, `HRM panel should remain open before clicking ${label}`);
+      const node = panel.elements.find(
+        (element) => element.kind === "button" && element.label === label,
+      );
+      assert.ok(node, `HRM board should expose playable ${label}`);
+      await clickElement(node);
+      if (index < path.length - 1) {
+        await game.step({ frames: 12 });
+        assert.ok(
+          (await doorDisplacement()) < 0.05,
+          `door 265 must remain closed after only ${index + 1} connected node(s)`,
+        );
+      }
+    }
+
+    const won = (await game.ui.state()).active_panel;
+    assert.ok(won, "winning should leave the result panel visible");
+    assert.ok(
+      won.elements.some(
+        (element) => element.texture?.toLowerCase() === "winh.pcx",
+      ),
+      `a connected three-node path should render the retail HACK success art; ` +
+        `rng=${game.logs().filter((line) => line.includes("HRM rng")).join(" | ")}`,
+    );
+    assert.ok(
+      won.elements.some(
+        (element) => element.kind === "text" && element.text === costText,
+      ),
+      "the success overlay must not obscure the authored cost value",
+    );
+
+    await game.step({ frames: 120 });
+    const doorMovement = await doorDisplacement();
+    assert.ok(
+      doorMovement > 1,
+      `HRM success should TurnOn linked door 265 (moved ${doorMovement.toFixed(2)}; ` +
+        `before=${doorBefore.position})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #539

## Summary

- parse the retail `P$HackDiff` property and 48-byte HRM tuning parameters
- implement the Earth technical-training HackDiff panel with real nanite payment, randomized mines and outcomes, START/RESET, connected-three victory, terminal critical failure, and authored result art/audio
- activate authored SwitchLinks only after a genuine win while preserving numeric-keypad precedence and legacy MedSci keypad behavior
- add a physical Earth SDK scenario that picks up the authored nanite stack, frobs the panel, pays the real cost, completes each objective, and verifies the linked door stays closed until the third successful node

## Verification

- negative-first replay on the exact base failed before the implementation
- focused HackDiff unit tests: 9 passed
- retail `P$HackDiff` parser and HRM asset tests passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- SDK unit suite: 127 tests, 14 passed / 113 e2e skipped
- Earth physical HackDiff e2e passed twice consecutively
- Earth HackDiff plus legacy MedSci numeric-keypad e2es passed together
- full SDK e2e: 126/127 passed; the sole unrelated alertness-churn timeout passed immediately in isolation, and all 23 mission-load tests passed
- final Codex and independent fallback reviews: clean, with all seven earlier edge-case findings closed
- native Claude review was unavailable: the CLI reported it was not logged in, and the retry hung under the local runtime; the preserved attempts were replaced by the independent fallback review
- final dupfinder audit: no actionable duplication

## Play-through evidence

Captured headlessly through the deterministic fixed-step debug runtime. Both runs use the same normal player path: physically pick up Earth’s authored nanites, physically frob the HackDiff panel, then interact with its rendered controls. No direct entity messages, inventory injection, or forced success are used.

### Looping exact-base → final-fix replay

| Exact base `be38d04` | Final fix |
|:--:|:--:|
| ![Exact-base Earth keypad replay](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/base-539.gif) | ![Final Earth HRM replay](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/fix-539.gif) |
| HackDiff was incorrectly presented as a numeric keypad. | Pay authored cost → light three connected nodes → `SUCCESS` → linked door opens. |

### Before → after

![Exact base numeric keypad beside final HRM board](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/before-after-539.png)

### Rendered objective proof

| Exact-base keypad | Final HRM start board |
|:--:|:--:|
| ![Exact-base numeric keypad](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/base-539.png) | ![Final HRM board with authored cost](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/fix-start-539.png) |

| Genuine connected-three success | Linked Earth door open |
|:--:|:--:|
| ![WINH success with connected top-row path and cost retained](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/fix-539.png) | ![Earth door opened through the keypad SwitchLink](https://gist.githubusercontent.com/tommy-xr/2395a90d43b84b0586442d132662d004/raw/door-open-539.png) |

<sub>Captured via `/v1/step` + `/v1/screenshot` at a fixed 60 Hz simulation timestep. The final RNG-inclusive replay preserves the durable Earth scenario’s exact pre-START frame timing.</sub>

