### PR TITLE
fix: unseal the Operations deck (switch-driven bulkheads + email trap objectives)

### DIFF
--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -5,9 +5,7 @@ use crate::physics::PhysicsWorld;
 
 use super::{
     Effect, MessagePayload, Script,
-    script_util::{
-        play_environmental_sound, send_to_all_switch_links, send_to_all_switch_links_and_self,
-    },
+    script_util::{play_environmental_sound, send_to_all_switch_links},
 };
 
 pub struct BaseButton {}
@@ -19,6 +17,27 @@ impl BaseButton {
     pub fn is_locked(&self, entity_id: EntityId, world: &World) -> bool {
         super::script_util::is_entity_locked(world, entity_id)
     }
+
+    /// The refusal a locked button gives instead of activating, or `None` when
+    /// it is free to activate. Button subclasses gate their own action on this.
+    pub fn locked_effect(&self, entity_id: EntityId, world: &World) -> Option<Effect> {
+        self.is_locked(entity_id, world).then(|| Effect::PlaySound {
+            handle: AudioHandle::new(),
+            name: "hackfail".to_owned(),
+        })
+    }
+
+    /// What every button does when it is pressed, apart from its own action:
+    /// relay `TurnOn` to its switch links and play the activate sound. The
+    /// button's *own* action is the caller's business - `BaseButton` notifies
+    /// itself, subclasses run theirs directly.
+    pub fn activate_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let switch_link_effect =
+            send_to_all_switch_links(world, entity_id, MessagePayload::TurnOn { from: entity_id });
+        let sound_effect =
+            play_environmental_sound(world, entity_id, "activate", vec![], AudioHandle::new());
+        Effect::combine(vec![switch_link_effect, sound_effect])
+    }
 }
 impl Script for BaseButton {
     fn handle_message(
@@ -29,28 +48,17 @@ impl Script for BaseButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                if self.is_locked(entity_id, world) {
-                    Effect::PlaySound {
-                        handle: AudioHandle::new(),
-                        name: "hackfail".to_owned(),
-                    }
-                } else {
-                    let switch_link_effect = send_to_all_switch_links_and_self(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    let sound_effect = play_environmental_sound(
-                        world,
-                        entity_id,
-                        "activate",
-                        vec![],
-                        AudioHandle::new(),
-                    );
-                    Effect::combine(vec![switch_link_effect, sound_effect])
-                }
-            }
+            MessagePayload::Frob => self.locked_effect(entity_id, world).unwrap_or_else(|| {
+                // A plain button's own action is to notify itself, so proxy
+                // scripts on the same entity see the press as a TurnOn.
+                let notify_self = Effect::Send {
+                    msg: super::Message {
+                        payload: MessagePayload::TurnOn { from: entity_id },
+                        to: entity_id,
+                    },
+                };
+                Effect::combine(vec![self.activate_effect(entity_id, world), notify_self])
+            }),
 
             // In some places (like the computer for the engine room in eng1), invisible buttons are used as proxies -
             // there will be an actual button that sends a 'TurnOn' message to an invisible button. Not sure why

--- a/shock2vr/src/scripts/level_change_button.rs
+++ b/shock2vr/src/scripts/level_change_button.rs
@@ -4,12 +4,47 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{BaseButton, Effect, MessagePayload, Script};
 
-pub struct LevelChangeButton {}
+/// The level-change bulkhead button. The original's script class derives from
+/// the base button class, so it *also* behaves like a button: frobbing it
+/// relays `TurnOn` over its switch links, and the level change itself happens
+/// on `TurnOn`. (The shipped `PropScripts` sets `inherits: false`, which drops
+/// the archetype's `BaseButton`, so the port has to compose it explicitly.)
+///
+/// The `TurnOn` half matters because bulkheads are commonly driven
+/// *indirectly*: the button the player touches relays through a quest-bit
+/// filter to a hidden co-located changer object, which only ever receives
+/// `TurnOn`.
+///
+/// A frob changes level immediately rather than by way of a self-addressed
+/// `TurnOn`: sibling scripts on the same entity can consume the frob too (the
+/// rick3 shuttle button also runs `FrobQB`, which destroys the entity), and a
+/// deferred message would never reach it.
+pub struct LevelChangeButton {
+    base_button: BaseButton,
+}
 impl LevelChangeButton {
     pub fn new() -> LevelChangeButton {
-        LevelChangeButton {}
+        LevelChangeButton {
+            base_button: BaseButton::new(),
+        }
+    }
+
+    fn transition_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
+        let Ok(level_file) = v_dest_level.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+
+        let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
+        let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
+        Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
+            level_file: format!("{}.mis", level_file.0),
+            loc: maybe_dest_loc,
+            entities_to_trigger: vec![],
+            vitals_transition: super::PlayerVitalsTransition::Preserve,
+        })
     }
 }
 
