### PR TITLE
fix(debug): stop game loop on SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "glfw",
  "humantime",
  "image 0.24.7",
+ "libc",
  "serde",
  "serde_json",
  "shipyard",

--- a/runtimes/debug_runtime/Cargo.toml
+++ b/runtimes/debug_runtime/Cargo.toml
@@ -29,6 +29,9 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 image = "0.24"
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
 # FFmpeg is disabled on Windows due to build complexity
 [target.'cfg(not(windows))'.dependencies]
 shock2vr = { path = "../../shock2vr" }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -260,6 +260,8 @@ async fn start_http_server(
     listener: tokio::net::TcpListener,
     command_tx: mpsc::UnboundedSender<RuntimeCommand>,
 ) -> anyhow::Result<()> {
+    let signal_command_tx = command_tx.clone();
+
     // Create the router with health endpoint
     let app = Router::new()
         .route("/v1/health", get(health_check))
@@ -372,7 +374,7 @@ async fn start_http_server(
 
     // Start the server with graceful shutdown
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(signal_command_tx))
         .await?;
 
     Ok(())
@@ -3381,7 +3383,7 @@ async fn get_recent_audio() -> Json<Value> {
 }
 
 /// Wait for shutdown signal (Ctrl+C)
-async fn shutdown_signal() {
+async fn shutdown_signal(command_tx: mpsc::UnboundedSender<RuntimeCommand>) {
     let ctrl_c = async {
         signal::ctrl_c()
             .await
@@ -3406,5 +3408,30 @@ async fn shutdown_signal() {
         _ = terminate => {
             info!("Received SIGTERM, shutting down gracefully...");
         },
+    }
+
+    request_game_loop_shutdown(&command_tx);
+}
+
+fn request_game_loop_shutdown(command_tx: &mpsc::UnboundedSender<RuntimeCommand>) {
+    if command_tx.send(RuntimeCommand::Shutdown).is_err() {
+        info!("Game loop already stopped while handling shutdown signal");
+    }
+}
+
+#[cfg(test)]
+mod shutdown_tests {
+    use super::*;
+
+    #[test]
+    fn process_signal_requests_game_loop_shutdown() {
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+
+        request_game_loop_shutdown(&command_tx);
+
+        assert!(matches!(
+            command_rx.try_recv(),
+            Ok(RuntimeCommand::Shutdown)
+        ));
     }
 }

--- a/runtimes/debug_runtime/tests/sigterm.rs
+++ b/runtimes/debug_runtime/tests/sigterm.rs
@@ -1,0 +1,105 @@
+#![cfg(unix)]
+
+use std::{
+    io::{Read, Write},
+    net::{SocketAddr, TcpListener, TcpStream},
+    path::Path,
+    process::{Child, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn unused_local_port() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral test port");
+    listener.local_addr().expect("read ephemeral port").port()
+}
+
+fn info_is_ready(port: u16) -> bool {
+    let address = SocketAddr::from(([127, 0, 0, 1], port));
+    let Ok(mut stream) = TcpStream::connect_timeout(&address, Duration::from_millis(100)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
+
+    if stream
+        .write_all(b"GET /v1/info HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .is_err()
+    {
+        return false;
+    }
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).is_ok() && response.starts_with("HTTP/1.1 200")
+}
+
+fn captured_output(child: &mut Child) -> String {
+    let mut output = String::new();
+    if let Some(stdout) = child.stdout.as_mut() {
+        let _ = stdout.read_to_string(&mut output);
+    }
+    if let Some(stderr) = child.stderr.as_mut() {
+        let _ = stderr.read_to_string(&mut output);
+    }
+    output
+}
+
+#[test]
+#[ignore = "requires a working GLFW display/window server"]
+fn sigterm_stops_the_whole_runtime() {
+    let port = unused_local_port();
+    let child = Command::new(env!("CARGO_BIN_EXE_debug_runtime"))
+        .args(["--mission", "debug_minimal", "--port", &port.to_string()])
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("launch debug_runtime");
+    let mut child = ChildGuard(child);
+
+    let ready_deadline = Instant::now() + Duration::from_secs(30);
+    while !info_is_ready(port) {
+        if let Some(status) = child.0.try_wait().expect("poll debug_runtime startup") {
+            let output = captured_output(&mut child.0);
+            panic!("debug_runtime exited before becoming ready: {status}\n{output}");
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "debug_runtime did not become ready within 30 seconds"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    // SAFETY: `child.id()` names the live child process guarded above, and
+    // SIGTERM has no pointer or memory-safety preconditions.
+    let result = unsafe { libc::kill(child.0.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(result, 0, "send SIGTERM to debug_runtime");
+
+    let exit_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(status) = child.0.try_wait().expect("poll debug_runtime exit") {
+            assert!(
+                status.success(),
+                "debug_runtime exited unsuccessfully: {status}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < exit_deadline,
+            "debug_runtime kept running after SIGTERM"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    TcpListener::bind(("127.0.0.1", port)).expect("SIGTERM should release the HTTP port");
+}


### PR DESCRIPTION
Fixes #630

Campaign: Operations deck · sim-unit completion goal · legacy assets · fixed campaign (no randomized seed)

## Summary

- forward Ctrl+C/SIGTERM shutdown from the Axum signal future to the existing game-loop command channel
- let both the HTTP server and blocking GLFW loop terminate cleanly instead of leaving an unreachable CPU-burning process
- add a CI-safe unit regression for signal-to-game-loop forwarding
- add an explicit display-required process smoke test that waits for `/v1/info`, sends SIGTERM, requires a successful exit, and verifies the port can be rebound

The process smoke is ignored by default because `debug_runtime` initializes GLFW even for a hidden window, while GitHub Linux has no X11 display and GitHub macOS cannot allocate the requested NSGL pixel format. It runs locally with `--ignored`; the ordinary forwarding regression runs in CI on every platform.

No gameplay semantics change.

## Negative-first proof

Before the implementation, the process regression failed with:

`debug_runtime kept running after SIGTERM`

After the implementation it passes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p debug_runtime shutdown_tests::process_signal_requests_game_loop_shutdown`
- `cargo test -p debug_runtime --test sigterm -- --ignored --nocapture`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (307 passed)