### PR TITLE
fix:  non-creatures at visible selectable surfaces

### DIFF
--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -49,11 +49,16 @@ await game.input.trigger("PathfindingTestCycle");
 // Continuous input channels
 await game.input.set("right_hand.trigger_value", 1.0);
 
-// Aim at a live creature hitbox through the production camera/weapon path.
+// Aim through the production camera/weapon/interaction path. Creatures select
+// a classified live hitbox; doors/buttons select their nearest visible surface.
 // Prefer this over hand-composing head.rotation: raw head controls are
 // pawn-local, so mission spawns and loaded saves can rotate their world result.
 const aim = await game.player.aimAt(target, { hitbox: "torso" });
 // aim reports the selected owner/proxy/body/joint/world point and any fallback.
+// Use { hitbox: "center" } only when you deliberately want the entity origin.
+await game.input.set("right_hand.squeeze_value", 1); // frob highlighted target
+await game.step({ frames: 2 });
+await game.input.set("right_hand.squeeze_value", 0);
 
 // Verify state instead of scraping logs
 const status = await game.pathfindingTest.status();

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -85,8 +85,11 @@ export class PlayerApi {
   /**
    * Aim the production flat camera, interaction ray, and weapon at an entity.
    *
-   * Creature targets use their live classified damage proxies. Other entities,
-   * or unavailable classifications, gracefully fall back to the entity center.
+   * Creature targets use their live classified damage proxies. Other entities
+   * first use the nearest visible selectable surface on the center ray.
+   * Occluded targets and unavailable classifications gracefully fall back to
+   * the entity center. Request `center` to aim at the origin explicitly.
+   *
    * This accounts for authored and save-restored pawn rotation; raw
    * `head.look` / `head.rotation` are pawn-local.
    */
@@ -120,12 +123,23 @@ export class PlayerApi {
         (point) =>
           point.classification === "limb" || point.classification === "extremity",
       );
-    } else if (requested === "center") {
+    } else if (requested === "center" || requested === "surface") {
       candidates = [];
     }
     candidates.sort((a, b) => distance(a.position) - distance(b.position));
     const selected = candidates[0];
-    const worldPoint = selected?.position ?? detail.position;
+    let surfacePoint: Vec3 | undefined;
+    if (selected === undefined && requested !== "center") {
+      const surface = await this.client.post<RayCastResult>("/v1/physics/raycast", {
+        start: eye,
+        end: detail.position,
+        collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      });
+      if (surface?.entity_id === entityId && surface.hit_point !== null) {
+        surfacePoint = surface.hit_point;
+      }
+    }
+    const worldPoint = selected?.position ?? surfacePoint ?? detail.position;
     const headRotation = headRotationForWorldPoint(
       snapshot.player.position,
       snapshot.player.rotation,
@@ -142,10 +156,13 @@ export class PlayerApi {
       body_id: selected?.body_id ?? null,
       joint_id: selected?.joint_id ?? null,
       requested,
-      classification: selected?.classification ?? "center",
+      classification: selected?.classification ?? (surfacePoint ? "surface" : "center"),
       world_point: worldPoint,
       head_rotation: headRotation,
-      fallback_used: selected === undefined && requested !== "center",
+      fallback_used:
+        selected === undefined &&
+        requested !== "center" &&
+        (requested !== "surface" || surfacePoint === undefined),
     };
   }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -142,6 +142,7 @@ export type AimClassification =
   | "head"
   | "torso"
   | "limb"
+  | "surface"
   | "center"
   | "nearest";
 
