### PR TITLE
fix: implement replicator nanite economy

### DIFF
--- a/dark/src/properties/prop_replicator.rs
+++ b/dark/src/properties/prop_replicator.rs
@@ -2,14 +2,14 @@ use std::io;
 
 use shipyard::Component;
 
-use crate::ss2_common::{read_string_with_size, read_u32};
+use crate::ss2_common::{read_i32, read_string_with_size};
 use serde::{Deserialize, Serialize};
 
 const NUM_REPLICATOR_ITEMS: usize = 6;
 
 #[derive(Debug, Component, Clone, Deserialize, Serialize)]
 pub struct PropReplicatorContents {
-    pub costs: [u32; NUM_REPLICATOR_ITEMS],
+    pub costs: [i32; NUM_REPLICATOR_ITEMS],
     pub object_names: [String; NUM_REPLICATOR_ITEMS],
 }
 
@@ -25,17 +25,34 @@ impl PropReplicatorContents {
         ];
 
         let costs = [
-            read_u32(reader),
-            read_u32(reader),
-            read_u32(reader),
-            read_u32(reader),
-            read_u32(reader),
-            read_u32(reader),
+            read_i32(reader),
+            read_i32(reader),
+            read_i32(reader),
+            read_i32(reader),
+            read_i32(reader),
+            read_i32(reader),
         ];
 
         PropReplicatorContents {
             costs,
             object_names,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    #[test]
+    fn contents_preserve_signed_authored_costs() {
+        let mut bytes = vec![0; NUM_REPLICATOR_ITEMS * 64];
+        for cost in [-1_i32, 0, 3, 4, 40, i32::MAX] {
+            bytes.write_all(&cost.to_le_bytes()).unwrap();
+        }
+
+        let parsed = PropReplicatorContents::read(&mut Cursor::new(bytes), (6 * 64 + 6 * 4) as u32);
+        assert_eq!(parsed.costs, [-1, 0, 3, 4, 40, i32::MAX]);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     fs::File,
     io::BufReader,
     rc::Rc,
@@ -2443,6 +2443,31 @@ impl MissionCore {
         ret
     }
 
+    /// Canonical destruction cleanup for one runtime entity. Keep interaction
+    /// state and incoming inventory links in sync before the entity id can be
+    /// recycled, then tear down its scripts, physics, render state, and
+    /// attached children through [`Self::remove_entity`].
+    fn destroy_entity(&mut self, entity_id: EntityId) {
+        self.interaction.on_entity_destroyed(entity_id);
+        self.flat_ui.on_entity_destroyed(entity_id);
+        // `PlayerInfo` mirrors the interaction controller each update, but
+        // later effects in this batch may inspect it before then.
+        if let Ok(mut player) = self.world.borrow::<UniqueViewMut<PlayerInfo>>() {
+            if player.left_hand_entity_id == Some(entity_id) {
+                player.left_hand_entity_id = None;
+            }
+            if player.right_hand_entity_id == Some(entity_id) {
+                player.right_hand_entity_id = None;
+            }
+        }
+        // Only a contained item (no world presence, PropHasRefs false) can
+        // leave a dangling inventory `Contains` link behind.
+        if !crate::util::has_refs(&self.world, entity_id) {
+            self.remove_incoming_contains_links(entity_id);
+        }
+        self.remove_entity(entity_id);
+    }
+
     pub fn remove_entity(&mut self, entity_id: EntityId) {
         // Entities riding this one (attached particle trails/FX) die with it -
         // otherwise a projectile's trail would linger at its last transform
@@ -2650,7 +2675,8 @@ impl MissionCore {
             player_info.entity_id
         };
 
-        for effect in effects {
+        let mut effects = VecDeque::from(effects);
+        while let Some(effect) = effects.pop_front() {
             match effect {
                 Effect::AcquireKeyCard { key_card } => {
                     let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
@@ -3490,31 +3516,7 @@ impl MissionCore {
                 }
                 Effect::DestroyEntity { entity_id } => {
                     info!("!!!Destroying entity: {:?}", entity_id);
-                    self.interaction.on_entity_destroyed(entity_id);
-                    self.flat_ui.on_entity_destroyed(entity_id);
-                    // `PlayerInfo` mirrors the interaction controller each
-                    // update, but effects later in this same batch may inspect
-                    // it before then. Clear destroyed hand/wield references
-                    // atomically so no system can observe a live player
-                    // pointing at a dead (or recycled) entity.
-                    if let Ok(mut player) = self.world.borrow::<UniqueViewMut<PlayerInfo>>() {
-                        if player.left_hand_entity_id == Some(entity_id) {
-                            player.left_hand_entity_id = None;
-                        }
-                        if player.right_hand_entity_id == Some(entity_id) {
-                            player.right_hand_entity_id = None;
-                        }
-                    }
-                    // Only a contained item (no world presence, PropHasRefs
-                    // false) can leave a dangling inventory `Contains` link
-                    // behind. World-present entities - FX spangs, projectiles,
-                    // creatures - are never `Contains` targets, so skip the
-                    // full link scan for them (several are destroyed per frame
-                    // in combat).
-                    if !crate::util::has_refs(&self.world, entity_id) {
-                        self.remove_incoming_contains_links(entity_id);
-                    }
-                    self.remove_entity(entity_id);
+                    self.destroy_entity(entity_id);
                 }
                 Effect::ResetGravity { entity_id } => {
                     self.physics.set_gravity(entity_id, 1.0);
@@ -3625,6 +3627,56 @@ impl MissionCore {
                         }
                     } else {
                         warn!("TrainerPurchase dropped: gamesys has no cost tables");
+                    }
+                }
+
+                Effect::ReplicatorPurchase {
+                    cost,
+                    template_name,
+                    position,
+                    orientation,
+                } => {
+                    use crate::scripts::script_util::debit_player_nanites;
+
+                    let template_exists = self
+                        .template_name_to_template_id
+                        .contains_key(&template_name.to_ascii_lowercase());
+                    if cost <= 0 || !template_exists {
+                        info!(
+                            "Replicator purchase refused: invalid request for {} at cost {}",
+                            template_name, cost
+                        );
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "repfail".to_owned(),
+                        });
+                    } else if let Some(exhausted) = debit_player_nanites(&self.world, cost) {
+                        for entity_id in exhausted {
+                            self.destroy_entity(entity_id);
+                        }
+                        let created = self.create_entity_by_template_name(
+                            asset_cache,
+                            &template_name,
+                            position,
+                            orientation,
+                        );
+                        debug_assert!(
+                            created.is_some(),
+                            "prevalidated replicator template disappeared"
+                        );
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "replic2e".to_owned(),
+                        });
+                    } else {
+                        info!(
+                            "Replicator purchase refused: {} costs {} nanites",
+                            template_name, cost
+                        );
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "repfail".to_owned(),
+                        });
                     }
                 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -427,6 +427,18 @@ pub enum Effect {
         target: crate::scripts::gui::TrainerTarget,
     },
 
+    /// Buy one replicator item: atomically revalidate the player's live
+    /// carried nanite stacks, debit `cost`, then create the item at the
+    /// authored output marker. `ReplicatorGui` pre-validates for immediate
+    /// refusal text, but the effect handler is authoritative so two
+    /// same-frame selections cannot both spend the same balance.
+    ReplicatorPurchase {
+        cost: i32,
+        template_name: String,
+        position: Point3<f32>,
+        orientation: Quaternion<f32>,
+    },
+
     /// Acquire an O/S upgrade trait at a trait machine: atomically validate
     /// (machine unused, trait not owned, a free slot), record the trait on the
     /// persistent character sheet, mark the machine used (a quest bit keyed by

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -8,6 +8,7 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::{
     gui::{Gui, GuiComponent, GuiConfig, GuiCursor},
     mission::GlobalEntityMetadata,
+    quest_info::QuestInfo,
     util::{get_position_from_transform, get_rotation_from_transform},
 };
 
@@ -15,14 +16,18 @@ use crate::gui;
 
 use crate::scripts::{Effect, script_util::*};
 
+use super::traits::TRAIT_REPLICATOR_EXPERT;
+
 pub struct ReplicatorGui;
 
 #[derive(Clone, Debug, Default)]
-pub struct ReplicatorState {}
+pub struct ReplicatorState {
+    message: Option<String>,
+}
 
 #[derive(Clone)]
 pub enum ReplicatorMsg {
-    SelectItem(String),
+    SelectItem(usize),
 }
 
 impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
@@ -31,7 +36,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
         _cursor: &Option<GuiCursor>,
         entity_id: EntityId,
         world: &World,
-        _state: &ReplicatorState,
+        state: &ReplicatorState,
     ) -> Vec<GuiComponent<ReplicatorMsg>> {
         let button_height = 60.0;
         let initial_padding_y = 10.0;
@@ -58,26 +63,34 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                 .with_position(vec2(0.0, 0.0))
                 .with_size(vec2(188.0, 296.0)),
         ];
