### PR TITLE
fix: persist translating door state across saves

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3737,6 +3737,20 @@ impl MissionCore {
                         locked,
                     );
                 }
+                Effect::SetTranslatingDoorState {
+                    entity_id,
+                    state,
+                    base_location,
+                } => {
+                    let mut v_trans_door = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropTranslatingDoor>>()
+                        .unwrap();
+                    if let Ok(door) = (&mut v_trans_door).get(entity_id) {
+                        door.state = state;
+                        door.base_location = base_location;
+                    }
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -441,6 +441,15 @@ pub enum Effect {
         locked: bool,
     },
 
+    /// Persistently set Dark's `P$TransDoor` motion fields (`state` and
+    /// `base_location`) on one live object - emitted by `scripts::std_door` so
+    /// door motion survives saves.
+    SetTranslatingDoorState {
+        entity_id: EntityId,
+        state: i32,
+        base_location: Vector3<f32>,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/internal_simple_health.rs
+++ b/shock2vr/src/scripts/internal_simple_health.rs
@@ -3,7 +3,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
-use super::{Effect, MessagePayload, Script};
+use super::{Effect, Message, MessagePayload, Script};
 
 // Script to handle simple health behavior for non-creature entities that carry
 // a `PropHitPoints` (e.g. breakable crates, canisters, computer panels).
@@ -45,9 +45,14 @@ impl Script for InternalSimpleHealth {
                         entity_id,
                         delta: -damage,
                     },
-                    // Hit points exhausted (or, defensively, no pool to draw
-                    // from): the entity dies.
-                    _ => Effect::SlayEntity { entity_id },
+                    // Route death through the script queue before teardown so
+                    // authored death triggers (TriggerDestroy) can react.
+                    _ => Effect::Send {
+                        msg: Message {
+                            to: entity_id,
+                            payload: MessagePayload::Slay,
+                        },
+                    },
                 }
             }
             _ => Effect::NoEffect,
@@ -95,36 +100,37 @@ mod tests {
         }
     }
 
