### PR TITLE
fix: preserve carried item archetypes across missions

### DIFF
--- a/shock2vr/src/hud/virtual_arms.rs
+++ b/shock2vr/src/hud/virtual_arms.rs
@@ -157,12 +157,7 @@ pub(crate) fn get_wielded_psi_power(world: &World) -> Option<(String, i32)> {
 
     // Is the wielded weapon the psi amp? Resolved via its template's class
     // tags, the same mechanism as `get_wielded_ammo_type`.
-    let template_id = world
-        .borrow::<View<dark::properties::PropTemplateId>>()
-        .ok()?
-        .get(weapon)
-        .ok()?
-        .template_id;
+    let template_id = crate::scripts::script_util::entity_class_template_id(world, weapon)?;
     let class_tags = world
         .borrow::<UniqueView<crate::mission::mission_core::GlobalTemplateClassTags>>()
         .ok()?;

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -620,6 +620,19 @@ pub fn initialize_entity_with_props(
     ancestors.push(template_id);
 
     world.add_component(entity_id, PropTemplateId { template_id });
+    // A concrete object's positive ID belongs to this mission only. Preserve
+    // its nearest gamesys archetype separately so carried objects retain a
+    // stable class identity in later missions whose positive IDs may collide.
+    let canonical_template_id = ancestors
+        .iter()
+        .rev()
+        .copied()
+        .find(|ancestor| *ancestor < 0)
+        .unwrap_or(template_id);
+    world.add_component(
+        entity_id,
+        RuntimePropCanonicalTemplateId(canonical_template_id),
+    );
 
     for parent_id in ancestors {
         let maybe_parent_props = entity_info.entity_to_properties.get(&parent_id);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -489,7 +489,8 @@ impl MissionCore {
 
         // Create a map of template name (ie 'HE Explosion' to the template id).
         // This is important for creating entities based on template name
-        let template_name_to_template_id = create_template_name_map(game_entity_info);
+        let (template_name_to_template_id, unique_gamesys_template_names) =
+            create_template_name_map(game_entity_info);
 
         world.add_unique(GlobalEntityMetadata(template_name_to_template_id.clone()));
         world.add_unique(Time::default());
@@ -613,8 +614,8 @@ impl MissionCore {
             } else {
                 Box::new(VrInteraction::new())
             };
-        let (left_hand_entity, right_hand_entity, maybe_inventory_entity) =
-            held_item_save_data.instantiate(&mut world);
+        let (left_hand_entity, right_hand_entity, maybe_inventory_entity) = held_item_save_data
+            .instantiate_with_legacy_template_names(&mut world, &unique_gamesys_template_names);
 
         // Instantiate inventory
         // TODO: This should be move into the held_item_save_data
@@ -5090,7 +5091,9 @@ impl MissionCore {
     }
 }
 
-fn create_template_name_map(game_entity_info: &Gamesys) -> HashMap<String, EntityMetadata> {
+fn create_template_name_map(
+    game_entity_info: &Gamesys,
+) -> (HashMap<String, EntityMetadata>, HashMap<String, i32>) {
     let mut gamesys_world = World::new();
     game_entity_info.entity_info.initialize_world_with_entities(
         &mut gamesys_world,
@@ -5099,6 +5102,7 @@ fn create_template_name_map(game_entity_info: &Gamesys) -> HashMap<String, Entit
     );
 
     let mut name_to_template_id = HashMap::new();
+    let mut template_ids_by_exact_name: HashMap<String, Vec<i32>> = HashMap::new();
 
     gamesys_world.run(
         |v_sym_name: View<dark::properties::PropSymName>,
@@ -5121,11 +5125,21 @@ fn create_template_name_map(game_entity_info: &Gamesys) -> HashMap<String, Entit
                         obj_short_name: v_obj_short_name.get(entity_id).map(|p| p.0.clone()).ok(),
                     },
                 );
+                if template_id.template_id < 0 {
+                    template_ids_by_exact_name
+                        .entry(sym_name.0.clone())
+                        .or_default()
+                        .push(template_id.template_id);
+                }
             }
         },
     );
 
-    name_to_template_id
+    let unique_template_names = template_ids_by_exact_name
+        .into_iter()
+        .filter_map(|(name, ids)| (ids.len() == 1).then_some((name, ids[0])))
+        .collect();
+    (name_to_template_id, unique_template_names)
 }
 
 /// Create a map of template IDs to their class tag data for script access

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -382,6 +382,70 @@ mod tests {
     }
 
     #[test]