-        for i in 0..6 {
+        for (i, (obj_name, authored_cost)) in replicator_contents
+            .object_names
+            .iter()
+            .zip(replicator_contents.costs)
+            .enumerate()
+        {
             let float_i = i.to_f32().unwrap();
 
-            if replicator_contents.object_names[i].is_empty() {
+            if obj_name.is_empty() || authored_cost <= 0 {
+                continue;
+            }
+            let cost = effective_replicator_cost(world, authored_cost);
+            if cost <= 0 {
                 continue;
             }
 
-            let obj_name = replicator_contents.object_names[i].clone();
-
-            let metadata = entity_metadata.0.get(&obj_name).unwrap();
+            let metadata = entity_metadata.0.get(obj_name).unwrap();
             let obj_icon = metadata.obj_icon.as_ref().unwrap();
 
             components.push(
-                gui::button(ReplicatorMsg::SelectItem(obj_name.clone()))
+                gui::button(ReplicatorMsg::SelectItem(i))
                     .with_position(vec2(
                         0.0,
                         initial_padding_y + (button_height + button_padding) * float_i,
                     ))
                     .with_size(vec2(button_width, button_height))
-                    .with_image("key0.pcx"),
+                    .with_image("key0.pcx")
+                    .with_label(&format!("buy:{obj_name}")),
             );
 
             components.push(replicator_icon(obj_icon, float_i));
@@ -88,21 +101,32 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     button_height / 2.0 + (button_height + button_padding) * float_i,
                 )));
             }
