### PR TITLE
fix(tools): read game data from a 25th Anniversary install in bench, dq maps and the font viewer

### DIFF
--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -12,7 +12,7 @@
 //! `File::open`ing the data root and failing on a 25AE install.
 
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -51,7 +51,9 @@ pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
     ]
 }
 
-/// Every mission file available in `data_root`, lowercased and sorted.
+/// Every mission file available in `data_root`, sorted, with the spelling that
+/// opens it: a loose file keeps its on-disk case (which is what a case-sensitive
+/// filesystem needs), an archived one its lowercased archive name.
 ///
 /// A classic install has them loose at the data root; a 25AE install has them
 /// inside `sshock2.kpf` under `data/`, so a caller that only reads the directory
@@ -59,19 +61,22 @@ pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
 /// is how a "run against every mission" tool silently ends up running against
 /// nothing.
 pub fn mission_names(data_root: &Path) -> Vec<String> {
-    let mut names: BTreeSet<String> = loose_mission_names(data_root);
-    names.extend(archived_mission_names(data_root));
-    names.into_iter().collect()
+    // Keyed by lowercased name so the same mission present in both layouts is
+    // listed once, with the loose spelling winning.
+    let mut names: BTreeMap<String, String> = archived_mission_names(data_root);
+    names.extend(loose_mission_names(data_root));
+    names.into_values().collect()
 }
 
-fn loose_mission_names(data_root: &Path) -> BTreeSet<String> {
+fn loose_mission_names(data_root: &Path) -> BTreeMap<String, String> {
     let Ok(entries) = std::fs::read_dir(data_root) else {
-        return BTreeSet::new();
+        return BTreeMap::new();
     };
     entries
         .filter_map(|entry| entry.ok())
-        .map(|entry| entry.file_name().to_string_lossy().to_ascii_lowercase())
-        .filter(|name| name.ends_with(".mis"))
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.to_ascii_lowercase().ends_with(".mis"))
+        .map(|name| (name.to_ascii_lowercase(), name))
         .collect()
 }
 
@@ -79,15 +84,15 @@ fn loose_mission_names(data_root: &Path) -> BTreeSet<String> {
 /// classic install, and for an archive that cannot be opened - the caller
 /// reports "no missions" either way, and the mount layer gives the real error
 /// when something then tries to *read* a mission.
-fn archived_mission_names(data_root: &Path) -> BTreeSet<String> {
+fn archived_mission_names(data_root: &Path) -> BTreeMap<String, String> {
     if !is_25th_anniversary_install(data_root) {
-        return BTreeSet::new();
+        return BTreeMap::new();
     }
     let Ok(file) = std::fs::File::open(data_root.join(BASE_ARCHIVE)) else {
-        return BTreeSet::new();
+        return BTreeMap::new();
     };
     let Ok(archive) = zip::ZipArchive::new(std::io::BufReader::new(file)) else {
-        return BTreeSet::new();
+        return BTreeMap::new();
     };
     archive
         .file_names()
@@ -95,7 +100,8 @@ fn archived_mission_names(data_root: &Path) -> BTreeSet<String> {
             let lower = name.to_ascii_lowercase();
             let relative = lower.strip_prefix(ARCHIVE_DATA_PREFIX)?;
             // Only the missions themselves, not anything nested deeper.
-            (relative.ends_with(".mis") && !relative.contains('/')).then(|| relative.to_owned())
+            (relative.ends_with(".mis") && !relative.contains('/'))
+                .then(|| (relative.to_owned(), relative.to_owned()))
         })
         .collect()
 }
@@ -112,7 +118,8 @@ pub fn asset_paths(data_root: &Path) -> Box<dyn AbstractAssetPath> {
 }
 
 /// Open a raw data file by name (`shock2.gam`, `medsci1.mis`, `motiondb.bin`)
-/// from the resolved data root, in whichever layout is present.
+/// from the resolved data root, in whichever layout is present. `None` means
+/// "no mount has that name" - the cause of a filesystem error is not reported.
 ///
 /// The mounts are built once per process because indexing a 25AE archive is not
 /// free and callers like `cargo bn path bench --all` read every mission through
@@ -120,12 +127,14 @@ pub fn asset_paths(data_root: &Path) -> Box<dyn AbstractAssetPath> {
 pub fn open_data_file(name: &str) -> Option<Box<dyn ReadableAndSeekable>> {
     static PATHS: OnceLock<Box<dyn AbstractAssetPath>> = OnceLock::new();
     let data_root = crate::paths::data_root();
-    PATHS
-        .get_or_init(|| asset_paths(data_root))
-        .get_reader(
-            data_root.to_string_lossy().into_owned(),
-            name.to_ascii_lowercase(),
-        )
+    let paths = PATHS.get_or_init(|| asset_paths(data_root));
+    let base_path = data_root.to_string_lossy().into_owned();
+    // Archive keys are lowercased, but the loose-file mount resolves a name
+    // byte-for-byte, so an on-disk `Earth.mis` only opens under its own
+    // spelling on a case-sensitive filesystem.
+    paths
+        .get_reader(base_path.clone(), name.to_ascii_lowercase())
+        .or_else(|| paths.get_reader(base_path, name.to_owned()))
         .map(RefCell::into_inner)
 }
 
@@ -224,16 +233,18 @@ mod tests {
         );
     }
 
+    /// A loose mission keeps its on-disk spelling: that is the only name that
+    /// opens it on a case-sensitive filesystem.
     #[test]
     fn classic_install_lists_loose_missions() {
         let dir = TempDir::new("classic-missions");
-        std::fs::write(dir.path().join("earth.mis"), b"mission").unwrap();
+        std::fs::write(dir.path().join("Earth.MIS"), b"mission").unwrap();
         std::fs::write(dir.path().join("medsci1.mis"), b"mission").unwrap();
         std::fs::write(dir.path().join("shock2.gam"), b"gamesys").unwrap();
 
         assert_eq!(
             mission_names(dir.path()),
-            vec!["earth.mis".to_owned(), "medsci1.mis".to_owned()]
+            vec!["Earth.MIS".to_owned(), "medsci1.mis".to_owned()]
         );
     }
 

--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -11,14 +11,20 @@
 //! no bundle storage) resolve exactly the same files the game does, instead of
 //! `File::open`ing the data root and failing on a 25AE install.
 
+use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::path::Path;
+use std::sync::OnceLock;
 
-use engine::assets::asset_paths::{AbstractAssetPath, AssetPath};
+use engine::assets::asset_paths::{AbstractAssetPath, AssetPath, ReadableAndSeekable};
 
 use crate::zip_asset_path::ZipAssetPath;
 
 /// The single archive a 25th Anniversary Edition install ships its data in.
 const BASE_ARCHIVE: &str = "sshock2.kpf";
+
+/// Where that archive keeps the gamesys and the missions.
+const ARCHIVE_DATA_PREFIX: &str = "data/";
 
 /// Whether `data_root` is a 25th Anniversary Edition install rather than a
 /// classic one. The remaster ships its data inside `sshock2.kpf`; a classic
@@ -41,8 +47,57 @@ pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
         // `motiondb.bin` moved from the data root to `res/mschema/`, and the
         // missions + gamesys live under `data/`.
         ZipAssetPath::with_prefix(archive.clone(), "data/res/mschema/"),
-        ZipAssetPath::with_prefix(archive, "data/"),
+        ZipAssetPath::with_prefix(archive, ARCHIVE_DATA_PREFIX),
     ]
