### PR TITLE
fix: implement TrapUnlock so locked buttons can actually be unlocked

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3713,6 +3713,13 @@ impl MissionCore {
                         self.world.add_component(entity_id, PropObjState(state));
                     }
                 }
+                Effect::SetLocked { entity_id, locked } => {
+                    crate::scripts::script_util::set_entity_locked(
+                        &mut self.world,
+                        entity_id,
+                        locked,
+                    );
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -433,6 +433,15 @@ pub enum Effect {
         state: ObjectState,
     },
 
+    /// Persistently set Dark's `P$Locked` on one live object. This is the
+    /// lock state `script_util::is_entity_locked` consults, so a button or
+    /// door unlocked by a `TrapUnlock` becomes usable. Because Locked is a
+    /// registered Dark property, mission save/load serializes the result.
+    SetLocked {
+        entity_id: EntityId,
+        locked: bool,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -433,10 +433,9 @@ pub enum Effect {
         state: ObjectState,
     },
 
-    /// Persistently set Dark's `P$Locked` on one live object. This is the
-    /// lock state `script_util::is_entity_locked` consults, so a button or
-    /// door unlocked by a `TrapUnlock` becomes usable. Because Locked is a
-    /// registered Dark property, mission save/load serializes the result.
+    /// Persistently set Dark's `P$Locked` on one live object - the lock state
+    /// `script_util::is_entity_locked` consults. Emitted by the in-world lock
+    /// traps; see `scripts::trap_lock`.
     SetLocked {
         entity_id: EntityId,
         locked: bool,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -45,6 +45,7 @@ mod trap_destroyer;
 mod trap_email;
 mod trap_exp_once;
 mod trap_inverter;
+mod trap_lock;
 mod trap_new_tripwire;
 mod trap_off_filter;
 mod trap_on_filter;
@@ -131,6 +132,7 @@ use self::{
     trap_email::TrapEmail,
     trap_exp_once::TrapEXPOnce,
     trap_inverter::TrapInverter,
+    trap_lock::TrapLock,
     trap_new_tripwire::TrapNewTripwire,
     trap_on_filter::TrapOffFilter,
     trap_qb_filter::TrapQBFilter,
@@ -455,7 +457,11 @@ impl ScriptWorld {
             "transluceinoutprop" => Box::new(NoopScript::new()),
 
             // KEYCARD stuff
-            "trapunlock" => Box::new(NoopScript::new()),
+            // Lock traps: triggering sets the lock state of the objects the
+            // trap controls via SwitchLinks (eng1's Unlock Trap hands out the
+            // elevator / grav-lift call buttons this way).
+            "traplock" => Box::new(TrapLock::lock()),
+            "trapunlock" => Box::new(TrapLock::unlock()),
 
             "createsound" => Box::new(CreateSound::new()),
 

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -45,7 +45,6 @@ mod trap_destroyer;
 mod trap_email;
 mod trap_exp_once;
 mod trap_inverter;
-mod trap_lock;
 mod trap_new_tripwire;
 mod trap_off_filter;
 mod trap_on_filter;
@@ -61,6 +60,7 @@ mod trap_teleport;
 mod trap_teleport_player;
 mod trap_trip_level;
 mod trap_tweq;
+mod trap_unlock;
 mod trigger_collide;
 mod trigger_multi;
 mod tweq_depressable;
@@ -132,7 +132,6 @@ use self::{
     trap_email::TrapEmail,
     trap_exp_once::TrapEXPOnce,
     trap_inverter::TrapInverter,
-    trap_lock::TrapLock,
     trap_new_tripwire::TrapNewTripwire,
     trap_on_filter::TrapOffFilter,
     trap_qb_filter::TrapQBFilter,
@@ -146,6 +145,7 @@ use self::{
     trap_teleport_player::TrapTeleportPlayer,
     trap_trip_level::TrapTripLevel,
     trap_tweq::TrapTweq,
+    trap_unlock::TrapUnlock,
     trigger_collide::TriggerCollide,
     trigger_multi::TriggerMulti,
     tweq_depressable::TweqDepressable,
@@ -457,11 +457,10 @@ impl ScriptWorld {
             "transluceinoutprop" => Box::new(NoopScript::new()),
 
             // KEYCARD stuff
-            // Lock traps: triggering sets the lock state of the objects the
-            // trap controls via SwitchLinks (eng1's Unlock Trap hands out the
-            // elevator / grav-lift call buttons this way).
-            "traplock" => Box::new(TrapLock::lock()),
-            "trapunlock" => Box::new(TrapLock::unlock()),
+            // The unlock trap sets the lock state of the objects it controls
+            // via SwitchLinks (eng1's Unlock Trap hands out the elevator /
+            // grav-lift call buttons this way).
+            "trapunlock" => Box::new(TrapUnlock::new()),
 
             "createsound" => Box::new(CreateSound::new()),
 

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -54,6 +54,21 @@ pub fn is_entity_locked(world: &World, entity_id: EntityId) -> bool {
     }
 }
 
+/// Set the lock state of one live entity, writing Dark's own `P$Locked`
+/// property. That is the same state [`is_entity_locked`] reads, and because
+/// Locked is a registered Dark property, mission save/load persists it with
+/// the rest. This is the application of `Effect::SetLocked` - the in-world
+/// lock traps (`TrapLock` / `TrapUnlock`) are its only source.
+pub fn set_entity_locked(world: &mut World, entity_id: EntityId, locked: bool) {
+    let is_alive = world
+        .borrow::<shipyard::EntitiesView>()
+        .map(|entities| entities.is_alive(entity_id))
+        .unwrap_or(false);
+    if is_alive {
+        world.add_component(entity_id, dark::properties::PropLocked(locked));
+    }
+}
+
 /// Whether a translating door is nearer its closed endpoint than its open
 /// one (i.e. worth opening). `None` for entities that aren't translating
 /// doors.

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -55,10 +55,9 @@ pub fn is_entity_locked(world: &World, entity_id: EntityId) -> bool {
 }
 
 /// Set the lock state of one live entity, writing Dark's own `P$Locked`
-/// property. That is the same state [`is_entity_locked`] reads, and because
-/// Locked is a registered Dark property, mission save/load persists it with
-/// the rest. This is the application of `Effect::SetLocked` - the in-world
-/// lock traps (`TrapLock` / `TrapUnlock`) are its only source.
+/// property - the same state [`is_entity_locked`] reads. This is the
+/// application of `Effect::SetLocked`; see `scripts::trap_lock` for why the
+/// lock lives in the property rather than in runtime state.
 pub fn set_entity_locked(world: &mut World, entity_id: EntityId, locked: bool) {
     let is_alive = world
         .borrow::<shipyard::EntitiesView>()

--- a/shock2vr/src/scripts/trap_lock.rs
+++ b/shock2vr/src/scripts/trap_lock.rs
@@ -18,10 +18,16 @@ use super::{Effect, MessagePayload, Script, script_util::get_all_switch_links};
 /// so it is the same state every lock check already reads and mission
 /// save/load persists it with the rest of the registered properties.
 ///
-/// Only the trigger (`TurnOn`) acts; `TurnOff` is left alone rather than
-/// guessing at an inverse, matching the trigger-only traps already here
-/// (`TrapSlayer`, `TrapQBSet`). Levels that want the inverse wire a
-/// `TrapInverter`.
+/// Only the trigger (`TurnOn`) acts; `TurnOff` is ignored, matching the
+/// trigger-only traps already here (`TrapSlayer`, `TrapQBSet`). The missions
+/// convert an off-edge into a trigger themselves - `TrapInverter` and the
+/// on/off filters exist for exactly that - so a trap acting on both edges
+/// would make those relays meaningless. Shipped data does route an off-edge
+/// into an unlock trap (rec2's Inverter 760 also feeds Unlock Trap 148, which
+/// a plain button drives directly too), and reading that as "re-lock" would
+/// risk sealing a progression button; ignoring it can only ever leave
+/// something unlocked that the original re-locked, which cannot soft-lock a
+/// player.
 pub struct TrapLock {
     locked: bool,
 }
@@ -94,18 +100,13 @@ mod tests {
         })
     }
 
-    /// Apply what the trap emitted, exactly as `Mission::handle_effects` does.
+    /// Apply what the trap emitted, exactly as `Mission::handle_effects` does:
+    /// the shared flatten, then the shared `SetLocked` application.
     fn apply(world: &mut World, effect: Effect) {
-        for (entity_id, locked) in lock_changes(effect) {
-            set_entity_locked(world, entity_id, locked);
-        }
-    }
-
-    fn lock_changes(effect: Effect) -> Vec<(EntityId, bool)> {
-        match effect {
-            Effect::SetLocked { entity_id, locked } => vec![(entity_id, locked)],
-            Effect::Combined { effects } => effects.into_iter().flat_map(lock_changes).collect(),
-            _ => vec![],
+        for effect in Effect::flatten(vec![effect]) {
+            if let Effect::SetLocked { entity_id, locked } = effect {
+                set_entity_locked(world, entity_id, locked);
+            }
         }
     }
 

--- a/shock2vr/src/scripts/trap_lock.rs
+++ b/shock2vr/src/scripts/trap_lock.rs
@@ -1,0 +1,218 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::get_all_switch_links};
+
+/// Dark's in-world lock traps (`TrapLock` / `TrapUnlock`).
+///
+/// When the trap is triggered it sets the lock state of every object it
+/// controls through its SwitchLinks - `TrapUnlock` clears the lock,
+/// `TrapLock` sets it. This is the mechanism the missions use to hand out
+/// buttons and doors that have no key: e.g. eng1's "Unlock Trap" is fired by
+/// a Once Router and unlocks the elevator/grav-lift call buttons, which are
+/// authored `PropLocked(true)` with no `PropKeyDst` and are otherwise
+/// permanently refused by `script_util::is_entity_locked`.
+///
+/// The lock lives in Dark's own `P$Locked` property (via `Effect::SetLocked`),
+/// so it is the same state every lock check already reads and mission
+/// save/load persists it with the rest of the registered properties.
+///
+/// Only the trigger (`TurnOn`) acts; `TurnOff` is left alone rather than
+/// guessing at an inverse, matching the trigger-only traps already here
+/// (`TrapSlayer`, `TrapQBSet`). Levels that want the inverse wire a
+/// `TrapInverter`.
+pub struct TrapLock {
+    locked: bool,
+}
+
+impl TrapLock {
+    /// `TrapLock`: triggering locks the linked objects.
+    pub fn lock() -> TrapLock {
+        TrapLock { locked: true }
+    }
+
+    /// `TrapUnlock`: triggering unlocks the linked objects.
+    pub fn unlock() -> TrapLock {
+        TrapLock { locked: false }
+    }
+}
+
+impl Script for TrapLock {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { from: _ } => Effect::combine(
+                get_all_switch_links(world, entity_id)
+                    .into_iter()
+                    .map(|target| Effect::SetLocked {
+                        entity_id: target,
+                        locked: self.locked,
+                    })
+                    .collect(),
+            ),
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quest_info::QuestInfo;
+    use crate::scripts::ScriptWorld;
+    use crate::scripts::script_util::{is_entity_locked, set_entity_locked};
+    use dark::properties::{Link, Links, PropLocked, ToLink, WrappedEntityId};
+
+    /// Resolve the trap the way the game does - by its authored script name -
+    /// so the registry wiring is under test alongside the behavior.
+    fn authored_script(name: &str) -> Box<dyn Script> {
+        ScriptWorld::create_script(name.to_owned())
+    }
+
+    /// An eng1-style call button: `PropLocked(true)` with no `PropKeyDst`, so
+    /// no key or quest state can ever satisfy it.
+    fn keyless_locked_button(world: &mut World) -> EntityId {
+        world.add_entity(PropLocked(true))
+    }
+
+    fn trap_with_switch_links(world: &mut World, targets: &[EntityId]) -> EntityId {
+        world.add_entity(Links {
+            to_links: targets
+                .iter()
+                .map(|target| ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(*target)),
+                    link: Link::SwitchLink,
+                })
+                .collect(),
+        })
+    }
+
+    /// Apply what the trap emitted, exactly as `Mission::handle_effects` does.
+    fn apply(world: &mut World, effect: Effect) {
+        for (entity_id, locked) in lock_changes(effect) {
+            set_entity_locked(world, entity_id, locked);
+        }
+    }
+
+    fn lock_changes(effect: Effect) -> Vec<(EntityId, bool)> {
+        match effect {
+            Effect::SetLocked { entity_id, locked } => vec![(entity_id, locked)],
+            Effect::Combined { effects } => effects.into_iter().flat_map(lock_changes).collect(),
+            _ => vec![],
+        }
+    }
+
+    #[test]
+    fn triggering_an_unlock_trap_unlocks_every_button_it_controls() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let first = keyless_locked_button(&mut world);
+        let second = keyless_locked_button(&mut world);
+        let untargeted = keyless_locked_button(&mut world);
+        let trap = trap_with_switch_links(&mut world, &[first, second]);
+
+        assert!(is_entity_locked(&world, first));
+        assert!(is_entity_locked(&world, second));
+
+        let effect = authored_script("TrapUnlock").handle_message(
+            trap,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: trap },
+        );
+        apply(&mut world, effect);
+
+        assert!(!is_entity_locked(&world, first));
+        assert!(!is_entity_locked(&world, second));
+        assert!(
+            is_entity_locked(&world, untargeted),
+            "a button the trap does not control must stay locked"
+        );
+    }
+
+    #[test]
+    fn triggering_a_lock_trap_locks_the_button_it_controls() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let button = world.add_entity(PropLocked(false));
+        let trap = trap_with_switch_links(&mut world, &[button]);
+
+        assert!(!is_entity_locked(&world, button));
+
+        let effect = authored_script("TrapLock").handle_message(
+            trap,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: trap },
+        );
+        apply(&mut world, effect);
+
+        assert!(is_entity_locked(&world, button));
+    }
+
+    /// The unlock must outlive the session: the lock lives in the registered
+    /// `P$Locked` property, so a normal mission save/load carries it.
+    #[test]
+    fn a_trap_unlocked_button_stays_unlocked_across_a_save_load_round_trip() {
+        use crate::save_load::EntitySaveData;
+        use std::collections::HashMap;
+        use std::fs::File;
+
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let button = keyless_locked_button(&mut world);
+        let still_locked = keyless_locked_button(&mut world);
+        let trap = trap_with_switch_links(&mut world, &[button]);
+
+        let effect = authored_script("TrapUnlock").handle_message(
+            trap,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: trap },
+        );
+        apply(&mut world, effect);
+
+        let (all_properties, _, _) = dark::properties::get::<File>();
+        let mut save = EntitySaveData::empty();
+        save.all_entities = vec![button.inner(), still_locked.inner()];
+        save.properties = all_properties
+            .iter()
+            .map(|prop| (prop.name(), prop.serialize(&world)))
+            .collect::<HashMap<_, _>>();
+
+        let mut loaded = World::new();
+        loaded.add_unique(QuestInfo::new());
+        let (_, old_to_new) = save.instantiate(&mut loaded);
+
+        assert!(
+            !is_entity_locked(&loaded, old_to_new[&button]),
+            "the unlock must survive save/load"
+        );
+        assert!(is_entity_locked(&loaded, old_to_new[&still_locked]));
+    }
+
+    #[test]
+    fn an_untriggered_unlock_trap_leaves_its_target_locked() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let button = keyless_locked_button(&mut world);
+        let trap = trap_with_switch_links(&mut world, &[button]);
+
+        let effect = authored_script("TrapUnlock").handle_message(
+            trap,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOff { from: trap },
+        );
+        apply(&mut world, effect);
+
+        assert!(is_entity_locked(&world, button));
+    }
+}

