### PR TITLE
feat: enable high-detail (PMNM) meshes by default on desktop

### DIFF
--- a/dark/src/high_detail.rs
+++ b/dark/src/high_detail.rs
@@ -1,0 +1,41 @@
+//! Whether to render the 25th Anniversary Edition's high-detail (`PMNM`) meshes.
+//!
+//! Model loading lives in this crate, which has no access to `shock2vr`'s
+//! `GameOptions`, so the decision is published here as a process-wide setting
+//! that `shock2vr` writes once at startup. That replaces the `SS2_PMNM_MESHES`
+//! env var this began as - env vars are effectively unsettable in a Quest APK,
+//! which made the feature impossible to control on the platform that most needs
+//! to control it.
+//!
+//! Defaults are per-platform, because the tradeoff differs:
+//!
+//! - **Desktop: on.** The upgraded creature meshes are ~7x the triangles of the
+//!   originals and cost about 2x the draw calls, which desktop absorbs easily.
+//!   It is also a no-op on a classic install: those assets carry no `PMNM`
+//!   chunk at all (verified across all 1576 `.bin` files), so nothing changes
+//!   for anyone not running the remaster's data.
+//! - **Android/Quest: off.** That same 7x/2x has not been measured on device.
+//!   Turn it on explicitly once it has.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// See the module docs for why these differ.
+const fn platform_default() -> bool {
+    !cfg!(target_os = "android")
+}
+
+static ENABLED: AtomicBool = AtomicBool::new(platform_default());
+
+/// The default for this platform, before any explicit override.
+pub fn default_enabled() -> bool {
+    platform_default()
+}
+
+/// Set once at startup, before any model is loaded.
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}

--- a/dark/src/lib.rs
+++ b/dark/src/lib.rs
@@ -4,6 +4,7 @@ pub mod font;
 pub mod gamesys;
 pub mod glb_model;
 pub mod glb_skeleton;
+pub mod high_detail;
 pub mod hit_box;
 pub mod map;
 pub mod mission;

--- a/dark/src/ss2_bin_ai_loader.rs
+++ b/dark/src/ss2_bin_ai_loader.rs
@@ -805,15 +805,7 @@ pub fn pmnm_bind_matrices(skeleton: &Skeleton) -> [Matrix4<f32>; MAX_JOINTS] {
     out
 }
 