+}
+
+/// Every mission file available in `data_root`, lowercased and sorted.
+///
+/// A classic install has them loose at the data root; a 25AE install has them
+/// inside `sshock2.kpf` under `data/`, so a caller that only reads the directory
+/// sees *no* missions at all there - an empty list rather than an error, which
+/// is how a "run against every mission" tool silently ends up running against
+/// nothing.
+pub fn mission_names(data_root: &Path) -> Vec<String> {
+    let mut names: BTreeSet<String> = loose_mission_names(data_root);
+    names.extend(archived_mission_names(data_root));
+    names.into_iter().collect()
+}
+
+fn loose_mission_names(data_root: &Path) -> BTreeSet<String> {
+    let Ok(entries) = std::fs::read_dir(data_root) else {
+        return BTreeSet::new();
+    };
+    entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().to_ascii_lowercase())
+        .filter(|name| name.ends_with(".mis"))
+        .collect()
+}
+
+/// The `.mis` entries directly under the archive's `data/` folder. Empty for a
+/// classic install, and for an archive that cannot be opened - the caller
+/// reports "no missions" either way, and the mount layer gives the real error
+/// when something then tries to *read* a mission.
+fn archived_mission_names(data_root: &Path) -> BTreeSet<String> {
+    if !is_25th_anniversary_install(data_root) {
+        return BTreeSet::new();
+    }
+    let Ok(file) = std::fs::File::open(data_root.join(BASE_ARCHIVE)) else {
+        return BTreeSet::new();
+    };
+    let Ok(archive) = zip::ZipArchive::new(std::io::BufReader::new(file)) else {
+        return BTreeSet::new();
+    };
+    archive
+        .file_names()
+        .filter_map(|name| {
+            let lower = name.to_ascii_lowercase();
+            let relative = lower.strip_prefix(ARCHIVE_DATA_PREFIX)?;
+            // Only the missions themselves, not anything nested deeper.
+            (relative.ends_with(".mis") && !relative.contains('/')).then(|| relative.to_owned())
+        })
+        .collect()
 }
 
 /// An asset-path layer that resolves only the raw data files - no textures,
@@ -54,6 +109,24 @@ pub fn asset_paths(data_root: &Path) -> Box<dyn AbstractAssetPath> {
     let mut mounts = data_file_mounts(data_root);
     mounts.push(AssetPath::folder(String::new()));
     AssetPath::combine(mounts)
+}
+
+/// Open a raw data file by name (`shock2.gam`, `medsci1.mis`, `motiondb.bin`)
+/// from the resolved data root, in whichever layout is present.
+///
+/// The mounts are built once per process because indexing a 25AE archive is not
+/// free and callers like `cargo bn path bench --all` read every mission through
+/// here.
+pub fn open_data_file(name: &str) -> Option<Box<dyn ReadableAndSeekable>> {
+    static PATHS: OnceLock<Box<dyn AbstractAssetPath>> = OnceLock::new();
+    let data_root = crate::paths::data_root();
+    PATHS
+        .get_or_init(|| asset_paths(data_root))
+        .get_reader(
+            data_root.to_string_lossy().into_owned(),
+            name.to_ascii_lowercase(),
+        )
+        .map(RefCell::into_inner)
 }
 
 #[cfg(test)]
@@ -148,6 +221,42 @@ mod tests {
         assert_eq!(
             read(dir.path(), "motiondb.bin").as_deref(),
             Some(&b"archived motiondb"[..])
+        );
+    }
+
+    #[test]
+    fn classic_install_lists_loose_missions() {
+        let dir = TempDir::new("classic-missions");
+        std::fs::write(dir.path().join("earth.mis"), b"mission").unwrap();
+        std::fs::write(dir.path().join("medsci1.mis"), b"mission").unwrap();
+        std::fs::write(dir.path().join("shock2.gam"), b"gamesys").unwrap();
+
+        assert_eq!(
+            mission_names(dir.path()),
+            vec!["earth.mis".to_owned(), "medsci1.mis".to_owned()]
+        );
+    }
+
+    /// A 25AE install has no loose `.mis` at all, so reading the directory finds
+    /// nothing - the missions have to be enumerated out of the archive.
+    #[test]
+    fn anniversary_install_lists_missions_from_the_archive() {
+        let dir = TempDir::new("25th-missions");
+        write_archive(
+            dir.path(),
+            &[
+                ("data/medsci1.mis", b"mission"),
+                ("data/earth.mis", b"mission"),
+                ("data/shock2.gam", b"gamesys"),
+                // Not a mission at the data root - must not be listed.
+                ("data/res/mschema/motiondb.bin", b"motiondb"),
+                ("data/saves/quick.mis", b"nested"),
+            ],
+        );
+
+        assert_eq!(
+            mission_names(dir.path()),
+            vec!["earth.mis".to_owned(), "medsci1.mis".to_owned()]
         );
     }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -184,9 +184,7 @@ fn mount_family(
     }
 }
 
-fn build_25th_anniversary_mounts(
-    bundle_storage: Arc<dyn Storage>,
-) -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
+fn build_25th_anniversary_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
     let mut mounts: Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> = Vec::new();
 
     for family in RESOURCE_FAMILIES {
@@ -211,9 +209,93 @@ fn build_25th_anniversary_mounts(
     // need those files without any of the resource families above.
     mounts.extend(data_files::data_file_mounts(paths::data_root()));
 
-    mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
-    mounts.push(AssetPath::folder("".to_owned()));
     mounts
+}
+
+/// Every game asset mount except the bundle (engine storage) and the loose-file
+/// fallback, which the callers below append in that order.
+///
+/// A 25th Anniversary install keeps everything inside KPF archives, so it needs
+/// a different mount list from a classic install's loose `.crf`s.
+fn resource_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
+    if is_25th_anniversary_install() {
+        info!("25th Anniversary Edition install detected; mounting KPF archives");
+        build_25th_anniversary_mounts()
+    } else {
+        build_classic_mounts()
+    }
+}
+
+fn build_classic_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
+    vec![
+        AssetPath::folder(resource_path("res/mesh")),
+        // AssetPath::folder(resource_path("res/mesh/txt16")),
+        AssetPath::folder(resource_path("res/obj")),
+        // AssetPath::folder(resource_path("res/obj/txt16")),
+        ZipAssetPath::new(resource_path("res/obj.crf")),
+        ZipAssetPath::new(resource_path("res/bitmap.crf")),
+        // Log/email sender portraits + deck icons (the reader panel art).
+        ZipAssetPath::new(resource_path("res/book.crf")),
+        ZipAssetPath::new(resource_path("res/fam.crf")),
+        // Also mounted under the "iface/" namespace: iface.crf shares seven
+        // basenames with the obj/bitmap mounts above (access/block/log/
+        // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
+        // means those plain names must keep resolving to the model
+        // textures. GUI code that wants the interface art requests the
+        // archive-qualified "iface/<name>" key instead.
+        ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
+        ZipAssetPath::new(resource_path("res/intrface.crf")),
+        ZipAssetPath::new(resource_path("res/mesh.crf")),
+        ZipAssetPath::new(resource_path("res/motions.crf")),
+        ZipAssetPath::new(resource_path("res/objicon.crf")),
+        ZipAssetPath::new(resource_path("res/snd.crf")),
+        ZipAssetPath::new(resource_path("res/snd2.crf")),
+        ZipAssetPath::new(resource_path("res/song.crf")),
+        ZipAssetPath::new2(resource_path("res/strings.crf"), false),
+        // Textures
+        // AssetPath::folder("res/bitmap".to_owned()),
+        // AssetPath::folder("res/bitmap/txt16".to_owned()),
+        //AssetPath::folder("res/fam".to_owned()),
+        // Models
+        // AssetPath::folder("res/mesh/txt16".to_owned()),
+        // AssetPath::folder("res/obj".to_owned()),
+        // AssetPath::folder("res/mesh".to_owned()),
+        // Animations
+        //AssetPath::folder("res/motions".to_owned()),
+        // Audio
+        // AssetPath::folder("res/snd".to_owned()),
+        // AssetPath::folder("res/snd/amb".to_owned()),
+        // AssetPath::folder("res/snd/Assassin".to_owned()),
+        // AssetPath::folder("res/snd/BBetty".to_owned()),
+        // AssetPath::folder("res/snd/Devices".to_owned()),
+        // AssetPath::folder("res/snd/GRUB".to_owned()),
+        // AssetPath::folder("res/snd/HITS".to_owned()),
+        // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
+        // AssetPath::folder("res/snd/Midwife/english".to_owned()),
+        // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
+        // AssetPath::folder("res/snd/Overlord/english".to_owned()),
+        // AssetPath::folder("res/snd/SONGS".to_owned()),
+        // AssetPath::folder("res/snd/TurrCam".to_owned()),
+        // AssetPath::folder("res/snd/Weapons".to_owned()),
+        // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
+        // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
+        // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
+        // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
+        // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
+    ]
+}
+
+/// The game's asset mounts for a CLI tool: everything [`Game::init`] mounts
+/// except the bundle assets, which need engine storage (and therefore a
+/// renderer) that a tool does not have.
+///
+/// A tool that reads a *resource family* - the interface art `dq maps` wants,
+/// say - needs this rather than [`data_files::asset_paths`], because on a 25AE
+/// install those families live inside the KPF archives behind the mod layers.
+pub fn tool_asset_paths() -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
+    let mut mounts = resource_mounts();
+    mounts.push(AssetPath::folder("".to_owned()));
+    AssetPath::combine(mounts)
 }
 
 /// Whether a mission file is available to load, in whichever layout is in use.
