### PR TITLE
fix: apply a log disc's authored quest bit when it is read

### DIFF
--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -5,9 +5,7 @@ use crate::physics::PhysicsWorld;
 
 use super::{
     Effect, MessagePayload, Script,
-    script_util::{
-        play_environmental_sound, send_to_all_switch_links, send_to_all_switch_links_and_self,
-    },
+    script_util::{play_environmental_sound, send_to_all_switch_links},
 };
 
 pub struct BaseButton {}
@@ -19,6 +17,27 @@ impl BaseButton {
     pub fn is_locked(&self, entity_id: EntityId, world: &World) -> bool {
         super::script_util::is_entity_locked(world, entity_id)
     }
+
+    /// The refusal a locked button gives instead of activating, or `None` when
+    /// it is free to activate. Button subclasses gate their own action on this.
+    pub fn locked_effect(&self, entity_id: EntityId, world: &World) -> Option<Effect> {
+        self.is_locked(entity_id, world).then(|| Effect::PlaySound {
+            handle: AudioHandle::new(),
+            name: "hackfail".to_owned(),
+        })
+    }
+
+    /// What every button does when it is pressed, apart from its own action:
+    /// relay `TurnOn` to its switch links and play the activate sound. The
+    /// button's *own* action is the caller's business - `BaseButton` notifies
+    /// itself, subclasses run theirs directly.
+    pub fn activate_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let switch_link_effect =
+            send_to_all_switch_links(world, entity_id, MessagePayload::TurnOn { from: entity_id });
+        let sound_effect =
+            play_environmental_sound(world, entity_id, "activate", vec![], AudioHandle::new());
+        Effect::combine(vec![switch_link_effect, sound_effect])
+    }
 }
 impl Script for BaseButton {
     fn handle_message(
@@ -29,28 +48,17 @@ impl Script for BaseButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                if self.is_locked(entity_id, world) {
-                    Effect::PlaySound {
-                        handle: AudioHandle::new(),
-                        name: "hackfail".to_owned(),
-                    }
-                } else {
-                    let switch_link_effect = send_to_all_switch_links_and_self(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    let sound_effect = play_environmental_sound(
-                        world,
-                        entity_id,
-                        "activate",
-                        vec![],
-                        AudioHandle::new(),
-                    );
-                    Effect::combine(vec![switch_link_effect, sound_effect])
-                }
-            }
+            MessagePayload::Frob => self.locked_effect(entity_id, world).unwrap_or_else(|| {
+                // A plain button's own action is to notify itself, so proxy
+                // scripts on the same entity see the press as a TurnOn.
+                let notify_self = Effect::Send {
+                    msg: super::Message {
+                        payload: MessagePayload::TurnOn { from: entity_id },
+                        to: entity_id,
+                    },
+                };
+                Effect::combine(vec![self.activate_effect(entity_id, world), notify_self])
+            }),
 
             // In some places (like the computer for the engine room in eng1), invisible buttons are used as proxies -
             // there will be an actual button that sends a 'TurnOn' message to an invisible button. Not sure why

--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -1,9 +1,8 @@
-use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
 
 pub struct FrobQB {}
 impl FrobQB {
@@ -20,29 +19,12 @@ impl Script for FrobQB {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
-                let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
-
-                let check_qbval = v_qbval
-                    .get(entity_id)
-                    .map(|v| v.0)
-                    .unwrap_or(QuestBitValue::COMPLETE);
-
-                if let Ok(qb_name) = &v_qbname.get(entity_id) {
-                    Effect::Combined {
-                        effects: vec![
-                            Effect::SetQuestBit {
-                                quest_bit_name: qb_name.0.to_owned(),
-                                quest_bit_value: check_qbval,
-                            },
-                            Effect::DestroyEntity { entity_id },
-                        ],
-                    }
-                } else {
-                    Effect::NoEffect
-                }
-            }
+            MessagePayload::Frob => match set_quest_bit_effect(world, entity_id) {
+                Some(quest_bit_effect) => Effect::Combined {
+                    effects: vec![quest_bit_effect, Effect::DestroyEntity { entity_id }],
+                },
+                None => Effect::NoEffect,
+            },
             _ => Effect::NoEffect,
         }
     }

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -13,11 +13,15 @@
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::PropLog;
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
+use crate::quest_info::QuestInfo;
 use crate::runtime_props::RuntimePropLogData;
-use crate::scripts::{Effect, MessagePayload, script_util::send_to_all_switch_links};
+use crate::scripts::{
+    Effect, MessagePayload,
+    script_util::{send_to_all_switch_links, set_quest_bit_effect},
+};
 
 const PANEL_W: f32 = 188.0;
 const PANEL_H: f32 = 296.0;
@@ -104,6 +108,29 @@ fn readable_log(world: &World, entity_id: EntityId) -> Option<(u32, u32)> {
         Ok(log) if log.deck > 0 && log.log > 0 && log.log != LOG_UNSET => Some((log.deck, log.log)),
         _ => None,
     }
+}
+
+/// Whether applying `effect` would move an objective *backwards*
+/// (`COMPLETE` -> `INCOMPLETE`). `Effect::SetQuestBit` overwrites, and the disc
+/// survives for re-reading, so its authored value must never undo progress the
+/// player has already made. Gating on log collection instead would be wrong
+/// twice over: distinct discs can grant the same bit (eng1's `Note_1_6` is
+/// authored on two logs), and a log collected before logs granted quest bits at
+/// all would then never hand out its objective. `QuestBitValue` is ordered
+/// `UNKNOWN(0) < INCOMPLETE(1) < COMPLETE(2)`, and discs do author `COMPLETE`
+/// (ops4's `Note_4_1`), so this must compare values rather than test for unset.
+fn is_downgrade(world: &World, effect: &Effect) -> bool {
+    let Effect::SetQuestBit {
+        quest_bit_name,
+        quest_bit_value,
+    } = effect
+    else {
+        return false;
+    };
+    world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|quests| quests.read_quest_bit_value(quest_bit_name).bits() > quest_bit_value.bits())
+        .unwrap_or(false)
 }
 
 fn transcript_line_count(world: &World, entity_id: EntityId) -> usize {
@@ -241,7 +268,7 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         // keep that one-shot contract by firing the links only on the frob that
         // first collects the log (replaying audio / reopening is fine).
         let already_collected = world
-            .borrow::<shipyard::UniqueView<crate::quest_info::QuestInfo>>()
+            .borrow::<UniqueView<QuestInfo>>()
             .map(|q| q.has_collected_log(deck, log))
             .unwrap_or(false);
         let switchlinks = if already_collected {
@@ -249,7 +276,13 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         } else {
             send_to_all_switch_links(world, entity_id, MessagePayload::TurnOn { from: entity_id })
         };
-        Effect::combine(vec![collect, audio, switchlinks])
+        // The disc also carries the objective it hands out
+        // (PropQuestBitName/PropQuestBitValue) - some logs are the sole grantor
+        // of an objective, with no links to relay through.
+        let quest_bit = set_quest_bit_effect(world, entity_id)
+            .filter(|effect| !is_downgrade(world, effect))
+            .unwrap_or(Effect::NoEffect);
+        Effect::combine(vec![collect, audio, switchlinks, quest_bit])
     }
 
     /// A disc with no readable log (unset `PropLog` sentinel) must not open an
