### PR TITLE
fix: preserve tripwire overlap across load

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -114,8 +114,8 @@ pub struct PropPosition {
 
 /// How an entity arrived at its current position when marked `PropTeleported`.
 /// Distinguishes player-initiated movement (which fires tripwires on arrival,
-/// like the original engine) from a scripted teleport trap (whose arrival must
-/// NOT re-fire the tripwire it lands in - see #515).
+/// like the original engine) from arrivals whose initial sensor overlaps must
+/// be reconstructed without replaying tripwire ENTER.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum TeleportSource {
     /// Player-initiated movement teleport: VR teleport locomotion or a debug
@@ -126,12 +126,17 @@ pub enum TeleportSource {
     /// Tripwire ENTER is suppressed for this arrival so a return teleport that
     /// lands inside another trap's tripwire box doesn't re-fire it (#515).
     ScriptedTrap,
+    /// Save/load rebuilt the physics world at the serialized player position.
+    /// Initial sensor overlaps are tracked, but their ENTER is not replayed;
+    /// leaving and genuinely re-entering later still fires normally (#547).
+    LoadRestore,
 }
 
 #[derive(Debug, Component, Serialize, Deserialize)]
 /// Marks an entity as having just teleported (VR teleport locomotion, teleport
-/// traps, debug teleport). Tripwires fire on teleport-entry like the original
-/// engine, EXCEPT for `ScriptedTrap` arrivals which are suppressed (#515).
+/// traps, debug teleport, or save restore). Tripwires fire on locomotion
+/// teleport-entry like the original engine; the other sources reconstruct
+/// their arrival without replaying ENTER.
 pub struct PropTeleported {
     pub countdown_timer: f32, // Remaining time to be considered 'recently teleported'
     #[serde(default)]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -43,7 +43,7 @@ use dark::{
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
         PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropTeleported,
         PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState, PropertyDefinition, RenderType,
-        ToLink, TripFlags, TweqAnimationState, WrappedEntityId,
+        TeleportSource, ToLink, TripFlags, TweqAnimationState, WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -1169,6 +1169,13 @@ impl MissionCore {
             |mut v_teleported: ViewMut<dark::properties::PropTeleported>| {
                 let mut ents_to_remove = Vec::new();
                 for (id, door) in (&mut v_teleported).iter().with_id() {
+                    // Load restoration is a one-script-update marker, not a
+                    // wall-clock timer. It must survive even a slow first
+                    // frame so initial sensor overlaps can be reconstructed.
+                    if door.source == TeleportSource::LoadRestore {
+                        continue;
+                    }
+
                     door.countdown_timer -= time.elapsed.as_secs_f32();
 
                     if door.countdown_timer < 0.0 {
@@ -1292,6 +1299,27 @@ impl MissionCore {
             self.script_world.update(&self.world, &self.physics, time)
         );
         effects.append(&mut script_effects);
+
+        // Any load-restored entity that did not overlap a tripwire still only
+        // needs the marker for the first physics-backed script update. Paused
+        // zero-time updates cannot emit initial overlaps, so they must retain
+        // it. Clear after the first nonzero update so a genuine sensor entry on
+        // a later frame is never suppressed.
+        if !time.elapsed.is_zero() {
+            self.world.run(|mut v_teleported: ViewMut<PropTeleported>| {
+                let load_restores = (&v_teleported)
+                    .iter()
+                    .with_id()
+                    .filter_map(|(id, marker)| {
+                        (marker.source == TeleportSource::LoadRestore).then_some(id)
+                    })
+                    .collect::<Vec<_>>();
+
+                for id in load_restores {
+                    v_teleported.remove(id);
+                }
+            });
+        }
 
         // Handle any pending entity triggers now that scripts are initialized
         if !self.pending_entity_triggers.is_empty() {

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -277,7 +277,7 @@ pub fn load_mission_from_save_data(
         save_data.global_data.rotation,
     );
 
-    let active_mission = Mission::load(
+    let mut active_mission = Mission::load(
         current_mission,
         asset_cache,
         audio_context,
@@ -287,6 +287,26 @@ pub fn load_mission_from_save_data(
         populator,
         save_data.global_data.held_items,
         game_options,
+    );
+
+    // A loaded mission rebuilds Rapier from scratch. Mark the restored player
+    // so the first BeginIntersect events reconstruct already-existing sensor
+    // overlaps without replaying their ENTER actions (#547). This is distinct
+    // from locomotion teleport (which must trigger) and scripted teleport
+    // suppression (#515).
+    let player_entity = {
+        let player = active_mission
+            .mission_core
+            .world
+            .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
+            .unwrap();
+        player.entity_id
+    };
+    active_mission.mission_core.world.add_component(
+        player_entity,
+        dark::properties::PropTeleported::with_source(
+            dark::properties::TeleportSource::LoadRestore,
+        ),
     );
 
     (active_mission, save_data.level_data)

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -19,21 +19,15 @@ pub fn is_player(world: &World, entity_id: EntityId) -> bool {
     v_prop_player.get(entity_id).is_ok()
 }
 
-/// Did this entity arrive via a *scripted* teleport trap (as opposed to walking
-/// or VR teleport locomotion)? Scripted-trap arrivals must not fire tripwire
-/// ENTER, so a return teleport that lands inside another trap's box doesn't
-/// re-fire it (#515). Locomotion teleports still fire (e.g. ops1 cutscene).
-fn arrived_via_scripted_teleport(world: &World, entity_id: EntityId) -> bool {
+fn teleport_source(world: &World, entity_id: EntityId) -> Option<TeleportSource> {
     let v_teleported = world.borrow::<View<PropTeleported>>().unwrap();
-    matches!(
-        v_teleported.get(entity_id),
-        Ok(t) if t.source == TeleportSource::ScriptedTrap
-    )
+    v_teleported.get(entity_id).ok().map(|marker| marker.source)
 }
 
 pub struct TrapNewTripwire {
     has_activated: bool,
     entity_in_trap: HashSet<EntityId>,
+    reconstructed_after_load: HashSet<EntityId>,
     trip_flags: TripFlags,
 }
 impl TrapNewTripwire {
@@ -42,6 +36,7 @@ impl TrapNewTripwire {
             trip_flags: TripFlags::DEFAULT,
             has_activated: false,
             entity_in_trap: HashSet::new(),
+            reconstructed_after_load: HashSet::new(),
         }
     }
 
@@ -123,15 +118,29 @@ impl Script for TrapNewTripwire {
         // tripwire).
         match msg {
             MessagePayload::SensorBeginIntersect { with } => {
-                // The ONE exception: a *scripted* teleport trap. Its arrival must
-                // not touch this tripwire at all - no ENTER signal AND not tracked
-                // as present. If we tracked it, walking back out would fire an
-                // unbalanced EXIT TurnOff and re-trigger the trap (the earth.mis
-                // montage loop, #515). This matches the original engine ignoring
-                // teleported-in entities. Consume the marker so a later walk-in to
-                // a *different* nearby tripwire still fires normally.
-                if arrived_via_scripted_teleport(world, *with) {
-                    return Effect::ClearTeleportedMarker { entity_id: *with };
+                match teleport_source(world, *with) {
+                    // A scripted teleport trap's arrival must not touch this
+                    // tripwire at all - no ENTER signal and not tracked as
+                    // present. Tracking it would make walking back out emit an
+                    // unbalanced EXIT TurnOff and re-trigger the earth montage
+                    // loop (#515).
+                    Some(TeleportSource::ScriptedTrap) => {
+                        return Effect::ClearTeleportedMarker { entity_id: *with };
+                    }
+                    // Loading creates a new physics world, so Rapier reports
+                    // every sensor containing the restored player as a fresh
+                    // BeginIntersect. Reconstruct that existing overlap in the
+                    // transient set without replaying ENTER. Unlike a scripted
+                    // teleport, track presence so leaving establishes the clean
+                    // edge needed for a later genuine re-entry (#547).
+                    Some(TeleportSource::LoadRestore) => {
+                        if self.should_activate(world, entity_id, *with, &trip_flags.trip_flags) {
+                            self.entity_in_trap.insert(*with);
+                            self.reconstructed_after_load.insert(*with);
+                        }
+                        return Effect::NoEffect;
+                    }
+                    Some(TeleportSource::Locomotion) | None => {}
                 }
 
                 if self.should_activate(world, entity_id, *with, &trip_flags.trip_flags) {
@@ -156,6 +165,7 @@ impl Script for TrapNewTripwire {
             }
             MessagePayload::SensorEndIntersect { with } => {
                 let had_keys_before = !self.entity_in_trap.is_empty();
+                let was_reconstructed_after_load = self.reconstructed_after_load.remove(with);
 
                 self.entity_in_trap.remove(with);
 
@@ -166,7 +176,17 @@ impl Script for TrapNewTripwire {
                     with, has_keys_now, had_keys_before, trip_flags
                 );
 
-                if !has_keys_now && had_keys_before && self.trip_flags.contains(TripFlags::EXIT) {
+                // The first EndIntersect paired with a load-reconstructed
+                // overlap is not a gameplay EXIT edge. Emitting TurnOff here
+                // would be as unbalanced as replaying ENTER and, on Earth,
+                // would activate the same teleport wiring while merely
+                // leaving the lobby sensor. Once removed, a later genuine
+                // enter/exit pair behaves normally.
+                if !was_reconstructed_after_load
+                    && !has_keys_now
+                    && had_keys_before
+                    && self.trip_flags.contains(TripFlags::EXIT)
+                {
                     send_to_all_switch_links(
                         world,
                         entity_id,

--- a/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
@@ -30,6 +30,10 @@ const BASIC_CHEM = 242;
 const BASIC_JUICE = 355;
 const BASIC_EXIT_TRIPWIRE = 380;
 const BASIC_EXIT_DESTINATION = 379;
+const TECHNICAL_ENTRY_TRIPWIRE = 314;
+const TECHNICAL_ENTRY_DESTINATION = 324;
+const TECHNICAL_EXIT_TRIPWIRE = 375;
+const TECHNICAL_EXIT_DESTINATION = 372;
 
 const ADVANCED_EXITS = [
   { name: "Weapons", tripwire: 374, destination: 371 },
@@ -329,3 +333,113 @@ for (const advanced of ADVANCED_EXITS) {
     },
   );
 }
+
+test(
+  "loading at the Earth Technical lobby return does not replay tripwire ENTER",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
+    });
+    await game.step({ frames: 5 });
+
+    // Carry a real mission item through the genuine Technical exit so this
+    // setup also proves the authored cleanup + return teleport completed
+    // before saving.
+    const juice = await exactlyOne(game, BASIC_JUICE, "control Juice bottle");
+    await game.player.give(juice.id);
+    await crossRealExit(
+      game,
+      TECHNICAL_EXIT_TRIPWIRE,
+      TECHNICAL_EXIT_DESTINATION,
+    );
+    assert.equal(
+      (await game.player.inventory()).count,
+      0,
+      "Technical exit should clean up training inventory before the save",
+    );
+
+    const lobbyPosition = await game.player.position();
+    const technicalEntryDestination = await exactlyOne(
+      game,
+      TECHNICAL_ENTRY_DESTINATION,
+      "Technical entry teleport destination",
+    );
+    const [entryX, , entryZ] = technicalEntryDestination.position;
+    assert.ok(
+      Math.hypot(lobbyPosition.x - entryX, lobbyPosition.z - entryZ) > 100,
+      `genuine Technical exit should return to the lobby, got ${JSON.stringify(lobbyPosition)}`,
+    );
+
+    await game.step({ frames: 10 });
+    const saveName = `earth_technical_lobby_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+
+    // Loading is synchronous: first prove the serialized position itself was
+    // restored, then step the newly-built physics world. Before #547 that
+    // first step creates a fresh overlap with entry tripwire 314, replays its
+    // ENTER, and sends the player back to destination 324.
+    const loadedPosition = await game.player.position();
+    assert.ok(
+      Math.hypot(
+        loadedPosition.x - lobbyPosition.x,
+        loadedPosition.z - lobbyPosition.z,
+      ) < 1,
+      `load should initially restore the saved lobby position: saved=${JSON.stringify(lobbyPosition)} loaded=${JSON.stringify(loadedPosition)}`,
+    );
+    await game.step({ frames: 5 });
+    const settledPosition = await game.player.position();
+    assert.ok(
+      Math.hypot(
+        settledPosition.x - lobbyPosition.x,
+        settledPosition.z - lobbyPosition.z,
+      ) < 3,
+      `initial overlap reconstruction must not replay ENTER: lobby=${JSON.stringify(lobbyPosition)} afterStep=${JSON.stringify(settledPosition)}`,
+    );
+    assert.equal(
+      (await game.player.inventory()).count,
+      0,
+      "the cleaned inventory should remain empty after load",
+    );
+
+    // Suppression is only for the overlap reconstructed by load. Leave the
+    // real entry sensor with bounded collision-valid movement, then walk back
+    // into its authored center: a later genuine ENTER must still activate 324.
+    const technicalEntry = await exactlyOne(
+      game,
+      TECHNICAL_ENTRY_TRIPWIRE,
+      "Technical lobby entry tripwire",
+    );
+    const [sensorX, sensorY, sensorZ] = technicalEntry.position;
+    const outside = {
+      x: sensorX + 4,
+      y: sensorY + 0.5,
+      z: sensorZ,
+    };
+    const leave = await game.player.moveTo(outside);
+    assert.ok(leave.moved, `player should leave entry sensor: ${JSON.stringify(leave)}`);
+    await game.step({ frames: 8 });
+    const outsidePosition = await game.player.position();
+    assert.ok(
+      Math.hypot(outsidePosition.x - sensorX, outsidePosition.z - sensorZ) > 3,
+      `load-reconstructed overlap should end without activating the entry wiring: outside=${JSON.stringify(outside)} actual=${JSON.stringify(outsidePosition)}`,
+    );
+    const reenter = await game.player.moveTo({
+      x: sensorX,
+      y: sensorY + 0.5,
+      z: sensorZ,
+    });
+    assert.ok(
+      reenter.moved,
+      `player should genuinely re-enter entry sensor: ${JSON.stringify(reenter)}`,
+    );
+    await game.step({ frames: 12 });
+    const reenteredPosition = await game.player.position();
+    assert.ok(
+      Math.hypot(reenteredPosition.x - entryX, reenteredPosition.z - entryZ) < 3,
+      `genuine leave/re-entry should still activate destination 324: destination=${JSON.stringify(technicalEntryDestination.position)} actual=${JSON.stringify(reenteredPosition)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- mark save-restored players separately from locomotion and scripted teleports
- reconstruct initial tripwire occupancy without replaying ENTER or its paired first EXIT
- expire the load marker after the first physics-backed script update, preserving paused and slow-load ordering
- add an Earth Technical objective regression covering genuine exit, save/load, stable lobby position, and later genuine re-entry

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (238 passed)
- `npm test` in `tools/shock2-sdk` (14 passed, 117 E2E skipped)
- focused Earth Technical save/load/re-entry E2E
- #515 montage teleport-loop E2E
- transitions trigger/locomotion E2E
- full SDK E2E: all 131 tests passed (41 before an ENOSPC interruption; 90/90 continuation after cleaning only the worktree build target)
- independent adversarial review: clean after timing/order fixes
- dupfinder: 3,227 functions semantically indexed; fallback jscpd scanned 1,618 files; no actionable duplication touching changed hunks

Fixes #547