### PR TITLE
Add entity-oriented world-space aiming to debug SDK

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -49,10 +49,16 @@ sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 the script directly and is fine for diagnosis, but it does **not** prove a player
 could do it. To frob the way a player does, in flat mode (the default):
 
-1. **Aim** — the target must be under the crosshair. The flat path raycasts from
-   the camera (`FlatInteraction` passes `head_rotation` through), so turn with
-   `{left_hand.thumbstick:[turn,0]}` / set `head.rotation`, and confirm with
-   `GET /v1/info` or a screenshot that the thing is actually centered.
+1. **Aim** — the target must be under the crosshair. With the preferred SDK,
+   call `game.player.aimAt(entity, {hitbox:"torso"})` (`head`, `limb`,
+   `center`, and `nearest` are also available). It selects a live classified
+   creature damage proxy, reports the chosen owner/body/joint/world point and
+   any fallback, and accounts for pawn rotation restored from a save while
+   still driving the production camera and `FlatInteraction` ray. Raw `head.look` and
+   `head.rotation` are **pawn-local**, not world-space; do not use an identity
+   quaternion as a world-facing direction. If using raw HTTP, turn with
+   `{left_hand.thumbstick:[turn,0]}` and confirm the highlighted entity via
+   `GET /v1/info` or a screenshot before squeezing.
 2. **Squeeze** — the use button is **`right_hand.squeeze_value`**, on a *rising
    edge*: set it `>0.5`, `step`, then back to `0.0`, `step`.
    **`trigger_value` fires the wielded weapon — it does NOT frob.**

--- a/shock2vr/src/creature/hit_boxes.rs
+++ b/shock2vr/src/creature/hit_boxes.rs
@@ -20,10 +20,9 @@ use super::{get_entity_creature, hit_box_script::HitBoxScript};
 
 #[derive(Component)]
 pub struct RuntimePropHitBox {
-    #[allow(dead_code)]
     pub parent_entity_id: EntityId,
-    #[allow(dead_code)]
     pub hit_box_type: HitBoxType,
+    pub joint_id: JointId,
 }
 
 #[derive(Clone, Debug)]