@@ -819,72 +901,14 @@ impl Game {
         dark::high_detail::set_enabled(high_detail);
         info!("high-detail (PMNM) meshes: {high_detail}");
 
-        // A 25th Anniversary install keeps everything inside KPF archives, so it
-        // needs a different mount list from a classic install's loose `.crf`s.
-        let asset_paths = if is_25th_anniversary_install() {
-            info!("25th Anniversary Edition install detected; mounting KPF archives");
-            AssetPath::combine(build_25th_anniversary_mounts(bundle_storage.clone()))
-        } else {
-            AssetPath::combine(vec![
-                AssetPath::folder(resource_path("res/mesh")),
-                // AssetPath::folder(resource_path("res/mesh/txt16")),
-                AssetPath::folder(resource_path("res/obj")),
-                // AssetPath::folder(resource_path("res/obj/txt16")),
-                ZipAssetPath::new(resource_path("res/obj.crf")),
-                ZipAssetPath::new(resource_path("res/bitmap.crf")),
-                // Log/email sender portraits + deck icons (the reader panel art).
-                ZipAssetPath::new(resource_path("res/book.crf")),
-                ZipAssetPath::new(resource_path("res/fam.crf")),
-                // Also mounted under the "iface/" namespace: iface.crf shares seven
-                // basenames with the obj/bitmap mounts above (access/block/log/
-                // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
-                // means those plain names must keep resolving to the model
-                // textures. GUI code that wants the interface art requests the
-                // archive-qualified "iface/<name>" key instead.
-                ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
-                ZipAssetPath::new(resource_path("res/intrface.crf")),
-                ZipAssetPath::new(resource_path("res/mesh.crf")),
-                ZipAssetPath::new(resource_path("res/motions.crf")),
-                ZipAssetPath::new(resource_path("res/objicon.crf")),
-                ZipAssetPath::new(resource_path("res/snd.crf")),
-                ZipAssetPath::new(resource_path("res/snd2.crf")),
-                ZipAssetPath::new(resource_path("res/song.crf")),
-                ZipAssetPath::new2(resource_path("res/strings.crf"), false),
-                // Bundle assets
-                BundleAssetPath::new("".to_owned(), bundle_storage),
-                // Textures
-                // AssetPath::folder("res/bitmap".to_owned()),
-                // AssetPath::folder("res/bitmap/txt16".to_owned()),
-                //AssetPath::folder("res/fam".to_owned()),
-                // Models
-                // AssetPath::folder("res/mesh/txt16".to_owned()),
-                // AssetPath::folder("res/obj".to_owned()),
-                // AssetPath::folder("res/mesh".to_owned()),
-                // Animations
-                //AssetPath::folder("res/motions".to_owned()),
-                // Motion db
-                AssetPath::folder("".to_owned()),
-                // Audio
-                // AssetPath::folder("res/snd".to_owned()),
-                // AssetPath::folder("res/snd/amb".to_owned()),
-                // AssetPath::folder("res/snd/Assassin".to_owned()),
-                // AssetPath::folder("res/snd/BBetty".to_owned()),
-                // AssetPath::folder("res/snd/Devices".to_owned()),
-                // AssetPath::folder("res/snd/GRUB".to_owned()),
-                // AssetPath::folder("res/snd/HITS".to_owned()),
-                // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
-                // AssetPath::folder("res/snd/Midwife/english".to_owned()),
-                // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
-                // AssetPath::folder("res/snd/Overlord/english".to_owned()),
-                // AssetPath::folder("res/snd/SONGS".to_owned()),
-                // AssetPath::folder("res/snd/TurrCam".to_owned()),
-                // AssetPath::folder("res/snd/Weapons".to_owned()),
-                // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
-                // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
-                // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
-                // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
-                // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
-            ])
+        // Every mount except the bundle assets, which need the engine storage a
+        // CLI tool has no way to build - see `tool_asset_paths`.
+        let asset_paths = {
+            let mut mounts = resource_mounts();
+            mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
+            // Motion db and anything else still loose at the data root.
+            mounts.push(AssetPath::folder("".to_owned()));
+            AssetPath::combine(mounts)
         };
         // Global items
         let base_path = paths::data_root().to_string_lossy().into_owned();

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -184,118 +184,71 @@ fn mount_family(
     }
 }
 
-fn build_25th_anniversary_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
+/// The 25AE mounts for one resource family, highest priority first: every mod
+/// layer allowed to override it, then the base archive.
+fn anniversary_family_mounts(
+    family: &str,
+) -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
+    let mut mounts: Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> = Vec::new();
+    for archive in MOD_ARCHIVES {
+        if !mod_layer_may_override(family, archive) {
+            continue;
+        }
+        let path = resource_path(archive);
+        if Path::new(&path).exists() {
+            mounts.push(mount_family(path, &format!("{family}/"), family));
+        }
+    }
+    // The base archive keeps the original `data/res/<family>/` layout.
+    mounts.push(mount_family(
+        resource_path("sshock2.kpf"),
+        &format!("data/res/{family}/"),
+        family,
+    ));
+    mounts
+}
+
+/// The mounts for a *single* resource family, for a CLI tool that needs one
+/// family's files without a renderer - `dq maps` reads the map rectangles out
+/// of `intrface`, which a classic install keeps in `res/intrface.crf` and a
+/// 25AE one inside the KPF layers.
+///
+/// Same archives, same precedence the game resolves that family through. A
+/// missing archive contributes no mount, so a lookup comes back empty instead
+/// of panicking inside the archive reader.
+pub fn resource_family_paths(
+    family: &str,
+) -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
+    let mounts = if is_25th_anniversary_install() {
+        anniversary_family_mounts(family)
+    } else {
+        // A `.crf` holds one family at its root, so it needs no prefix.
+        let archive = resource_path(&format!("res/{family}.crf"));
+        if Path::new(&archive).exists() {
+            vec![mount_family(archive, "", family)]
+        } else {
+            Vec::new()
+        }
+    };
+    AssetPath::combine(mounts)
+}
+
+fn build_25th_anniversary_mounts(
+    bundle_storage: Arc<dyn Storage>,
+) -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
     let mut mounts: Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> = Vec::new();
 
     for family in RESOURCE_FAMILIES {
-        for archive in MOD_ARCHIVES {
-            if !mod_layer_may_override(family, archive) {
-                continue;
-            }
-            let path = resource_path(archive);
-            if Path::new(&path).exists() {
-                mounts.push(mount_family(path, &format!("{family}/"), family));
-            }
-        }
-        // The base archive keeps the original `data/res/<family>/` layout.
-        mounts.push(mount_family(
-            resource_path("sshock2.kpf"),
-            &format!("data/res/{family}/"),
-            family,
-        ));
+        mounts.extend(anniversary_family_mounts(family));
     }
 
     // The gamesys, missions and motiondb - shared with the CLI tools, which
     // need those files without any of the resource families above.
     mounts.extend(data_files::data_file_mounts(paths::data_root()));
 
