### PR TITLE
feat(play-through): add campaign restart and bonus rolls

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   fix (PR "Fixes #n"), then REPLAY from the advancing frontier - until a mission
   (then the game) plays through with no new blocker. Aggregates every session into
   a self-contained HTML timeline report. Invoke with a mission (default medsci1)
-  and a goal (default: reach the level's exit).
+  and a goal (default: reach the level's exit), or with `--restart` to discard
+  campaign progress while preserving the current roll.
 ---
 
 # play-through — the playtest → review → fix → replay loop
@@ -182,11 +183,12 @@ them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
    regulators), `operations` (ops2 elevator → cutscene → sim unit overrides),
    `recreation` (painting codes → transmitter), `command`, `rickenbacker`
    (destroy the eggs), `shodan` (end sequence + boss AI).
-2. **Special tweak** — a playstyle/verification constraint for every session in
-   the campaign: none, melee-only, loot-everything, cutscene/research/regen/
-   camera-alarm verification, Navy (hack/repair/modify), Marine (standard/
-   electronic/organic/heavy weapons), OSA (psi tiers 1–5), AI/pathfinding
-   stress, or a detailed test run.
+2. **Bonus objective / special tweak** — a playstyle or verification constraint
+   for every session in the campaign: none, melee-only, loot-everything, hack
+   everything hackable, repair everything repairable, buy from every replicator,
+   verify OS upgraders, cutscene/research/regen/camera-alarm verification, Navy
+   (hack/repair/modify), Marine (standard/electronic/organic/heavy weapons), OSA
+   (psi tiers 1–5), AI/pathfinding stress, or a detailed test run.
 3. **Asset set** — legacy assets or the 25th Anniversary assets (loaded
    directly from the stock `.kpf` install since #557); the pick is the
    `DARK_ASSET_PATH` every runtime in the campaign must be launched with. Only
@@ -197,6 +199,7 @@ them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
 ```
 node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)
 node .agents/skills/play-through/playthrough-state.mjs roll seed=42      # reproducible roll
+node .agents/skills/play-through/playthrough-state.mjs roll --restart    # keep roll, discard progress
 node .agents/skills/play-through/playthrough-state.mjs roll --force scenario=hydroponics tweak=melee-only assets=legacy
 node .agents/skills/play-through/scenarios.mjs list                      # browse all ids
 ```
@@ -204,23 +207,26 @@ node .agents/skills/play-through/scenarios.mjs list                      # brows
 **The roll happens once per campaign and then sticks**: like `init`, `roll` is
 idempotent — re-invoking the skill mid-campaign keeps the existing roll, so the
 frontier, scenario, tweak, and assets stay consistent across iterations
-(`--force` starts a fresh campaign with a new roll). `show` re-surfaces the
-goal, the tweak instructions, and the `DARK_ASSET_PATH` in its NEXT line every
-iteration — **feed the tweak instructions and campaign goal into every
-`playtest` prompt**, and treat a tweak's verifications as first-class findings
-(a broken psi power under an OSA tweak is a real finding even if the mission
-could be finished without it). Every roll prints its `seed`, so any campaign
-can be reproduced exactly (the RNG stream is identical whether or not picks
-were forced alongside the seed).
+(`--force` starts a fresh campaign with a new roll). `--restart` is different:
+it preserves the current seed, scenario, tweak, assets, mission order, and fix
+branch while resetting iteration to 0 and clearing the frontier, blockers, and
+history. `show` re-surfaces the goal, the tweak instructions, and the
+`DARK_ASSET_PATH` in its NEXT line every iteration — **feed the tweak
+instructions and campaign goal into every `playtest` prompt**, and treat a
+tweak's verifications as first-class findings (a broken psi power under an OSA
+tweak is a real finding even if the mission could be finished without it).
+Every roll prints its `seed`, so any campaign can be reproduced exactly (the
+RNG stream is identical whether or not picks were forced alongside the seed).
 
 **Tweak setup gaps.** Most scenarios start mid-game with a fresh character, so
-a class tweak (Marine/Navy/OSA) may require gear, skills, or psi tiers the
-start state doesn't have. Provisioning the loadout is then the **first job of
+a class tweak (Marine/Navy/OSA) may require gear, skills, or psi tiers the start
+state doesn't have. Bonus objectives may similarly require hacking/repair skill,
+tools, or nanites. Provisioning those prerequisites is then the **first job of
 iteration 0** — use the debug runtime's legitimate levers (spawn/give,
-career-relevant items found in the level) to establish it. If the tooling
+career-relevant items found in the level) to establish them. If the tooling
 can't provision what the tweak needs, record that as a **tooling/setup gap**
 (and satisfy as much of the tweak as is reachable) — do NOT file "X is broken"