-/// Whether the high-detail `PMNM` path is enabled.
-///
-/// An env var rather than the `--experimental` flag list because model loading
-/// lives in `dark`, which has no access to `shock2vr`'s options (the same reason
-/// `SS2_DEBUG_NORMALS` works this way).
+/// Whether the high-detail `PMNM` path is enabled. See [`crate::high_detail`].
 pub fn pmnm_enabled() -> bool {
-    // Not `is_some()`: that would make `SS2_PMNM_MESHES=0` *enable* the path.
-    matches!(
-        std::env::var("SS2_PMNM_MESHES").as_deref(),
-        Ok("1" | "true" | "yes")
-    )
+    crate::high_detail::enabled()
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -800,7 +800,29 @@ impl Game {
         self.active_game_scene.as_debuggable_mut()
     }
 
+    /// Resolve the high-detail (`PMNM`) mesh setting from the experimental flags,
+    /// falling back to the platform default.
+    ///
+    /// Two explicit flags rather than one, because the default differs per
+    /// platform: `high_detail_meshes` forces it on (for measuring on Quest, where
+    /// it is off by default), `no_high_detail_meshes` forces it off (to rule it
+    /// out on desktop, where it is on).
+    fn resolve_high_detail_meshes(features: &HashSet<String>) -> bool {
+        if features.contains("no_high_detail_meshes") {
+            false
+        } else if features.contains("high_detail_meshes") {
+            true
+        } else {
+            dark::high_detail::default_enabled()
+        }
+    }
+
     pub fn init(options: GameOptions, bundle_storage: Arc<dyn Storage>) -> Game {
+        // Must happen before any model is loaded.
+        let high_detail = Self::resolve_high_detail_meshes(&options.experimental_features);
+        dark::high_detail::set_enabled(high_detail);
+        info!("high-detail (PMNM) meshes: {high_detail}");
+
         // A 25th Anniversary install keeps everything inside KPF archives, so it
         // needs a different mount list from a classic install's loose `.crf`s.
         let asset_paths = if is_25th_anniversary_install() {
@@ -1383,5 +1405,45 @@ impl Game {
             .unwrap_or_else(|| name.to_owned());
         trace!("resolved sound schema {} to {}", name, ret);
         ret
+    }
+}
+
+#[cfg(test)]
+mod high_detail_flag_tests {
+    use super::*;
+
+    fn features(list: &[&str]) -> HashSet<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn defaults_to_the_platform_default_when_unspecified() {
+        assert_eq!(
+            Game::resolve_high_detail_meshes(&features(&[])),
+            dark::high_detail::default_enabled()
+        );
+    }
+
+    #[test]
+    fn opt_out_flag_disables_it() {
+        assert!(!Game::resolve_high_detail_meshes(&features(&[
+            "no_high_detail_meshes"
+        ])));
+    }
+
+    #[test]
+    fn opt_in_flag_enables_it() {
+        assert!(Game::resolve_high_detail_meshes(&features(&[
+            "high_detail_meshes"
+        ])));
+    }
+
+    /// Opting out is the safer outcome, so it wins a contradiction.
+    #[test]
+    fn opt_out_beats_opt_in() {
+        assert!(!Game::resolve_high_detail_meshes(&features(&[
+            "high_detail_meshes",
+            "no_high_detail_meshes"
+        ])));
     }
 }


### PR DESCRIPTION
Makes the 25th Anniversary Edition's high-detail creature meshes the default on desktop, and replaces the env var they were gated behind with a real setting.

## Why the env var had to go

`SS2_PMNM_MESHES` was always a stopgap. Model loading lives in `dark`, which has no access to `shock2vr`'s `GameOptions` — so the switch became an env var. But **env vars are effectively unsettable in a Quest APK**, which meant the feature couldn't be controlled on the platform that most needs to control it.

`dark::high_detail` now publishes a process-wide setting with a per-platform default, written once by `shock2vr` before any model loads.

## The defaults, and why they differ

| platform | default | reasoning |
| --- | --- | --- |
| Desktop | **on** | absorbs the cost easily; clear visual win |
| Android / Quest | **off** | the cost has not been measured on device |

The measured cost, across the 64 creature meshes that exist in both sets:

| | vanilla | high-detail |
| --- | --- | --- |
| triangles | 18,289 | 132,320 (**7.2×**) |
| draw calls | 75 | 159 (**2.1×**) |

On mobile the draw-call doubling usually bites harder than the triangles, which is why Quest stays off until someone runs it there.

**Turning this on is a provable no-op for classic installs**: their assets contain no `PMNM` chunk at all — 0 of 1,576 `.bin` files. Nothing changes for anyone not running the remaster's data.

`--experimental no_high_detail_meshes` forces it off, `high_detail_meshes` forces it on (for measuring on Quest), and opting out wins a contradiction since that's the safer outcome.

## Two things checked before flipping the default

**The joint-mapping outlier was a red herring.** I'd previously flagged `grunt_s` as having a joint off by ~1.0 unit. That residual is **pivot 17, which has zero vertices skinned to it** — cosmetically irrelevant. The largest deviation on any joint that actually skins geometry is **0.023 world units** across both outlier meshes. I had been reporting an aggregate max without checking whether it mattered; `pmnm_joints` now prints per-pivot residuals alongside their weighted-vertex counts so that can't hide again.

**Ragdolls are correct, and provably don't affect physics.** The high-detail mesh renders as a coherent body, and the ragdoll's physics is **bit-identical** to the vanilla-mesh path — max position delta `0.0000` across all 21 bodies after 180 frames. That's hard evidence for the "hitboxes and ragdoll fitting are untouched" claim, which until now was asserted by construction rather than measured.

## Validation

| asset set | e2e |
| --- | --- |
| classic | **141 / 142** |
| 25AE + full mod stack, high-detail on | **139 / 142** |

Every failure traced, none caused by this change:

- `earth-psionic-training` — **already fails on `main`** with classic data (verified by checking out main and running it). Worth a separate look.
- `alertness-churn` (#481) and `ragdoll-death` — known flaky; both fail intermittently on a classic install too.

Plus 4 new unit tests covering the flag resolution.

## Still open for Quest

Measuring the 7.2× / 2.1× on device is the gate for flipping the Android default. The write-up in `projects/25th-anniversary-assets.md` also still lists the synchronous DDS decode and KPF asset delivery as unexamined.