-    mounts
-}
-
-/// Every game asset mount except the bundle (engine storage) and the loose-file
-/// fallback, which the callers below append in that order.
-///
-/// A 25th Anniversary install keeps everything inside KPF archives, so it needs
-/// a different mount list from a classic install's loose `.crf`s.
-fn resource_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
-    if is_25th_anniversary_install() {
-        info!("25th Anniversary Edition install detected; mounting KPF archives");
-        build_25th_anniversary_mounts()
-    } else {
-        build_classic_mounts()
-    }
-}
-
-fn build_classic_mounts() -> Vec<Box<dyn engine::assets::asset_paths::AbstractAssetPath>> {
-    vec![
-        AssetPath::folder(resource_path("res/mesh")),
-        // AssetPath::folder(resource_path("res/mesh/txt16")),
-        AssetPath::folder(resource_path("res/obj")),
-        // AssetPath::folder(resource_path("res/obj/txt16")),
-        ZipAssetPath::new(resource_path("res/obj.crf")),
-        ZipAssetPath::new(resource_path("res/bitmap.crf")),
-        // Log/email sender portraits + deck icons (the reader panel art).
-        ZipAssetPath::new(resource_path("res/book.crf")),
-        ZipAssetPath::new(resource_path("res/fam.crf")),
-        // Also mounted under the "iface/" namespace: iface.crf shares seven
-        // basenames with the obj/bitmap mounts above (access/block/log/
-        // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
-        // means those plain names must keep resolving to the model
-        // textures. GUI code that wants the interface art requests the
-        // archive-qualified "iface/<name>" key instead.
-        ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
-        ZipAssetPath::new(resource_path("res/intrface.crf")),
-        ZipAssetPath::new(resource_path("res/mesh.crf")),
-        ZipAssetPath::new(resource_path("res/motions.crf")),
-        ZipAssetPath::new(resource_path("res/objicon.crf")),
-        ZipAssetPath::new(resource_path("res/snd.crf")),
-        ZipAssetPath::new(resource_path("res/snd2.crf")),
-        ZipAssetPath::new(resource_path("res/song.crf")),
-        ZipAssetPath::new2(resource_path("res/strings.crf"), false),
-        // Textures
-        // AssetPath::folder("res/bitmap".to_owned()),
-        // AssetPath::folder("res/bitmap/txt16".to_owned()),
-        //AssetPath::folder("res/fam".to_owned()),
-        // Models
-        // AssetPath::folder("res/mesh/txt16".to_owned()),
-        // AssetPath::folder("res/obj".to_owned()),
-        // AssetPath::folder("res/mesh".to_owned()),
-        // Animations
-        //AssetPath::folder("res/motions".to_owned()),
-        // Audio
-        // AssetPath::folder("res/snd".to_owned()),
-        // AssetPath::folder("res/snd/amb".to_owned()),
-        // AssetPath::folder("res/snd/Assassin".to_owned()),
-        // AssetPath::folder("res/snd/BBetty".to_owned()),
-        // AssetPath::folder("res/snd/Devices".to_owned()),
-        // AssetPath::folder("res/snd/GRUB".to_owned()),
-        // AssetPath::folder("res/snd/HITS".to_owned()),
-        // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
-        // AssetPath::folder("res/snd/Midwife/english".to_owned()),
-        // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
-        // AssetPath::folder("res/snd/Overlord/english".to_owned()),
-        // AssetPath::folder("res/snd/SONGS".to_owned()),
-        // AssetPath::folder("res/snd/TurrCam".to_owned()),
-        // AssetPath::folder("res/snd/Weapons".to_owned()),
-        // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
-        // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
-        // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
-        // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
-        // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
-    ]
-}
-
-/// The game's asset mounts for a CLI tool: everything [`Game::init`] mounts
-/// except the bundle assets, which need engine storage (and therefore a
-/// renderer) that a tool does not have.
-///
-/// A tool that reads a *resource family* - the interface art `dq maps` wants,
-/// say - needs this rather than [`data_files::asset_paths`], because on a 25AE
-/// install those families live inside the KPF archives behind the mod layers.
-pub fn tool_asset_paths() -> Box<dyn engine::assets::asset_paths::AbstractAssetPath> {
-    let mut mounts = resource_mounts();
+    mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
     mounts.push(AssetPath::folder("".to_owned()));
-    AssetPath::combine(mounts)
+    mounts
 }
 
 /// Whether a mission file is available to load, in whichever layout is in use.
