### PR TITLE
fix: SDK aim visibility and occluder reporting

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -50,11 +50,18 @@ the script directly and is fine for diagnosis, but it does **not** prove a playe
 could do it. To frob the way a player does, in flat mode (the default):
 
 1. **Aim** — the target must be under the crosshair. With the preferred SDK,
-   call `game.player.aimAt(entity, {hitbox:"torso"})` (`head`, `limb`,
-   `center`, and `nearest` are also available). It selects a live classified
-   creature damage proxy, reports the chosen owner/body/joint/world point and
-   any fallback, and accounts for pawn rotation restored from a save while
-   still driving the production camera and `FlatInteraction` ray. Raw `head.look` and
+   call `game.player.aimAt(entity, {hitbox:"torso", visibility:"required"})`
+   (`head`, `limb`, `center`, and `nearest` are also available). It selects a
+   visible live classified creature damage proxy and throws a structured
+   `AimOcclusionError` (including the blocker entity/body) when every matching
+   point is blocked. `fallback_used` only says whether hitbox classification
+   fell back; it does **not** mean the point is visible. The visibility check is
+   explicitly from the flat camera eye (`origin:"view"`), not the offset weapon
+   muzzle, so after firing step the simulation and verify ammo plus target HP
+   rather than inferring a hit from successful aim alone. The helper reports
+   the chosen owner/body/joint/world point and accounts for pawn rotation
+   restored from a save while still driving the production camera and
+   `FlatInteraction` ray. Raw `head.look` and
    `head.rotation` are **pawn-local**, not world-space; do not use an identity
    quaternion as a world-facing direction. If using raw HTTP, turn with
    `{left_hand.thumbstick:[turn,0]}` and confirm the highlighted entity via

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -231,6 +231,7 @@ pub struct RayCastRequest {
     pub end: [f32; 3],
     pub collision_groups: Option<Vec<String>>,
     pub max_distance: Option<f32>,
+    pub ignore_sensors: Option<bool>,
 }
 
 /// Result of physics raycast
@@ -242,6 +243,7 @@ pub struct RayCastResult {
     pub distance: Option<f32>,
     pub entity_id: Option<i32>,
     pub entity_name: Option<String>,
+    pub body_id: Option<u32>,
     pub collision_group: Option<String>,
     pub is_sensor: bool,
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -859,6 +859,7 @@ fn process_command(
                     groups: request
                         .collision_groups
                         .unwrap_or_else(|| vec!["entity".to_string(), "level".to_string()]),
+                    ignore_sensors: request.ignore_sensors.unwrap_or(false),
                 };
 
                 // Perform the raycast
@@ -872,6 +873,7 @@ fn process_command(
                     distance: hit.distance,
                     entity_id: hit.entity_id,
                     entity_name: hit.entity_name,
+                    body_id: hit.body_id,
                     collision_group: hit.collision_group,
                     is_sensor: hit.is_sensor,
                 }
@@ -884,6 +886,7 @@ fn process_command(
                     distance: None,
                     entity_id: None,
                     entity_name: None,
+                    body_id: None,
                     collision_group: None,
                     is_sensor: false,
                 }
@@ -2783,6 +2786,7 @@ async fn perform_raycast(
             distance: None,
             entity_id: None,
             entity_name: None,
+            body_id: None,
             collision_group: None,
             is_sensor: false,
         });
@@ -2800,6 +2804,7 @@ async fn perform_raycast(
                 distance: None,
                 entity_id: None,
                 entity_name: None,
+                body_id: None,
                 collision_group: None,
                 is_sensor: false,
             })

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -216,6 +216,7 @@ pub struct DebugRayHit {
     pub distance: Option<f32>,
     pub entity_id: Option<i32>,
     pub entity_name: Option<String>,
+    pub body_id: Option<u32>,
     pub collision_group: Option<String>,
     pub is_sensor: bool,
 }
