### PR TITLE
fix(sdk): aim ordinary centers at selectable surfaces

### DIFF
--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -57,15 +57,19 @@ const aim = await game.player.aimAt(target, {
   hitbox: "torso",
   visibility: "required",
 });
-// aim reports the selected owner/proxy/body/joint/world point and view LOS.
-// If every matching proxy is blocked it throws AimOcclusionError, whose
+// aim reports the selected owner/proxy/body/joint/world point, view LOS, and
+// whether the production-equivalent interaction ray confirmed the requested
+// target. If every matching proxy is blocked it throws AimOcclusionError, whose
 // structured result identifies the blocker. `fallback_used` only describes
 // hitbox classification; it never means the target is visible.
 //
 // Visibility is checked from the flat camera eye (`origin: "view"`). It does
 // not guarantee that the offset weapon muzzle is clear, so step and verify the
 // shot/target state instead of treating a successful aim as proof of damage.
-// Use { hitbox: "center" } only when you deliberately want the entity origin.
+//
+// For ordinary objects, { hitbox: "center" } means the visible selectable
+// surface on the center ray; the authored position is only a fallback. It still
+// means the authored center for a classified creature.
 await game.input.set("right_hand.squeeze_value", 1); // frob highlighted target
 await game.step({ frames: 2 });
 await game.input.set("right_hand.squeeze_value", 0);

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -100,9 +100,9 @@ export class PlayerApi {
    * Aim the production flat camera, interaction ray, and weapon at an entity.
    *
    * Creature targets use their live classified damage proxies. Other entities
-   * first use the nearest visible selectable surface on the center ray.
-   * Occluded targets and unavailable classifications gracefully fall back to
-   * the entity center. Request `center` to aim at the origin explicitly.
+   * first use the nearest visible selectable surface on the center ray,
+   * including explicit `center` requests. Occluded targets and unavailable
+   * classifications gracefully fall back to the authored entity position.
    *
    * This accounts for authored and save-restored pawn rotation; raw
    * `head.look` / `head.rotation` are pawn-local.
@@ -202,7 +202,11 @@ export class PlayerApi {
       selected ??= candidates[0];
     }
 
+    // An explicit `center` on a classified creature keeps authored-center
+    // semantics; ordinary objects resolve `center` to their visible surface.
+    const explicitCreatureCenter = requested === "center" && aimPoints.length > 0;
     let surfacePoint: Vec3 | undefined;
+    let interactionTargetId: number | null = null;
     if (candidates.length === 0) {
       if (options?.visibility === "required") {
         const check = await checkViewVisibility(detail.position);
@@ -215,12 +219,15 @@ export class PlayerApi {
         ) {
           surfacePoint = check.hit.hit_point;
         }
-      } else if (requested !== "center") {
+      } else if (!explicitCreatureCenter) {
         const surface = await this.client.post<RayCastResult>("/v1/physics/raycast", {
           start: eye,
           end: detail.position,
           collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+          // Match the production interaction ray, which ignores trigger sensors.
+          ignore_sensors: true,
         });
+        interactionTargetId = surface?.entity_id ?? null;
         if (surface?.entity_id === entityId && surface.hit_point !== null) {
           surfacePoint = surface.hit_point;
         }
@@ -245,14 +252,18 @@ export class PlayerApi {
       head_rotation: headRotation,
       fallback_used:
         selected === undefined &&
-        requested !== "center" &&
-        (requested !== "surface" || surfacePoint === undefined),
+        !explicitCreatureCenter &&
+        (requested === "center"
+          ? surfacePoint === undefined
+          : requested !== "surface" || surfacePoint === undefined),
       visibility: visibility ?? {
         state: "unchecked",
         origin: "view",
         target_distance: distance(worldPoint),
         blocker: null,
       },
+      interaction_target_id: interactionTargetId,
+      target_confirmed: interactionTargetId === entityId,
     };
     if (result.visibility.state === "blocked") {
       throw new AimOcclusionError(result);

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -184,6 +184,10 @@ export interface AimResult {
   fallback_used: boolean;
   /** Classification fallback and visibility are independent. */
   visibility: AimVisibility;
+  /** Production-equivalent interaction-ray hit used to choose the aim point. */
+  interaction_target_id: number | null;
+  /** Whether that interaction ray selected the requested runtime entity. */
+  target_confirmed: boolean;
 }
 
 /** A clip queued behind the currently-playing head clip. */

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -86,3 +86,46 @@ test(
     );
   },
 );
+
+test(
+  "ops4: aimAt center selects the offset-pivot button and production squeeze opens its doors",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
+    });
+    await game.step({ frames: 2 });
+
+    const buttons = await game.entities.byTemplate(334);
+    assert.equal(buttons.length, 1, "expected the offset-pivot door button");
+    const [leftDoor] = await game.entities.byTemplate(331);
+    const [rightDoor] = await game.entities.byTemplate(332);
+    assert.ok(leftDoor && rightDoor, "expected both linked Ops doors");
+    await game.player.teleport({ x: 53.5, y: -9.796, z: -60.8 });
+
+    const aim = await game.player.aimAt(buttons[0], { hitbox: "center" });
+    assert.equal(aim.classification, "surface");
+    assert.equal(aim.entity_id, buttons[0].id);
+    assert.equal(aim.interaction_target_id, buttons[0].id);
+    assert.equal(aim.target_confirmed, true);
+
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 120 });
+
+    const [openedLeft, openedRight] = await Promise.all([
+      game.entities.detail(leftDoor.id),
+      game.entities.detail(rightDoor.id),
+    ]);
+    assert.ok(
+      Math.abs(openedLeft.position[0] - leftDoor.position[0]) > 1,
+      "left linked door should translate open",
+    );
+    assert.ok(
+      Math.abs(openedRight.position[0] - rightDoor.position[0]) > 1,
+      "right linked door should translate open",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -193,7 +193,7 @@ test("aimAt reports center fallback when another entity occludes the target surf
   assert.equal(aim.fallback_used, true);
 });
 