@@ -271,10 +304,26 @@ mod tests {
     use super::*;
     use crate::gui::GuiScript;
     use crate::physics::PhysicsWorld;
+    use crate::quest_info::QuestInfo;
     use crate::scripts::Script;
     use crate::time::Time;
     use crate::vr_config::Handedness;
     use cgmath::point2;
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    /// The `(name, value)` quest bits a (possibly combined) effect sets.
+    fn quest_bits(effect: Effect) -> Vec<(String, QuestBitValue)> {
+        Effect::flatten(vec![effect])
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::SetQuestBit {
+                    quest_bit_name,
+                    quest_bit_value,
+                } => Some((quest_bit_name, quest_bit_value)),
+                _ => None,
+            })
+            .collect()
+    }
 
     /// Whether a (possibly combined) effect includes opening the panel.
     fn opens_panel(effect: Effect) -> bool {
@@ -398,6 +447,74 @@ mod tests {
                 .map(String::as_str),
             Some("l1"),
             "reopening must reset the scroll position"
+        );
+    }
+
+    /// A log disc carrying `PropQuestBitName`/`PropQuestBitValue` grants that
+    /// objective on the frob that first collects it. Some logs (e.g. ops3's
+    /// Bronson log -> `Note_4_6`) have no links at all, so the quest-bit pair on
+    /// the disc is the objective's only grantor.
+    #[test]
+    fn frobbing_a_log_grants_its_authored_objective() {
+        let mut world = World::new();
+        let disc = world.add_entity((
+            PropLog {
+                deck: 4,
+                email: 33,
+                log: 7,
+                note: 0,
+                video: 0,
+            },
+            PropQuestBitName("Note_4_6".to_owned()),
+            PropQuestBitValue(QuestBitValue::INCOMPLETE),
+        ));
+        let gui = MediaGui;
+        assert_eq!(
+            quest_bits(gui.on_frob(disc, &world)),
+            vec![("Note_4_6".to_owned(), QuestBitValue::INCOMPLETE)]
+        );
+    }
+
+    /// ...but the disc survives for re-reading, and `SetQuestBit` overwrites, so
+    /// an authored INCOMPLETE must never knock an objective the player has since
+    /// COMPLETEd back to incomplete (the hazard `TrapEmail` hit in #558). The
+    /// gate compares values rather than "has this log been collected": distinct
+    /// discs can grant the same bit, and discs do author COMPLETE.
+    #[test]
+    fn a_log_never_downgrades_an_objective_the_player_completed() {
+        let disc_with_bit = |value: QuestBitValue, already: QuestBitValue| {
+            let mut world = World::new();
+            let disc = world.add_entity((
+                PropLog {
+                    deck: 4,
+                    email: 33,
+                    log: 7,
+                    note: 0,
+                    video: 0,
+                },
+                PropQuestBitName("Note_4_6".to_owned()),
+                PropQuestBitValue(value),
+            ));
+            let mut quest_info = QuestInfo::new();
+            quest_info.collect_log(4, 7);
+            quest_info.set_quest_bit_value("Note_4_6", already);
+            world.add_unique(quest_info);
+            quest_bits(MediaGui.on_frob(disc, &world))
+        };
+
+        assert!(
+            disc_with_bit(QuestBitValue::INCOMPLETE, QuestBitValue::COMPLETE).is_empty(),
+            "re-reading must not knock a completed objective back to incomplete"
+        );
+        // A disc authoring COMPLETE still completes an active objective, and
+        // re-applying the same value is harmless - only downgrades are dropped.
+        assert_eq!(
+            disc_with_bit(QuestBitValue::COMPLETE, QuestBitValue::INCOMPLETE),
+            vec![("Note_4_6".to_owned(), QuestBitValue::COMPLETE)]
+        );
+        assert_eq!(
+            disc_with_bit(QuestBitValue::INCOMPLETE, QuestBitValue::INCOMPLETE),
+            vec![("Note_4_6".to_owned(), QuestBitValue::INCOMPLETE)]
         );
     }
 

