### PR TITLE
fix: give dimension-less ladders a collider from their model bounds (#589)

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -886,11 +886,16 @@ pub fn create_physics_representation(
             .unwrap();
         let immobile = v_immobile.get(entity_id).is_ok();
 
-        if let (Ok(pos), Ok(dimensions), Ok(phys_type)) = (
-            v_pos.get(entity_id),
-            v_dimensions.get(entity_id),
-            v_phys_type.get(entity_id),
-        ) {
+        // `P$PhysDims` is optional: an author who never opened the physics
+        // dimensions dialog leaves the object with only a physics *type*. The
+        // original engine then falls back to the model's bounding box - the
+        // shipped data proves it, because every ladder that *does* carry
+        // authored dimensions carries exactly the model bbox (e.g. eng1's
+        // `Ladder 16'` #945: size (1.65, 6.40, 0.14) == ladder.bin's bounds).
+        // Without this fallback the object silently got no collider at all, so
+        // most ladders were neither solid nor climbable (issue #589).
+        let maybe_dimensions = v_dimensions.get(entity_id).ok();
+        if let (Ok(pos), Ok(phys_type)) = (v_pos.get(entity_id), v_phys_type.get(entity_id)) {
             let qrotation = pos.rotation;
 
             let mut is_sensor = false;
@@ -922,17 +927,27 @@ pub fn create_physics_representation(
                 // scale_factor *= 1.2;
             }
 
+            // Without authored dimensions, fall back to the model bounds
+            // (`abs_dimensions`, already clamped to a minimum size above).
+            let unscaled_size = maybe_dimensions
+                .map(|dimensions| dimensions.size)
+                .unwrap_or(abs_dimensions);
             let size = vec3(
-                dimensions.size.x.abs() * scale_factor.x.abs(),
-                dimensions.size.y.abs() * scale_factor.y.abs(),
-                dimensions.size.z.abs() * scale_factor.z.abs(),
+                unscaled_size.x.abs() * scale_factor.x.abs(),
+                unscaled_size.y.abs() * scale_factor.y.abs(),
+                unscaled_size.z.abs() * scale_factor.z.abs(),
             );
 
-            let shape = match phys_type.phys_type {
-                PhysicsModelType::ORIENTED_BOUNDING_BOX => PhysicsShape::Cuboid(size),
-                PhysicsModelType::SPHERE => {
+            let shape = match (phys_type.phys_type, maybe_dimensions) {
+                (PhysicsModelType::ORIENTED_BOUNDING_BOX, _) => PhysicsShape::Cuboid(size),
+                (PhysicsModelType::SPHERE, Some(dimensions)) => {
                     PhysicsShape::Sphere(dimensions.radius0.abs().max(dimensions.radius1.abs()))
                 }
+                // A sphere with no authored dimensions has no authored radius
+                // either, and the model's bounding *sphere* would swallow the
+                // whole object (a 16' ladder becomes an 8' ball). The bounding
+                // box is the only geometry we have, so use it.
+                (PhysicsModelType::SPHERE, None) => PhysicsShape::Cuboid(size),
                 _ => {
                     warn!("unhandled physics type: {:?}", phys_type);
                     return None;
@@ -957,6 +972,10 @@ pub fn create_physics_representation(
                 CollisionGroup::entity()
             };
 
+            let offset = maybe_dimensions
+                .map(|dimensions| dimensions.offset0)
+                .unwrap_or(Vector3::zero());
+
             let rigid_body_handle = if !immobile && phys_type.phys_type == PhysicsModelType::SPHERE
             {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
@@ -964,7 +983,7 @@ pub fn create_physics_representation(
                     entity_id,
                     pos.position,
                     qrotation,
-                    dimensions.offset0,
+                    offset,
                     shape,
                     //size,
                     group,
@@ -976,7 +995,7 @@ pub fn create_physics_representation(
                     entity_id,
                     pos.position,
                     qrotation,
-                    dimensions.offset0,
+                    offset,
                     size,
                     group,
                     is_sensor,
@@ -1016,7 +1035,92 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use collision::Aabb3;
     use dark::properties::{Links, ToLink};
+
+    /// A ladder-shaped entity: climbable terrain with a physics type but - like
+    /// most shipped ladders - no `P$PhysDims` at all.
+    fn add_ladder(world: &mut World, phys_type: PhysicsModelType) -> EntityId {
+        world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysAttr {
+                gravity_scale: 1.0,
+                mass: 30.0,
+                density: 1.0,
+                elasticity: 1.0,
+                friction: 0.0,
+                cog: Vector3::zero(),
+                rotation_axes: 7,
+                rest_axes: 63,
+                // The shipped ladder value: the four vertical sides.
+                climbable: 27,
+                edge_trigger: false,
+            },
+            PropImmobile(true),
+        ))
+    }
+
+    /// `ladder.bin`'s bounds: 16 SS2 ft tall, flat against a wall.
+    fn ladder_model() -> Model {
+        Model::from_glb(
+            vec![],
+            Aabb3::new(
+                Point3::new(-0.823, -3.2, -0.071),
+                Point3::new(0.823, 3.2, 0.071),
+            ),
+            None,
+        )
+    }
+
+    /// A climbable entity with no `PropPhysDimensions` still gets a collider,
+    /// sized from the model bounds and tagged climbable (issue #589 - 24 of
+    /// eng1's 30 ladders had no collider at all, so they were neither solid nor
+    /// climbable). Negative-first: before the fallback, the missing dimensions
+    /// property made `create_physics_representation` return `None`.
+    #[test]
+    fn climbable_without_dimensions_gets_collider_from_model_bounds() {
+        for phys_type in [
+            PhysicsModelType::ORIENTED_BOUNDING_BOX,
+            // The leaf ladder templates say SPHERE while their parent says OBB;
+            // with no authored radius the model box is all we have.
+            PhysicsModelType::SPHERE,
+        ] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_ladder(&mut world, phys_type);
+            let model = ladder_model();
+
+            let handle =
+                create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                    .expect("climbable entity without dimensions should still get a collider");
+
+            let size = physics
+                .cuboid_full_size(handle)
+                .expect("collider should be a box matching the model bounds");
+            assert!(
+                (size.y - 6.4).abs() < 0.01,
+                "collider should be as tall as the model ({size:?})"
+            );
+
+            let bodies = physics.debug_list_bodies();
+            assert_eq!(bodies.len(), 1, "expected exactly one body in the world");
+            let groups = &bodies[0].collision_groups;
+            assert!(
+                groups.iter().any(|g| g == "climbable"),
+                "ladder collider should be climbable, got {groups:?}"
+            );
+        }
+    }
 
     fn contains_link(to: EntityId) -> ToLink {
         ToLink {

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -886,15 +886,53 @@ pub fn create_physics_representation(
             .unwrap();
         let immobile = v_immobile.get(entity_id).is_ok();
 
+        // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
+        // extra marker membership so player movement can detect contact.
+        // Simplifications: `climbable` is plausibly a per-face bitmask in
+        // the original engine (27 = the four vertical sides on ladders) -
+        // any non-zero value marks the whole collider climbable here. And
+        // only this (non-frobbable) creation branch checks it: all known
+        // ladders are plain terrain objects; a frobbable climbable would
+        // need the same treatment in the branch above.
+        let is_climbable = v_phys_attr
+            .get(entity_id)
+            .map(|pa| pa.climbable != 0)
+            .unwrap_or(false);
+
         // `P$PhysDims` is optional: an author who never opened the physics
-        // dimensions dialog leaves the object with only a physics *type*. The
-        // original engine then falls back to the model's bounding box - the
-        // shipped data proves it, because every ladder that *does* carry
-        // authored dimensions carries exactly the model bbox (e.g. eng1's
-        // `Ladder 16'` #945: size (1.65, 6.40, 0.14) == ladder.bin's bounds).
-        // Without this fallback the object silently got no collider at all, so
-        // most ladders were neither solid nor climbable (issue #589).
+        // dimensions dialog leaves the object with only a physics *type*, and
+        // the object then got no collider at all - which is why most ladders
+        // were neither solid nor climbable (issue #589). The original engine
+        // falls back to the model's bounds, and the shipped data proves it:
+        // every ladder that *does* carry authored dimensions carries exactly
+        // its model's bbox (e.g. eng1's `Ladder 16'` #945: size
+        // (1.65, 6.40, 0.14) == ladder.bin's bounds, offset zero == its
+        // bbox center).
+        //
+        // Deliberately limited to *climbable* objects. The same fallback
+        // applied to every dimension-less physics object turns ~187 further
+        // props solid across the shipped missions (hydro2 pipe runs, station
+        // windows and crates, bar stools) - plausibly also faithful, but a
+        // separate change with its own traversal testing, not a silent
+        // side effect of a ladder fix.
         let maybe_dimensions = v_dimensions.get(entity_id).ok();
+        let model_bounds = if maybe_dimensions.is_none() && is_climbable {
+            // Raw model bounds - deliberately NOT `abs_dimensions`, whose
+            // minimum-size clamp would make a fallback ladder 41% thicker
+            // than the authored ladder standing next to it. Degenerate sizes
+            // are already guarded by `sanitize_collider_size`.
+            maybe_model
+                .as_ref()
+                .and_then(|model| model.bounding_box())
+                .map(|bbox| {
+                    (
+                        bbox.max - bbox.min,
+                        bbox.min.to_vec() + (bbox.max - bbox.min) / 2.0,
+                    )
+                })
+        } else {
+            None
+        };
         if let (Ok(pos), Ok(phys_type)) = (v_pos.get(entity_id), v_phys_type.get(entity_id)) {
             let qrotation = pos.rotation;
 
@@ -927,11 +965,13 @@ pub fn create_physics_representation(
                 // scale_factor *= 1.2;
             }
 
-            // Without authored dimensions, fall back to the model bounds
-            // (`abs_dimensions`, already clamped to a minimum size above).
-            let unscaled_size = maybe_dimensions
-                .map(|dimensions| dimensions.size)
-                .unwrap_or(abs_dimensions);
+            // No authored dimensions and no usable model bounds: nothing to
+            // build a collider from, so behave as before (no physics).
+            let unscaled_size = match (maybe_dimensions, model_bounds) {
+                (Some(dimensions), _) => dimensions.size,
+                (None, Some((size, _))) => size,
+                (None, None) => return None,
+            };
             let size = vec3(
                 unscaled_size.x.abs() * scale_factor.x.abs(),
                 unscaled_size.y.abs() * scale_factor.y.abs(),
@@ -943,10 +983,10 @@ pub fn create_physics_representation(
                 (PhysicsModelType::SPHERE, Some(dimensions)) => {
                     PhysicsShape::Sphere(dimensions.radius0.abs().max(dimensions.radius1.abs()))
                 }
-                // A sphere with no authored dimensions has no authored radius
-                // either, and the model's bounding *sphere* would swallow the
-                // whole object (a 16' ladder becomes an 8' ball). The bounding
-                // box is the only geometry we have, so use it.
+                // The leaf ladder templates say SPHERE where their parent says
+                // OBB, but carry no radius to go with it (and a bounding
+                // sphere would swallow the room: a 16' ladder becomes an 8'
+                // ball). The bounding box is the only geometry we have.
                 (PhysicsModelType::SPHERE, None) => PhysicsShape::Cuboid(size),
                 _ => {
                     warn!("unhandled physics type: {:?}", phys_type);
@@ -954,29 +994,26 @@ pub fn create_physics_representation(
                 }
             };
 
-            // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
-            // extra marker membership so player movement can detect contact.
-            // Simplifications: `climbable` is plausibly a per-face bitmask in
-            // the original engine (27 = the four vertical sides on ladders) -
-            // any non-zero value marks the whole collider climbable here. And
-            // only this (non-frobbable) creation branch checks it: all known
-            // ladders are plain terrain objects; a frobbable climbable would
-            // need the same treatment in the branch above.
-            let is_climbable = v_phys_attr
-                .get(entity_id)
-                .map(|pa| pa.climbable != 0)
-                .unwrap_or(false);
             let group = if is_climbable {
                 CollisionGroup::climbable_entity()
             } else {
                 CollisionGroup::entity()
             };
 
-            let offset = maybe_dimensions
-                .map(|dimensions| dimensions.offset0)
-                .unwrap_or(Vector3::zero());
+            let offset = match (maybe_dimensions, model_bounds) {
+                (Some(dimensions), _) => dimensions.offset0,
+                (None, Some((_, center))) => center,
+                (None, None) => Vector3::zero(),
+            };
 
-            let rigid_body_handle = if !immobile && phys_type.phys_type == PhysicsModelType::SPHERE
+            // Only an object with authored dimensions takes the dynamic path.
+            // A dimension-less SPHERE has no authored radius, so a dynamic
+            // body would be a model-box-shaped prop falling under gravity -
+            // the fallback exists to make static geometry solid, not to
+            // animate it.
+            let rigid_body_handle = if !immobile
+                && maybe_dimensions.is_some()
+                && phys_type.phys_type == PhysicsModelType::SPHERE
             {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
                 physics.add_dynamic(
@@ -1035,12 +1072,13 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::InnerSpace;
     use collision::Aabb3;
     use dark::properties::{Links, ToLink};
 
     /// A ladder-shaped entity: climbable terrain with a physics type but - like
     /// most shipped ladders - no `P$PhysDims` at all.
-    fn add_ladder(world: &mut World, phys_type: PhysicsModelType) -> EntityId {
+    fn add_ladder(world: &mut World, phys_type: PhysicsModelType, climbable: u32) -> EntityId {
         world.add_entity((
             PropPosition {
                 position: vec3(0.0, 0.0, 0.0),
@@ -1062,8 +1100,7 @@ mod tests {
                 cog: Vector3::zero(),
                 rotation_axes: 7,
                 rest_axes: 63,
-                // The shipped ladder value: the four vertical sides.
-                climbable: 27,
+                climbable,
                 edge_trigger: false,
             },
             PropImmobile(true),
@@ -1082,6 +1119,8 @@ mod tests {
         )
     }
 
+    const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
     /// A climbable entity with no `PropPhysDimensions` still gets a collider,
     /// sized from the model bounds and tagged climbable (issue #589 - 24 of
     /// eng1's 30 ladders had no collider at all, so they were neither solid nor
@@ -1097,29 +1136,71 @@ mod tests {
         ] {
             let mut world = World::new();
             let mut physics = PhysicsWorld::new();
-            let entity_id = add_ladder(&mut world, phys_type);
+            let entity_id = add_ladder(&mut world, phys_type, 27);
             let model = ladder_model();
 
             let handle =
                 create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
                     .expect("climbable entity without dimensions should still get a collider");
 
+            // The full model bounds, unclamped: an authored ladder standing
+            // next to a fallback one must have the same solidity.
             let size = physics
                 .cuboid_full_size(handle)
                 .expect("collider should be a box matching the model bounds");
             assert!(
-                (size.y - 6.4).abs() < 0.01,
-                "collider should be as tall as the model ({size:?})"
+                (size - LADDER_SIZE).magnitude() < 0.01,
+                "collider should match the model bounds {LADDER_SIZE:?}, got {size:?}"
             );
 
             let bodies = physics.debug_list_bodies();
             assert_eq!(bodies.len(), 1, "expected exactly one body in the world");
+            assert_eq!(
+                bodies[0].body_type, "kinematic",
+                "a dimension-less ladder must not become a falling dynamic prop"
+            );
             let groups = &bodies[0].collision_groups;
             assert!(
                 groups.iter().any(|g| g == "climbable"),
                 "ladder collider should be climbable, got {groups:?}"
             );
         }
+    }
+
+    /// The fallback is scoped to climbable objects: a non-climbable entity with
+    /// no `PropPhysDimensions` keeps the old behavior (no collider), so the
+    /// ladder fix does not silently turn set dressing solid.
+    #[test]
+    fn non_climbable_without_dimensions_still_gets_no_collider() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_ladder(&mut world, PhysicsModelType::ORIENTED_BOUNDING_BOX, 0);
+        let model = ladder_model();
+
+        assert!(
+            create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                .is_none(),
+            "non-climbable entities must keep their previous (collider-less) behavior"
+        );
+    }
+
+    /// A non-immobile climbable object with no dimensions must not become a
+    /// dynamic body: there is no authored radius for the SPHERE path, so the
+    /// fallback builds static geometry, never a gravity-driven prop.
+    #[test]
+    fn dimensionless_sphere_never_becomes_dynamic() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_ladder(&mut world, PhysicsModelType::SPHERE, 27);
+        world.remove::<(PropImmobile,)>(entity_id);
+        let model = ladder_model();
+
+        create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+            .expect("climbable entity without dimensions should still get a collider");
+
+        let bodies = physics.debug_list_bodies();
+        assert_eq!(bodies.len(), 1);
+        assert_eq!(bodies[0].body_type, "kinematic");
     }
 
     fn contains_link(to: EntityId) -> ToLink {


### PR DESCRIPTION
Fixes #589

## The bug

`create_physics_representation` gated collider creation on **all three** of `PropPosition`, `PropPhysDimensions` and `PropPhysType` resolving. `P$PhysDims` is optional in the shipped data, so any climbable object without it got no collider at all — neither solid nor climbable. In eng1 that was **24 of 30 ladder entities**, including `Ladder 16'` (object 1877) and 9 of the 10 rungs in each nacelle shaft.

## Why the model bounding box is the faithful fallback

The shipped data answers this directly: every ladder that *does* carry authored dimensions carries **exactly its model's bounds**. eng1's `Ladder 16'` #945 and #317 both have `PhysDims.size == (1.646, 6.400, 0.142)`, which is `res/obj/LADDER.BIN`'s bbox `(4.115, 0.356, 16.001)` ft after the engine's Z-up→Y-up swizzle and `/SCALE_FACTOR`; their `offset0` is zero, which is that bbox's center. So DromEd defaults these dimensions from the model, and objects whose author never opened the dimensions dialog simply inherited the default at runtime.

Shape: the leaf ladder templates declare `PhysType: SPHERE` while their parent `Ladders` (-783) declares `ORIENTED_BOUNDING_BOX`, and every ladder with authored dimensions overrides back to `OBB`. `PhysAttr.climbable = 27` is a per-face bitmask (the four vertical sides), which is an OBB concept. With no authored radius, a bounding *sphere* would also swallow the room — a 16' ladder becomes an 8'-radius ball. So a dimension-less object is built as a box from the model bounds.

## Scope: climbable objects only

Applied to *every* dimension-less physics object, the same fallback makes **~187 further props solid** across the shipped missions (hydro2 pipe runs, station windows/crates/consoles, earth bar stools, medsci2 sparking cables). That is plausibly also faithful, but it is a traversal-affecting change that deserves its own PR and playtesting — not a silent side effect of a ladder fix. The fallback is therefore gated on `PropPhysAttr.climbable != 0`, a general property, not a template id or name. Objects with authored dimensions are untouched, and the dynamic-body path now requires authored dimensions so a dimension-less object can never become a gravity-driven box.

## Verification

**Negative-first unit tests** (`shock2vr/src/mission/entity_creator.rs`): with the fallback removed, `climbable_without_dimensions_gets_collider_from_model_bounds` and `dimensionless_sphere_never_becomes_dynamic` fail with *"climbable entity without dimensions should still get a collider"*; with it they pass. They assert all three collider axes match the model bounds, that the body is kinematic, and that the collider carries the `climbable` membership. `non_climbable_without_dimensions_still_gets_no_collider` pins the scope.

**Live (debug runtime, eng1, branch vs `main`, keyed by mission object id since runtime ids are not stable):**

| | main | branch |
| --- | --- | --- |
| ladder entities with a collider | 6 / 30 | **30 / 30** |
| total physics bodies | 1237 | 1261 |
| entities that gained a body | — | **24, all ladders, all kinematic** |
| entities that lost a body | — | 0 |

`Ladder 16'` object 1877 — the one named in the issue — goes from `total_count: 0` to one kinematic body with `collision_groups: ["entity", "climbable"]`.

**Climb**, eng1 `Rick Ladder 16` (object 1911), pushing into the ladder with the right thumbstick:

```
start (settled at base): y = -15.60
t=0.17s  y = -14.70
t=0.33s  y = -13.70
t=0.50s  y = -12.70   (6.0 wu/s = the 0.6 x walk-speed climb rate)
```

**No new stickiness**: the same four-direction walk from the medsci1 spawn moves identically before and after (5.61 / 0.60 / 0.71 / 8.28 world units); no entity lost a collider and nothing outside the ladder set gained one.

`cargo fmt --check --all`, `RUSTFLAGS="-D warnings" cargo check` over the 10 desktop packages, `cargo test -p shock2vr` (278 pass), and the SDK smoke test `missions.e2e.test.ts` (all 23 missions load) are green.

## Notes for follow-up (not fixed here)

- **The eng1 `Ladder 16'` #1877 renders lying flat — that is faithful to the data, not a bug in our rotation pipeline.** Its authored angles are `bank=90°, pitch=0, heading=300.89°`; a 90° bank about the object's X axis lays a Z-up ladder model on its back. The pipeline checks out independently: the heading is the third angle slot (dominant across the data — 605 of 677 rotated eng1 objects rotate only about it) and is mapped to world up correctly, and every other ladder in eng1/medsci1/hydro1 has bank=pitch=0. So #1877 is set dressing lying on the deck, **not the route up to the Engineering Control mezzanine** that #589 assumed.
- **Climb engagement still fails on some shafts even with colliders present.** At medsci1's `(-41.3, ·, 16.55)` ladder the player gains only ~0.07 wu before the grip drops, from every approach. That is downstream of this fix (the colliders and `climbable` membership are there) and looks like a separate gap in `climb_redirect` / contact selection over stacked colliders — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
