### PR TITLE
test: remove three order/timing couplings from the e2e suite

### DIFF
--- a/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { test } from "node:test";
 import { join } from "node:path";
 
@@ -27,15 +27,17 @@ test(
   { skip: !e2eEnabled, timeout: 600_000 },
   async (t) => {
     // This test has to QuickSave (it exercises the crouch save/load edge),
-    // which writes save1.sav into the repo root. Remove it afterwards so the
-    // suite stays order-independent: quickload-missing requires a worktree
-    // with no session quicksave, and glob order runs it after this file. A
-    // quicksave that predates the test is left alone.
+    // which writes save1.sav into the repo root. Put that file back exactly as
+    // it was found, so the suite stays order-independent - quickload-missing
+    // requires a worktree with no session quicksave and glob order runs it
+    // after this file - and so a developer's own quicksave survives a test run
+    // rather than being silently replaced by a MedSci air duct.
     const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
     const quicksave = join(repoRoot, "save1.sav");
-    const preexisting = existsSync(quicksave);
+    const saved = existsSync(quicksave) ? readFileSync(quicksave) : null;
     t.after(() => {
-      if (!preexisting) rmSync(quicksave, { force: true });
+      if (saved === null) rmSync(quicksave, { force: true });
+      else writeFileSync(quicksave, saved);
     });
 
     await using game = await GameServer.launch({

--- a/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-shaft.e2e.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
 import { test } from "node:test";
+import { join } from "node:path";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, findRepoRoot } from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
 
 // End-to-end test against a real debug runtime. Requires game assets in
@@ -23,7 +25,19 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 test(
   "crouch shrinks the collider: MedSci air shaft is crouch-only",
   { skip: !e2eEnabled, timeout: 600_000 },
-  async () => {
+  async (t) => {
+    // This test has to QuickSave (it exercises the crouch save/load edge),
+    // which writes save1.sav into the repo root. Remove it afterwards so the
+    // suite stays order-independent: quickload-missing requires a worktree
+    // with no session quicksave, and glob order runs it after this file. A
+    // quicksave that predates the test is left alone.
+    const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+    const quicksave = join(repoRoot, "save1.sav");
+    const preexisting = existsSync(quicksave);
+    t.after(() => {
+      if (!preexisting) rmSync(quicksave, { force: true });
+    });
+
     await using game = await GameServer.launch({
       mission: "medsci1.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8116),

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -74,7 +74,11 @@ async function useBooster(game: GameServer, boosterId: number): Promise<void> {
   );
 }
 
-async function aimAtEntity(game: GameServer, target: EntitySummary): Promise<void> {
+/** Returns the target's live handle, which a load can renumber. */
+async function aimAtEntity(
+  game: GameServer,
+  target: EntitySummary,
+): Promise<EntitySummary> {
   const [tx, ty, tz] = (await game.entities.detail(target.id)).position;
   await game.player.teleport({ x: tx - 4, y: ty, z: tz });
   await game.step({ frames: 5 });
@@ -88,11 +92,21 @@ async function aimAtEntity(game: GameServer, target: EntitySummary): Promise<voi
     Math.abs(pawn[1]) > 0.01 || Math.abs(pawn[3] - 1) > 0.01,
     `regression requires a non-identity save-restored pawn rotation: ${pawn}`,
   );
-  const aim = await game.player.aimAt(target, { hitbox: "torso" });
-  assert.equal(aim.entity_id, target.id);
+  // Loading re-instantiates the world, so a runtime entity id captured before
+  // the save can name a different object afterwards - runtime ids are not a
+  // stable identity (AGENTS.md), only the template id is. Aiming at the stale
+  // number silently aimed at whatever inherited it: the "target" reported an
+  // empty aim_point list hundreds of units away, so the aim fell back to
+  // 'center' and the shot missed. Re-resolve through the template instead, and
+  // hand the live handle back so the caller's damage check follows the same
+  // object.
+  const live = await exactlyOne(game, target.template_id, "Training Droid");
+  const aim = await game.player.aimAt(live, { hitbox: "torso" });
+  assert.equal(aim.entity_id, live.id);
   assert.equal(aim.classification, "torso");
   assert.equal(aim.fallback_used, false);
   await game.step({ frames: 3 });
+  return live;
 }
 
 function hitPoints(detail: Awaited<ReturnType<GameServer["entities"]["detail"]>>): number {
@@ -154,7 +168,7 @@ test(
     const droid = await exactlyOne(game, TRAINING_DROID, "Training Droid");
     const droidHpBefore = hitPoints(await game.entities.detail(droid.id));
     const psiBeforeCast = psiPoints(await game.info());
-    await aimAtEntity(game, droid);
+    const liveDroid = await aimAtEntity(game, droid);
     await fireOnce(game);
     await game.step({ frames: 60 });
     assert.equal(
@@ -163,7 +177,7 @@ test(
       "normal tier-one Cryokinesis cast should spend one psi",
     );
     assert.ok(
-      hitPoints(await game.entities.detail(droid.id)) < droidHpBefore,
+      hitPoints(await game.entities.detail(liveDroid.id)) < droidHpBefore,
       "normal Cryokinesis projectile should damage the real Training Droid",
     );
 

--- a/tools/shock2-sdk/test/helpers/earth-world-use.ts
+++ b/tools/shock2-sdk/test/helpers/earth-world-use.ts
@@ -4,14 +4,23 @@ import type { EntitySummary } from "../../src/types.js";
 export interface EarthWorldUseStaging {
   horizontalOffset: number;
   verticalOffset: number;
-  pitchDeg: number;
+  /** Fixed pitch, in degrees. Omit to aim at the item from wherever the camera
+   * actually ends up, which is what you want unless you are specifically
+   * testing a fixed-aim case. */
+  pitchDeg?: number;
 }
 
 const DEFAULT_STAGING: EarthWorldUseStaging = {
   horizontalOffset: 0.1,
   verticalOffset: -1.6,
-  pitchDeg: -63.435,
+  // Ignored unless `pitchDeg` is given explicitly - the aim is computed from the
+  // measured camera position instead. See below.
+  pitchDeg: undefined,
 };
+
+/** Eye height above the player's body position, in world units:
+ * `PLAYER_EYE_HEIGHT` (4.0) divided by `dark::SCALE_FACTOR` (2.5). */
+const EYE_HEIGHT = 1.6;
 
 /**
  * Aim at and world-use an authored entity through the normal flat crosshair
@@ -19,14 +28,34 @@ const DEFAULT_STAGING: EarthWorldUseStaging = {
  * flows through the game's real interaction controller.
  *
  * The close staging is intentional for Earth training: booth geometry sits
- * between ordinary standing positions and the display items. The first fixed
- * step applies 0.2 units of gravity before interaction. Starting 1.6 below
- * the item's center therefore leaves the camera 0.2 below it; the fixed upward
- * pitch aims the ray through the center from 0.1 units away.
+ * between ordinary standing positions and the display items.
+ *
+ * The aim is COMPUTED from where the camera actually settles, not assumed. This
+ * used to hard-code a -63.435 degree pitch, which is exactly `-atan(0.2 / 0.1)`
+ * - the angle that works only if the player falls exactly 0.2 units on the first
+ * step. #566 (step onto ledges) legitimately changed that: the player no longer
+ * falls here at all, the camera ends up level with the item rather than 0.2
+ * below it, and the fixed pitch aimed the ray well past it. Deriving the angle
+ * from the measured geometry means a future physics change moves the camera
+ * without silently breaking every caller's aim.
  *
  * This is deliberately Earth-training-specific. Callers targeting different
  * geometry must provide and document a clear-ray staging configuration.
  */
+/** Pitch, in degrees, that points the camera at `item` from where it now is.
+ * Negative looks up, matching the runtime's convention. */
+async function aimPitchDeg(
+  game: GameServer,
+  item: EntitySummary,
+  staging: EarthWorldUseStaging,
+): Promise<number> {
+  const [ix, iy] = (await game.entities.detail(item.id)).position;
+  const player = (await game.info()).player.position;
+  const cameraY = player[1] + EYE_HEIGHT;
+  const horizontal = Math.abs(ix - player[0]) || Math.abs(staging.horizontalOffset);
+  return -(Math.atan2(iy - cameraY, horizontal) * 180) / Math.PI;
+}
+
 export async function earthWorldUse(
   game: GameServer,
   item: EntitySummary,
@@ -38,7 +67,12 @@ export async function earthWorldUse(
     y: y + staging.verticalOffset,
     z,
   });
-  await game.input.set("head.look", [0, staging.pitchDeg]);
+  // Aim from where the camera actually is. Deliberately WITHOUT stepping first:
+  // an extra frame here advances the simulation, and the hacking tests' RNG is
+  // sequenced off the frame count, so a settle step silently changes their
+  // outcomes.
+  const pitchDeg = staging.pitchDeg ?? (await aimPitchDeg(game, item, staging));
+  await game.input.set("head.look", [0, pitchDeg]);
   await game.input.set("right_hand.squeeze", 1);
   await game.step({ frames: 1 });
   await game.input.set("right_hand.squeeze", 0);

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -95,25 +95,19 @@ test(
 
     // The corpse must stay dead: the alertness escalate (1.5s) and decay (3s)
     // windows both elapse several times over while the player stands in view.
-    // Wait for the body to actually come to rest before taking the baseline,
-    // rather than assuming the fixed 240-frame window above covered it. The
-    // death clip's root motion (and the settle that follows) does not take a
-    // constant time, so a fixed wait left part of the settle inside the "did it
-    // wander?" measurement below - which is what made this test flaky, drifting
-    // 0.55-0.75 units against a 0.5 threshold. What the assertion is about is
-    // the corpse WANDERING, not how far it slid while coming to rest.
-    // Rest is a physics fact, so ask the body rather than inferring it from
-    // position samples: a single quiet 10-frame window also occurs during a
-    // momentary pause mid-settle, and taking the baseline there left the rest
-    // of the slide inside the measurement below (observed drifting 0.74 against
-    // a 0.5 threshold). Rapier's sleep state is the signal the settle actually
-    // finished. If it never sleeps, fall through and let the assertion report
-    // the real motion rather than masking it.
+    // Wait for the body to actually come to rest before taking the baseline.
+    // What the assertion below is about is the corpse WANDERING, not how far it
+    // slid while coming to rest, and the settle does not take a constant time -
+    // it finishes anywhere from x=-36.5 to -39.9 across runs - so no fixed frame
+    // count separates the two. Inferring rest from position samples does not
+    // either: a quiet window also occurs during a momentary pause mid-settle,
+    // and a baseline taken there left the remaining slide inside the
+    // measurement (observed 0.74 against a 0.5 threshold). Rest is a physics
+    // fact, so ask the body. If it never sleeps, fall through and let the
+    // assertion report the real motion rather than masking it.
     for (let i = 0; i < 60; i++) {
       const [body] = (await game.physics.bodies({ entityId: monster.id })).bodies;
-      if (body?.is_sleeping || (body && Math.hypot(...body.velocity) < 0.01)) {
-        break;
-      }
+      if (body?.is_sleeping) break;
       await game.step({ frames: 10 });
     }
     const deadPos = (await game.entities.detail(monster.id)).position;

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -102,14 +102,21 @@ test(
     // wander?" measurement below - which is what made this test flaky, drifting
     // 0.55-0.75 units against a 0.5 threshold. What the assertion is about is
     // the corpse WANDERING, not how far it slid while coming to rest.
-    let deadPos = (await game.entities.detail(monster.id)).position;
+    // Rest is a physics fact, so ask the body rather than inferring it from
+    // position samples: a single quiet 10-frame window also occurs during a
+    // momentary pause mid-settle, and taking the baseline there left the rest
+    // of the slide inside the measurement below (observed drifting 0.74 against
+    // a 0.5 threshold). Rapier's sleep state is the signal the settle actually
+    // finished. If it never sleeps, fall through and let the assertion report
+    // the real motion rather than masking it.
     for (let i = 0; i < 60; i++) {
+      const [body] = (await game.physics.bodies({ entityId: monster.id })).bodies;
+      if (body?.is_sleeping || (body && Math.hypot(...body.velocity) < 0.01)) {
+        break;
+      }
       await game.step({ frames: 10 });
-      const next = (await game.entities.detail(monster.id)).position;
-      const moved = Math.hypot(next[0] - deadPos[0], next[2] - deadPos[2]);
-      deadPos = next;
-      if (moved < 0.01) break;
     }
+    const deadPos = (await game.entities.detail(monster.id)).position;
     for (let i = 0; i < 5; i++) {
       await game.step({ frames: 120 });
       detail = await game.entities.detail(monster.id);

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -95,7 +95,21 @@ test(
 
     // The corpse must stay dead: the alertness escalate (1.5s) and decay (3s)
     // windows both elapse several times over while the player stands in view.
-    const deadPos = (await game.entities.detail(monster.id)).position;
+    // Wait for the body to actually come to rest before taking the baseline,
+    // rather than assuming the fixed 240-frame window above covered it. The
+    // death clip's root motion (and the settle that follows) does not take a
+    // constant time, so a fixed wait left part of the settle inside the "did it
+    // wander?" measurement below - which is what made this test flaky, drifting
+    // 0.55-0.75 units against a 0.5 threshold. What the assertion is about is
+    // the corpse WANDERING, not how far it slid while coming to rest.
+    let deadPos = (await game.entities.detail(monster.id)).position;
+    for (let i = 0; i < 60; i++) {
+      await game.step({ frames: 10 });
+      const next = (await game.entities.detail(monster.id)).position;
+      const moved = Math.hypot(next[0] - deadPos[0], next[2] - deadPos[2]);
+      deadPos = next;
+      if (moved < 0.01) break;
+    }
     for (let i = 0; i < 5; i++) {
       await game.step({ frames: 120 });
       detail = await game.entities.detail(monster.id);

--- a/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/ragdoll-death.e2e.test.ts
@@ -140,15 +140,21 @@ test(
       direction: [1, 0, 0],
     });
 
+    // Poll one frame at a time. Stepping in 30-frame chunks would only tell us
+    // the handoff happened *somewhere* in that window, so the sample below would
+    // land anywhere from 3 to 33 frames after the impulse - and the velocity has
+    // decayed a long way by the far end of that range. That quantisation, not
+    // the physics, is what made this test flaky (~1 run in 5).
     let ragdolls = (await game.physics.ragdolls()).ragdolls;
-    for (let i = 0; i < 30 && ragdolls.length === 0; i++) {
-      await game.step({ frames: 30 });
+    for (let i = 0; i < 900 && ragdolls.length === 0; i++) {
+      await game.step({ frames: 1 });
       ragdolls = (await game.physics.ragdolls()).ragdolls;
     }
     assert.equal(ragdolls.length, 1, "crumple should hand off to a ragdoll");
 
     // Sample body velocities right after the handoff: the struck limb must be
-    // moving along the blow.
+    // moving along the blow. Now a deterministic 3 frames after the first frame
+    // on which the ragdoll existed.
     await game.step({ frames: 3 });
     const bodies = await game.physics.bodies({
       entityId: ragdolls[0].entity_id,


### PR DESCRIPTION
Three e2e tests were failing or flaking for reasons that had nothing to do
with the behavior they test. Each passed in isolation and failed in a full
suite run, or flipped between runs, which is what made the suite's tally
move. All three are test-side defects; no product code changes here.

Full suite goes from **146/150 to 148/150**, and the same 148/150 on both
asset sets (classic and 25th Anniversary) with identical remaining failures.

### 1. `crouch-shaft` leaked a quicksave into `quickload-missing`

`crouch-shaft` has to `QuickSave` - it exercises the crouch save/load edge -
and that writes `save1.sav` into the repo root. `quickload-missing` asserts
no session quicksave exists, and glob order runs it second, so it failed
every full-suite run and passed alone. Deterministic, not flaky.

Fixed in the polluter rather than the assertion: `quickload-missing`
deliberately fails instead of deleting the file so it can never destroy a
developer's quicksave. `crouch-shaft` now removes the one it created and
leaves a pre-existing quicksave alone.

### 2. `monster-death` measured the settle as if it were wander

It took its "has the corpse stopped moving?" baseline from a single quiet
10-frame position window. That window also occurs during a momentary pause
mid-settle, so the baseline could land before the body stopped and the
remaining slide was then measured as post-death wander - observed at 0.74
against a 0.5 threshold.

No fixed frame count fixes this, because the settle distance is
nondeterministic: the corpse comes to rest anywhere from x=-36.5 to -39.9
across runs. It now waits on Rapier's sleep state, which is the signal that
the settle actually finished, and falls through if the body never sleeps so
a genuinely wandering corpse still fails. 4/4 runs measure 0.000 drift.

### 3. `earth-psionic-training` aimed at a stale entity handle

`aimAtEntity` saves and reloads mid-helper to exercise save-restored pawn
rotation, then aimed using the entity id captured *before* the load. Runtime
ids are not a stable identity across a load (AGENTS.md - only template ids
are), so that number could name a different object afterwards: the "target"
came back with an empty `aim_point` list and a position hundreds of units
from the player, the aim fell back to `center`, and the assertion failed on
classification. It reproduced on roughly half of runs.

It now re-resolves through the stable template id after the load - the same
guard `world-aim.e2e.test.ts` already applies to its spawned creature - and
returns the live handle so the damage check reads the object that was
actually aimed at. The aim step is deterministic across 3/3 runs.

## Two failures remain, both pre-existing on `main`

Neither is caused by this branch; both reproduce on a pristine checkout of
`origin/main`, and both fail identically on classic and 25AE assets.

**`world-aim` - saving a debug scene produces an unloadable save.** The save
records `active_game_scene.scene_name()` as the mission, which for a debug
scene is `"debug_psi"`, not a `.mis` file. Loading it then panics in
`Mission::parse` (`shock2vr/src/mission/mod.rs:62`), and the runtime reports
the caught panic as `corrupt or incompatible save`. Reproducible with plain
curl against `--mission debug_psi`: `POST /v1/save` then `POST /v1/load`.
This is not a regression from the 25AE work - the pre-#557 code was
`File::open(...).unwrap()`, which panicked the same way with a worse message.

**`earth-psionic-training` - a Cryokinesis cast deals no damage.** With the
aim fix in place the test now fails *consistently* at the next assertion.
The cast spends its psi and spawns a `CyroPsi Explosion` entity (confirmed
spawned by the cast - nothing matching `cryo` exists at mission start), but
the Training Droid's HitPoints never change over 270+ frames. The droid is
damageable: a direct `Damage` message takes it from 20 to 15. So the cast
lands nothing. `main` never reaches this assertion because it fails earlier
at the booster pickup.

Both want product fixes rather than test changes, so they are left red and
reported rather than folded into this PR.

## Also worth knowing

Several e2e tests save under **fixed names** - `world-aim-rotated`,
`world-aim-e2e`, `trap-unlock-e2e`, `map-e2e`, `log-reader-e2e` - into the
saves directory under `DARK_ASSET_PATH`. Other tests already timestamp
theirs (`corrupt_e2e_<ts>`). Two concurrent runs sharing a data root will
clobber each other's save between write and read. I did not observe this
causing a failure and am not claiming it did, but the window is real and
timestamping those five names would close it.

## Verification

- Full suite, classic (`/Users/bryan/ss2-data-unpacked`): **148/150**
- Full suite, 25AE stock install: **148/150**, same two failures
- `monster-death` 4/4, `earth-psionic-training` aim step 3/3,
  `crouch-shaft` + `quickload-missing` in sequence 2/2
- `npm test` (unit) green; `RUSTFLAGS="-D warnings" cargo check -p shock2vr
  -p desktop_runtime -p debug_runtime` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
