### PR TITLE
feat(play-through): roll a randomized campaign (scenario + tweak + asset set)

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -80,7 +80,9 @@ Classify each validated finding two ways:
     feature, and it must be **faithful**, not a shim.
 
 **Blockers first** (they gate progress). File a GitHub issue (domain + kind,
-mission, repro: exact levers + step count, expected vs actual, the screenshot).
+mission, repro: exact levers + step count, expected vs actual, the screenshot,
+and — in a rolled campaign — the campaign configuration: scenario, tweak,
+asset set, seed; same on the fix PR).
 
 **Fixing a feature gap — faithfulness is required:**
 - The fix agent must **investigate the original System Shock 2 behavior AND the
@@ -186,7 +188,11 @@ them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
    electronic/organic/heavy weapons), OSA (psi tiers 1–5), AI/pathfinding
    stress, or a detailed test run.
 3. **Asset set** — legacy assets or the 25th Anniversary assets; the pick is the
-   `DARK_ASSET_PATH` every runtime in the campaign must be launched with.
+   `DARK_ASSET_PATH` every runtime in the campaign must be launched with. Only
+   sets that are actually loadable (`shock2.gam` present at the path) enter the
+   random draw; an unusable set can still be forced with `assets=<id>` and the
+   roll prints a warning (e.g. the 25th Anniversary install is packed `.kpf`
+   until it's unpacked / the engine learns to read it).
 
 ```
 node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)
@@ -204,7 +210,23 @@ iteration — **feed the tweak instructions and campaign goal into every
 `playtest` prompt**, and treat a tweak's verifications as first-class findings
 (a broken psi power under an OSA tweak is a real finding even if the mission
 could be finished without it). Every roll prints its `seed`, so any campaign
-can be reproduced exactly.
+can be reproduced exactly (the RNG stream is identical whether or not picks
+were forced alongside the seed).
+
+**Tweak setup gaps.** Most scenarios start mid-game with a fresh character, so
+a class tweak (Marine/Navy/OSA) may require gear, skills, or psi tiers the
+start state doesn't have. Provisioning the loadout is then the **first job of
+iteration 0** — use the debug runtime's legitimate levers (spawn/give,
+career-relevant items found in the level) to establish it. If the tooling
+can't provision what the tweak needs, record that as a **tooling/setup gap**
+(and satisfy as much of the tweak as is reachable) — do NOT file "X is broken"
+game bugs for things the character was never given.
+
+**Record the roll everywhere it matters:** every issue filed and every fix PR
+opened during a campaign must state the rolled configuration — scenario, tweak,
+asset set, and seed (e.g. `campaign: hydroponics · melee-only · legacy · seed
+42`) — so a reader can tell whether a finding is specific to a playstyle or
+asset set, and can reproduce the campaign that surfaced it.
 
 ## Autonomous mode (`--auto`)
 

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -168,6 +168,44 @@ Optionally record a **video** of a session — capture frames at a cadence durin
 play and stitch with the **`video-capture`** skill (60Hz sim / 4 = real-time
 15fps). Local artifact.
 
+## Campaign randomization (`roll`)
+
+**Every new campaign starts with a roll.** Instead of always marching
+earth→shodan, the campaign randomizer picks three independent axes and persists
+them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
+
+1. **Mission-sequence scenario** — one of eight slices of the game, each with
+   its own mission order and goal: `earth-to-medsci` (training → station →
+   medsci1/2), `engineering` (power to the elevator), `hydroponics` (Toxin-A →
+   regulators), `operations` (ops2 elevator → cutscene → sim unit overrides),
+   `recreation` (painting codes → transmitter), `command`, `rickenbacker`
+   (destroy the eggs), `shodan` (end sequence + boss AI).
+2. **Special tweak** — a playstyle/verification constraint for every session in
+   the campaign: none, melee-only, loot-everything, cutscene/research/regen/
+   camera-alarm verification, Navy (hack/repair/modify), Marine (standard/
+   electronic/organic/heavy weapons), OSA (psi tiers 1–5), AI/pathfinding
+   stress, or a detailed test run.
+3. **Asset set** — legacy assets or the 25th Anniversary assets; the pick is the
+   `DARK_ASSET_PATH` every runtime in the campaign must be launched with.
+
+```
+node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)
+node .agents/skills/play-through/playthrough-state.mjs roll seed=42      # reproducible roll
+node .agents/skills/play-through/playthrough-state.mjs roll --force scenario=hydroponics tweak=melee-only assets=legacy
+node .agents/skills/play-through/scenarios.mjs list                      # browse all ids
+```
+
+**The roll happens once per campaign and then sticks**: like `init`, `roll` is
+idempotent — re-invoking the skill mid-campaign keeps the existing roll, so the
+frontier, scenario, tweak, and assets stay consistent across iterations
+(`--force` starts a fresh campaign with a new roll). `show` re-surfaces the
+goal, the tweak instructions, and the `DARK_ASSET_PATH` in its NEXT line every
+iteration — **feed the tweak instructions and campaign goal into every
+`playtest` prompt**, and treat a tweak's verifications as first-class findings
+(a broken psi power under an OSA tweak is a real finding even if the mission
+could be finished without it). Every roll prints its `seed`, so any campaign
+can be reproduced exactly.
+
 ## Autonomous mode (`--auto`)
 
 Invoke the `play-through` skill with `--auto` using the host agent's skill syntax.
@@ -177,30 +215,34 @@ run** — no setup step. State persists in that ledger so it resumes at the
 frontier and marches forward instead of re-treading:
 
 ```
