### PR TITLE
fix(gameplay): preserve keycard pickup effects

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -23,7 +23,9 @@ use crate::{
     runtime_props::RuntimePropReloading,
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
-    virtual_hand::{VirtualHandEffect, can_grab_item, is_wieldable_weapon},
+    virtual_hand::{
+        VirtualHandEffect, can_grab_item, is_wieldable_weapon, uses_scripted_world_frob,
+    },
 };
 
 /// Fallback viewmodel framing offset (look space: +x right, +y up, -z forward),
@@ -118,7 +120,9 @@ impl FlatPlayerController {
     /// Apply the original flat pickup split: weapons become the first-person
     /// viewmodel, while ordinary loot goes straight into the backpack.
     fn pick_up(&mut self, world: &World, entity_id: EntityId) -> Vec<VirtualHandEffect> {
-        if is_wieldable_weapon(world, entity_id) {
+        if uses_scripted_world_frob(world, entity_id) {
+            vec![out_message(entity_id, MessagePayload::Frob)]
+        } else if is_wieldable_weapon(world, entity_id) {
             self.wield(entity_id)
         } else {
             vec![VirtualHandEffect::StoreItem { entity_id }]
@@ -287,7 +291,7 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::PropPlayerGun;
+    use dark::properties::{FrobFlag, PropFrobInfo, PropPlayerGun};
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -342,6 +346,32 @@ mod tests {
                 [VirtualHandEffect::HoldItem { entity_id }] if *entity_id == weapon
             ),
             "weapon pickup should preserve flat auto-wield"
+        );
+    }
+
+    #[test]
+    fn world_use_of_scripted_pickup_dispatches_frob_instead_of_bypassing_it() {
+        let mut world = World::new();
+        let keycard = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::MOVE | FrobFlag::SCRIPT,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, keycard);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                }] if *to == keycard
+            ),
+            "a MOVE | SCRIPT pickup must run its authored Frob path"
         );
     }
 }

