### PR TITLE
feat(play-through): keep auto campaigns running

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   fix (PR "Fixes #n"), then REPLAY from the advancing frontier - until a mission
   (then the game) plays through with no new blocker. Aggregates every session into
   a self-contained HTML timeline report. Invoke with a mission (default medsci1)
-  and a goal (default: reach the level's exit), or with `--restart` to discard
+  and a goal (default: reach the level's exit). Use `--auto` to keep iterating to
+  campaign completion, `--auto-once` for one iteration, or `--restart` to discard
   campaign progress while preserving the current roll.
 ---
 
@@ -255,32 +256,41 @@ asset set, and seed (e.g. `campaign: hydroponics · melee-only · legacy · seed
 42`) — so a reader can tell whether a finding is specific to a playstyle or
 asset set, and can reproduce the campaign that surfaced it.
 
-## Autonomous mode (`--auto`)
+## Autonomous modes (`--auto`, `--auto-once`)
 
-Invoke the `play-through` skill with `--auto` using the host agent's skill syntax.
-Run exactly one iteration per invocation; a host automation or loop facility may
-schedule subsequent invocations. It **auto-creates the campaign ledger on first
-run** — no setup step. State persists in that ledger so it resumes at the
-frontier and marches forward instead of re-treading:
+Choose the mode from the user's invocation:
+
+- **`--auto` — persistent:** keep running complete playtest → review → fix →
+  replay iterations in the same invocation. Continue across iteration and
+  mission boundaries until the campaign finishes, the same blocker's fix fails
+  three times, or progress genuinely requires human input.
+- **`--auto-once` — bounded:** run exactly one complete iteration, persist its
+  result, report, and return. A later invocation resumes from the ledger.
+
+Both modes **auto-create the campaign ledger on first run** — no setup step.
+State persists in that ledger so work survives restarts and context compaction,
+resumes at the frontier, and never re-treads solved ground:
 
 ```
-node .agents/skills/play-through/playthrough-state.mjs roll      # idempotent; --auto calls it (--force re-rolls)
+node .agents/skills/play-through/playthrough-state.mjs roll      # idempotent; both autonomous modes call it
 node .agents/skills/play-through/playthrough-state.mjs show      # ledger + the NEXT action
 #   blocker add <level> <bug|feature-gap> <issue#> <desc...>   ·  blocker set <issue#> <status> [pr#]
+#   blocker fail <issue#> [pr#]                                (counts failed fixes; pauses on failure 3)
 #   advance <level> <saveName> <x,y,z> [note...]               (sets frontier, bumps iteration)
+#   complete <finalLevel> [note...]                             (marks the campaign finished)
 ```
 
 The ledger holds: the campaign **roll** (`scenario` + `tweak` + `assets`, with
 its `seed`), `frontier` (the game **save** to `/v1/load` from), the
-`blockers` ledger (issue → PR → status), and `fix_branch` — the running branch
-that **stacks each fix** so the campaign plays *past* an already-fixed-but-
-unmerged blocker.
+`blockers` ledger (issue → PR → status + failed-fix count), terminal campaign
+completion, and `fix_branch` — the running branch that **stacks each fix** so
+the campaign plays *past* an already-fixed-but-unmerged blocker.
 
 **Restart the current roll:** invoke the skill with `--restart`. Before the
 normal iteration, run `playthrough-state.mjs roll --restart` exactly once, then
-`show`. This disregards recorded gameplay progress but respects the current
-roll; subsequent invocations must omit `--restart` so they resume normally. A
-missing ledger is rolled normally.
+`show`. Consume `--restart` once; every later iteration in the same `--auto`
+invocation uses plain idempotent `roll`. This disregards recorded gameplay
+progress but respects the current roll. A missing ledger is rolled normally.
 
 **Clear & start a new campaign:** `playthrough-state.mjs roll --force` (wipes
 the ledger back to iteration 0 with a fresh scenario/tweak/assets roll; plain
@@ -289,7 +299,8 @@ clean slate also recreate the `fix_branch` off current `main` and delete stale
 frontier saves (`<data_root>/saves/frontier*.sav`) — otherwise the fresh
 campaign just launches mission 0 with no frontier to load, which is harmless.
 
-**Each `--auto` iteration** (do exactly one; a host loop may repeat it):
+**Each autonomous iteration:**
+
 1. `playthrough-state.mjs roll` (idempotent — rolls scenario + tweak + assets
    and creates the ledger on the first iteration, keeps the roll after), then
    `show` → read the frontier + NEXT action (goal, tweak, `DARK_ASSET_PATH`).
@@ -305,19 +316,35 @@ campaign just launches mission 0 with no frontier to load, which is harmless.
    **`fix_branch`** (stacked) and opens a PR `Fixes #n`. `blocker add` /
    `blocker set` in the ledger.
 7. **Re-validate:** rebuild `fix_branch`, reload the frontier save, confirm the
-   playtest now gets **past** the blocker.
-8. **Advance:** `POST /v1/save {file:"frontier"}` at the new furthest point;
-   `playthrough-state.mjs advance <level> frontier <x,y,z>`.
+   playtest now gets **past** the blocker. If it does not, run `blocker fail
+   <issue#> [pr#]`. Failures one and two return to triage/fix with the new
+   evidence; failure three is terminal and requires a human.
+8. **Advance:** `POST /v1/save {file:"frontier"}` at the new furthest point and
+   run `playthrough-state.mjs advance <level> frontier <x,y,z>`. If a valid
+   session instead clears the final mission and campaign goal, run
+   `playthrough-state.mjs complete <finalLevel> <note...>`.
 9. Render the session report (+ optional video).
+10. **Continue or return:** with `--auto-once`, report this iteration and return.
+    With `--auto`, run `show` and immediately begin the next iteration unless a
+    terminal condition below has been reached.
 
 **Guardrails (don't skip):**
+
 - **Merge gate is the human.** Fixes open PRs; *you* merge (or CI+`/xreview` gate).
   The `fix_branch` stack lets the campaign progress while PRs await review — the
-  goal is a reviewable stack, not auto-merge.
-- **Max iterations / budget** — stop after N iterations (default ~10) or the turn's
-  token target, and report.
-- **Recurrence = pause.** If a blocker isn't cleared after its fix (step 7 fails),
-  `blocker set <n> failed` and **stop for a human** — don't loop on a bad fix.
+  goal is a reviewable stack, not auto-merge. An open PR awaiting human merge
+  does not stop `--auto`; continue from the stacked fix branch.
+- **Three failed fixes = pause.** Count every distinct fix or revision that
+  fails step 7 with `blocker fail`. Re-triage and revise after failures one and
+  two. On failure three, the ledger marks the blocker failed; stop and give the
+  human the issue, PR, attempts, and evidence.
+- **Human input = pause.** Stop only when progress requires new authority,
+  credentials, external coordination, or a material choice that cannot safely
+  be inferred. Ask the smallest blocking question and preserve the frontier.
+- **Do not stop `--auto` at routine boundaries.** An iteration ending, a report
+  being ready, context compaction, a long-running CI check, or an unmerged green
+  PR is not a terminal condition. Continue until campaign completion, three
+  failed fixes on one blocker, or required human input.
 
 ## Notes
 - Delegate playtest, review, and each fix when supported; otherwise keep the

--- a/.claude/skills/play-through/playthrough-state.mjs
+++ b/.claude/skills/play-through/playthrough-state.mjs
@@ -1,5 +1,5 @@
-// Ledger for the autonomous play-through loop (--auto). Persists the state that
-// makes repeated play-through skill invocations resumable across iterations:
+// Ledger for the autonomous play-through modes (--auto / --auto-once). Persists
+// the state that makes play-through work resumable across iterations:
 // the frontier (furthest state, as a game save), the blocker->fix ledger, and
 // the stacked-fixes branch. Atomic read-modify-write so a loop agent never
 // corrupts it by hand-editing JSON.
@@ -16,8 +16,10 @@
 //                                       keeps that roll but discards progress.
 //     show                              print the ledger + the recommended next action
 //     advance <level> <save> <x,y,z> [note...]   set frontier, bump iteration, log history
+//     complete <level> [note...]        mark the campaign complete at its final mission
 //     blocker add <level> <bug|feature-gap> <issue#> <desc...>   record a found blocker (status:open)
-//     blocker set <issue#> <status> [pr#]        update a blocker (status: open|reworking|merged|failed)
+//     blocker set <issue#> <status> [pr#]        update a blocker (status: open|reworking|merged)
+//     blocker fail <issue#> [pr#]       count a failed fix; pause after the third failure
 //
 // State file: $PT_STATE, else /tmp/claude/playthrough/state.json.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -27,18 +29,35 @@ import { roll } from "./scenarios.mjs";
 const FILE = process.env.PT_STATE || "/tmp/claude/playthrough/state.json";
 const load = () => (existsSync(FILE) ? JSON.parse(readFileSync(FILE, "utf8")) : null);
 const save = (s) => { mkdirSync(dirname(FILE), { recursive: true }); writeFileSync(FILE, JSON.stringify(s, null, 2) + "\n"); };
-const baseState = (order, fixBranch) => ({ iteration: 0, mission_order: order, fix_branch: fixBranch, frontier: null, blockers: [], history: [] });
+const baseState = (order, fixBranch) => ({
+  iteration: 0,
+  mission_order: order,
+  fix_branch: fixBranch,
+  frontier: null,
+  blockers: [],
+  history: [],
+  completed: false,
+  completion: null,
+});
 
 const [cmd, ...args] = process.argv.slice(2);
 const rest = args; // command-specific positional args (after the command)
 
 function nextAction(s) {
   const openBlockers = s.blockers.filter((b) => !["merged"].includes(b.status));
-  const failed = s.blockers.find((b) => b.status === "failed");
+  const failed = s.blockers.find((b) =>
+    (b.fix_failures ?? (b.status === "failed" ? 3 : 0)) >= 3
+  );
   const campaign = (s.assets ? ` Launch every runtime with DARK_ASSET_PATH=${s.assets.path} (${s.assets.name}).` : "")
     + (s.scenario ? ` Campaign goal: ${s.scenario.goal}` : "")
     + (s.tweak && s.tweak.id !== "none" ? ` TWEAK [${s.tweak.name}]: ${s.tweak.instructions}` : "");
-  if (failed) return `PAUSE — blocker #${failed.issue} (${failed.desc}) fix did not clear it; needs a human.`;
+  if (s.completed) {
+    return `COMPLETE — ${s.completion?.note || `finished ${s.completion?.level || "the campaign"}`}`;
+  }
+  if (failed) {
+    const failures = failed.fix_failures ?? 3;
+    return `PAUSE — blocker #${failed.issue} (${failed.desc}) fix failed ${failures} times and needs a human.`;
+  }
   if (!s.frontier) return `Iteration ${s.iteration}: launch fresh at "${s.mission_order[0]}" and playtest.` + campaign;
   return `Iteration ${s.iteration}: rebuild the '${s.fix_branch}' branch, launch a runtime, POST /v1/load {file:"${s.frontier.save}"} (resumes ${s.frontier.level}), and playtest onward.`
     + (openBlockers.length ? ` Open fix PRs to merge: ${openBlockers.map((b) => `#${b.pr ?? "?"}(${b.status})`).join(", ")}.` : "")
@@ -47,8 +66,8 @@ function nextAction(s) {
 
 switch (cmd) {
   case "init": {
-    // Idempotent: safe to call at the start of every --auto iteration. Only
-    // creates the ledger if absent; `--force` resets an existing campaign.
+    // Idempotent: safe to call at the start of every autonomous iteration.
+    // Only creates the ledger if absent; `--force` resets an existing campaign.
     if (existsSync(FILE) && !args.includes("--force")) {
       console.log(`ledger already exists at ${FILE} (iteration ${load().iteration}) — kept. Use --force to reset.`);
       break;
@@ -76,6 +95,8 @@ switch (cmd) {
       s.frontier = null;
       s.blockers = [];
       s.history = [];
+      s.completed = false;
+      s.completion = null;
       save(s);
       console.log(`restarted campaign at ${FILE} — discarded progress and kept the current roll.`);
       if (s.scenario) {
@@ -147,24 +168,72 @@ switch (cmd) {
     console.log(`frontier -> ${level} (save '${saveName}'); iteration now ${s.iteration}`);
     break;
   }
+  case "complete": {
+    const s = load(); if (!s) process.exit(1);
+    const [level, ...note] = rest;
+    const finalLevel = s.mission_order[s.mission_order.length - 1];
+    if (level !== finalLevel) {
+      console.error(`cannot complete at '${level || ""}' — final mission is '${finalLevel}'`);
+      process.exit(1);
+    }
+    const completionNote = note.join(" ") || `finished ${level}`;
+    s.completed = true;
+    s.completion = { level, note: completionNote };
+    s.history.push({ iteration: s.iteration, level, note: completionNote, completed: true });
+    save(s);
+    console.log(`campaign complete at ${level}: ${completionNote}`);
+    break;
+  }
   case "blocker": {
     const s = load(); if (!s) process.exit(1);
     const [sub, ...bargs] = args;
     if (sub === "add") {
       const [level, kind, issue, ...desc] = bargs;
-      s.blockers.push({ issue: Number(issue), level, kind, desc: desc.join(" "), pr: null, status: "open" });
+      s.blockers.push({
+        issue: Number(issue),
+        level,
+        kind,
+        desc: desc.join(" "),
+        pr: null,
+        status: "open",
+        fix_failures: 0,
+      });
       console.log(`recorded blocker #${issue} (${kind}) @ ${level}`);
     } else if (sub === "set") {
       const [issue, status, pr] = bargs;
       const b = s.blockers.find((x) => x.issue === Number(issue));
       if (!b) { console.error(`no blocker #${issue}`); process.exit(1); }
+      if (status === "failed") {
+        console.error("use 'blocker fail <issue#> [pr#]' to count a failed fix");
+        process.exit(1);
+      }
+      if (!["open", "reworking", "merged"].includes(status)) {
+        console.error(`invalid blocker status '${status}' — use open, reworking, or merged`);
+        process.exit(1);
+      }
       b.status = status; if (pr) b.pr = Number(pr);
       console.log(`blocker #${issue} -> ${status}${pr ? ` (PR #${pr})` : ""}`);
-    } else { console.error("usage: blocker add|set ..."); process.exit(1); }
+    } else if (sub === "fail") {
+      const [issue, pr] = bargs;
+      const b = s.blockers.find((x) => x.issue === Number(issue));
+      if (!b) { console.error(`no blocker #${issue}`); process.exit(1); }
+      const previousFailures = b.fix_failures ?? 0;
+      if (previousFailures >= 3) {
+        console.error(`blocker #${issue} already failed 3 times and needs a human`);
+        process.exit(1);
+      }
+      b.fix_failures = previousFailures + 1;
+      b.status = b.fix_failures >= 3 ? "failed" : "reworking";
+      if (pr) b.pr = Number(pr);
+      console.log(
+        `blocker #${issue} fix failure ${b.fix_failures}/3`
+          + (b.status === "failed" ? " — pause for a human" : " — revise and replay"),
+      );
+    } else { console.error("usage: blocker add|set|fail ..."); process.exit(1); }
     save(s);
     break;
   }
   default:
-    console.error("usage: init | roll [--force|--restart] | show | advance | blocker add|set (see file header)");
+    console.error("usage: init | roll [--force|--restart] | show | advance | complete | blocker add|set|fail (see file header)");
     process.exit(1);
 }

--- a/.claude/skills/play-through/playthrough-state.test.mjs
+++ b/.claude/skills/play-through/playthrough-state.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const SCRIPT = fileURLToPath(new URL("./playthrough-state.mjs", import.meta.url));
+
+function withLedger(runTest) {
+  const dir = mkdtempSync(join(tmpdir(), "playthrough-state-"));
+  const stateFile = join(dir, "state.json");
+  const run = (...args) =>
+    spawnSync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+      env: { ...process.env, PT_STATE: stateFile },
+    });
+  const state = () => JSON.parse(readFileSync(stateFile, "utf8"));
+
+  try {
+    runTest({ run, state });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("a blocker pauses autonomous play only after its third failed fix", () => {
+  withLedger(({ run, state }) => {
+    assert.equal(run("init", "order=rec1,rec2").status, 0);
+    assert.equal(
+      run("blocker", "add", "rec1", "feature-gap", "42", "broken", "objective").status,
+      0,
+    );
+
+    const bypass = run("blocker", "set", "42", "failed");
+    assert.notEqual(bypass.status, 0);
+    assert.match(bypass.stderr, /use 'blocker fail/);
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      const failure = run("blocker", "fail", "42", "100");
+      assert.equal(failure.status, 0, failure.stderr);
+      assert.equal(state().blockers[0].fix_failures, attempt);
+      assert.equal(state().blockers[0].status, "reworking");
+      assert.doesNotMatch(run("show").stdout, /PAUSE/);
+    }
+
+    const thirdFailure = run("blocker", "fail", "42", "100");
+    assert.equal(thirdFailure.status, 0, thirdFailure.stderr);
+    assert.equal(state().blockers[0].fix_failures, 3);
+    assert.equal(state().blockers[0].status, "failed");
+    assert.match(run("show").stdout, /PAUSE.*failed 3 times.*needs a human/s);
+  });
+});
+
+test("campaign completion is persisted and surfaced as the terminal action", () => {
+  withLedger(({ run, state }) => {
+    assert.equal(run("init", "order=rec1,rec2").status, 0);
+
+    const premature = run("complete", "rec1", "not", "at", "the", "end");
+    assert.notEqual(premature.status, 0);
+    assert.match(premature.stderr, /final mission.*rec2/);
+
+    const completed = run("complete", "rec2", "campaign", "exit", "reached");
+    assert.equal(completed.status, 0, completed.stderr);
+    assert.equal(state().completed, true);
+    assert.equal(state().completion.level, "rec2");
+    assert.equal(state().completion.note, "campaign exit reached");
+    assert.match(run("show").stdout, /COMPLETE.*campaign exit reached/s);
+  });
+});


### PR DESCRIPTION
## Summary
- rename the current one-iteration behavior to `--auto-once`
- make `--auto` continue across iteration and mission boundaries until campaign completion, three failed fixes on the same blocker, or required human input
- persist campaign completion and per-blocker failed-fix counts in the play-through ledger
- reject `blocker set ... failed` so terminal failure cannot bypass the three-attempt counter

## Behavior
- `--auto-once`: run one complete playtest → review → fix → replay iteration, persist it, and return
- `--auto`: immediately begin the next iteration after reporting; green-but-unmerged PRs, CI waits, reports, and context compaction are explicitly non-terminal
- failures 1–2: record with `blocker fail`, re-triage, revise, and replay
- failure 3: mark the blocker failed and pause for a human
- final campaign goal: record with `complete <finalLevel> [note...]` and stop successfully

## Validation
- negative-first ledger tests: 0/2 passed before the new commands existed
- `node --check .claude/skills/play-through/playthrough-state.mjs`
- `node --test .claude/skills/play-through/playthrough-state.test.mjs` — 2 passed
- skill package validation via `quick_validate.py` — valid
- pre-push `cargo fmt --all -- --check` — passed
