### PR TITLE
fix(ai): melee AI damages the player on the animation's contact frame

### DIFF
--- a/dark/src/motion/mod.rs
+++ b/dark/src/motion/mod.rs
@@ -304,8 +304,20 @@ bitflags! {
         const UNK2 = 1 << 10;
         const UNK3 = 1 << 11;
         const UNK4 = 1 << 12;
-        const UNK5 = 1 << 13;
-        const UNK6 = 1 << 14;
+
+        /// Melee contact window open / close - the frames during which a swing
+        /// can connect (the Dark "damage hitbox" triggers that ShockEd's motion
+        /// editor authors on melee moves).
+        ///
+        /// Identified by scanning every clip referenced by the shipped motion
+        /// schemas (`references/animation_{0,2,4}.spew`, 997 clips): these two
+        /// bits appear together, in this order, in essentially only
+        /// `+meleecombat` clips - every melee *attack* clip carries them, the
+        /// "std" transition clips of those same schema entries do not, and no
+        /// `+rangedcombat` clip has them (those carry `FIRE` instead).
+        const MELEE_CONTACT_START = 1 << 13;
+        const MELEE_CONTACT_END = 1 << 14;
+
         const UNK7 = 1 << 15;
         const UNK8 = 1 << 16;
     }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -412,6 +412,10 @@ pub enum Link {
     Replicator,
     SwitchLink,
     MissSpang,
+    /// From a melee AI to the weapon archetype it strikes with (its pipe,
+    /// claw, spike). The weapon carries the `StimSource` links that decide
+    /// what a connecting swing does to the victim.
+    Weapon,
     /// From a projectile archetype to a victim archetype class; the payload is
     /// the template id of the spang (impact effect, e.g. a blood or sparks
     /// particle group) to spawn when that projectile hits a descendant of the
@@ -986,6 +990,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_link("L$AIPatrol", |_| Link::AIPatrol),
         define_link("L$Clip", |_| Link::Clip),
         define_link("L$Miss Span", |_| Link::MissSpang),
+        define_link("L$Weapon", |_| Link::Weapon),
         //define_link("L$TPath", |_| Link::TPath),
         //define_link("L$TPathNext", |_| Link::TPath),
     ];

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -500,6 +500,9 @@ impl MissionCore {
         world.add_unique(
             crate::mission::reload::GlobalProjectileClips::from_entity_info(&entity_info_rc),
         );
+        world.add_unique(
+            crate::mission::stim_response::GlobalContactStims::from_entity_info(&entity_info_rc),
+        );
         // Reuse the obj-icons already hydrated into the template metadata above
         // (keyed by template id) rather than rescanning every template.
         let template_obj_icons: HashMap<i32, String> = template_name_to_template_id
@@ -668,6 +671,18 @@ impl MissionCore {
 
         world.add_unique(GlobalTemplateIdMap(template_to_entity_id.clone()));
 
+        // Give the player the links `The Player` archetype authors - chiefly
+        // its receptrons (inherited from `Human Vulnerability`), which are what
+        // decide how hard an incoming stim hits. Without them the player is
+        // inert to every act/react damage source in the gamesys.
+        entity_creator::initialize_links_for_entity(
+            THE_PLAYER_TEMPLATE_ID,
+            player_entity,
+            &entity_info_rc,
+            &template_to_entity_id,
+            &mut world,
+        );
+
         // Start background music
         initialize_background_music(&abstract_mission.song_params, asset_cache, audio_context);
 
@@ -702,6 +717,13 @@ impl MissionCore {
         let mut id_to_physics = HashMap::new();
         let mut id_to_bitmap = HashMap::new();
         let mut script_world = ScriptWorld::new();
+        // The player has no `P$Scripts` in the gamesys, so give it its damage
+        // handler explicitly - otherwise Damage messages sent to the player
+        // are dropped and nothing can hurt it.
+        script_world.add_entity2(
+            player_entity,
+            Box::new(crate::scripts::player_script::PlayerScript),
+        );
 
         let world_entity_id = world.add_entity(RuntimePropDoNotSerialize {});
         if let Some(collider) = abstract_mission.physics_geometry {

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -157,6 +157,7 @@ pub fn resolve_stim_damage(
 
 #[cfg(test)]
 mod tests {
+    use dark::properties::{StimSourceOptions, TemplateLinks, ToLink, ToTemplateLink};
     use super::*;
 
     const HIGH_EXPLOSIVE: i32 = -376;
@@ -267,5 +268,106 @@ mod tests {
             resolve_stim_damage(&receiver, HIGH_EXPLOSIVE, 100.0),
             Some(7.0)
         );
+    }
+
+    // --- Contact stims: the authored source of AI melee damage -------------
+
+    // Real shock2.gam ids, so the numbers below are the shipped ones.
+    const WEAPON_BASH: i32 = -3058;
+    const VENOM: i32 = -387;
+    const LEAD_PIPE: i32 = -365; // the pipe hybrid's melee weapon
+
+    fn entity_info_with_links(template_id: i32, links: Vec<ToTemplateLink>) -> SystemShock2EntityInfo {
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        entity_info.entity_to_properties.insert(template_id, vec![]);
+        entity_info
+            .template_to_links
+            .insert(template_id, TemplateLinks { to_links: links });
+        entity_info
+    }
+
+    fn stim_source(to_template_id: i32, intensity: f32, propagator: StimPropagator) -> ToTemplateLink {
+        ToTemplateLink {
+            to_template_id,
+            link: Link::StimSource(StimSourceOptions {
+                intensity,
+                propagator,
+            }),
+        }
+    }
+
+    #[test]
+    fn only_contact_stims_are_collected() {
+        // `Lead Pipe` emits WeaponBash at 10 on contact (shock2.gam). A radius
+        // stim is an explosion-style emitter, not a swing landing.
+        let entity_info = entity_info_with_links(
+            LEAD_PIPE,
+            vec![
+                stim_source(WEAPON_BASH, 10.0, StimPropagator::Contact),
+                stim_source(VENOM, 3.0, StimPropagator::Radius { radius: 5.0 }),
+            ],
+        );
+
+        let stims = GlobalContactStims::from_entity_info(&entity_info);
+
+        assert_eq!(stims.0.get(&LEAD_PIPE), Some(&vec![(WEAPON_BASH, 10.0)]));
+    }
+
+    fn world_with_victim(
+        stims: GlobalContactStims,
+        receptrons: Vec<(i32, ReceptronOptions)>,
+    ) -> (World, EntityId) {
+        let mut world = World::new();
+        world.add_unique(stims);
+        let victim = world.add_entity(Links {
+            to_links: receptrons
+                .into_iter()
+                .map(|(to_template_id, options)| ToLink {
+                    to_template_id,
+                    to_entity_id: None,
+                    link: Link::Receptron(options),
+                })
+                .collect(),
+        });
+        (world, victim)
+    }
+
+    #[test]
+    fn a_melee_weapon_damages_a_victim_through_its_own_receptrons() {
+        // The whole authored chain: `Lead Pipe` emits WeaponBash at 10, and the
+        // player inherits a x1 WeaponBash damage receptron from
+        // `Human Vulnerability` - so a connecting pipe swing costs 10 hit points.
+        let mut table = HashMap::new();
+        table.insert(LEAD_PIPE, vec![(WEAPON_BASH, 10.0)]);
+        let (world, victim) =
+            world_with_victim(GlobalContactStims(table), vec![(WEAPON_BASH, damage(16, 1.0))]);
+
+        assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 10.0);
+    }
+
+    #[test]
+    fn a_victim_with_no_receptron_for_the_stim_is_unharmed() {
+        // Type effectiveness still applies: a swing whose stim the victim has
+        // no response to does nothing (a robot has no WeaponBash receptron).
+        let mut table = HashMap::new();
+        table.insert(LEAD_PIPE, vec![(WEAPON_BASH, 10.0)]);
+        let (world, victim) = world_with_victim(
+            GlobalContactStims(table),
+            vec![(HIGH_EXPLOSIVE, damage(33, 4.0))],
+        );
+
+        assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 0.0);
+    }
+
+    #[test]
+    fn an_emitter_with_no_contact_stims_deals_nothing() {
+        // An inert object (no melee weapon archetype behind it) cannot hurt
+        // anyone, even at point-blank range.
+        let (world, victim) = world_with_victim(
+            GlobalContactStims(HashMap::new()),
+            vec![(WEAPON_BASH, damage(16, 1.0))],
+        );
+
+        assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 0.0);
     }
 }

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -1,4 +1,104 @@
-use dark::properties::{ReceptronEffect, ReceptronOptions};
+use std::collections::HashMap;
+
+use dark::{
+    properties::{Link, Links, ReceptronEffect, ReceptronOptions, StimPropagator},
+    ss2_entity_info::{self, SystemShock2EntityInfo},
+};
+use shipyard::{EntityId, Get, Unique, UniqueView, View, World};
+
+/// Every archetype's effective `Contact` stim sources - the `L$arSrcDesc`
+/// links whose propagator is `Contact`, inherited down the metaproperty
+/// hierarchy the same way properties are - as `(stim archetype, intensity)`.
+///
+/// A contact stim fires when the emitting object touches something. For an
+/// AI's melee weapon (the hybrid's `Lead Pipe`, a `Rumbler Claw`, a `Midwife
+/// Spike`) that touch *is* the swing landing, so these links are where the
+/// gamesys authors AI melee damage: `Lead Pipe -> WeaponBash @ 10`, `Rumbler
+/// Claw -> WeaponBash @ 20`, `Baby Arachnid Claw -> WeaponBash @ 2`, etc.
+///
+/// Keyed by template id rather than entity id because these archetypes are
+/// never instantiated - a melee weapon is a virtual object hanging off the
+/// creature's `L$Weapon` link.
+#[derive(Unique, Clone, Default)]
+pub struct GlobalContactStims(pub HashMap<i32, Vec<(i32, f32)>>);
+
+impl GlobalContactStims {
+    pub fn from_entity_info(entity_info: &SystemShock2EntityInfo) -> Self {
+        let hierarchy = ss2_entity_info::get_hierarchy(entity_info);
+        let mut contact_stims = HashMap::new();
+
+        for template_id in entity_info.entity_to_properties.keys() {
+            let mut ancestors = ss2_entity_info::get_ancestors(hierarchy, template_id);
+            ancestors.push(*template_id);
+            let mut stims: Vec<(i32, f32)> = Vec::new();
+            for ancestor in ancestors {
+                let Some(links) = entity_info.template_to_links.get(&ancestor) else {
+                    continue;
+                };
+                for link in &links.to_links {
+                    let Link::StimSource(options) = &link.link else {
+                        continue;
+                    };
+                    if options.propagator != StimPropagator::Contact {
+                        continue;
+                    }
+                    // A child archetype re-authoring the same stim replaces the
+                    // inherited intensity rather than stacking with it.
+                    match stims.iter_mut().find(|(stim, _)| *stim == link.to_template_id) {
+                        Some(existing) => existing.1 = options.intensity,
+                        None => stims.push((link.to_template_id, options.intensity)),
+                    }
+                }
+            }
+            if !stims.is_empty() {
+                contact_stims.insert(*template_id, stims);
+            }
+        }
+
+        Self(contact_stims)
+    }
+}
+
+/// The damage `emitter_template`'s contact stims deal to `victim`, resolved
+/// through the victim's own receptrons (so vulnerabilities, armor Amplify
+/// receptrons and outright immunities all apply exactly as they do for
+/// explosions and projectiles). Contributions from every contact stim the
+/// emitter carries are summed; a victim with no receptron for a stim simply
+/// feels nothing from it.
+pub fn contact_stim_damage(world: &World, emitter_template: i32, victim: EntityId) -> f32 {
+    let Ok(contact_stims) = world.borrow::<UniqueView<GlobalContactStims>>() else {
+        return 0.0;
+    };
+    let Some(stims) = contact_stims.0.get(&emitter_template) else {
+        return 0.0;
+    };
+
+    let receptrons = victim_receptrons(world, victim);
+    stims
+        .iter()
+        .filter_map(|(stim_template_id, intensity)| {
+            resolve_stim_damage(&receptrons, *stim_template_id, *intensity)
+        })
+        .filter(|damage| *damage > 0.0)
+        .sum()
+}
+
+fn victim_receptrons(world: &World, victim: EntityId) -> Vec<(i32, ReceptronOptions)> {
+    let Ok(v_links) = world.borrow::<View<Links>>() else {
+        return Vec::new();
+    };
+    let Ok(links) = v_links.get(victim) else {
+        return Vec::new();
+    };
+    links
+        .to_links
+        .iter()
+        .filter_map(|link| match &link.link {
+            Link::Receptron(options) => Some((link.to_template_id, options.clone())),
+            _ => None,
+        })
+        .collect()
+}
 
 /// Resolve what damage a stim deals to a receiver, given the receiver's
 /// receptron links (as `(stim_template_id, options)` pairs, i.e. the entity's

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -44,7 +44,10 @@ impl GlobalContactStims {
                     }
                     // A child archetype re-authoring the same stim replaces the
                     // inherited intensity rather than stacking with it.
-                    match stims.iter_mut().find(|(stim, _)| *stim == link.to_template_id) {
+                    match stims
+                        .iter_mut()
+                        .find(|(stim, _)| *stim == link.to_template_id)
+                    {
                         Some(existing) => existing.1 = options.intensity,
                         None => stims.push((link.to_template_id, options.intensity)),
                     }
@@ -157,8 +160,8 @@ pub fn resolve_stim_damage(
 
 #[cfg(test)]
 mod tests {
-    use dark::properties::{StimSourceOptions, TemplateLinks, ToLink, ToTemplateLink};
     use super::*;
+    use dark::properties::{StimSourceOptions, TemplateLinks, ToLink, ToTemplateLink};
 
     const HIGH_EXPLOSIVE: i32 = -376;
     const EMP: i32 = -374;
@@ -277,7 +280,10 @@ mod tests {
     const VENOM: i32 = -387;
     const LEAD_PIPE: i32 = -365; // the pipe hybrid's melee weapon
 
-    fn entity_info_with_links(template_id: i32, links: Vec<ToTemplateLink>) -> SystemShock2EntityInfo {
+    fn entity_info_with_links(
+        template_id: i32,
+        links: Vec<ToTemplateLink>,
+    ) -> SystemShock2EntityInfo {
         let mut entity_info = SystemShock2EntityInfo::empty();
         entity_info.entity_to_properties.insert(template_id, vec![]);
         entity_info
@@ -286,7 +292,11 @@ mod tests {
         entity_info
     }
 
-    fn stim_source(to_template_id: i32, intensity: f32, propagator: StimPropagator) -> ToTemplateLink {
+    fn stim_source(
+        to_template_id: i32,
+        intensity: f32,
+        propagator: StimPropagator,
+    ) -> ToTemplateLink {
         ToTemplateLink {
             to_template_id,
             link: Link::StimSource(StimSourceOptions {
@@ -339,8 +349,10 @@ mod tests {
         // `Human Vulnerability` - so a connecting pipe swing costs 10 hit points.
         let mut table = HashMap::new();
         table.insert(LEAD_PIPE, vec![(WEAPON_BASH, 10.0)]);
-        let (world, victim) =
-            world_with_victim(GlobalContactStims(table), vec![(WEAPON_BASH, damage(16, 1.0))]);
+        let (world, victim) = world_with_victim(
+            GlobalContactStims(table),
+            vec![(WEAPON_BASH, damage(16, 1.0))],
+        );
 
         assert_eq!(contact_stim_damage(&world, LEAD_PIPE, victim), 10.0);
     }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -378,13 +378,7 @@ pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &Physic
         return Effect::NoEffect;
     }
 
-    if !is_player_visible_in_fov(
-        entity_id,
-        world,
-        physics,
-        Deg(0.0),
-        MONSTER_FOV_HALF_ANGLE,
-    ) {
+    if !is_player_visible_in_fov(entity_id, world, physics, Deg(0.0), MONSTER_FOV_HALF_ANGLE) {
         return Effect::NoEffect;
     }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -330,6 +330,93 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
     }
 }
 
+/// Monster FOV half-angle, in degrees (matches `FovDebugConfig::monster()`).
+/// Shared by sight checks and the melee connect check so an AI can only hit
+/// what it could see.
+pub const MONSTER_FOV_HALF_ANGLE: f32 = 60.0;
+
+/// How close an AI must be to melee. The attack behavior uses this to decide
+/// whether to keep swinging, and a swing may only connect inside it.
+pub const MELEE_ATTACK_RANGE: f32 = 8.0 / SCALE_FACTOR;
+
+///
+/// Melee Contact
+///
+/// A melee swing reaching its contact frame. Dark authors the connect moment
+/// on the animation itself - ShockEd's motion editor marks a damage window on
+/// the attack clip, which the port surfaces as the `MELEE_CONTACT_START`
+/// motion flag - so this runs off the animation, not a timer.
+///
+/// The blow itself is resolved entirely from the gamesys: the attacker's
+/// `L$Weapon` archetype (`Lead Pipe`, `Rumbler Claw`, `Midwife Spike`, ...)
+/// carries the `Contact` stim sources that describe what a landing hit does
+/// (`WeaponBash` at an authored intensity, plus e.g. `Venom` for arachnids),
+/// and the victim's own receptrons turn those into damage. Nothing here
+/// invents a damage number.
+///
+/// The swing connects only if the player is actually within melee range and
+/// inside the attacker's field of view - the AI swings at where it believes
+/// the target is, but only reality can be hit.
+pub fn melee_contact_attack(world: &World, entity_id: EntityId, physics: &PhysicsWorld) -> Effect {
+    let Some((player_entity_id, player_pos)) = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .ok()
+        .map(|player| (player.entity_id, player.pos))
+    else {
+        return Effect::NoEffect;
+    };
+
+    let in_range = {
+        let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
+        v_current_pos
+            .get(entity_id)
+            .ok()
+            .map(|pos| (pos.position - player_pos).magnitude() < MELEE_ATTACK_RANGE)
+            .unwrap_or(false)
+    };
+    if !in_range {
+        return Effect::NoEffect;
+    }
+
+    if !is_player_visible_in_fov(
+        entity_id,
+        world,
+        physics,
+        Deg(0.0),
+        MONSTER_FOV_HALF_ANGLE,
+    ) {
+        return Effect::NoEffect;
+    }
+
+    let Some((weapon_template_id, _)) =
+        get_first_link_with_template_and_data(world, entity_id, |link| match link {
+            Link::Weapon => Some(()),
+            _ => None,
+        })
+    else {
+        return Effect::NoEffect;
+    };
+
+    let damage = crate::mission::stim_response::contact_stim_damage(
+        world,
+        weapon_template_id,
+        player_entity_id,
+    );
+    if damage <= 0.0 {
+        return Effect::NoEffect;
+    }
+
+    Effect::Send {
+        msg: crate::scripts::Message {
+            to: player_entity_id,
+            payload: crate::scripts::MessagePayload::Damage {
+                amount: damage,
+                impact: None,
+            },
+        },
+    }
+}
+
 /// Where this AI should chase: its last-known target position when it has
 /// published awareness (frozen at the point sight broke), falling back to
 /// the player's true position for entities without awareness (scripts that

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -771,10 +771,9 @@ impl Script for AnimatedMonsterAI {
 
         let delta = time.elapsed.as_secs_f32();
 
-        // Monster FOV is 60 degrees half-angle (matches FovDebugConfig::monster())
         // Monster rotation is set directly via Effect::SetRotation, so pose.rotation
         // already contains the heading. Pass Deg(0.0) to avoid applying it twice.
-        const MONSTER_FOV_HALF_ANGLE: f32 = 60.0;
+        use super::ai_util::MONSTER_FOV_HALF_ANGLE;
         // A pinned alertness (DebugForceChase) acts as permanent sight of
         // the player: no decay, and the last-known position tracks them live
         let is_visible = self.alertness_pinned
@@ -1317,6 +1316,13 @@ impl Script for AnimatedMonsterAI {
                         return Effect::NoEffect;
                     }
                     fire_ranged_projectile(world, entity_id)
+                } else if motion_flags.contains(MotionFlags::MELEE_CONTACT_START) {
+                    // The swing reached its authored contact frame - resolve
+                    // the hit through the attacker's melee weapon archetype.
+                    if self.is_dead || is_killed(entity_id, world) {
+                        return Effect::NoEffect;
+                    }
+                    super::ai_util::melee_contact_attack(world, entity_id, physics)
                 // } else if motion_flags.contains(MotionFlags::END) {
                 //     Effect::QueueAnimationBySchema {
                 //         entity_id,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -30,6 +30,7 @@ mod melee_weapon;
 mod obj_consume_button;
 mod once_room;
 mod once_router;
+pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
 mod reduce_psi;

--- a/shock2vr/src/scripts/player_script.rs
+++ b/shock2vr/src/scripts/player_script.rs
@@ -1,0 +1,50 @@
+use dark::properties::PropHitPoints;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// The player's own damage handler.
+///
+/// The player is an ordinary damageable entity - it carries `P$HitPoints` /
+/// `P$MAX_HP` from `The Player` archetype and the receptrons it inherits from
+/// `Human Vulnerability` - but nothing was translating a `Damage` message into
+/// an actual hit-point loss, so every attack aimed at the player was silently
+/// dropped. This script closes that gap the same way `AnimatedMonsterAI` does
+/// for creatures, so any damage source (AI melee, and later projectiles and
+/// explosions) reaches the player through the one shared message path.
+pub struct PlayerScript;
+
+impl Script for PlayerScript {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Damage { amount, .. } => {
+                // A dead player takes no further hits (death handling itself
+                // is not implemented yet - see #561 follow-ups).
+                if is_dead(world, entity_id) {
+                    return Effect::NoEffect;
+                }
+                Effect::AdjustHitPoints {
+                    entity_id,
+                    delta: -(amount.round() as i32),
+                }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+fn is_dead(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropHitPoints>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|hp| hp.hit_points <= 0))
+        .unwrap_or(false)
+}

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -377,6 +377,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::Corpse(_) => "Corpse".to_string(),
                 Link::AIProjectile(_) => "AIProjectile".to_string(),
                 Link::AIRangedWeapon => "AIRangedWeapon".to_string(),
+                Link::Weapon => "Weapon".to_string(),
                 Link::Clip => "Clip".to_string(),
                 Link::GunFlash(_) => "GunFlash".to_string(),
                 Link::LandingPoint => "LandingPoint".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -587,6 +587,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::Corpse(_) => "Corpse".to_string(),
         dark::properties::Link::AIProjectile(_) => "AIProjectile".to_string(),
         dark::properties::Link::AIRangedWeapon => "AIRangedWeapon".to_string(),
+        dark::properties::Link::Weapon => "Weapon".to_string(),
         dark::properties::Link::Clip => "Clip".to_string(),
         dark::properties::Link::GunFlash(_) => "GunFlash".to_string(),
         dark::properties::Link::LandingPoint => "LandingPoint".to_string(),


### PR DESCRIPTION
Part of #561 — melee only. Ranged AI and turrets remain inert; see "Deferred" below.

Hostile melee AI can now hurt the player, through the game's own data rather than any invented number.

## The authored mechanism

Two pieces of shipped data drive this, and neither was being read:

**1. When a swing connects** — Dark authors the connect moment on the animation itself (ShockEd's motion editor marks a damage window on the attack clip). Scanning every clip referenced by the shipped motion schemas (`references/animation_{0,2,4}.spew`, 997 clips) shows motion-flag bits 13 and 14 appear together, in that order, essentially only in `+meleecombat` clips: every melee *attack* clip carries them, the "std" transition clips of those same schema entries do not, and no `+rangedcombat` clip has them (those carry `FIRE`). They are named `MELEE_CONTACT_START` / `MELEE_CONTACT_END`. Damage therefore lands on the animation's real contact frame, not on a timer.

**2. How much it hurts** — a melee AI links to its weapon archetype with `L$Weapon`, and that archetype carries the `Contact` act/react stim sources describing what a landing hit does. From `shock2.gam`:

| creature | weapon | contact stims |
|---|---|---|
| Once-Grunt (pipe hybrid) | `Lead Pipe` | WeaponBash @ 10 |
| Rumbler | `Rumbler Claw` | WeaponBash @ 20 |
| Arachnid | `Arachnid Claw` | WeaponBash @ 10, Venom @ 3 |
| Baby Arachnid | `Baby Arachnid Claw` | WeaponBash @ 2, Venom @ 1 |
| Midwife | `Midwife Spike` | WeaponBash @ 5 |
| Monkey | `Monkey Claw` | WeaponBash @ 4 |

The victim's own receptrons turn those into damage — the player inherits `WeaponBash -> Damage x1.0` from `Human Vulnerability`, so a pipe swing costs 10 of the player's 30 hit points. Vulnerabilities, armor `Amplify` receptrons and outright immunities all apply automatically, because this reuses the same `resolve_stim_damage` the explosion path already uses.

> Note on `P$HTHCombat`: it was the obvious candidate, but it is not the damage source. Its three floats sit in the same magnitude band as the other authored melee/ranged *distances* (`P$AIRCRange` is 5–100; `HTHCombat` is 1.5–8.5, vs. the port's existing `8.0` melee-engagement range), and the values contradict creature threat ordering as damage (hybrid `8.5` > rumbler `8.0`), while the weapon stim intensities match it exactly (rumbler 20 > hybrid 10 > midwife 5 > monkey 4 > baby arachnid 2). Left unparsed.

## What changed

- `dark`: name motion-flag bits 13/14; parse `L$Weapon` into `Link::Weapon`.
- `GlobalContactStims` (`mission/stim_response.rs`): each archetype's effective `Contact` stim sources, inherited down the metaproperty hierarchy — same shape as `GlobalProjectileClips`. Keyed by template id because melee weapons are never instantiated.
- `PlayerScript`: the player already carried `P$HitPoints` and receptrons but had no script, so every `Damage` message aimed at it was dropped. It now handles `Damage` -> `AdjustHitPoints`, the same path creatures use — so any future damage source (projectiles, explosions) reaches the player without new plumbing. The player entity is also given its archetype's links, which is what makes its receptrons readable at runtime.
- `ai_util::melee_contact_attack`, dispatched from `AnimatedMonsterAI`'s existing `AnimationFlagTriggered` handler right beside the `FIRE` branch. Gated on the player genuinely being within melee range and inside the attacker's FOV cone — the AI swings at where it *believes* the target is, but only reality can be hit. Both gates reuse existing constants (`8.0 / SCALE_FACTOR`, the 60° monster FOV half-angle), now shared rather than duplicated.

No new damage constants, no debug hooks in the mechanism.

## Verification

Unit tests in `mission/stim_response.rs` cover contact-stim collection (radius stims excluded), receptron resolution, and both no-response cases. `cargo test -p shock2vr`: 259 passed. `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean.

**Negative-first, live on `eng1.mis`** — identical scripted scenario, run twice against real builds of the debug runtime:

| | before (melee hook reverted) | after |
|---|---|---|
| player at spawn, inert props 1.8–2.7u away, 600 frames | 30/30 | 30/30 |
| pipe hybrid in `MeleeAttack` at melee range, 600 frames | **30/30 — zero damage** | **30 -> 0** |

The "after" run drops in exact 10-point steps (30 -> 20 -> 10 -> 0), matching `Lead Pipe`'s authored WeaponBash intensity of 10 through the player's x1.0 receptron. The inert-prop control confirms objects with no melee weapon archetype cannot hurt the player even at point-blank range with AI forced to chase.

## Deferred

- **Ranged AI and turrets** (`ranged_attack_behavior.rs`, `turret_ai.rs`): still emit no shot. Their contact-stim analogue is projectile-borne, so they need the projectile path to damage the player rather than this contact path.
- **Player death**: hit points reach 0 and stop; nothing reacts to it yet.
- **`AITargetVisible: false`** from the issue is a **separate** root cause, not fixed here. Reproduced live: the hybrid reporting it was facing 90° away from the player, outside the 60° FOV half-angle — sensing itself works, and moving the player into the cone immediately escalated it to alertness `Low` with the last-known position recorded. The real defect is that an idle AI never re-acquires: it wandered off and decayed back to `Lowest` while the player stood still 1.2 units away. That is alertness/idle-turning behavior, with no code in common with damage emission. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