-test("aimAt center remains an explicit origin target without a surface query", async () => {
+test("aimAt center uses and confirms an ordinary entity's selectable surface", async () => {
   const detail = {
     entity_id: 470,
     name: "Airlock Door",
@@ -212,24 +212,44 @@ test("aimAt center remains an explicit origin target without a surface query", a
       rotation: [0, 0, 0, 1],
     },
   } as FrameSnapshot;
-  const writes: string[] = [];
+  const writes: Array<{ path: string; body: unknown }> = [];
   const client = {
     get: async (path: string) => {
       if (path === "/v1/entities/470") return detail;
       if (path === "/v1/info") return snapshot;
       throw new Error(`unexpected GET ${path}`);
     },
-    post: async (path: string) => {
-      writes.push(path);
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") {
+        return {
+          hit: true,
+          hit_point: [30, -7, 17.25],
+          hit_normal: [0, 0, -1],
+          distance: 4.25,
+          entity_id: 470,
+          entity_name: "Airlock Door",
+          collision_group: "selectable",
+          is_sensor: false,
+        };
+      }
     },
   };
   const player = new PlayerApi(client as unknown as HttpClient);
 
   const aim = await player.aimAt(470, { hitbox: "center" });
 
-  assert.equal(aim.classification, "center");
+  assert.equal(aim.classification, "surface");
   assert.equal(aim.fallback_used, false);
-  assert.deepEqual(writes, ["/v1/control/input"]);
+  assert.deepEqual(aim.world_point, [30, -7, 17.25]);
+  assert.equal(aim.interaction_target_id, 470);
+  assert.equal(aim.target_confirmed, true);
+  assert.equal(writes[0]?.path, "/v1/physics/raycast");
+  assert.equal(
+    (writes[0]?.body as { ignore_sensors?: boolean }).ignore_sensors,
+    true,
+  );
+  assert.equal(writes[1]?.path, "/v1/control/input");
 });
 
 test("aimAt visibility required skips an occluded classified proxy", async () => {


### PR DESCRIPTION
## Summary

- make `aimAt(entity, { hitbox: "center" })` target the visible selectable surface for ordinary objects while preserving authored-center semantics for classified creatures
- send `ignore_sensors` on the SDK's surface-selection raycast so target acquisition matches production interaction rays (the runtime-side `ignore_sensors` support landed in #634; this PR was restacked on it and its duplicate Rust changes dropped)
- report `interaction_target_id` and `target_confirmed` in `AimResult`
- cover the offset-pivot Ops4 button through the production squeeze path

Fixes #635

Campaign: operations · sim-unit tweak · legacy assets · seed unavailable (legacy ledger)

## Validation

- negative-first unit regression failed on the old explicit-origin behavior, then passed with the fix
- `npm test` (20 passed, 131 e2e skipped)
- Ops4 offset-pivot aim/use e2e passed twice; both authored linked doors opened
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- full `npm run test:e2e`: 147 passed / 4 failed before the final fixture-timing correction. The feature test failure was caused by stepping while staged over an authored void; the corrected production same-frame sequence passed twice. The other failures were unrelated: Earth psi booster 288 world-use (reproduced in isolation), QuickLoad detecting a pre-existing session quicksave, and world-aim encountering a stale/incompatible `world-aim-e2e` save.