@@ -224,11 +225,15 @@ pub struct DebugRayHit {
 #[derive(Debug, Clone)]
 pub struct RaycastMask {
     pub groups: Vec<String>,
+    pub ignore_sensors: bool,
 }
 
 impl RaycastMask {
     pub fn new(groups: Vec<String>) -> Self {
-        Self { groups }
+        Self {
+            groups,
+            ignore_sensors: false,
+        }
     }
 
     pub fn all() -> Self {
@@ -242,6 +247,7 @@ impl RaycastMask {
                 "hitbox".to_string(),
                 "raycast".to_string(),
             ],
+            ignore_sensors: false,
         }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5917,7 +5917,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         // Perform raycast using existing physics system
         match self
             .physics
-            .ray_cast3(start, end, collision_groups, None, false)
+            .ray_cast3(start, end, collision_groups, None, mask.ignore_sensors)
         {
             Some(hit) => {
                 let entity_name = hit.maybe_entity_id.and_then(|id| {
@@ -5927,15 +5927,22 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         },
                     )
                 });
+                let body_id = hit
+                    .maybe_rigid_body_handle
+                    .map(|handle| handle.into_raw_parts().0);
+                let collision_group = body_id
+                    .and_then(|id| self.physics.debug_body_detail(id))
+                    .and_then(|detail| detail.collision_groups.into_iter().next());
 
                 DebugRayHit {
                     hit: true,
                     hit_point: Some([hit.hit_point.x, hit.hit_point.y, hit.hit_point.z]),
                     hit_normal: Some([hit.hit_normal.x, hit.hit_normal.y, hit.hit_normal.z]),
-                    distance: Some((end - start).magnitude()),
+                    distance: Some((hit.hit_point - start).magnitude()),
                     entity_id: hit.maybe_entity_id.map(|id| id.inner() as i32),
                     entity_name,
-                    collision_group: None, // TODO: Add collision group info
+                    body_id,
+                    collision_group,
                     is_sensor: hit.is_sensor,
                 }
             }
@@ -5946,6 +5953,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 distance: None,
                 entity_id: None,
                 entity_name: None,
+                body_id: None,
                 collision_group: None,
                 is_sensor: false,
             },

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -53,8 +53,18 @@ await game.input.set("right_hand.trigger_value", 1.0);
 // a classified live hitbox; doors/buttons select their nearest visible surface.
 // Prefer this over hand-composing head.rotation: raw head controls are
 // pawn-local, so mission spawns and loaded saves can rotate their world result.
-const aim = await game.player.aimAt(target, { hitbox: "torso" });
-// aim reports the selected owner/proxy/body/joint/world point and any fallback.
+const aim = await game.player.aimAt(target, {
+  hitbox: "torso",
+  visibility: "required",
+});
+// aim reports the selected owner/proxy/body/joint/world point and view LOS.
+// If every matching proxy is blocked it throws AimOcclusionError, whose
+// structured result identifies the blocker. `fallback_used` only describes
+// hitbox classification; it never means the target is visible.
+//
+// Visibility is checked from the flat camera eye (`origin: "view"`). It does
+// not guarantee that the offset weapon muzzle is clear, so step and verify the
+// shot/target state instead of treating a successful aim as proof of damage.
 // Use { hitbox: "center" } only when you deliberately want the entity origin.
 await game.input.set("right_hand.squeeze_value", 1); // frob highlighted target
 await game.step({ frames: 2 });

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -30,8 +30,10 @@ import type {
   TransitionsResult,
   WaitForOptions,
   AiPathEntry,
-  AimClassification,
+  AimOptions,
+  AimPoint,
   AimResult,
+  AimVisibility,
   Vec3,
 } from "./types.js";
 
@@ -40,6 +42,18 @@ export class CommandError extends Error {
   constructor(public readonly result: CommandResult) {
     super(result.message);
     this.name = "CommandError";
+  }
+}
+
+/** Error thrown when `aimAt(..., { visibility: "required" })` is occluded. */
+export class AimOcclusionError extends Error {
+  constructor(public readonly result: AimResult) {
+    const blocker = result.visibility.blocker;
+    const label =
+      blocker?.entity_name ??
+      (blocker?.entity_id === null ? "world geometry" : `entity ${blocker?.entity_id}`);
+    super(`view from camera eye to entity ${result.entity_id} is blocked by ${label}`);
+    this.name = "AimOcclusionError";
   }
 }
 