--- a/shock2vr/src/scripts/trap_unlock.rs
+++ b/shock2vr/src/scripts/trap_unlock.rs
@@ -4,47 +4,30 @@ use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script, script_util::get_all_switch_links};
 
-/// Dark's in-world lock traps (`TrapLock` / `TrapUnlock`).
+/// Dark's in-world lock trap (`TrapUnlock`).
 ///
-/// When the trap is triggered it sets the lock state of every object it
-/// controls through its SwitchLinks - `TrapUnlock` clears the lock,
-/// `TrapLock` sets it. This is the mechanism the missions use to hand out
-/// buttons and doors that have no key: e.g. eng1's "Unlock Trap" is fired by
-/// a Once Router and unlocks the elevator/grav-lift call buttons, which are
-/// authored `PropLocked(true)` with no `PropKeyDst` and are otherwise
-/// permanently refused by `script_util::is_entity_locked`.
+/// The trap sets the lock state of every object it controls through its
+/// SwitchLinks: `TurnOn` unlocks them, `TurnOff` locks them again. This is how
+/// the missions hand out buttons that have no key - eng1's "Unlock Trap" is
+/// fired by a Once Router when main power comes back and unlocks the
+/// elevator / grav-lift call buttons, which are authored `PropLocked(true)`
+/// with no `PropKeyDst` and are otherwise permanently refused by
+/// `script_util::is_entity_locked`. Both edges are authored: rec2 drives its
+/// unlock trap from a button (unlock) *and* from an inverter on the dining
+/// ambush (re-lock), a lock/unlock cycle on the same card slot.
 ///
 /// The lock lives in Dark's own `P$Locked` property (via `Effect::SetLocked`),
 /// so it is the same state every lock check already reads and mission
 /// save/load persists it with the rest of the registered properties.
