### PR TITLE
fix(physics): fire sensors crossed by a validated player move

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1250,6 +1250,53 @@ pub enum CollisionEvent {
     },
 }
 
+/// Predicate selecting *only* sensor colliders - the volumes the player's
+/// ENTER/EXIT tracking is built from. Shared by the per-frame poll in
+/// [`PhysicsWorld::move_player`] and the swept poll in
+/// [`PhysicsWorld::move_player_validated`] so both observe the same set.
+fn is_sensor_collider(_handle: ColliderHandle, collider: &Collider) -> bool {
+    collider.is_sensor()
+}
+
+/// Entity ids of every sensor volume overlapping `shape` at `pos`. Callers pass
+/// a sensor-filtered pipeline so the broad phase does the narrowing; the
+/// `is_sensor` check keeps the result correct for any pipeline.
+fn sensors_overlapping(
+    queries: &QueryPipeline,
+    pos: &Isometry<Real>,
+    shape: &dyn Shape,
+) -> HashSet<EntityId> {
+    queries
+        .intersect_shape(*pos, shape)
+        .filter(|(_handle, collider)| collider.is_sensor())
+        .filter_map(|(_handle, collider)| EntityId::from_inner(collider.user_data as u64))
+        .collect()
+}
+
+/// ENTER/EXIT events for a change in the set of sensors containing the player.
+/// EXIT events come first, matching the order the per-frame diff has always
+/// emitted them in.
+fn sensor_transition_events(
+    previous: &HashSet<EntityId>,
+    current: &HashSet<EntityId>,
+    player_id: EntityId,
+) -> Vec<CollisionEvent> {
+    let mut events = Vec::new();
+    for expired in previous.difference(current) {
+        events.push(CollisionEvent::EndIntersect {
+            sensor_id: *expired,
+            entity_id: player_id,
+        });
+    }
+    for entered in current.difference(previous) {
+        events.push(CollisionEvent::BeginIntersect {
+            sensor_id: *entered,
+            entity_id: player_id,
+        });
+    }
+    events
+}
+
 #[derive(Debug)]
 pub enum PhysicsShape {
     Capsule { height: f32, radius: f32 },
@@ -1306,6 +1353,20 @@ pub struct PhysicsWorld {
 
     // Sensor Intersection List
     player_sensor_intersections: HashSet<EntityId>,
+
+    // Sensor ENTER/EXIT edges observed along a swept `move_player_validated`
+    // hop, in traversal order. The per-frame poll in `move_player` only samples
+    // the pose at the start of each frame, so a hop that crosses a volume
+    // between two frames would otherwise leave no trace; these are queued here
+    // and drained by the next frame's poll ahead of its own diff.
+    //
+    // A hop covers up to a walking second in one call, so a volume crossed
+    // whole reports its ENTER and EXIT in the same drained batch (walking
+    // spreads the pair over the frames it spends inside). That is the same
+    // compression the hop already applies to the player's position. Queued
+    // edges are only delivered by a stepped frame, so moving while the sim is
+    // paused accumulates them until it resumes.
+    pending_player_sensor_events: Vec<CollisionEvent>,
 
     // Entities already reported by report_nonfinite_rigid_body_state, so a
     // body fed bad state every frame (e.g. NaN animation joints driving a
@@ -1789,6 +1850,7 @@ impl PhysicsWorld {
         let character_shape = character_collider.shared_shape().clone();
         let mut pos = *character_body.position();
         let gravity = player_gravity_step(character_body);
+        let player_id = EntityId::from_inner(character_body.user_data as u64);
 
         // Same collision filter the real player movement uses: collide with the
         // collidable groups, ignore the player's own body and all sensors.
@@ -1805,6 +1867,13 @@ impl PhysicsWorld {
         // Normalized horizontal walk direction.
         let walk_dir = vector![delta_h.x / dist, 0.0, delta_h.z / dist];
         let mut distance_moved = 0.0;
+        // Sensor volumes the player occupies, carried across the sweep. The hop
+        // is committed as one jump, so without polling per substep any volume
+        // entered and left between the endpoints would never be observed (#654).
+        // Substeps are the same size real walking covers in one frame, so this
+        // samples the swept path at exactly the fidelity thumbstick walking does.
+        let mut occupied_sensors = self.player_sensor_intersections.clone();
+        let mut swept_sensor_events = Vec::new();
         {
             let queries = self.broad_phase.as_query_pipeline(
                 self.narrow_phase.query_dispatcher(),
@@ -1812,6 +1881,27 @@ impl PhysicsWorld {
                 &self.collider_set,
                 filter,
             );
+            // Sensors are excluded from `filter` (they must never block the
+            // move); observing them is a separate query over the same pipeline.
+            let sensor_queries =
+                queries.with_filter(QueryFilter::new().predicate(&is_sensor_collider));
+            let observe_sensors =
+                |pos: &Isometry<Real>,
+                 occupied: &mut HashSet<EntityId>,
+                 events: &mut Vec<CollisionEvent>| {
+                    if let Some(player_id) = player_id {
+                        let current =
+                            sensors_overlapping(&sensor_queries, pos, character_shape.as_ref());
+                        events.extend(sensor_transition_events(occupied, &current, player_id));
+                        *occupied = current;
+                    }
+                };
+
+            // Sample the starting pose first: the cached occupancy was taken at
+            // the last stepped frame, and a direct relocation since then (a
+            // teleport with no frame in between) can have moved the player into
+            // or out of a volume the cache has not seen yet.
+            observe_sensors(&pos, &mut occupied_sensors, &mut swept_sensor_events);
 
             // Walk toward the target one substep at a time. The iteration bound
             // is the worst case a *progressing* move can need (every substep
@@ -1849,11 +1939,20 @@ impl PhysicsWorld {
                 let progress = mvt.translation.dot(&walk_dir);
                 pos = Translation::from(mvt.translation) * pos;
                 distance_moved += progress.max(0.0);
+                observe_sensors(&pos, &mut occupied_sensors, &mut swept_sensor_events);
                 if progress < attempt * PLAYER_MOVE_PROGRESS_FRACTION {
                     break;
                 }
             }
         }
+
+        // Hand the traversed edges to the next frame's poll, and leave it the
+        // occupancy at the final pose so it does not re-fire what was already
+        // reported here (or miss an EXIT for something left mid-hop). Both are
+        // unchanged when there is no player entity to attribute edges to.
+        self.player_sensor_intersections = occupied_sensors;
+        self.pending_player_sensor_events
+            .append(&mut swept_sensor_events);
 
         let new_position = nvec_to_cgmath(pos.translation.vector);
 
@@ -2281,6 +2380,7 @@ impl PhysicsWorld {
             debug_pipeline,
 
             player_sensor_intersections: HashSet::new(),
+            pending_player_sensor_events: Vec::new(),
 
             reported_nonfinite_entities: HashSet::new(),
 
@@ -2659,59 +2759,30 @@ impl PhysicsWorld {
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
 
-        let mut collision_events = Vec::new();
-        let mut current_sensor_intersections = HashSet::new();
-        profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
+        // Edges already observed along a swept `move_player_validated` hop come
+        // first: they happened before this frame's pose. They also leave
+        // `player_sensor_intersections` at the hop's final occupancy, so the
+        // diff below sees no change for anything they already reported.
+        let mut collision_events = std::mem::take(&mut self.pending_player_sensor_events);
+        let current_sensor_intersections = profile!(scope: "physics", level: TRACE, "physics.intersections_with_shape", {
             // Only consider sensor colliders for player/sensor intersections.
-            let sensor_filter = QueryFilter::new()
-                .predicate(&|_collider_handle: ColliderHandle, _c: &Collider| _c.is_sensor());
+            let sensor_filter = QueryFilter::new().predicate(&is_sensor_collider);
             let queries = self.broad_phase.as_query_pipeline(
                 dispatcher,
                 &self.rigid_body_set,
                 &self.collider_set,
                 sensor_filter,
             );
-            for (handle, collider) in
-                queries.intersect_shape(original_position, character_shape.as_ref())
-            {
-                if collider.is_sensor() {
-                    if let (Some(_entity1_id), Some(entity2_id)) = (
-                        EntityId::from_inner(character_user_data as u64),
-                        EntityId::from_inner(collider.user_data as u64),
-                    ) {
-                        current_sensor_intersections.insert(entity2_id);
-                    }
-                }
-                let _ = handle;
-            }
+            sensors_overlapping(&queries, &original_position, character_shape.as_ref())
         });
 
         let player_id = EntityId::from_inner(character_user_data as u64).unwrap();
 
-        let new_collisions: HashSet<EntityId> = current_sensor_intersections
-            .difference(&self.player_sensor_intersections)
-            .cloned()
-            .collect::<HashSet<EntityId>>();
-
-        let no_longer_collisions: HashSet<EntityId> = self
-            .player_sensor_intersections
-            .difference(&current_sensor_intersections)
-            .cloned()
-            .collect();
-
-        for expired_collision in no_longer_collisions {
-            collision_events.push(CollisionEvent::EndIntersect {
-                sensor_id: expired_collision,
-                entity_id: player_id,
-            });
-        }
-
-        for new_collision in new_collisions {
-            collision_events.push(CollisionEvent::BeginIntersect {
-                sensor_id: new_collision,
-                entity_id: player_id,
-            });
-        }
+        collision_events.extend(sensor_transition_events(
+            &self.player_sensor_intersections,
+            &current_sensor_intersections,
+            player_id,
+        ));
 
         self.player_sensor_intersections = current_sensor_intersections;
 
@@ -4768,6 +4839,171 @@ mod tests {
         assert!(
             walked > 3.0,
             "walking on a rotated platform should progress ~6 units, moved {walked}"
+        );
+    }
+
+    #[test]
+    fn sensor_transitions_report_exits_before_entries() {
+        let player_id = EntityId::from_inner(1).unwrap();
+        let left = EntityId::from_inner(2).unwrap();
+        let entered = EntityId::from_inner(3).unwrap();
+        let previous = HashSet::from([left]);
+        let current = HashSet::from([entered]);
+
+        let events = sensor_transition_events(&previous, &current, player_id);
+
+        assert_eq!(events.len(), 2, "one exit and one entry: {events:?}");
+        assert!(
+            matches!(events[0], CollisionEvent::EndIntersect { sensor_id, .. } if sensor_id == left),
+            "the exit must be reported first: {events:?}"
+        );
+        assert!(
+            matches!(events[1], CollisionEvent::BeginIntersect { sensor_id, .. } if sensor_id == entered),
+            "the entry must follow the exit: {events:?}"
+        );
+        assert!(
+            sensor_transition_events(&previous, &previous, player_id).is_empty(),
+            "unchanged occupancy is not an edge"
+        );
+    }
+
+    /// A validated move (`/v1/player/move`, the automation navigation
+    /// primitive) must fire the sensors it crosses, like walking does.
+    /// (Negative-first: the hop was committed as one atomic translation and
+    /// sensors were only polled once per frame, so a volume entered and left
+    /// between two frames fired nothing at all - automated playtests walked
+    /// straight through tripwires, issue #654.)
+    #[test]
+    fn validated_move_fires_sensors_crossed_along_the_hop() {
+        let sensor_id = EntityId::from_inner(3000).unwrap();
+        // Settle the player at x=-2, hop toward `target_x` through a thin
+        // sensor slab standing at x=0, then take one frame; report the sensor
+        // events that frame delivered.
+        let run = |target_x: f32| -> Vec<CollisionEvent> {
+            let mut world = PhysicsWorld::new();
+            let floor_verts = vec![
+                point![-100.0, 0.0, -100.0],
+                point![100.0, 0.0, -100.0],
+                point![100.0, 0.0, 100.0],
+                point![-100.0, 0.0, 100.0],
+            ];
+            let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+            world.add_collider(
+                EntityId::from_inner(1000).unwrap(),
+                ColliderBuilder::trimesh(floor_verts, floor_tris)
+                    .expect("floor trimesh")
+                    .build(),
+            );
+            world.add_collider(
+                sensor_id,
+                ColliderBuilder::cuboid(0.15, 2.0, 4.0)
+                    .translation(vector![0.0, 1.0, 0.0])
+                    .sensor(true)
+                    .build(),
+            );
+            let mut player =
+                world.create_player(vec3(-2.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+            for _ in 0..30 {
+                world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            }
+            let current = world.get_player_translation(&player);
+            world.move_player_validated(vec3(target_x, current.y, current.z), &mut player);
+            let (_, events) = world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            // The hop is the only thing that moved: a second idle frame must
+            // not replay anything the hop already reported.
+            let (_, extra) = world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            assert!(
+                extra.is_empty(),
+                "a stationary follow-up frame must not re-fire: {extra:?}"
+            );
+            events
+        };
+
+        // Passing through: enter then exit, in traversal order.
+        let crossed = run(2.0);
+        assert_eq!(
+            crossed.len(),
+            2,
+            "crossing a sensor must fire enter then exit: {crossed:?}"
+        );
+        assert!(
+            matches!(crossed[0], CollisionEvent::BeginIntersect { sensor_id: id, .. } if id == sensor_id),
+            "the crossing must enter first: {crossed:?}"
+        );
+        assert!(
+            matches!(crossed[1], CollisionEvent::EndIntersect { sensor_id: id, .. } if id == sensor_id),
+            "the crossing must then exit: {crossed:?}"
+        );
+
+        // Ending inside: exactly one enter, and no duplicate from the
+        // per-frame poll that used to be the only thing reporting it.
+        let ended_inside = run(0.0);
+        assert_eq!(
+            ended_inside.len(),
+            1,
+            "a hop ending inside a sensor fires one enter: {ended_inside:?}"
+        );
+        assert!(
+            matches!(ended_inside[0], CollisionEvent::BeginIntersect { sensor_id: id, .. } if id == sensor_id),
+            "a hop ending inside a sensor must enter it: {ended_inside:?}"
+        );
+    }
+
+    /// The cached occupancy is only as fresh as the last stepped frame, so a
+    /// teleport with no frame in between can leave the player standing in a
+    /// volume the cache has never seen. The sweep therefore samples its own
+    /// starting pose before walking; without that, a hop whose first substep
+    /// already leaves the volume reports neither the entry nor the exit.
+    #[test]
+    fn validated_move_reports_a_volume_the_player_was_teleported_into() {
+        let sensor_id = EntityId::from_inner(3000).unwrap();
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        world.add_collider(
+            sensor_id,
+            ColliderBuilder::cuboid(0.15, 2.0, 4.0)
+                .translation(vector![0.0, 1.0, 0.0])
+                .sensor(true)
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(-2.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+
+        // Land just inside the far edge of the slab (the overlap band reaches
+        // 0.47 with the capsule's radius), so the very first walk substep
+        // already carries the player out of it.
+        let settled = world.get_player_translation(&player);
+        world.set_player_translation(vec3(0.4, settled.y, settled.z), &mut player);
+        world.move_player_validated(vec3(2.0, settled.y, settled.z), &mut player);
+        let (_, events) = world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        assert_eq!(
+            events.len(),
+            2,
+            "the teleported-into volume must report entry then exit: {events:?}"
+        );
+        assert!(
+            matches!(events[0], CollisionEvent::BeginIntersect { sensor_id: id, .. } if id == sensor_id),
+            "the entry established by the teleport must be reported: {events:?}"
+        );
+        assert!(
+            matches!(events[1], CollisionEvent::EndIntersect { sensor_id: id, .. } if id == sensor_id),
+            "walking out of it must then report the exit: {events:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/tripwire-crossing.e2e.test.ts
+++ b/tools/shock2-sdk/test/tripwire-crossing.e2e.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position } from "../src/index.js";
+
+// End-to-end test for sensor ENTER/EXIT along a validated player move
+// (POST /v1/player/move, game.player.moveTo) - GitHub #654.
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+//
+// Negative-first: the validated move covered its whole hop inside one atomic
+// commit while sensors were polled once per stepped frame, so a hop that
+// PASSED THROUGH a trigger volume between two frames fired nothing at all. The
+// "crosses" case below therefore failed (note_6_1 stayed "unknown") before the
+// swept sensor poll was added. Automated playtests navigate with this call, so
+// a skipped trigger reads back as a false "this trigger is broken" finding -
+// and can walk past a real progression wire unnoticed.
+//
+// A hop that ENDS INSIDE a volume always worked (the next frame's poll catches
+// it); that case is asserted too, so the fix cannot regress it. Walking the
+// same volume with the thumbstick is the reference behaviour both hops must
+// match. (The no-double-fire invariant is asserted on the raw event stream by
+// `validated_move_fires_sensors_crossed_along_the_hop` in physics/mod.rs.)
+//
+// command1's arrival Tripwire (mission object 2308) feeds an EmailTrap that
+// grants the Note_6_1 objective. Entities are discovered by stable mission
+// object id / name - runtime entity ids differ every launch.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8222);
+
+const TRIPWIRE_OBJECT_ID = 2308;
+const OBJECTIVE = "note_6_1";
+// The wire is a 1.6-deep box centred on its position, so anything beyond 0.8
+// (plus the player's ~0.32 radius) from the centre is clear of it. The two
+// offsets keep the crossing hop (APPROACH + BEYOND = 4.0) inside the 5.0-unit
+// clamp on a validated move, so a clamp can never be mistaken for a block.
+const WIRE_HALF_DEPTH = 0.8;
+const APPROACH = 2.4;
+const BEYOND = 1.6;
+
+interface Arrival {
+  wire: Position;
+  start: Position;
+}
+
+/**
+ * Open the arrival lift doors that stand between the command1 spawn and the
+ * tripwire, then park the player one short hop in front of the wire (outside
+ * it, so any crossing below is a genuine edge).
+ */
+async function arriveAtTripwire(game: GameServer): Promise<Arrival> {
+  await game.step({ frames: 5 });
+
+  const wires = await game.entities.byTemplate(TRIPWIRE_OBJECT_ID);
+  assert.equal(
+    wires.length,
+    1,
+    `expected the command1 arrival tripwire (object ${TRIPWIRE_OBJECT_ID}), ` +
+      `got ${JSON.stringify(wires.map((w) => w.name))}`,
+  );
+  const [wx, wy, wz] = wires[0].position;
+
+  // The lift doors are closed on arrival and block the corridor to the wire.
+  const doors = await game.entities.list({ filter: "Elevator Door" });
+  assert.ok(
+    doors.entities.length > 0,
+    "expected the command1 arrival lift doors between the spawn and the wire",
+  );
+  for (const door of doors.entities) {
+    await game.entities.sendMessage(door.id, { type: "TurnOn" });
+  }
+  await game.step({ frames: 180 });
+
+  const spawn = await game.player.position();
+  const start: Position = { x: wx, y: spawn.y, z: wz - APPROACH };
+  await game.player.teleport(start);
+  await game.step({ frames: 10 });
+
+  const settled = await game.player.position();
+  assert.ok(
+    Math.abs(settled.z - wz) > WIRE_HALF_DEPTH,
+    `the approach must start outside the wire, got z=${settled.z} vs wire z=${wz}`,
+  );
+  assert.equal(
+    await game.quests.get(OBJECTIVE),
+    "unknown",
+    "the arrival objective must not be granted before the wire is crossed",
+  );
+
+  return { wire: { x: wx, y: wy, z: wz }, start: settled };
+}
+
+test(
+  "command1: a validated move that passes THROUGH the arrival tripwire fires it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: basePort,
+    });
+    const { wire, start } = await arriveAtTripwire(game);
+
+    const move = await game.player.moveTo({
+      x: wire.x,
+      y: start.y,
+      z: wire.z + BEYOND,
+    });
+    await game.step({ frames: 30 });
+
+    assert.equal(move.blocked, false, "the corridor through the wire should be clear");
+    assert.ok(
+      move.new_position[2] - wire.z > WIRE_HALF_DEPTH,
+      `the hop must end past the wire (a pass-through, not a landing inside), ` +
+        `ended at z=${move.new_position[2]} vs wire z=${wire.z}`,
+    );
+    assert.equal(
+      await game.quests.get(OBJECTIVE),
+      "incomplete",
+      "crossing the wire with a validated move must fire it (#654)",
+    );
+  },
+);
+
+test(
+  "command1: a validated move that ENDS INSIDE the arrival tripwire fires it once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: basePort + 1,
+    });
+    const { wire, start } = await arriveAtTripwire(game);
+
+    const move = await game.player.moveTo({ x: wire.x, y: start.y, z: wire.z });
+    await game.step({ frames: 30 });
+
+    assert.ok(
+      Math.abs(move.new_position[2] - wire.z) < WIRE_HALF_DEPTH,
+      `the hop must stop inside the wire, ended at z=${move.new_position[2]} ` +
+        `vs wire z=${wire.z}`,
+    );
+    assert.equal(
+      await game.quests.get(OBJECTIVE),
+      "incomplete",
+      "a hop ending inside the wire must fire it",
+    );
+
+    const emails = (await game.audio.recent()).sounds.filter((sound) =>
+      sound.tags.some(([key, value]) => key === "kind" && value === "email"),
+    );
+    assert.equal(
+      emails.length,
+      1,
+      `the email should play exactly once, got ${JSON.stringify(emails)}`,
+    );
+  },
+);
+
+test(
+  "command1: walking the arrival tripwire with the thumbstick fires it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: basePort + 2,
+    });
+    const { wire, start } = await arriveAtTripwire(game);
+
+    await game.input.lookAtWorldPoint([wire.x, start.y, wire.z + APPROACH]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 10 });
+
+    const end = await game.player.position();
+    assert.ok(
+      end.z - wire.z > WIRE_HALF_DEPTH,
+      `walking forward should carry the player past the wire, got z=${end.z} ` +
+        `vs wire z=${wire.z}`,
+    );
+    assert.equal(
+      await game.quests.get(OBJECTIVE),
+      "incomplete",
+      "walking through the wire must fire it (the reference behaviour)",
+    );
+  },
+);


### PR DESCRIPTION
`POST /v1/player/move` could carry the player **through** a trigger volume without firing it. Walking the same path with the thumbstick fires it normally.

Fixes #654

## Mechanism

`move_player_validated` walks the hop in `PLAYER_MOVE_SUBSTEP` increments inside one `as_query_pipeline` block and commits the whole motion with a single `set_player_translation`. The player's sensor ENTER/EXIT diff lives in `move_player` and is evaluated **once per stepped frame**, sampled at that frame's starting pose. So:

- a hop that **ends inside** a volume still fires on the next frame (the diff catches it);
- only a hop that **passes through** one tunnels it, silently.

That matters beyond one mission: `/v1/player/move` is the documented, collision-checked way an automated playtest navigates, so a skipped volume reads back as a false *"this trigger never fired"* finding — and a real progression wire can be walked past unnoticed (e.g. `command1`'s arrival tripwire, and its exit tripwire to `rick1`).

## Fix

Poll the sensors along the sweep — at the starting pose and after every walk substep — and queue the ENTER/EXIT edges, in traversal order, for the next frame's poll. That poll also inherits the hop's final occupancy, so nothing already reported fires twice, and an EXIT for something left mid-hop isn't lost.

- **Same fidelity as walking.** `PLAYER_MOVE_SUBSTEP` is exactly the distance real walking covers in one frame, so the swept path is sampled at the same density the per-frame poll gives thumbstick movement.
- **Why the starting pose too.** The cached occupancy is only as fresh as the last stepped frame; a teleport with no frame in between can leave the player standing in a volume the cache has never seen.
- **Collision behaviour untouched.** `.exclude_sensors()` on the *movement* filter is correct — sensors must never block the move. They are observed through a separate sensor-only query over the same pipeline, so the player still cannot tunnel through solid geometry.
- The per-frame diff in `move_player` now goes through the same two helpers (`sensors_overlapping`, `sensor_transition_events`), so the two navigation mechanisms agree by construction.

A hop covers up to a walking second in one call, so a volume crossed whole reports its ENTER and EXIT in the same drained batch — the same compression the hop already applies to the player's position.

## Verification

**Negative-first**, both layers. With the swept poll removed:

- `physics::tests::validated_move_fires_sensors_crossed_along_the_hop` fails on the pass-through case (`crossing a sensor must fire enter then exit: []`) and passes on the ends-inside case, exactly matching the reported behaviour.
- The new e2e `command1: a validated move that passes THROUGH the arrival tripwire fires it` fails with `note_6_1` still `'unknown'`; the ends-inside and thumbstick tests pass both before and after.

With the fix, all pass:

```
tools/shock2-sdk/test/tripwire-crossing.e2e.test.ts
  ✔ command1: a validated move that passes THROUGH the arrival tripwire fires it
  ✔ command1: a validated move that ENDS INSIDE the arrival tripwire fires it once
  ✔ command1: walking the arrival tripwire with the thumbstick fires it
```

The e2e tests cross the mission's arrival `Tripwire` (mission object **2308**, `ENTER|EXIT|PLAYER`, wired to the `EmailTrap` that grants `Note_6_1`), discovered by stable mission object id / name — no hardcoded runtime entity ids.

Rust unit tests added: the pass-through / ends-inside event stream (including "a stationary follow-up frame must not re-fire"), the teleport-then-hop case, and the pure ENTER/EXIT ordering of `sensor_transition_events`.

Also run: `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr` (331 pass), `cargo fmt --all`, and the full SDK e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
