### PR TITLE
fix: persist player vitals across saves and mission transitions

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -94,9 +94,9 @@ use engine::{
 use mission::entity_populator::{EntityPopulator, MissionEntityPopulator, SaveFileEntityPopulator};
 use quest_info::QuestInfo;
 
-use save_load::{EntitySaveData, GlobalData, HeldItemSaveData, SaveData};
+use save_load::{EntitySaveData, GlobalData, HeldItemSaveData, PlayerVitals, SaveData};
 use scenes::LoadingScene;
-use scripts::GlobalEffect;
+use scripts::{GlobalEffect, PlayerVitalsTransition};
 use shipyard::*;
 use time::Time;
 use tracing::{Level, info, span, trace, warn};
@@ -182,6 +182,7 @@ struct PendingTransition {
     entities_to_trigger: Vec<String>,
     quest_info: QuestInfo,
     held_data: HeldItemSaveData,
+    player_vitals: Option<PlayerVitals>,
     /// The CPU parse running on a worker thread. While this is in flight the loading
     /// screen renders (and animates) every frame; once it finishes, the main thread runs
     /// the GPU `build` and swaps to the mission.
@@ -384,7 +385,7 @@ impl Game {
     /// Capture the outgoing scene's save data (so its state survives the transition)
     /// and return the context the new mission needs. Must run while the outgoing scene
     /// is still active.
-    fn save_active_scene(&mut self) -> (QuestInfo, HeldItemSaveData) {
+    fn save_active_scene(&mut self) -> (QuestInfo, HeldItemSaveData, Option<PlayerVitals>) {
         let current_quest_info = self
             .active_game_scene
             .world()
@@ -405,7 +406,9 @@ impl Game {
             current_save_data,
         );
 
-        (current_quest_info, held_data)
+        let player_vitals = save_load::capture_player_vitals(self.active_game_scene.world());
+
+        (current_quest_info, held_data, player_vitals)
     }
 
     /// Load a mission (using previously-captured save context) and make it the active
@@ -416,6 +419,7 @@ impl Game {
         spawn_loc: SpawnLocation,
         quest_info: QuestInfo,
         held_data: HeldItemSaveData,
+        player_vitals: Option<PlayerVitals>,
     ) {
         let populator: Box<dyn EntityPopulator> = {
             if let Some(save_data) = self
@@ -441,12 +445,21 @@ impl Game {
             held_data,
             &self.options,
         );
+        save_load::restore_player_vitals(&active_mission.mission_core.world, player_vitals);
         self.active_game_scene = Box::new(active_mission);
     }
 
-    fn switch_mission(&mut self, level_name: String, spawn_loc: SpawnLocation) {
-        let (quest_info, held_data) = self.save_active_scene();
-        self.load_mission_into_scene(level_name, spawn_loc, quest_info, held_data);
+    fn switch_mission(
+        &mut self,
+        level_name: String,
+        spawn_loc: SpawnLocation,
+        vitals_transition: PlayerVitalsTransition,
+    ) {
+        let (quest_info, held_data, mut player_vitals) = self.save_active_scene();
+        if vitals_transition == PlayerVitalsTransition::InitializeFromDestination {
+            player_vitals = None;
+        }
+        self.load_mission_into_scene(level_name, spawn_loc, quest_info, held_data, player_vitals);
     }
 
     /// Start a background transition: save the outgoing scene, spawn the GL-free level
@@ -457,12 +470,16 @@ impl Game {
         level_name: String,
         spawn_loc: SpawnLocation,
         entities_to_trigger: Vec<String>,
+        vitals_transition: PlayerVitalsTransition,
     ) {
         tracing::info!(
             "[loading-screen] begin_transition -> {} (background parse)",
             level_name
         );
-        let (quest_info, held_data) = self.save_active_scene();
+        let (quest_info, held_data, mut player_vitals) = self.save_active_scene();
+        if vitals_transition == PlayerVitalsTransition::InitializeFromDestination {
+            player_vitals = None;
+        }
 
         // Spawn the GL-free parse off-thread. It owns `Arc`s of the asset-path layer and
         // the global context (gamesys + definitions), all `Send + Sync`, and produces a
@@ -482,6 +499,7 @@ impl Game {
             entities_to_trigger,
             quest_info,
             held_data,
+            player_vitals,
             parse_handle,
             frames_shown: 0,
         });
@@ -522,6 +540,7 @@ impl Game {
             pending.held_data,
             &self.options,
         );
+        save_load::restore_player_vitals(&mission.mission_core.world, pending.player_vitals);
         self.active_game_scene = Box::new(mission);
 
         for entity_name in pending.entities_to_trigger {
@@ -534,9 +553,10 @@ impl Game {
         level_name: String,
         spawn_loc: SpawnLocation,
         entities_to_trigger: Vec<String>,
+        vitals_transition: PlayerVitalsTransition,
     ) {
         // First, switch to the new mission
-        self.switch_mission(level_name, spawn_loc);
+        self.switch_mission(level_name, spawn_loc, vitals_transition);
 
         // Then, queue the entities to be triggered after scripts are initialized
         for entity_name in entities_to_trigger {
@@ -585,6 +605,7 @@ impl Game {
             level_file,
             loc,
             entities_to_trigger: vec![],
+            vitals_transition: PlayerVitalsTransition::Preserve,
         });
     }
 
@@ -593,7 +614,8 @@ impl Game {
     /// `file` is a bare name (no extension / path separators - validate at the
     /// edge); it resolves to `<data_root>/saves/<file>.sav`. This is the same
     /// serialization an in-game quicksave performs (`GlobalEffect::Save`) -
-    /// active mission, player position/rotation, quest bits, and held items.
+    /// active mission, player position/rotation, quest bits, held items, and
+    /// exact current/maximum player vitals.
     /// Returns the scene name that was saved so the caller can report it.
     pub fn save_game(&mut self, file: String) -> String {
         let path = save_file_path(&file);
@@ -607,10 +629,11 @@ impl Game {
     }
 
     /// Load a previously-saved game from `<data_root>/saves/<file>.sav`,
-    /// restoring the active mission, player position/rotation, quest bits, and
-    /// held items. The switch is synchronous (no loading-screen deferral), so
-    /// the returned scene name already reflects the restored mission. The caller
-    /// must ensure the file exists - the load path panics on a missing file.
+    /// restoring the active mission, player position/rotation, quest bits, held
+    /// items, and exact current/maximum player vitals. The switch is synchronous
+    /// (no loading-screen deferral), so the returned scene name already reflects
+    /// the restored mission. The caller must ensure the file exists - the load
+    /// path panics on a missing file.
     pub fn load_game(&mut self, file: String) -> String {
         let path = save_file_path(&file);
         self.handle_global_effect(GlobalEffect::Load {
@@ -1001,6 +1024,7 @@ impl Game {
             position,
             rotation,
             quest_info,
+            player_vitals: save_load::capture_player_vitals(self.active_game_scene.world()),
             active_mission: self.active_game_scene.scene_name().to_string(),
             is_crouched,
         };
@@ -1019,6 +1043,7 @@ impl Game {
                 level_file,
                 loc,
                 entities_to_trigger,
+                vitals_transition,
             } => {
                 let spawn_loc = match loc {
                     None => SpawnLocation::MapDefault,
@@ -1026,9 +1051,19 @@ impl Game {
                 };
 
                 if self.loading_screen_enabled() {
-                    self.begin_transition(level_file, spawn_loc, entities_to_trigger);
+                    self.begin_transition(
+                        level_file,
+                        spawn_loc,
+                        entities_to_trigger,
+                        vitals_transition,
+                    );
                 } else {
-                    self.switch_mission_with_trigger(level_file, spawn_loc, entities_to_trigger);
+                    self.switch_mission_with_trigger(
+                        level_file,
+                        spawn_loc,
+                        entities_to_trigger,
+                        vitals_transition,
+                    );
                 }
             }
             GlobalEffect::TestReload => {
@@ -1051,9 +1086,14 @@ impl Game {
                 let level_name = self.active_game_scene.scene_name().to_string();
                 let spawn_loc = SpawnLocation::PositionRotation(position, rotation);
                 if self.loading_screen_enabled() {
-                    self.begin_transition(level_name, spawn_loc, vec![]);
+                    self.begin_transition(
+                        level_name,
+                        spawn_loc,
+                        vec![],
+                        PlayerVitalsTransition::Preserve,
+                    );
                 } else {
-                    self.switch_mission(level_name, spawn_loc);
+                    self.switch_mission(level_name, spawn_loc, PlayerVitalsTransition::Preserve);
                 }
             }
             GlobalEffect::Quit => {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -536,11 +536,9 @@ impl MissionCore {
         // The choice is persisted as a quest bit, so it re-applies on every
         // deployment; with no career selected the player template defaults
         // (30 HP, 40/50 psi) stand. Absolute values keep re-application
-        // idempotent across level loads. Setting current = max mirrors the
-        // engine's existing model: the player is `RuntimePropDoNotSerialize` and
-        // its HP/psi are re-seeded from the template on every load (there is no
-        // current-HP persistence yet), so this only changes the values arrived
-        // with, not whether a reset happens.
+        // idempotent across level loads. These are the deliberate first-career
+        // and legacy-save defaults; ordinary transitions and current-format
+        // saves restore their exact persisted pools after mission construction.
         if let Some(career) = crate::career::Career::from_quest_info(&quest_info) {
             let loadout = career.loadout();
             world.run(
@@ -3838,10 +3836,9 @@ impl MissionCore {
                                 // Tank (Trait8): the original raises the
                                 // ceiling AND current HP by the bonus (buying
                                 // at 25/30 yields 30/35), clamped to the new
-                                // max. Loads re-derive both from the trait
-                                // list (current HP is not persisted - it
-                                // re-seeds from template + career + traits),
-                                // so the live grant cannot double-apply.
+                                // max. Loads first re-derive the trait-adjusted
+                                // default, then restore the persisted live pool,
+                                // so the grant cannot double-apply.
                                 drop(quests);
                                 let player_entity = self
                                     .world

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -16,9 +16,9 @@
 //! bits), so it rides the existing persistence path for free: it survives level
 //! transitions (`QuestInfo` is threaded through `Game::save_active_scene` ->
 //! `load_mission_into_scene`) and save/load (`QuestInfo` is embedded in
-//! `SaveData::global_data`). This mirrors how hp/psi "persist": those are
-//! re-derived from the persisted career quest bits on every mission load
-//! (`mission_core.rs`); stats are the same idea but accumulate across tours.
+//! `SaveData::global_data`). HP/PSI use a sibling global-data snapshot: mission
+//! construction first derives template/career/trait defaults, then ordinary
+//! transitions and current-format saves restore the exact live pools.
 //!
 //! Deferred (storage + grants only, per issue #453): career-specific stat
 //! baselines (all careers start from the uniform [`PlayerStats::default`]

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -1,9 +1,11 @@
 mod entity_save_data;
 mod held_item_save_data;
+mod player_vitals;
 mod save_data;
 
 pub use entity_save_data::*;
 pub use held_item_save_data::*;
+pub use player_vitals::*;
 pub use save_data::*;
 
 use std::{

--- a/shock2vr/src/save_load/player_vitals.rs
+++ b/shock2vr/src/save_load/player_vitals.rs
@@ -1,0 +1,211 @@
+use dark::properties::{PropHitPoints, PropMaxHitPoints, PropPsiState};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, UniqueView, View, ViewMut, World};
+
+use crate::mission::PlayerInfo;
+
+/// Restored pools reserve half the signed range for subsequent authored
+/// healing/trait adjustments. Retail values are two digits; reaching this
+/// boundary requires a malformed or hand-edited save.
+const MAX_RESTORED_VITAL_POINTS: i32 = i32::MAX / 2;
+
+/// One persisted current/maximum player resource pool.
+///
+/// Both values are signed in the save schema so malformed or hand-edited
+/// saves can be normalized before the unsigned Dark `P$MAX_HP` property is
+/// written back into the ECS.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlayerVitalPool {
+    pub current: i32,
+    pub maximum: i32,
+}
+
+/// Capture the player identified by the mission's `PlayerInfo` unique.
+pub(crate) fn capture_player_vitals(world: &World) -> Option<PlayerVitals> {
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
+    PlayerVitals::capture(world, player.entity_id)
+}
+
+/// Restore a persisted snapshot onto the destination mission's rebuilt player.
+/// `None` intentionally leaves the template/career/trait-derived defaults in
+/// place (legacy saves and first career selection).
+pub(crate) fn restore_player_vitals(world: &World, vitals: Option<PlayerVitals>) {
+    let Some(vitals) = vitals else {
+        return;
+    };
+    let Ok(player) = world.borrow::<UniqueView<PlayerInfo>>() else {
+        return;
+    };
+    vitals.restore(world, player.entity_id);
+}
+
+impl PlayerVitalPool {
+    fn clamped(self) -> PlayerVitalPool {
+        let maximum = self.maximum.clamp(0, MAX_RESTORED_VITAL_POINTS);
+        PlayerVitalPool {
+            current: self.current.clamp(0, maximum),
+            maximum,
+        }
+    }
+}
+
+/// Player health and psi state that follows the player between missions and is
+/// stored independently from mission entities and held-item serialization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlayerVitals {
+    pub hit_points: PlayerVitalPool,
+    pub psi_points: PlayerVitalPool,
+}
+
+impl PlayerVitals {
+    /// Capture the live player pools. A scene without all four authored
+    /// properties has no restorable vitals state.
+    pub(crate) fn capture(world: &World, player: EntityId) -> Option<PlayerVitals> {
+        let hit_points = world.borrow::<View<PropHitPoints>>().ok()?;
+        let max_hit_points = world.borrow::<View<PropMaxHitPoints>>().ok()?;
+        let psi_points = world.borrow::<View<PropPsiState>>().ok()?;
+        let hp = hit_points.get(player).ok()?;
+        let max_hp = max_hit_points.get(player).ok()?;
+        let psi = psi_points.get(player).ok()?;
+
+        Some(PlayerVitals {
+            hit_points: PlayerVitalPool {
+                current: hp.hit_points,
+                maximum: i32::try_from(max_hp.hit_points).unwrap_or(i32::MAX),
+            },
+            psi_points: PlayerVitalPool {
+                current: psi.psi_points,
+                maximum: psi.max_psi_points,
+            },
+        })
+    }
+
+    /// Restore maximums first, then clamp each current value into its restored
+    /// pool. Career and O/S-trait derivation runs before this method; a valid
+    /// persisted snapshot therefore wins exactly, while malformed saves cannot
+    /// create negative maximums or overfilled pools.
+    pub(crate) fn restore(self, world: &World, player: EntityId) {
+        let hit_points = self.hit_points.clamped();
+        let psi_points = self.psi_points.clamped();
+
+        world.run(
+            |mut hp: ViewMut<PropHitPoints>,
+             mut max_hp: ViewMut<PropMaxHitPoints>,
+             mut psi: ViewMut<PropPsiState>| {
+                if let Ok(value) = (&mut hp).get(player) {
+                    value.hit_points = hit_points.current;
+                }
+                if let Ok(value) = (&mut max_hp).get(player) {
+                    value.hit_points = hit_points.maximum as u32;
+                }
+                if let Ok(value) = (&mut psi).get(player) {
+                    value.psi_points = psi_points.current;
+                    value.max_psi_points = psi_points.maximum;
+                }
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn player_world() -> (World, EntityId) {
+        let mut world = World::new();
+        let player = world.add_entity((
+            PropHitPoints { hit_points: 27 },
+            PropMaxHitPoints { hit_points: 35 },
+            PropPsiState {
+                psi_points: 4,
+                max_psi_points: 60,
+                unknown: 50,
+            },
+        ));
+        (world, player)
+    }
+
+    #[test]
+    fn captures_current_and_maximum_pools_exactly() {
+        let (world, player) = player_world();
+
+        assert_eq!(
+            PlayerVitals::capture(&world, player),
+            Some(PlayerVitals {
+                hit_points: PlayerVitalPool {
+                    current: 27,
+                    maximum: 35,
+                },
+                psi_points: PlayerVitalPool {
+                    current: 4,
+                    maximum: 60,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn restore_preserves_maximums_and_clamps_currents() {
+        let (world, player) = player_world();
+        PlayerVitals {
+            hit_points: PlayerVitalPool {
+                current: 80,
+                maximum: 52,
+            },
+            psi_points: PlayerVitalPool {
+                current: -3,
+                maximum: 73,
+            },
+        }
+        .restore(&world, player);
+
+        let restored = PlayerVitals::capture(&world, player).unwrap();
+        assert_eq!(
+            restored,
+            PlayerVitals {
+                hit_points: PlayerVitalPool {
+                    current: 52,
+                    maximum: 52,
+                },
+                psi_points: PlayerVitalPool {
+                    current: 0,
+                    maximum: 73,
+                },
+            }
+        );
+        let psi = world.borrow::<View<PropPsiState>>().unwrap();
+        assert_eq!(psi.get(player).unwrap().unknown, 50);
+    }
+
+    #[test]
+    fn restore_limits_malformed_extreme_maxima_before_later_adjustments() {
+        let (world, player) = player_world();
+        PlayerVitals {
+            hit_points: PlayerVitalPool {
+                current: i32::MAX,
+                maximum: i32::MAX,
+            },
+            psi_points: PlayerVitalPool {
+                current: i32::MAX,
+                maximum: i32::MAX,
+            },
+        }
+        .restore(&world, player);
+
+        let restored = PlayerVitals::capture(&world, player).unwrap();
+        assert_eq!(
+            restored.hit_points,
+            PlayerVitalPool {
+                current: MAX_RESTORED_VITAL_POINTS,
+                maximum: MAX_RESTORED_VITAL_POINTS,
+            }
+        );
+        assert_eq!(
+            restored.psi_points,
+            PlayerVitalPool {
+                current: MAX_RESTORED_VITAL_POINTS,
+                maximum: MAX_RESTORED_VITAL_POINTS,
+            }
+        );
+    }
+}

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -3,7 +3,7 @@
  *
  * Data type for information we serialize to load/save the game
  */
-use super::{EntitySaveData, HeldItemSaveData};
+use super::{EntitySaveData, HeldItemSaveData, PlayerVitals};
 use crate::quest_info::QuestInfo;
 use cgmath::{Quaternion, Vector3};
 use serde::{Deserialize, Serialize};
@@ -42,9 +42,68 @@ pub struct GlobalData {
     pub rotation: Quaternion<f32>,
     pub quest_info: QuestInfo,
     pub held_items: HeldItemSaveData,
+    /// Exact live player HP/PSI pools. Older saves omit this field and retain
+    /// the pre-existing template/career initialization behavior.
+    #[serde(default)]
+    pub player_vitals: Option<PlayerVitals>,
     pub active_mission: String,
     /// Whether the player was crouched at save time. Defaults false for
     /// saves that predate crouch.
     #[serde(default)]
     pub is_crouched: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::save_load::{PlayerVitalPool, PlayerVitals};
+    use cgmath::{Quaternion, vec3};
+
+    fn global_data(player_vitals: Option<PlayerVitals>) -> GlobalData {
+        GlobalData {
+            position: vec3(1.0, 2.0, 3.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            quest_info: QuestInfo::new(),
+            held_items: HeldItemSaveData::empty(),
+            player_vitals,
+            active_mission: "earth.mis".to_owned(),
+            is_crouched: false,
+        }
+    }
+
+    fn sample_vitals() -> PlayerVitals {
+        PlayerVitals {
+            hit_points: PlayerVitalPool {
+                current: 27,
+                maximum: 35,
+            },
+            psi_points: PlayerVitalPool {
+                current: 4,
+                maximum: 60,
+            },
+        }
+    }
+
+    #[test]
+    fn player_vitals_round_trip_current_and_maximum_values() {
+        let original = global_data(Some(sample_vitals()));
+        let decoded: GlobalData =
+            serde_json::from_value(serde_json::to_value(&original).unwrap()).unwrap();
+
+        assert_eq!(decoded.player_vitals, Some(sample_vitals()));
+    }
+
+    #[test]
+    fn older_save_without_player_vitals_uses_existing_load_defaults() {
+        let mut legacy = serde_json::to_value(global_data(Some(sample_vitals()))).unwrap();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("player_vitals")
+            .unwrap();
+
+        let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
+
+        assert_eq!(decoded.player_vitals, None);
+    }
 }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -219,6 +219,8 @@ impl GameScene for MainMenuScene {
                     level_file: NEW_GAME_MISSION.to_owned(),
                     loc: None,
                     entities_to_trigger: vec![],
+                    vitals_transition:
+                        crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
                 })]
             }
             Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -288,6 +288,10 @@ pub fn load_mission_from_save_data(
         save_data.global_data.held_items,
         game_options,
     );
+    crate::save_load::restore_player_vitals(
+        &active_mission.mission_core.world,
+        save_data.global_data.player_vitals,
+    );
 
     // A loaded mission rebuilds Rapier from scratch. Mark the restored player
     // so the first BeginIntersect events reconstruct already-existing sensor

--- a/shock2vr/src/scripts/choose_mission.rs
+++ b/shock2vr/src/scripts/choose_mission.rs
@@ -120,6 +120,7 @@ impl Script for ChooseMissionScript {
                             level_file: "station.mis".to_string(),
                             loc: None,
                             entities_to_trigger,
+                            vitals_transition: super::PlayerVitalsTransition::Preserve,
                         }),
                     ])
                 } else {
@@ -140,6 +141,7 @@ impl Script for ChooseMissionScript {
                             level_file,
                             loc: dest_loc,
                             entities_to_trigger: vec![],
+                            vitals_transition: super::PlayerVitalsTransition::Preserve,
                         }),
                     ])
                 }

--- a/shock2vr/src/scripts/choose_service.rs
+++ b/shock2vr/src/scripts/choose_service.rs
@@ -63,6 +63,7 @@ impl Script for ChooseServiceScript {
                         level_file: format!("{}.mis", dest_level.0),
                         loc: dest_loc,
                         entities_to_trigger: vec![career.station_start_trigger(1)],
+                        vitals_transition: super::PlayerVitalsTransition::InitializeFromDestination,
                     }));
                 }
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -17,6 +17,18 @@ use crate::{
 
 use super::Message;
 
+/// How a level transition initializes the destination player's HP/PSI pools.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlayerVitalsTransition {
+    /// Carry the live pools into the destination. This is the normal behavior
+    /// for deck changes, reloads, and station training-year transitions.
+    Preserve,
+    /// Let the destination derive fresh pools from its player template,
+    /// selected career, and persistent traits. Used when character creation
+    /// deliberately selects the first career loadout.
+    InitializeFromDestination,
+}
+
 #[derive(Clone, Debug)]
 pub enum GlobalEffect {
     // Save the game state to the given file_name
@@ -33,6 +45,7 @@ pub enum GlobalEffect {
         level_file: String,
         loc: Option<i32>,
         entities_to_trigger: Vec<String>,
+        vitals_transition: PlayerVitalsTransition,
     },
 
     // Test the reload functionality (as if saving + loading)

--- a/shock2vr/src/scripts/gui/elevator.rs
+++ b/shock2vr/src/scripts/gui/elevator.rs
@@ -220,6 +220,7 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
                     level_file: level.clone(),
                     loc: Some(22),
                     entities_to_trigger: vec![],
+                    vitals_transition: crate::scripts::PlayerVitalsTransition::Preserve,
                 }),
             ),
         }

--- a/shock2vr/src/scripts/level_change_button.rs
+++ b/shock2vr/src/scripts/level_change_button.rs
@@ -32,6 +32,7 @@ impl Script for LevelChangeButton {
                     level_file: format!("{}.mis", level_file.0),
                     loc: maybe_dest_loc,
                     entities_to_trigger: vec![],
+                    vitals_transition: super::PlayerVitalsTransition::Preserve,
                 })
             }
             _ => Effect::NoEffect,

--- a/shock2vr/src/scripts/trap_trip_level.rs
+++ b/shock2vr/src/scripts/trap_trip_level.rs
@@ -32,6 +32,7 @@ impl Script for TrapTripLevel {
                     level_file: format!("{}.mis", level_file.0),
                     loc: maybe_dest_loc,
                     entities_to_trigger: vec![],
+                    vitals_transition: super::PlayerVitalsTransition::Preserve,
                 })
             }
             _ => Effect::NoEffect,

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -161,12 +161,12 @@ test(
       (hpBefore as number) + 5,
       "Tank max-HP bonus re-derives after load (not doubled)",
     );
-    // Current HP is not persisted: it re-seeds to the (trait-adjusted) max on
-    // load, so the live +5 current-HP grant cannot double-apply.
+    // Current and maximum HP persist together. This full-health snapshot stays
+    // exactly 35/35, so the live +5 grant cannot double-apply on load.
     assert.equal(
       hpLoaded.hit_points,
       hpLoaded.max_hit_points,
-      "current HP re-seeds to max on load (live grant does not double)",
+      "current HP persists exactly at the trait-adjusted max",
     );
     const machine2 = await findMachine(game, 133);
     await standNear(game, machine2.id);

--- a/tools/shock2-sdk/test/save-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/save-load.e2e.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 
 import { GameServer, HttpError, findRepoRoot } from "../src/index.js";
 import type { Position } from "../src/types.js";
+import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
 
 // End-to-end test for the save-to-file / load-from-file endpoints. Requires game
 // assets in Data/ and compiles the runtime on first run, so it is opt-in:
@@ -22,8 +24,36 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8101);
 
+interface PlayerVitals {
+  hitPoints: number;
+  maxHitPoints: number;
+  psiPoints: number;
+  maxPsiPoints: number;
+}
+
 function distance(a: Position, b: Position): number {
   return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+function playerVitals(
+  info: Awaited<ReturnType<GameServer["info"]>>,
+): PlayerVitals {
+  const {
+    hit_points: hitPoints,
+    max_hit_points: maxHitPoints,
+    psi_points: psiPoints,
+    max_psi_points: maxPsiPoints,
+  } = info.player;
+  assert.notEqual(hitPoints, null, "player should have current hit points");
+  assert.notEqual(maxHitPoints, null, "player should have maximum hit points");
+  assert.notEqual(psiPoints, null, "player should have current psi points");
+  assert.notEqual(maxPsiPoints, null, "player should have maximum psi points");
+  return {
+    hitPoints: hitPoints as number,
+    maxHitPoints: maxHitPoints as number,
+    psiPoints: psiPoints as number,
+    maxPsiPoints: maxPsiPoints as number,
+  };
 }
 
 // Locate the on-disk .sav for a freshly-saved name by scanning the candidate
@@ -193,5 +223,85 @@ test(
       "medsci1.mis",
       "runtime should stay live on medsci1 after a failed load",
     );
+  },
+);
+
+test(
+  "current and maximum player vitals survive mission transition and cross-process save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Negative-first for #551: Earth Psionic Training gives us a production
+    // path to non-default PSI and HP. The authored room entry sets PSI to 5,
+    // then a real psi-amp burnout spends one point and deals three damage.
+    // Before the fix, the transition below resets 27/30 HP + 4/50 PSI to the
+    // destination's template defaults, and a fresh-process load does likewise.
+    const saveName = `player_vitals_e2e_${Date.now()}`;
+    let expected: PlayerVitals;
+
+    {
+      await using game = await GameServer.launch({
+        mission: "earth.mis",
+        port: basePort + 3,
+      });
+      await game.step({ frames: 5 });
+
+      await crossEarthTrainingTripwire(game, 320, 325);
+      const [amp] = await game.entities.byTemplate(290);
+      assert.ok(amp, "Earth Psionic Training should contain its authored Psi Amp");
+      await earthWorldUse(game, amp);
+      assert.equal(
+        (await game.info()).player.wielded_entity_id,
+        amp.id,
+        "normal world-use should wield the authored Psi Amp",
+      );
+
+      await game.input.set("right_hand.trigger", 1);
+      await game.step({ frames: 130 });
+      await game.input.set("right_hand.trigger", 0);
+      await game.step({ frames: 45 });
+
+      expected = playerVitals(await game.info());
+      assert.deepEqual(
+        expected,
+        {
+          hitPoints: 27,
+          maxHitPoints: 30,
+          psiPoints: 4,
+          maxPsiPoints: 50,
+        },
+        "the test setup should establish non-default current HP and PSI",
+      );
+
+      await game.transitionLevel("medsci1.mis");
+      await game.step({ frames: 5 });
+      assert.equal((await game.info()).mission, "medsci1.mis");
+      assert.deepEqual(
+        playerVitals(await game.info()),
+        expected,
+        "an ordinary mission transition should carry exact current and maximum vitals",
+      );
+
+      const saveResult = await game.save(saveName);
+      assert.equal(saveResult.success, true);
+      assert.equal(saveResult.mission, "medsci1.mis");
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "eng1.mis",
+        port: basePort + 4,
+      });
+      await game.step({ frames: 2 });
+      assert.equal((await game.info()).mission, "eng1.mis");
+
+      const loadResult = await game.load(saveName);
+      assert.equal(loadResult.success, true);
+      assert.equal(loadResult.mission, "medsci1.mis");
+      assert.deepEqual(
+        playerVitals(await game.info()),
+        expected,
+        "a fresh runtime process should restore exact current and maximum vitals",
+      );
+    }
   },
 );

--- a/tools/shock2-sdk/test/station-flow.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-flow.e2e.test.ts
@@ -140,7 +140,9 @@ test(
     assert.equal(await game.quests.get("career_navy"), "unknown", "Navy bit should be clear");
     assert.equal(await game.quests.get("career_osa"), "unknown", "OSA bit should be clear");
     // Marine loadout applied on the station load.
+    assert.equal(info.player.hit_points, 45, "first Marine selection starts at full career HP");
     assert.equal(info.player.max_hit_points, 45, "Marine deploys with 45 max HP");
+    assert.equal(info.player.psi_points, 20, "first Marine selection starts at full career psi");
     assert.equal(info.player.max_psi_points, 20, "Marine deploys with 20 max psi");
 
     // #453: the persistent character sheet exists and starts at baseline (no
@@ -292,7 +294,13 @@ test(
 async function enlist(
   branch: keyof typeof CAREER_DOORS,
   port: number,
-): Promise<{ bit: string; maxHp: number | null; maxPsi: number | null }> {
+): Promise<{
+  bit: string;
+  hitPoints: number | null;
+  maxHp: number | null;
+  psiPoints: number | null;
+  maxPsi: number | null;
+}> {
   const door = CAREER_DOORS[branch];
   await using game = await GameServer.launch({ mission: "earth.mis", port });
   await game.step({ frames: 5 });
@@ -308,7 +316,9 @@ async function enlist(
   );
   return {
     bit: await game.quests.get(door.bit),
+    hitPoints: info.player.hit_points,
     maxHp: info.player.max_hit_points,
+    psiPoints: info.player.psi_points,
     maxPsi: info.player.max_psi_points,
   };
 }
@@ -323,12 +333,16 @@ test(
     // marker (P$Service=1). Correct engine behavior yields the Navy career.
     const navy = await enlist("navy", basePort);
     assert.equal(navy.bit, "complete", "Navy door should set career_navy (despite the 'SendToMarines' misnomer)");
+    assert.equal(navy.hitPoints, CAREER_DOORS.navy.maxHp, "Navy starts at full career HP");
     assert.equal(navy.maxHp, CAREER_DOORS.navy.maxHp, "Navy deploys with 35 max HP");
+    assert.equal(navy.psiPoints, CAREER_DOORS.navy.maxPsi, "Navy starts at full career psi");
     assert.equal(navy.maxPsi, CAREER_DOORS.navy.maxPsi, "Navy deploys with 35 max psi");
 
     const osa = await enlist("osa", basePort + 1);
     assert.equal(osa.bit, "complete", "OSA door should set career_osa");
+    assert.equal(osa.hitPoints, CAREER_DOORS.osa.maxHp, "OSA starts at full career HP");
     assert.equal(osa.maxHp, CAREER_DOORS.osa.maxHp, "OSA deploys with 30 max HP");
+    assert.equal(osa.psiPoints, CAREER_DOORS.osa.maxPsi, "OSA starts at full career psi");
     assert.equal(osa.maxPsi, CAREER_DOORS.osa.maxPsi, "OSA deploys with 60 max psi");
   },
 );


### PR DESCRIPTION
## Summary

- persist current and maximum HP/PSI in an explicit backward-compatible global save snapshot
- carry exact vitals through ordinary synchronous and deferred mission transitions
- initialize fresh template/career/trait pools only for New Game and the first deliberate career selection
- clamp malformed saved pools before restoring them
- add negative-first cross-process save/load, mission-transition, career-initialization, serde, and extreme-value coverage

Fixes #551

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 246 passed
- focused save-load Rust tests after review delta — 7 passed
- `npm test` in `tools/shock2-sdk` — 14 passed, 118 opt-in skipped
- focused vitals E2E — passed after real Earth burnout, Earth to MedSci transition, and fresh-process load
- station career-flow E2E — 2 passed; Marine/Navy/OSA all initialize current=max from the chosen loadout
- full SDK E2E — 131/132 passed; the unrelated directional-ragdoll velocity threshold missed once and passed its immediate isolated rerun

## Review

Cross-engine xreview found no Critical or High issues. Codex identified one Medium malformed-maximum overflow risk; the final delta adds a restoration safety ceiling and extreme-value regression. Claude reported only nonblocking Low notes. The cold dupfinder semantic review was stopped after 10 minutes at 1286/3259 embeddings; its prevention index found no existing vitals persistence helper to reuse.