+    fn reload_migrates_legacy_carried_clip_from_unique_saved_sym_name() {
+        use crate::save_load::{EntitySaveData, backfill_legacy_canonical_template_ids};
+
+        const SOURCE_SMALL_CLIP_OBJECT: i32 = 1496;
+        const DESTINATION_PELLET_BOX: i32 = -42;
+
+        let mut fixture = Fixture::new(0, 0);
+        fixture
+            .world
+            .add_unique(GlobalTemplateHierarchy(HashMap::from([
+                (SMALL_STD_CLIP, vec![STD_CLIP]),
+                (SOURCE_SMALL_CLIP_OBJECT, vec![DESTINATION_PELLET_BOX]),
+            ])));
+
+        let old_clip = EntityId::new_from_index_and_gen(1496, 0);
+        let mut legacy = EntitySaveData::empty();
+        legacy.all_entities.push(old_clip.inner());
+        legacy.properties.insert(
+            "__P$InternalTemplateId".to_owned(),
+            HashMap::from([(
+                old_clip.inner(),
+                serde_json::json!({"template_id": SOURCE_SMALL_CLIP_OBJECT}),
+            )]),
+        );
+        legacy.properties.insert(
+            "P$SymName".to_owned(),
+            HashMap::from([(old_clip.inner(), serde_json::json!("Small Standard Clip"))]),
+        );
+        legacy.properties.insert(
+            "P$StackCoun".to_owned(),
+            HashMap::from([(old_clip.inner(), serde_json::json!(6))]),
+        );
+        assert!(legacy.canonical_template_ids.is_empty());
+
+        backfill_legacy_canonical_template_ids(
+            &mut legacy,
+            &HashMap::from([
+                ("Pistol".to_owned(), PISTOL),
+                ("Small Standard Clip".to_owned(), SMALL_STD_CLIP),
+            ]),
+        );
+        let (_, remapped) = legacy.instantiate(&mut fixture.world);
+        let reserve = remapped[&old_clip];
+        let mut links = fixture.world.borrow::<ViewMut<Links>>().unwrap();
+        (&mut links)
+            .get(fixture.inventory)
+            .unwrap()
+            .to_links
+            .push(ToLink {
+                link: Link::Contains(0),
+                to_entity_id: Some(WrappedEntityId(reserve)),
+                to_template_id: SOURCE_SMALL_CLIP_OBJECT,
+            });
+        drop(links);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 6);
+        assert_eq!(fixture.rounds(reserve), 0);
+        assert_eq!(outcome.rounds_loaded, 6);
+        assert_eq!(outcome.depleted_items, vec![reserve]);
+    }
+
+    #[test]
     fn reload_accepts_every_authored_assault_standard_clip_target() {
         let mut fixture = Fixture::new(0, 0);
         fixture.set_standard_projectile(ASSAULT_STD_PROJECTILE);

--- a/shock2vr/src/mission/reload.rs
+++ b/shock2vr/src/mission/reload.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use dark::{
-    properties::{Link, Links, PropGunState, PropStackCount, PropTemplateId},
+    properties::{Link, Links, PropGunState, PropStackCount},
     ss2_entity_info::{self, SystemShock2EntityInfo},
 };
 use shipyard::{EntityId, Get, Unique, UniqueView, View, ViewMut, World};
@@ -105,8 +105,7 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
     };
 
     let matching_reserve: Vec<EntityId> = {
-        let Ok((templates, stacks, hierarchy)) = world.borrow::<(
-            View<PropTemplateId>,
+        let Ok((stacks, hierarchy)) = world.borrow::<(
             View<PropStackCount>,
             UniqueView<crate::mission::GlobalTemplateHierarchy>,
         )>() else {
@@ -115,11 +114,13 @@ pub(crate) fn load_from_reserve(world: &World, weapon: EntityId, capacity: i32) 
         reserve_items
             .into_iter()
             .filter(|item| {
-                let Ok(template) = templates.get(*item) else {
+                let Some(class_template_id) =
+                    crate::scripts::script_util::entity_class_template_id(world, *item)
+                else {
                     return false;
                 };
                 let compatible = compatible_clip_templates.iter().any(|clip_template| {
-                    hierarchy.is_or_descends_from(template.template_id, *clip_template)
+                    hierarchy.is_or_descends_from(class_template_id, *clip_template)
                 });
                 compatible && stacks.get(*item).is_ok_and(|stack| stack.0 > 0)
             })
@@ -162,7 +163,7 @@ mod tests {
     use super::*;
     use crate::{
         mission::{GlobalTemplateHierarchy, PlayerInfo},
-        runtime_props::RuntimePropSelectedAmmo,
+        runtime_props::{RuntimePropCanonicalTemplateId, RuntimePropSelectedAmmo},
     };
     use cgmath::{Quaternion, Vector3};
     use dark::properties::{
@@ -268,6 +269,32 @@ mod tests {
             item
         }
 
+        fn reserve_with_canonical_template(
+            &mut self,
+            concrete_template_id: i32,
+            canonical_template_id: i32,
+            rounds: i32,
+        ) -> EntityId {
+            let item = self.world.add_entity((
+                PropTemplateId {
+                    template_id: concrete_template_id,
+                },
+                RuntimePropCanonicalTemplateId(canonical_template_id),
+                PropStackCount(rounds),
+            ));
+            let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
+            (&mut links)
+                .get(self.inventory)
+                .unwrap()
+                .to_links
+                .push(ToLink {
+                    link: Link::Contains(0),
+                    to_entity_id: Some(WrappedEntityId(item)),
+                    to_template_id: concrete_template_id,
+                });
+            item
+        }
+
         fn set_standard_projectile(&mut self, template_id: i32) {
             let mut links = self.world.borrow::<ViewMut<Links>>().unwrap();
             let weapon_links = (&mut links).get(self.weapon).unwrap();
@@ -326,6 +353,32 @@ mod tests {
         assert_eq!(fixture.rounds(second), 0);
         assert_eq!(outcome.rounds_loaded, 12);
         assert_eq!(outcome.depleted_items, vec![first, second]);
+    }
+
+    #[test]
+    fn reload_uses_preserved_archetype_when_concrete_id_collides_across_missions() {
+        const SOURCE_SMALL_CLIP_OBJECT: i32 = 1496;
+        const DESTINATION_PELLET_BOX: i32 = -42;
+
+        let mut fixture = Fixture::new(0, 0);
+        // The destination reuses positive object 1496 for an unrelated pellet
+        // box. The carried source object retains 1496 as its concrete identity,
+        // while its stable eng1 archetype provenance remains Small Std Clip.
+        fixture
+            .world
+            .add_unique(GlobalTemplateHierarchy(HashMap::from([
+                (SMALL_STD_CLIP, vec![STD_CLIP]),
+                (SOURCE_SMALL_CLIP_OBJECT, vec![DESTINATION_PELLET_BOX]),
+            ])));
+        let reserve =
+            fixture.reserve_with_canonical_template(SOURCE_SMALL_CLIP_OBJECT, SMALL_STD_CLIP, 6);
+
+        let outcome = load_from_reserve(&fixture.world, fixture.weapon, 12);
+
+        assert_eq!(fixture.ammo(), 6);
+        assert_eq!(fixture.rounds(reserve), 0);
+        assert_eq!(outcome.rounds_loaded, 6);
+        assert_eq!(outcome.depleted_items, vec![reserve]);
     }
 
     #[test]

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -175,6 +175,17 @@ impl RuntimePropReloading {
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropSelectedAmmo(pub usize);
 
+/// Stable gamesys archetype identity for an entity.
+///
+/// `PropTemplateId` intentionally retains a concrete level object's positive
+/// mission ID. Those IDs are only meaningful within their source mission and
+/// may alias unrelated objects after the entity is carried to another level.
+/// Class-based gameplay uses this canonical (nearest negative) archetype
+/// instead. `EntitySaveData` explicitly persists it across transitions and
+/// save/load.
+#[derive(Component, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimePropCanonicalTemplateId(pub i32);
+
 /// Which phase the psi amp's hold-to-overload meter is in. `Charging` fills
 /// the bar; `Overloaded`/`Burnout` are brief result flashes after release.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -5,7 +5,9 @@ use engine::game_log;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 
-use crate::runtime_props::{RuntimePropDeathPose, RuntimePropSelectedAmmo};
+use crate::runtime_props::{
+    RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropSelectedAmmo,
+};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EntitySaveData {
@@ -26,6 +28,10 @@ pub struct EntitySaveData {
     /// the Dark property registry.
     #[serde(default)]
     pub selected_ammo: HashMap<u64 /* entity id */, usize>,
+    /// Stable gamesys archetype for entities whose `PropTemplateId` is a
+    /// positive, mission-local object ID.
+    #[serde(default)]
+    pub canonical_template_ids: HashMap<u64 /* entity id */, i32>,
 }
 
 impl EntitySaveData {
@@ -37,6 +43,7 @@ impl EntitySaveData {
             links: HashMap::new(),
             death_poses: HashMap::new(),
             selected_ammo: HashMap::new(),
+            canonical_template_ids: HashMap::new(),
         }
     }
     pub fn instantiate(
@@ -90,6 +97,15 @@ impl EntitySaveData {
             let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
             if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
                 world.add_component(*new_entity_id, RuntimePropSelectedAmmo(*selected_ammo));
+            }
+        }
+        for (old_entity_id, canonical_template_id) in &self.canonical_template_ids {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(
+                    *new_entity_id,
+                    RuntimePropCanonicalTemplateId(*canonical_template_id),
+                );
             }
         }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
@@ -164,5 +180,24 @@ mod tests {
         .unwrap();
 
         assert!(data.selected_ammo.is_empty());
+        assert!(data.canonical_template_ids.is_empty());
+    }
+
+    #[test]
+    fn instantiate_restores_canonical_template_on_the_remapped_entity() {
+        let old_entity = EntityId::new_from_index_and_gen(9, 2);
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(old_entity.inner());
+        data.canonical_template_ids
+            .insert(old_entity.inner(), -1358);
+        let mut world = World::new();
+
+        let (_, entity_map) = data.instantiate(&mut world);
+
+        let new_entity = entity_map[&old_entity];
+        let canonical = world
+            .borrow::<View<RuntimePropCanonicalTemplateId>>()
+            .unwrap();
+        assert_eq!(canonical.get(new_entity).unwrap().0, -1358);
     }
 }

--- a/shock2vr/src/save_load/held_item_save_data.rs
+++ b/shock2vr/src/save_load/held_item_save_data.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 
@@ -54,5 +56,90 @@ impl HeldItemSaveData {
             right_hand_entity_id,
             inventory_entity_id,
         )
+    }
+
+    /// Instantiate held entities while conservatively migrating saves written
+    /// before canonical archetype provenance was persisted.
+    ///
+    /// Old saves still contain each entity's effective `P$SymName`. Only an
+    /// exact name with one unique negative gamesys template is accepted;
+    /// ambiguous and mission-specific names remain unresolved.
+    pub fn instantiate_with_legacy_template_names(
+        &self,
+        world: &mut World,
+        unique_gamesys_templates: &HashMap<String, i32>,
+    ) -> (Option<EntityId>, Option<EntityId>, Option<EntityId>) {
+        let mut migrated = self.clone();
+        backfill_legacy_canonical_template_ids(
+            &mut migrated.held_entities,
+            unique_gamesys_templates,
+        );
+        migrated.instantiate(world)
+    }
+}
+
+pub(crate) fn backfill_legacy_canonical_template_ids(
+    entities: &mut EntitySaveData,
+    unique_gamesys_templates: &HashMap<String, i32>,
+) {
+    let Some(saved_names) = entities.properties.get("P$SymName") else {
+        return;
+    };
+    for (entity_id, saved_name) in saved_names {
+        if entities.canonical_template_ids.contains_key(entity_id) {
+            continue;
+        }
+        let Some(name) = saved_name.as_str() else {
+            continue;
+        };
+        if let Some(template_id) = unique_gamesys_templates.get(name) {
+            entities
+                .canonical_template_ids
+                .insert(*entity_id, *template_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_entity(name: &str) -> EntitySaveData {
+        let old_entity = EntityId::new_from_index_and_gen(12, 1);
+        let mut entities = EntitySaveData::empty();
+        entities.all_entities.push(old_entity.inner());
+        entities.properties.insert(
+            "P$SymName".to_owned(),
+            HashMap::from([(old_entity.inner(), serde_json::json!(name))]),
+        );
+        entities
+    }
+
+    #[test]
+    fn legacy_backfill_requires_an_exact_unique_gamesys_name() {
+        let mut exact = legacy_entity("Pistol");
+        backfill_legacy_canonical_template_ids(
+            &mut exact,
+            &HashMap::from([("Pistol".to_owned(), -17)]),
+        );
+        assert_eq!(
+            exact
+                .canonical_template_ids
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![-17]
+        );
+
+        let mut different_case = legacy_entity("pistol");
+        backfill_legacy_canonical_template_ids(
+            &mut different_case,
+            &HashMap::from([("Pistol".to_owned(), -17)]),
+        );
+        assert!(different_case.canonical_template_ids.is_empty());
+
+        let mut unmatched = legacy_entity("Mission Specific Object");
+        backfill_legacy_canonical_template_ids(&mut unmatched, &HashMap::new());
+        assert!(unmatched.canonical_template_ids.is_empty());
     }
 }

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -20,7 +20,10 @@ use crate::{
     creature::RuntimePropHitBox,
     gui::GuiPropProxyEntity,
     mission::{GlobalTemplateIdMap, PlayerInfo},
-    runtime_props::{RuntimePropDeathPose, RuntimePropDoNotSerialize, RuntimePropSelectedAmmo},
+    runtime_props::{
+        RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropDoNotSerialize,
+        RuntimePropSelectedAmmo,
+    },
     scripts::script_util,
     util::partition_map,
 };
@@ -95,6 +98,9 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
 
     let v_links = world.borrow::<View<Links>>().unwrap();
     let v_selected_ammo = world.borrow::<View<RuntimePropSelectedAmmo>>().unwrap();
+    let v_canonical_templates = world
+        .borrow::<View<RuntimePropCanonicalTemplateId>>()
+        .unwrap();
     let v_entities = world.borrow::<EntitiesView>().unwrap();
 
     let (all_properties, _, _) = dark::properties::get::<File>();
@@ -165,6 +171,16 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
     let (held_selected_ammo, world_selected_ammo) = partition_map(raw_selected_ammo, |entity_id| {
         held_entities.contains(entity_id)
     });
+    let raw_canonical_templates: HashMap<u64, i32> = v_canonical_templates
+        .iter()
+        .with_id()
+        .filter(|(entity_id, _)| !entities_to_filter.contains(&entity_id.inner()))
+        .map(|(entity_id, canonical)| (entity_id.inner(), canonical.0))
+        .collect();
+    let (held_canonical_templates, world_canonical_templates) =
+        partition_map(raw_canonical_templates, |entity_id| {
+            held_entities.contains(entity_id)
+        });
 
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
@@ -173,6 +189,7 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         all_entities: all_world_entities,
         death_poses: world_death_poses,
         selected_ammo: world_selected_ammo,
+        canonical_template_ids: world_canonical_templates,
     };
 
     let held_entity_data = EntitySaveData {
@@ -182,6 +199,7 @@ pub fn to_save_data(world: &World) -> (EntitySaveData, HeldItemSaveData) {
         properties: held_serialized_properties,
         death_poses: held_death_poses,
         selected_ammo: held_selected_ammo,
+        canonical_template_ids: held_canonical_templates,
     };
 
     let held_metadata = HeldItemSaveData {

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -19,6 +19,22 @@ use std::collections::HashMap;
 
 use super::{Effect, Message, MessagePayload};
 
+/// Stable class identity for hierarchy/tag lookups. Concrete objects retain a
+/// positive mission-local `PropTemplateId`, while carried objects preserve
+/// their source gamesys archetype separately across level transitions.
+pub(crate) fn entity_class_template_id(world: &World, entity: EntityId) -> Option<i32> {
+    world
+        .borrow::<View<crate::runtime_props::RuntimePropCanonicalTemplateId>>()
+        .ok()
+        .and_then(|canonical| canonical.get(entity).ok().map(|id| id.0))
+        .or_else(|| {
+            world
+                .borrow::<View<PropTemplateId>>()
+                .ok()
+                .and_then(|templates| templates.get(entity).ok().map(|id| id.template_id))
+        })
+}
+
 pub fn is_message_turnon_or_turnoff(msg: &MessagePayload) -> bool {
     match msg {
         MessagePayload::TurnOn { from: _ } => true,
@@ -196,10 +212,7 @@ pub fn choose_impact_spang(world: &World, projectile: EntityId, victim: EntityId
 /// authored for this victim's class.
 fn choose_hit_spang(world: &World, projectile: EntityId, victim: EntityId) -> Option<i32> {
     let victim = resolve_proxy_entity(world, victim);
-    let victim_template = world
-        .borrow::<View<PropTemplateId>>()
-        .ok()
-        .and_then(|v| v.get(victim).ok().map(|t| t.template_id))?;
+    let victim_template = entity_class_template_id(world, victim)?;
     let hierarchy = world.borrow::<UniqueView<GlobalTemplateHierarchy>>().ok()?;
     get_all_links_with_template(world, projectile, |link| {
         if let Link::HitSpang(spang_template) = link {


### PR DESCRIPTION
## Summary

- preserve each entity's nearest gamesys archetype separately from its concrete, mission-local `PropTemplateId`
- serialize/remap that canonical identity across level transitions and save/load, with a default for older saves
- use the stable class identity for reserve-ammo reload, psi-amp HUD classification, and projectile hit-spang hierarchy checks

Concrete mission object identity remains unchanged; this adds the missing globally stable class/provenance identity rather than rewriting object IDs or hardcoding Operations ammo.

## Regression coverage

The negative regression models the real eng1 → ops2 collision: carried positive object `1496` has canonical Small Standard Clip archetype `-1358`, while destination hierarchy aliases positive `1496` to unrelated Pellet Shot Box `-42`. Reload must load six pistol rounds and deplete the reserve.

Also covers canonical identity remapping through `EntitySaveData` and older-save serde defaults.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p shock2vr reload_uses_preserved_archetype_when_concrete_id_collides_across_missions`
- `cargo test -p shock2vr instantiate_restores_canonical_template_on_the_remapped_entity`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`

Fixes #624
