### PR TITLE
Fix QuickLoad panic when no quicksave exists

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1007,12 +1007,21 @@ fn process_command(
                 game.load_game(file.clone())
             }));
             let result = match outcome {
-                Ok(mission) => commands::SaveLoadResult {
+                Ok(Ok(mission)) => commands::SaveLoadResult {
                     success: true,
                     message: format!("Loaded '{}' ({})", file, mission),
                     file,
                     mission,
                 },
+                Ok(Err(error)) => {
+                    tracing::error!("Failed to load '{}': {}", file, error);
+                    commands::SaveLoadResult {
+                        success: false,
+                        message: format!("Failed to load '{}': {}", file, error),
+                        file,
+                        mission: String::new(),
+                    }
+                }
                 Err(_) => {
                     tracing::error!("Load of '{}' panicked (caught to keep runtime alive)", file);
                     commands::SaveLoadResult {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -70,7 +70,8 @@ pub fn player_eye_height_for(crouched: bool) -> f32 {
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::OpenOptions,
+    fs::{File, OpenOptions},
+    io,
     path::Path,
     rc::Rc,
     sync::Arc,
@@ -107,6 +108,11 @@ use crate::{
     scripts::Effect,
 };
 use zip_asset_path::ZipAssetPath;
+
+fn read_save_file(path: &Path) -> io::Result<SaveData> {
+    let mut file = File::open(path)?;
+    Ok(SaveData::read(&mut file))
+}
 
 /// Whether `data_root` is a 25th Anniversary Edition install rather than a
 /// classic one. The remaster ships its data inside `sshock2.kpf`; a classic
@@ -768,14 +774,11 @@ impl Game {
     /// restoring the active mission, player position/rotation, quest bits, held
     /// items, and exact current/maximum player vitals. The switch is synchronous
     /// (no loading-screen deferral), so the returned scene name already reflects
-    /// the restored mission. The caller must ensure the file exists - the load
-    /// path panics on a missing file.
-    pub fn load_game(&mut self, file: String) -> String {
+    /// the restored mission. A missing save leaves the active game unchanged.
+    pub fn load_game(&mut self, file: String) -> io::Result<String> {
         let path = save_file_path(&file);
-        self.handle_global_effect(GlobalEffect::Load {
-            file_name: path.to_string_lossy().into_owned(),
-        });
-        self.scene_name().to_string()
+        self.load_from_file(path.to_string_lossy().into_owned())?;
+        Ok(self.scene_name().to_string())
     }
 
     /// Get access to the debug scene interface if available
@@ -1123,9 +1126,8 @@ impl Game {
         save_data.write(&mut zip_file);
     }
 
-    fn load_from_file(&mut self, file_name: String) {
-        let mut file = OpenOptions::new().read(true).open(file_name).unwrap();
-        let save_data = SaveData::read(&mut file);
+    fn load_from_file(&mut self, file_name: String) -> io::Result<()> {
+        let save_data = read_save_file(Path::new(&file_name))?;
         let was_crouched = save_data.global_data.is_crouched;
         let (mut mission, level_map) = Self::load_from_save_data(
             save_data,
@@ -1143,6 +1145,7 @@ impl Game {
         }
         self.active_game_scene = Box::new(mission);
         self.mission_to_save_data = level_map;
+        Ok(())
     }
 
     fn load_from_save_data(
@@ -1213,7 +1216,11 @@ impl Game {
     fn handle_global_effect(&mut self, global_effect: GlobalEffect) {
         match global_effect {
             GlobalEffect::Save { file_name } => self.save_to_file(file_name),
-            GlobalEffect::Load { file_name } => self.load_from_file(file_name),
+            GlobalEffect::Load { file_name } => {
+                if let Err(error) = self.load_from_file(file_name.clone()) {
+                    warn!("Unable to load save '{}': {}", file_name, error);
+                }
+            }
             GlobalEffect::TransitionLevel {
                 level_file,
                 loc,
@@ -1409,8 +1416,9 @@ impl Game {
 }
 
 #[cfg(test)]
-mod high_detail_flag_tests {
+mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn features(list: &[&str]) -> HashSet<String> {
         list.iter().map(|s| s.to_string()).collect()
@@ -1445,5 +1453,18 @@ mod high_detail_flag_tests {
             "high_detail_meshes",
             "no_high_detail_meshes"
         ])));
+    }
+
+    #[test]
+    fn missing_save_file_returns_an_error_instead_of_panicking() {
+        let missing = std::env::temp_dir().join(PathBuf::from(format!(
+            "shock2vr-missing-save-{}-{}.sav",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        )));
+
+        let result = read_save_file(&missing);
+
+        assert!(result.is_err());
     }
 }

--- a/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
+++ b/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+import { join } from "node:path";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "QuickLoad without a session quicksave leaves the runtime healthy",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_minimal",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
+    });
+
+    // Establish the precondition without deleting or overwriting a user's
+    // quicksave. A stale save1.sav should fail rather than mask the regression.
+    const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+    assert.equal(
+      existsSync(join(repoRoot, "save1.sav")),
+      false,
+      "the test requires a worktree with no pre-existing session quicksave",
+    );
+
+    await game.input.trigger("QuickLoad");
+    await game.step({ frames: 1 });
+
+    assert.equal((await game.health()).status, "ok");
+    assert.equal((await game.info()).mission, "debug_minimal");
+    assert.ok(
+      game
+        .logs()
+        .some((line) => line.includes("Unable to load save 'save1.sav'")),
+      "missing QuickLoad should be recorded in the runtime log",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #617

## Summary

- make the shared production load path return a missing-file error instead of unwrapping
- preserve the active scene and log a warning when the QuickLoad action has no `save1.sav`
- propagate named-load I/O failures through the debug runtime result
- add unit and SDK end-to-end regression coverage proving the runtime stays healthy

## Negative-first

Added `missing_save_file_returns_an_error_instead_of_panicking` before the guarded reader existed; it failed to compile because `read_save_file` did not exist. On baseline, the SDK production sequence (`QuickLoad`, step one frame, health) reproduced exit code 101 at `shock2vr/src/lib.rs:1127`.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (299 passed)
- `cd tools/shock2-sdk && npm test`
- `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked SHOCK2_E2E=1 SHOCK2_E2E_PORT=8137 node --test dist/test/quickload-missing.e2e.test.js`