### PR TITLE
docs: document DARK_ASSET_PATH as an alternative to copying into Data/

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,7 +25,32 @@
 
 ### 2. Provide data files
 
+Either copy the files into the repo, or point the engine at an existing copy.
+
+**Option A — copy into `Data/`**
+
 - Copy local game files (\*.mis, res folder) into the `shock2quest/Data` folder
+
+**Option B — set `DARK_ASSET_PATH`**
+
+Point the engine at game files that live outside the repo (handy when sharing
+one copy of the data across several clones):
+
+```bash
+export DARK_ASSET_PATH=/path/to/your/shock2/data
+```
+
+**Either way, the data directory must contain at least one _sentinel_ file** —
+`shock2.gam`, `res/obj.crf`, `res/mesh.crf`, or `motiondb.bin`. This is how the
+engine recognizes a directory as game data.
+
+> **Gotcha:** if `DARK_ASSET_PATH` is set but contains no sentinel, it does *not*
+> fail. It logs a warning and falls back to searching `./Data`, `../Data`,
+> `../../Data`, `.` — which typically surfaces later as a confusing
+> `shock2.gam not found`, even though the variable looks correctly set. If you
+> hit that, check the sentinels before anything else.
+
+Resolution order lives in `shock2vr/src/paths.rs`.
 
 ### 2b. Enable git hooks (recommended)
 


### PR DESCRIPTION
## Why

`DEVELOPMENT.md` §2 only described copying game files into `Data/`, so the `DARK_ASSET_PATH` escape hatch was effectively undiscoverable from the setup guide. It is documented in `CLAUDE.md` and implemented in `shock2vr/src/paths.rs`, but a human following DEVELOPMENT.md never learned it existed.

## What

- Splits §2 into two options: copy into `Data/`, or set `DARK_ASSET_PATH`.
- Documents the **sentinel requirement** (`shock2.gam`, `res/obj.crf`, `res/mesh.crf`, `motiondb.bin`) — neither `DEVELOPMENT.md` nor `CLAUDE.md` mentioned it.
- Calls out the failure mode: a `DARK_ASSET_PATH` with no sentinel does *not* error. `resolve_desktop_data_root` logs a warning and falls back to searching `./Data`, `../Data`, `../../Data`, `.`, which surfaces later as a confusing `shock2.gam not found` while the variable looks correctly set.

## Verification

Confirmed against a real data directory outside the repo (`Data/` containing only `ADD_GAME_FILES_HERE.txt`):

With `DARK_ASSET_PATH` set — loads:
```
INFO Loading gamesys + mission data from shock2.gam and earth.mis
INFO Loaded 4541 entities from gamesys
INFO Loaded 547 entities from mission
INFO Merged total: 5088 entities
```

Unset — reproduces the documented fallback and error:
```
WARN Falling back to default Data path; no sentinel files were found
     candidates=["./Data", "../Data", "../../Data", "."]
Error: shock2.gam not found. Checked these directories: ./Data, ../Data, ../../Data, .
```

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)