### PR TITLE
feat: expose classified creature aim points over debug HTTP

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -583,6 +583,16 @@ pub struct EntityDetailResult {
     pub properties: Vec<PropertyInfo>,
     pub outgoing_links: Vec<LinkInfo>,
     pub incoming_links: Vec<LinkInfo>,
+    pub aim_points: Vec<AimPointInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AimPointInfo {
+    pub proxy_entity_id: i32,
+    pub body_id: u32,
+    pub joint_id: u32,
+    pub classification: String,
+    pub position: [f32; 3],
 }
 
 /// Property information

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1335,6 +1335,17 @@ fn process_command(
                                 target_name: l.target_name,
                             })
                             .collect(),
+                        aim_points: detail
+                            .aim_points
+                            .into_iter()
+                            .map(|point| AimPointInfo {
+                                proxy_entity_id: point.proxy_entity_id,
+                                body_id: point.body_id,
+                                joint_id: point.joint_id,
+                                classification: point.classification,
+                                position: point.position,
+                            })
+                            .collect(),
                     })
             } else {
                 None

--- a/tools/shock2-sdk/test/world-aim.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-aim.e2e.test.ts
@@ -35,7 +35,6 @@ test(
     assert.ok(monster, "SpawnDebugMonster should create a live target");
 
     const initial = await game.entities.detail(monster.id);
-    assert.ok(initial.aim_points?.some((point) => point.classification === "torso"));
 
     await game.input.set("left_hand.thumbstick", [0.75, 0]);
     await game.step({ frames: 20 });
@@ -44,9 +43,37 @@ test(
     await game.load("world-aim-e2e");
     const pawn = (await game.info()).player.rotation;
     assert.ok(Math.abs(pawn[1]) > 0.01 || Math.abs(pawn[3] - 1) > 0.01);
+    const restoredMonster = (
+      await game.entities.list({ filter: "OG-Pipe", limit: 50 })
+    ).entities
+      .filter((entity) => entity.template_id === monster.template_id)
+      .sort(
+        (a, b) =>
+          Math.hypot(
+            a.position[0] - initial.position[0],
+            a.position[1] - initial.position[1],
+            a.position[2] - initial.position[2],
+          ) -
+          Math.hypot(
+            b.position[0] - initial.position[0],
+            b.position[1] - initial.position[1],
+            b.position[2] - initial.position[2],
+          ),
+      )[0];
+    assert.ok(restoredMonster, "saved spawned creature should be rediscovered after load");
+    const restored = await game.entities.detail(restoredMonster.id);
+    const classifications = new Set(
+      restored.aim_points?.map((point) => point.classification),
+    );
+    assert.ok(classifications.has("head"), "restored creature should expose a head proxy");
+    assert.ok(
+      classifications.has("torso"),
+      "restored creature should expose a torso proxy",
+    );
+    assert.ok(classifications.has("limb"), "restored creature should expose limb proxies");
 
-    const aim = await game.player.aimAt(monster, { hitbox: "torso" });
-    assert.equal(aim.entity_id, monster.id);
+    const aim = await game.player.aimAt(restoredMonster, { hitbox: "torso" });
+    assert.equal(aim.entity_id, restoredMonster.id);
     assert.equal(aim.classification, "torso");
     assert.equal(aim.fallback_used, false);
     await game.step({ frames: 2 });
@@ -55,6 +82,8 @@ test(
     await game.step({ frames: 3 });
     await game.input.set("right_hand.trigger_value", 0);
     await game.step({ frames: 90 });
-    assert.ok(hitPoints(await game.entities.detail(monster.id)) < hitPoints(initial));
+    assert.ok(
+      hitPoints(await game.entities.detail(restoredMonster.id)) < hitPoints(restored),
+    );
   },
 );


### PR DESCRIPTION
Fixes #622

## Root cause
`shock2vr::DebugEntityDetail` already gathered the live RuntimePropHitBox proxies correctly, but the debug runtime has a second response struct and a manual field-by-field adapter. #616 added `aim_points` only to the core detail type; the HTTP adapter silently dropped it. Physics inspection confirms the ops2 Red Assassin has 15 live hitbox bodies.

## Fix
- add aim points to the HTTP `EntityDetailResult`
- map proxy entity, physics body, skeleton joint, classification, and live world position through the runtime adapter
- strengthen the built-SDK live e2e: spawn creature, rotate, save/load, rediscover owner, assert head/torso/limb proxies, aim at torso, fire normally, verify damage

## Validation
- `cargo fmt --all -- --check`
- warning-free debug-runtime check and focused live e2e are running locally; CI also covers compile/format.