### PR TITLE
fix: let a gripped ladder be climbed down, not just up (#603)

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -99,6 +99,15 @@ obstruction, not a step. Only the horizontal direction of the target is used;
 gravity decides the vertical, so aim at where you want to *stand*, not at a
 point in the air.
 
+**Ladders are not walked, they're climbed** — `/v1/player/move` never grips one.
+Aim the head with `{"head.look":[yaw_deg,pitch_deg]}` and hold
+`right_hand.thumbstick:[0,1]` (push *into* the ladder). **Pitch is positive
+DOWN**: `+60` looks at the floor and descends, `-60` looks at the ceiling and
+ascends — the same rotation drives the camera and the movement, so a negative
+pitch climbs *up* no matter what you meant. To enter a descent from the top of a
+shaft, step off the lip and then push back *toward* the ladder while looking
+down; the grip catches within a step's worth of falling.
+
 **Doors block the shapecast** — you can't move through a closed one. The pattern:
 move up to the door → it trips the tripwire (or `Frob` it) → `step` and wait for
 it to open (re-screenshot) → then `move` through. That's genuine door-by-door

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1651,7 +1651,12 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 ///
 /// Recognized channels:
 /// - `head.rotation`                : `[x, y, z, w]` quaternion
-/// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z)
+/// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z).
+///   **Pitch is POSITIVE DOWN** - `+60` looks at the floor, `-60` at the ceiling
+///   - matching the desktop runtime, where mouse-down increments pitch. The same
+///   rotation drives movement, so on a ladder `+pitch` descends and `-pitch`
+///   ascends; assuming the opposite is what made issue #603 read as "descent is
+///   broken".
 /// - `{left,right}_hand.trigger`    : number in [0, 1] (alias `trigger_value`)
 /// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1655,8 +1655,8 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 ///   **Pitch is POSITIVE DOWN** - `+60` looks at the floor, `-60` at the ceiling
 ///   - matching the desktop runtime, where mouse-down increments pitch. The same
 ///   rotation drives movement, so on a ladder `+pitch` descends and `-pitch`
-///   ascends; assuming the opposite is what made issue #603 read as "descent is
-///   broken".
+///   ascends - a test that pitches `-60` to "look down" at a ladder climbs UP,
+///   which is how issue #603's repro was written.
 /// - `{left,right}_hand.trigger`    : number in [0, 1] (alias `trigger_value`)
 /// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -362,13 +362,20 @@ fn try_step_up(
 /// the hydro2 Sector-C stack (eleven 0.8-spaced `Rick Ladder` rungs at
 /// `(59.6, -2.0..6.0, 22.2)`): descending from the top, the climb cast returned
 /// **zero** translation at y 3.27 and the player hung there for as long as the
-/// input was held. Excluding climbables is safe - the redirect is purely
-/// vertical, so it can never push the player deeper into anything - and the
-/// walk/gravity passes still collide with ladders normally, so a ladder is still
-/// solid to someone who is not climbing it.
+/// input was held. The walk and gravity passes are untouched, so a ladder stays
+/// solid to anyone who is not climbing it, and the climb still collides with
+/// real geometry (the floor at the shaft's foot, a ceiling above) - which is
+/// what keeps the `CLIMB_MIN_PROGRESS_FRACTION` walk fallback working.
+///
+/// Two things this deliberately does not do: the exclusion covers EVERY
+/// climbable, not just the gripped one - stacked rungs are separate entities, so
+/// there is no single collider or body to scope the exclusion to, and scoping it
+/// to the rung that supplied the grip would reinstate the bug on the rung above
+/// or below it. (A second, unrelated ladder in the same vertical path would also
+/// be passed through; the shipped maps have no such case.)
 struct ClimbPass<'a> {
     movement: Vector<Real>,
-    queries: &'a QueryPipeline<'a>,
+    queries: QueryPipeline<'a>,
 }
 
 /// Downward translation (world units) applied to the player capsule per