@@ -22,20 +57,104 @@ impl Script for LevelChangeButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
-                let level_file = v_dest_level.get(entity_id).unwrap();
-
-                let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
-                let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
-                Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                    level_file: format!("{}.mis", level_file.0),
-                    loc: maybe_dest_loc,
-                    entities_to_trigger: vec![],
-                    vitals_transition: super::PlayerVitalsTransition::Preserve,
-                })
-            }
+            // The activate half is the shared button press (relay + sound). No
+            // shipped level-change object has outgoing switch links, and a
+            // relay queued alongside a transition would be dropped with the
+            // outgoing scene anyway - it is here so the button behaves like a
+            // button, not because any mission depends on it.
+            MessagePayload::Frob => self
+                .base_button
+                .locked_effect(entity_id, world)
+                .unwrap_or_else(|| {
+                    Effect::combine(vec![
+                        self.base_button.activate_effect(entity_id, world),
+                        self.transition_effect(entity_id, world),
+                    ])
+                }),
+            MessagePayload::TurnOn { from: _ } => self.transition_effect(entity_id, world),
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, PropDestLevel, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn transition_target(effect: &Effect) -> Option<String> {
+        match effect {
+            Effect::GlobalEffect(super::super::GlobalEffect::TransitionLevel {
+                level_file,
+                ..
+            }) => Some(level_file.clone()),
+            Effect::Combined { effects } => effects.iter().find_map(transition_target),
+            _ => None,
+        }
+    }
+
+    fn sent_messages(effect: &Effect) -> Vec<(EntityId, MessagePayload)> {
+        match effect {
+            Effect::Send { msg } => vec![(msg.to, msg.payload.clone())],
+            Effect::Combined { effects } => effects.iter().flat_map(sent_messages).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    #[test]
+    fn turn_on_over_a_switch_link_transitions_the_level() {
+        let mut world = World::new();
+        let entity_id = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(transition_target(&effect), Some("ops3.mis".to_owned()));
+    }
+
+    #[test]
+    fn frob_relays_turn_on_to_switch_links_and_transitions_immediately() {
+        let mut world = World::new();
+        let changer = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let entity_id = world.add_entity((
+            PropDestLevel("ops3".to_owned()),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(changer)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        let sent = sent_messages(&effect);
+        assert!(
+            sent.iter().any(|(to, payload)| *to == changer
+                && matches!(payload, MessagePayload::TurnOn { from: _ })),
+            "frob must relay TurnOn over switch links, got {sent:?}"
+        );
+        // The transition is in the frob's own effect, not deferred behind a
+        // self-addressed message - a sibling script (rick3's FrobQB) can
+        // destroy the entity on the same frob.
+        assert_eq!(
+            transition_target(&effect),
+            Some("ops3.mis".to_owned()),
+            "frob must transition immediately, got {sent:?}"
+        );
+        assert!(
+            !sent.iter().any(|(to, _)| *to == entity_id),
+            "frob must not defer its own action behind a self-message, got {sent:?}"
+        );
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -471,6 +471,30 @@ fn collect_contained_items(
     });
 }
 
+/// The `SetQuestBit` effect for an entity's authored quest-bit pair
+/// (`PropQuestBitName` + `PropQuestBitValue`, defaulting to `COMPLETE` when no
+/// value is authored). `None` when the entity carries no quest-bit name.
+/// Shared by every trap that applies a quest bit as part of its action.
+pub fn set_quest_bit_effect(world: &World, entity_id: EntityId) -> Option<Effect> {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
+    let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
+
+    let quest_bit_value = v_qbval
+        .get(entity_id)
+        .map(|v| v.0)
+        .unwrap_or(QuestBitValue::COMPLETE);
+
+    v_qbname
+        .get(entity_id)
+        .ok()
+        .map(|qb_name| Effect::SetQuestBit {
+            quest_bit_name: qb_name.0.to_owned(),
+            quest_bit_value,
+        })
+}
+
 pub fn get_all_switch_links(world: &World, producing_entity_id: EntityId) -> Vec<EntityId> {
     let links = world.borrow::<View<Links>>().unwrap();
     let mut linked_entities = Vec::new();

--- a/shock2vr/src/scripts/trap_email.rs
+++ b/shock2vr/src/scripts/trap_email.rs
@@ -1,10 +1,12 @@
 use dark::properties::PropLog;
-use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+use super::{
+    Effect, MessagePayload, Script,
+    script_util::{send_to_all_switch_links, set_quest_bit_effect},
+};
 
 pub struct TrapEmail {}
 impl TrapEmail {
@@ -23,39 +25,105 @@ impl Script for TrapEmail {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_sound = world.borrow::<View<PropLog>>().unwrap();
-                let maybe_trip_sound = v_sound.get(entity_id);
-                let _handle = AudioHandle::new();
-                //self.playing_sounds.push(handle.clone());
-                if let Ok(sound) = maybe_trip_sound {
-                    let email_effect = if sound.deck > 0 && sound.email > 0 {
-                        Effect::PlayEmail {
-                            deck: sound.deck,
-                            email: sound.email,
-                            force: false,
-                        }
-                    } else {
-                        Effect::NoEffect
-                    };
+                let v_log = world.borrow::<View<PropLog>>().unwrap();
+                let email_effect = match v_log.get(entity_id) {
+                    Ok(log) if log.deck > 0 && log.email > 0 => Effect::PlayEmail {
+                        deck: log.deck,
+                        email: log.email,
+                        force: false,
+                    },
+                    _ => Effect::NoEffect,
+                };
 
-                    let switchlink_effects = send_to_all_switch_links(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    Effect::Combined {
-                        effects: vec![
-                            email_effect,
-                            switchlink_effects,
-                            Effect::DestroyEntity { entity_id },
-                        ],
-                    }
-                } else {
-                    Effect::NoEffect
+                // The email trap also carries the objective it hands out
+                // (PropQuestBitName/PropQuestBitValue) - the email and the
+                // objective it describes are authored on the same entity.
+                let quest_bit_effect =
+                    set_quest_bit_effect(world, entity_id).unwrap_or(Effect::NoEffect);
+
+                let switchlink_effects = send_to_all_switch_links(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                );
+
+                // The trap is consumed once it fires. The tripwires that feed
+                // these traps fire on every crossing, and re-applying the quest
+                // bit would knock an already-COMPLETE objective back to
+                // INCOMPLETE (QuestInfo::set_quest_bit_value overwrites).
+                // has_played_email only suppresses the audio, not the objective
+                // or the switch-link relay.
+                Effect::Combined {
+                    effects: vec![
+                        email_effect,
+                        quest_bit_effect,
+                        switchlink_effects,
+                        Effect::DestroyEntity { entity_id },
+                    ],
                 }
             }
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    use super::*;
+
+    fn quest_bits(effect: &Effect) -> Vec<(String, QuestBitValue)> {
+        match effect {
+            Effect::SetQuestBit {
+                quest_bit_name,
+                quest_bit_value,
+            } => vec![(quest_bit_name.clone(), *quest_bit_value)],
+            Effect::Combined { effects } => effects.iter().flat_map(quest_bits).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn plays_email(effect: &Effect) -> bool {
+        match effect {
+            Effect::PlayEmail { .. } => true,
+            Effect::Combined { effects } => effects.iter().any(plays_email),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn turn_on_grants_the_authored_objective() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropLog {
+                deck: 4,
+                email: 1,
+                log: 33,
+                note: 0,
+                video: 0,
+            },
+            PropQuestBitName("Note_4_2".to_owned()),
+            PropQuestBitValue(QuestBitValue::INCOMPLETE),
+        ));
+        let physics = PhysicsWorld::new();
+        let mut trap = TrapEmail::new();
+
+        let effect = trap.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(
+            quest_bits(&effect),
+            vec![("Note_4_2".to_owned(), QuestBitValue::INCOMPLETE)]
+        );
+        assert!(
+            plays_email(&effect),
+            "the objective must be granted alongside the email, not instead of it"
+        );
     }
 }

--- a/shock2vr/src/scripts/trap_qb_set.rs
+++ b/shock2vr/src/scripts/trap_qb_set.rs
@@ -1,9 +1,8 @@
-use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
 
 pub struct TrapQBSet {}
 impl TrapQBSet {
@@ -21,23 +20,9 @@ impl Script for TrapQBSet {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
-                let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
-
-                let check_qbval = v_qbval
-                    .get(entity_id)
-                    .map(|v| v.0)
-                    .unwrap_or(QuestBitValue::COMPLETE);
-
-                if let Ok(qb_name) = &v_qbname.get(entity_id) {
+                if let Some(quest_bit_effect) = set_quest_bit_effect(world, entity_id) {
                     Effect::Combined {
-                        effects: vec![
-                            Effect::SetQuestBit {
-                                quest_bit_name: qb_name.0.to_owned(),
-                                quest_bit_value: check_qbval,
-                            },
-                            Effect::DestroyEntity { entity_id },
-                        ],
+                        effects: vec![quest_bit_effect, Effect::DestroyEntity { entity_id }],
                     }
                 } else {
                     Effect::NoEffect

--- a/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
+++ b/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for TrapEmail granting its authored objective (GitHub #556).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: TrapEmail read only PropLog, so it played the email audio but
+// never applied the entity's PropQuestBitName/PropQuestBitValue pair. On ops1
+// that meant Note_4_2 ("reprogram the three Simulation Units") - the starting
+// point of the whole Operations objective chain, with no other grantor anywhere
+// in ops1-ops4 - was never handed out.
+//
+// The trap stays once-only (it consumes itself): the tripwires feeding these
+// traps fire on every crossing, and re-applying the quest bit would knock an
+// already-COMPLETE objective back to INCOMPLETE.
+//
+// The authored chain is Tripwire 277 -> QB Filter 278 (on ShodanRoom) ->
+// EmailTrap 279. Discover entities by their stable mission object id
+// (`template_id`), never by runtime entity id.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops1: the email trap grants Note_4_2 and is consumed once fired",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "unknown",
+      "the Sim Unit objective should not be granted before the trap fires",
+    );
+
+    // The QB Filter ahead of the trap only passes after the SHODAN reveal.
+    await game.quests.set("ShodanRoom", "complete");
+
+    const filters = await game.entities.byTemplate(278);
+    assert.equal(
+      filters.length,
+      1,
+      `expected the ops1 QB Filter (object 278), got ${JSON.stringify(filters.map((f) => f.name))}`,
+    );
+
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "incomplete",
+      "the email trap should grant Note_4_2 as an active (INCOMPLETE) objective",
+    );
+
+    const emails = (await game.audio.recent()).sounds.filter((sound) =>
+      sound.tags.some(([key, value]) => key === "kind" && value === "email"),
+    );
+    assert.equal(
+      emails.length,
+      1,
+      `the email should play exactly once, got ${JSON.stringify(emails)}`,
+    );
+
+    // The trap is consumed, so re-crossing the tripwire later - after the
+    // player has actually completed the Sim Unit objective on ops3/ops4 -
+    // cannot downgrade it back to INCOMPLETE.
+    assert.equal(
+      (await game.entities.byTemplate(279)).length,
+      0,
+      "the email trap should be consumed once it fires",
+    );
+    await game.quests.set("note_4_2", "complete");
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "complete",
+      "re-triggering the trap chain must not knock a completed objective " +
+        "back to incomplete",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for switch-driven level-change buttons (GitHub #555).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: LevelChangeButton used to handle only `Frob`, dropping a
+// `TurnOn` that arrived over a SwitchLink. On the Operations deck the button
+// the player actually touches relays through a quest-bit filter to a hidden
+// co-located changer object that only ever receives `TurnOn`, so every Ops
+// bulkhead was sealed and the deck was unfinishable.
+//
+// ops2 object 185 is the visible ops3 bulkhead button; it relays
+// 185 -> 995 (QB Filter on ShodanRoom) -> 992 (the changer, dest ops3).
+// Runtime entity ids are not stable across runs, so discover the button by its
+// stable *mission object id*, reported in the `template_id` field.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops2: frobbing the visible bulkhead button relays TurnOn and transitions to ops3",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8125),
+    });
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).mission,
+      "ops2.mis",
+      "should start in ops2",
+    );
+
+    // The relay is gated on the ShodanRoom reveal (QB Filter 995).
+    await game.quests.set("ShodanRoom", "complete");
+
+    const buttons = await game.entities.byTemplate(185);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops2 ops3-bulkhead button (object 185), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops3.mis",
+      "frobbing the visible ops2 bulkhead button should reach the hidden " +
+        "changer over its switch links and transition to ops3",
+    );
+  },
+);
+
+test(
+  "ops3: a directly-frobbed level change button still transitions",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8126),
+    });
+    await game.step({ frames: 2 });
+
+    // ops3 object 742 carries LevelChangeButton with no switch links at all -
+    // the regression guard that routing frob through BaseButton (frob -> TurnOn
+    // to self) keeps directly-frobbed buttons working.
+    const buttons = await game.entities.byTemplate(742);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops3 ops2-bulkhead button (object 742), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops2.mis",
+      "frobbing a level change button directly should still transition",
+    );
+  },
+);


