### PR TITLE
docs(play-through): keep campaign and fix branches current, and land PRs green

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -101,6 +101,23 @@ fix agent follows the repo's incremental, review, and negative-first-test
 discipline, opens a PR `Fixes #n`, and re-validates. Non-blockers: log them,
 keep playing past them.
 
+**Opening the PR is not the finish line — the fix agent watches it land green:**
+- `cargo fmt --check --all`. `format` is a separate, fast-failing CI job, and it
+  fails on changes that compile and test perfectly.
+- **Restack before finishing.** Fix agents branch off whatever `main` was when
+  they spawned; on a long run `main` moves underneath them (it may even have
+  refactored the very function being fixed). `git fetch origin && git rebase
+  origin/main`, resolve, then **re-run the tests** — a conflict resolution can
+  silently drop a test or revert half a hunk.
+- **Read `gh pr checks <N>`** after pushing, and fix what's red. A PR is done
+  when CI is green, not when the push succeeds.
+- **Widen the build check when touching shared types.** AGENTS.md's
+  `-p shock2vr -p desktop_runtime -p debug_runtime` skips `tools/`, which CI
+  builds — so a new variant on a `dark` enum breaks `dark_query`'s exhaustive
+  matches with a clean local check. For enum/trait changes, check every
+  non-Android package (`dark_viewer`, `dark_query`, `debug_command`,
+  `hitbox_analyzer`, `bench` too).
+
 ## 5. Replay & frontier
 
 Track the **frontier**: the furthest state reached. The robust, faithful way to

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -129,6 +129,25 @@ launch, since fixes rebuild the binary) resumes with `POST /v1/load
 only) and manual `transitionLevel`+`teleport` do not. Each iteration starts at
 the frontier and pushes further.
 
+**Rebase the campaign branch on `main` every iteration**, before the replay
+build. A campaign runs for many hours while `main` keeps moving, and a stale
+`fix_branch` makes the loop hunt ghosts: in the Engineering campaign a session
+hit a hard crash entering eng1 (`asset_cache` unwrapping `None` on a missing
+model, via an alert security camera's model swap), reported it as a Critical
+blocker, and burned the rest of the session on it — the fix had already landed
+upstream in #576. A stale branch also silently re-tests bugs that are already
+gone, and makes every fix PR conflict later. So each iteration:
+
+```
+git fetch origin && git merge origin/main   # or rebase; resolve, then re-run tests
+RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime
+cargo test -p shock2vr
+```
+
+If a session reports a crash or a hard blocker, **check whether it reproduces on
+current `main` before filing** — "already fixed upstream" is a real and common
+outcome, and filing it anyway wastes a reviewer's time.
+
 ## Report (aggregate, self-contained)
 
 Each `playtest` emits a `data.json` next to its screenshots. Render a session (or


### PR DESCRIPTION
Two process fixes to the `play-through` skill, both learned the hard way during the Engineering campaign that is currently running. No code changes — `SKILL.md` only.

## 1. Fix agents must land their PR green, not just open it

The skill told fix agents to open a PR and stop. Two of this campaign's three PRs were red on arrival:

- **#578** passed locally but failed CI's separate, fast-failing `format` job.
- **#581** added a `Link::Weapon` variant and failed `build` on **every** platform, because `AGENTS.md`'s documented validation command (`-p shock2vr -p desktop_runtime -p debug_runtime`) skips `tools/`, and `dark_query` matches on `Link` exhaustively. The agent had followed the documented command exactly and still shipped a red PR.

Both branches were also stale by the time their agent finished — in one case `main` had refactored the very function being fixed (`frob_qb.rs` moved to a shared `script_util::set_quest_bit_effect` helper), so the branch needed a real conflict resolution and a re-run of its tests, not just a push.

So the skill now says: `cargo fmt --check --all`, restack on `main` and **re-run the tests after resolving**, read `gh pr checks`, and widen the package list when touching a shared enum or trait.

## 2. Rebase the campaign branch on `main` every iteration

A campaign runs for many hours while `main` keeps moving, and the loop's `fix_branch` was only ever rebased by accident.

The concrete cost: a playtest session hit a hard crash entering eng1 — `asset_cache.rs` unwrapping `None` on a missing model, reached through an alert security camera's model swap — reported it as a **Critical** progress blocker, and spent the remainder of the session on it. That crash had already been fixed upstream in #576. I reproduced the panic on the stale branch, merged `main`, and confirmed the identical repro now transitions cleanly.

A stale campaign branch also silently re-tests bugs that are already gone, and guarantees every fix PR conflicts later.

The skill now prescribes a fetch + merge + re-validate at the start of each iteration, and adds a rule: **if a session reports a crash or hard blocker, check whether it reproduces on current `main` before filing** — "already fixed upstream" is a common outcome and filing it anyway wastes reviewer time.

---

Note: the campaign's mission walkthrough notes (`eng2.md`, `hydro1/2/3.md`) are deliberately **not** in this PR — #582 already adds `eng1.md` and `hydro.md`, so those need reconciling separately rather than being tangled into a process change.
