### PR TITLE
Fix Station service hall step-up

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -122,6 +122,18 @@ fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<
     Some(desired_h - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
 }
 
+/// Whether testing a vertical capsule only at the end of `lift` also covers
+/// every side contact its rounded cap could sweep through along the way.
+///
+/// This holds when the capsule's cylindrical segment spans the whole lift: a
+/// point touched by the moving cap then still intersects the full-radius
+/// cylinder at the endpoint. It does not hold for the shorter crouched player.
+fn lifted_pose_covers_swept_cap(shape: &dyn Shape, lift: Real) -> bool {
+    shape
+        .as_capsule()
+        .is_some_and(|capsule| 2.0 * capsule.half_height() >= lift)
+}
+
 /// Step-up probe (the original engine's stair-climbing approach: probe up,
 /// forward, then down from the blocked position). Called when the player's
 /// horizontal movement was mostly blocked; returns the extra translation that
@@ -183,12 +195,34 @@ fn try_step_up(
         )
     };
 
-    // 1) Headroom directly above.
-    if cast(pos, Vector::y(), step_height, 0.0).is_some() {
-        return None;
+    let lifted = Translation::from(Vector::y() * step_height) * pos;
+    // 1) Headroom directly above. A capsule pressed against a nearly-vertical
+    // level-trimesh riser can produce a zero-time "penetrating" hit whose
+    // normal is lateral (Station's service-hall riser is one example). That
+    // contact does not oppose the upward probe and must not masquerade as a
+    // ceiling. Only ignore this narrow initial-contact case; later hits and
+    // normals with a meaningful downward component still block. Because that
+    // first lateral hit can mask another collider (or another triangle in the
+    // same mesh), also verify that the fully lifted pose does not intersect
+    // anything before accepting the clearance.
+    if let Some((_, hit)) = cast(pos, Vector::y(), step_height, 0.0) {
+        // For a vertical capsule, an endpoint overlap is sufficient to cover
+        // contacts swept by its rounded cap only when the cylindrical segment
+        // is at least as long as this lift. The standing capsule satisfies
+        // that invariant; the shorter crouched capsule does not, so retain the
+        // old conservative rejection while crouched rather than risk skipping
+        // a narrow intermediate protrusion.
+        let is_initial_tangential_contact = hit.status
+            == rapier3d::parry::query::ShapeCastStatus::PenetratingOrWithinTargetDist
+            && hit.normal1.y >= -1.0e-4;
+        if !is_initial_tangential_contact
+            || !lifted_pose_covers_swept_cap(shape, step_height)
+            || queries.intersect_shape(lifted, shape).next().is_some()
+        {
+            return None;
+        }
     }
     // 2) Forward clearance at the lifted height.
-    let lifted = Translation::from(Vector::y() * step_height) * pos;
     if cast(&lifted, dir, forward, 0.0).is_some() {
         return None;
     }
@@ -2835,6 +2869,121 @@ mod tests {
             ledge < 0.1,
             "a 3 ft ledge must not be auto-stepped, rose {ledge}"
         );
+    }
+
+    /// Height gained while walking into a Station-style step built as one
+    /// connected level trimesh. Unlike a separate cuboid, the vertical riser
+    /// remains the first contact of an upward sweep when the capsule is
+    /// pressed against it.
+    fn run_level_trimesh_step(ceiling_bottom: Option<f32>, crouched: bool) -> f32 {
+        let mut world = PhysicsWorld::new();
+        let step_height = 0.6;
+        let half_width = 4.0;
+        // Match the tiny non-vertical error in Station's authored riser. Its
+        // face normal has a roughly -5e-6 vertical component, so an upward
+        // cast from beside it reports a zero-time contact even though the
+        // surface is lateral to the cast.
+        let riser_top_x = -0.000_003;
+        let verts = vec![
+            // Lower floor.
+            point![-8.0, 0.0, -half_width],
+            point![0.0, 0.0, -half_width],
+            point![0.0, 0.0, half_width],
+            point![-8.0, 0.0, half_width],
+            // Upper tread.
+            point![riser_top_x, step_height, -half_width],
+            point![8.0, step_height, -half_width],
+            point![8.0, step_height, half_width],
+            point![riser_top_x, step_height, half_width],
+        ];
+        let tris = vec![
+            [0u32, 1, 2],
+            [0, 2, 3],
+            [1, 4, 7],
+            [1, 7, 2],
+            [4, 5, 6],
+            [4, 6, 7],
+        ];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(verts, tris)
+                .expect("connected step trimesh")
+                .build(),
+        );
+
+        if let Some(bottom) = ceiling_bottom {
+            world.add_kinematic(
+                EntityId::from_inner(1001).unwrap(),
+                vec3(0.0, bottom + 0.2, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(16.0, 0.4, 8.0),
+                CollisionGroup::entity(),
+                false,
+            );
+        }
+
+        let mut player =
+            world.create_player(vec3(-2.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        if crouched {
+            assert!(
+                world.set_player_crouch(true, &mut player),
+                "test player should enter crouch"
+            );
+        }
+        let start = world.get_player_translation(&player);
+        let mut max_y = start.y;
+        for _ in 0..120 {
+            world.update(Vector3::new(0.05, 0.0, 0.0), &mut player);
+            max_y = max_y.max(world.get_player_translation(&player).y);
+        }
+        max_y - start.y
+    }
+
+    /// Station's service-hall rise is part of the level trimesh. At the
+    /// blocked pose, its vertical face is a zero-time tangential contact for
+    /// the upward step probe; that side contact must not be mistaken for a
+    /// ceiling.
+    #[test]
+    fn player_steps_up_connected_level_trimesh() {
+        let rise = run_level_trimesh_step(None, false);
+        assert!(
+            rise > 0.5,
+            "a 0.6u connected-trimesh riser should be stepped up, rose {rise}"
+        );
+    }
+
+    /// Ignoring a tangential riser contact must not permit stepping through a
+    /// real ceiling that leaves insufficient room for the player's final pose.
+    #[test]
+    fn player_does_not_step_connected_trimesh_without_headroom() {
+        let rise = run_level_trimesh_step(Some(2.3), false);
+        assert!(
+            rise < 0.1,
+            "a connected-trimesh riser under a true low ceiling must block, rose {rise}"
+        );
+    }
+
+    /// The standing capsule's cylindrical segment covers the full step probe,
+    /// but the crouched capsule's does not. This is the safety gate on using an
+    /// endpoint overlap after a tangential contact masked the original sweep.
+    #[test]
+    fn only_standing_capsule_endpoint_covers_step_sweep() {
+        let standing = Capsule::new_y(
+            (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+            PLAYER_RADIUS / SCALE_FACTOR,
+        );
+        let crouched = Capsule::new_y(
+            (PLAYER_CROUCH_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR,
+            PLAYER_RADIUS / SCALE_FACTOR,
+        );
+        let step_height = PLAYER_STEP_HEIGHT / SCALE_FACTOR;
+
+        assert!(lifted_pose_covers_swept_cap(&standing, step_height));
+        assert!(!lifted_pose_covers_swept_cap(&crouched, step_height));
     }
 
     /// Walking along the top of a yaw-ROTATED kinematic cuboid (e.g. the

--- a/tools/shock2-sdk/test/station-service-step.e2e.test.ts
+++ b/tools/shock2-sdk/test/station-service-step.e2e.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// The service hall's lower floor and upper tread are joined in one level
+// trimesh. A tiny vertical component in the riser's face normal makes Rapier
+// report that lateral face as a zero-time hit during the upward step probe.
+//
+// Negative-first: before the headroom contact classification fix, ordinary
+// thumbstick locomotion stalls at z~6.44 with the player center still at
+// y~-3.80. Crossing the 0.6u rise puts the center near y=-3.20 and allows
+// forward progress beyond z=6.8.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "station.mis: ordinary locomotion steps onto the service-hall tread",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8349),
+    });
+    await game.step({ frames: 5 });
+
+    // Teleport only to stage before the blocker. All progress through and
+    // beyond it uses the same continuous thumbstick path as desktop gameplay.
+    await game.player.teleport({ x: 14.04, y: -3.8, z: 4.7 });
+    await game.step({ frames: 30 });
+
+    await game.input.set("right_hand.thumbstick", [0.787, 0.616]);
+    await game.step({ frames: 12 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const approach = await game.player.position();
+    assert.ok(
+      approach.x < 13.6 && approach.z > 6.2,
+      `expected to reach the service step approach, got ` +
+        `(${approach.x.toFixed(3)}, ${approach.y.toFixed(3)}, ${approach.z.toFixed(3)})`,
+    );
+
+    await game.input.set("right_hand.thumbstick", [0.957, 0.29]);
+    await game.step({ frames: 12 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    const crossed = await game.player.position();
+    assert.ok(
+      crossed.y > -3.4,
+      `expected the player center on the upper tread (y > -3.4), got ` +
+        `(${crossed.x.toFixed(3)}, ${crossed.y.toFixed(3)}, ${crossed.z.toFixed(3)})`,
+    );
+    assert.ok(
+      crossed.z > 6.8,
+      `expected forward progress past the riser (z > 6.8), got ` +
+        `(${crossed.x.toFixed(3)}, ${crossed.y.toFixed(3)}, ${crossed.z.toFixed(3)})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #499.

## What changed

- Treat only a zero-time, nearly lateral upward capsule contact as a tangential riser contact instead of false headroom.
- Preserve continuous-sweep safety: the exception is limited to capsules whose cylindrical span covers the full lift, and the fully lifted pose must be overlap-free.
- Keep crouched movement conservative because its shorter capsule cannot prove that invariant.
- Add a connected level-trimesh regression matching Station's authored face-normal error, plus real-ceiling and capsule-shape safety coverage.
- Add a `station.mis` SDK scenario that stages before the blocker, then crosses it using ordinary thumbstick input.

## Negative-first evidence

Before the production fix:

- Rust connected-trimesh regression failed: `a 0.6u connected-trimesh riser should be stepped up, rose 0.21549273`.
- The upward cast reported a zero-time almost-pure lateral contact (`normal1 ≈ [-1, -7e-8, -1e-7]`).
- Station ordinary locomotion stalled at `(13.344, -3.796, 6.487)` instead of reaching the upper tread.

## Validation

- `cargo test -p shock2vr physics::tests:: -- --nocapture` — 13 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- SDK `npm test`
- Focused Station scenario, including 3/3 reliability replay
- Full SDK e2e suite — 130 passed, 0 failed
- `xreview` code + visual passes — no remaining Critical/High/Medium findings

## Visual proof

![Station service-hall step traversal](https://gist.githubusercontent.com/tommy-xr/6d78290f2f5d4fa4f663b758d04bd549/raw/issue-499-station-step.gif)

<sub>Same deterministic `station.mis` thumbstick sequence on `f9bf4e1` and `4b2019c`. Baseline bumps then stalls at `y=-3.796, z=6.487`; the fixed build reaches the upper tread at `y=-3.196` and advances to `z=8.001`. Camera yaw was adjusted only after locomotion for visibility.</sub>

### Before → after

![Station service-hall step before and after](https://gist.githubusercontent.com/tommy-xr/6d78290f2f5d4fa4f663b758d04bd549/raw/issue-499-before-after.png)
