### PR TITLE
feat(skill): add sequential random issue fixer

### DIFF
--- a/.claude/skills/fix-random-issues/SKILL.md
+++ b/.claude/skills/fix-random-issues/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: fix-random-issues
+description: >-
+  Randomly sample X open GitHub issues from shock2quest and process them
+  sequentially, delegating one issue at a time to an isolated agent that must
+  reproduce or confirm the problem, implement a focused fix, verify it, and open
+  a reviewable PR. Use for requests to fix, sweep, tackle, or work through a
+  bounded number of random open shock2quest issues.
+---
+
+# Fix random issues
+
+Run a bounded issue-fixing sweep. Freeze one unbiased random sample, then give
+each selected issue to exactly one issue worker. Finish or stop that worker
+before starting the next.
+
+## Inputs
+
+- Read `X` as the maximum number of sampled issues; default to `1`. Require a
+  positive integer.
+- Resolve the repository from the checkout, normally
+  `tommy-xr/shock2quest`. Honor an explicit repository override.
+- Accept an optional seed. Generate and report one when omitted.
+
+Do not silently replace skipped, closed, duplicate, already-fixed, or
+unreproducible selections. Each still consumes one sample slot. This preserves
+the random sample and makes the run produce up to X fixes rather than
+cherry-picking X easy fixes. If fewer than X issues are open, process all of
+them and report the smaller sample.
+
+## 1. Preflight and freeze the sample
+
+1. Read `AGENTS.md`, `README.md`, and `DEVELOPMENT.md`.
+2. Confirm `gh` authentication, repository access, and push/PR access before
+   starting a worker. Never merge a PR or close an issue directly.
+3. Record the checkout's initial status. Preserve all existing user changes.
+   Use an isolated branch/worktree for every issue; never stack unrelated issue
+   fixes.
+4. Select the full sample once:
+
+   ```bash
+   node .agents/skills/fix-random-issues/scripts/select-open-issues.mjs X \
+     --repo tommy-xr/shock2quest
+   ```
+
+   Add `--seed <value>` when supplied. `.agents/skills` is the compatibility
+   symlink to `.claude/skills`, so this command works for both Claude and Codex.
+5. Keep the emitted repository, seed, and ordered `selected` array as the run
+   ledger. Do not rerun the draw unless the user explicitly requests a new
+   sample.
+
+The selector samples all open issues without inspecting difficulty, labels, or
+assignees first. Random means random; do not quietly filter the pool.
+
+## 2. Process the selected issues serially
+
+For each selected issue, in emitted order:
+
+1. Re-read it with `gh issue view`, including its current state, body, comments,
+   labels, and assignees. Skip it if it is no longer open. Check current
+   `origin/main` for an existing fix or superseding PR before editing.
+2. Start one issue worker using the host's delegation tool. Prefer a
+   host-provided isolated worktree. Otherwise create a unique branch/worktree
+   from current `origin/main`, named along the lines of
+   `fix/issue-<number>-<slug>`.
+3. Give the worker the prompt contract below and the worktree path. Wait for its
+   final result. Do not start another issue worker concurrently. If the worker
+   uses a required helper such as `pr-visuals`, wait for that helper too.
+4. Inspect the worker's evidence, diff, tests, commit, PR, and CI result. Ask the
+   same worker for corrections when its result is incomplete. Do not take over
+   silently or delegate the issue to a second worker.
+5. Record one terminal result:
+   - `fixed`: reproduction/confirmation, focused fix, local verification,
+     conventional commit, PR containing `Fixes #N`, and green CI.
+   - `skipped`: closed, duplicate, superseded, or already fixed on current main.
+   - `not reproduced`: reasonable evidence failed to confirm the report.
+   - `blocked`: a concrete product decision, unavailable dependency/hardware,
+     unsafe scope, or persistent verification/CI failure prevents completion.
+6. Remove a temporary worktree only when it is clean and every change is safely
+   committed and pushed. Otherwise preserve it and report its path.
+
+One issue is complete before the next begins. Sequential processing is a
+correctness boundary, not merely a preference.
+
+## Issue-worker prompt contract
+
+Pass the issue number, URL, frozen title, repository, base branch, and isolated
+worktree. Instruct the worker:
+
+```text
+Own issue #N end to end in the supplied isolated worktree.
+
+Read AGENTS.md, README.md, and DEVELOPMENT.md first. Read the full issue and
+comments. Work only on this issue; preserve unrelated changes.
+
+REPRODUCE: Confirm the reported behavior on current origin/main before changing
+code. For a feature gap, confirm the missing/stubbed behavior and investigate
+the faithful System Shock 2 flow. Add and run a negative test first whenever a
+test can exercise the fix. Do not guess or implement a speculative fix when the
+issue cannot be reproduced.
+
+FIX: Make the smallest faithful change that resolves the issue through the
+game's real systems. Follow existing patterns. Do not use debug-only shims as
+the product fix. Keep one logical conventional commit.
+
+VERIFY: Run the focused test, the repository's warning-free package checks,
+format checks, and every runtime/SDK/e2e verification required by AGENTS.md for
+the affected area. For visual changes, use the pr-visuals skill and include the
+required still/GIF and before/after evidence.
+
+DELIVER: Fetch and rebase onto current origin/main, rerun affected verification,
+push the branch, and open one conventional-title PR whose body includes
+reproduction evidence, the fix, tests, and `Fixes #N`. Watch PR checks to a
+terminal result and fix failures caused by the change. Never merge the PR or
+close the issue yourself.
+
+Return: status; pre-fix reproduction; root cause; files changed; tests and exact
+results; commit SHA; PR URL; CI status; remaining risks. If skipped,
+unreproduced, or blocked, make no speculative changes and return concrete
+evidence plus the clean worktree status.
+```
+
+Treat a worker report without pre-fix evidence or without targeted verification
+as incomplete. A PR URL alone is not completion.
+
+## 3. Report the sweep
+
+Return the repository, seed, requested count, actual sampled count, and a table
+in sampled order with:
+
+| Issue | Result | Evidence | Commit / PR | Verification |
+|---|---|---|---|---|
+
+State `fixed K of S sampled issues (X requested)`. List preserved worktree paths
+and blockers. Do not claim skipped or merely patched issues as fixed.

--- a/.claude/skills/fix-random-issues/agents/openai.yaml
+++ b/.claude/skills/fix-random-issues/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix Random Issues"
+  short_description: "Fix random open issues one at a time"
+  default_prompt: "Use $fix-random-issues to attempt 3 randomly selected open shock2quest issues sequentially."

--- a/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
+++ b/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+function usage() {
+  console.log(`Usage:
+  node select-open-issues.mjs <count> [--repo OWNER/REPO] [--seed VALUE]
+
+Randomly select a fixed sample of open GitHub issues. Output is JSON.
+
+Options:
+  --repo OWNER/REPO  Repository to query (default: current gh repository)
+  --seed VALUE       Reproducible shuffle seed (default: random 128-bit hex)
+  -h, --help         Show this help`);
+}
+
+function fail(message) {
+  console.error(`select-open-issues: ${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  let count;
+  let repo;
+  let seed;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "-h" || argument === "--help") {
+      usage();
+      process.exit(0);
+    }
+    if (argument === "--repo" || argument === "--seed") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        fail(`${argument} requires a value`);
+      }
+      if (argument === "--repo") {
+        repo = value;
+      } else {
+        seed = value;
+      }
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith("--repo=")) {
+      repo = argument.slice("--repo=".length);
+      continue;
+    }
+    if (argument.startsWith("--seed=")) {
+      seed = argument.slice("--seed=".length);
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      fail(`unknown option: ${argument}`);
+    }
+    if (count !== undefined) {
+      fail(`unexpected positional argument: ${argument}`);
+    }
+    count = Number(argument);
+  }
+
+  if (!Number.isSafeInteger(count) || count < 1) {
+    fail("count must be a positive integer");
+  }
+  if (repo !== undefined && !/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    fail("repo must have the form OWNER/REPO");
+  }
+  if (seed === "") {
+    fail("seed must not be empty");
+  }
+
+  return { count, repo, seed };
+}
+
+function runGh(args) {
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message;
+    fail(`gh ${args[0]} failed: ${detail}`);
+  }
+}
+
+function resolveRepository(explicitRepository) {
+  if (explicitRepository) {
+    return explicitRepository;
+  }
+  const repository = runGh([
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+  if (!repository) {
+    fail("could not resolve the current GitHub repository");
+  }
+  return repository;
+}
+
+function hashSeed(value) {
+  let hash = 0x811c9dc5;
+  for (const byte of Buffer.from(value, "utf8")) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function seededRandom(seed) {
+  let state = hashSeed(seed);
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle(values, random) {
+  const result = [...values];
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = Math.floor(random() * (index + 1));
+    [result[index], result[other]] = [result[other], result[index]];
+  }
+  return result;
+}
+
+function listOpenIssues(repository) {
+  const endpoint = `repos/${repository}/issues?state=open&per_page=100`;
+  const raw = runGh(["api", "--paginate", "--slurp", endpoint]);
+  let pages;
+  try {
+    pages = JSON.parse(raw);
+  } catch (error) {
+    fail(`could not parse GitHub response: ${error.message}`);
+  }
+
+  if (!Array.isArray(pages)) {
+    fail("GitHub response was not a paginated issue list");
+  }
+
+  return pages
+    .flat()
+    .filter((issue) => !issue.pull_request)
+    .map((issue) => ({
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+      labels: (issue.labels ?? []).map((label) =>
+        typeof label === "string" ? label : label.name
+      ),
+      assignees: (issue.assignees ?? []).map((assignee) => assignee.login),
+    }))
+    .sort((left, right) => left.number - right.number);
+}
+
+const options = parseArgs(process.argv.slice(2));
+const repository = resolveRepository(options.repo);
+const seed = options.seed ?? randomBytes(16).toString("hex");
+const openIssues = listOpenIssues(repository);
+const selected = shuffle(openIssues, seededRandom(seed)).slice(0, options.count);
+
+console.log(
+  JSON.stringify(
+    {
+      repository,
+      seed,
+      requested: options.count,
+      available: openIssues.length,
+      sampled: selected.length,
+      selected,
+    },
+    null,
+    2
+  )
+);


### PR DESCRIPTION
## Summary

- add a repo-local fix-random-issues manager skill available through both .claude/skills and the .agents compatibility symlink
- freeze a seeded random sample of open shock2quest issues and delegate them to isolated workers one at a time
- require pre-fix reproduction, focused implementation, repository-appropriate verification, reviewable PRs, and green CI for each successful issue
- add a dependency-free Node selector that paginates all open GitHub issues and excludes pull requests

## Testing

- skill-creator quick_validate.py
- node --check .claude/skills/fix-random-issues/scripts/select-open-issues.mjs
- live selector smoke test against tommy-xr/shock2quest (61 open issues)
- repeated seeded draw with byte-for-byte comparison