### PR TITLE
fix(pathfinding): seal permanently closed doors

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -989,6 +989,13 @@ impl PropTranslatingDoor {
     pub fn is_permanently_open(&self) -> bool {
         !self.has_travel() && self.state == 1
     }
+
+    /// A doorway that can never open: no travel, and not authored open.
+    /// These doors remain physical barriers regardless of their lock state
+    /// (e.g. medsci1's space-shield membranes).
+    pub fn is_permanently_closed(&self) -> bool {
+        !self.has_travel() && self.state != 1
+    }
 }
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1078,18 +1078,18 @@ impl MissionCore {
         // Sync live door state into the pathfinding service: impassable
         // doors make their below-door cells unpathable, so A* routes around
         // them (or stops at them) instead of through them. Impassable means
-        // locked-and-closed, OR a door this engine cannot operate at all - no
-        // runtime entity, or no TransDoor prop (e.g. medsci1's space-shield
-        // membranes, which StdDoor can't move; AIs wedged against them
-        // forever - issue #489). Unlocked closed translating doors stay
-        // pathable - pursuing AIs open those on arrival.
+        // locked-and-closed, a zero-travel TransDoor authored closed (e.g.
+        // medsci1's space-shield membranes), OR a door this engine cannot
+        // operate at all - no runtime entity or no TransDoor prop. Unlocked
+        // closed translating doors with real travel stay pathable - pursuing
+        // AIs open those on arrival.
         if time.elapsed.as_secs_f32() > 0.0 {
             if let Some(service) = &self.pathfinding_service {
                 if let Ok(id_map) = self
                     .world
                     .borrow::<UniqueView<crate::mission::GlobalTemplateIdMap>>()
                 {
-                    let locked: std::collections::HashSet<i32> = service
+                    let blocked: std::collections::HashSet<i32> = service
                         .path_database
                         .cell_doors
                         .iter()
@@ -1100,19 +1100,10 @@ impl MissionCore {
                                 // nothing can ever open it
                                 return true;
                             };
-                            match crate::scripts::script_util::door_is_closed(&self.world, ent) {
-                                Some(true) => {
-                                    crate::scripts::script_util::is_entity_locked(&self.world, ent)
-                                }
-                                Some(false) => false,
-                                // Not a translating door: neither AIs nor
-                                // StdDoor can move it - a wall until shield/
-                                // rotating door support exists
-                                None => true,
-                            }
+                            crate::scripts::script_util::door_blocks_pathfinding(&self.world, ent)
                         })
                         .collect();
-                    service.set_locked_doors(locked);
+                    service.set_blocked_doors(blocked);
                 }
             }
         }

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -193,11 +193,12 @@ pub struct PathfindingService {
     /// cells) so one blocked doorway can't seal every other entrance into
     /// a large cell.
     blocked_links: std::sync::Mutex<HashMap<(u32, u32), f32>>,
-    /// Mission object ids of doors that are currently locked AND closed -
-    /// A* refuses links into their below-door cells (the runtime door gate;
-    /// closed-but-openable doors stay pathable and are opened on arrival).
+    /// Mission object ids of doors that are impassable: locked-and-closed,
+    /// permanently closed, or otherwise inoperable. A* refuses links into
+    /// their below-door cells; closed-but-openable doors stay pathable and
+    /// are opened on arrival.
     /// Synced from live door state by the mission update.
-    locked_doors: std::sync::RwLock<std::collections::HashSet<i32>>,
+    blocked_doors: std::sync::RwLock<std::collections::HashSet<i32>>,
     queries: AtomicU64,
     stressed_retries: AtomicU64,
     no_route: AtomicU64,
@@ -265,18 +266,19 @@ impl PathfindingService {
             ai_paths: std::sync::Mutex::new(HashMap::new()),
             ai_steering: std::sync::Mutex::new(HashMap::new()),
             blocked_links: std::sync::Mutex::new(HashMap::new()),
-            locked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
+            blocked_doors: std::sync::RwLock::new(std::collections::HashSet::new()),
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
             no_route: AtomicU64::new(0),
         }
     }
 