@@ -151,7 +152,7 @@ export interface AimResult {
   body_id: number | null;
   joint_id: number | null;
   requested: AimClassification;
-  classification: string;
+  classification: AimPoint["classification"] | "surface" | "center";
   world_point: Vec3;
   head_rotation: Quat;
   fallback_used: boolean;

--- a/tools/shock2-sdk/test/door-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/door-frob.e2e.test.ts
@@ -6,8 +6,8 @@ import type { EntitySummary, Vec3 } from "../src/types.js";
 
 // End-to-end coverage for the StdDoor script/effect/collider path after a Frob
 // is dispatched. Earth mission objects 80/81 have no incoming SwitchLinks, so
-// the StdDoor script itself must toggle. The campaign play-through separately
-// covers normal player targeting and use-button dispatch to this same payload.
+// the StdDoor script itself must toggle. This uses normal player targeting and
+// the production flat-mode squeeze interaction, not a script-message injection.
 //
 // Negative-first: before #495, MessagePayload::Frob was ignored by StdDoor, so
 // both the entity transform and its kinematic body remained at z=63.38 and the
@@ -36,35 +36,54 @@ test(
       await game.entities.list({ filter: "Interrogation Room", limit: 20 })
     ).entities;
     assert.ok(candidates.length >= 2, "expected Earth's Interrogation Room door pair");
-    const door = candidates.reduce((nearest, candidate) =>
+    const authoredDoor = candidates.reduce((nearest, candidate) =>
       distanceSquared(candidate, TARGET) < distanceSquared(nearest, TARGET)
         ? candidate
         : nearest,
     );
     assert.ok(
-      distanceSquared(door, TARGET) < 0.01,
-      `expected recruitment door near ${JSON.stringify(TARGET)}, got ${JSON.stringify(door.position)}`,
+      distanceSquared(authoredDoor, TARGET) < 0.01,
+      `expected recruitment door near ${JSON.stringify(TARGET)}, got ${JSON.stringify(authoredDoor.position)}`,
     );
 
+    await game.player.teleport({ x: 5.0, y: 24.0, z: 57.0 });
+    const visibleSurface = await game.raycast({
+      start: [5, 25.6, 57],
+      end: TARGET,
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+    });
+    const door = candidates.find((candidate) => candidate.id === visibleSurface.entity_id);
+    assert.ok(
+      door,
+      `expected the visible surface to belong to the door pair, got ${JSON.stringify(visibleSurface)}`,
+    );
     const before = await game.entities.detail(door.id);
     const beforeBodies = (await game.physics.bodies({ entityId: door.id })).bodies;
     assert.equal(beforeBodies.length, 1, "the door should own one kinematic body");
 
-    await game.entities.sendMessage(door.id, { type: "Frob" });
+    const aim = await game.player.aimAt(door);
+    assert.equal(aim.classification, "surface", JSON.stringify(aim));
+    assert.equal(aim.entity_id, door.id);
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
     await game.step({ frames: 60 });
 
     const open = await game.entities.detail(door.id);
     const openBody = (await game.physics.bodies({ entityId: door.id })).bodies[0];
     assert.ok(
-      open.position[2] > before.position[2] + 1.2,
-      `frob should slide the door open, before=${before.position[2]}, after=${open.position[2]}`,
+      Math.abs(open.position[2] - before.position[2]) > 1.2,
+      `frob should slide the selected leaf open, before=${before.position[2]}, after=${open.position[2]}`,
     );
     assert.ok(
       Math.abs(openBody.position[2] - open.position[2]) < 0.01,
       "the kinematic collider must follow the opened door transform",
     );
 
-    await game.entities.sendMessage(door.id, { type: "Frob" });
+    await game.player.aimAt(door);
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
     await game.step({ frames: 60 });
 
     const closed = await game.entities.detail(door.id);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -79,5 +79,150 @@ test("aimAt gracefully falls back when a connected runtime omits aim_points", as
   assert.equal(aim.classification, "center");
   assert.equal(aim.fallback_used, true);
   assert.deepEqual(aim.world_point, detail.position);
-  assert.equal(writes[0]?.path, "/v1/control/input");
+  assert.equal(writes.at(-1)?.path, "/v1/control/input");
+});
+
+test("aimAt uses a visible non-creature selectable surface before its center", async () => {
+  const detail = {
+    entity_id: 470,
+    name: "Airlock Door",
+    template_id: 470,
+    position: [30, -7, 18],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [30, -8.6, 13],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/470") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") {
+        return {
+          hit: true,
+          hit_point: [30, -7, 17.25],
+          hit_normal: [0, 0, -1],
+          distance: 4.25,
+          entity_id: 470,
+          entity_name: "Airlock Door",
+          collision_group: "selectable",
+          is_sensor: false,
+        };
+      }
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(470);
+
+  assert.equal(aim.classification, "surface");
+  assert.deepEqual(aim.world_point, [30, -7, 17.25]);
+  assert.equal(aim.fallback_used, true);
+  assert.equal(writes[0]?.path, "/v1/physics/raycast");
+  assert.deepEqual(
+    (writes[0]?.body as { collision_groups: string[] }).collision_groups,
+    ["entity", "selectable", "world", "ui", "raycast"],
+  );
+  assert.equal(writes[1]?.path, "/v1/control/input");
+});
+
+test("aimAt reports center fallback when another entity occludes the target surface", async () => {
+  const detail = {
+    entity_id: 185,
+    name: "Level Transition",
+    template_id: 185,
+    position: [31.5, -7.9, 17.8],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [32.34, -8.596, 13.49],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/185") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string) => {
+      if (path === "/v1/physics/raycast") {
+        return {
+          hit: true,
+          hit_point: [31.8, -7.8, 15.2],
+          hit_normal: [0, 0, -1],
+          distance: 1.8,
+          entity_id: 470,
+          entity_name: "Airlock Door",
+          collision_group: "entity",
+          is_sensor: false,
+        };
+      }
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(185);
+
+  assert.equal(aim.classification, "center");
+  assert.deepEqual(aim.world_point, detail.position);
+  assert.equal(aim.fallback_used, true);
+});
+
+test("aimAt center remains an explicit origin target without a surface query", async () => {
+  const detail = {
+    entity_id: 470,
+    name: "Airlock Door",
+    template_id: 470,
+    position: [30, -7, 18],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [30, -8.6, 13],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const writes: string[] = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/470") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string) => {
+      writes.push(path);
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(470, { hitbox: "center" });
+
+  assert.equal(aim.classification, "center");
+  assert.equal(aim.fallback_used, false);
+  assert.deepEqual(writes, ["/v1/control/input"]);
 });


### PR DESCRIPTION
Fixes #627

## Summary
- preserve classified creature hitbox aiming and explicit `center` origin aiming
- resolve non-creature targets to the first visible production-interaction surface before falling back to their entity center
- report `surface` in the typed aim result so callers can distinguish a selectable point from an occluded center fallback
- document door/button aiming and exercise a real Earth door through `aimAt` + flat squeeze instead of debug Frob injection

The surface query uses the existing debug-runtime raycast with the same interaction groups as flat world use. It accepts the point only when the first hit belongs to the requested runtime entity, so the Ops loc200 gate behind a closed leaf remains correctly reported as a center fallback rather than tunneling through the occluder.

## Negative-first
The new unit test initially failed with `actual: center`, `expected: surface` on the previous implementation.

## Validation
- `cd tools/shock2-sdk && npm test` (20 passed, 130 opt-in skipped)
- `SHOCK2_E2E=1 SHOCK2_E2E_PORT=8197 node --test dist/test/door-frob.e2e.test.js` (1 passed; production aim + squeeze opens and closes the selected leaf)
- `git diff --check`
