### PR TITLE
feat(debug): provision items and character progression headlessly

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -222,11 +222,32 @@ RNG stream is identical whether or not picks were forced alongside the seed).
 a class tweak (Marine/Navy/OSA) may require gear, skills, or psi tiers the start
 state doesn't have. Bonus objectives may similarly require hacking/repair skill,
 tools, or nanites. Provisioning those prerequisites is then the **first job of
-iteration 0** — use the debug runtime's legitimate levers (spawn/give,
-career-relevant items found in the level) to establish them. If the tooling
-can't provision what the tweak needs, record that as a **tooling/setup gap**
-(and satisfy as much of the tweak as is reachable) — do NOT file "X is broken"
-game bugs for capabilities or resources the character was never given.
+iteration 0** — use the debug runtime's **provisioning levers** to establish them:
+
+```ts
+await game.player.spawnItem("Shotgun");        // by template name...
+await game.player.spawnItem(-18);              // ...or stable template id (Assault Rifle)
+await game.player.setStats({                   // free "training" (no module cost)
+  skills: { standard_weapons: 4, hack: 4 },
+  strength: 3,
+  psi_tier: 2,
+  cyber_modules: 20,
+});
+```
+
+(`POST /v1/player/spawn-item` / `POST /v1/player/stats`; also
+`game.player.give(entityId)` for an item the level already contains.) Spawned
+items land in the backpack like any pickup — wield a weapon by double-clicking
+it in the use-mode inventory strip. Provisioning only *raises* the sheet, only
+accepts genuine pickup items, and only takes **gamesys** templates (negative
+ids), so it can't duplicate a level's unique quest items: it is a starting
+state, not a way to skip gameplay. Note the sheet is storage for most fields —
+only Hack + cyber_affinity currently drive anything (hacking difficulty), so
+"trained standard_weapons" does not yet change how a gun behaves; don't read
+that as a bug. If the tooling still can't provision what a tweak or bonus
+objective needs, record that as a **tooling/setup gap** (and satisfy as much of
+it as is reachable) — do NOT file "X is broken" game bugs for capabilities or
+resources the character was never given.
 
 **Record the roll everywhere it matters:** every issue filed and every fix PR
 opened during a campaign must state the rolled configuration — scenario, tweak,

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -74,15 +74,17 @@ e.g. a ragdoll falling — erratic.) `/v1/physics/joints` reports each impulse
 joint's anchor separation + applied impulse (bone-labeled) for ragdoll
 constraint diagnostics.
 
-### Phase 5: Game Commands 🔴 NOT STARTED
+### Phase 5: Game Commands 🟡 PARTIAL
 
-| Task                                          | Status         |
-| --------------------------------------------- | -------------- |
-| Game command endpoint (`/v1/control/command`) | ❌ Placeholder |
-| Spawn command                                 | ❌             |
-| Save/load commands                            | ❌             |
-| Level transition                              | ❌             |
-| God mode, noclip                              | ❌             |
+Dedicated typed endpoints rather than one stringly-typed command dispatcher -
+the `/v1/control/command` placeholder was removed as dead API surface.
+
+| Task                                                  | Status |
+| ----------------------------------------------------- | ------ |
+| Debug provisioning (`/v1/player/spawn-item`, `/v1/player/stats`) | ✅     |
+| Save/load commands (`/v1/save`, `/v1/load`)           | ✅     |
+| Level transition (`/v1/control/transition-level`)     | ✅     |
+| God mode, noclip                                      | ❌     |
 
 ### Phase 6: TypeScript API ✅ COMPLETE
 
@@ -226,7 +228,8 @@ GET  /v1/physics/bodies   - List physics bodies
 GET  /v1/physics/bodies/{id} - Physics body details
 GET  /v1/control/input    - Get input state
 POST /v1/control/input    - Set input channel