-    /// Replace the set of locked-and-closed doors (mission object ids).
-    /// Their below-door cells become unpathable until unlocked/opened.
-    pub fn set_locked_doors(&self, doors: std::collections::HashSet<i32>) {
-        if let Ok(mut locked) = self.locked_doors.write() {
-            *locked = doors;
+    /// Replace the set of impassable doors (mission object ids). Their
+    /// below-door cells remain unpathable until the next state sync removes
+    /// them.
+    pub fn set_blocked_doors(&self, doors: std::collections::HashSet<i32>) {
+        if let Ok(mut blocked) = self.blocked_doors.write() {
+            *blocked = doors;
         }
     }
 
@@ -703,16 +705,16 @@ impl PathfindingService {
             return false;
         }
 
-        // Door gate: a below-door cell whose door is locked (and closed) is
-        // not traversable - the AI can't follow the player through it.
-        // Closed-but-openable doors stay pathable; the pursuing AI opens
-        // them on arrival.
+        // Door gate: a below-door cell whose door is impassable is not
+        // traversable - the AI can't follow the player through it.
+        // Closed-but-openable doors stay pathable; the pursuing AI opens them
+        // on arrival.
         if dest.flags.contains(PathCellFlags::BELOW_DOOR) {
             if let Some(door) = self.cell_to_door.get(&link.to_cell) {
                 if self
-                    .locked_doors
+                    .blocked_doors
                     .read()
-                    .map(|locked| locked.contains(door))
+                    .map(|blocked| blocked.contains(door))
                     .unwrap_or(false)
                 {
                     return false;
@@ -1324,13 +1326,13 @@ pub(crate) mod tests {
             "unlocked door cell must be pathable"
         );
 
-        service.set_locked_doors([99].into());
+        service.set_blocked_doors([99].into());
         assert!(
             service.find_path(start, goal, MovementBits::WALK).is_none(),
             "locked door cell must be unpathable"
         );
 
-        service.set_locked_doors(Default::default());
+        service.set_blocked_doors(Default::default());
         assert!(
             service.find_path(start, goal, MovementBits::WALK).is_some(),
             "unlocking must restore the route"

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -113,6 +113,27 @@ pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
     Some(to_closed <= to_open)
 }
 
+/// Whether a cell-gating entity is an obstacle A* must not cross.
+///
+/// Closed-but-unlocked translating doors stay pathable because a pursuing AI
+/// opens them on arrival. Entities that are not translating doors cannot be
+/// operated by `StdDoor`, so they remain walls.
+pub fn door_blocks_pathfinding(world: &World, entity_id: EntityId) -> bool {
+    match door_is_closed(world, entity_id) {
+        Some(true) => {
+            let permanently_closed = world
+                .borrow::<View<dark::properties::PropTranslatingDoor>>()
+                .unwrap()
+                .get(entity_id)
+                .map(|door| door.is_permanently_closed())
+                .unwrap_or(false);
+            permanently_closed || is_entity_locked(world, entity_id)
+        }
+        Some(false) => false,
+        None => true,
+    }
+}
+
 pub fn get_all_links_with_template<TData>(
     world: &World,
     producing_entity_id: EntityId,
@@ -771,7 +792,9 @@ pub fn change_to_first_model(world: &World, entity_id: EntityId) -> Effect {
 
 #[cfg(test)]
 mod tests {
-    use super::{debit_player_nanites, door_is_closed, plan_stack_payment};
+    use super::{
+        debit_player_nanites, door_blocks_pathfinding, door_is_closed, plan_stack_payment,
+    };
     use crate::mission::PlayerInfo;
     use crate::runtime_props::RuntimePropTransform;
     use cgmath::{Matrix4, Quaternion, Vector3, vec3};
@@ -820,6 +843,33 @@ mod tests {
         let (world, door) = door_world(at, at, 0, at);
 
         assert_eq!(door_is_closed(&world, door), Some(true));
+    }
+
+    #[test]
+    fn a_zero_travel_door_authored_closed_blocks_pathfinding() {
+        // medsci1's space shields have no lock, but have nowhere to move:
+        // A* must treat their below-door cells as permanently sealed (#606).
+        let at = vec3(-15.5, 1.4, 61.0);
+        let (world, door) = door_world(at, at, 0, at);
+
+        assert!(door_blocks_pathfinding(&world, door));
+    }
+
+    #[test]
+    fn a_permanently_open_door_does_not_block_pathfinding() {
+        let at = vec3(18.0, -0.4, 41.8);
+        let (world, door) = door_world(at, at, 1, at);
+
+        assert!(!door_blocks_pathfinding(&world, door));
+    }
+
+    #[test]
+    fn an_unlocked_travelling_door_does_not_block_pathfinding() {
+        let closed = vec3(10.3, -0.4, 42.0);
+        let open = vec3(10.3, -0.4, 44.3);
+        let (world, door) = door_world(closed, open, 0, closed);
+
+        assert!(!door_blocks_pathfinding(&world, door));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #606

## Reproduction

`medsci1.mis` mission objects 469 and 948 (`space_shield_10x24`, template `-2839`) are translating doors authored with state 0 and identical open/closed endpoints. They have no `PropLocked`, so `door_is_closed` correctly reported closed but the mission's A* state sync classified them as traversable: its closed-door branch only tested the lock.

This is a general retail authoring pattern, not a shield-name special case. The survey documented in #606 / merged #607 found 25 zero-travel doors authored closed across the shipped missions.

Negative-first regression on unmodified behavior:

```text
cargo test -p shock2vr --lib scripts::script_util::tests::a_zero_travel_door_authored_closed_blocks_pathfinding -- --exact

assertion failed: door_blocks_pathfinding(&world, door)
test result: FAILED. 0 passed; 1 failed
```

## Fix

- Add `PropTranslatingDoor::is_permanently_closed()` beside the existing permanent-open semantic.
- Classify a closed door as an A* blocker when it is either locked or permanently closed.
- Keep zero-travel authored-open doors and ordinary unlocked travelling doors pathable.
- Rename the service's internal locked-door set to blocked doors and correct the stale comment that said the medsci shields lacked a TransDoor property.

## Runtime path evidence

The stable shield identity was discovered each run by name; no runtime entity ID was hardcoded. The runtime reported mission IDs 469 and 948 at the authored shield location.

Cell 298 is the `BELOW_DOOR` cell at mission object 469. Without live door-state sync, the raw database query crosses it directly:

```text
cargo bn path show medsci1.mis \
  --from=-17.7,-1.2,63.4 --to=-13.3,-1.2,60.0

start cell: Some(299)  goal cell: Some(288)
4 waypoints ... [1] cell Some(298)
```

After one positive-dt update synced the fixed door state, the debug runtime's real `/v1/pathfinding-test` request for the same points reported:

```text
No direct path found. Computed fallback path with 8 waypoints to closest reachable position (-12.47, -1.20, 60.97).
```

Thus A* stops on the reachable side instead of routing through the immovable shield. The unit controls prove a permanently-open door and a closed, unlocked door with real travel remain pathable; the existing path service gate test still proves clearing a transient door block restores its route.

## Path benchmark

Identical command before and after:

```text
cargo bn path bench medsci1.mis --queries 500 --seed 6062026 --json
```

| Metric | Before | After |
| --- | ---: | ---: |
| found / no route | 496 / 4 | 496 / 4 |
| mean inflation | 1.7015939 | 1.7015939 |
| p95 inflation | 2.8828557 | 2.8828557 |
| mean waypoints | 40.73387 | 40.73387 |
| find path p50 / p95 / max (us) | 446 / 729 / 1699 | 468 / 788 / 1798 |

Quality/results are identical. The small timing delta is run-to-run machine noise; this benchmark loads static AIPATH data and does not run the mission's live door-state sync.

## Verification

- `cargo test -p dark` — 66 unit + 8 mission integration passed.
- `cargo test -p shock2vr` — 350 passed.
- Focused blocker controls — 10 passed; path service door gate passed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed.
- `cargo fmt --all -- --check` — passed.
- Full SDK e2e: 167 / 169 passed, including all 23 mission loads and the pathfinding scenario. Both failures reproduce identically on clean current `origin/main` (`ff27da16`): Earth Cryokinesis does not damage the Training Droid, and `world-aim-e2e` loads an already corrupt/incompatible save. Neither exercises door/path-state classification.

## Visual determination

No rendering, HUD, model, material, animation, or other visible asset changed. This is navigation-state behavior only, so `pr-visuals` does not apply.