@@ -408,13 +415,19 @@ fn step_player_movement(
     // (the floor the player is standing on when the redirect points DOWN, a
     // ceiling above them when it points up) would otherwise pin them in place
     // with nothing left to walk out with.
+    //
+    // Progress is measured as SIGNED VERTICAL travel, not the raw translation
+    // length: the redirect is purely vertical, so any horizontal component in
+    // the result is the character controller sliding off something in the way -
+    // sideways travel is the blocked case, not a climb.
     if let Some(ClimbPass {
         movement: climb,
         queries: climb_queries,
     }) = climb
     {
-        let mvt = controller.move_shape(dt, climb_queries, shape, pos, climb, |_c| ());
-        if mvt.translation.norm() > CLIMB_MIN_PROGRESS_FRACTION * climb.norm() {
+        let mvt = controller.move_shape(dt, &climb_queries, shape, pos, climb, |_c| ());
+        let climbed = mvt.translation.y * climb.y.signum();
+        if climbed > CLIMB_MIN_PROGRESS_FRACTION * climb.y.abs() {
             return mvt;
         }
     }
@@ -1880,12 +1893,6 @@ impl PhysicsWorld {
                 &self.collider_set,
                 movement_filter,
             );
-            let climb_queries = self.broad_phase.as_query_pipeline(
-                dispatcher,
-                &self.rigid_body_set,
-                &self.collider_set,
-                climb_pass_filter,
-            );
             step_player_movement(
                 &player_handle.controller,
                 &queries,
@@ -1896,7 +1903,7 @@ impl PhysicsWorld {
                 gravity,
                 climb_movement.map(|movement| ClimbPass {
                     movement,
-                    queries: &climb_queries,
+                    queries: queries.with_filter(climb_pass_filter),
                 }),
             )
         });
@@ -3175,17 +3182,18 @@ mod tests {
 
     /// Issue #603: a gripped ladder must be climbable DOWN, not just up. The
     /// player stands against the rung stack (at the resting gap a real approach
-    /// leaves - `PLAYER_CONTACT_OFFSET`), climbs it, then looks down (a
-    /// downward-pitched push, still into the face) and must ride it back to the
-    /// floor.
+    /// leaves - `PLAYER_CONTACT_OFFSET`) and looks down: a downward-pitched
+    /// push, still into the face, must ride the ladder back to the floor at the
+    /// climb rate.
     ///
     /// Negative-first: while the climb cast collided with the ladder itself,
-    /// the rungs' horizontal caps blocked a capsule standing flush against them
-    /// in BOTH directions - this test rose 0.05 wu in 60 frames of climbing
-    /// before the fix, and never got to the descent. Live on hydro2's Sector-C
-    /// stack the same block topped the ascent out at y 5.2 and, coming back
-    /// down, pinned the player at y 3.27 with the climb cast returning exactly
-    /// zero translation for as long as the input was held.
+    /// the horizontal cap of the rung the capsule overlapped stopped the
+    /// descent dead - before the fix this test covered 0.45 wu in 200 frames
+    /// (y 6.50 -> 6.05) instead of reaching the floor. Live on hydro2's
+    /// Sector-C stack the same block pinned the player at y 5.39, with the climb
+    /// cast returning exactly zero translation for as long as "look down +
+    /// push" was held (and, going the other way, topped the ascent out at
+    /// y 5.2 instead of clearing the ladder).
     #[test]
     fn player_descends_a_stacked_rung_ladder() {
         let mut world = PhysicsWorld::new();
@@ -3203,7 +3211,7 @@ mod tests {
                 .build(),
         );
         // The same shipped-size rung stack as the ascent test: 0.9 x 0.8 x 0.1,
-        // contiguous from y=0 to y=8. Its climbable face is at x = -4.95.
+        // contiguous from y=0 to y=8. Its climbable face is at x = -5.05.
         for rung in 0..10 {
             world.add_kinematic(
                 EntityId::from_inner(2001 + rung).unwrap(),
@@ -3215,46 +3223,40 @@ mod tests {
                 false,
             );
         }
-        // Standing against the ladder, at the gap a walked-in approach settles
-        // to: the capsule radius plus the resting contact offset. This is where
-        // a climbing player actually is (measured live on hydro2: 0.04 wu of
-        // clearance), and it is what puts the rungs' horizontal caps in the
-        // path of the descent cast.
-        let stand_x = -4.95 - (PLAYER_RADIUS + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+        // A gripped player six rungs up, flush against the face at the gap the
+        // walk pass leaves before the grip takes over (capsule radius + resting
+        // contact offset). That is where a climbing player actually sits
+        // (measured live on hydro2: 0.04 wu of clearance) and it is what puts
+        // the rungs' horizontal caps in the path of the descent cast.
+        let stand_x = -5.05 - (PLAYER_RADIUS + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
         let mut player =
-            world.create_player(vec3(stand_x, 1.0, 0.0), EntityId::from_inner(3000).unwrap());
-        for _ in 0..30 {
-            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-        }
-        let floor = world.get_player_translation(&player);
+            world.create_player(vec3(stand_x, 6.5, 0.0), EntityId::from_inner(3000).unwrap());
+
+        // Looking down 60 degrees while still pushing into the face.
         let walk = 25.0 / SCALE_FACTOR / 60.0;
-        // Climb dead-on to the middle of the shaft.
-        for _ in 0..60 {
-            world.update(Vector3::new(walk, 0.0, 0.0), &mut player);
+        let descend = Vector3::new(walk * 0.5, -walk * 0.866, 0.0);
+        for _ in 0..40 {
+            world.update(descend, &mut player);
         }
-        let top = world.get_player_translation(&player);
+        let after = world.get_player_translation(&player);
+        // 40 frames at the climb rate (CLIMB_SPEED_SCALE * walk * cos 60) covers
+        // 2 wu; a free fall covers 8 and would already be on the floor.
         assert!(
-            top.y - floor.y > 3.0,
-            "setup: the player should have climbed the stack first, reached {top:?}"
+            after.y < 6.2,
+            "looking down and pushing into a ladder must descend it, stuck at {after:?}"
+        );
+        assert!(
+            after.y > 4.0,
+            "the descent must ride the ladder at the climb rate, not fall - reached {after:?} in 40 frames"
         );
 
-        // Now look down 60 degrees and keep pushing into the ladder: the same
-        // input, pitched down, must descend at the climb rate.
-        let descend = Vector3::new(walk * 0.5, -walk * 0.866, 0.0);
-        for _ in 0..120 {
+        for _ in 0..160 {
             world.update(descend, &mut player);
         }
         let end = world.get_player_translation(&player);
-
         assert!(
-            end.y < floor.y + 0.2,
-            "looking down and pushing must climb back DOWN to the floor at y {}, ended {end:?} (from {top:?})",
-            floor.y
-        );
-        assert!(
-            (end.z - top.z).abs() < 0.45,
-            "the descent must not slide the player off the ladder, drifted {}",
-            end.z - top.z
+            end.y < 1.2,
+            "the descent must carry the player all the way to the floor, ended {end:?}"
         );
     }
 
@@ -3268,8 +3270,8 @@ mod tests {
     /// Negative-first: while the climb cast collided with the ladder itself the
     /// grip caught but could not move the player down at all - the rung their
     /// capsule overlapped blocked the descent - so the push back toward the
-    /// ladder just shoved them onto the landing again (this test finished at
-    /// x +8.3, y +7.4, i.e. walking away across the landing).
+    /// ladder just shoved them onto the landing again (before the fix this test
+    /// was back at x -1.66, y +7.40, i.e. up on the landing).
     #[test]
     fn player_enters_a_descent_from_the_top_lip() {
         let quad = |x0: f32, x1: f32, y: f32| {
@@ -3342,6 +3344,10 @@ mod tests {
             world.update(onto_the_ladder, &mut player);
         }
         let gripped = world.get_player_translation(&player);
+        assert!(
+            gripped.x < -5.05,
+            "the push back toward the ladder must grip it, not shove the player onto the landing again - at {gripped:?}"
+        );
         assert!(
             gripped.y > 3.0,
             "the grip must catch the fall near the top of the shaft, dropped to {gripped:?} in 40 frames \

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -350,6 +350,27 @@ fn try_step_up(
     land(slide_dir)
 }
 
+/// One frame of gripped ladder movement: the vertical redirect from
+/// [`climb_redirect`], plus the query pipeline it is cast against.
+///
+/// The climb cast gets its OWN pipeline because it must ignore **climbable
+/// colliders themselves**. A grip slides the player vertically along the face it
+/// holds, so the ladder standing in that path is not an obstacle - but to the
+/// character controller it is ordinary solid geometry, and a capsule that grazes
+/// it (which is exactly where a gripped player sits) has its vertical cast
+/// stopped dead by the horizontal cap of whatever rung it overlaps. Measured on
+/// the hydro2 Sector-C stack (eleven 0.8-spaced `Rick Ladder` rungs at
+/// `(59.6, -2.0..6.0, 22.2)`): descending from the top, the climb cast returned
+/// **zero** translation at y 3.27 and the player hung there for as long as the
+/// input was held. Excluding climbables is safe - the redirect is purely
+/// vertical, so it can never push the player deeper into anything - and the
+/// walk/gravity passes still collide with ladders normally, so a ladder is still
+/// solid to someone who is not climbing it.
+struct ClimbPass<'a> {
+    movement: Vector<Real>,
+    queries: &'a QueryPipeline<'a>,
+}
+
 /// Downward translation (world units) applied to the player capsule per
 /// movement frame, honoring the body's gravity scale.
 fn player_gravity_step(character_body: &RigidBody) -> Real {
@@ -367,8 +388,9 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
 /// result can never pass through geometry.
 ///
 /// `climb` is the ladder redirect vector when the player grips a climbable
-/// surface: it replaces both the walk input and the gravity pass - unless it
-/// achieves nothing, in which case the frame walks normally (see
+/// surface, paired with the query pipeline the climb cast runs against (see
+/// [`ClimbPass`]): it replaces both the walk input and the gravity pass - unless
+/// it achieves nothing, in which case the frame walks normally (see
 /// `CLIMB_MIN_PROGRESS_FRACTION`).
 fn step_player_movement(
     controller: &KinematicCharacterController,
@@ -378,7 +400,7 @@ fn step_player_movement(
     desired: Vector<Real>,
     dt: Real,
     gravity: Real,
-    climb: Option<Vector<Real>>,
+    climb: Option<ClimbPass<'_>>,
 ) -> EffectiveCharacterMovement {
     // Ladder: the climb vector replaces both the walk and the gravity pass.
     // Only if it actually moves the player, though - a climb consumes the
@@ -386,8 +408,12 @@ fn step_player_movement(
     // (the floor the player is standing on when the redirect points DOWN, a
     // ceiling above them when it points up) would otherwise pin them in place
     // with nothing left to walk out with.
-    if let Some(climb) = climb {
-        let mvt = controller.move_shape(dt, queries, shape, pos, climb, |_c| ());
+    if let Some(ClimbPass {
+        movement: climb,
+        queries: climb_queries,
+    }) = climb
+    {
+        let mvt = controller.move_shape(dt, climb_queries, shape, pos, climb, |_c| ());
         if mvt.translation.norm() > CLIMB_MIN_PROGRESS_FRACTION * climb.norm() {
             return mvt;
         }
@@ -1834,12 +1860,31 @@ impl PhysicsWorld {
             })
         };
 
+        // The climb cast collides with everything the walk does EXCEPT the
+        // climbable surfaces themselves - see `ClimbPass`. Membership is checked
+        // by predicate rather than by group filter because a ladder is also an
+        // `ENTITY`, so masking the CLIMBABLE bit out of the group filter would
+        // not exclude it.
+        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            !collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        };
+        let climb_pass_filter = movement_filter.predicate(&not_climbable);
+
         let mvt = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             let queries = self.broad_phase.as_query_pipeline(
                 dispatcher,
                 &self.rigid_body_set,
                 &self.collider_set,
                 movement_filter,
+            );
+            let climb_queries = self.broad_phase.as_query_pipeline(
+                dispatcher,
+                &self.rigid_body_set,
+                &self.collider_set,
+                climb_pass_filter,
             );
             step_player_movement(
                 &player_handle.controller,
@@ -1849,7 +1894,10 @@ impl PhysicsWorld {
                 desired_movement,
                 self.integration_parameters.dt,
                 gravity,
-                climb_movement,
+                climb_movement.map(|movement| ClimbPass {
+                    movement,
+                    queries: &climb_queries,
+                }),
             )
         });
 
@@ -3122,6 +3170,191 @@ mod tests {
         assert!(
             drift.abs() < 0.45,
             "the climb must not slide the player off the 0.9-wide ladder, drifted {drift}"
+        );
+    }
+
+    /// Issue #603: a gripped ladder must be climbable DOWN, not just up. The
+    /// player stands against the rung stack (at the resting gap a real approach
+    /// leaves - `PLAYER_CONTACT_OFFSET`), climbs it, then looks down (a
+    /// downward-pitched push, still into the face) and must ride it back to the
+    /// floor.
+    ///
+    /// Negative-first: while the climb cast collided with the ladder itself,
+    /// the rungs' horizontal caps blocked a capsule standing flush against them
+    /// in BOTH directions - this test rose 0.05 wu in 60 frames of climbing
+    /// before the fix, and never got to the descent. Live on hydro2's Sector-C
+    /// stack the same block topped the ascent out at y 5.2 and, coming back
+    /// down, pinned the player at y 3.27 with the climb cast returning exactly
+    /// zero translation for as long as the input was held.
+    #[test]
+    fn player_descends_a_stacked_rung_ladder() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        // The same shipped-size rung stack as the ascent test: 0.9 x 0.8 x 0.1,
+        // contiguous from y=0 to y=8. Its climbable face is at x = -4.95.
+        for rung in 0..10 {
+            world.add_kinematic(
+                EntityId::from_inner(2001 + rung).unwrap(),
+                vec3(-5.0, 0.4 + 0.8 * rung as f32, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.1, 0.8, 0.9),
+                CollisionGroup::climbable_entity(),
+                false,
+            );
+        }
+        // Standing against the ladder, at the gap a walked-in approach settles
+        // to: the capsule radius plus the resting contact offset. This is where
+        // a climbing player actually is (measured live on hydro2: 0.04 wu of
+        // clearance), and it is what puts the rungs' horizontal caps in the
+        // path of the descent cast.
+        let stand_x = -4.95 - (PLAYER_RADIUS + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+        let mut player =
+            world.create_player(vec3(stand_x, 1.0, 0.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let floor = world.get_player_translation(&player);
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        // Climb dead-on to the middle of the shaft.
+        for _ in 0..60 {
+            world.update(Vector3::new(walk, 0.0, 0.0), &mut player);
+        }
+        let top = world.get_player_translation(&player);
+        assert!(
+            top.y - floor.y > 3.0,
+            "setup: the player should have climbed the stack first, reached {top:?}"
+        );
+
+        // Now look down 60 degrees and keep pushing into the ladder: the same
+        // input, pitched down, must descend at the climb rate.
+        let descend = Vector3::new(walk * 0.5, -walk * 0.866, 0.0);
+        for _ in 0..120 {
+            world.update(descend, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            end.y < floor.y + 0.2,
+            "looking down and pushing must climb back DOWN to the floor at y {}, ended {end:?} (from {top:?})",
+            floor.y
+        );
+        assert!(
+            (end.z - top.z).abs() < 0.45,
+            "the descent must not slide the player off the ladder, drifted {}",
+            end.z - top.z
+        );
+    }
+
+    /// Issue #603 / `projects/climbing.md`: entering a descent **from the top
+    /// lip**. The player stands on the landing whose floor is flush with the
+    /// ladder's top (eng1's Engine Core shaft: landing feet at y -12.80, top
+    /// rung capped at -12.80), steps off into the shaft, and - still looking
+    /// down - pushes back toward the ladder. The grip must catch them within a
+    /// step's worth of falling and carry them down at the climb rate.
+    ///
+    /// Negative-first: while the climb cast collided with the ladder itself the
+    /// grip caught but could not move the player down at all - the rung their
+    /// capsule overlapped blocked the descent - so the push back toward the
+    /// ladder just shoved them onto the landing again (this test finished at
+    /// x +8.3, y +7.4, i.e. walking away across the landing).
+    #[test]
+    fn player_enters_a_descent_from_the_top_lip() {
+        let quad = |x0: f32, x1: f32, y: f32| {
+            let verts = vec![
+                point![x0, y, -100.0],
+                point![x1, y, -100.0],
+                point![x1, y, 100.0],
+                point![x0, y, 100.0],
+            ];
+            ColliderBuilder::trimesh(verts, vec![[0u32, 1, 2], [0, 2, 3]]).expect("trimesh")
+        };
+
+        let mut world = PhysicsWorld::new();
+        // Shaft floor, and the landing above it - its lip flush with the
+        // ladder's near face, so the shaft is everything at x < -4.95.
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            quad(-100.0, 100.0, 0.0).build(),
+        );
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            quad(-4.95, 100.0, 6.4).build(),
+        );
+        // Rung stack from the shaft floor up to the landing (top rung capped at
+        // y = 6.4). Its climbable face points into the shaft, at x = -5.05.
+        for rung in 0..8 {
+            world.add_kinematic(
+                EntityId::from_inner(2001 + rung).unwrap(),
+                vec3(-5.0, 0.4 + 0.8 * rung as f32, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.1, 0.8, 0.9),
+                CollisionGroup::climbable_entity(),
+                false,
+            );
+        }
+
+        let mut player =
+            world.create_player(vec3(-3.0, 7.5, 0.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..60 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let landing = world.get_player_translation(&player);
+        assert!(
+            landing.y > 6.0,
+            "setup: the player should be standing on the landing, at {landing:?}"
+        );
+
+        // Walk off the lip, looking down. Nothing to grip yet - the ladder top
+        // is level with the floor being walked off.
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let off_the_lip = Vector3::new(-walk * 0.5, -walk * 0.866, 0.0);
+        for _ in 0..30 {
+            world.update(off_the_lip, &mut player);
+            if world.get_player_translation(&player).x < -5.2 {
+                break;
+            }
+        }
+        let lip = world.get_player_translation(&player);
+        assert!(
+            lip.x < -5.05,
+            "setup: the player should have stepped past the ladder into the shaft, at {lip:?}"
+        );
+
+        // Still looking down, push BACK toward the ladder: the natural "back
+        // down the ladder" input. The grip must catch and take over from the
+        // fall.
+        let onto_the_ladder = Vector3::new(walk * 0.5, -walk * 0.866, 0.0);
+        for _ in 0..40 {
+            world.update(onto_the_ladder, &mut player);
+        }
+        let gripped = world.get_player_translation(&player);
+        assert!(
+            gripped.y > 3.0,
+            "the grip must catch the fall near the top of the shaft, dropped to {gripped:?} in 40 frames \
+             (a free fall covers the whole 6 wu shaft in 30)"
+        );
+
+        for _ in 0..120 {
+            world.update(onto_the_ladder, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            end.y < 1.2,
+            "the descent must carry the player to the shaft floor, ended {end:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #603

Based on `main` (PR #598 has landed there as 12ba580).

## Two separate things were wrong

**1. The reported input was inverted.** `head.look`'s `pitch` is **positive down**
in this codebase — `camera_rotation` builds the head quaternion so its `-Z` is
`-camera_forward`, and the desktop runtime feeds mouse `delta_y` straight into
`pitch`, so mouse-down increments it. Screenshots confirm: `pitch +60` shows the
floor, `pitch -60` the ceiling. The same rotation drives the movement vector, so
#603's `-60°` "pitching down" produced a movement vector with `y = +0.144` —
i.e. it was pushing **up** the ladder. That is the "pushing forward climbs up
again" half of the report. Documented on the `head.look` channel and in the
playtest skill so the next agent doesn't repeat it.

**2. With the correct pitch, the descent really was broken — the ladder's own
colliders blocked the climb they exist to enable.** PR #598's climb pass casts
the redirect through the same query filter as the walk, so the rungs are
ordinary solid geometry to it. A gripped player sits *flush* against the face
(the walk pass presses them to the resting contact offset before the grip takes
over and drops the horizontal input), which puts the **horizontal cap** of
whichever rung the capsule overlaps directly in the path of the vertical cast.

Instrumented on hydro2's Sector-C stack (eleven 0.8-spaced `Rick Ladder` rungs at
`(59.6, -2.0…6.0, 22.2)`) — the climb cast returned **exactly zero**:

```
CLIMBSTEP climb=[0, -0.05, 0]  applied=[0, 0, 0]  grounded=false  pos=[59.6, 3.274, 22.61]
```

## The fix

The climb cast now runs against its own `QueryPipeline` — the movement one
`with_filter`ed by a predicate that rejects colliders carrying the `CLIMBABLE`
membership. (A predicate, not a group mask: a ladder is also an `ENTITY`, so
masking the bit out of the group filter would not exclude it.) The walk and
gravity passes are untouched, so a ladder stays solid to anyone who is not
climbing it, and the climb still collides with real geometry — the floor at the
shaft's foot, a ceiling above — which is what keeps the
`CLIMB_MIN_PROGRESS_FRACTION` walk fallback working.

The exclusion is deliberately **global** rather than scoped to the gripped
ladder: stacked rungs are separate entities, so scoping it to the rung that
supplied the grip would reinstate the bug on the rung above or below it.

Also from `/xreview`: the climb's progress test now measures **signed vertical
travel** instead of the raw translation length. The redirect is purely vertical,
so any horizontal component in the result is the character controller sliding
off an obstruction — the blocked case, which must fall back to walking, not be
counted as a climb.

## Negative-first tests (`shock2vr/src/physics/mod.rs`)

Both fail on the parent commit and pass here:

| test | without the fix |
| --- | --- |
| `player_descends_a_stacked_rung_ladder` — a gripped player mid-shaft, flush against the rungs, looks down and pushes | covered **0.45 wu in 200 frames** (y 6.50 → 6.05) instead of riding down to the floor |
| `player_enters_a_descent_from_the_top_lip` — steps off a landing flush with the ladder top, then pushes back toward the ladder while looking down | the grip caught but could not move them down, so the push shoved them **back onto the landing** (x −1.66, y +7.40) |

All 287 `shock2vr` tests pass; `cargo fmt --check --all` and
`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
are clean.

## Live (debug runtime, same repro, same binary before/after)

**hydro2 Sector-C stack** — climb up, then look down (`pitch +60`) and hold forward:

| | before | after |
| --- | --- | --- |
| ascent, `pitch 0` | y −0.996 → **5.2**, and falls back to −0.996 the moment input is released | y −0.996 → **5.399**, holds when released |
| descent from the top | **5.392 → 5.392** — did not move at all in 150 frames of "look down + push" | 5.399 → 4.699 → 3.949 → … → **−1.00** at a steady 3.0 wu/s (= 6 × cos 60°), clean step-off |

**hydro2 top-lip / ACR2 (#605).** The shaft down to the ACR2 chamber
(`Rick Ladder 16` at `(33.65, ·, −53.6)`, regulator obj 913 at y −6) is
**reachable** — walking off the upper floor at `(36.0, −0.996, −53.6)` looking
down drops 2.2 wu, the grip catches, and the climb carries the player to the
chamber floor at y **−6.996**. This one behaves *identically before and after*
the fix (it is a single tall collider, not a rung stack), so ACR2 was **not**
gated on the descent bug — worth noting on #605.

**Top-lip entry** (`projects/climbing.md`'s untested case), eng1 Engine Core
landing at y −11.796: walking straight off the lip is a free fall (as in the
original — you walked into a hole away from the ladder), but stepping off and
pushing **back toward** the ladder while looking down grabs it after ~0.8 wu and
descends at the climb rate: −13.384 → −13.884 → −14.884 → −15.384 → floor
−15.558.

**eng1 ascent regression — unchanged, matching #598's numbers exactly:**

- Engine Core stack (tmpls 377/413/339/414/415 at `(0.10, −16.4…−13.2, −22.95)`):
  reaches the landing at y **−11.796** from every heading tested (0°, ±10°, ±20°,
  ±30°, ±35°, ±40°); dead-on rate −15.558 → −14.858 → −13.858 → −12.858 =
  **6.0 wu/s**.
- `Rick Ladder 16` (obj 1911): −15.596 → −14.896 → −13.896 → **−12.896** =
  **6.0 wu/s** dead-on; 5.9 / 5.6 wu/s at 10° / 20° off.

## Not fixed here

- **No fall damage on landing**, noted in #603. Out of scope — it is a damage
  question, not a climbing one, and nothing in this change touches it.
- Walking straight off a shaft's lip *away* from the ladder still free-falls.
  That matches the original engine's rule (you must be touching the climbable
  face and pushing into it); the working move is to press back toward the ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