-game bugs for things the character was never given.
+game bugs for capabilities or resources the character was never given.
 
 **Record the roll everywhere it matters:** every issue filed and every fix PR
 opened during a campaign must state the rolled configuration — scenario, tweak,
@@ -249,12 +255,18 @@ its `seed`), `frontier` (the game **save** to `/v1/load` from), the
 that **stacks each fix** so the campaign plays *past* an already-fixed-but-
 unmerged blocker.
 
+**Restart the current roll:** invoke the skill with `--restart`. Before the
+normal iteration, run `playthrough-state.mjs roll --restart` exactly once, then
+`show`. This disregards recorded gameplay progress but respects the current
+roll; subsequent invocations must omit `--restart` so they resume normally. A
+missing ledger is rolled normally.
+
 **Clear & start a new campaign:** `playthrough-state.mjs roll --force` (wipes
 the ledger back to iteration 0 with a fresh scenario/tweak/assets roll; plain
-`init --force` still exists for a fixed, non-randomized order). For a *truly* clean slate also recreate the
-`fix_branch` off current `main` and delete stale frontier saves (`<data_root>/
-saves/frontier*.sav`) — otherwise the fresh campaign just launches mission 0 with
-no frontier to load, which is harmless.
+`init --force` still exists for a fixed, non-randomized order). For a *truly*
+clean slate also recreate the `fix_branch` off current `main` and delete stale
+frontier saves (`<data_root>/saves/frontier*.sav`) — otherwise the fresh
+campaign just launches mission 0 with no frontier to load, which is harmless.
 
 **Each `--auto` iteration** (do exactly one; a host loop may repeat it):
 1. `playthrough-state.mjs roll` (idempotent — rolls scenario + tweak + assets

--- a/.claude/skills/play-through/playthrough-state.mjs
+++ b/.claude/skills/play-through/playthrough-state.mjs
@@ -6,13 +6,14 @@
 //
 //   node playthrough-state.mjs <cmd> [args]
 //     init [order=earth,station,medsci1,eng1,...] [fixBranch=playthrough-fixes]
-//     roll [seed=N] [scenario=<id>] [tweak=<id>] [assets=<id>] [fixBranch=...] [--force]
+//     roll [seed=N] [scenario=<id>] [tweak=<id>] [assets=<id>] [fixBranch=...] [--force|--restart]
 //                                       init a RANDOMIZED campaign: pick a mission-
 //                                       sequence scenario, a special tweak, and an
 //                                       asset set (see scenarios.mjs) and persist
 //                                       them in the ledger. Idempotent like init —
 //                                       an existing campaign keeps its roll;
-//                                       --force re-rolls from scratch.
+//                                       --force re-rolls from scratch; --restart
+//                                       keeps that roll but discards progress.
 //     show                              print the ledger + the recommended next action
 //     advance <level> <save> <x,y,z> [note...]   set frontier, bump iteration, log history
 //     blocker add <level> <bug|feature-gap> <issue#> <desc...>   record a found blocker (status:open)
@@ -61,11 +62,33 @@ switch (cmd) {
   case "roll": {
     // Randomized init: pick scenario + tweak + asset set and persist them so
     // every later iteration of the campaign plays under the same roll.
-    // Idempotent like init — only rolls when no ledger exists (--force resets).
-    if (existsSync(FILE) && !args.includes("--force")) {
+    // Idempotent like init — only rolls when no ledger exists. `--force`
+    // replaces the roll; `--restart` preserves it and clears campaign progress.
+    const force = args.includes("--force");
+    const restart = args.includes("--restart");
+    if (force && restart) {
+      console.error("--force and --restart are mutually exclusive: use --force for a new roll or --restart to keep the current roll");
+      process.exit(1);
+    }
+    if (existsSync(FILE) && restart) {
+      const s = load();
+      s.iteration = 0;
+      s.frontier = null;
+      s.blockers = [];
+      s.history = [];
+      save(s);
+      console.log(`restarted campaign at ${FILE} — discarded progress and kept the current roll.`);
+      if (s.scenario) {
+        console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name} · seed: ${s.seed}`);
+      } else {
+        console.log("WARNING: this fixed-order campaign predates randomization, so there is no scenario/tweak/assets roll to report.");
+      }
+      break;
+    }
+    if (existsSync(FILE) && !force) {
       const s = load();
       if (s.scenario) {
-        console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --force to re-roll.`);
+        console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --restart to discard progress or --force to re-roll.`);
         console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name}`);
       } else {
         console.log(`WARNING: ledger at ${FILE} (iteration ${s.iteration}) predates campaign randomization — it has NO scenario/tweak/assets roll.`);
@@ -142,6 +165,6 @@ switch (cmd) {
     break;
   }
   default:
-    console.error("usage: init | roll | show | advance | blocker add|set (see file header)");
+    console.error("usage: init | roll [--force|--restart] | show | advance | blocker add|set (see file header)");
     process.exit(1);
 }

--- a/.claude/skills/play-through/scenarios.mjs
+++ b/.claude/skills/play-through/scenarios.mjs
@@ -1,7 +1,7 @@
 // Campaign randomization tables for the play-through skill: the mission-sequence
-// scenarios and the special-tweak playstyles a campaign can roll. Consumed by
-// `playthrough-state.mjs roll` (which persists the pick in the ledger) — run
-// directly only to browse the tables:
+// scenarios and the bonus-objective / special-tweak playstyles a campaign can
+// roll. Consumed by `playthrough-state.mjs roll` (which persists the pick in the
+// ledger) — run directly only to browse the tables:
 //
 //   node scenarios.mjs list          print all scenarios and tweaks with ids
 
@@ -74,6 +74,26 @@ export const TWEAKS = [
     id: "loot-everything",
     name: "Loot everything",
     instructions: "Grab and loot everything possible: search every corpse and container, pick up every item, and report anything that can't be grabbed or looted.",
+  },
+  {
+    id: "hack-everything",
+    name: "Hack everything hackable",
+    instructions: "Find and hack every hackable object in each mission, not just those on the shortest route; verify each successful hack changes the object's behavior as expected and report anything the game identifies as hackable that cannot be hacked.",
+  },
+  {
+    id: "repair-everything",
+    name: "Repair everything repairable",
+    instructions: "Find and repair every repairable object in each mission, not just those on the shortest route; verify each repair restores the expected function and report anything the game identifies as repairable that cannot be repaired.",
+  },
+  {
+    id: "buy-every-replicator",
+    name: "Buy from every replicator",
+    instructions: "Find every replicator in each mission and buy at least one item from each; verify the transaction consumes the expected nanites and dispenses the selected item, including hacked inventory where available.",
+  },
+  {
+    id: "verify-os-upgraders",
+    name: "Verify OS upgraders",
+    instructions: "Find and use every OS Upgrade Unit in each mission; choose different upgrades where possible, verify each grants the selected upgrade and follows the expected one-use behavior, and report any missing or incorrect upgrade effect.",
   },
   {
     id: "verify-cutscenes",
@@ -222,7 +242,7 @@ if (process.argv[1]?.endsWith("scenarios.mjs")) {
   if (cmd === "list") {
     console.log("Scenarios:");
     for (const s of SCENARIOS) console.log(`  ${s.id.padEnd(18)} ${s.missions.join(",").padEnd(28)} ${s.goal}`);
-    console.log("Tweaks:");
+    console.log("Bonus objectives / tweaks:");
     for (const t of TWEAKS) console.log(`  ${t.id.padEnd(22)} ${t.instructions}`);
     console.log("Asset sets:");
     for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})${assetSetUsable(a) ? "" : " [NOT USABLE: no data-root sentinel — force-only, excluded from random draw]"}`);


### PR DESCRIPTION
## Summary

- add a roll --restart option that discards campaign progress while preserving the current roll and fix branch
- add hack-everything, repair-everything, buy-every-replicator, and verify-os-upgraders bonus objectives to the second roll axis
- document restart behavior and prerequisite provisioning for the new objectives

## Validation

- checked both modified JavaScript modules with node --check
- exercised roll, advance, blocker tracking, and restart against an isolated ledger
- asserted restart preserves roll/configuration while clearing iteration, frontier, blockers, and history
- asserted all four new objectives can be selected through roll()
- verified --force and --restart are mutually exclusive
- ran the skill-creator quick validator successfully
- pre-push cargo formatting check passed