-node .agents/skills/play-through/playthrough-state.mjs init      # idempotent; --auto calls it (--force resets)
+node .agents/skills/play-through/playthrough-state.mjs roll      # idempotent; --auto calls it (--force re-rolls)
 node .agents/skills/play-through/playthrough-state.mjs show      # ledger + the NEXT action
 #   blocker add <level> <bug|feature-gap> <issue#> <desc...>   ·  blocker set <issue#> <status> [pr#]
 #   advance <level> <saveName> <x,y,z> [note...]               (sets frontier, bumps iteration)
 ```
 
-The ledger holds: `frontier` (the game **save** to `/v1/load` from), the
+The ledger holds: the campaign **roll** (`scenario` + `tweak` + `assets`, with
+its `seed`), `frontier` (the game **save** to `/v1/load` from), the
 `blockers` ledger (issue → PR → status), and `fix_branch` — the running branch
 that **stacks each fix** so the campaign plays *past* an already-fixed-but-
 unmerged blocker.
 
-**Clear & start a new campaign:** `playthrough-state.mjs init --force` (wipes the
-ledger back to iteration 0). For a *truly* clean slate also recreate the
+**Clear & start a new campaign:** `playthrough-state.mjs roll --force` (wipes
+the ledger back to iteration 0 with a fresh scenario/tweak/assets roll; plain
+`init --force` still exists for a fixed, non-randomized order). For a *truly* clean slate also recreate the
 `fix_branch` off current `main` and delete stale frontier saves (`<data_root>/
 saves/frontier*.sav`) — otherwise the fresh campaign just launches mission 0 with
 no frontier to load, which is harmless.
 
 **Each `--auto` iteration** (do exactly one; a host loop may repeat it):
-1. `playthrough-state.mjs init` (idempotent — creates the ledger on the first
-   iteration, keeps it after), then `show` → read the frontier + NEXT action.
+1. `playthrough-state.mjs roll` (idempotent — rolls scenario + tweak + assets
+   and creates the ledger on the first iteration, keeps the roll after), then
+   `show` → read the frontier + NEXT action (goal, tweak, `DARK_ASSET_PATH`).
 2. **Resume:** build the runtime from the **`fix_branch`** (so accrued fixes are
-   in), launch it, and `POST /v1/load {file: frontier.save}` — or launch the first
-   mission fresh at iteration 0.
-3. **Playtest** from here toward the goal (the `playtest` primitive) → `data.json`.
+   in), launch it **with the campaign's `DARK_ASSET_PATH`**, and `POST /v1/load
+   {file: frontier.save}` — or launch the first mission fresh at iteration 0.
+3. **Playtest** from here toward the goal (the `playtest` primitive), passing the
+   campaign goal + the tweak instructions into the playtest prompt → `data.json`.
 4. **Review** the session (§2). Shallow/invalid → re-playtest with guidance.
 5. **Triage** the blocker (bug vs **feature-gap** — §3-4; feature-gaps get a
    *faithful*, non-shim fix).

--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -187,12 +187,12 @@ them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
    camera-alarm verification, Navy (hack/repair/modify), Marine (standard/
    electronic/organic/heavy weapons), OSA (psi tiers 1–5), AI/pathfinding
    stress, or a detailed test run.
-3. **Asset set** — legacy assets or the 25th Anniversary assets; the pick is the
+3. **Asset set** — legacy assets or the 25th Anniversary assets (loaded
+   directly from the stock `.kpf` install since #557); the pick is the
    `DARK_ASSET_PATH` every runtime in the campaign must be launched with. Only
-   sets that are actually loadable (`shock2.gam` present at the path) enter the
-   random draw; an unusable set can still be forced with `assets=<id>` and the
-   roll prints a warning (e.g. the 25th Anniversary install is packed `.kpf`
-   until it's unpacked / the engine learns to read it).
+   sets where a data-root sentinel exists (`shock2.gam` / `sshock2.kpf` / ...,
+   same list as `paths::data_root()`) enter the random draw; a missing install
+   can still be forced with `assets=<id>` and the roll prints a warning.
 
 ```
 node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)

--- a/.claude/skills/play-through/playthrough-state.mjs
+++ b/.claude/skills/play-through/playthrough-state.mjs
@@ -6,6 +6,13 @@
 //
 //   node playthrough-state.mjs <cmd> [args]
 //     init [order=earth,station,medsci1,eng1,...] [fixBranch=playthrough-fixes]