--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -1,4 +1,5 @@
-use shipyard::{EntityId, UniqueView, World};
+use dark::properties::PropKeySrc;
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
@@ -21,6 +22,19 @@ impl Script for FrobQB {
         match msg {
             MessagePayload::Frob => match set_quest_bit_effect(world, entity_id) {
                 Some(quest_bit_effect) => {
+                    // PropKeySrc entities always receive `internal_keycard`.
+                    // That script owns both access acquisition and the card's
+                    // physical transfer/consumption, so FrobQB must contribute
+                    // only the authored quest bit. Otherwise the two scripts
+                    // would both reparent (or destroy) the same entity.
+                    let is_keycard = world
+                        .borrow::<View<PropKeySrc>>()
+                        .map(|keycards| keycards.get(entity_id).is_ok())
+                        .unwrap_or(false);
+                    if is_keycard {
+                        return quest_bit_effect;
+                    }
+
                     // What happens to the object after the quest bit is awarded
                     // is decided by its `PropFrobInfo`, not by this script: a
                     // pickup item (`world_action` with MOVE/USE_AMMO - the
@@ -146,6 +160,43 @@ mod tests {
                 .iter()
                 .any(|effect| matches!(effect, Effect::DestroyEntity { .. })),
             "a take-able object must not be destroyed, got {effects:?}"
+        );
+    }
+
+    #[test]
+    fn keycard_frob_qb_leaves_physical_ownership_to_the_keycard_script() {
+        use dark::properties::{KeyCard, PropKeySrc};
+
+        let (mut world, object, _inventory) = quest_object_world(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        world.add_component(
+            object,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+
+        let effects = Effect::flatten(vec![FrobQB::new().handle_message(
+            object,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_1_10"
+            )),
+            "FrobQB must still award the keycard's authored quest bit, got {effects:?}"
+        );
+        assert!(
+            !effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DropEntityInfo { .. } | Effect::DestroyEntity { .. }
+            )),
+            "the internal keycard script must be the sole physical owner, got {effects:?}"
         );
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -296,18 +296,28 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             // feeds an item into a container (drop_entity_into_container).
             // Guarded by the same grabbability check as the debug give
             // lever: reparenting a non-grabbable entity would corrupt it.
-            // Use-only contained objects (notably corpse audio logs) still
-            // need their normal Frob behavior when clicked; they are consumed
-            // or recorded in place rather than moved into the backpack.
+            // Scripted contained objects (including MOVE | SCRIPT keycards)
+            // must run their authored Frob behavior first; their scripts own
+            // any transfer/consumption so quest and access effects cannot be
+            // bypassed. Ordinary MOVE loot keeps the direct transfer.
             ContainerGuiMsg::Take(ent) => {
+                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                    return (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    );
+                }
                 if !crate::virtual_hand::can_grab_item(world, *ent) {
                     let is_use_only = world
                         .borrow::<View<PropFrobInfo>>()
                         .map(|frob| {
-                            frob.get(*ent).is_ok_and(|frob| {
-                                frob.world_action.contains(FrobFlag::SCRIPT)
-                                    || frob.inventory_action.contains(FrobFlag::SCRIPT)
-                            })
+                            frob.get(*ent)
+                                .is_ok_and(|frob| frob.inventory_action.contains(FrobFlag::SCRIPT))
                         })
                         .unwrap_or(false);
                     return if is_use_only {
@@ -354,12 +364,12 @@ mod tests {
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.
-    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+    fn loot_world_with_action(world_action: FrobFlag) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let item = world.add_entity((
             PropObjIcon("icn_psi".to_owned()),
             PropFrobInfo {
-                world_action: FrobFlag::MOVE,
+                world_action,
                 inventory_action: FrobFlag::empty(),
                 tool_action: FrobFlag::empty(),
             },
@@ -382,6 +392,10 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        loot_world_with_action(FrobFlag::MOVE)
     }
 
     fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
@@ -435,6 +449,33 @@ mod tests {
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn loot_container_click_frobs_a_scripted_pickup() {
+        let (world, container, item, _inventory) =
+            loot_world_with_action(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "taking MOVE | SCRIPT loot must run its authored Frob path, got {effect:?}"
+        );
     }
 
     /// Use-only objects can be contained too. Audio logs are the critical

--- a/shock2vr/src/scripts/internal_keycard_script.rs
+++ b/shock2vr/src/scripts/internal_keycard_script.rs
@@ -1,8 +1,8 @@
 use dark::properties::PropKeySrc;
 
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script};
 
@@ -35,13 +35,132 @@ impl Script for KeyCardScript {
                     }
                 };
 
-                let destroy_self = Effect::DestroyEntity { entity_id };
-                Effect::Combined {
-                    effects: vec![acquire_key_card, destroy_self],
-                }
+                // A physical (`MOVE` / `USE_AMMO`) card remains legible in the
+                // player's backpack after granting access. This script is the
+                // sole owner of a keycard's physical fate; authored scripts
+                // such as FrobQB contribute their side effects but do not
+                // independently reparent the same entity.
+                let physical_fate = if crate::virtual_hand::can_grab_item(world, entity_id) {
+                    world
+                        .borrow::<UniqueView<PlayerInfo>>()
+                        .map(|player| Effect::DropEntityInfo {
+                            parent_entity_id: player.inventory_entity_id,
+                            dropped_entity_id: entity_id,
+                        })
+                        .unwrap_or(Effect::DestroyEntity { entity_id })
+                } else {
+                    Effect::DestroyEntity { entity_id }
+                };
+
+                Effect::combine(vec![acquire_key_card, physical_fate])
             }
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{FrobFlag, KeyCard, Links, PropFrobInfo, PropKeySrc};
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::KeyCardScript;
+
+    fn keycard_world(world_action: FrobFlag) -> (World, shipyard::EntityId, shipyard::EntityId) {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+            PropFrobInfo {
+                world_action,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, keycard, inventory)
+    }
+
+    #[test]
+    fn frobbing_a_takeable_keycard_grants_access_and_stores_it() {
+        let (world, keycard, inventory) = keycard_world(FrobFlag::MOVE | FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            keycard,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::AcquireKeyCard { key_card }
+                    if key_card.region_id == 32 && key_card.lock_id == 0
+            )),
+            "frobbing a keycard must grant its access state, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DropEntityInfo {
+                    parent_entity_id,
+                    dropped_entity_id,
+                } if *parent_entity_id == inventory && *dropped_entity_id == keycard
+            )),
+            "a MOVE keycard must remain as a physical backpack item, got {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { .. })),
+            "a MOVE keycard must not be destroyed, got {effects:?}"
+        );
+    }
+
+    #[test]
+    fn frobbing_a_use_only_keycard_still_consumes_it() {
+        let (world, keycard, _inventory) = keycard_world(FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            keycard,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AcquireKeyCard { .. })),
+            "use-only keycards must still grant access, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DestroyEntity { entity_id } if *entity_id == keycard
+            )),
+            "use-only keycards must keep consume-on-frob behavior, got {effects:?}"
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -512,6 +512,20 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
+/// Whether taking this world item must go through its authored scripts before
+/// the physical transfer. `MOVE | SCRIPT` quest items and keycards use this
+/// route so pickup cannot bypass their quest/access side effects.
+pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropFrobInfo>>()
+        .map(|frob_info| {
+            frob_info
+                .get(entity_id)
+                .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
+        })
+        .unwrap_or(false)
+}
+
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
 /// a melee arm (`PropLimbModel`). Clicking one in the backpack/strip wields it
 /// (`Effect::GrabEntity`) instead of using it; shared by `ContainerGui` and the