@@ -95,7 +109,7 @@ export class PlayerApi {
    */
   async aimAt(
     entity: number | Pick<EntitySummary, "id">,
-    options?: { hitbox?: AimClassification; eyeHeight?: number },
+    options?: AimOptions,
   ): Promise<AimResult> {
     const entityId = typeof entity === "number" ? entity : entity.id;
     const requested = options?.hitbox ?? "torso";
@@ -115,7 +129,8 @@ export class PlayerApi {
     // Entity detail is a versioned runtime capability. Older runtimes (and a
     // stale binary encountered by the campaign) omit aim_points entirely;
     // aiming must remain usable and report its center fallback, not crash.
-    let candidates = detail.aim_points ?? [];
+    const aimPoints = detail.aim_points ?? [];
+    let candidates = [...aimPoints];
     if (requested === "head" || requested === "torso") {
       candidates = candidates.filter((point) => point.classification === requested);
     } else if (requested === "limb") {
@@ -127,18 +142,91 @@ export class PlayerApi {
       candidates = [];
     }
     candidates.sort((a, b) => distance(a.position) - distance(b.position));
-    const selected = candidates[0];
-    let surfacePoint: Vec3 | undefined;
-    if (selected === undefined && requested !== "center") {
-      const surface = await this.client.post<RayCastResult>("/v1/physics/raycast", {
+    const targetIds = new Set([
+      entityId,
+      ...aimPoints.map((point) => point.proxy_entity_id),
+    ]);
+    const checkViewVisibility = async (
+      point: Vec3,
+    ): Promise<{ visibility: AimVisibility; hit: RayCastResult }> => {
+      const hit = await this.client.post<RayCastResult>("/v1/physics/raycast", {
         start: eye,
-        end: detail.position,
-        collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+        end: point,
+        collision_groups: [
+          "entity",
+          "hitbox",
+          "selectable",
+          "world",
+          "ui",
+          "raycast",
+        ],
+        // Match production interaction/projectile rays: enclosing tripwire and
+        // room sensors are not physical visibility blockers.
+        ignore_sensors: true,
       });
-      if (surface?.entity_id === entityId && surface.hit_point !== null) {
-        surfacePoint = surface.hit_point;
+      const visible = !hit.hit || (hit.entity_id !== null && targetIds.has(hit.entity_id));
+      return {
+        hit,
+        visibility: {
+          state: visible ? "visible" : "blocked",
+          origin: "view",
+          target_distance: distance(point),
+          blocker: visible
+            ? null
+            : {
+                entity_id: hit.entity_id,
+                entity_name: hit.entity_name,
+                body_id: hit.body_id ?? null,
+                collision_group: hit.collision_group,
+                hit_point: hit.hit_point,
+                distance: hit.distance,
+              },
+        },
+      };
+    };
+
+    let selected: AimPoint | undefined = candidates[0];
+    let visibility: AimVisibility | undefined;
+    if (options?.visibility === "required" && candidates.length > 0) {
+      selected = undefined;
+      for (const candidate of candidates) {
+        const check = await checkViewVisibility(candidate.position);
+        visibility ??= check.visibility;
+        if (check.visibility.state === "visible") {
+          selected = candidate;
+          visibility = check.visibility;
+          break;
+        }
+      }
+      // Preserve the closest requested-class target in the structured error.
+      selected ??= candidates[0];
+    }
+
+    let surfacePoint: Vec3 | undefined;
+    if (candidates.length === 0) {
+      if (options?.visibility === "required") {
+        const check = await checkViewVisibility(detail.position);
+        visibility = check.visibility;
+        if (
+          check.visibility.state === "visible" &&
+          check.hit.entity_id !== null &&
+          targetIds.has(check.hit.entity_id) &&
+          check.hit.hit_point !== null
+        ) {
+          surfacePoint = check.hit.hit_point;
+        }
+      } else if (requested !== "center") {
+        const surface = await this.client.post<RayCastResult>("/v1/physics/raycast", {
+          start: eye,
+          end: detail.position,
+          collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+        });
+        if (surface?.entity_id === entityId && surface.hit_point !== null) {
+          surfacePoint = surface.hit_point;
+        }
       }
     }
+
     const worldPoint = selected?.position ?? surfacePoint ?? detail.position;
     const headRotation = headRotationForWorldPoint(
       snapshot.player.position,
@@ -146,11 +234,7 @@ export class PlayerApi {
       worldPoint,
       eyeHeight,
     );
-    await this.client.post("/v1/control/input", {
-      channel: "head.rotation",
-      value: headRotation,
-    });
-    return {
+    const result: AimResult = {
       entity_id: entityId,
       proxy_entity_id: selected?.proxy_entity_id ?? null,
       body_id: selected?.body_id ?? null,
@@ -163,7 +247,21 @@ export class PlayerApi {
         selected === undefined &&
         requested !== "center" &&
         (requested !== "surface" || surfacePoint === undefined),
+      visibility: visibility ?? {
+        state: "unchecked",
+        origin: "view",
+        target_distance: distance(worldPoint),
+        blocker: null,
+      },
     };
+    if (result.visibility.state === "blocked") {
+      throw new AimOcclusionError(result);
+    }
+    await this.client.post("/v1/control/input", {
+      channel: "head.rotation",
+      value: headRotation,
+    });
+    return result;
   }
 
   /** The items the player is carrying (backpack + hand-held), for verifying pickups. */

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { HttpClient, HttpError } from "./client.js";
 export {
+  AimOcclusionError,
   AudioApi,
   CommandError,
   EntitiesApi,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -146,6 +146,32 @@ export type AimClassification =
   | "center"
   | "nearest";
 
+export interface AimOptions {
+  hitbox?: AimClassification;
+  eyeHeight?: number;
+  /**
+   * `required` verifies line of sight from the flat camera eye and rejects an
+   * occluded target. It does not claim clearance from the weapon muzzle.
+   */
+  visibility?: "unchecked" | "required";
+}
+
+export interface AimVisibilityBlocker {
+  entity_id: number | null;
+  entity_name: string | null;
+  body_id: number | null;
+  collision_group: string | null;
+  hit_point: Vec3 | null;
+  distance: number | null;
+}
+
+export interface AimVisibility {
+  state: "unchecked" | "visible" | "blocked";
+  origin: "view";
+  target_distance: number;
+  blocker: AimVisibilityBlocker | null;
+}
+
 export interface AimResult {
   entity_id: number;
   proxy_entity_id: number | null;
@@ -156,6 +182,8 @@ export interface AimResult {
   world_point: Vec3;
   head_rotation: Quat;
   fallback_used: boolean;
+  /** Classification fallback and visibility are independent. */
+  visibility: AimVisibility;
 }
 
 /** A clip queued behind the currently-playing head clip. */
@@ -219,6 +247,7 @@ export interface RayCastRequest {
   end: Vec3;
   collision_groups?: string[];
   max_distance?: number;
+  ignore_sensors?: boolean;
 }
 
 export interface RayCastResult {
@@ -228,6 +257,8 @@ export interface RayCastResult {
   distance: number | null;
   entity_id: number | null;
   entity_name: string | null;
+  /** Optional when connected to runtimes predating blocker-body reporting. */
+  body_id?: number | null;
   collision_group: string | null;
   is_sensor: boolean;
 }

--- a/tools/shock2-sdk/test/ops2-aim-visibility.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-aim-visibility.e2e.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { AimOcclusionError, GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops2: required head aim reports the Midwife doorway occluder",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8221),
+    });
+    const midwife = (
+      await game.entities.list({ filter: "Midwife", limit: 20 })
+    ).entities.find((entity) => entity.template_id === 352);
+    assert.ok(midwife, "ops2 should contain the Midwife");
+
+    // Campaign reproduction: just outside the small room at z=83, where the
+    // classified head point is behind the doorway frame.
+    await game.player.teleport({ x: 62.08, y: -15.796, z: 83 });
+    await game.step({ frames: 2 });
+
+    await assert.rejects(
+      game.player.aimAt(midwife, {
+        hitbox: "head",
+        visibility: "required",
+      }),
+      (error: unknown) => {
+        if (!(error instanceof AimOcclusionError)) return false;
+        const { result } = error;
+        assert.equal(result.classification, "head");
+        assert.equal(result.fallback_used, false);
+        assert.equal(result.visibility.state, "blocked");
+        assert.equal(result.visibility.origin, "view");
+        assert.ok(result.visibility.blocker?.hit_point);
+        assert.ok(
+          result.visibility.blocker?.entity_id !== null ||
+            result.visibility.blocker?.body_id !== null,
+          "occlusion should identify its entity or rigid body",
+        );
+        assert.ok(
+          (result.visibility.blocker?.distance ?? Number.POSITIVE_INFINITY) <
+            result.visibility.target_distance,
+        );
+        return true;
+      },
+    );
+  },
+);

--- a/tools/shock2-sdk/test/world-aim.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-aim.e2e.test.ts
@@ -72,10 +72,15 @@ test(
     );
     assert.ok(classifications.has("limb"), "restored creature should expose limb proxies");
 
-    const aim = await game.player.aimAt(restoredMonster, { hitbox: "torso" });
+    const aim = await game.player.aimAt(restoredMonster, {
+      hitbox: "torso",
+      visibility: "required",
+    });
     assert.equal(aim.entity_id, restoredMonster.id);
     assert.equal(aim.classification, "torso");
     assert.equal(aim.fallback_used, false);
+    assert.equal(aim.visibility.state, "visible");
+    assert.equal(aim.visibility.origin, "view");
     await game.step({ frames: 2 });
 
     await game.input.set("right_hand.trigger_value", 1);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  AimOcclusionError,
   headRotationForWorldPoint,
   HttpClient,
   PlayerApi,
 } from "../src/index.js";
-import type { EntityDetailResult, FrameSnapshot } from "../src/index.js";
+import type {
+  EntityDetailResult,
+  FrameSnapshot,
+  RayCastResult,
+} from "../src/index.js";
 
 type Quat = [number, number, number, number];
 
@@ -225,4 +230,181 @@ test("aimAt center remains an explicit origin target without a surface query", a
   assert.equal(aim.classification, "center");
   assert.equal(aim.fallback_used, false);
   assert.deepEqual(writes, ["/v1/control/input"]);
+});
+
+test("aimAt visibility required skips an occluded classified proxy", async () => {
+  const detail = {
+    entity_id: 363,
+    name: "Midwife",
+    template_id: 352,
+    position: [56.7, -14.3, 81.3],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [
+      {
+        proxy_entity_id: 1341,
+        body_id: 814,
+        joint_id: 11,
+        classification: "limb",
+        position: [56.9, -13.5, 81.5],
+      },
+      {
+        proxy_entity_id: 1344,
+        body_id: 815,
+        joint_id: 12,
+        classification: "limb",
+        position: [56.5, -14, 81],
+      },
+    ],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [62, -15.8, 83],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const doorway: RayCastResult = {
+    hit: true,
+    hit_point: [60.1, -14.4, 82.5],
+    hit_normal: [1, 0, 0],
+    distance: 2.1,
+    entity_id: 77,
+    entity_name: "Doorway frame",
+    body_id: 501,
+    collision_group: "world",
+    is_sensor: false,
+  };
+  const visibleProxy: RayCastResult = {
+    hit: true,
+    hit_point: detail.aim_points[1].position,
+    hit_normal: [1, 0, 0],
+    distance: 5.7,
+    entity_id: detail.aim_points[1].proxy_entity_id,
+    entity_name: null,
+    body_id: detail.aim_points[1].body_id,
+    collision_group: "hitbox",
+    is_sensor: false,
+  };
+  const raycasts = [doorway, visibleProxy];
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/363") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") return raycasts.shift();
+      return undefined;
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(363, {
+    hitbox: "limb",
+    visibility: "required",
+  });
+
+  assert.equal(aim.proxy_entity_id, 1344);
+  assert.equal(aim.fallback_used, false);
+  assert.equal(aim.visibility.state, "visible");
+  assert.equal(aim.visibility.origin, "view");
+  assert.equal(aim.visibility.blocker, null);
+  assert.ok(Math.abs(aim.visibility.target_distance - 5.8558) < 0.001);
+  assert.equal(
+    writes.filter(({ path }) => path === "/v1/physics/raycast").length,
+    2,
+  );
+  assert.equal(
+    (
+      writes.find(({ path }) => path === "/v1/physics/raycast")
+        ?.body as { ignore_sensors: boolean }
+    ).ignore_sensors,
+    true,
+  );
+  assert.equal(writes.at(-1)?.path, "/v1/control/input");
+});
+
+test("aimAt visibility required reports the blocker when every proxy is occluded", async () => {
+  const detail = {
+    entity_id: 363,
+    name: "Midwife",
+    template_id: 352,
+    position: [56.7, -14.3, 81.3],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [
+      {
+        proxy_entity_id: 1343,
+        body_id: 812,
+        joint_id: 9,
+        classification: "head",
+        position: [56.8, -13.2, 81.4],
+      },
+    ],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [62, -15.8, 83],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const doorway: RayCastResult = {
+    hit: true,
+    hit_point: [60.1, -14.4, 82.5],
+    hit_normal: [1, 0, 0],
+    distance: 2.1,
+    entity_id: 77,
+    entity_name: "Doorway frame",
+    body_id: 501,
+    collision_group: "world",
+    is_sensor: false,
+  };
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/363") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") return doorway;
+      return undefined;
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  await assert.rejects(
+    player.aimAt(363, { hitbox: "head", visibility: "required" }),
+    (error: unknown) => {
+      if (!(error instanceof AimOcclusionError)) return false;
+      assert.equal(error.result.proxy_entity_id, 1343);
+      assert.equal(error.result.visibility.state, "blocked");
+      assert.equal(error.result.visibility.origin, "view");
+      assert.ok(
+        Math.abs(error.result.visibility.target_distance - 5.5317) < 0.001,
+      );
+      assert.deepEqual(error.result.visibility.blocker, {
+        entity_id: 77,
+        entity_name: "Doorway frame",
+        body_id: 501,
+        collision_group: "world",
+        hit_point: [60.1, -14.4, 82.5],
+        distance: 2.1,
+      });
+      return true;
+    },
+  );
+  assert.equal(
+    writes.some(({ path }) => path === "/v1/control/input"),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary

- add opt-in `visibility: "required"` to `player.aimAt`, choosing the nearest visible same-class proxy
- throw structured `AimOcclusionError` without rotating the camera when every candidate is blocked
- report view-origin visibility independently from hitbox classification fallback
- add blocker rigid-body ID, collision group, and actual hit distance to debug raycasts
- let visibility rays ignore trigger/room sensors like production interaction and projectile rays
- document that view LOS does not guarantee offset muzzle clearance
- add the exact ops2 Midwife doorway regression

## Validation

- `npm test` (22 passed, 130 opt-in skipped)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` (307 passed)
- `SHOCK2_E2E=1 node --test dist/test/ops2-aim-visibility.e2e.test.js`
- live ops2 replay at the campaign frontier reports the doorway blocker at 4.25 units before the 5.96-unit Midwife head target

The pre-existing `world-aim.e2e.test.ts` save/load scenario still fails before reaching aim with `corrupt or incompatible save`; the new focused ops2 regression passes independently.

Fixes #633