+//     roll [seed=N] [scenario=<id>] [tweak=<id>] [assets=<id>] [fixBranch=...] [--force]
+//                                       init a RANDOMIZED campaign: pick a mission-
+//                                       sequence scenario, a special tweak, and an
+//                                       asset set (see scenarios.mjs) and persist
+//                                       them in the ledger. Idempotent like init —
+//                                       an existing campaign keeps its roll;
+//                                       --force re-rolls from scratch.
 //     show                              print the ledger + the recommended next action
 //     advance <level> <save> <x,y,z> [note...]   set frontier, bump iteration, log history
 //     blocker add <level> <bug|feature-gap> <issue#> <desc...>   record a found blocker (status:open)
@@ -14,6 +21,7 @@
 // State file: $PT_STATE, else /tmp/claude/playthrough/state.json.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { roll } from "./scenarios.mjs";
 
 const FILE = process.env.PT_STATE || "/tmp/claude/playthrough/state.json";
 const load = () => (existsSync(FILE) ? JSON.parse(readFileSync(FILE, "utf8")) : null);
@@ -25,10 +33,14 @@ const rest = args; // command-specific positional args (after the command)
 function nextAction(s) {
   const openBlockers = s.blockers.filter((b) => !["merged"].includes(b.status));
   const failed = s.blockers.find((b) => b.status === "failed");
+  const campaign = (s.assets ? ` Launch every runtime with DARK_ASSET_PATH=${s.assets.path} (${s.assets.name}).` : "")
+    + (s.scenario ? ` Campaign goal: ${s.scenario.goal}` : "")
+    + (s.tweak && s.tweak.id !== "none" ? ` TWEAK [${s.tweak.name}]: ${s.tweak.instructions}` : "");
   if (failed) return `PAUSE — blocker #${failed.issue} (${failed.desc}) fix did not clear it; needs a human.`;
-  if (!s.frontier) return `Iteration ${s.iteration}: launch fresh at "${s.mission_order[0]}" and playtest.`;
+  if (!s.frontier) return `Iteration ${s.iteration}: launch fresh at "${s.mission_order[0]}" and playtest.` + campaign;
   return `Iteration ${s.iteration}: rebuild the '${s.fix_branch}' branch, launch a runtime, POST /v1/load {file:"${s.frontier.save}"} (resumes ${s.frontier.level}), and playtest onward.`
-    + (openBlockers.length ? ` Open fix PRs to merge: ${openBlockers.map((b) => `#${b.pr ?? "?"}(${b.status})`).join(", ")}.` : "");
+    + (openBlockers.length ? ` Open fix PRs to merge: ${openBlockers.map((b) => `#${b.pr ?? "?"}(${b.status})`).join(", ")}.` : "")
+    + campaign;
 }
 
 switch (cmd) {
@@ -43,6 +55,49 @@ switch (cmd) {
     const fixBranch = rest.find((a) => a.startsWith("fixBranch="))?.slice(10) || "playthrough-fixes";
     save({ iteration: 0, mission_order: order, fix_branch: fixBranch, frontier: null, blockers: [], history: [] });
     console.log(`initialized ${FILE} (${order.length} missions, fix branch '${fixBranch}')`);
+    break;
+  }
+  case "roll": {
+    // Randomized init: pick scenario + tweak + asset set and persist them so
+    // every later iteration of the campaign plays under the same roll.
+    // Idempotent like init — only rolls when no ledger exists (--force resets).
+    if (existsSync(FILE) && !args.includes("--force")) {
+      const s = load();
+      console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --force to re-roll.`);
+      if (s.scenario) console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name}`);
+      break;
+    }
+    const kv = (k) => rest.find((a) => a.startsWith(`${k}=`))?.slice(k.length + 1);
+    let picked;
+    try {
+      picked = roll({
+        seed: kv("seed") ? Number(kv("seed")) : undefined,
+        scenarioId: kv("scenario"),
+        tweakId: kv("tweak"),
+        assetsId: kv("assets"),
+      });
+    } catch (e) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    const fixBranch = kv("fixBranch") || "playthrough-fixes";
+    save({
+      iteration: 0,
+      mission_order: picked.scenario.missions,
+      fix_branch: fixBranch,
+      frontier: null,
+      blockers: [],
+      history: [],
+      seed: picked.seed,
+      scenario: { id: picked.scenario.id, name: picked.scenario.name, goal: picked.scenario.goal },
+      tweak: picked.tweak,
+      assets: picked.assets,
+    });
+    console.log(`rolled campaign (seed ${picked.seed}) -> ${FILE}`);
+    console.log(`  scenario: ${picked.scenario.name} [${picked.scenario.id}] — ${picked.scenario.missions.join(", ")}`);
+    console.log(`  goal:     ${picked.scenario.goal}`);
+    console.log(`  tweak:    ${picked.tweak.name} [${picked.tweak.id}] — ${picked.tweak.instructions}`);
+    console.log(`  assets:   ${picked.assets.name} [${picked.assets.id}] — DARK_ASSET_PATH=${picked.assets.path}`);
     break;
   }
   case "show": {
@@ -80,6 +135,6 @@ switch (cmd) {
     break;
   }
   default:
-    console.error("usage: init | show | advance | blocker add|set (see file header)");
+    console.error("usage: init | roll | show | advance | blocker add|set (see file header)");
     process.exit(1);
 }

--- a/.claude/skills/play-through/playthrough-state.mjs
+++ b/.claude/skills/play-through/playthrough-state.mjs
@@ -26,6 +26,7 @@ import { roll } from "./scenarios.mjs";
 const FILE = process.env.PT_STATE || "/tmp/claude/playthrough/state.json";
 const load = () => (existsSync(FILE) ? JSON.parse(readFileSync(FILE, "utf8")) : null);
 const save = (s) => { mkdirSync(dirname(FILE), { recursive: true }); writeFileSync(FILE, JSON.stringify(s, null, 2) + "\n"); };
+const baseState = (order, fixBranch) => ({ iteration: 0, mission_order: order, fix_branch: fixBranch, frontier: null, blockers: [], history: [] });
 
 const [cmd, ...args] = process.argv.slice(2);
 const rest = args; // command-specific positional args (after the command)
@@ -53,7 +54,7 @@ switch (cmd) {
     }
     const order = (rest.find((a) => a.startsWith("order="))?.slice(6) || "earth,station,medsci1,medsci2,eng1,eng2,hydro1,hydro2,hydro3,ops1,ops2,ops3,ops4,rec1,rec2,rec3,command1,command2,rick1,rick2,rick3,many,shodan").split(",");
     const fixBranch = rest.find((a) => a.startsWith("fixBranch="))?.slice(10) || "playthrough-fixes";
-    save({ iteration: 0, mission_order: order, fix_branch: fixBranch, frontier: null, blockers: [], history: [] });
+    save(baseState(order, fixBranch));
     console.log(`initialized ${FILE} (${order.length} missions, fix branch '${fixBranch}')`);
     break;
   }
@@ -63,15 +64,25 @@ switch (cmd) {
     // Idempotent like init — only rolls when no ledger exists (--force resets).
     if (existsSync(FILE) && !args.includes("--force")) {
       const s = load();
-      console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --force to re-roll.`);
-      if (s.scenario) console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name}`);
+      if (s.scenario) {
+        console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --force to re-roll.`);
+        console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name}`);
+      } else {
+        console.log(`WARNING: ledger at ${FILE} (iteration ${s.iteration}) predates campaign randomization — it has NO scenario/tweak/assets roll.`);
+        console.log(`Kept as-is (a mid-campaign re-roll would strand its frontier). Finish or abandon it, then 'roll --force' to start a rolled campaign.`);
+      }
       break;
     }
     const kv = (k) => rest.find((a) => a.startsWith(`${k}=`))?.slice(k.length + 1);