--- a/shock2vr/src/scripts/level_change_button.rs
+++ b/shock2vr/src/scripts/level_change_button.rs
@@ -4,12 +4,47 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{BaseButton, Effect, MessagePayload, Script};
 
-pub struct LevelChangeButton {}
+/// The level-change bulkhead button. The original's script class derives from
+/// the base button class, so it *also* behaves like a button: frobbing it
+/// relays `TurnOn` over its switch links, and the level change itself happens
+/// on `TurnOn`. (The shipped `PropScripts` sets `inherits: false`, which drops
+/// the archetype's `BaseButton`, so the port has to compose it explicitly.)
+///
+/// The `TurnOn` half matters because bulkheads are commonly driven
+/// *indirectly*: the button the player touches relays through a quest-bit
+/// filter to a hidden co-located changer object, which only ever receives
+/// `TurnOn`.
+///
+/// A frob changes level immediately rather than by way of a self-addressed
+/// `TurnOn`: sibling scripts on the same entity can consume the frob too (the
+/// rick3 shuttle button also runs `FrobQB`, which destroys the entity), and a
+/// deferred message would never reach it.
+pub struct LevelChangeButton {
+    base_button: BaseButton,
+}
 impl LevelChangeButton {
     pub fn new() -> LevelChangeButton {
-        LevelChangeButton {}
+        LevelChangeButton {
+            base_button: BaseButton::new(),
+        }
+    }
+
+    fn transition_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
+        let Ok(level_file) = v_dest_level.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+
+        let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
+        let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
+        Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
+            level_file: format!("{}.mis", level_file.0),
+            loc: maybe_dest_loc,
+            entities_to_trigger: vec![],
+            vitals_transition: super::PlayerVitalsTransition::Preserve,
+        })
     }
 }
 
