### PR TITLE
fix: let doors authored permanently open be walked through (#602)

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -91,7 +91,7 @@ use std::{
 };
 
 use crate::{SCALE_FACTOR, ss2_common::*};
-use cgmath::{Deg, Quaternion, Rotation3, Vector3, vec3};
+use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, Vector3, vec3};
 use shipyard::{
     Component, EntityId, Get, IntoIter, IntoWithId, TupleAddComponent, View, ViewMut, World,
 };
@@ -937,6 +937,23 @@ impl PropTranslatingDoor {
             // closing / opening / halted / unknown: as authored
             _ => self.base_location,
         }
+    }
+
+    /// Whether the two endpoints differ, i.e. the door has somewhere to go.
+    /// A door authored with `closed == open` has none: it can never move, so
+    /// its open/closed state can't be read back from its position (speed is
+    /// irrelevant - there is nowhere to travel to).
+    pub fn has_travel(&self) -> bool {
+        let travel = self.base_open_location - self.base_closed_location;
+        travel.magnitude2() > 1e-6
+    }
+
+    /// A doorway the level authors left permanently open: no travel, and an
+    /// authored state of open. The retail data has 10 of these (hydro2's
+    /// survey-lab doors and the hydro airlock pairs); nothing can ever move
+    /// them, so treating them as closed seals the rooms behind them (#602).
+    pub fn is_permanently_open(&self) -> bool {
+        !self.has_travel() && self.state == 1
     }
 }
 

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -23,8 +23,8 @@ use dark::{
         PropClassTag, PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo,
         PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropModelName,
         PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
-        PropRenderType, PropScale, PropSymName, PropTemplateId, PropTripFlags, RenderType,
-        StimPropagator, StimSourceOptions, TemplateLinks, WrappedEntityId,
+        PropRenderType, PropScale, PropSymName, PropTemplateId, PropTranslatingDoor, PropTripFlags,
+        RenderType, StimPropagator, StimSourceOptions, TemplateLinks, WrappedEntityId,
     },
     ss2_entity_info,
 };