+
+            // Retail draws the three-digit price beneath the item icon.
+            components.push(
+                gui::text(&format!("{cost:03}"))
+                    .with_position(vec2(
+                        19.0,
+                        47.0 + (button_height + button_padding) * float_i,
+                    ))
+                    .with_size(vec2(34.0, 12.0)),
+            );
         }
 
-        // components.push(GuiComponent::Text {
-        //     position: vec2(10.0, 50.0),
-        //     size: vec2(button_width, button_height),
-        //     font: "mainfont.fon".to_owned(),
-        //     text: "10,50".to_owned(),
-        // });
-
-        // components.push(GuiComponent::Text {
-        //     position: vec2(120.0, 250.0),
-        //     size: vec2(button_width, button_height),
-        //     font: "mainfont.fon".to_owned(),
-        //     text: "120,250".to_owned(),
-        // });
+        // REPLIC.PCX supplies "YOUR NANITES:"; retail places a four-digit
+        // live balance at (104, 274) beside it.
+        components.push(
+            gui::text(&format!("{:04}", player_nanite_total(world)))
+                .with_position(vec2(104.0, 274.0))
+                .with_size(vec2(40.0, 14.0)),
+        );
+        if let Some(message) = &state.message {
+            components.push(
+                gui::text(message)
+                    .with_position(vec2(10.0, 248.0))
+                    .with_size(vec2(168.0, 14.0)),
+            );
+        }
 
         components
     }
@@ -114,32 +138,306 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
         }
     }
 
