### PR TITLE
fix: a save taken while a camera is alert no longer panics on load

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -282,6 +282,13 @@ pub struct PlayerMapLocation(pub Option<i32>);
 #[derive(Unique, Clone)]
 pub struct GlobalTemplateHierarchy(pub HashMap<i32, Vec<i32>>);
 
+/// The merged (mission + gamesys) entity info, so scripts can consult an
+/// entity's *authored* template properties at runtime - e.g. a camera's
+/// original model name - rather than re-deriving them from mutated runtime
+/// state that persists into saves.
+#[derive(Unique, Clone)]
+pub struct GlobalEntityInfo(pub Arc<SystemShock2EntityInfo>);
+
 /// The trainer upgrade cost tables from the gamesys
 /// (`STATCOST`/`WTECHCOST`/`WSKILLCOST`/`PSICOST` chunks), so the trainer
 /// panel and the `TrainerPurchase` effect handler price upgrades from the
@@ -510,6 +517,7 @@ impl MissionCore {
         world.add_unique(GlobalTemplateHierarchy(
             ss2_entity_info::get_hierarchy(&entity_info_rc).clone(),
         ));
+        world.add_unique(GlobalEntityInfo(entity_info_rc.clone()));
         world.add_unique(GlobalTrainerCosts(
             game_entity_info.trainer_costs().cloned(),
         ));
@@ -3409,8 +3417,16 @@ impl MissionCore {
                         //drop(scene_obj);
 
                         let _ext_name = model_name.clone();
-                        let orig_model =
-                            asset_cache.get(&MODELS_IMPORTER, &format!("{model_name}.BIN"));
+                        // A missing model must never take down the frame (or a
+                        // load): keep the current model and complain loudly.
+                        let Some(orig_model) =
+                            asset_cache.get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
+                        else {
+                            tracing::error!(
+                                "ChangeModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current model"
+                            );
+                            continue;
+                        };
 
                         let orig_model_ref = orig_model.as_ref();
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -282,13 +282,6 @@ pub struct PlayerMapLocation(pub Option<i32>);
 #[derive(Unique, Clone)]
 pub struct GlobalTemplateHierarchy(pub HashMap<i32, Vec<i32>>);
 
-/// The merged (mission + gamesys) entity info, so scripts can consult an
-/// entity's *authored* template properties at runtime - e.g. a camera's
-/// original model name - rather than re-deriving them from mutated runtime
-/// state that persists into saves.
-#[derive(Unique, Clone)]
-pub struct GlobalEntityInfo(pub Arc<SystemShock2EntityInfo>);
-
 /// The trainer upgrade cost tables from the gamesys
 /// (`STATCOST`/`WTECHCOST`/`WSKILLCOST`/`PSICOST` chunks), so the trainer
 /// panel and the `TrainerPurchase` effect handler price upgrades from the
@@ -517,7 +510,6 @@ impl MissionCore {
         world.add_unique(GlobalTemplateHierarchy(
             ss2_entity_info::get_hierarchy(&entity_info_rc).clone(),
         ));
-        world.add_unique(GlobalEntityInfo(entity_info_rc.clone()));
         world.add_unique(GlobalTrainerCosts(
             game_entity_info.trainer_costs().cloned(),
         ));
@@ -3446,8 +3438,16 @@ impl MissionCore {
                 } => {
                     if let Some(model) = self.id_to_model.get(&entity_id) {
                         let xform = model.get_transform();
-                        let donor_model =
-                            asset_cache.get(&MODELS_IMPORTER, &format!("{model_name}.BIN"));
+                        // Same hazard as ChangeModel above: a missing donor
+                        // model must not panic the frame.
+                        let Some(donor_model) =
+                            asset_cache.get_opt(&MODELS_IMPORTER, &format!("{model_name}.BIN"))
+                        else {
+                            tracing::error!(
+                                "SetVhotsFromModel: model '{model_name}.BIN' could not be loaded for entity {entity_id:?} - keeping current vhots"
+                            );
+                            continue;
+                        };
                         let vhots = Model::transform(donor_model.as_ref(), xform).vhots();
                         self.world.add_component(entity_id, RuntimePropVhots(vhots));
                     }

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -1,15 +1,15 @@
 use cgmath::{Deg, Quaternion, Rotation3};
 use dark::properties::{
-    AIAlertLevel, PropAIAlertCap, PropAIAlertness, PropAIAwareDelay, PropAICamera, PropAIDevice,
-    PropModelName, PropPosition, PropSpeechVoice, PropTemplateId, PropVoiceIndex,
+    AIAlertLevel, InternalPropOriginalModelName, PropAIAlertCap, PropAIAlertness, PropAIAwareDelay,
+    PropAICamera, PropAIDevice, PropModelName, PropPosition, PropSpeechVoice, PropVoiceIndex,
 };
 use num_traits::ToPrimitive;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    mission::{GlobalEntityInfo, PlayerInfo},
+    mission::PlayerInfo,
     physics::PhysicsWorld,
-    scripts::{Effect, ai::ai_util, script_util, speech_util},
+    scripts::{Effect, ai::ai_util, speech_util},
     time::Time,
 };
 
@@ -317,11 +317,21 @@ impl CameraAI {
         }
 
         // The alert models are derived from the camera's *authored* model, not
-        // from whatever model it is currently showing - a camera saved while
-        // alert has the alert model in its `PropModelName`, and re-deriving
-        // from that would produce nonexistent models on load.
-        let base_model = template_model_name(world, entity_id)
-            .or(current_model)
+        // from whatever model it is currently showing: a camera saved while
+        // alert carries the alert model in its `PropModelName`, and re-deriving
+        // from that would produce nonexistent models on load. The authored name
+        // is recorded at entity creation and persisted with the save, so it
+        // survives the round trip.
+        let original_model = world
+            .borrow::<View<InternalPropOriginalModelName>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|m| m.0.clone()));
+
+        let base_model = original_model
+            // No authored model recorded (e.g. a camera created outside the
+            // normal entity path): fall back to the live model, mapped back to
+            // its idle variant so an alert model cannot compound.
+            .or_else(|| current_model.map(|model| idle_model(&model)))
             .unwrap_or_else(|| "camgrn".to_string());
 
         // Use the shared AlertnessTimings
@@ -568,34 +578,8 @@ fn move_towards_angle(current: f32, target: f32, max_delta: f32) -> f32 {
     }
 }
 
