### PR TITLE
docs: add play-through walkthroughs for earth, station, medsci2, eng1, hydro, ops

### DIFF
--- a/.claude/skills/play-through/walkthroughs/earth.md
+++ b/.claude/skills/play-through/walkthroughs/earth.md
@@ -1,0 +1,359 @@
+# Walkthrough — Earth (tram → training → service choice → station)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+complete Earth character-creation route, including the optional training that a
+normal player can skip. It is not a coordinate script: use signs, doors,
+instructors, visible objects, and screenshots to navigate. The positions below
+are recovery anchors and evidence checks, not permission to teleport past a
+world interaction.
+
+Earth has two different completion standards:
+
+- **Campaign progression:** ride the correct gravshaft, choose one service, and
+  arrive in `station.mis` with that career applied.
+- **Earth depth pass:** do all of the above **and** genuinely exercise Basic
+  Training and all three Advanced Training rooms before recruitment. This is
+  the standard for the current whole-game play-through.
+
+The basketball secret and completing station transitions for all three careers
+are useful focused checks, but they are not required in one advancing campaign
+run. Entering any career tripwire leaves Earth, so one run cannot honestly
+transition through all three.
+
+Mission object ids and positions below are stable in `earth.mis`; runtime
+entity ids are not. Rediscover runtime entities by name and `template_id` after
+every launch or transition.
+
+## Route overview
+
+1. Leave the UNN tram and cross the boardwalk.
+2. Use the **left / x≈9.6 UP gravshaft**, not the right-hand DOWN shaft.
+3. Complete Basic Training.
+4. Enter the west-side Advanced Training lobby and complete Weapons, Technical,
+   and Psionic training.
+5. Return to the hub, open the north-side service passage's real doors, and
+   reach the career concourse.
+6. Inspect the Marine, Navy, and OSA entrances, choose one, and walk through
+   its tripwire.
+7. Verify `station.mis`, the mutually exclusive career quest bit, the designed
+   station arrival, and the branch's starting HP/psi.
+
+## Phase 1 — tram and gravshaft
+
+The fresh Earth spawn is inside the tram at approximately
+**(10.7, 1.5, −11.3)**.
+
+1. Let the player settle, then walk forward out of the tram. Continue across
+   the boardwalk to the gravshaft wall around z≈12–14. A real traversal must
+   move from z<−10 to z>10; teleporting from the tram does not cover the known
+   floor-contact regression.
+2. Enter the shaft on the **left when facing the pair from the tram**, centered
+   near **x=9.6**. This is room `Up` (mission object 270) and negative room
+   gravity should carry the player from y≈2 to street level above y=18.
+3. Exit when the top `Stop` room cancels the lift. The neighboring shaft at
+   **x≈12.0** is room `Down` (object 227); standing there at the bottom should
+   not lift the player.
+
+Use “x≈9.6 UP shaft” in evidence because retail walkthroughs describe the shaft
+from differing viewpoints and therefore disagree on the word “left/right.”
+
+Optional secret: the basketball on the arch near the gravshafts is a legitimate
+exploration pickup. Record it if reachable through normal jumping/climbing, but
+do not let it delay the critical route or use a debug give to claim the secret.
+
+## Phase 2 — Basic Training (optional to retail, required for depth)
+
+Follow the visible **Basic Training** signs and enter the training area before
+choosing a service. The sign entity is mission object 392
+(`Basic_Training_Sign`) at approximately **(11.6, 27.3, 58.0)**.
+
+The Basic entrance is the centered north passage at x≈11.6. Tripwire 359 opens
+door leaves 358/368 around z≈59.6; the actual entry tripwire is object 378 near
+**(11.56, 24.25, 66.65)**. It teleports the player to the authored Basic course
+near **(5.6, 22.2, 237.4)**. This is Basic Training—not a recruitment interview
+or a years-of-service montage.
+
+The purpose is to prove the tutorial mechanics, not merely visit the rooms.
+Follow the instructor prompts and demonstrate each available lesson:
+
+1. Pick up the supplied object through a normal world interaction.
+2. Open the inventory, select and move/use an inventory item, and verify the
+   item actually appears in the inventory rather than relying on the pickup
+   animation alone.
+3. Frob a wall control or switch and observe the linked world response.
+4. Move/select the supplied item in the inventory. Do not invent an
+   item-on-item combination: the mission authors no second Basic combine
+   target, and Fermium has no effectful use in this course.
+5. Examine an object and open/read or play the supplied log/data item.
+6. Traverse the movement lesson, including its ladder/platform and
+   jump/mantle/climb affordance, without teleporting across it.
+7. Leave by the real exit tripwire (object 380). Its linked player teleport
+   trap 379 must return the player once to approximately
+   **(11.61, 24.26, 65.79)**, without an automatic re-entry loop.
+
+The course begins behind timed fields. Wait for the authored delays, operate
+the highlighted Simple Button through player Frob, cross the lesson tripwires,
+climb the real ladder, and traverse the upper platform. Do not damage or
+teleport through the fields.
+
+Two authored objective anchors must be deliberately sought rather than inferred
+from the main path:
+
+- Audio Log object **301** at approximately
+  **(11.51, 21.63, 263.72)** (`PropLog { deck: 1, email: 33, log: 24 }`).
+  Pick it up normally and verify that its log/playback state is exposed.
+- Crate object **307** at approximately **(19.24, 21.60, 264.63)**, whose
+  `Contains` link holds Fermium object **242**. Open the crate, transfer the
+  contents normally, and inspect/use the inventory item as the lesson requests.
+
+Training narration/text can be absent while the physical lesson still works.
+In that case, deliberately search for the lesson, attempt its normal
+interaction if reachable, and report the missing/inaccessible objective
+separately. Do not call Basic “fully covered” after only completing its
+button/ladder course.
+
+## Phase 3 — all three Advanced Training rooms
+
+Follow the **Advanced Training** sign (mission object 393,
+`Advanced_Training_Sign`, around **(6.4, 27.3, 51.2)**). Visit all three labeled
+rooms. The order is flexible, but evidence must distinguish them.
+
+From the hub, enter the west/lower-x passage centered around z≈51.2. Door
+leaves 74 and 79 are controlled by the large approach tripwire 383. Approach
+on-center, allow roughly 20 simulation frames for both leaves and their
+colliders to finish sliding to z≈48.8/53.6, then cross toward lower x. A move
+attempt made off-center or while the leaves are still opening is tester error,
+not a blocker.
+
+The three lobby entry tripwires are arranged north/south around x≈−15.24:
+
+| Room | Entry tripwire | Authored destination | Exit tripwire / return |
+| --- | --- | --- | --- |
+| Weapons | 313, z≈50.34 | trap 319, (77.90, 23.2, 183.82) | 374 → trap 371, z≈50.46 |
+| Technical | 314, z≈56.74 | trap 324, (160.64, 22.8, 182.14) | 375 → trap 372, z≈56.81 |
+| Psionic | 320, z≈63.16 | trap 325, (215.22, 24.0, 191.87) | 376 → trap 373, z≈63.16 |
+
+Walk through each real entry and real exit. Do not use those coordinates as
+raw teleports. The exit traps intentionally vaporize the temporary training
+inventory; prove each exercise before leaving its room.
+
+Each lobby aperture has an authored **0.8-world-unit raised threshold**. Back
+off, center on the room's tripwire z coordinate, face west, and use sustained
+normal locomotion so the character controller can autostep onto it. The debug
+`/v1/player/move` helper performs a direct capsule shape cast without autostep,
+so a blocked helper move is not evidence that these entrances are impassable.
+
+### Weapons
+
+The key authored objects are pistol 246, clips 247–251, Training Droid 547,
+laser pistol 253, and recharging station 258.
+
+1. Pick up the supplied pistol and ammunition. The pistol starts empty.
+2. Equip the pistol, load it through normal inventory/weapon handling, and
+   fire at the training robot/target until there is visible hit or damage
+   evidence.
+3. Pick up and equip the supplied energy weapon.
+4. Use the recharge station on that weapon and verify the charge increases.
+5. Fire it at the training robot/target and observe an impact/damage response.
+
+Merely giving the player a weapon, sending a debug `Damage` message, or firing
+into empty space does not cover this room. Do not use generic Reload to
+substitute for the laser station: the objective is specifically station-driven
+energy recharge. Also record whether pistol reload actually consumes one of
+the supplied clips and whether the real exit removes the temporary gear.
+
+### Technical
+
+The key authored objects are nanites 257, keypad 266 controlling door 265,
+inside button 595, replicator 262, and output marker 284.
+
+1. Pick up the supplied nanites and record the initial amount.
+2. Frob the locked training keypad and enter the real hacking UI.
+3. Complete the hack by making the required connected path; verify the target
+   changes state and loot its contents normally.
+4. Frob the replicator and buy an item with nanites. Verify both the delivered
+   item and the nanite decrease.
+5. Attempt the room's replicator hack if exposed, and record whether it changes
+   the available inventory. Treat an absent or nonfunctional hacking mechanic
+   as a feature-gap finding rather than silently skipping it.
+
+Opening the target through a message injection or supplying nanites through the
+debug API invalidates this coverage. A numeric keypad without an authored code
+does not satisfy the hacking objective.
+
+### Psionic
+
+The key authored objects are psi hypos 275/288/289, psi amp 290, and Training
+Droid 593.
+
+1. Pick up the supplied psi amp and psi hypo.
+2. Equip/use them through normal player interaction.
+3. Select the available Cryokinesis power through the normal UI/input path and
+   manifest it at the Training Droid.
+4. Require psi to decrease and the droid's health to decrease.
+5. Use a psi hypo from inventory and require psi to recover.
+
+Also record whether the authored room-entry psi adjustment occurred and whether
+the exit removes the temporary amp/hypos. Simply holding the amp or cycling a
+debug power selector is not completion.
+
+If the current port cannot expose the intended psi selection/cast path, record
+the first failed real interaction precisely and classify the room as uncovered.
+
+## Phase 4 — exact route to the service concourse
+
+This is the easy place to mistake collision for a broken route. The service
+concourse is **not** the west-side Advanced lobby.
+
+1. Return from the last Advanced room to its real lobby destination, then walk
+   east/higher-x through doors 74/79 to the broad hub.
+2. Locate the north/increasing-z service passage around x≈5. The
+   `Interrogation Room` doors, objects
+   **80** at about **(5.01, 24, 59.79)** and **81** at about
+   **(5.00, 24, 63.38)**, have **no incoming SwitchLinks**. Center the reticle
+   on each door and frob it. Wait for the panel and its collider to slide clear
+   before walking through.
+3. Once north of the second frobbed door, the passage opens into the three-way
+   service concourse around z≈65–70.
+
+Evidence must distinguish the tripwire-opened Advanced doors 74/79 from the
+player-frobbed service doors 80/81. Teleporting to a career tripwire or
+injecting `Frob` directly into a discovered door entity does not prove
+navigation/player interaction.
+
+## Phase 5 — inspect all services, then choose one
+
+Before committing, visit the signed threshold of all three branches while
+remaining outside their terminal tripwire. Record a screenshot/observation of
+each sign and doorway:
+
+- **Marines:** from the common concourse, take the western branch, then turn
+  south. Terminal tripwire 309 is at approximately
+  **(−2.50, 24.0, 68.16)**.
+- **Navy:** continue north on the western side. Terminal tripwire 217 is at
+  approximately **(0.51, 24.0, 84.06)**.
+- **OSA:** take the eastern/northeastern branch, continue north, then east.
+  Terminal tripwire 218 is at approximately
+  **(16.86, 24.0, 80.75)**.
+
+Do not step across a threshold while scouting: each ENTER signal immediately
+fires `TrapNewTripwire → SwitchLink → ChooseService` and transitions to
+`station.mis`.
+
+Choose the intended career only after all three entrances have been identified.
+Walk through its threshold and allow the transition to finish:
+
+| Branch | Mission wiring | Required station evidence |
+| --- | --- | --- |
+| Marine | tripwire 309 → marker 311, `PropService(0)` | `career_marine=complete`; Navy/OSA unknown; max HP 45, max psi 20 |
+| Navy | tripwire 217 → marker 609, `PropService(1)` | `career_navy=complete`; Marine/OSA unknown; max HP 35, max psi 35 |
+| OSA | tripwire 218 → marker 219, `PropService(2)` | `career_osa=complete`; Marine/Navy unknown; max HP 30, max psi 60 |
+
+The Navy destination marker is misleadingly named `SendToMarines` in retail
+data. Judge the branch by `PropService(1)` and `career_navy`, not that editor
+name.
+
+All three markers target `station.mis`, destination location 2501. A successful
+transition arrives near the authored station start at approximately
+**(81.78, −3.6, 16.54)**. Immediately after arrival, `player.stats` should
+exist and `granted_years` should still be empty; station tours have not yet
+been completed.
+
+## Strict acceptance checklist
+
+An **Earth depth pass** is valid only when one continuous fresh campaign session
+shows all of:
+
+- The player walks from the tram to the gravshafts and rides the x≈9.6 UP shaft
+  to street level.
+- Basic Training is entered and its supplied pickup, inventory/item, switch,
+  inspect/log, and movement interactions are attempted genuinely; any
+  unavailable lesson is reported at its first failed interaction.
+- Weapons Training proves every numbered lesson above: the supplied pistol and
+  clips are acquired normally; reload consumes matching reserve ammunition;
+  pistol fire damages the real training target; the supplied laser is charged
+  by the authored station rather than a generic reload/debug effect; and laser
+  fire damages the target.
+- Technical Training proves every numbered lesson above: the supplied nanites
+  are acquired; the locked target is opened through the real connected-path
+  hacking UI; a replicator purchase delivers the selected item and debits the
+  correct nanites; and the replicator hack changes its available inventory.
+- Psionic Training proves every numbered lesson above: the supplied amp and
+  hypo are acquired and used normally; Cryokinesis is selected and manifested
+  at the real Training Droid; psi and droid health both decrease; and a psi
+  hypo restores psi.
+- Each Advanced room's real exit returns to the lobby. Before/after inventory
+  evidence must prove that its temporary weapon/ammo, technical supplies, or
+  amp/hypos were removed by the authored exit, rather than merely recording
+  whether cleanup happened.
+- The Basic course is allowed to run through its timers, its course is
+  traversed under collision, its exit tripwire fires, and the player returns
+  exactly once. Before/after inventory evidence proves that the Basic course's
+  temporary supplied items were removed by its authored exit.
+- From the hub, the player enters the west-side Advanced lobby through
+  tripwire-opened doors 74/79, later returns east to the hub, and player-frobs
+  service-passage doors 80/81.
+- Marine, Navy, and OSA entrances are all located and observed before one is
+  selected.
+- One real career threshold is crossed; `station.mis` loads at the designed
+  area, exactly one matching `career_*` bit is complete, and its HP/psi values
+  match the table. The initial Station inventory baseline must contain no
+  leaked Earth training gear or supplies.
+- No `/v1/player/teleport`, direct transition, quest mutation, entity-message
+  injection, debug give, or collision bypass substitutes for any gate above.
+  A teleport may restore a previously validated saved frontier, but that
+  resumed evidence cannot be used to claim the skipped Earth traversal.
+
+A **minimum campaign pass** may omit all training and visit only the chosen
+service entrance, because retail permits that. Label such a result
+`progression-only`; do not present it as the requested Earth depth pass.
+
+If any required Advanced interaction or exit cleanup fails, the Earth depth
+verdict is **BLOCKED at that interaction** even when the player could walk on
+to recruitment. Record and triage the failure; do not downgrade it to a passing
+run with a side finding.
+
+Focused branch replays may start from a saved pre-choice frontier to validate
+the two unchosen service transitions. Each replay must still walk through the
+real threshold and verify its own quest/stats; directly firing the destination
+marker is only a wiring diagnostic.
+
+## Engine watch-points for triage
+
+1. The tram floor and the UP gravshaft are known regression surfaces. Report
+   the exact position and movement trace if either ordinary walk or room
+   gravity stalls.
+2. Both the Basic entrance at x≈11.6 and the Advanced entrance around
+   x≈5/z≈51.2 can pin an off-center player while their leaves move. Wait for
+   the doors to reach their authored open endpoints and retry on-center before
+   reporting a blocker.
+3. The scripted Basic-course return must suppress stale entry-tripwire tracking.
+   More than one automatic return/re-entry is a teleport-loop regression.
+4. Low Basic-course walls require observed steering. A long held input into a wall
+   is a test-navigation failure unless bounded corrective attempts prove the
+   passage itself is impassable.
+5. Doors 80/81 are intentionally player-frobbed `StdDoor`s with no incoming
+   SwitchLinks. Waiting for an automatic trigger is tester error; a correctly
+   targeted player frob that does not move both the panel and collider is a
+   gameplay bug.
+6. Several Earth tutorial prompts use `EarthText`; the current script registry
+   may not reproduce all retail narration/UI. Separate missing presentation
+   from the underlying pickup, inventory, weapon, hack, psi, and movement
+   mechanics, and report both where appropriate.
+
+## Sources
+
+- [SShock2.com full walkthrough](https://www.sshock2.com/ss2walk/) — tram,
+  training recommendation, recruitment, and career choice.
+- [RPGClassics System Shock 2 walkthrough](https://shrines.rpgclassics.com/pc/sysshock2/walkthrough.shtml)
+  — independent confirmation that Basic and all three Advanced Training rooms
+  are optional but recommended.
+- [GameBanshee character creation guide](https://www.gamebanshee.com/systemshock2/character/charactercreation.php)
+  — career roles and their effect on starting character development.
+- Local `cargo dq entities earth.mis` inspection (2026-07-23) — gravshaft
+  rooms, signs, training and service-passage doors, tripwires, destination
+  markers, service values, and station location.
+- `tools/shock2-sdk/test/earth-tram-exit.e2e.test.ts`,
+  `gravshaft.e2e.test.ts`, `door-frob.e2e.test.ts`,
+  `montage-teleport-loop.e2e.test.ts`, and `station-flow.e2e.test.ts` — current
+  runtime regression evidence and observable state.

--- a/.claude/skills/play-through/walkthroughs/eng1.md
+++ b/.claude/skills/play-through/walkthroughs/eng1.md
@@ -1,0 +1,281 @@
+# Walkthrough — eng1 + eng2 (Engineering: restore main power)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+**story-critical Engineering path**, cross-checked against the retail objective
+strings, external walkthroughs, and `eng1.mis` / `eng2.mis` entity wiring. It is
+not enough to cross the eng1↔eng2 bulkhead or to make an elevator transition:
+Engineering is complete only after the player has performed the Fluidics,
+nacelle, and master-power sequence through the real in-world objects.
+
+This is not a movement script. Observe and react, traverse with bounded
+`/v1/player/move`, fight or evade threats, and use the anchors below to identify
+the intended objective rather than teleporting between coordinates.
+
+Positions and positive IDs below are mission-file object identities from
+`cargo dq`; resolve runtime entities anew by name and stable `template_id` each
+launch. Never retain a concrete runtime entity ID. The arrival coordinates from
+the earlier campaign seed are retained where useful.
+
+## What Engineering actually is
+
+- `eng1.mis` is Engineering A: coolant tubes, Engineering/Fluidics Control,
+  Auxiliary Storage 4/5, Engine Core, both nacelles, the master-power room, the
+  main deck elevator, and the Security Station.
+- `eng2.mis` is Engineering B: Command Control and Cargo Bays 1A/1B/2A/2B.
+- The bulkhead between them is a **routine round-trip connector**, not an
+  objective completion point.
+- The Security access card and Utility Storage 4 supplies/hazard suit are useful
+  but optional. They are not the narrative gate.
+- The keypad `94834` in the Engine Core is for the much later self-destruct
+  return to Engineering. Do not use it during the first visit.
+- Completing the first visit sends the player to the main elevator and
+  **Hydroponics (deck 3)**. In this port the main elevator's Hydro button loads
+  `hydro2.mis` at loc 22, not `hydro1.mis`.
+
+## Arrival, connectors, and major anchors
+
+| Purpose | Stable mission object | Position | Expected behavior |
+| --- | --- | --- | --- |
+| Arrival from MedSci conduit | eng1 arrival | about (44.6, −15.2, −40.4) | Engineering Control alcove; protective-clothing sign and nearby log/desk |
+| Return to MedSci | `Tripwire Level` 463 | (44.70, −10.24, −33.90) | `MedSci1`, loc 12 |
+| eng1 → eng2 | `Bulk_On_Button` 1124 | (2.7, −11.1, −198.2) | Frob transitions to `eng2`, loc 100 |
+| eng2 → eng1 | `Bulk_On_Button` 1080 | (−2.7, −11.1, −192.2) | Frob transitions to `eng1`, loc 100 |
+| Main elevator panel | `Master Elevator Button` 629 | (−9.61, −15.09, −111.38) | Opens the five-deck elevator UI |
+| Locked elevator-door control | `Elevator Button` 990 | (−8.75, −14.77, −116.78) | Initially locked; master-power router unlocks it |
+
+The eng1→eng2 button was successfully frobbed in campaign iteration 6. That
+proved the connector only; the session then bridged the interior and therefore
+did **not** validate Engineering's objectives.
+
+## Required items, codes, and evidence
+
+| Item / code | Genuine source and location | Purpose / evidence |
+| --- | --- | --- |
+| Engineering Control direction | Sanger log 13, entity 451, by the Eng Control door at (0.78, −2.37, −166.92) | Read its in-game transcript: it says she went to Cargo Bay 2 and should activate `Note_1_6` |
+| Cargo Bay 2A/2B access card | entity 520, **inside corpse 233** in Cargo Bay 1A at (−33.31, −12.32, −282.73), eng2 | Card region `16384`; opens the Cargo Bay 2 reader/doors |
+| Code **15061** | Sanger's “Locked in” log 5, entity 1426, **inside corpse 507** on the upper level of Cargo Bay 2B at (31.61, 2.17, −172.71), eng2 | Read its in-game transcript before using the code; it advances the objective from finding the code (`Note_1_6`) to knowing it (`Note_1_8`) |
+| Engineering Control keypad | keypad 1181 at (−1.59, −0.60, −168.60), eng1 | Code 15061; opens door 1091 and completes `Note_1_6` + `Note_1_8` |
+| Fluidics-backdoor instructions | Delacroix log 7, entity 1421 at (1.80, −2.75, −177.29), eng1 | Read its in-game transcript: it names 45m/dEx, Command Control, Aux Storage 5, and code 34760, and advances the override objective |
+| Code **34760** | learned from Delacroix log 7 in-game | Opens Aux Storage 5 keypad 1726 at (−41.12, −14.97, −53.95); typing it from this document is not discovery coverage |
+| Hardware override 45m/dEx | circuit board entity 705 (`obj:engcard5`, displayed as “Part #45M/dEX”) at (−52.30, −14.92, −51.09), eng1 | Picking it up completes `Note_1_10`; must survive the transition to eng2 |
+| Systems Monitoring Unit | `Card_ Box` 676 at (0.00, 9.89, −290.06), Command Control, eng2 | `ObjConsumeButton`, consumes a `Circuitboard`; sets `CircuitBoardPlaced` and completes `Note_1_9` |
+| Optional supplies | keypad 1372 at (−1.81, −14.94, −94.55), code **59004** | Utility Storage 4; hazard suit/supplies, completes `Note_1_11` |
+| Optional Security access | Security Card 901 inside Male Corpse 1331 near (−1.73, −12.69, −186.58); Card slot 1335 at (−3.57, −10.89, −184.80) | Opens Security Station door 2080; useful loot/medical access, not a plot gate |
+
+Contained cards and logs must be looted via the corpse/container MFD. Finding
+their editor coordinates and calling a debug give/teleport is not genuine play.
+
+## Critical path
+
+### Phase A — establish the coolant-radiation problem (eng1)
+
+1. Arrive from the MedSci maintenance conduit around
+   (44.6, −15.2, −40.4). Polito's first-visit objective is to reset the Engine
+   Core and restore elevator power.
+2. Follow the coolant-tube route to the Engine Core access computer / sealed
+   door. `Core Access` entity 459 is at (−1.69, −14.0, −29.60). The protective
+   seals should prevent Engine Core access while radiation remains; the player
+   is directed to purge the tubes.
+3. Reach Engineering Control. Loot Sanger's log 13 (entity 451) by its locked
+   entrance and open its media panel. Read the in-game transcript that directs
+   the player to Cargo Bay 2 for the changed code; record `Note_1_6` becoming
+   active before leaving.
+4. Travel normally to the south bulkhead and frob eng1
+   `Bulk_On_Button` 1124 to enter eng2.
+
+Merely knowing 15061 out of band is insufficient coverage. A focused regression
+may enter a known code, but an end-to-end campaign session should acquire the
+lead and Sanger log through play.
+
+### Phase B — Cargo Bays: obtain the access card and Sanger's code (eng2)
+
+5. In Cargo Bay 1A, frob corpse 233 and click the **Cargo Bay 2A/2B access
+   card** (entity 520) in its container UI.
+6. Use that card on the Cargo Bay 2 reader. The reader is Card slot 1585 at
+   (18.66, −10.97, −251.56), switching Cargo Bay doors 1378 and 1391.
+7. Traverse Cargo Bay 2 to its upper level (cargo lifts are part of the genuine
+   route). In Cargo Bay 2B, frob corpse 507 and loot Sanger's **“Locked in”**
+   audio log 1426. Open its media panel and visibly read **15061** before using
+   that code; record the `Note_1_6` → `Note_1_8` objective progression.
+8. Return through eng2 `Bulk_On_Button` 1080 to eng1. Inventory and quest state
+   must survive this round trip.
+
+### Phase C — open Engineering Control and prepare the backdoor (eng1 → eng2)
+
+9. Enter **15061** on Engineering Control keypad 1181 and go inside.
+10. Attempt/use the Fluidics controls and acquire Delacroix's “Fluidics
+    backdoor” log 1421. Open its media panel and visibly read the 45m/dEx
+    instructions and **34760** before going to Auxiliary Storage 5. Record the
+    `Note_1_13` override objective and its transition to the acquire/install
+    objectives. Before installation, Fluidics must not falsely complete the
+    purge: its invisible frob target (`Fluidic Button` 1114 at
+    (−0.003, −0.624, −177.207)) is filtered on `CircuitBoardPlaced`.
+11. Travel through the irradiated coolant area to Auxiliary Storage 5. Use
+    **34760** on keypad 1726 and pick up Part **45m/dEX** (entity 705).
+    Radiation is a real environmental constraint; use available rad hypos or
+    the optional hazard suit rather than raw teleporting through the tubes.
+12. Carry 45m/dEX back through the bulkhead to eng2, reach upper Command
+    Control, and use it on the **Systems Monitoring Unit / Card Box 676**. The
+    item should be consumed and `CircuitBoardPlaced` should change state.
+13. Return through the bulkhead to eng1. This is the second required
+    cross-mission persistence check.
+
+### Phase D — purge the tubes and enter the Engine Core (eng1)
+
+14. Use `Fluidic Button` 1114 in Engineering Control again. With
+    `CircuitBoardPlaced` set, QB Filter 523 fires Once Router 287. The intended
+    consequences are observable and stateful:
+
+    - the Fluidics computer changes from off to on;
+    - radiation in the coolant tubes is purged;
+    - `EngineRadClear` is set;
+    - objectives `Note_1_7` and `Note_1_2` complete;
+    - Core Access changes/unlocks so the Engine Core can be entered.
+
+15. Walk back through the now-purged coolant route and enter the Engine Core.
+    Passing a still-closed access door by collision exploit or teleport is not
+    completion.
+
+### Phase E — restart both nacelles and master power (eng1)
+
+16. In the port nacelle control room, frob the **Port Nacelle Computer** 1736
+    at (32.15, −13.86, 19.24). It sets `Note_1_3` complete.
+17. In the starboard nacelle control room, frob the **Starboard Nacelle
+    Computer** 1834 at (−41.90, −13.87, 19.24). It sets `Note_1_4` complete.
+    Order does not matter, but both are required.
+18. Both computers feed Multi Trigger 881. Only after both have fired should
+    `NacellesFrobbed` be set and the Master Power objective become available.
+19. Ride the Engine Core grav lift to the upper master-control room. Use the
+    visible **Master Power Computer** 1103 / overlaid frob target
+    `Master Power Button` 1870 at (1.376, 5.936, −16.688).
+20. Its QB filter/router must perform the real completion effects:
+
+    - master-power computer changes from off to on;
+    - `CorePower` is set;
+    - `Note_1_5` and `Note_1_1` complete;
+    - `ElevState` changes;
+    - Unlock Trap 1213 unlocks elevator-door control 990;
+    - Polito sends the “Core online” message directing the player to the
+      elevator.
+
+### Phase F — unlock Hydroponics
+
+21. Return to the main elevator near z≈−111. The original seed mistook this for
+    a local vertical connector; it is the inter-deck elevator.
+22. Frob `Master Elevator Button` 629, then click **Hydroponics (3)** in the
+    elevator MFD. A genuine transition lands in **`hydro2.mis` loc 22**.
+23. Preserve the frontier only after confirming the Hydro mission loaded with
+    inventory and Engineering quest state intact.
+
+## Ordered objective evidence
+
+Engineering's objective list is a state machine, not a bag of final bits.
+Capture `/v1/quests` and the corresponding world/media evidence at each stage
+below. An objective that never becomes active, completes out of order, or is
+skipped because the player already knows a code is a progression failure.
+
+| Order | Required authored progression |
+| --- | --- |
+| 1 | Read Sanger log 13 in-game → `Note_1_6` (find the Engineering Control code) becomes active |
+| 2 | Loot/read Sanger log 5 from corpse 507 → `Note_1_8` conveys 15061; the earlier search objective advances |
+| 3 | Enter Engineering Control and encounter the blocked Fluidics path → `Note_1_13` (find an override) is represented |
+| 4 | Read Delacroix log 7 in-game, enter 34760, and take 45m/dEx → `Note_1_10` advances/completes |
+| 5 | Insert 45m/dEx in Command Control → `Note_1_9` completes |
+| 6 | Use Fluidics after installation → `Note_1_7` and `Note_1_2` complete |
+| 7 | Reset starboard and port nacelles → `Note_1_4` and `Note_1_3` complete |
+| 8 | Reset Master Power → `Note_1_5` and `Note_1_1` complete |
+
+`Note_1_11` (Utility Storage 4) remains optional. `Note_1_14` is the next-deck
+directive and need not complete inside Engineering.
+
+## Genuine-play acceptance gate
+
+Mark Engineering **PASS** only if one reviewed session (or a frontier-backed
+sequence of sessions) demonstrates all of the following:
+
+1. Normal eng1 arrival and physical traversal to the sealed Engine Core /
+   Engineering Control; no setup teleport beyond an explicitly recorded
+   frontier resume.
+2. Sanger log 13 is acquired at the Engineering Control entrance and its
+   in-game transcript is visibly read before the Cargo Bay trip; `Note_1_6`
+   appears through the authored interaction.
+3. Genuine eng1→eng2→eng1 travel through bulkhead buttons 1124/1080.
+4. Cargo Bay 2 card is looted from corpse 233 and actually used to open Cargo
+   Bay 2; Sanger log 5 is looted from corpse 507 and its transcript visibly
+   conveys 15061 before the keypad is used; `Note_1_8` advances.
+5. Keypad 1181 accepts the learned 15061 and the player enters Engineering
+   Control. The pre-install Fluidics attempt must not purge the tubes.
+6. Delacroix log 7 is acquired and its in-game transcript visibly conveys the
+   45m/dEx route and 34760 before Auxiliary Storage 5 is opened. Evidence shows
+   the `Note_1_13` → `Note_1_10` / `Note_1_9` progression.
+7. 45m/dEx is obtained behind keypad 1726 (34760), carried across a mission
+   transition, inserted into Card Box 676, consumed, and
+   `CircuitBoardPlaced` persists after returning to eng1; `Note_1_10` and
+   `Note_1_9` advance at their corresponding interactions.
+8. Fluidics activation happens only after the override is installed and
+   produces the purge/Core Access effects. Evidence should include quests
+   `Note_1_7` + `Note_1_2`, `EngineRadClear`, a changed Fluidics/Core Access
+   state, and normal passage into the Core.
+9. Both distinct nacelle computers are frobbed in-world; `Note_1_3` and
+   `Note_1_4` complete and `NacellesFrobbed` changes.
+10. Master Power is then activated in-world; `CorePower`, `Note_1_5`, and
+   `Note_1_1` reflect completion and elevator control 990 is unlocked.
+11. The ordered quest evidence includes `Note_1_6`, `_8`, `_13`, `_10`, `_9`,
+    `_7`, `_2`, `_4`, `_3`, `_5`, and `_1`; no final-state-only snapshot may
+    substitute for the interaction-by-interaction record.
+12. The player returns normally to the main elevator, selects Hydroponics in its
+   actual MFD, and loads hydro2 with carried inventory/quest state preserved.
+13. Screenshots and `data.json` steps show each major interaction and its
+    consequence. Quest-state assertions alone are not proof if the player
+    debug-messaged traps or skipped world traversal.
+
+Any session that only reaches eng2, directly enters known codes without the
+campaign's discovery path, presses an elevator that happened to be available,
+or forces a transition to Hydro is **invalid/shallow**, not a clean pass.
+
+## Engine watch-points / likely feature-gap boundaries
+
+- The port currently treats an unset `ElevState` as elevator-accessible for
+  playability (`scripts/gui/elevator.rs`). Therefore **successful elevator
+  travel is not proof that power was restored**; the quest/object evidence in
+  the acceptance gate is mandatory.
+- **Log quest-bit metadata is a current objective blocker.** Sanger log 13
+  (entity 451) carries `PropQuestBitName("Note_1_6")`, and Delacroix log 7
+  (entity 1421) carries `PropQuestBitName("Note_1_9")`; neither has a
+  SwitchLink fallback. The current `MediaGui` / `CollectLog` path records and
+  displays a log but does not apply that metadata. If reading either log fails
+  to advance its authored objective sequence, mark Engineering blocked and fix
+  the log interaction. Do not inject the bit or accept a readable transcript
+  as a substitute for objective progression.
+- Card/corpse container looting, keypad entry, card readers, cross-level
+  inventory/quest persistence, cargo/grav lifts, `ObjConsumeButton`,
+  `TrapQBFilter`, `TriggerMulti`, model swaps, radiation clearing, and elevator
+  MFD interaction are all independently exercised by this path. Report the
+  first failed real mechanism as the blocker; do not replace it with a debug
+  message or transition.
+- Radiation survival equipment is optional in the original path. Missing the
+  optional Security Station or hazard suit is not itself a failed playtest;
+  failure of the purge to remove the hazard or open Core Access is.
+- The nine “RadKey Card”/radbutton observations in the old seed were a
+  misidentification of the Auxiliary Storage 5 area. The plot item there is the
+  ordinary Circuitboard entity 705, displayed as **Part #45M/dEX**.
+- No NPC named Delacroix is expected on this deck. Her audio log supplies the
+  backdoor instructions.
+
+## Sources
+
+- Retail data: `Data/res/strings/NOTES.STR` (ordered Engineering objectives),
+  `Data/res/strings/LEVEL01.STR` (Polito emails and Sanger/Delacroix logs), and
+  `OBJNAME.STR` (Part #45M/dEX / computer display names).
+- Mission wiring: `cargo dq entities eng1.mis ...` and
+  `cargo dq entities eng2.mis ...` (2026-07-23), especially entities 459, 629,
+  705, 1114, 1124, 1181, 1726, 1736, 1834, 1870 (eng1) and 233, 507, 520, 676,
+  1080, 1426, 1585 (eng2), plus their SwitchLinks and quest-bit traps.
+- [SystemShock.org objective list](https://www.systemshock.org/index.php?topic=48.0)
+  — ordered Engineering objectives and codes.
+- [System Shock Wiki — Engineering Deck](https://shodan.fandom.com/wiki/Engineering_Deck)
+  — first-visit synopsis, optional Security card, and A/B deck split.
+- [GameFAQs walkthrough (Bahamut_Zero)](https://gamefaqs.gamespot.com/switch/513867-system-shock-2-25th-anniversary-remaster/faqs/8959)
+  — coolant tubes, Cargo Bays, Engine Core, and elevator progression.
+- [RPGClassics walkthrough](https://archive.rpgclassics.com/shrines/pc/sysshock2/walkthrough.shtml)
+  — both nacelles, master-power room, and main-elevator handoff.

--- a/.claude/skills/play-through/walkthroughs/hydro.md
+++ b/.claude/skills/play-through/walkthroughs/hydro.md
@@ -1,0 +1,317 @@
+# Walkthrough — Hydroponics (hydro2 → hydro1 / hydro3 → hydro2 → Operations)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+**real Deck 3 objective path**, cross-checked against retail walkthroughs and
+the entities, links, and quest-bit traps in `hydro1.mis`, `hydro2.mis`, and
+`hydro3.mis`. It is not a movement script: observe and react, but do not count
+touching the three maps or taking the elevator as completion.
+
+Hydroponics' plot objective is to restore the main elevator's Hydro display.
+The player must trigger the authored research assignment, obtain and genuinely
+research Toxin-A, collect enough vials, insert one into each of four
+Environmental Regulators, and return to the main elevator before going to
+Operations.
+
+Positions below are mission `PropPosition` coordinates and are useful search
+anchors. Mission object ids are stable only within the named `.mis` file;
+runtime entity ids are not stable. At runtime, resolve by name and `template_id`.
+
+## Valid campaign start
+
+The campaign reaches **`hydro2.mis`**, the central Hydroponics B/C map, through
+the main elevator after restoring it in Engineering. Preserve the carried
+inventory, keycards, player upgrades, and quest bits from that transition.
+
+A fresh launch directly into `hydro2.mis` is useful for investigation but is
+**not** an end-to-end acceptance start. In particular, the port deliberately
+treats an unset `ElevState` as an accessible elevator, so a fresh-launch tester
+can click Operations without exercising Hydroponics. Likewise, manually setting
+quest bits, giving plot items, teleporting through doors, or invoking a direct
+level transition invalidates objective coverage.
+
+## Deck topology and legitimate transitions
+
+| from | world interaction | mission object / position | destination |
+| --- | --- | --- | --- |
+| Engineering / another tram stop | Main Elevator panel | `hydro2` Master Elevator Button id 537, tmpl −1723 @ (7.2, −0.4, 0.0) | `hydro2`, elevator marker 22 |
+| `hydro2` (B/C) | Sector A bulkhead button | id 998, tmpl −3622 @ (39.4, 3.6, −70.0) | `hydro1`, loc 301 |
+| `hydro1` (A) | return bulkhead button | id 442, tmpl −3622 @ (7.8, 2.0, 50.4) | `hydro2`, loc 301 |
+| `hydro2` (B/C) | Sector D bulkhead button | id 1617, tmpl −3622 @ (60.0, 2.8, 69.8) | `hydro3`, loc 302 |
+| `hydro3` (D) | return bulkhead button | id 408, tmpl −3622 @ (28.0, 2.8, −25.4) | `hydro2`, loc 302 |
+| `hydro2` | Main Elevator panel, click **Operations (4)** | Master Elevator Button id 537 | **`ops2.mis`**, elevator marker 22 |
+
+`hydro2` is the hub and contains the B and C regulators. `hydro1` is Sector A;
+`hydro3` is Sector D. All three missions contain copies of the quest-bit
+completion check, so the fourth regulator can legitimately be the last one
+visited in any order.
+
+## Plot items and objective anchors
+
+### Toxin-A
+
+Toxin-A is template **−1341**, `Anti-Annelid Toxin`. There are five vials in
+the shipped missions; four are consumed by the four regulators:
+
+| mission object | legitimate source |
+| --- | --- |
+| `hydro2` id 2140 @ (12.8, 0.3, −53.2) | loose vial |
+| `hydro2` id 547 | in Desk id 713 @ (25.8, −1.3, 42.4) |
+| `hydro2` id 1185 | in Desk id 675 @ (25.8, −1.3, 35.6) |
+| `hydro2` id 1186 | in chemical-storage Desk id 354 @ (60.5, −2.5, −40.0); the desk also holds Vanadium and two Antimony samples |
+| `hydro1` id 1199 | spare vial in MS Female Corpse id 466 @ (17.2, 0.0, 56.2) |
+
+The loose vial, `hydro2` id 2140, is the most visible introduction to the item,
+but **picking it up does not initiate the objective**. Three
+`TrapNewTripwire` volumes independently route to `EVENT1-Router` id 1437:
+
+| tripwire | position |
+| --- | --- |
+| `hydro2` id 1323 | (21.6, −0.4, 39.2) |
+| `hydro2` id 1322 | (14.2, −0.4, −58.8), near loose vial 2140 |
+| `hydro2` id 2087 | (57.6, −1.6, −41.8) |
+
+Crossing any one through normal movement immediately drives
+`NOTE_3_2=INCOMPLETE` and email 302. Its delayed branch awards 10 cyber modules
+after 20 seconds / 1200 fixed frames. A depth pass must record the real Event-1
+tripwire consequence and separately pick up vial 2140 in-world; do not infer
+either one from the other or reject an otherwise valid order merely because
+the tripwire fired first.
+
+The two desks around x≈25 are the toxin laboratory. Retail walkthroughs
+describe a jammed-door / broken-window approach, but local mission inspection
+does not expose a breakable lab-window entity. Use the observed door/aperture
+route rather than assuming a particular pane: stable anchors are HydroDoorWide
+id 183 @ (23.8, −0.4, 46.0), Science Table id 716 @
+(19.2, −1.1, 38.4), desks 675 / 713, and Event-1 tripwire 1323.
+Container contents must be taken through the real loot panel; they are not
+floor objects.
+
+Original behavior requires **Research 1**, supplied either by buying the skill
+with the Event-1 module award or using the nearby **LabAssistant** implant
+(`hydro2` id 1064, tmpl −969 @ (25.6, −0.6, 35.9)). Research consumes Antimony
+(Sb), Vanadium (V), then Antimony and completes quest bit `Note_3_2`. The
+chemical-storage desk above contains the required V and two Sb samples.
+
+### Access cards
+
+| card | source | real gate |
+| --- | --- | --- |
+| Hydro B, tmpl **−1495** | `hydro2` id 942, inside HYD Male Corpse id 754 @ (72.1, −1.7, −15.6), by the monkey corridor | B card readers, region 128 (for example ids 1120 / 1122) |
+| Hydro A, tmpl **−1494** | `hydro2` id 934, inside HYD Female Corpse id 1297 @ (46.1, −8.6, −39.4), in cold-storage / B maintenance | A card readers, region 64 (ids 1132 / 1597), then the `hydro1` bulkhead |
+| Hydro D, tmpl **−1496** | `hydro1` id 79, inside HYD Male Corpse id 471 @ (38.1, 0.0, 9.1), in the first Sector A cultivation area | D card readers, region 256 (ids 1152 / 1177), then the `hydro3` bulkhead |
+
+Loot each corpse and click the card in the container MFD. Do not use
+`/v1/player/give` for contained cards.
+
+### Environmental Regulators
+
+Every regulator accepts only an entity whose `PropSymName` is
+`Anti-Annelid Toxin`. In flat mode, frobbing the regulator consumes the first
+matching carried vial. In VR, provide the held vial for consumption.
+
+| regulator | area and route anchor |
+| --- | --- |
+| **ACR1** | `hydro1` id 141, tmpl −2659 @ **(28.8, 2.4, −68.2)** — far end of Sector A cultivation |
+| **ACR2** | `hydro2` id 913, tmpl −1151 @ **(33.4, −6.0, −50.0)** — icy Sector B maintenance / cold storage; descend through the floor opening and use the ladder stack around (33.7, −4.8, −53.6) to leave |
+| **ACR3** | `hydro2` id 910, tmpl −1151 @ **(76.0, −2.0, 23.4)** — Sector C maintenance; climb the ladder around (59.6, −2.0, 22.2), pass through the office, and take the downward ramp |
+| **ACR4** | `hydro3` id 247, tmpl −1151 @ **(43.6, −1.6, −40.2)** — Sector D, down the ramp past the control / turbine area |
+
+Concrete traversal anchors for the two central routes:
+
+- **Sector C / ACR3:** Rick Ladder ids 551–564 form the vertical stack at
+  x=59.6, z=22.2 from y=−2.0 to 6.0; breakable CrackedGlass id 657 is at
+  (57.0, 2.6, 18.4); upper doors 1196 / 1195 and tripwire 1194 are around
+  (62.2, 4.0, 27.2); corpse 406 and ACR3 are at the lower far end. The
+  descending ramp itself is brush geometry and has no entity id.
+- **Cold storage / ACR2:** FrostedGlass1 id 795 @ (28.4, 3.6, −46.4) is the
+  concrete breach/drop anchor; ladder ids 110 / 520 are at
+  (33.65, −4.8, −53.6) and (33.65, −0.8, −53.6); ACR2 and the Hydro A-card
+  corpse 1297 are on the lower route. The floor opening is brush geometry and
+  has no entity id.
+
+## Critical path
+
+### 1. Establish the real objective in central Hydro B/C (`hydro2`)
+
+1. Arrive through the main elevator with the Engineering campaign state.
+2. Explore the security / Biological Survey side instead of selecting another
+   elevator floor. Deal with hybrids, monkeys, Midwives, eggs, cameras, and
+   other threats using normal player combat or avoidance.
+3. Cross one of the real Event-1 tripwires through bounded movement. Confirm
+   email 302 and `Note_3_2=INCOMPLETE` immediately, then wait 1200 fixed frames
+   and confirm the delayed 10-module award. Separately reach loose Toxin-A vial
+   id 2140 at (12.8, 0.3, −53.2) and pick it up in-world.
+4. Reach the Toxin-A laboratory through an observed, collision-respecting
+   door/aperture route, using door 183, table 716, and desks 675 / 713 as
+   evidence anchors. Loot the LabAssistant implant if needed, additional vials,
+   and the required chemicals. Do not manufacture a breakable-window test:
+   local data contains no substantiated breakable lab pane.
+5. **Research Toxin-A through the real research flow.** Confirm `Note_3_2` is
+   complete before treating any vial as usable. Merely possessing the
+   `Anti-Annelid Toxin` entity is not research coverage.
+
+### 2. Exercise both central-map regulators and their traversal gates
+
+6. Reach Sector C maintenance by genuinely climbing the ladder, crossing the
+   office, and descending the ramp. Insert a researched vial into **ACR3**.
+7. Reach the B monkey corridor and loot the **Hydro B card** from its corpse.
+   Use the actual B card reader rather than moving through the locked door.
+8. Enter the cold-storage drop, reach **ACR2**, insert a second researched vial,
+   and loot the **Hydro A card** from the nearby corpse. Climb back out rather
+   than teleporting to the upper floor.
+9. Obtain the remaining vials from the lab / chemical storeroom as needed.
+
+The order of ACR2 and ACR3 may vary. What matters is that both the ladder/ramp
+route and the cold-storage drop/return are honestly traversed.
+
+### 3. Complete Sector A (`hydro1`)
+
+10. Use the Hydro A card at its reader, walk to the Sector A bulkhead, frob its
+   real button, and transition to `hydro1`.
+11. Traverse the cultivation rooms. Loot the **Hydro D card** from the Sector A
+    corpse; the nearby corpse with the spare Toxin-A may be used if only three
+    central-map vials were collected.
+12. Reach **ACR1** at the far end and insert a researched vial.
+13. Walk back and use the return bulkhead button to reach `hydro2`.
+
+### 4. Complete Sector D (`hydro3`)
+
+14. Use the Hydro D card at its reader, reach the Sector D bulkhead, and take
+    the real transition to `hydro3`.
+15. Traverse the grim entrance, control / turbine rooms, ramp, enemies, and
+    eggs to **ACR4**. Insert one researched vial.
+16. Require ACR4's previously unknown quest bit to change to
+    `INCOMPLETE` / raw 1, its regulator model to change, and inventory to fall
+    by exactly one vial; then return through the bulkhead to `hydro2`.
+
+Sector A and Sector D can be completed in either order after their cards are
+available. Do not infer success merely from having visited both missions.
+After whichever unique regulator is actually fourth—ACR4 when A precedes D,
+or ACR1 when D precedes A—allow at least 10 seconds / 600 fixed frames for the
+shipped 1-, 3-, and 6-second completion delays and objective messages.
+
+### 5. Verify completion and take the real exit
+
+17. Inspect `/v1/quests`. Each regulator activation bit **`ACR1`…`ACR4` must
+    have changed from unknown to `incomplete` (raw bits 1) at its own unique
+    insertion**. This counterintuitive value is the mission's “activated”
+    marker, not evidence that insertion failed.
+18. Genuine completion of all four drives the linked checks and delays:
+    `Note_3_1=complete`, `Note_3_3=complete`, `ElevState=complete`, and the next
+    objective `Note_3_4=incomplete`. `Note_3_2=complete` independently proves
+    that Toxin-A was researched.
+19. Return to the Hydro main-elevator lobby and reproduce a screenshot from the
+    same viewpoint used on arrival. The broken `B_Hydro_Screen` / `elsha`
+    display must be gone and the working `Hydro_Screen` / `elhyd` display must
+    be present. The completion chain destroys object 550 and teleports object
+    710 into place; quest bits alone do not prove this world consequence.
+20. Frob Master Elevator Button 537, select the labeled
+    **Operations (4)** button in the real elevator MFD, and verify the mission
+    becomes **`ops2.mis`**. Save the campaign frontier there.
+
+## Acceptance checklist — what counts as genuine play
+
+A Hydroponics pass is valid only if the session evidence shows all of:
+
+- Entry from the advancing Engineering campaign state, with no fresh-mission
+  quest reset or direct Hydro launch used as proof.
+- One Event-1 tripwire crossed through bounded movement; email 302 and
+  `Note_3_2=INCOMPLETE` recorded immediately and the delayed 10-module award
+  recorded after 1200 frames. Loose Toxin-A vial 2140 is also reached and
+  picked up in-world as separate evidence.
+- Research 1 or the LabAssistant obtained legitimately, Sb/V/Sb supplied, and
+  `Note_3_2=complete` through the real research mechanic.
+- Four distinct vials consumed by four unique machines: before each use its
+  matching ACR bit is unknown, after use that bit is raw 1, its model changes,
+  and inventory count falls. Re-frobbing one already activated regulator does
+  not count as another insertion.
+- After the fourth unique insertion and its delayed completion evidence, save
+  the game, record the fifth vial's entity/count, and re-frob one specifically
+  identified activated regulator. A correct negative probe leaves inventory
+  and objective/world effects unchanged. If the vial is consumed, file the
+  gameplay bug and reload the pre-probe save before advancing.
+- Hydro B, A, and D cards looted from their real corpses and their actual card
+  readers used.
+- Genuine traversal of the lab's observed door/aperture route, the Sector C
+  ladder/ramp, the cold-storage breach/drop and ladder return, and the
+  `hydro1` / `hydro3` bulkheads using bounded movement. Evidence uses the stable
+  anchors listed above on both sides of each brush-geometry passage. A raw
+  teleport is allowed only to resume a saved frontier, never to bridge one of
+  these gates.
+- Threats encountered on the critical route handled with normal combat or
+  sensible avoidance—not debug `Damage` messages as a substitute for play.
+- Final quest state recorded after the delays: `ACR1..4` raw 1,
+  `Note_3_1`, `Note_3_2`, `Note_3_3`, and `ElevState` complete.
+- Before/after screenshots from the same elevator-lobby viewpoint show the
+  broken `elsha` display replaced by the working `elhyd` Hydro display.
+- Physical return to the `hydro2` elevator and a real Elevator MFD transition
+  to `ops2`.
+
+The following are specifically **insufficient**: visiting all three mission
+files, frobbing only their return buttons, consuming unresearched vials because
+the port permits it, setting ACR / Note / ElevState bits through the debug API,
+starting with a desk vial while skipping both the Event-1 tripwire and loose
+vial pickup, citing `ElevState` or an enabled Operations button without the
+authored display repair, repeatedly feeding vials to one regulator, clicking
+Operations before completing the regulators, or direct-transitioning to
+`ops2`.
+
+## Engine watch-points for triage
+
+1. **Research is a likely feature-gap blocker.** As of 2026-07-23,
+   `ResearchableScript`, `ResearchableUseScript`, and the LabAssistant's
+   `StatBoostImplant` are registered to `UnimplementedScript` in
+   `shock2vr/src/scripts/mod.rs`; Toxin-A's research-time, chemical, and text
+   metadata are also unparsed. Meanwhile `ObjConsumeButton` checks only the
+   carried item's symbolic name, so the port may consume an unresearched vial.
+   If a real playtest cannot perform research, classify it as a `[gameplay]`
+   **feature gap**; neither buying Research 1 nor merely equipping LabAssistant
+   proves the missing research flow, and the consumption bypass must not be
+   blessed.
+2. **Cross-mission state is essential.** Cards, remaining vials, `ACR1..4`, and
+   research/objective bits must survive both `hydro2↔hydro1` and
+   `hydro2↔hydro3`, plus save/reload at the frontier.
+3. **Completion is delayed.** The mission chains 1-, 3-, and 6-second trap
+   delays; step at least 600 frames after the fourth regulator before reporting
+   a missing state transition.
+4. **`ElevState` and Operations access are not Hydro completion evidence.**
+   Current elevator gating allows Operations both when `ElevState` is unset
+   (raw 0) and when it is `INCOMPLETE` (raw 1), including an honest
+   Engineering-derived campaign. Require `ACR1..4`, the `Note_3_*` sequence,
+   and a same-view before/after showing `elsha` replaced by `elhyd`. Reaching
+   `ops2` proves only the exit interaction.
+5. **Traversal is coverage.** Ladder climbing, observed lab access, the
+   cold-storage breach/drop, corpse/desk container UI, keycard readers,
+   regulator item consumption, and the elevator MFD are all required
+   mechanics. Report a blocker at the first failed real gate rather than
+   warping past it.
+6. **Repeated regulator use is unsafe in the current port.** `ObjConsumeButton`
+   has no activated-state guard and can destroy another matching vial on a
+   second Frob even though the one-shot ACR/XP traps have already disappeared.
+   Identify the unique regulator and verify its bit/model transition before
+   counting an insertion. Preserve the fifth vial for a save/reload negative
+   probe: if an already activated regulator consumes it, file a gameplay bug
+   and resume from the pre-probe save rather than corrupting the advancing
+   inventory.
+
+## Sources
+
+- [SShock2.com full walkthrough, Deck 3](https://www.sshock2.com/ss2walk/) —
+  detailed B/C → A → D route, cards, regulator locations, and return to the
+  elevator.
+- [GameFAQs guide by garkimasera, Deck 3](https://gamefaqs.gamespot.com/pc/185706-system-shock-2/faqs/27508) —
+  concise critical path, research chemicals, four regulators, and module
+  rewards.
+- [GameFAQs guide by DC, Deck 3](https://gamefaqs.gamespot.com/pc/185706-system-shock-2/faqs/7173) —
+  independent route description for the toxin lab, card chain, cold storage,
+  Sector A, and Sector D. Its window wording is treated as narrative guidance,
+  not as a local entity assertion.
+- [Port Forward Hydroponics walkthrough](https://portforward.com/games/walkthroughs/System-Shock-2/Hydroponics.htm) —
+  screenshot-backed lab, research, traversal, and regulator sequence.
+- Local `cargo dq entities hydro1.mis|hydro2.mis|hydro3.mis` inspection
+  (2026-07-23) — item containment, stable templates, positions, key regions,
+  transition destinations, regulator SwitchLinks, and quest-bit completion
+  chain.
+- `shock2vr/src/scripts/obj_consume_button.rs`,
+  `shock2vr/src/scripts/mod.rs`, and `shock2vr/src/scripts/gui/elevator.rs` —
+  current port behavior and the research / consumption / elevator watch-points.

--- a/.claude/skills/play-through/walkthroughs/medsci1.md
+++ b/.claude/skills/play-through/walkthroughs/medsci1.md
@@ -30,20 +30,54 @@ Three exits (live `/v1/transitions`):
 The deck's **main elevator is inoperative** (Master Elevator Button tmpl 1041 at
 (0.4, 0, −40.4), Double Elevator Doors ~(0.8, 0.2, −42)) — it is NOT the exit.
 The story objective chain: cryo escape → Science sector → **medsci2 round trip**
-(Grassi → Watts, who has code 12451) → back → maintenance conduit → Engineering.
+(Grassi's Crew card → Watts' office R&D card) → back to medsci1 R&D → Watts'
+deck-2/log-14 audio log with code 12451 → maintenance conduit → Engineering.
+
+## Valid campaign start
+
+For end-to-end acceptance, enter `medsci1` through the real Station deployment
+flow with the selected career, character upgrades, inventory, and quest state
+preserved. Waking in the cryo bay after that transition is the campaign start.
+
+A fresh `--mission medsci1.mis` launch is useful for isolated investigation,
+but it does not prove the Earth / Station handoff or campaign persistence.
+Likewise, a frontier save may resume already-proven ground, but raw teleport,
+`/v1/player/give`, `/v1/quests` mutation, debug entity messages, and direct
+level transitions cannot be used to bridge a critical-path gate.
 
 ## Codes & required items
 
 | Item / code | Where | Unlocks |
 | --- | --- | --- |
 | Wrench (tmpl 990) | **inside** MS Male Corpse (tmpl 1177) @ (−37.3, −5.5, 31.8), cryo bay near spawn — frob the corpse, click the Wrench in the loot panel (`/v1/ui`) | smash debris blocking the first ladder; melee |
-| **Code 45100** | audio log (Amanpour) on first corpse past the card door | cryo-recovery exit door (keypad tmpl 1681 @ (−26.5, 0.2, −12.7)) |
+| **Code 45100** | Amanpour audio log, mission id 1608 (deck 2 / log 20), inside MS Male Corpse id 1680 @ (−31.3, −1.1, −9.5); loot it through the corpse MFD and visibly read 45100 in its transcript | cryo-recovery exit door (keypad tmpl 1681 @ (−26.5, 0.2, −12.7)) |
 | Cryo Card (tmpl 1050) @ (−24.3, 0.0, −1.4) | upper walkway after the first ladder | first card-reader door |
 | Power cell #1: Dead Power Cell tmpl 1767 @ (−13.8, −6.5, −34.3) | near jammed door; charge at Recharging Station tmpl 125 @ (−15.8, −6.0, −27.9) | Aux Power receptor tmpl 1766 @ (−13.1, −5.8, −33.1) → jammed cryo-escape door. (Spare Wrench tmpl 1707 @ (−18.5, −6.7, −29.3) here.) |
 | Science Card (tmpl 338) @ (−16.6, 1.2, −68.9) | corpse near the "ghost" (upgrade-hub exit) | card door into the Science sector proper |
 | Power cell #2: Dead Power Cell tmpl 1186 @ (29.8, −1.1, −75.7) | reception near the "MED" sign (Polito points it out) | Aux Power receptor tmpl 1128 @ (32.1, 0.9, −76.8) → powers the **north Medical bulkhead** (→ medsci2) |
-| **Code 12451** | Watts' audio log, R&D — **in medsci2** | maintenance conduit keypad tmpl 809 @ (6.3, 0.4, −47.4) → the eng1 exit |
+| **Code 12451** | Watts' deck-2/log-14 audio log, on Watts in **medsci1 R&D** after returning from medsci2 with the R&D card | maintenance conduit keypad tmpl 809 @ (6.3, 0.4, −47.4) → the eng1 exit |
 | Optional: code 00000 (cryo closet, BrawnBoost); code 98383 (sub-armory, medsci2 side) | | |
+
+## Ordered objective snapshots
+
+Record `/v1/quests` at these boundaries. `incomplete` (raw bit 1) means an
+objective / marker is active; `complete` means it has been resolved. These
+snapshots supplement physical evidence—they do not replace the interaction:
+
+| after genuine interaction | expected objective evidence |
+| --- | --- |
+| campaign arrival / early cryo | `Note_2_2` is the active secure-airlock objective; record its baseline and its completion after the airlock path |
+| charged cell #2 inserted into Aux Power 1128 | `Note_2_10=complete` (direct mission SwitchLink); `Note_2_9` is the Grassi/Crew-card objective |
+| Crew Card looted from Grassi in MedSci2 | `grassicard=incomplete` (raw 1) and `Note_2_9=complete` |
+| R&D Card looted from Watts' Crew office | `RDGrab=incomplete` (raw 1) and `Note_2_5=complete` |
+| physical Watts encounter in MedSci1 R&D | `Note_2_3=complete` |
+| Watts' deck-2/log-14 disc genuinely acquired | `wattsy=incomplete` (raw 1), `Note_2_6=complete`, and `Note_2_7=incomplete` (the newly learned 12451 note) |
+| 12451 accepted by maintenance keypad 809 | `Note_2_7=complete`; `Note_2_1` is the continuing goal to reach Deck 4 |
+
+The card and Watts marker rows are driven by the mission's `FrobQB` /
+Simple-QB-trigger chains. If the in-world action succeeds visually but its
+ordered objective snapshot does not advance, report the objective integration
+failure rather than setting the bit by hand.
 
 ## Critical path (granular)
 
@@ -58,52 +92,100 @@ The story objective chain: cryo escape → Science sector → **medsci2 round tr
    ladder stack sits at (−17.5, −6.0…−2.0, 14.5).)*
 4. **Pick up the Cryo Card** (tmpl 1050, (−24.3, 0.0, −1.4)); use it on the
    card-reader door.
-5. **First corpse: audio log with code 45100**; enter it on **keypad tmpl 1681**
+5. **First corpse: Amanpour audio log id 1608** inside corpse id 1680. Frob the
+   corpse, click the contained disc, and visibly read **45100** in its deck-2 /
+   log-20 transcript; then enter it on **keypad tmpl 1681**
    (−26.5, 0.2, −12.7) to open the cryo-recovery exit door.
 6. **Air-shaft crawl** section (low-clearance passage), leads down toward the
    jammed-door area.
 7. **Power cell puzzle #1**: take Dead Power Cell (tmpl 1767), charge it at the
    Recharging Station (tmpl 125), insert into Aux Power (tmpl 1766) — the
    jammed door opens.
-8. **Cyber-upgrade hub**: Polito awards modules; 4 upgrade stations. (Optional:
+8. Continue through the real secure-airlock route into EmailRoom **`free1`**
+   (entity 1408). Require the objective activated by EmailTrap 1131 to change
+   from `Note_2_2=incomplete` to `Note_2_2=complete` when the authored room is
+   entered; hearing an email without the quest transition is not completion.
+9. **Cyber-upgrade hub**: Polito awards modules; 4 upgrade stations. (Optional:
    cryo closet keypad 00000 nearby.)
-9. **Ride the lift up** out of the lower level (Elevator Path pair tmpl 262/263:
+10. **Ride the lift up** out of the lower level (Elevator Path pair tmpl 262/263:
    (−27.6, −7.9, −54.5) → (−27.6, −1.7, −54.5)).
-10. **Take the Science Card** (tmpl 338, (−16.6, 1.2, −68.9)) from the corpse
+11. **Take the Science Card** (tmpl 338, (−16.6, 1.2, −68.9)) from the corpse
     near the "ghost"; it opens the card door out.
-11. **First combat: 2 hybrids** past that door. Then a second platform ride up
+12. **First combat: 2 hybrids** past that door. Then a second platform ride up
     to the elevator lobby.
 
 ### Phase B — Science sector → Medical bulkhead (upper floor)
-12. **Elevator lobby** (~(0.4, 0, −40)): pressing the elevator button triggers
+13. **Elevator lobby** (~(0.4, 0, −40)): pressing the elevator button triggers
     Polito's "elevator is inoperative" objective chain. The **maintenance
     conduit door** (keypad tmpl 809, (6.3, 0.4, −47.4); "To Maintenence Shaft"
     sign tmpl 1281 at (5.4, −1.6, −49.1)) is here but **locked — code 12451 not
     known yet**. Security cameras (5 on the deck) start appearing.
-13. **Power cell #2**: scripted explosion near the "MED" sign; take Dead Power
+14. **Power cell #2**: scripted explosion near the "MED" sign; take Dead Power
     Cell (tmpl 1186, (29.8, −1.1, −75.7)) from reception.
-14. Pass the Xerxes computer room / bio-reconstruction room (optional: activate
+15. Pass the Xerxes computer room / bio-reconstruction room (optional: activate
     the Quantum Bio-Reconstruction machine; pistol near the info kiosk).
-15. **Turret gauntlet**: catwalk over a room with 2 Slug Turrets (turrets in
+16. **Turret gauntlet**: catwalk over a room with 2 Slug Turrets (turrets in
     data: tmpl 610 (3.2, −5.2, −14.0), tmpl 611 (−4.7, −5.3, −6.1), tmpl 1015
     (18.8, −0.4, 9.5)). Recharge the power cell at a Recharging Station
     (tmpl 506 (−6.8, −4.0, −13.1) or tmpl 273 (10.5, −2.8, 33.0)).
-16. **Insert the charged cell into Aux Power tmpl 1128** (32.1, 0.9, −76.8) →
+17. **Insert the charged cell into Aux Power tmpl 1128** (32.1, 0.9, −76.8) →
     the north Medical bulkhead powers up; hit `Bulk_On_Button` tmpl 1009 →
     **level transition to medsci2**.
 
 ### Phase C — medsci2 excursion (required; separate walkthrough)
-17. Medical sector → Grassi's corpse (Crew access card) → Crew Quarters →
-    Watts' office (R&D card) → **Watts' audio log with code 12451** → return
-    through the bulkhead to medsci1.
+18. Medical sector → Grassi's corpse (Crew access card) → Crew Quarters →
+    Watts' office desk (R&D card) → return through the bulkhead to medsci1 →
+    use the R&D card to enter medsci1 R&D → meet Watts and loot/read his
+    **deck-2/log-14 audio log with code 12451**.
 
 ### Phase D — Exit to Engineering
-18. Back at the conduit: **enter 12451 on keypad tmpl 809** — door opens (the
+19. Back at the conduit: **enter 12451 on keypad tmpl 809** — door opens (the
     keypad SwitchLinks the door + an Experience Trap: cyber-module award).
-19. **Climb DOWN the shaft ladder** (`Rick Ladder 16` tmpl 1140 at
+20. **Climb DOWN the shaft ladder** (`Rick Ladder 16` tmpl 1140 at
     (12.6, −5.6, −42.7)) — one Blue Monkey may be around the conduit.
-20. At the bottom, the **Tripwire (tmpl 764) fires → eng1.mis** (loc 21, near
+21. At the bottom, the **Tripwire (tmpl 764) fires → eng1.mis** (loc 21, near
     Engineering Control). medsci1 done.
+
+## Acceptance checklist — what counts as genuine play
+
+A MedSci1 pass is valid only if the session evidence shows all of:
+
+- Campaign entry from Station (or a documented frontier resuming already-proven
+  play), with character and quest state preserved.
+- Wrench looted from its corpse, blocking debris broken, and both early ladder
+  stacks traversed through normal player movement.
+- Cryo Card acquired and used at its real reader.
+- Corpse id 1680 opened, Amanpour disc id 1608 clicked through the loot MFD,
+  deck 2 / log 20 recorded in `player.collected_logs`, and the in-game reader
+  visibly showing **45100** before that code is entered on keypad 1681.
+- The air-shaft crawl genuinely traversed; Power Cell #1 carried, charged, and
+  inserted; the secure-airlock objective activated and then completed by
+  physically entering `free1` / entity 1408; both lift platforms ridden;
+  Science Card acquired and used at its actual reader.
+- Power Cell #2 carried from reception, charged, and inserted into Aux Power
+  1128, with `Note_2_10=complete`, followed by the real north Medical bulkhead
+  transition.
+- The complete MedSci2 loop proven under `medsci2.md`: Grassi's Crew Card,
+  Crew reader/door, Watts-office desk R&D Card, and a real return bulkhead, with
+  card and objective state surviving back into MedSci1.
+- The R&D Card used at the MedSci1 reader; physical Watts reached and frobbed;
+  deck-2/log-14 taken from his loot MFD; visible transcript showing **12451**;
+  and `wattsy`, `Note_2_6`, and `Note_2_7` advancing in the expected order.
+- **12451** entered through the real maintenance keypad 809, the conduit door
+  crossed, the shaft ladder descended, and the bottom tripwire physically
+  transitioning the campaign to **`eng1.mis` loc 21**.
+
+Codes remembered from a walkthrough, source file, mission property, or previous
+run are not valid conveyance. Typing 45100 without reading Amanpour's disc, or
+12451 without taking Watts' disc and advancing its objective chain, invalidates
+the playthrough even if the keypad opens. Debug-given items, injected quest
+bits, direct door messages, debug damage in place of combat, and direct level
+transitions are likewise insufficient.
+
+If EmailTrap 1131 presents the secure-airlock objective but genuine entry into
+`free1` / entity 1408 does not complete `Note_2_2`, classify it as a campaign
+objective-metadata feature gap. `TrapEmail` presentation or downstream
+traversal alone must not be used to waive the missing quest transition.
 
 ## Required non-walk mechanics — engine watch-points
 
@@ -111,7 +193,7 @@ Pure walk + frob does **NOT** finish this level. Each of these is required and
 is a potential feature-gap finding for the play-through loop — test them
 honestly (report a blocker rather than teleporting past):
 
-1. **Ladder climbing** (steps 3, 19) — ladders have `PropPhysAttr.climbable: 27`.
+1. **Ladder climbing** (steps 3, 20) — ladders have `PropPhysAttr.climbable: 27`.
    Flat (desktop-style) climbing is implemented as of 2026-07: push toward the
    ladder to ascend, look down + push to descend. Known gaps: entering a
    descent from the top lip is untested (the grip needs horizontal overlap),

--- a/.claude/skills/play-through/walkthroughs/medsci2.md
+++ b/.claude/skills/play-through/walkthroughs/medsci2.md
@@ -1,0 +1,274 @@
+# Walkthrough — medsci2 (Medical / Crew round trip to MedSci R&D)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+**genuine MedSci2 excursion required by the MedSci1 campaign**, cross-checked
+against retail walkthroughs and the entities, containment links, key regions,
+quest bits, and transitions in `medsci2.mis` and `medsci1.mis`.
+
+This is not a movement script. Observe and react, but do not count entering
+`medsci2`, visiting Watts' empty office, or returning through a bulkhead as
+completion. The excursion's purpose is to acquire the Crew card, use it to enter
+Crew Quarters, loot the R&D card from Watts' desk, carry it back into MedSci1,
+and use it to reach the actual Dr. Watts and learn code **12451** in fiction.
+
+## Important map correction
+
+Retail guides often describe Medical, Crew, and R&D as one continuous Deck 2
+route. The port splits that route between two mission files:
+
+- **`medsci2.mis`** contains Medical, Biopsy, Crew Quarters, Watts' office, and
+  the R&D access card.
+- **`medsci1.mis`** contains the R&D sector, the physical Dr. Watts encounter,
+  Watts' audio logs, and the maintenance conduit keypad that accepts 12451.
+
+Therefore, the physical Watts encounter is **not** a MedSci2 entity. A tester
+searching `medsci2` for Watts, or claiming to have received 12451 merely by
+reaching his office, is on the wrong map / has not completed the objective.
+
+Mission object ids below are stable only within the named `.mis` file. Runtime
+entity ids are not stable; discover entities by name and `template_id` each run.
+Positions are mission `PropPosition` coordinates and are route anchors, not
+authorization to teleport.
+
+## Valid campaign start
+
+Start from the advancing `medsci1` campaign after the second power-cell puzzle:
+the dead cell from Medical reception has been charged, inserted into Aux Power,
+and the **north Medical bulkhead** has been opened normally. Enter through its
+button at about `(43.9, 0.0, -76.4)`, transitioning to **`medsci2` loc 100**.
+
+A fresh direct launch of `medsci2.mis` can inspect entities, but does not prove:
+
+- that the power-cell / bulkhead gate worked;
+- that inventory and quest state survived the first transition;
+- that the acquired cards survive the return transition; or
+- that the full MedSci1 → MedSci2 → MedSci1 objective loop is playable.
+
+Do not use `/v1/player/give`, raw teleport, direct transition, injected quest
+bits, or entity messages in place of the in-world interactions below.
+
+## Mission topology and transitions
+
+The expected campaign route makes a loop rather than simply touching MedSci2:
+
+| leg | real interaction | mission object / position | result |
+| --- | --- | --- | --- |
+| MedSci1 → Medical | powered north bulkhead button | `medsci1` id 1009 @ about (43.9, 0.0, −76.4) | `medsci2`, loc 100 |
+| Medical → Crew | Crew card reader | `medsci2` id 681 @ (41.6, 0.0, −70.9), or opposite-side reader id 1277 | opens Security Door id 1635 |
+| Crew → MedSci1 | southern return bulkhead button | `medsci2` id 470 @ (28.1, 0.0, −20.4) | `medsci1`, loc 300, near the R&D approach |
+| alternate backtrack | northern return bulkhead button | `medsci2` id 463 @ (26.5, 0.0, −76.4) | `medsci1`, loc 100 |
+| MedSci1 → R&D | R&D card reader | `medsci1` id 1464 @ (−2.4, 0.2, 9.7), or opposite-side reader id 1576 | opens Security Door id 425 and awards the linked objective XP |
+
+The southern return is the retail-style continuation after Crew and places the
+player on the useful side of the MedSci1 loop. The northern button is a valid
+way back if the player deliberately backtracks, but returning without the R&D
+card is not progress.
+
+## Required items and objective evidence
+
+### 1. Crew card — Grassi / Biopsy corpse
+
+- `medsci2` mission object **1904**, `Crew Card`, parent template **−532**
+- contained by MS Male Corpse **id 105** at
+  **(−16.1, −6.6, −112.7)**
+- key region **8**
+- quest bit **`grassicard`** is set to raw `1` (`incomplete`) when frobbed
+
+From the upper Medical rooms, reach the lower Biopsy area by the real ladder
+stack around **(−13.8, −3.6, −116.0)**. Frob the corpse, inspect its container
+MFD, and click the Crew Card. It is contained loot and never legitimately lies
+on the floor at the card's authored coordinates.
+
+The card must then be used at a region-8 reader. Reader id 681 SwitchLinks both
+the Crew Security Door and EmailTrap id 536, so a genuine use opens the blast
+door and advances the accompanying objective communication.
+
+### 2. R&D card — Watts' Crew-quarters desk
+
+- `medsci2` mission object **772**, `R and D Card`, parent template **−533**
+- contained by Desk #2 **id 503** at **(39.9, −5.7, 34.5)**
+- key region **4**
+- quest bit **`RDGrab`** is set to raw `1` (`incomplete`) when frobbed
+- the same desk also contains the optional MFD Game Player
+
+Proceed through Crew Quarters to the office marked by Dr. Watts sign id 422 at
+about **(42.5, −4.3, 41.9)**. Watts himself is not here. Frob the desk and click
+the R&D Card in its container panel.
+
+There are no region-4 R&D readers in `medsci2`; mission data contains only the
+region-8 Crew readers. This is deliberate evidence that the R&D card must be
+carried back to `medsci1`.
+
+### 3. Watts and the 12451 log — after returning to MedSci1
+
+- Dr. Watts is `medsci1` mission object **734** at
+  **(−18.5, −4.6, 30.2)**
+- the posed / invulnerable Watts entity contains audio logs ids 251 and 252
+- log **id 251** has `PropLog { deck: 2, log: 14 }` and carries quest-bit
+  metadata named **`wattsy`**
+- the shipped `LEVEL02.STR` transcript explicitly conveys conduit code
+  **12451**
+
+Use the carried R&D card at one of the MedSci1 region-4 readers, pass through
+the now-open R&D door, and traverse the sector to Watts. Reach and frob the
+physical character; his loot MFD must open. Click the deck-2 log-14 disc and
+read its transcript through the game UI. A valid run records deck 2 / log 14 in
+`player.collected_logs`, shows **12451** to the player, and advances the
+mission's campaign-objective chain: `wattsy=incomplete` (raw marker bit 1),
+`Note_2_6=complete`, and `Note_2_7=incomplete` (the newly active note containing
+12451).
+
+Knowing 12451 from this guide, a source file, or a previous run is not objective
+coverage. Nor is a visible transcript alone sufficient if the campaign remains
+stuck on “get the code from Dr. Watts.” The campaign requires both a working
+in-fiction conveyance path and the authored objective advancement.
+
+## Ordered objective snapshots
+
+Capture `/v1/quests` at each boundary; do not infer progression from doors or
+text alone:
+
+| genuine boundary | expected objective evidence |
+| --- | --- |
+| Crew Card clicked in Grassi's corpse | `grassicard=incomplete` (raw 1), then `Note_2_9=complete` |
+| R&D Card clicked in Watts' Crew-office desk | `RDGrab=incomplete` (raw 1), then `Note_2_5=complete` |
+| return to MedSci1, use the R&D card, physically reach Watts | `Note_2_3=complete`; `Note_2_6` remains the active “get the code” objective |
+| click Watts' deck-2/log-14 disc | deck 2 / log 14 collected, `wattsy=incomplete` (raw 1), `Note_2_6=complete`, `Note_2_7=incomplete` |
+| later accept 12451 at MedSci1 keypad 809 | `Note_2_7=complete` |
+
+The first two marker-to-note transitions are explicit `FrobQB` /
+Simple-QB-trigger chains in `medsci2.mis`. The Watts chain is authored in
+`medsci1.mis`: Simple QB Trigger id 1284 watches `wattsy` and SwitchLinks QB
+setters for `Note_2_6=complete` and `Note_2_7=incomplete`.
+
+## Critical path
+
+### Phase A — enter Medical and find Grassi
+
+1. From the real MedSci1 frontier, charge and install the second power cell,
+   frob the powered north bulkhead button, and verify the mission becomes
+   `medsci2` at loc 100 with carried state intact.
+2. Explore the Medical / Biopsy route using bounded movement. Handle hybrids,
+   cameras, and other threats through normal combat or sensible avoidance.
+3. Descend the Biopsy ladder near `(−13.8, −3.6, −116.0)` to the lower floor.
+   Do not raw-teleport to the corpse.
+4. Frob MS Male Corpse id 105 and click the contained Crew Card. Confirm the
+   player acquired key region 8 and `grassicard` appeared.
+5. Climb / traverse back out of the lower Biopsy area by normal movement.
+
+### Phase B — use Crew access and search Watts' office
+
+6. Reach the Crew entrance around `(39.2, 0.5, −69.7)`. Use the actual Crew
+   card reader and allow Security Door id 1635 to open before crossing it.
+7. Traverse Crew Quarters rather than jumping to its far end. Treat its
+   enemies, doors, lower-level changes, and container interactions as gameplay
+   coverage.
+8. Find Watts' marked office and frob Desk #2 id 503. Click the contained
+   **R and D Card** and confirm key region 4 plus `RDGrab`.
+9. Walk back to the southern Medical / Science bulkhead and frob return button
+   id 470. Verify transition to `medsci1` loc 300 without losing the R&D card,
+   Crew card, inventory, health, or quest bits.
+
+### Phase C — finish the cross-map objective in MedSci1 R&D
+
+10. Walk to R&D reader id 1464 or 1576 and use the carried region-4 card. Wait
+    for Security Door id 425 to open, then cross it normally.
+11. Traverse R&D to Dr. Watts id 734 at `(−18.5, −4.6, 30.2)`. Frob Watts and
+    verify his loot panel contains both audio logs.
+12. Click audio log id 251 (deck 2 / log 14) and open/read its transcript in the
+    log UI. Confirm the visible text conveys **12451** and the collected-log
+    state persists. Inspect `/v1/quests`: `wattsy` must appear, `Note_2_6` must
+    become complete, and `Note_2_7` must become the active incomplete note. A
+    readable transcript without this transition is a campaign blocker, not a
+    completed objective.
+13. Only then return to the maintenance conduit keypad in MedSci1 and enter
+    12451 as part of the enclosing `medsci1` walkthrough.
+
+## Acceptance checklist — what counts as genuine play
+
+A MedSci2 round-trip pass is valid only if the session evidence shows all of:
+
+- Entry through the powered MedSci1 north bulkhead from campaign state, not a
+  fresh direct MedSci2 launch used as end-to-end proof.
+- Bounded traversal to the lower Biopsy area and back, including the ladder;
+  no raw teleport bridging the vertical gate.
+- Grassi's corpse container opened and Crew Card id 1904 clicked through the
+  loot MFD; region 8 and `grassicard` recorded.
+- The real Crew reader used, Security Door id 1635 opened, and the player
+  physically crossed into Crew Quarters.
+- Watts' office reached through Crew; Desk id 503 opened and R&D Card id 772
+  clicked through the loot MFD; region 4 and `RDGrab` recorded.
+- A real return-bulkhead interaction and MedSci2 → MedSci1 transition, with
+  both cards and quest state preserved across the mission boundary.
+- The R&D card used at a region-4 reader in MedSci1 and R&D Door id 425 crossed.
+- The physical Watts entity reached and frobbed; deck-2 log 14 taken from his
+  loot panel, recorded in `player.collected_logs`, and its in-game transcript
+  visibly read as containing 12451.
+- The same real log acquisition setting `wattsy` and driving
+  `Note_2_6=complete` → `Note_2_7=incomplete`; visible text or collected-log
+  state alone cannot substitute for campaign progression.
+- Critical-route threats handled with player movement/combat/avoidance, not
+  debug `Damage`, `TurnOn`, or direct-transition messages.
+
+The following are specifically **insufficient**: touching both mission files,
+opening either return bulkhead without the R&D card, giving either card through
+the debug API, injecting `grassicard` / `RDGrab` / `wattsy`, using the R&D card
+without first opening Crew legitimately, typing 12451 from walkthrough
+knowledge, or reading `LEVEL02.STR` outside the game instead of acquiring
+Watts' disc. A visible 12451 transcript while `wattsy` is absent or
+`Note_2_6` / `Note_2_7` remain unchanged is also insufficient.
+
+## Engine watch-points for triage
+
+1. **Contained-card acquisition combines two scripts.** Crew and R&D cards use
+   `KeyCardScript` to acquire their key region and `FrobQB` to set their quest
+   bit / destroy the world entity. Verify both effects happen after a container
+   click. A disappearing card without the matching region or quest bit is a
+   real `[gameplay]` bug.
+2. **The cross-mission boundary is the core test.** Region-4 access and
+   `RDGrab` must survive MedSci2 → MedSci1. Do not work around a lost card by
+   giving another one or manually opening Door 425.
+3. **Watts' loot/log reader has a likely integration edge.** The current
+   `creature-loot.e2e.test.ts` proves that Watts opens a loot panel and that
+   clicking log 14 records it. It then teleports to the contained disc's own
+   authored position before reopening the reader because the disc retains that
+   position and the reader's walk-away check can close when the player stands
+   at Watts. A genuine playtest must not use that workaround. If clicking the
+   disc at Watts cannot leave/open a readable transcript containing 12451,
+   classify it as a `[gameplay]` bug in the objective's conveyance path.
+4. **Watts is intentionally posed and invulnerable.** Do not attack or
+   debug-damage him. The required interaction is frob → container MFD → log.
+5. **The current log script does not apply `wattsy`: campaign-blocking feature
+   gap.** Log id 251 carries `PropQuestBitName("wattsy")`, and mission trigger
+   1284 depends on that marker to complete `Note_2_6` and activate `Note_2_7`.
+   The port's `MediaGui` / `CollectLog` path currently records the log, resolves
+   its strings, plays audio, and fires SwitchLinks, but does not consume the
+   quest-bit metadata. If real acquisition therefore leaves `wattsy` absent and
+   `Note_2_6` / `Note_2_7` unchanged, classify it as a campaign-blocking
+   `[gameplay]` **feature gap**. Do not bless a visible-transcript-only pass,
+   inject the marker, or type 12451 to play past it.
+6. **Traversal is coverage.** The Biopsy ladder, Crew reader/door, desk loot
+   UI, southern bulkhead, R&D reader/door, and Watts container/log UI are all
+   required gates. Stop and report the first failed real interaction rather
+   than warping past it.
+
+## Sources
+
+- [SShock2.com full walkthrough, Deck 2](https://www.sshock2.com/ss2walk/) —
+  Biopsy corpse, Crew card, Watts' office, R&D card, Watts, and 12451 route.
+- [GameFAQs guide by DC](https://gamefaqs.gamespot.com/pc/185706-system-shock-2/faqs/7173) —
+  independent Medical → Crew → R&D ordering and Watts location.
+- [GameFAQs guide by garkimasera](https://gamefaqs.gamespot.com/pc/185706-system-shock-2/faqs/27508) —
+  R&D-card desk, Watts logs, 12451, and return to the maintenance conduit.
+- [GameBanshee Medical](https://www.gamebanshee.com/systemshock2/walkthrough/medscimedical.php)
+  and [Science](https://www.gamebanshee.com/systemshock2/walkthrough/medsciscience.php) —
+  split-area confirmation of the Crew-office card and Watts encounter.
+- Local `cargo dq entities medsci2.mis ...` and
+  `cargo dq entities medsci1.mis ...` inspection (2026-07-23) — containment,
+  positions, key regions, card-reader SwitchLinks, transitions, Watts, and logs.
+- `Data/res/strings/LEVEL02.STR` (`LogText14`),
+  `tools/shock2-sdk/test/creature-loot.e2e.test.ts`,
+  `tools/shock2-sdk/test/log-reader.e2e.test.ts`,
+  `shock2vr/src/scripts/internal_keycard_script.rs`, and
+  `shock2vr/src/scripts/frob_qb.rs` — current code conveyance, persistence, and
+  interaction watch-points.

--- a/.claude/skills/play-through/walkthroughs/ops.md
+++ b/.claude/skills/play-through/walkthroughs/ops.md
@@ -1,0 +1,615 @@
+# Walkthrough — ops1 / ops2 / ops3 / ops4 (Operations, deck 4: the SHODAN reveal + the three Sim Units)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+**story-critical Operations path**, cross-checked against public retail
+walkthroughs and then verified against `ops1.mis` … `ops4.mis` entity data with
+`cargo dq`. Reaching a bulkhead or riding an elevator is *not* completion:
+Operations is complete only after the player has taken the SHODAN reveal in
+Polito's office and reprogrammed all three Simulation Units with their three
+override chips, through the real in-world objects.
+
+This is not a movement script. Observe and react, traverse with bounded
+movement, fight or evade, and use the anchors below to identify the intended
+objective rather than teleporting between coordinates.
+
+**Positions and positive IDs below are mission-file object identities** from
+`cargo dq`. Runtime entity IDs are assigned per launch and are **not stable** —
+resolve entities anew each run by name and by the stable `template_id`, and
+never hardcode a runtime entity ID.
+
+## What the four Ops missions actually are
+
+Operations is one deck split into four map sections. The shipped mission files
+map 1:1 onto the sectors the public walkthroughs call Ops A–D:
+
+| File | Sector | What it is | Size |
+| --- | --- | --- | --- |
+| `ops2.mis` | **Ops B** | **The hub and the deck's real entry point.** Main lobby off the main elevator, XERXES core/crates, bio-reconstruction, Systems Administration + conference room, Crew Quarters blocks, Chemical Store Room, upgrade lounge. All three outbound bulkheads live here. | 1005 objects |
+| `ops1.mis` | **Ops A** | **Dr. Polito's office — the SHODAN reveal.** A tiny, one-way, cutscene-only leaf: SHODAN screen wall, force-door FX, egg/grub cutscene props, four "Rumbler" set pieces, one corridor. | 225 objects |
+| `ops3.mis` | **Ops C** | Data Storage, lounges/upgrade rooms, Mess Hall + galley/cold storage, radiation-leak corridor, Operations Offices — **Sim Unit 1 (Quantum)**, both Crystal Shards, Chip C's carrier. | 863 objects |
+| `ops4.mis` | **Ops D** | Power Ops / Power Administration, System Operations, Fluid Ops, Barracks + firing range + Brig, the armory keypad, Security stations, Command Center / Ops Override — **Sim Unit 2 (Linear)** and **Sim Unit 3 (Interpolated)**, Chip B's carrier. | 771 objects |
+
+`ops1.mis` being tiny and cutscene-shaped is confirmed by its contents: SHODAN
+screen tiles (`SHODAN_Screen_TL/TM/TR/BL/BM/BR`), `CutSceneNine`,
+`EggsandGrubsControl` + `FirstEgg` (`CS9_EggsandGrubs` / `GrubEgg` scripts),
+`MasterForceField` routing five `force door fx`, `Rumbler1..4` with
+`RumblerLoc1..4`, `Polito_Sign` ×2, and a single `Bulk_On_Button`.
+
+Note for map cross-reference: sshock2.com ships `map_ops2/3/4.html` but
+`map_ops1.html` is a "no map available" placeholder — the retail game has no
+automap for sector A either. The walkthroughs' "Operations deck" prose therefore
+maps onto four `.mis` files, not one.
+
+## Arrival, the ops2 hub, and the connector graph
+
+Operations is entered from the **main inter-deck elevator**, which is the only
+inter-deck bridge in this port. `shock2vr/src/scripts/gui/elevator.rs`'s
+`ELEVATOR_STOPS` list is `["eng1.mis", "medsci1.mis", "hydro2.mis",
+"ops2.mis", "rec1.mis"]`, so deck 4 "Operations" loads **`ops2.mis`**, and the
+prior campaign observed it arriving at **loc 22**.
+
+`ops2` has four `Level Start Marker`s for the bulkhead locs plus a cluster of
+four loc-22 markers (ids 560, 1019, 1020, 1021, 1022, all `PropStartLoc(22)`
+around (17.2…20.0, −8.1…−8.2, −1.4…−4.0)) — the elevator car floor.
+
+| Purpose | Stable mission object | Position | Destination |
+| --- | --- | --- | --- |
+| **Main elevator panel (ops2 hub)** | `Master Elevator Button` **537** (`S$ElevatorButton`) | (19.99, −8.10, −1.41) | Opens the five-deck elevator MFD; arrival loc for the deck is **22** |
+| ops2 → **ops1** (Polito's office) | `Bulk_On_Button` **361** → hidden changer **1001** | (16.60, −7.90, 4.30) | `ops1`, loc **100** |
+| ops1 → ops2 | `Bulk_On_Button` **285** | (19.40, −7.90, 8.50) | `ops2`, loc **100** |
+| ops2 → **ops3** | `Bulk_On_Button` **185** → gated changer **992** | (31.50, −7.90, 17.80) | `ops3`, loc **200** |
+| ops3 → ops2 | `Bulk_On_Button` **742** | (27.20, −7.90, 25.80) | `ops2`, loc **200** |
+| ops2 → **ops4** | `Bulk_On_Button` **404** → gated changer **999** | (52.90, −7.90, −8.20) | `ops4`, loc **300** |
+| ops4 → ops2 | `Bulk_On_Button` **556** | (49.60, −7.90, −20.50) | `ops2`, loc **300** |
+| ops2 → **ops3 (second, far bulkhead)** | `Bulk_On_Button` **409** | (59.00, −7.90, 142.70) | `ops3`, loc **400** |
+| ops3 → ops2 (far) | `Bulk_On_Button` **927** | (63.40, −7.90, 146.90) | `ops2`, loc **400** |
+
+Matching arrival markers: ops1 loc 100 = (16.60, −7.90, 4.30) [object 72];
+ops2 loc 100 = (19.40, −7.90, 8.50) [365], loc 200 = (35.70, −7.90, 15.00)
+[420], loc 300 = (47.80, −7.90, −6.90) [433], loc 400 = (61.80, −7.90, 146.90)
+[443]; ops3 loc 200 = (23.00, −7.90, 28.60) [921], loc 400 = (60.60, −7.90,
+142.70) [735]; ops4 loc 300 = (54.70, −7.90, −21.80) [340].
+
+**ops1 is a leaf hanging off ops2, and ops3/ops4 are gated.** This is the single
+most important structural fact on this deck, and it is authored in the data, not
+inferred:
+
+- The three ops2 buttons the player actually touches (185, 361, 404) carry a
+  **mission-level `PropScripts { scripts: ["BaseButton"], inherits: false }`**
+  that *overrides* the `Bulk_On_Button` template's `LevelChangeButton`. They do
+  not change level themselves. Co-located with each is a hidden second object
+  (992, 1001, 999) that keeps `LevelChangeButton` and carries the real
+  `PropDestLevel` / `PropDestLoc`.
+- Button **361** (→ ops1) SwitchLinks **straight** to changer 1001. It works
+  from the moment the player arrives.
+- Button **185** (→ ops3) links to `QB Filter` **995** and `Anti-QB Trigger`
+  **993**; button **404** (→ ops4) links to `QB Filter` **998** and `Anti-QB
+  Trigger` **997**. Both filters are keyed on the quest bit **`ShodanRoom`**,
+  and only then fire changers 992 / 999. The Anti-QB triggers have **no
+  outgoing links at all** — before `ShodanRoom` is set, pressing those bulkhead
+  buttons does *nothing*.
+- Conversely, `Simple QB Trigger` **1003** (`ShodanRoom`, at (12.94, −7.90,
+  4.23)) fires **`KillBulk1` 1002**, a `TrapDestroy` aimed at changer **1001**.
+  Once the reveal has happened, **the way back into Polito's office is
+  destroyed**. Sector A is one-way and one-time.
+
+So the visit order is forced: **elevator → ops2 hub → ops1 (reveal) → back to
+ops2 → then ops3 and ops4 in either order.**
+
+## Ops A (`ops1`) — the SHODAN reveal, and everything it unlocks
+
+Route: arrive at (16.60, −7.90, 4.30) and walk in −x along the corridor.
+
+| Object | Position | What it does |
+| --- | --- | --- |
+| `New Tripwire` **80** | (1.20, −8.80, 6.40) | fires `Ops Crew` 79 (scripted crew set piece) |
+| `New Tripwire` **277** | (−9.16, −7.40, 6.40) | → `QB Filter` **278** (`ShodanRoom`) → `EmailTrap` **279** |
+| **`New Tripwire` 204 — the reveal trigger** | (−13.73, −7.89, 6.22) | → `CutSceneNine` 135, `Marker` 12, and four QB sets |
+| `QB Set` **114** | (−1.76, −8.60, −14.50) | sets **`ShodanRoom` = INCOMPLETE** (i.e. the bit becomes set) |
+| `QB Set` **264** | (2.71, −11.25, 11.07) | **`Note_2_1` = COMPLETE** (MedSci's "reach Deck 4") |
+| `QB Set` **296** | (2.71, −11.25, 13.07) | **`Note_1_14` = COMPLETE** (Engineering's next-deck directive) |
+| `QB Set` **297** | (2.71, −11.25, 15.07) | **`Note_3_4` = COMPLETE** ("Get to Deck 4 to meet Dr. Polito") |
+| `EmailTrap` **279** | (−4.14, −7.40, 5.55) | `PropLog { deck: 4, email: 1 }` — SHODAN's **"Fix the Sim Units"** — and sets **`Note_4_2` = INCOMPLETE** ("Reprogram the three Sim Units") |
+
+Note the ordering the geometry implies: 277 (x ≈ −9.2) is crossed *before* 204
+(x ≈ −13.7) on the way in, so its `ShodanRoom` filter fails and no email fires;
+the cutscene at 204 sets the bit; **on the way back out** 277 fires again, this
+time passing the filter, and delivers the "Fix the Sim Units" email plus the
+`Note_4_2` objective. A session that never walks back out of the office will
+never receive the deck's headline objective.
+
+Also present: `MasterForceField` 200 (`TrapRouter`) driving five `force door fx`
+at (−2.14, −6.88, 25.21); `EggsandGrubsControl` 145 (`CS9_EggsandGrubs`) at
+(−8.12, −7.02, 25.20) driving `FirstEgg` 139 (`GrubEgg`, at (−30.70, −7.10,
+41.93)); `SlowDoorControl` 205 / `FastDoorControl` 209 near (−3.5, −6.0,
+−16.4) driving the wall/floor/roof "Dummy Door" panels of the reveal set;
+`Rumbler1..4` (191, 196, 197, 198) with `RumblerLoc1..4`; `Airlock Door 1/2`
+(130, 261, 265, 267); `SafeTeleportLoc` 199.
+
+## The genuine objective chain (ordered, with the in-world gate for each)
+
+Retail objective strings (`Data/res/strings/NOTES.STR`) for deck 4:
+
+- `Note_4_1` — "Find the passcode for the MedSci2 sub armory."
+- `Note_4_2` — **"Reprogram the three Sim Units."**
+- `Note_4_3` — "Go to the Command Deck."
+- `Note_4_4` — "Go to the Recreation Deck"
+- `Note_4_5` — "Malick has booby-trapped Sim Unit 3."
+- `Note_4_6` — "Weapons lockup code is 13433."
+- `Note_4_8` — "Create a data access channel from the Command Center."
+- `Note_4_9` — "Go to the Engine Core on the Engineering Deck."
+
+| Order | Where | Required authored progression | Driven by |
+| --- | --- | --- | --- |
+| 1 | ops2 → ops1 | Enter Polito's office; the reveal cutscene fires; `ShodanRoom` is set and `Note_2_1` / `Note_3_4` / `Note_1_14` complete | tripwire 204 → QB sets 114, 264, 296, 297 |
+| 2 | ops1 (on the way out) | SHODAN's "Fix the Sim Units" email arrives and **`Note_4_2` becomes active** | tripwire 277 → filter 278 → `EmailTrap` 279 |
+| 3 | ops2 hub | The ops3 and ops4 bulkhead buttons now actually work | filters 995 / 998 gated on `ShodanRoom` |
+| 4 | ops2 (Systems Administration) | Kill **`Red Assassin` 254** and loot **Chip A** (Quantum, object 554) from its body | `Contains` link 254 → 554; Chip A also SwitchLinks `Experience Trap` 1089 |
+| 5 | ops3 (Data Storage) | Kill/loot **`Docile` 125** for **Chip C** (Interpolated, object 840) | `Contains` link 125 → 840; XP trap 1348 |
+| 6 | ops4 (near the Command Center) | Kill **`Red Assassin` 436** and loot **Chip B** (Linear, object 438) | `Contains` link 436 → 438; XP trap 844 |
+| 7 | ops3 (Operations Offices) | Use Chip A on **`SimComp_1` 810** → **`Comp1`** set | `ObjConsumeButton`, `PropConsumeType("Chip A")` |
+| 8 | ops4 | Use Chip B on **`SimComp_2` 437** → **`Comp2`** set | `PropConsumeType("Chip B")` |
+| 9 | ops4 (Power Ops lower) | Use Chip C on **`SimComp_3` 444** → **`Comp3`** set | `PropConsumeType("Chip C")` |
+| 10 | whichever unit is last | The three-way QB filter chain passes → **`Reprogram`** set, **`Note_4_2` = COMPLETE**, XP award, and SHODAN's follow-up email | see below |
+
+Each Sim Unit fires the *same* three-stage `Comp1 → Comp2 → Comp3` filter chain
+so that the completion happens at whichever unit is used last:
+
+- ops3 `SimComp_1` 810 → `QB Set Comp 1` **1368** (`Comp1`) + `Trigger Delay`
+  1369 → `QB Filter Comp 1` **1370** → **1371** (`Comp2`) → **1372** (`Comp3`)
+  → `Gone To Rec` 1374 / `Not Gone 2 Rec` 1373 / `QB Set Reprogram` **1376**
+  (`Reprogram`) / `Experience Trap` 1375 / `QB Set` **1377** (`Note_4_2` =
+  COMPLETE).
+- ops4 `SimComp_2` 437 → `QB Set Comp 2` **811** + delay 812 → filters 813
+  (`Comp1`) → 814 (`Comp2`) → **815** (`Comp3`) → `QB Gone To Rec A` 816
+  (`transmit`) / `Not Gone 2 Rec A` 817 / `QB Set` **483** (`Note_4_2` =
+  COMPLETE) / `Reprogram A` 835 / XP 836.
+- ops4 `SimComp_3` 444 → `QB Set Comp 3` **448** + delay 449 → filters 450
+  (`Comp1`) → 451 (`Comp2`) → **452** (`Comp3`) → `Gone 2 Rec B` 453 / `Not
+  Gone To Rec B` 454 / `QB Set` **484** (`Note_4_2` = COMPLETE) / `Reprogram B`
+  839 / XP 840.
+
+The `Gone To Rec` / `Not Gone 2 Rec` pair (keyed on the **`transmit`** bit,
+which Recreation sets) selects which SHODAN email plays: `Email 9` /
+`Email 9A` / `Email 9B` ("I am pleased… proceed to the Recreation deck") if
+Rec has *not* been done, or `Email 8` / `Email 8A` / `Email 8B` ("Xerxes is
+diminished… I have activated the primary elevator shaft. Take it to deck 6") if
+it has. **Ops and Rec are order-independent by design**; a playtest must not
+treat "SHODAN said go to Rec" as the only valid outcome.
+
+Each unit also fires an `Anti-QB Trigger` on **`Reprogram`** (ops3 685, ops4
+1213 and 1215) → an `Experience Trap`, i.e. the per-unit cyber-module award is
+paid only while the deck is not yet finished.
+
+Additional deck-4 side objectives, all data-verified:
+
+| Objective | Activated by | Completed by |
+| --- | --- | --- |
+| `Note_4_6` "Weapons lockup code is 13433" | ops3 **audio log 1349** (deck 4 / log 7, Bronson "No shirkers") at (18.27, −9.57, 34.02), which carries `PropQuestBitName("Note_4_6")` = INCOMPLETE | ops4 `Keypad` **333** (`PropKeypadCode(13433)`) at (60.59, −8.83, −59.55) → `QB Set` **489** (`Note_4_6` = COMPLETE) + `Ops Door` 331/332 |
+| `Note_4_5` "Malick has booby-trapped Sim Unit 3" | ops4 **audio log 465** (deck 4 / log 6, Malick "Sim Unit 3") at (6.32, −9.57, −10.03), `PropQuestBitName("Note_4_5")` = INCOMPLETE | ops4 `New Tripwire` **602** at (−9.89, −15.18, −9.49), immediately at `SimComp_3` (−9.94, −14.80, −7.51). It fires `QB Set` **828** (`Note_4_5` = COMPLETE) *and* opens `Grate` 391 / `Grate` 753 and an **`AI Signal Trap` 612** — that is the spider ambush |
+| `Note_4_1` "Find the passcode for the MedSci2 sub armory" | (set on an earlier deck) | ops4 **audio log 525** (deck 4 / log 11, Bronson "MedSci armory code" = **98383**) at (73.06, −15.57, −117.60), `PropQuestBitName("Note_4_1")` = COMPLETE |
+| `Note_5_2` "Return to the Ops Deck" | ops2 `QB Filter` **128** → `QB Set` **180**, at (22.00, −8.80, 0.00) near the elevator | ops2 `QB Filter` **1101** (`transmit`) → `QB Set` **1103** (`Note_5_2` = COMPLETE) at (23.83, −8.00, −2.61) |
+
+### The late-game second visit (NOT part of the first pass)
+
+`ops4` also contains the **Ops Override / Command Center** step the player
+returns for *after* the Command deck:
+
+- `Ops Comp` **460** at (75.35, −8.37, −116.45) → `OpsCom QB Set` **532**
+  (`opscom`), `Message Trap` 502, `EmailTrap` 569, `QB Set` **388**
+  (**`Note_6_3` = COMPLETE**, "Go to the Command Center on the Ops Deck") and
+  `QB Set` **879** (**`Note_4_9` = INCOMPLETE**, "Go to the Engine Core on the
+  Engineering Deck").
+  `Ops Comp` 460 inherits from a **`COM Plot Items`** template branch, i.e. it
+  is authored as a *Command-deck* plot item that happens to live on Ops.
+- `Card slot` **493** at (68.36, −9.14, −113.15) (`TweqLockedButton`,
+  `PropLocked(true)`), fed by `New Tripwire` 458 — the card-locked approach to
+  that room. The card that opens it is the **Ops Override access card**, which
+  the public walkthroughs place on the **Command deck bridge**, not on Ops. No
+  object in `ops1..ops4` was found holding it.
+
+A first-visit playtest should **not** be expected to reach `Note_6_3` /
+`Note_4_9`. If it does, something has mis-gated.
+
+## Items, codes, and where they are genuinely learned
+
+| Item / code | Genuine source (data-verified) | Purpose |
+| --- | --- | --- |
+| **Chip A** — "A Quantum Simulation chip" (obj 554, ops2) | **inside `Red Assassin` 254** (tmpl −3398, model `redass`) at (63.39, −8.02, 10.98) | Consumed by `SimComp_1` (ops3) |
+| **Chip B** — "A Linear Simulation chip" (obj 438, ops4) | **inside `Red Assassin` 436** (tmpl −3398) at (67.48, −9.02, −103.53) | Consumed by `SimComp_2` (ops4) |
+| **Chip C** — "An Interpolated Simulation chip" (obj 840, ops3) | **inside `Docile` 125** (tmpl −1073, also model `redass`) at (17.18, −8.02, 47.95) | Consumed by `SimComp_3` (ops4) |
+
+All three carriers also SwitchLink a **`Ninja Run Trap`** (ops2 388, ops3 807,
+ops4 445) — they are authored to flee, so a session that lets one escape may
+strand a chip.
+| **Code 13433** (weapons lockup) | ops3 audio log **1349** (deck 4 / log 7, Bronson "No shirkers"): *"I've changed the weapons lockup code to 13433."* | ops4 `Keypad` **333** |
+| **Code 98383** (MedSci2 sub-armory) | ops4 audio log **525** (deck 4 / log 11, Bronson) | A *back-reference* to MedSci; nothing on Ops uses it |
+| **Security Card** (obj **707**, ops4) | world-placed at (49.66, −12.34, −132.19) — **not** in a container | `Card slot` **619** (50.67, −11.74, −133.36) → `Sec Station Door` 571; `Card slot` **620** (54.24, −11.74, −139.45) → `Sec Station Door` 617. Both also have `Unlock Trap` 479 as an alternate opener |
+| **Crystal Shard** ×2 (ops3 **748**, **773**) | 748 at (25.24, −9.48, 49.35); 773 at (37.02, −9.48, 143.87). Both `weapontype crystalshard`, `PropObjState(Unresearched)`, `ResearchableScript` | First Exotic melee weapon; SHODAN's email "An elegant weapon" is the authored brief |
+
+Contained items (chips, the logs marked "inside" below) must be looted through
+the corpse/container MFD. Finding editor coordinates and calling a debug
+give/teleport is not genuine play.
+
+## Audio logs on the deck (`PropLog { deck: 4, log: N }`)
+
+| Log | Speaker / subject | Object | Where |
+| --- | --- | --- | --- |
+| 1 | **Yount**, "Sim Units" | ops2 **67** | (23.60, −7.93, 10.08) — arrival crates by the XERXES core |
+| 16 | **Malick**, "My red friends" — the three override chips are with three cyborgs "dressed in red" | ops2 **544** | (45.90, −9.57, 4.54) |
+| 10 | **Siddons**, "Civil war" | ops2 **545**, **inside `Desk #2` 383** | (69.93, −8.85, −5.70) |
+| 15 | **Korenchkin**, "Everything old…" — the assassin-cyborg programme | ops2 **547**, **inside `Locker` 546** | (54.99, −14.80, 58.04) |
+| 18 | **Siddons**, "Bad feeling…" | ops2 **1090** | (65.23, −9.97, 121.44) |
+| 19 | **Suarez**, "Let's do it" | ops2 **1093** | (68.44, −9.57, 24.13) |
+| 32 | Chemical manifest (Ops storage closet 089) | ops2 **1125** | (58.57, −8.57, 137.93) |
+| 5 | **Malick**, "Good bye" — Bronson kills him mid-log | ops2 **1495** | (47.71, −15.97, 69.47) |
+| 2 | **Malick**, "Bronson" — he hacked two Sim Units | ops3 **825**, **inside `Desk #2` 151** | (23.99, −8.88, 144.85) |
+| 3 | **Bronson**, "Sabotage" | ops3 **826** | (24.27, −5.57, 78.95) |
+| 9 | **Wood**, "Crystal gifts" — the two shards | ops3 **828** | (−4.37, −7.95, 52.89) |
+| **7** | **Bronson**, "No shirkers" — **code 13433** | ops3 **1349** | (18.27, −9.57, 34.02); carries `Note_4_6` |
+| 20 | **Bayliss**, "What gives?" | ops3 **1357** | (−16.47, −12.77, 128.82) |
+| 4 | **Bronson**, "Martial law" | ops4 **464**, **inside `Locker` 364** | (74.06, −8.80, −59.62) |
+| **6** | **Malick**, "Sim Unit 3" — the booby trap | ops4 **465** | (6.32, −9.57, −10.03); carries `Note_4_5` |
+| 8 | **Diego**, "Cease and desist" | ops4 **466**, **inside `Desk #2` 378** | (47.33, −13.28, −138.35) |
+| **11** | **Bronson**, "MedSci armory code" — **98383** | ops4 **525** | (73.06, −15.57, −117.60); carries `Note_4_1` |
+| 12 | **Bronson**, "Resist" — her death log | ops4 **526**, **inside `OPS Female Corpse` 146** | (47.93, −11.78, −140.96) |
+| 14 | **Suarez**, "Don't stop" | ops4 **827** | (34.74, −10.77, −51.04) |
+| 13 | **Delacroix**, "The main elevator" — reprogram the Sim Units *and* power the deck-5 transmitter so the bridge elevator works | ops4 **831** | (75.47, −10.77, −102.49) |
+
+Log text lives in `Data/res/strings/LEVEL04.STR` (`LogTextN`), SHODAN's deck-4
+emails in the same file (`EmailTextN`). Emails present in the data: 1 "Fix the
+Sim Units", 3 "Destroy my enemies", 6 "An elegant weapon" (crystal shard), 7
+"Our alliance" (approaching a Sim Unit), 8 "The cancer" (all units done, Rec
+already finished → deck 6), 9 "I am pleased" (all units done → Recreation), 10
+"Well done" (second visit; self-destruct code 94834).
+
+## Known-tricky mechanics on this deck
+
+- **`ObjConsumeButton` chip insertion.** The Sim Units are *not* hacked. Each is
+  an `ObjConsumeButton` with a `PropConsumeType` naming its chip — the same
+  mechanism as Engineering's Card Box / Systems Monitoring Unit, which is known
+  to work. A Sim Unit that accepts the wrong chip, or that fires its QB chain
+  without consuming an item, is a bug.
+- **Overridden button scripts.** Because ops2's visible bulkhead buttons are
+  demoted to `BaseButton` and the level change lives on a hidden co-located
+  object, a port that resolves scripts from the template instead of the
+  entity-level `PropScripts { inherits: false }` would let the player skip the
+  `ShodanRoom` gate entirely. Verify that pressing 185 / 404 **before** the
+  reveal does nothing.
+- **`TrapDestroy` on the return path.** `KillBulk1` 1002 destroys the ops1
+  changer after the reveal. If the port does not implement `TrapDestroy`, ops1
+  will stay reachable — cosmetically harmless, but it means the one-way design
+  is not being exercised.
+- **Replicators.** ops2 `RepBase` **461** / `RepScreen` **462**; ops3 `RepBase`
+  **118** / `RepScreen` **127** and `RepBase` **693** / `RepScreen` **694**. The
+  walkthroughs describe one Ops replicator as hackable for a Recycler; hacking +
+  nanite economy landed recently (#545, #546), so these are worth exercising.
+- **Security computers and cameras.** `Security Comp` in ops2 (133, 346), ops3
+  (266, 271, 346) and ops4 (268, 273, 291, 346); `Security Camera` in ops2 (339,
+  350) and ops3 (268, 273, 350). Camera alert → security level is a real
+  mechanic on this deck.
+- **Turrets.** ops3 `Slug Turret` **1167**, **1170** (`S$turret`); ops4 `Laser
+  Turret` **281**, **284**, **328**, **335**, **700**. ops3 also has a `Laser
+  Turret Corpse` 1260 (a destroyed prop, not a threat).
+- **Sim Unit 3 spider trap.** Malick's log 6 warns of it. `New Tripwire` **602**
+  at (−9.89, −15.18, −9.49) opens `Grate` 391 and `Grate` 753 and fires
+  `AI Signal Trap` **612** — the arachnid ambush — alongside completing
+  `Note_4_5`. If the grates or the AI signal do not fire, the encounter is
+  silently missing even though the objective ticks.
+- **Egg/grub set pieces.** `Floor Egg Tripwire` (template −1651) is used heavily
+  in all three big sectors (ops2 ×8, ops3 ×17, ops4 ×5). ops2 also has a
+  `Midwife` (**352**) and `Midwife Shot` (1505) — the egg-guarding set piece.
+- **Grav lifts.** ops4 `Lift 1` **572** (`BaseElevator`) at (45.30, −10.94,
+  −106.00) with call buttons **599** (45.80, −13.75, −104.64) and **600**
+  (45.80, −8.97, −104.64) on `Elevator Path` 594/595; ops3 `Cargo Lift` **1035**
+  on paths 1039/1040 with buttons 1041/1042. Vertical traversal is required.
+- **Crystal Shard research.** Both shards ship `PropObjState(Unresearched)` and
+  `ResearchableScript`; researching needs the right chemical, so the Ops
+  chemical store (log 32's manifest) is thematically linked.
+
+## What a valid playtest must cover, per mission
+
+### ops2 (Ops B) — the hub
+1. Arrival at loc 22 via the real elevator MFD (or a documented frontier
+   resume), with inventory and quest state from deck 3 preserved.
+2. `Note_3_4` ("Get to Deck 4 to meet Dr. Polito") is active on arrival.
+3. Physically walk the hub, loot the arrival crates, take **Yount log 1**
+   (object 67).
+4. Confirm bulkhead buttons **185** and **404** are inert before the reveal.
+5. Frob **361** and transition to ops1 loc 100.
+6. After the reveal: return, confirm 185 and 404 now work, and confirm 361 has
+   been destroyed / no longer transitions.
+7. Reach Systems Administration, kill `Red Assassin` **254**, and loot **Chip
+   A** through its container MFD.
+8. Optional but valuable: replicator 461, `Midwife` 352 + its eggs, the
+   hackable crates 1540/1541.
+
+### ops1 (Ops A) — the reveal
+1. Walk in from (16.60, −7.90, 4.30) under normal movement.
+2. Trip **204**: the cutscene set (SHODAN screens, force doors, rumblers) plays.
+3. `ShodanRoom` becomes set; `Note_2_1`, `Note_3_4`, `Note_1_14` complete.
+4. Walk back out past **277**: SHODAN's "Fix the Sim Units" email arrives and
+   **`Note_4_2` becomes active**. This must be observed, not assumed.
+5. Return through `Bulk_On_Button` **285** to ops2 loc 100.
+
+### ops3 (Ops C)
+1. Enter via ops2 button 185 → loc 200 (or 409 → loc 400).
+2. Data Storage: deal with `Docile` **125** and loot **Chip C** (840).
+3. Take at least one **Crystal Shard** (748 or 773) and observe SHODAN's
+   "elegant weapon" email; research it if the research path is being exercised.
+4. Loot and **read** Bronson log **1349** so **`Note_4_6` (13433)** becomes
+   active *before* ops4's keypad is used.
+5. Reach `SimComp_1` **810** at (39.55, −8.40, 166.31), insert **Chip A**,
+   confirm the chip is consumed, `Comp1` is set, and the unit's model swaps
+   (`simqua` → `simover`).
+6. Survive the Slug Turrets 1167/1170 and the Mess Hall / cold-storage set
+   pieces.
+7. Return via 742 (loc 200) or 927 (loc 400) with state intact.
+
+### ops4 (Ops D)
+1. Enter via ops2 button 404 → loc 300.
+2. Enter **13433** on `Keypad` **333** using the code learned from log 1349;
+   `Note_4_6` completes and `Ops Door` 331/332 open.
+3. Kill `Red Assassin` **436** and loot **Chip B** (438).
+4. Loot Bronson log **525** → `Note_4_1` completes (98383 for MedSci2).
+5. Loot Malick log **465** → `Note_4_5` becomes active (Sim Unit 3 trap).
+6. Take the **Security Card** 707 and use it at `Card slot` **619** and/or
+   **620** to open the Sec Station doors.
+7. Insert **Chip B** into `SimComp_2` **437** at (49.41, −12.40, −141.12)
+   → `Comp2`.
+8. Ride grav lift 572 / descend to Power Ops lower, trip the Sim Unit 3 trap
+   (`Note_4_5` completes), and insert **Chip C** into `SimComp_3` **444** at
+   (−9.94, −14.80, −7.51) → `Comp3`.
+9. On the third unit: **`Reprogram` is set, `Note_4_2` completes**, the XP trap
+   pays out, and one of the SHODAN emails 8/9 arrives depending on `transmit`.
+10. Return to ops2 and take the main elevator onward (Recreation if `transmit`
+    is unset).
+
+## Genuine-play acceptance gate for Operations
+
+Mark Operations **PASS** only if one reviewed session (or a frontier-backed
+sequence) demonstrates all of:
+
+1. Real elevator arrival into `ops2` loc 22 with deck-3 state preserved.
+2. Physical traversal to the ops1 bulkhead and a real transition to `ops1`.
+3. The reveal cutscene fires from tripwire 204 under normal movement, and
+   `ShodanRoom` / `Note_2_1` / `Note_3_4` / `Note_1_14` change accordingly.
+4. Walking back out delivers SHODAN's "Fix the Sim Units" email and activates
+   **`Note_4_2`**.
+5. The ops3 / ops4 bulkheads are demonstrated inert *before* and working
+   *after* the reveal.
+6. All three chips are **looted from their carriers' containers** (254, 125,
+   436) — not spawned, not found on the floor.
+7. Each chip is inserted into its **matching** Sim Unit through the real
+   `ObjConsumeButton` frob, and each sets its `Comp` bit and swaps the unit's
+   model.
+8. `Note_4_2` completes only on the third insertion, with `Reprogram` set and
+   an XP award, and exactly one of email 8 / email 9 delivered.
+9. Bronson log 1349 is looted and its transcript visibly shows **13433**
+   *before* keypad 333 is used; `Note_4_6` activates then completes.
+10. Malick log 465 is looted (`Note_4_5` active) before the Sim Unit 3 trap, and
+    `Note_4_5` completes at the trap.
+11. Bronson log 525 is looted and `Note_4_1` completes.
+12. At least one cross-bulkhead round trip (ops2 ↔ ops3 and ops2 ↔ ops4) with
+    chips and quest state surviving both transitions.
+13. Screenshots and `data.json` steps show each interaction and its consequence.
+    Quest-state assertions alone are not proof.
+
+A session that reaches ops3/ops4, kills things, and reports "deck explored" but
+never inserts a chip is **shallow, not a pass**. Typing 13433 without reading
+log 1349, debug-giving a chip, injecting a quest bit, or messaging a Sim Unit
+directly all invalidate the run.
+
+## Engine watch-points / likely feature-gap boundaries
+
+- **Log quest-bit metadata is the same suspected blocker as Engineering.** Three
+  Ops logs carry `PropQuestBitName` directly on the disc entity — ops3 **1349**
+  (`Note_4_6`), ops4 **465** (`Note_4_5`), ops4 **525** (`Note_4_1`) — with no
+  SwitchLink fallback. Engineering's walkthrough already records that the
+  current `MediaGui` / `CollectLog` path displays a log but does not apply that
+  metadata. If reading these logs does not move their objectives, report the
+  objective-integration failure; do not inject the bit.
+- **The `ShodanRoom` gate depends on entity-level script override.** See
+  "Known-tricky mechanics". This is the highest-value thing to test first,
+  because if it fails open the whole deck's intended order collapses, and if it
+  fails closed the deck is unfinishable.
+- **`TrapDestroy` (KillBulk1 1002)** — verify whether it is implemented.
+- **`CS9_EggsandGrubs` / `TransluceInOutHolo` / `TrapRouter` / `TrapDelay`** —
+  the ops1 reveal set piece is built from these. A missing script here would
+  most likely present as "the cutscene did not play" while the QB sets still
+  fire from tripwire 204 (they are separate SwitchLinks), so **check the quest
+  bits separately from the visuals**.
+- **`ObjConsumeButton` with three distinct `PropConsumeType` values** — the
+  Engineering path exercised exactly one. Wrong-chip acceptance is a plausible
+  regression.
+- **`turret` and `Security Comp` scripts** are exercised heavily here.
+- ops3 and ops4 both contain `Regen_Hologram` objects (ops2 1082, ops3 855,
+  ops4 1082) — the bio-reconstruction machines. Death/respawn behavior on this
+  deck depends on them.
+
+## Data-vs-walkthrough discrepancies (trust the data)
+
+1. **"Only bulkhead 41 is open at first."** The public walkthroughs state this
+   as a soft observation. The data shows *why*: `ShodanRoom` filters 995/998.
+   Confirmed, with a mechanism.
+2. **"Hack the three Simulation Units."** Several summaries say the units are
+   *hacked*. In the shipped data they are `ObjConsumeButton`s that **consume a
+   chip** (`PropConsumeType "Chip A" / "Chip B" / "Chip C"`). There is no
+   hacking script on `SimComp_1/2/3`. The lore word is "reprogram"; the
+   mechanic is insertion.
+3. **Sim Unit distribution.** The SS2 wiki's objectives section claims one unit
+   per sector B/C/D. The data agrees with the walkthroughs instead: **none in
+   ops2**, **one in ops3** (`SimComp_1`), **two in ops4** (`SimComp_2`,
+   `SimComp_3`).
+4. **"No keycard is found on Operations."** The data contradicts this: `ops4`
+   contains a world-placed **`Security Card` 707** at (49.66, −12.34, −132.19)
+   which drives `Card slot` 619/620 → the two `Sec Station Door`s. What is
+   *absent* from ops1..ops4 is the **Ops Override access card** for `Card slot`
+   493 — consistent with it being a Command-deck item.
+5. **Third assassin's name.** Chip C's carrier is object **125 named `Docile`**
+   on template **−1073**, not the `Red Assassin` template (−3398) used by ops2
+   254 / ops4 436 — but it uses the same `redass` model and the same
+   `Ninja Run Trap` wiring, so it *is* the third red assassin. Consistent with
+   the walkthroughs' note that the Data Storage assassin is usually killed by
+   the exploding-barrel trap rather than fought. **A playtest must search by
+   both names and by both template ids**, not just "Red Assassin".
+6. **Crystal shard count and placement.** Wood's log says "two gifts"; the data
+   has exactly two shards and **both are in `ops3`** (sector C), matching
+   sshock2 and contradicting any account that places one elsewhere on the deck.
+7. **`map_ops1.html` is a placeholder.** Sector A has no retail automap, which
+   is consistent with `ops1.mis` being a 225-object cutscene room.
+8. **No living named NPC on this deck.** Bronson, Malick, Wood, Delacroix and
+   Korenchkin appear only as logs and corpses in the data. Do not expect a
+   Miranda Wood encounter.
+9. **Second visit is out of scope for a first pass.** `Note_6_3` / `Note_4_9` /
+   the `opscom` bit hang off `Ops Comp` 460 behind a card slot with no card on
+   this deck.
+
+## Open questions
+
+- **Where is `Note_4_2` re-activated if a player somehow reaches ops3/ops4 first?**
+  Only `EmailTrap` 279 in `ops1` sets it. If a save resumes mid-deck without it,
+  the objective list will be wrong; a frontier resume should carry it.
+- **`Card slot` 493's SwitchLink target is `Ops Crew` 187, not a door.** That is
+  unusual; the actual Command-Center door wiring for the second visit was not
+  fully traced. Worth a follow-up `cargo dq` pass before anyone tests the
+  second visit.
+- **`Note_4_3`, `Note_4_4`, `Note_4_8`** ("Go to the Command Deck", "Go to the
+  Recreation Deck", "Create a data access channel from the Command Center") have
+  strings in `NOTES.STR` but **no `TrapQBSet` in ops1..ops4 was found setting
+  them**. They are presumably driven from `rec1`/`command1`. Do not treat their
+  absence on Ops as a bug.
+- Which of the three Ops replicators (ops2 461, ops3 118, ops3 693) is the
+  Recycler-hack one was not determined from the data.
+
+## Sources
+
+- Mission wiring: `cargo dq entities ops1.mis|ops2.mis|ops3.mis|ops4.mis …`
+  (2026-07-24), especially objects 72, 114, 204, 264, 277–279, 285, 296, 297
+  (ops1); 128, 185, 254, 352, 361, 404, 409, 461, 537, 554, 992, 995, 998,
+  999, 1001–1004, 1092, 1101, 1103 (ops2); 125, 685, 742, 810, 825–828, 840,
+  927, 1349, 1357, 1368–1377 (ops3); 333, 340, 436–438, 444, 448–456, 460,
+  464–466, 483, 484, 489, 493, 525, 526, 532, 556, 602, 619, 620, 707,
+  811–819, 827, 828, 831, 835, 839, 879 (ops4), plus their SwitchLinks,
+  `Contains` links and quest-bit traps.
+- Retail text: `Data/res/strings/LEVEL04.STR` (deck-4 SHODAN emails and audio
+  logs, including 13433 / 98383 / 94834) and `Data/res/strings/NOTES.STR`
+  (ordered `Note_4_*`, `Note_5_*`, `Note_6_*` objective strings).
+- Port behavior: `shock2vr/src/scripts/gui/elevator.rs` (`ELEVATOR_STOPS` —
+  deck 4 loads `ops2.mis`).
+- [sshock2.com full walkthrough](http://www.sshock2.com/ss2walk/) and its
+  sector maps [map_ops2](http://www.sshock2.com/ss2walk/map_ops2.html),
+  [map_ops3](http://www.sshock2.com/ss2walk/map_ops3.html),
+  [map_ops4](http://www.sshock2.com/ss2walk/map_ops4.html)
+  ([map_ops1](http://www.sshock2.com/ss2walk/map_ops1.html) is a "no map"
+  placeholder).
+- [portforward.com — Operations](https://portforward.com/games/walkthroughs/System-Shock-2/Operations.htm)
+  — screenshot-by-screenshot route.
+- [System Shock Wiki — Operations Deck](https://shodan.fandom.com/wiki/Operations_Deck),
+  plus its [Codes](https://shodan.fandom.com/wiki/Codes),
+  [Simulation Unit](https://shodan.fandom.com/wiki/Simulation_Unit),
+  [Crystal Shard](https://shodan.fandom.com/wiki/Crystal_Shard) and
+  [Malick](https://shodan.fandom.com/wiki/Malick) pages.
+- [Steam access-code guide](https://steamcommunity.com/sharedfiles/filedetails/?id=161214166).
+
+---
+
+## Campaign findings (verified in play, 2026-07)
+
+Recorded from five playtest sessions and their adversarial reviews. Everything
+below was confirmed by walking or by mission data, not inferred.
+
+### The verified ops4 route south
+
+Two sessions concluded ops4's south was unreachable. **It is not.** The jam at
+(53.5, −8.60, −27.6) is the **end of a lane, not the boundary of a region**.
+From the loc-300 arrival (54.7, −7.9, −21.8):
+
+```
+(54.5,-18) -> (50,-19) -> south lane x~53 to (52.8,-8.6,-27.6)
+then WEST along z=-27:  (48,-27) (44,-27) (40,-27) (36,-27)
+then the x~42-44 corridor SOUTH:
+  (42,-38) (42,-42) (42,-46)  [y drops to -9.0]
+  (43,-50) (50,-53) (54,-55) (58,-58) (60.5,-59)
+ends ~1.5u from Keypad 333 (60.59,-8.83,-59.55)
+```
+
+Two snags, both cleared by a **2-unit lateral offset** (not capsule bugs): the
+floor pipes at (36.6 / 37.2, −8.4, −34.0) and the x ≈ 44.6 RickPipes.
+
+### Navmesh queries are NOT a reachability oracle here
+
+`ops4` has **846 disconnected walk components** across 2204 cells. A
+`cargo bn path show` / `path component` query is confined to the arrival's own
+island **by construction**, so it will always "prove" the rest of the deck
+unreachable. That is a tautology, not evidence. Additional traps:
+
+- `bench path show` has **no `--bridges` flag` (only `path bench` does).
+- `path cell` matches in the **XZ plane only**, so it cannot distinguish the
+  Power Ops upper/lower floors.
+- Negative-leading coordinates are silently misparsed as flags (issue #571) —
+  always use `--from=` / `--to=` with an `=`.
+
+**The player is physics-driven, not navmesh-driven.** Decide reachability by
+walking; when a lane jams, strafe laterally 2–6u and retry before concluding
+anything is unreachable.
+
+### The grav-lift "trap room" is authored — and has an escape
+
+The force barrier at x = 35.70, z = −106.0 that seals the grav-lift pocket is
+**not a softlock**. `New Tripwire` **662** (`ENTER|ONCE|PLAYER`) fires
+`Teleport Trap` **656/657/660**, and `TrapTeleport` moves its switch-link
+targets — the Force Bars — to the trap position (the barrier sits exactly at
+trap 656's position; Force Bar 658's base position is (41.6, −0.4, −81.4)).
+
+The way out is inside the pocket: **`Junction Box` 685 (3 HP) → `Destroy Trap`
+664 → destroys Force Bars 545/658/659.** Shoot the junction box.
+
+### Objective activation vs completion are separately authored
+
+For every Ops objective, **activation and completion live on different objects**:
+
+| Objective | Activated by | Completed by |
+| --- | --- | --- |
+| `Note_4_2` | ops1 `EmailTrap` **279** (on the walk back out) | ops4 `QB Set` **483**, behind the three-comp AND gate |
+| `Note_4_6` | ops3 log **1349** (`PropQuestBitName`) | ops4 `QB Set` **489** (keypad 333) |
+| `Note_4_5` | — | ops4 `QB Set` **828** (tripwire 602) |
+
+Issue **#568** breaks only the *activation* half (log discs' quest bits are
+ignored), which is why an objective can be observed completing while never
+having been active. That is the bug, not authored behavior.
+
+### The Sim Unit AND gate
+
+`SimComp_3` **444** → **448** → `TriggerDelay` **449** → QB Filter `Comp 1`
+(**450**) → `Comp 2` (**451**) → `Comp 3` (**815**) → `QB Set` **483**
+(`Note_4_2` = COMPLETE) + **835** (`Reprogram`).
+
+It is **impossible** to set 483 without all three comps, so observing
+`Note_4_2` complete independently corroborates that all three units were
+genuinely reprogrammed.
+
+Chip → unit mapping and tweqs: `SimComp_1` **810** Chip A `simqua→simover` ·
+`SimComp_2` **437** Chip B `simlin→simover` · `SimComp_3` **444** Chip C
+`simint→simover`. `ObjConsumeButton` matches `PropConsumeType` against the
+item's `PropSymName` (case-insensitive) and destroys the item on consume.
+
+### Interaction paths that automation gets wrong
+
+- **World pickup is `right_hand.squeeze`** against the crosshair target, via
+  `FlatPlayerController::update` → `can_grab_item` → `pick_up`/`StoreItem`.
+  Injecting `{Frob}` can never pick anything up.
+- **Wield is a double-click** on a use-mode strip slot: two `pointer.pressed`
+  1→0 edges within **20 stepped frames** and 24 canvas px. A single click only
+  lifts the item to the drag cursor. There is deliberately no separate hand slot.
+- **Container loot** (chips, corpse items) must go through the container MFD.
+  **Never** `/v1/player/give` a container-held item — it permanently severs the
+  `Contains` link (issue #572) and destroys the loot path for every later run.
+
+### Known broken on this deck (open issues)
+
+`#569` world ammo has no colliders (varies per instance — `HE Clip` 752 gets one,
+identically-propertied clips do not) · `#573` **a save taken while a camera is
+red is permanently unloadable** · `#574` ladder segments without
+`PropPhysDimensions` get no collider, so ops4's Rick Ladders can't be gripped
+from the top · `#571` / `#572` tooling hazards above.

--- a/.claude/skills/play-through/walkthroughs/station.md
+++ b/.claude/skills/play-through/walkthroughs/station.md
@@ -1,0 +1,298 @@
+# Walkthrough — earth → station (recruitment and three training years)
+
+Context for the `playtest` agent and the `play-through` reviewer. This is the
+real character-generation path from the Ramsey Recruitment Center into the
+Von Braun campaign. The player must choose a service on `earth.mis`, walk the
+Wake Island / Station 74 training corridor three times, choose one of three
+authored assignments each year, and deploy naturally to `medsci1.mis`.
+
+This is not a coordinate script. Observe the signs, recruiter, year display,
+and three assignment exhibits; walk through the chosen service door and
+assignment lane. The coordinates and mission object IDs below are diagnostic
+anchors for review, not permission to teleport onto the outcome trigger.
+
+Positive IDs are stable mission-file object identities from `cargo dq`.
+Runtime entity IDs change on every load and must be rediscovered by name or
+`template_id`. Reloading `station.mis` after years 1 and 2 is an authored part
+of this sequence, so rediscover all runtime entities after each reload.
+
+## What this sequence must prove
+
+- Earth career selection works through a physical door crossing.
+- Exactly one of Marine, Navy, or OSA persists as the player's career.
+- Station arrives at its authored recruitment-deck spawn and stages the
+  matching service/year exhibit.
+- Three distinct assignment choices are visible each year and the chosen lane
+  grants the matching reward.
+- Years advance monotonically: no bits → `training_year_2` → `_3` → `_4`.
+- The first two assignments legitimately reload Station with the next year's
+  authored content. The third deploys to MedSci instead of looping a fourth
+  time.
+- Career, loadout, accumulated stats/skills/psi disciplines, and inventory
+  survive all transitions.
+
+## Earth handoff — choose a service in-world
+
+Finish or deliberately decline the optional Earth training rooms, then enter
+one of the three career doors on foot. The career-door tripwire centers below
+are useful for diagnosing the real `TrapNewTripwire → SwitchLink →
+ChooseService` wiring, but teleporting onto one is only a focused regression
+probe, not a genuine play-through.
+
+| Service | Earth tripwire center | Career bit | Station loadout |
+| --- | --- | --- | --- |
+| Marines | (−2.499, 24.0, 68.163) | `career_marine` | 45 max HP, 20 max psi |
+| Navy | (0.509, 24.0, 84.064) | `career_navy` | 35 max HP, 35 max psi |
+| OSA | (16.858, 24.0, 80.747) | `career_osa` | 30 max HP, 60 max psi, extra Kinetic Redirection / `PsiPull` |
+
+The Navy marker is mislabeled `SendToMarines` in the retail mission data, but
+its `P$Service=1` correctly means Navy. Judge the persisted quest bit and
+loadout, not that editor name.
+
+On the transition to `station.mis`, require:
+
+1. Exactly the selected `career_*` bit is `complete`; the other two remain
+   `unknown`.
+2. HP/psi match the table.
+3. `player.stats.granted_years` is empty and no `training_year_*` bit is
+   complete.
+4. The player is near the authored `Starting_Location` object 132,
+   (81.780, −3.600, 16.539), rather than the world origin.
+5. The appropriate first-year START root has run:
+   `START_01` Marines, `START_11` Navy, or `START_21` OSA.
+
+Recruiter staging is **year-specific, not career-specific**. In year 1, object
+881 (`MaleRec`) moves from below the map to about (15.6, −3.2, 10.4) for every
+career. That proves the shared `YEAR-1` presentation ran, but not which career
+root ran. Prove the career using the three matching assignment objects listed
+below. The editor markers `GO-MARINES`, `GO-NAVY`, and `GO-OSA` are inert.
+
+## Station layout and the honest route
+
+All three years reuse the same long recruitment corridor:
+
+1. Start on the recruit deck around x≈81.8.
+2. Follow the only forward public route toward decreasing x. Pass the
+   service-specific recruiter and year display. Do not bridge walls or jump to
+   the far end.
+   Exercise the real corridor doors: approach sensors 95 and 157 open doors
+   156 and 158; initial debrief sensor 766 opens door 153; sensor 173 opens
+   door 68.
+3. At x≈0, stop and inspect all three service/year assignment exhibits. The
+   START router moves the current three authored mission objects into these
+   positions:
+
+   | Tour index | Exhibit lane | Assignment trigger |
+   | --- | --- | --- |
+   | 0 | (0.012, −1.6, +8.0) | tripwire 741 at (−22.6, −5.6, +8.0) → marker 125 |
+   | 1 | (0.012, −1.6, 0.0) | tripwire 124 at (−22.6, −5.6, 0.0) → marker 126 |
+   | 2 | (0.012, −1.6, −8.0) | tripwire 745 at (−22.6, −5.6, −8.0) → marker 127 |
+
+4. Choose based on the visible assignment/reward, then walk through that same
+   lane. The final lane-door sensors 309/305/742 must first open doors
+   310/306/743 for the +8/center/−8 lanes; continue on foot until the
+   corresponding ENTER tripwire fires. The marker's `P$CharGenRo` value
+   (0/1/2) is the selected tour.
+5. After years 1 and 2, allow the normal `station.mis` transition to finish,
+   confirm the next year is staged, and walk the corridor again. After year 3,
+   require the real marker transition to `medsci1.mis`.
+
+Do not rely on left/right labels, which depend on approach and camera
+orientation. Match the visible assignment text to the +8, center, or −8 lane
+when reviewing telemetry.
+
+Use these stable mission-object IDs to prove that the correct three signs
+replaced the preceding year's set:
+
+| Career | Year 1 (+8 / 0 / −8) | Year 2 (+8 / 0 / −8) | Year 3 (+8 / 0 / −8) |
+| --- | --- | --- | --- |
+| Marines | 356 / 358 / 359 | 360 / 361 / 362 | 369 / 370 / 388 |
+| Navy | 389 / 390 / 395 | 396 / 397 / 398 | 399 / 400 / 401 |
+| OSA | 402 / 406 / 407 | 408 / 409 / 410 | 411 / 412 / 413 |
+
+## The three-year choice matrix
+
+`Mission1..27` in `Data/res/strings/CHARGEN.STR` are the retail assignment and
+debrief texts. The current runtime stores the following grants in
+`player.stats`. Tour 0/1/2 always corresponds to the +8/0/−8 lane above.
+
+### Marines
+
+| Year | Tour 0 / +8 | Tour 1 / center | Tour 2 / −8 |
+| --- | --- | --- | --- |
+| 1 (`START_01`) | Mission1, UNN Gallo: **+2 Strength** | Mission2, Io Survival School: **+2 Endurance** | Mission3, Guadacanal Station: **+2 Agility** |
+| 2 (`START_02`) | Mission4, UNN Antigua: **+1 Energy Weapons, +1 Cyber Affinity** | Mission5, Asteroid Belt: **+1 Heavy Weapons, +1 Cyber Affinity** | Mission6, Port MacArthur: **+2 Standard Weapons** |
+| 3 (`START_03`) | Mission7, UNN Home Office: **+1 Maintenance** | Mission8, Polidies Station: **+1 Modify** | Mission9, UNN Antigua: **+1 Repair** |
+
+Staging anchors for the Marine tour-0 path used by the current end-to-end test:
+after year 1, `Marines 4` object 360 must be at (0.012, −1.6, +8); after year
+2, `Marines 7` object 369 must occupy the same exhibit lane. The corresponding
+objects for the other lanes are equally valid choices.
+
+### Navy
+
+| Year | Tour 0 / +8 | Tour 1 / center | Tour 2 / −8 |
+| --- | --- | --- | --- |
+| 1 (`START_11`) | Mission10, UNN Lucille: **+1 Hack, +1 Strength** | Mission11, UNN Lucille: **+1 Repair, +1 Strength** | Mission12, UNN Lucille: **+1 Modify, +1 Strength** |
+| 2 (`START_12`) | Mission13, UNN Carfax: **+2 Cyber Affinity** | Mission14, UNN Pierce: **+1 Maintenance** | Mission15, LaVerne Tactical School: **+2 Standard Weapons** |
+| 3 (`START_13`) | Mission16, Marie Curie Research: **+1 Research** | Mission17, Io Survival Training: **+2 Endurance** | Mission18, Yamamoto Station: **+2 Agility** |
+
+### OSA
+
+| Year | Tour 0 / +8 | Tour 1 / center | Tour 2 / −8 |
+| --- | --- | --- | --- |
+| 1 (`START_21`) | Mission19, Shao Ling: **Cryokinesis + Psychogenic Cyber Affinity** | Mission20, Ru Nang: **Cryokinesis + Kinetic Redirection** | Mission21, Chu Lun: **Cryokinesis + Psycho-reflective Screen** |
+| 2 (`START_22`) | Mission22, OSA Central Core: **+2 Psionic Ability** | Mission23, Ki Luan: **+1 Research** | Mission24, Io Facility: **+2 Endurance** |
+| 3 (`START_23`) | Mission25: **+1 Strength, +1 Agility, +1 Cyber Affinity + Psychogenic Agility** | Mission26: same stats **+ Neuro-Reflex Dampening** | Mission27: same stats **+ Remote Electron Tampering** |
+
+The retail OSA year-1 text also says Tier Two psi disciplines are unlocked. The
+port currently records the named disciplines in `player.stats.psi_disciplines`
+but does not yet wire all training grants into the active psi-power system.
+Record that limitation separately; do not claim active-power behavior from the
+stored list alone.
+
+## Year-by-year state transitions
+
+### Year 1
+
+1. Confirm the service's year-1 START root, recruiter, `YEAR-1` display, and
+   three year-1 assignments are visibly staged.
+2. Record baseline `player.stats` before choosing.
+3. Walk from the spawn through the corridor and enter one chosen assignment
+   lane.
+4. The chosen reward applies once, `granted_years` becomes `[1]`, and exactly
+   `training_year_2` becomes complete.
+5. A transition back to `station.mis` is expected. It must activate the
+   selected service's year-2 root, not repeat year 1.
+
+### Year 2
+
+1. Confirm `START_02`, `START_12`, or `START_22`, the `YEAR-2` display, and
+   three different year-2 assignments. A stale recruiter/year-1 set is a
+   blocker even if the exit tripwires remain reachable.
+2. Walk the corridor again and enter the intended lane.
+3. Require the exact year-2 reward, `granted_years == [1, 2]`, and completed
+   bits `training_year_2` plus `training_year_3`.
+4. The second transition back to Station is also expected and must stage the
+   service's year-3 root.
+
+An optional persistence probe may save and reload here, then compare the whole
+character sheet byte-for-byte. This is not part of the retail narrative path,
+so label it as a save/load test rather than a fourth training transition.
+
+### Year 3 and deployment
+
+1. Confirm `START_03`, `START_13`, or `START_23`, the `YEAR-3` display, and
+   the three authored final-year assignments. The robot/dance presentation in
+   the retail sequence is useful visual evidence that year 3 staged correctly,
+   but the assignment objects and reward are authoritative.
+2. Walk the corridor a third time and enter the chosen lane.
+3. Require the exact year-3 reward, `granted_years == [1, 2, 3]`, and completed
+   bits `training_year_2`, `_3`, and `_4`. `training_year_1` is intentionally
+   never authored; the counter begins at year 1 and writes the next year.
+4. The same ChooseMission marker now follows its `PropDestLevel=MedSci1` and
+   `PropDestLoc=2502`. It must load `medsci1.mis` naturally.
+5. In MedSci, recheck the selected career bit, HP/psi loadout, full accumulated
+   character sheet, and finite player position. Then continue with the
+   MedSci walkthrough.
+
+A third reload into Station, a fourth walk down the corridor, repeated
+year-3 assignments, or rewards that apply twice indicates a progression loop
+and is a campaign blocker.
+
+## Genuine-play acceptance gate
+
+Mark this segment **PASS** only when one reviewed session demonstrates:
+
+1. A career door is approached and crossed on foot in Earth; no direct
+   `TurnOn`, transition API, or career-bit mutation.
+2. Station loads at object 132's authored spawn with exactly one career bit
+   and the correct branch loadout.
+3. The year-1 presentation stages its shared recruiter and year display, while
+   the selected career's START root stages all three matching assignment
+   exhibits.
+4. For each of three years, the player physically traverses from the spawn
+   area to x≈0, inspects the available assignments, and continues through the
+   selected matching lane to x≈−22.6. Meaningful movement steps and screenshots
+   must cover the corridor; a single player teleport does not.
+5. The first and second choices produce exactly two legitimate Station
+   reloads, with year-2 then year-3 content visibly replacing the prior year.
+6. Each chosen reward matches its career/year/tour matrix entry and is applied
+   only once. `granted_years` and `training_year_*` advance monotonically.
+7. The third choice naturally loads MedSci1, where career, loadout, and all
+   accumulated rewards persist.
+8. `data.json` records screenshots before each lane choice, the physical entry,
+   the resulting quest/stat delta, each reload's newly staged content, and the
+   final MedSci frontier.
+
+The campaign needs one coherent career path, not all three careers in a single
+session. Branch-focused follow-ups should repeat the full Earth enlistment and
+at least enough genuine Station traversal to validate Navy/OSA-specific
+staging and rewards.
+
+## What the current SDK tests do and do not prove
+
+`station-flow.e2e.test.ts` is a valuable regression net: it teleports onto the
+real Earth and Station tripwire volumes, thereby exercising genuine
+`TrapNewTripwire → SwitchLink → ChooseService/ChooseMission` script wiring. Its
+Marine tour-0 chain correctly checks:
+
+- START staging;
+- +2 Strength, then +1 Energy Weapons/+1 Cyber Affinity, then +1 Maintenance;
+- `[1] → [1,2] → [1,2,3]` reward persistence;
+- the two Station reloads, a mid-flow save/load, and final MedSci deployment;
+- all three career doors in independent fresh launches.
+
+It deliberately does **not** prove:
+
+- normal navigation from Earth's lobby to a career door;
+- the long Station corridor or collision/door traversal;
+- inspection or selection of tour 1 and tour 2 lanes;
+- a complete Navy or OSA three-year run;
+- that visible recruiter, year, and assignment presentation is correct beyond
+  the explicit staging anchors.
+
+The sibling `station-career*.e2e.test.ts` tests are even narrower: direct
+marker `TurnOn` or `transitionLevel()` calls validate state/persistence in
+isolation, not the player's path. Use these tests to diagnose failures, never
+as the acceptance evidence for this walkthrough.
+
+## Engine watch-points
+
+- A tripwire teleport can fire the same ENTER sensor as walking, so quest bits
+  alone cannot distinguish a shallow test from genuine traversal. Review the
+  movement history and screenshots.
+- Runtime entity IDs are invalid after every Station reload. Keeping one ID
+  across years can silently act on a different object.
+- The three assignment triggers are always physically present. Therefore an
+  advancing year bit does not prove the corresponding START router staged the
+  correct visible assignments.
+- Career HP/psi are reapplied from the persisted career bit on mission load.
+  Verify both the bit and the values; either one alone is incomplete evidence.
+- OSA's career loadout supplies active Kinetic Redirection, while OSA tour
+  disciplines are currently character-sheet storage. Keep those two mechanisms
+  distinct in findings.
+- Station is intentionally low-combat. Its meaningful mechanics are traversal,
+  trigger wiring, scripted staging, branching, reward application, repeated
+  level transitions, and persistence. Do not invent a combat requirement.
+
+## Sources
+
+- Retail data: `Data/res/strings/CHARGEN.STR` (`Mission1..27`, year labels, and
+  exact rewards).
+- Runtime tables/state machine: `shock2vr/src/career.rs`,
+  `shock2vr/src/player_stats.rs`, `shock2vr/src/scripts/choose_service.rs`, and
+  `shock2vr/src/scripts/choose_mission.rs`.
+- Mission wiring: `cargo dq entities earth.mis ...` and
+  `cargo dq entities station.mis ...` (2026-07-23), especially Station objects
+  124–127, 132, 741, 745, and START roots 917–926/950.
+- SDK characterization:
+  `tools/shock2-sdk/test/station-flow.e2e.test.ts`,
+  `station-career.e2e.test.ts`, and `station-career-attributes.e2e.test.ts`.
+- [Official System Shock 2 manual](https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/238210/manuals/System%20Shock%202%20-%20Manual.pdf?t=1742502733)
+  — recruitment facility, service branches, and career missions.
+- [SShock2 walkthrough](https://www.sshock2.com/ss2walk/) — Earth service
+  selection, three-door training years, and MedSci handoff.
+- [GameBanshee character creation](https://www.gamebanshee.com/systemshock2/character/charactercreation.php)
+  and [GameFAQs walkthrough](https://gamefaqs.gamespot.com/ps4/513865-system-shock-2-25th-anniversary-remaster/faqs/8959)
+  — branch assignments and reward cross-check.


### PR DESCRIPTION
## What

Adds the mission walkthroughs generated during the last play-through campaign, and expands `medsci1.md` with what that campaign uncovered.

New walkthroughs: `earth.md`, `station.md`, `medsci2.md`, `eng1.md`, `hydro.md`, `ops.md`.

`medsci1.md` updates:
- exact entity/mission ids for the Amanpour audio log carrying code **45100**
- corrected **12451** chain — Watts' deck-2/log-14 log is found on Watts in *medsci1* R&D after the medsci2 card round trip, not in medsci2
- "valid campaign start" rules (real Station handoff vs. a bare `--mission medsci1.mis` launch; no bridging a critical-path gate with teleport / `give` / quest mutation)
- ordered `/v1/quests` objective snapshots per critical-path beat, so a session can prove progression rather than assert it

## Why

These files are the ground truth the `play-through` skill reviews each session against. Without a walkthrough for a deck, the review step can't distinguish real progression from wandering. Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)