-POST /v1/control/command  - Execute game command (placeholder)
+POST /v1/player/spawn-item - Provision an item template into the inventory
+POST /v1/player/stats     - Provision skills/stats/psi tier/cyber modules
 POST /v1/screenshot       - Capture screenshot
 ```
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -93,11 +93,20 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<Result<(), String>>,
     },
 
+    /// Provision a fresh item from a template into the player's inventory.
+    SpawnItem {
+        template: shock2vr::game_scene::DebugItemTemplate,
+        reply: oneshot::Sender<Result<shock2vr::game_scene::DebugSpawnedItem, String>>,
+    },
+
+    /// Provision the player's character sheet (stats/skills/psi tier/modules).
+    SetPlayerStats {
+        request: shock2vr::game_scene::DebugPlayerStatsRequest,
+        reply: oneshot::Sender<Result<shock2vr::player_stats::PlayerStats, String>>,
+    },
+
     /// Get current player position
     GetPlayerPosition(oneshot::Sender<Vector3<f32>>),
-
-    /// Execute a game command (spawn, save, etc.)
-    RunGameCommand(String, Vec<String>, oneshot::Sender<CommandResult>),
 
     /// Pathfinding test command (set_start, set_goal, reset)
     PathfindingTest(String, oneshot::Sender<CommandResult>),

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -2739,6 +2739,7 @@ async fn give_item(
 /// Addressed by template, the only identity stable across runs: either the
 /// gamesys template name ("Shotgun") or the template id (-19). Exactly one.
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SpawnItemRequest {
     template: Option<String>,
     template_id: Option<i32>,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -293,6 +293,8 @@ async fn start_http_server(
         .route("/v1/player/inventory", get(get_player_inventory))
         .route("/v1/transitions", get(list_transitions))
         .route("/v1/player/give", axum::routing::post(give_item))
+        .route("/v1/player/spawn-item", axum::routing::post(spawn_item))
+        .route("/v1/player/stats", axum::routing::post(set_player_stats))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
@@ -305,7 +307,6 @@ async fn start_http_server(
         .route("/v1/ragdoll/metrics", get(get_ragdoll_metrics))
         .route("/v1/control/input", get(get_input_state))
         .route("/v1/control/input", axum::routing::post(set_input_channel))
-        .route("/v1/control/command", axum::routing::post(run_game_command))
         .route(
             "/v1/pathfinding-test",
             axum::routing::post(pathfinding_test).get(pathfinding_test_status),
@@ -356,10 +357,15 @@ async fn start_http_server(
     info!("  POST /v1/quests/:name     - Set a quest bit {{value: unknown|incomplete|complete}}");
     info!("  GET  /v1/player/inventory - Snapshot the player's carried items");
     info!("  POST /v1/player/give      - Put an existing entity in the inventory {{entity_id}}");
+    info!(
+        "  POST /v1/player/spawn-item - Provision a fresh item into the inventory {{template|template_id}}"
+    );
+    info!(
+        "  POST /v1/player/stats     - Provision the character sheet {{skills, stats, psi_tier, cyber_modules}}"
+    );
     info!("  POST /v1/physics/raycast  - Perform physics raycast for collision testing");
     info!("  GET  /v1/control/input    - Retrieve controller/input state");
     info!("  POST /v1/control/input    - Update controller/input channels");
-    info!("  POST /v1/control/command  - Execute gameplay commands (save, spawn, etc.)");
     info!(
         "  POST /v1/input/action     - Trigger a discrete input action (e.g. PathfindingTestCycle)"
     );
@@ -1183,15 +1189,21 @@ fn process_command(
                 }
             }
         }
-        RuntimeCommand::RunGameCommand(_command, _args, reply) => {
-            // TODO: Implement game command execution
-            let result = CommandResult {
-                success: false,
-                message: "Game commands not yet implemented".to_string(),
-                data: None,
+        RuntimeCommand::SpawnItem { template, reply } => {
+            // Goes through `Game` (not the debuggable scene directly) because
+            // instantiating the item needs the game-owned asset cache.
+            let result = game.debug_spawn_item(&template);
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send spawn-item result - receiver dropped");
+            }
+        }
+        RuntimeCommand::SetPlayerStats { request, reply } => {
+            let result = match game.debug_scene_mut() {
+                Some(scene) => scene.set_player_stats(&request),
+                None => Err("no debuggable scene available".to_string()),
             };
-            if let Err(_) = reply.send(result) {
-                tracing::warn!("Failed to send command result - receiver dropped");
+            if reply.send(result).is_err() {
+                tracing::warn!("Failed to send set-player-stats result - receiver dropped");
             }
         }
         RuntimeCommand::PathfindingTest(action, reply) => {
@@ -2321,14 +2333,6 @@ struct PositionResponse {
     position: [f32; 3],
 }
 
-/// Request payload for executing a gameplay command
-#[derive(serde::Deserialize)]
-struct GameCommandRequest {
-    command: String,
-    #[serde(default)]
-    args: Vec<String>,
-}
-
 /// Request payload for pathfinding test command
 #[derive(serde::Deserialize)]
 struct PathfindingTestRequest {
@@ -2726,6 +2730,83 @@ async fn give_item(
         Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
         Err(_) => {
             tracing::error!("Failed to receive give-item result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// Request body for provisioning a fresh item into the player's inventory.
+/// Addressed by template, the only identity stable across runs: either the
+/// gamesys template name ("Shotgun") or the template id (-19). Exactly one.
+#[derive(serde::Deserialize)]
+struct SpawnItemRequest {
+    template: Option<String>,
+    template_id: Option<i32>,
+}
+
+/// HTTP handler for debug provisioning of an item: instantiate a template and
+/// put it in the player's backpack, as if it had been picked up. Only genuine
+/// pickup items are accepted (the same rule `/v1/player/give` applies).
+async fn spawn_item(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<SpawnItemRequest>,
+) -> Result<Json<shock2vr::game_scene::DebugSpawnedItem>, (StatusCode, String)> {
+    use shock2vr::game_scene::DebugItemTemplate;
+    let template = match (request.template, request.template_id) {
+        (Some(name), None) => DebugItemTemplate::Name(name),
+        (None, Some(id)) => DebugItemTemplate::Id(id),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "provide exactly one of 'template' (name) or 'template_id'".to_string(),
+            ));
+        }
+    };
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::SpawnItem {
+            template,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send SpawnItem command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(Ok(item)) => Ok(Json(item)),
+        Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
+        Err(_) => {
+            tracing::error!("Failed to receive spawn-item result - sender dropped");
+            Err(game_loop_unavailable())
+        }
+    }
+}
+
+/// HTTP handler for debug provisioning of the character sheet. The body mirrors
+/// the read-side `player.stats` shape from `/v1/info`; every field is optional
+/// and names the level to establish. Responds with the resulting sheet.
+async fn set_player_stats(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    LenientJson(request): LenientJson<shock2vr::game_scene::DebugPlayerStatsRequest>,
+) -> Result<Json<shock2vr::player_stats::PlayerStats>, (StatusCode, String)> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if command_tx
+        .send(RuntimeCommand::SetPlayerStats {
+            request,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send SetPlayerStats command - game loop receiver dropped");
+        return Err(game_loop_unavailable());
+    }
+    match reply_rx.await {
+        Ok(Ok(stats)) => Ok(Json(stats)),
+        Ok(Err(e)) => Err((StatusCode::BAD_REQUEST, e)),
+        Err(_) => {
+            tracing::error!("Failed to receive set-player-stats result - sender dropped");
             Err(game_loop_unavailable())
         }
     }
@@ -3208,34 +3289,6 @@ async fn set_input_channel(
         // the previous silent success.
         Ok(Err(msg)) => Err((StatusCode::BAD_REQUEST, msg)),
         Err(_) => Err(game_loop_unavailable()),
-    }
-}
-
-/// HTTP endpoint handler: Execute a gameplay command via the runtime
-async fn run_game_command(
-    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
-    LenientJson(request): LenientJson<GameCommandRequest>,
-) -> Result<Json<CommandResult>, StatusCode> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-
-    if command_tx
-        .send(RuntimeCommand::RunGameCommand(
-            request.command,
-            request.args,
-            reply_tx,
-        ))
-        .is_err()
-    {
-        tracing::error!("Failed to send RunGameCommand - game loop receiver dropped");
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    match reply_rx.await {
-        Ok(result) => Ok(Json(result)),
-        Err(_) => {
-            tracing::error!("Failed to receive RunGameCommand result - sender dropped");
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
     }
 }
 

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -370,8 +370,8 @@ pub struct DebugInventoryItem {
 
 /// Which template a debug spawn should instantiate. Templates are the only
 /// stable identity across runs (runtime entity ids are not), so provisioning
-/// addresses them either by id (the negative `PropTemplateId` space, or a
-/// positive mission-object id) or by gamesys template name.
+/// addresses them either by gamesys template id (the negative `PropTemplateId`
+/// space) or by gamesys template name.
 #[derive(Debug, Clone)]
 pub enum DebugItemTemplate {
     Id(i32),
@@ -394,6 +394,7 @@ pub struct DebugSpawnedItem {
 /// Provisioning only ever raises - a target below the current level is an
 /// error, so a request can never silently un-train a character.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DebugPlayerStatsRequest {
     pub strength: Option<i32>,
     pub endurance: Option<i32>,
@@ -410,6 +411,7 @@ pub struct DebugPlayerStatsRequest {
 /// Target skill levels, mirroring `player.stats.skills`. Named fields (rather
 /// than a map) keep the shape identical to the read side.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DebugSkillLevelsRequest {
     pub standard_weapons: Option<i32>,
     pub energy_weapons: Option<i32>,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -368,6 +368,60 @@ pub struct DebugInventoryItem {
     pub location: String,
 }
 
+/// Which template a debug spawn should instantiate. Templates are the only
+/// stable identity across runs (runtime entity ids are not), so provisioning
+/// addresses them either by id (the negative `PropTemplateId` space, or a
+/// positive mission-object id) or by gamesys template name.
+#[derive(Debug, Clone)]
+pub enum DebugItemTemplate {
+    Id(i32),
+    Name(String),
+}
+
+/// The item a debug spawn provisioned into the player's backpack.
+#[derive(Debug, Serialize, Clone)]
+pub struct DebugSpawnedItem {
+    /// Runtime entity id of the fresh item (same id space as `/v1/entities`).
+    pub entity_id: i32,
+    /// The template it was instantiated from (stable across runs).
+    pub template_id: i32,
+    pub name: Option<String>,
+}
+
+/// Debug provisioning target for the player's character sheet. Mirrors the
+/// read-side `player.stats` shape (`GET /v1/info`); every field is optional and
+/// names the *level to establish*, not a delta. Omitted fields are untouched.
+/// Provisioning only ever raises - a target below the current level is an
+/// error, so a request can never silently un-train a character.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DebugPlayerStatsRequest {
+    pub strength: Option<i32>,
+    pub endurance: Option<i32>,
+    pub agility: Option<i32>,
+    pub psionic_ability: Option<i32>,
+    pub cyber_affinity: Option<i32>,
+    #[serde(default)]
+    pub skills: DebugSkillLevelsRequest,
+    pub psi_tier: Option<i32>,
+    /// Target cyber-module balance (the upgrade currency).
+    pub cyber_modules: Option<i32>,
+}
+
+/// Target skill levels, mirroring `player.stats.skills`. Named fields (rather
+/// than a map) keep the shape identical to the read side.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DebugSkillLevelsRequest {
+    pub standard_weapons: Option<i32>,
+    pub energy_weapons: Option<i32>,
+    pub heavy_weapons: Option<i32>,
+    pub exotic_weapons: Option<i32>,
+    pub hack: Option<i32>,
+    pub repair: Option<i32>,
+    pub modify: Option<i32>,
+    pub maintenance: Option<i32>,
+    pub research: Option<i32>,
+}
+
 /// Snapshot of the flat-mode UI state for debug introspection (`GET /v1/ui`).
 /// `mode` is "shooter" (mouse-look, no cursor) or "use" (cursor-driven
 /// metagame UI, the original game's Tab mode). `active_panel` is the
@@ -688,6 +742,32 @@ pub trait DebuggableScene {
     /// unsupported.
     fn give_item(&mut self, _entity_id: EntityId) -> Result<(), String> {
         Err("scene does not support giving items".to_string())
+    }
+
+    /// Debug provisioning: instantiate `template` and put the fresh item into
+    /// the player's backpack, exactly as [`give_item`](Self::give_item) does for
+    /// an item already in the world - so only genuine pickup items can be
+    /// provisioned. Takes the asset cache because instantiation loads the
+    /// item's model/textures. Default: unsupported.
+    fn spawn_item_for_player(
+        &mut self,
+        _asset_cache: &mut AssetCache,
+        _template: &DebugItemTemplate,
+    ) -> Result<DebugSpawnedItem, String> {
+        Err("scene does not support spawning items".to_string())
+    }
+
+    /// Debug provisioning: raise the player's character sheet (stats, skills,
+    /// psi tier, cyber modules) to the requested levels, through the same
+    /// `PlayerStats` mutations a trainer purchase performs - free of charge,
+    /// since this establishes a starting loadout rather than playing the
+    /// economy. Validated as a whole: on any invalid target nothing is applied.
+    /// Returns the resulting sheet. Default: unsupported.
+    fn set_player_stats(
+        &mut self,
+        _request: &DebugPlayerStatsRequest,
+    ) -> Result<crate::player_stats::PlayerStats, String> {
+        Err("scene does not support a character sheet".to_string())
     }
 
     /// Level-transition triggers in this scene (where each leads + its position),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -796,6 +796,22 @@ impl Game {
         self.active_game_scene.as_debuggable_mut()
     }
 
+    /// Debug provisioning: instantiate an item template straight into the
+    /// player's backpack (see
+    /// [`DebuggableScene::spawn_item_for_player`](game_scene::DebuggableScene::spawn_item_for_player)).
+    /// Lives on `Game` rather than being reachable through `debug_scene_mut`
+    /// because entity creation also needs the game-owned `AssetCache`.
+    pub fn debug_spawn_item(
+        &mut self,
+        template: &game_scene::DebugItemTemplate,
+    ) -> Result<game_scene::DebugSpawnedItem, String> {
+        let asset_cache = &mut self.asset_cache;
+        self.active_game_scene
+            .as_debuggable_mut()
+            .ok_or_else(|| "no debuggable scene available".to_string())?
+            .spawn_item_for_player(asset_cache, template)
+    }
+
     /// Resolve the high-detail (`PMNM`) mesh setting from the experimental flags,
     /// falling back to the platform default.
     ///

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6399,6 +6399,16 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .template_id
             }
         };
+        // Gamesys templates only (the negative id space). Positive ids address
+        // *this mission's* authored objects, and duplicating one would hand the
+        // player a second copy of a unique quest item (a keycard, a log) - a way
+        // to fake progress rather than to provision a loadout.
+        if template_id >= 0 {
+            return Err(format!(
+                "template id {} is a mission object; provisioning takes gamesys templates (negative ids)",
+                template_id
+            ));
+        }
         if !self
             .entity_info
             .entity_to_properties
@@ -6431,7 +6441,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         // leaves nothing behind.
         if let Err(e) = self.give_item(entity_id) {
             self.destroy_entity(entity_id);
-            return Err(e);
+            // Report the template, not the entity: the instance is gone, and the
+            // caller never saw its id.
+            return Err(format!(
+                "template {} is not a pickup item ({})",
+                template_id, e
+            ));
         }
 
         let name = self
@@ -6451,7 +6466,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         request: &crate::game_scene::DebugPlayerStatsRequest,
     ) -> Result<crate::player_stats::PlayerStats, String> {
         use crate::player_stats::{Skill, Stat};
-        use crate::scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP, apply_purchase};
+        use crate::scripts::gui::{
+            PSI_TIER_CAP, SKILL_CAP, STAT_CAP, TrainerTarget, apply_purchase,
+        };
 
         let mut quests = self
             .world
@@ -6537,7 +6554,13 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             check("psi_tier", target, stats.psi_tier, PSI_TIER_CAP)?;
         }
         if let Some(target) = request.cyber_modules {
-            check("cyber_modules", target, stats.cyber_modules, i32::MAX)?;
+            // No cap on the currency, so only the "raises only" half applies.
+            if target < stats.cyber_modules {
+                return Err(format!(
+                    "cannot lower cyber_modules from {} to {} (provisioning only raises)",
+                    stats.cyber_modules, target
+                ));
+            }
         }
 
         // Apply through the same `PlayerStats` mutations a trainer purchase
@@ -6558,15 +6581,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         }
         if let Some(target) = request.psi_tier {
             // Tiers unlock sequentially, exactly as the psi trainer sells them.
-            while stats.psi_tier < target {
-                apply_purchase(
-                    stats,
-                    crate::scripts::gui::TrainerTarget::PsiTier(stats.psi_tier + 1),
-                );
+            for tier in (stats.psi_tier + 1)..=target {
+                apply_purchase(stats, TrainerTarget::PsiTier(tier));
             }
         }
         if let Some(target) = request.cyber_modules {
-            stats.award_cyber_modules(target - stats.cyber_modules);
+            stats.award_cyber_modules(target.saturating_sub(stats.cyber_modules));
         }
 
         let result = stats.clone();

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6383,6 +6383,197 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         }
     }
 
+    fn spawn_item_for_player(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        template: &crate::game_scene::DebugItemTemplate,
+    ) -> Result<crate::game_scene::DebugSpawnedItem, String> {
+        use crate::game_scene::{DebugItemTemplate, DebugSpawnedItem};
+
+        let template_id = match template {
+            DebugItemTemplate::Id(id) => *id,
+            DebugItemTemplate::Name(name) => {
+                self.template_name_to_template_id
+                    .get(&name.to_ascii_lowercase())
+                    .ok_or_else(|| format!("no template named '{}'", name))?
+                    .template_id
+            }
+        };
+        if !self
+            .entity_info
+            .entity_to_properties
+            .contains_key(&template_id)
+        {
+            return Err(format!("unknown template id {}", template_id));
+        }
+
+        // Spawn at the player's position: containment immediately makes the
+        // item non-physical, so the spawn point is never observed - it just has
+        // to be somewhere valid for instantiation.
+        let (position, rotation) = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            (vec3_to_point3(player.pos), player.rotation)
+        };
+        let info = self.create_entity_with_position(
+            asset_cache,
+            template_id,
+            position,
+            rotation,
+            Matrix4::identity(),
+            CreateEntityOptions::default(),
+        );
+        let entity_id = info.entity_id;
+
+        // Route the fresh entity through the very same pickup path as an item
+        // found in the world, so provisioning inherits its eligibility rule:
+        // only genuine pickup items land in the backpack. A creature or door
+        // template is rejected here - and destroyed again, so a refused request
+        // leaves nothing behind.
+        if let Err(e) = self.give_item(entity_id) {
+            self.destroy_entity(entity_id);
+            return Err(e);
+        }
+
+        let name = self
+            .world
+            .borrow::<View<dark::properties::PropSymName>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).ok().map(|s| s.0.clone()));
+        Ok(DebugSpawnedItem {
+            entity_id: entity_id.inner() as i32,
+            template_id,
+            name,
+        })
+    }
+
+    fn set_player_stats(
+        &mut self,
+        request: &crate::game_scene::DebugPlayerStatsRequest,
+    ) -> Result<crate::player_stats::PlayerStats, String> {
+        use crate::player_stats::{Skill, Stat};
+        use crate::scripts::gui::{PSI_TIER_CAP, SKILL_CAP, STAT_CAP, apply_purchase};
+
+        let mut quests = self
+            .world
+            .borrow::<UniqueViewMut<QuestInfo>>()
+            .map_err(|_| "scene has no quest info".to_string())?;
+        let stats = quests.player_stats_mut();
+
+        let stat_targets = [
+            (Stat::Strength, request.strength, "strength"),
+            (Stat::Endurance, request.endurance, "endurance"),
+            (Stat::Agility, request.agility, "agility"),
+            (
+                Stat::PsionicAbility,
+                request.psionic_ability,
+                "psionic_ability",
+            ),
+            (
+                Stat::CyberAffinity,
+                request.cyber_affinity,
+                "cyber_affinity",
+            ),
+        ];
+        let skill_targets = [
+            (
+                Skill::StandardWeapons,
+                request.skills.standard_weapons,
+                "standard_weapons",
+            ),
+            (
+                Skill::EnergyWeapons,
+                request.skills.energy_weapons,
+                "energy_weapons",
+            ),
+            (
+                Skill::HeavyWeapons,
+                request.skills.heavy_weapons,
+                "heavy_weapons",
+            ),
+            (
+                Skill::ExoticWeapons,
+                request.skills.exotic_weapons,
+                "exotic_weapons",
+            ),
+            (Skill::Hack, request.skills.hack, "hack"),
+            (Skill::Repair, request.skills.repair, "repair"),
+            (Skill::Modify, request.skills.modify, "modify"),
+            (
+                Skill::Maintenance,
+                request.skills.maintenance,
+                "maintenance",
+            ),
+            (Skill::Research, request.skills.research, "research"),
+        ];
+
+        // Validate everything before mutating anything, so a rejected request
+        // never leaves the character sheet half-provisioned.
+        let check = |field: &str, target: i32, current: i32, cap: i32| -> Result<(), String> {
+            if target < current {
+                return Err(format!(
+                    "cannot lower {} from {} to {} (provisioning only raises)",
+                    field, current, target
+                ));
+            }
+            if target > cap {
+                return Err(format!(
+                    "{} maxes out at {} (asked for {})",
+                    field, cap, target
+                ));
+            }
+            Ok(())
+        };
+        for (stat, target, field) in stat_targets {
+            if let Some(target) = target {
+                check(field, target, stats.stat_level(stat), STAT_CAP)?;
+            }
+        }
+        for (skill, target, field) in skill_targets {
+            if let Some(target) = target {
+                check(field, target, stats.skill_level(skill), SKILL_CAP)?;
+            }
+        }
+        if let Some(target) = request.psi_tier {
+            check("psi_tier", target, stats.psi_tier, PSI_TIER_CAP)?;
+        }
+        if let Some(target) = request.cyber_modules {
+            check("cyber_modules", target, stats.cyber_modules, i32::MAX)?;
+        }
+
+        // Apply through the same `PlayerStats` mutations a trainer purchase
+        // performs, one level at a time - just without the module cost.
+        for (stat, target, _) in stat_targets {
+            if let Some(target) = target {
+                while stats.stat_level(stat) < target {
+                    stats.raise_stat(stat);
+                }
+            }
+        }
+        for (skill, target, _) in skill_targets {
+            if let Some(target) = target {
+                while stats.skill_level(skill) < target {
+                    stats.raise_skill(skill);
+                }
+            }
+        }
+        if let Some(target) = request.psi_tier {
+            // Tiers unlock sequentially, exactly as the psi trainer sells them.
+            while stats.psi_tier < target {
+                apply_purchase(
+                    stats,
+                    crate::scripts::gui::TrainerTarget::PsiTier(stats.psi_tier + 1),
+                );
+            }
+        }
+        if let Some(target) = request.cyber_modules {
+            stats.award_cyber_modules(target - stats.cyber_modules);
+        }
+
+        let result = stats.clone();
+        info!("Debug provisioning set player stats: {:?}", result);
+        Ok(result)
+    }
+
     fn list_transitions(&self) -> Vec<crate::game_scene::DebugTransition> {
         use dark::properties::{PropDestLevel, PropDestLoc, PropPosition, PropSymName};
         use shipyard::Get;

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -384,6 +384,22 @@ impl crate::game_scene::DebuggableScene for Mission {
         self.mission_core.give_item(entity_id)
     }
 
+    fn spawn_item_for_player(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        template: &crate::game_scene::DebugItemTemplate,
+    ) -> Result<crate::game_scene::DebugSpawnedItem, String> {
+        self.mission_core
+            .spawn_item_for_player(asset_cache, template)
+    }
+
+    fn set_player_stats(
+        &mut self,
+        request: &crate::game_scene::DebugPlayerStatsRequest,
+    ) -> Result<crate::player_stats::PlayerStats, String> {
+        self.mission_core.set_player_stats(request)
+    }
+
     fn list_transitions(&self) -> Vec<crate::game_scene::DebugTransition> {
         self.mission_core.list_transitions()
     }

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -51,8 +51,8 @@ pub enum TrainerMode {
 }
 
 /// Stats cap at 6 (start 1); skills cap at 6 (start 0); psi tiers cap at 5.
-const STAT_CAP: i32 = 6;
-const SKILL_CAP: i32 = 6;
+pub const STAT_CAP: i32 = 6;
+pub const SKILL_CAP: i32 = 6;
 pub const PSI_TIER_CAP: i32 = 5;
 
 /// The cost of buying `target`'s next level given the player's current sheet,

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -51,6 +51,10 @@ await game.player.setStats({
   psi_tier: 2,
   cyber_modules: 20,
 });
+// NB: the sheet is persistent storage, but only some of it drives gameplay
+// today (Hack + cyber_affinity gate hacking; the weapon proficiencies and psi
+// tier are not yet wired to any derived effect). Provisioning them establishes
+// the character, not a behavior change.
 
 // Entities
 const doors = await game.entities.list({ filter: "*Door*", limit: 10 });

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -34,6 +34,24 @@ await game.step({ duration: "1s" });
 const pos = await game.player.position();
 await game.player.teleport({ x: pos.x + 5, y: pos.y, z: pos.z });
 
+// Debug provisioning: establish a starting loadout a scenario doesn't hand you
+// (e.g. a "Marine" playstyle in a mid-game level). Items are addressed by
+// template - name or the stable template id - and land in the backpack exactly
+// as a pickup does; only genuine pickup items are accepted. Wield one by
+// double-clicking it in the use-mode inventory strip.
+const shotgun = await game.player.spawnItem("Shotgun");
+await game.player.spawnItem(-18); // Assault Rifle, by stable template id
+
+// The character sheet, mirroring the read side (`(await game.info()).player.stats`).
+// Every field is optional and names the level to establish; provisioning only
+// raises (a lower target, or one above the cap, throws 400).
+await game.player.setStats({
+  strength: 3,
+  skills: { standard_weapons: 4 },
+  psi_tier: 2,
+  cyber_modules: 20,
+});
+
 // Entities
 const doors = await game.entities.list({ filter: "*Door*", limit: 10 });
 const detail = await game.entities.detail(doors.entities[0].id);

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -27,6 +27,9 @@ import type {
   RecentAudioResult,
   UiState,
   PlayerInventoryResult,
+  PlayerStats,
+  PlayerStatsRequest,
+  SpawnedItem,
   TransitionsResult,
   WaitForOptions,
   AiPathEntry,
@@ -290,6 +293,35 @@ export class PlayerApi {
     return this.client.post<CommandResult>("/v1/player/give", {
       entity_id: entityId,
     });
+  }
+
+  /**
+   * Debug provisioning: instantiate an item template and put it straight into
+   * the player's backpack, as if it had been picked up. Address it by gamesys
+   * template name (`"Shotgun"`, case-insensitive) or by template id (`-19`) -
+   * templates are the only identity stable across runs.
+   *
+   * Only genuine pickup items are accepted; a creature or door template throws
+   * (400) and nothing is left in the world. Wielding a provisioned weapon is a
+   * separate step (double-click it in the use-mode inventory strip).
+   */
+  async spawnItem(template: string | number): Promise<SpawnedItem> {
+    return this.client.post<SpawnedItem>(
+      "/v1/player/spawn-item",
+      typeof template === "number" ? { template_id: template } : { template },
+    );
+  }
+
+  /**
+   * Debug provisioning: raise the character sheet to the requested levels
+   * (stats, skills, psi tier, cyber modules) through the same `PlayerStats`
+   * mutations a trainer purchase performs, free of charge. Every field is
+   * optional and names the level to establish; omitted fields are untouched.
+   * Only raises - a target below the current level throws (400), as does one
+   * above the cap (stats/skills 6, psi tier 5). Returns the resulting sheet.
+   */
+  async setStats(request: PlayerStatsRequest): Promise<PlayerStats> {
+    return this.client.post<PlayerStats>("/v1/player/stats", request);
   }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -472,6 +472,32 @@ export interface PlayerInventoryResult {
   count: number;
 }
 
+/** An item provisioned into the backpack by `POST /v1/player/spawn-item`. */
+export interface SpawnedItem {
+  /** Runtime entity id of the fresh item (same id space as /v1/entities). */
+  entity_id: number;
+  /** The template it was instantiated from - stable across runs. */
+  template_id: number;
+  name: string | null;
+}
+
+/** Debug provisioning target for the character sheet (`POST /v1/player/stats`).
+ * Mirrors the read-side `player.stats` shape; every field is optional and names
+ * the level to establish (not a delta). Provisioning only raises: a target
+ * below the current level is rejected with a 400. */
+export interface PlayerStatsRequest {
+  strength?: number;
+  endurance?: number;
+  agility?: number;
+  psionic_ability?: number;
+  cyber_affinity?: number;
+  skills?: Partial<SkillLevels>;
+  /** Highest psi tier unlocked (0..=5, granted sequentially). */
+  psi_tier?: number;
+  /** Target cyber-module balance (the upgrade currency). */
+  cyber_modules?: number;
+}
+
 /**
  * One drawn element of the active flat-mode MFD panel. `label` gives
  * clickable elements a semantic identity (keypad digits "0"-"9", "clear",

--- a/tools/shock2-sdk/test/provisioning.e2e.test.ts
+++ b/tools/shock2-sdk/test/provisioning.e2e.test.ts
@@ -123,16 +123,41 @@ test(
       /status 400|no template named/,
       "an unknown template name is rejected",
     );
-    const entitiesBefore = (await game.entities.list({ limit: 500 })).entities.length;
+    // Count by name, not by a truncated listing: `limit` truncates server-side,
+    // so a total-count comparison would pass no matter what leaked.
+    const gruntCount = async () =>
+      (await game.entities.list({ filter: "*OG-Pipe*", limit: 500 })).entities.length;
+    const gruntsBefore = await gruntCount();
     await assert.rejects(
       game.player.spawnItem(GRUNT_TEMPLATE),
       /status 400|not a pickup/,
       "a creature template is not provisionable",
     );
     assert.equal(
-      (await game.entities.list({ limit: 500 })).entities.length,
-      entitiesBefore,
+      await gruntCount(),
+      gruntsBefore,
       "a refused spawn must leave nothing behind in the world",
+    );
+
+    // Mission objects (positive ids) are refused: duplicating one would hand
+    // the player a second copy of a unique quest item.
+    const missionObject = (await game.entities.list({ limit: 50 })).entities.find(
+      (e) => e.template_id > 0,
+    );
+    assert.ok(missionObject, "expected a mission object in command1");
+    await assert.rejects(
+      game.player.spawnItem(missionObject.template_id),
+      /status 400|mission object/,
+      "provisioning takes gamesys templates, not mission objects",
+    );
+
+    // A misspelled field is a 400, not a silent no-op that would make the
+    // playtest think the character was provisioned when it wasn't.
+    await assert.rejects(
+      // @ts-expect-error - deliberately misspelled field
+      game.player.setStats({ stength: 5 }),
+      /status 400|unknown field/,
+      "an unknown stat field is rejected",
     );
 
     await assert.rejects(

--- a/tools/shock2-sdk/test/provisioning.e2e.test.ts
+++ b/tools/shock2-sdk/test/provisioning.e2e.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// End-to-end test for the debug provisioning levers (POST /v1/player/spawn-item
+// and POST /v1/player/stats) - what an automated playtest needs to establish a
+// starting loadout for a class tweak (e.g. "Marine: acquire and fire pistol,
+// shotgun, assault rifle") in a scenario that starts mid-game with a fresh
+// character.
+//
+// Negative-first: before these endpoints existed there was no way to get a
+// weapon the level does not contain, and no way at all to set skills - the
+// spawn lever was one hardcoded template (Pistol) and /v1/control/command was a
+// stub. Both calls below 404 on the base commit.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const SHOTGUN_TEMPLATE = -19;
+const ASSAULT_RIFLE_TEMPLATE = -18;
+const GRUNT_TEMPLATE = -397; // og-pipe grunt: a creature, not a pickup item
+
+function ammoOf(detail: { properties: { name: string; value: string }[] }): number {
+  const p = detail.properties.find((x) => x.name === "Ammo");
+  assert.ok(p, "a provisioned gun should expose an Ammo property");
+  return Number(p.value);
+}
+
+test(
+  "provisioning: spawn weapons by template and train the skill that uses them",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // command1.mis is a mid-game deck: the campaign scenario where the start
+    // state is a fresh character with nothing.
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8348),
+    });
+    await game.step({ frames: 5 });
+
+    // --- A fresh character: untrained, unarmed ---
+    const before = (await game.info()).player.stats;
+    assert.ok(before, "player should have a character sheet");
+    assert.equal(before.skills.standard_weapons, 0, "fresh character is untrained");
+    const carriedBefore = await game.player.inventory();
+    assert.ok(
+      !carriedBefore.items.some((i) => i.name === "Shotgun"),
+      "command1 start state carries no shotgun",
+    );
+
+    // --- Provision the character sheet (a Marine loadout) ---
+    const trained = await game.player.setStats({
+      strength: 3,
+      skills: { standard_weapons: 4, maintenance: 2 },
+      cyber_modules: 20,
+    });
+    assert.equal(trained.skills.standard_weapons, 4);
+    assert.equal(trained.skills.maintenance, 2);
+    assert.equal(trained.strength, 3);
+    assert.equal(trained.cyber_modules, 20);
+    // Untouched fields keep their values.
+    assert.equal(trained.skills.hack, before.skills.hack, "omitted skills are untouched");
+    assert.equal(trained.endurance, before.endurance, "omitted stats are untouched");
+    // The write is visible through the read side (same PlayerStats).
+    const liveStats = (await game.info()).player.stats;
+    assert.deepEqual(liveStats, trained, "/v1/info should report the provisioned sheet");
+
+    // --- Provision the weapons: by name and by stable template id ---
+    const shotgun = await game.player.spawnItem("Shotgun");
+    assert.equal(shotgun.template_id, SHOTGUN_TEMPLATE, "name resolves to the stable template");
+    assert.equal(shotgun.name, "Shotgun");
+    const rifle = await game.player.spawnItem(ASSAULT_RIFLE_TEMPLATE);
+    assert.equal(rifle.name, "Assault Rifle");
+
+    const carried = await game.player.inventory();
+    for (const item of [shotgun, rifle]) {
+      const row = carried.items.find((i) => i.entity_id === item.entity_id);
+      assert.ok(row, `${item.name} should be carried (got ${JSON.stringify(carried.items)})`);
+      assert.equal(row.location, "inventory", "a provisioned item lands in the backpack");
+    }
+    // A backpack item is out of the physical world, like any real pickup.
+    assert.equal(
+      (await game.physics.bodies({ entityId: shotgun.entity_id })).bodies.length,
+      0,
+      "a provisioned item must not keep a world physics body",
+    );
+
+    // --- Wield the provisioned shotgun through the real flat UI (Tab into use
+    // mode, double-click the strip item), exactly as a player would ---
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const stripShotgun = (await game.ui.state()).strip?.elements.find(
+      (e) => e.kind === "button" && e.label === "Shotgun",
+    );
+    assert.ok(stripShotgun, "the provisioned shotgun should appear in the inventory strip");
+    await clickUiElement(game, stripShotgun); // lift...
+    await clickUiElement(game, stripShotgun); // ...double-click wields
+    await game.input.trigger("ToggleUseMode"); // back to shooter mode
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      shotgun.entity_id,
+      "a provisioned weapon should be wieldable",
+    );
+
+    // --- Fire it: a provisioned weapon is a real weapon (ammo decrements) ---
+    const startAmmo = ammoOf(await game.entities.detail(shotgun.entity_id));
+    assert.ok(startAmmo > 0, `the shotgun should spawn loaded (got ${startAmmo})`);
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(shotgun.entity_id)),
+      startAmmo - 1,
+      "firing a provisioned shotgun consumes a round",
+    );
+
+    // --- Refusals ---
+    await assert.rejects(
+      game.player.spawnItem("Definitely Not A Template"),
+      /status 400|no template named/,
+      "an unknown template name is rejected",
+    );
+    const entitiesBefore = (await game.entities.list({ limit: 500 })).entities.length;
+    await assert.rejects(
+      game.player.spawnItem(GRUNT_TEMPLATE),
+      /status 400|not a pickup/,
+      "a creature template is not provisionable",
+    );
+    assert.equal(
+      (await game.entities.list({ limit: 500 })).entities.length,
+      entitiesBefore,
+      "a refused spawn must leave nothing behind in the world",
+    );
+
+    await assert.rejects(
+      game.player.setStats({ skills: { standard_weapons: 1 } }),
+      /status 400|only raises/,
+      "provisioning must not lower a trained skill",
+    );
+    await assert.rejects(
+      game.player.setStats({ strength: 9 }),
+      /status 400|maxes out/,
+      "provisioning must respect the stat cap",
+    );
+    // A rejected request applies nothing: the sheet is exactly as provisioned.
+    assert.deepEqual(
+      (await game.info()).player.stats,
+      trained,
+      "refused provisioning must not partially apply",
+    );
+
+    // The runtime stays live and the loadout intact after the refusals.
+    assert.equal(
+      ammoOf(await game.entities.detail(shotgun.entity_id)),
+      startAmmo - 1,
+      "the wielded shotgun survives the refused requests",
+    );
+  },
+);


### PR DESCRIPTION
## The gap

The `play-through` campaign loop rolls a playstyle **tweak** — "Marine (standard weapons): acquire and fire pistol, shotgun, assault rifle", "Navy: hack/repair/modify", "OSA: psi tiers 1-5" — and then starts most scenarios **mid-game with a fresh character**: 30/30 HP, every stat 1, every skill 0, no weapons, 0 cyber modules, psi tier 0. The skill sanctions provisioning that loadout as the first job of iteration 0, but the levers didn't exist:

| Lever | State before |
| --- | --- |
| `POST /v1/control/command` | stub — `// TODO: Implement game command execution`, returns `"Game commands not yet implemented"` |
| `InputAction::SpawnDebugItem` | one hardcoded template (Pistol) |
| `POST /v1/player/give` | only works on an entity **already in the level** |
| skills / stats / psi tier / modules | no write path at all (read-only in `/v1/info`) |