-///
-/// Only the trigger (`TurnOn`) acts; `TurnOff` is ignored, matching the
-/// trigger-only traps already here (`TrapSlayer`, `TrapQBSet`). The missions
-/// convert an off-edge into a trigger themselves - `TrapInverter` and the
-/// on/off filters exist for exactly that - so a trap acting on both edges
-/// would make those relays meaningless. Shipped data does route an off-edge
-/// into an unlock trap (rec2's Inverter 760 also feeds Unlock Trap 148, which
-/// a plain button drives directly too), and reading that as "re-lock" would
-/// risk sealing a progression button; ignoring it can only ever leave
-/// something unlocked that the original re-locked, which cannot soft-lock a
-/// player.
-pub struct TrapLock {
-    locked: bool,
-}
+pub struct TrapUnlock {}
 
-impl TrapLock {
-    /// `TrapLock`: triggering locks the linked objects.
-    pub fn lock() -> TrapLock {
-        TrapLock { locked: true }
-    }
-
-    /// `TrapUnlock`: triggering unlocks the linked objects.
-    pub fn unlock() -> TrapLock {
-        TrapLock { locked: false }
+impl TrapUnlock {
+    pub fn new() -> TrapUnlock {
+        TrapUnlock {}
     }
 }
 
-impl Script for TrapLock {
+impl Script for TrapUnlock {
     fn handle_message(
         &mut self,
         entity_id: EntityId,
@@ -52,18 +35,21 @@ impl Script for TrapLock {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        match msg {
-            MessagePayload::TurnOn { from: _ } => Effect::combine(
-                get_all_switch_links(world, entity_id)
-                    .into_iter()
-                    .map(|target| Effect::SetLocked {
-                        entity_id: target,
-                        locked: self.locked,
-                    })
-                    .collect(),
-            ),
-            _ => Effect::NoEffect,
-        }
+        let locked = match msg {
+            MessagePayload::TurnOn { from: _ } => false,
+            MessagePayload::TurnOff { from: _ } => true,
+            _ => return Effect::NoEffect,
+        };
+
+        Effect::combine(
+            get_all_switch_links(world, entity_id)
+                .into_iter()
+                .map(|target| Effect::SetLocked {
+                    entity_id: target,
+                    locked,
+                })
+                .collect(),
+        )
     }
 }
 
@@ -77,8 +63,8 @@ mod tests {
 
     /// Resolve the trap the way the game does - by its authored script name -
     /// so the registry wiring is under test alongside the behavior.
-    fn authored_script(name: &str) -> Box<dyn Script> {
-        ScriptWorld::create_script(name.to_owned())
+    fn authored_trap() -> Box<dyn Script> {
+        ScriptWorld::create_script("TrapUnlock".to_owned())
     }
 
     /// An eng1-style call button: `PropLocked(true)` with no `PropKeyDst`, so
@@ -100,9 +86,11 @@ mod tests {
         })
     }
 
-    /// Apply what the trap emitted, exactly as `Mission::handle_effects` does:
-    /// the shared flatten, then the shared `SetLocked` application.
-    fn apply(world: &mut World, effect: Effect) {
+    /// Deliver a message to the trap and apply what it emitted, exactly as
+    /// `Mission::handle_effects` does: the shared flatten, then the shared
+    /// `SetLocked` application.
+    fn trigger(world: &mut World, trap: EntityId, msg: MessagePayload) {
+        let effect = authored_trap().handle_message(trap, world, &PhysicsWorld::new(), &msg);
         for effect in Effect::flatten(vec![effect]) {
             if let Effect::SetLocked { entity_id, locked } = effect {
                 set_entity_locked(world, entity_id, locked);
@@ -111,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn triggering_an_unlock_trap_unlocks_every_button_it_controls() {
+    fn turning_the_trap_on_unlocks_every_button_it_controls() {
         let mut world = World::new();
         world.add_unique(QuestInfo::new());
         let first = keyless_locked_button(&mut world);
@@ -122,13 +110,7 @@ mod tests {
         assert!(is_entity_locked(&world, first));
         assert!(is_entity_locked(&world, second));
 
-        let effect = authored_script("TrapUnlock").handle_message(
-            trap,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::TurnOn { from: trap },
-        );
-        apply(&mut world, effect);
+        trigger(&mut world, trap, MessagePayload::TurnOn { from: trap });
 
         assert!(!is_entity_locked(&world, first));
         assert!(!is_entity_locked(&world, second));
@@ -138,22 +120,30 @@ mod tests {
         );
     }
 
+    /// The mirror edge, authored in rec2: an inverter delivers `TurnOff` and
+    /// the card slot locks again.
     #[test]
-    fn triggering_a_lock_trap_locks_the_button_it_controls() {
+    fn turning_the_trap_off_locks_the_button_again() {
         let mut world = World::new();
         world.add_unique(QuestInfo::new());
-        let button = world.add_entity(PropLocked(false));
+        let button = keyless_locked_button(&mut world);
         let trap = trap_with_switch_links(&mut world, &[button]);
 
+        trigger(&mut world, trap, MessagePayload::TurnOn { from: trap });
         assert!(!is_entity_locked(&world, button));
 
-        let effect = authored_script("TrapLock").handle_message(
-            trap,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::TurnOn { from: trap },
-        );
-        apply(&mut world, effect);
+        trigger(&mut world, trap, MessagePayload::TurnOff { from: trap });
+        assert!(is_entity_locked(&world, button));
+    }
+
+    #[test]
+    fn a_message_that_is_not_a_switch_edge_leaves_the_lock_alone() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let button = keyless_locked_button(&mut world);
+        let trap = trap_with_switch_links(&mut world, &[button]);
+
+        trigger(&mut world, trap, MessagePayload::Frob);
 
         assert!(is_entity_locked(&world, button));
     }
@@ -172,13 +162,7 @@ mod tests {
         let still_locked = keyless_locked_button(&mut world);
         let trap = trap_with_switch_links(&mut world, &[button]);
 
-        let effect = authored_script("TrapUnlock").handle_message(
-            trap,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::TurnOn { from: trap },
-        );
-        apply(&mut world, effect);
+        trigger(&mut world, trap, MessagePayload::TurnOn { from: trap });
 
         let (all_properties, _, _) = dark::properties::get::<File>();
         let mut save = EntitySaveData::empty();
@@ -197,23 +181,5 @@ mod tests {
             "the unlock must survive save/load"
         );
         assert!(is_entity_locked(&loaded, old_to_new[&still_locked]));
-    }
-
-    #[test]
-    fn an_untriggered_unlock_trap_leaves_its_target_locked() {
-        let mut world = World::new();
-        world.add_unique(QuestInfo::new());
-        let button = keyless_locked_button(&mut world);
-        let trap = trap_with_switch_links(&mut world, &[button]);
-
-        let effect = authored_script("TrapUnlock").handle_message(
-            trap,
-            &world,
-            &PhysicsWorld::new(),
-            &MessagePayload::TurnOff { from: trap },
-        );
-        apply(&mut world, effect);
-
-        assert!(is_entity_locked(&world, button));
     }
 }

--- a/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+
+// End-to-end test for the in-world lock traps (GitHub #590).
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: `TrapUnlock` was mapped to a no-op script, and
+// `is_entity_locked` refuses a `PropLocked(true)` entity that has no
+// `PropKeyDst` unconditionally ("nothing can unlock it"). So a button the
+// original game hands out via an unlock trigger stayed locked for the whole
+// game - firing the trap changed nothing and the button kept answering
+// `hackfail`.
+//
+// eng1 wiring (stable mission object ids, reported as `template_id`):
+//   Once Router 878 -> Unlock Trap 1213 -> buttons 990, 1787, 1210
+//   grav-lift button 1787 -> Lift 1 (1856)
+//   storage-4 button 948 -> its own Unlock Trap 838 (deliberately NOT fired)
+// Runtime entity ids are not stable across runs, so everything is discovered by
+// mission object id.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const UNLOCK_TRAP = 1213; // controls the grav-lift button
+const GRAV_LIFT_BUTTON = 1787;
+const GRAV_LIFT = 1856;
+const UNLOCKED_TWIN_BUTTON = 1871; // control: never locked
+const UNRELATED_LOCKED_BUTTON = 948; // control: its unlock trap stays unfired
+
+/** The refusal sound a locked button plays instead of activating. */
+const REFUSAL = "hackfail";
+
+async function only(game: GameServer, objectId: number) {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one eng1 object ${objectId}, got ${JSON.stringify(found.map((e) => e.name))}`,
+  );
+  return found[0];
+}
+
+async function liftPosition(game: GameServer): Promise<Vec3> {
+  return (await only(game, GRAV_LIFT)).position;
+}
+
+function moved(a: Vec3, b: Vec3): boolean {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]) > 0.5;
+}
+
+async function lastSoundSequence(game: GameServer): Promise<number> {
+  const { sounds } = await game.audio.recent();
+  return sounds.length === 0 ? 0 : sounds[sounds.length - 1].sequence;
+}
+
+/**
+ * Press a button by mission object id and report what the world did: whether it
+ * refused (played the locked-button sound) and where the grav lift ended up.
+ */
+async function press(game: GameServer, objectId: number) {
+  const since = await lastSoundSequence(game);
+  const liftBefore = await liftPosition(game);
+
+  const button = await only(game, objectId);
+  await game.entities.sendMessage(button.id, { type: "Frob" });
+  await game.step({ frames: 180 });
+
+  const { sounds } = await game.audio.recent();
+  const played = sounds
+    .filter((sound) => sound.sequence > since)
+    .map((sound) => sound.sample.toLowerCase());
+  return {
+    refused: played.includes(REFUSAL),
+    liftMoved: moved(liftBefore, await liftPosition(game)),
+    played,
+  };
+}
+
+test(
+  "eng1: a locked grav-lift button only works once its unlock trap fires",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
+    });
+    await game.step({ frames: 10 });
+
+    // Before: the button is PropLocked with no key, so it refuses and the lift
+    // never moves.
+    const locked = await press(game, GRAV_LIFT_BUTTON);
+    assert.equal(
+      locked.refused,
+      true,
+      `a locked button should refuse; played ${JSON.stringify(locked.played)}`,
+    );
+    assert.equal(
+      locked.liftMoved,
+      false,
+      "a refused press must not call the lift",
+    );
+
+    // Fire the unlock trap over the same SwitchLink path the Once Router uses.
+    const trap = await only(game, UNLOCK_TRAP);
+    await game.entities.sendMessage(trap.id, { type: "TurnOn" });
+    await game.step({ frames: 10 });
+
+    // After: the same button now drives the lift.
+    const unlocked = await press(game, GRAV_LIFT_BUTTON);
+    assert.equal(
+      unlocked.refused,
+      false,
+      "the unlocked button must not refuse",
+    );
+    assert.equal(
+      unlocked.liftMoved,
+      true,
+      "after its unlock trap fires the button should call the grav lift",
+    );
+
+    // Control: a button whose own unlock trap was never fired stays locked.
+    const stillLocked = await press(game, UNRELATED_LOCKED_BUTTON);
+    assert.equal(
+      stillLocked.refused,
+      true,
+      "firing one unlock trap must not unlock unrelated locked buttons",
+    );
+
+    // Control: the never-locked twin button still relays to the lift.
+    const twin = await press(game, UNLOCKED_TWIN_BUTTON);
+    assert.equal(twin.refused, false, "the twin button was never locked");
+    assert.equal(
+      twin.liftMoved,
+      true,
+      "the unlocked twin button should keep working",
+    );
+
+    // The unlock is real game state, not session state: it must survive a
+    // save/load round trip (P$Locked is a registered Dark property).
+    await game.save("trap-unlock-e2e");
+    await game.load("trap-unlock-e2e");
+    await game.step({ frames: 10 });
+
+    const afterLoad = await press(game, GRAV_LIFT_BUTTON);
+    assert.equal(afterLoad.refused, false, "the unlock must survive save/load");
+    assert.equal(
+      afterLoad.liftMoved,
+      true,
+      "the reloaded button should still call the grav lift",
+    );
+
+    const stillLockedAfterLoad = await press(game, UNRELATED_LOCKED_BUTTON);
+    assert.equal(
+      stillLockedAfterLoad.refused,
+      true,
+      "a still-locked button must stay locked across save/load too",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
@@ -166,12 +166,13 @@ test(
     await game.entities.sendMessage(trap.id, { type: "TurnOff" });
     await game.step({ frames: 10 });
 
+    // Only the refusal is asserted here: by this point the lift is still
+    // travelling from the previous press, so its position is not a signal.
     const relocked = await press(game, GRAV_LIFT_BUTTON);
     assert.equal(
       relocked.refused,
       true,
       "turning the unlock trap off should lock its buttons again",
     );
-    assert.equal(relocked.liftMoved, false, "a re-locked button must refuse");
   },
 );

--- a/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
@@ -16,14 +16,14 @@ import type { Vec3 } from "../src/types.js";
 // `hackfail`.
 //
 // eng1 wiring (stable mission object ids, reported as `template_id`):
-//   Once Router 878 -> Unlock Trap 1213 -> buttons 990, 1787, 1210
+//   QB Filter 155 -> Once Router 878 -> Unlock Trap 1213 -> buttons 990, 1787, 1210
 //   grav-lift button 1787 -> Lift 1 (1856)
 //   storage-4 button 948 -> its own Unlock Trap 838 (deliberately NOT fired)
 // Runtime entity ids are not stable across runs, so everything is discovered by
 // mission object id.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const UNLOCK_TRAP = 1213; // controls the grav-lift button
+const ONCE_ROUTER = 878; // power restoration fires this, which fires the trap
 const GRAV_LIFT_BUTTON = 1787;
 const GRAV_LIFT = 1856;
 const UNLOCKED_TWIN_BUTTON = 1871; // control: never locked
@@ -102,9 +102,10 @@ test(
       "a refused press must not call the lift",
     );
 
-    // Fire the unlock trap over the same SwitchLink path the Once Router uses.
-    const trap = await only(game, UNLOCK_TRAP);
-    await game.entities.sendMessage(trap.id, { type: "TurnOn" });
+    // Fire the authored chain the player actually triggers: the Once Router
+    // relays TurnOn over its SwitchLinks, one of which is the Unlock Trap.
+    const router = await only(game, ONCE_ROUTER);
+    await game.entities.sendMessage(router.id, { type: "TurnOn" });
     await game.step({ frames: 10 });
 
     // After: the same button now drives the lift.

--- a/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
+++ b/tools/shock2-sdk/test/trap-unlock.e2e.test.ts
@@ -24,6 +24,7 @@ import type { Vec3 } from "../src/types.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 const ONCE_ROUTER = 878; // power restoration fires this, which fires the trap
+const UNLOCK_TRAP = 1213; // the trap itself, for the off-edge (re-lock) check
 const GRAV_LIFT_BUTTON = 1787;
 const GRAV_LIFT = 1856;
 const UNLOCKED_TWIN_BUTTON = 1871; // control: never locked
@@ -158,5 +159,19 @@ test(
       true,
       "a still-locked button must stay locked across save/load too",
     );
+
+    // The mirror edge: an off-edge at the trap (what rec2's inverter delivers
+    // to its unlock trap during the dining ambush) locks the button again.
+    const trap = await only(game, UNLOCK_TRAP);
+    await game.entities.sendMessage(trap.id, { type: "TurnOff" });
+    await game.step({ frames: 10 });
+
+    const relocked = await press(game, GRAV_LIFT_BUTTON);
+    assert.equal(
+      relocked.refused,
+      true,
+      "turning the unlock trap off should lock its buttons again",
+    );
+    assert.equal(relocked.liftMoved, false, "a re-locked button must refuse");
   },
 );


### PR DESCRIPTION
Fixes #590

`"trapunlock"` was mapped to `NoopScript`, and `script_util::is_entity_locked`
returns `true` unconditionally for a `PropLocked(true)` entity with no
`PropKeyDst` ("Locked with no key destination - nothing can unlock it"). Every
button System Shock 2 hands out through an in-world unlock trigger was therefore
locked for the whole game - on eng1 the elevator-door (obj 990), grav-lift (1787)
and storage-4 (948) call buttons all answered `hackfail` forever, even after
their unlock trap had fired.

## How the unlock flows

Entirely through the game's own trigger/link path - no entity id, template or
mission is special-cased anywhere:

```
QB Filter 155 -> Once Router 878 -> Unlock Trap 1213 -> SwitchLinks -> buttons 990 / 1787 / 1210
```

`TrapUnlock` is instantiated from the authored script name in the normal
`create_script` registry, reacts to the `TurnOn`/`TurnOff` that arrive over
SwitchLinks like any other trap, and acts on the targets it reads from its own
SwitchLinks via the shared `script_util::get_all_switch_links`.

## Where the locked state lives

In Dark's own `P$Locked` property, written through a new `Effect::SetLocked`
(applied in `MissionCore::handle_effects`, the pattern `SetObjectState` /
`SetVisibility` already use). That is the *same* state `is_entity_locked`
already reads, so there is no second source of truth - and because `P$Locked` is
a registered Dark property, `save_load` serializes it with the rest, so the
unlock survives save/load for free.

## Both edges

`TurnOn` unlocks, `TurnOff` locks. Both are authored: rec2 drives Unlock Trap
148 from a button (unlock) *and* from Inverter 760 on the delayed dining ambush
(re-lock) for the same card slot 241.

I did **not** add a separate `TrapLock` script. With `TurnOff` handled it would
be redundant, and no shipped mission or gamesys template references the name
(checked with `cargo dq --filter 'S$traplock'` across all 23 missions) - it would
have been dead code.

## Verification

**Negative-first** (both levels fail without the change, pass with it):

- `cargo test -p shock2vr trap_unlock` - with `"trapunlock"` reverted to
  `NoopScript`, 3 of 4 tests fail (`assertion failed: !is_entity_locked(...)`,
  `the unlock must survive save/load`); restored, all 4 pass. The tests resolve
  the script through the real `ScriptWorld::create_script` registry, apply the
  emitted effect through the real `Effect::flatten` + `set_entity_locked`, and
  assert through the real `is_entity_locked`.
- `tools/shock2-sdk/test/trap-unlock.e2e.test.ts` (new) - with the no-op
  restored the e2e fails on `the unlocked button must not refuse`; with the fix
  it passes.

**Live, on eng1 via the debug runtime** (entities resolved by mission object id,
never a hardcoded runtime id):

| step | result |
| --- | --- |
| frob grav-lift button 1787 before the trap fires | refused (`hackfail`), lift stays at y = -13.0 |
| fire Once Router 878 (the authored chain), frob 1787 again | no refusal, lift moves to y = -22.5 |
| control: button 948, whose own unlock trap 838 was never fired | still refused |
| control: unlocked twin button 1871 | still works, lift moves |
| save + load, frob 1787 | no refusal, lift moves - unlock persisted |
| control after load: button 948 | still refused |
| `TurnOff` the trap, frob 1787 | refused again |

**Checks:** `cargo fmt --check --all`,
`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`,
`cargo test -p shock2vr` (279 passed), and the full SDK e2e suite.

## Review

Ran the two-engine adversarial review. Both engines independently confirmed the
change uses the real in-world trigger/link flow and fakes nothing, and both
raised the same Medium - that `TurnOff` should lock - which is adopted here.
Codex's Low (drop the unused `TrapLock`) is adopted too. Remaining Lows
(doc duplication, driving the e2e through the Once Router instead of the trap)
are fixed in follow-up commits.

Deferred: `P$LockCnt` (Dark's nested lock refcount) is still unparsed; the port
treats the lock as a boolean, which is sufficient for all shipped wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
