### PR TITLE
fix: gracefully fall back when aim metadata is unavailable

### DIFF
--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -109,7 +109,10 @@ export class PlayerApi {
     const distance = (point: Vec3) =>
       Math.hypot(point[0] - eye[0], point[1] - eye[1], point[2] - eye[2]);
 
-    let candidates = detail.aim_points;
+    // Entity detail is a versioned runtime capability. Older runtimes (and a
+    // stale binary encountered by the campaign) omit aim_points entirely;
+    // aiming must remain usable and report its center fallback, not crash.
+    let candidates = detail.aim_points ?? [];
     if (requested === "head" || requested === "torso") {
       candidates = candidates.filter((point) => point.classification === requested);
     } else if (requested === "limb") {

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -123,7 +123,11 @@ export interface EntityDetailResult {
   properties: PropertyInfo[];
   outgoing_links: LinkInfo[];
   incoming_links: LinkInfo[];
-  aim_points: AimPoint[];
+  /**
+   * Live classified creature hitboxes. Optional for compatibility with debug
+   * runtimes predating the aim-point capability.
+   */
+  aim_points?: AimPoint[];
 }
 
 export interface AimPoint {

--- a/tools/shock2-sdk/test/world-aim.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-aim.e2e.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function hitPoints(detail: EntityDetailResult): number {
+  return Number(
+    detail.properties.find((property) => property.name === "HitPoints")?.value ?? 0,
+  );
+}
+
+test(
+  "built SDK aims at a live torso after rotated save/load and ordinary fire hits",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_psi",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
+    });
+    await game.step({ frames: 5 });
+
+    const before = new Set(
+      (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities.map(
+        (entity) => entity.id,
+      ),
+    );
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const monster = (
+      await game.entities.list({ filter: "OG-Pipe", limit: 50 })
+    ).entities.find((entity) => !before.has(entity.id));
+    assert.ok(monster, "SpawnDebugMonster should create a live target");
+
+    const initial = await game.entities.detail(monster.id);
+    assert.ok(initial.aim_points?.some((point) => point.classification === "torso"));
+
+    await game.input.set("left_hand.thumbstick", [0.75, 0]);
+    await game.step({ frames: 20 });
+    await game.input.set("left_hand.thumbstick", [0, 0]);
+    await game.save("world-aim-e2e");
+    await game.load("world-aim-e2e");
+    const pawn = (await game.info()).player.rotation;
+    assert.ok(Math.abs(pawn[1]) > 0.01 || Math.abs(pawn[3] - 1) > 0.01);
+
+    const aim = await game.player.aimAt(monster, { hitbox: "torso" });
+    assert.equal(aim.entity_id, monster.id);
+    assert.equal(aim.classification, "torso");
+    assert.equal(aim.fallback_used, false);
+    await game.step({ frames: 2 });
+
+    await game.input.set("right_hand.trigger_value", 1);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger_value", 0);
+    await game.step({ frames: 90 });
+    assert.ok(hitPoints(await game.entities.detail(monster.id)) < hitPoints(initial));
+  },
+);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { headRotationForWorldPoint } from "../src/index.js";
+import {
+  headRotationForWorldPoint,
+  HttpClient,
+  PlayerApi,
+} from "../src/index.js";
+import type { EntityDetailResult, FrameSnapshot } from "../src/index.js";
 
 type Quat = [number, number, number, number];
 
@@ -35,4 +40,44 @@ test("world aim rejects an undefined zero-length direction", () => {
     () => headRotationForWorldPoint([1, 2, 3], [0, 0, 0, 1], [1, 3.6, 3]),
     /target must differ/,
   );
+});
+
+test("aimAt gracefully falls back when a connected runtime omits aim_points", async () => {
+  const detail = {
+    entity_id: 531,
+    name: "Red Assassin",
+    template_id: 254,
+    position: [65, -7.5, 10],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [61, -7.5, 10],
+      rotation: [0, Math.SQRT1_2, 0, Math.SQRT1_2],
+    },
+  } as FrameSnapshot;
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/531") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(531, { hitbox: "torso" });
+
+  assert.equal(aim.entity_id, 531);
+  assert.equal(aim.classification, "center");
+  assert.equal(aim.fallback_used, true);
+  assert.deepEqual(aim.world_point, detail.position);
+  assert.equal(writes[0]?.path, "/v1/control/input");
 });


### PR DESCRIPTION
Fixes #619

## Summary
- treat `aim_points` as an optional/versioned runtime capability
- fall back to entity center with `fallback_used: true` instead of crashing
- add a built-dist regression for the exact missing-field response from the Operations campaign
- add focused live coverage for classified torso aim after turn + save/load followed by ordinary psi fire

## Root cause
The iteration-11 entity response genuinely omitted `aim_points`. The campaign executable also lacked the serializer string while newly built shock2vr rlibs contained it, consistent with a stale concurrent cargo link completing after the campaign branch merged #616. This is not camelCase/snake_case. The SDK should still be compatible with runtimes lacking the capability.

## Validation
- `cd tools/shock2-sdk && npm test` (146 tests; 17 pass, 129 opt-in e2e skipped)
- focused live e2e attempted in a fresh isolated worktree; the first-time Rust build was interrupted by the heavily concurrent campaign environment before producing a runtime binary. The scenario is checked in and uses the built dist package.