So a Marine campaign could not obtain a shotgun unless the level happened to contain one, and no tweak could establish progression.

## The API

Two dedicated typed endpoints, next to `/v1/player/give`:

```
POST /v1/player/spawn-item   {"template": "Shotgun"}  |  {"template_id": -19}
  -> {"entity_id": 1238, "template_id": -19, "name": "Shotgun"}

POST /v1/player/stats        {"strength": 3, "skills": {"standard_weapons": 4},
                              "psi_tier": 2, "cyber_modules": 20}
  -> the resulting PlayerStats (same shape as `/v1/info` -> player.stats)
```

SDK: `game.player.spawnItem("Shotgun" | -19)` and `game.player.setStats({...})`.

**Why this shape** — the codebase already favors dedicated typed endpoints (`/v1/player/give`, `/v1/player/teleport`, `/v1/player/move`, `/v1/quests/:name`) over a stringly-typed dispatcher: they get real request/response types, real 400s, and typed SDK methods. Fleshing out `/v1/control/command` would have re-introduced argv parsing for no gain, so **the placeholder is removed as dead API surface** (nothing in the repo, the SDK, or the skills called it).

## It provisions; it does not fake gameplay

- **Items go through the real pickup path.** `spawn_item_for_player` instantiates the template and then calls the very same `give_item` an item found in the world goes through, so it inherits that eligibility rule: only genuine pickup items (`can_grab_item`) land in the backpack. A creature/door template is refused **and destroyed again**, so a refused request leaves nothing in the world.
- **Gamesys templates only** (negative ids). Positive ids address *this mission's* authored objects; spawning one duplicated a unique quest item (found during review: `{"template_id": 1247}` handed the player a second command1 *Shuttle Access Key*). That is faking progress, so it is refused.
- **Progression goes through the trainer mutations** — `raise_stat` / `raise_skill` / `apply_purchase` / `award_cyber_modules`, respecting the trainer caps (stats/skills 6, psi tier 5, tiers sequential) — just without the module cost, since this establishes a starting state rather than playing the economy. It **only raises**; a lower target is a 400, so a request can never silently un-train a character. The whole request is validated before anything mutates.
- No "kill entity" or "set quest bit" shortcut was added.

