### PR TITLE
docs: require Conventional Commit style for commit messages and PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ the same workflow and engine reference.
 - Follow existing patterns and conventions in the codebase
 - Run tests after each change (if available)
 - Use descriptive commit messages that explain the "why"
+- Commit messages and PR titles use Conventional Commit style: `type(scope): summary`
+  (e.g. `fix(physics): mantle over ladder tops`, `feat(play-through): ...`,
+  `docs:`, `test:`, `refactor:`). Scope is optional; the type prefix is not.
 
 ### 3. Visual Changes
 


### PR DESCRIPTION
## Summary

- document the `type(scope): summary` convention (Conventional Commits) for commit messages and PR titles in AGENTS.md

## Why

The repo follows this style in practice (`fix(physics):`, `feat:`, `docs:`…), but AGENTS.md only said "use descriptive commit messages". Agents that infer conventions from the docs — notably Codex-authored fix PRs (#644, #641, #639, #618, #616) — drift to plain titles. AGENTS.md is the canonical guidance shared by Claude Code and Codex (CLAUDE.md symlinks to it), so one bullet there covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)