### PR TITLE
fix(ai): eliminate post-churn mid-route freezes - dead-AI ghost routes, blocked-crossing memory, line-of-fire gate, pinned-body unstick

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1035,13 +1035,26 @@ impl MissionCore {
         }
 
         // Drop AI path records (and their debug visuals) for entities that
-        // no longer exist, so dead AIs don't ghost in GET /v1/ai/paths
+        // no longer exist OR are dead, so they don't ghost in
+        // GET /v1/ai/paths. A killed monster keeps its entity (the corpse),
+        // so liveness alone isn't enough: without the hit-point check a
+        // corpse advertises its pre-death route - frozen mid-route, forever
+        // - to tooling and tests (issue #481's dominant "frozen AI" class).
         if time.elapsed.as_secs_f32() > 0.0 {
             if let Some(service) = &self.pathfinding_service {
-                if let Ok(entities) = self.world.borrow::<shipyard::EntitiesView>() {
+                if let (Ok(entities), Ok(v_hit_points)) = (
+                    self.world.borrow::<shipyard::EntitiesView>(),
+                    self.world.borrow::<View<PropHitPoints>>(),
+                ) {
                     service.prune_ai_paths(|inner| {
                         shipyard::EntityId::from_inner(inner)
-                            .map(|id| entities.is_alive(id))
+                            .map(|id| {
+                                entities.is_alive(id)
+                                    && v_hit_points
+                                        .get(id)
+                                        .map(|hp| hp.hit_points > 0)
+                                        .unwrap_or(true)
+                            })
                             .unwrap_or(false)
                     });
                 }

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -30,8 +30,8 @@ pub struct PathQueryRequest {
     pub goal: Vector3<f32>,
     pub movement_bits: MovementBits,
     /// Mission time (seconds) at submit, for expiring the entity's
-    /// steering-reported blocked cells (see
-    /// `PathfindingService::report_blocked_cell`)
+    /// steering-reported blocked crossings (see
+    /// `PathfindingService::report_blocked_link`)
     pub now_seconds: f32,
 }
 
@@ -74,10 +74,10 @@ impl AsyncPathfinding {
             .spawn(move || {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
-                    // Cells this AI's steering reported as physically
+                    // Crossings this AI's steering reported as physically
                     // blocked (stall mid-route) are excluded, so the
                     // post-stall re-path routes around the obstacle
-                    let avoid = service.blocked_cells(request.entity, request.now_seconds);
+                    let avoid = service.blocked_links(request.entity, request.now_seconds);
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -234,5 +234,44 @@ mod tests {
             service.ai_paths().iter().any(|(entity, _)| *entity == 9),
             "worker must record the attempt for GET /v1/ai/paths"
         );
+    }
+
+    #[test]
+    fn worker_applies_the_entitys_blocked_links() {
+        // Cell 0 -> goal in cell 2, but this entity reported the 1 -> 2
+        // crossing blocked: the worker must return a PARTIAL route ending
+        // at cell 1 instead of the full route through the obstacle.
+        let service = Arc::new(PathfindingService::new(Arc::new(
+            crate::pathfinding::tests::three_cell_db(
+                dark::mission::path_database::PathCellFlags::empty(),
+            ),
+        )));
+        service.report_blocked_link(11, 1, 2, 0.0);
+        let async_pf = AsyncPathfinding::spawn(service.clone());
+        assert!(async_pf.submit(PathQueryRequest {
+            entity: 11,
+            start: cgmath::vec3(1.0, 0.0, 1.0),
+            goal: cgmath::vec3(5.0, 0.0, 1.0),
+            movement_bits: MovementBits::WALK,
+            now_seconds: 1.0,
+        }));
+        let response = wait_for_result(&async_pf, 11).expect("worker must respond");
+        assert_eq!(response.outcome, AiPathOutcome::Partial);
+        assert_eq!(
+            *response.waypoints.last().unwrap(),
+            cgmath::vec3(3.0, 0.0, 1.0),
+            "partial route must end at cell 1's center, before the blockage"
+        );
+
+        // Another entity is unaffected by 11's report
+        assert!(async_pf.submit(PathQueryRequest {
+            entity: 12,
+            start: cgmath::vec3(1.0, 0.0, 1.0),
+            goal: cgmath::vec3(5.0, 0.0, 1.0),
+            movement_bits: MovementBits::WALK,
+            now_seconds: 1.0,
+        }));
+        let response = wait_for_result(&async_pf, 12).expect("worker must respond");
+        assert_eq!(response.outcome, AiPathOutcome::Full);
     }
 }

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -29,6 +29,10 @@ pub struct PathQueryRequest {
     pub start: Vector3<f32>,
     pub goal: Vector3<f32>,
     pub movement_bits: MovementBits,
+    /// Mission time (seconds) at submit, for expiring the entity's
+    /// steering-reported blocked cells (see
+    /// `PathfindingService::report_blocked_cell`)
+    pub now_seconds: f32,
 }
 
 /// The computed route (or lack of one) for an entity's latest request
@@ -70,14 +74,24 @@ impl AsyncPathfinding {
             .spawn(move || {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
+                    // Cells this AI's steering reported as physically
+                    // blocked (stall mid-route) are excluded, so the
+                    // post-stall re-path routes around the obstacle
+                    let avoid = service.blocked_cells(request.entity, request.now_seconds);
                     let path = service
-                        .find_path(request.start, request.goal, request.movement_bits)
+                        .find_path_avoiding(
+                            request.start,
+                            request.goal,
+                            request.movement_bits,
+                            &avoid,
+                        )
                         .or_else(|| {
                             outcome = AiPathOutcome::Partial;
-                            service.find_path_toward(
+                            service.find_path_toward_avoiding(
                                 request.start,
                                 request.goal,
                                 request.movement_bits,
+                                &avoid,
                             )
                         });
                     let waypoints = match path {
@@ -185,6 +199,7 @@ mod tests {
             start: cgmath::vec3(1.0, 0.0, 1.0),
             goal: cgmath::vec3(5.0, 0.0, 1.0),
             movement_bits: MovementBits::WALK,
+            now_seconds: 0.0,
         }));
         let response = wait_for_result(&async_pf, 7).expect("worker must respond");
         assert_eq!(response.outcome, AiPathOutcome::Full);
@@ -210,6 +225,7 @@ mod tests {
             start: cgmath::vec3(5.0, 0.0, 1.0),
             goal: cgmath::vec3(500.0, 0.0, 500.0),
             movement_bits: MovementBits::WALK,
+            now_seconds: 0.0,
         }));
         let response = wait_for_result(&async_pf, 9).expect("worker must respond");
         assert_ne!(response.outcome, AiPathOutcome::Full);

--- a/shock2vr/src/pathfinding/async_queries.rs
+++ b/shock2vr/src/pathfinding/async_queries.rs
@@ -74,10 +74,10 @@ impl AsyncPathfinding {
             .spawn(move || {
                 while let Ok(request) = rx.recv() {
                     let mut outcome = AiPathOutcome::Full;
-                    // Crossings this AI's steering reported as physically
-                    // blocked (stall mid-route) are excluded, so the
-                    // post-stall re-path routes around the obstacle
-                    let avoid = service.blocked_links(request.entity, request.now_seconds);
+                    // Crossings ANY AI's steering reported as physically
+                    // blocked (stall mid-route) are excluded, so re-paths -
+                    // including fresh arrivals' - route around the obstacle
+                    let avoid = service.blocked_links(request.now_seconds);
                     let path = service
                         .find_path_avoiding(
                             request.start,
@@ -237,16 +237,17 @@ mod tests {
     }
 
     #[test]
-    fn worker_applies_the_entitys_blocked_links() {
-        // Cell 0 -> goal in cell 2, but this entity reported the 1 -> 2
-        // crossing blocked: the worker must return a PARTIAL route ending
-        // at cell 1 instead of the full route through the obstacle.
+    fn worker_applies_blocked_links() {
+        // Cell 0 -> goal in cell 2, but an AI reported the 1 -> 2 crossing
+        // blocked: the worker must return a PARTIAL route ending at cell 1
+        // instead of the full route through the obstacle - for EVERY AI,
+        // not just the reporter.
         let service = Arc::new(PathfindingService::new(Arc::new(
             crate::pathfinding::tests::three_cell_db(
                 dark::mission::path_database::PathCellFlags::empty(),
             ),
         )));
-        service.report_blocked_link(11, 1, 2, 0.0);
+        service.report_blocked_link(1, 2, 0.0);
         let async_pf = AsyncPathfinding::spawn(service.clone());
         assert!(async_pf.submit(PathQueryRequest {
             entity: 11,
@@ -263,7 +264,7 @@ mod tests {
             "partial route must end at cell 1's center, before the blockage"
         );
 
-        // Another entity is unaffected by 11's report
+        // The exclusion is shared: another entity's query avoids it too
         assert!(async_pf.submit(PathQueryRequest {
             entity: 12,
             start: cgmath::vec3(1.0, 0.0, 1.0),
@@ -272,6 +273,6 @@ mod tests {
             now_seconds: 1.0,
         }));
         let response = wait_for_result(&async_pf, 12).expect("worker must respond");
-        assert_eq!(response.outcome, AiPathOutcome::Full);
+        assert_eq!(response.outcome, AiPathOutcome::Partial);
     }
 }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -47,15 +47,16 @@ const BRIDGE_BUCKET: f32 = 12.0 / SCALE_FACTOR;
 /// prefer clear floor, but allow squeezing past baked furniture
 const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 
-/// How long a steering-reported blocked cell stays excluded from an AI's
-/// path queries. Long enough that the re-path (and several after it) route
-/// around the obstacle instead of reproducing the blocked route; short
-/// enough that a transient blocker (another creature, a shoved crate) is
-/// retried within a minute.
-const BLOCKED_CELL_TTL_SECONDS: f32 = 30.0;
-/// Cap on remembered blocked cells per AI (oldest evicted) - bounds memory
-/// and lets a badly-fenced AI eventually retry its earliest failures.
-const MAX_BLOCKED_CELLS_PER_ENTITY: usize = 8;
+/// How long a steering-reported blocked crossing stays excluded from an
+/// AI's path queries. Long enough that the re-path (and several after it)
+/// route around the obstacle instead of reproducing the blocked route;
+/// short enough that a transient blocker (a shoved crate) is retried
+/// within a minute.
+const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
+/// Cap on remembered blocked crossings per AI (oldest evicted) - bounds
+/// memory and lets a badly-fenced AI eventually retry its earliest
+/// failures.
+const MAX_BLOCKED_LINKS_PER_ENTITY: usize = 8;
 
 /// Per-frame cap on AI-initiated pathfind queries. A slot now covers the
 /// full fallback chain (A* + stressed retry + partial-route Dijkstra when
@@ -180,13 +181,16 @@ pub struct PathfindingService {
     ai_paths: std::sync::Mutex<HashMap<u64, AiPathRecord>>,
     /// Live steering state per AI (what it is actually following right now)
     ai_steering: std::sync::Mutex<HashMap<u64, AiSteeringDebug>>,
-    /// Cells an AI's steering failed to approach (a stall fired mid-route):
-    /// obstacles the mesh doesn't model, e.g. a physical prop sitting on a
-    /// walkable link. Entries are `(cell, expiry in mission seconds)`; the
-    /// entity's path queries treat unexpired cells as unpathable so the
-    /// post-stall re-path routes around the obstacle instead of reproducing
-    /// the identical blocked route forever (issue #481's grind loop).
-    ai_blocked_cells: std::sync::Mutex<HashMap<u64, Vec<(u32, f32)>>>,
+    /// Cell crossings an AI's steering failed to traverse (a stall fired
+    /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
+    /// sitting on a walkable link. Entries are
+    /// `((from_cell, to_cell), expiry in mission seconds)`; the entity's
+    /// path queries skip unexpired crossings so the post-stall re-path
+    /// routes around the obstacle instead of reproducing the identical
+    /// blocked route forever (issue #481's grind loop). Directed-link
+    /// granularity (not whole cells) so one blocked doorway can't seal
+    /// every other entrance into a large cell.
+    ai_blocked_links: std::sync::Mutex<HashMap<u64, Vec<((u32, u32), f32)>>>,
     /// Mission object ids of doors that are currently locked AND closed -
     /// A* refuses links into their below-door cells (the runtime door gate;
     /// closed-but-openable doors stay pathable and are opened on arrival).
@@ -258,7 +262,7 @@ impl PathfindingService {
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
-            ai_blocked_cells: std::sync::Mutex::new(HashMap::new()),
+            ai_blocked_links: std::sync::Mutex::new(HashMap::new()),
             locked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
@@ -289,44 +293,51 @@ impl PathfindingService {
         if let Ok(mut steering) = self.ai_steering.lock() {
             steering.retain(|&entity, _| keep(entity));
         }
-        if let Ok(mut blocked) = self.ai_blocked_cells.lock() {
+        if let Ok(mut blocked) = self.ai_blocked_links.lock() {
             blocked.retain(|&entity, _| keep(entity));
         }
     }
 
-    /// Remember that `entity` could not physically approach `cell` (its
-    /// steering stalled mid-route): the cell is excluded from this entity's
-    /// path queries until the entry expires, so the post-stall re-path
-    /// doesn't reproduce the identical blocked route.
-    pub fn report_blocked_cell(&self, entity: u64, cell: u32, now_seconds: f32) {
-        let Ok(mut blocked) = self.ai_blocked_cells.lock() else {
+    /// Remember that `entity` could not physically traverse the crossing
+    /// `from_cell -> to_cell` (its steering stalled mid-route): the crossing
+    /// is excluded from this entity's path queries until the entry expires,
+    /// so the post-stall re-path doesn't reproduce the identical blocked
+    /// route.
+    pub fn report_blocked_link(&self, entity: u64, from_cell: u32, to_cell: u32, now_seconds: f32) {
+        let Ok(mut blocked) = self.ai_blocked_links.lock() else {
             return;
         };
         let entries = blocked.entry(entity).or_default();
-        let expiry = now_seconds + BLOCKED_CELL_TTL_SECONDS;
-        entries.retain(|&(c, e)| c != cell && e > now_seconds);
-        entries.push((cell, expiry));
-        if entries.len() > MAX_BLOCKED_CELLS_PER_ENTITY {
-            let excess = entries.len() - MAX_BLOCKED_CELLS_PER_ENTITY;
+        let expiry = now_seconds + BLOCKED_LINK_TTL_SECONDS;
+        let link = (from_cell, to_cell);
+        entries.retain(|&(l, e)| l != link && e > now_seconds);
+        entries.push((link, expiry));
+        if entries.len() > MAX_BLOCKED_LINKS_PER_ENTITY {
+            let excess = entries.len() - MAX_BLOCKED_LINKS_PER_ENTITY;
             entries.drain(0..excess);
         }
     }
 
-    /// The cells currently excluded from `entity`'s path queries (unexpired
-    /// steering-reported blockages). Expired entries are dropped.
-    pub fn blocked_cells(&self, entity: u64, now_seconds: f32) -> std::collections::HashSet<u32> {
-        let Ok(mut blocked) = self.ai_blocked_cells.lock() else {
+    /// The `(from_cell, to_cell)` crossings currently excluded from
+    /// `entity`'s path queries (unexpired steering-reported blockages).
+    /// Expired entries are dropped.
+    pub fn blocked_links(
+        &self,
+        entity: u64,
+        now_seconds: f32,
+    ) -> std::collections::HashSet<(u32, u32)> {
+        let Ok(mut blocked) = self.ai_blocked_links.lock() else {
             return std::collections::HashSet::new();
         };
         let Some(entries) = blocked.get_mut(&entity) else {
             return std::collections::HashSet::new();
         };
         entries.retain(|&(_, expiry)| expiry > now_seconds);
-        let cells = entries.iter().map(|&(cell, _)| cell).collect();
+        let links = entries.iter().map(|&(link, _)| link).collect();
         if entries.is_empty() {
             blocked.remove(&entity);
         }
-        cells
+        links
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -460,15 +471,16 @@ impl PathfindingService {
         )
     }
 
-    /// `find_path` with an extra set of cells to treat as unpathable -
-    /// steering-reported blockages (see `report_blocked_cell`), so an AI's
-    /// re-path after a stall routes around the obstacle it just hit.
+    /// `find_path` with a set of directed cell crossings to treat as
+    /// impassable - steering-reported blockages (see `report_blocked_link`),
+    /// so an AI's re-path after a stall routes around the obstacle it just
+    /// hit.
     pub fn find_path_avoiding(
         &self,
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<u32>,
+        avoid: &std::collections::HashSet<(u32, u32)>,
     ) -> Option<Vec<Vector3<f32>>> {
         self.queries.fetch_add(1, Ordering::Relaxed);
         if let Some(path) = self.find_path_with_bits(start, goal, movement_bits, avoid) {
@@ -511,7 +523,7 @@ impl PathfindingService {
         )
     }
 
-    /// `find_path_toward` with steering-reported blocked cells excluded
+    /// `find_path_toward` with steering-reported blocked crossings excluded
     /// (see `find_path_avoiding`) - the partial route then ends BEFORE the
     /// obstacle instead of running through it.
     pub fn find_path_toward_avoiding(
@@ -519,7 +531,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<u32>,
+        avoid: &std::collections::HashSet<(u32, u32)>,
     ) -> Option<Vec<Vector3<f32>>> {
         let start_cell = self.cell_from_position(start)?;
         let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell, |&cell| {
@@ -560,7 +572,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<u32>,
+        avoid: &std::collections::HashSet<(u32, u32)>,
     ) -> Option<Vec<Vector3<f32>>> {
         // Find start and goal cells
         let start_cell_id = self.cell_from_position(start)?;
@@ -744,14 +756,14 @@ impl PathfindingService {
     /// Get the successors of a cell for A* pathfinding
     ///
     /// Returns a list of (target_cell_id, cost) pairs for cells reachable
-    /// from the given cell. `avoid` holds steering-reported blocked cells
-    /// (physical obstacles the mesh doesn't model) - links into them are
-    /// skipped.
+    /// from the given cell. `avoid` holds steering-reported blocked
+    /// crossings (physical obstacles the mesh doesn't model) - those
+    /// directed links are skipped.
     fn get_successors(
         &self,
         cell_id: u32,
         movement_bits: MovementBits,
-        avoid: &std::collections::HashSet<u32>,
+        avoid: &std::collections::HashSet<(u32, u32)>,
     ) -> Vec<(u32, u32)> {
         let Some(link_indices) = self.links_by_cell.get(cell_id as usize) else {
             return Vec::new();
@@ -759,7 +771,8 @@ impl PathfindingService {
         link_indices
             .iter()
             .filter(|&&idx| {
-                !avoid.contains(&self.link_at(idx).to_cell) && self.can_use_link(idx, movement_bits)
+                !avoid.contains(&(cell_id, self.link_at(idx).to_cell))
+                    && self.can_use_link(idx, movement_bits)
             })
             .map(|&idx| {
                 let link = self.link_at(idx);
@@ -1576,20 +1589,20 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn reported_blocked_cell_excludes_it_from_that_entitys_queries() {
+    fn reported_blocked_link_excludes_that_crossing_from_the_entitys_queries() {
         let service = service(three_cell_db(PathCellFlags::empty()));
         let start = vec3(1.0, 0.0, 1.0);
         let goal = vec3(5.0, 0.0, 1.0);
-        // Without a report the route crosses cell 1 normally
+        // Without a report the route crosses 0 -> 1 -> 2 normally
         assert!(service.find_path(start, goal, MovementBits::WALK).is_some());
 
-        // A stall reported against cell 1 severs this entity's only route:
-        // the full search fails and the partial fallback reports no
-        // progress possible (the AI parks instead of grinding into the
-        // obstacle - issue #481)
-        service.report_blocked_cell(7, 1, 0.0);
-        let avoid = service.blocked_cells(7, 1.0);
-        assert!(avoid.contains(&1));
+        // A stall reported against the 0 -> 1 crossing severs this entity's
+        // only route: the full search fails and the partial fallback
+        // reports no progress possible (the AI parks instead of grinding
+        // into the obstacle - issue #481)
+        service.report_blocked_link(7, 0, 1, 0.0);
+        let avoid = service.blocked_links(7, 1.0);
+        assert!(avoid.contains(&(0, 1)));
         assert!(
             service
                 .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
@@ -1601,20 +1614,27 @@ pub(crate) mod tests {
                 .is_none()
         );
 
-        // Other entities are unaffected
-        assert!(service.blocked_cells(8, 1.0).is_empty());
+        // Only that DIRECTED crossing is excluded - a route already past it
+        // (start in cell 1) still enters cell 2, and other entities are
+        // unaffected
+        assert!(
+            service
+                .find_path_avoiding(vec3(3.0, 0.0, 1.0), goal, MovementBits::WALK, &avoid)
+                .is_some()
+        );
+        assert!(service.blocked_links(8, 1.0).is_empty());
     }
 
     #[test]
-    fn blocked_cells_expire_after_their_ttl() {
+    fn blocked_links_expire_after_their_ttl() {
         let service = service(three_cell_db(PathCellFlags::empty()));
-        service.report_blocked_cell(7, 1, 100.0);
+        service.report_blocked_link(7, 0, 1, 100.0);
         assert!(
             service
-                .blocked_cells(7, 100.0 + BLOCKED_CELL_TTL_SECONDS - 1.0)
-                .contains(&1)
+                .blocked_links(7, 100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
+                .contains(&(0, 1))
         );
-        let expired = service.blocked_cells(7, 100.0 + BLOCKED_CELL_TTL_SECONDS + 1.0);
+        let expired = service.blocked_links(7, 100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
         assert!(expired.is_empty(), "entries must expire: {expired:?}");
         // The route is usable again once the entry expired
         assert!(
@@ -1630,7 +1650,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn prune_drops_steering_and_blocked_cells_with_the_path_record() {
+    fn prune_drops_steering_and_blocked_links_with_the_path_record() {
         let service = service(three_cell_db(PathCellFlags::empty()));
         service.record_ai_path(
             7,
@@ -1649,13 +1669,13 @@ pub(crate) mod tests {
                 stall_seconds: 0.0,
             },
         );
-        service.report_blocked_cell(7, 1, 0.0);
+        service.report_blocked_link(7, 0, 1, 0.0);
 
         // Entity 7 died (or despawned): every per-AI record goes with it
         service.prune_ai_paths(|entity| entity != 7);
         assert!(service.ai_paths().is_empty());
         assert!(service.ai_steering(7).is_none());
-        assert!(service.blocked_cells(7, 0.0).is_empty());
+        assert!(service.blocked_links(7, 0.0).is_empty());
     }
 
     #[test]

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -53,10 +53,9 @@ const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 /// short enough that a transient blocker (a shoved crate) is retried
 /// within a minute.
 const BLOCKED_LINK_TTL_SECONDS: f32 = 30.0;
-/// Cap on remembered blocked crossings per AI (oldest evicted) - bounds
-/// memory and lets a badly-fenced AI eventually retry its earliest
-/// failures.
-const MAX_BLOCKED_LINKS_PER_ENTITY: usize = 8;
+/// Cap on remembered blocked crossings (new reports dropped while full of
+/// live entries) - bounds memory; entries expire on their TTL.
+const MAX_BLOCKED_LINKS: usize = 64;
 
 /// Per-frame cap on AI-initiated pathfind queries. A slot now covers the
 /// full fallback chain (A* + stressed retry + partial-route Dijkstra when
@@ -181,16 +180,19 @@ pub struct PathfindingService {
     ai_paths: std::sync::Mutex<HashMap<u64, AiPathRecord>>,
     /// Live steering state per AI (what it is actually following right now)
     ai_steering: std::sync::Mutex<HashMap<u64, AiSteeringDebug>>,
-    /// Cell crossings an AI's steering failed to traverse (a stall fired
+    /// Cell crossings some AI's steering failed to traverse (a stall fired
     /// mid-route): obstacles the mesh doesn't model, e.g. a physical prop
-    /// sitting on a walkable link. Entries are
-    /// `((from_cell, to_cell), expiry in mission seconds)`; the entity's
-    /// path queries skip unexpired crossings so the post-stall re-path
-    /// routes around the obstacle instead of reproducing the identical
-    /// blocked route forever (issue #481's grind loop). Directed-link
-    /// granularity (not whole cells) so one blocked doorway can't seal
-    /// every other entrance into a large cell.
-    ai_blocked_links: std::sync::Mutex<HashMap<u64, Vec<((u32, u32), f32)>>>,
+    /// or a scripted stationary NPC sitting on a walkable link. Entries map
+    /// `(from_cell, to_cell) -> expiry in mission seconds`. SHARED across
+    /// AIs: the blockage is a physical fact about the world, and per-AI
+    /// memory let a capture pocket re-trap every fresh arrival while each
+    /// separately re-learned it (measured at medsci1's FemaleMedsci
+    /// pocket). All AI path queries skip unexpired crossings, so after the
+    /// first capture the re-paths - everyone's - route around the obstacle
+    /// (issue #481's grind loop). Directed-link granularity (not whole
+    /// cells) so one blocked doorway can't seal every other entrance into
+    /// a large cell.
+    blocked_links: std::sync::Mutex<HashMap<(u32, u32), f32>>,
     /// Mission object ids of doors that are currently locked AND closed -
     /// A* refuses links into their below-door cells (the runtime door gate;
     /// closed-but-openable doors stay pathable and are opened on arrival).
@@ -262,7 +264,7 @@ impl PathfindingService {
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
-            ai_blocked_links: std::sync::Mutex::new(HashMap::new()),
+            blocked_links: std::sync::Mutex::new(HashMap::new()),
             locked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
@@ -283,9 +285,10 @@ impl PathfindingService {
         self.bridge_links.len()
     }
 
-    /// Drop AI path (and steering / blocked-cell) records whose entity no
-    /// longer satisfies `keep` (it despawned, or died - a corpse keeps its
-    /// entity), so introspection doesn't report ghosts
+    /// Drop AI path and steering records whose entity no longer satisfies
+    /// `keep` (it despawned, or died - a corpse keeps its entity), so
+    /// introspection doesn't report ghosts. Blocked crossings are world
+    /// facts, not per-entity records - they expire on their own TTL.
     pub fn prune_ai_paths(&self, keep: impl Fn(u64) -> bool) {
         if let Ok(mut paths) = self.ai_paths.lock() {
             paths.retain(|&entity, _| keep(entity));
@@ -293,51 +296,33 @@ impl PathfindingService {
         if let Ok(mut steering) = self.ai_steering.lock() {
             steering.retain(|&entity, _| keep(entity));
         }
-        if let Ok(mut blocked) = self.ai_blocked_links.lock() {
-            blocked.retain(|&entity, _| keep(entity));
-        }
     }
 
-    /// Remember that `entity` could not physically traverse the crossing
-    /// `from_cell -> to_cell` (its steering stalled mid-route): the crossing
-    /// is excluded from this entity's path queries until the entry expires,
-    /// so the post-stall re-path doesn't reproduce the identical blocked
-    /// route.
-    pub fn report_blocked_link(&self, entity: u64, from_cell: u32, to_cell: u32, now_seconds: f32) {
-        let Ok(mut blocked) = self.ai_blocked_links.lock() else {
+    /// Remember that an AI could not physically traverse the crossing
+    /// `from_cell -> to_cell` (its steering stalled mid-route): the
+    /// crossing is excluded from ALL AI path queries until the entry
+    /// expires, so re-paths route around the obstacle - including for
+    /// fresh arrivals that haven't hit it yet.
+    pub fn report_blocked_link(&self, from_cell: u32, to_cell: u32, now_seconds: f32) {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
             return;
         };
-        let entries = blocked.entry(entity).or_default();
-        let expiry = now_seconds + BLOCKED_LINK_TTL_SECONDS;
-        let link = (from_cell, to_cell);
-        entries.retain(|&(l, e)| l != link && e > now_seconds);
-        entries.push((link, expiry));
-        if entries.len() > MAX_BLOCKED_LINKS_PER_ENTITY {
-            let excess = entries.len() - MAX_BLOCKED_LINKS_PER_ENTITY;
-            entries.drain(0..excess);
+        blocked.retain(|_, &mut expiry| expiry > now_seconds);
+        if blocked.len() >= MAX_BLOCKED_LINKS && !blocked.contains_key(&(from_cell, to_cell)) {
+            return; // full of live entries - drop rather than grow unbounded
         }
+        blocked.insert((from_cell, to_cell), now_seconds + BLOCKED_LINK_TTL_SECONDS);
     }
 
-    /// The `(from_cell, to_cell)` crossings currently excluded from
-    /// `entity`'s path queries (unexpired steering-reported blockages).
-    /// Expired entries are dropped.
-    pub fn blocked_links(
-        &self,
-        entity: u64,
-        now_seconds: f32,
-    ) -> std::collections::HashSet<(u32, u32)> {
-        let Ok(mut blocked) = self.ai_blocked_links.lock() else {
+    /// The `(from_cell, to_cell)` crossings currently excluded from AI path
+    /// queries (unexpired steering-reported blockages). Expired entries are
+    /// dropped.
+    pub fn blocked_links(&self, now_seconds: f32) -> std::collections::HashSet<(u32, u32)> {
+        let Ok(mut blocked) = self.blocked_links.lock() else {
             return std::collections::HashSet::new();
         };
-        let Some(entries) = blocked.get_mut(&entity) else {
-            return std::collections::HashSet::new();
-        };
-        entries.retain(|&(_, expiry)| expiry > now_seconds);
-        let links = entries.iter().map(|&(link, _)| link).collect();
-        if entries.is_empty() {
-            blocked.remove(&entity);
-        }
-        links
+        blocked.retain(|_, &mut expiry| expiry > now_seconds);
+        blocked.keys().copied().collect()
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -1589,19 +1574,20 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn reported_blocked_link_excludes_that_crossing_from_the_entitys_queries() {
+    fn reported_blocked_link_excludes_that_crossing_from_queries() {
         let service = service(three_cell_db(PathCellFlags::empty()));
         let start = vec3(1.0, 0.0, 1.0);
         let goal = vec3(5.0, 0.0, 1.0);
         // Without a report the route crosses 0 -> 1 -> 2 normally
         assert!(service.find_path(start, goal, MovementBits::WALK).is_some());
 
-        // A stall reported against the 0 -> 1 crossing severs this entity's
-        // only route: the full search fails and the partial fallback
-        // reports no progress possible (the AI parks instead of grinding
-        // into the obstacle - issue #481)
-        service.report_blocked_link(7, 0, 1, 0.0);
-        let avoid = service.blocked_links(7, 1.0);
+        // A stall reported against the 0 -> 1 crossing severs the only
+        // route: the full search fails and the partial fallback reports no
+        // progress possible (the AI parks instead of grinding into the
+        // obstacle - issue #481). The exclusion is SHARED - the blockage is
+        // a physical fact, and it must protect fresh arrivals too.
+        service.report_blocked_link(0, 1, 0.0);
+        let avoid = service.blocked_links(1.0);
         assert!(avoid.contains(&(0, 1)));
         assert!(
             service
@@ -1615,26 +1601,24 @@ pub(crate) mod tests {
         );
 
         // Only that DIRECTED crossing is excluded - a route already past it
-        // (start in cell 1) still enters cell 2, and other entities are
-        // unaffected
+        // (start in cell 1) still enters cell 2
         assert!(
             service
                 .find_path_avoiding(vec3(3.0, 0.0, 1.0), goal, MovementBits::WALK, &avoid)
                 .is_some()
         );
-        assert!(service.blocked_links(8, 1.0).is_empty());
     }
 
     #[test]
     fn blocked_links_expire_after_their_ttl() {
         let service = service(three_cell_db(PathCellFlags::empty()));
-        service.report_blocked_link(7, 0, 1, 100.0);
+        service.report_blocked_link(0, 1, 100.0);
         assert!(
             service
-                .blocked_links(7, 100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
+                .blocked_links(100.0 + BLOCKED_LINK_TTL_SECONDS - 1.0)
                 .contains(&(0, 1))
         );
-        let expired = service.blocked_links(7, 100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
+        let expired = service.blocked_links(100.0 + BLOCKED_LINK_TTL_SECONDS + 1.0);
         assert!(expired.is_empty(), "entries must expire: {expired:?}");
         // The route is usable again once the entry expired
         assert!(
@@ -1650,7 +1634,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn prune_drops_steering_and_blocked_links_with_the_path_record() {
+    fn prune_drops_steering_with_the_path_record() {
         let service = service(three_cell_db(PathCellFlags::empty()));
         service.record_ai_path(
             7,
@@ -1669,13 +1653,14 @@ pub(crate) mod tests {
                 stall_seconds: 0.0,
             },
         );
-        service.report_blocked_link(7, 0, 1, 0.0);
+        service.report_blocked_link(0, 1, 0.0);
 
-        // Entity 7 died (or despawned): every per-AI record goes with it
+        // Entity 7 died (or despawned): its per-AI records go with it, but
+        // reported blockages are world facts and stay until their TTL
         service.prune_ai_paths(|entity| entity != 7);
         assert!(service.ai_paths().is_empty());
         assert!(service.ai_steering(7).is_none());
-        assert!(service.blocked_links(7, 0.0).is_empty());
+        assert!(service.blocked_links(0.0).contains(&(0, 1)));
     }
 
     #[test]

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -47,6 +47,16 @@ const BRIDGE_BUCKET: f32 = 12.0 / SCALE_FACTOR;
 /// prefer clear floor, but allow squeezing past baked furniture
 const BLOCKING_CELL_COST_PENALTY: u32 = 4;
 
+/// How long a steering-reported blocked cell stays excluded from an AI's
+/// path queries. Long enough that the re-path (and several after it) route
+/// around the obstacle instead of reproducing the blocked route; short
+/// enough that a transient blocker (another creature, a shoved crate) is
+/// retried within a minute.
+const BLOCKED_CELL_TTL_SECONDS: f32 = 30.0;
+/// Cap on remembered blocked cells per AI (oldest evicted) - bounds memory
+/// and lets a badly-fenced AI eventually retry its earliest failures.
+const MAX_BLOCKED_CELLS_PER_ENTITY: usize = 8;
+
 /// Per-frame cap on AI-initiated pathfind queries. A slot now covers the
 /// full fallback chain (A* + stressed retry + partial-route Dijkstra when
 /// the goal is unreachable), benched at ~0.5ms p95 / ~3ms worst per slot on
@@ -170,6 +180,13 @@ pub struct PathfindingService {
     ai_paths: std::sync::Mutex<HashMap<u64, AiPathRecord>>,
     /// Live steering state per AI (what it is actually following right now)
     ai_steering: std::sync::Mutex<HashMap<u64, AiSteeringDebug>>,
+    /// Cells an AI's steering failed to approach (a stall fired mid-route):
+    /// obstacles the mesh doesn't model, e.g. a physical prop sitting on a
+    /// walkable link. Entries are `(cell, expiry in mission seconds)`; the
+    /// entity's path queries treat unexpired cells as unpathable so the
+    /// post-stall re-path routes around the obstacle instead of reproducing
+    /// the identical blocked route forever (issue #481's grind loop).
+    ai_blocked_cells: std::sync::Mutex<HashMap<u64, Vec<(u32, f32)>>>,
     /// Mission object ids of doors that are currently locked AND closed -
     /// A* refuses links into their below-door cells (the runtime door gate;
     /// closed-but-openable doors stay pathable and are opened on arrival).
@@ -241,6 +258,7 @@ impl PathfindingService {
             relaxed: bridge_islands,
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
+            ai_blocked_cells: std::sync::Mutex::new(HashMap::new()),
             locked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
@@ -261,12 +279,54 @@ impl PathfindingService {
         self.bridge_links.len()
     }
 
-    /// Drop AI path records whose entity no longer satisfies `keep`
-    /// (e.g. it despawned), so introspection doesn't report ghosts
+    /// Drop AI path (and steering / blocked-cell) records whose entity no
+    /// longer satisfies `keep` (it despawned, or died - a corpse keeps its
+    /// entity), so introspection doesn't report ghosts
     pub fn prune_ai_paths(&self, keep: impl Fn(u64) -> bool) {
         if let Ok(mut paths) = self.ai_paths.lock() {
             paths.retain(|&entity, _| keep(entity));
         }
+        if let Ok(mut steering) = self.ai_steering.lock() {
+            steering.retain(|&entity, _| keep(entity));
+        }
+        if let Ok(mut blocked) = self.ai_blocked_cells.lock() {
+            blocked.retain(|&entity, _| keep(entity));
+        }
+    }
+
+    /// Remember that `entity` could not physically approach `cell` (its
+    /// steering stalled mid-route): the cell is excluded from this entity's
+    /// path queries until the entry expires, so the post-stall re-path
+    /// doesn't reproduce the identical blocked route.
+    pub fn report_blocked_cell(&self, entity: u64, cell: u32, now_seconds: f32) {
+        let Ok(mut blocked) = self.ai_blocked_cells.lock() else {
+            return;
+        };
+        let entries = blocked.entry(entity).or_default();
+        let expiry = now_seconds + BLOCKED_CELL_TTL_SECONDS;
+        entries.retain(|&(c, e)| c != cell && e > now_seconds);
+        entries.push((cell, expiry));
+        if entries.len() > MAX_BLOCKED_CELLS_PER_ENTITY {
+            let excess = entries.len() - MAX_BLOCKED_CELLS_PER_ENTITY;
+            entries.drain(0..excess);
+        }
+    }
+
+    /// The cells currently excluded from `entity`'s path queries (unexpired
+    /// steering-reported blockages). Expired entries are dropped.
+    pub fn blocked_cells(&self, entity: u64, now_seconds: f32) -> std::collections::HashSet<u32> {
+        let Ok(mut blocked) = self.ai_blocked_cells.lock() else {
+            return std::collections::HashSet::new();
+        };
+        let Some(entries) = blocked.get_mut(&entity) else {
+            return std::collections::HashSet::new();
+        };
+        entries.retain(|&(_, expiry)| expiry > now_seconds);
+        let cells = entries.iter().map(|&(cell, _)| cell).collect();
+        if entries.is_empty() {
+            blocked.remove(&entity);
+        }
+        cells
     }
 
     /// Record the latest path an AI computed (key: EntityId::inner())
@@ -392,8 +452,26 @@ impl PathfindingService {
         goal: Vector3<f32>,
         movement_bits: MovementBits,
     ) -> Option<Vec<Vector3<f32>>> {
+        self.find_path_avoiding(
+            start,
+            goal,
+            movement_bits,
+            &std::collections::HashSet::new(),
+        )
+    }
+
+    /// `find_path` with an extra set of cells to treat as unpathable -
+    /// steering-reported blockages (see `report_blocked_cell`), so an AI's
+    /// re-path after a stall routes around the obstacle it just hit.
+    pub fn find_path_avoiding(
+        &self,
+        start: Vector3<f32>,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        avoid: &std::collections::HashSet<u32>,
+    ) -> Option<Vec<Vector3<f32>>> {
         self.queries.fetch_add(1, Ordering::Relaxed);
-        if let Some(path) = self.find_path_with_bits(start, goal, movement_bits) {
+        if let Some(path) = self.find_path_with_bits(start, goal, movement_bits, avoid) {
             return Some(path);
         }
         // Second pass: a failed pathfind is retried with the stressed
@@ -404,7 +482,7 @@ impl PathfindingService {
         {
             self.stressed_retries.fetch_add(1, Ordering::Relaxed);
             if let Some(path) =
-                self.find_path_with_bits(start, goal, movement_bits | MovementBits::STRESSED)
+                self.find_path_with_bits(start, goal, movement_bits | MovementBits::STRESSED, avoid)
             {
                 return Some(path);
             }
@@ -425,9 +503,27 @@ impl PathfindingService {
         goal: Vector3<f32>,
         movement_bits: MovementBits,
     ) -> Option<Vec<Vector3<f32>>> {
+        self.find_path_toward_avoiding(
+            start,
+            goal,
+            movement_bits,
+            &std::collections::HashSet::new(),
+        )
+    }
+
+    /// `find_path_toward` with steering-reported blocked cells excluded
+    /// (see `find_path_avoiding`) - the partial route then ends BEFORE the
+    /// obstacle instead of running through it.
+    pub fn find_path_toward_avoiding(
+        &self,
+        start: Vector3<f32>,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        avoid: &std::collections::HashSet<u32>,
+    ) -> Option<Vec<Vector3<f32>>> {
         let start_cell = self.cell_from_position(start)?;
         let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell, |&cell| {
-            self.get_successors(cell, movement_bits)
+            self.get_successors(cell, movement_bits, avoid)
         });
 
         let distance_to_goal = |cell: u32| -> f32 {
@@ -464,6 +560,7 @@ impl PathfindingService {
         start: Vector3<f32>,
         goal: Vector3<f32>,
         movement_bits: MovementBits,
+        avoid: &std::collections::HashSet<u32>,
     ) -> Option<Vec<Vector3<f32>>> {
         // Find start and goal cells
         let start_cell_id = self.cell_from_position(start)?;
@@ -472,7 +569,7 @@ impl PathfindingService {
         // Use pathfinding crate for A* algorithm
         let result = pathfinding::directed::astar::astar(
             &start_cell_id,
-            |&cell_id| self.get_successors(cell_id, movement_bits),
+            |&cell_id| self.get_successors(cell_id, movement_bits, avoid),
             |&cell_id| self.heuristic(cell_id, goal_cell_id),
             |&cell_id| cell_id == goal_cell_id,
         )?;
@@ -564,7 +661,7 @@ impl PathfindingService {
 
         // Find all reachable cells using Dijkstra's algorithm
         let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell_id, |&cell_id| {
-            self.get_successors(cell_id, movement_bits)
+            self.get_successors(cell_id, movement_bits, &std::collections::HashSet::new())
         });
 
         // Find the reachable cell closest to the goal
@@ -646,14 +743,24 @@ impl PathfindingService {
 
     /// Get the successors of a cell for A* pathfinding
     ///
-    /// Returns a list of (target_cell_id, cost) pairs for cells reachable from the given cell.
-    fn get_successors(&self, cell_id: u32, movement_bits: MovementBits) -> Vec<(u32, u32)> {
+    /// Returns a list of (target_cell_id, cost) pairs for cells reachable
+    /// from the given cell. `avoid` holds steering-reported blocked cells
+    /// (physical obstacles the mesh doesn't model) - links into them are
+    /// skipped.
+    fn get_successors(
+        &self,
+        cell_id: u32,
+        movement_bits: MovementBits,
+        avoid: &std::collections::HashSet<u32>,
+    ) -> Vec<(u32, u32)> {
         let Some(link_indices) = self.links_by_cell.get(cell_id as usize) else {
             return Vec::new();
         };
         link_indices
             .iter()
-            .filter(|&&idx| self.can_use_link(idx, movement_bits))
+            .filter(|&&idx| {
+                !avoid.contains(&self.link_at(idx).to_cell) && self.can_use_link(idx, movement_bits)
+            })
             .map(|&idx| {
                 let link = self.link_at(idx);
                 let mut cost = (link.cost as u32).max(1);
@@ -1466,6 +1573,89 @@ pub(crate) mod tests {
         assert!(!budget.try_acquire(), "budget must exhaust");
         budget.reset();
         assert!(budget.try_acquire(), "reset must refill the budget");
+    }
+
+    #[test]
+    fn reported_blocked_cell_excludes_it_from_that_entitys_queries() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        let start = vec3(1.0, 0.0, 1.0);
+        let goal = vec3(5.0, 0.0, 1.0);
+        // Without a report the route crosses cell 1 normally
+        assert!(service.find_path(start, goal, MovementBits::WALK).is_some());
+
+        // A stall reported against cell 1 severs this entity's only route:
+        // the full search fails and the partial fallback reports no
+        // progress possible (the AI parks instead of grinding into the
+        // obstacle - issue #481)
+        service.report_blocked_cell(7, 1, 0.0);
+        let avoid = service.blocked_cells(7, 1.0);
+        assert!(avoid.contains(&1));
+        assert!(
+            service
+                .find_path_avoiding(start, goal, MovementBits::WALK, &avoid)
+                .is_none()
+        );
+        assert!(
+            service
+                .find_path_toward_avoiding(start, goal, MovementBits::WALK, &avoid)
+                .is_none()
+        );
+
+        // Other entities are unaffected
+        assert!(service.blocked_cells(8, 1.0).is_empty());
+    }
+
+    #[test]
+    fn blocked_cells_expire_after_their_ttl() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        service.report_blocked_cell(7, 1, 100.0);
+        assert!(
+            service
+                .blocked_cells(7, 100.0 + BLOCKED_CELL_TTL_SECONDS - 1.0)
+                .contains(&1)
+        );
+        let expired = service.blocked_cells(7, 100.0 + BLOCKED_CELL_TTL_SECONDS + 1.0);
+        assert!(expired.is_empty(), "entries must expire: {expired:?}");
+        // The route is usable again once the entry expired
+        assert!(
+            service
+                .find_path_avoiding(
+                    vec3(1.0, 0.0, 1.0),
+                    vec3(5.0, 0.0, 1.0),
+                    MovementBits::WALK,
+                    &expired
+                )
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn prune_drops_steering_and_blocked_cells_with_the_path_record() {
+        let service = service(three_cell_db(PathCellFlags::empty()));
+        service.record_ai_path(
+            7,
+            AiPathRecord {
+                goal: vec3(5.0, 0.0, 1.0),
+                waypoints: vec![vec3(1.0, 0.0, 1.0)],
+                outcome: AiPathOutcome::Full,
+            },
+        );
+        service.record_ai_steering(
+            7,
+            AiSteeringDebug {
+                next_waypoint: 0,
+                path_len: 1,
+                target: None,
+                stall_seconds: 0.0,
+            },
+        );
+        service.report_blocked_cell(7, 1, 0.0);
+
+        // Entity 7 died (or despawned): every per-AI record goes with it
+        service.prune_ai_paths(|entity| entity != 7);
+        assert!(service.ai_paths().is_empty());
+        assert!(service.ai_steering(7).is_none());
+        assert!(service.blocked_cells(7, 0.0).is_empty());
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -491,6 +491,45 @@ pub fn separation_bias(
     bias
 }
 
+/// Whether any OTHER living creature stands within `radius` (XZ, same
+/// floor) of `position` - the occupancy check behind the stall-report
+/// crowd gate. A separate boolean rather than `separation_bias != 0`:
+/// symmetric neighbors cancel the summed bias vector to zero while very
+/// much still crowding the AI.
+pub fn has_living_creature_within(
+    world: &World,
+    entity_id: EntityId,
+    position: Vector3<f32>,
+    radius: f32,
+) -> bool {
+    let v_creature = world.borrow::<View<PropCreature>>().unwrap();
+    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
+    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
+    for (other_id, (_, xform)) in (&v_creature, &v_transform).iter().with_id() {
+        if other_id == entity_id {
+            continue;
+        }
+        // Corpses don't crowd (they're ragdolls on the floor)
+        if v_hit_points
+            .get(other_id)
+            .map(|hp| hp.hit_points <= 0)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let other = xform.0.transform_point(point3(0.0, 0.0, 0.0));
+        if (position.y - other.y).abs() > 2.0 {
+            continue; // different floor
+        }
+        let dx = position.x - other.x;
+        let dz = position.z - other.z;
+        if (dx * dx + dz * dz).sqrt() < radius {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn is_killed(entity_id: EntityId, world: &World) -> bool {
     let v_prop_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
 
@@ -606,6 +645,55 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
     };
 
     false
+}
+
+/// Whether `from_entity` has a clear line of FIRE to the player - the
+/// occlusion gate for standing ranged attacks. Unlike `is_player_visible`
+/// (sight: WORLD geometry only), this also tests door and prop colliders,
+/// because projectiles collide with those - an AI allowed to stop and
+/// shoot through a closed door or a crate stands rooted firing into it
+/// for as long as its target stays known (issue #481's stand-and-shoot
+/// freeze). A living creature as the first hit still counts as clear:
+/// allies wander off on their own, and refusing to stand behind one would
+/// flap the chase/attack transition every time the ally shifts (holding
+/// fire while an ally blocks the shot is #614).
+pub fn has_line_of_fire(from_entity: EntityId, world: &World, physics: &PhysicsWorld) -> bool {
+    if is_player_psi_invisible(world) {
+        return false;
+    }
+
+    let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+    let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
+
+    let Ok(ent_pos) = v_current_pos.get(from_entity) else {
+        return false;
+    };
+    let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
+    let end_point = point3(0.0, 0.0, 0.0) + u_player.pos;
+    let direction = (end_point - start_point).normalize();
+    let distance = (end_point - start_point).magnitude();
+    let result = physics.ray_cast2(
+        start_point,
+        direction,
+        distance,
+        InternalCollisionGroups::WORLD
+            | InternalCollisionGroups::ENTITY
+            | InternalCollisionGroups::SELECTABLE,
+        Some(from_entity),
+        true,
+    );
+    match result {
+        None => true,
+        Some(hit) => hit
+            .maybe_entity_id
+            .map(|id| {
+                world
+                    .borrow::<View<PropCreature>>()
+                    .map(|v| v.contains(id))
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false),
+    }
 }
 
 /// Check if the player is visible from an entity within a field of view
@@ -759,5 +847,37 @@ mod separation_tests {
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"
         );
+    }
+
+    #[test]
+    fn occupancy_sees_symmetric_neighbors_the_bias_cancels() {
+        // The stall-report crowd gate must not be fooled by neighbors on
+        // opposite sides: their separation bias sums to zero (above) while
+        // the AI is very much crowded.
+        let mut world = World::new();
+        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
+        spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
+        spawn_creature(&mut world, vec3(-1.0, 0.0, 0.0), 10);
+        assert!(has_living_creature_within(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            2.4
+        ));
+    }
+
+    #[test]
+    fn occupancy_ignores_corpses_far_neighbors_and_other_floors() {
+        let mut world = World::new();
+        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
+        spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 0); // corpse
+        spawn_creature(&mut world, vec3(10.0, 0.0, 0.0), 10); // out of radius
+        spawn_creature(&mut world, vec3(1.0, 5.0, 0.0), 10); // floor above
+        assert!(!has_living_creature_within(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            2.4
+        ));
     }
 }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -495,12 +495,17 @@ pub fn separation_bias(
 /// floor) of `position` - the occupancy check behind the stall-report
 /// crowd gate. A separate boolean rather than `separation_bias != 0`:
 /// symmetric neighbors cancel the summed bias vector to zero while very
-/// much still crowding the AI.
+/// much still crowding the AI. When `toward` is given (an XZ direction),
+/// only neighbors on that side count - a creature BEHIND a stalled AI
+/// cannot be what is blocking its way forward, and suppressing the
+/// blocked-crossing report for it would leave a genuine prop blockage
+/// unreported.
 pub fn has_living_creature_within(
     world: &World,
     entity_id: EntityId,
     position: Vector3<f32>,
     radius: f32,
+    toward: Option<Vector3<f32>>,
 ) -> bool {
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
@@ -521,11 +526,17 @@ pub fn has_living_creature_within(
         if (position.y - other.y).abs() > 2.0 {
             continue; // different floor
         }
-        let dx = position.x - other.x;
-        let dz = position.z - other.z;
-        if (dx * dx + dz * dz).sqrt() < radius {
-            return true;
+        let dx = other.x - position.x;
+        let dz = other.z - position.z;
+        if (dx * dx + dz * dz).sqrt() >= radius {
+            continue;
         }
+        if let Some(toward) = toward {
+            if dx * toward.x + dz * toward.z <= 0.0 {
+                continue; // behind (or exactly abeam) - not in the way
+            }
+        }
+        return true;
     }
     false
 }
@@ -862,7 +873,24 @@ mod separation_tests {
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
-            2.4
+            2.4,
+            None
+        ));
+        // Directional: only the neighbor AHEAD counts. Toward +x there is
+        // one; toward +z there is none.
+        assert!(has_living_creature_within(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            2.4,
+            Some(vec3(1.0, 0.0, 0.0))
+        ));
+        assert!(!has_living_creature_within(
+            &world,
+            me,
+            vec3(0.0, 0.0, 0.0),
+            2.4,
+            Some(vec3(0.0, 0.0, 1.0))
         ));
     }
 
@@ -877,7 +905,8 @@ mod separation_tests {
             &world,
             me,
             vec3(0.0, 0.0, 0.0),
-            2.4
+            2.4,
+            None
         ));
     }
 }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -608,8 +608,9 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
     false
 }
 
-/// Whether `from_entity` has a clear line of FIRE to the player - the
-/// occlusion gate for standing ranged attacks. Unlike `is_player_visible`
+/// Whether `from_entity` has a clear line of FIRE to `target` (its known
+/// aim point - see `chase_target`) - the occlusion gate for standing
+/// ranged attacks. Unlike `is_player_visible`
 /// (sight: WORLD geometry only), this also tests door and prop colliders,
 /// because projectiles collide with those - an AI allowed to stop and
 /// shoot through a closed door or a crate stands rooted firing into it
@@ -618,19 +619,23 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
 /// allies wander off on their own, and refusing to stand behind one would
 /// flap the chase/attack transition every time the ally shifts (holding
 /// fire while an ally blocks the shot is #614).
-pub fn has_line_of_fire(from_entity: EntityId, world: &World, physics: &PhysicsWorld) -> bool {
+pub fn has_line_of_fire(
+    from_entity: EntityId,
+    world: &World,
+    physics: &PhysicsWorld,
+    target: Vector3<f32>,
+) -> bool {
     if is_player_psi_invisible(world) {
         return false;
     }
 
-    let u_player = world.borrow::<UniqueView<PlayerInfo>>().unwrap();
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
 
     let Ok(ent_pos) = v_current_pos.get(from_entity) else {
         return false;
     };
     let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
-    let end_point = point3(0.0, 0.0, 0.0) + u_player.pos;
+    let end_point = point3(0.0, 0.0, 0.0) + target;
     let direction = (end_point - start_point).normalize();
     let distance = (end_point - start_point).magnitude();
     let result = physics.ray_cast2(

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -491,56 +491,6 @@ pub fn separation_bias(
     bias
 }
 
-/// Whether any OTHER living creature stands within `radius` (XZ, same
-/// floor) of `position` - the occupancy check behind the stall-report
-/// crowd gate. A separate boolean rather than `separation_bias != 0`:
-/// symmetric neighbors cancel the summed bias vector to zero while very
-/// much still crowding the AI. When `toward` is given (an XZ direction),
-/// only neighbors on that side count - a creature BEHIND a stalled AI
-/// cannot be what is blocking its way forward, and suppressing the
-/// blocked-crossing report for it would leave a genuine prop blockage
-/// unreported.
-pub fn has_living_creature_within(
-    world: &World,
-    entity_id: EntityId,
-    position: Vector3<f32>,
-    radius: f32,
-    toward: Option<Vector3<f32>>,
-) -> bool {
-    let v_creature = world.borrow::<View<PropCreature>>().unwrap();
-    let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
-    let v_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
-    for (other_id, (_, xform)) in (&v_creature, &v_transform).iter().with_id() {
-        if other_id == entity_id {
-            continue;
-        }
-        // Corpses don't crowd (they're ragdolls on the floor)
-        if v_hit_points
-            .get(other_id)
-            .map(|hp| hp.hit_points <= 0)
-            .unwrap_or(false)
-        {
-            continue;
-        }
-        let other = xform.0.transform_point(point3(0.0, 0.0, 0.0));
-        if (position.y - other.y).abs() > 2.0 {
-            continue; // different floor
-        }
-        let dx = other.x - position.x;
-        let dz = other.z - position.z;
-        if (dx * dx + dz * dz).sqrt() >= radius {
-            continue;
-        }
-        if let Some(toward) = toward {
-            if dx * toward.x + dz * toward.z <= 0.0 {
-                continue; // behind (or exactly abeam) - not in the way
-            }
-        }
-        return true;
-    }
-    false
-}
-
 pub fn is_killed(entity_id: EntityId, world: &World) -> bool {
     let v_prop_hit_points = world.borrow::<View<PropHitPoints>>().unwrap();
 
@@ -858,55 +808,5 @@ mod separation_tests {
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"
         );
-    }
-
-    #[test]
-    fn occupancy_sees_symmetric_neighbors_the_bias_cancels() {
-        // The stall-report crowd gate must not be fooled by neighbors on
-        // opposite sides: their separation bias sums to zero (above) while
-        // the AI is very much crowded.
-        let mut world = World::new();
-        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
-        spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 10);
-        spawn_creature(&mut world, vec3(-1.0, 0.0, 0.0), 10);
-        assert!(has_living_creature_within(
-            &world,
-            me,
-            vec3(0.0, 0.0, 0.0),
-            2.4,
-            None
-        ));
-        // Directional: only the neighbor AHEAD counts. Toward +x there is
-        // one; toward +z there is none.
-        assert!(has_living_creature_within(
-            &world,
-            me,
-            vec3(0.0, 0.0, 0.0),
-            2.4,
-            Some(vec3(1.0, 0.0, 0.0))
-        ));
-        assert!(!has_living_creature_within(
-            &world,
-            me,
-            vec3(0.0, 0.0, 0.0),
-            2.4,
-            Some(vec3(0.0, 0.0, 1.0))
-        ));
-    }
-
-    #[test]
-    fn occupancy_ignores_corpses_far_neighbors_and_other_floors() {
-        let mut world = World::new();
-        let me = spawn_creature(&mut world, vec3(0.0, 0.0, 0.0), 10);
-        spawn_creature(&mut world, vec3(1.0, 0.0, 0.0), 0); // corpse
-        spawn_creature(&mut world, vec3(10.0, 0.0, 0.0), 10); // out of radius
-        spawn_creature(&mut world, vec3(1.0, 5.0, 0.0), 10); // floor above
-        assert!(!has_living_creature_within(
-            &world,
-            me,
-            vec3(0.0, 0.0, 0.0),
-            2.4,
-            None
-        ));
     }
 }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -244,7 +244,7 @@ impl AnimatedMonsterAI {
                 // distance (ChaseBehavior::next_behavior escalates back to
                 // an attack on arrival via the same shared helper). Without
                 // the range check, a far-away High AI stood still swinging.
-                attack_behavior_for_distance(world, entity_id)
+                attack_behavior_for_distance(world, _physics, entity_id)
                     .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new())))
             }
         }

--- a/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/chase_behavior.rs
@@ -75,10 +75,10 @@ impl Behavior for ChaseBehavior {
     fn next_behavior(
         &mut self,
         world: &World,
-        _physics: &PhysicsWorld,
+        physics: &PhysicsWorld,
         entity_id: EntityId,
     ) -> NextBehavior {
-        match super::attack_behavior_for_distance(world, entity_id) {
+        match super::attack_behavior_for_distance(world, physics, entity_id) {
             Some(behavior) => NextBehavior::Next(behavior),
             None => NextBehavior::Stay,
         }

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -26,7 +26,10 @@ use std::cell::RefCell;
 use dark::SCALE_FACTOR;
 use shipyard::{EntityId, World};
 
-use crate::scripts::ai::ai_util::{chase_target_distance, has_ranged_weapon};
+use crate::{
+    physics::PhysicsWorld,
+    scripts::ai::ai_util::{chase_target_distance, has_ranged_weapon, is_player_visible},
+};
 
 /// The attack behavior for the current distance to the player, or None when
 /// out of attack range (the caller should chase to close the distance).
@@ -35,6 +38,7 @@ use crate::scripts::ai::ai_util::{chase_target_distance, has_ranged_weapon};
 /// the two mechanisms can't disagree.
 pub fn attack_behavior_for_distance(
     world: &World,
+    physics: &PhysicsWorld,
     entity_id: EntityId,
 ) -> Option<Box<RefCell<dyn Behavior>>> {
     let distance = chase_target_distance(world, entity_id)?;
@@ -44,9 +48,15 @@ pub fn attack_behavior_for_distance(
 
     // Only ranged-armed AIs stop to shoot; melee AIs must keep chasing or
     // they stall at mid-range bouncing between chase and ranged-attack.
+    // Stopping also requires an actual line of fire: a target that is
+    // KNOWN but occluded (heard through a wall, straight-line close on
+    // another floor) must be chased, or the AI stands rooted firing into
+    // geometry for as long as its alertness holds - permanently under a
+    // pinned alert (issue #481's stand-and-shoot freeze).
     if distance > ranged_min_attack_distance
         && distance < ranged_max_attack_distance
         && has_ranged_weapon(world, entity_id)
+        && is_player_visible(entity_id, world, physics)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
     } else if distance < melee_attack_distance {

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -28,7 +28,9 @@ use shipyard::{EntityId, World};
 
 use crate::{
     physics::PhysicsWorld,
-    scripts::ai::ai_util::{chase_target_distance, has_line_of_fire, has_ranged_weapon},
+    scripts::ai::ai_util::{
+        chase_target, chase_target_distance, has_line_of_fire, has_ranged_weapon,
+    },
 };
 
 /// The attack behavior for the current distance to the player, or None when
@@ -41,6 +43,12 @@ pub fn attack_behavior_for_distance(
     physics: &PhysicsWorld,
     entity_id: EntityId,
 ) -> Option<Box<RefCell<dyn Behavior>>> {
+    // Distance and line of fire both gate against the AI's KNOWN target
+    // (the last-known position when awareness is published, the player's
+    // true position otherwise) - the same point chase steering faces and
+    // the FIRE flag shoots toward, so the ray can't approve a shot the AI
+    // isn't actually taking.
+    let target = chase_target(world, entity_id)?;
     let distance = chase_target_distance(world, entity_id)?;
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
     let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
@@ -56,7 +64,7 @@ pub fn attack_behavior_for_distance(
     if distance > ranged_min_attack_distance
         && distance < ranged_max_attack_distance
         && has_ranged_weapon(world, entity_id)
-        && has_line_of_fire(entity_id, world, physics)
+        && has_line_of_fire(entity_id, world, physics, target)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
     } else if distance < melee_attack_distance {

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -28,7 +28,7 @@ use shipyard::{EntityId, World};
 
 use crate::{
     physics::PhysicsWorld,
-    scripts::ai::ai_util::{chase_target_distance, has_ranged_weapon, is_player_visible},
+    scripts::ai::ai_util::{chase_target_distance, has_line_of_fire, has_ranged_weapon},
 };
 
 /// The attack behavior for the current distance to the player, or None when
@@ -56,7 +56,7 @@ pub fn attack_behavior_for_distance(
     if distance > ranged_min_attack_distance
         && distance < ranged_max_attack_distance
         && has_ranged_weapon(world, entity_id)
-        && is_player_visible(entity_id, world, physics)
+        && has_line_of_fire(entity_id, world, physics)
     {
         Some(Box::new(RefCell::new(RangedAttackBehavior)))
     } else if distance < melee_attack_distance {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -358,7 +358,14 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // XZ plane at the WAYPOINT's height (an edge-inset waypoint
                 // then resolves to the cell beyond the crossing; keeping Y
                 // fixed avoids blacklisting a stacked floor's cell).
-                let crowded = separation.x * separation.x + separation.z * separation.z > 1e-6;
+                // Occupancy, not the summed separation vector - symmetric
+                // neighbors cancel the bias to zero while still crowding
+                let crowded = ai_util::has_living_creature_within(
+                    world,
+                    entity_id,
+                    position,
+                    SEPARATION_RADIUS,
+                );
                 let toward = waypoint - position;
                 let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
                 if !crowded && toward_len > 1e-3 {

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -429,12 +429,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         .or_else(|| service.cell_from_position(waypoint));
                     if let (Some(from), Some(to)) = (from, to) {
                         if from != to {
-                            service.report_blocked_link(
-                                entity_id.inner(),
-                                from,
-                                to,
-                                time.total.as_secs_f32(),
-                            );
+                            service.report_blocked_link(from, to, time.total.as_secs_f32());
                         }
                     }
                 }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -369,7 +369,6 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                     SEPARATION_RADIUS,
                     Some(toward),
                 );
-                let mut reported = false;
                 if !crowded && toward_len > 1e-3 {
                     let step = BLOCKED_PROBE_DISTANCE / toward_len;
                     let probe = Vector3::new(
@@ -389,26 +388,17 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                                 to,
                                 time.total.as_secs_f32(),
                             );
-                            reported = true;
                         }
                     }
                 }
-                if reported {
-                    // The excluded crossing guarantees the next route is
-                    // DIFFERENT, so re-path immediately from where we stand
-                    // - the blind back-out exists to keep an identical
-                    // re-path from re-wedging, which no longer applies. This
-                    // keeps a blocked cycle at ~stall length instead of
-                    // stall + retreat (long enough to read as a freeze).
-                    self.clear_path();
-                    self.repath_cooldown = 0.0;
-                    return Some((Steering::from_current(_current_heading), Effect::NoEffect));
-                }
-                // Unreported stall (crowd jam ahead, or the blockage is
-                // inside our own cell): back out toward the previous
-                // waypoint (or straight back when the route began here),
-                // then re-path from clear ground - jittered so mutually
-                // blocking AIs unstick on different frames
+                // ALWAYS back out toward the previous waypoint before
+                // re-pathing, reported or not: the retreat both disengages
+                // the body from whatever it wedged on (an AI boxed among
+                // furniture that only re-paths in place never physically
+                // frees itself - measured as a hard zero-movement freeze
+                // when an immediate-re-path variant was tried) and staggers
+                // mutually blocking AIs (jittered). The excluded crossing
+                // then makes the fresh route different as well.
                 let retreat = self
                     .path
                     .get(self.next_waypoint.saturating_sub(1))

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -72,6 +72,14 @@ const DISPLACEMENT_STALL_DISTANCE: f32 = 1.0 / SCALE_FACTOR;
 /// AI pinned behind a scripted NPC beside a desk). Slightly longer than
 /// STALL_SECONDS so the progress check stays the common path.
 const DISPLACEMENT_STALL_SECONDS: f32 = 4.0;
+/// Physical unstick, last resort: after TWO consecutive stalls with no
+/// displacement between them - the body is PINNED (e.g. overlapping a
+/// scripted NPC's capsule beside furniture; steering, retreats and
+/// re-paths all command motion the solver cancels) - nudge the body this
+/// far (2 Dark feet, about one body radius) toward the retreat point to
+/// break the equilibrium. A rare small pop beats a monster frozen forever
+/// (issue #481's terminal pocket).
+const UNSTICK_NUDGE_DISTANCE: f32 = 2.0 / SCALE_FACTOR;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -107,6 +115,10 @@ pub struct PathFollowSteeringStrategy {
     /// Displacement watchdog: where the AI was when the anchor was set, and
     /// how long ago (see DISPLACEMENT_STALL_SECONDS)
     displacement_anchor: Option<(Vector3<f32>, f32)>,
+    /// Where the previous stall fired - a new stall from (nearly) the same
+    /// spot means retreat + re-path freed nothing and the body is pinned
+    /// (see UNSTICK_NUDGE_DISTANCE)
+    last_stall_position: Option<Vector3<f32>>,
 }
 
 impl PathFollowSteeringStrategy {
@@ -134,6 +146,7 @@ impl PathFollowSteeringStrategy {
             stall_seconds: 0.0,
             recovery: None,
             displacement_anchor: None,
+            last_stall_position: None,
         }
     }
 
@@ -366,6 +379,9 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         let displaced_stall = match self.displacement_anchor {
             Some((anchor, _)) if xz_distance(position, anchor) >= DISPLACEMENT_STALL_DISTANCE => {
                 self.displacement_anchor = Some((position, 0.0));
+                // Real movement: the next stall (if any) is a fresh incident,
+                // not a continuation of a pinned body
+                self.last_stall_position = None;
                 false
             }
             Some((anchor, age)) => {
@@ -439,13 +455,44 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         let (_, forward) = ai_util::get_position_and_forward(world, entity_id);
                         position - forward * 2.0
                     });
+                // Pinned-body unstick (last resort): the previous stall
+                // fired from (nearly) this same spot, so its retreat and
+                // re-path freed nothing - physically nudge toward the
+                // retreat point (known-walkable route ground) to break the
+                // solver equilibrium
+                let pinned = self
+                    .last_stall_position
+                    .map(|prev| xz_distance(position, prev) < DISPLACEMENT_STALL_DISTANCE)
+                    .unwrap_or(false);
+                self.last_stall_position = Some(position);
+                let unstick_effect = if pinned {
+                    let dir = retreat - position;
+                    let len = (dir.x * dir.x + dir.z * dir.z).sqrt();
+                    if len > 1e-3 {
+                        let step = UNSTICK_NUDGE_DISTANCE.min(len);
+                        let nudged = Vector3::new(
+                            position.x + dir.x / len * step,
+                            position.y,
+                            position.z + dir.z / len * step,
+                        );
+                        Effect::SetPositionRotation {
+                            entity_id,
+                            position: nudged,
+                            rotation: crate::util::get_rotation_from_transform(world, entity_id),
+                        }
+                    } else {
+                        Effect::NoEffect
+                    }
+                } else {
+                    Effect::NoEffect
+                };
                 let jitter = rand::thread_rng().gen_range(0.8..1.6);
                 self.recovery = Some((STALL_RECOVERY_SECONDS * jitter, retreat));
                 self.clear_path();
                 self.repath_cooldown = STALL_RECOVERY_SECONDS * jitter;
                 return Some((
                     Steering::turn_to_point(vec3_to_point3(position), vec3_to_point3(retreat)),
-                    Effect::NoEffect,
+                    unstick_effect,
                 ));
             }
         }

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -279,6 +279,7 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                         start: position,
                         goal,
                         movement_bits: MovementBits::WALK,
+                        now_seconds: time.total.as_secs_f32(),
                     });
                 }
                 // Budget exhausted: defer to a later frame, cooldown untouched
@@ -338,6 +339,29 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         } else {
             self.stall_seconds += time.elapsed.as_secs_f32();
             if self.stall_seconds >= STALL_SECONDS {
+                // Remember the cell we could not approach (TTL'd, per AI):
+                // the mesh says the link is walkable but something physical
+                // - a prop on the route, geometry the mesh doesn't model -
+                // stopped us. Excluding it from this AI's next queries makes
+                // the post-stall re-path route AROUND the obstacle; without
+                // this the fresh route is identical and the stall/retreat/
+                // re-path cycle grinds against the obstacle forever
+                // (issue #481). Probe just past the waypoint along the
+                // approach so an edge-inset waypoint resolves to the cell
+                // BEYOND the crossing, not the one we're standing in.
+                let toward = waypoint - position;
+                let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
+                let probe = if toward_len > 1e-3 {
+                    waypoint + toward * (WAYPOINT_ADVANCE_DISTANCE / toward_len)
+                } else {
+                    waypoint
+                };
+                if let Some(cell) = service
+                    .cell_from_position(probe)
+                    .or_else(|| service.cell_from_position(waypoint))
+                {
+                    service.report_blocked_cell(entity_id.inner(), cell, time.total.as_secs_f32());
+                }
                 // Back out toward the previous waypoint (or straight back
                 // when the route began here), then re-path from clear ground
                 let retreat = self

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -61,6 +61,17 @@ const STALL_SECONDS: f32 = 3.0;
 const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
+/// Displacement watchdog: with an active waypoint, failing to move this far
+/// (XZ, 1 Dark foot) ...
+const DISPLACEMENT_STALL_DISTANCE: f32 = 1.0 / SCALE_FACTOR;
+/// ...within this long also counts as a stall. Micro-sliding around a
+/// blocking capsule (another creature, a prop corner) can keep improving
+/// the waypoint distance by more than the epsilon, resetting the progress
+/// check forever while the body stays effectively in place - net
+/// displacement is the ground truth (issue #481's last freeze pocket, an
+/// AI pinned behind a scripted NPC beside a desk). Slightly longer than
+/// STALL_SECONDS so the progress check stays the common path.
+const DISPLACEMENT_STALL_SECONDS: f32 = 4.0;
 /// How far past the stalled waypoint (XZ) to probe for the cell on the far
 /// side of the crossing when reporting a blocked link - just enough to step
 /// off the shared edge without skipping a narrow destination cell (0.5
@@ -93,6 +104,9 @@ pub struct PathFollowSteeringStrategy {
     stall_seconds: f32,
     /// Active stall recovery: seconds left, and the point to back out toward
     recovery: Option<(f32, Vector3<f32>)>,
+    /// Displacement watchdog: where the AI was when the anchor was set, and
+    /// how long ago (see DISPLACEMENT_STALL_SECONDS)
+    displacement_anchor: Option<(Vector3<f32>, f32)>,
 }
 
 impl PathFollowSteeringStrategy {
@@ -119,6 +133,7 @@ impl PathFollowSteeringStrategy {
             stall_best: f32::INFINITY,
             stall_seconds: 0.0,
             recovery: None,
+            displacement_anchor: None,
         }
     }
 
@@ -133,6 +148,7 @@ impl PathFollowSteeringStrategy {
         self.stall_waypoint = usize::MAX;
         self.stall_best = f32::INFINITY;
         self.stall_seconds = 0.0;
+        self.displacement_anchor = None;
     }
 }
 
@@ -343,7 +359,27 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
             self.stall_seconds = 0.0;
         } else {
             self.stall_seconds += time.elapsed.as_secs_f32();
-            if self.stall_seconds >= STALL_SECONDS {
+        }
+        // Displacement watchdog: micro-sliding around a blocking capsule can
+        // reset the waypoint-progress check above forever while the body
+        // stays put - fall back to net displacement
+        let displaced_stall = match self.displacement_anchor {
+            Some((anchor, _)) if xz_distance(position, anchor) >= DISPLACEMENT_STALL_DISTANCE => {
+                self.displacement_anchor = Some((position, 0.0));
+                false
+            }
+            Some((anchor, age)) => {
+                let age = age + time.elapsed.as_secs_f32();
+                self.displacement_anchor = Some((anchor, age));
+                age >= DISPLACEMENT_STALL_SECONDS
+            }
+            None => {
+                self.displacement_anchor = Some((position, 0.0));
+                false
+            }
+        };
+        {
+            if self.stall_seconds >= STALL_SECONDS || displaced_stall {
                 // Remember the crossing we could not traverse (TTL'd, per
                 // AI): the mesh says the link is walkable but something
                 // physical - a prop on the route, geometry the mesh doesn't

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -351,25 +351,20 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // AI's next queries makes the post-stall re-path route
                 // AROUND the obstacle; without this the fresh route is
                 // identical and the stall/retreat/re-path cycle grinds
-                // against the obstacle forever (issue #481). Skipped when a
-                // living creature is in the way AHEAD (directional occupancy
-                // - a neighbor behind us can't be the blocker): those jams
-                // clear on their own (retreat + separation), and a 30s
-                // exclusion would over-react. The probe steps just past the
-                // waypoint in the XZ plane at the WAYPOINT's height (an
-                // edge-inset waypoint then resolves to the cell beyond the
-                // crossing; keeping Y fixed avoids blacklisting a stacked
-                // floor's cell).
+                // against the obstacle forever (issue #481). Reported even
+                // when another creature is nearby: a "living blocker" can be
+                // a scripted, stationary NPC (medsci1's FemaleMedsci crawl
+                // scene) that never wanders off - suppressing the report for
+                // it turned the retreat loop back into a permanent freeze
+                // (measured). Mutual AI jams simply mark the contested
+                // crossing on both sides and route apart; the TTL reopens it.
+                // The probe steps just past the waypoint in the XZ plane at
+                // the WAYPOINT's height (an edge-inset waypoint then
+                // resolves to the cell beyond the crossing; keeping Y fixed
+                // avoids blacklisting a stacked floor's cell).
                 let toward = waypoint - position;
                 let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
-                let crowded = ai_util::has_living_creature_within(
-                    world,
-                    entity_id,
-                    position,
-                    SEPARATION_RADIUS,
-                    Some(toward),
-                );
-                if !crowded && toward_len > 1e-3 {
+                if toward_len > 1e-3 {
                     let step = BLOCKED_PROBE_DISTANCE / toward_len;
                     let probe = Vector3::new(
                         waypoint.x + toward.x * step,

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -352,22 +352,24 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                 // AROUND the obstacle; without this the fresh route is
                 // identical and the stall/retreat/re-path cycle grinds
                 // against the obstacle forever (issue #481). Skipped when a
-                // living creature is crowding us: those jams clear on their
-                // own (retreat + separation), and a 30s exclusion would
-                // over-react. The probe steps just past the waypoint in the
-                // XZ plane at the WAYPOINT's height (an edge-inset waypoint
-                // then resolves to the cell beyond the crossing; keeping Y
-                // fixed avoids blacklisting a stacked floor's cell).
-                // Occupancy, not the summed separation vector - symmetric
-                // neighbors cancel the bias to zero while still crowding
+                // living creature is in the way AHEAD (directional occupancy
+                // - a neighbor behind us can't be the blocker): those jams
+                // clear on their own (retreat + separation), and a 30s
+                // exclusion would over-react. The probe steps just past the
+                // waypoint in the XZ plane at the WAYPOINT's height (an
+                // edge-inset waypoint then resolves to the cell beyond the
+                // crossing; keeping Y fixed avoids blacklisting a stacked
+                // floor's cell).
+                let toward = waypoint - position;
+                let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
                 let crowded = ai_util::has_living_creature_within(
                     world,
                     entity_id,
                     position,
                     SEPARATION_RADIUS,
+                    Some(toward),
                 );
-                let toward = waypoint - position;
-                let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
+                let mut reported = false;
                 if !crowded && toward_len > 1e-3 {
                     let step = BLOCKED_PROBE_DISTANCE / toward_len;
                     let probe = Vector3::new(
@@ -387,11 +389,26 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
                                 to,
                                 time.total.as_secs_f32(),
                             );
+                            reported = true;
                         }
                     }
                 }
-                // Back out toward the previous waypoint (or straight back
-                // when the route began here), then re-path from clear ground
+                if reported {
+                    // The excluded crossing guarantees the next route is
+                    // DIFFERENT, so re-path immediately from where we stand
+                    // - the blind back-out exists to keep an identical
+                    // re-path from re-wedging, which no longer applies. This
+                    // keeps a blocked cycle at ~stall length instead of
+                    // stall + retreat (long enough to read as a freeze).
+                    self.clear_path();
+                    self.repath_cooldown = 0.0;
+                    return Some((Steering::from_current(_current_heading), Effect::NoEffect));
+                }
+                // Unreported stall (crowd jam ahead, or the blockage is
+                // inside our own cell): back out toward the previous
+                // waypoint (or straight back when the route began here),
+                // then re-path from clear ground - jittered so mutually
+                // blocking AIs unstick on different frames
                 let retreat = self
                     .path
                     .get(self.next_waypoint.saturating_sub(1))

--- a/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
+++ b/shock2vr/src/scripts/ai/steering/path_follow_steering_strategy.rs
@@ -61,6 +61,11 @@ const STALL_SECONDS: f32 = 3.0;
 const STALL_RECOVERY_SECONDS: f32 = 0.8;
 /// Progress smaller than this doesn't count toward un-stalling (jitter)
 const STALL_PROGRESS_EPSILON: f32 = 0.25 / SCALE_FACTOR;
+/// How far past the stalled waypoint (XZ) to probe for the cell on the far
+/// side of the crossing when reporting a blocked link - just enough to step
+/// off the shared edge without skipping a narrow destination cell (0.5
+/// Dark feet)
+const BLOCKED_PROBE_DISTANCE: f32 = 0.5 / SCALE_FACTOR;
 /// Crowd separation: repel from living creatures within this radius (6 Dark
 /// feet - about two body widths)
 const SEPARATION_RADIUS: f32 = 6.0 / SCALE_FACTOR;
@@ -339,28 +344,44 @@ impl SteeringStrategy for PathFollowSteeringStrategy {
         } else {
             self.stall_seconds += time.elapsed.as_secs_f32();
             if self.stall_seconds >= STALL_SECONDS {
-                // Remember the cell we could not approach (TTL'd, per AI):
-                // the mesh says the link is walkable but something physical
-                // - a prop on the route, geometry the mesh doesn't model -
-                // stopped us. Excluding it from this AI's next queries makes
-                // the post-stall re-path route AROUND the obstacle; without
-                // this the fresh route is identical and the stall/retreat/
-                // re-path cycle grinds against the obstacle forever
-                // (issue #481). Probe just past the waypoint along the
-                // approach so an edge-inset waypoint resolves to the cell
-                // BEYOND the crossing, not the one we're standing in.
+                // Remember the crossing we could not traverse (TTL'd, per
+                // AI): the mesh says the link is walkable but something
+                // physical - a prop on the route, geometry the mesh doesn't
+                // model - stopped us. Excluding that directed link from this
+                // AI's next queries makes the post-stall re-path route
+                // AROUND the obstacle; without this the fresh route is
+                // identical and the stall/retreat/re-path cycle grinds
+                // against the obstacle forever (issue #481). Skipped when a
+                // living creature is crowding us: those jams clear on their
+                // own (retreat + separation), and a 30s exclusion would
+                // over-react. The probe steps just past the waypoint in the
+                // XZ plane at the WAYPOINT's height (an edge-inset waypoint
+                // then resolves to the cell beyond the crossing; keeping Y
+                // fixed avoids blacklisting a stacked floor's cell).
+                let crowded = separation.x * separation.x + separation.z * separation.z > 1e-6;
                 let toward = waypoint - position;
                 let toward_len = (toward.x * toward.x + toward.z * toward.z).sqrt();
-                let probe = if toward_len > 1e-3 {
-                    waypoint + toward * (WAYPOINT_ADVANCE_DISTANCE / toward_len)
-                } else {
-                    waypoint
-                };
-                if let Some(cell) = service
-                    .cell_from_position(probe)
-                    .or_else(|| service.cell_from_position(waypoint))
-                {
-                    service.report_blocked_cell(entity_id.inner(), cell, time.total.as_secs_f32());
+                if !crowded && toward_len > 1e-3 {
+                    let step = BLOCKED_PROBE_DISTANCE / toward_len;
+                    let probe = Vector3::new(
+                        waypoint.x + toward.x * step,
+                        waypoint.y,
+                        waypoint.z + toward.z * step,
+                    );
+                    let from = service.cell_from_position(position);
+                    let to = service
+                        .cell_from_position(probe)
+                        .or_else(|| service.cell_from_position(waypoint));
+                    if let (Some(from), Some(to)) = (from, to) {
+                        if from != to {
+                            service.report_blocked_link(
+                                entity_id.inner(),
+                                from,
+                                to,
+                                time.total.as_secs_f32(),
+                            );
+                        }
+                    }
                 }
                 // Back out toward the previous waypoint (or straight back
                 // when the route began here), then re-path from clear ground

--- a/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
+++ b/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
@@ -61,49 +61,73 @@ test(
     //   crowd-separation equilibrium (separation holds neighbors apart at
     //   roughly its 2.4-unit radius); such pairs are crowd dynamics, not a
     //   navigation freeze (see #487 / the furniture-route issue).
-    const before = new Map<number, [number, number, number]>();
-    for (const h of hybrids) {
-      const d = await game.entities.detail(h.id);
-      before.set(h.id, d.position);
-    }
-    await game.step({ frames: 300 }); // 5s observation window
-
-    const routes = new Map(
-      (await game.pathfinding.aiPaths()).map((e) => [e.entity_id, e] as const),
-    );
-    const positions = new Map<number, [number, number, number]>();
-    for (const h of hybrids) {
-      positions.set(h.id, (await game.entities.detail(h.id)).position);
-    }
-    const frozen: string[] = [];
-    for (const h of hybrids) {
-      const p = positions.get(h.id)!;
-      const moved = dist3(p, before.get(h.id)!);
-      const route = routes.get(h.id);
-      if (!route || route.outcome === "Failed" || route.waypoints.length === 0) continue;
-      if (dist3(p, playerPos) < 6.0) continue; // arrived / engaging
-      // medsci1's sealed surgery ward (far north): its guards spawn penned
-      // among surgical beds/scanner panels under shield membranes the engine
-      // can't open - a content quirk no navigation fix addresses (see the
-      // #489 PR for screenshots). The ward is unreachable from the play
-      // space, so excluding it costs no pursuit coverage.
-      if (p[2] > 55.0) continue;
-      const jammed = hybrids.some(
-        (o) => o.id !== h.id && dist3(positions.get(o.id)!, p) < 2.5,
-      );
-      if (jammed) continue; // mutual crowd jam - tracked separately
-      const routeEnd = route.waypoints[route.waypoints.length - 1];
-      const remaining = distXZ(p, routeEnd);
-      if (remaining > 3.0 && moved < 0.3) {
-        frozen.push(
-          `${h.id} at [${p.map((v) => v.toFixed(1)).join(", ")}]: ${remaining.toFixed(1)} XZ from its route end, moved ${moved.toFixed(2)} in 5s (${route.outcome} route, ${route.waypoints.length} wps)`,
-        );
+    //
+    // The signature must PERSIST across two consecutive 5s windows. #481
+    // defines the freeze as zero movement over 30+ seconds, indefinitely -
+    // and every diagnosed real freeze measures 0.00-0.15 per window forever
+    // (corpse ghost-routes, the med-bed grind loop, stand-and-shoot). But a
+    // single window can also catch a LEGITIMATE stall-recovery cycle
+    // mid-flight (3s stall + jittered back-out + re-path around the
+    // reported blockage - measured 0.26-0.29 in 5s at medsci1's desk/chair
+    // chokepoint) which resolves in the next few seconds. One window flags
+    // suspects; only those still failing the full filter over the SECOND
+    // window (fresh routes, fresh positions) count as frozen.
+    const sampleWindow = async (
+      suspects: { id: number; name: string }[],
+    ): Promise<string[]> => {
+      const before = new Map<number, [number, number, number]>();
+      for (const h of suspects) {
+        before.set(h.id, (await game.entities.detail(h.id)).position);
       }
+      await game.step({ frames: 300 }); // 5s observation window
+
+      const routes = new Map(
+        (await game.pathfinding.aiPaths()).map((e) => [e.entity_id, e] as const),
+      );
+      const positions = new Map<number, [number, number, number]>();
+      for (const h of hybrids) {
+        positions.set(h.id, (await game.entities.detail(h.id)).position);
+      }
+      const frozen: string[] = [];
+      for (const h of suspects) {
+        const p = positions.get(h.id)!;
+        const moved = dist3(p, before.get(h.id)!);
+        const route = routes.get(h.id);
+        if (!route || route.outcome === "Failed" || route.waypoints.length === 0) continue;
+        if (dist3(p, playerPos) < 6.0) continue; // arrived / engaging
+        // medsci1's sealed surgery ward (far north): its guards spawn penned
+        // among surgical beds/scanner panels under shield membranes the engine
+        // can't open - a content quirk no navigation fix addresses (see the
+        // #489 PR for screenshots). The ward is unreachable from the play
+        // space, so excluding it costs no pursuit coverage.
+        if (p[2] > 55.0) continue;
+        const jammed = hybrids.some(
+          (o) => o.id !== h.id && dist3(positions.get(o.id)!, p) < 2.5,
+        );
+        if (jammed) continue; // mutual crowd jam - tracked separately
+        const routeEnd = route.waypoints[route.waypoints.length - 1];
+        const remaining = distXZ(p, routeEnd);
+        if (remaining > 3.0 && moved < 0.3) {
+          frozen.push(
+            `${h.id} at [${p.map((v) => v.toFixed(1)).join(", ")}]: ${remaining.toFixed(1)} XZ from its route end, moved ${moved.toFixed(2)} in 5s (${route.outcome} route, ${route.waypoints.length} wps)`,
+          );
+        }
+      }
+      return frozen;
+    };
+
+    const suspects = await sampleWindow(hybrids);
+    let frozen: string[] = [];
+    if (suspects.length > 0) {
+      const suspectIds = new Set(
+        suspects.map((s) => Number(s.split(" ")[0])),
+      );
+      frozen = await sampleWindow(hybrids.filter((h) => suspectIds.has(h.id)));
     }
     assert.deepEqual(
       frozen,
       [],
-      `AIs frozen mid-route after alertness churn:\n  ${frozen.join("\n  ")}`,
+      `AIs frozen mid-route after alertness churn (persisted across two 5s windows):\n  ${frozen.join("\n  ")}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
+++ b/tools/shock2-sdk/test/alertness-churn.e2e.test.ts
@@ -74,7 +74,7 @@ test(
     // window (fresh routes, fresh positions) count as frozen.
     const sampleWindow = async (
       suspects: { id: number; name: string }[],
-    ): Promise<string[]> => {
+    ): Promise<{ id: number; diagnostic: string }[]> => {
       const before = new Map<number, [number, number, number]>();
       for (const h of suspects) {
         before.set(h.id, (await game.entities.detail(h.id)).position);
@@ -88,7 +88,7 @@ test(
       for (const h of hybrids) {
         positions.set(h.id, (await game.entities.detail(h.id)).position);
       }
-      const frozen: string[] = [];
+      const frozen: { id: number; diagnostic: string }[] = [];
       for (const h of suspects) {
         const p = positions.get(h.id)!;
         const moved = dist3(p, before.get(h.id)!);
@@ -108,26 +108,26 @@ test(
         const routeEnd = route.waypoints[route.waypoints.length - 1];
         const remaining = distXZ(p, routeEnd);
         if (remaining > 3.0 && moved < 0.3) {
-          frozen.push(
-            `${h.id} at [${p.map((v) => v.toFixed(1)).join(", ")}]: ${remaining.toFixed(1)} XZ from its route end, moved ${moved.toFixed(2)} in 5s (${route.outcome} route, ${route.waypoints.length} wps)`,
-          );
+          frozen.push({
+            id: h.id,
+            diagnostic: `${h.id} at [${p.map((v) => v.toFixed(1)).join(", ")}]: ${remaining.toFixed(1)} XZ from its route end, moved ${moved.toFixed(2)} in 5s (${route.outcome} route, ${route.waypoints.length} wps)`,
+          });
         }
       }
       return frozen;
     };
 
     const suspects = await sampleWindow(hybrids);
-    let frozen: string[] = [];
+    let frozen: { id: number; diagnostic: string }[] = [];
     if (suspects.length > 0) {
-      const suspectIds = new Set(
-        suspects.map((s) => Number(s.split(" ")[0])),
-      );
+      const suspectIds = new Set(suspects.map((s) => s.id));
       frozen = await sampleWindow(hybrids.filter((h) => suspectIds.has(h.id)));
     }
+    const diagnostics = frozen.map((f) => f.diagnostic);
     assert.deepEqual(
-      frozen,
+      diagnostics,
       [],
-      `AIs frozen mid-route after alertness churn (persisted across two 5s windows):\n  ${frozen.join("\n  ")}`,
+      `AIs frozen mid-route after alertness churn (persisted across two 5s windows):\n  ${diagnostics.join("\n  ")}`,
     );
   },
 );


### PR DESCRIPTION
## Problem

After an alert → decay → forced re-alert cycle (the #481 repro), monsters read as **frozen mid-route**: a valid multi-waypoint route in `GET /v1/ai/paths`, alertness High, and zero movement, indefinitely. The e2e regression test `alertness-churn.e2e.test.ts` failed **5 of 6 baseline runs** on classic game data.

## Diagnosis (live forensics on the debug runtime)

Repeated instrumented churn runs on `medsci1`, holding the runtime open on each caught specimen and interrogating `/v1/entities/:id`, `/v1/entities/:id/animation`, `/v1/physics/bodies` and `/v1/ai/paths` frame-by-frame. **Five** distinct mechanisms — none of them the animation race the issue speculated about (every frozen AI had run clips playing and root velocity commanded):

1. **Corpses advertised routes** (the dominant baseline class — 5 of 6 baseline failure specimens). During the pinned chase, shotgun hybrids fire through their own side (#614); hybrids killed by that cross-fire keep their entity, so the liveness-only prune never dropped their `AiPathRecord` — `/v1/ai/paths` reported the pre-death route forever. Caught specimen: `AIBehavior: Dead`, `HitPoints: -1`, body asleep, 16-waypoint route still advertised.

2. **The post-stall re-path reproduced the blocked route.** A shipped WALK link on the lower deck (cells 489→492, both flag-free) runs through a **med-bed prop** the nav mesh doesn't model. Path steering leads the chain (per #488), so the AI ran into the bed; the stall escape backed out and re-pathed — to the **identical** route — and ground against the bed indefinitely.

3. **Stand-and-shoot.** `attack_behavior_for_distance` gated RangedAttack on **distance only**. A shotgun hybrid whose known-but-occluded target fell in the 6–16-unit window (straight-line through a floor) stood rooted cycling 1.5 s shot clips into geometry with one 0.18 s run stride between — net drift ~0.15 per 6 s, forever under a pinned alert.

4. **Micro-sliding defeated the stall detector.** An AI wedged against the scripted `FemaleMedsci` NPC (a live 10-HP creature pinned to her crawl-scene mark beside the desk chokepoint) slid around her capsule with waypoint-distance improvements just over the progress epsilon, resetting the 3 s stall timer forever — no report, no retreat, 0.01–0.09 movement across consecutive windows. (An intermediate revision that suppressed reports when a living creature stood ahead made this strictly worse — measured and reverted; living blockers are not always transient.)

5. **The capture pocket re-trapped every fresh arrival.** With per-entity blockage memory, each NEW hybrid funneling into the pocket had to re-learn it from scratch (every failing specimen was a *different* entity at the same coordinates with the same 8-waypoint route) — and a fully pinned body (bit-identical position for 6+ s with 5 u/s commanded; the solver cancels everything) cannot learn its way out at all.

## Fix

- **Prune dead AIs' records** (`mission_core.rs`): the per-frame prune also drops path records for entities whose hit points reached zero (a corpse keeps its entity), and `prune_ai_paths` clears the steering map with the path record.
- **Steering-reported blocked crossings, shared** (`pathfinding/mod.rs`, `async_queries.rs`, `path_follow_steering_strategy.rs`): when a stall fires, the strategy reports the **directed cell crossing** it could not traverse (current cell → the cell just past the stalled waypoint, probed in the XZ plane at the waypoint's height). The exclusion is **global** (a blockage is a physical fact about the world, and per-AI memory measurably could not break the capture conveyor), TTL 30 s, capped: every AI's queries route **around** the obstacle, or end before it and the AI parks instead of grinding. Directed-link granularity keeps one blocked doorway from sealing a large cell's other entrances. The jittered back-out is kept unconditionally (an immediate-re-path variant left boxed AIs re-pathing in place without freeing the capsule — measured, reverted).
- **Displacement watchdog** (`path_follow_steering_strategy.rs`): with an active waypoint, failing to move 1 Dark foot in 4 s counts as a stall regardless of waypoint-distance jitter — net displacement is the ground truth micro-sliding can't fake.
- **Pinned-body unstick, last resort**: a stall firing from (nearly) the same spot as the previous one means that stall's retreat and re-path freed nothing — the body is physically pinned. It is nudged one body radius (2 Dark feet) toward the retreat point (known-walkable route ground) to break the solver equilibrium. Any real displacement between stalls resets the trigger, so ordinary recovery never teleports.
- **Line-of-fire gate** (`behavior/mod.rs`, `ai_util.rs`): RangedAttack also requires a clear projectile line (`has_line_of_fire`: WORLD | ENTITY | SELECTABLE raycast — doors and props block, matching projectile collision) to the AI's **known target** — the same point steering faces and the FIRE flag shoots toward. No line → keep chasing. A living creature as first hit counts as clear (allies wander off or fall to the shot; ally fire discipline is #614).

### Test change (with evidence)

#481 defines the freeze as **zero movement over 30+ seconds, indefinitely** — and every diagnosed permanent freeze measures 0.00–0.15 per 5 s window forever. The test's single 5 s window also tripped on a **legitimate stall-recovery cycle** sampled mid-flight (3 s stall + back-out + re-path around the reported blockage, measured 0.26–0.29 — the AI escapes in the following seconds). The freeze signature now must persist across **two consecutive 5 s windows** (fresh routes and positions in each): every permanent mode still fails both — validated live, including mechanism 4's specimen at 0.01 in the second window — while a bounded (~5 s) recovery cycle cannot.

## Verification

Repeated runs of `alertness-churn.e2e.test.ts` (classic data via `DARK_ASSET_PATH`):

| build | runs | failures |
|---|---|---|
| `origin/main` | 6 | **5** |
| final branch | 10 | **0** |

Intermediate revisions were each measured the same way (6–10 runs per iteration, ~60 measured runs total); the two that regressed — immediate-re-path-without-retreat and the living-creature report-suppression gate — were caught by these loops with live forensics and reverted (the commit history documents both). An independent instrumented repro loop (fresh launch + churn + the test's exact filter + per-frame forensics on any hit) confirmed each diagnosed mechanism on a live specimen before its fix.

- New unit tests: a reported crossing severs the route in that direction only (full + partial fallback; reverse direction unaffected; exclusion shared across entities); TTL expiry restores the route; prune drops steering with the path record while blockages persist to their TTL; the async worker applies blocked links for every requester (Partial route ending before the blockage).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean; `cargo fmt --all`; 302 shock2vr + 70 dark unit tests green.
- `cargo bn path bench medsci1.mis --queries 300 --seed 42`: 297/300 found, path p95 816 µs (the only non-AI-path overhead is an empty-set `HashSet::contains` per link expansion).
- Full SDK e2e suite on the final build: **141/142** — the one failure (`earth-psionic-training`, a booster-carry assertion) **reproduces identically on `origin/main`** with the same data: pre-existing, unrelated to AI.
- Cross-engine review (`/xreview`, Claude + Codex, three passes): no Critical findings; every High/Medium was either fixed (probe-Y distortion [AGREED], cell→directed-link granularity, line-of-fire target consistency, projectile-aware occlusion, structured test suspects) or measured-and-reverted (crowd gate, immediate re-path). Accepted, documented: a query in flight when an AI dies can re-insert its record for at most one frame before the next prune; a genuinely jammed doorway stays globally excluded for up to the 30 s TTL (escalating TTLs noted as future work).

Out of scope, observed while diagnosing: ranged AIs fire without checking whether an ally blocks the line — that is what kills the chokepoint hybrids in the first place. Filed as #614.

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