+    const rawSeed = kv("seed");
+    if (rawSeed !== undefined && !Number.isFinite(Number(rawSeed))) {
+      console.error(`invalid seed '${rawSeed}' — must be a number`);
+      process.exit(1);
+    }
     let picked;
     try {
       picked = roll({
-        seed: kv("seed") ? Number(kv("seed")) : undefined,
+        seed: rawSeed !== undefined ? Number(rawSeed) : undefined,
         scenarioId: kv("scenario"),
         tweakId: kv("tweak"),
         assetsId: kv("assets"),
@@ -82,18 +93,14 @@ switch (cmd) {
     }
     const fixBranch = kv("fixBranch") || "playthrough-fixes";
     save({
-      iteration: 0,
-      mission_order: picked.scenario.missions,
-      fix_branch: fixBranch,
-      frontier: null,
-      blockers: [],
-      history: [],
+      ...baseState(picked.scenario.missions, fixBranch),
       seed: picked.seed,
       scenario: { id: picked.scenario.id, name: picked.scenario.name, goal: picked.scenario.goal },
       tweak: picked.tweak,
       assets: picked.assets,
     });
     console.log(`rolled campaign (seed ${picked.seed}) -> ${FILE}`);
+    for (const w of picked.warnings) console.log(`  WARNING: ${w}`);
     console.log(`  scenario: ${picked.scenario.name} [${picked.scenario.id}] — ${picked.scenario.missions.join(", ")}`);
     console.log(`  goal:     ${picked.scenario.goal}`);
     console.log(`  tweak:    ${picked.tweak.name} [${picked.tweak.id}] — ${picked.tweak.instructions}`);

--- a/.claude/skills/play-through/scenarios.mjs
+++ b/.claude/skills/play-through/scenarios.mjs
@@ -159,10 +159,11 @@ export const TWEAKS = [
 
 // Asset set to launch with: exported as DARK_ASSET_PATH for every runtime the
 // campaign starts. Paths are the two install locations used on our machines.
-// A set is only eligible for the random draw when it's actually loadable
-// (data_root's sentinel `shock2.gam` exists there) — e.g. the 25th Anniversary
-// install ships packed .kpf archives the engine can't read yet, so until it's
-// unpacked it can only be forced (assets=25th), never rolled.
+// A set is only eligible for the random draw when a data-root sentinel exists
+// there — the same sentinel list as `shock2vr::paths::data_root()`: loose
+// classic data (`shock2.gam`, ...) or a 25th Anniversary install
+// (`sshock2.kpf`, supported since #557). A set with no sentinel (missing or
+// broken install) can still be forced (assets=<id>), never rolled.
 export const ASSET_SETS = [
   {
     id: "legacy",
@@ -176,7 +177,8 @@ export const ASSET_SETS = [
   },
 ];
 
-export const assetSetUsable = (a) => existsSync(join(a.path, "shock2.gam"));
+const DATA_ROOT_SENTINELS = ["shock2.gam", "res/obj.crf", "res/mesh.crf", "motiondb.bin", "sshock2.kpf"];
+export const assetSetUsable = (a) => DATA_ROOT_SENTINELS.some((f) => existsSync(join(a.path, f)));
 
 // Deterministic PRNG (mulberry32) so a roll is reproducible from its seed.
 function mulberry32(seed) {
@@ -211,7 +213,7 @@ export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
   const assets = assetsId ? byId(ASSET_SETS, assetsId, "assets") : rolledAssets;
   const warnings = [];
   if (!assetSetUsable(assets))
-    warnings.push(`asset set '${assets.id}' has no shock2.gam at ${assets.path} — the engine cannot load it as-is (packed/missing install?)`);
+    warnings.push(`asset set '${assets.id}' has no data-root sentinel (shock2.gam / sshock2.kpf / ...) at ${assets.path} — the engine cannot load it (missing install?)`);
   return { seed: s, scenario, tweak, assets, warnings };
 }
 
@@ -223,7 +225,7 @@ if (process.argv[1]?.endsWith("scenarios.mjs")) {
     console.log("Tweaks:");
     for (const t of TWEAKS) console.log(`  ${t.id.padEnd(22)} ${t.instructions}`);
     console.log("Asset sets:");
-    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})${assetSetUsable(a) ? "" : " [NOT USABLE: no shock2.gam — force-only, excluded from random draw]"}`);
+    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})${assetSetUsable(a) ? "" : " [NOT USABLE: no data-root sentinel — force-only, excluded from random draw]"}`);
   } else if (cmd) {
     console.error("usage: node scenarios.mjs list");
     process.exit(1);

--- a/.claude/skills/play-through/scenarios.mjs
+++ b/.claude/skills/play-through/scenarios.mjs
@@ -5,6 +5,9 @@
 //
 //   node scenarios.mjs list          print all scenarios and tweaks with ids
 
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 export const SCENARIOS = [
   {
     id: "earth-to-medsci",
@@ -21,8 +24,8 @@ export const SCENARIOS = [
   {
     id: "hydroponics",
     name: "Hydroponics",
-    missions: ["hydro1", "hydro2", "hydro3"],
-    goal: "Start from the elevator, get and research the Toxin-A vials, and apply them to the environmental regulators.",
+    missions: ["hydro2", "hydro1", "hydro3"],
+    goal: "Start from the elevator (hydro2 is the elevator hub), get and research the Toxin-A vials, and apply them to the environmental regulators.",
   },
   {
     id: "operations",
@@ -156,6 +159,10 @@ export const TWEAKS = [
 
 // Asset set to launch with: exported as DARK_ASSET_PATH for every runtime the
 // campaign starts. Paths are the two install locations used on our machines.
+// A set is only eligible for the random draw when it's actually loadable
+// (data_root's sentinel `shock2.gam` exists there) — e.g. the 25th Anniversary
+// install ships packed .kpf archives the engine can't read yet, so until it's
+// unpacked it can only be forced (assets=25th), never rolled.
 export const ASSET_SETS = [
   {
     id: "legacy",
@@ -169,6 +176,8 @@ export const ASSET_SETS = [
   },
 ];
 
+export const assetSetUsable = (a) => existsSync(join(a.path, "shock2.gam"));
+
 // Deterministic PRNG (mulberry32) so a roll is reproducible from its seed.
 function mulberry32(seed) {
   let a = seed >>> 0;
@@ -181,7 +190,9 @@ function mulberry32(seed) {
 }
 
 // Roll a campaign: random scenario + tweak + asset set, seeded. Any of the
-// three can be forced by id.
+// three can be forced by id. The RNG stream is drawn identically whether or
+// not picks are forced, so `seed=N` alone always reproduces the same random
+// draws regardless of which overrides were combined with it.
 export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
   const s = seed ?? Math.floor(Math.random() * 2 ** 31);
   const rng = mulberry32(s);
@@ -190,16 +201,18 @@ export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
     if (!hit) throw new Error(`unknown ${label} '${id}' (see: node scenarios.mjs list)`);
     return hit;
   };
-  const scenario = scenarioId
-    ? byId(SCENARIOS, scenarioId, "scenario")
-    : SCENARIOS[Math.floor(rng() * SCENARIOS.length)];
-  const tweak = tweakId
-    ? byId(TWEAKS, tweakId, "tweak")
-    : TWEAKS[Math.floor(rng() * TWEAKS.length)];
-  const assets = assetsId
-    ? byId(ASSET_SETS, assetsId, "assets")
-    : ASSET_SETS[Math.floor(rng() * ASSET_SETS.length)];
-  return { seed: s, scenario, tweak, assets };
+  const draw = (table) => table[Math.floor(rng() * table.length)];
+  const rolledScenario = draw(SCENARIOS);
+  const rolledTweak = draw(TWEAKS);
+  const usableSets = ASSET_SETS.filter(assetSetUsable);
+  const rolledAssets = draw(usableSets.length ? usableSets : ASSET_SETS);
+  const scenario = scenarioId ? byId(SCENARIOS, scenarioId, "scenario") : rolledScenario;
+  const tweak = tweakId ? byId(TWEAKS, tweakId, "tweak") : rolledTweak;
+  const assets = assetsId ? byId(ASSET_SETS, assetsId, "assets") : rolledAssets;
+  const warnings = [];
+  if (!assetSetUsable(assets))
+    warnings.push(`asset set '${assets.id}' has no shock2.gam at ${assets.path} — the engine cannot load it as-is (packed/missing install?)`);
+  return { seed: s, scenario, tweak, assets, warnings };
 }
 
 if (process.argv[1]?.endsWith("scenarios.mjs")) {
@@ -210,7 +223,7 @@ if (process.argv[1]?.endsWith("scenarios.mjs")) {
     console.log("Tweaks:");
     for (const t of TWEAKS) console.log(`  ${t.id.padEnd(22)} ${t.instructions}`);
     console.log("Asset sets:");
-    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})`);
+    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})${assetSetUsable(a) ? "" : " [NOT USABLE: no shock2.gam — force-only, excluded from random draw]"}`);
   } else if (cmd) {
     console.error("usage: node scenarios.mjs list");
     process.exit(1);

--- a/.claude/skills/play-through/scenarios.mjs
+++ b/.claude/skills/play-through/scenarios.mjs
@@ -1,0 +1,218 @@
+// Campaign randomization tables for the play-through skill: the mission-sequence
+// scenarios and the special-tweak playstyles a campaign can roll. Consumed by
+// `playthrough-state.mjs roll` (which persists the pick in the ledger) — run
+// directly only to browse the tables:
+//
+//   node scenarios.mjs list          print all scenarios and tweaks with ids
+
+export const SCENARIOS = [
+  {
+    id: "earth-to-medsci",
+    name: "Earth → Station → MedSci",
+    missions: ["earth", "station", "medsci1", "medsci2"],
+    goal: "Complete basic + advanced training on Earth, progress through the station (career choice), then play medsci1 and medsci2 to their exits.",
+  },
+  {
+    id: "engineering",
+    name: "Engineering",
+    missions: ["eng1", "eng2"],
+    goal: "Play eng1 and eng2; get power enabled to the elevator.",
+  },
+  {
+    id: "hydroponics",
+    name: "Hydroponics",
+    missions: ["hydro1", "hydro2", "hydro3"],
+    goal: "Start from the elevator, get and research the Toxin-A vials, and apply them to the environmental regulators.",
+  },
+  {
+    id: "operations",
+    name: "Operations",
+    missions: ["ops2", "ops1", "ops3", "ops4"],
+    goal: "Start at ops2 (the elevator), go through the cutscene, then complete the simulation unit overrides.",
+  },
+  {
+    id: "recreation",
+    name: "Recreation",
+    missions: ["rec1", "rec2", "rec3"],
+    goal: "Identify the codes from the paintings and activate the transmitter.",
+  },
+  {
+    id: "command",
+    name: "Command",
+    missions: ["command1", "command2"],
+    goal: "Play through the command missions to their exits.",
+  },
+  {
+    id: "rickenbacker",
+    name: "Rickenbacker",
+    missions: ["rick1", "rick2", "rick3"],
+    goal: "Play through the Rickenbacker missions, destroying the eggs.",
+  },
+  {
+    id: "shodan",
+    name: "SHODAN finale",
+    missions: ["shodan"],
+    goal: "Verify the end-game sequence and the final boss battle, especially the SHODAN AI.",
+  },
+];
+
+export const TWEAKS = [
+  {
+    id: "none",
+    name: "None",
+    instructions: "No special constraint — play as you wish.",
+  },
+  {
+    id: "melee-only",
+    name: "Melee only",
+    instructions: "Use only melee weapons (wrench, laser rapier, crystal shard) for all combat; never fire a ranged weapon.",
+  },
+  {
+    id: "loot-everything",
+    name: "Loot everything",
+    instructions: "Grab and loot everything possible: search every corpse and container, pick up every item, and report anything that can't be grabbed or looted.",
+  },
+  {
+    id: "verify-cutscenes",
+    name: "Verify cutscenes",
+    instructions: "Verify every cutscene / scripted sequence along the path: trigger each one, watch it play out, and report any that fail to start, hang, or misbehave.",
+  },
+  {
+    id: "verify-research",
+    name: "Verify research + chemicals",
+    instructions: "Verify researching and chemicals work as expected: pick up researchable items, run research, fetch the required chemicals, and confirm each research completes with the right result.",
+  },
+  {
+    id: "navy-tech",
+    name: "Navy (hack/repair/modify)",
+    instructions: "Play as Navy: hack, repair, or modify whenever possible — every keypad, security computer, replicator, broken weapon, and upgradable weapon along the path.",
+  },
+  {
+    id: "marine-standard",
+    name: "Marine (standard weapons)",
+    instructions: "Play as Marine: acquire and fire every standard weapon available on the path (pistol, shotgun, assault rifle), verifying each fires, reloads, and damages enemies.",
+  },
+  {
+    id: "marine-electronic",
+    name: "Marine (electronic weapons)",
+    instructions: "Play as Marine: acquire and fire every energy/electronic weapon available on the path (laser pistol, EMP rifle), verifying each fires, recharges, and damages appropriate enemies.",
+  },
+  {
+    id: "marine-organic",
+    name: "Marine (organic weapons)",
+    instructions: "Play as Marine: acquire and fire every exotic/organic weapon available on the path (viral proliferator, worm launcher, crystal shard), verifying each works.",
+  },
+  {
+    id: "marine-heavy",
+    name: "Marine (heavy weapons)",
+    instructions: "Play as Marine: acquire and fire every heavy weapon available on the path (grenade launcher, fusion cannon), verifying each fires and its projectiles/explosions behave.",
+  },
+  {
+    id: "osa-tier1",
+    name: "OSA (tier 1 psi)",
+    instructions: "Play as OSA: use and verify every tier 1 psi power (e.g. kinetic redirection, psycho-reflective screen, neuro-reflex dampening, cryokinesis, remote electron tampering).",
+  },
+  {
+    id: "osa-tier2",
+    name: "OSA (tier 2 psi)",
+    instructions: "Play as OSA: use and verify every tier 2 psi power (e.g. adrenaline overproduction, neural decontamination, cerebro-stimulated regeneration, psychogenic agility, recursive psionic amplification, localized pyrokinesis).",
+  },
+  {
+    id: "osa-tier3",
+    name: "OSA (tier 3 psi)",
+    instructions: "Play as OSA: use and verify every tier 3 psi power (e.g. electron cascade, energy reflection, neural toxin-blocker, enhanced motion sensitivity, projected cryokinesis, psionic hypnogenesis).",
+  },
+  {
+    id: "osa-tier4",
+    name: "OSA (tier 4 psi)",
+    instructions: "Play as OSA: use and verify every tier 4 psi power (e.g. photonic redirection, remote pattern detection, electron suppression, psychogenic cyber-affinity, imposed neural restructuring, cerebro-energetic extension).",
+  },
+  {
+    id: "osa-tier5",
+    name: "OSA (tier 5 psi)",
+    instructions: "Play as OSA: use and verify every tier 5 psi power (e.g. instantaneous quantum relocation, imposed vacillation, metacreative barrier, external psionic detonation, psycho-reflective aura, soma transference).",
+  },
+  {
+    id: "verify-regen",
+    name: "Verify regeneration units",
+    instructions: "Verify the quantum bio-reconstruction (regeneration) units on every deck in the sequence: activate each one, die, and confirm respawn at the unit works.",
+  },
+  {
+    id: "verify-camera-alarms",
+    name: "Verify camera alarms",
+    instructions: "Verify security camera alarm triggers: let cameras spot you, confirm the alarm raises, and confirm it alerts enemies and draws them to you.",
+  },
+  {
+    id: "ai-pathfinding",
+    name: "AI / pathfinding stress",
+    instructions: "Exercise the AI and pathfinding specially: kite enemies across rooms and floors, lure them through doors and around obstacles, and report any stuck, teleporting, or route-failing AI (verify with GET /v1/ai/paths).",
+  },
+  {
+    id: "detailed",
+    name: "Detailed test run",
+    instructions: "Detailed test run: move slowly, interact with everything interactive, read every log/email, verify every objective update, and record smaller issues that a speed-run would skip.",
+  },
+];
+
+// Asset set to launch with: exported as DARK_ASSET_PATH for every runtime the
+// campaign starts. Paths are the two install locations used on our machines.
+export const ASSET_SETS = [
+  {
+    id: "legacy",
+    name: "Legacy assets",
+    path: `${process.env.HOME}/ss2-data-unpacked`,
+  },
+  {
+    id: "25th",
+    name: "25th Anniversary assets",
+    path: `${process.env.HOME}/ss2-25th`,
+  },
+];
+
+// Deterministic PRNG (mulberry32) so a roll is reproducible from its seed.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Roll a campaign: random scenario + tweak + asset set, seeded. Any of the
+// three can be forced by id.
+export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
+  const s = seed ?? Math.floor(Math.random() * 2 ** 31);
+  const rng = mulberry32(s);
+  const byId = (table, id, label) => {
+    const hit = table.find((e) => e.id === id);
+    if (!hit) throw new Error(`unknown ${label} '${id}' (see: node scenarios.mjs list)`);
+    return hit;
+  };
+  const scenario = scenarioId
+    ? byId(SCENARIOS, scenarioId, "scenario")
+    : SCENARIOS[Math.floor(rng() * SCENARIOS.length)];
+  const tweak = tweakId
+    ? byId(TWEAKS, tweakId, "tweak")
+    : TWEAKS[Math.floor(rng() * TWEAKS.length)];
+  const assets = assetsId
+    ? byId(ASSET_SETS, assetsId, "assets")
+    : ASSET_SETS[Math.floor(rng() * ASSET_SETS.length)];
+  return { seed: s, scenario, tweak, assets };
+}
+
+if (process.argv[1]?.endsWith("scenarios.mjs")) {
+  const [cmd] = process.argv.slice(2);
+  if (cmd === "list") {
+    console.log("Scenarios:");
+    for (const s of SCENARIOS) console.log(`  ${s.id.padEnd(18)} ${s.missions.join(",").padEnd(28)} ${s.goal}`);
+    console.log("Tweaks:");
+    for (const t of TWEAKS) console.log(`  ${t.id.padEnd(22)} ${t.instructions}`);
+    console.log("Asset sets:");
+    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})`);
+  } else if (cmd) {
+    console.error("usage: node scenarios.mjs list");
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What

Adds campaign randomization to the `play-through` skill. A new `roll` command initializes a campaign by randomly picking three independent axes, persisted in the ledger so every iteration plays under the same roll:

1. **Mission-sequence scenario** — one of 8 slices of the game (earth→medsci, engineering, hydroponics, operations, recreation, command, rickenbacker, shodan), each with its own mission order and goal.
2. **Special tweak** — one of 20 playstyle/verification constraints (none, melee-only, loot-everything, cutscene/research/regen/camera-alarm verification, Navy hack/repair/modify, Marine weapon families, OSA psi tiers 1–5, AI/pathfinding stress, detailed run) with concrete instructions fed into each playtest prompt.
3. **Asset set** — legacy (`~/ss2-data-unpacked`) vs 25th Anniversary (`~/ss2-25th`, loaded from the stock `.kpf` install since #557), applied as `DARK_ASSET_PATH` for every runtime the campaign launches.

```
node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)
node .agents/skills/play-through/playthrough-state.mjs roll seed=42      # reproducible
node .agents/skills/play-through/playthrough-state.mjs roll --force scenario=hydroponics tweak=melee-only assets=legacy
node .agents/skills/play-through/scenarios.mjs list                      # browse ids
```

## Reliability design

- **Roll once, then stick**: `roll` is idempotent like `init` — re-invocations mid-campaign keep the existing roll, so frontier/scenario/tweak/assets stay consistent across `--auto` iterations. `--force` starts a fresh campaign; a pre-randomizer ledger gets an explicit warning instead of a silent no-op.
- **Reproducible**: seeded mulberry32; the RNG stream is drawn identically whether or not picks are forced, so `seed=N` alone reproduces any roll. Non-numeric seeds are rejected.
- **Asset sets are validated**: a set enters the random draw only if a data-root sentinel exists at its path (`shock2.gam` / `sshock2.kpf` / ..., mirroring `paths::data_root()`); a missing install is force-only with a loud warning.
- **Surfaced every iteration**: `show`'s NEXT line carries the goal, tweak instructions, and `DARK_ASSET_PATH`; SKILL.md requires the rolled configuration (scenario · tweak · assets · seed) on every issue and fix PR the campaign files.
- **Tweak setup gaps**: mid-game scenarios start with a fresh character, so SKILL.md directs iteration 0 to provision class-tweak loadouts via debug levers and to record unprovisionable tweaks as tooling gaps, not game bugs.

## Review

Cross-engine `/xreview` (Claude subagent + Codex CLI) ran on the initial commit; the follow-up commits fix its findings: hydro starts at hydro2 (the elevator hub), seed validation, force-stable RNG stream, asset-set sentinel validation, explicit handling of pre-randomizer ledgers, shared ledger constructor. Rebased on main after KPF support (#557) landed so the 25th Anniversary set is genuinely rollable.

All command paths re-verified after the fixes (seeded/idempotent/forced/error/legacy-ledger/asset-draw — both asset sets now appear in the random draw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