## Verification

**Negative-first** (`tools/shock2-sdk/test/provisioning.e2e.test.ts`, gated behind `SHOCK2_E2E=1`): on the base commit the test fails with `POST /v1/player/stats failed with status 404`. With the change it passes against a real `command1.mis` runtime — the campaign scenario itself:

- fresh character confirmed (`standard_weapons === 0`, no shotgun carried)
- `setStats` raises standard_weapons 4 / maintenance 2 / strength 3 / 20 modules; omitted fields untouched; `/v1/info` reports the same sheet
- Shotgun by **name** and Assault Rifle by **stable template id** land in the backpack (`location: "inventory"`, no world physics body — like any real pickup)
- the shotgun is **wielded through the real flat UI** (Tab into use mode, double-click the strip item) and **fired**: ammo 6 -> 5
- refusals: unknown name, a creature template (with a name-filtered leak check — a total-count check would be vacuous: `command1` has 1233 entities and listings truncate), a mission object, a lowered skill, an over-cap stat, and a misspelled field; the sheet is unchanged after every refusal

Also run: the full SDK e2e suite, `cargo test -p shock2vr`, `npm test`, `cargo fmt --all`, and
`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query -p dark_viewer -p bench -p hitbox_analyzer -p debug_command`.

## Review

`/xreview` (Claude subagent + Codex) ran over the first commit; the second commit is the fix-up. Resolved: mission-object spawning (High — quest-item duplication), `deny_unknown_fields` on both request bodies (a misspelled field used to return 200 with nothing applied — precisely the false "X is broken" report the skill warns against), the vacuous leak assertion, an error naming a destroyed entity, an unreachable `i32::MAX` cap check, and an unchecked module-delta subtraction. Both engines independently confirmed the create/give/destroy path leaks nothing and that `set_player_stats` is atomic.

## Docs

`play-through`'s "Tweak setup gaps" paragraph now points at the levers — with the caveat that most of the sheet is storage today (only Hack + cyber_affinity drive anything), so a campaign doesn't read "trained standard_weapons changed nothing" as a game bug — plus `tools/shock2-sdk/README.md` and `projects/debug-runtime.md` (Phase 5 was "NOT STARTED").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
