### PR TITLE
fix: climb straight up a gripped ladder instead of sliding off it (#596)

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -886,11 +886,16 @@ pub fn create_physics_representation(
             .unwrap();
         let immobile = v_immobile.get(entity_id).is_ok();
 
-        if let (Ok(pos), Ok(dimensions), Ok(phys_type)) = (
-            v_pos.get(entity_id),
-            v_dimensions.get(entity_id),
-            v_phys_type.get(entity_id),
-        ) {
+        // `P$PhysDims` is optional: an author who never opened the physics
+        // dimensions dialog leaves the object with only a physics *type*. The
+        // original engine then falls back to the model's bounding box - the
+        // shipped data proves it, because every ladder that *does* carry
+        // authored dimensions carries exactly the model bbox (e.g. eng1's
+        // `Ladder 16'` #945: size (1.65, 6.40, 0.14) == ladder.bin's bounds).
+        // Without this fallback the object silently got no collider at all, so
+        // most ladders were neither solid nor climbable (issue #589).
+        let maybe_dimensions = v_dimensions.get(entity_id).ok();
+        if let (Ok(pos), Ok(phys_type)) = (v_pos.get(entity_id), v_phys_type.get(entity_id)) {
             let qrotation = pos.rotation;
 
             let mut is_sensor = false;
@@ -922,17 +927,27 @@ pub fn create_physics_representation(
                 // scale_factor *= 1.2;
             }
 
+            // Without authored dimensions, fall back to the model bounds
+            // (`abs_dimensions`, already clamped to a minimum size above).
+            let unscaled_size = maybe_dimensions
+                .map(|dimensions| dimensions.size)
+                .unwrap_or(abs_dimensions);
             let size = vec3(
-                dimensions.size.x.abs() * scale_factor.x.abs(),
-                dimensions.size.y.abs() * scale_factor.y.abs(),
-                dimensions.size.z.abs() * scale_factor.z.abs(),
+                unscaled_size.x.abs() * scale_factor.x.abs(),
+                unscaled_size.y.abs() * scale_factor.y.abs(),
+                unscaled_size.z.abs() * scale_factor.z.abs(),
             );
 
-            let shape = match phys_type.phys_type {
-                PhysicsModelType::ORIENTED_BOUNDING_BOX => PhysicsShape::Cuboid(size),
-                PhysicsModelType::SPHERE => {
+            let shape = match (phys_type.phys_type, maybe_dimensions) {
+                (PhysicsModelType::ORIENTED_BOUNDING_BOX, _) => PhysicsShape::Cuboid(size),
+                (PhysicsModelType::SPHERE, Some(dimensions)) => {
                     PhysicsShape::Sphere(dimensions.radius0.abs().max(dimensions.radius1.abs()))
                 }
+                // A sphere with no authored dimensions has no authored radius
+                // either, and the model's bounding *sphere* would swallow the
+                // whole object (a 16' ladder becomes an 8' ball). The bounding
+                // box is the only geometry we have, so use it.
+                (PhysicsModelType::SPHERE, None) => PhysicsShape::Cuboid(size),
                 _ => {
                     warn!("unhandled physics type: {:?}", phys_type);
                     return None;
@@ -957,6 +972,10 @@ pub fn create_physics_representation(
                 CollisionGroup::entity()
             };
 
+            let offset = maybe_dimensions
+                .map(|dimensions| dimensions.offset0)
+                .unwrap_or(Vector3::zero());
+
             let rigid_body_handle = if !immobile && phys_type.phys_type == PhysicsModelType::SPHERE
             {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
@@ -964,7 +983,7 @@ pub fn create_physics_representation(
                     entity_id,
                     pos.position,
                     qrotation,
-                    dimensions.offset0,
+                    offset,
                     shape,
                     //size,
                     group,
@@ -976,7 +995,7 @@ pub fn create_physics_representation(
                     entity_id,
                     pos.position,
                     qrotation,
-                    dimensions.offset0,
+                    offset,
                     size,
                     group,
                     is_sensor,
@@ -1016,7 +1035,92 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use collision::Aabb3;
     use dark::properties::{Links, ToLink};
+
+    /// A ladder-shaped entity: climbable terrain with a physics type but - like
+    /// most shipped ladders - no `P$PhysDims` at all.
+    fn add_ladder(world: &mut World, phys_type: PhysicsModelType) -> EntityId {
+        world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysAttr {
+                gravity_scale: 1.0,
+                mass: 30.0,
+                density: 1.0,
+                elasticity: 1.0,
+                friction: 0.0,
+                cog: Vector3::zero(),
+                rotation_axes: 7,
+                rest_axes: 63,
+                // The shipped ladder value: the four vertical sides.
+                climbable: 27,
+                edge_trigger: false,
+            },
+            PropImmobile(true),
+        ))
+    }
+
+    /// `ladder.bin`'s bounds: 16 SS2 ft tall, flat against a wall.
+    fn ladder_model() -> Model {
+        Model::from_glb(
+            vec![],
+            Aabb3::new(
+                Point3::new(-0.823, -3.2, -0.071),
+                Point3::new(0.823, 3.2, 0.071),
+            ),
+            None,
+        )
+    }
+
+    /// A climbable entity with no `PropPhysDimensions` still gets a collider,
+    /// sized from the model bounds and tagged climbable (issue #589 - 24 of
+    /// eng1's 30 ladders had no collider at all, so they were neither solid nor
+    /// climbable). Negative-first: before the fallback, the missing dimensions
+    /// property made `create_physics_representation` return `None`.
+    #[test]
+    fn climbable_without_dimensions_gets_collider_from_model_bounds() {
+        for phys_type in [
+            PhysicsModelType::ORIENTED_BOUNDING_BOX,
+            // The leaf ladder templates say SPHERE while their parent says OBB;
+            // with no authored radius the model box is all we have.
+            PhysicsModelType::SPHERE,
+        ] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_ladder(&mut world, phys_type);
+            let model = ladder_model();
+
+            let handle =
+                create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                    .expect("climbable entity without dimensions should still get a collider");
+
+            let size = physics
+                .cuboid_full_size(handle)
+                .expect("collider should be a box matching the model bounds");
+            assert!(
+                (size.y - 6.4).abs() < 0.01,
+                "collider should be as tall as the model ({size:?})"
+            );
+
+            let bodies = physics.debug_list_bodies();
+            assert_eq!(bodies.len(), 1, "expected exactly one body in the world");
+            let groups = &bodies[0].collision_groups;
+            assert!(
+                groups.iter().any(|g| g == "climbable"),
+                "ladder collider should be climbable, got {groups:?}"
+            );
+        }
+    }
 
     fn contains_link(to: EntityId) -> ToLink {
         ToLink {

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -886,15 +886,53 @@ pub fn create_physics_representation(
             .unwrap();
         let immobile = v_immobile.get(entity_id).is_ok();
 
+        // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
+        // extra marker membership so player movement can detect contact.
+        // Simplifications: `climbable` is plausibly a per-face bitmask in
+        // the original engine (27 = the four vertical sides on ladders) -
+        // any non-zero value marks the whole collider climbable here. And
+        // only this (non-frobbable) creation branch checks it: all known
+        // ladders are plain terrain objects; a frobbable climbable would
+        // need the same treatment in the branch above.
+        let is_climbable = v_phys_attr
+            .get(entity_id)
+            .map(|pa| pa.climbable != 0)
+            .unwrap_or(false);
+
         // `P$PhysDims` is optional: an author who never opened the physics
-        // dimensions dialog leaves the object with only a physics *type*. The
-        // original engine then falls back to the model's bounding box - the
-        // shipped data proves it, because every ladder that *does* carry
-        // authored dimensions carries exactly the model bbox (e.g. eng1's
-        // `Ladder 16'` #945: size (1.65, 6.40, 0.14) == ladder.bin's bounds).
-        // Without this fallback the object silently got no collider at all, so
-        // most ladders were neither solid nor climbable (issue #589).
+        // dimensions dialog leaves the object with only a physics *type*, and
+        // the object then got no collider at all - which is why most ladders
+        // were neither solid nor climbable (issue #589). The original engine
+        // falls back to the model's bounds, and the shipped data proves it:
+        // every ladder that *does* carry authored dimensions carries exactly
+        // its model's bbox (e.g. eng1's `Ladder 16'` #945: size
+        // (1.65, 6.40, 0.14) == ladder.bin's bounds, offset zero == its
+        // bbox center).
+        //
+        // Deliberately limited to *climbable* objects. The same fallback
+        // applied to every dimension-less physics object turns ~187 further
+        // props solid across the shipped missions (hydro2 pipe runs, station
+        // windows and crates, bar stools) - plausibly also faithful, but a
+        // separate change with its own traversal testing, not a silent
+        // side effect of a ladder fix.
         let maybe_dimensions = v_dimensions.get(entity_id).ok();
+        let model_bounds = if maybe_dimensions.is_none() && is_climbable {
+            // Raw model bounds - deliberately NOT `abs_dimensions`, whose
+            // minimum-size clamp would make a fallback ladder 41% thicker
+            // than the authored ladder standing next to it. Degenerate sizes
+            // are already guarded by `sanitize_collider_size`.
+            maybe_model
+                .as_ref()
+                .and_then(|model| model.bounding_box())
+                .map(|bbox| {
+                    (
+                        bbox.max - bbox.min,
+                        bbox.min.to_vec() + (bbox.max - bbox.min) / 2.0,
+                    )
+                })
+        } else {
+            None
+        };
         if let (Ok(pos), Ok(phys_type)) = (v_pos.get(entity_id), v_phys_type.get(entity_id)) {
             let qrotation = pos.rotation;
 
@@ -927,11 +965,13 @@ pub fn create_physics_representation(
                 // scale_factor *= 1.2;
             }
 
-            // Without authored dimensions, fall back to the model bounds
-            // (`abs_dimensions`, already clamped to a minimum size above).
-            let unscaled_size = maybe_dimensions
-                .map(|dimensions| dimensions.size)
-                .unwrap_or(abs_dimensions);
+            // No authored dimensions and no usable model bounds: nothing to
+            // build a collider from, so behave as before (no physics).
+            let unscaled_size = match (maybe_dimensions, model_bounds) {
+                (Some(dimensions), _) => dimensions.size,
+                (None, Some((size, _))) => size,
+                (None, None) => return None,
+            };
             let size = vec3(
                 unscaled_size.x.abs() * scale_factor.x.abs(),
                 unscaled_size.y.abs() * scale_factor.y.abs(),
@@ -943,10 +983,10 @@ pub fn create_physics_representation(
                 (PhysicsModelType::SPHERE, Some(dimensions)) => {
                     PhysicsShape::Sphere(dimensions.radius0.abs().max(dimensions.radius1.abs()))
                 }
-                // A sphere with no authored dimensions has no authored radius
-                // either, and the model's bounding *sphere* would swallow the
-                // whole object (a 16' ladder becomes an 8' ball). The bounding
-                // box is the only geometry we have, so use it.
+                // The leaf ladder templates say SPHERE where their parent says
+                // OBB, but carry no radius to go with it (and a bounding
+                // sphere would swallow the room: a 16' ladder becomes an 8'
+                // ball). The bounding box is the only geometry we have.
                 (PhysicsModelType::SPHERE, None) => PhysicsShape::Cuboid(size),
                 _ => {
                     warn!("unhandled physics type: {:?}", phys_type);
@@ -954,29 +994,26 @@ pub fn create_physics_representation(
                 }
             };
 
-            // Climbable surfaces (ladders: PropPhysAttr.climbable != 0) carry an
-            // extra marker membership so player movement can detect contact.
-            // Simplifications: `climbable` is plausibly a per-face bitmask in
-            // the original engine (27 = the four vertical sides on ladders) -
-            // any non-zero value marks the whole collider climbable here. And
-            // only this (non-frobbable) creation branch checks it: all known
-            // ladders are plain terrain objects; a frobbable climbable would
-            // need the same treatment in the branch above.
-            let is_climbable = v_phys_attr
-                .get(entity_id)
-                .map(|pa| pa.climbable != 0)
-                .unwrap_or(false);
             let group = if is_climbable {
                 CollisionGroup::climbable_entity()
             } else {
                 CollisionGroup::entity()
             };
 
-            let offset = maybe_dimensions
-                .map(|dimensions| dimensions.offset0)
-                .unwrap_or(Vector3::zero());
+            let offset = match (maybe_dimensions, model_bounds) {
+                (Some(dimensions), _) => dimensions.offset0,
+                (None, Some((_, center))) => center,
+                (None, None) => Vector3::zero(),
+            };
 
-            let rigid_body_handle = if !immobile && phys_type.phys_type == PhysicsModelType::SPHERE
+            // Only an object with authored dimensions takes the dynamic path.
+            // A dimension-less SPHERE has no authored radius, so a dynamic
+            // body would be a model-box-shaped prop falling under gravity -
+            // the fallback exists to make static geometry solid, not to
+            // animate it.
+            let rigid_body_handle = if !immobile
+                && maybe_dimensions.is_some()
+                && phys_type.phys_type == PhysicsModelType::SPHERE
             {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
                 physics.add_dynamic(
@@ -1035,12 +1072,13 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::InnerSpace;
     use collision::Aabb3;
     use dark::properties::{Links, ToLink};
 
     /// A ladder-shaped entity: climbable terrain with a physics type but - like
     /// most shipped ladders - no `P$PhysDims` at all.
-    fn add_ladder(world: &mut World, phys_type: PhysicsModelType) -> EntityId {
+    fn add_ladder(world: &mut World, phys_type: PhysicsModelType, climbable: u32) -> EntityId {
         world.add_entity((
             PropPosition {
                 position: vec3(0.0, 0.0, 0.0),
@@ -1062,8 +1100,7 @@ mod tests {
                 cog: Vector3::zero(),
                 rotation_axes: 7,
                 rest_axes: 63,
-                // The shipped ladder value: the four vertical sides.
-                climbable: 27,
+                climbable,
                 edge_trigger: false,
             },
             PropImmobile(true),
@@ -1082,6 +1119,8 @@ mod tests {
         )
     }
 
+    const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
     /// A climbable entity with no `PropPhysDimensions` still gets a collider,
     /// sized from the model bounds and tagged climbable (issue #589 - 24 of
     /// eng1's 30 ladders had no collider at all, so they were neither solid nor
@@ -1097,29 +1136,71 @@ mod tests {
         ] {
             let mut world = World::new();
             let mut physics = PhysicsWorld::new();
-            let entity_id = add_ladder(&mut world, phys_type);
+            let entity_id = add_ladder(&mut world, phys_type, 27);
             let model = ladder_model();
 
             let handle =
                 create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
                     .expect("climbable entity without dimensions should still get a collider");
 
+            // The full model bounds, unclamped: an authored ladder standing
+            // next to a fallback one must have the same solidity.
             let size = physics
                 .cuboid_full_size(handle)
                 .expect("collider should be a box matching the model bounds");
             assert!(
-                (size.y - 6.4).abs() < 0.01,
-                "collider should be as tall as the model ({size:?})"
+                (size - LADDER_SIZE).magnitude() < 0.01,
+                "collider should match the model bounds {LADDER_SIZE:?}, got {size:?}"
             );
 
             let bodies = physics.debug_list_bodies();
             assert_eq!(bodies.len(), 1, "expected exactly one body in the world");
+            assert_eq!(
+                bodies[0].body_type, "kinematic",
+                "a dimension-less ladder must not become a falling dynamic prop"
+            );
             let groups = &bodies[0].collision_groups;
             assert!(
                 groups.iter().any(|g| g == "climbable"),
                 "ladder collider should be climbable, got {groups:?}"
             );
         }
+    }
+
+    /// The fallback is scoped to climbable objects: a non-climbable entity with
+    /// no `PropPhysDimensions` keeps the old behavior (no collider), so the
+    /// ladder fix does not silently turn set dressing solid.
+    #[test]
+    fn non_climbable_without_dimensions_still_gets_no_collider() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_ladder(&mut world, PhysicsModelType::ORIENTED_BOUNDING_BOX, 0);
+        let model = ladder_model();
+
+        assert!(
+            create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                .is_none(),
+            "non-climbable entities must keep their previous (collider-less) behavior"
+        );
+    }
+
+    /// A non-immobile climbable object with no dimensions must not become a
+    /// dynamic body: there is no authored radius for the SPHERE path, so the
+    /// fallback builds static geometry, never a gravity-driven prop.
+    #[test]
+    fn dimensionless_sphere_never_becomes_dynamic() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_ladder(&mut world, PhysicsModelType::SPHERE, 27);
+        world.remove::<(PropImmobile,)>(entity_id);
+        let model = ladder_model();
+
+        create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+            .expect("climbable entity without dimensions should still get a collider");
+
+        let bodies = physics.debug_list_bodies();
+        assert_eq!(bodies.len(), 1);
+        assert_eq!(bodies[0].body_type, "kinematic");
     }
 
     fn contains_link(to: EntityId) -> ToLink {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -100,12 +100,19 @@ const CLIMB_SPEED_SCALE: f32 = 0.6;
 /// forward progress and creep them up the wall instead.
 const MIN_CLIMB_GRIP_FRACTION: f32 = 0.5;
 
+/// How much of the requested climb the cast must actually achieve for the frame
+/// to count as climbing rather than walking (see [`step_player_movement`]).
+/// Anything at or below this is a redirect wedged into solid geometry, not a
+/// climb.
+const CLIMB_MIN_PROGRESS_FRACTION: f32 = 0.1;
+
 /// Half-Life-style flat ladder movement: convert the into-ladder component of
 /// the desired movement into a vertical climb. `toward_ladder` is the
 /// horizontal unit normal from the player toward the climbable surface (from
-/// the contact query - NOT the collider-center direction, which gains a lateral
-/// component whenever the player is off-center and steers the player sideways
-/// off the ladder). Returns `None` when the player is not pushing mostly toward
+/// the contact query - NOT the collider-center direction, which tilts away from
+/// the surface whenever the player is off-center and so mis-measures both the
+/// grip test and the climb speed). Returns `None` when the player is not
+/// pushing mostly toward
 /// the ladder (no grip - normal walking/gravity applies). Looking down (a
 /// downward-pitched desired movement) descends instead of ascending, so the
 /// same input walks down a shaft ladder; the sign flip at the pitch threshold
@@ -361,7 +368,9 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
 /// result can never pass through geometry.
 ///
 /// `climb` is the ladder redirect vector when the player grips a climbable
-/// surface: it replaces both the walk input and the gravity pass.
+/// surface: it replaces both the walk input and the gravity pass - unless it
+/// achieves nothing, in which case the frame walks normally (see
+/// `CLIMB_MIN_PROGRESS_FRACTION`).
 fn step_player_movement(
     controller: &KinematicCharacterController,
     queries: &QueryPipeline,
@@ -372,36 +381,41 @@ fn step_player_movement(
     gravity: Real,
     climb: Option<Vector<Real>>,
 ) -> EffectiveCharacterMovement {
+    // Ladder: the climb vector replaces both the walk and the gravity pass.
+    // Only if it actually moves the player, though - a climb consumes the
+    // horizontal input, so a grip whose redirect is cast into solid geometry
+    // (the floor the player is standing on when the redirect points DOWN, a
+    // ceiling above them when it points up) would otherwise pin them in place
+    // with nothing left to walk out with.
+    if let Some(climb) = climb {
+        let mvt = controller.move_shape(dt, queries, shape, pos, climb, |_c| ());
+        if mvt.translation.norm() > CLIMB_MIN_PROGRESS_FRACTION * climb.norm() {
+            return mvt;
+        }
+    }
     // Walk and gravity run as separate passes - NOT the old up-bump hack
     // (there is no artificial upward movement): a combined walk+gravity cast
     // points into the floor the player rests on, which degenerates into
-    // zero-progress resting contacts (see `PLAYER_REST_LIFT`). While gripping a
-    // ladder the climb vector replaces both passes.
-    let (walk, apply_gravity) = match climb {
-        Some(climb) => (climb, false),
-        None => (desired, true),
-    };
-    let mut mvt = controller.move_shape(dt, queries, shape, pos, walk, |_c| ());
-    if apply_gravity {
-        let after_walk = Translation::from(mvt.translation) * pos;
-        let fall = controller.move_shape(
-            dt,
-            queries,
-            shape,
-            &after_walk,
-            Vector::y() * gravity,
-            |_c| (),
-        );
-        mvt.translation += fall.translation;
-        mvt.grounded = fall.grounded;
-        if mvt.grounded {
-            mvt.translation += Vector::y() * (PLAYER_REST_LIFT / SCALE_FACTOR);
-        }
+    // zero-progress resting contacts (see `PLAYER_REST_LIFT`).
+    let mut mvt = controller.move_shape(dt, queries, shape, pos, desired, |_c| ());
+    let after_walk = Translation::from(mvt.translation) * pos;
+    let fall = controller.move_shape(
+        dt,
+        queries,
+        shape,
+        &after_walk,
+        Vector::y() * gravity,
+        |_c| (),
+    );
+    mvt.translation += fall.translation;
+    mvt.grounded = fall.grounded;
+    if mvt.grounded {
+        mvt.translation += Vector::y() * (PLAYER_REST_LIFT / SCALE_FACTOR);
     }
     // Stairs: if grounded walking was blocked, probe for a step and hop onto
     // it. (Grounded-only: an airborne player pressed against a wall must not
     // ratchet up ledges.)
-    if climb.is_none() && mvt.grounded {
+    if mvt.grounded {
         if let Some(step) = try_step_up(
             queries,
             shape,
@@ -1795,8 +1809,8 @@ impl PhysicsWorld {
                 // Grip the closest climbable within reach, by contact distance,
                 // and take the contact's *face normal* as the climb direction.
                 // (The collider-center direction is wrong when the player is
-                // off-center: its lateral component steers the player sideways
-                // off the ladder - a positive-feedback drift.)
+                // off-center: it tilts away from the face, which under-reads
+                // the into-ladder push the grip test and climb speed use.)
                 let mut nearest: Option<(f32, Vector<Real>)> = None;
                 for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
                     let contact = rapier3d::parry::query::contact(
@@ -3109,6 +3123,66 @@ mod tests {
         assert!(
             drift.abs() < 0.45,
             "the climb must not slide the player off the 0.9-wide ladder, drifted {drift}"
+        );
+    }
+
+    /// A grip whose climb cannot move the player must not pin them in place.
+    /// Standing at a ladder's foot while looking down redirects the push into a
+    /// DESCENT, which is cast straight into the floor; since a grip also
+    /// consumes the horizontal input and suppresses gravity, the player would
+    /// be frozen with nothing to walk out with. The frame must fall back to
+    /// normal walking, so pushing 30 degrees across the ladder still carries
+    /// the player along it.
+    #[test]
+    fn a_climb_that_cannot_move_the_player_walks_instead() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        // A wide climbable wall at x=-5 (wide, so this is about the descent
+        // cast hitting the floor - not about running out of ladder).
+        world.add_kinematic(
+            EntityId::from_inner(2001).unwrap(),
+            vec3(-5.0, 5.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.2, 10.0, 20.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(-6.0, 1.0, 0.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        // Pushing 30 degrees across the wall (still inside the grip cone) while
+        // pitched down - a downward redirect, cast into the floor.
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let desired = Vector3::new(
+            walk * 30f32.to_radians().cos(),
+            -walk,
+            walk * 30f32.to_radians().sin(),
+        );
+        for _ in 0..60 {
+            world.update(desired, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            (end.z - start.z) > 0.5,
+            "a climb that cannot move the player must fall back to walking, moved {} along the wall (ended {end:?})",
+            end.z - start.z
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -112,11 +112,10 @@ const CLIMB_MIN_PROGRESS_FRACTION: f32 = 0.1;
 /// the contact query - NOT the collider-center direction, which tilts away from
 /// the surface whenever the player is off-center and so mis-measures both the
 /// grip test and the climb speed). Returns `None` when the player is not
-/// pushing mostly toward
-/// the ladder (no grip - normal walking/gravity applies). Looking down (a
-/// downward-pitched desired movement) descends instead of ascending, so the
-/// same input walks down a shaft ladder; the sign flip at the pitch threshold
-/// matches classic ladder feel.
+/// pushing mostly toward the ladder (no grip - normal walking/gravity
+/// applies). Looking down (a downward-pitched desired movement) descends
+/// instead of ascending, so the same input walks down a shaft ladder; the sign
+/// flip at the pitch threshold matches classic ladder feel.
 ///
 /// **A grip climbs straight up the face: the horizontal movement is dropped
 /// entirely, not just its into-ladder component.** The into-ladder part has to

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -90,28 +90,55 @@ const CLIMB_REACH: f32 = 1.0 / SCALE_FACTOR;
 /// redirected to vertical movement at this scale).
 const CLIMB_SPEED_SCALE: f32 = 0.6;
 
+/// How much of the desired horizontal movement must point INTO the climbable
+/// surface before the player grips it: 0.5 is a 60 degree cone around the
+/// contact normal. Below it the push is mostly along the surface, which is
+/// someone walking PAST a wall-mounted ladder, not climbing it - they keep
+/// walking (and keep gravity). Since a grip now consumes the whole horizontal
+/// input (see [`climb_redirect`]), without this floor a ladder set into a
+/// corridor wall would act as flypaper: a grazing input would zero the player's
+/// forward progress and creep them up the wall instead.
+const MIN_CLIMB_GRIP_FRACTION: f32 = 0.5;
+
 /// Half-Life-style flat ladder movement: convert the into-ladder component of
 /// the desired movement into a vertical climb. `toward_ladder` is the
-/// horizontal unit **face normal** from the player toward the climbable
-/// surface (from the contact query - NOT the collider-center direction, which
-/// gains a lateral component whenever the player is off-center and steers the
-/// player sideways off the ladder). Returns `None` when the player is not
-/// pushing toward the ladder (no grip - normal walking/gravity applies).
-/// Looking down (a downward-pitched desired movement) descends instead of
-/// ascending, so the same input walks down a shaft ladder; the sign flip at
-/// the pitch threshold matches classic ladder feel.
+/// horizontal unit normal from the player toward the climbable surface (from
+/// the contact query - NOT the collider-center direction, which gains a lateral
+/// component whenever the player is off-center and steers the player sideways
+/// off the ladder). Returns `None` when the player is not pushing mostly toward
+/// the ladder (no grip - normal walking/gravity applies). Looking down (a
+/// downward-pitched desired movement) descends instead of ascending, so the
+/// same input walks down a shaft ladder; the sign flip at the pitch threshold
+/// matches classic ladder feel.
 ///
-/// The into-ladder component is removed from the horizontal movement: the
-/// character controller's slope limiting treats a vertical climbable face as
-/// an unclimbable slope and cancels the ascent when the player also pushes
-/// into it (empirically: ascent drops from ~7u to ~0.3u over 240 frames).
-/// Lateral (along-ladder) movement is preserved. The vertical component of
-/// `desired` (head pitch / debug fly channel) is dropped so climb speed
-/// depends only on the into-ladder push.
+/// **A grip climbs straight up the face: the horizontal movement is dropped
+/// entirely, not just its into-ladder component.** The into-ladder part has to
+/// go because the character controller's slope limiting treats a vertical
+/// climbable face as an unclimbable slope and cancels the ascent when the
+/// player also pushes into it (empirically: ascent drops from ~7u to ~0.3u over
+/// 240 frames). Passing the remaining ALONG-face part through is what broke
+/// issue #596: shipped ladders are ~0.9 world units wide, so a few degrees of
+/// heading error slides the player off the side at walk speed (10 wu/s x sin
+/// theta) in a fraction of the ~0.5 s the 6 wu/s climb needs - and once the
+/// capsule is past the ladder's edge the contact normal turns diagonal, so even
+/// a dead-on push resolves into a sideways shove that carries the player
+/// further off (a positive feedback loop: measured as a stall after ~1.4 wu
+/// with the player shoved ~1.1 wu sideways, on stacked-rung AND single-collider
+/// ladders alike). Climbing straight up removes both: the redirect can no
+/// longer steer the player off the surface it is gripping. Stepping off at the
+/// top is unaffected - the grip drops once the capsule clears the ladder's top
+/// and normal walking carries the player onto the landing.
+///
+/// The vertical component of `desired` (head pitch / debug fly channel) is
+/// dropped so climb speed depends only on the into-ladder push.
 fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<Vector<Real>> {
     let desired_h = vector![desired.x, 0.0, desired.z];
+    let speed = desired_h.norm();
+    if speed <= 1e-6 {
+        return None;
+    }
     let into = desired_h.dot(&toward_ladder);
-    if into <= 1e-6 {
+    if into < MIN_CLIMB_GRIP_FRACTION * speed {
         return None;
     }
     let vertical = if desired.y < -0.25 * into {
@@ -119,7 +146,7 @@ fn climb_redirect(desired: Vector<Real>, toward_ladder: Vector<Real>) -> Option<
     } else {
         into
     };
-    Some(desired_h - toward_ladder * into + Vector::y() * vertical * CLIMB_SPEED_SCALE)
+    Some(Vector::y() * vertical * CLIMB_SPEED_SCALE)
 }
 
 /// How much (SS2 ft) the step probe's clearance sweeps shrink the player
@@ -2997,6 +3024,91 @@ mod tests {
         assert!(
             plain_ascent.abs() < 0.5,
             "a plain wall must not be climbable, rose {plain_ascent}"
+        );
+    }
+
+    /// A push that only grazes the ladder (mostly along its face) is walking
+    /// past it, not climbing it, so it must not grip - otherwise a ladder set
+    /// into a corridor wall becomes flypaper, since a grip consumes the whole
+    /// horizontal input.
+    #[test]
+    fn climb_redirect_ignores_a_grazing_push() {
+        let toward = vector![1.0, 0.0, 0.0];
+        // ~15 degrees into the face: mostly walking along it.
+        assert!(climb_redirect(vector![0.026, 0.0, 0.097], toward).is_none());
+        // ~70 degrees into the face: climbing.
+        assert!(climb_redirect(vector![0.094, 0.0, 0.034], toward).is_some());
+    }
+
+    /// Issue #596: real ladders are built as a STACK of ~0.8 wu rung colliders
+    /// only ~0.9 wu wide (eng1's Engine Core shaft, medsci1's cryo bay), and a
+    /// player rarely faces one dead-on. Pushing into such a ladder a few
+    /// degrees off perpendicular must still climb it.
+    ///
+    /// Negative-first: while `climb_redirect` passed the along-face component
+    /// of the push through, that residue slid the player off the 0.9 wu-wide
+    /// ladder at walk speed - the ascent stalled after ~1 wu and the player was
+    /// shoved sideways clear of the rungs, ending back on the floor (before the
+    /// fix this test finished at y +0.00, 2.40 wu off the ladder's center),
+    /// which is exactly the live symptom.
+    #[test]
+    fn player_climbs_a_stacked_rung_ladder_when_pushing_slightly_off_angle() {
+        let mut world = PhysicsWorld::new();
+        // Floor top at y=0 (parentless trimesh, like level geometry).
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        // Five stacked rungs, each the size of a shipped `rickladd` collider
+        // (0.9 wide x 0.8 tall x 0.1 deep), contiguous from y=0 to y=4.
+        for rung in 0..5 {
+            world.add_kinematic(
+                EntityId::from_inner(2001 + rung).unwrap(),
+                vec3(-5.0, 0.4 + 0.8 * rung as f32, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.1, 0.8, 0.9),
+                CollisionGroup::climbable_entity(),
+                false,
+            );
+        }
+        let mut player =
+            world.create_player(vec3(-6.0, 1.0, 0.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        // A frame of walking (25 SS2 ft/s at 60 Hz), aimed 20 degrees off the
+        // ladder's face normal.
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let desired = Vector3::new(
+            walk * 20f32.to_radians().cos(),
+            0.0,
+            walk * 20f32.to_radians().sin(),
+        );
+        for _ in 0..40 {
+            world.update(desired, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        let ascent = end.y - start.y;
+        let drift = end.z - start.z;
+
+        assert!(
+            ascent > 3.0,
+            "an off-angle push should still climb the rung stack, rose {ascent} (ended {end:?})"
+        );
+        assert!(
+            drift.abs() < 0.45,
+            "the climb must not slide the player off the 0.9-wide ladder, drifted {drift}"
         );
     }
 


### PR DESCRIPTION
Fixes #596

Stacked on #595 (which gives these ladders their colliders) — base branch `fix/589-ladder-collider-fallback`.

## Root cause: it was never about the stack

The issue suspected stacked rung colliders (or a seam between them). It isn't. Straight-on, the eng1 Engine Core stack climbs perfectly — 6 wu/s right across every rung seam, from all four approach distances in the report. And the "working control", the single-collider `Rick Ladder 16` (obj 1911), **fails identically once you are 10° off perpendicular**:

| eng1 `Rick Ladder 16` (obj 1911), 0.5 s of forward push | before |
| --- | --- |
| dead-on | y −15.60 → **−12.80** (6.0 wu/s) |
| 10° off | rose ~1.0, slid off the ladder, fell back to the floor, stuck |
| 20° off | rose ~1.8, slid off the ladder, fell back to the floor, stuck |

What distinguishes the failing runs from the working ones is the **heading**, not the geometry. `climb_redirect` removed the into-ladder component of the push (it has to: the character controller treats a vertical climbable face as an unclimbable slope and cancels the ascent) but passed the remaining **along-face** component through at full walk speed. Shipped ladders are **0.9 world units wide** (`rickladd`'s model bounds; the authored 16 ft ladder is the same width), so:

- a few degrees of heading error slides the player sideways at `10 wu/s × sin θ` — 3.4 wu/s at 20°, i.e. off a 0.45 wu half-width ladder in ~0.15 s, while the 6 wu/s climb needs ~0.5 s to cover the shaft; and
- once the capsule is past the ladder's edge the contact normal turns **diagonal**, so `desired_h − toward·into` resolves a dead-on push into a *sideways shove* — a positive feedback loop that carries the player further off. Measured on the Engine Core stack: pushing straight at the ladder from 0.15 wu off its edge produced pure lateral drift and **zero** climb.

That is exactly the reported symptom — rise ~1.4 wu, then stall forever, shoved from x 0.10 to x −0.99 (the wall beside the ladder) — reproduced here at 20-30° off perpendicular from all four approach distances.

## The fix

**A grip climbs straight up the face**: the horizontal movement is dropped entirely, not just its into-ladder component, so the redirect can no longer steer the player off the surface it is gripping. Because a grip now consumes the whole horizontal input, two guards come with it:

- `MIN_CLIMB_GRIP_FRACTION` (0.5, a 60° cone) — a grazing push is someone walking *past* a wall-mounted ladder, not climbing it, so it does not grip. Without this a ladder set into a corridor wall would be flypaper.
- a climb frame that **achieves nothing** falls back to a normal walk + gravity pass (`CLIMB_MIN_PROGRESS_FRACTION`). Standing at a ladder's foot while looking down aims the redirect *down into the floor*; with the horizontal input consumed and gravity suppressed, the player would otherwise be frozen in place. (Found by `/xreview`; measured 0.31 wu of movement over 60 frames before the guard, 7.35 wu after.)

Stepping off at the top is unaffected — the grip drops once the capsule clears the ladder's top and normal walking carries the player onto the landing.

## Verification

**Negative-first unit tests** (`shock2vr/src/physics/mod.rs`), each failing on the parent commit and passing here:

| test | without the fix |
| --- | --- |
| `player_climbs_a_stacked_rung_ladder_when_pushing_slightly_off_angle` — five 0.9 × 0.8 × 0.1 rung colliders stacked contiguously (the shipped `rickladd` collider size), pushed 20° off the face normal | *"an off-angle push should still climb the rung stack, rose 0.0000007"* — the player slid 2.40 wu off the ladder and ended back on the floor |
| `climb_redirect_ignores_a_grazing_push` — 15° into the face must not grip, 70° must | grips at 15° |
| `a_climb_that_cannot_move_the_player_walks_instead` — grounded at the foot, pitched down, pushing 30° across the ladder | *"moved 0.31"* (frozen) vs 7.35 with the guard |

**Live (debug runtime, eng1 + medsci1, same binary before/after):**

eng1 **Engine Core stacked ladder** (obj 377/413/339/414/415 at `(0.10, −16.8…−12.8, −22.95)`), settled at the foot at y −15.56, holding forward:

| approach heading | before | after |
| --- | --- | --- |
| dead-on | −15.56 → **−11.80** (tops out on the landing, feet −12.83) | −15.56 → **−11.80** |
| 10° off | −15.56 → −11.80 | −15.56 → **−11.80** |
| 20° off | −15.56 → **−14.96**, shoved to x −0.99, stalled | −15.56 → **−11.80** |
| 30° off | −15.56 → **−15.56** (no climb at all), shoved to x −0.96 | −15.56 → **−11.80** |
| −10° / −20° | −15.56 → −11.80 | −15.56 → −11.80 |

eng1 **`Rick Ladder 16` (obj 1911) — the working control**, 0.5 s of push:

| | before | after |
| --- | --- | --- |
| dead-on | −15.596 → −14.796 → −13.796 → **−12.796** (6.0 wu/s) | **identical**, 6.0 wu/s |
| 10° off | rose ~1.0 then slid off and fell back | −15.596 → **−12.839** (5.5 wu/s), drift 0.03 |
| 20° off | rose ~1.8 then slid off and fell back | −15.596 → **−12.965** (5.3 wu/s), drift 0.06 |

**Descent** (climb, then look down and keep pushing) still works on both, at 6 × cos(pitch) and all the way back to the floor: Engine Core stack −13.158 → **−15.562**; `Rick Ladder 16` −13.296 → **−15.600**.

**medsci1 cryo-bay stack** (six rungs at `(−41.3, −6.2…−1.6, 16.55)`), the second failing case in the issue:

| approach heading | before | after |
| --- | --- | --- |
| dead-on | −5.80 → **−2.57** (the ladder top) | −5.80 → **−2.57** |
| ±10° | slid off, fell down the shaft (−10.5 / −10.7) | −5.80 → **−2.60 / −2.70** |
| ±20° | slid off, fell down the shaft (−13.6) | −5.80 → **−2.71 / −2.84** |

Descent there works too (−2.70 → −5.36 at 4.2 wu/s).

`cargo fmt --check --all`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` and `cargo test -p shock2vr` (281 pass) are green.

**SDK e2e suite**: the full suite was run over this change; `flat climbing: pushing into a ladder ascends it` and all 23 mission loads pass. Two failures, neither from this change:

- `Earth Psionic Training …` fails **identically on the base branch** (pre-existing here; the fix for it is not in this stack).
- `no AI freezes mid-route after alertness churn (#481)` is flaky. It passes on the final code, and it cannot be affected by this change: the test never moves the player (it teleports once and steps), and replaying its exact 2 740-frame scenario with a grip counter instrumented in `move_player` logs **zero** grips — the climb path never executes there. AI movement does not use the character controller at all (`step_player_movement` is called only by `move_player` / `move_player_validated`).

## Deliberate tradeoffs

- **No shimmying while gripping.** You climb straight up or down; to move sideways you let go (release, or turn more than 60° away). That is what removes the drift, and it matches how the shipped ladders are built — a 0.9 wu-wide plank you either are on or are not.
- **No grip hysteresis.** The 60° cone is applied every frame, so turning more than 60° away mid-climb drops the grip and you fall (previously the limit was 90°). Adding acquire/retain thresholds would mean carrying climb state on `PlayerHandle`; not worth it until a shaft actually needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
