### PR TITLE
fix: restore Earth psionic training objectives

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -125,6 +125,65 @@ pub struct PlayerInfo {
     pub inventory_entity_id: EntityId,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PsiKitUseOutcome {
+    NotUsed,
+    DecrementedStack,
+    DestroyEntity,
+}
+
+fn update_player_psi_points(world: &World, update: impl FnOnce(i32) -> i32) -> bool {
+    let player_entity = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
+    let mut psi_states = world
+        .borrow::<ViewMut<dark::properties::PropPsiState>>()
+        .unwrap();
+    if let Ok(psi) = (&mut psi_states).get(player_entity) {
+        let maximum = psi.max_psi_points.max(0);
+        let updated = update(psi.psi_points).clamp(0, maximum);
+        let changed = psi.psi_points != updated;
+        psi.psi_points = updated;
+        changed
+    } else {
+        false
+    }
+}
+
+/// Apply the stateful portion of one psi-kit effect against the live world.
+/// The caller performs canonical entity teardown for [`PsiKitUseOutcome::DestroyEntity`].
+fn apply_psi_kit_use(world: &World, entity_id: EntityId, amount: i32) -> PsiKitUseOutcome {
+    if amount <= 0 {
+        return PsiKitUseOutcome::NotUsed;
+    }
+    let is_alive = world
+        .borrow::<EntitiesView>()
+        .is_ok_and(|entities| entities.is_alive(entity_id));
+    if !is_alive {
+        return PsiKitUseOutcome::NotUsed;
+    }
+    let stack_count = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()
+        .and_then(|stacks| stacks.get(entity_id).ok().map(|stack| stack.0));
+    if stack_count.is_some_and(|stack| stack <= 0) {
+        return PsiKitUseOutcome::NotUsed;
+    }
+    if !update_player_psi_points(world, |current| current.saturating_add(amount)) {
+        return PsiKitUseOutcome::NotUsed;
+    }
+
+    if stack_count.is_some_and(|stack| stack > 1) {
+        let mut stacks = world
+            .borrow::<ViewMut<dark::properties::PropStackCount>>()
+            .unwrap();
+        if let Ok(stack) = (&mut stacks).get(entity_id) {
+            stack.0 -= 1;
+        }
+        PsiKitUseOutcome::DecrementedStack
+    } else {
+        PsiKitUseOutcome::DestroyEntity
+    }
+}
+
 /// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
 /// used to pose the flat melee viewmodel in its ready stance.
 const MELEE_IDLE_CLIP: &str = "ph212203";
@@ -2981,17 +3040,35 @@ impl MissionCore {
                 }
 
                 Effect::SpendPsiPoints { amount } => {
-                    let player_entity = self
-                        .world
-                        .borrow::<UniqueView<PlayerInfo>>()
-                        .unwrap()
-                        .entity_id;
-                    let mut v_psi = self
-                        .world
-                        .borrow::<ViewMut<dark::properties::PropPsiState>>()
-                        .unwrap();
-                    if let Ok(psi) = (&mut v_psi).get(player_entity) {
-                        psi.psi_points = (psi.psi_points - amount).max(0);
+                    update_player_psi_points(&self.world, |current| current.saturating_sub(amount));
+                }
+
+                Effect::SetPsiPoints { points } => {
+                    update_player_psi_points(&self.world, |_| points);
+                }
+
+                Effect::UsePsiKit { entity_id, amount } => {
+                    // This mutation and the consumption below happen while
+                    // processing one effect against live state. Two boosters
+                    // used in the same update therefore add independently;
+                    // a duplicate use of an already-destroyed booster no-ops.
+                    let outcome = apply_psi_kit_use(&self.world, entity_id, amount);
+                    if outcome == PsiKitUseOutcome::NotUsed {
+                        continue;
+                    }
+
+                    let sound = crate::scripts::script_util::play_environmental_sound(
+                        &self.world,
+                        entity_id,
+                        "activate",
+                        vec![],
+                        AudioHandle::new(),
+                    );
+                    if outcome == PsiKitUseOutcome::DestroyEntity {
+                        self.destroy_entity(entity_id);
+                    }
+                    if !matches!(sound, Effect::NoEffect) {
+                        effects.push_front(sound);
                     }
                 }
 
@@ -5515,6 +5592,17 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         let stack_count = self
             .world
             .run(|v: View<dark::properties::PropStackCount>| v.get(id).ok().map(|s| s.0));
+        // Live health is rendered in the HUD target label and is equally
+        // useful to deterministic gameplay scenarios (for example proving a
+        // real projectile damaged its intended target).
+        let hit_points = self
+            .world
+            .run(|v: View<dark::properties::PropHitPoints>| v.get(id).ok().map(|hp| hp.hit_points));
+        let max_hit_points = self
+            .world
+            .run(|v: View<dark::properties::PropMaxHitPoints>| {
+                v.get(id).ok().map(|hp| hp.hit_points)
+            });
 
         self.world.run(
             |v_pos: View<dark::properties::PropPosition>,
@@ -5585,6 +5673,18 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "StackCount".to_string(),
                         value: stack.to_string(),
+                    });
+                }
+                if let Some(hit_points) = hit_points {
+                    properties.push(DebugPropertyInfo {
+                        name: "HitPoints".to_string(),
+                        value: hit_points.to_string(),
+                    });
+                }
+                if let Some(max_hit_points) = max_hit_points {
+                    properties.push(DebugPropertyInfo {
+                        name: "MaxHitPoints".to_string(),
+                        value: max_hit_points.to_string(),
                     });
                 }
 