+    fn resets_state_on_frob(&self) -> bool {
+        true
+    }
+
     fn handle_msg(
         &self,
         entity_id: EntityId,
         world: &World,
-        state: &ReplicatorState,
+        _state: &ReplicatorState,
         msg: &ReplicatorMsg,
     ) -> (ReplicatorState, Effect) {
         match msg {
-            ReplicatorMsg::SelectItem(item) => {
-                let maybe_link =
-                    get_first_link_of_type(world, entity_id, dark::properties::Link::Replicator);
-                let link = maybe_link.unwrap();
+            ReplicatorMsg::SelectItem(slot) => {
+                let contents = world
+                    .borrow::<View<PropReplicatorContents>>()
+                    .ok()
+                    .and_then(|view| view.get(entity_id).ok().cloned());
+                let Some(contents) = contents else {
+                    return (
+                        ReplicatorState {
+                            message: Some("Replicator offline".to_owned()),
+                        },
+                        Effect::NoEffect,
+                    );
+                };
+                let Some((item, authored_cost)) = contents
+                    .object_names
+                    .get(*slot)
+                    .zip(contents.costs.get(*slot))
+                    .filter(|(item, cost)| !item.is_empty() && **cost > 0)
+                else {
+                    return (
+                        ReplicatorState {
+                            message: Some("Item unavailable".to_owned()),
+                        },
+                        Effect::NoEffect,
+                    );
+                };
+                let cost = effective_replicator_cost(world, *authored_cost);
+                // Retail treats a post-discount cost of zero as a failed
+                // selection, not a free vend (`ShockReplicate`: cost != 0).
+                if cost <= 0 {
+                    return (
+                        ReplicatorState {
+                            message: Some("Item unavailable".to_owned()),
+                        },
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "repfail".to_owned(),
+                        },
+                    );
+                }
+                if spend_player_nanites(world, cost).is_none() {
+                    return (
+                        ReplicatorState {
+                            message: Some("Insufficient nanites".to_owned()),
+                        },
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "repfail".to_owned(),
+                        },
+                    );
+                }
+                let Some(link) =
+                    get_first_link_of_type(world, entity_id, dark::properties::Link::Replicator)
+                else {
+                    return (
+                        ReplicatorState {
+                            message: Some("Replicator offline".to_owned()),
+                        },
+                        Effect::NoEffect,
+                    );
+                };
 
-                let eff = Effect::CreateEntityByTemplateName {
-                    template_name: item.to_owned(),
+                let purchase = Effect::ReplicatorPurchase {
+                    cost,
+                    template_name: item.clone(),
                     position: get_position_from_transform(world, link, vec3(0.0, 0.0, 0.0)),
                     orientation: get_rotation_from_transform(world, link),
                 };
 
-                let sound_eff = Effect::PlaySound {
-                    handle: AudioHandle::new(),
-                    name: "replic2e".to_owned(),
-                };
-
-                (state.clone(), Effect::combine(vec![eff, sound_eff]))
+                (ReplicatorState { message: None }, purchase)
             }
         }
+    }
+}
+
+/// Retail's Replicator Expert trait applies an integer 20% discount. Resolve
+/// this from the persistent character sheet for both rendering and purchase
+/// handling so the quoted and charged prices cannot diverge.
+fn effective_replicator_cost(world: &World, authored_cost: i32) -> i32 {
+    let has_expert = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|quests| quests.player_stats().has_os_trait(TRAIT_REPLICATOR_EXPERT))
+        .unwrap_or(false);
+    if has_expert {
+        ((i64::from(authored_cost) * 8) / 10) as i32
+    } else {
+        authored_cost
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::PlayerInfo;
+    use crate::runtime_props::RuntimePropTransform;
+    use cgmath::{Matrix4, Quaternion};
+    use dark::properties::{
+        Link, Links, PropObjIcon, PropPosition, PropStackCount, ToLink, WrappedEntityId,
+    };
+
+    fn creates_template(effect: &Effect) -> bool {
+        match effect {
+            Effect::CreateEntityByTemplateName { .. } | Effect::ReplicatorPurchase { .. } => true,
+            Effect::Combined { effects } => effects.iter().any(creates_template),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn unaffordable_or_zero_cost_selection_does_not_create_an_item() {
+        let mut world = World::new();
+        let output = world.add_entity((
+            RuntimePropTransform(Matrix4::from_translation(vec3(1.0, 2.0, 3.0))),
+            PropPosition {
+                position: vec3(1.0, 2.0, 3.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+        ));
+        let replicator = world.add_entity((
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(output)),
+                    link: Link::Replicator,
+                }],
+            },
+            PropReplicatorContents {
+                costs: [3, 0, 0, 0, 0, 0],
+                object_names: [
+                    "Food Snack".to_owned(),
+                    "Free Snack".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+        ));
+
+        let gui = ReplicatorGui;
+        let (_state, effect) = gui.handle_msg(
+            replicator,
+            &world,
+            &ReplicatorState { message: None },
+            &ReplicatorMsg::SelectItem(0),
+        );
+
+        assert!(
+            !creates_template(&effect),
+            "an unaffordable replicator selection must not mint an item: {effect:?}"
+        );
+
+        let (_state, zero_cost_effect) = gui.handle_msg(
+            replicator,
+            &world,
+            &ReplicatorState { message: None },
+            &ReplicatorMsg::SelectItem(1),
+        );
+        assert!(
+            !creates_template(&zero_cost_effect),
+            "a zero-cost replicator slot must not mint a free item: {zero_cost_effect:?}"
+        );
+        assert!(
+            gui.resets_state_on_frob(),
+            "reopening the panel should clear transient refusal text"
+        );
+    }
+
+    #[test]
+    fn affordable_selection_debits_authored_cost_before_creating_item() {
+        let mut world = World::new();
+        let nanites = world.add_entity((
+            PropObjIcon("nan_ic".to_owned()),
+            PropStackCount(10),
+            Links::empty(),
+        ));
+        let inventory = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(nanites)),
+                link: Link::Contains(0),
+            }],
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        let output = world.add_entity((
+            RuntimePropTransform(Matrix4::from_translation(vec3(1.0, 2.0, 3.0))),
+            PropPosition {
+                position: vec3(1.0, 2.0, 3.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+        ));
+        let replicator = world.add_entity((
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(output)),
+                    link: Link::Replicator,
+                }],
+            },
+            PropReplicatorContents {
+                costs: [3, 1, 0, 0, 0, 0],
+                object_names: [
+                    "Food Snack".to_owned(),
+                    "Almost Free Snack".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+        ));
+
+        let (_state, effect) = ReplicatorGui.handle_msg(
+            replicator,
+            &world,
+            &ReplicatorState { message: None },
+            &ReplicatorMsg::SelectItem(0),
+        );
+        assert!(
+            matches!(
+                effect,
+                Effect::ReplicatorPurchase {
+                    cost: 3,
+                    ref template_name,
+                    ..
+                } if template_name == "Food Snack"
+            ),
+            "an affordable click should defer one authoritative purchase: {effect:?}"
+        );
+        assert_eq!(
+            player_nanite_total(&world),
+            10,
+            "GUI pre-validation must not mutate before effect handling"
+        );
+
+        let mut quests = QuestInfo::new();
+        assert!(
+            quests
+                .player_stats_mut()
+                .add_os_trait(TRAIT_REPLICATOR_EXPERT)
+        );
+        world.add_unique(quests);
+        let (_state, discounted_to_zero) = ReplicatorGui.handle_msg(
+            replicator,
+            &world,
+            &ReplicatorState { message: None },
+            &ReplicatorMsg::SelectItem(1),
+        );
+        assert!(
+            !creates_template(&discounted_to_zero),
+            "Replicator Expert must not turn an authored cost of 1 into a free vend"
+        );
+    }
+
+    #[test]
+    fn replicator_expert_applies_retail_integer_discount() {
+        let world = World::new();
+        assert_eq!(effective_replicator_cost(&world, 41), 41);
+
+        let mut quests = QuestInfo::new();
+        assert!(
+            quests
+                .player_stats_mut()
+                .add_os_trait(TRAIT_REPLICATOR_EXPERT)
+        );
+        world.add_unique(quests);
+
+        assert_eq!(effective_replicator_cost(&world, 3), 2);
+        assert_eq!(effective_replicator_cost(&world, 41), 32);
+        assert_eq!(
+            effective_replicator_cost(&world, 1),
+            0,
+            "the caller must refuse this retail zero-cost result rather than vend for free"
+        );
+        assert_eq!(
+            effective_replicator_cost(&world, i32::MAX),
+            1_717_986_917,
+            "the retail integer discount must not saturate before division"
+        );
     }
 }

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -11,9 +11,9 @@
 //! flag is a quest bit keyed by the machine's stable mission object id (also
 //! `QuestInfo`, so it survives save/load and deck re-entry), and
 //! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
