### PR TITLE
fix(rec): implement authored PictureSwap cycle

### DIFF
--- a/dark/src/properties/prop_tweq.rs
+++ b/dark/src/properties/prop_tweq.rs
@@ -77,6 +77,12 @@ impl PropTweqRotateState {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTweqModelState {
     pub animation_state: TweqAnimationState,
+    /// Current slot in [`PropTweqModelConfig::model_names`].
+    ///
+    /// Dark persists this as the model tweq's `Frame #`. Older shock2quest
+    /// saves did not serialize it, so they resume at the authored first frame.
+    #[serde(default)]
+    pub frame: usize,
 }
 
 impl PropTweqModelState {
@@ -85,9 +91,12 @@ impl PropTweqModelState {
         let animation_state = TweqAnimationState::from_bits(animation_state_bits.into()).unwrap();
         let _misc = read_u16(reader); // misc state, is this used?
         let _time = read_u16(reader); // misc state, is this used?
-        let _frame = read_u16(reader); // misc state, is this used?
+        let frame = read_u16(reader);
 
-        PropTweqModelState { animation_state }
+        PropTweqModelState {
+            animation_state,
+            frame: frame.into(),
+        }
     }
 }
 
@@ -243,5 +252,27 @@ impl PropTweqDeleteConfig {
             halt,
             rate: Duration::from_millis(rate.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{PropTweqModelState, TweqAnimationState};
+
+    #[test]
+    fn model_state_reads_the_authored_frame_number() {
+        let mut bytes = Cursor::new([
+            0x02, 0x00, // animation state: reverse
+            0x00, 0x00, // misc
+            0x7b, 0x00, // time
+            0x04, 0x00, // frame number
+        ]);
+
+        let state = PropTweqModelState::read(&mut bytes, 8);
+
+        assert!(state.animation_state.contains(TweqAnimationState::REVERSE));
+        assert_eq!(state.frame, 4);
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -30,6 +30,7 @@ mod melee_weapon;
 mod obj_consume_button;
 mod once_room;
 mod once_router;
+mod picture_swap;
 pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
@@ -95,6 +96,7 @@ use self::gui::{
     TrainerMode, TraitGui,
 };
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
+use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
 use self::reduce_psi::ReducePsi;
@@ -730,7 +732,7 @@ impl ScriptWorld {
             // rec1
             // elevator buttons
             "elevatorbutton" => gui_script(Box::new(ElevatorGui)),
-            "pictureswap" => Box::new(NoopScript::new()),
+            "pictureswap" => Box::new(PictureSwap::new()),
             "testimplant" => Box::new(UnimplementedScript::new(&script_name)),
 
             // ric2:

--- a/shock2vr/src/scripts/picture_swap.rs
+++ b/shock2vr/src/scripts/picture_swap.rs
@@ -1,0 +1,255 @@
+use dark::properties::{PropTweqModelConfig, PropTweqModelState};
+use shipyard::{EntityId, Get, View, ViewMut, World};
+
+use crate::{physics::PhysicsWorld, time::Time};
+
+use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+
+/// Retail `PictureSwap` transition length (`StaticOver`, 1.0 seconds).
+const STATIC_DURATION_SECONDS: f32 = 1.0;
+
+/// The Recreation deck's interactive code-art display.
+///
+/// The original script inherits `ModelSwappable`: an accepted `FrobWorldEnd`
+/// or `TurnOn` advances once to the interstitial static model, starts the
+/// one-second `StaticOver` timer, then advances once more to the next picture.
+/// It rejects another activation while that transition is underway and relays
+/// `TurnOn` over its authored SwitchLinks.
+pub struct PictureSwap {
+    static_time_remaining: Option<f32>,
+}
+
+impl PictureSwap {
+    pub fn new() -> Self {
+        Self {
+            static_time_remaining: None,
+        }
+    }
+
+    fn activate(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        if self.static_time_remaining.is_some() {
+            return Effect::NoEffect;
+        }
+
+        let Some(change_to_static) = advance_model(world, entity_id) else {
+            return Effect::NoEffect;
+        };
+        self.static_time_remaining = Some(STATIC_DURATION_SECONDS);
+
+        Effect::combine(vec![
+            change_to_static,
+            send_to_all_switch_links(world, entity_id, MessagePayload::TurnOn { from: entity_id }),
+        ])
+    }
+}
+
+impl Script for PictureSwap {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        // A save taken during the retail script's one-second static phase
+        // persists the odd model-tweq frame. Script-local timers are not part
+        // of shock2quest saves, so reconstruct that pending completion.
+        let v_state = world.borrow::<View<PropTweqModelState>>().unwrap();
+        if v_state
+            .get(entity_id)
+            .is_ok_and(|state| state.frame % 2 == 1)
+        {
+            self.static_time_remaining = Some(STATIC_DURATION_SECONDS);
+        }
+        Effect::NoEffect
+    }
+
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob | MessagePayload::TurnOn { .. } => self.activate(entity_id, world),
+            _ => Effect::NoEffect,
+        }
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let Some(remaining) = self.static_time_remaining else {
+            return Effect::NoEffect;
+        };
+        let remaining = remaining - time.elapsed.as_secs_f32();
+        if remaining > 0.0 {
+            self.static_time_remaining = Some(remaining);
+            return Effect::NoEffect;
+        }
+
+        self.static_time_remaining = None;
+        advance_model(world, entity_id).unwrap_or(Effect::NoEffect)
+    }
+}
+
+/// Advance the persisted model-tweq frame by one, wrapping after its last
+/// authored model just like retail `ModelSwappable`.
+fn advance_model(world: &World, entity_id: EntityId) -> Option<Effect> {
+    let v_config = world.borrow::<View<PropTweqModelConfig>>().unwrap();
+    let mut v_state = world.borrow::<ViewMut<PropTweqModelState>>().unwrap();
+    let config = v_config.get(entity_id).ok()?;
+    let state = (&mut v_state).get(entity_id).ok()?;
+    let model_count = config.model_names.len();
+    if model_count == 0 {
+        return None;
+    }
+    let next_frame = (state.frame + 1) % model_count;
+    let model_name = config.model_names.get(next_frame)?.clone();
+    state.frame = next_frame;
+
+    Some(Effect::ChangeModel {
+        entity_id,
+        model_name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use dark::properties::{
+        Link, Links, PropTweqModelConfig, PropTweqModelState, ToLink, TweqAnimationConfig,
+        TweqAnimationState, TweqHalt, WrappedEntityId,
+    };
+    use shipyard::{Get, View, World};
+
+    use super::*;
+
+    fn picture_world() -> (World, EntityId) {
+        let mut world = World::new();
+        let target = world.add_entity(());
+        let picture = world.add_entity((
+            PropTweqModelConfig {
+                animation_config: TweqAnimationConfig::empty(),
+                halt: TweqHalt::Continue,
+                model_names: vec![
+                    "pic05".to_owned(),
+                    "static".to_owned(),
+                    "pic03".to_owned(),
+                    "static".to_owned(),
+                    "code10".to_owned(),
+                    "static".to_owned(),
+                ],
+            },
+            PropTweqModelState {
+                animation_state: TweqAnimationState::empty(),
+                frame: 0,
+            },
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 1,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        (world, picture)
+    }
+
+    fn changed_model(effect: Effect) -> Option<String> {
+        Effect::flatten(vec![effect])
+            .into_iter()
+            .find_map(|effect| match effect {
+                Effect::ChangeModel { model_name, .. } => Some(model_name),
+                _ => None,
+            })
+    }
+
+    fn frame(world: &World, entity_id: EntityId) -> usize {
+        world
+            .borrow::<View<PropTweqModelState>>()
+            .unwrap()
+            .get(entity_id)
+            .unwrap()
+            .frame
+    }
+
+    #[test]
+    fn frob_uses_static_then_advances_to_the_next_picture_after_one_second() {
+        let (world, picture) = picture_world();
+        let physics = PhysicsWorld::new();
+        let mut script = PictureSwap::new();
+
+        let effect = script.handle_message(picture, &world, &physics, &MessagePayload::Frob);
+        assert_eq!(changed_model(effect), Some("static".to_owned()));
+        assert_eq!(frame(&world, picture), 1);
+
+        let effect = script.update(
+            picture,
+            &world,
+            &physics,
+            &Time {
+                elapsed: Duration::from_millis(999),
+                total: Duration::from_millis(999),
+            },
+        );
+        assert_eq!(changed_model(effect), None);
+        assert_eq!(frame(&world, picture), 1);
+
+        let effect = script.update(
+            picture,
+            &world,
+            &physics,
+            &Time {
+                elapsed: Duration::from_millis(1),
+                total: Duration::from_secs(1),
+            },
+        );
+        assert_eq!(changed_model(effect), Some("pic03".to_owned()));
+        assert_eq!(frame(&world, picture), 2);
+    }
+
+    #[test]
+    fn activation_relays_turn_on_and_rejects_reentry_during_static() {
+        let (world, picture) = picture_world();
+        let physics = PhysicsWorld::new();
+        let mut script = PictureSwap::new();
+
+        let effects = Effect::flatten(vec![script.handle_message(
+            picture,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: picture },
+        )]);
+        assert!(effects.iter().any(|effect| {
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: super::super::Message {
+                        payload: MessagePayload::TurnOn { from },
+                        ..
+                    }
+                } if *from == picture
+            )
+        }));
+
+        let ignored = script.handle_message(picture, &world, &physics, &MessagePayload::Frob);
+        assert!(matches!(ignored, Effect::NoEffect));
+        assert_eq!(frame(&world, picture), 1);
+    }
+
+    #[test]
+    fn model_swappable_wraps_after_the_sixth_authored_frame() {
+        let (world, picture) = picture_world();
+        {
+            let mut state = world.borrow::<ViewMut<PropTweqModelState>>().unwrap();
+            (&mut state).get(picture).unwrap().frame = 5;
+        }
+
+        assert_eq!(
+            changed_model(advance_model(&world, picture).unwrap()),
+            Some("pic05".to_owned())
+        );
+        assert_eq!(frame(&world, picture), 0);
+    }
+}

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end coverage for the Recreation deck's authored PictureSwap flow
+// (#587). Code Pic 1's model tweq is:
+//
+//   pic05 -> static -> pic03 -> static -> code10 -> static -> ...
+//
+// The original PictureSwap script advances two frames per activation: it shows
+// the intervening static model for one second, then advances to the next
+// picture. This test uses the production flat interaction ray and squeeze
+// input, not the debug message-injection endpoint.
+//
+// Negative-first: with `pictureswap` mapped to NoopScript, the first model
+// assertion after the normal frob reads `pic05` instead of `static`.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const CODE_PIC_1 = "Code Pic 1";
+
+function modelOf(detail: {
+  properties: { name: string; value: string }[];
+}): string {
+  const model = detail.properties.find((property) => property.name === "Model");
+  assert.ok(model, "Code Pic should expose its live Model property");
+  return model.value;
+}
+
+async function frobThroughReticle(
+  game: GameServer,
+  entity: { id: number; position: [number, number, number] },
+): Promise<void> {
+  // This side of rec1's picture has an unobstructed selectable surface. The
+  // teleport only stages the player; aim and frob use production paths.
+  await game.player.teleport({
+    x: entity.position[0] + 3,
+    y: entity.position[1] - 1,
+    z: entity.position[2],
+  });
+  await game.step({ frames: 3 });
+  const aim = await game.player.aimAt(entity, { visibility: "required" });
+  assert.equal(aim.classification, "surface", JSON.stringify(aim));
+
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 2 });
+}
+
+test(
+  "rec1.mis: a normal frob reveals Code Pic 1's code10 model through static",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8153),
+    });
+    await game.step({ frames: 5 });
+
+    const pictures = (
+      await game.entities.list({ filter: CODE_PIC_1, limit: 20 })
+    ).entities;
+    const picture = pictures.find((entity) => entity.name === CODE_PIC_1);
+    assert.ok(picture, `expected rec1's authored ${CODE_PIC_1}`);
+    assert.equal(modelOf(await game.entities.detail(picture.id)), "pic05");
+
+    await frobThroughReticle(game, picture);
+    assert.equal(
+      modelOf(await game.entities.detail(picture.id)),
+      "static",
+      "the accepted frob should immediately show the transition model",
+    );
+    await game.step({ frames: 30 });
+    assert.equal(
+      modelOf(await game.entities.detail(picture.id)),
+      "static",
+      "PictureSwap should retain static for the authored one-second delay",
+    );
+    await game.step({ frames: 31 });
+    assert.equal(modelOf(await game.entities.detail(picture.id)), "pic03");
+
+    await frobThroughReticle(game, picture);
+    assert.equal(modelOf(await game.entities.detail(picture.id)), "static");
+    await game.step({ frames: 61 });
+    assert.equal(
+      modelOf(await game.entities.detail(picture.id)),
+      "code10",
+      "the second normal frob should visibly reveal this frame's code segment",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #587

## Summary
- implement the retail `PictureSwap` two-phase cycle from authored `PropTweqModelConfig` / `PropTweqModelState`
- advance to static immediately, hold the retail 1.0-second `StaticOver` phase, then reveal the next picture; reject reentry, wrap the six authored frames, and relay `TurnOn` over `SwitchLink`
- preserve the authored frame number through parser/save state and cover the production reticle + squeeze interaction in `rec1.mis`

## Faithfulness
I inspected all four Code Art templates and reverse-engineered retail `allobjs.osm` behavior. This deliberately does not use the click-by-click static/bounce behavior from the earlier prototype: one accepted activation advances twice with a timed static phase, exactly as the retail script does. There are no hardcoded code digits or debug-only gameplay shims.

## Validation
- negative-first production e2e: failed before the fix (`pic05` remained instead of static)
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p dark -p engine -p engine_ffmpeg -p shock2vr -p desktop_runtime -p debug_runtime -p dark_viewer -p dark_query -p debug_command -p hitbox_analyzer -p bench -p asset_probe`
- `cargo test -p dark model_state_reads_the_authored_frame_number` — 1 passed
- `cargo test -p shock2vr` — 344 passed, 0 failed
- `npm test` — 25 passed, 0 failed, 143 e2e skipped
- focused production `picture-swap.e2e` — 1 passed
- full SDK e2e before the final main restack — 164/166 passed, including PictureSwap, every 23-mission load through `shodan.mis`, `rec1 → command1`, and `rick3 → many`
- the two full-suite failures reproduce on the `origin/main` baseline: Earth Cryokinesis sometimes misses the Training Droid; world-aim rejects its freshly written save as corrupt/incompatible. Both also reproduce alone and touch no changed code here.
- exact-tree post-restack full SDK e2e — 166/168 passed; the only failures were the same two baseline-reproduced cases above. PictureSwap passed via normal frob in 8.9s; all 23 mission loads through `shodan.mis`, `rec1 → command1`, and `rick3 → many` passed
- autonomous replay: `pic05 → static → pic03 → static → code10`; frontier saved successfully with `shodanroom=1` and `reprogram=1`

## Visuals

Transition:

![PictureSwap transition](https://gist.githubusercontent.com/tommy-xr/95f328e11683472e37fe387e306ba787/raw/picture-swap-transition.gif)

Before / after:

![PictureSwap before and after](https://gist.githubusercontent.com/tommy-xr/95f328e11683472e37fe387e306ba787/raw/picture-swap-before-after.png)

Final `code10` still:

![PictureSwap code10](https://gist.githubusercontent.com/tommy-xr/95f328e11683472e37fe387e306ba787/raw/picture-swap-code10.png)

## Campaign
custom late-game sequence rec1→rec3→command→rickenbacker→many→shodan; fixed campaign (no randomized tweak/assets/seed)