### PR TITLE
fix(rec): implement PictureSwap so the transmitter code can be read

### DIFF
--- a/dark/src/properties/prop_tweq.rs
+++ b/dark/src/properties/prop_tweq.rs
@@ -77,6 +77,11 @@ impl PropTweqRotateState {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTweqModelState {
     pub animation_state: TweqAnimationState,
+    /// Index into [`PropTweqModelConfig::model_names`] of the model currently
+    /// displayed. Authored data starts at 0; the model tweq advances it (see
+    /// `PictureSwap`). Older saves predate the field and resume from frame 0.
+    #[serde(default)]
+    pub frame: usize,
 }
 
 impl PropTweqModelState {
@@ -85,9 +90,12 @@ impl PropTweqModelState {
         let animation_state = TweqAnimationState::from_bits(animation_state_bits.into()).unwrap();
         let _misc = read_u16(reader); // misc state, is this used?
         let _time = read_u16(reader); // misc state, is this used?
-        let _frame = read_u16(reader); // misc state, is this used?
+        let frame = read_u16(reader);
 
-        PropTweqModelState { animation_state }
+        PropTweqModelState {
+            animation_state,
+            frame: frame as usize,
+        }
     }
 }
 

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -30,6 +30,7 @@ mod melee_weapon;
 mod obj_consume_button;
 mod once_room;
 mod once_router;
+mod picture_swap;
 pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
@@ -93,6 +94,7 @@ use self::gui::{
     TrainerMode, TraitGui,
 };
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
+use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
 use self::reduce_psi::ReducePsi;
@@ -723,7 +725,7 @@ impl ScriptWorld {
             // rec1
             // elevator buttons
             "elevatorbutton" => gui_script(Box::new(ElevatorGui)),
-            "pictureswap" => Box::new(NoopScript::new()),
+            "pictureswap" => Box::new(PictureSwap::new()),
             "testimplant" => Box::new(UnimplementedScript::new(&script_name)),
 
             // ric2:

--- a/shock2vr/src/scripts/picture_swap.rs
+++ b/shock2vr/src/scripts/picture_swap.rs
@@ -1,0 +1,229 @@
+use dark::properties::{
+    PropTweqModelConfig, PropTweqModelState, TweqAnimationConfig, TweqAnimationState, TweqHalt,
+};
+use shipyard::{EntityId, Get, View, ViewMut, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// `PictureSwap` - the Rec deck's `Code Art` picture frames.
+///
+/// The frames carry a model tweq (`PropTweqModelConfig` / `PropTweqModelState`)
+/// whose frame list alternates artwork and static, ending with a digit of the
+/// transmitter code. Frobbing a frame steps that tweq forward by one frame
+/// instead of letting time drive it, so the player reads the code off the art.
+pub struct PictureSwap {}
+
+impl PictureSwap {
+    pub fn new() -> PictureSwap {
+        PictureSwap {}
+    }
+}
+
+impl Script for PictureSwap {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob => advance_frame(world, entity_id),
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+/// Position within a model tweq: which frame is showing, and which way the
+/// animation is currently walking the frame list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelFrame {
+    pub index: usize,
+    pub reverse: bool,
+}
+
+/// Advance a model tweq by a single frame, honoring its animation config.
+///
+/// Mirrors the engine's per-tick model tweq step: forward until the last
+/// authored model, then "hit the edge". At an edge, a halt action other than
+/// `Continue` ends the tweq (`None`); otherwise a `WRAP` tweq jumps back to
+/// the opposite end while a non-wrapping one bounces - it reverses direction
+/// and steps inward. `ONEBOUNCE` only lets the halt action fire once the tweq
+/// is already running in reverse (i.e. after the bounce off the top).
+fn advance_frame_index(config: &PropTweqModelConfig, current: ModelFrame) -> Option<ModelFrame> {
+    let top = config.model_names.len().checked_sub(1)?;
+
+    let hit_edge = |top_edge: bool| -> Option<ModelFrame> {
+        let one_bounce = config
+            .animation_config
+            .contains(TweqAnimationConfig::ONEBOUNCE);
+        if (!one_bounce || current.reverse) && !matches!(config.halt, TweqHalt::Continue) {
+            return None;
+        }
+
+        if config.animation_config.contains(TweqAnimationConfig::WRAP) {
+            Some(ModelFrame {
+                index: if top_edge { 0 } else { top },
+                reverse: current.reverse,
+            })
+        } else {
+            Some(ModelFrame {
+                index: if top_edge {
+                    top.saturating_sub(1)
+                } else {
+                    1.min(top)
+                },
+                reverse: !current.reverse,
+            })
+        }
+    };
+
+    if current.reverse {
+        if current.index > 0 {
+            Some(ModelFrame {
+                index: current.index - 1,
+                reverse: true,
+            })
+        } else {
+            hit_edge(false)
+        }
+    } else if current.index < top {
+        Some(ModelFrame {
+            index: current.index + 1,
+            reverse: false,
+        })
+    } else {
+        hit_edge(true)
+    }
+}
+
+/// Step the entity's model tweq one frame forward and swap in the new model.
+/// The new position is written back to `PropTweqModelState` so it survives
+/// save/load and further frobs continue the cycle.
+fn advance_frame(world: &World, entity_id: EntityId) -> Effect {
+    let v_config = world.borrow::<View<PropTweqModelConfig>>().unwrap();
+    let mut v_state = world.borrow::<ViewMut<PropTweqModelState>>().unwrap();
+
+    let Ok(config) = v_config.get(entity_id) else {
+        return Effect::NoEffect;
+    };
+    let Ok(state) = (&mut v_state).get(entity_id) else {
+        return Effect::NoEffect;
+    };
+
+    let current = ModelFrame {
+        index: state.frame,
+        reverse: state.animation_state.contains(TweqAnimationState::REVERSE),
+    };
+
+    let Some(next) = advance_frame_index(config, current) else {
+        return Effect::NoEffect;
+    };
+
+    state.frame = next.index;
+    state
+        .animation_state
+        .set(TweqAnimationState::REVERSE, next.reverse);
+
+    Effect::ChangeModel {
+        entity_id,
+        model_name: config.model_names[next.index].to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(
+        model_count: usize,
+        animation_config: TweqAnimationConfig,
+        halt: TweqHalt,
+    ) -> PropTweqModelConfig {
+        PropTweqModelConfig {
+            animation_config,
+            halt,
+            model_names: (0..model_count).map(|i| format!("model{i}")).collect(),
+        }
+    }
+
+    fn frame(index: usize, reverse: bool) -> ModelFrame {
+        ModelFrame { index, reverse }
+    }
+
+    /// Walk `steps` frames from the start of the tweq, collecting each index.
+    fn walk(config: &PropTweqModelConfig, steps: usize) -> Vec<Option<usize>> {
+        let mut current = frame(0, false);
+        (0..steps)
+            .map(|_| match advance_frame_index(config, current) {
+                Some(next) => {
+                    current = next;
+                    Some(next.index)
+                }
+                None => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn code_art_frames_bounce_off_the_last_model() {
+        // The authored Rec deck frames: 6 models, no flags, halt Continue.
+        let config = config(6, TweqAnimationConfig::empty(), TweqHalt::Continue);
+
+        assert_eq!(
+            walk(&config, 12),
+            [1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2].map(Some)
+        );
+    }
+
+    #[test]
+    fn wrapping_tweq_restarts_at_the_first_model() {
+        let config = config(3, TweqAnimationConfig::WRAP, TweqHalt::Continue);
+
+        assert_eq!(walk(&config, 5), [1, 2, 0, 1, 2].map(Some));
+    }
+
+    #[test]
+    fn non_continue_halt_stops_at_the_edge() {
+        let config = config(3, TweqAnimationConfig::empty(), TweqHalt::StopTweq);
+
+        assert_eq!(walk(&config, 4), [Some(1), Some(2), None, None]);
+    }
+
+    #[test]
+    fn one_bounce_halts_only_after_reversing() {
+        let config = config(3, TweqAnimationConfig::ONEBOUNCE, TweqHalt::StopTweq);
+
+        // Bounces off the top, runs back down, then halts at the bottom edge.
+        assert_eq!(walk(&config, 5), [Some(1), Some(2), Some(1), Some(0), None]);
+    }
+
+    #[test]
+    fn reverse_direction_steps_back_toward_the_first_model() {
+        let config = config(6, TweqAnimationConfig::empty(), TweqHalt::Continue);
+
+        assert_eq!(
+            advance_frame_index(&config, frame(4, true)),
+            Some(frame(3, true))
+        );
+    }
+
+    #[test]
+    fn a_single_model_has_nowhere_to_advance() {
+        let config = config(1, TweqAnimationConfig::empty(), TweqHalt::Continue);
+
+        assert_eq!(
+            advance_frame_index(&config, frame(0, false)),
+            Some(frame(0, true))
+        );
+    }
+
+    #[test]
+    fn an_empty_model_list_never_advances() {
+        let config = config(0, TweqAnimationConfig::empty(), TweqHalt::Continue);
+
+        assert_eq!(advance_frame_index(&config, frame(0, false)), None);
+    }
+}

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end coverage for the PictureSwap script (#587): the Rec deck's
+// `Code Art` frames carry a model tweq whose frames spell out part of the
+// transmitter code 14106. Each frob must advance one entry of
+// `PropTweqModelConfig.model_names`, so the code frame (`code10` on rec1's
+// Code Pic 1) becomes visible in-world.
+//
+// Negative-first: with `pictureswap` mapped to NoopScript, the frame never
+// leaves its authored `pic05` model and the code cannot be read.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// rec1's two frames, identified by their authored names (runtime entity ids
+// change every launch).
+const CODE_PIC_1 = "Code Pic 1"; // models: pic05 static pic03 static code10 static
+const CODE_PIC_3 = "Code Pic 3"; // models: pic01 static pic08 static code6 static
+
+function modelOf(detail: { properties: { name: string; value: string }[] }): string {
+  const p = detail.properties.find((x) => x.name === "Model");
+  assert.ok(p, "entity should expose a Model property");
+  return p.value;
+}
+
+test(
+  "rec1.mis: frobbing a Code Art frame advances its model tweq",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8153),
+    });
+    await game.step({ frames: 5 });
+
+    const frames = (await game.entities.list({ filter: "Code Pic", limit: 50 }))
+      .entities;
+    const pic1 = frames.find((e) => e.name === CODE_PIC_1);
+    const pic3 = frames.find((e) => e.name === CODE_PIC_3);
+    assert.ok(pic1, `expected the ${CODE_PIC_1} frame in rec1`);
+    assert.ok(pic3, `expected the ${CODE_PIC_3} frame in rec1`);
+
+    assert.equal(modelOf(await game.entities.detail(pic1.id)), "pic05");
+
+    // The authored cycle is a bounce (no WRAP flag), so frobs walk the list
+    // forward one entry at a time: the code digit is the 5th entry.
+    const expected = ["static", "pic03", "static", "code10", "static"];
+    for (const model of expected) {
+      await game.entities.sendMessage(pic1.id, { type: "Frob" });
+      await game.step({ frames: 2 });
+      assert.equal(
+        modelOf(await game.entities.detail(pic1.id)),
+        model,
+        `frob should advance the frame to ${model}`,
+      );
+    }
+
+    // At the top edge, a non-wrapping tweq reverses instead of restarting, so
+    // the next frob steps back toward the code frame rather than to pic05.
+    await game.entities.sendMessage(pic1.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+    assert.equal(modelOf(await game.entities.detail(pic1.id)), "code10");
+
+    // The second rec1 frame cycles independently to its own digit.
+    assert.equal(modelOf(await game.entities.detail(pic3.id)), "pic01");
+    for (let i = 0; i < 4; i++) {
+      await game.entities.sendMessage(pic3.id, { type: "Frob" });
+      await game.step({ frames: 2 });
+    }
+    assert.equal(modelOf(await game.entities.detail(pic3.id)), "code6");
+  },
+);


### PR DESCRIPTION
Fixes #587

> [!WARNING]
> **Draft — NOT yet validated.** The agent that wrote this was terminated by an API error before it could run the build, the tests, or any in-game verification. The code is committed as it was written. **Do not merge before** `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo fmt --all -- --check`, the unit tests, the e2e test, and an in-game check pass. Treat the description below as the author's stated intent, not as verified behavior.

## Problem

The Rec deck authors the transmitter code **14106** across four `Code Art` picture frames (gamesys template −2936). Each frame carries a model tweq whose frame list alternates artwork and static and ends on a digit of the code (`code1` / `code4` / `code10` / `code6`); frobbing the frame advances that tweq.

`PictureSwap` was mapped to `NoopScript`, so the frames only ever rendered their initial artwork — the code was unobtainable in-world and the deck's only objective (activate Transmitter Tower 89, earn `Transmit`) could not be started.

## Approach

A frob steps the entity's model tweq one frame and emits `Effect::ChangeModel`, matching the other tweq scripts. Per the commit message, the step follows the engine's model-tweq rules rather than a naive `(i + 1) % len`: it walks forward to the last authored model, and at an edge either halts (halt action other than `Continue`), wraps (the `WRAP` config flag), or bounces — reversing direction and stepping inward.

## Files

- `shock2vr/src/scripts/picture_swap.rs` (new)
- `shock2vr/src/scripts/mod.rs` — replaces the `NoopScript` mapping
- `dark/src/properties/prop_tweq.rs`
- `tools/shock2-sdk/test/picture-swap.e2e.test.ts` (new)

## Verification still owed

- [ ] `cargo fmt --all -- --check` and `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [ ] Negative-first evidence: the e2e test fails without the fix
- [ ] Unit + e2e tests pass
- [ ] In-game: frob `Code Art` object 79 @ (−4.72, −1.85, −158.68) in rec1 and confirm the model advances to `code10`
- [ ] All four frames readable across rec1/rec2/rec3: `[1` · `4` · `10` · `6]` = 14106
- [ ] Visual evidence (still + GIF) per the repo's Visual Changes rule — the displayed model changes, so this qualifies

## Context

Found by a rec1 play-through session. Related: #588 (switched light objects don't affect rendering). Not related: texture animation, which was suspected and verified working (200 ms via the `AnimatingScreenTex` metaprop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)