### PR DESCRIPTION
Two engine fixes that between them make the Operations deck finishable. Both are general script-behavior gaps, not Ops-specific patches — the same classes of breakage exist on other decks.

Fixes #555
Fixes #556

## 1. `LevelChangeButton` ignores `TurnOn` over a SwitchLink (#555)

`LevelChangeButton::handle_message` matched only `Frob`; a `TurnOn` arriving over a SwitchLink fell through to `NoEffect`. On Ops the button the player actually touches is a plain `BaseButton` that relays through a quest-bit filter to a hidden co-located changer object which **only ever receives `TurnOn`** (`185 → 995 → 992`, `361 → 1001`, `404 → 998 → 999`), so every Ops bulkhead was sealed and the deck was unfinishable.

The original's script class derives from the base button class, so the button both relays and changes level. `LevelChangeButton` now shares `BaseButton`'s press behavior through two small helpers on `BaseButton` (`locked_effect` + `activate_effect`, so nothing is copy-pasted):

- `Frob` → locked check, relay `TurnOn` to switch links, activate sound, **and perform the transition directly**
- `TurnOn` → performs the `TransitionLevel`

The transition runs directly on frob rather than via a self-addressed `TurnOn`. That detail matters: rick3's shuttle button carries `SimpleLevelChangeButton` **and** `FrobQB`, and `FrobQB` destroys the entity on the same frob — a deferred self-message would arrive at a dead entity. (The first version of this change did defer it, and `simple-level-change-button.e2e.test.ts` caught the regression.)