@@ -6316,6 +6416,127 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
         self.script_world.dispatch(Message { to: id, payload });
         true
+    }
+}
+
+#[cfg(test)]
+mod psi_kit_use_tests {
+    use dark::properties::{PropPsiState, PropStackCount};
+    use shipyard::{EntitiesView, Get, View};
+
+    use super::*;
+
+    fn world_with_player(psi_points: i32) -> World {
+        let mut world = World::new();
+        let inventory_entity_id = world.add_entity(());
+        let player = world.add_entity(PropPsiState {
+            psi_points,
+            max_psi_points: 50,
+            unknown: 50,
+        });
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id,
+        });
+        world
+    }
+
+    fn apply_effect_batch(world: &mut World, effects: Vec<Effect>) {
+        for effect in effects {
+            let Effect::UsePsiKit { entity_id, amount } = effect else {
+                panic!("unexpected effect in psi-kit test batch");
+            };
+            if apply_psi_kit_use(world, entity_id, amount) == PsiKitUseOutcome::DestroyEntity {
+                // Production performs MissionCore's canonical teardown here;
+                // this state-level regression has no render/physics/script maps.
+                world.delete_entity(entity_id);
+            }
+        }
+    }
+
+    fn player_psi_points(world: &World) -> i32 {
+        let player = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
+        world
+            .borrow::<View<PropPsiState>>()
+            .unwrap()
+            .get(player)
+            .unwrap()
+            .psi_points
+    }
+
+    #[test]
+    fn two_same_update_psi_kit_effects_restore_against_live_state_and_consume_both() {
+        let mut world = world_with_player(5);
+        let first = world.add_entity(PropStackCount(1));
+        let second = world.add_entity(PropStackCount(1));
+
+        // Both effects represent Frobs dispatched before one handle_effects
+        // pass. Applying them as one batch must not reuse a stale psi snapshot.
+        apply_effect_batch(
+            &mut world,
+            vec![
+                Effect::UsePsiKit {
+                    entity_id: first,
+                    amount: 20,
+                },
+                Effect::UsePsiKit {
+                    entity_id: second,
+                    amount: 20,
+                },
+            ],
+        );
+
+        assert_eq!(player_psi_points(&world), 45);
+        let entities = world.borrow::<EntitiesView>().unwrap();
+        assert!(!entities.is_alive(first));
+        assert!(!entities.is_alive(second));
+    }
+
+    #[test]
+    fn psi_kit_clamps_to_max_and_consumes_only_one_stack_unit() {
+        let mut world = world_with_player(45);
+        let booster = world.add_entity(PropStackCount(2));
+
+        assert_eq!(
+            apply_psi_kit_use(&world, booster, 20),
+            PsiKitUseOutcome::DecrementedStack
+        );
+        assert_eq!(player_psi_points(&world), 50);
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(booster)
+                .unwrap()
+                .0,
+            1
+        );
+    }
+
+    #[test]
+    fn psi_kit_at_full_pool_leaves_the_source_untouched() {
+        let mut world = world_with_player(50);
+        let booster = world.add_entity(PropStackCount(1));
+
+        assert_eq!(
+            apply_psi_kit_use(&world, booster, 20),
+            PsiKitUseOutcome::NotUsed
+        );
+        assert_eq!(player_psi_points(&world), 50);
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(booster));
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(booster)
+                .unwrap()
+                .0,
+            1
+        );
     }
 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -171,6 +171,21 @@ pub enum Effect {
         amount: i32,
     },
 