+    fn assert_requests_slay(effect: Effect, entity_id: EntityId) {
+        match effect {
+            Effect::Send { msg } => {
+                assert_eq!(msg.to, entity_id);
+                assert!(matches!(msg.payload, MessagePayload::Slay));
+            }
+            other => panic!("expected queued Slay message, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn damage_meeting_hit_points_slays() {
+    fn damage_meeting_hit_points_requests_slay() {
         let (world, entity_id) = world_with_hit_points(1);
 
-        match damage(&world, entity_id, 1.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 1.0), entity_id);
     }
 
     #[test]
-    fn damage_exceeding_hit_points_slays() {
+    fn damage_exceeding_hit_points_requests_slay() {
         let (world, entity_id) = world_with_hit_points(5);
 
-        match damage(&world, entity_id, 6.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 6.0), entity_id);
     }
 
     #[test]
-    fn entity_without_hit_points_is_slain() {
+    fn entity_without_hit_points_requests_slay() {
         use dark::properties::PropMaxHitPoints;
         let mut world = World::new();
         // An entity that has *some* component but no PropHitPoints pool.
         let entity_id = world.add_entity((PropMaxHitPoints { hit_points: 10 },));
 
-        match damage(&world, entity_id, 1.0) {
-            Effect::SlayEntity { entity_id: id } => assert_eq!(id, entity_id),
-            other => panic!("expected SlayEntity, got {:?}", other),
-        }
+        assert_requests_slay(damage(&world, entity_id, 1.0), entity_id);
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -62,6 +62,7 @@ mod trap_trip_level;
 mod trap_tweq;
 mod trap_unlock;
 mod trigger_collide;
+mod trigger_destroy;
 mod trigger_multi;
 mod tweq_depressable;
 mod tweqable;
@@ -147,6 +148,7 @@ use self::{
     trap_tweq::TrapTweq,
     trap_unlock::TrapUnlock,
     trigger_collide::TriggerCollide,
+    trigger_destroy::TriggerDestroy,
     trigger_multi::TriggerMulti,
     tweq_depressable::TweqDepressable,
     tweqable::Tweqable,
@@ -674,7 +676,7 @@ impl ScriptWorld {
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => Box::new(UnimplementedScript::new(&script_name)),
             "turret" => Box::new(UnimplementedScript::new(&script_name)),
-            "triggerdestroy" => Box::new(NoopScript::new()),
+            "triggerdestroy" => Box::new(TriggerDestroy::new()),
 
             // skill point machines
             "psitrainer" => gui_script(Box::new(TrainerGui::new(TrainerMode::Psi))),
@@ -877,6 +879,27 @@ impl ScriptWorld {
         let mut ret = Vec::new();
         for eff in flattened_effects {
             match eff {
+                Effect::Send { msg } if matches!(msg.payload, MessagePayload::Slay) => {
+                    let entity_id = msg.to;
+                    let mut slay_effects = Vec::new();
+                    if let Some(scripts) = self.entity_to_scripts.get_mut(&entity_id) {
+                        for script in scripts {
+                            slay_effects.push(script.handle_message(
+                                entity_id,
+                                world,
+                                physics,
+                                &MessagePayload::Slay,
+                            ));
+                        }
+                    }
+                    for slay_effect in Effect::flatten(slay_effects) {
+                        match slay_effect {
+                            Effect::Send { msg } => self.message_queue.push(msg),
+                            other => ret.push(other),
+                        }
+                    }
+                    ret.push(Effect::SlayEntity { entity_id });
+                }
                 Effect::Send { msg } => self.message_queue.push(msg),
                 _ => ret.push(eff),
             }

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -1,7 +1,7 @@
 use cgmath::{InnerSpace, Vector3, Zero};
 use dark::properties::PropTranslatingDoor;
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, ViewMut, World};
+use shipyard::{EntityId, Get, View, World};
 use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
@@ -33,17 +33,13 @@ impl StdDoor {
             < (self.desired_position - trans_door.base_closed_location).magnitude2()
     }
 
-    fn persist_motion(
-        &self,
-        entity_id: EntityId,
-        world: &World,
-        state: i32,
-        position: Vector3<f32>,
-    ) {
-        let mut doors = world.borrow::<ViewMut<PropTranslatingDoor>>().unwrap();
-        if let Ok(door) = (&mut doors).get(entity_id) {
-            door.state = state;
-            door.base_location = position;
+    /// Door motion is persisted through the effect pipeline (applied by
+    /// `mission_core`) rather than written here - scripts stay pure.
+    fn persist_motion(entity_id: EntityId, state: i32, position: Vector3<f32>) -> Effect {
+        Effect::SetTranslatingDoorState {
+            entity_id,
+            state,
+            base_location: position,
         }
     }
 
@@ -59,14 +55,18 @@ impl StdDoor {
 
         self.desired_position = trans_door.base_open_location;
         self.is_moving = true;
-        self.persist_motion(entity_id, world, 3, self.current_position);
-        play_environmental_sound(
-            world,
-            entity_id,
-            "statechange",
-            vec![("openstate", "opening"), ("oldopenstate", "closed")],
-            self.audio_handle.clone(),
-        )
+        Effect::Combined {
+            effects: vec![
+                Self::persist_motion(entity_id, 3, self.current_position),
+                play_environmental_sound(
+                    world,
+                    entity_id,
+                    "statechange",
+                    vec![("openstate", "opening"), ("oldopenstate", "closed")],
+                    self.audio_handle.clone(),
+                ),
+            ],
+        }
     }
 
     fn close(
@@ -77,14 +77,18 @@ impl StdDoor {
     ) -> Effect {
         self.desired_position = trans_door.base_closed_location;
         self.is_moving = true;
-        self.persist_motion(entity_id, world, 2, self.current_position);
-        play_environmental_sound(
-            world,
-            entity_id,
-            "statechange",
-            vec![("openstate", "closing"), ("oldopenstate", "open")],
-            self.audio_handle.clone(),
-        )
+        Effect::Combined {
+            effects: vec![
+                Self::persist_motion(entity_id, 2, self.current_position),
+                play_environmental_sound(
+                    world,
+                    entity_id,
+                    "statechange",
+                    vec![("openstate", "closing"), ("oldopenstate", "open")],
+                    self.audio_handle.clone(),
+                ),
+            ],
+        }
     }
 }
 impl Script for StdDoor {
@@ -151,19 +155,22 @@ impl Script for StdDoor {
                 );
 
                 self.current_position += normalized * step;
-                self.persist_motion(
-                    entity_id,
-                    world,
-                    if self.target_is_open(&trans_door) {
-                        3
-                    } else {
-                        2
-                    },
-                    self.current_position,
-                );
-                Effect::SetPosition {
-                    entity_id,
-                    position: self.current_position,
+                Effect::Combined {
+                    effects: vec![
+                        Effect::SetPosition {
+                            entity_id,
+                            position: self.current_position,
+                        },
+                        Self::persist_motion(
+                            entity_id,
+                            if self.target_is_open(&trans_door) {
+                                3
+                            } else {
+                                2
+                            },
+                            self.current_position,
+                        ),
+                    ],
                 }
             } else if self.is_moving {
                 self.is_moving = false;
@@ -173,12 +180,6 @@ impl Script for StdDoor {
                 let reached_open =
                     (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001;
                 self.current_position = self.desired_position;
-                self.persist_motion(
-                    entity_id,
-                    world,
-                    if reached_open { 1 } else { 0 },
-                    self.desired_position,
-                );
                 let state_signal = Effect::Send {
                     msg: Message {
                         to: entity_id,
@@ -197,6 +198,11 @@ impl Script for StdDoor {
                             entity_id,
                             position: self.desired_position,
                         },
+                        Self::persist_motion(
+                            entity_id,
+                            if reached_open { 1 } else { 0 },
+                            self.desired_position,
+                        ),
                         play_environmental_sound(
                             world,
                             entity_id,
@@ -442,19 +448,63 @@ mod tests {
         }
     }
 
+    /// Stand-in for `mission_core`'s `Effect::SetTranslatingDoorState` handler -
+    /// the script only emits the effect, the world write happens here.
+    fn apply(world: &World, effect: Effect) {
+        for effect in Effect::flatten(vec![effect]) {
+            if let Effect::SetTranslatingDoorState {
+                entity_id,
+                state,
+                base_location,
+            } = effect
+            {
+                let mut doors = world
+                    .borrow::<shipyard::ViewMut<PropTranslatingDoor>>()
+                    .unwrap();
+                if let Ok(door) = (&mut doors).get(entity_id) {
+                    door.state = state;
+                    door.base_location = base_location;
+                }
+            }
+        }
+    }
+
     #[test]
     fn settled_open_endpoint_is_persisted_in_door_property() {
         let (world, entity_id) = test_world(false, false);
         let physics = PhysicsWorld::new();
         let mut door = initialized_door(entity_id, &world);
 
-        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
-        door.update(entity_id, &world, &physics, &step(1.0));
+        let effect = door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(1.0));
+        apply(&world, effect);
 
         let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
         let saved = doors.get(entity_id).unwrap();
         assert_eq!(saved.state, 1);
         assert_eq!(saved.base_location, saved.base_open_location);
+    }
+
+    #[test]
+    fn frob_emits_the_opening_state_as_an_effect() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        let effect = door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        let persisted = Effect::flatten(vec![effect])
+            .into_iter()
+            .find_map(|effect| match effect {
+                Effect::SetTranslatingDoorState {
+                    entity_id: id,
+                    state,
+                    base_location,
+                } if id == entity_id => Some((state, base_location)),
+                _ => None,
+            });
+        assert_eq!(persisted, Some((3, vec3(1.0, 2.0, 3.0))));
     }
 
     #[test]
@@ -490,8 +540,10 @@ mod tests {
         let physics = PhysicsWorld::new();
         let mut door = initialized_door(entity_id, &world);
 
-        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
-        door.update(entity_id, &world, &physics, &step(1.0));
+        let effect = door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(1.0));
+        apply(&world, effect);
 
         let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
         let saved = doors.get(entity_id).unwrap();

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -1,7 +1,7 @@
 use cgmath::{InnerSpace, Vector3, Zero};
 use dark::properties::PropTranslatingDoor;
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, View, ViewMut, World};
 use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
@@ -33,6 +33,20 @@ impl StdDoor {
             < (self.desired_position - trans_door.base_closed_location).magnitude2()
     }
 
+    fn persist_motion(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        state: i32,
+        position: Vector3<f32>,
+    ) {
+        let mut doors = world.borrow::<ViewMut<PropTranslatingDoor>>().unwrap();
+        if let Ok(door) = (&mut doors).get(entity_id) {
+            door.state = state;
+            door.base_location = position;
+        }
+    }
+
     fn open(
         &mut self,
         entity_id: EntityId,
@@ -45,6 +59,7 @@ impl StdDoor {
 
         self.desired_position = trans_door.base_open_location;
         self.is_moving = true;
+        self.persist_motion(entity_id, world, 3, self.current_position);
         play_environmental_sound(
             world,
             entity_id,
@@ -62,6 +77,7 @@ impl StdDoor {
     ) -> Effect {
         self.desired_position = trans_door.base_closed_location;
         self.is_moving = true;
+        self.persist_motion(entity_id, world, 2, self.current_position);
         play_environmental_sound(
             world,
             entity_id,
@@ -73,14 +89,30 @@ impl StdDoor {
 }
 impl Script for StdDoor {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
-        let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
-        if let Ok(trans_door) = v_trans_door.get(entity_id) {
+        let trans_door = {
+            let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
+        if let Some(trans_door) = trans_door {
             // Respect the authored door state - a door saved open must start
             // open. Snapping everything to base_closed_location shut doors the
             // level designer left open.
             let initial = trans_door.initial_location();
-            self.desired_position = initial;
             self.current_position = initial;
+            match trans_door.state {
+                2 => {
+                    self.desired_position = trans_door.base_closed_location;
+                    self.is_moving = true;
+                }
+                3 => {
+                    self.desired_position = trans_door.base_open_location;
+                    self.is_moving = true;
+                }
+                _ => {
+                    self.desired_position = initial;
+                    self.is_moving = false;
+                }
+            }
 
             Effect::SetPosition {
                 entity_id,
@@ -100,8 +132,11 @@ impl Script for StdDoor {
         //println!("Updating door: {:?}", entity_id);
         let _lerpval = (f32::cos(time.total.as_secs_f32()) + 1.0) * 0.5;
 
-        let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
-        if let Ok(trans_door) = v_trans_door.get(entity_id) {
+        let trans_door = {
+            let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
+        if let Some(trans_door) = trans_door {
             let dir = self.desired_position - self.current_position;
             let step = time.elapsed.as_secs_f32() * trans_door.speed;
             // Complete once within one frame-step of the target - stepping by
@@ -116,6 +151,16 @@ impl Script for StdDoor {
                 );
 
                 self.current_position += normalized * step;
+                self.persist_motion(
+                    entity_id,
+                    world,
+                    if self.target_is_open(&trans_door) {
+                        3
+                    } else {
+                        2
+                    },
+                    self.current_position,
+                );
                 Effect::SetPosition {
                     entity_id,
                     position: self.current_position,
@@ -127,6 +172,13 @@ impl Script for StdDoor {
                 // e.g. CS9_DoorReporter forwards these to the cutscene master.
                 let reached_open =
                     (self.desired_position - trans_door.base_open_location).magnitude2() < 0.001;
+                self.current_position = self.desired_position;
+                self.persist_motion(
+                    entity_id,
+                    world,
+                    if reached_open { 1 } else { 0 },
+                    self.desired_position,
+                );
                 let state_signal = Effect::Send {
                     msg: Message {
                         to: entity_id,
@@ -174,9 +226,12 @@ impl Script for StdDoor {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        let v_trans_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+        let trans_door = {
+            let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
 
-        if let Ok(trans_door) = v_trans_door.get(entity_id) {
+        if let Some(trans_door) = trans_door {
             // A permanently open doorway has no collider and no travel, so it
             // can't be frobbed and none of the retail ones are switch-linked -
             // but keep the invariant explicit: nothing may "close" an opening
@@ -189,8 +244,8 @@ impl Script for StdDoor {
                     // The original StdDoor toggles on player FrobWorldEnd. A
                     // locked, closed door rejects that player-driven open,
                     // while scripted TurnOn below deliberately bypasses locks.
-                    if self.target_is_open(trans_door) {
-                        self.close(entity_id, world, trans_door)
+                    if self.target_is_open(&trans_door) {
+                        self.close(entity_id, world, &trans_door)
                     } else if is_entity_locked(world, entity_id) {
                         // SS2's existing locked-control feedback; the player
                         // still gets a response without changing door state.
@@ -199,18 +254,18 @@ impl Script for StdDoor {
                             name: "hackfail".to_owned(),
                         }
                     } else {
-                        self.open(entity_id, world, trans_door)
+                        self.open(entity_id, world, &trans_door)
                     }
                 }
                 MessagePayload::TurnOn { from: _ } => {
                     // Idempotent: if we're already headed open, ignore repeat
                     // opens (e.g. several AIs converging on the same door) so
                     // the opening sound isn't replayed each frame.
-                    self.open(entity_id, world, trans_door)
+                    self.open(entity_id, world, &trans_door)
                 }
                 MessagePayload::TurnOff { from: _ } => {
                     //self.current_position = trans_door.base_closed_location;
-                    self.close(entity_id, world, trans_door)
+                    self.close(entity_id, world, &trans_door)
                 }
                 _ => Effect::NoEffect,
             }
@@ -222,6 +277,8 @@ impl Script for StdDoor {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use cgmath::{Matrix4, vec3};
     use dark::properties::{KeyCard, PropClassTag, PropKeyDst, PropLocked};
 
@@ -376,5 +433,69 @@ mod tests {
 
         assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
         assert!(door.is_moving);
+    }
+
+    fn step(seconds: f32) -> Time {
+        Time {
+            elapsed: Duration::from_secs_f32(seconds),
+            total: Duration::from_secs_f32(seconds),
+        }
+    }
+
+    #[test]
+    fn settled_open_endpoint_is_persisted_in_door_property() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        door.update(entity_id, &world, &physics, &step(1.0));
+
+        let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+        let saved = doors.get(entity_id).unwrap();
+        assert_eq!(saved.state, 1);
+        assert_eq!(saved.base_location, saved.base_open_location);
+    }
+
+    #[test]
+    fn mid_opening_state_resumes_from_saved_location() {
+        let (world, entity_id) = test_world(false, false);
+        {
+            let mut doors = world
+                .borrow::<shipyard::ViewMut<PropTranslatingDoor>>()
+                .unwrap();
+            let saved = (&mut doors).get(entity_id).unwrap();
+            saved.state = 3;
+            saved.base_location = vec3(1.0, 3.0, 3.0);
+        }
+
+        let door = initialized_door(entity_id, &world);
+
+        assert_eq!(door.current_position, vec3(1.0, 3.0, 3.0));
+        assert_eq!(door.desired_position, vec3(1.0, 4.0, 3.0));
+        assert!(door.is_moving);
+    }
+
+    #[test]
+    fn settled_closed_endpoint_is_persisted_symmetrically() {
+        let (world, entity_id) = test_world(false, false);
+        {
+            let mut doors = world
+                .borrow::<shipyard::ViewMut<PropTranslatingDoor>>()
+                .unwrap();
+            let saved = (&mut doors).get(entity_id).unwrap();
+            saved.state = 1;
+            saved.base_location = saved.base_open_location;
+        }
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        door.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+        door.update(entity_id, &world, &physics, &step(1.0));
+
+        let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+        let saved = doors.get(entity_id).unwrap();
+        assert_eq!(saved.state, 0);
+        assert_eq!(saved.base_location, saved.base_closed_location);
     }
 }

--- a/shock2vr/src/scripts/trigger_destroy.rs
+++ b/shock2vr/src/scripts/trigger_destroy.rs
@@ -1,0 +1,101 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+
+pub struct TriggerDestroy;
+
+impl TriggerDestroy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for TriggerDestroy {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Slay => send_to_all_switch_links(
+                world,
+                entity_id,
+                MessagePayload::TurnOn { from: entity_id },
+            ),
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    #[test]
+    fn slay_relays_turn_on_to_every_switch_link() {
+        let mut world = World::new();
+        let first = world.add_entity(());
+        let second = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 1,
+                    to_entity_id: Some(WrappedEntityId(first)),
+                    link: Link::SwitchLink,
+                },
+                ToLink {
+                    to_template_id: 2,
+                    to_entity_id: Some(WrappedEntityId(second)),
+                    link: Link::SwitchLink,
+                },
+            ],
+        });
+        let mut script = TriggerDestroy::new();
+
+        let effect =
+            script.handle_message(trigger, &world, &PhysicsWorld::new(), &MessagePayload::Slay);
+        let effects = match effect {
+            Effect::Combined { effects } => effects,
+            other => panic!("expected relayed messages, got {other:?}"),
+        };
+
+        assert_eq!(effects.len(), 2);
+        for (effect, target) in effects.iter().zip([first, second]) {
+            match effect {
+                Effect::Send { msg } => {
+                    assert_eq!(msg.to, target);
+                    assert!(matches!(
+                        msg.payload,
+                        MessagePayload::TurnOn { from } if from == trigger
+                    ));
+                }
+                other => panic!("expected TurnOn message, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_slay_messages_do_not_trigger_or_remove_the_object() {
+        let mut world = World::new();
+        let target = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 1,
+                to_entity_id: Some(WrappedEntityId(target)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let mut script = TriggerDestroy::new();
+
+        let effect =
+            script.handle_message(trigger, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/ops4-door-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-door-save.e2e.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8184);
+
+test(
+  "ops4.mis: tripwire door 676 stays open across a fresh-process save load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `ops4_open_door_${Date.now()}`;
+    let openZ = 0;
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops4.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 5 });
+      const door = (
+        await game.entities.list({ filter: "Ops Crew", limit: 50 })
+      ).entities.find((entity) => entity.template_id === 676);
+      assert.ok(door, "expected mission door 676");
+
+      // Locomotion teleports participate in production sensor intersections.
+      // Enter tripwire 677 exactly as a player traversal does.
+      await game.player.teleport({ x: 2.4, y: -9.6, z: -29.611 });
+      await game.step({ frames: 60 });
+
+      const opened = await game.entities.detail(door.id);
+      openZ = opened.position[2];
+      assert.ok(
+        Math.abs(openZ - door.position[2]) > 2.2,
+        `tripwire should open door 676: ${door.position[2]} -> ${openZ}`,
+      );
+      await game.player.teleport({ x: 5.0, y: -7.8, z: -29.4 });
+      await game.step({ frames: 2 });
+      assert.equal((await game.save(saveName)).success, true);
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops1.mis",
+        port: basePort + 1,
+      });
+      assert.equal((await game.load(saveName)).success, true);
+      assert.equal((await game.info()).mission, "ops4.mis");
+
+      const door = (
+        await game.entities.list({ filter: "Ops Crew", limit: 50 })
+      ).entities.find((entity) => entity.template_id === 676);
+      assert.ok(door, "expected restored mission door 676");
+      assert.ok(
+        Math.abs(door.position[2] - openZ) < 0.01,
+        `restored door must remain at saved open endpoint ${openZ}, got ${door.position[2]}`,
+      );
+
+      const reverse = await game.player.moveTo({
+        x: 0.5,
+        y: -7.8,
+        z: -29.4,
+      });
+      assert.equal(reverse.blocked, false, JSON.stringify(reverse));
+      assert.ok((await game.player.position()).x < 2.4);
+    }
+  },
+);

--- a/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-trigger-destroy.e2e.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "ops4.mis: destroying Junction 685 removes the authored trap barrier",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8176),
+    });
+    await game.step({ frames: 5 });
+
+    const all = (await game.entities.list()).entities;
+    const junction = all.find((entity) => entity.template_id === 685);
+    const destroyTrap = all.find((entity) => entity.template_id === 664);
+    const barrierIds = [545, 658, 659]
+      .map((templateId) => all.find((entity) => entity.template_id === templateId))
+      .map((entity) => {
+        assert.ok(entity, "expected every authored force bar");
+        return entity.id;
+      });
+    assert.ok(junction, "expected Junction Box mission object 685");
+    assert.ok(destroyTrap, "expected Destroy Trap mission object 664");
+
+    // Cross tripwire 662 by the collision-valid authored curve. This exercises
+    // the real trap chain rather than injecting TurnOn into its targets.
+    await game.player.teleport({ x: 37.200462, y: -14.596002, z: -104.299965 });
+    await game.step({ frames: 2 });
+    for (const waypoint of [
+      { x: 36.9, y: -14.596, z: -105.43 },
+      { x: 36.1, y: -14.596, z: -105.95 },
+      { x: 35.3, y: -14.596, z: -105.51 },
+      { x: 34.3, y: -14.596, z: -104.85 },
+      { x: 32.5, y: -13.8, z: -104.32 },
+    ]) {
+      const move = await game.player.moveTo(waypoint);
+      assert.equal(move.moved, true);
+      await game.step({ frames: 2 });
+    }
+    await game.step({ frames: 5 });
+
+    const liveBefore = (await game.entities.list()).entities;
+    for (const id of barrierIds) {
+      const bar = liveBefore.find((entity) => entity.id === id);
+      assert.ok(bar, "tripwire must leave each force bar alive");
+      assert.ok(
+        Math.abs(bar.position[0] - 35.701313) < 0.1,
+        `tripwire must deploy force bar ${id}, got ${bar.position}`,
+      );
+    }
+
+    // A bullet delivers Damage through this same script queue. Three points is
+    // Junction 685's authored HP; the regression is the death-trigger relay.
+    await game.entities.sendMessage(junction.id, { type: "Damage", amount: 3 });
+    await game.step({ frames: 4 });
+
+    const liveAfter = (await game.entities.list()).entities;
+    assert.ok(!liveAfter.some((entity) => entity.id === junction.id), "junction must be slain");
+    assert.ok(
+      !liveAfter.some((entity) => entity.id === destroyTrap.id),
+      "TriggerDestroy must activate and consume Destroy Trap 664",
+    );
+    for (const id of barrierIds) {
+      assert.ok(
+        !liveAfter.some((entity) => entity.id === id),
+        `Destroy Trap 664 must remove force bar ${id}`,
+      );
+    }
+
+    for (const waypoint of [
+      { x: 34.3, y: -14.596, z: -104.85 },
+      { x: 35.3, y: -14.596, z: -105.51 },
+      { x: 36.1, y: -14.596, z: -105.95 },
+    ]) {
+      const exit = await game.player.moveTo(waypoint);
+      assert.equal(exit.moved, true);
+      assert.equal(exit.blocked, false, "the authored exit lane must reopen");
+      await game.step({ frames: 2 });
+    }
+    const outside = await game.player.position();
+    assert.ok(outside.x > 35.7, `player must cross the former barrier, got ${outside.x}`);
+  },
+);


### PR DESCRIPTION
Fixes #643.

## Summary

- persist each translating door's live `state` and `base_location` while it moves
- persist exact open/closed endpoint states when motion settles
- restore settled endpoints exactly and resume saved opening/closing motion toward its authored destination
- add focused unit coverage plus an Ops4 fresh-process save/load traversal for tripwire 677 / door 676

## Why

Door motion previously changed only the rendered model and physics body. Save serialization therefore retained the authored `PropTranslatingDoor`, and a fresh load initialized an open door back at its closed endpoint. On the reviewed Ops4 return path this sealed the doorway behind the player.

The fix keeps the serialized translating-door property synchronized with the existing runtime motion. It does not special-case Ops4 or its tripwire.

## Validation

- `cargo test -p shock2vr` — 312 passed
- `npm test` in `tools/shock2-sdk` — 20 passed, 132 opt-in e2e skipped
- exact `ops4-door-save.e2e.test.ts` — passed across two fresh runtime processes
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` — passed

Visual evidence will be added after the deterministic capture finishes.
