### PR TITLE
docs(playtest): document flat-mode frobbing (squeeze, not trigger)

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -43,6 +43,32 @@ the `play-through` manager triages and delegates fixes.
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 
+### Frobbing *in world* (flat mode) — squeeze, not trigger
+
+`POST /v1/entities/:id/message {type:"Frob"}` is a **debug injection**: it drives
+the script directly and is fine for diagnosis, but it does **not** prove a player
+could do it. To frob the way a player does, in flat mode (the default):
+
+1. **Aim** — the target must be under the crosshair. The flat path raycasts from
+   the camera (`FlatInteraction` passes `head_rotation` through), so turn with
+   `{left_hand.thumbstick:[turn,0]}` / set `head.rotation`, and confirm with
+   `GET /v1/info` or a screenshot that the thing is actually centered.
+2. **Squeeze** — the use button is **`right_hand.squeeze_value`**, on a *rising
+   edge*: set it `>0.5`, `step`, then back to `0.0`, `step`.
+   **`trigger_value` fires the wielded weapon — it does NOT frob.**
+3. The target must be frobbable (`PropFrobInfo`) and is the *highlighted* entity
+   under the reticle; `GET /v1/info` reports what's highlighted.
+
+```bash
+curl -X POST .../v1/control/input -d '{"right_hand.squeeze_value": 1.0}'
+curl -X POST .../v1/step -d '{"frames": 2}'
+curl -X POST .../v1/control/input -d '{"right_hand.squeeze_value": 0.0}'
+curl -X POST .../v1/step -d '{"frames": 2}'
+```
+
+A session that reports "frob does nothing" **without** having driven the squeeze
+edge has not tested frobbing — that finding will be rejected at review.
+
 **Tab opens the inventory UI in flat mode.** `POST /v1/input/action
 {action:"ToggleUseMode"}` enters the original's metagame "use" mode: `/v1/ui`
 flips to `mode:"use"` and its `strip` lists the carried items as labeled,


### PR DESCRIPTION
## Why

A playtest probe could not get an in-world frob to fire from a walkway. It swept head yaw 0–360° at six pitches in two input modes and came away suspecting the flat aim path was broken.

It isn't. `FlatInteraction` passes `head_rotation` through, so the flat frob ray already aims from the camera. The actual use button is **`right_hand.squeeze_value` on a rising edge** (`flat_player_controller.rs:246-247`) — **`trigger_value` fires the wielded weapon instead**.

This was documented nowhere (not the playtest skill, the play-through skill, or CLAUDE.md), so every session has to rediscover it. Since frobbing is how nearly every objective on every deck is completed, a session that never drives the squeeze edge can honestly report "frob does nothing" and look like it found an engine bug — a systematic source of false findings in the play-through loop.

## What

Adds a "Frobbing *in world* (flat mode)" section to the playtest skill covering:

- the **aim → squeeze → release** sequence, with a runnable curl example
- that the target must be under the crosshair and frobbable (`PropFrobInfo`), and that `GET /v1/info` reports what's highlighted
- that `POST /v1/entities/:id/message {type:"Frob"}` is a **debug injection** — fine for diagnosis, but not proof a player could do it
- an instruction to the review gate: reject "frob does nothing" when the squeeze edge was never driven

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)