### PR TITLE
fix: implement real replicator hacking and hacked inventory

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -21,6 +21,7 @@ mod prop_hack_diff;
 mod prop_hit_points;
 mod prop_key;
 mod prop_log;
+mod prop_obj_state;
 mod prop_particles;
 mod prop_phys_attr;
 mod prop_phys_initial_velocity;
@@ -59,6 +60,7 @@ pub use prop_hack_diff::*;
 pub use prop_hit_points::*;
 pub use prop_key::*;
 pub use prop_log::*;
+pub use prop_obj_state::*;
 pub use prop_particles::*;
 pub use prop_phys_attr::*;
 pub use prop_phys_initial_velocity::*;
@@ -1375,6 +1377,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$ObjState",
+            PropObjState::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$ObjShort",
             read_variable_length_string,
             PropObjShortName,
@@ -1566,6 +1574,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$RepConten",
             PropReplicatorContents::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RepHacked",
+            PropReplicatorHackedContents::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_obj_state.rs
+++ b/dark/src/properties/prop_obj_state.rs
@@ -1,0 +1,84 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::read_i32;
+
+/// Persistent Dark object state (`P$ObjState` / `eObjState`).
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ObjectState {
+    #[default]
+    Normal,
+    Broken,
+    Destroyed,
+    Unresearched,
+    Locked,
+    Hacked,
+    /// Preserve an unfamiliar retail/mod value instead of losing it on save.
+    Unknown(i32),
+}
+
+impl ObjectState {
+    pub fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::Normal,
+            1 => Self::Broken,
+            2 => Self::Destroyed,
+            3 => Self::Unresearched,
+            4 => Self::Locked,
+            5 => Self::Hacked,
+            value => Self::Unknown(value),
+        }
+    }
+
+    pub fn raw(self) -> i32 {
+        match self {
+            Self::Normal => 0,
+            Self::Broken => 1,
+            Self::Destroyed => 2,
+            Self::Unresearched => 3,
+            Self::Locked => 4,
+            Self::Hacked => 5,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropObjState(pub ObjectState);
+
+impl PropObjState {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 4, "P$ObjState must contain one signed 32-bit state");
+        Self(ObjectState::from_raw(read_i32(reader)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn reads_all_retail_states_and_preserves_unknown_values() {
+        for raw in 0_i32..=5 {
+            let state = PropObjState::read(&mut Cursor::new(raw.to_le_bytes()), 4);
+            assert_eq!(state.0.raw(), raw);
+        }
+        let unknown = PropObjState::read(&mut Cursor::new(17_i32.to_le_bytes()), 4);
+        assert_eq!(unknown, PropObjState(ObjectState::Unknown(17)));
+    }
+
+    #[test]
+    fn broken_and_hacked_round_trip_through_save_json() {
+        for state in [ObjectState::Broken, ObjectState::Hacked] {
+            let json = serde_json::to_value(PropObjState(state)).unwrap();
+            assert_eq!(
+                serde_json::from_value::<PropObjState>(json).unwrap(),
+                PropObjState(state)
+            );
+        }
+    }
+}

--- a/dark/src/properties/prop_replicator.rs
+++ b/dark/src/properties/prop_replicator.rs
@@ -13,29 +13,56 @@ pub struct PropReplicatorContents {
     pub object_names: [String; NUM_REPLICATOR_ITEMS],
 }
 
+#[derive(Debug, Component, Clone, Deserialize, Serialize)]
+pub struct PropReplicatorHackedContents {
+    pub costs: [i32; NUM_REPLICATOR_ITEMS],
+    pub object_names: [String; NUM_REPLICATOR_ITEMS],
+}
+
+fn read_contents<T: io::Seek + io::Read>(
+    reader: &mut T,
+    len: u32,
+) -> ([String; NUM_REPLICATOR_ITEMS], [i32; NUM_REPLICATOR_ITEMS]) {
+    assert_eq!(
+        len,
+        (NUM_REPLICATOR_ITEMS * 64 + NUM_REPLICATOR_ITEMS * 4) as u32,
+        "replicator contents must be one retail sRepContents record"
+    );
+    let object_names = [
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+        read_string_with_size(reader, 64).to_ascii_lowercase(),
+    ];
+    let costs = [
+        read_i32(reader),
+        read_i32(reader),
+        read_i32(reader),
+        read_i32(reader),
+        read_i32(reader),
+        read_i32(reader),
+    ];
+    (object_names, costs)
+}
+
 impl PropReplicatorContents {
-    pub fn read<T: io::Seek + io::Read>(reader: &mut T, _len: u32) -> PropReplicatorContents {
-        let object_names = [
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-            read_string_with_size(reader, 64).to_ascii_lowercase(),
-        ];
-
-        let costs = [
-            read_i32(reader),
-            read_i32(reader),
-            read_i32(reader),
-            read_i32(reader),
-            read_i32(reader),
-            read_i32(reader),
-        ];
-
-        PropReplicatorContents {
-            costs,
+    pub fn read<T: io::Seek + io::Read>(reader: &mut T, len: u32) -> Self {
+        let (object_names, costs) = read_contents(reader, len);
+        Self {
             object_names,
+            costs,
+        }
+    }
+}
+
+impl PropReplicatorHackedContents {
+    pub fn read<T: io::Seek + io::Read>(reader: &mut T, len: u32) -> Self {
+        let (object_names, costs) = read_contents(reader, len);
+        Self {
+            object_names,
+            costs,
         }
     }
 }
@@ -52,7 +79,13 @@ mod tests {
             bytes.write_all(&cost.to_le_bytes()).unwrap();
         }
 
-        let parsed = PropReplicatorContents::read(&mut Cursor::new(bytes), (6 * 64 + 6 * 4) as u32);
+        let parsed =
+            PropReplicatorContents::read(&mut Cursor::new(bytes.clone()), (6 * 64 + 6 * 4) as u32);
         assert_eq!(parsed.costs, [-1, 0, 3, 4, 40, i32::MAX]);
+
+        let hacked =
+            PropReplicatorHackedContents::read(&mut Cursor::new(bytes), (6 * 64 + 6 * 4) as u32);
+        assert_eq!(hacked.costs, parsed.costs);
+        assert_eq!(hacked.object_names, parsed.object_names);
     }
 }

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -37,6 +37,9 @@ pub struct GuiPropProxyEntity {
     entity_id: EntityId,
 }
 
+#[derive(Component, Clone, Copy)]
+pub struct GuiPropProxySize(pub Vector2<f32>);
+
 impl GuiManager {
     pub fn new() -> GuiManager {
         GuiManager {
@@ -64,6 +67,7 @@ impl GuiManager {
                 GuiPropProxyEntity {
                     entity_id: parent_entity,
                 },
+                GuiPropProxySize(world_size),
                 RuntimePropDoNotSerialize,
             ));
             self.entity_id_to_proxy_entity_id.insert(parent_entity, ent);
@@ -83,7 +87,7 @@ impl GuiManager {
             );
             id_to_physics.insert(ent, physics_handle);
 
-            let script = Box::new(ProxyGuiScript::new(world_size, parent_entity));
+            let script = Box::new(ProxyGuiScript::new(parent_entity));
             scripts.add_entity2(ent, script);
 
             e.insert(GuiInstanceInfo {
@@ -97,6 +101,15 @@ impl GuiManager {
         } else {
             let instance: &mut GuiInstanceInfo = self.handle_to_instance.get_mut(&handle).unwrap();
             instance.components = components;
+            if instance.world_size != world_size {
+                instance.world_size = world_size;
+                world.add_component(instance.proxy_entity, GuiPropProxySize(world_size));
+                physics.resize_kinematic_cuboid(
+                    instance.physics_handle,
+                    instance.proxy_entity,
+                    vec3(world_size.x, world_size.y, 0.0),
+                );
+            }
             let pos = get_position_from_transform(world, parent_entity, offset);
             let facing = get_rotation_from_transform(world, parent_entity);
             physics.set_position_rotation(instance.physics_handle, pos.to_vec(), facing)
@@ -139,5 +152,63 @@ impl GuiManager {
             //ret.push(gui_obj);
         }
         ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Matrix4, vec2, vec3};
+    use shipyard::Get;
+
+    use super::*;
+
+    #[test]
+    fn live_panel_resize_updates_render_input_and_collider_geometry() {
+        let mut world = World::new();
+        let parent = world.add_entity((RuntimePropTransform(Matrix4::from_scale(1.0)),));
+        let mut physics = PhysicsWorld::new();
+        let mut scripts = ScriptWorld::new();
+        let mut id_to_physics = HashMap::new();
+        let mut manager = GuiManager::new();
+        let handle = GuiHandle::new();
+
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            handle,
+            parent,
+            vec2(261.0, 296.0),
+            vec3(0.0, 0.0, -1.0),
+            Vec::new(),
+        );
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            handle,
+            parent,
+            vec2(188.0, 296.0),
+            vec3(0.0, 0.0, -1.0),
+            Vec::new(),
+        );
+
+        let instance = manager.handle_to_instance.get(&handle).unwrap();
+        assert_eq!(instance.world_size, vec2(188.0, 296.0));
+        assert_eq!(
+            world
+                .borrow::<View<GuiPropProxySize>>()
+                .unwrap()
+                .get(instance.proxy_entity)
+                .unwrap()
+                .0,
+            vec2(188.0, 296.0)
+        );
+        assert_eq!(
+            physics.cuboid_full_size(instance.physics_handle),
+            Some(vec3(188.0, 296.0, 0.01))
+        );
     }
 }

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -56,7 +56,7 @@ where
         _physics: &PhysicsWorld,
         _time: &Time,
     ) -> Effect {
-        let config = self.gui.get_config();
+        let config = self.gui.get_config_for(entity_id, world, &self.state);
         let mut components = {
             let cursor = &self.last_cursor;
             self.gui
@@ -108,9 +108,7 @@ where
                 if !self.gui.opens_on_frob(entity_id, world) {
                     return frob_effect;
                 }
-                if self.gui.resets_state_on_frob() {
-                    self.state = TState::default();
-                }
+                self.gui.prepare_state_on_frob(&mut self.state);
                 Effect::combine(vec![Effect::OpenPanel { entity: entity_id }, frob_effect])
             }
             MessagePayload::GUIHover {
@@ -120,7 +118,7 @@ where
                 is_grabbing,
                 hand,
             } => {
-                let config = self.gui.get_config();
+                let config = self.gui.get_config_for(entity_id, world, &self.state);
                 let cursor = point2(
                     screen_coordinates.x * config.screen_size_in_pixels.x,
                     screen_coordinates.y * config.screen_size_in_pixels.y,

--- a/shock2vr/src/gui/mod.rs
+++ b/shock2vr/src/gui/mod.rs
@@ -51,6 +51,13 @@ where
 
     fn get_config(&self) -> GuiConfig;
 
+    /// State-aware panel geometry. Most panels are fixed-size and use
+    /// `get_config`; overlays with a companion plug (the retail replicator
+    /// PLUGHACK sidecar) can widen only while that companion is present.
+    fn get_config_for(&self, _entity_id: EntityId, _world: &World, _state: &TState) -> GuiConfig {
+        self.get_config()
+    }
+
     fn handle_msg(
         &self,
         entity_id: EntityId,
@@ -83,5 +90,14 @@ where
     /// starts back at the top instead of the last scroll position.
     fn resets_state_on_frob(&self) -> bool {
         false
+    }
+
+    /// Prepare transient state when a frob reopens this panel. The default
+    /// honors `resets_state_on_frob`; stateful flows can preserve only the
+    /// portion that must survive closing and reopening.
+    fn prepare_state_on_frob(&self, state: &mut TState) {
+        if self.resets_state_on_frob() {
+            *state = TState::default();
+        }
     }
 }

--- a/shock2vr/src/gui/proxy_gui_script.rs
+++ b/shock2vr/src/gui/proxy_gui_script.rs
@@ -9,17 +9,15 @@ use crate::{
     util::vec3_to_point3,
 };
 
+use super::GuiPropProxySize;
+
 pub struct ProxyGuiScript {
-    world_size: Vector2<f32>,
     parent_entity_id: EntityId,
 }
 
 impl ProxyGuiScript {
-    pub fn new(world_size: Vector2<f32>, parent_entity_id: EntityId) -> ProxyGuiScript {
-        ProxyGuiScript {
-            world_size,
-            parent_entity_id,
-        }
+    pub fn new(parent_entity_id: EntityId) -> ProxyGuiScript {
+        ProxyGuiScript { parent_entity_id }
     }
 }
 
@@ -62,13 +60,18 @@ impl Script for ProxyGuiScript {
                 let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
                 let maybe_transform = v_transform.get(entity_id);
                 if let Ok(transform) = maybe_transform {
+                    let world_size = world
+                        .borrow::<View<GuiPropProxySize>>()
+                        .ok()
+                        .and_then(|sizes| sizes.get(entity_id).ok().map(|size| size.0))
+                        .unwrap_or(Vector2::new(1.0, 1.0));
                     let inv_transform = transform.0.inverse_transform().unwrap();
                     let local_point =
                         inv_transform.transform_point(vec3_to_point3(*world_position));
 
                     let screen_point = point2(
-                        1.0 - (local_point.x + self.world_size.x / 2.0) / self.world_size.x,
-                        1.0 - (local_point.y + self.world_size.y / 2.0) / self.world_size.y,
+                        1.0 - (local_point.x + world_size.x / 2.0) / world_size.x,
+                        1.0 - (local_point.y + world_size.y / 2.0) / world_size.y,
                     );
 
                     Effect::Send {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -39,11 +39,11 @@ use dark::{
         AmbientSoundFlags, Link, LinkDefinition, LinkDefinitionWithData, Links, PhysicsModelType,
         PropAIAlertness, PropAIMode, PropAmbientHacked, PropClassTag, PropCreature,
         PropFrameAnimState, PropHasRefs, PropHitPoints, PropLimbModel, PropLocalPlayer,
-        PropModelName, PropMotionActorTags, PropParticleGroup, PropParticleLaunchInfo,
-        PropPhysDimensions, PropPhysInitialVelocity, PropPhysState, PropPhysType, PropPlayerGun,
-        PropPosition, PropRenderType, PropScripts, PropTeleported, PropTripFlags,
-        PropTweqDeleteConfig, PropTweqDeleteState, PropertyDefinition, RenderType, ToLink,
-        TripFlags, TweqAnimationState, WrappedEntityId,
+        PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
+        PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
+        PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropTeleported,
+        PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState, PropertyDefinition, RenderType,
+        ToLink, TripFlags, TweqAnimationState, WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -3560,6 +3560,16 @@ impl MissionCore {
                         .unwrap_or(false);
                     if is_alive {
                         self.world.add_component(entity_id, PropHasRefs(visible));
+                    }
+                }
+                Effect::SetObjectState { entity_id, state } => {
+                    let is_alive = self
+                        .world
+                        .borrow::<shipyard::EntitiesView>()
+                        .map(|entities| entities.is_alive(entity_id))
+                        .unwrap_or(false);
+                    if is_alive {
+                        self.world.add_component(entity_id, PropObjState(state));
                     }
                 }
                 Effect::SetQuestBit {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -708,6 +708,40 @@ impl PhysicsWorld {
         );
     }
 
+    /// Resize every cuboid collider attached to a kinematic body. GUI panels
+    /// use this when their authored pixel geometry changes while the proxy
+    /// entity remains live.
+    pub fn resize_kinematic_cuboid(
+        &mut self,
+        handle: RigidBodyHandle,
+        entity_id: EntityId,
+        size: Vector3<f32>,
+    ) {
+        let size = sanitize_collider_size(entity_id, "resize_kinematic_cuboid", size);
+        let Some(body) = self.rigid_body_set.get(handle) else {
+            return;
+        };
+        let collider_handles = body.colliders().to_vec();
+        let shape = SharedShape::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0);
+        for collider_handle in collider_handles {
+            if let Some(collider) = self.collider_set.get_mut(collider_handle) {
+                collider.set_shape(shape.clone());
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cuboid_full_size(&self, handle: RigidBodyHandle) -> Option<Vector3<f32>> {
+        let body = self.rigid_body_set.get(handle)?;
+        let collider = self.collider_set.get(*body.colliders().first()?)?;
+        let cuboid = collider.shape().as_cuboid()?;
+        Some(vec3(
+            cuboid.half_extents.x * 2.0,
+            cuboid.half_extents.y * 2.0,
+            cuboid.half_extents.z * 2.0,
+        ))
+    }
+
     pub fn remove_impulse_joint(&mut self, handle: ImpulseJointHandle) {
         self.impulse_joint_set.remove(handle, true);
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -2,7 +2,9 @@ use cgmath::{Matrix4, Point3, Quaternion, Vector2, Vector3, Vector4};
 use dark::{
     EnvSoundQuery,
     motion::{MotionQueryItem, MotionQuerySelectionStrategy},
-    properties::{AIAlertLevel, AIMode, KeyCard, PropGunState, QuestBitValue, TeleportSource},
+    properties::{
+        AIAlertLevel, AIMode, KeyCard, ObjectState, PropGunState, QuestBitValue, TeleportSource,
+    },
 };
 use engine::audio::AudioHandle;
 use shipyard::EntityId;
@@ -393,6 +395,14 @@ pub enum Effect {
     SetVisibility {
         entity_id: EntityId,
         visible: bool,
+    },
+
+    /// Persistently set Dark's `P$ObjState` on one live object. Replicator HRM
+    /// success uses Hacked; a critical failure uses Broken. Because ObjState is
+    /// a registered Dark property, mission save/load serializes the result.
+    SetObjectState {
+        entity_id: EntityId,
+        state: ObjectState,
     },
 
     ResetGravity {

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -33,7 +33,7 @@ const BOARD_DX: f32 = 30.0;
 const BOARD_DY: f32 = 36.0;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum HackPhase {
+pub(crate) enum HackPhase {
     #[default]
     Unpaid,
     Playing,
@@ -44,7 +44,7 @@ enum HackPhase {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-enum HackNode {
+pub(crate) enum HackNode {
     #[default]
     Free,
     Lit,
@@ -54,10 +54,10 @@ enum HackNode {
 }
 
 #[derive(Clone, Debug)]
-struct HackState {
-    phase: HackPhase,
-    nodes: [HackNode; BOARD_WIDTH * BOARD_HEIGHT],
-    rng_state: u64,
+pub(crate) struct HackState {
+    pub(crate) phase: HackPhase,
+    pub(crate) nodes: [HackNode; BOARD_WIDTH * BOARD_HEIGHT],
+    pub(crate) rng_state: u64,
 }
 
 impl Default for HackState {
@@ -70,11 +70,11 @@ impl Default for HackState {
     }
 }
 
-const fn board_index(x: usize, y: usize) -> usize {
+pub(crate) const fn board_index(x: usize, y: usize) -> usize {
     y * BOARD_WIDTH + x
 }
 
-const fn base_hack_board() -> [HackNode; BOARD_WIDTH * BOARD_HEIGHT] {
+pub(crate) const fn base_hack_board() -> [HackNode; BOARD_WIDTH * BOARD_HEIGHT] {
     use HackNode::{Empty as E, Free as F};
     [
         E, E, F, F, F, //
@@ -246,7 +246,15 @@ fn draw_number(num: u32) -> Vec<GuiComponent<KeyPadMsg>> {
     ret
 }
 
-fn draw_hack_board(state: &HackState, diff: PropHackDiff) -> Vec<GuiComponent<KeyPadMsg>> {
+pub(crate) fn draw_hack_board<TMsg, F>(
+    state: &HackState,
+    diff: PropHackDiff,
+    wrap: F,
+) -> Vec<GuiComponent<TMsg>>
+where
+    TMsg: Clone,
+    F: Fn(KeyPadMsg) -> TMsg + Copy,
+{
     let mut components = vec![
         gui::image("hack.pcx")
             .with_position(vec2(0.0, 0.0))
@@ -301,7 +309,7 @@ fn draw_hack_board(state: &HackState, diff: PropHackDiff) -> Vec<GuiComponent<Ke
             // zero-alpha button supplies a normal 16x16 hit target without
             // painting a placeholder over that authored art.
             components.push(
-                gui::button(KeyPadMsg::PlayNode { x, y })
+                gui::button(wrap(KeyPadMsg::PlayNode { x, y }))
                     .with_position(position)
                     .with_size(vec2(16.0, 16.0))
                     .with_image("hrmpip.pcx")
@@ -343,7 +351,7 @@ fn draw_hack_board(state: &HackState, diff: PropHackDiff) -> Vec<GuiComponent<Ke
                 ("start0.pcx", "start1.pcx", "start-hack")
             };
         components.push(
-            gui::button(KeyPadMsg::StartHack)
+            gui::button(wrap(KeyPadMsg::StartHack))
                 .with_position(vec2(157.0, 232.0))
                 .with_size(vec2(20.0, 56.0))
                 .with_image(normal)
@@ -354,21 +362,25 @@ fn draw_hack_board(state: &HackState, diff: PropHackDiff) -> Vec<GuiComponent<Ke
     components
 }
 
-fn handle_hack_msg(
+pub(crate) struct HackOutcomeEffects {
+    pub(crate) success: fn(EntityId, &World) -> Effect,
+    pub(crate) critical_failure: fn(EntityId, &World) -> Effect,
+}
+
+pub(crate) fn handle_hack_msg(
     entity_id: EntityId,
     world: &World,
-    state: &KeyPadState,
+    state: &HackState,
     msg: &KeyPadMsg,
     diff: PropHackDiff,
-) -> (KeyPadState, Effect) {
+    outcomes: HackOutcomeEffects,
+) -> (HackState, Effect) {
     let mut new_state = state.clone();
     match msg {
-        KeyPadMsg::StartHack
-            if !matches!(new_state.hack.phase, HackPhase::Won | HackPhase::Lost) =>
-        {
+        KeyPadMsg::StartHack if !matches!(new_state.phase, HackPhase::Won | HackPhase::Lost) => {
             let cost = hack_cost(diff);
             let Some(payment) = spend_player_nanites(world, cost) else {
-                new_state.hack.phase = HackPhase::InsufficientNanites;
+                new_state.phase = HackPhase::InsufficientNanites;
                 return (
                     new_state,
                     Effect::PlaySound {
@@ -386,7 +398,7 @@ fn handle_hack_msg(
                 rng_state,
                 "HRM rng initialized after mine placement"
             );
-            new_state.hack = HackState {
+            new_state = HackState {
                 phase: HackPhase::Playing,
                 nodes,
                 rng_state,
@@ -403,12 +415,10 @@ fn handle_hack_msg(
             )
         }
         KeyPadMsg::PlayNode { x, y }
-            if *x < BOARD_WIDTH
-                && *y < BOARD_HEIGHT
-                && new_state.hack.phase == HackPhase::Playing =>
+            if *x < BOARD_WIDTH && *y < BOARD_HEIGHT && new_state.phase == HackPhase::Playing =>
         {
             let index = board_index(*x, *y);
-            let node = new_state.hack.nodes[index];
+            let node = new_state.nodes[index];
             if !matches!(node, HackNode::Free | HackNode::Mine) {
                 return (
                     new_state,
@@ -420,26 +430,22 @@ fn handle_hack_msg(
             }
 
             let was_mine = node == HackNode::Mine;
-            let roll = outcome_roll(&mut new_state.hack.rng_state);
+            let roll = outcome_roll(&mut new_state.rng_state);
             tracing::debug!(
                 entity = entity_id.inner(),
                 roll,
-                rng_state = new_state.hack.rng_state,
+                rng_state = new_state.rng_state,
                 "HRM rng outcome"
             );
             let (chance, _) = effective_hack_values(world, diff);
             if roll_succeeds(roll, chance) {
-                new_state.hack.nodes[index] = HackNode::Lit;
-                if has_connected_three(&new_state.hack.nodes) {
-                    new_state.hack.phase = HackPhase::Won;
+                new_state.nodes[index] = HackNode::Lit;
+                if has_connected_three(&new_state.nodes) {
+                    new_state.phase = HackPhase::Won;
                     return (
                         new_state,
                         Effect::combine(vec![
-                            send_to_all_switch_links_and_self(
-                                world,
-                                entity_id,
-                                MessagePayload::TurnOn { from: entity_id },
-                            ),
+                            (outcomes.success)(entity_id, world),
                             Effect::PlaySound {
                                 handle: AudioHandle::new(),
                                 name: "hack_success".to_owned(),
@@ -448,18 +454,21 @@ fn handle_hack_msg(
                     );
                 }
             } else if was_mine {
-                new_state.hack.phase = HackPhase::Lost;
+                new_state.phase = HackPhase::Lost;
                 return (
                     new_state,
-                    Effect::PlaySound {
-                        handle: AudioHandle::new(),
-                        name: "hack_critical".to_owned(),
-                    },
+                    Effect::combine(vec![
+                        (outcomes.critical_failure)(entity_id, world),
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "hack_critical".to_owned(),
+                        },
+                    ]),
                 );
             } else {
-                new_state.hack.nodes[index] = HackNode::Burned;
-                if !board_has_potential_path(&new_state.hack.nodes) {
-                    new_state.hack.phase = HackPhase::Unwinnable;
+                new_state.nodes[index] = HackNode::Burned;
+                if !board_has_potential_path(&new_state.nodes) {
+                    new_state.phase = HackPhase::Unwinnable;
                 }
             }
 
@@ -475,6 +484,14 @@ fn handle_hack_msg(
     }
 }
 
+fn keypad_hack_success(entity_id: EntityId, world: &World) -> Effect {
+    send_to_all_switch_links_and_self(world, entity_id, MessagePayload::TurnOn { from: entity_id })
+}
+
+fn keypad_hack_critical_failure(_entity_id: EntityId, _world: &World) -> Effect {
+    Effect::NoEffect
+}
+
 impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
     fn get_components(
         &self,
@@ -485,7 +502,7 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
     ) -> Vec<GuiComponent<KeyPadMsg>> {
         let hack_diff = hack_diff_for_entity(_world, _entity_id);
         if let Some(hack_diff) = hack_diff {
-            return draw_hack_board(&_state.hack, hack_diff);
+            return draw_hack_board(&_state.hack, hack_diff, |msg| msg);
         }
 
         let button_width = 45.0;
@@ -614,7 +631,24 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
     ) -> (KeyPadState, crate::Effect) {
         let hack_diff = hack_diff_for_entity(world, entity_id);
         if let Some(hack_diff) = hack_diff {
-            return handle_hack_msg(entity_id, world, state, msg, hack_diff);
+            let (hack, effect) = handle_hack_msg(
+                entity_id,
+                world,
+                &state.hack,
+                msg,
+                hack_diff,
+                HackOutcomeEffects {
+                    success: keypad_hack_success,
+                    critical_failure: keypad_hack_critical_failure,
+                },
+            );
+            return (
+                KeyPadState {
+                    hack,
+                    ..state.clone()
+                },
+                effect,
+            );
         }
 
         let v_prop_keypad_code = world.borrow::<View<PropKeypadCode>>().unwrap();
@@ -790,12 +824,9 @@ mod tests {
     fn critical_loss_is_terminal_for_the_live_panel_state() {
         let mut world = World::new();
         let entity = world.add_entity(());
-        let state = KeyPadState {
-            hack: HackState {
-                phase: HackPhase::Lost,
-                ..HackState::default()
-            },
-            ..KeyPadState::default()
+        let state = HackState {
+            phase: HackPhase::Lost,
+            ..HackState::default()
         };
         let diff = PropHackDiff {
             success_chance: 50,
@@ -803,9 +834,19 @@ mod tests {
             cost: 3.0,
         };
 
-        let (after, effect) = handle_hack_msg(entity, &world, &state, &KeyPadMsg::StartHack, diff);
+        let (after, effect) = handle_hack_msg(
+            entity,
+            &world,
+            &state,
+            &KeyPadMsg::StartHack,
+            diff,
+            HackOutcomeEffects {
+                success: keypad_hack_success,
+                critical_failure: keypad_hack_critical_failure,
+            },
+        );
 
-        assert_eq!(after.hack.phase, HackPhase::Lost);
+        assert_eq!(after.phase, HackPhase::Lost);
         assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -1,12 +1,14 @@
 use cgmath::{Vector2, Vector3, vec2, vec3};
-use dark::properties::PropReplicatorContents;
+use dark::properties::{
+    ObjectState, PropHackDiff, PropObjState, PropReplicatorContents, PropReplicatorHackedContents,
+};
 use engine::audio::AudioHandle;
 use num_traits::ToPrimitive;
 
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    gui::{Gui, GuiComponent, GuiConfig, GuiCursor},
+    gui::{ButtonHoverBehavior, Gui, GuiComponent, GuiConfig, GuiCursor},
     mission::GlobalEntityMetadata,
     quest_info::QuestInfo,
     util::{get_position_from_transform, get_rotation_from_transform},
@@ -16,18 +18,110 @@ use crate::gui;
 
 use crate::scripts::{Effect, script_util::*};
 
-use super::traits::TRAIT_REPLICATOR_EXPERT;
+use super::{
+    keypad::{
+        HackOutcomeEffects, HackPhase, HackState, KeyPadMsg, draw_hack_board, handle_hack_msg,
+    },
+    traits::TRAIT_REPLICATOR_EXPERT,
+};
 
 pub struct ReplicatorGui;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum ReplicatorPanel {
+    #[default]
+    Inventory,
+    Hacking,
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct ReplicatorState {
     message: Option<String>,
+    panel: ReplicatorPanel,
+    hack: HackState,
 }
 
 #[derive(Clone)]
 pub enum ReplicatorMsg {
     SelectItem(usize),
+    OpenHack,
+    Hack(KeyPadMsg),
+}
+
+#[derive(Clone)]
+struct ReplicatorInventory {
+    costs: [i32; 6],
+    object_names: [String; 6],
+}
+
+fn object_state(world: &World, entity_id: EntityId) -> ObjectState {
+    world
+        .borrow::<View<PropObjState>>()
+        .ok()
+        .and_then(|states| states.get(entity_id).ok().map(|state| state.0))
+        .unwrap_or(ObjectState::Normal)
+}
+
+fn active_inventory(world: &World, entity_id: EntityId) -> Option<ReplicatorInventory> {
+    match object_state(world, entity_id) {
+        ObjectState::Broken | ObjectState::Destroyed => None,
+        ObjectState::Hacked => world
+            .borrow::<View<PropReplicatorHackedContents>>()
+            .ok()
+            .and_then(|contents| {
+                contents
+                    .get(entity_id)
+                    .ok()
+                    .map(|contents| ReplicatorInventory {
+                        costs: contents.costs,
+                        object_names: contents.object_names.clone(),
+                    })
+            }),
+        _ => world
+            .borrow::<View<PropReplicatorContents>>()
+            .ok()
+            .and_then(|contents| {
+                contents
+                    .get(entity_id)
+                    .ok()
+                    .map(|contents| ReplicatorInventory {
+                        costs: contents.costs,
+                        object_names: contents.object_names.clone(),
+                    })
+            }),
+    }
+}
+
+fn hack_diff(world: &World, entity_id: EntityId) -> Option<PropHackDiff> {
+    world
+        .borrow::<View<PropHackDiff>>()
+        .ok()
+        .and_then(|diffs| diffs.get(entity_id).ok().copied())
+}
+
+fn can_hack(world: &World, entity_id: EntityId) -> bool {
+    !matches!(
+        object_state(world, entity_id),
+        ObjectState::Broken | ObjectState::Destroyed | ObjectState::Hacked
+    ) && hack_diff(world, entity_id).is_some()
+        && world
+            .borrow::<View<PropReplicatorHackedContents>>()
+            .ok()
+            .is_some_and(|contents| contents.get(entity_id).is_ok())
+}
+
+fn replicator_hack_success(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::SetObjectState {
+        entity_id,
+        state: ObjectState::Hacked,
+    }
+}
+
+fn replicator_hack_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::SetObjectState {
+        entity_id,
+        state: ObjectState::Broken,
+    }
 }
 
 impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
@@ -38,19 +132,24 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
         world: &World,
         state: &ReplicatorState,
     ) -> Vec<GuiComponent<ReplicatorMsg>> {
+        if state.panel == ReplicatorPanel::Hacking {
+            if let Some(diff) = hack_diff(world, entity_id) {
+                return draw_hack_board(&state.hack, diff, ReplicatorMsg::Hack);
+            }
+        }
+
         let button_height = 60.0;
         let initial_padding_y = 10.0;
         let button_width = 188.0;
         let button_padding = 4.0;
-
-        let v_prop_replicator = world.borrow::<View<PropReplicatorContents>>().unwrap();
-        let replicator_contents = v_prop_replicator.get(entity_id).unwrap();
-
-        let entity_metadata = world.borrow::<UniqueView<GlobalEntityMetadata>>().unwrap();
+        let replicator_contents = active_inventory(world, entity_id);
+        let current_state = object_state(world, entity_id);
+        let has_sidecar = can_hack(world, entity_id) || current_state == ObjectState::Broken;
+        let main_x = if has_sidecar { 73.0 } else { 0.0 };
 
         let replicator_icon = |icon: &str, position: f32| GuiComponent::Image {
             position: vec2(
-                10.0,
+                main_x + 10.0,
                 5.0 + initial_padding_y + (button_height + button_padding) * position,
             ),
             size: vec2(30.0, button_height - 10.0),
@@ -60,56 +159,86 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
 
         let mut components: Vec<GuiComponent<ReplicatorMsg>> = vec![
             gui::image("replic.pcx")
-                .with_position(vec2(0.0, 0.0))
+                .with_position(vec2(main_x, 0.0))
                 .with_size(vec2(188.0, 296.0)),
         ];
-        for (i, (obj_name, authored_cost)) in replicator_contents
-            .object_names
-            .iter()
-            .zip(replicator_contents.costs)
-            .enumerate()
-        {
-            let float_i = i.to_f32().unwrap();
+        if let Some(replicator_contents) = replicator_contents {
+            let entity_metadata = world.borrow::<UniqueView<GlobalEntityMetadata>>().unwrap();
+            for (i, (obj_name, authored_cost)) in replicator_contents
+                .object_names
+                .iter()
+                .zip(replicator_contents.costs)
+                .enumerate()
+            {
+                let float_i = i.to_f32().unwrap();
 
-            if obj_name.is_empty() || authored_cost <= 0 {
-                continue;
+                if obj_name.is_empty() || authored_cost <= 0 {
+                    continue;
+                }
+                let cost = effective_replicator_cost(world, authored_cost);
+                if cost <= 0 {
+                    continue;
+                }
+
+                let metadata = entity_metadata.0.get(obj_name).unwrap();
+                let obj_icon = metadata.obj_icon.as_ref().unwrap();
+
+                components.push(
+                    gui::button(ReplicatorMsg::SelectItem(i))
+                        .with_position(vec2(
+                            main_x,
+                            initial_padding_y + (button_height + button_padding) * float_i,
+                        ))
+                        .with_size(vec2(button_width, button_height))
+                        .with_image("key0.pcx")
+                        .with_label(&format!("buy:{obj_name}")),
+                );
+
+                components.push(replicator_icon(obj_icon, float_i));
+
+                if let Some(short_name) = metadata.obj_short_name.as_ref() {
+                    components.push(gui::text(short_name).with_position(vec2(
+                        main_x + 50.0,
+                        button_height / 2.0 + (button_height + button_padding) * float_i,
+                    )));
+                }
+
+                // Retail draws the three-digit price beneath the item icon.
+                components.push(
+                    gui::text(&format!("{cost:03}"))
+                        .with_position(vec2(
+                            main_x + 19.0,
+                            47.0 + (button_height + button_padding) * float_i,
+                        ))
+                        .with_size(vec2(34.0, 12.0)),
+                );
             }
-            let cost = effective_replicator_cost(world, authored_cost);
-            if cost <= 0 {
-                continue;
-            }
+        }
 
-            let metadata = entity_metadata.0.get(obj_name).unwrap();
-            let obj_icon = metadata.obj_icon.as_ref().unwrap();
-
+        if can_hack(world, entity_id) {
+            // Retail raises this 73x194 companion beside the MFD, with its
+            // 52x74 PLUGH button at sidecar-local (16,114).
             components.push(
-                gui::button(ReplicatorMsg::SelectItem(i))
-                    .with_position(vec2(
-                        0.0,
-                        initial_padding_y + (button_height + button_padding) * float_i,
-                    ))
-                    .with_size(vec2(button_width, button_height))
-                    .with_image("key0.pcx")
-                    .with_label(&format!("buy:{obj_name}")),
+                gui::image("plughack.pcx")
+                    .with_position(vec2(0.0, 96.0))
+                    .with_size(vec2(73.0, 194.0)),
             );
-
-            components.push(replicator_icon(obj_icon, float_i));
-
-            if let Some(short_name) = metadata.obj_short_name.as_ref() {
-                components.push(gui::text(short_name).with_position(vec2(
-                    50.0,
-                    button_height / 2.0 + (button_height + button_padding) * float_i,
-                )));
-            }
-
-            // Retail draws the three-digit price beneath the item icon.
             components.push(
-                gui::text(&format!("{cost:03}"))
-                    .with_position(vec2(
-                        19.0,
-                        47.0 + (button_height + button_padding) * float_i,
-                    ))
-                    .with_size(vec2(34.0, 12.0)),
+                gui::button(ReplicatorMsg::OpenHack)
+                    .with_position(vec2(16.0, 210.0))
+                    .with_size(vec2(52.0, 74.0))
+                    .with_image("plugh0.pcx")
+                    .with_hover(ButtonHoverBehavior::Texture("plugh1.pcx".to_owned()))
+                    .with_label("hack-replicator"),
+            );
+        } else if current_state == ObjectState::Broken {
+            // Original raises the repair plug for a broken replicator. Repair
+            // is not implemented yet, so expose the authored status art but
+            // deliberately no clickable repair/hack/purchase path.
+            components.push(
+                gui::image("plugrep.pcx")
+                    .with_position(vec2(0.0, 96.0))
+                    .with_size(vec2(73.0, 194.0)),
             );
         }
 
@@ -117,13 +246,20 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
         // live balance at (104, 274) beside it.
         components.push(
             gui::text(&format!("{:04}", player_nanite_total(world)))
-                .with_position(vec2(104.0, 274.0))
+                .with_position(vec2(main_x + 104.0, 274.0))
                 .with_size(vec2(40.0, 14.0)),
         );
-        if let Some(message) = &state.message {
+        let message = if current_state == ObjectState::Broken {
+            Some("Replicator broken; repair required")
+        } else if active_inventory(world, entity_id).is_none() {
+            Some("Replicator offline")
+        } else {
+            state.message.as_deref()
+        };
+        if let Some(message) = message {
             components.push(
                 gui::text(message)
-                    .with_position(vec2(10.0, 248.0))
+                    .with_position(vec2(main_x + 10.0, 248.0))
                     .with_size(vec2(168.0, 14.0)),
             );
         }
@@ -138,27 +274,41 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
         }
     }
 
-    fn resets_state_on_frob(&self) -> bool {
-        true
+    fn get_config_for(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        state: &ReplicatorState,
+    ) -> GuiConfig {
+        let has_sidecar = state.panel == ReplicatorPanel::Inventory
+            && (can_hack(world, entity_id)
+                || object_state(world, entity_id) == ObjectState::Broken);
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -1.0),
+            screen_size_in_pixels: Vector2::new(if has_sidecar { 261.0 } else { 188.0 }, 296.0),
+        }
+    }
+
+    fn prepare_state_on_frob(&self, state: &mut ReplicatorState) {
+        if state.panel != ReplicatorPanel::Hacking || state.hack.phase != HackPhase::Playing {
+            *state = ReplicatorState::default();
+        }
     }
 
     fn handle_msg(
         &self,
         entity_id: EntityId,
         world: &World,
-        _state: &ReplicatorState,
+        state: &ReplicatorState,
         msg: &ReplicatorMsg,
     ) -> (ReplicatorState, Effect) {
         match msg {
             ReplicatorMsg::SelectItem(slot) => {
-                let contents = world
-                    .borrow::<View<PropReplicatorContents>>()
-                    .ok()
-                    .and_then(|view| view.get(entity_id).ok().cloned());
-                let Some(contents) = contents else {
+                let Some(contents) = active_inventory(world, entity_id) else {
                     return (
                         ReplicatorState {
                             message: Some("Replicator offline".to_owned()),
+                            ..state.clone()
                         },
                         Effect::NoEffect,
                     );
@@ -172,6 +322,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     return (
                         ReplicatorState {
                             message: Some("Item unavailable".to_owned()),
+                            ..state.clone()
                         },
                         Effect::NoEffect,
                     );
@@ -183,6 +334,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     return (
                         ReplicatorState {
                             message: Some("Item unavailable".to_owned()),
+                            ..state.clone()
                         },
                         Effect::PlaySound {
                             handle: AudioHandle::new(),
@@ -194,6 +346,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     return (
                         ReplicatorState {
                             message: Some("Insufficient nanites".to_owned()),
+                            ..state.clone()
                         },
                         Effect::PlaySound {
                             handle: AudioHandle::new(),
@@ -207,6 +360,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     return (
                         ReplicatorState {
                             message: Some("Replicator offline".to_owned()),
+                            ..state.clone()
                         },
                         Effect::NoEffect,
                     );
@@ -219,7 +373,58 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                     orientation: get_rotation_from_transform(world, link),
                 };
 
-                (ReplicatorState { message: None }, purchase)
+                (
+                    ReplicatorState {
+                        message: None,
+                        ..state.clone()
+                    },
+                    purchase,
+                )
+            }
+            ReplicatorMsg::OpenHack => {
+                if can_hack(world, entity_id) {
+                    (
+                        ReplicatorState {
+                            message: None,
+                            panel: ReplicatorPanel::Hacking,
+                            hack: HackState::default(),
+                        },
+                        Effect::NoEffect,
+                    )
+                } else {
+                    (state.clone(), Effect::NoEffect)
+                }
+            }
+            ReplicatorMsg::Hack(hack_msg) => {
+                let Some(diff) = hack_diff(world, entity_id) else {
+                    return (state.clone(), Effect::NoEffect);
+                };
+                if state.panel != ReplicatorPanel::Hacking
+                    || matches!(
+                        object_state(world, entity_id),
+                        ObjectState::Broken | ObjectState::Destroyed
+                    )
+                {
+                    return (state.clone(), Effect::NoEffect);
+                }
+                let (hack, effect) = handle_hack_msg(
+                    entity_id,
+                    world,
+                    &state.hack,
+                    hack_msg,
+                    diff,
+                    HackOutcomeEffects {
+                        success: replicator_hack_success,
+                        critical_failure: replicator_hack_critical_failure,
+                    },
+                );
+                (
+                    ReplicatorState {
+                        hack,
+                        ..state.clone()
+                    },
+                    effect,
+                )
             }
         }
     }
@@ -242,6 +447,7 @@ fn effective_replicator_cost(world: &World, authored_cost: i32) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use super::super::keypad::{HackNode, HackPhase, base_hack_board, board_index};
     use super::*;
     use crate::mission::PlayerInfo;
     use crate::runtime_props::RuntimePropTransform;
@@ -256,6 +462,132 @@ mod tests {
             Effect::Combined { effects } => effects.iter().any(creates_template),
             _ => false,
         }
+    }
+
+    #[test]
+    fn hack_action_requires_an_authored_hacked_inventory() {
+        let mut world = World::new();
+        let replicator = world.add_entity((
+            PropHackDiff {
+                success_chance: 50,
+                critical_chance: 0,
+                cost: 3.0,
+            },
+            PropReplicatorContents {
+                costs: [3, 0, 0, 0, 0, 0],
+                object_names: [
+                    "chips".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+        ));
+
+        assert!(
+            !can_hack(&world, replicator),
+            "success must not turn a usable machine into an offline Hacked state"
+        );
+        world.add_component(
+            replicator,
+            PropReplicatorHackedContents {
+                costs: [70, 0, 0, 0, 0, 0],
+                object_names: [
+                    "small he clip".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+        );
+        assert!(can_hack(&world, replicator));
+    }
+
+    #[test]
+    fn critical_hack_loss_persistently_breaks_and_disables_the_replicator() {
+        let mut world = World::new();
+        let replicator = world.add_entity((
+            PropHackDiff {
+                success_chance: 0,
+                critical_chance: 0,
+                cost: 3.0,
+            },
+            PropReplicatorContents {
+                costs: [3, 0, 0, 0, 0, 0],
+                object_names: [
+                    "chips".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+            PropReplicatorHackedContents {
+                costs: [70, 0, 0, 0, 0, 0],
+                object_names: [
+                    "small he clip".to_owned(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                    String::new(),
+                ],
+            },
+        ));
+        let mut nodes = base_hack_board();
+        nodes[board_index(2, 0)] = HackNode::Mine;
+        let state = ReplicatorState {
+            panel: ReplicatorPanel::Hacking,
+            hack: HackState {
+                phase: HackPhase::Playing,
+                nodes,
+                rng_state: 1,
+            },
+            ..ReplicatorState::default()
+        };
+
+        let (after, effect) = ReplicatorGui.handle_msg(
+            replicator,
+            &world,
+            &state,
+            &ReplicatorMsg::Hack(KeyPadMsg::PlayNode { x: 2, y: 0 }),
+        );
+        assert_eq!(after.hack.phase, HackPhase::Lost);
+
+        let mut applied = false;
+        for effect in Effect::flatten(vec![effect]) {
+            if let Effect::SetObjectState { entity_id, state } = effect {
+                assert_eq!(entity_id, replicator);
+                assert_eq!(state, ObjectState::Broken);
+                world.add_component(entity_id, PropObjState(state));
+                applied = true;
+            }
+        }
+        assert!(applied, "critical loss must emit persistent Broken state");
+        assert_eq!(object_state(&world, replicator), ObjectState::Broken);
+        assert!(active_inventory(&world, replicator).is_none());
+        assert!(!can_hack(&world, replicator));
+
+        let reopened =
+            ReplicatorGui.get_components(&None, replicator, &world, &ReplicatorState::default());
+        assert!(
+            reopened.iter().any(|component| matches!(
+                component,
+                GuiComponent::Image { texture, .. } if texture == "plugrep.pcx"
+            )),
+            "broken state should expose the authored repair status sidecar"
+        );
+        assert!(
+            reopened
+                .iter()
+                .all(|component| !matches!(component, GuiComponent::Button { .. })),
+            "broken state must disable every purchase and hack action"
+        );
     }
 
     #[test]
@@ -294,7 +626,7 @@ mod tests {
         let (_state, effect) = gui.handle_msg(
             replicator,
             &world,
-            &ReplicatorState { message: None },
+            &ReplicatorState::default(),
             &ReplicatorMsg::SelectItem(0),
         );
 
@@ -306,17 +638,42 @@ mod tests {
         let (_state, zero_cost_effect) = gui.handle_msg(
             replicator,
             &world,
-            &ReplicatorState { message: None },
+            &ReplicatorState::default(),
             &ReplicatorMsg::SelectItem(1),
         );
         assert!(
             !creates_template(&zero_cost_effect),
             "a zero-cost replicator slot must not mint a free item: {zero_cost_effect:?}"
         );
-        assert!(
-            gui.resets_state_on_frob(),
-            "reopening the panel should clear transient refusal text"
-        );
+        let mut refused_state = ReplicatorState {
+            message: Some("Insufficient nanites".to_owned()),
+            ..ReplicatorState::default()
+        };
+        gui.prepare_state_on_frob(&mut refused_state);
+        assert_eq!(refused_state.message, None);
+    }
+
+    #[test]
+    fn reopening_preserves_only_a_paid_in_progress_hack() {
+        let gui = ReplicatorGui;
+        let mut playing = ReplicatorState {
+            panel: ReplicatorPanel::Hacking,
+            hack: HackState {
+                phase: HackPhase::Playing,
+                rng_state: 42,
+                ..HackState::default()
+            },
+            ..ReplicatorState::default()
+        };
+        gui.prepare_state_on_frob(&mut playing);
+        assert_eq!(playing.panel, ReplicatorPanel::Hacking);
+        assert_eq!(playing.hack.phase, HackPhase::Playing);
+        assert_eq!(playing.hack.rng_state, 42);
+
+        playing.hack.phase = HackPhase::Won;
+        gui.prepare_state_on_frob(&mut playing);
+        assert_eq!(playing.panel, ReplicatorPanel::Inventory);
+        assert_eq!(playing.hack.phase, HackPhase::Unpaid);
     }
 
     #[test]
@@ -375,7 +732,7 @@ mod tests {
         let (_state, effect) = ReplicatorGui.handle_msg(
             replicator,
             &world,
-            &ReplicatorState { message: None },
+            &ReplicatorState::default(),
             &ReplicatorMsg::SelectItem(0),
         );
         assert!(
@@ -405,7 +762,7 @@ mod tests {
         let (_state, discounted_to_zero) = ReplicatorGui.handle_msg(
             replicator,
             &world,
-            &ReplicatorState { message: None },
+            &ReplicatorState::default(),
             &ReplicatorMsg::SelectItem(1),
         );
         assert!(

--- a/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-economy.e2e.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary, UiElement } from "../src/types.js";
+import {
+  carriedNaniteTotal,
+  physicallyOpenEarthReplicator,
+} from "./helpers/earth-replicator.js";
 import { earthWorldUse } from "./helpers/earth-world-use.js";
-import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
 
 // Honest Earth Technical Training regression for #543. Runtime entity ids are
 // rediscovered every launch; the positive ids are stable authored mission
@@ -23,51 +26,6 @@ const EARTH_NANITE_REWARD = 542;
 const EARTH_REPLICATOR = 262;
 const EARTH_REPLICATOR_OUTPUT = 284;
 const CHIPS_TEMPLATE = -92;
-
-async function clickElement(game: GameServer, element: UiElement) {
-  const [x, y, width, height] = element.screen_rect;
-  await game.input.set("pointer.position", [
-    x + width / 2,
-    y + height / 2,
-  ]);
-  await game.step({ frames: 2 });
-  await game.input.set("pointer.pressed", 1);
-  await game.step({ frames: 2 });
-  await game.input.set("pointer.pressed", 0);
-  await game.step({ frames: 2 });
-}
-
-async function carriedNaniteTotal(game: GameServer): Promise<number> {
-  const inventory = await game.player.inventory();
-  let total = 0;
-  for (const item of inventory.items) {
-    if (!item.name?.toLowerCase().includes("nanite")) continue;
-    const detail = await game.entities.detail(item.entity_id);
-    const stack = detail.properties.find(
-      (property) => property.name === "StackCount",
-    );
-    assert.ok(stack, `carried nanite entity ${item.entity_id} needs StackCount`);
-    total += Number(stack.value);
-  }
-  return total;
-}
-
-async function physicallyOpenReplicator(
-  game: GameServer,
-  replicator: EntitySummary,
-) {
-  const [x, _y, z] = (await game.entities.detail(replicator.id)).position;
-  // This is the same clear standing point used by the accepted Technical
-  // play-through. The fresh Earth body heading makes negative yaw face the
-  // machine; a modest upward pitch hits its green interaction screen.
-  await teleportVerified(game, { x: x - 1.59, y: 21.404, z: z - 2.23 });
-  await game.input.set("head.look", [-35.3, -22]);
-  await game.step({ frames: 3 });
-  await game.input.set("right_hand.squeeze", 1);
-  await game.step({ frames: 2 });
-  await game.input.set("right_hand.squeeze", 0);
-  await game.step({ frames: 5 });
-}
 
 test(
   "Earth replicator charges authored prices and refuses unaffordable output",
@@ -97,7 +55,7 @@ test(
       "physical pickup should carry both authored 250 + 20 nanite stacks",
     );
 
-    await physicallyOpenReplicator(game, replicator);
+    await physicallyOpenEarthReplicator(game, replicator);
     const opened = (await game.ui.state()).active_panel;
     assert.ok(opened, "physical replicator frob should open an MFD panel");
     assert.equal(opened.template_id, EARTH_REPLICATOR);
@@ -132,7 +90,7 @@ test(
     const chipsBefore = new Set(
       (await game.entities.byTemplate(CHIPS_TEMPLATE)).map((entity) => entity.id),
     );
-    await clickElement(game, chipsButton);
+    await clickUiElement(game, chipsButton);
     await game.step({ frames: 20 });
     assert.equal(
       await carriedNaniteTotal(game),
@@ -166,7 +124,7 @@ test(
       (element) => element.label === "close",
     );
     assert.ok(close, "replicator panel should expose the ordinary close control");
-    await clickElement(game, close);
+    await clickUiElement(game, close);
     await earthWorldUse(game, dispensedChips);
     assert.ok(
       (await game.player.inventory()).items.some(
@@ -175,7 +133,7 @@ test(
       "the physically dispensed Chips should be collectible normally",
     );
 
-    await physicallyOpenReplicator(game, replicator);
+    await physicallyOpenEarthReplicator(game, replicator);
     // Spend through both carried StackCounts. After Chips, 267 - 6*40 - 2*4
     // leaves 19; the second Juice crosses the remaining balance of the first
     // stack, so exact payment must remove that exhausted entity and continue
@@ -187,7 +145,7 @@ test(
         (element) => element.label === "buy:small standard clip",
       );
       assert.ok(clip, "Standard Clip row should remain available");
-      await clickElement(game, clip);
+      await clickUiElement(game, clip);
     }
     for (let purchase = 0; purchase < 2; purchase++) {
       const panel = (await game.ui.state()).active_panel;
@@ -196,7 +154,7 @@ test(
         (element) => element.label === "buy:juice bottle",
       );
       assert.ok(juice, "Juice row should remain available");
-      await clickElement(game, juice);
+      await clickUiElement(game, juice);
     }
     assert.equal(
       await carriedNaniteTotal(game),
@@ -243,7 +201,7 @@ test(
       (element) => element.label === "buy:small standard clip",
     );
     assert.ok(unaffordableClip, "unaffordable row should remain inspectable");
-    await clickElement(game, unaffordableClip);
+    await clickUiElement(game, unaffordableClip);
     await game.step({ frames: 20 });
 
     assert.equal(

--- a/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-replicator-hacking.e2e.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiPanel } from "../src/types.js";
+import {
+  carriedNaniteTotal,
+  physicallyOpenEarthReplicator,
+} from "./helpers/earth-replicator.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// Honest Earth Technical Training regression for #544. Runtime ids are
+// rediscovered after every load; positive ids below are stable authored
+// mission objects. Teleport only stages a clear camera position. Nanite pickup,
+// replicator frob, sidecar/HRM input, purchase, and output collection all use
+// ordinary rendered-world/player input.
+//
+// Negative-first evidence (2026-07-23): against exact #543 head cc466f9,
+// physical pickup and frob succeed and the normal 003/004/040 inventory is
+// visible, but no PLUGHACK sidecar or `hack-replicator` action exists.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const EARTH_NANITES = 257;
+const EARTH_REPLICATOR = 262;
+const EARTH_REPLICATOR_OUTPUT = 284;
+
+function button(panel: UiPanel, label: string): UiElement {
+  const found = panel.elements.find(
+    (element) => element.kind === "button" && element.label === label,
+  );
+  assert.ok(found, `panel should expose button ${label}`);
+  return found;
+}
+
+function texts(panel: UiPanel): string[] {
+  return panel.elements
+    .filter((element) => element.kind === "text")
+    .map((element) => element.text ?? "");
+}
+
+async function activePanel(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "replicator interaction should keep an MFD panel open");
+  return panel;
+}
+
+test(
+  "Earth replicator: hack sidecar, paid HRM win, hacked purchase, save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8157),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    await game.step({ frames: 5 });
+
+    const [nanites] = await game.entities.byTemplate(EARTH_NANITES);
+    const [replicator] = await game.entities.byTemplate(EARTH_REPLICATOR);
+    const [output] = await game.entities.byTemplate(EARTH_REPLICATOR_OUTPUT);
+    assert.ok(nanites, "Earth should contain authored nanite pile 257");
+    assert.ok(replicator, "Earth should contain authored replicator 262");
+    assert.ok(output, "Earth should contain authored output marker 284");
+
+    await earthWorldUse(game, nanites);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      250,
+      "physical pickup should carry the authored 250-nanite stack",
+    );
+
+    await physicallyOpenEarthReplicator(game, replicator);
+    const normal = await activePanel(game);
+    assert.equal(normal.template_id, EARTH_REPLICATOR);
+    assert.ok(
+      button(normal, "buy:chips"),
+      "unhacked replicator should retain its normal inventory",
+    );
+    assert.ok(
+      normal.elements.some(
+        (element) => element.texture?.toLowerCase() === "plughack.pcx",
+      ),
+      "unhacked HackDiff replicator should render the original PLUGHACK sidecar",
+    );
+
+    await clickUiElement(game, button(normal, "hack-replicator"));
+    const boardBeforePayment = await activePanel(game);
+    assert.ok(
+      boardBeforePayment.elements.some(
+        (element) => element.texture?.toLowerCase() === "hack.pcx",
+      ),
+      "sidecar action should open the shared retail HRM board",
+    );
+    const authoredCost = texts(boardBeforePayment).find((text) => /^\d+$/.test(text));
+    assert.equal(authoredCost, "3", "Earth RepBase should expose authored hack cost 3");
+
+    await clickUiElement(game, button(boardBeforePayment, "start-hack"));
+    assert.equal(
+      await carriedNaniteTotal(game),
+      247,
+      "starting the real board should charge exactly the authored hack cost",
+    );
+
+    // Try the compact top-row route first, but react to the actual outcome:
+    // the authored board may burn its third top node. The same live board then
+    // has a vertical continuation through x=2. This is genuine HRM play, not a
+    // direct success message or an assumption that any one roll must win.
+    for (const label of [
+      "node-2-0",
+      "node-3-0",
+      "node-4-0",
+      "node-2-1",
+      "node-2-2",
+      "node-2-3",
+    ]) {
+      const current = await activePanel(game);
+      if (
+        current.elements.some(
+          (element) => element.texture?.toLowerCase() === "winh.pcx",
+        )
+      ) {
+        break;
+      }
+      await clickUiElement(game, button(current, label));
+    }
+    const won = await activePanel(game);
+    assert.ok(
+      won.elements.some(
+        (element) => element.texture?.toLowerCase() === "winh.pcx",
+      ),
+      `connected-three should win the real HRM board; rng=${game
+        .logs()
+        .filter((line) => line.includes("HRM rng"))
+        .join(" | ")}`,
+    );
+
+    await clickUiElement(game, button(won, "close"));
+    await physicallyOpenEarthReplicator(game, replicator);
+    const hacked = await activePanel(game);
+    for (const label of [
+      "buy:small he clip",
+      "buy:small standard clip",
+      "buy:med patch",
+    ]) {
+      assert.ok(button(hacked, label), `hacked inventory should expose ${label}`);
+    }
+    for (const expected of ["070", "025", "020", "0247"]) {
+      assert.ok(
+        texts(hacked).includes(expected),
+        `hacked inventory should render ${expected}; got ${JSON.stringify(texts(hacked))}`,
+      );
+    }
+    assert.ok(
+      !hacked.elements.some(
+        (element) =>
+          element.label === "hack-replicator" ||
+          element.texture?.toLowerCase() === "plughack.pcx",
+      ),
+      "a hacked replicator should not offer the hack sidecar again",
+    );
+
+    const heClipsBefore = new Set(
+      (
+        await game.entities.list({
+          filter: "*HE Clip*",
+          limit: 100,
+        })
+      ).entities.map((entity) => entity.id),
+    );
+    await clickUiElement(game, button(hacked, "buy:small he clip"));
+    await game.step({ frames: 20 });
+    assert.equal(
+      await carriedNaniteTotal(game),
+      177,
+      "hacked purchase should use the authored 70-nanite price",
+    );
+    const dispensed = (
+      await game.entities.list({
+        filter: "*HE Clip*",
+        limit: 100,
+      })
+    ).entities.find((entity) => !heClipsBefore.has(entity.id));
+    assert.ok(dispensed, "successful hacked purchase should create Small HE Clip");
+    const outputPosition = (await game.entities.detail(output.id)).position;
+    const itemPosition = (await game.entities.detail(dispensed.id)).position;
+    assert.ok(
+      Math.hypot(
+        itemPosition[0] - outputPosition[0],
+        itemPosition[1] - outputPosition[1],
+        itemPosition[2] - outputPosition[2],
+      ) < 2,
+      "hacked purchase should appear at authored output marker 284",
+    );
+
+    await clickUiElement(game, button(await activePanel(game), "close"));
+    await earthWorldUse(game, dispensed);
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === dispensed.id,
+      ),
+      "physically dispensed hacked item should be collectible",
+    );
+
+    const saveName = `earth_replicator_hacked_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      177,
+      "post-hack nanite balance should survive save/load",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some((item) =>
+        item.name?.toLowerCase().includes("he clip"),
+      ),
+      "physically collected hacked item should survive save/load",
+    );
+
+    const [loadedReplicator] = await game.entities.byTemplate(EARTH_REPLICATOR);
+    assert.ok(loadedReplicator, "save/load should restore authored replicator 262");
+    await physicallyOpenEarthReplicator(game, loadedReplicator);
+    const loadedHacked = await activePanel(game);
+    assert.ok(
+      button(loadedHacked, "buy:small he clip"),
+      "loaded replicator should reopen with hacked inventory",
+    );
+    for (const expected of ["070", "025", "020", "0177"]) {
+      assert.ok(
+        texts(loadedHacked).includes(expected),
+        `loaded hacked panel should render ${expected}; got ${JSON.stringify(texts(loadedHacked))}`,
+      );
+    }
+    assert.ok(
+      !loadedHacked.elements.some(
+        (element) =>
+          element.label === "hack-replicator" ||
+          element.texture?.toLowerCase() === "plughack.pcx",
+      ),
+      "persistent Hacked state should suppress the sidecar after load",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/helpers/earth-replicator.ts
+++ b/tools/shock2-sdk/test/helpers/earth-replicator.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+import type { EntitySummary } from "../../src/types.js";
+import { teleportVerified } from "./teleport.js";
+
+/** Total every real carried nanite StackCount exposed through inventory. */
+export async function carriedNaniteTotal(game: GameServer): Promise<number> {
+  const inventory = await game.player.inventory();
+  let total = 0;
+  for (const item of inventory.items) {
+    if (!item.name?.toLowerCase().includes("nanite")) continue;
+    const detail = await game.entities.detail(item.entity_id);
+    const stack = detail.properties.find(
+      (property) => property.name === "StackCount",
+    );
+    assert.ok(stack, `carried nanite entity ${item.entity_id} needs StackCount`);
+    total += Number(stack.value);
+  }
+  return total;
+}
+
+/**
+ * Stage at Earth Technical Training's clear standing point and physically frob
+ * the authored replicator through the normal crosshair/squeeze path.
+ */
+export async function physicallyOpenEarthReplicator(
+  game: GameServer,
+  replicator: EntitySummary,
+): Promise<void> {
+  const [x, _y, z] = (await game.entities.detail(replicator.id)).position;
+  await teleportVerified(game, { x: x - 1.59, y: 21.404, z: z - 2.23 });
+  await game.input.set("head.look", [-35.3, -22]);
+  await game.step({ frames: 3 });
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 5 });
+}

--- a/tools/shock2-sdk/test/helpers/ui.ts
+++ b/tools/shock2-sdk/test/helpers/ui.ts
@@ -1,0 +1,19 @@
+import type { GameServer } from "../../src/index.js";
+import type { UiElement } from "../../src/types.js";
+
+/** Click the center of one introspected flat-panel element through real input. */
+export async function clickUiElement(
+  game: GameServer,
+  element: UiElement,
+): Promise<void> {
+  const [x, y, width, height] = element.screen_rect;
+  await game.input.set("pointer.position", [
+    x + width / 2,
+    y + height / 2,
+  ]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}


### PR DESCRIPTION
Fixes #544

Implements the retail replicator hacking path: the authored PLUGHACK sidecar, shared real HRM board and authored cost, persistent Hacked/Broken object states, distinct RepHacked inventory/prices, and save/load persistence. Critical hack failure exposes the authored broken/repair-required state and disables purchasing/hacking; repair remains a separate gameplay gap.

Exact stack:
- base: fix-543-replicator-economy at cc466f9a874b890ae001fbd809e98fdbe7eb6660
- head: fbd63cce2e0260a5a22ecd0446f4bb77aea1c3ed

Validation complete:
- focused ObjState, RepHacked, shared HRM/keypad, replicator, critical-loss, paid-reopen, and live GUI-resize Rust tests
- strict RUSTFLAGS=-D warnings check for shock2vr, desktop_runtime, and debug_runtime
- SDK TypeScript compile and fast suite: 14 active passed, 115 E2E skipped as designed
- #543 economy regression: authored prices, cross-stack debit, physical output, persistence, and unaffordable refusal pass
- #544 physical Earth scenario: real 250 pickup → left PLUGHACK → authored cost 3 → adaptive real HRM win → hacked 070/025/020 stock → HE output pickup → 177 balance → save/load passes
- manager frontier replay on exact head: paid-board close/reopen, three burns then alternate-column win, hacked output/persistence, and real Earth exit cleanup pass
- full SDK E2E: 126/129 on the broad run; the three unrelated timing/physics misses each pass alone on this exact head (alertness churn 1/1, monster death 1/1, ragdoll death 2/2). All 23 mission-load cases pass.
- two-engine adversarial re-review: no Critical, High, or Medium findings remain; the initial VR live-size, missing RepHacked stock, and paid-board reopen findings were fixed and re-reviewed
- dupfinder final-head review: no actionable duplication across 16 changed files / 3,222 indexed functions; optional jscpd token pass unavailable
- GitHub Android, macOS, Ubuntu, and Windows checks pass
- exact-source media below passed MIME, byte-identity, rendered-tag, and independent visual review

## Exact-source visual proof

![Earth replicator hacking flow](https://gist.githubusercontent.com/tommy-xr/3b4fd8e7734e765d0c94929f383544bb/raw/4f2ec0b6fd980a07c489cacc26974a9d18daf87f/replicator-hacking-demo.gif)

<sub>Physical Earth nanite pickup and replicator frob → authored PLUGHACK sidecar → paid real HRM board → SUCCESS → hacked 070/025/020 inventory → 70-nanite purchase → hacked inventory still present after save/load. Captured headlessly at fbd63cce2e0260a5a22ecd0446f4bb77aea1c3ed through deterministic fixed-timestep debug-runtime input and screenshots.</sub>

## Before → after

![Before and after PLUGHACK sidecar](https://gist.githubusercontent.com/tommy-xr/3b4fd8e7734e765d0c94929f383544bb/raw/4f2ec0b6fd980a07c489cacc26974a9d18daf87f/replicator-hacking-before-after.png)

<sub>The same fresh Earth pickup, camera, and physical-frob sequence: base cc466f9a874b890ae001fbd809e98fdbe7eb6660 has the normal MFD alone; head fbd63cce2e0260a5a22ecd0446f4bb77aea1c3ed adds the authored PLUGHACK sidecar on its left.</sub>