@@ -305,25 +258,9 @@ pub fn tool_asset_paths() -> Box<dyn engine::assets::asset_paths::AbstractAssetP
 /// before asking the game to load it (the debug runtime's `transition-level`
 /// endpoint, for one) must not just stat the filesystem.
 pub fn mission_exists(mission_file: &str) -> bool {
-    if Path::new(&resource_path(mission_file)).exists() {
-        return true;
-    }
-    if !is_25th_anniversary_install() {
-        return false;
-    }
-    let wanted = format!("data/{}", mission_file.to_ascii_lowercase());
-    let Ok(file) = std::fs::File::open(resource_path("sshock2.kpf")) else {
-        return false;
-    };
-    let Ok(mut archive) = zip::ZipArchive::new(std::io::BufReader::new(file)) else {
-        return false;
-    };
-    (0..archive.len()).any(|i| {
-        archive
-            .by_index(i)
-            .map(|e| e.name().to_ascii_lowercase() == wanted)
-            .unwrap_or(false)
-    })
+    data_files::mission_names(paths::data_root())
+        .iter()
+        .any(|mission| mission.eq_ignore_ascii_case(mission_file))
 }
 
 pub fn resource_path(str: &str) -> String {
@@ -901,14 +838,72 @@ impl Game {
         dark::high_detail::set_enabled(high_detail);
         info!("high-detail (PMNM) meshes: {high_detail}");
 
-        // Every mount except the bundle assets, which need the engine storage a
-        // CLI tool has no way to build - see `tool_asset_paths`.
-        let asset_paths = {
-            let mut mounts = resource_mounts();
-            mounts.push(BundleAssetPath::new("".to_owned(), bundle_storage));
-            // Motion db and anything else still loose at the data root.
-            mounts.push(AssetPath::folder("".to_owned()));
-            AssetPath::combine(mounts)
+        // A 25th Anniversary install keeps everything inside KPF archives, so it
+        // needs a different mount list from a classic install's loose `.crf`s.
+        let asset_paths = if is_25th_anniversary_install() {
+            info!("25th Anniversary Edition install detected; mounting KPF archives");
+            AssetPath::combine(build_25th_anniversary_mounts(bundle_storage.clone()))
+        } else {
+            AssetPath::combine(vec![
+                AssetPath::folder(resource_path("res/mesh")),
+                // AssetPath::folder(resource_path("res/mesh/txt16")),
+                AssetPath::folder(resource_path("res/obj")),
+                // AssetPath::folder(resource_path("res/obj/txt16")),
+                ZipAssetPath::new(resource_path("res/obj.crf")),
+                ZipAssetPath::new(resource_path("res/bitmap.crf")),
+                // Log/email sender portraits + deck icons (the reader panel art).
+                ZipAssetPath::new(resource_path("res/book.crf")),
+                ZipAssetPath::new(resource_path("res/fam.crf")),
+                // Also mounted under the "iface/" namespace: iface.crf shares seven
+                // basenames with the obj/bitmap mounts above (access/block/log/
+                // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins
+                // means those plain names must keep resolving to the model
+                // textures. GUI code that wants the interface art requests the
+                // archive-qualified "iface/<name>" key instead.
+                ZipAssetPath::with_namespace(resource_path("res/iface.crf"), "iface"),
+                ZipAssetPath::new(resource_path("res/intrface.crf")),
+                ZipAssetPath::new(resource_path("res/mesh.crf")),
+                ZipAssetPath::new(resource_path("res/motions.crf")),
+                ZipAssetPath::new(resource_path("res/objicon.crf")),
+                ZipAssetPath::new(resource_path("res/snd.crf")),
+                ZipAssetPath::new(resource_path("res/snd2.crf")),
+                ZipAssetPath::new(resource_path("res/song.crf")),
+                ZipAssetPath::new2(resource_path("res/strings.crf"), false),
+                // Bundle assets
+                BundleAssetPath::new("".to_owned(), bundle_storage),
+                // Textures
+                // AssetPath::folder("res/bitmap".to_owned()),
+                // AssetPath::folder("res/bitmap/txt16".to_owned()),
+                //AssetPath::folder("res/fam".to_owned()),
+                // Models
+                // AssetPath::folder("res/mesh/txt16".to_owned()),
+                // AssetPath::folder("res/obj".to_owned()),
+                // AssetPath::folder("res/mesh".to_owned()),
+                // Animations
+                //AssetPath::folder("res/motions".to_owned()),
+                // Motion db
+                AssetPath::folder("".to_owned()),
+                // Audio
+                // AssetPath::folder("res/snd".to_owned()),
+                // AssetPath::folder("res/snd/amb".to_owned()),
+                // AssetPath::folder("res/snd/Assassin".to_owned()),
+                // AssetPath::folder("res/snd/BBetty".to_owned()),
+                // AssetPath::folder("res/snd/Devices".to_owned()),
+                // AssetPath::folder("res/snd/GRUB".to_owned()),
+                // AssetPath::folder("res/snd/HITS".to_owned()),
+                // AssetPath::folder("res/snd/MaintBot/english".to_owned()),
+                // AssetPath::folder("res/snd/Midwife/english".to_owned()),
+                // AssetPath::folder("res/snd/OGRUNT/english".to_owned()),
+                // AssetPath::folder("res/snd/Overlord/english".to_owned()),
+                // AssetPath::folder("res/snd/SONGS".to_owned()),
+                // AssetPath::folder("res/snd/TurrCam".to_owned()),
+                // AssetPath::folder("res/snd/Weapons".to_owned()),
+                // AssetPath::folder("res/snd2/vBriefs/ENGLISH".to_owned()),
+                // AssetPath::folder("res/snd2/vCs/ENGLISH".to_owned()),
+                // AssetPath::folder("res/snd2/vEmails/english".to_owned()),
+                // AssetPath::folder("res/snd2/vLogs/english".to_owned()),
+                // AssetPath::folder("res/snd2/vTriggers/english".to_owned()),
+            ])
         };
         // Global items
         let base_path = paths::data_root().to_string_lossy().into_owned();

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -258,6 +258,9 @@ fn build_25th_anniversary_mounts(
 /// before asking the game to load it (the debug runtime's `transition-level`
 /// endpoint, for one) must not just stat the filesystem.
 pub fn mission_exists(mission_file: &str) -> bool {
+    if Path::new(&resource_path(mission_file)).exists() {
+        return true;
+    }
     data_files::mission_names(paths::data_root())
         .iter()
         .any(|mission| mission.eq_ignore_ascii_case(mission_file))

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -136,6 +136,11 @@ fn run_path_command(command: PathCommand) -> Result<()> {
                     }
                 }
             }
+            // A run where every mission failed would otherwise print an empty
+            // table (or `[]`) and exit 0 - a benchmark of nothing looks clean.
+            if reports.is_empty() {
+                return Err(anyhow!("no mission produced a benchmark report"));
+            }
             if json {
                 println!("{}", serde_json::to_string_pretty(&reports)?);
             } else {

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -13,8 +13,6 @@
 //!   cargo bn path show medsci1.mis --from " -10,0,5" --to "20,0,30"
 //!   cargo bn path cell medsci1.mis --at "20,0,30"
 
-use std::fs::File;
-use std::io::BufReader;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -27,7 +25,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
 use shock2vr::pathfinding::PathfindingService;
-use shock2vr::paths;
+use shock2vr::{data_files, paths};
 
 #[derive(Parser)]
 #[command(name = "bench", about = "Benchmark and inspect engine subsystems")]
@@ -239,12 +237,16 @@ fn dump_component_at(db: PathDatabase, at: Vector3<f32>) {
 
 fn resolve_missions(mission: Option<String>, all: bool) -> Result<Vec<String>> {
     if all {
-        let mut missions: Vec<String> = std::fs::read_dir(paths::data_root())?
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name().to_string_lossy().to_string())
-            .filter(|name| name.ends_with(".mis"))
-            .collect();
-        missions.sort();
+        let data_root = paths::data_root();
+        let missions = data_files::mission_names(data_root);
+        // Benchmarking nothing at all would otherwise look like a clean run.
+        if missions.is_empty() {
+            return Err(anyhow!(
+                "no .mis files found in the game data at {} - set DARK_ASSET_PATH to your \
+                 System Shock 2 install if that is the wrong directory",
+                data_root.display()
+            ));
+        }
         Ok(missions)
     } else {
         mission
@@ -254,9 +256,14 @@ fn resolve_missions(mission: Option<String>, all: bool) -> Result<Vec<String>> {
 }
 
 fn load_path_database(mission: &str) -> Result<PathDatabase> {
-    let path = paths::data_root().join(mission);
-    let file = File::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
-    let mut reader = BufReader::new(file);
+    // Through the asset-path layer rather than the filesystem: a 25th
+    // Anniversary install keeps every mission inside `sshock2.kpf`.
+    let mut reader = data_files::open_data_file(mission).with_context(|| {
+        format!(
+            "failed to open {mission} in the game data at {}",
+            paths::data_root().display()
+        )
+    })?;
     let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
     PathDatabase::read(&toc, &mut reader)
         .ok_or_else(|| anyhow!("no usable AIPATH data (missing chunk or unsupported version)"))

--- a/tools/bench/src/main.rs
+++ b/tools/bench/src/main.rs
@@ -110,11 +110,20 @@ fn main() -> Result<()> {
 fn run_path_command(command: PathCommand) -> Result<()> {
     match command {
         PathCommand::Stats { mission, all } => {
+            let mut reported = 0;
             for mission in resolve_missions(mission, all)? {
                 match load_path_database(&mission) {
-                    Ok(db) => print_stats(&mission, db),
+                    Ok(db) => {
+                        print_stats(&mission, db);
+                        reported += 1;
+                    }
                     Err(e) => println!("{mission}: {e}"),
                 }
+            }
+            // Same reason as `bench` below: a run that reported on nothing must
+            // not look like a clean one.
+            if reported == 0 {
+                return Err(anyhow!("no mission could be read"));
             }
         }
         PathCommand::Bench {

--- a/tools/dark_query/src/data_loader.rs
+++ b/tools/dark_query/src/data_loader.rs
@@ -5,38 +5,22 @@ use dark::{
     ss2_chunk_file_reader,
     ss2_entity_info::{self, SystemShock2EntityInfo, merge_with_gamesys},
 };
-use engine::assets::asset_paths::{AbstractAssetPath, ReadableAndSeekable};
+use engine::assets::asset_paths::ReadableAndSeekable;
 use shock2vr::{data_files, paths};
-use std::cell::RefCell;
-use std::sync::OnceLock;
 use tracing::info;
-
-/// The data-file mounts, built once per process: indexing a 25th Anniversary
-/// archive is not free, and both the gamesys and the mission go through here.
-fn data_file_paths() -> &'static dyn AbstractAssetPath {
-    static PATHS: OnceLock<Box<dyn AbstractAssetPath>> = OnceLock::new();
-    &**PATHS.get_or_init(|| data_files::asset_paths(paths::data_root()))
-}
 
 /// Open a raw data file (the gamesys, a mission, `motiondb.bin`) through the
 /// same asset-path layer the game uses, so a 25th Anniversary install - where
 /// nothing is loose on disk and everything lives inside `sshock2.kpf` - works
 /// just like a classic one.
 pub fn open_data_file(name: &str) -> Result<Box<dyn ReadableAndSeekable>> {
-    let data_root = paths::data_root();
-    data_file_paths()
-        .get_reader(
-            data_root.to_string_lossy().into_owned(),
-            name.to_ascii_lowercase(),
+    data_files::open_data_file(name).with_context(|| {
+        format!(
+            "{name} not found in the game data at {} - set DARK_ASSET_PATH to your \
+             System Shock 2 install if that is the wrong directory",
+            paths::data_root().display()
         )
-        .map(RefCell::into_inner)
-        .with_context(|| {
-            format!(
-                "{name} not found in the game data at {} - set DARK_ASSET_PATH to your \
-                 System Shock 2 install if that is the wrong directory",
-                data_root.display()
-            )
-        })
+    })
 }
 
 /// Load the full gamesys (shock2.gam) including speech DB and sound schema

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -640,11 +640,11 @@ fn handle_maps_command(mission: &str) -> Result<()> {
 
     // The map rectangles live in the *interface resource family*, which a
     // classic install keeps in `res/intrface.crf` and a 25th Anniversary one
-    // inside `sshock2.kpf` (possibly overridden by a mod layer). Mount the
-    // game's own family list rather than a single archive so both resolve.
+    // inside `sshock2.kpf` (possibly overridden by a mod layer). Mount that
+    // family the way the game does rather than one hardcoded archive.
     let mut asset_cache = engine::assets::asset_cache::AssetCache::new(
         data_path.clone(),
-        shock2vr::tool_asset_paths(),
+        shock2vr::resource_family_paths("intrface"),
     );
 
     match dark::map::MapChunkData::load_from_mission(&mut asset_cache, mission) {

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use shock2vr::zip_asset_path::ZipAssetPath;
 use tracing::info;
 
 mod data_loader;
@@ -639,26 +638,14 @@ fn handle_maps_command(mission: &str) -> Result<()> {
     let data_root = shock2vr::paths::data_root();
     let data_path = data_root.to_string_lossy().to_string();
 
-    // Production runtime ONLY has intrface.crf - no fallback to folders
-    let intrface_crf_path = data_root.join("res/intrface.crf");
-    if !intrface_crf_path.exists() {
-        // A 25th Anniversary install keeps the interface family inside
-        // `sshock2.kpf`, which needs the renderer's family mounts, not the
-        // data-file ones this tool uses elsewhere. Fail with a message rather
-        // than panicking inside the archive reader.
-        anyhow::bail!(
-            "{} not found - `maps` needs a classic install with loose .crf archives",
-            intrface_crf_path.display()
-        );
-    }
-
-    println!(
-        "Using intrface.crf archive: {}",
-        intrface_crf_path.display()
+    // The map rectangles live in the *interface resource family*, which a
+    // classic install keeps in `res/intrface.crf` and a 25th Anniversary one
+    // inside `sshock2.kpf` (possibly overridden by a mod layer). Mount the
+    // game's own family list rather than a single archive so both resolve.
+    let mut asset_cache = engine::assets::asset_cache::AssetCache::new(
+        data_path.clone(),
+        shock2vr::tool_asset_paths(),
     );
-    let asset_path = ZipAssetPath::new(intrface_crf_path.to_string_lossy().to_string());
-    let mut asset_cache =
-        engine::assets::asset_cache::AssetCache::new(data_path.clone(), asset_path);
 
     match dark::map::MapChunkData::load_from_mission(&mut asset_cache, mission) {
         Ok(map_data) => {

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -84,13 +84,6 @@ struct Cli {
     debug_hitboxes: bool,
 }
 
-fn resolve_data_path(resource: &str) -> String {
-    paths::data_root()
-        .join(resource)
-        .to_string_lossy()
-        .into_owned()
-}
-
 fn normalize_clip_name(raw: &str) -> Result<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -222,7 +215,6 @@ fn create_scene(
     animation_flag_provided: bool,
     scale: f32,
     asset_cache: &mut engine::assets::asset_cache::AssetCache,
-    data_resolver: fn(&str) -> String,
     debug_skeletons: bool,
     debug_hit_boxes: bool,
 ) -> Result<Box<dyn ToolScene>, Box<dyn std::error::Error>> {
@@ -254,7 +246,7 @@ fn create_scene(
             Ok(Box::new(scene))
         }
     } else if lower.ends_with(".fon") {
-        let scene = FontViewerScene::from_file(filename.to_string(), data_resolver)?;
+        let scene = FontViewerScene::from_file(filename.to_string(), asset_cache)?;
         Ok(Box::new(scene))
     } else if lower.ends_with(".glb") {
         if animation_flag_provided {
@@ -372,7 +364,6 @@ pub fn main() {
             animation_flag_provided,
             cli.scale,
             &mut game.asset_cache,
-            resolve_data_path,
             debug_skeletons,
             debug_hit_boxes,
         ) {
@@ -388,7 +379,6 @@ pub fn main() {
         animation_flag_provided,
         cli.scale,
         &mut game.asset_cache,
-        resolve_data_path,
         debug_skeletons,
         debug_hit_boxes,
     ) {

--- a/tools/dark_viewer/src/scenes/font_viewer.rs
+++ b/tools/dark_viewer/src/scenes/font_viewer.rs
@@ -6,8 +6,6 @@ use dark::font::Font;
 use engine::assets::asset_cache::AssetCache;
 use engine::materials::ScreenSpaceMaterial;
 use engine::scene::{Scene, SceneObject};
-use std::fs::File;
-use std::io::BufReader;
 use std::time::Duration;
 
 pub struct FontViewerScene {
@@ -20,14 +18,17 @@ pub struct FontViewerScene {
 }
 
 impl FontViewerScene {
+    /// Load a font through the game's asset paths, so a name resolves the same
+    /// way the game resolves it: out of the interface archive (`MAINAA.FON`) on
+    /// either install layout, or from a loose path under the data root.
     pub fn from_file(
         font_file_path: String,
-        resource_path_fn: fn(&str) -> String,
+        asset_cache: &AssetCache,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Load font
-        let font_file = File::open(resource_path_fn(&font_file_path))?;
-        let mut font_reader = BufReader::new(font_file);
-        let font = Font::read(&mut font_reader);
+        let font_reader = asset_cache
+            .get_raw_reader(&font_file_path)
+            .ok_or_else(|| format!("Could not find font {font_file_path} in the game data"))?;
+        let font = Font::read(&mut *font_reader.borrow_mut());
 
         Ok(FontViewerScene {
             font_file_path,

--- a/tools/dark_viewer/src/scenes/font_viewer.rs
+++ b/tools/dark_viewer/src/scenes/font_viewer.rs
@@ -6,6 +6,9 @@ use dark::font::Font;
 use engine::assets::asset_cache::AssetCache;
 use engine::materials::ScreenSpaceMaterial;
 use engine::scene::{Scene, SceneObject};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 use std::time::Duration;
 
 pub struct FontViewerScene {
@@ -18,17 +21,21 @@ pub struct FontViewerScene {
 }
 
 impl FontViewerScene {
-    /// Load a font through the game's asset paths, so a name resolves the same
-    /// way the game resolves it: out of the interface archive (`MAINAA.FON`) on
-    /// either install layout, or from a loose path under the data root.
+    /// Load a font from a path on disk, or - failing that - through the game's
+    /// asset paths, so a bare `MAINAA.FON` resolves the way the game resolves
+    /// it: out of the interface archive on either install layout.
     pub fn from_file(
         font_file_path: String,
         asset_cache: &AssetCache,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let font_reader = asset_cache
-            .get_raw_reader(&font_file_path)
-            .ok_or_else(|| format!("Could not find font {font_file_path} in the game data"))?;
-        let font = Font::read(&mut *font_reader.borrow_mut());
+        let font = if Path::new(&font_file_path).is_file() {
+            Font::read(&mut BufReader::new(File::open(&font_file_path)?))
+        } else {
+            let reader = asset_cache
+                .get_raw_reader(&font_file_path)
+                .ok_or_else(|| format!("Could not find font {font_file_path} in the game data"))?;
+            Font::read(&mut *reader.borrow_mut())
+        };
 
         Ok(FontViewerScene {
             font_file_path,

--- a/tools/dark_viewer/src/scenes/font_viewer.rs
+++ b/tools/dark_viewer/src/scenes/font_viewer.rs
@@ -6,9 +6,10 @@ use dark::font::Font;
 use engine::assets::asset_cache::AssetCache;
 use engine::materials::ScreenSpaceMaterial;
 use engine::scene::{Scene, SceneObject};
+use shock2vr::paths;
 use std::fs::File;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 
 pub struct FontViewerScene {
@@ -21,15 +22,24 @@ pub struct FontViewerScene {
 }
 
 impl FontViewerScene {
-    /// Load a font from a path on disk, or - failing that - through the game's
-    /// asset paths, so a bare `MAINAA.FON` resolves the way the game resolves
-    /// it: out of the interface archive on either install layout.
+    /// Load a font from a path on disk - as given, or under the data root, both
+    /// of which the old `data_root().join(..)` resolution accepted - and
+    /// otherwise through the game's asset paths, so a bare `MAINAA.FON`
+    /// resolves the way the game resolves it: out of the interface archive on
+    /// either install layout.
     pub fn from_file(
         font_file_path: String,
         asset_cache: &AssetCache,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let font = if Path::new(&font_file_path).is_file() {
-            Font::read(&mut BufReader::new(File::open(&font_file_path)?))
+        let on_disk = [
+            PathBuf::from(&font_file_path),
+            paths::data_root().join(&font_file_path),
+        ]
+        .into_iter()
+        .find(|candidate| candidate.is_file());
+
+        let font = if let Some(path) = on_disk {
+            Font::read(&mut BufReader::new(File::open(path)?))
         } else {
             let reader = asset_cache
                 .get_raw_reader(&font_file_path)


### PR DESCRIPTION
## Problem

#649 routed `dark_query` through the asset layer so `cargo dq` reads a **25th Anniversary Edition** install. The other tools still assumed loose files. The worst of them fails *silently*:

```console
# 25AE install: every mission lives inside sshock2.kpf
$ DARK_ASSET_PATH=/path/to/ss2-25th cargo bn path bench --all
mission         cells   links  found/miss   badcell  lookup p50    path p95 noroute p95  toward p95  inflate  turn deg  waypts bridges   build
$ echo $?
0
```

That is the whole output: `resolve_missions` `read_dir`s the data root for `*.mis`, finds none, and the command prints a bare header and **exits 0 having benchmarked nothing**. `AGENTS.md` tells agents to run `cargo bn path bench` before and after touching pathfinding, so a pathfinding change could be "measured" against zero missions and look fine.

The single-mission path at least says something:

```console
$ DARK_ASSET_PATH=/path/to/ss2-25th cargo bn path stats medsci1.mis
medsci1.mis: failed to open /path/to/ss2-25th/medsci1.mis
```

`cargo dq maps` and `dark_viewer`'s font viewer were loose-file only too.

## Approach

Everything reuses the `ZipAssetPath` / `AssetPath` layer — no second KPF parser.

**`tools/bench`** — missions open through `data_files::open_data_file`, and `--all` enumerates through `data_files::mission_names`, which lists the archive's `data/*.mis` as well as the directory. An empty mission list is now an error, as is a run where no mission could be read at all (`bench` and `stats` both), so a benchmark of nothing can no longer pass for a clean run.

**`data_files::open_data_file`** is `dark_query`'s `data_loader::open_data_file` helper (mounts built once per process — indexing the KPF is not free and `--all` opens 23 missions) moved into the module both tools share; `dark_query` now delegates to it instead of keeping its own copy.

**`cargo dq maps`** reads the *interface resource family*, not a data file: a classic install keeps it in `res/intrface.crf`, a 25AE one inside `sshock2.kpf` under `data/res/intrface/`, possibly overridden by a mod layer. The new `shock2vr::resource_family_paths(family)` returns the mounts for **one** family — the same archives, in the same precedence, that the game resolves that family through — so `dq maps` mounts `intrface` on either layout. On 25AE that means the mod stack is honoured (see below).

**`Game::init` is untouched.** The first cut factored its mount list into a shared builder; review pointed out that mounting everything makes any tool die inside `ZipAssetPath`'s `File::open(..).unwrap()` when an unrelated archive is missing, so the family-scoped helper replaced it and the runtime's mount list is not restructured at all. `mission_exists` drops its private copy of the archive scan (it now delegates to `mission_names`) but keeps its filesystem short-circuit, so its behaviour is unchanged.

**`dark_viewer`'s font viewer** takes the asset cache instead of `File::open`ing the data root: a path that exists on disk (as given or under the data root, both of which the old resolution accepted) still wins, otherwise a bare `MAINAA.FON` resolves out of the interface archive the way the game resolves it.

## Not in this PR

- **`find_video_file` / cutscenes → #660.** This one is *not* a loose-vs-archive problem: cutscene videos are loose files in both layouts, so `data_files` does not apply. A 25AE install ships no `.avi` at all — it has Theora/Vorbis `.ogv` under `cutscenes/{original,enhanced,kex}/` with different basenames. Supporting them means a shared resolver (the game's own `resolve_cutscene_path` / `is_cutscene_mission` have the identical gap, and fixing only the viewer would diverge them), extension dispatch for `.ogv`, and verifying the decoder against Theora plus the stray `Data: none` stream `ffprobe` reports. That is a feature, not path plumbing — filed as #660.
- **`tools/hitbox_analyzer` — deliberately unchanged, closing that bullet.** It is a "point me at a directory" analysis tool: it takes a filesystem path (default `Data/res/mesh`), globs `*.bin`, and pairs each mesh with its **sibling `.cal`** (`mesh_path.with_extension("cal")`). It never resolves a name through the data root, so there is nothing to route through the asset layer; making it archive-aware would mean re-inventing its input model (enumerate a family, resolve sibling files through mounts) for a one-off analysis tool that already works against any unpacked mesh directory on either install. The one real nit — its default `Data/res/mesh` bypasses `paths::data_root()` — is unrelated to the archive layout.

## Verification

Both installs, real data. Placeholders below stand in for the local install paths.

### bench — negative first

**Before** (base commit, 25AE install) — the silent-empty-list bug reproduced above: `bench --all` prints only the header and exits 0; `stats medsci1.mis` prints `failed to open /path/to/ss2-25th/medsci1.mis`.

**After**, same commands on the same install:

```console
$ DARK_ASSET_PATH=/path/to/ss2-25th cargo bn path stats medsci1.mis
=== medsci1.mis ===
cells: 4695  vertices: 9900  links: 27035
cell flags: unpathable=3 below_door=532 blocking_obb=366 moving_terrain=1
...
walk connectivity: 4325 pathable cells in 1683 components; largest: [1266, 260, 108, 104, 77]; isolated cells: 1523
```

**Byte-identical to the classic install's output** (`diff` of the two `stats` runs is empty), and `bench --all` benchmarks all 23 missions on both installs with **identical** cells/links/found-miss/inflate/turn/waypoint columns — only the latency columns differ, as they must:

```console
$ diff <(awk '{print $1,$2,$3,$4,$5,$10,$11,$12,$13}' bench-all-classic.txt) \
       <(awk '{print $1,$2,$3,$4,$5,$10,$11,$12,$13}' bench-all-25th.txt) && echo identical
identical
```

The empty/unreadable cases now fail loudly:

```console
$ DARK_ASSET_PATH=/path/to/empty-dir cargo bn path bench --all
Error: no .mis files found in the game data at ../../Data - set DARK_ASSET_PATH to your System Shock 2 install if that is the wrong directory   # exit 1
$ DARK_ASSET_PATH=/path/to/gamesys-only cargo bn path stats medsci1.mis
medsci1.mis: failed to open medsci1.mis in the game data at /path/to/gamesys-only
Error: no mission could be read   # exit 1
```

### dq maps

**Before**, 25AE: `Error: /path/to/ss2-25th/res/intrface.crf not found - 'maps' needs a classic install with loose .crf archives`. **After**: the map rectangles print on both installs.

On classic the output is **unchanged from the base commit** (the before/after diff is only the removed `Using intrface.crf archive: ...` line). Across installs the two outputs differ in exactly 3 of 20 rectangles — and that is **correct**: `mods/scp.kpf` ships its own `intrface/medsci1/english/p001ra.bin`, which the mod stack overrides with, i.e. what the game itself renders there. Confirmed by hashing the three copies:

| source | sha1 (first 12) |
| --- | --- |
| classic `res/intrface.crf` | `8f6e780013fb` |
| 25AE `sshock2.kpf` (base) | `8f6e780013fb` |
| 25AE `mods/scp.kpf` | `a1aa708bb4cc` |

A data root with no archives now gives a clean error instead of panicking inside the archive reader:

```console
$ DARK_ASSET_PATH=/path/to/gamesys-only cargo dq maps MEDSCI1
Error loading map data for MEDSCI1: Could not load revealed rects: MEDSCI1/english/P001RA.BIN
```

### dark_viewer font viewer

```console
$ DARK_ASSET_PATH=/path/to/ss2-25th     cargo dv MAINAA.FON --debug-no-render            # Scene creation succeeded.
$ DARK_ASSET_PATH=/path/to/ss2-classic  cargo dv MAINAA.FON --debug-no-render            # Scene creation succeeded.
$ DARK_ASSET_PATH=/path/to/ss2-classic  cargo dv res/fonts/BLUEAA.FON --debug-no-render  # Scene creation succeeded.
$ DARK_ASSET_PATH=/path/to/ss2-25th     cargo dv /abs/path/to/MAINAA.FON --debug-no-render  # Scene creation succeeded.
$ DARK_ASSET_PATH=/path/to/ss2-25th     cargo dv NOSUCH.FON --debug-no-render
Error creating scene: Could not find font NOSUCH.FON in the game data
```

Before this change the bare `MAINAA.FON` form failed on **both** installs (it was `File::open`ed relative to the data root).

### No runtime regression

`shock2vr` is touched, so: the debug runtime was launched on `command1.mis` against **both** installs, stepped 30 frames and queried entities — both load, step and report the same objects (`Double Elevator Door`, `template_id` 142/418/233/277, identical positions; runtime entity ids differ per launch as documented).

### Tests

`shock2vr/src/data_files.rs` gains 2 asset-free unit tests beside #649's three, using the same scratch-directory + generated-`sshock2.kpf` pattern: one asserts a classic layout lists its loose missions **with their on-disk spelling** (`Earth.MIS`, not `earth.mis` — the only name that opens on a case-sensitive filesystem), the other that a 25AE layout enumerates `data/*.mis` out of the archive while excluding `data/res/mschema/motiondb.bin` and anything nested deeper. Negative test first: with the archive-enumeration line disabled (the old loose-only assumption) the 25AE test fails with `left: []`; with it, green.

```
RUSTFLAGS="-D warnings" cargo check --all-targets -p shock2vr -p desktop_runtime -p debug_runtime \
  -p dark_query -p dark_viewer -p bench -p hitbox_analyzer -p debug_command   # clean
cargo test -p shock2vr   # 330 passed
cargo test -p dark       # 63 passed
cargo fmt --all
```

Plus the SDK e2e suite (`SHOCK2_E2E=1`) — result in a comment below.

## Review

`/xreview` (Claude subagent + Codex CLI), three rounds. Both engines independently raised the same two Mediums on the first cut, and both are fixed:

- **Mounting the whole game to read one family.** The first cut's `tool_asset_paths()` eagerly constructed every `.crf`/KPF mount, and `ZipAssetPath` `unwrap()`s its `File::open`, so `dq maps` against a data root missing an unrelated archive panicked where it used to fail with a message (and on 25AE it re-indexed the KPF 13+ times). Replaced by `resource_family_paths(family)`, which mounts one family with each archive existence-guarded — and which let `Game::init` be left completely alone.
- **Lowercasing loose mission names.** `mission_names` reported an on-disk `Earth.mis` under a spelling that cannot be opened on a case-sensitive filesystem. Loose missions now keep their on-disk spelling (dedup stays case-insensitive) and `open_data_file` falls back to the name as given after the lowercased lookup archives need.

Also applied from the reviews: `mission_exists` delegates its archive scan to `mission_names` instead of duplicating it; the font viewer accepts on-disk and data-root-relative paths again; `bench`/`stats` fail when no mission produced output (the same "vacuous success" one step later); `open_data_file`'s doc says plainly that `None` does not carry the underlying io error.

Not changed, deliberately: `mission_names` collapses read/zip errors into "no missions" rather than returning a `Result` (the caller's message covers it, and `mission_exists` is a `bool`); `--json` still omits per-mission load errors when at least one mission succeeds (pre-existing); and `mission_exists` keeps the pre-existing case-mismatch nuance of its filesystem short-circuit — that one belongs in the loader, not here. One nuance worth recording: `with_prefix_opts` keeps the *first* duplicate basename where the classic constructors keep the last, which cannot affect `dq maps` (it requests full relative paths) but is worth watching if another family is exposed this way.

Fixes #648. Cutscene videos split out as #660.