@@ -691,6 +691,20 @@ pub fn create_physics_representation(
     maybe_model: &Option<&Model>,
     entity_id: EntityId,
 ) -> Option<RigidBodyHandle> {
+    // A door the authors left permanently open (no travel between its open and
+    // closed endpoints, authored open) has nowhere to retract to: a collider
+    // for it is a slab welded across the doorway that nothing can ever move,
+    // sealing the rooms behind it (#602). Give it no collision at all.
+    let is_permanently_open_door = world
+        .borrow::<View<PropTranslatingDoor>>()
+        .unwrap()
+        .get(entity_id)
+        .map(|door| door.is_permanently_open())
+        .unwrap_or(false);
+    if is_permanently_open_door {
+        return None;
+    }
+
     let (
         v_pos,
         v_phys_attr,
@@ -1214,6 +1228,89 @@ mod tests {
     fn has_refs_of(world: &World, entity: EntityId) -> Option<bool> {
         let v = world.borrow::<View<PropHasRefs>>().unwrap();
         v.get(entity).ok().map(|p| p.0)
+    }
+
+    /// A translating door as the retail data authors it: a thin oriented box
+    /// at `at`, travelling from `closed` to `open`.
+    fn add_door(
+        world: &mut World,
+        at: Vector3<f32>,
+        closed: Vector3<f32>,
+        open: Vector3<f32>,
+        state: i32,
+    ) -> EntityId {
+        world.add_entity((
+            PropPosition {
+                position: at,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::ORIENTED_BOUNDING_BOX,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysDimensions {
+                radius0: 0.0,
+                radius1: 0.0,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: vec3(2.4, 3.2, 0.2),
+                unk1: 0,
+                unk2: 0,
+            },
+            dark::properties::PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 0.0,
+                speed: 0.0,
+                axis: 0,
+                state,
+                base_closed_location: closed,
+                base_open_location: open,
+                base_location: closed,
+            },
+        ))
+    }
+
+    #[test]
+    fn a_permanently_open_door_gets_no_collider() {
+        // hydro2 obj 135: open == closed and authored open, so it can never
+        // move aside - a collider there seals the doorway forever (#602).
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let at = vec3(18.0, -0.4, 41.8);
+        let door = add_door(&mut world, at, at, at, 1);
+
+        assert_eq!(
+            create_physics_representation(&mut world, &mut physics, &None, door),
+            None
+        );
+    }
+
+    #[test]
+    fn an_ordinary_door_still_gets_a_collider() {
+        // hydro2 obj 529, the control: real travel, so it blocks while closed.
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let closed = vec3(10.3, -0.4, 42.0);
+        let open = vec3(10.3, -0.4, 44.3);
+        let door = add_door(&mut world, closed, closed, open, 0);
+
+        assert!(create_physics_representation(&mut world, &mut physics, &None, door).is_some());
+    }
+
+    #[test]
+    fn a_zero_travel_door_authored_closed_still_gets_a_collider() {
+        // e.g. medsci1's space shields: no travel, authored closed - they stay
+        // solid walls.
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let at = vec3(-15.5, 1.4, 61.0);
+        let door = add_door(&mut world, at, at, at, 0);
+
+        assert!(create_physics_representation(&mut world, &mut physics, &None, door).is_some());
     }
 
     #[test]

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -68,15 +68,24 @@ pub fn set_entity_locked(world: &mut World, entity_id: EntityId, locked: bool) {
     }
 }
 
-/// Whether a translating door is nearer its closed endpoint than its open
-/// one (i.e. worth opening). `None` for entities that aren't translating
-/// doors.
+/// Whether a translating door is closed (i.e. worth opening): normally that
+/// means it is nearer its closed endpoint than its open one, but a door with
+/// no travel - whose endpoints coincide, so position says nothing - answers
+/// from its authored state. `None` for entities that aren't translating doors.
 pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
     use cgmath::InnerSpace;
     let v_door = world
         .borrow::<View<dark::properties::PropTranslatingDoor>>()
         .unwrap();
     let door = v_door.get(entity_id).ok()?;
+    // A door with no travel can never leave its authored pose, and both
+    // endpoints sit on top of each other - the distance test below is
+    // degenerate there (equal distances always read as "closed"). Answer from
+    // the authored state instead, so a permanently open doorway isn't
+    // reported shut (#602).
+    if !door.has_travel() {
+        return Some(!door.is_permanently_open());
+    }
     // StdDoor drives the live transform via SetPosition each frame.
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
     let current = v_transform
@@ -749,11 +758,67 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 
 #[cfg(test)]
 mod tests {
-    use super::{debit_player_nanites, plan_stack_payment};
+    use super::{debit_player_nanites, door_is_closed, plan_stack_payment};
     use crate::mission::PlayerInfo;
-    use cgmath::{Quaternion, vec3};
-    use dark::properties::{Link, Links, PropObjIcon, PropStackCount, ToLink, WrappedEntityId};
-    use shipyard::{Get, View, World};
+    use crate::runtime_props::RuntimePropTransform;
+    use cgmath::{Matrix4, Quaternion, Vector3, vec3};
+    use dark::properties::{
+        Link, Links, PropObjIcon, PropStackCount, PropTranslatingDoor, ToLink, WrappedEntityId,
+    };
+    use shipyard::{EntityId, Get, View, World};
+
+    fn door_world(
+        closed: Vector3<f32>,
+        open: Vector3<f32>,
+        state: i32,
+        at: Vector3<f32>,
+    ) -> (World, EntityId) {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 0.0,
+                speed: 0.0,
+                axis: 0,
+                state,
+                base_closed_location: closed,
+                base_open_location: open,
+                base_location: closed,
+            },
+            RuntimePropTransform(Matrix4::from_translation(at)),
+        ));
+        (world, entity_id)
+    }
+
+    #[test]
+    fn a_zero_travel_door_authored_open_is_not_reported_closed() {
+        // hydro2's survey-lab doors: open and closed endpoints coincide, so
+        // the distance comparison is degenerate and must not decide (#602).
+        let at = vec3(18.0, -0.4, 41.8);
+        let (world, door) = door_world(at, at, 1, at);
+
+        assert_eq!(door_is_closed(&world, door), Some(false));
+    }
+
+    #[test]
+    fn a_zero_travel_door_authored_closed_is_still_reported_closed() {
+        let at = vec3(18.0, -0.4, 41.8);
+        let (world, door) = door_world(at, at, 0, at);
+
+        assert_eq!(door_is_closed(&world, door), Some(true));
+    }
+
+    #[test]
+    fn a_normal_door_is_reported_from_its_live_position() {
+        let closed = vec3(10.3, -0.4, 42.0);
+        let open = vec3(10.3, -0.4, 44.3);
+        let (closed_world, at_closed) = door_world(closed, open, 0, closed);
+        let (open_world, at_open) = door_world(closed, open, 0, open);
+
+        assert_eq!(door_is_closed(&closed_world, at_closed), Some(true));
+        assert_eq!(door_is_closed(&open_world, at_open), Some(false));
+    }
 
     #[test]
     fn stack_payment_is_atomic_when_total_is_insufficient() {

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -177,6 +177,13 @@ impl Script for StdDoor {
         let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
 
         if let Ok(trans_door) = v_trans_door.get(entity_id) {
+            // A permanently open doorway has no collider and no travel, so it
+            // can't be frobbed and none of the retail ones are switch-linked -
+            // but keep the invariant explicit: nothing may "close" an opening
+            // that has nowhere to move to (it would only replay door sounds).
+            if trans_door.is_permanently_open() {
+                return Effect::NoEffect;
+            }
             match msg {
                 MessagePayload::Frob => {
                     // The original StdDoor toggles on player FrobWorldEnd. A
@@ -263,6 +270,46 @@ mod tests {
         let mut door = StdDoor::new();
         door.initialize(entity_id, world);
         door
+    }
+
+    /// A doorway authored permanently open: no travel, state open (#602).
+    fn permanently_open_world() -> (World, EntityId) {
+        let mut world = World::new();
+        let at = vec3(18.0, -0.4, 41.8);
+        let entity_id = world.add_entity((
+            PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 0.0,
+                speed: 0.0,
+                axis: 0,
+                state: 1,
+                base_closed_location: at,
+                base_open_location: at,
+                base_location: at,
+            },
+            PropClassTag::from_string("doortype scidoor"),
+            RuntimePropTransform(Matrix4::from_translation(at)),
+        ));
+        world.add_unique(QuestInfo::new());
+        (world, entity_id)
+    }
+
+    #[test]
+    fn a_permanently_open_door_ignores_frob_and_turn_off() {
+        let (world, entity_id) = permanently_open_world();
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        for msg in [
+            MessagePayload::Frob,
+            MessagePayload::TurnOff { from: entity_id },
+            MessagePayload::TurnOn { from: entity_id },
+        ] {
+            let effect = door.handle_message(entity_id, &world, &physics, &msg);
+            assert!(matches!(effect, Effect::NoEffect));
+            assert!(!door.is_moving);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #602

## The bug

`hydro2.mis` objects **135** and **183** (`HydroDoorWide`, the survey lab's only two
connections) are authored `closed: 0.0, open: 0.0, speed: 0.0, state: 1` with
`base_open_location == base_closed_location`: **zero travel, authored open**. Nothing can
ever move them, yet the port gave each one a kinematic slab across its doorway, so the lab
— and the Toxin-A vials 547 / 1185 it holds — was unreachable and `Note_3_3` uncompletable.

Two things kept them shut:

1. `script_util::door_is_closed` decides open/closed by comparing the door's distance to
   each endpoint. With the endpoints identical that comparison is degenerate
   (`to_closed <= to_open` is always true), so it always answered "closed" — which also
   fed AI door-opening and the pathfinding door-sealing logic.
2. `entity_creator::create_physics_representation` gave the door a collider at that
   position, and no message could move it away because there is nowhere to move to.

## The fix

Treat "no travel" as *unmovable*, and answer from the authored state instead of position:

- `PropTranslatingDoor::has_travel()` / `is_permanently_open()` (`dark`).
- `door_is_closed`: when a door has no travel, report `state != open` rather than running
  the degenerate distance test.
- `create_physics_representation`: a permanently open door gets **no collider** — its
  "open position" is the doorway itself, so the only way for it to be open is to not
  collide.
- `StdDoor::handle_message`: ignores frob / `TurnOn` / `TurnOff` on such a door. This one
  is defensive rather than load-bearing — none of the 10 retail doors are switch-linked,
  and with no collider a frob ray can't reach them — but it keeps the invariant explicit:
  nothing may "close" an opening that has nowhere to move to.

Doors with real travel are untouched, and zero-travel doors authored **closed** keep
today's behavior (medsci1's space shields, the cryo tube doors, eng2's cargo-bay doors
stay solid).

## How general is this authoring pattern?

Survey of `PropTranslatingDoor` over all 23 missions (686 doors):

| | state 0 (closed) | state 1 (open) |
| --- | --- | --- |
| **zero travel** | 25 | **10** ← fixed here |
| nonzero travel | 650 | 1 |

The 10 are hydro2 135/183 plus the `Airlock Door 1`/`Airlock Door 2` pairs in
hydro1 (439/440), hydro2 (995/996, 1614/1615) and hydro3 (380/381) — so this unsealed
four more doorways beyond the reported ones. All 22 `speed == 0` doors are a subset of the
35 zero-travel ones; no door in the retail data has travel with zero speed.

## Negative-first evidence

Tests written first, against unmodified `main` (`cargo test -p shock2vr --lib`):

```
---- mission::entity_creator::tests::a_permanently_open_door_gets_no_collider ----
  left: Some(RigidBodyHandle(Index { index: 0, generation: 0 }))
 right: None
---- scripts::script_util::tests::a_zero_travel_door_authored_open_is_not_reported_closed ----
  left: Some(true)
 right: Some(false)
---- scripts::std_door::tests::a_permanently_open_door_ignores_frob_and_turn_off ----
  assertion failed: matches!(effect, Effect::NoEffect)

test result: FAILED. 279 passed; 3 failed
```

With the fix: `292 passed; 0 failed`. The suite also includes control tests that an
ordinary travelling door and a zero-travel **closed** door still get colliders, and that
`door_is_closed` still reads a normal door from its live position.

## Live verification (`cargo dbgr --mission hydro2.mis`)

| check | before | after |
| --- | --- | --- |
| physics bodies on doors 135 / 183 | 1 each | 0 each |
| walk +x through the doorway at `(18.0, -0.4, 41.8)` | hard stop at `x = 17.54` | passes through to `x = 24.84` |
| reach Toxin-A vial 547 `(23.4, -1.0, 40.9)` | unreachable | player stands 0.18 away |
| reach Toxin-A vial 1185 `(22.4, -1.1, 37.5)` | unreachable | player stands 0.49 away |

Controls (same session, after the fix):

- **obj 529** — closed at `z = 42.0` stops the player at `x = 10.76`; frob → opens to
  `z = 44.3`; player then walks through to `x = 3.54`; frob again → back to `42.0`.
- **obj 612** — `TurnOff` → closed `z = 50.8`; frob → open `z = 48.4`.
- **not everything became passable**: a third ordinary door (obj 1486, `(10.3, -0.4, 33.2)`)
  still has its collider and still stops the player dead at `x = 10.76` while closed.

`cargo fmt --check --all`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
and `cargo test -p shock2vr` (292 passed) are clean.

Full SDK e2e suite (`SHOCK2_E2E=1`): **140 / 141 pass**, including all 23 mission loads.
The one failure — `earth-psionic-training.e2e.test.ts`, "normal world-use should physically
carry booster 288" — is **pre-existing and unrelated**: it reproduces identically on
`origin/main` at bd7326f (checked out and re-run on its own), touches no doors, and the
door-specific `earth.mis: StdDoor Frob opens and closes its collider` scenario passes.

## Reviewed, and deliberately out of scope

Cross-engine review (Codex: no findings; Claude subagent: independently reproduced the
data survey and found the save/load round-trip, the missing-rigid-body paths, AI door
opening and the epsilon all sound) surfaced one adjacent **pre-existing** bug: the mirror
case, zero-travel doors authored *closed* (medsci1's space shields and 24 others), is not
sealed for A* either — filed as #606 rather than widened into this PR, since it changes
cell passability across several decks and wants its own `cargo bn path bench` run.

## Known limitation

The door leaf is still **rendered** in the doorway — the player now walks through a
visible slab. Deliberately out of scope: the collision fix is what unblocks the level, and
suppressing the model is a separate visual judgement call (the original engine draws the
leaf at its open location too, which for these doors is the doorway). Worth a follow-up if
it reads badly in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