@@ -111,6 +110,7 @@ impl HitBoxManager {
                             RuntimePropHitBox {
                                 parent_entity_id,
                                 hit_box_type: hitbox_type.clone(),
+                                joint_id: *joint_id,
                             },
                         );
 

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -180,6 +180,16 @@ pub struct DebugEntityDetail {
     pub properties: Vec<DebugPropertyInfo>,
     pub outgoing_links: Vec<DebugLinkInfo>,
     pub incoming_links: Vec<DebugLinkInfo>,
+    pub aim_points: Vec<DebugAimPoint>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugAimPoint {
+    pub proxy_entity_id: i32,
+    pub body_id: u32,
+    pub joint_id: u32,
+    pub classification: String,
+    pub position: [f32; 3],
 }
 
 /// Property information for debug display

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5617,8 +5617,38 @@ impl crate::game_scene::DebuggableScene for MissionCore {
     }
 
     fn entity_detail(&self, id: EntityId) -> Option<crate::game_scene::DebugEntityDetail> {
-        use crate::game_scene::{DebugEntityDetail, DebugLinkInfo, DebugPropertyInfo};
+        use crate::game_scene::{
+            DebugAimPoint, DebugEntityDetail, DebugLinkInfo, DebugPropertyInfo,
+        };
         use shipyard::*;
+
+        let aim_points = self
+            .world
+            .run(|hitboxes: View<crate::creature::RuntimePropHitBox>| {
+                hitboxes
+                    .iter()
+                    .with_id()
+                    .filter(|(_, hitbox)| hitbox.parent_entity_id == id)
+                    .filter_map(|(proxy_id, hitbox)| {
+                        let handle = *self.id_to_physics.get(&proxy_id)?;
+                        let body = self.physics.debug_body_detail(handle.into_raw_parts().0)?;
+                        Some(DebugAimPoint {
+                            proxy_entity_id: proxy_id.inner() as i32,
+                            body_id: body.body_id,
+                            joint_id: hitbox.joint_id,
+                            classification: match hitbox.hit_box_type {
+                                crate::creature::HitBoxType::Head => "head",
+                                crate::creature::HitBoxType::Body => "torso",
+                                crate::creature::HitBoxType::Limb => "limb",
+                                crate::creature::HitBoxType::Extremity => "extremity",
+                                crate::creature::HitBoxType::NoDamage => "no_damage",
+                            }
+                            .to_string(),
+                            position: body.position,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            });
 
         // Looked up outside the main run: the closure below is at shipyard's
         // view-count limit.
@@ -5823,6 +5853,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties,
                     outgoing_links,
                     incoming_links,
+                    aim_points: aim_points.clone(),
                 })
             },
         )

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -49,6 +49,12 @@ await game.input.trigger("PathfindingTestCycle");
 // Continuous input channels
 await game.input.set("right_hand.trigger_value", 1.0);
 
+// Aim at a live creature hitbox through the production camera/weapon path.
+// Prefer this over hand-composing head.rotation: raw head controls are
+// pawn-local, so mission spawns and loaded saves can rotate their world result.
+const aim = await game.player.aimAt(target, { hitbox: "torso" });
+// aim reports the selected owner/proxy/body/joint/world point and any fallback.
+
 // Verify state instead of scraping logs
 const status = await game.pathfindingTest.status();
 // => { state: "WaitingForGoal", test_path_waypoints: 0 }

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -30,6 +30,9 @@ import type {
   TransitionsResult,
   WaitForOptions,
   AiPathEntry,
+  AimClassification,
+  AimResult,
+  Vec3,
 } from "./types.js";
 
 /** Error thrown when the game reports a command failed (success: false). */
@@ -77,6 +80,70 @@ export class PlayerApi {
    */
   async moveTo(target: Position): Promise<MoveResult> {
     return this.client.post<MoveResult>("/v1/player/move", target);
+  }
+
+  /**
+   * Aim the production flat camera, interaction ray, and weapon at an entity.
+   *
+   * Creature targets use their live classified damage proxies. Other entities,
+   * or unavailable classifications, gracefully fall back to the entity center.
+   * This accounts for authored and save-restored pawn rotation; raw
+   * `head.look` / `head.rotation` are pawn-local.
+   */
+  async aimAt(
+    entity: number | Pick<EntitySummary, "id">,
+    options?: { hitbox?: AimClassification; eyeHeight?: number },
+  ): Promise<AimResult> {
+    const entityId = typeof entity === "number" ? entity : entity.id;
+    const requested = options?.hitbox ?? "torso";
+    const [detail, snapshot] = await Promise.all([
+      this.client.get<EntityDetailResult>(`/v1/entities/${entityId}`),
+      this.client.get<FrameSnapshot>("/v1/info"),
+    ]);
+    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const eye: Vec3 = [
+      snapshot.player.position[0],
+      snapshot.player.position[1] + eyeHeight,
+      snapshot.player.position[2],
+    ];
+    const distance = (point: Vec3) =>
+      Math.hypot(point[0] - eye[0], point[1] - eye[1], point[2] - eye[2]);
+
+    let candidates = detail.aim_points;
+    if (requested === "head" || requested === "torso") {
+      candidates = candidates.filter((point) => point.classification === requested);
+    } else if (requested === "limb") {
+      candidates = candidates.filter(
+        (point) =>
+          point.classification === "limb" || point.classification === "extremity",
+      );
+    } else if (requested === "center") {
+      candidates = [];
+    }
+    candidates.sort((a, b) => distance(a.position) - distance(b.position));
+    const selected = candidates[0];
+    const worldPoint = selected?.position ?? detail.position;
+    const headRotation = headRotationForWorldPoint(
+      snapshot.player.position,
+      snapshot.player.rotation,
+      worldPoint,
+      eyeHeight,
+    );
+    await this.client.post("/v1/control/input", {
+      channel: "head.rotation",
+      value: headRotation,
+    });
+    return {
+      entity_id: entityId,
+      proxy_entity_id: selected?.proxy_entity_id ?? null,
+      body_id: selected?.body_id ?? null,
+      joint_id: selected?.joint_id ?? null,
+      requested,
+      classification: selected?.classification ?? "center",
+      world_point: worldPoint,
+      head_rotation: headRotation,
+      fallback_used: selected === undefined && requested !== "center",
+    };
   }
 
   /** The items the player is carrying (backpack + hand-held), for verifying pickups. */
@@ -178,6 +245,77 @@ export class InputApi {
   async set(channel: string, value: unknown): Promise<void> {
     await this.client.post("/v1/control/input", { channel, value });
   }
+
+  /**
+   * Point the production flat-mode camera/interaction ray at a world position.
+   *
+   * Unlike the low-level `head.look` and `head.rotation` channels, this method
+   * accounts for the player's authored or save-restored body rotation. The
+   * resulting head rotation still flows through the normal camera,
+   * FlatInteraction, and weapon paths; this is aiming, not a debug hit shim.
+   *
+   * `eyeHeight` defaults to the flat player's standing eye height. Pass a
+   * different value when deliberately testing crouched aiming.
+   */
+  async lookAtWorldPoint(target: Vec3, options?: { eyeHeight?: number }): Promise<void> {
+    const [{ position }, snapshot] = await Promise.all([
+      this.client.get<{ position: Vec3 }>("/v1/player/position"),
+      this.client.get<FrameSnapshot>("/v1/info"),
+    ]);
+    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const localHeadRotation = headRotationForWorldPoint(
+      position,
+      snapshot.player.rotation,
+      target,
+      eyeHeight,
+    );
+    await this.set("head.rotation", localHeadRotation);
+  }
+}
+
+type Quat = [number, number, number, number];
+
+function multiplyQuat(a: Quat, b: Quat): Quat {
+  const [ax, ay, az, aw] = a;
+  const [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+}
+
+function lookQuat(direction: Vec3): Quat {
+  const length = Math.hypot(...direction);
+  if (length === 0) throw new Error("look-at target must differ from the player's eye position");
+  const [bx, by, bz] = direction.map((value) => value / length) as Vec3;
+  const dot = -bz;
+  if (dot < -0.999999) return [0, 1, 0, 0];
+  const quaternion: Quat = [by, -bx, 0, 1 + dot];
+  const quaternionLength = Math.hypot(...quaternion);
+  return quaternion.map((value) => value / quaternionLength) as Quat;
+}
+
+/** Pure look-at transform, exported so callers can verify/control custom rigs. */
+export function headRotationForWorldPoint(
+  playerPosition: Vec3,
+  playerRotation: Quat,
+  target: Vec3,
+  eyeHeight = 1.6,
+): Quat {
+  const worldLook = lookQuat([
+    target[0] - playerPosition[0],
+    target[1] - (playerPosition[1] + eyeHeight),
+    target[2] - playerPosition[2],
+  ]);
+  const inversePawn: Quat = [
+    -playerRotation[0],
+    -playerRotation[1],
+    -playerRotation[2],
+    playerRotation[3],
+  ];
+  return multiplyQuat(inversePawn, worldLook);
 }
 
 /** Physics rigid-body inspection (positions, velocities). */

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -4,6 +4,7 @@ export {
   CommandError,
   EntitiesApi,
   Game,
+  headRotationForWorldPoint,
   InputApi,
   PathfindingTestApi,
   PlayerApi,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -123,6 +123,34 @@ export interface EntityDetailResult {
   properties: PropertyInfo[];
   outgoing_links: LinkInfo[];
   incoming_links: LinkInfo[];
+  aim_points: AimPoint[];
+}
+
+export interface AimPoint {
+  proxy_entity_id: number;
+  body_id: number;
+  joint_id: number;
+  classification: "head" | "torso" | "limb" | "extremity" | "no_damage";
+  position: Vec3;
+}
+
+export type AimClassification =
+  | "head"
+  | "torso"
+  | "limb"
+  | "center"
+  | "nearest";
+
+export interface AimResult {
+  entity_id: number;
+  proxy_entity_id: number | null;
+  body_id: number | null;
+  joint_id: number | null;
+  requested: AimClassification;
+  classification: string;
+  world_point: Vec3;
+  head_rotation: Quat;
+  fallback_used: boolean;
 }
 
 /** A clip queued behind the currently-playing head clip. */

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -3,7 +3,6 @@ import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
 import type { EntitySummary, UiElement } from "../src/types.js";
-import { aimAtWorldPoint } from "./helpers/aim.js";
 import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
 import { earthWorldUse } from "./helpers/earth-world-use.js";
 import { clickUiElement } from "./helpers/ui.js";
@@ -79,7 +78,20 @@ async function aimAtEntity(game: GameServer, target: EntitySummary): Promise<voi
   const [tx, ty, tz] = (await game.entities.detail(target.id)).position;
   await game.player.teleport({ x: tx - 4, y: ty, z: tz });
   await game.step({ frames: 5 });
-  await aimAtWorldPoint(game, [tx, ty + 1, tz]);
+  await game.input.set("left_hand.thumbstick", [0.75, 0]);
+  await game.step({ frames: 20 });
+  await game.input.set("left_hand.thumbstick", [0, 0]);
+  await game.save("world-aim-rotated");
+  await game.load("world-aim-rotated");
+  const pawn = (await game.info()).player.rotation;
+  assert.ok(
+    Math.abs(pawn[1]) > 0.01 || Math.abs(pawn[3] - 1) > 0.01,
+    `regression requires a non-identity save-restored pawn rotation: ${pawn}`,
+  );
+  const aim = await game.player.aimAt(target, { hitbox: "torso" });
+  assert.equal(aim.entity_id, target.id);
+  assert.equal(aim.classification, "torso");
+  assert.equal(aim.fallback_used, false);
   await game.step({ frames: 3 });
 }
 

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { headRotationForWorldPoint } from "../src/index.js";
+
+type Quat = [number, number, number, number];
+
+function multiplyQuat(a: Quat, b: Quat): Quat {
+  const [ax, ay, az, aw] = a;
+  const [bx, by, bz, bw] = b;
+  return [
+    aw * bx + ax * bw + ay * bz - az * by,
+    aw * by - ax * bz + ay * bw + az * bx,
+    aw * bz + ax * by - ay * bx + az * bw,
+    aw * bw - ax * bx - ay * by - az * bz,
+  ];
+}
+
+test("world aim cancels a non-identity save-restored pawn rotation", () => {
+  const pawn: Quat = [0, Math.SQRT1_2, 0, Math.SQRT1_2];
+  const head = headRotationForWorldPoint([5, 2, 5], pawn, [-5, 3.6, 5]);
+  const composed = multiplyQuat(pawn, head);
+  const expected = headRotationForWorldPoint(
+    [5, 2, 5],
+    [0, 0, 0, 1],
+    [-5, 3.6, 5],
+  );
+  composed.forEach((component, index) => {
+    assert.ok(Math.abs(component - expected[index]) < 1e-6);
+  });
+  assert.notDeepEqual(head, expected, "raw world rotation would aim incorrectly");
+});
+
+test("world aim rejects an undefined zero-length direction", () => {
+  assert.throws(
+    () => headRotationForWorldPoint([1, 2, 3], [0, 0, 0, 1], [1, 3.6, 3]),
+    /target must differ/,
+  );
+});


### PR DESCRIPTION
Fixes #615

## Summary
- expose live creature damage proxies with owner, body, joint, classification, and world point through entity detail
- add `game.player.aimAt(entity, { hitbox })` for `head`, `torso`, `limb`, `center`, and `nearest`, with explicit fallback reporting
- compensate for authored/save-restored pawn rotation while driving the normal head input, camera, FlatInteraction, and weapon path
- document raw head controls as pawn-local and update playtest guidance

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cd tools/shock2-sdk && npm test` (144 tests: 16 pass, 128 opt-in skipped)
- targeted Earth production projectile scenario was attempted; it failed before reaching aim at its pre-existing booster pickup assertion (`normal world-use should physically carry booster 288`)

The Earth scenario now turns the pawn, saves, reloads, resolves the live torso proxy, verifies the selection, and then uses the ordinary projectile attack once the earlier scenario setup succeeds.