The old `.unwrap()` on `PropDestLevel` became a graceful `NoEffect`, since `TurnOn` can now reach buttons without one.

## 2. `TrapEmail` ignores `PropQuestBitName` (#556)

`TrapEmail` read only `PropLog`, so an email trap carrying a quest-bit pair played its audio but never granted the objective it describes. On ops1, object 279 carries `Note_4_2` / `INCOMPLETE` — the starting point of the entire Operations objective chain, with no other grantor anywhere in ops1–ops4.

It now applies the entity's quest bit on `TurnOn`, via a new `script_util::set_quest_bit_effect` helper shared with `TrapQBSet` rather than duplicated.

The trap stays **once-only** (it still consumes itself). Removing the `DestroyEntity` was tried and reverted: `QuestInfo::has_played_email` only suppresses the *audio*, not the quest bit or the switch-link relay, and the tripwires feeding these traps fire on every crossing — so a surviving trap would knock an already-COMPLETE `Note_4_2` back to INCOMPLETE when the player walks back into ops1 from ops3/ops4 (and would replay medsci1's sound/tweq sequence off trap 638). Both `/xreview` engines flagged this independently; there is now an e2e regression guard for it.

## Testing (negative-first)

Rust unit tests (`shock2vr/src/scripts/{level_change_button,trap_email}.rs`) and SDK e2e scenarios (`tools/shock2-sdk/test/{ops-bulkhead-button,email-trap-objective}.e2e.test.ts`). All were confirmed **red on `main`** and green with the fix:

| Test | On `main` | With fix |
| --- | --- | --- |
| `turn_on_over_a_switch_link_transitions_the_level` | fail (`None`) | pass |
| `frob_relays_turn_on_to_switch_links_and_self` | fail (no messages) | pass |
| `turn_on_grants_the_authored_objective` | fail (no quest bit) | pass |
| e2e: ops2 visible bulkhead button → ops3 | fail (stays ops2) | pass |
| e2e: ops1 email trap grants `note_4_2` | fail (`unknown`) | pass |
| e2e: ops3 direct-frob button → ops2 (regression guard) | pass | pass |
| e2e: re-trigger must not downgrade a COMPLETE objective | — | pass (fails without the `DestroyEntity`) |
| e2e: rec1 + rick3 `SimpleLevelChangeButton` (existing tests) | pass | pass |

Live-verified on the debug runtime: frobbing the visible ops2 bulkhead button transitions to ops3; the ops1 chain grants `note_4_2` as incomplete, plays `EM0401` exactly once, and re-firing after completion leaves the objective complete.

Full SDK e2e suite (`npm run test:e2e`, 140 tests): the two failures that remain — `power-cell-flat` ("frobbing the Dead Power Cell should wield it") and `alertness-churn` (#481) — are **pre-existing**. `power-cell-flat` fails identically on `main`; `alertness-churn` is flaky at the same 1-in-3 rate on `main` and on this branch.

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt --check`, and `cargo test -p shock2vr` (258 passing) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
