### PR TITLE
fix(gameplay): honor MOVE when frobbing ordinary items

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -308,6 +308,23 @@ pub fn create_entity_core(
         processed_scripts.push("internal_keycard".to_owned());
     }
 
+    // `MOVE` is an engine frob action, not an object script. Ordinary goodies
+    // such as Med Patches and armor only inherit that flag, so give them the
+    // internal handler that moves them into the backpack on Frob. Objects that
+    // also request SCRIPT keep their existing authored ownership (notably
+    // FrobQB's circuit-board/quest-item transfer).
+    let needs_frob_move = {
+        let v_frob_info = world.borrow::<View<PropFrobInfo>>().unwrap();
+        v_frob_info.get(entity_id).is_ok_and(|frob| {
+            !frob.world_action.contains(FrobFlag::SCRIPT)
+                && (frob.world_action.contains(FrobFlag::MOVE)
+                    || frob.world_action.contains(FrobFlag::USE_AMMO))
+        })
+    };
+    if needs_frob_move {
+        processed_scripts.push("internal_frob_move".to_owned());
+    }
+
     // Explosion SFX templates (class tag "explosiontype", e.g. HE / Incendiary
     // Explosion) with radius stim sources (arSrcDesc) blast once on spawn.
     // Radius sources WITHOUT the tag (electrical sparks, Swarm, Rad Burst) are

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -1,0 +1,159 @@
+use dark::properties::FrobFlag;
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
+
+use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
+
+/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior for
+/// ordinary pickup items that do not ask an authored script to handle Frob.
+///
+/// `MOVE | SCRIPT` objects keep their existing scripted ownership. In
+/// particular, `FrobQB` must award the Engineering circuit board's quest bit
+/// and transfer it exactly once.
+pub struct InternalFrobMove;
+
+impl InternalFrobMove {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for InternalFrobMove {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) {
+            return Effect::NoEffect;
+        }
+
+        let handles_move = {
+            let frob_info = world
+                .borrow::<View<dark::properties::PropFrobInfo>>()
+                .unwrap();
+            frob_info.get(entity_id).is_ok_and(|frob_info| {
+                !frob_info.world_action.contains(FrobFlag::SCRIPT)
+                    && (frob_info.world_action.contains(FrobFlag::MOVE)
+                        || frob_info.world_action.contains(FrobFlag::USE_AMMO))
+            })
+        };
+        if !handles_move {
+            return Effect::NoEffect;
+        }
+
+        // The undifferentiated Frob message is also used by inventory UI.
+        // Once carried, the item's `inventory_action` belongs to its ordinary
+        // script; do not re-parent it through its world MOVE action.
+        if player_carried_items(world).contains(&entity_id) {
+            return Effect::NoEffect;
+        }
+
+        let Ok(player) = world.borrow::<UniqueView<PlayerInfo>>() else {
+            return Effect::NoEffect;
+        };
+        Effect::DropEntityInfo {
+            parent_entity_id: player.inventory_entity_id,
+            dropped_entity_id: entity_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{FrobFlag, Link, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::InternalFrobMove;
+
+    fn pickup_world(
+        world_action: FrobFlag,
+        already_carried: bool,
+    ) -> (World, shipyard::EntityId, shipyard::EntityId) {
+        let mut world = World::new();
+        let item = world.add_entity(PropFrobInfo {
+            world_action,
+            inventory_action: FrobFlag::SCRIPT,
+            tool_action: FrobFlag::empty(),
+        });
+        let inventory = world.add_entity(if already_carried {
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(item)),
+                    link: Link::Contains(0),
+                }],
+            }
+        } else {
+            Links::empty()
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, item, inventory)
+    }
+
+    #[test]
+    fn world_frob_moves_an_ordinary_pickup_to_the_backpack() {
+        let (world, item, inventory) = pickup_world(FrobFlag::MOVE, false);
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(
+            effect,
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } if parent_entity_id == inventory && dropped_entity_id == item
+        ));
+    }
+
+    #[test]
+    fn inventory_frob_does_not_reapply_the_world_move() {
+        let (world, item, _inventory) = pickup_world(FrobFlag::MOVE, true);
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn scripted_move_remains_owned_by_the_authored_script() {
+        let (world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -22,6 +22,7 @@ pub mod gui;
 mod internal_collision_type;
 mod internal_explosion;
 pub mod internal_fast_projectile;
+mod internal_frob_move;
 mod internal_keycard_script;
 mod internal_simple_health;
 mod internal_switch_held_model;
@@ -95,6 +96,7 @@ use self::gui::{
     ContainerGui, ElevatorGui, GamePigGui, KeyPadGui, MapGui, MediaGui, ReplicatorGui, TrainerGui,
     TrainerMode, TraitGui,
 };
+use self::internal_frob_move::InternalFrobMove;
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
@@ -537,6 +539,7 @@ impl ScriptWorld {
             "internal_map" => gui_script(Box::new(MapGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
+            "internal_frob_move" => Box::new(InternalFrobMove::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),
             "internal_room_trigger" => Box::new(RoomTrigger::new()),
             "internal_simple_health" => Box::new(InternalSimpleHealth::new()),

--- a/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable eng1 mission-object ids. Runtime entity ids are rediscovered every
+// launch and must never be hardcoded.
+const VACC_SUIT_OBJ = 1450;
+const MED_PATCH_OBJ = 1318;
+const CIRCUIT_BOARD_OBJ = 705;
+
+test(
+  "eng1: frobbing MOVE items picks them up and preserves the scripted circuit board flow",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8192),
+    });
+    await game.step({ frames: 2 });
+
+    const [vaccSuit] = await game.entities.byTemplate(VACC_SUIT_OBJ);
+    const [medPatch] = await game.entities.byTemplate(MED_PATCH_OBJ);
+    const [circuitBoard] = await game.entities.byTemplate(CIRCUIT_BOARD_OBJ);
+    assert.ok(vaccSuit?.name === "Vacc Suit", "expected eng1 Vacc Suit obj 1450");
+    assert.ok(medPatch?.name === "Med Patch", "expected eng1 Med Patch obj 1318");
+    assert.ok(
+      circuitBoard?.name === "Circuitboard",
+      "expected eng1 circuit board obj 705",
+    );
+
+    // The suit and patch inherit Goodies' world-action MOVE, with no SCRIPT
+    // world action to perform that transfer for them. Before #591 an injected
+    // Frob only reached their ordinary scripts and both remained uncarried.
+    for (const item of [vaccSuit, medPatch]) {
+      await game.entities.sendMessage(item.id, { type: "Frob" });
+      await game.step({ frames: 2 });
+      const inventory = await game.player.inventory();
+      assert.equal(
+        inventory.items.find((entry) => entry.entity_id === item.id)?.location,
+        "inventory",
+        `frobbing ${item.name} must honor PropFrobInfo MOVE; got ${JSON.stringify(inventory.items)}`,
+      );
+    }
+
+    // The circuit board is MOVE | SCRIPT. Its existing FrobQB path must still
+    // both transfer the unique board and award the authored quest bit.
+    await game.entities.sendMessage(circuitBoard.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((entry) => entry.entity_id === circuitBoard.id)
+        ?.location,
+      "inventory",
+      `circuit board must remain pickable; got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      await game.quests.get("note_1_10"),
+      "complete",
+      "circuit board FrobQB must still award note_1_10",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #591.

## Reproduction

On current `origin/main`, the eng1 Vacc Suit and a Med Patch were rediscovered
each launch by stable mission object id (`1450` and `1318`; the issue's
`1166`/`340` were per-run runtime ids). Sending either object's normal `Frob`
message and stepping left the inventory empty and the entity present.

Both objects are authored container contents and therefore have no world physics
body, so a close-range squeeze has no selectable body to grab. The Engineering
circuit board (obj `705`) was checked separately: its existing `MOVE | SCRIPT`
`FrobQB` flow correctly transferred it and completed `note_1_10`.

## Root cause and fix

The suit and patch inherit `PropFrobInfo.world_action = MOVE` from `Goodies`.
`MOVE` is an engine frob action, but the recreation only dispatched `Frob` to
object scripts. These ordinary items have no authored world-frob script that
performs the transfer, so the message was a no-op.

This adds a small property-backed internal script for non-`SCRIPT` `MOVE` /
`USE_AMMO` items. It moves a world or loot-container item into the player's
backpack, ignores items already carried (so inventory use stays on
`inventory_action`), and deliberately leaves `MOVE | SCRIPT` objects on their
existing authored paths. The circuit board therefore still transfers exactly
once and awards its quest bit.

## Verification

Negative-first: the new eng1 SDK scenario failed on the base revision with:

```text
frobbing Vacc Suit must honor PropFrobInfo MOVE; got []
```

Post-fix:

- `cargo test -p shock2vr`: 347 passed
- Focused internal MOVE tests: 3 passed
- Focused eng1 SDK scenario: passed (Vacc Suit, Med Patch, circuit board +
  `note_1_10`)
- `npm test`: 25 passed, 144 opt-in e2e skipped
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: clean
- `cargo fmt --all -- --check`: clean
- Full `npm run test:e2e`: 167 passed, 2 failed, 0 skipped. Both failures
  reproduce identically on clean `origin/main`: Earth Cryokinesis does not
  damage the Training Droid, and the world-aim save immediately reloads as
  corrupt/incompatible. The new eng1 scenario passed in the full sweep.

## Visual verification

![Authored MOVE item pickup demo](https://gist.githubusercontent.com/tommy-xr/dd8f63bcbdd144069348d29783655f7c/raw/issue-591-after.gif)

<sub>Frobbing an authored MOVE item now transfers it into the player's inventory; MOVE | SCRIPT quest items retain their existing path. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After

![Med Patch carried in the inventory strip](https://gist.githubusercontent.com/tommy-xr/dd8f63bcbdd144069348d29783655f7c/raw/issue-591-after.png)

### Before → after

![Before and after authored MOVE item pickup](https://gist.githubusercontent.com/tommy-xr/dd8f63bcbdd144069348d29783655f7c/raw/issue-591-before-after.png)