@@ -22,20 +57,104 @@ impl Script for LevelChangeButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
-                let level_file = v_dest_level.get(entity_id).unwrap();
-
-                let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
-                let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
-                Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                    level_file: format!("{}.mis", level_file.0),
-                    loc: maybe_dest_loc,
-                    entities_to_trigger: vec![],
-                    vitals_transition: super::PlayerVitalsTransition::Preserve,
-                })
-            }
+            // The activate half is the shared button press (relay + sound). No
+            // shipped level-change object has outgoing switch links, and a
+            // relay queued alongside a transition would be dropped with the
+            // outgoing scene anyway - it is here so the button behaves like a
+            // button, not because any mission depends on it.
+            MessagePayload::Frob => self
+                .base_button
+                .locked_effect(entity_id, world)
+                .unwrap_or_else(|| {
+                    Effect::combine(vec![
+                        self.base_button.activate_effect(entity_id, world),
+                        self.transition_effect(entity_id, world),
+                    ])
+                }),
+            MessagePayload::TurnOn { from: _ } => self.transition_effect(entity_id, world),
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, PropDestLevel, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn transition_target(effect: &Effect) -> Option<String> {
+        match effect {
+            Effect::GlobalEffect(super::super::GlobalEffect::TransitionLevel {
+                level_file,
+                ..
+            }) => Some(level_file.clone()),
+            Effect::Combined { effects } => effects.iter().find_map(transition_target),
+            _ => None,
+        }
+    }
+
+    fn sent_messages(effect: &Effect) -> Vec<(EntityId, MessagePayload)> {
+        match effect {
+            Effect::Send { msg } => vec![(msg.to, msg.payload.clone())],
+            Effect::Combined { effects } => effects.iter().flat_map(sent_messages).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    #[test]
+    fn turn_on_over_a_switch_link_transitions_the_level() {
+        let mut world = World::new();
+        let entity_id = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(transition_target(&effect), Some("ops3.mis".to_owned()));
+    }
+
+    #[test]
+    fn frob_relays_turn_on_to_switch_links_and_transitions_immediately() {
+        let mut world = World::new();
+        let changer = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let entity_id = world.add_entity((
+            PropDestLevel("ops3".to_owned()),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(changer)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        let sent = sent_messages(&effect);
+        assert!(
+            sent.iter().any(|(to, payload)| *to == changer
+                && matches!(payload, MessagePayload::TurnOn { from: _ })),
+            "frob must relay TurnOn over switch links, got {sent:?}"
+        );
+        // The transition is in the frob's own effect, not deferred behind a
+        // self-addressed message - a sibling script (rick3's FrobQB) can
+        // destroy the entity on the same frob.
+        assert_eq!(
+            transition_target(&effect),
+            Some("ops3.mis".to_owned()),
+            "frob must transition immediately, got {sent:?}"
+        );
+        assert!(
+            !sent.iter().any(|(to, _)| *to == entity_id),
+            "frob must not defer its own action behind a self-message, got {sent:?}"
+        );
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -471,6 +471,30 @@ fn collect_contained_items(
     });
 }
 
+/// The `SetQuestBit` effect for an entity's authored quest-bit pair
+/// (`PropQuestBitName` + `PropQuestBitValue`, defaulting to `COMPLETE` when no
+/// value is authored). `None` when the entity carries no quest-bit name.
+/// Shared by every trap that applies a quest bit as part of its action.
+pub fn set_quest_bit_effect(world: &World, entity_id: EntityId) -> Option<Effect> {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
+    let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
+
+    let quest_bit_value = v_qbval
+        .get(entity_id)
+        .map(|v| v.0)
+        .unwrap_or(QuestBitValue::COMPLETE);
+
+    v_qbname
+        .get(entity_id)
+        .ok()
+        .map(|qb_name| Effect::SetQuestBit {
+            quest_bit_name: qb_name.0.to_owned(),
+            quest_bit_value,
+        })
+}
+
 pub fn get_all_switch_links(world: &World, producing_entity_id: EntityId) -> Vec<EntityId> {
     let links = world.borrow::<View<Links>>().unwrap();
     let mut linked_entities = Vec::new();

--- a/shock2vr/src/scripts/trap_email.rs
+++ b/shock2vr/src/scripts/trap_email.rs
@@ -1,10 +1,12 @@
 use dark::properties::PropLog;
-use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+use super::{
+    Effect, MessagePayload, Script,
+    script_util::{send_to_all_switch_links, set_quest_bit_effect},
+};
 
 pub struct TrapEmail {}
 impl TrapEmail {
@@ -23,39 +25,105 @@ impl Script for TrapEmail {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_sound = world.borrow::<View<PropLog>>().unwrap();
-                let maybe_trip_sound = v_sound.get(entity_id);
-                let _handle = AudioHandle::new();
-                //self.playing_sounds.push(handle.clone());
-                if let Ok(sound) = maybe_trip_sound {
-                    let email_effect = if sound.deck > 0 && sound.email > 0 {
-                        Effect::PlayEmail {
-                            deck: sound.deck,
-                            email: sound.email,
-                            force: false,
-                        }
-                    } else {
-                        Effect::NoEffect
-                    };
+                let v_log = world.borrow::<View<PropLog>>().unwrap();
+                let email_effect = match v_log.get(entity_id) {
+                    Ok(log) if log.deck > 0 && log.email > 0 => Effect::PlayEmail {
+                        deck: log.deck,
+                        email: log.email,
+                        force: false,
+                    },
+                    _ => Effect::NoEffect,
+                };
 
-                    let switchlink_effects = send_to_all_switch_links(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    Effect::Combined {
-                        effects: vec![
-                            email_effect,
-                            switchlink_effects,
-                            Effect::DestroyEntity { entity_id },
-                        ],
-                    }
-                } else {
-                    Effect::NoEffect
+                // The email trap also carries the objective it hands out
+                // (PropQuestBitName/PropQuestBitValue) - the email and the
+                // objective it describes are authored on the same entity.
+                let quest_bit_effect =
+                    set_quest_bit_effect(world, entity_id).unwrap_or(Effect::NoEffect);
+
+                let switchlink_effects = send_to_all_switch_links(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                );
+
+                // The trap is consumed once it fires. The tripwires that feed
+                // these traps fire on every crossing, and re-applying the quest
+                // bit would knock an already-COMPLETE objective back to
+                // INCOMPLETE (QuestInfo::set_quest_bit_value overwrites).
+                // has_played_email only suppresses the audio, not the objective
+                // or the switch-link relay.
+                Effect::Combined {
+                    effects: vec![
+                        email_effect,
+                        quest_bit_effect,
+                        switchlink_effects,
+                        Effect::DestroyEntity { entity_id },
+                    ],
                 }
             }
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    use super::*;
+
+    fn quest_bits(effect: &Effect) -> Vec<(String, QuestBitValue)> {
+        match effect {
+            Effect::SetQuestBit {
+                quest_bit_name,
+                quest_bit_value,
+            } => vec![(quest_bit_name.clone(), *quest_bit_value)],
+            Effect::Combined { effects } => effects.iter().flat_map(quest_bits).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn plays_email(effect: &Effect) -> bool {
+        match effect {
+            Effect::PlayEmail { .. } => true,
+            Effect::Combined { effects } => effects.iter().any(plays_email),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn turn_on_grants_the_authored_objective() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropLog {
+                deck: 4,
+                email: 1,
+                log: 33,
+                note: 0,
+                video: 0,
+            },
+            PropQuestBitName("Note_4_2".to_owned()),
+            PropQuestBitValue(QuestBitValue::INCOMPLETE),
+        ));
+        let physics = PhysicsWorld::new();
+        let mut trap = TrapEmail::new();
+
+        let effect = trap.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(
+            quest_bits(&effect),
+            vec![("Note_4_2".to_owned(), QuestBitValue::INCOMPLETE)]
+        );
+        assert!(
+            plays_email(&effect),
+            "the objective must be granted alongside the email, not instead of it"
+        );
     }
 }

--- a/shock2vr/src/scripts/trap_qb_set.rs
+++ b/shock2vr/src/scripts/trap_qb_set.rs
@@ -1,9 +1,8 @@
-use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
 
 pub struct TrapQBSet {}
 impl TrapQBSet {
@@ -21,23 +20,9 @@ impl Script for TrapQBSet {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
-                let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
-
-                let check_qbval = v_qbval
-                    .get(entity_id)
-                    .map(|v| v.0)
-                    .unwrap_or(QuestBitValue::COMPLETE);
-
-                if let Ok(qb_name) = &v_qbname.get(entity_id) {
+                if let Some(quest_bit_effect) = set_quest_bit_effect(world, entity_id) {
                     Effect::Combined {
-                        effects: vec![
-                            Effect::SetQuestBit {
-                                quest_bit_name: qb_name.0.to_owned(),
-                                quest_bit_value: check_qbval,
-                            },
-                            Effect::DestroyEntity { entity_id },
-                        ],
+                        effects: vec![quest_bit_effect, Effect::DestroyEntity { entity_id }],
                     }
                 } else {
                     Effect::NoEffect

--- a/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
+++ b/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for TrapEmail granting its authored objective (GitHub #556).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: TrapEmail read only PropLog, so it played the email audio but
+// never applied the entity's PropQuestBitName/PropQuestBitValue pair. On ops1
+// that meant Note_4_2 ("reprogram the three Simulation Units") - the starting
+// point of the whole Operations objective chain, with no other grantor anywhere
+// in ops1-ops4 - was never handed out.
+//
+// The trap stays once-only (it consumes itself): the tripwires feeding these
+// traps fire on every crossing, and re-applying the quest bit would knock an
+// already-COMPLETE objective back to INCOMPLETE.
+//
+// The authored chain is Tripwire 277 -> QB Filter 278 (on ShodanRoom) ->
+// EmailTrap 279. Discover entities by their stable mission object id
+// (`template_id`), never by runtime entity id.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops1: the email trap grants Note_4_2 and is consumed once fired",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "unknown",
+      "the Sim Unit objective should not be granted before the trap fires",
+    );
+
+    // The QB Filter ahead of the trap only passes after the SHODAN reveal.
+    await game.quests.set("ShodanRoom", "complete");
+
+    const filters = await game.entities.byTemplate(278);
+    assert.equal(
+      filters.length,
+      1,
+      `expected the ops1 QB Filter (object 278), got ${JSON.stringify(filters.map((f) => f.name))}`,
+    );
+
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "incomplete",
+      "the email trap should grant Note_4_2 as an active (INCOMPLETE) objective",
+    );
+
+    const emails = (await game.audio.recent()).sounds.filter((sound) =>
+      sound.tags.some(([key, value]) => key === "kind" && value === "email"),
+    );
+    assert.equal(
+      emails.length,
+      1,
+      `the email should play exactly once, got ${JSON.stringify(emails)}`,
+    );
+
+    // The trap is consumed, so re-crossing the tripwire later - after the
+    // player has actually completed the Sim Unit objective on ops3/ops4 -
+    // cannot downgrade it back to INCOMPLETE.
+    assert.equal(
+      (await game.entities.byTemplate(279)).length,
+      0,
+      "the email trap should be consumed once it fires",
+    );
+    await game.quests.set("note_4_2", "complete");
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "complete",
+      "re-triggering the trap chain must not knock a completed objective " +
+        "back to incomplete",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for a log disc granting its authored objective (GitHub #568).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: MediaGui::on_frob emitted CollectLog + PlaySound + the
+// switch-link relay, but never applied the disc's PropQuestBitName /
+// PropQuestBitValue pair. ops3's Bronson log (object 1349 -> Note_4_6) has zero
+// links in either direction, so the quest-bit pair on the disc is the
+// objective's only grantor - it could never be handed out.
+//
+// Re-reading must NOT re-apply it: SetQuestBit overwrites, so the authored
+// INCOMPLETE would knock an objective the player has since COMPLETEd back to
+// incomplete. The application is gated by the same `already_collected` one-shot
+// that guards the switch-link send.
+//
+// The disc is discovered by its stable mission object id (`template_id`), never
+// by runtime entity id.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops3: reading the Bronson log grants Note_4_6, and re-reading cannot downgrade it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await game.quests.get("note_4_6"),
+      "unknown",
+      "the objective should not be granted before the log is read",
+    );
+
+    const discs = await game.entities.byTemplate(1349);
+    assert.equal(
+      discs.length,
+      1,
+      `expected the ops3 Bronson log (object 1349), got ${JSON.stringify(discs.map((d) => d.name))}`,
+    );
+
+    await game.entities.sendMessage(discs[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      await game.quests.get("note_4_6"),
+      "incomplete",
+      "reading the log should grant Note_4_6 as an active (INCOMPLETE) objective",
+    );
+
+    // Once the player has actually completed the objective, re-reading the disc
+    // (which survives, unlike the original's destroy-on-pickup) must leave it
+    // complete.
+    await game.quests.set("note_4_6", "complete");
+    await game.entities.sendMessage(discs[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+    assert.equal(
+      await game.quests.get("note_4_6"),
+      "complete",
+      "re-reading a collected log must not knock a completed objective back to incomplete",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for switch-driven level-change buttons (GitHub #555).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: LevelChangeButton used to handle only `Frob`, dropping a
+// `TurnOn` that arrived over a SwitchLink. On the Operations deck the button
+// the player actually touches relays through a quest-bit filter to a hidden
+// co-located changer object that only ever receives `TurnOn`, so every Ops
+// bulkhead was sealed and the deck was unfinishable.
+//
+// ops2 object 185 is the visible ops3 bulkhead button; it relays
+// 185 -> 995 (QB Filter on ShodanRoom) -> 992 (the changer, dest ops3).
+// Runtime entity ids are not stable across runs, so discover the button by its
+// stable *mission object id*, reported in the `template_id` field.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops2: frobbing the visible bulkhead button relays TurnOn and transitions to ops3",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8125),
+    });
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).mission,
+      "ops2.mis",
+      "should start in ops2",
+    );
+
+    // The relay is gated on the ShodanRoom reveal (QB Filter 995).
+    await game.quests.set("ShodanRoom", "complete");
+
+    const buttons = await game.entities.byTemplate(185);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops2 ops3-bulkhead button (object 185), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops3.mis",
+      "frobbing the visible ops2 bulkhead button should reach the hidden " +
+        "changer over its switch links and transition to ops3",
+    );
+  },
+);
+
+test(
+  "ops3: a directly-frobbed level change button still transitions",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8126),
+    });
+    await game.step({ frames: 2 });
+
+    // ops3 object 742 carries LevelChangeButton with no switch links at all -
+    // the regression guard that routing frob through BaseButton (frob -> TurnOn
+    // to self) keeps directly-frobbed buttons working.
+    const buttons = await game.entities.byTemplate(742);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops3 ops2-bulkhead button (object 742), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops2.mis",
+      "frobbing a level change button directly should still transition",
+    );
+  },
+);


### PR DESCRIPTION
Reading a log disc recorded it in `collected_logs` but never applied the disc's authored `PropQuestBitName` / `PropQuestBitValue`, so a log that is the **sole grantor** of an objective never granted it.

Fixes #568

## The gap

`MediaGui::on_frob` emitted `CollectLog` + `PlaySound` + the switch-link relay, and stopped there. ops3's Bronson log (object 1349 → `Note_4_6`) carries the quest-bit pair with **zero links in either direction**, so no relay fallback exists — the objective could never be handed out. Same shape on ops4 465 (`Note_4_5`) and 525 (`Note_4_1`).

This is a general engine gap: it affects every mission's logs, not just Operations.

## The fix

`on_frob` now applies the disc's quest bit through the shared `script_util::set_quest_bit_effect` helper (introduced in #558 for exactly this reuse).

The interesting half is **when not to apply it**. `Effect::SetQuestBit` overwrites, and this port's disc survives for re-reading (a deliberate deviation from the original's destroy-on-pickup), so a naive application lets a re-read knock an objective the player has since COMPLETEd back to INCOMPLETE — the same hazard #558 hit with `TrapEmail`. The effect is therefore dropped when it would **downgrade** the bit.

Both `/xreview` engines independently flagged that reusing the switch-link send's `already_collected` one-shot for this — the gate the issue suggested — would be the wrong key. It is wrong twice over:

- **Distinct discs can grant the same bit.** eng1 objects 451 (`deck 1 / log 13`) and 936 (`deck 1 / log 14`) both author `Note_1_6`; reading one, completing the objective, then reading the *other* (never collected, so ungated) would still downgrade it. rec1 and many.mis have the same shape.
- **A log collected in an older save would never grant its objective at all** — it is already in `collected_logs`, so the gate would suppress it forever. That includes medsci1's `wattsy` disc, which sits at the play-through campaign's medsci1 frontier.

Testing for "unset" instead would also be wrong: ops4 525 authors `Note_4_1` as **COMPLETE**, i.e. a disc whose job is to complete an already-active objective. Hence the value comparison (`UNKNOWN(0) < INCOMPLETE(1) < COMPLETE(2)`).

`FrobQB` held a fourth, un-deduped copy of the same property lookup (the issue noted it could fold in); it now calls the same helper, with identical semantics including the `COMPLETE` default for a missing `PropQuestBitValue`.

## Testing (negative-first)

| Test | Without the fix | With the fix |
| --- | --- | --- |
| `frobbing_a_log_grants_its_authored_objective` | fail (`[]` vs `[("Note_4_6", INCOMPLETE)]`) | pass |
| `a_log_never_downgrades_an_objective_the_player_completed` | fail when the gate is removed | pass |
| e2e: ops3 Bronson log grants `note_4_6`, re-read cannot downgrade it | — | pass |

Both Rust tests were confirmed red first: the grant test against the unpatched `on_frob`, and the downgrade guard against a version with the fix applied but *ungated*. The e2e resolves the disc by its stable mission object id (`template_id` 1349), never a runtime entity id.

Live-verified on the debug runtime (`ops3.mis`, port 8221) — issue #568's exact repro:

```
disc (object 1349) runtime id = 703
before:                       note_4_6 = unknown
after frob:                   note_4_6 = incomplete
after re-frob (was complete): note_4_6 = complete
```

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt`, and `cargo test -p shock2vr` (260 passing) are green.

Full SDK e2e suite (`npm run test:e2e`, 140 tests): **139 pass, 1 fail** — `alertness-churn` (#481), the known flake also documented as pre-existing on #558. `power-cell-flat` and `monster-death` both passed this run.

## `/xreview`

Both engines agreed on one Medium finding — the `already_collected` gate does not actually prevent the downgrade it exists to prevent — which is resolved by the value-based gate described above (and which also fixes the older-save and shared-`(deck, log)` cases the Claude reviewer raised separately). Both confirmed the effect ordering is sound (`CollectLog` precedes `SetQuestBit` in the same batch, `Effect::flatten` preserves order) and that the `FrobQB` fold-in is semantically identical. No simplicity findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