-//! implemented for the subset with existing consumers (Tank, Naturally Able -
-//! see [`live_effect_note`]); everything else is storage-only for now, listed
-//! per-trait in the PR.
+//! implemented for the subset with existing consumers (Tank, Naturally Able,
+//! Replicator Expert - see [`live_effect_note`]); everything else is
+//! storage-only for now, listed per-trait in the PR.
 
 use cgmath::{Vector2, Vector3, vec2};
 use engine::assets::asset_cache::AssetCache;
@@ -50,6 +50,7 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 /// Retail trait ids with live gameplay effects here (see the effect handler).
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
 pub const TRAIT_TANK: u8 = 8;
+pub const TRAIT_REPLICATOR_EXPERT: u8 = 13;
 
 /// Tank: "+5 maximum hit points" (TRAITS.STR Trait8). The original raises the
 /// ceiling AND current HP by the bonus on purchase (buying at 25/30 yields
@@ -391,6 +392,7 @@ pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        TRAIT_REPLICATOR_EXPERT => Some("20% replicator discount"),
         _ => None,
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -14,7 +14,7 @@ use dark::{
     ss2_entity_info::SystemShock2EntityInfo,
 };
 use engine::audio::AudioHandle;
-use shipyard::{Component, EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
+use shipyard::{Component, EntityId, Get, IntoIter, IntoWithId, UniqueView, View, ViewMut, World};
 use std::collections::HashMap;
 
 use super::{Effect, Message, MessagePayload};
@@ -324,26 +324,7 @@ pub fn spend_player_nanites(world: &World, amount: i32) -> Option<Effect> {
         return Some(Effect::NoEffect);
     }
 
-    let icons = world.borrow::<View<dark::properties::PropObjIcon>>().ok()?;
-    let stacks = world
-        .borrow::<View<dark::properties::PropStackCount>>()
-        .ok()?;
-    let nanite_stacks: Vec<_> = player_carried_items(world)
-        .into_iter()
-        .filter_map(|entity| {
-            let icon = icons.get(entity).ok()?;
-            let stack = stacks.get(entity).ok()?.0;
-            (icon.0.eq_ignore_ascii_case("nan_ic") && stack > 0).then_some((entity, stack))
-        })
-        .collect();
-
-    let debits = plan_stack_payment(
-        &nanite_stacks
-            .iter()
-            .map(|(_, stack)| *stack)
-            .collect::<Vec<_>>(),
-        amount,
-    )?;
+    let (nanite_stacks, debits) = player_nanite_payment_plan(world, amount)?;
     let mut effects = Vec::new();
     for ((entity_id, stack), paid) in nanite_stacks.into_iter().zip(debits) {
         if paid == 0 {
@@ -361,13 +342,96 @@ pub fn spend_player_nanites(world: &World, amount: i32) -> Option<Effect> {
     Some(Effect::combine(effects))
 }
 
+/// Atomically debit the player's live carried nanite stacks. Returns the
+/// entities whose stack count reached zero so the mission can remove their
+/// runtime state before vending an item. A stale or insufficient plan leaves
+/// every stack unchanged.
+pub fn debit_player_nanites(world: &World, amount: i32) -> Option<Vec<EntityId>> {
+    if amount <= 0 {
+        return None;
+    }
+
+    let (nanite_stacks, debits) = player_nanite_payment_plan(world, amount)?;
+    let mut stacks = world
+        .borrow::<ViewMut<dark::properties::PropStackCount>>()
+        .ok()?;
+
+    // Validate every live stack before applying any mutation.
+    for ((entity_id, _), paid) in nanite_stacks.iter().zip(&debits) {
+        if *paid > 0 && stacks.get(*entity_id).ok()?.0 < *paid {
+            return None;
+        }
+    }
+
+    let mut exhausted = Vec::new();
+    for ((entity_id, _), paid) in nanite_stacks.into_iter().zip(debits) {
+        if paid == 0 {
+            continue;
+        }
+        let stack = (&mut stacks).get(entity_id).ok()?;
+        stack.0 -= paid;
+        if stack.0 == 0 {
+            exhausted.push(entity_id);
+        }
+    }
+    Some(exhausted)
+}
+
+/// The player's spendable nanite balance across all real carried stacks.
+/// Uses the same identification and traversal as [`spend_player_nanites`], so
+/// the UI balance and the debit path cannot disagree.
+pub fn player_nanite_total(world: &World) -> i32 {
+    player_nanite_stacks(world)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(_, stack)| stack)
+        .fold(0, i32::saturating_add)
+}
+
+fn player_nanite_payment_plan(
+    world: &World,
+    amount: i32,
+) -> Option<(Vec<(EntityId, i32)>, Vec<i32>)> {
+    let nanite_stacks = player_nanite_stacks(world)?;
+    let debits = plan_stack_payment(
+        &nanite_stacks
+            .iter()
+            .map(|(_, stack)| *stack)
+            .collect::<Vec<_>>(),
+        amount,
+    )?;
+    Some((nanite_stacks, debits))
+}
+
+fn player_nanite_stacks(world: &World) -> Option<Vec<(EntityId, i32)>> {
+    let icons = world.borrow::<View<dark::properties::PropObjIcon>>().ok()?;
+    let stacks = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()?;
+    Some(
+        player_carried_items(world)
+            .into_iter()
+            .filter_map(|entity| {
+                let icon = icons.get(entity).ok()?;
+                let stack = stacks.get(entity).ok()?.0;
+                (icon.0.eq_ignore_ascii_case("nan_ic") && stack > 0).then_some((entity, stack))
+            })
+            .collect(),
+    )
+}
+
 /// Plan an atomic payment across ordered stacks. Each returned entry is the
 /// amount debited from the corresponding stack.
 fn plan_stack_payment(stacks: &[i32], amount: i32) -> Option<Vec<i32>> {
     if amount <= 0 {
         return Some(vec![0; stacks.len()]);
     }
-    if stacks.iter().copied().sum::<i32>() < amount {
+    let total = stacks
+        .iter()
+        .copied()
+        .filter(|stack| *stack > 0)
+        .fold(0, i32::saturating_add);
+    if total < amount {
         return None;
     }
 
@@ -647,7 +711,11 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 
 #[cfg(test)]
 mod tests {
-    use super::plan_stack_payment;
+    use super::{debit_player_nanites, plan_stack_payment};
+    use crate::mission::PlayerInfo;
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Link, Links, PropObjIcon, PropStackCount, ToLink, WrappedEntityId};
+    use shipyard::{Get, View, World};
 
     #[test]
     fn stack_payment_is_atomic_when_total_is_insufficient() {
@@ -662,5 +730,52 @@ mod tests {
     #[test]
     fn stack_payment_ignores_non_positive_entries() {
         assert_eq!(plan_stack_payment(&[-1, 0, 5], 3), Some(vec![0, 0, 3]));
+    }
+
+    #[test]
+    fn live_nanite_debit_crosses_stacks_and_refuses_a_second_stale_purchase() {
+        let mut world = World::new();
+        let first = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(2)));
+        let second = world.add_entity((PropObjIcon("nan_ic".to_owned()), PropStackCount(3)));
+        let inventory = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(first)),
+                    link: Link::Contains(0),
+                },
+                ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(second)),
+                    link: Link::Contains(0),
+                },
+            ],
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        assert_eq!(debit_player_nanites(&world, 3), Some(vec![first]));
+        assert_eq!(
+            debit_player_nanites(&world, 3),
+            None,
+            "a second same-tick purchase must revalidate the mutated balance"
+        );
+
+        let stacks = world.borrow::<View<PropStackCount>>().unwrap();
+        assert_eq!(stacks.get(first).unwrap().0, 0);
+        assert_eq!(stacks.get(second).unwrap().0, 2);
+        drop(stacks);
+        assert_eq!(
+            debit_player_nanites(&world, 0),
+            None,
+            "the authoritative debit path must reject a free purchase"
+        );
     }
 }

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement } from "../src/types.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// Honest Earth Technical Training regression for #543. Runtime entity ids are
+// rediscovered every launch; the positive ids are stable authored mission
+// objects. Setup uses teleport only to stage the camera, while pickup, frob,
+// row selection, output collection, and all resulting state changes flow
+// through ordinary rendered-world/player input.
+//
+// Negative-first evidence (2026-07-23): against 89ed730, the physical frob
+// opens the replicator and a Chips click creates collectible template -92, but
+// the panel exposes neither authored prices nor the carried balance and the
+// both real StackCount entities remain unchanged at 250 + 20.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const EARTH_NANITES = 257;
+const EARTH_NANITE_REWARD = 542;
+const EARTH_REPLICATOR = 262;
+const EARTH_REPLICATOR_OUTPUT = 284;
+const CHIPS_TEMPLATE = -92;
+
+async function clickElement(game: GameServer, element: UiElement) {
+  const [x, y, width, height] = element.screen_rect;
+  await game.input.set("pointer.position", [
+    x + width / 2,
+    y + height / 2,
+  ]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+async function carriedNaniteTotal(game: GameServer): Promise<number> {
+  const inventory = await game.player.inventory();
+  let total = 0;
+  for (const item of inventory.items) {
+    if (!item.name?.toLowerCase().includes("nanite")) continue;
+    const detail = await game.entities.detail(item.entity_id);
+    const stack = detail.properties.find(
+      (property) => property.name === "StackCount",
+    );
+    assert.ok(stack, `carried nanite entity ${item.entity_id} needs StackCount`);
+    total += Number(stack.value);
+  }
+  return total;
+}
+
+async function physicallyOpenReplicator(
+  game: GameServer,
+  replicator: EntitySummary,
+) {
+  const [x, _y, z] = (await game.entities.detail(replicator.id)).position;
+  // This is the same clear standing point used by the accepted Technical
+  // play-through. The fresh Earth body heading makes negative yaw face the
+  // machine; a modest upward pitch hits its green interaction screen.
+  await teleportVerified(game, { x: x - 1.59, y: 21.404, z: z - 2.23 });
+  await game.input.set("head.look", [-35.3, -22]);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 5 });
+}
+
+test(
+  "Earth replicator charges authored prices and refuses unaffordable output",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8156),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    await game.step({ frames: 5 });
+
+    const [nanites] = await game.entities.byTemplate(EARTH_NANITES);
+    const [naniteReward] = await game.entities.byTemplate(EARTH_NANITE_REWARD);
+    const [replicator] = await game.entities.byTemplate(EARTH_REPLICATOR);
+    const [output] = await game.entities.byTemplate(EARTH_REPLICATOR_OUTPUT);
+    assert.ok(nanites, "Earth should contain authored nanite pile 257");
+    assert.ok(naniteReward, "Earth should contain authored nanite reward 542");
+    assert.ok(replicator, "Earth should contain authored replicator 262");
+    assert.ok(output, "Earth should contain authored replicator output 284");
+
+    await earthWorldUse(game, nanites);
+    await earthWorldUse(game, naniteReward);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      270,
+      "physical pickup should carry both authored 250 + 20 nanite stacks",
+    );
+
+    await physicallyOpenReplicator(game, replicator);
+    const opened = (await game.ui.state()).active_panel;
+    assert.ok(opened, "physical replicator frob should open an MFD panel");
+    assert.equal(opened.template_id, EARTH_REPLICATOR);
+
+    const chipsButton = opened.elements.find(
+      (element) =>
+        element.kind === "button" && element.label === "buy:chips",
+    );
+    const juiceButton = opened.elements.find(
+      (element) =>
+        element.kind === "button" && element.label === "buy:juice bottle",
+    );
+    const clipButton = opened.elements.find(
+      (element) =>
+        element.kind === "button" &&
+        element.label === "buy:small standard clip",
+    );
+    assert.ok(chipsButton, "replicator should expose the authored Chips row");
+    assert.ok(juiceButton, "replicator should expose the authored Juice row");
+    assert.ok(clipButton, "replicator should expose the authored Standard Clip row");
+
+    const text = opened.elements
+      .filter((element) => element.kind === "text")
+      .map((element) => element.text ?? "");
+    for (const expected of ["003", "004", "040", "0270"]) {
+      assert.ok(
+        text.includes(expected),
+        `replicator should visibly render ${expected}; got ${JSON.stringify(text)}`,
+      );
+    }
+
+    const chipsBefore = new Set(
+      (await game.entities.byTemplate(CHIPS_TEMPLATE)).map((entity) => entity.id),
+    );
+    await clickElement(game, chipsButton);
+    await game.step({ frames: 20 });
+    assert.equal(
+      await carriedNaniteTotal(game),
+      267,
+      "selecting Chips should deduct its authored 3-nanite price",
+    );
+    const afterChipsText = (await game.ui.state()).active_panel?.elements
+      .filter((element) => element.kind === "text")
+      .map((element) => element.text ?? "");
+    assert.ok(
+      afterChipsText?.includes("0267"),
+      `the visible balance should update after payment; got ${JSON.stringify(afterChipsText)}`,
+    );
+
+    const dispensedChips = (await game.entities.byTemplate(CHIPS_TEMPLATE)).find(
+      (entity) => !chipsBefore.has(entity.id),
+    );
+    assert.ok(dispensedChips, "successful payment should create Chips");
+    const outputPosition = (await game.entities.detail(output.id)).position;
+    const chipsPosition = (await game.entities.detail(dispensedChips.id)).position;
+    assert.ok(
+      Math.hypot(
+        chipsPosition[0] - outputPosition[0],
+        chipsPosition[1] - outputPosition[1],
+        chipsPosition[2] - outputPosition[2],
+      ) < 2,
+      "the purchase should appear at authored output marker 284",
+    );
+
+    const close = (await game.ui.state()).active_panel?.elements.find(
+      (element) => element.label === "close",
+    );
+    assert.ok(close, "replicator panel should expose the ordinary close control");
+    await clickElement(game, close);
+    await earthWorldUse(game, dispensedChips);
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === dispensedChips.id,
+      ),
+      "the physically dispensed Chips should be collectible normally",
+    );
+
+    await physicallyOpenReplicator(game, replicator);
+    // Spend through both carried StackCounts. After Chips, 267 - 6*40 - 2*4
+    // leaves 19; the second Juice crosses the remaining balance of the first
+    // stack, so exact payment must remove that exhausted entity and continue
+    // into the other real stack.
+    for (let purchase = 0; purchase < 6; purchase++) {
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, `panel should remain open before clip purchase ${purchase + 1}`);
+      const clip = panel.elements.find(
+        (element) => element.label === "buy:small standard clip",
+      );
+      assert.ok(clip, "Standard Clip row should remain available");
+      await clickElement(game, clip);
+    }
+    for (let purchase = 0; purchase < 2; purchase++) {
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, `panel should remain open before Juice purchase ${purchase + 1}`);
+      const juice = panel.elements.find(
+        (element) => element.label === "buy:juice bottle",
+      );
+      assert.ok(juice, "Juice row should remain available");
+      await clickElement(game, juice);
+    }
+    assert.equal(
+      await carriedNaniteTotal(game),
+      19,
+      "successful purchases should each deduct exactly their authored price",
+    );
+    const inventoryAfterCrossStackPayment = await game.player.inventory();
+    const remainingNanites = inventoryAfterCrossStackPayment.items.filter(
+      (item) => item.name?.toLowerCase().includes("nanite"),
+    );
+    assert.equal(
+      remainingNanites.length,
+      1,
+      "cross-stack payment should remove the exhausted nanite entity",
+    );
+    const remainingStack = (
+      await game.entities.detail(remainingNanites[0].entity_id)
+    ).properties.find((property) => property.name === "StackCount");
+    assert.equal(
+      Number(remainingStack?.value),
+      19,
+      "cross-stack payment should leave the exact remainder on the live stack",
+    );
+    assert.equal(
+      inventoryAfterCrossStackPayment.count,
+      2,
+      "destroyed stack cleanup must remove its Contains link before a dispensed entity can recycle the id",
+    );
+    assert.deepEqual(
+      new Set(
+        inventoryAfterCrossStackPayment.items.map((item) => item.entity_id),
+      ),
+      new Set([dispensedChips.id, remainingNanites[0].entity_id]),
+      "only the physically collected Chips and live nanite remainder should be carried",
+    );
+
+    const clipsBeforeRefusal = await game.entities.list({
+      filter: "*Standard Clip*",
+      limit: 100,
+    });
+    const refusalPanel = (await game.ui.state()).active_panel;
+    assert.ok(refusalPanel, "panel should remain open before refused purchase");
+    const unaffordableClip = refusalPanel.elements.find(
+      (element) => element.label === "buy:small standard clip",
+    );
+    assert.ok(unaffordableClip, "unaffordable row should remain inspectable");
+    await clickElement(game, unaffordableClip);
+    await game.step({ frames: 20 });
+
+    assert.equal(
+      await carriedNaniteTotal(game),
+      19,
+      "an unaffordable selection must not debit any partial payment",
+    );
+    const clipsAfterRefusal = await game.entities.list({
+      filter: "*Standard Clip*",
+      limit: 100,
+    });
+    assert.equal(
+      clipsAfterRefusal.entities.length,
+      clipsBeforeRefusal.entities.length,
+      "an unaffordable selection must not mint a free output item",
+    );
+    const refused = (await game.ui.state()).active_panel;
+    assert.ok(
+      refused?.elements.some(
+        (element) =>
+          element.kind === "text" &&
+          element.text === "Insufficient nanites",
+      ),
+      "the visible panel should explain the refusal",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #543

## What changed

- preserve the six authored replicator prices as signed values and render the retail three-digit price/balance fields
- quote Replicator Expert's 20% discount through one shared pricing path
- vend through a single authoritative `ReplicatorPurchase` effect that revalidates the template and atomically debits live nanite stacks before creating output
- debit exact totals across multiple stacks, destroy exhausted stacks through the canonical entity-removal path, and refuse zero/negative, invalid, or unaffordable purchases
- resolve the selected slot against current replicator contents at click time, leaving a stable seam for hacked inventory work
- add a physical Earth mission scenario covering pickup, UI pricing, purchase, spawned output collection, cross-stack depletion, exhausted-stack cleanup, and refusal

## Validation

- `cargo test -p dark properties::prop_replicator::tests::contents_preserve_signed_authored_costs -- --nocapture`
- `cargo test -p shock2vr scripts::gui::replicator::tests -- --nocapture`
- `cargo test -p shock2vr scripts::script_util::tests::live_nanite_debit_crosses_stacks_and_refuses_a_second_stale_purchase -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test` — 14 passed, 114 skipped
- focused Earth economy E2E twice — passed; the new scenario also passed in the full E2E
- full SDK E2E — 127/128 passed in 43m46s; every mission load passed. The sole failure was the unrelated `alertness-churn.e2e` (#481), which then passed isolated on both the exact stacked base (103s) and this head (79s) under the same environment, classifying it as nondeterministic AI-route flakiness
- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub CI — build, macOS, Ubuntu, and Windows all passed

## Review

- negative-first regression proved the base minted an unaffordable item
- independent fallback review and Codex review: clean, no actionable findings
- native Claude review was attempted with Node 22 but timed out without output; this is recorded rather than treated as a successful review
- duplicate prevention lookup found and reused the existing nanite/inventory helpers; the final exact seven-file embedding review had no actionable duplication (the optional jscpd token-clone pass was unavailable and is recorded as skipped)

## Visual evidence

Deterministic exact-source before/after capture is embedded below (authored `003/004/040`, balance `0250` to `0247`, physical Chips output). The version-pinned media was byte-verified after upload and an independent visual review found no actionable issues.

![Replicator economy demo](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/replicator-economy-543.gif)

<sub>Fresh Earth Technical Training: physically collect the authored 250-nanite stack, frob RepBase, inspect authored prices <code>003 / 004 / 040</code>, then buy Chips through the atomic purchase path (<code>0250 → 0247</code>). Captured headlessly through deterministic fixed-timestep input and screenshots.</sub>

### Before → after

![Exact base versus final replicator economy](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/before-after-543.png)

### Atomic purchase → physical output

![Atomic nanite debit and physical Chips output](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/purchase-output-543.png)

<details>
<summary>Individual full-resolution audited stills</summary>

- [Exact base panel](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/base-543.png)
- [Final panel before purchase](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/final-before-543.png)
- [Final panel after purchase](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/final-after-543.png)
- [Targeted physical Chips output](https://gist.githubusercontent.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd/raw/71546a330645c9d3bc0ba190032d1c755fd711b8/final-output-543.png)
- [Complete media gist](https://gist.github.com/tommy-xr/2acdaf2c704d75111eb196e19d9fcfcd)

</details>