+    /// Set the player's current psi-point pool, clamped to `[0, max]`.
+    /// Emitted by authored psi consumables and training-room scripts.
+    SetPsiPoints {
+        points: i32,
+    },
+
+    /// Atomically restore the live player's psi pool and consume one unit of
+    /// the originating booster. Applied against live state so simultaneous
+    /// uses add independently, while an already-full pool or an already-used
+    /// entity remains untouched.
+    UsePsiKit {
+        entity_id: EntityId,
+        amount: i32,
+    },
+
     /// Activate (or refresh) a sustained psi power on the player for
     /// `duration_secs` (`ActivePsiPowers` unique). Emitted by the psi amp
     /// when a sustained (activation type 1) power is cast; a per-frame tick

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -31,6 +31,8 @@ mod obj_consume_button;
 mod once_room;
 mod once_router;
 mod psi_amp_script;
+mod psi_kit;
+mod reduce_psi;
 mod room_trigger;
 pub mod script_util;
 mod setup_initial_debrief;
@@ -91,6 +93,8 @@ use self::gui::{
 };
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::psi_amp_script::PsiAmpScript;
+use self::psi_kit::PsiKitScript;
+use self::reduce_psi::ReducePsi;
 use self::trap_signal::TrapSignal;
 use self::{
     base_button::BaseButton,
@@ -659,7 +663,7 @@ impl ScriptWorld {
             ])),
             "ectoplasm" => Box::new(UnimplementedScript::new(&script_name)),
             "medpatchscript" => Box::new(UnimplementedScript::new(&script_name)),