-/// The model name authored on the entity's template (the camera's original,
-/// idle model), independent of any model changes applied at runtime. `None`
-/// in contexts without entity info (e.g. debug scenes).
-fn template_model_name(world: &World, entity_id: EntityId) -> Option<String> {
-    let template_id = {
-        let v_template_id = world.borrow::<View<PropTemplateId>>().ok()?;
-        v_template_id.get(entity_id).ok()?.template_id
-    };
-
-    let entity_info = {
-        let u_entity_info = world.borrow::<UniqueView<GlobalEntityInfo>>().ok()?;
-        u_entity_info.0.clone()
-    };
-
-    script_util::hydrate_template_component::<PropModelName>(template_id, &entity_info).map(|m| m.0)
-}
-
 fn derive_models(base_model: &str) -> CameraModels {
-    let (raw_stem, ext) = base_model
-        .rsplit_once('.')
-        .map(|(stem, ext)| (stem.to_string(), Some(ext.to_string())))
-        .unwrap_or_else(|| (base_model.to_string(), None));
-
-    // Deriving from a model this function itself produced has to yield the
-    // same set again - an alert model that leaked back in (a camera saved
-    // while alert carries its alert model in `PropModelName`) would otherwise
-    // compound into models that do not exist.
-    let stem = idle_stem(&raw_stem);
+    let (stem, ext) = split_model_name(base_model);
 
     let lower_stem = stem.to_ascii_lowercase();
     let (yellow_stem, red_stem) = if lower_stem.ends_with("grn") {
@@ -617,39 +601,42 @@ fn derive_models(base_model: &str) -> CameraModels {
     };
 
     CameraModels {
-        green: rebuild(stem),
+        green: base_model.to_string(),
         yellow: rebuild(yellow_stem),
         red: rebuild(red_stem),
     }
 }
 
-/// Map an alert-model stem back to the idle (green) stem it was derived from,
-/// inverting the suffix scheme `derive_models` applies. A stem that is already
-/// an idle stem is returned unchanged, which makes the derivation idempotent.
-fn idle_stem(stem: &str) -> String {
+fn split_model_name(model_name: &str) -> (String, Option<String>) {
+    model_name
+        .rsplit_once('.')
+        .map(|(stem, ext)| (stem.to_string(), Some(ext.to_string())))
+        .unwrap_or_else(|| (model_name.to_string(), None))
+}
+
+/// Map a camera's alert model back to the idle model it was derived from,
+/// inverting the suffix scheme `derive_models` applies (the shipped cameras use
+/// `camgrn`/`camyel`/`camred`). A model that is already an idle model is
+/// returned unchanged, so deriving from the result is idempotent. Only used on
+/// the fallback path, where the model in hand may be an alert one.
+fn idle_model(model_name: &str) -> String {
+    let (stem, ext) = split_model_name(model_name);
     let lower = stem.to_ascii_lowercase();
 
-    // `{stem}_yel` / `{stem}_red` - the fallback scheme for models with no
-    // recognized color suffix.
-    if lower.ends_with("_yel") || lower.ends_with("_red") {
-        return stem[..stem.len() - 4].to_string();
-    }
+    let idle_stem = if lower.ends_with("_yel") || lower.ends_with("_red") {
+        // `{stem}_yel` / `{stem}_red` - the fallback scheme for models with no
+        // recognized color suffix.
+        stem[..stem.len() - 4].to_string()
+    } else if lower.ends_with("yel") || lower.ends_with("red") {
+        format!("{}grn", &stem[..stem.len() - 3])
+    } else {
+        stem
+    };
 
-    // `{prefix}yellow` / `{prefix}yel` pair back with `green` / `grn`.
-    if lower.ends_with("yellow") {
-        return format!("{}green", &stem[..stem.len() - 6]);
+    match ext {
+        Some(ext) => format!("{idle_stem}.{ext}"),
+        None => idle_stem,
     }
-    if lower.ends_with("yel") {
-        return format!("{}grn", &stem[..stem.len() - 3]);
-    }
-
-    // `{prefix}red` is the alert model of both color schemes; the shipped
-    // camera models use the three-letter one (`camgrn`/`camyel`/`camred`).
-    if lower.ends_with("red") {
-        return format!("{}grn", &stem[..stem.len() - 3]);
-    }
-
-    stem.to_string()
 }
 
 fn level_to_u32(level: AIAlertLevel) -> u32 {
@@ -689,22 +676,38 @@ mod tests {
     }
 
     // A camera saved while alert comes back with its alert model in
-    // `PropModelName`; re-deriving from that must not compound (which produced
-    // the nonexistent `camred_red` and panicked the load).
+    // `PropModelName`; deriving from that must not compound (which produced the
+    // nonexistent `camred_red` and panicked the load). Where the fallback path
+    // has only that model to go on, `idle_model` makes the derivation
+    // idempotent.
     #[test]
-    fn derivation_is_idempotent_across_alert_models() {
+    fn deriving_from_an_alert_model_matches_deriving_from_the_idle_model() {
         let base = models("camgrn");
-        assert_eq!(models(&base.1), base, "deriving from the yellow model");
-        assert_eq!(models(&base.2), base, "deriving from the red model");
+        assert_eq!(
+            models(&idle_model(&base.1)),
+            base,
+            "deriving from the yellow model"
+        );
+        assert_eq!(
+            models(&idle_model(&base.2)),
+            base,
+            "deriving from the red model"
+        );
     }
 
     #[test]
-    fn derivation_is_idempotent_with_an_extension_and_unknown_suffixes() {
-        let with_ext = models("camgrn.bin");
-        assert_eq!(models(&with_ext.2), with_ext);
+    fn idle_models_and_extensions_survive_the_round_trip() {
+        // An idle model is left alone...
+        assert_eq!(idle_model("camgrn"), "camgrn");
+        assert_eq!(idle_model("camgrn.bin"), "camgrn.bin");
 
+        // ...and the extension is preserved through the inverse.
+        let with_ext = models("camgrn.bin");
+        assert_eq!(models(&idle_model(&with_ext.2)), with_ext);
+
+        // The `_yel`/`_red` fallback scheme inverts too.
         let fallback = models("securitycam");
-        assert_eq!(models(&fallback.1), fallback);
-        assert_eq!(models(&fallback.2), fallback);
+        assert_eq!(models(&idle_model(&fallback.1)), fallback);
+        assert_eq!(models(&idle_model(&fallback.2)), fallback);
     }
 }

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -1,15 +1,15 @@
 use cgmath::{Deg, Quaternion, Rotation3};
 use dark::properties::{
     AIAlertLevel, PropAIAlertCap, PropAIAlertness, PropAIAwareDelay, PropAICamera, PropAIDevice,
-    PropModelName, PropPosition, PropSpeechVoice, PropVoiceIndex,
+    PropModelName, PropPosition, PropSpeechVoice, PropTemplateId, PropVoiceIndex,
 };
 use num_traits::ToPrimitive;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    mission::PlayerInfo,
+    mission::{GlobalEntityInfo, PlayerInfo},
     physics::PhysicsWorld,
-    scripts::{Effect, ai::ai_util, speech_util},
+    scripts::{Effect, ai::ai_util, script_util, speech_util},
     time::Time,
 };
 
@@ -288,11 +288,7 @@ impl CameraAI {
             .cloned()
             .unwrap_or(default_aware_delay);
 
-        let base_model = v_model_name
-            .get(entity_id)
-            .ok()
-            .map(|m| m.0.clone())
-            .unwrap_or_else(|| "camgrn".to_string());
+        let current_model = v_model_name.get(entity_id).ok().map(|m| m.0.clone());
 
         let initial_alertness = v_alertness
             .get(entity_id)
@@ -319,6 +315,14 @@ impl CameraAI {
                 entity_id
             );
         }
+
+        // The alert models are derived from the camera's *authored* model, not
+        // from whatever model it is currently showing - a camera saved while
+        // alert has the alert model in its `PropModelName`, and re-deriving
+        // from that would produce nonexistent models on load.
+        let base_model = template_model_name(world, entity_id)
+            .or(current_model)
+            .unwrap_or_else(|| "camgrn".to_string());
 
         // Use the shared AlertnessTimings
         let timings = AlertnessTimings::from_aware_delay(&aware_delay);
@@ -564,11 +568,34 @@ fn move_towards_angle(current: f32, target: f32, max_delta: f32) -> f32 {
     }
 }
 
+/// The model name authored on the entity's template (the camera's original,
+/// idle model), independent of any model changes applied at runtime. `None`
+/// in contexts without entity info (e.g. debug scenes).
+fn template_model_name(world: &World, entity_id: EntityId) -> Option<String> {
+    let template_id = {
+        let v_template_id = world.borrow::<View<PropTemplateId>>().ok()?;
+        v_template_id.get(entity_id).ok()?.template_id
+    };
+
+    let entity_info = {
+        let u_entity_info = world.borrow::<UniqueView<GlobalEntityInfo>>().ok()?;
+        u_entity_info.0.clone()
+    };
+
+    script_util::hydrate_template_component::<PropModelName>(template_id, &entity_info).map(|m| m.0)
+}
+
 fn derive_models(base_model: &str) -> CameraModels {
-    let (stem, ext) = base_model
+    let (raw_stem, ext) = base_model
         .rsplit_once('.')
         .map(|(stem, ext)| (stem.to_string(), Some(ext.to_string())))
         .unwrap_or_else(|| (base_model.to_string(), None));
+
+    // Deriving from a model this function itself produced has to yield the
+    // same set again - an alert model that leaked back in (a camera saved
+    // while alert carries its alert model in `PropModelName`) would otherwise
+    // compound into models that do not exist.
+    let stem = idle_stem(&raw_stem);
 
     let lower_stem = stem.to_ascii_lowercase();
     let (yellow_stem, red_stem) = if lower_stem.ends_with("grn") {
@@ -590,10 +617,39 @@ fn derive_models(base_model: &str) -> CameraModels {
     };
 
     CameraModels {
-        green: base_model.to_string(),
+        green: rebuild(stem),
         yellow: rebuild(yellow_stem),
         red: rebuild(red_stem),
     }
+}
+
+/// Map an alert-model stem back to the idle (green) stem it was derived from,
+/// inverting the suffix scheme `derive_models` applies. A stem that is already
+/// an idle stem is returned unchanged, which makes the derivation idempotent.
+fn idle_stem(stem: &str) -> String {
+    let lower = stem.to_ascii_lowercase();
+
+    // `{stem}_yel` / `{stem}_red` - the fallback scheme for models with no
+    // recognized color suffix.
+    if lower.ends_with("_yel") || lower.ends_with("_red") {
+        return stem[..stem.len() - 4].to_string();
+    }
+
+    // `{prefix}yellow` / `{prefix}yel` pair back with `green` / `grn`.
+    if lower.ends_with("yellow") {
+        return format!("{}green", &stem[..stem.len() - 6]);
+    }
+    if lower.ends_with("yel") {
+        return format!("{}grn", &stem[..stem.len() - 3]);
+    }
+
+    // `{prefix}red` is the alert model of both color schemes; the shipped
+    // camera models use the three-letter one (`camgrn`/`camyel`/`camred`).
+    if lower.ends_with("red") {
+        return format!("{}grn", &stem[..stem.len() - 3]);
+    }
+
+    stem.to_string()
 }
 
 fn level_to_u32(level: AIAlertLevel) -> u32 {
@@ -608,5 +664,47 @@ impl CameraModels {
             // Low and Lowest both show green - camera is in "safe" state
             AIAlertLevel::Low | AIAlertLevel::Lowest => &self.green,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn models(base: &str) -> (String, String, String) {
+        let m = derive_models(base);
+        (m.green, m.yellow, m.red)
+    }
+
+    #[test]
+    fn derives_alert_models_from_the_idle_model() {
+        assert_eq!(
+            models("camgrn"),
+            (
+                "camgrn".to_string(),
+                "camyel".to_string(),
+                "camred".to_string()
+            )
+        );
+    }
+
+    // A camera saved while alert comes back with its alert model in
+    // `PropModelName`; re-deriving from that must not compound (which produced
+    // the nonexistent `camred_red` and panicked the load).
+    #[test]
+    fn derivation_is_idempotent_across_alert_models() {
+        let base = models("camgrn");
+        assert_eq!(models(&base.1), base, "deriving from the yellow model");
+        assert_eq!(models(&base.2), base, "deriving from the red model");
+    }
+
+    #[test]
+    fn derivation_is_idempotent_with_an_extension_and_unknown_suffixes() {
+        let with_ext = models("camgrn.bin");
+        assert_eq!(models(&with_ext.2), with_ext);
+
+        let fallback = models("securitycam");
+        assert_eq!(models(&fallback.1), fallback);
+        assert_eq!(models(&fallback.2), fallback);
     }
 }

--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -5,9 +5,7 @@ use crate::physics::PhysicsWorld;
 
 use super::{
     Effect, MessagePayload, Script,
-    script_util::{
-        play_environmental_sound, send_to_all_switch_links, send_to_all_switch_links_and_self,
-    },
+    script_util::{play_environmental_sound, send_to_all_switch_links},
 };
 
 pub struct BaseButton {}
@@ -19,6 +17,27 @@ impl BaseButton {
     pub fn is_locked(&self, entity_id: EntityId, world: &World) -> bool {
         super::script_util::is_entity_locked(world, entity_id)
     }
+
+    /// The refusal a locked button gives instead of activating, or `None` when
+    /// it is free to activate. Button subclasses gate their own action on this.
+    pub fn locked_effect(&self, entity_id: EntityId, world: &World) -> Option<Effect> {
+        self.is_locked(entity_id, world).then(|| Effect::PlaySound {
+            handle: AudioHandle::new(),
+            name: "hackfail".to_owned(),
+        })
+    }
+
+    /// What every button does when it is pressed, apart from its own action:
+    /// relay `TurnOn` to its switch links and play the activate sound. The
+    /// button's *own* action is the caller's business - `BaseButton` notifies
+    /// itself, subclasses run theirs directly.
+    pub fn activate_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let switch_link_effect =
+            send_to_all_switch_links(world, entity_id, MessagePayload::TurnOn { from: entity_id });
+        let sound_effect =
+            play_environmental_sound(world, entity_id, "activate", vec![], AudioHandle::new());
+        Effect::combine(vec![switch_link_effect, sound_effect])
+    }
 }
 impl Script for BaseButton {
     fn handle_message(
@@ -29,28 +48,17 @@ impl Script for BaseButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                if self.is_locked(entity_id, world) {
-                    Effect::PlaySound {
-                        handle: AudioHandle::new(),
-                        name: "hackfail".to_owned(),
-                    }
-                } else {
-                    let switch_link_effect = send_to_all_switch_links_and_self(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    let sound_effect = play_environmental_sound(
-                        world,
-                        entity_id,
-                        "activate",
-                        vec![],
-                        AudioHandle::new(),
-                    );
-                    Effect::combine(vec![switch_link_effect, sound_effect])
-                }
-            }
+            MessagePayload::Frob => self.locked_effect(entity_id, world).unwrap_or_else(|| {
+                // A plain button's own action is to notify itself, so proxy
+                // scripts on the same entity see the press as a TurnOn.
+                let notify_self = Effect::Send {
+                    msg: super::Message {
+                        payload: MessagePayload::TurnOn { from: entity_id },
+                        to: entity_id,
+                    },
+                };
+                Effect::combine(vec![self.activate_effect(entity_id, world), notify_self])
+            }),
 
             // In some places (like the computer for the engine room in eng1), invisible buttons are used as proxies -
             // there will be an actual button that sends a 'TurnOn' message to an invisible button. Not sure why

--- a/shock2vr/src/scripts/level_change_button.rs
+++ b/shock2vr/src/scripts/level_change_button.rs
@@ -4,12 +4,47 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{BaseButton, Effect, MessagePayload, Script};
 
-pub struct LevelChangeButton {}
+/// The level-change bulkhead button. The original's script class derives from
+/// the base button class, so it *also* behaves like a button: frobbing it
+/// relays `TurnOn` over its switch links, and the level change itself happens
+/// on `TurnOn`. (The shipped `PropScripts` sets `inherits: false`, which drops
+/// the archetype's `BaseButton`, so the port has to compose it explicitly.)
+///
+/// The `TurnOn` half matters because bulkheads are commonly driven
+/// *indirectly*: the button the player touches relays through a quest-bit
+/// filter to a hidden co-located changer object, which only ever receives
+/// `TurnOn`.
+///
+/// A frob changes level immediately rather than by way of a self-addressed
+/// `TurnOn`: sibling scripts on the same entity can consume the frob too (the
+/// rick3 shuttle button also runs `FrobQB`, which destroys the entity), and a
+/// deferred message would never reach it.
+pub struct LevelChangeButton {
+    base_button: BaseButton,
+}
 impl LevelChangeButton {
     pub fn new() -> LevelChangeButton {
-        LevelChangeButton {}
+        LevelChangeButton {
+            base_button: BaseButton::new(),
+        }
+    }
+
+    fn transition_effect(&self, entity_id: EntityId, world: &World) -> Effect {
+        let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
+        let Ok(level_file) = v_dest_level.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+
+        let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
+        let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
+        Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
+            level_file: format!("{}.mis", level_file.0),
+            loc: maybe_dest_loc,
+            entities_to_trigger: vec![],
+            vitals_transition: super::PlayerVitalsTransition::Preserve,
+        })
     }
 }
 
@@ -22,20 +57,104 @@ impl Script for LevelChangeButton {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Frob => {
-                let v_dest_level = world.borrow::<View<PropDestLevel>>().unwrap();
-                let level_file = v_dest_level.get(entity_id).unwrap();
-
-                let v_dest_loc = world.borrow::<View<PropDestLoc>>().unwrap();
-                let maybe_dest_loc = v_dest_loc.get(entity_id).ok().map(|dest_loc| dest_loc.0);
-                Effect::GlobalEffect(super::GlobalEffect::TransitionLevel {
-                    level_file: format!("{}.mis", level_file.0),
-                    loc: maybe_dest_loc,
-                    entities_to_trigger: vec![],
-                    vitals_transition: super::PlayerVitalsTransition::Preserve,
-                })
-            }
+            // The activate half is the shared button press (relay + sound). No
+            // shipped level-change object has outgoing switch links, and a
+            // relay queued alongside a transition would be dropped with the
+            // outgoing scene anyway - it is here so the button behaves like a
+            // button, not because any mission depends on it.
+            MessagePayload::Frob => self
+                .base_button
+                .locked_effect(entity_id, world)
+                .unwrap_or_else(|| {
+                    Effect::combine(vec![
+                        self.base_button.activate_effect(entity_id, world),
+                        self.transition_effect(entity_id, world),
+                    ])
+                }),
+            MessagePayload::TurnOn { from: _ } => self.transition_effect(entity_id, world),
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, PropDestLevel, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn transition_target(effect: &Effect) -> Option<String> {
+        match effect {
+            Effect::GlobalEffect(super::super::GlobalEffect::TransitionLevel {
+                level_file,
+                ..
+            }) => Some(level_file.clone()),
+            Effect::Combined { effects } => effects.iter().find_map(transition_target),
+            _ => None,
+        }
+    }
+
+    fn sent_messages(effect: &Effect) -> Vec<(EntityId, MessagePayload)> {
+        match effect {
+            Effect::Send { msg } => vec![(msg.to, msg.payload.clone())],
+            Effect::Combined { effects } => effects.iter().flat_map(sent_messages).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    #[test]
+    fn turn_on_over_a_switch_link_transitions_the_level() {
+        let mut world = World::new();
+        let entity_id = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(transition_target(&effect), Some("ops3.mis".to_owned()));
+    }
+
+    #[test]
+    fn frob_relays_turn_on_to_switch_links_and_transitions_immediately() {
+        let mut world = World::new();
+        let changer = world.add_entity(PropDestLevel("ops3".to_owned()));
+        let entity_id = world.add_entity((
+            PropDestLevel("ops3".to_owned()),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(changer)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = LevelChangeButton::new();
+
+        let effect = button.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        let sent = sent_messages(&effect);
+        assert!(
+            sent.iter().any(|(to, payload)| *to == changer
+                && matches!(payload, MessagePayload::TurnOn { from: _ })),
+            "frob must relay TurnOn over switch links, got {sent:?}"
+        );
+        // The transition is in the frob's own effect, not deferred behind a
+        // self-addressed message - a sibling script (rick3's FrobQB) can
+        // destroy the entity on the same frob.
+        assert_eq!(
+            transition_target(&effect),
+            Some("ops3.mis".to_owned()),
+            "frob must transition immediately, got {sent:?}"
+        );
+        assert!(
+            !sent.iter().any(|(to, _)| *to == entity_id),
+            "frob must not defer its own action behind a self-message, got {sent:?}"
+        );
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -471,6 +471,30 @@ fn collect_contained_items(
     });
 }
 
+/// The `SetQuestBit` effect for an entity's authored quest-bit pair
+/// (`PropQuestBitName` + `PropQuestBitValue`, defaulting to `COMPLETE` when no
+/// value is authored). `None` when the entity carries no quest-bit name.
+/// Shared by every trap that applies a quest bit as part of its action.
+pub fn set_quest_bit_effect(world: &World, entity_id: EntityId) -> Option<Effect> {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
+    let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
+
+    let quest_bit_value = v_qbval
+        .get(entity_id)
+        .map(|v| v.0)
+        .unwrap_or(QuestBitValue::COMPLETE);
+
+    v_qbname
+        .get(entity_id)
+        .ok()
+        .map(|qb_name| Effect::SetQuestBit {
+            quest_bit_name: qb_name.0.to_owned(),
+            quest_bit_value,
+        })
+}
+
 pub fn get_all_switch_links(world: &World, producing_entity_id: EntityId) -> Vec<EntityId> {
     let links = world.borrow::<View<Links>>().unwrap();
     let mut linked_entities = Vec::new();

--- a/shock2vr/src/scripts/trap_email.rs
+++ b/shock2vr/src/scripts/trap_email.rs
@@ -1,10 +1,12 @@
 use dark::properties::PropLog;
-use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+use super::{
+    Effect, MessagePayload, Script,
+    script_util::{send_to_all_switch_links, set_quest_bit_effect},
+};
 
 pub struct TrapEmail {}
 impl TrapEmail {
@@ -23,39 +25,105 @@ impl Script for TrapEmail {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_sound = world.borrow::<View<PropLog>>().unwrap();
-                let maybe_trip_sound = v_sound.get(entity_id);
-                let _handle = AudioHandle::new();
-                //self.playing_sounds.push(handle.clone());
-                if let Ok(sound) = maybe_trip_sound {
-                    let email_effect = if sound.deck > 0 && sound.email > 0 {
-                        Effect::PlayEmail {
-                            deck: sound.deck,
-                            email: sound.email,
-                            force: false,
-                        }
-                    } else {
-                        Effect::NoEffect
-                    };
+                let v_log = world.borrow::<View<PropLog>>().unwrap();
+                let email_effect = match v_log.get(entity_id) {
+                    Ok(log) if log.deck > 0 && log.email > 0 => Effect::PlayEmail {
+                        deck: log.deck,
+                        email: log.email,
+                        force: false,
+                    },
+                    _ => Effect::NoEffect,
+                };
 
-                    let switchlink_effects = send_to_all_switch_links(
-                        world,
-                        entity_id,
-                        MessagePayload::TurnOn { from: entity_id },
-                    );
-                    Effect::Combined {
-                        effects: vec![
-                            email_effect,
-                            switchlink_effects,
-                            Effect::DestroyEntity { entity_id },
-                        ],
-                    }
-                } else {
-                    Effect::NoEffect
+                // The email trap also carries the objective it hands out
+                // (PropQuestBitName/PropQuestBitValue) - the email and the
+                // objective it describes are authored on the same entity.
+                let quest_bit_effect =
+                    set_quest_bit_effect(world, entity_id).unwrap_or(Effect::NoEffect);
+
+                let switchlink_effects = send_to_all_switch_links(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                );
+
+                // The trap is consumed once it fires. The tripwires that feed
+                // these traps fire on every crossing, and re-applying the quest
+                // bit would knock an already-COMPLETE objective back to
+                // INCOMPLETE (QuestInfo::set_quest_bit_value overwrites).
+                // has_played_email only suppresses the audio, not the objective
+                // or the switch-link relay.
+                Effect::Combined {
+                    effects: vec![
+                        email_effect,
+                        quest_bit_effect,
+                        switchlink_effects,
+                        Effect::DestroyEntity { entity_id },
+                    ],
                 }
             }
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+
+    use super::*;
+
+    fn quest_bits(effect: &Effect) -> Vec<(String, QuestBitValue)> {
+        match effect {
+            Effect::SetQuestBit {
+                quest_bit_name,
+                quest_bit_value,
+            } => vec![(quest_bit_name.clone(), *quest_bit_value)],
+            Effect::Combined { effects } => effects.iter().flat_map(quest_bits).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn plays_email(effect: &Effect) -> bool {
+        match effect {
+            Effect::PlayEmail { .. } => true,
+            Effect::Combined { effects } => effects.iter().any(plays_email),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn turn_on_grants_the_authored_objective() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropLog {
+                deck: 4,
+                email: 1,
+                log: 33,
+                note: 0,
+                video: 0,
+            },
+            PropQuestBitName("Note_4_2".to_owned()),
+            PropQuestBitValue(QuestBitValue::INCOMPLETE),
+        ));
+        let physics = PhysicsWorld::new();
+        let mut trap = TrapEmail::new();
+
+        let effect = trap.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(
+            quest_bits(&effect),
+            vec![("Note_4_2".to_owned(), QuestBitValue::INCOMPLETE)]
+        );
+        assert!(
+            plays_email(&effect),
+            "the objective must be granted alongside the email, not instead of it"
+        );
     }
 }

--- a/shock2vr/src/scripts/trap_qb_set.rs
+++ b/shock2vr/src/scripts/trap_qb_set.rs
@@ -1,9 +1,8 @@
-use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
 
 pub struct TrapQBSet {}
 impl TrapQBSet {
@@ -21,23 +20,9 @@ impl Script for TrapQBSet {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from: _ } => {
-                let v_qbname = world.borrow::<View<PropQuestBitName>>().unwrap();
-                let v_qbval = world.borrow::<View<PropQuestBitValue>>().unwrap();
-
-                let check_qbval = v_qbval
-                    .get(entity_id)
-                    .map(|v| v.0)
-                    .unwrap_or(QuestBitValue::COMPLETE);
-
-                if let Ok(qb_name) = &v_qbname.get(entity_id) {
+                if let Some(quest_bit_effect) = set_quest_bit_effect(world, entity_id) {
                     Effect::Combined {
-                        effects: vec![
-                            Effect::SetQuestBit {
-                                quest_bit_name: qb_name.0.to_owned(),
-                                quest_bit_value: check_qbval,
-                            },
-                            Effect::DestroyEntity { entity_id },
-                        ],
+                        effects: vec![quest_bit_effect, Effect::DestroyEntity { entity_id }],
                     }
                 } else {
                     Effect::NoEffect

--- a/tools/shock2-sdk/test/camera-alert-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/camera-alert-save.e2e.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first for #573: a save taken while a security camera is in its
+// alert (red) state was permanently unloadable. The camera derived its alert
+// models from its CURRENT model, so a save carrying `camred` re-derived
+// `camred_red` on load - a model that does not exist - and the load panicked.
+// Before the fix, the load below takes down the game-loop thread and this test
+// fails (the runtime never comes back with the restored mission).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8203);
+
+// medsci1 object 102 - a Security Camera (`cameraalert` script) with a clear
+// line of sight to the vantage point used below. Template ids are stable
+// across runs; runtime entity ids are not.
+const CAMERA_TEMPLATE_ID = 102;
+
+function prop(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+async function camera(game: GameServer): Promise<EntitySummary> {
+  const [cam] = await game.entities.byTemplate(CAMERA_TEMPLATE_ID);
+  assert.ok(cam, `medsci1 should contain camera template ${CAMERA_TEMPLATE_ID}`);
+  return cam;
+}
+
+test(
+  "a save taken while a camera is alert reloads with the camera's state intact",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    const saveName = `camera_alert_e2e_${Date.now()}`;
+
+    // --- Session 1: let the camera see the player, then save while it is red.
+    {
+      await using game = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 10 });
+
+      const cam = await camera(game);
+      assert.equal(
+        prop(await game.entities.detail(cam.id), "Model"),
+        "camgrn",
+        "the camera should start on its idle (green) model",
+      );
+
+      // Stand in the camera's sweep, in line of sight, and hold still: the
+      // camera escalates on its own (Moderate ~3s, High ~6s of visibility).
+      const [cx, cy, cz] = cam.position;
+      await game.player.teleport({ x: cx - 2.83, y: cy - 1.9, z: cz + 2.83 });
+
+      let model: string | undefined;
+      for (let i = 0; i < 20 && model !== "camred"; i++) {
+        await game.step({ frames: 120 });
+        model = prop(await game.entities.detail(cam.id), "Model");
+      }
+      assert.equal(model, "camred", "the camera should reach its alert model");
+
+      const detail = await game.entities.detail(cam.id);
+      assert.equal(prop(detail, "AIAlertness"), "High");
+
+      const saveResult = await game.save(saveName);
+      assert.equal(saveResult.success, true, "save should report success");
+    }
+
+    // --- Session 2: a FRESH process loads that save. This is where the bug
+    // --- bit: the alert model persisted, and re-deriving from it panicked.
+    {
+      await using game = await GameServer.launch({
+        mission: "eng1.mis",
+        port: basePort + 1,
+      });
+      await game.step({ frames: 2 });
+
+      const loadResult = await game.load(saveName);
+      assert.equal(loadResult.success, true, "load should report success");
+      assert.equal(loadResult.mission, "medsci1.mis");
+
+      // Runtime is alive and on the restored mission (a panic in the load
+      // would have taken the game loop with it).
+      assert.equal((await game.info()).mission, "medsci1.mis");
+
+      const cam = await camera(game);
+      const detail = await game.entities.detail(cam.id);
+      assert.equal(
+        prop(detail, "Model"),
+        "camred",
+        "the camera's alert model should round-trip through the save",
+      );
+      assert.equal(
+        prop(detail, "AIAlertness"),
+        "High",
+        "the camera's alert state should round-trip through the save",
+      );
+
+      // And it stays a real model as the restored camera keeps running - the
+      // derivation must not compound into a nonexistent model.
+      await game.step({ frames: 60 });
+      assert.equal(prop(await game.entities.detail(cam.id), "Model"), "camred");
+    }
+  },
+);

--- a/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
+++ b/tools/shock2-sdk/test/email-trap-objective.e2e.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for TrapEmail granting its authored objective (GitHub #556).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: TrapEmail read only PropLog, so it played the email audio but
+// never applied the entity's PropQuestBitName/PropQuestBitValue pair. On ops1
+// that meant Note_4_2 ("reprogram the three Simulation Units") - the starting
+// point of the whole Operations objective chain, with no other grantor anywhere
+// in ops1-ops4 - was never handed out.
+//
+// The trap stays once-only (it consumes itself): the tripwires feeding these
+// traps fire on every crossing, and re-applying the quest bit would knock an
+// already-COMPLETE objective back to INCOMPLETE.
+//
+// The authored chain is Tripwire 277 -> QB Filter 278 (on ShodanRoom) ->
+// EmailTrap 279. Discover entities by their stable mission object id
+// (`template_id`), never by runtime entity id.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops1: the email trap grants Note_4_2 and is consumed once fired",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "unknown",
+      "the Sim Unit objective should not be granted before the trap fires",
+    );
+
+    // The QB Filter ahead of the trap only passes after the SHODAN reveal.
+    await game.quests.set("ShodanRoom", "complete");
+
+    const filters = await game.entities.byTemplate(278);
+    assert.equal(
+      filters.length,
+      1,
+      `expected the ops1 QB Filter (object 278), got ${JSON.stringify(filters.map((f) => f.name))}`,
+    );
+
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "incomplete",
+      "the email trap should grant Note_4_2 as an active (INCOMPLETE) objective",
+    );
+
+    const emails = (await game.audio.recent()).sounds.filter((sound) =>
+      sound.tags.some(([key, value]) => key === "kind" && value === "email"),
+    );
+    assert.equal(
+      emails.length,
+      1,
+      `the email should play exactly once, got ${JSON.stringify(emails)}`,
+    );
+
+    // The trap is consumed, so re-crossing the tripwire later - after the
+    // player has actually completed the Sim Unit objective on ops3/ops4 -
+    // cannot downgrade it back to INCOMPLETE.
+    assert.equal(
+      (await game.entities.byTemplate(279)).length,
+      0,
+      "the email trap should be consumed once it fires",
+    );
+    await game.quests.set("note_4_2", "complete");
+    await game.entities.sendMessage(filters[0].id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+    assert.equal(
+      await game.quests.get("note_4_2"),
+      "complete",
+      "re-triggering the trap chain must not knock a completed objective " +
+        "back to incomplete",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for switch-driven level-change buttons (GitHub #555).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: LevelChangeButton used to handle only `Frob`, dropping a
+// `TurnOn` that arrived over a SwitchLink. On the Operations deck the button
+// the player actually touches relays through a quest-bit filter to a hidden
+// co-located changer object that only ever receives `TurnOn`, so every Ops
+// bulkhead was sealed and the deck was unfinishable.
+//
+// ops2 object 185 is the visible ops3 bulkhead button; it relays
+// 185 -> 995 (QB Filter on ShodanRoom) -> 992 (the changer, dest ops3).
+// Runtime entity ids are not stable across runs, so discover the button by its
+// stable *mission object id*, reported in the `template_id` field.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops2: frobbing the visible bulkhead button relays TurnOn and transitions to ops3",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8125),
+    });
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).mission,
+      "ops2.mis",
+      "should start in ops2",
+    );
+
+    // The relay is gated on the ShodanRoom reveal (QB Filter 995).
+    await game.quests.set("ShodanRoom", "complete");
+
+    const buttons = await game.entities.byTemplate(185);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops2 ops3-bulkhead button (object 185), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops3.mis",
+      "frobbing the visible ops2 bulkhead button should reach the hidden " +
+        "changer over its switch links and transition to ops3",
+    );
+  },
+);
+
+test(
+  "ops3: a directly-frobbed level change button still transitions",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8126),
+    });
+    await game.step({ frames: 2 });
+
+    // ops3 object 742 carries LevelChangeButton with no switch links at all -
+    // the regression guard that routing frob through BaseButton (frob -> TurnOn
+    // to self) keeps directly-frobbed buttons working.
+    const buttons = await game.entities.byTemplate(742);
+    assert.equal(
+      buttons.length,
+      1,
+      `expected the ops3 ops2-bulkhead button (object 742), got ${JSON.stringify(buttons.map((b) => b.name))}`,
+    );
+
+    await game.entities.sendMessage(buttons[0].id, { type: "Frob" });
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops2.mis",
+      "frobbing a level change button directly should still transition",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #573

A save taken while a security camera was in its alert (red) state was **permanently unloadable** — the load hard-panicked and the save was unrecoverable.

## Root cause

`CameraAI::build_config` derived the yellow/red model names from the entity's **current** `PropModelName`. The alert model persists into the save, so on reload the base became `camred`, the red variant became the nonexistent `camred_red`, and `Effect::ChangeModel` unwrapped the missing asset → panic on the game-loop thread.

## The fix

- **`shock2vr/src/scripts/ai/camera_ai.rs`** — the alert models are now derived from the camera's **authored** model. `InternalPropOriginalModelName` already records each entity's authored model at creation (`entity_creator.rs`) and is serialized as `__P$OriginalModelName` with every save, so the base survives the round trip. If no authored model is recorded (a camera created outside the normal entity path), the fallback maps the live model back to its idle variant (`idle_model`) so an alert model still cannot compound.
- **`shock2vr/src/mission/mission_core.rs`** — `Effect::ChangeModel` no longer unwraps a missing model: it logs an error and keeps the current model. The sibling `Effect::SetVhotsFromModel` arm had the identical unwrap and is guarded the same way. A missing model asset can no longer panic a frame or a load.

No string special-casing of `camred`/`camgrn`, no save sanitizing, no load-time patching.

## Negative-first evidence

**Unit** (`cargo test -p shock2vr`): with the normalization removed, `derive_models("camyel")` returns `("camyel", "camyel_yel", "camyel_red")` instead of the idle set — exactly the compounding that produced `camred_red`:

```
assertion `left == right` failed: deriving from the yellow model
  left: ("camyel", "camyel_yel", "camyel_red")
 right: ("camgrn", "camyel", "camred")
```

**e2e** (`tools/shock2-sdk/test/camera-alert-save.e2e.test.ts`): stands in a medsci1 camera's view until it goes red, saves, and loads the save in a **fresh runtime process**. Against the pre-fix engine the load kills the game loop:

```
not ok 1 - a save taken while a camera is alert reloads with the camera's state intact
  error: 'GET .../v1/info failed with status 503: Game loop unavailable - the game thread may have crashed'
```

With the fix it passes: the mission restores and the camera round-trips as `camred` / `AIAlertness: High`.

**The real poisoned save loads.** `ops_frontier_iter4` (the ops4 save from the play-through that panicked 3/3) now loads cleanly, with the offending camera (obj 293) restored to `camred` / `High` and the other three cameras green — and no `camred_red` in the log at all, i.e. the authored-model path resolved it and the fallback was never needed.

**`ChangeModel` guard proven in isolation:** with the camera fix reverted and only the `ChangeModel` guard in place, `ops_frontier_iter4` still loads, logging instead of panicking:

```
ERROR shock2vr::mission::mission_core: ChangeModel: model 'camred_red.BIN' could not be loaded
for entity EId(52.0) - keeping current model
```

## Follow-up (not in this PR)

`cameradeath` is currently an unimplemented script. When it lands, the camera's forced model sync on init will overwrite a destroyed camera's `camdam` model with the derived idle/alert model after a load. Worth a guard at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
