### PR TITLE
fix(dark_query): read game data from a 25th Anniversary install

### DIFF
--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -48,9 +48,8 @@ pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
 /// An asset-path layer that resolves only the raw data files - no textures,
 /// sounds or bundle storage, so a CLI tool can build it without a renderer.
 ///
-/// Use `data_root` as the base path when reading through it (that is what the
-/// loose-file mount resolves against), e.g.
-/// `AssetCache::new(data_root.to_string_lossy().into_owned(), asset_paths(data_root))`.
+/// Pass `data_root` as the `base_path` argument of `exists`/`get_reader`: that
+/// is what the loose-file mount resolves names against.
 pub fn asset_paths(data_root: &Path) -> Box<dyn AbstractAssetPath> {
     let mut mounts = data_file_mounts(data_root);
     mounts.push(AssetPath::folder(String::new()));

--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -1,0 +1,166 @@
+//! Resolving the raw game-data files - the gamesys (`shock2.gam`), the missions
+//! (`*.mis`) and `motiondb.bin` - in whichever install layout is present.
+//!
+//! A classic install keeps them loose at the data root. A 25th Anniversary
+//! Edition install has none of them on disk: everything lives inside
+//! `sshock2.kpf`, with the gamesys and missions under `data/` and `motiondb.bin`
+//! under `data/res/mschema/`.
+//!
+//! The renderer's mount list (`Game::init`) already handles both layouts; this
+//! module owns the data-file part of it so that CLI tools with no renderer (and
+//! no bundle storage) resolve exactly the same files the game does, instead of
+//! `File::open`ing the data root and failing on a 25AE install.
+
+use std::path::Path;
+
+use engine::assets::asset_paths::{AbstractAssetPath, AssetPath};
+
+use crate::zip_asset_path::ZipAssetPath;
+
+/// The single archive a 25th Anniversary Edition install ships its data in.
+const BASE_ARCHIVE: &str = "sshock2.kpf";
+
+/// Whether `data_root` is a 25th Anniversary Edition install rather than a
+/// classic one. The remaster ships its data inside `sshock2.kpf`; a classic
+/// install has loose `.crf` archives instead.
+pub fn is_25th_anniversary_install(data_root: &Path) -> bool {
+    data_root.join(BASE_ARCHIVE).exists()
+}
+
+/// The archive mounts that hold the raw data files, highest priority first.
+///
+/// Empty for a classic install, where those files are loose at the data root and
+/// the folder mount finds them.
+pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
+    if !is_25th_anniversary_install(data_root) {
+        return Vec::new();
+    }
+
+    let archive = data_root.join(BASE_ARCHIVE).to_string_lossy().into_owned();
+    vec![
+        // `motiondb.bin` moved from the data root to `res/mschema/`, and the
+        // missions + gamesys live under `data/`.
+        ZipAssetPath::with_prefix(archive.clone(), "data/res/mschema/"),
+        ZipAssetPath::with_prefix(archive, "data/"),
+    ]
+}
+
+/// An asset-path layer that resolves only the raw data files - no textures,
+/// sounds or bundle storage, so a CLI tool can build it without a renderer.
+///
+/// Use `data_root` as the base path when reading through it (that is what the
+/// loose-file mount resolves against), e.g.
+/// `AssetCache::new(data_root.to_string_lossy().into_owned(), asset_paths(data_root))`.
+pub fn asset_paths(data_root: &Path) -> Box<dyn AbstractAssetPath> {
+    let mut mounts = data_file_mounts(data_root);
+    mounts.push(AssetPath::folder(String::new()));
+    AssetPath::combine(mounts)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// A scratch directory that removes itself when the test ends.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> TempDir {
+            let path = std::env::temp_dir().join(format!(
+                "shock2vr-data-files-{}-{}",
+                std::process::id(),
+                name
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            TempDir(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Write a stand-in for the 25AE archive holding `entries`.
+    fn write_archive(root: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(root.join(BASE_ARCHIVE)).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        for (name, contents) in entries {
+            writer
+                .start_file(*name, zip::write::FileOptions::default())
+                .unwrap();
+            writer.write_all(contents).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    fn read(root: &Path, name: &str) -> Option<Vec<u8>> {
+        let paths = asset_paths(root);
+        let reader = paths.get_reader(root.to_string_lossy().into_owned(), name.to_owned())?;
+        let mut bytes = Vec::new();
+        reader.borrow_mut().read_to_end(&mut bytes).unwrap();
+        Some(bytes)
+    }
+
+    #[test]
+    fn classic_install_reads_loose_data_files() {
+        let dir = TempDir::new("classic");
+        std::fs::write(dir.path().join("shock2.gam"), b"loose gamesys").unwrap();
+
+        assert!(!is_25th_anniversary_install(dir.path()));
+        assert_eq!(
+            read(dir.path(), "shock2.gam").as_deref(),
+            Some(&b"loose gamesys"[..])
+        );
+    }
+
+    /// The 25AE install has no loose files at all - the gamesys, the missions and
+    /// `motiondb.bin` have to come out of `sshock2.kpf`.
+    #[test]
+    fn anniversary_install_reads_data_files_out_of_the_archive() {
+        let dir = TempDir::new("25th");
+        write_archive(
+            dir.path(),
+            &[
+                ("data/shock2.gam", b"archived gamesys"),
+                ("data/command1.mis", b"archived mission"),
+                ("data/res/mschema/motiondb.bin", b"archived motiondb"),
+            ],
+        );
+
+        assert!(is_25th_anniversary_install(dir.path()));
+        assert_eq!(
+            read(dir.path(), "shock2.gam").as_deref(),
+            Some(&b"archived gamesys"[..])
+        );
+        assert_eq!(
+            read(dir.path(), "command1.mis").as_deref(),
+            Some(&b"archived mission"[..])
+        );
+        assert_eq!(
+            read(dir.path(), "motiondb.bin").as_deref(),
+            Some(&b"archived motiondb"[..])
+        );
+    }
+
+    #[test]
+    fn a_missing_data_file_resolves_to_nothing_rather_than_panicking() {
+        let dir = TempDir::new("missing");
+        write_archive(dir.path(), &[("data/shock2.gam", b"archived gamesys")]);
+
+        assert!(!asset_paths(dir.path()).exists(
+            dir.path().to_string_lossy().into_owned(),
+            "nope.mis".to_owned()
+        ));
+        assert_eq!(read(dir.path(), "nope.mis"), None);
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -12,6 +12,7 @@ pub mod time;
 
 pub mod career;
 mod creature;
+pub mod data_files;
 mod flat_player_controller;
 mod gui;
 mod hand_glove;
@@ -114,11 +115,11 @@ fn read_save_file(path: &Path) -> io::Result<SaveData> {
     Ok(SaveData::read(&mut file))
 }
 
-/// Whether `data_root` is a 25th Anniversary Edition install rather than a
-/// classic one. The remaster ships its data inside `sshock2.kpf`; a classic
-/// install has loose `.crf` archives instead.
+/// Whether the resolved data root is a 25th Anniversary Edition install rather
+/// than a classic one. The remaster ships its data inside `sshock2.kpf`; a
+/// classic install has loose `.crf` archives instead.
 pub fn is_25th_anniversary_install() -> bool {
-    Path::new(&resource_path("sshock2.kpf")).exists()
+    data_files::is_25th_anniversary_install(paths::data_root())
 }
 
 /// Resource families, in the order a lookup should consult them.
@@ -206,16 +207,9 @@ fn build_25th_anniversary_mounts(
         ));
     }
 
-    // `motiondb.bin` moved from the data root to `res/mschema/`, and the
-    // missions + gamesys live under `data/`.
-    mounts.push(ZipAssetPath::with_prefix(
-        resource_path("sshock2.kpf"),
-        "data/res/mschema/",
-    ));
-    mounts.push(ZipAssetPath::with_prefix(
-        resource_path("sshock2.kpf"),
-        "data/",
-    ));
+    // The gamesys, missions and motiondb - shared with the CLI tools, which
+    // need those files without any of the resource families above.
+    mounts.extend(data_files::data_file_mounts(paths::data_root()));
 
     mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
     mounts.push(AssetPath::folder("".to_owned()));

--- a/shock2vr/src/paths.rs
+++ b/shock2vr/src/paths.rs
@@ -14,11 +14,6 @@ pub fn data_root() -> &'static Path {
     Path::new("/sdcard/shock2quest")
 }
 
-#[cfg(target_os = "android")]
-pub fn search_roots() -> &'static [&'static str] {
-    &["/sdcard/shock2quest"]
-}
-
 #[cfg(not(target_os = "android"))]
 static DATA_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
@@ -40,11 +35,6 @@ const SENTINELS: &[&str] = &[
 #[cfg(not(target_os = "android"))]
 pub fn data_root() -> &'static Path {
     DATA_ROOT.get_or_init(resolve_desktop_data_root).as_path()
-}
-
-#[cfg(not(target_os = "android"))]
-pub fn search_roots() -> &'static [&'static str] {
-    DESKTOP_CANDIDATES
 }
 
 #[cfg(not(target_os = "android"))]

--- a/tools/dark_query/src/data_loader.rs
+++ b/tools/dark_query/src/data_loader.rs
@@ -5,9 +5,38 @@ use dark::{
     ss2_chunk_file_reader,
     ss2_entity_info::{self, SystemShock2EntityInfo, merge_with_gamesys},
 };
-use shock2vr::paths;
-use std::{fs::File, io::BufReader};
+use engine::assets::asset_paths::{AbstractAssetPath, ReadableAndSeekable};
+use shock2vr::{data_files, paths};
+use std::cell::RefCell;
+use std::sync::OnceLock;
 use tracing::info;
+
+/// The data-file mounts, built once per process: indexing a 25th Anniversary
+/// archive is not free, and both the gamesys and the mission go through here.
+fn data_file_paths() -> &'static dyn AbstractAssetPath {
+    static PATHS: OnceLock<Box<dyn AbstractAssetPath>> = OnceLock::new();
+    &**PATHS.get_or_init(|| data_files::asset_paths(paths::data_root()))
+}
+
+/// Open a raw data file (the gamesys, a mission, `motiondb.bin`) through the
+/// same asset-path layer the game uses, so a 25th Anniversary install - where
+/// nothing is loose on disk and everything lives inside `sshock2.kpf` - works
+/// just like a classic one.
+pub fn open_data_file(name: &str) -> Result<RefCell<Box<dyn ReadableAndSeekable>>> {
+    let data_root = paths::data_root();
+    data_file_paths()
+        .get_reader(
+            data_root.to_string_lossy().into_owned(),
+            name.to_ascii_lowercase(),
+        )
+        .with_context(|| {
+            format!(
+                "{name} not found in the game data at {} - set DARK_ASSET_PATH to your \
+                 System Shock 2 install if that is the wrong directory",
+                data_root.display()
+            )
+        })
+}
 
 /// Load the full gamesys (shock2.gam) including speech DB and sound schema
 pub fn load_gamesys() -> Result<gamesys::Gamesys> {
@@ -15,21 +44,14 @@ pub fn load_gamesys() -> Result<gamesys::Gamesys> {
 
     let (properties, links, links_with_data) = get();
 
-    // Load shock2.gam file
-    let data_root = paths::data_root();
-    let gam_path = data_root.join("shock2.gam");
-    if !gam_path.exists() {
-        return Err(anyhow::anyhow!(
-            "shock2.gam not found. Checked these directories: {}",
-            paths::search_roots().join(", ")
-        ));
-    }
+    let game_reader = open_data_file("shock2.gam")?;
 
-    let game_file =
-        File::open(&gam_path).with_context(|| format!("Failed to open {}", gam_path.display()))?;
-    let mut game_reader = BufReader::new(game_file);
-
-    let gamesys = gamesys::read(&mut game_reader, &links, &links_with_data, &properties);
+    let gamesys = gamesys::read(
+        &mut *game_reader.borrow_mut(),
+        &links,
+        &links_with_data,
+        &properties,
+    );
 
     info!(
         "Loaded {} entities from gamesys",
@@ -53,24 +75,14 @@ pub fn load_gamesys_with_mission(mission_name: &str) -> Result<SystemShock2Entit
     );
 
     let gamesys = load_gamesys()?;
-    let data_root = paths::data_root();
     let (properties, links, links_with_data) = get();
 
     // Load mission file
-    let mission_path = data_root.join(mission_name);
-    if !mission_path.exists() {
-        return Err(anyhow::anyhow!(
-            "Mission file {} not found.",
-            mission_path.display()
-        ));
-    }
-
-    let mission_file = File::open(&mission_path)
-        .with_context(|| format!("Failed to open {}", mission_path.display()))?;
-    let mut mission_reader = BufReader::new(mission_file);
+    let mission_reader = open_data_file(mission_name)?;
+    let mut mission_reader = mission_reader.borrow_mut();
 
     // Read mission table of contents to get entity data chunks
-    let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(&mut mission_reader);
+    let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(&mut *mission_reader);
 
     // Extract entity info directly without asset loading
     let mission_entity_info = ss2_entity_info::new(
@@ -78,7 +90,7 @@ pub fn load_gamesys_with_mission(mission_name: &str) -> Result<SystemShock2Entit
         &links,
         &links_with_data,
         &properties,
-        &mut mission_reader,
+        &mut *mission_reader,
     );
 
     // Merge gamesys + mission data

--- a/tools/dark_query/src/data_loader.rs
+++ b/tools/dark_query/src/data_loader.rs
@@ -22,13 +22,14 @@ fn data_file_paths() -> &'static dyn AbstractAssetPath {
 /// same asset-path layer the game uses, so a 25th Anniversary install - where
 /// nothing is loose on disk and everything lives inside `sshock2.kpf` - works
 /// just like a classic one.
-pub fn open_data_file(name: &str) -> Result<RefCell<Box<dyn ReadableAndSeekable>>> {
+pub fn open_data_file(name: &str) -> Result<Box<dyn ReadableAndSeekable>> {
     let data_root = paths::data_root();
     data_file_paths()
         .get_reader(
             data_root.to_string_lossy().into_owned(),
             name.to_ascii_lowercase(),
         )
+        .map(RefCell::into_inner)
         .with_context(|| {
             format!(
                 "{name} not found in the game data at {} - set DARK_ASSET_PATH to your \
@@ -44,14 +45,9 @@ pub fn load_gamesys() -> Result<gamesys::Gamesys> {
 
     let (properties, links, links_with_data) = get();
 
-    let game_reader = open_data_file("shock2.gam")?;
+    let mut game_reader = open_data_file("shock2.gam")?;
 
-    let gamesys = gamesys::read(
-        &mut *game_reader.borrow_mut(),
-        &links,
-        &links_with_data,
-        &properties,
-    );
+    let gamesys = gamesys::read(&mut game_reader, &links, &links_with_data, &properties);
 
     info!(
         "Loaded {} entities from gamesys",
@@ -78,11 +74,10 @@ pub fn load_gamesys_with_mission(mission_name: &str) -> Result<SystemShock2Entit
     let (properties, links, links_with_data) = get();
 
     // Load mission file
-    let mission_reader = open_data_file(mission_name)?;
-    let mut mission_reader = mission_reader.borrow_mut();
+    let mut mission_reader = open_data_file(mission_name)?;
 
     // Read mission table of contents to get entity data chunks
-    let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(&mut *mission_reader);
+    let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(&mut mission_reader);
 
     // Extract entity info directly without asset loading
     let mission_entity_info = ss2_entity_info::new(
@@ -90,7 +85,7 @@ pub fn load_gamesys_with_mission(mission_name: &str) -> Result<SystemShock2Entit
         &links,
         &links_with_data,
         &properties,
-        &mut *mission_reader,
+        &mut mission_reader,
     );
 
     // Merge gamesys + mission data

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -815,25 +815,17 @@ fn show_unparsed_data(entity_id: i32, entity_info: &dark::ss2_entity_info::Syste
 }
 
 fn handle_aipath_command(mission: &str, limit: Option<usize>) -> Result<()> {
-    use std::fs::File;
-
     info!("Loading AIPATH data from {}...", mission);
 
     // Load the mission file
-    let data_root = shock2vr::paths::data_root();
-    let mission_path = data_root.join(mission);
-
-    if !mission_path.exists() {
-        anyhow::bail!("Mission file not found: {}", mission_path.display());
-    }
-
-    let mut file = File::open(&mission_path)?;
+    let reader = data_loader::open_data_file(mission)?;
+    let mut file = reader.borrow_mut();
 
     // Parse AIPATH chunk directly
-    let table_of_contents = dark::ss2_chunk_file_reader::read_table_of_contents(&mut file);
+    let table_of_contents = dark::ss2_chunk_file_reader::read_table_of_contents(&mut *file);
 
     // Parse AIPATH chunk
-    if let Some(path_database) = dark::mission::PathDatabase::read(&table_of_contents, &mut file) {
+    if let Some(path_database) = dark::mission::PathDatabase::read(&table_of_contents, &mut *file) {
         println!("=== AIPATH Database from {} ===", mission);
         println!(
             "Cells: {}, Vertices: {}, Links: {}",

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -641,6 +641,16 @@ fn handle_maps_command(mission: &str) -> Result<()> {
 
     // Production runtime ONLY has intrface.crf - no fallback to folders
     let intrface_crf_path = data_root.join("res/intrface.crf");
+    if !intrface_crf_path.exists() {
+        // A 25th Anniversary install keeps the interface family inside
+        // `sshock2.kpf`, which needs the renderer's family mounts, not the
+        // data-file ones this tool uses elsewhere. Fail with a message rather
+        // than panicking inside the archive reader.
+        anyhow::bail!(
+            "{} not found - `maps` needs a classic install with loose .crf archives",
+            intrface_crf_path.display()
+        );
+    }
 
     println!(
         "Using intrface.crf archive: {}",
@@ -818,14 +828,13 @@ fn handle_aipath_command(mission: &str, limit: Option<usize>) -> Result<()> {
     info!("Loading AIPATH data from {}...", mission);
 
     // Load the mission file
-    let reader = data_loader::open_data_file(mission)?;
-    let mut file = reader.borrow_mut();
+    let mut file = data_loader::open_data_file(mission)?;
 
     // Parse AIPATH chunk directly
-    let table_of_contents = dark::ss2_chunk_file_reader::read_table_of_contents(&mut *file);
+    let table_of_contents = dark::ss2_chunk_file_reader::read_table_of_contents(&mut file);
 
     // Parse AIPATH chunk
-    if let Some(path_database) = dark::mission::PathDatabase::read(&table_of_contents, &mut *file) {
+    if let Some(path_database) = dark::mission::PathDatabase::read(&table_of_contents, &mut file) {
         println!("=== AIPATH Database from {} ===", mission);
         println!(
             "Cells: {}, Vertices: {}, Links: {}",

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -1,11 +1,9 @@
 use anyhow::Result;
 use dark::motion::{MotionDB, MotionQuery, MotionQueryItem, MotionQuerySelectionStrategy};
-use shock2vr::paths;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
-use std::path::Path;
 use tracing::info;
+
+use crate::data_loader::open_data_file;
 
 pub struct MotionAnalyzer {
     motion_db: MotionDB,
@@ -15,12 +13,8 @@ pub struct MotionAnalyzer {
 impl MotionAnalyzer {
     pub fn new() -> Result<Self> {
         // Load motion database
-        let motiondb_path = find_motiondb_file()?;
-        info!("Loading motion database from: {}", motiondb_path.display());
-
-        let motiondb_file = File::open(motiondb_path)?;
-        let mut motiondb_reader = BufReader::new(motiondb_file);
-        let motion_db = MotionDB::read(&mut motiondb_reader);
+        let motiondb_reader = open_data_file("motiondb.bin")?;
+        let motion_db = MotionDB::read(&mut *motiondb_reader.borrow_mut());
 
         // Create creature name mapping based on ActorType enum
         let mut creature_name_to_id = HashMap::new();
@@ -203,10 +197,8 @@ impl MotionAnalyzer {
         // The per-frame root-y stream lives in the clip file (res/motions/
         // <name>_.mc), not the motion database - print its curve when the
         // unpacked file is available
-        let mc_path = paths::data_root().join(format!("res/motions/{}_.mc", name));
-        if let Ok(file) = File::open(&mc_path) {
-            let mut reader = BufReader::new(file);
-            let clip = dark::motion::MotionClip::read(&mut reader, mps);
+        if let Ok(reader) = open_data_file(&format!("res/motions/{}_.mc", name)) {
+            let clip = dark::motion::MotionClip::read(&mut *reader.borrow_mut(), mps);
             let ys: Vec<f32> = clip.root_transforms.iter().map(|m| m.w.y).collect();
             if !ys.is_empty() {
                 let n = ys.len();
@@ -245,8 +237,8 @@ impl MotionAnalyzer {
             }
         } else {
             println!(
-                "  root y:       (no unpacked clip at {})",
-                mc_path.display()
+                "  root y:       (no clip res/motions/{}_.mc in the data)",
+                name
             );
         }
         Ok(())
@@ -311,20 +303,4 @@ fn parse_tags(tags: &[String]) -> Result<Vec<MotionQueryItem>> {
     }
 
     Ok(motion_query_items)
-}
-
-fn find_motiondb_file() -> Result<std::path::PathBuf> {
-    // Try common locations for motiondb.bin
-    let data_motiondb_path = paths::data_root().join("motiondb.bin");
-    let possible_paths = ["motiondb.bin", &data_motiondb_path.to_string_lossy()];
-
-    for path in &possible_paths {
-        if Path::new(path).exists() {
-            return Ok(Path::new(path).to_path_buf());
-        }
-    }
-
-    anyhow::bail!(
-        "Could not find motiondb.bin. Please run from project root or ensure motiondb.bin is in the current directory or Data/ subdirectory."
-    );
 }

--- a/tools/dark_query/src/motion_analyzer.rs
+++ b/tools/dark_query/src/motion_analyzer.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use dark::motion::{MotionDB, MotionQuery, MotionQueryItem, MotionQuerySelectionStrategy};
+use shock2vr::paths;
 use std::collections::HashMap;
 use tracing::info;
 
@@ -13,8 +14,8 @@ pub struct MotionAnalyzer {
 impl MotionAnalyzer {
     pub fn new() -> Result<Self> {
         // Load motion database
-        let motiondb_reader = open_data_file("motiondb.bin")?;
-        let motion_db = MotionDB::read(&mut *motiondb_reader.borrow_mut());
+        let mut motiondb_reader = open_data_file("motiondb.bin")?;
+        let motion_db = MotionDB::read(&mut motiondb_reader);
 
         // Create creature name mapping based on ActorType enum
         let mut creature_name_to_id = HashMap::new();
@@ -197,8 +198,8 @@ impl MotionAnalyzer {
         // The per-frame root-y stream lives in the clip file (res/motions/
         // <name>_.mc), not the motion database - print its curve when the
         // unpacked file is available
-        if let Ok(reader) = open_data_file(&format!("res/motions/{}_.mc", name)) {
-            let clip = dark::motion::MotionClip::read(&mut *reader.borrow_mut(), mps);
+        if let Ok(mut reader) = open_data_file(&format!("res/motions/{}_.mc", name)) {
+            let clip = dark::motion::MotionClip::read(&mut reader, mps);
             let ys: Vec<f32> = clip.root_transforms.iter().map(|m| m.w.y).collect();
             if !ys.is_empty() {
                 let n = ys.len();
@@ -237,8 +238,9 @@ impl MotionAnalyzer {
             }
         } else {
             println!(
-                "  root y:       (no clip res/motions/{}_.mc in the data)",
-                name
+                "  root y:       (no clip res/motions/{}_.mc in the game data at {})",
+                name,
+                paths::data_root().display()
             );
         }
         Ok(())


### PR DESCRIPTION
## Problem

`cargo dq` could not read a **25th Anniversary Edition** asset set, so all game-data research was silently forced onto a legacy unpacked install:

```console
$ DARK_ASSET_PATH=/Users/hacker/ss2-25th cargo dq entities command1.mis --limit 5
Error: shock2.gam not found. Checked these directories: ./Data, ../Data, ../../Data, .
```

## Root cause

`tools/dark_query/src/data_loader.rs` opened `<data_root>/shock2.gam` and `<data_root>/<mission>.mis` as **loose files**. A 25AE install has neither on disk — the gamesys, the missions and `motiondb.bin` all live inside `sshock2.kpf`. `paths::data_root()` already accepts such a directory (`sshock2.kpf` is one of its sentinels, added with #557), so the data root resolved fine; only the `File::open` failed.

The error message compounded it: it printed `paths::search_roots()` — the hardcoded `./Data, ../Data, …` candidate list — even though `DARK_ASSET_PATH` had resolved somewhere else entirely, so the message named directories that had nothing to do with the failure.

## Approach

The runtime has resolved these files through the asset-path layer since #557, so instead of adding a second KPF reader, the **data-file part of that mount list moves into `shock2vr::data_files`** and both the runtime and the CLI use it:

- `data_files::data_file_mounts(data_root)` — the two `sshock2.kpf` mounts that hold the gamesys/missions (`data/`) and `motiondb.bin` (`data/res/mschema/`), empty for a classic install.
- `data_files::asset_paths(data_root)` — those mounts plus the loose-file folder mount; a whole asset-path layer a CLI can build with no renderer and no bundle storage.
- `Game::init`'s 25AE mount list is **unchanged in content and order** — it now calls `data_file_mounts` for its last two mounts. `is_25th_anniversary_install()` moved into the same module and keeps its old signature via `paths::data_root()`.

`dark_query` reads the gamesys, missions, `motiondb.bin` and the `res/motions/*_.mc` clips through `data_loader::open_data_file`, which goes through that layer (mounts built once per process). The error now names the **resolved** data root and mentions `DARK_ASSET_PATH`.

`dq maps` is the one subcommand not covered: it reads the *interface resource family* from `res/intrface.crf`, which a 25AE install keeps inside the KPF behind the renderer's family mounts. It now fails with a message instead of panicking inside the archive reader — see #648 for that and the other tools.

## Verification

**Before** (base commit, 25AE install):

```console
$ DARK_ASSET_PATH=/Users/hacker/ss2-25th cargo dq entities command1.mis --limit 5
Error: shock2.gam not found. Checked these directories: ./Data, ../Data, ../../Data, .
```

**After** (same command) — identical to the legacy install's output, including the entity counts:

```console
$ DARK_ASSET_PATH=/Users/hacker/ss2-25th cargo dq entities command1.mis --limit 5
INFO Loaded 4541 entities from gamesys
INFO Loaded 917 entities from mission
INFO Merged total: 5458 entities
ID       | Type     | Names                                    | Template | Props | Links | Unparsed
---------+----------+------------------------------------------+----------+-------+-------+---------
-5223    | Template | sym:small shockwave                      | -3598    | 4     | 0     | Yes
-5220    | Template | sym:anim texture break                   | -363     | 4     | 0     | Yes
-4995    | Template | sym:Active Protocol Box                  | -2250    | 2     | 4     | Yes
-4964    | Template | sym:BlueForceField                       | -505     | 4     | 0     | Yes
-4858    | Template | sym:Big EMP Explosion                    | -382     | 6     | 1     | Yes

Showing 5 of 5458 entities (limited)
```

**Data agreement between the two installs.** Ran `entities --limit 400`, `entities --filter "*Door*"`, `templates 22`, `motion`, `motion-info`, `speech`, `sound` and `aipath` against both `DARK_ASSET_PATH=/Users/hacker/ss2-25th` and `DARK_ASSET_PATH=/Users/hacker/ss2-data-unpacked`; every output is byte-identical once log timestamps are stripped. The only exception is `templates`' *unparsed property* list, whose order comes from a `HashSet` and differs run-to-run **on the same install** (pre-existing; same 16 entries either way).

Per-subcommand, both installs:

| command | 25AE | classic |
| --- | --- | --- |
| `entities` / `templates` / `speech` / `sound` / `aipath` / `motion` / `motion-info` | ok | ok |
| `maps` | clear error (#648) | ok |

`motion-info humdie3` resolves its `.mc` clip out of the KPF and prints the same root-y curve as the legacy run.

**No runtime regression from the mount refactor.** Launched the debug runtime on `command1.mis` against **both** installs, stepped 30 frames and queried entities — both load, step and report the same objects (e.g. `Double Elevator Door`, `template_id` 142, identical position).

**Error message, after:**

```console
$ DARK_ASSET_PATH=/Users/hacker/ss2-25th cargo dq entities nosuch.mis
Error: nosuch.mis not found in the game data at /Users/hacker/ss2-25th - set DARK_ASSET_PATH to your System Shock 2 install if that is the wrong directory
```

**Automated test.** `shock2vr/src/data_files.rs` has three unit tests that need no game assets: they build a scratch classic layout (a loose file) and a scratch 25AE layout (a generated zip named `sshock2.kpf` holding `data/shock2.gam`, `data/command1.mis`, `data/res/mschema/motiondb.bin`) and assert the layer reads each file, plus that a missing name resolves to `None` rather than panicking. Negative test done first: with `data_file_mounts` stubbed to return no mounts (the old loose-file assumption), `anniversary_install_reads_data_files_out_of_the_archive` fails; with the mounts it passes.

Note that CI's test job runs `-p engine -p desktop_runtime -p dark_viewer -p dark_query -p debug_runtime -p debug_command` — **not** `-p shock2vr` — so these tests (and the other 321 shock2vr unit tests) do not run in CI today. They pass under `cargo test -p shock2vr` in ~6s with no assets; widening the CI package list looks worthwhile but is left out of this PR.

**Build + tests**

```
RUSTFLAGS="-D warnings" cargo check --all-targets -p shock2vr -p desktop_runtime -p debug_runtime \
  -p dark_query -p dark_viewer -p bench -p hitbox_analyzer -p debug_command   # clean
cargo test -p shock2vr   # 324 passed
cargo test -p dark       # 63 passed
cargo test -p dark_query # ok
cargo fmt --all -- --check  # clean
```

Plus the SDK e2e suite (`SHOCK2_E2E=1`).

## Review

`/xreview` (Claude subagent + Codex CLI) — no Critical/High findings from either engine; both independently confirmed the mount list is unchanged in content and order and that the archive's in-memory `Cursor` satisfies the same `Read + Seek` contract the chunk parsers use. Applied from their Medium/Low findings: `open_data_file` returns the reader instead of the engine's `RefCell` wrapper (dropping the `&mut *x.borrow_mut()` ceremony), `dq maps` errors instead of panicking, the now-orphaned `paths::search_roots()` is deleted, and the "no unpacked motion clip" message keeps the data root. Not changed, deliberately: a *corrupt* (as opposed to missing) archive still panics inside `ZipAssetPath`, which is pre-existing behavior shared with the runtime; and names are lowercased before lookup, matching what `AssetCache::get_raw_reader` and `mission_exists` already do.

