### PR TITLE
Fix TriggerDestroy death relays

### DIFF
--- a/shock2vr/src/scripts/internal_simple_health.rs
+++ b/shock2vr/src/scripts/internal_simple_health.rs
@@ -3,7 +3,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, Message, MessagePayload, Script};
 
 // Script to handle simple health behavior for non-creature entities that carry
 // a `PropHitPoints` (e.g. breakable crates, canisters, computer panels).
@@ -45,9 +45,14 @@ impl Script for InternalSimpleHealth {
                         entity_id,
                         delta: -damage,
                     },
-                    // Hit points exhausted (or, defensively, no pool to draw
-                    // from): the entity dies.
-                    _ => Effect::SlayEntity { entity_id },
+                    // Route death through the script queue before teardown so
+                    // authored death triggers (TriggerDestroy) can react.
+                    _ => Effect::Send {
+                        msg: Message {
+                            to: entity_id,
+                            payload: MessagePayload::Slay,
+                        },
+                    },
                 }
             }
             _ => Effect::NoEffect,
@@ -95,36 +100,37 @@ mod tests {
         }
     }
 
+    fn assert_requests_slay(effect: Effect, entity_id: EntityId) {
+        match effect {
+            Effect::Send { msg } => {
+                assert_eq!(msg.to, entity_id);
+                assert!(matches!(msg.payload, MessagePayload::Slay));
+            }
+            other => panic!("expected queued Slay message, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn damage_meeting_hit_points_slays() {
+    fn damage_meeting_hit_points_requests_slay() {
         let (world, entity_id) = world_with_hit_points(1);
 
-        match damage(&world, entity_id, 1.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 1.0), entity_id);
     }
 
     #[test]
-    fn damage_exceeding_hit_points_slays() {
+    fn damage_exceeding_hit_points_requests_slay() {
         let (world, entity_id) = world_with_hit_points(5);
 
-        match damage(&world, entity_id, 6.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 6.0), entity_id);
     }
 
     #[test]
-    fn entity_without_hit_points_is_slain() {
+    fn entity_without_hit_points_requests_slay() {
         use dark::properties::PropMaxHitPoints;
         let mut world = World::new();
         // An entity that has *some* component but no PropHitPoints pool.
         let entity_id = world.add_entity((PropMaxHitPoints { hit_points: 10 },));
 
-        match damage(&world, entity_id, 1.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 1.0), entity_id);
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -62,6 +62,7 @@ mod trap_trip_level;
 mod trap_tweq;
 mod trap_unlock;
 mod trigger_collide;
+mod trigger_destroy;
 mod trigger_multi;
 mod tweq_depressable;
 mod tweqable;
@@ -147,6 +148,7 @@ use self::{
     trap_tweq::TrapTweq,
     trap_unlock::TrapUnlock,
     trigger_collide::TriggerCollide,
+    trigger_destroy::TriggerDestroy,
     trigger_multi::TriggerMulti,
     tweq_depressable::TweqDepressable,
     tweqable::Tweqable,
@@ -674,7 +676,7 @@ impl ScriptWorld {
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => Box::new(UnimplementedScript::new(&script_name)),
             "turret" => Box::new(UnimplementedScript::new(&script_name)),
-            "triggerdestroy" => Box::new(NoopScript::new()),
+            "triggerdestroy" => Box::new(TriggerDestroy::new()),
 
             // skill point machines
             "psitrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Psi))),
@@ -877,6 +879,27 @@ impl ScriptWorld {
         let mut ret = Vec::new();
         for eff in flattened_effects {
             match eff {
+                Effect::Send { msg } if matches!(msg.payload, MessagePayload::Slay) => {
+                    let entity_id = msg.to;
+                    let mut slay_effects = Vec::new();
+                    if let Some(scripts) = self.entity_to_scripts.get_mut(&entity_id) {
+                        for script in scripts {
+                            slay_effects.push(script.handle_message(
+                                entity_id,
+                                world,
+                                physics,
+                                &MessagePayload::Slay,
+                            ));
+                        }
+                    }
+                    for slay_effect in Effect::flatten(slay_effects) {
+                        match slay_effect {
+                            Effect::Send { msg } => self.message_queue.push(msg),
+                            other => ret.push(other),
+                        }
+                    }
+                    ret.push(Effect::SlayEntity { entity_id });
+                }
                 Effect::Send { msg } => self.message_queue.push(msg),
                 _ => ret.push(eff),
             }

--- a/shock2vr/src/scripts/trigger_destroy.rs
+++ b/shock2vr/src/scripts/trigger_destroy.rs
@@ -1,0 +1,101 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+
+pub struct TriggerDestroy;
+
+impl TriggerDestroy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for TriggerDestroy {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Slay => send_to_all_switch_links(
+                world,
+                entity_id,
+                MessagePayload::TurnOn { from: entity_id },
+            ),
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    #[test]
+    fn slay_relays_turn_on_to_every_switch_link() {
+        let mut world = World::new();
+        let first = world.add_entity(());
+        let second = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 1,
+                    to_entity_id: Some(WrappedEntityId(first)),
+                    link: Link::SwitchLink,
+                },
+                ToLink {
+                    to_template_id: 2,
+                    to_entity_id: Some(WrappedEntityId(second)),
+                    link: Link::SwitchLink,
+                },
+            ],
+        });
+        let mut script = TriggerDestroy::new();
+
+        let effect =
+            script.handle_message(trigger, &world, &PhysicsWorld::new(), &MessagePayload::Slay);
+        let effects = match effect {
+            Effect::Combined { effects } => effects,
+            other => panic!("expected relayed messages, got {other:?}"),
+        };
+
+        assert_eq!(effects.len(), 2);
+        for (effect, target) in effects.iter().zip([first, second]) {
+            match effect {
+                Effect::Send { msg } => {
+                    assert_eq!(msg.to, target);
+                    assert!(matches!(
+                        msg.payload,
+                        MessagePayload::TurnOn { from } if from == trigger
+                    ));
+                }
+                other => panic!("expected TurnOn message, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_slay_messages_do_not_trigger_or_remove_the_object() {
+        let mut world = World::new();
+        let target = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 1,
+                to_entity_id: Some(WrappedEntityId(target)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let mut script = TriggerDestroy::new();
+
+        let effect =
+            script.handle_message(trigger, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops4.mis: destroying Junction 685 removes the authored trap barrier",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8176),
+    });
+    await game.step({ frames: 5 });
+
+    const all = (await game.entities.list()).entities;
+    const junction = all.find((entity) => entity.template_id === 685);
+    const destroyTrap = all.find((entity) => entity.template_id === 664);
+    const barrierIds = [545, 658, 659]
+      .map((templateId) => all.find((entity) => entity.template_id === templateId))
+      .map((entity) => {
+        assert.ok(entity, "expected every authored force bar");
+        return entity.id;
+      });
+    assert.ok(junction, "expected Junction Box mission object 685");
+    assert.ok(destroyTrap, "expected Destroy Trap mission object 664");
+
+    // Cross tripwire 662 by the collision-valid authored curve. This exercises
+    // the real trap chain rather than injecting TurnOn into its targets.
+    await game.player.teleport({ x: 37.200462, y: -14.596002, z: -104.299965 });
+    await game.step({ frames: 2 });
+    for (const waypoint of [
+      { x: 36.9, y: -14.596, z: -105.43 },
+      { x: 36.1, y: -14.596, z: -105.95 },
+      { x: 35.3, y: -14.596, z: -105.51 },
+      { x: 34.3, y: -14.596, z: -104.85 },
+      { x: 32.5, y: -13.8, z: -104.32 },
+    ]) {
+      const move = await game.player.moveTo(waypoint);
+      assert.equal(move.moved, true);
+      await game.step({ frames: 2 });
+    }
+    await game.step({ frames: 5 });
+
+    const liveBefore = (await game.entities.list()).entities;
+    for (const id of barrierIds) {
+      const bar = liveBefore.find((entity) => entity.id === id);
+      assert.ok(bar, "tripwire must leave each force bar alive");
+      assert.ok(
+        Math.abs(bar.position[0] - 35.701313) < 0.1,
+        `tripwire must deploy force bar ${id}, got ${bar.position}`,
+      );
+    }
+
+    // A bullet delivers Damage through this same script queue. Three points is
+    // Junction 685's authored HP; the regression is the death-trigger relay.
+    await game.entities.sendMessage(junction.id, { type: "Damage", amount: 3 });
+    await game.step({ frames: 4 });
+
+    const liveAfter = (await game.entities.list()).entities;
+    assert.ok(!liveAfter.some((entity) => entity.id === junction.id), "junction must be slain");
+    assert.ok(
+      !liveAfter.some((entity) => entity.id === destroyTrap.id),
+      "TriggerDestroy must activate and consume Destroy Trap 664",
+    );
+    for (const id of barrierIds) {
+      assert.ok(
+        !liveAfter.some((entity) => entity.id === id),
+        `Destroy Trap 664 must remove force bar ${id}`,
+      );
+    }
+
+    for (const waypoint of [
+      { x: 34.3, y: -14.596, z: -104.85 },
+      { x: 35.3, y: -14.596, z: -105.51 },
+      { x: 36.1, y: -14.596, z: -105.95 },
+    ]) {
+      const exit = await game.player.moveTo(waypoint);
+      assert.equal(exit.moved, true);
+      assert.equal(exit.blocked, false, "the authored exit lane must reopen");
+      await game.step({ frames: 2 });
+    }
+    const outside = await game.player.position();
+    assert.ok(outside.x > 35.7, `player must cross the former barrier, got ${outside.x}`);
+  },
+);


### PR DESCRIPTION
Fixes #640

## Summary

- implement `TriggerDestroy` as the authored death-to-SwitchLink relay
- queue non-creature lethal damage through `MessagePayload::Slay` before the existing single teardown
- add unit coverage for relay/no-op behavior and an Ops4 trap-room e2e

## Root cause

`TriggerDestroy` was registered as a no-op, while lethal simple-health damage bypassed the script death message and removed the object directly. Junction Box 685 therefore disappeared without activating Destroy Trap 664, leaving Force Bars 545/658/659 permanently deployed.

## Validation

- `cargo test -p shock2vr` (309 passed)
- Ops4 TriggerDestroy e2e: authored tripwire entry, junction teardown, and collision-valid exit
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- targeted Explosion e2e (same-frame death/explosion timing preserved)

The full SDK e2e run reached 55 passing scenarios before being stopped after
the first implementation was superseded. It reproduced the pre-existing Earth
Psionic Training failure; its Explosion timing failure was addressed in the
final commit and the exact Explosion scenario is green.

Campaign: operations · iteration 37 · legacy assets

## Visual verification

![Ops4 force barrier disappears when Junction 685 is destroyed](https://gist.githubusercontent.com/tommy-xr/9c1fc9eb7ed2143a23c8fd7748e62ab8/raw/ops4-trigger-destroy.gif)

<sub>The deployed three-row trap barrier is removed by the authored Junction 685 → Destroy Trap 664 chain. Captured headlessly through deterministic fixed-timestep stepping.</sub>

### Before → after

![Ops4 TriggerDestroy before and after](https://gist.githubusercontent.com/tommy-xr/9c1fc9eb7ed2143a23c8fd7748e62ab8/raw/ops4-trigger-before-after.png)
