### PR TITLE
fix(physics): carry passengers on authored moving terrain

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -369,6 +369,23 @@ pub struct PropPhysDimensions {
     pub unk2: u32,
 }
 
+/// `P$MovingTer` - marks a physical object as authored moving terrain.
+/// Dark stores both the current active state and its previous state.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropMovingTerrain {
+    pub active: bool,
+    pub previous_active: bool,
+}
+
+impl PropMovingTerrain {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropMovingTerrain {
+        PropMovingTerrain {
+            active: read_bool(reader),
+            previous_active: read_bool(reader),
+        }
+    }
+}
+
 // TODO: Is there a player prop
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropLocalPlayer {}
@@ -427,6 +444,10 @@ pub enum Link {
     /// psi bolt visuals); on a concrete (mission-placed) particle entity it
     /// names the object to follow.
     ParticleAttachement(ParticleAttachOptions),
+    /// Rigid physics attachment from the source object to the destination
+    /// object. Dark drives the source from the destination's motion plus the
+    /// authored world-space offset (tram wall/floor assemblies, lifts).
+    PhysAttach(PhysAttachOptions),
     TPathInit,
     TPath(TPathData),
     /// From a patrol-point object to the next patrol point on its route. An AI
@@ -565,6 +586,19 @@ pub struct ParticleAttachOptions {
     pub vhot: i32,
     pub joint: i32,
     pub submodel: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PhysAttachOptions {
+    pub offset: Vector3<f32>,
+}
+
+impl PhysAttachOptions {
+    pub fn read(reader: &mut Box<dyn ReadAndSeek>, _len: u32) -> PhysAttachOptions {
+        PhysAttachOptions {
+            offset: read_vec3(reader) / SCALE_FACTOR,
+        }
+    }
 }
 
 impl ParticleAttachOptions {
@@ -1038,6 +1072,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "LD$Particle",
             ParticleAttachOptions::read,
             Link::ParticleAttachement,
+        ),
+        define_link_with_data(
+            "L$PhysAttac",
+            "LD$PhysAtta",
+            PhysAttachOptions::read,
+            Link::PhysAttach,
         ),
         define_link_with_data(
             "L$AIProject",
@@ -1514,6 +1554,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$PhysType",
             PropPhysType::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$MovingTer",
+            PropMovingTerrain::read,
             identity,
             accumulator::latest,
         ),
@@ -2162,6 +2208,34 @@ mod tests {
     fn read_stim_source(payload: Vec<u8>) -> StimSourceOptions {
         let mut cursor: Box<dyn ReadAndSeek> = Box::new(Cursor::new(payload));
         StimSourceOptions::read(&mut cursor, 108)
+    }
+
+    #[test]
+    fn phys_attach_offset_uses_world_axes_and_scale() {
+        // command1 Tram Front -> Tram stores the Dark-space vector
+        // (-10, -0.1875, -0.5), which read_vec3 maps to world
+        // (10, -0.5, -0.1875) before the global 2.5 scale.
+        let mut bytes = Vec::new();
+        for value in [-10.0f32, -0.1875, -0.5] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        let mut cursor: Box<dyn ReadAndSeek> = Box::new(Cursor::new(bytes));
+        let options = PhysAttachOptions::read(&mut cursor, 12);
+
+        assert_eq!(options.offset, vec3(4.0, -0.2, -0.075));
+    }
+
+    #[test]
+    fn moving_terrain_reads_active_and_previous_state() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        let mut cursor = Cursor::new(bytes);
+
+        let property = PropMovingTerrain::read(&mut cursor, 8);
+
+        assert!(property.active);
+        assert!(!property.previous_active);
     }
 
     #[test]

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -216,6 +216,57 @@ fn eng1_patrol_data_parses() {
 }
 
 #[test]
+fn command1_tram_physical_attachments_parse() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let info = load_mission_entity_info(&data, "command1.mis");
+
+    let mut attachments = info
+        .template_to_links
+        .iter()
+        .flat_map(|(source, links)| {
+            links
+                .to_links
+                .iter()
+                .filter_map(move |link| match link.link {
+                    Link::PhysAttach(options) => {
+                        Some((*source, link.to_template_id, options.offset))
+                    }
+                    _ => None,
+                })
+        })
+        .collect::<Vec<_>>();
+    attachments.sort_by_key(|(source, _, _)| *source);
+
+    assert_eq!(
+        attachments
+            .iter()
+            .map(|(source, _, _)| *source)
+            .collect::<Vec<_>>(),
+        vec![146, 152, 153, 155, 156, 199],
+        "command1 tram should have five collision parts and its button physically attached"
+    );
+    assert!(
+        attachments
+            .iter()
+            .all(|(_, destination, _)| *destination == 137),
+        "every tram child should attach to root object 137"
+    );
+    let front = attachments
+        .iter()
+        .find(|(source, _, _)| *source == 152)
+        .expect("Tram Front attachment should parse");
+    assert_eq!(front.2, cgmath::vec3(4.0, -0.2, -0.075));
+    assert!(
+        !info.unparsed_links.contains_key("L$PhysAttac")
+            && !info.unparsed_link_data.contains_key("LD$PhysAtta"),
+        "the physical attachment relation and its payload must both be typed"
+    );
+}
+
+#[test]
 fn medsci1_deaf_metaproperty_delivers_hearing_component() {
     let Some(data) = data_root() else {
         eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -823,20 +823,26 @@ impl MissionCore {
         // Mission-placed particle entities follow the object their concrete
         // ParticleAttachement link names (steam rides its machinery): bolt
         // them with RuntimePropAttachment, preserving the authored relative
-        // pose.
+        // pose. Physical attachments are registered directly with Rapier
+        // below; their bodies then feed the normal physics-to-render sync.
         {
             let mut attachments: Vec<(EntityId, EntityId, Matrix4<f32>)> = Vec::new();
+            let mut physical_attachments: Vec<(EntityId, EntityId, Vector3<f32>)> = Vec::new();
             {
                 let v_links = world.borrow::<View<Links>>().unwrap();
                 let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
                 for (id, links) in v_links.iter().with_id() {
                     for link in &links.to_links {
-                        if !matches!(link.link, dark::properties::Link::ParticleAttachement(_)) {
-                            continue;
-                        }
                         let Some(parent) = link.to_entity_id else {
                             continue;
                         };
+                        if let dark::properties::Link::PhysAttach(options) = &link.link {
+                            physical_attachments.push((id, parent.0, options.offset));
+                            continue;
+                        }
+                        if !matches!(link.link, dark::properties::Link::ParticleAttachement(_)) {
+                            continue;
+                        }
                         let (Ok(child_xform), Ok(parent_xform)) =
                             (v_transform.get(id), v_transform.get(parent.0))
                         else {
@@ -856,6 +862,14 @@ impl MissionCore {
                         local_transform,
                     },
                 );
+            }
+            for (child, parent, offset) in physical_attachments {
+                if !physics.attach_kinematic(child, parent, offset) {
+                    warn!(
+                        "ignoring PhysAttach {:?} -> {:?}: both objects need kinematic physics bodies",
+                        child, parent
+                    );
+                }
             }
         }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1318,6 +1318,14 @@ pub struct PlayerHandle {
     top_out: Option<ClimbTopOut>,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct KinematicAttachment {
+    parent: RigidBodyHandle,
+    /// Dark's PhysAttach offset is world-space translation, not a transform
+    /// composed with the parent's rotation.
+    offset: Vector<Real>,
+}
+
 impl PlayerHandle {
     /// Whether the player collider is currently the crouched capsule. This is
     /// the *actual* state (stand-up can be refused for lack of headroom), not
@@ -1343,6 +1351,11 @@ pub struct PhysicsWorld {
     rigid_bodies_with_forces: Vec<RigidBodyHandle>,
 
     entity_id_to_body: HashMap<EntityId, RigidBodyHandle>,
+
+    // Dark PhysAttach links rigidly drive a kinematic child's translation
+    // from its parent's next translation plus an authored world-space offset.
+    // Keyed by child because Dark permits at most one physical parent.
+    kinematic_attachments: HashMap<RigidBodyHandle, KinematicAttachment>,
 
     // TODO:
     // physics_hooks: Box<dyn PhysicsHooks>,
@@ -2171,6 +2184,81 @@ impl PhysicsWorld {
         *handle
     }
 
+    /// Attach one kinematic entity to another using Dark's PhysAttach
+    /// translation semantics (`child = parent + offset`). Returns false when
+    /// either entity has no kinematic body.
+    pub fn attach_kinematic(
+        &mut self,
+        child_entity: EntityId,
+        parent_entity: EntityId,
+        offset: Vector3<f32>,
+    ) -> bool {
+        let (Some(&child), Some(&parent)) = (
+            self.entity_id_to_body.get(&child_entity),
+            self.entity_id_to_body.get(&parent_entity),
+        ) else {
+            return false;
+        };
+        if !self.rigid_body_set[child].is_kinematic() || !self.rigid_body_set[parent].is_kinematic()
+        {
+            return false;
+        }
+
+        self.kinematic_attachments.insert(
+            child,
+            KinematicAttachment {
+                parent,
+                offset: vec_to_nvec(offset),
+            },
+        );
+        true
+    }
+
+    fn attachment_target_translation(
+        &self,
+        child: RigidBodyHandle,
+        visiting: &mut HashSet<RigidBodyHandle>,
+    ) -> Option<Vector<Real>> {
+        let attachment = self.kinematic_attachments.get(&child)?;
+        if !visiting.insert(child) {
+            tracing::warn!(
+                "[physics] cyclic kinematic attachment involving body {:?}; leaving it in place",
+                child
+            );
+            return None;
+        }
+
+        let parent_translation = if self.kinematic_attachments.contains_key(&attachment.parent) {
+            self.attachment_target_translation(attachment.parent, visiting)?
+        } else {
+            self.rigid_body_set
+                .get(attachment.parent)?
+                .next_position()
+                .translation
+                .vector
+        };
+        visiting.remove(&child);
+        Some(parent_translation + attachment.offset)
+    }
+
+    fn update_kinematic_attachments(&mut self) {
+        let targets = self
+            .kinematic_attachments
+            .keys()
+            .copied()
+            .filter_map(|child| {
+                self.attachment_target_translation(child, &mut HashSet::new())
+                    .map(|target| (child, target))
+            })
+            .collect::<Vec<_>>();
+
+        for (child, target) in targets {
+            if let Some(body) = self.rigid_body_set.get_mut(child) {
+                body.set_next_kinematic_translation(target);
+            }
+        }
+    }
+
     pub fn remove(&mut self, entity_id: EntityId) {
         let entity_as_int = entity_id.inner() as u128;
         let mut bodies_to_remove = Vec::new();
@@ -2179,6 +2267,9 @@ impl PhysicsWorld {
                 bodies_to_remove.push(handle);
             }
         }
+        self.kinematic_attachments.retain(|child, attachment| {
+            !bodies_to_remove.contains(child) && !bodies_to_remove.contains(&attachment.parent)
+        });
         for handle in bodies_to_remove {
             self.rigid_body_set.remove(
                 handle,
@@ -2376,6 +2467,7 @@ impl PhysicsWorld {
             // physics_hooks: Box::new(physics_hooks),
             // event_handler: Box::new(event_handler),
             entity_id_to_body: HashMap::new(),
+            kinematic_attachments: HashMap::new(),
 
             debug_pipeline,
 
@@ -2523,6 +2615,12 @@ impl PhysicsWorld {
         facing: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        // Queue every PhysAttach child at its parent's same next-frame target
+        // before Rapier derives kinematic velocities. Moving-terrain assemblies
+        // (tram floor + walls/buttons) therefore advance as one physical body,
+        // matching Dark's source->destination attachment flow.
+        self.update_kinematic_attachments();
+
         // Attribute any non-finite body state to its entity before the step
         // consumes it (see report_nonfinite_rigid_body_state) - by the time
         // parry panics, the culprit is already named in the log.
@@ -4839,6 +4937,89 @@ mod tests {
         assert!(
             walked > 3.0,
             "walking on a rotated platform should progress ~6 units, moved {walked}"
+        );
+    }
+
+    /// A stationary player supported by a moving kinematic body must inherit
+    /// that body's displacement. This is the generic moving-terrain behavior
+    /// used by authored lifts and trams: every PhysAttach collision part moves
+    /// with the support, and the passenger remains aboard without supplying
+    /// locomotion input.
+    #[test]
+    fn stationary_player_is_carried_by_moving_kinematic_support() {
+        use cgmath::Rotation3;
+
+        let run = |attach_front_wall: bool| {
+            let mut world = PhysicsWorld::new();
+            let support_id = EntityId::from_inner(1001).unwrap();
+            let wall_id = EntityId::from_inner(1002).unwrap();
+            let support = world.add_kinematic(
+                support_id,
+                vec3(0.0, 1.0, 0.0),
+                Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), cgmath::Deg(90.0)),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(4.0, 0.4, 10.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            // A thin front wall crossing the direction of travel, like
+            // command1's Tram Front. Left stationary it blocks the passenger
+            // at its contact boundary while the floor moves out underneath.
+            let wall = world.add_kinematic(
+                wall_id,
+                vec3(4.0, 2.6, 0.0),
+                Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), cgmath::Deg(90.0)),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(3.0, 3.2, 0.4),
+                CollisionGroup::entity(),
+                false,
+            );
+            if attach_front_wall {
+                assert!(world.attach_kinematic(wall_id, support_id, vec3(4.0, 1.6, 0.0)));
+            }
+            let mut player =
+                world.create_player(vec3(0.0, 3.0, 0.0), EntityId::from_inner(2000).unwrap());
+
+            for _ in 0..30 {
+                world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            }
+            let player_start = world.get_player_translation(&player);
+            let support_start = world.get_position(support).unwrap();
+            let wall_start = world.get_position(wall).unwrap();
+
+            for frame in 1..=60 {
+                world.set_translation(support, support_start + vec3(frame as f32 * 0.2, 0.0, 0.0));
+                world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            }
+
+            let player_end = world.get_player_translation(&player);
+            let support_end = world.get_position(support).unwrap();
+            let wall_end = world.get_position(wall).unwrap();
+            (
+                player_end.x - player_start.x,
+                support_end.x - support_start.x,
+                wall_end.x - wall_start.x,
+            )
+        };
+
+        let (blocked_player, _, stationary_wall) = run(false);
+        assert!(
+            blocked_player < 4.0 && stationary_wall.abs() < 0.01,
+            "without PhysAttach propagation the wall should strand the passenger: player {blocked_player}, wall {stationary_wall}"
+        );
+
+        let (player_displacement, support_displacement, wall_displacement) = run(true);
+        assert!(
+            support_displacement > 11.9,
+            "test support should move twelve units, moved {support_displacement}"
+        );
+        assert!(
+            (wall_displacement - support_displacement).abs() < 0.01,
+            "attached wall must match support displacement: wall {wall_displacement}, support {support_displacement}"
+        );
+        assert!(
+            player_displacement > 10.0 && (player_displacement - support_displacement).abs() < 1.5,
+            "stationary passenger should remain aboard the moving support: player {player_displacement}, support {support_displacement}"
         );
     }
 

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -385,6 +385,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::MissSpang => "MissSpang".to_string(),
                 Link::HitSpang(_) => "HitSpang".to_string(),
                 Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
+                Link::PhysAttach(_) => "PhysAttach".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),
                 Link::TPath(_) => "TPath".to_string(),
                 Link::AIPatrol => "AIPatrol".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -594,6 +594,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::MissSpang => "MissSpang".to_string(),
         dark::properties::Link::HitSpang(_) => "HitSpang".to_string(),
         dark::properties::Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
+        dark::properties::Link::PhysAttach(opts) => format!("PhysAttach({:?})", opts),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),
         dark::properties::Link::TPath(_) => "TPath".to_string(),
         dark::properties::Link::AIPatrol => "AIPatrol".to_string(),

--- a/tools/shock2-sdk/test/command-tram.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-tram.e2e.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// End-to-end coverage for command1's authored moving-terrain assembly. Runtime
+// ids are intentionally discovered every launch: mission object ids are the
+// stable handles for the attached button/front wall, while the root has a
+// unique authored name.
+//
+// Negative-first: before #663, only the Tram root/floor advanced. Its
+// PhysAttach children remained at the station, so Tram Front pinned a
+// correctly boarded passenger at x=-374.16 while the root moved twelve units.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const TRAM_BUTTON_OBJECT = 199;
+const TRAM_FRONT_OBJECT = 152;
+
+const delta = (after: Vec3, before: Vec3): Vec3 => [
+  after[0] - before[0],
+  after[1] - before[1],
+  after[2] - before[2],
+];
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+test(
+  "command1.mis: authored tram assembly carries a boarded passenger",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8184),
+    });
+    await game.step({ frames: 5 });
+
+    const tram = only(
+      (await game.entities.list({ filter: "Tram", limit: 30 })).entities.filter(
+        (entity) => entity.name === "Tram",
+      ),
+      "authored Tram root",
+    );
+    const tramFront = only(
+      await game.entities.byTemplate(TRAM_FRONT_OBJECT),
+      "Tram Front mission object",
+    );
+    const button = only(
+      await game.entities.byTemplate(TRAM_BUTTON_OBJECT),
+      "in-car tram button mission object",
+    );
+
+    // Teleport is setup only. Board through the open side doorway with the
+    // bounded, shape-cast-validated move endpoint before asserting carry.
+    await game.player.teleport({ x: -377.6, y: -16.4, z: 5.2 });
+    await game.step({ frames: 2 });
+    const boarding = await game.player.moveTo({
+      x: tram.position[0] - 0.25,
+      y: -16.4,
+      z: tram.position[2] + 0.08,
+    });
+    assert.equal(boarding.moved, true, "player should walk through the tram doorway");
+    assert.equal(boarding.blocked, false, "open tram doorway should not block boarding");
+    await game.step({ frames: 10 });
+
+    const playerBefore = await game.player.position();
+    const tramBefore = (await game.entities.detail(tram.id)).position;
+    const frontBefore = (await game.entities.detail(tramFront.id)).position;
+    const buttonBefore = (await game.entities.detail(button.id)).position;
+    assert.ok(
+      Math.abs(playerBefore.x - tramBefore[0]) < 1 &&
+        Math.abs(playerBefore.z - tramBefore[2]) < 1,
+      `player must be inside the car before dispatch: player=${JSON.stringify(playerBefore)}, tram=${JSON.stringify(tramBefore)}`,
+    );
+
+    const aim = await game.player.aimAt(button, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(aim.entity_id, button.id, JSON.stringify(aim));
+    assert.equal(aim.visibility.state, "visible", JSON.stringify(aim));
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 60 });
+
+    const playerAfter = await game.player.position();
+    const tramAfter = (await game.entities.detail(tram.id)).position;
+    const frontAfter = (await game.entities.detail(tramFront.id)).position;
+    const buttonAfter = (await game.entities.detail(button.id)).position;
+    const tramTravel = delta(tramAfter, tramBefore);
+    const frontTravel = delta(frontAfter, frontBefore);
+    const buttonTravel = delta(buttonAfter, buttonBefore);
+    const playerTravel = playerAfter.x - playerBefore.x;
+
+    assert.ok(
+      tramTravel[0] > 10,
+      `production button should dispatch the tram, travel=${JSON.stringify(tramTravel)}`,
+    );
+    assert.ok(
+      Math.abs(frontTravel[0] - tramTravel[0]) < 0.05,
+      `PhysAttach front wall must track the root: front=${JSON.stringify(frontTravel)}, tram=${JSON.stringify(tramTravel)}`,
+    );
+    assert.ok(
+      Math.abs(buttonTravel[0] - tramTravel[0]) < 0.05,
+      `PhysAttach button must track the root: button=${JSON.stringify(buttonTravel)}, tram=${JSON.stringify(tramTravel)}`,
+    );
+    assert.ok(
+      playerTravel > 10 && Math.abs(playerAfter.x - tramAfter[0]) < 2,
+      `stationary passenger must remain aboard: player travel=${playerTravel}, tram travel=${tramTravel[0]}, relative x=${playerAfter.x - tramAfter[0]}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse Dark Engine `PhysAttach` links and moving-terrain state into typed mission data
- propagate translation-only physical attachments before each Rapier step so collision shells and controls track their kinematic parent
- cover Command tram parsing, generic moving-support behavior, and production doorway/button/passenger travel end to end

## Root cause

Rapier already carries a grounded player on a moving kinematic support. The Command tram root and floor moved, but its authored `PhysAttach` collision parts did not. The stationary front wall pinned the passenger at x=-374.16 while the floor continued down the track. Driving every attached child from the parent next-position plus the authored world-space offset matches the original Dark Engine behavior and keeps normal contact carry intact.

## Visual verification

![Command tram ride after fix](https://gist.githubusercontent.com/tommy-xr/f1ebdac2c61b1366fe06c6c6b06c683c/raw/command-tram-after.gif)

<sub>Authored PhysAttach tram parts now move with the car, keeping the player aboard through deterministic fixed-step transit. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After still

![Command tram after fix](https://gist.githubusercontent.com/tommy-xr/f1ebdac2c61b1366fe06c6c6b06c683c/raw/command-tram-after.png)

### Before → after

![Command tram before and after](https://gist.githubusercontent.com/tommy-xr/f1ebdac2c61b1366fe06c6c6b06c683c/raw/command-tram-before-after.png)

## Validation

- `cargo test -p dark` (73 passed)
- `cargo test -p shock2vr` (337 passed)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query`
- `npm test` in `tools/shock2-sdk` (25 passed, 140 opt-in skipped)
- focused Command tram e2e on 25th Anniversary assets (passed)
- full serial SDK e2e: 163/165 passed, including Command tram and all adjacent Command scenarios; the two failures reproduce on unmodified `origin/main` (Earth Cryokinesis misses Training Droid; debug-scene save reload tries to mount `debug_psi` as a mission)

Fixes #663