--- a/tools/shock2-sdk/test/keycard-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/keycard-pickup.e2e.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable mission-object ids. Runtime ids are rediscovered after every launch
+// and level transition.
+const REC2_CREW_CORPSE = 419;
+const REC2_CREW_KEY = 996;
+const REC1_CREW_SLOT = 293;
+const REC1_CREW_DOORS = [1580, 1582] as const;
+
+test(
+  "Rec Crew Key loot grants access, remains visible, and opens the Crew gate",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8193),
+    });
+    await game.step({ frames: 5 });
+
+    const [corpse] = await game.entities.byTemplate(REC2_CREW_CORPSE);
+    const [keycard] = await game.entities.byTemplate(REC2_CREW_KEY);
+    assert.ok(corpse, "expected rec2 female corpse mission object 419");
+    assert.equal(keycard?.name, "Rec Crew Key", "expected Rec Crew Key object 996");
+
+    // Production loot flow: open the corpse's ContainerGui and click the
+    // contained card. MOVE | SCRIPT must dispatch Frob rather than bypassing
+    // the card's FrobQB and internal keycard scripts.
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "frobbing corpse 419 should open its loot panel");
+    const cardButton = panel.elements.find(
+      (element) =>
+        element.kind === "button" &&
+        element.entity_id === keycard.id &&
+        element.label === "Rec Crew Key",
+    );
+    assert.ok(cardButton, "corpse 419 should expose the Rec Crew Key loot button");
+    await clickUiElement(game, cardButton);
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === keycard.id)?.location,
+      "inventory",
+      `the physical card must remain in the backpack; got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      await game.quests.get("crewcahd"),
+      "incomplete",
+      "the card's authored FrobQB quest bit must run during loot Take",
+    );
+
+    // Key access is persistent player state rather than inferred from the
+    // physical inventory item. Carry it through the real mission-load path,
+    // then exercise the matching region-32/lock-0 slot and authored doors.
+    await game.transitionLevel("rec1.mis");
+    await game.step({ frames: 5 });
+
+    const [slot] = await game.entities.byTemplate(REC1_CREW_SLOT);
+    assert.ok(slot, "expected rec1 Crew card slot mission object 293");
+    const doors = await Promise.all(
+      REC1_CREW_DOORS.map(async (objectId) => {
+        const [door] = await game.entities.byTemplate(objectId);
+        assert.ok(door, `expected rec1 Crew door mission object ${objectId}`);
+        return door;
+      }),
+    );
+    const before = doors.map((door) => door.position);
+
+    await game.entities.sendMessage(slot.id, { type: "Frob" });
+    await game.step({ frames: 180 });
+
+    for (const [index, door] of doors.entries()) {
+      const after = (await game.entities.detail(door.id)).position;
+      const displacement = Math.hypot(
+        after[0] - before[index][0],
+        after[1] - before[index][1],
+        after[2] - before[index][2],
+      );
+      assert.ok(
+        displacement > 1.0,
+        `Crew slot 293 must open door ${REC1_CREW_DOORS[index]}; ` +
+          `before=${before[index]}, after=${after}`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
Fixes #583.

## Reproduction and root cause

Recreation's authored progression requires the Rec Crew Key (`rec2` mission
object 996, region 32 / lock 0) from corpse 419. The card is
`MOVE | SCRIPT`, but both production pickup surfaces bypassed its scripted
`Frob`:

- flat world use stored the item directly;
- `ContainerGuiMsg::Take` reparented loot directly.

That left the physical card in the backpack without running `FrobQB` or
`internal_keycard`, so `crewcahd` and `AcquireKeyCard` never fired. Back in
`rec1`, matching slot 293 rejected the player and linked doors 1580/1582 stayed
closed.

The inverse path was also broken: a direct scripted `Frob` granted access, but
`KeyCardScript` unconditionally destroyed the physical card. `FrobQB` already
tried to transfer `MOVE` quest objects, so simply adding another transfer to
the keycard script would give two scripts ownership of the same containment.

## Change

- Route `MOVE | SCRIPT` flat pickups and loot-panel Take through the authored
  `Frob` path. Ordinary non-scripted `MOVE` loot keeps its existing direct
  pickup behavior.
- Make `internal_keycard` the sole owner of a keycard's physical fate:
  takeable cards grant access and move into the backpack; use-only cards retain
  the historical consume behavior.
- Make `FrobQB` contribute only its authored quest bit for `PropKeySrc`
  entities, avoiding duplicate reparent/destroy effects.
- Add a focused SDK scenario that clicks the real rec2 corpse-loot button,
  verifies the card and `crewcahd`, transitions to rec1, and confirms slot 293
  opens both authored Crew doors.

## Negative-first

The new unit tests were run against the pre-fix implementation and failed on
all intended symptoms:

- flat pickup returned direct `StoreItem`;
- loot Take returned direct `DropEntityInfo`;
- `KeyCardScript` returned `AcquireKeyCard + DestroyEntity`;
- `FrobQB` independently returned a second `DropEntityInfo`.

All pass after the ownership/routing change.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 352 passed
- `cd tools/shock2-sdk && npm test` — 25 passed, 145 e2e tests skipped as designed
- focused `keycard-pickup.e2e.test.ts` — passed
- full `npm run test:e2e` — 168/170 passed, including all 23 mission loads,
  normal flat pickup, container/inventory flows, and the new Rec Crew gate
  scenario

The two full-suite failures are confirmed pre-existing on a clean
`origin/main` worktree:

- Earth Psionic Training: Cryokinesis spends psi but does not damage the
  Training Droid.
- `world-aim.e2e.test.ts`: the fixed-name `world-aim-e2e` save is rejected as
  corrupt/incompatible immediately after saving.

## Campaign

Fixed-order late-game play-through campaign, iteration 004/005. This ledger
predates randomized campaign metadata, so it has no scenario/tweak/assets/seed
roll to report.

## Visual verification

![Rec Crew Key scripted pickup demo](https://gist.githubusercontent.com/tommy-xr/bcc9e21e353e09e9ef4b5b63f5ada9c4/raw/rec-crew-key-demo.gif)

<sub>Scripted pickup now grants access and keeps the Rec Crew Key visible in the inventory strip. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After

![Rec Crew Key retained in the inventory strip](https://gist.githubusercontent.com/tommy-xr/bcc9e21e353e09e9ef4b5b63f5ada9c4/raw/rec-crew-key-after.png)

### Before → after

![Before and after scripted Rec Crew Key pickup](https://gist.githubusercontent.com/tommy-xr/bcc9e21e353e09e9ef4b5b63f5ada9c4/raw/rec-crew-key-before-after.png)
