### PR TITLE
fix(scripts): stop BaseElevator overshooting its target node

### DIFF
--- a/shock2vr/src/scripts/base_elevator.rs
+++ b/shock2vr/src/scripts/base_elevator.rs
@@ -107,7 +107,12 @@ impl Script for BaseElevator {
         time: &Time,
     ) -> Effect {
         let dir = self.desired_position - self.current_position;
-        if dir.magnitude2() > 0.001 {
+        let step = time.elapsed.as_secs_f32() * self.speed;
+        // Complete once within one frame-step of the target - stepping by
+        // a fixed amount can otherwise overshoot and oscillate around a
+        // small distance threshold forever, so the elevator never finishes
+        // and can never be dispatched again.
+        if dir.magnitude() > step.max(0.001) {
             let normalized = dir.normalize();
 
             trace!(
@@ -116,18 +121,25 @@ impl Script for BaseElevator {
             );
 
             self.is_moving = true;
-            self.current_position += normalized * time.elapsed.as_secs_f32() * self.speed;
+            self.current_position += normalized * step;
             Effect::SetPosition {
                 entity_id,
                 position: self.current_position,
             }
         } else if self.is_moving {
+            // Land exactly on the node rather than a step short of it.
+            self.current_position = self.desired_position;
+            // Captured before move_to_next_target() retargets desired_position.
+            let position = self.current_position;
             if self.is_dontstop_elevator {
                 self.move_to_next_target(world);
             } else {
                 self.is_moving = false;
             }
-            Effect::NoEffect
+            Effect::SetPosition {
+                entity_id,
+                position,
+            }
         } else {
             Effect::NoEffect
         }
@@ -163,6 +175,157 @@ impl Script for BaseElevator {
             // }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn frame() -> Time {
+        Time {
+            elapsed: Duration::from_secs_f32(1.0 / 60.0),
+            total: Duration::from_secs_f32(1.0 / 60.0),
+        }
+    }
+
+    fn position_at(x: f32) -> PropPosition {
+        PropPosition {
+            position: Vector3::new(x, 0.0, 0.0),
+            cell: 0,
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        }
+    }
+
+    /// A two-stop elevator - like a tram between its terminals: the entity sits
+    /// on the first node, which TPaths to the second at `speed`.
+    fn two_stop_world(start_x: f32, end_x: f32, speed: f32) -> (World, EntityId) {
+        let mut world = World::new();
+        let end_node = world.add_entity((position_at(end_x), Links::empty()));
+        let start_node = world.add_entity((
+            position_at(start_x),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(end_node)),
+                    link: Link::TPath(TPathData { speed }),
+                }],
+            },
+        ));
+        let elevator = world.add_entity((
+            position_at(start_x),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(start_node)),
+                    link: Link::TPathInit,
+                }],
+            },
+        ));
+        (world, elevator)
+    }
+
+    /// Steps until the elevator stops, returning the effect of the frame it
+    /// arrived on.
+    fn run_until_stopped(
+        elevator: &mut BaseElevator,
+        entity_id: EntityId,
+        world: &World,
+        physics: &PhysicsWorld,
+        max_frames: u32,
+    ) -> Effect {
+        for _ in 0..max_frames {
+            let effect = elevator.update(entity_id, world, physics, &frame());
+            if !elevator.is_moving {
+                return effect;
+            }
+        }
+        panic!(
+            "elevator never stopped: at {:?}, target {:?}",
+            elevator.current_position, elevator.desired_position
+        );
+    }
+
+    /// The command1 tram (speed 12): 193.100 wu at 0.2 wu/frame is 965.5 steps,
+    /// so the residual lands on the worst-case midpoint of a step (#653).
+    #[test]
+    fn a_fast_elevator_arrives_at_its_node_and_can_be_dispatched_again() {
+        let (world, entity_id) = two_stop_world(-377.53342, -184.43343, 12.0);
+        let physics = PhysicsWorld::new();
+        let mut elevator = BaseElevator::new();
+        elevator.initialize(entity_id, &world);
+
+        let turn_on = MessagePayload::TurnOn { from: entity_id };
+        let effect = elevator.handle_message(entity_id, &world, &physics, &turn_on);
+        assert!(matches!(effect, Effect::PlaySound { .. }));
+        assert!(elevator.is_moving);
+
+        let arrival = run_until_stopped(&mut elevator, entity_id, &world, &physics, 2000);
+
+        assert_eq!(elevator.current_position, vec3(-184.43343, 0.0, 0.0));
+        assert!(matches!(
+            arrival,
+            Effect::SetPosition { position, .. } if position == vec3(-184.43343, 0.0, 0.0)
+        ));
+
+        // The user-visible symptom: a jammed elevator can never be recalled.
+        let effect = elevator.handle_message(entity_id, &world, &physics, &turn_on);
+        assert!(matches!(effect, Effect::PlaySound { .. }));
+        assert!(elevator.is_moving);
+        assert_eq!(elevator.desired_position, vec3(-377.53342, 0.0, 0.0));
+    }
+
+    #[test]
+    fn a_slow_elevator_still_arrives_exactly_on_its_node() {
+        let (world, entity_id) = two_stop_world(0.0, 4.0, 2.4);
+        let physics = PhysicsWorld::new();
+        let mut elevator = BaseElevator::new();
+        elevator.initialize(entity_id, &world);
+
+        elevator.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+        run_until_stopped(&mut elevator, entity_id, &world, &physics, 2000);
+
+        assert_eq!(elevator.current_position, vec3(4.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn a_continuous_elevator_retargets_the_next_node_on_arrival() {
+        let (world, entity_id) = two_stop_world(-377.53342, -184.43343, 12.0);
+        let physics = PhysicsWorld::new();
+        let mut elevator = BaseElevator::continuous();
+        elevator.initialize(entity_id, &world);
+
+        elevator.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        let mut arrival = None;
+        for _ in 0..2000 {
+            let effect = elevator.update(entity_id, &world, &physics, &frame());
+            if elevator.desired_position == vec3(-377.53342, 0.0, 0.0) {
+                arrival = Some(effect);
+                break;
+            }
+        }
+        // It reports the node it reached, not the one it just retargeted.
+        assert!(matches!(
+            arrival,
+            Some(Effect::SetPosition { position, .. }) if position == vec3(-184.43343, 0.0, 0.0)
+        ));
+        assert!(elevator.is_moving);
     }
 }
 


### PR DESCRIPTION
`BaseElevator::update()` stepped a fixed distance per frame but tested arrival against a **squared** distance compared to an unsquared threshold:

```rust
let dir = self.desired_position - self.current_position;
if dir.magnitude2() > 0.001 {
```

so the real arrival window was `sqrt(0.001)` = 0.0316 wu while the per-frame step is `speed * dt`. Any elevator whose step exceeded twice that window (`step > 0.0632`, i.e. TPath **speed > 3.79 wu/s** at the 60 Hz fixed timestep) overshot its node and oscillated around it forever. `is_moving` never cleared, and `handle_message(TurnOn)` early-returns `Effect::NoEffect` while moving — so the elevator ran exactly once and could never be recalled. This blocked reaching `command2`: the command1 tram (speed 12) travels 193.100 wu at 0.2 wu/frame = 965.5 steps, landing the residual exactly on the worst-case midpoint.

## Fix

Mirror the pattern `StdDoor` already carries for the same failure mode (`std_door.rs`: `if dir.magnitude() > step.max(0.001)`): complete once within one frame-step of the target, snap to the node, and clear `is_moving`. The arrival arm now emits `Effect::SetPosition` at the node instead of `NoEffect`, so the elevator lands exactly on its stop rather than up to one step short. For a `DontStopElevator`, the position of the node just reached is captured before `move_to_next_target()` retargets.

## Verification

**Unit tests** (`shock2vr/src/scripts/base_elevator.rs`), negative first — all three fail on `main`:

```
test a_fast_elevator_arrives_at_its_node_and_can_be_dispatched_again ... FAILED
  elevator never stopped: at Vector3 [-184.3271, 0.0, 0.0], target Vector3 [-184.43343, 0.0, 0.0]
test a_slow_elevator_still_arrives_exactly_on_its_node ... FAILED
  left: Vector3 [3.9999974, 0.0, 0.0]  right: Vector3 [4.0, 0.0, 0.0]
test a_continuous_elevator_retargets_the_next_node_on_arrival ... FAILED
```

and pass with the fix. The fast test uses the exact command1 tram geometry (−377.53342 → −184.43343 at speed 12, the worst-case half-step residual) and asserts the follow-up `TurnOn` dispatches again — the actual user-visible symptom. `cargo test -p shock2vr`: 331 passed.

**End-to-end** on the debug runtime (`command1.mis`, tram resolved by `template_id` 137, call button by `template_id` 199 — no hardcoded runtime ids):

```
frob call button (dispatch 1): x -377.53 -> ... -> -184.43343, then stationary
frob call button (dispatch 2): x -184.43 -> ... ->  -75.83342, then stationary
```

Before this change the tram oscillated between x = −184.3271 and −184.5271 forever and the second frob did nothing.

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo fmt --all` applied; SDK e2e suite run.

## Notes

- Audited the other `magnitude2()` call sites in `shock2vr`/`dark` for the same squared-vs-unsquared mistake — the rest are epsilon/degeneracy guards or compare two squared quantities (`std_door`, `script_util::door_is_closed`, `mission_core` ambient radius). No second instance of this bug.
- Pre-existing and out of scope: a TPath node with `speed == 0` still leaves `is_moving` set forever (zero progress per frame), unchanged by this fix. Worth a follow-up if any shipped path point turns out to be time-authored rather than speed-authored (`TPathData::read` keeps `speed` and discards `time`).

Fixes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