-            "psikitscript" => Box::new(UnimplementedScript::new(&script_name)),
+            "psikitscript" => Box::new(PsiKitScript::new()),
             "computer" => Box::new(UnimplementedScript::new(&script_name)),
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => Box::new(UnimplementedScript::new(&script_name)),
@@ -753,7 +757,7 @@ impl ScriptWorld {
             "chemical" => Box::new(NoopScript::new()),
             "chooseservice" => Box::new(ChooseServiceScript::new()),
             "infocomputer" => Box::new(UnimplementedScript::new(&script_name)),
-            "reducepsi" => Box::new(UnimplementedScript::new(&script_name)),
+            "reducepsi" => Box::new(ReducePsi::new()),
             "replicatorscript" => gui_script(Box::new(ReplicatorGui)),
             "researchablescript" => Box::new(UnimplementedScript::new(&script_name)),
             "setupinitialdebrief" => {

--- a/shock2vr/src/scripts/psi_kit.rs
+++ b/shock2vr/src/scripts/psi_kit.rs
@@ -1,0 +1,90 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// The retail psi hypo (`PsiKitScript`): inventory use restores 20 psi and
+/// consumes one unit from its stack.
+///
+/// At an already-full pool the original reports `misc\\PsiMaxed` and leaves
+/// the stack untouched. This port does not yet have a generic HUD-text effect,
+/// but preserves the consequential behavior: no refill and no consumption.
+pub struct PsiKitScript;
+
+impl PsiKitScript {
+    /// Retail `PsiKitScript` uses a 20-point psi bonus (also stated for the Psi
+    /// Hypo in the original System Shock 2 manual).
+    const RESTORE_AMOUNT: i32 = 20;
+
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for PsiKitScript {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) {
+            return Effect::NoEffect;
+        }
+
+        Effect::UsePsiKit {
+            entity_id,
+            amount: Self::RESTORE_AMOUNT,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::PsiKitScript;
+
+    fn world_with_booster() -> (World, shipyard::EntityId) {
+        let mut world = World::new();
+        let booster = world.add_entity(());
+        (world, booster)
+    }
+
+    #[test]
+    fn frob_requests_one_atomic_twenty_point_use() {
+        let (world, booster) = world_with_booster();
+        let effect = PsiKitScript::new().handle_message(
+            booster,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UsePsiKit {
+                entity_id,
+                amount: 20
+            } if entity_id == booster
+        ));
+    }
+
+    #[test]
+    fn unrelated_messages_do_nothing() {
+        let (world, booster) = world_with_booster();
+        let effect = PsiKitScript::new().handle_message(
+            booster,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: booster },
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/reduce_psi.rs
+++ b/shock2vr/src/scripts/reduce_psi.rs
@@ -1,0 +1,75 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// Earth Psionic Training's room-entry lesson.
+///
+/// The retail `ReducePsi` script responds to `TurnOn` by setting the player's
+/// pool to five psi points. Keeping the value in the script (rather than the
+/// Earth mission loader) preserves the authored Tripwire -> SwitchLink ->
+/// `ReducePsi` flow and lets any mission object use the same behavior.
+pub struct ReducePsi;
+
+impl ReducePsi {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for ReducePsi {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { .. } => Effect::SetPsiPoints { points: 5 },
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::ReducePsi;
+
+    #[test]
+    fn turn_on_sets_the_retail_training_value() {
+        let mut world = World::new();
+        let marker = world.add_entity(());
+        let source = world.add_entity(());
+
+        let effect = ReducePsi::new().handle_message(
+            marker,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: source },
+        );
+
+        assert!(matches!(effect, Effect::SetPsiPoints { points: 5 }));
+    }
+
+    #[test]
+    fn unrelated_messages_do_nothing() {
+        let mut world = World::new();
+        let marker = world.add_entity(());
+        let effect = ReducePsi::new().handle_message(
+            marker,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement } from "../src/types.js";
+import { aimAtWorldPoint } from "./helpers/aim.js";
+import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// Honest Earth Psionic Training regression for #548. Runtime ids are
+// discovered on every launch; positive template ids are stable mission object
+// ids. Teleports only stage outside real sensors or at clear item/target
+// sightlines. Entry, pickups, casting, inventory use, and exit all flow through
+// production input and authored mission links.
+//
+// Negative-first on the campaign parent: entry remains at 40 psi because
+// ReducePsi is unimplemented, and double-clicking a carried Psi Booster is a
+// no-op because PsiKitScript is unimplemented.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const PSIONIC_ENTRY_TRIPWIRE = 320;
+const PSIONIC_ENTRY_DESTINATION = 325;
+const PSI_BOOSTERS = [275, 288, 289] as const;
+const PSI_AMP = 290;
+const TRAINING_DROID = 593;
+const PSIONIC_EXIT_TRIPWIRE = 376;
+const PSIONIC_EXIT_DESTINATION = 373;
+
+function psiPoints(gameInfo: Awaited<ReturnType<GameServer["info"]>>): number {
+  const psi = gameInfo.player.psi_points;
+  assert.ok(psi !== null, "Earth player should have a psi pool");
+  return psi;
+}
+
+async function exactlyOne(
+  game: GameServer,
+  templateId: number,
+  label: string,
+): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(templateId);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one ${label} (${templateId}), got ${JSON.stringify(matches)}`,
+  );
+  return matches[0];
+}
+
+async function boosterStripElement(
+  game: GameServer,
+  entityId: number,
+): Promise<UiElement> {
+  const ui = await game.ui.state();
+  assert.equal(ui.mode, "use", "inventory use must happen in the live use-mode strip");
+  const element = ui.strip?.elements.find((candidate) => candidate.entity_id === entityId);
+  assert.ok(element, `use-mode strip should expose carried booster ${entityId}`);
+  return element;
+}
+
+async function useBooster(game: GameServer, boosterId: number): Promise<void> {
+  const element = await boosterStripElement(game, boosterId);
+  await clickUiElement(game, element);
+  assert.equal(
+    (await game.ui.state()).cursor?.entity_id,
+    boosterId,
+    "first click should lift the real carried booster onto the cursor",
+  );
+  await clickUiElement(game, element);
+  assert.equal(
+    (await game.ui.state()).cursor,
+    null,
+    "second click should complete inventory use and release the cursor",
+  );
+}
+
+async function aimAtEntity(game: GameServer, target: EntitySummary): Promise<void> {
+  const [tx, ty, tz] = (await game.entities.detail(target.id)).position;
+  await game.player.teleport({ x: tx - 4, y: ty, z: tz });
+  await game.step({ frames: 5 });
+  await aimAtWorldPoint(game, [tx, ty + 1, tz]);
+  await game.step({ frames: 3 });
+}
+
+function hitPoints(detail: Awaited<ReturnType<GameServer["entities"]["detail"]>>): number {
+  const property = detail.properties.find((candidate) => candidate.name === "HitPoints");
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+test(
+  "Earth Psionic Training reduces, refills, casts, and cleans up through real objectives",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8201),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(psiPoints(await game.info()), 40, "fresh Earth campaign psi");
+    await crossEarthTrainingTripwire(
+      game,
+      PSIONIC_ENTRY_TRIPWIRE,
+      PSIONIC_ENTRY_DESTINATION,
+    );
+    assert.equal(
+      psiPoints(await game.info()),
+      5,
+      "the authored ReducePsi entry lesson should set psi to five",
+    );
+
+    const boosters: EntitySummary[] = [];
+    for (const templateId of PSI_BOOSTERS) {
+      const booster = await exactlyOne(game, templateId, "authored Psi Booster");
+      await earthWorldUse(game, booster);
+      assert.ok(
+        (await game.player.inventory()).items.some(
+          (item) => item.entity_id === booster.id,
+        ),
+        `normal world-use should physically carry booster ${templateId}`,
+      );
+      boosters.push(booster);
+    }
+
+    const amp = await exactlyOne(game, PSI_AMP, "authored Psi Amp");
+    await earthWorldUse(game, amp);
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      amp.id,
+      "normal world-use should wield the authored Psi Amp",
+    );
+
+    // Exercise the walkthrough's explicit Y/CyclePsiPower lesson. A real
+    // mission knows only the default OSA power, so the selection remains
+    // Projected Cryokinesis and the HUD/API agree before the cast.
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.selected_psi_power, "Cryokinesis");
+
+    const droid = await exactlyOne(game, TRAINING_DROID, "Training Droid");
+    const droidHpBefore = hitPoints(await game.entities.detail(droid.id));
+    const psiBeforeCast = psiPoints(await game.info());
+    await aimAtEntity(game, droid);
+    await fireOnce(game);
+    await game.step({ frames: 60 });
+    assert.equal(
+      psiPoints(await game.info()),
+      psiBeforeCast - 1,
+      "normal tier-one Cryokinesis cast should spend one psi",
+    );
+    assert.ok(
+      hitPoints(await game.entities.detail(droid.id)) < droidHpBefore,
+      "normal Cryokinesis projectile should damage the real Training Droid",
+    );
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    let expectedPsi = psiBeforeCast - 1;
+    let expectedBoosters = boosters.length;
+    for (const booster of boosters) {
+      await useBooster(game, booster.id);
+      expectedPsi = Math.min(expectedPsi + 20, 50);
+      expectedBoosters -= 1;
+      assert.equal(
+        psiPoints(await game.info()),
+        expectedPsi,
+        "each Psi Booster restores 20 without exceeding the authored maximum",
+      );
+      assert.equal(
+        (await game.entities.byTemplate(booster.template_id)).length,
+        0,
+        `inventory use must consume exactly the authored booster ${booster.template_id}`,
+      );
+      assert.equal(
+        (await game.player.inventory()).items.filter(
+          (item) => item.name === "Psi Booster",
+        ).length,
+        expectedBoosters,
+      );
+    }
+    assert.equal(psiPoints(await game.info()), 50, "third booster clamps at max psi");
+
+    await crossEarthTrainingTripwire(
+      game,
+      PSIONIC_EXIT_TRIPWIRE,
+      PSIONIC_EXIT_DESTINATION,
+    );
+    assert.equal((await game.player.inventory()).count, 0);
+    let player = (await game.info()).player;
+    assert.equal(player.wielded_entity_id, null);
+    assert.equal(player.right_hand_entity_id, null);
+    assert.equal((await game.entities.byTemplate(PSI_AMP)).length, 0);
+
+    // Reopen the strip after cleanup: API and the captured visible UI must both
+    // show an actually-empty inventory, not a stale destroyed-item snapshot.
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 3 });
+    assert.equal((await game.ui.state()).mode, "shooter");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const reopened = await game.ui.state();
+    assert.equal(reopened.mode, "use");
+    assert.deepEqual(
+      reopened.strip?.elements.filter((element) => element.entity_id !== null),
+      [],
+      "reopened strip may draw its frame but must expose no carried item",
+    );
+    await game.screenshot("earth-psionic-empty-inventory.png");
+
+    player = (await game.info()).player;
+    assert.equal(player.wielded_entity_id, null);
+  },
+);

--- a/tools/shock2-sdk/test/helpers/aim.ts
+++ b/tools/shock2-sdk/test/helpers/aim.ts
@@ -1,0 +1,49 @@
+import type { GameServer } from "../../src/index.js";
+
+type Quat = [number, number, number, number];
+
+function multiplyQuat(a: Quat, b: Quat): Quat {
+  const [ax, ay, az, aw] = a;
+  const [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+}
+
+function lookQuat(direction: [number, number, number]): Quat {
+  const length = Math.hypot(...direction);
+  const [bx, by, bz] = direction.map((value) => value / length) as [
+    number,
+    number,
+    number,
+  ];
+  const dot = -bz;
+  if (dot < -0.999999) {
+    return [0, 1, 0, 0];
+  }
+  const quaternion: Quat = [by, -bx, 0, 1 + dot];
+  const quaternionLength = Math.hypot(...quaternion);
+  return quaternion.map((value) => value / quaternionLength) as Quat;
+}
+
+/**
+ * Aim the flat runtime's world-space view at a point while respecting the
+ * authored player pawn rotation.
+ */
+export async function aimAtWorldPoint(
+  game: GameServer,
+  target: [number, number, number],
+): Promise<void> {
+  const player = await game.player.position();
+  const pawn = (await game.info()).player.rotation as Quat;
+  const worldLook = lookQuat([
+    target[0] - player.x,
+    target[1] - (player.y + 1.6),
+    target[2] - player.z,
+  ]);
+  const inversePawn: Quat = [-pawn[0], -pawn[1], -pawn[2], pawn[3]];
+  await game.input.set("head.rotation", multiplyQuat(inversePawn, worldLook));
+}

--- a/tools/shock2-sdk/test/helpers/earth-tripwire.ts
+++ b/tools/shock2-sdk/test/helpers/earth-tripwire.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+
+import type { GameServer } from "../../src/index.js";
+
+/**
+ * Cross one authored Earth training tripwire through a bounded,
+ * collision-valid move and verify its linked teleport destination fired.
+ *
+ * Teleports only stage outside each cardinal face of the sensor. The actual
+ * interaction is Rapier's production SensorBeginIntersect path.
+ */
+export async function crossEarthTrainingTripwire(
+  game: GameServer,
+  tripwireTemplate: number,
+  destinationTemplate: number,
+): Promise<void> {
+  const tripwires = await game.entities.byTemplate(tripwireTemplate);
+  assert.equal(
+    tripwires.length,
+    1,
+    `expected exactly one Earth training tripwire ${tripwireTemplate}`,
+  );
+  const destinations = await game.entities.byTemplate(destinationTemplate);
+  assert.equal(
+    destinations.length,
+    1,
+    `expected exactly one Earth training destination ${destinationTemplate}`,
+  );
+  const [tripwire] = tripwires;
+  const [destination] = destinations;
+  const [x, y, z] = tripwire.position;
+  const [dx, , dz] = destination.position;
+
+  // Training rooms wall off different faces of their sensors. Try each
+  // cardinal approach, starting outside and entering the sensor under
+  // collision. The linked teleport proves the real tripwire fired.
+  const approaches = [
+    { x, y: y + 0.5, z: z - 4 },
+    { x: x - 4, y: y + 0.5, z },
+    { x: x + 4, y: y + 0.5, z },
+    { x, y: y + 0.5, z: z + 4 },
+  ];
+  for (const start of approaches) {
+    await game.player.teleport(start);
+    const beforeMove = await game.player.position();
+    assert.ok(
+      Math.hypot(beforeMove.x - dx, beforeMove.z - dz) >= 3,
+      "spatial setup must not teleport through the tripwire",
+    );
+    await game.step({ frames: 3 });
+    const afterSetup = await game.player.position();
+    assert.ok(
+      Math.hypot(afterSetup.x - dx, afterSetup.z - dz) >= 3,
+      "spatial setup must remain outside the tripwire sensor",
+    );
+    const moved = await game.player.moveTo({ x, y: y + 0.5, z });
+    await game.step({ frames: 12 });
+    const arrived = await game.player.position();
+    if (moved.moved && Math.hypot(arrived.x - dx, arrived.z - dz) < 3) {
+      return;
+    }
+  }
+
+  const arrived = await game.player.position();
+  assert.fail(
+    `tripwire ${tripwireTemplate} should fire its authored teleport to ${destinationTemplate}; ` +
+      `destination=${JSON.stringify(destination.position)} actual=${JSON.stringify(arrived)}`,
+  );
+}

--- a/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/vaporize-inventory.e2e.test.ts
@@ -3,6 +3,8 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, UiElement } from "../src/types.js";
+import { aimAtWorldPoint } from "./helpers/aim.js";
+import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
 import { teleportVerified } from "./helpers/teleport.js";
 
 // Earth training gives the player temporary supplies which must not escape the
@@ -72,37 +74,6 @@ async function squeeze(game: GameServer): Promise<void> {
   await game.step({ frames: 2 });
 }
 
-type Quat = [number, number, number, number];
-
-function multiplyQuat(a: Quat, b: Quat): Quat {
-  const [ax, ay, az, aw] = a;
-  const [bx, by, bz, bw] = b;
-  return [
-    aw * bx + ax * bw + ay * bz - az * by,
-    aw * by - ax * bz + ay * bw + az * bx,
-    aw * bz + ax * by - ay * bx + az * bw,
-    aw * bw - ax * bx - ay * by - az * bz,
-  ];
-}
-
-function lookQuat(direction: [number, number, number]): Quat {
-  const length = Math.hypot(...direction);
-  const [bx, by, bz] = direction.map((v) => v / length) as [
-    number,
-    number,
-    number,
-  ];
-  // Shortest-arc quaternion from flat controller local forward (0,0,-1)
-  // to the desired world direction.
-  const dot = -bz;
-  if (dot < -0.999999) {
-    return [0, 1, 0, 0];
-  }
-  const q: Quat = [by, -bx, 0, 1 + dot];
-  const qLength = Math.hypot(...q);
-  return q.map((v) => v / qLength) as Quat;
-}
-
 /**
  * Stand near an entity, compose a world-space look with the authored player
  * pawn rotation, and squeeze. Teleport is only spatial setup; acquisition
@@ -127,15 +98,7 @@ async function frobNormally(
   ];
   for (const stand of stands) {
     await teleportVerified(game, stand);
-    const player = await game.player.position();
-    const pawn = (await game.info()).player.rotation;
-    const eyeY = player.y + 1.6;
-    const dx = tx - player.x;
-    const dz = tz - player.z;
-    const desiredWorldLook = lookQuat([dx, aimY - eyeY, dz]);
-    const inversePawn: Quat = [-pawn[0], -pawn[1], -pawn[2], pawn[3]];
-    const head = multiplyQuat(inversePawn, desiredWorldLook);
-    await game.input.set("head.rotation", head);
+    await aimAtWorldPoint(game, [tx, aimY, tz]);
     await game.step({ frames: 3 });
     await squeeze(game);
     if (await didInteract()) {
@@ -193,60 +156,6 @@ async function acquireBasicItemsNormally(
   return { chemId: chem.entity_id! };
 }
 
-async function crossRealExit(
-  game: GameServer,
-  tripwireTemplate: number,
-  destinationTemplate: number,
-): Promise<void> {
-  const tripwire = await exactlyOne(game, tripwireTemplate, "training exit tripwire");
-  const destination = await exactlyOne(
-    game,
-    destinationTemplate,
-    "training exit teleport destination",
-  );
-  const [x, y, z] = tripwire.position;
-
-  const [dx, , dz] = destination.position;
-  // Training rooms wall off different faces of their exit sensors. Try each
-  // cardinal approach, starting just outside the sensor and entering through a
-  // bounded collision-valid move. Rapier's real SensorBeginIntersect then
-  // drives the tripwire SwitchLink.
-  const approaches = [
-    { x, y: y + 0.5, z: z - 4 },
-    { x: x - 4, y: y + 0.5, z },
-    { x: x + 4, y: y + 0.5, z },
-    { x, y: y + 0.5, z: z + 4 },
-  ];
-  for (const start of approaches) {
-    // Read the immediate paused position before any frame can generate a
-    // sensor event, then prove that the setup itself did not teleport us.
-    await game.player.teleport(start);
-    const beforeMove = await game.player.position();
-    assert.ok(
-      Math.hypot(beforeMove.x - dx, beforeMove.z - dz) >= 3,
-      "spatial setup must not teleport through the exit",
-    );
-    await game.step({ frames: 3 });
-    const afterSetup = await game.player.position();
-    assert.ok(
-      Math.hypot(afterSetup.x - dx, afterSetup.z - dz) >= 3,
-      "spatial setup must remain outside the exit sensor",
-    );
-    const moved = await game.player.moveTo({ x, y: y + 0.5, z });
-    await game.step({ frames: 12 });
-    const arrived = await game.player.position();
-    if (moved.moved && Math.hypot(arrived.x - dx, arrived.z - dz) < 3) {
-      return;
-    }
-  }
-
-  const arrived = await game.player.position();
-  assert.fail(
-    `tripwire ${tripwireTemplate} should fire its authored teleport to ${destinationTemplate}; ` +
-      `destination=${JSON.stringify(destination.position)} actual=${JSON.stringify(arrived)}`,
-  );
-}
-
 test(
   "earth Basic exit vaporizes supplies acquired through normal interactions",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -276,7 +185,7 @@ test(
       "Chem #1 should ride the cursor before crossing the exit",
     );
 
-    await crossRealExit(game, BASIC_EXIT_TRIPWIRE, BASIC_EXIT_DESTINATION);
+    await crossEarthTrainingTripwire(game, BASIC_EXIT_TRIPWIRE, BASIC_EXIT_DESTINATION);
 
     const inventory = await game.player.inventory();
     assert.equal(
@@ -319,7 +228,7 @@ for (const advanced of ADVANCED_EXITS) {
       await game.player.give(juice.id);
       assert.equal((await game.player.inventory()).count, 1);
 
-      await crossRealExit(game, advanced.tripwire, advanced.destination);
+      await crossEarthTrainingTripwire(game, advanced.tripwire, advanced.destination);
       assert.equal(
         (await game.player.inventory()).count,
         0,
@@ -349,7 +258,7 @@ test(
     // before saving.
     const juice = await exactlyOne(game, BASIC_JUICE, "control Juice bottle");
     await game.player.give(juice.id);
-    await crossRealExit(
+    await crossEarthTrainingTripwire(
       game,
       TECHNICAL_EXIT_TRIPWIRE,
       TECHNICAL_EXIT_DESTINATION,


### PR DESCRIPTION
Fixes #548.

Stacked on #549 (`fix-547-load-tripwire-overlap`).

## What changed

- implement the authored `ReducePsi` training script globally, setting the live
  player pool to 5 PSI on `TurnOn`
- implement `PsiKitScript` globally: restore 20 PSI, clamp at the authored
  maximum, consume exactly one source unit, and leave a full-pool use untouched
- apply PSI-kit restoration and consumption atomically against live state, so
  two uses delivered in one effect batch restore 5 → 45 and consume both
- add a detailed Earth Psionic Training scenario that crosses the real entry
  and exit tripwires, physically collects all boosters and the amp, explicitly
  cycles powers, casts Cryokinesis into the real training droid, uses each
  booster through the inventory strip, and verifies exit cleanup
- extract shared Earth aiming/tripwire helpers and keep the #547 save/load
  regression on the same real movement path

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 240/240 passed before the final two focused
  edge-case tests; focused PSI-kit suite is now 5/5
- `npm test` — 14 passed, 118 opt-in E2E tests skipped
- focused real-Earth Psionic Training replay — 1/1 passed
- full SDK E2E suite before the atomic review fix — 132/132 passed
- `dupfinder review` plus manual jscpd 5 fallback — no introduced exact clones;
  semantic neighbors reviewed
- cross-engine review: original Codex concurrency finding fixed; Codex delta
  review reports no findings / ship as-is; prior Claude full-slice review's
  provenance note addressed

## Visual proof

<!-- pr-visuals:earth-psionic -->

![Earth Psionic Training objective loop](https://gist.githubusercontent.com/tommy-xr/23d31dc478770a1803d1a4d75f346bcd/raw/earth-psionic-training.gif)

<sub>Earth Psionic Training now enforces the authored 5 PSI entry lesson and restores 20 PSI while consuming one booster. Captured headlessly through the real tripwire, world pickup, and inventory-use paths with deterministic fixed-timestep stepping.</sub>

### HEAD objective states

| Before booster use — 5 PSI, booster carried | After booster use — 25 PSI, booster consumed |
| --- | --- |
| ![HEAD before booster use](https://gist.githubusercontent.com/tommy-xr/23d31dc478770a1803d1a4d75f346bcd/raw/earth-psionic-head-before.png) | ![HEAD after booster use](https://gist.githubusercontent.com/tommy-xr/23d31dc478770a1803d1a4d75f346bcd/raw/earth-psionic-head-after.png) |

### Exact base → HEAD

![Exact base versus HEAD final state](https://gist.githubusercontent.com/tommy-xr/23d31dc478770a1803d1a4d75f346bcd/raw/earth-psionic-before-after.png)

<!-- /pr-visuals:earth-psionic -->
