### PR TITLE
fix(vr): crouch from tracked head height

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -1116,7 +1116,7 @@ fn render_swapchain(
     let width = swapchain.width;
     let height = swapchain.height;
 
-    let head_offset = stage_to_pawn(
+    let mut head_offset = stage_to_pawn(
         cgmath::Vector3::new(
             view.pose.position.x,
             view.pose.position.y,
@@ -1124,6 +1124,15 @@ fn render_swapchain(
         ),
         game.player_center_above_floor() + tracked_pose_drop,
     );
+    // The tracked eye belongs to a real body, not to the game capsule, so it
+    // must be held inside the collider crown: a physically crouched adult's
+    // eye sits well above the short crouched capsule, and uncapped the player
+    // sees over and through the very geometry the capsule clears (looking out
+    // of the world from inside a duct). Only the view is capped - hand poses
+    // have no such clipping concern and clamping them would break reaching up.
+    // The cap binds essentially only while crouched (or button-latched);
+    // standing it sits above any realistic head, so tracking stays 1:1.
+    head_offset.y = head_offset.y.min(game.player_eye_cap_above_center());
     let head_rotation = cgmath::Quaternion::new(
         view.pose.orientation.w,
         view.pose.orientation.x,

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -11,6 +11,7 @@ use shock2vr::Game;
 use shock2vr::GameOptions;
 use shock2vr::input_context::InputContext;
 use shock2vr::paths;
+use shock2vr::vr_crouch::VrCrouchDetector;
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
@@ -460,6 +461,8 @@ fn main() {
     // No discrete actions are mapped for VR controllers yet; this stays empty
     // until an OculusInputMapper is added.
     let mut action_state = shock2vr::input::InputActionState::new();
+    let mut vr_crouch = VrCrouchDetector::default();
+    let mut pending_stage_change_time = None;
 
     let _camera_pos = vec3(0.0, 5.0, 10.0);
 
@@ -501,6 +504,8 @@ fn main() {
                             ready_reported = false;
                             last_update_time = Instant::now();
                             frame_profiler.reset();
+                            vr_crouch.reset();
+                            pending_stage_change_time = None;
 
                             // let available_rates =
                             //     session.enumerate_display_refresh_rates().unwrap();
@@ -524,6 +529,14 @@ fn main() {
                 InstanceLossPending(_) => {
                     break 'main_loop;
                 }
+                ReferenceSpaceChangePending(e)
+                    if e.reference_space_type() == xr::ReferenceSpaceType::STAGE =>
+                {
+                    // The new floor origin applies at change_time, not when
+                    // this event is delivered. Recalibrate on the first frame
+                    // whose tracked poses use that new STAGE definition.
+                    pending_stage_change_time = Some(e.change_time());
+                }
                 EventsLost(e) => {
                     println!("lost {} events", e.lost_event_count());
                 }
@@ -545,6 +558,13 @@ fn main() {
         // predicting locations of controllers, viewpoints, etc.
         let xr_frame_state = frame_wait.wait().unwrap();
 
+        if let Some(change_time) = pending_stage_change_time {
+            if xr_frame_state.predicted_display_time.as_nanos() >= change_time.as_nanos() {
+                vr_crouch.reset();
+                pending_stage_change_time = None;
+            }
+        }
+
         let current = Instant::now();
         let total_time = current - render_time;
         let elapsed_time = current - last_update_time;
@@ -560,6 +580,9 @@ fn main() {
             .locate(&stage, xr_frame_state.predicted_display_time)
             .unwrap();
         let right_aim_location = right_aim_space
+            .locate(&stage, xr_frame_state.predicted_display_time)
+            .unwrap();
+        let head_location = head_space
             .locate(&stage, xr_frame_state.predicted_display_time)
             .unwrap();
 
@@ -649,6 +672,11 @@ fn main() {
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
         input_context.jump = jump_pressed;
+        let tracked_head_position = head_location.location_flags.contains(
+            xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
+        );
+        input_context.crouch =
+            vr_crouch.update(tracked_head_position.then_some(head_location.pose.position.y));
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -522,6 +522,11 @@ fn main() {
                             frame_profiler.reset();
                             vr_crouch.reset();
                             pending_stage_change_time = None;
+                            // A latched button crouch must not survive a
+                            // session restart (doffing the headset would
+                            // otherwise resume invisibly crouched).
+                            crouch_toggled = false;
+                            crouch_button_was_pressed = false;
 
                             // let available_rates =
                             //     session.enumerate_display_refresh_rates().unwrap();
@@ -578,6 +583,10 @@ fn main() {
             if xr_frame_state.predicted_display_time.as_nanos() >= change_time.as_nanos() {
                 vr_crouch.reset();
                 pending_stage_change_time = None;
+                // The reference space was redefined; drop the latched button
+                // crouch along with the height calibration.
+                crouch_toggled = false;
+                crouch_button_was_pressed = false;
             }
         }
 
@@ -614,14 +623,17 @@ fn main() {
             .state(&session, xr::Path::NULL)
             .unwrap()
             .current_state;
-        let crouch_pressed = crouch_action
-            .state(&session, xr::Path::NULL)
-            .unwrap()
-            .current_state;
-        if crouch_pressed && !crouch_button_was_pressed {
-            crouch_toggled = !crouch_toggled;
+        let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
+        // Only edge-detect while the action is live: with the session merely
+        // VISIBLE (system overlay up), current_state reads false even though
+        // the button may still be physically held, and treating that as a
+        // release would mint a spurious toggle on refocus.
+        if crouch_state.is_active {
+            if crouch_state.current_state && !crouch_button_was_pressed {
+                crouch_toggled = !crouch_toggled;
+            }
+            crouch_button_was_pressed = crouch_state.current_state;
         }
-        crouch_button_was_pressed = crouch_pressed;
 
         let left_trigger_value = left_trigger
             .state(&session, xr::Path::NULL)
@@ -656,31 +668,25 @@ fn main() {
         );
 
         // Feed the detector before the poses are transformed so this frame's
-        // physical stance decides both the crouch request and the button-latch
-        // view drop below.
+        // physical stance is available to the crouch request below. Tracked
+        // poses are NEVER artificially displaced for a button crouch: the eye
+        // cap in `render_swapchain` alone keeps the view inside the crouched
+        // collider, and it does so continuously (a rigid pose drop keyed on
+        // detector state produced below-floor eyes/hands and frame-size view
+        // pops at the hysteresis thresholds).
         let tracked_head_position = head_location.location_flags.contains(
             xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
         );
         let physically_crouched =
             vr_crouch.update(tracked_head_position.then_some(head_location.pose.position.y));
-        // Button-crouch while physically standing: drop the tracked poses by
-        // the capsule's stand/crouch height delta so the eye lands inside the
-        // crouched collider instead of poking through the ceiling it just
-        // gained clearance under. Physical crouch needs no drop - the head
-        // already moved.
-        let tracked_pose_drop = if crouch_toggled && !physically_crouched {
-            shock2vr::player_stand_crouch_drop()
-        } else {
-            0.0
-        };
-        let pose_anchor = game.player_center_above_floor() + tracked_pose_drop;
+        let center_above_floor = game.player_center_above_floor();
         let right_hand_position = stage_to_pawn(
             vec3(
                 right_aim_location.pose.position.x,
                 right_aim_location.pose.position.y,
                 right_aim_location.pose.position.z,
             ),
-            pose_anchor,
+            center_above_floor,
         );
 
         let left_hand_position = stage_to_pawn(
@@ -689,7 +695,7 @@ fn main() {
                 left_aim_location.pose.position.y,
                 left_aim_location.pose.position.z,
             ),
-            pose_anchor,
+            center_above_floor,
         );
         let left_hand_rotation = cgmath::Quaternion::new(
             left_aim_location.pose.orientation.w,
@@ -904,7 +910,6 @@ fn main() {
             true,
             &scene,
             false,
-            tracked_pose_drop,
         );
         let left_eye_elapsed = left_eye_started.elapsed();
         let right_eye_started = Instant::now();
@@ -919,7 +924,6 @@ fn main() {
             true,
             &scene,
             true,
-            tracked_pose_drop,
         );
         let right_eye_elapsed = right_eye_started.elapsed();
 
@@ -1103,7 +1107,6 @@ fn render_swapchain(
     _log: bool,
     scene: &Vec<SceneObject>,
     is_last: bool,
-    tracked_pose_drop: f32,
 ) -> () {
     let mut xr_swapchain = swapchain.handle.borrow_mut();
     let image_index1 = xr_swapchain.acquire_image().unwrap();
@@ -1122,7 +1125,7 @@ fn render_swapchain(
             view.pose.position.y,
             view.pose.position.z,
         ),
-        game.player_center_above_floor() + tracked_pose_drop,
+        game.player_center_above_floor(),
     );
     // The tracked eye belongs to a real body, not to the game capsule, so it
     // must be held inside the collider crown: a physically crouched adult's

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -342,6 +342,10 @@ fn main() {
         .create_action::<bool>("jump", "Jump", &[])
         .unwrap();
 
+    let crouch_action = action_set
+        .create_action::<bool>("crouch", "Crouch Toggle", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -417,6 +421,12 @@ fn main() {
                         .string_to_path("/user/hand/right/input/thumbstick/click")
                         .unwrap(),
                 ),
+                xr::Binding::new(
+                    &crouch_action,
+                    xr_instance
+                        .string_to_path("/user/hand/left/input/thumbstick/click")
+                        .unwrap(),
+                ),
             ],
         )
         .unwrap();
@@ -463,6 +473,12 @@ fn main() {
     let mut action_state = shock2vr::input::InputActionState::new();
     let mut vr_crouch = VrCrouchDetector::default();
     let mut pending_stage_change_time = None;
+    // Button-crouch alternative to the physical detector: left thumbstick
+    // click toggles a latched crouch request (mirroring jump on the right
+    // stick). Either source requests the crouch; the game's headroom-gated
+    // stand-up still decides when standing is actually possible.
+    let mut crouch_toggled = false;
+    let mut crouch_button_was_pressed = false;
 
     let _camera_pos = vec3(0.0, 5.0, 10.0);
 
@@ -598,6 +614,14 @@ fn main() {
             .state(&session, xr::Path::NULL)
             .unwrap()
             .current_state;
+        let crouch_pressed = crouch_action
+            .state(&session, xr::Path::NULL)
+            .unwrap()
+            .current_state;
+        if crouch_pressed && !crouch_button_was_pressed {
+            crouch_toggled = !crouch_toggled;
+        }
+        crouch_button_was_pressed = crouch_pressed;
 
         let left_trigger_value = left_trigger
             .state(&session, xr::Path::NULL)
@@ -631,14 +655,32 @@ fn main() {
             right_aim_location.pose.orientation.z,
         );
 
-        let center_above_floor = game.player_center_above_floor();
+        // Feed the detector before the poses are transformed so this frame's
+        // physical stance decides both the crouch request and the button-latch
+        // view drop below.
+        let tracked_head_position = head_location.location_flags.contains(
+            xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
+        );
+        let physically_crouched =
+            vr_crouch.update(tracked_head_position.then_some(head_location.pose.position.y));
+        // Button-crouch while physically standing: drop the tracked poses by
+        // the capsule's stand/crouch height delta so the eye lands inside the
+        // crouched collider instead of poking through the ceiling it just
+        // gained clearance under. Physical crouch needs no drop - the head
+        // already moved.
+        let tracked_pose_drop = if crouch_toggled && !physically_crouched {
+            shock2vr::player_stand_crouch_drop()
+        } else {
+            0.0
+        };
+        let pose_anchor = game.player_center_above_floor() + tracked_pose_drop;
         let right_hand_position = stage_to_pawn(
             vec3(
                 right_aim_location.pose.position.x,
                 right_aim_location.pose.position.y,
                 right_aim_location.pose.position.z,
             ),
-            center_above_floor,
+            pose_anchor,
         );
 
         let left_hand_position = stage_to_pawn(
@@ -647,7 +689,7 @@ fn main() {
                 left_aim_location.pose.position.y,
                 left_aim_location.pose.position.z,
             ),
-            center_above_floor,
+            pose_anchor,
         );
         let left_hand_rotation = cgmath::Quaternion::new(
             left_aim_location.pose.orientation.w,
@@ -672,11 +714,9 @@ fn main() {
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
         input_context.jump = jump_pressed;
-        let tracked_head_position = head_location.location_flags.contains(
-            xr::SpaceLocationFlags::POSITION_VALID | xr::SpaceLocationFlags::POSITION_TRACKED,
-        );
-        input_context.crouch =
-            vr_crouch.update(tracked_head_position.then_some(head_location.pose.position.y));
+        // The detector was already fed exactly once above (it keeps its
+        // standing calibration warm even while the button latch is active).
+        input_context.crouch = physically_crouched || crouch_toggled;
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();
@@ -864,6 +904,7 @@ fn main() {
             true,
             &scene,
             false,
+            tracked_pose_drop,
         );
         let left_eye_elapsed = left_eye_started.elapsed();
         let right_eye_started = Instant::now();
@@ -878,6 +919,7 @@ fn main() {
             true,
             &scene,
             true,
+            tracked_pose_drop,
         );
         let right_eye_elapsed = right_eye_started.elapsed();
 
@@ -1061,6 +1103,7 @@ fn render_swapchain(
     _log: bool,
     scene: &Vec<SceneObject>,
     is_last: bool,
+    tracked_pose_drop: f32,
 ) -> () {
     let mut xr_swapchain = swapchain.handle.borrow_mut();
     let image_index1 = xr_swapchain.acquire_image().unwrap();
@@ -1079,7 +1122,7 @@ fn render_swapchain(
             view.pose.position.y,
             view.pose.position.z,
         ),
-        game.player_center_above_floor(),
+        game.player_center_above_floor() + tracked_pose_drop,
     );
     let head_rotation = cgmath::Quaternion::new(
         view.pose.orientation.w,

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -19,10 +19,9 @@ pub struct InputContext {
     // scene wants a cursor (e.g. menus).
     pub pointer: Option<Pointer2D>,
 
-    // Flat-runtime crouch request (desktop key / debug-runtime channel). The
-    // *actual* crouch state can lag this: standing up is refused while there
-    // is no headroom. VR leaves this false - physically crouching moves the
-    // HMD instead.
+    // Runtime crouch request (flat key/debug channel, or physical VR head
+    // height). The *actual* crouch state can lag this: standing up is refused
+    // while there is no headroom.
     pub crouch: bool,
 
     // Ordinary locomotion jump request. Runtimes provide this as a held

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -34,6 +34,7 @@ mod ui;
 mod util;
 mod virtual_hand;
 mod vr_config;
+pub mod vr_crouch;
 pub mod zip_asset_path;
 
 use scenes::{

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -73,17 +73,6 @@ pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EY
 /// cannot poke through a low ceiling the collider clears.
 pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 
-/// How far (world units) a VR runtime must lower the tracked poses when the
-/// player requests crouch with a button while physically standing: the full
-/// stand/crouch capsule height delta. The feet stay planted as the capsule
-/// shrinks, so a physically standing eye would otherwise sit far above the
-/// crouched capsule's crown - outside the collider, poking through the very
-/// ceiling the crouch just gained clearance under. A *physical* crouch needs
-/// no such drop: the tracked head already moved.
-pub fn player_stand_crouch_drop() -> f32 {
-    2.0 * physics::player_crouch_center_shift()
-}
-
 /// Real-world meters per world unit: 1 world unit is `dark::SCALE_FACTOR`
 /// (2.5) SS2 feet, and an SS2 foot is a real foot (0.3048 m). VR runtimes
 /// divide floor-relative tracked poses (meters) by this before feeding them

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1461,6 +1461,14 @@ impl Game {
         physics::player_center_above_floor(self.active_game_scene.player_is_crouched())
     }
 
+    /// Highest the eye may sit (world units) above the player collider's
+    /// center for the current stance. VR runtimes clamp the tracked eye to
+    /// this so the camera cannot leave the collider crown; see
+    /// [`physics::player_eye_cap_above_center`].
+    pub fn player_eye_cap_above_center(&self) -> f32 {
+        physics::player_eye_cap_above_center(self.active_game_scene.player_is_crouched())
+    }
+
     pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
         let (scene, pos, rot) = self
             .active_game_scene

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -73,6 +73,17 @@ pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EY
 /// cannot poke through a low ceiling the collider clears.
 pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 
+/// How far (world units) a VR runtime must lower the tracked poses when the
+/// player requests crouch with a button while physically standing: the full
+/// stand/crouch capsule height delta. The feet stay planted as the capsule
+/// shrinks, so a physically standing eye would otherwise sit far above the
+/// crouched capsule's crown - outside the collider, poking through the very
+/// ceiling the crouch just gained clearance under. A *physical* crouch needs
+/// no such drop: the tracked head already moved.
+pub fn player_stand_crouch_drop() -> f32 {
+    2.0 * physics::player_crouch_center_shift()
+}
+
 /// Real-world meters per world unit: 1 world unit is `dark::SCALE_FACTOR`
 /// (2.5) SS2 feet, and an SS2 foot is a real foot (0.3048 m). VR runtimes
 /// divide floor-relative tracked poses (meters) by this before feeding them

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -101,17 +101,18 @@ const PLAYER_EYE_CAP_MARGIN: f32 = 0.2;
 /// tracked eye poses to this - a tracked head is a real body's head, not the
 /// game capsule's, and a physically crouched adult's eye is well above the
 /// short crouched capsule's crown. Uncapped, such a player sees over and
-/// through geometry the capsule itself clears. Crouched this is 1.2 ft above
-/// the center - 2.6 ft above the feet, exactly the flat runtime's
-/// [`crate::PLAYER_CROUCH_EYE_HEIGHT`]; standing it is 2.8 ft, which only an
-/// unusually tall player ever reaches, so tracking stays 1:1 in practice.
+/// through geometry the capsule itself clears. Crouched, the cap IS the flat
+/// runtime's [`crate::PLAYER_CROUCH_EYE_HEIGHT`] (2.6 ft above the feet), so
+/// VR and flat can never disagree about the crouched eye line; standing it is
+/// the crown less [`PLAYER_EYE_CAP_MARGIN`] (2.8 ft above the center), which
+/// only an unusually tall player ever reaches, so tracking stays 1:1 in
+/// practice.
 pub fn player_eye_cap_above_center(crouched: bool) -> f32 {
-    let height = if crouched {
-        PLAYER_CROUCH_HEIGHT
+    if crouched {
+        crate::PLAYER_CROUCH_EYE_HEIGHT / SCALE_FACTOR
     } else {
-        PLAYER_STANDING_HEIGHT
-    };
-    (height / 2.0 - PLAYER_EYE_CAP_MARGIN) / SCALE_FACTOR
+        (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_EYE_CAP_MARGIN) / SCALE_FACTOR
+    }
 }
 
 /// Height (world units) of the collider CENTER above the surface the player

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -91,6 +91,29 @@ pub fn player_crouch_center_shift() -> f32 {
     (PLAYER_STANDING_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR
 }
 
+/// Clearance (SS2 ft) kept between a capped eye and the capsule crown, so the
+/// camera stays strictly inside the collider rather than sitting exactly on
+/// its surface where a coplanar ceiling could still catch it.
+const PLAYER_EYE_CAP_MARGIN: f32 = 0.2;
+
+/// Highest the eye may sit (world units) above the collider CENTER for a
+/// stance: the capsule crown less [`PLAYER_EYE_CAP_MARGIN`]. VR runtimes clamp
+/// tracked eye poses to this - a tracked head is a real body's head, not the
+/// game capsule's, and a physically crouched adult's eye is well above the
+/// short crouched capsule's crown. Uncapped, such a player sees over and
+/// through geometry the capsule itself clears. Crouched this is 1.2 ft above
+/// the center - 2.6 ft above the feet, exactly the flat runtime's
+/// [`crate::PLAYER_CROUCH_EYE_HEIGHT`]; standing it is 2.8 ft, which only an
+/// unusually tall player ever reaches, so tracking stays 1:1 in practice.
+pub fn player_eye_cap_above_center(crouched: bool) -> f32 {
+    let height = if crouched {
+        PLAYER_CROUCH_HEIGHT
+    } else {
+        PLAYER_STANDING_HEIGHT
+    };
+    (height / 2.0 - PLAYER_EYE_CAP_MARGIN) / SCALE_FACTOR
+}
+
 /// Height (world units) of the collider CENTER above the surface the player
 /// stands on, per stance: half the capsule height plus the resting gap the
 /// character controller maintains. VR runtimes subtract this from the body

--- a/shock2vr/src/vr_crouch.rs
+++ b/shock2vr/src/vr_crouch.rs
@@ -1,0 +1,114 @@
+//! Turns floor-relative VR head height into the shared crouch request.
+
+const CROUCH_ENTER_HEIGHT_RATIO: f32 = 0.70;
+const CROUCH_EXIT_HEIGHT_RATIO: f32 = 0.85;
+
+// Reject impossible floor-relative heights before they can permanently poison
+// the session's max-height calibration. Zero is retained because putting a
+// tracked headset on the floor is still a meaningful crouch observation.
+const MAX_PLAUSIBLE_EYE_HEIGHT_METERS: f32 = 3.0;
+
+/// Stateful physical-crouch detector for floor-relative tracked head heights.
+///
+/// The detector calibrates standing eye height from the tallest valid sample
+/// seen in the current reference space. It uses separate enter/exit thresholds
+/// so ordinary tracking noise around either boundary cannot chatter the player
+/// collider between shapes.
+#[derive(Debug, Default)]
+pub struct VrCrouchDetector {
+    standing_eye_height: Option<f32>,
+    crouching: bool,
+}
+
+impl VrCrouchDetector {
+    /// Observe a tracked, floor-relative eye height in meters.
+    ///
+    /// `None` means tracking is currently unavailable; the last request is
+    /// retained until a valid sample returns.
+    pub fn update(&mut self, tracked_eye_height: Option<f32>) -> bool {
+        let Some(eye_height) = tracked_eye_height.filter(|height| {
+            height.is_finite() && (0.0..=MAX_PLAUSIBLE_EYE_HEIGHT_METERS).contains(height)
+        }) else {
+            return self.crouching;
+        };
+
+        // The first pose may arrive while the headset is being donned or while
+        // the user is already low. Let later, taller tracked poses refine the
+        // calibration without requiring a separate calibration UI.
+        let standing_eye_height = self
+            .standing_eye_height
+            .map_or(eye_height, |calibrated| calibrated.max(eye_height));
+        self.standing_eye_height = Some(standing_eye_height);
+
+        let height_ratio = eye_height / standing_eye_height;
+        if self.crouching {
+            if height_ratio > CROUCH_EXIT_HEIGHT_RATIO {
+                self.crouching = false;
+            }
+        } else if height_ratio < CROUCH_ENTER_HEIGHT_RATIO {
+            self.crouching = true;
+        }
+
+        self.crouching
+    }
+
+    /// Forget calibration after the runtime changes its floor reference space.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VrCrouchDetector;
+
+    #[test]
+    fn crouches_and_stands_with_hysteresis() {
+        let mut detector = VrCrouchDetector::default();
+
+        assert!(!detector.update(Some(1.70)));
+        assert!(!detector.update(Some(1.20)));
+        assert!(detector.update(Some(1.18)));
+
+        // Remain crouched throughout the dead band between 70% and 85%.
+        assert!(detector.update(Some(1.30)));
+        assert!(detector.update(Some(1.44)));
+        assert!(!detector.update(Some(1.45)));
+
+        // Remain standing throughout that same dead band.
+        assert!(!detector.update(Some(1.30)));
+    }
+
+    #[test]
+    fn calibration_adapts_when_the_first_sample_was_crouched() {
+        let mut detector = VrCrouchDetector::default();
+
+        assert!(!detector.update(Some(1.05)));
+        assert!(!detector.update(Some(1.70)));
+        assert!(detector.update(Some(1.10)));
+    }
+
+    #[test]
+    fn unavailable_or_invalid_tracking_preserves_the_current_request() {
+        let mut detector = VrCrouchDetector::default();
+        detector.update(Some(1.70));
+        assert!(detector.update(Some(1.00)));
+
+        assert!(detector.update(None));
+        assert!(detector.update(Some(f32::NAN)));
+        assert!(detector.update(Some(f32::INFINITY)));
+        assert!(detector.update(Some(-0.1)));
+        assert!(detector.update(Some(3.1)));
+    }
+
+    #[test]
+    fn reset_discards_state_and_calibration() {
+        let mut detector = VrCrouchDetector::default();
+        detector.update(Some(1.70));
+        assert!(detector.update(Some(1.00)));
+
+        detector.reset();
+
+        assert!(!detector.update(Some(1.00)));
+    }
+}

--- a/shock2vr/src/vr_crouch.rs
+++ b/shock2vr/src/vr_crouch.rs
@@ -40,6 +40,13 @@ impl VrCrouchDetector {
             .map_or(eye_height, |calibrated| calibrated.max(eye_height));
         self.standing_eye_height = Some(standing_eye_height);
 
+        // A headset resting on the floor legitimately calibrates 0.0; the
+        // ratio below would be 0/0 = NaN, which happens to preserve state via
+        // NaN comparison semantics - make that explicit instead of accidental.
+        if standing_eye_height <= 0.0 {
+            return self.crouching;
+        }
+
         let height_ratio = eye_height / standing_eye_height;
         if self.crouching {
             if height_ratio > CROUCH_EXIT_HEIGHT_RATIO {


### PR DESCRIPTION
Fixes #512

## What this adds

VR crouch, from two sources, on top of the feet-anchored tracked-pose pipeline from #848:

- **Physical crouch** (`shock2vr/src/vr_crouch.rs`): a stateful detector turns floor-relative tracked head height into the shared `InputContext.crouch` request. It calibrates standing height as the running max of valid samples, enters crouch below 70% and exits above 85% (hysteresis dead band against tracking noise), retains the last request through tracking loss, and recalibrates on session restart and reference-space changes (deferred to the exact `changeTime`). The existing feet-planted collider resize and headroom-gated stand-up path are reused unchanged.
- **Button crouch**: left-thumbstick click toggles a latched crouch request (mirroring jump on the right stick), ORed with the detector. The latch resets with the session and on reference-space changes, and its edge detection is gated on action liveness so a click spanning a focus loss cannot mint a spurious toggle.
- **Eye containment**: the rendered eye is capped just below the current capsule's crown (`player_eye_cap_above_center`). A tracked head is a real body's, not the capsule's — a physically crouched adult's eye sits well above the 2.8 ft crouched capsule, and uncapped the player sees over and through the very geometry the capsule clears. Crouched, the cap is derived directly from the flat runtime's `PLAYER_CROUCH_EYE_HEIGHT`, so VR and flat can never disagree about the crouched eye line; standing, it binds only for improbably tall players, so tracking stays 1:1.

## Review

Cross-engine adversarial review (two independent engines + a dedicated duplication pass) ran on the branch; all agreed findings are addressed in the final commit. Notably, an earlier revision rigidly dropped the tracked poses during a latched-but-standing crouch — both engines flagged that it could place the eye and hands below the floor and popped the view a frame-size step at the hysteresis thresholds; it was removed in favor of the cap, which achieves the same containment continuously. One accepted transient remains: when the detector fires mid-descent, the cap engages with a sub-second catch-up while the head continues down — on-device this reads as normal crouch feel.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `cargo test -p shock2vr` — 552 passed (includes the detector unit suite)
- `cargo apk build --release` — zero warnings (validates against openxr 0.21.1, post-#718)
- **Quest 3 on-device, iterated across three sessions**: physical crouch traverses the previously-impassable MedSci crouch-only duct; the crouched eye stays inside the duct (no seeing over/out of the world); standing eye height verified at the retail line against an NPC; steady 90 Hz, zero skipped frames throughout.

## Notes

- Debugging the eye-height reports along the way surfaced two adjacent issues, handled separately: launch-time ANRs from the unserviced Android event queue (#911, follow-up #910) and STAGE floor-origin instability when Guardian is disturbed by unattended launches (device automation now restores Guardian immediately after launch; a future hardening option is self-calibrating the floor from the detector's standing height).
- The detector's running-max calibration can be inflated by lifting the headset overhead while donning; thresholds recover on the next session or reference-space change. A decay/percentile calibration is a possible follow-up if it bothers in practice.
