### PR TITLE
fix: honor PropFrobInfo MOVE when frobbing FrobQB objects

### DIFF
--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -149,6 +149,46 @@ mod tests {
         );
     }
 
+    /// With no `PlayerInfo` (a debug scene) there is no backpack to transfer
+    /// into, so a take-able object falls back to consume-on-frob. Leaving it
+    /// alive would let a second frob re-fire the other scripts attached to it
+    /// (`BaseButton` resends every SwitchLink) after its one-shot award.
+    #[test]
+    fn a_takeable_object_is_consumed_when_there_is_no_backpack() {
+        let mut world = World::new();
+        let object = world.add_entity((
+            PropQuestBitName("Note_1_10".to_owned()),
+            PropQuestBitValue(QuestBitValue::COMPLETE),
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE | FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+
+        let effects = Effect::flatten(vec![FrobQB::new().handle_message(
+            object,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_1_10"
+            )),
+            "the quest bit must be awarded, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DestroyEntity { entity_id } if *entity_id == object
+            )),
+            "with no backpack the object must not be left frobbable, got {effects:?}"
+        );
+    }
+
     /// Use-in-place objects (corpses, the Shield Computer, plot buttons) have no
     /// MOVE in their world action and keep the consume-on-frob behavior.
     #[test]

--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -1,6 +1,6 @@
-use shipyard::{EntityId, World};
+use shipyard::{EntityId, UniqueView, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
 
@@ -20,12 +20,161 @@ impl Script for FrobQB {
     ) -> Effect {
         match msg {
             MessagePayload::Frob => match set_quest_bit_effect(world, entity_id) {
-                Some(quest_bit_effect) => Effect::Combined {
-                    effects: vec![quest_bit_effect, Effect::DestroyEntity { entity_id }],
-                },
+                Some(quest_bit_effect) => {
+                    // What happens to the object after the quest bit is awarded
+                    // is decided by its `PropFrobInfo`, not by this script: a
+                    // pickup item (`world_action` with MOVE/USE_AMMO - the
+                    // Engineering circuit board, the access key cards, the Big
+                    // Bomb) is *taken*, so it goes into the player's backpack
+                    // through the same `DropEntityInfo` transfer the grab and
+                    // loot-container paths use. Everything else (buttons,
+                    // corpses, computers) is used in place and consumed, as
+                    // before. `can_grab_item` is the shared eligibility rule -
+                    // reparenting anything else would corrupt it.
+                    //
+                    // A take-able object only goes to the backpack if there is
+                    // actually one to put it in. With no `PlayerInfo` (a debug
+                    // scene) we must still consume it: the award is one-shot,
+                    // and leaving the object frobbable would let a second frob
+                    // re-fire the other scripts attached to it - `BaseButton`
+                    // resends every SwitchLink - after the bit is already set.
+                    let backpack = if crate::virtual_hand::can_grab_item(world, entity_id) {
+                        world
+                            .borrow::<UniqueView<PlayerInfo>>()
+                            .map(|player| player.inventory_entity_id)
+                            .ok()
+                    } else {
+                        None
+                    };
+
+                    match backpack {
+                        Some(parent_entity_id) => Effect::combine(vec![
+                            quest_bit_effect,
+                            Effect::DropEntityInfo {
+                                parent_entity_id,
+                                dropped_entity_id: entity_id,
+                            },
+                        ]),
+                        None => Effect::combine(vec![
+                            quest_bit_effect,
+                            Effect::DestroyEntity { entity_id },
+                        ]),
+                    }
+                }
                 None => Effect::NoEffect,
             },
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{
+        FrobFlag, Links, PropFrobInfo, PropQuestBitName, PropQuestBitValue, QuestBitValue,
+    };
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::FrobQB;
+
+    /// A world with one `FrobQB` object carrying a quest bit, plus the player
+    /// info the inventory transfer resolves the backpack through.
+    fn quest_object_world(
+        world_action: FrobFlag,
+    ) -> (World, shipyard::EntityId, shipyard::EntityId) {
+        let mut world = World::new();
+        let object = world.add_entity((
+            PropQuestBitName("Note_1_10".to_owned()),
+            PropQuestBitValue(QuestBitValue::COMPLETE),
+            PropFrobInfo {
+                world_action,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, object, inventory)
+    }
+
+    /// The Engineering circuit board (eng1 obj 705) is `MOVE | SCRIPT`: frobbing
+    /// it must award its quest bit *and* hand it to the player. Destroying it
+    /// strands the eng2 receptor (#560).
+    #[test]
+    fn frobbing_a_takeable_object_awards_its_quest_bit_and_stores_it() {
+        let (world, object, inventory) = quest_object_world(FrobFlag::MOVE | FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![FrobQB::new().handle_message(
+            object,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_1_10"
+            )),
+            "the quest bit must still be awarded, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DropEntityInfo { parent_entity_id, dropped_entity_id }
+                    if *parent_entity_id == inventory && *dropped_entity_id == object
+            )),
+            "a take-able object must be transferred to the backpack, got {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { .. })),
+            "a take-able object must not be destroyed, got {effects:?}"
+        );
+    }
+
+    /// Use-in-place objects (corpses, the Shield Computer, plot buttons) have no
+    /// MOVE in their world action and keep the consume-on-frob behavior.
+    #[test]
+    fn frobbing_a_use_only_object_still_consumes_it() {
+        let (world, object, _inventory) = quest_object_world(FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![FrobQB::new().handle_message(
+            object,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_1_10"
+            )),
+            "the quest bit must be awarded, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DestroyEntity { entity_id } if *entity_id == object
+            )),
+            "a use-only object must still be consumed, got {effects:?}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #560.

Frobbing the Engineering circuit board awarded its quest bit and cyber modules and then **destroyed the object**, so it could never reach the player's inventory. There is exactly one circuit board in Engineering, so this made the entire eng1↔eng2 elevator-power chain unreachable.

## Cause

`FrobQB` unconditionally emitted `SetQuestBit` + `DestroyEntity`, ignoring the object's `PropFrobInfo`. eng1 obj 705 carries `PropFrobInfo { world_action: MOVE | SCRIPT }` — the script honored the `SCRIPT` half (the quest-bit award) and then deleted the object instead of honoring the `MOVE` half ("move it to inventory").

This affected every `MOVE` quest object, not just the board: the quest key cards (R&D, Crew, Shuttle Access, Ops Override, Rec Crew), the quest audio logs, and the Big Bomb. It was worst in VR, where `virtual_hand.rs` sends `Frob` on the trigger — a VR player who trigger-clicked the board destroyed it outright.

## Change

Decide the object's fate from its frob info instead of assuming:

- **Take-able** (`can_grab_item` — the shared MOVE/USE_AMMO eligibility rule) **and a backpack exists** → award the bit and transfer the object with `Effect::DropEntityInfo`, the same path the grab and loot-container takes already use.
- **Otherwise** (use-in-place objects: corpses, computers, plot buttons; or no `PlayerInfo` at all, as in a debug scene) → keep the historical consume-on-frob.

The no-backpack fallback is deliberate, and came out of review: awarding a one-shot bit while leaving the object frobbable would let a second frob re-fire every other script attached to it (`BaseButton` resends all of its SwitchLinks).

## Verification

**Negative-first.** Both new tests were run against the pre-fix production logic: `frobbing_a_takeable_object_awards_its_quest_bit_and_stores_it` fails with exactly the reported symptom —

```
a take-able object must be transferred to the backpack, got
[SetQuestBit { quest_bit_name: "Note_1_10", quest_bit_value: COMPLETE },
 DestroyEntity { entity_id: EId(0.0) }]
```

— while `frobbing_a_use_only_object_still_consumes_it` passes pre-fix, confirming the change is not over-broad. `a_takeable_object_is_consumed_when_there_is_no_backpack` covers the review fallback.

`cargo test -p shock2vr`: 259 pass. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean.

**Live, end to end** (debug runtime, eng1 → eng2):

1. Frob board (obj 705) → `/v1/player/inventory` shows `Circuitboard`, `/v1/quests` shows `note_1_10 = complete`. Pre-fix the entity simply vanished.
2. `transition-level` to eng2 → the board is still in inventory (new entity id, `location: "inventory"`).
3. Frob the Card Slot Box (tmpl 676, `PropConsumeType("Circuitboard")`) → inventory empties and quests become `circuitboardplaced` + `note_1_9 = complete`.

That is the whole blocked chain moving again.

## Review

Cross-engine adversarial review (Codex + Claude). Codex's Medium finding is fixed in the second commit. Its High finding is a **pre-existing, adjacent** gap that this PR does not introduce and does not fix: `flat_player_controller.rs:249-254` picks up any grabbable item directly and never sends `Frob`, so in flat mode the board can be taken without its quest bit firing. That was equally true before this change (the alternative was frobbing it, which destroyed it). Filed separately as #579 rather than scope-creeping this fix.

Found by the automated play-through loop (eng1 iteration 0).
