### PR TITLE
fix(gameplay): restore authored swimming and water exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `Ctrl` - crouch
 - `I` - move the floating inventory in front of you
 - `Alt+S` / `Alt+L` - quick save / quick load
-- `Space` - spawn a debug item
+- `Space` - jump / swim up
+- `F10` - spawn a debug item
 - `P` - cycle the pathfinding test (set start → set goal → show path)
 
 ## Building

--- a/dark/src/mission/cell.rs
+++ b/dark/src/mission/cell.rs
@@ -20,9 +20,31 @@ use crate::ss2_common::read_vec3;
 use super::CellPortal;
 use super::Plane;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellMedium {
+    Solid,
+    Air,
+    Water,
+    Unknown(u8),
+}
+
+impl From<u8> for CellMedium {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Solid,
+            1 => Self::Air,
+            2 => Self::Water,
+            value => Self::Unknown(value),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Cell {
     pub idx: u32,
+    pub medium: CellMedium,
+    pub flags: u8,
+    pub flow_group: u8,
     pub center: Vector3<f32>,
     pub radius: f32,
     pub portal_count: u8,
@@ -48,14 +70,14 @@ impl Cell {
         let cell_num_render_polys = reader.read_u8().unwrap();
         let portal_count = reader.read_u8().unwrap();
         let cell_num_planes = reader.read_u8().unwrap();
-        let _cell_medium = reader.read_u8().unwrap();
-        let _cell_flags = reader.read_u8().unwrap();
+        let medium = reader.read_u8().unwrap().into();
+        let flags = reader.read_u8().unwrap();
 
         let _nxn = reader.read_u32::<byteorder::LittleEndian>().unwrap();
         let _poly_map_size = reader.read_u16::<byteorder::LittleEndian>().unwrap();
 
         let cell_num_anim_lights = reader.read_u8().unwrap();
-        let _cell_flow_group = reader.read_u8().unwrap();
+        let flow_group = reader.read_u8().unwrap();
 
         let center = read_vec3(reader) / SCALE_FACTOR;
         let radius = reader.read_f32::<byteorder::LittleEndian>().unwrap() / SCALE_FACTOR;
@@ -112,6 +134,9 @@ impl Cell {
 
         let cell = Cell {
             idx: cell_idx,
+            medium,
+            flags,
+            flow_group,
             portal_count,
             portals,
             center,
@@ -422,5 +447,43 @@ fn read_light_info<T: io::Read>(debug_idx: u32, reader: &mut T) -> LightInfo {
         dynamic_lightmap_pointer,
         animation_flags,
         texture_pack_result: TexturePackResult::DEFAULT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use engine::texture_atlas::TexturePacker;
+
+    use super::{Cell, CellMedium};
+
+    #[test]
+    fn cell_preserves_authored_medium_flags_and_flow_group() {
+        let mut bytes = vec![
+            0,    // vertices
+            0,    // polygons
+            0,    // rendered polygons
+            0,    // portals
+            0,    // planes
+            2,    // water medium
+            0x41, // cell flags
+        ];
+        bytes.extend_from_slice(&0x1122_3344_u32.to_le_bytes());
+        bytes.extend_from_slice(&0x5566_u16.to_le_bytes());
+        bytes.push(0); // animated lights
+        bytes.push(7); // flow group
+        bytes.extend_from_slice(&[0; 12]); // center
+        bytes.extend_from_slice(&0.0_f32.to_le_bytes()); // radius
+        bytes.extend_from_slice(&0_u32.to_le_bytes()); // polygon indices
+        bytes.extend_from_slice(&0_u32.to_le_bytes()); // light index count
+
+        let mut reader = Cursor::new(bytes);
+        let mut packer = TexturePacker::<image::Rgb<u8>>::new_rgb(1, 1);
+        let cell = Cell::read(&mut reader, &mut packer, false, 42, 1);
+
+        assert_eq!(cell.medium, CellMedium::Water);
+        assert_eq!(cell.flags, 0x41);
+        assert_eq!(cell.flow_group, 7);
     }
 }

--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -68,6 +68,22 @@ pub struct SystemShock2Geometry {
     pub lightmap_pack_result: TexturePackResult,
 }
 
+#[derive(Debug, Clone)]
+pub struct WaterRenderInfo {
+    pub texture_prefixes: Vec<String>,
+    pub color: [u8; 3],
+    pub alpha: f32,
+}
+
+impl WaterRenderInfo {
+    pub fn texture_prefix(&self, flow_group: u8) -> &str {
+        self.texture_prefixes
+            .get(flow_group as usize)
+            .map(String::as_str)
+            .unwrap_or("bl")
+    }
+}
+
 pub struct SystemShock2Level {
     pub all_geometry: Vec<SystemShock2Geometry>,
 
@@ -83,6 +99,7 @@ pub struct SystemShock2Level {
     pub song_params: SongParams,
     pub bsp_tree: BspTree,
     pub path_database: Option<PathDatabase>,
+    pub water_render_info: WaterRenderInfo,
 }
 
 // Capstone for the loading-screen "foundation track" (projects/loading-screen.md, PR
@@ -221,7 +238,14 @@ pub fn read<T: io::Read + io::Seek>(
         obj_texture_families,
         reader,
     );
-    let all_geometry = create_geometry(asset_paths, base_path, &cells, &textures.0);
+    let water_render_info = read_water_render_info(&table_of_contents, reader);
+    let all_geometry = create_geometry(
+        asset_paths,
+        base_path,
+        &cells,
+        &textures.0,
+        &water_render_info,
+    );
 
     let _render_params = RenderParams::read(&table_of_contents, reader);
     let room_database = RoomDatabase::read(&table_of_contents, reader);
@@ -262,6 +286,83 @@ pub fn read<T: io::Read + io::Seek>(
         room_database,
         song_params,
         path_database,
+        water_render_info,
+    }
+}
+
+fn read_chunk_bytes<T: io::Read + io::Seek>(
+    table_of_contents: &ChunkFileTableOfContents,
+    reader: &mut T,
+    name: &str,
+) -> Option<Vec<u8>> {
+    let chunk = table_of_contents.get_chunk(name.to_string())?;
+    reader.seek(SeekFrom::Start(chunk.offset)).ok()?;
+    let mut bytes = vec![0; chunk.length as usize];
+    reader.read_exact(&mut bytes).ok()?;
+    Some(bytes)
+}
+
+fn fixed_string(bytes: &[u8]) -> String {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).trim().to_string()
+}
+
+fn parse_default_water_prefix(bytes: &[u8]) -> Option<String> {
+    let record_size = u32::from_le_bytes(bytes.get(0..4)?.try_into().ok()?) as usize;
+    let count = u32::from_le_bytes(bytes.get(4..8)?.try_into().ok()?) as usize;
+    if count < 2 || record_size < 16 {
+        return None;
+    }
+    let start = 8 + record_size;
+    let prefix = fixed_string(bytes.get(start..start + 16)?);
+    (!prefix.is_empty() && !prefix.eq_ignore_ascii_case("null")).then_some(prefix)
+}
+
+fn parse_water_bank(bytes: &[u8]) -> Option<([u8; 3], f32)> {
+    let color = [*bytes.first()?, *bytes.get(1)?, *bytes.get(2)?];
+    let alpha = f32::from_le_bytes(bytes.get(4..8)?.try_into().ok()?);
+    alpha.is_finite().then_some((color, alpha.clamp(0.0, 1.0)))
+}
+
+fn parse_flow_texture_prefixes(bytes: &[u8], default_prefix: &str) -> Vec<String> {
+    bytes
+        .chunks_exact(32)
+        .map(|record| {
+            let prefix = fixed_string(&record[4..32]);
+            if prefix.is_empty() {
+                default_prefix.to_string()
+            } else {
+                prefix
+            }
+        })
+        .collect()
+}
+
+fn read_water_render_info<T: io::Read + io::Seek>(
+    table_of_contents: &ChunkFileTableOfContents,
+    reader: &mut T,
+) -> WaterRenderInfo {
+    let default_prefix = read_chunk_bytes(table_of_contents, reader, "FAMILY")
+        .as_deref()
+        .and_then(parse_default_water_prefix)
+        .unwrap_or_else(|| "bl".to_string());
+    let (color, alpha) = read_chunk_bytes(table_of_contents, reader, "WATERBANKS")
+        .as_deref()
+        .and_then(parse_water_bank)
+        .unwrap_or(([50, 80, 100], 0.35));
+    let texture_prefixes = read_chunk_bytes(table_of_contents, reader, "FLOW_TEX")
+        .as_deref()
+        .map(|bytes| parse_flow_texture_prefixes(bytes, &default_prefix))
+        .filter(|prefixes| !prefixes.is_empty())
+        .unwrap_or_else(|| vec![default_prefix; 256]);
+
+    WaterRenderInfo {
+        texture_prefixes,
+        color,
+        alpha,
     }
 }
 
@@ -298,6 +399,7 @@ fn create_geometry(
     base_path: &str,
     cells: &Vec<Cell>,
     textures: &Vec<SystemShock2Texture>,
+    water_render_info: &WaterRenderInfo,
 ) -> Vec<SystemShock2Geometry> {
     let mut all_geometry: Vec<SystemShock2Geometry> = Vec::new();
     let mut cell_idx = 0;
@@ -313,11 +415,9 @@ fn create_geometry(
                 panic!("index doesn't match????");
             }
             let len = indices.len();
-            // TODO: What are 249/247 - BACKHACK or something?
-            if render_poly.texture_num == 249
-                || render_poly.texture_num == 247
-                || render_poly.texture_num == 248
-            {
+            // 247/248 are the two directed sides of a water boundary. Texture
+            // 249 is the unrelated sky/backhack surface and remains omitted.
+            if render_poly.texture_num == 249 {
                 continue;
             }
 
@@ -334,8 +434,22 @@ fn create_geometry(
             let sh_u = render_poly.u / 4096.0;
             let sh_v = render_poly.v / 4096.0;
 
-            let tex_info = &textures[render_poly.texture_num as usize];
-            let texture_dim = texture_dimensions(asset_paths, base_path, tex_info);
+            let texture_dim = if matches!(render_poly.texture_num, 247 | 248) {
+                let suffix = if render_poly.texture_num == 247 {
+                    "in"
+                } else {
+                    "out"
+                };
+                let prefix = water_render_info.texture_prefix(cell.flow_group);
+                texture_dimensions_for_asset(
+                    asset_paths,
+                    base_path,
+                    &format!("WATERHW/{prefix}{suffix}.PCX"),
+                )
+            } else {
+                let tex_info = &textures[render_poly.texture_num as usize];
+                texture_dimensions(asset_paths, base_path, tex_info)
+            };
 
             let rs_x = (texture_dim.width as f32) / 64.0;
             let rs_y = (texture_dim.height as f32) / 64.0;
@@ -514,8 +628,17 @@ fn texture_dimensions(
     )
     .to_ascii_lowercase();
 
+    texture_dimensions_for_asset(asset_paths, base_path, &tex_name)
+}
+
+fn texture_dimensions_for_asset(
+    asset_paths: &dyn AbstractAssetPath,
+    base_path: &str,
+    asset_name: &str,
+) -> TextureSize {
+    let asset_name = asset_name.to_ascii_lowercase();
     let dims = asset_paths
-        .get_reader(base_path.to_string(), tex_name.clone())
+        .get_reader(base_path.to_string(), asset_name.clone())
         .and_then(|r| {
             let mut bytes = Vec::new();
             std::io::Read::read_to_end(&mut *r.borrow_mut(), &mut bytes).ok()?;
@@ -525,11 +648,41 @@ fn texture_dimensions(
     match dims {
         Some((width, height)) => TextureSize { width, height },
         None => {
-            tracing::warn!("texture_dimensions: could not read PCX header for {tex_name}");
+            tracing::warn!("texture_dimensions: could not read PCX header for {asset_name}");
             TextureSize {
                 width: 1,
                 height: 1,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod water_tests {
+    use super::{parse_default_water_prefix, parse_flow_texture_prefixes, parse_water_bank};
+
+    #[test]
+    fn authored_water_chunks_select_texture_and_opacity() {
+        let mut family = Vec::new();
+        family.extend_from_slice(&24_u32.to_le_bytes());
+        family.extend_from_slice(&2_u32.to_le_bytes());
+        family.extend_from_slice(b"sky\0");
+        family.extend_from_slice(&[0; 20]);
+        family.extend_from_slice(b"bl\0");
+        family.extend_from_slice(&[0; 21]);
+        assert_eq!(parse_default_water_prefix(&family).as_deref(), Some("bl"));
+
+        let mut bank = vec![50, 80, 100, 0];
+        bank.extend_from_slice(&0.35_f32.to_le_bytes());
+        let (color, alpha) = parse_water_bank(&bank).expect("water bank");
+        assert_eq!(color, [50, 80, 100]);
+        assert!((alpha - 0.35).abs() < f32::EPSILON);
+
+        let mut flow = vec![0; 64];
+        flow[36..38].copy_from_slice(b"bl");
+        assert_eq!(
+            parse_flow_texture_prefixes(&flow, "default"),
+            ["default", "bl"]
+        );
     }
 }

--- a/dark/src/mission/scene_builder.rs
+++ b/dark/src/mission/scene_builder.rs
@@ -22,8 +22,29 @@ pub fn to_scene(
     let all_geometry = &level.all_geometry;
     let mut texture_to_vertices: HashMap<&u16, Vec<VertexPositionTextureLightmapAtlasNormal>> =
         HashMap::new();
+    let mut water_texture_to_vertices: HashMap<String, Vec<VertexPositionTextureNormal>> =
+        HashMap::new();
     for geometry in all_geometry {
         let texture_id = &geometry.texture_idx;
+
+        if matches!(*texture_id, 247 | 248) {
+            let suffix = if *texture_id == 247 { "in" } else { "out" };
+            let prefix = level
+                .cells
+                .get(geometry.cell_idx as usize)
+                .map(|cell| level.water_render_info.texture_prefix(cell.flow_group))
+                .unwrap_or("bl");
+            let texture_name = format!("WATERHW/{prefix}{suffix}.PCX");
+            let current_vertices = water_texture_to_vertices.entry(texture_name).or_default();
+            current_vertices.extend(geometry.verts.iter().map(|vertex| {
+                VertexPositionTextureNormal {
+                    position: vertex.position,
+                    uv: vertex.uv,
+                    normal: vertex.normal,
+                }
+            }));
+            continue;
+        }
 
         // Skip empty texture
         if *texture_id == 0 {
@@ -113,6 +134,24 @@ pub fn to_scene(
 
         let scene_object1 = engine::scene::scene_object::SceneObject::create(material, mesh);
         scene_objects.push(scene_object1)
+    }
+
+    for (texture_name, vertices) in water_texture_to_vertices {
+        let Some(texture) = asset_cache.get_opt(&TEXTURE_IMPORTER, &texture_name) else {
+            tracing::warn!("missing authored water texture {texture_name}");
+            continue;
+        };
+        let texture: Rc<dyn TextureTrait> = texture;
+        let mesh: Rc<Box<dyn engine::scene::Geometry>> =
+            Rc::new(Box::new(engine::scene::mesh::create(vertices)));
+        let material = RefCell::new(engine::scene::basic_material::create(
+            texture,
+            1.0,
+            1.0 - level.water_render_info.alpha,
+        ));
+        scene_objects.push(engine::scene::scene_object::SceneObject::create(
+            material, mesh,
+        ));
     }
 
     scene_objects

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -383,6 +383,8 @@ pub struct InputState {
     /// Crouch REQUEST (the `crouch` channel), not the resulting collider
     /// state - standing up is refused while there is no headroom.
     pub crouch: bool,
+    /// Held jump request; in water this continuously swims upward.
+    pub jump: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -414,6 +416,7 @@ impl Default for InputState {
             right_hand: InputHand::default(),
             pointer: None,
             crouch: false,
+            jump: false,
         }
     }
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1684,6 +1684,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
         left_hand: hand(&input.left_hand),
         right_hand: hand(&input.right_hand),
         crouch: input.crouch,
+        jump: input.jump,
     }
 }
 
@@ -1714,7 +1715,7 @@ fn input_channels_help() -> &'static str {
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
      {left,right}_hand.rotation [x,y,z,w], \
-     crouch 0|1 (stand-up refused without headroom); \
+     crouch 0|1 (stand-up refused without headroom), jump 0|1; \
      locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
      left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
 }
@@ -1857,6 +1858,16 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         // the player's body y (the collider center drops when crouched).
         "crouch" => {
             input.crouch = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            Ok(())
+        }
+        "jump" => {
+            input.jump = match num(channel, value)? {
                 v if v == 0.0 => false,
                 v if v == 1.0 => true,
                 v => {

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -36,7 +36,7 @@ impl DesktopInputMapper {
                 action: InputAction::PathfindingTestCycle,
             },
             Binding {
-                key: Key::Space,
+                key: Key::F10,
                 modifier: Modifier::None,
                 action: InputAction::SpawnDebugItem,
             },

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -684,6 +684,7 @@ fn process_events(
     }
 
     input_context.crouch = window.get_key(Key::LeftControl) == Action::Press;
+    input_context.jump = window.get_key(Key::Space) == Action::Press;
 
     // Discrete actions (spawn, save/load, inventory, pathfinding test) are
     // handled by the mapper, which edge-detects key presses.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -331,6 +331,9 @@ fn main() {
     let right_thumbstick_action = action_set
         .create_action::<xr::Vector2f>("right_hand_thumbstick", "Right Hand Thumbstick", &[])
         .unwrap();
+    let jump_action = action_set
+        .create_action::<bool>("jump", "Jump / Swim Up", &[])
+        .unwrap();
 
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
@@ -399,6 +402,12 @@ fn main() {
                     &right_thumbstick_action,
                     xr_instance
                         .string_to_path("/user/hand/right/input/thumbstick")
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &jump_action,
+                    xr_instance
+                        .string_to_path("/user/hand/right/input/thumbstick/click")
                         .unwrap(),
                 ),
             ],
@@ -534,6 +543,10 @@ fn main() {
             .state(&session, xr::Path::NULL)
             .unwrap()
             .current_state;
+        let jump = jump_action
+            .state(&session, xr::Path::NULL)
+            .unwrap()
+            .current_state;
 
         let left_trigger_value = left_trigger
             .state(&session, xr::Path::NULL)
@@ -600,6 +613,7 @@ fn main() {
         input_context.left_hand.squeeze_value = left_squeeze_value;
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
+        input_context.jump = jump;
         game.update(&time_context, &input_context, &mut action_state);
 
         // Must be called before any rendering is done!

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -291,7 +291,15 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::{FrobFlag, PropFrobInfo, PropPlayerGun};
+    use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
+
+    fn frob_info(world_action: FrobFlag) -> PropFrobInfo {
+        PropFrobInfo {
+            world_action,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        }
+    }
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -311,7 +319,7 @@ mod tests {
     fn world_use_of_nonweapon_stores_it_without_displacing_wielded_weapon() {
         let mut world = World::new();
         let pistol = world.add_entity(pistol());
-        let ammo = world.add_entity(());
+        let ammo = world.add_entity(frob_info(FrobFlag::MOVE));
         let mut controller = FlatPlayerController::new();
         controller.wield(pistol);
 
@@ -352,11 +360,7 @@ mod tests {
     #[test]
     fn world_use_of_scripted_pickup_dispatches_frob_instead_of_bypassing_it() {
         let mut world = World::new();
-        let keycard = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::MOVE | FrobFlag::SCRIPT,
-            inventory_action: FrobFlag::empty(),
-            tool_action: FrobFlag::empty(),
-        });
+        let keycard = world.add_entity(frob_info(FrobFlag::MOVE | FrobFlag::SCRIPT));
         let mut controller = FlatPlayerController::new();
 
         let effects = controller.pick_up(&world, keycard);
@@ -372,6 +376,35 @@ mod tests {
                 }] if *to == keycard
             ),
             "a MOVE | SCRIPT pickup must run its authored Frob path"
+        );
+    }
+
+    #[test]
+    fn world_use_of_move_only_keycard_dispatches_frob_for_injected_script() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            frob_info(FrobFlag::MOVE),
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+        ));
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, keycard);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                }] if *to == keycard
+            ),
+            "a MOVE-only PropKeySrc pickup must run its injected keycard Frob path"
         );
     }
 }

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -24,6 +24,10 @@ pub struct InputContext {
     // is no headroom. VR leaves this false - physically crouching moves the
     // HMD instead.
     pub crouch: bool,
+
+    // Held jump/swim-up request. The physics layer edge-detects dry jumps;
+    // underwater this remains continuous, matching Dark's swim control.
+    pub jump: bool,
 }
 
 impl InputContext {
@@ -35,6 +39,7 @@ impl InputContext {
             right_hand: Hand::default(),
             pointer: None,
             crouch: false,
+            jump: false,
         }
     }
 }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -308,17 +308,18 @@ pub fn create_entity_core(
         processed_scripts.push("internal_keycard".to_owned());
     }
 
-    // `MOVE` is an engine frob action, not an object script. Ordinary goodies
-    // such as Med Patches and armor only inherit that flag, so give them the
-    // internal handler that moves them into the backpack on Frob. Objects that
-    // also request SCRIPT keep their existing authored ownership (notably
-    // FrobQB's circuit-board/quest-item transfer).
+    // `MOVE` is an engine frob action, not an object script. Give every
+    // grabbable world-frob item the internal move handler even when it also
+    // requests SCRIPT: the authored scripts contribute side effects and the
+    // engine still performs the physical transfer. The only exceptions are
+    // paths that explicitly own transfer/consumption themselves (`FrobQB` and
+    // the injected keycard script).
     let needs_frob_move = {
         let v_frob_info = world.borrow::<View<PropFrobInfo>>().unwrap();
         v_frob_info.get(entity_id).is_ok_and(|frob| {
-            !frob.world_action.contains(FrobFlag::SCRIPT)
-                && (frob.world_action.contains(FrobFlag::MOVE)
-                    || frob.world_action.contains(FrobFlag::USE_AMMO))
+            (frob.world_action.contains(FrobFlag::MOVE)
+                || frob.world_action.contains(FrobFlag::USE_AMMO))
+                && !crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id)
         })
     };
     if needs_frob_move {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1203,11 +1203,22 @@ impl MissionCore {
             // actual state is read back via `player_is_crouched`).
             self.physics
                 .set_player_crouch(input_context.crouch, &mut self.player_handle);
+            let medium = self
+                .spatial_data
+                .as_deref()
+                .and_then(|spatial| spatial.get_cell_from_position(player.pos))
+                .map(|cell| cell.medium)
+                .filter(|medium| *medium == dark::mission::CellMedium::Water)
+                .map_or(crate::physics::PlayerMedium::Air, |_| {
+                    crate::physics::PlayerMedium::Water
+                });
             profile!(
                 "shock2.update.physics",
-                self.physics.update_with_facing(
+                self.physics.update_player_with_facing(
                     forward + cgmath::vec3(0.0, up_value, 0.0),
                     facing,
+                    medium,
+                    input_context.jump,
                     &mut self.player_handle,
                 )
             )

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1034,6 +1034,11 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
     -0.5 / SCALE_FACTOR * character_body.gravity_scale()
 }
 
+const PLAYER_JUMP_SPEED: Real = 10.0 / SCALE_FACTOR;
+const PLAYER_SWIM_UP_SPEED: Real = PLAYER_JUMP_SPEED / 4.0;
+const PLAYER_JUMP_GRAVITY: Real = 32.0 / SCALE_FACTOR;
+const PLAYER_SWIM_SPEED_SCALE: Real = 0.7;
+
 /// One frame of player locomotion: the character controller's walk pass, the
 /// gravity pass (with ground snapping and the resting lift), and the stair
 /// step-up probe. Shared by real player movement ([`PhysicsWorld::move_player`])
@@ -1429,6 +1434,12 @@ pub enum PhysicsShape {
     Sphere(f32),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlayerMedium {
+    Air,
+    Water,
+}
+
 pub struct PlayerHandle {
     // Player
     controller: KinematicCharacterController,
@@ -1445,6 +1456,12 @@ pub struct PlayerHandle {
     // then. Purely derived per-frame state (re-probed every move), so nothing
     // needs to save or restore it.
     support: Option<PlayerSupport>,
+    // Integrated vertical speed is only used for an authored jump arc. Normal
+    // walking retains the existing fixed gravity pass, while water supplies
+    // neutral buoyancy and its own held swim-up speed.
+    vertical_velocity: Real,
+    grounded: bool,
+    jump_was_down: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1829,6 +1846,8 @@ impl PhysicsWorld {
         player_handle: &mut PlayerHandle,
     ) {
         player_handle.top_out = None;
+        player_handle.vertical_velocity = 0.0;
+        player_handle.grounded = false;
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         let player_height = if player_handle.is_crouched {
             PLAYER_CROUCH_HEIGHT
@@ -2470,6 +2489,9 @@ impl PhysicsWorld {
             is_crouched: false,
             top_out: None,
             support: None,
+            vertical_velocity: 0.0,
+            grounded: false,
+            jump_was_down: false,
         }
     }
 
@@ -2738,7 +2760,13 @@ impl PhysicsWorld {
         desired_movement: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
-        self.update_with_facing(desired_movement, desired_movement, player_handle)
+        self.update_player_with_facing(
+            desired_movement,
+            desired_movement,
+            PlayerMedium::Air,
+            false,
+            player_handle,
+        )
     }
 
     /// Update player movement with an explicit world-space facing vector.
@@ -2748,6 +2776,23 @@ impl PhysicsWorld {
         &mut self,
         desired_movement: Vector3<f32>,
         facing: Vector3<f32>,
+        player_handle: &mut PlayerHandle,
+    ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        self.update_player_with_facing(
+            desired_movement,
+            facing,
+            PlayerMedium::Air,
+            false,
+            player_handle,
+        )
+    }
+
+    pub fn update_player_with_facing(
+        &mut self,
+        desired_movement: Vector3<f32>,
+        facing: Vector3<f32>,
+        medium: PlayerMedium,
+        jump: bool,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
         // Queue every PhysAttach child at its parent's same next-frame target
@@ -2783,7 +2828,7 @@ impl PhysicsWorld {
         let desired_movement = vec_to_nvec(desired_movement);
         let facing = vec_to_nvec(facing);
         let (mut collision_events, character_body) =
-            { self.move_player(desired_movement, facing, player_handle) };
+            { self.move_player(desired_movement, facing, medium, jump, player_handle) };
         let translation = nvec_to_cgmath(*character_body.translation());
 
         let mut additional_collision_events = { self.events.get_and_clear_events() };
@@ -2853,10 +2898,40 @@ impl PhysicsWorld {
 
     fn move_player(
         &mut self,
-        desired_movement: Vector<Real>,
+        mut desired_movement: Vector<Real>,
         facing: Vector<Real>,
+        medium: PlayerMedium,
+        jump: bool,
         player_handle: &mut PlayerHandle,
     ) -> (Vec<CollisionEvent>, &RigidBody) {
+        let dt = self.integration_parameters.dt;
+        let gravity = match medium {
+            PlayerMedium::Water => {
+                desired_movement *= PLAYER_SWIM_SPEED_SCALE;
+                if jump {
+                    desired_movement.y += PLAYER_SWIM_UP_SPEED * dt;
+                }
+                player_handle.vertical_velocity = 0.0;
+                0.0
+            }
+            PlayerMedium::Air => {
+                if jump && !player_handle.jump_was_down && player_handle.grounded {
+                    player_handle.vertical_velocity = PLAYER_JUMP_SPEED;
+                    player_handle.grounded = false;
+                    player_handle.support = None;
+                }
+                if player_handle.vertical_velocity != 0.0 {
+                    desired_movement.y += player_handle.vertical_velocity * dt;
+                    player_handle.vertical_velocity -= PLAYER_JUMP_GRAVITY * dt;
+                    0.0
+                } else {
+                    let character_body = &self.rigid_body_set[player_handle.character_handle];
+                    player_gravity_step(character_body)
+                }
+            }
+        };
+        player_handle.jump_was_down = jump;
+
         let character_body = &self.rigid_body_set[player_handle.character_handle];
         let original_position = *character_body.position();
         let character_user_data = character_body.user_data;
@@ -2868,8 +2943,6 @@ impl PhysicsWorld {
         // borrows are released before we build the query pipeline below.
         let character_shape = character_collider.shared_shape().clone();
         let character_pos = *character_collider.position();
-
-        let gravity = player_gravity_step(&self.rigid_body_set[player_handle.character_handle]);
 
         let movement_filter = player_movement_filter(player_handle.character_handle);
         let dispatcher = self.narrow_phase.query_dispatcher();
@@ -3018,23 +3091,60 @@ impl PhysicsWorld {
                 );
                 PlayerMovement { movement, top_out }
             } else {
-                step_player_movement(
-                    &player_handle.controller,
-                    &queries,
-                    character_shape.as_ref(),
-                    &character_pos,
-                    desired_movement,
-                    carry,
-                    self.integration_parameters.dt,
-                    gravity,
-                    climb_movement.map(|(movement, top_out)| ClimbPass {
-                        movement,
-                        top_out,
-                        validation_queries: queries,
-                        probe_queries: queries.with_filter(climb_pass_filter),
-                        scripted_queries: queries.with_filter(scripted_top_out_filter),
-                    }),
-                )
+                let general_mantle = (jump
+                    && !player_handle.is_crouched
+                    && climb_movement.is_none())
+                .then(|| {
+                    let direction = climb_top_out_direction(desired_movement, facing)?;
+                    let desired_h =
+                        vector![desired_movement.x, 0.0, desired_movement.z];
+                    let attempted = desired_h.norm();
+                    if attempted <= 1.0e-6 {
+                        return None;
+                    }
+                    let probe = player_handle.controller.move_shape(
+                        self.integration_parameters.dt,
+                        &queries,
+                        character_shape.as_ref(),
+                        &character_pos,
+                        desired_h,
+                        |_c| (),
+                    );
+                    let progress = probe.translation.dot(&(desired_h / attempted));
+                    if progress > PLAYER_MOVE_PROGRESS_FRACTION * attempted {
+                        return None;
+                    }
+                    plan_climb_top_out(
+                        &player_handle.controller,
+                        &queries,
+                        &queries,
+                        &queries.with_filter(scripted_top_out_filter),
+                        &character_pos,
+                        direction,
+                        CLIMB_TOP_OUT_PROBE_FORWARD,
+                        self.integration_parameters.dt,
+                    )
+                })
+                .flatten();
+                general_mantle.unwrap_or_else(|| {
+                    step_player_movement(
+                        &player_handle.controller,
+                        &queries,
+                        character_shape.as_ref(),
+                        &character_pos,
+                        desired_movement,
+                        carry,
+                        self.integration_parameters.dt,
+                        gravity,
+                        climb_movement.map(|(movement, top_out)| ClimbPass {
+                            movement,
+                            top_out,
+                            validation_queries: queries,
+                            probe_queries: queries.with_filter(climb_pass_filter),
+                            scripted_queries: queries.with_filter(scripted_top_out_filter),
+                        }),
+                    )
+                })
             }
         });
         let was_top_out = player_handle.top_out.is_some();
@@ -3049,6 +3159,10 @@ impl PhysicsWorld {
         self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
+        player_handle.grounded = mvt.grounded;
+        if mvt.grounded && player_handle.vertical_velocity < 0.0 {
+            player_handle.vertical_velocity = 0.0;
+        }
 
         // Edges already observed along a swept `move_player_validated` hop come
         // first: they happened before this frame's pose. They also leave
@@ -3938,6 +4052,134 @@ mod tests {
             EntityId::from_inner(1001).unwrap(),
         );
         (world, player)
+    }
+
+    #[test]
+    fn water_medium_suspends_gravity_and_jump_swims_upward() {
+        let mut world = PhysicsWorld::new();
+        let mut player =
+            world.create_player(vec3(0.0, 10.0, 0.0), EntityId::from_inner(1101).unwrap());
+        let start = world.get_player_translation(&player);
+
+        for _ in 0..60 {
+            world.update_player_with_facing(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                PlayerMedium::Water,
+                false,
+                &mut player,
+            );
+        }
+        let floating = world.get_player_translation(&player);
+        assert!(
+            (floating.y - start.y).abs() < 0.05,
+            "neutral buoyancy must hold the player in place, moved from {start:?} to {floating:?}"
+        );
+
+        for _ in 0..60 {
+            world.update_player_with_facing(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                PlayerMedium::Water,
+                true,
+                &mut player,
+            );
+        }
+        let swum = world.get_player_translation(&player);
+        assert!(
+            swum.y > floating.y + 0.2,
+            "holding jump in water must swim upward, moved from {floating:?} to {swum:?}"
+        );
+    }
+
+    #[test]
+    fn grounded_jump_has_a_ballistic_rise() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1200).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
+                .translation(vector![0.0, -0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(0.0, 1.0, 0.0), EntityId::from_inner(1201).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let grounded = world.get_player_translation(&player);
+
+        world.update_player_with_facing(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            PlayerMedium::Air,
+            true,
+            &mut player,
+        );
+        for _ in 0..10 {
+            world.update_player_with_facing(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                PlayerMedium::Air,
+                false,
+                &mut player,
+            );
+        }
+        let airborne = world.get_player_translation(&player);
+        assert!(
+            airborne.y > grounded.y + 0.1,
+            "a grounded jump must rise after the button is released, moved from {grounded:?} to {airborne:?}"
+        );
+    }
+
+    #[test]
+    fn held_jump_mantles_a_blocking_pool_lip_without_a_ladder() {
+        let quad = |x0: f32, x1: f32, y: f32| {
+            let verts = vec![
+                point![x0, y, -100.0],
+                point![x1, y, -100.0],
+                point![x1, y, 100.0],
+                point![x0, y, 100.0],
+            ];
+            ColliderBuilder::trimesh(verts, vec![[0u32, 1, 2], [0, 2, 3]]).expect("trimesh")
+        };
+
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1300).unwrap(),
+            quad(-100.0, 100.0, 0.0).build(),
+        );
+        world.add_collider(
+            EntityId::from_inner(1301).unwrap(),
+            quad(-5.2, 100.0, 1.2).build(),
+        );
+        let mut player =
+            world.create_player(vec3(-6.0, 1.0, 0.0), EntityId::from_inner(1302).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let mut saw_mantle = false;
+        for _ in 0..180 {
+            world.update_player_with_facing(
+                Vector3::new(walk, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                PlayerMedium::Water,
+                true,
+                &mut player,
+            );
+            saw_mantle |= player.top_out.is_some();
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            saw_mantle,
+            "a held jump against a pool lip must enter the mantle transition"
+        );
+        assert!(
+            end.x > -4.5 && end.y > 1.5,
+            "the mantle must leave the player standing beyond the upper lip, ended {end:?}"
+        );
     }
 
     fn step(world: &mut PhysicsWorld, player: &mut PlayerHandle, frames: usize) {

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -5,12 +5,12 @@ use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
 
-/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior for
-/// ordinary pickup items that do not ask an authored script to handle Frob.
+/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior.
 ///
-/// `MOVE | SCRIPT` objects keep their existing scripted ownership. In
-/// particular, `FrobQB` must award the Engineering circuit board's quest bit
-/// and transfer it exactly once.
+/// `MOVE | SCRIPT` means both actions happen: authored scripts keep their side
+/// effects while this handler performs the physical transfer. Entities whose
+/// scripts explicitly own transfer/consumption (`FrobQB` and keycards) never
+/// receive this handler and are guarded here too.
 pub struct InternalFrobMove;
 
 impl InternalFrobMove {
@@ -31,14 +31,17 @@ impl Script for InternalFrobMove {
             return Effect::NoEffect;
         }
 
+        if crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id) {
+            return Effect::NoEffect;
+        }
+
         let handles_move = {
             let frob_info = world
                 .borrow::<View<dark::properties::PropFrobInfo>>()
                 .unwrap();
             frob_info.get(entity_id).is_ok_and(|frob_info| {
-                !frob_info.world_action.contains(FrobFlag::SCRIPT)
-                    && (frob_info.world_action.contains(FrobFlag::MOVE)
-                        || frob_info.world_action.contains(FrobFlag::USE_AMMO))
+                frob_info.world_action.contains(FrobFlag::MOVE)
+                    || frob_info.world_action.contains(FrobFlag::USE_AMMO)
             })
         };
         if !handles_move {
@@ -65,7 +68,10 @@ impl Script for InternalFrobMove {
 #[cfg(test)]
 mod tests {
     use cgmath::{Quaternion, vec3};
-    use dark::properties::{FrobFlag, Link, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Link, Links, PropFrobInfo, PropKeySrc, PropScripts, ToLink,
+        WrappedEntityId,
+    };
     use shipyard::World;
 
     use crate::{
@@ -144,8 +150,8 @@ mod tests {
     }
 
     #[test]
-    fn scripted_move_remains_owned_by_the_authored_script() {
-        let (world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+    fn scripted_move_preserves_the_engine_transfer() {
+        let (world, item, inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
 
         let effect = InternalFrobMove::new().handle_message(
             item,
@@ -154,6 +160,61 @@ mod tests {
             &MessagePayload::Frob,
         );
 
-        assert!(matches!(effect, Effect::NoEffect));
+        assert!(matches!(
+            effect,
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } if parent_entity_id == inventory && dropped_entity_id == item
+        ));
+    }
+
+    #[test]
+    fn keycard_script_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "internal_keycard must remain the sole transfer owner, got {effect:?}"
+        );
+    }
+
+    #[test]
+    fn frob_qb_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropScripts {
+                scripts: vec!["BaseButton".to_owned(), "FrobQB".to_owned()],
+                inherits: true,
+            },
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "FrobQB must remain the sole transfer owner, got {effect:?}"
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -512,18 +512,25 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
-/// Whether taking this world item must go through its authored scripts before
-/// the physical transfer. `MOVE | SCRIPT` quest items and keycards use this
-/// route so pickup cannot bypass their quest/access side effects.
+/// Whether taking this world item must go through a script before the physical
+/// transfer. This includes authored `MOVE | SCRIPT` items and `PropKeySrc`
+/// items, whose `internal_keycard` script is injected at runtime even when the
+/// authored world action is only `MOVE`.
 pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
-    world
+    let has_authored_script = world
         .borrow::<View<PropFrobInfo>>()
         .map(|frob_info| {
             frob_info
                 .get(entity_id)
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
-        .unwrap_or(false)
+        .unwrap_or(false);
+
+    has_authored_script
+        || world
+            .borrow::<View<dark::properties::PropKeySrc>>()
+            .map(|keycards| keycards.get(entity_id).is_ok())
+            .unwrap_or(false)
 }
 
 /// Whether an authored script is already the sole owner of this item's

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -526,6 +526,37 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
         .unwrap_or(false)
 }
 
+/// Whether an authored script is already the sole owner of this item's
+/// physical fate on world Frob.
+///
+/// Most `MOVE | SCRIPT` objects need both halves of `PropFrobInfo`: their
+/// scripts run side effects while the engine performs `MOVE`. Two established
+/// script paths are exceptions: keycards' injected `internal_keycard` script
+/// and `FrobQB` both deliberately transfer or consume the object themselves.
+/// Giving either the engine move handler as well would reparent or destroy the
+/// same entity twice.
+pub(crate) fn scripted_world_frob_owns_transfer(world: &World, entity_id: EntityId) -> bool {
+    let is_keycard = world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false);
+    if is_keycard {
+        return true;
+    }
+
+    world
+        .borrow::<View<dark::properties::PropScripts>>()
+        .map(|scripts| {
+            scripts.get(entity_id).is_ok_and(|scripts| {
+                scripts
+                    .scripts
+                    .iter()
+                    .any(|script| script.eq_ignore_ascii_case("frobqb"))
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
 /// a melee arm (`PropLimbModel`). Clicking one in the backpack/strip wields it
 /// (`Effect::GrabEntity`) instead of using it; shared by `ContainerGui` and the

--- a/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8194);
+
+// Stable ops3 mission-object ids. Runtime ids are rediscovered after every
+// launch and load.
+const DOCILE = 125;
+const CHIP_C = 840;
+const WRENCH = 1176;
+const OPS3_BULKHEAD = 185;
+
+const cyberModules = async (game: GameServer) =>
+  (await game.info()).player.stats?.cyber_modules;
+
+const property = (detail: EntityDetailResult, name: string) =>
+  detail.properties.find((candidate) => candidate.name === name)?.value;
+
+const squeeze = async (game: GameServer) => {
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 8 });
+};
+
+const swingWrench = async (game: GameServer) => {
+  await game.input.set("right_hand.trigger_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger_value", 0);
+  await game.step({ frames: 20 });
+};
+
+test(
+  "ops3: after an authored bulkhead transition, normal combat and corpse UI transfer Chip C once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `ops_chip_c_e2e_${Date.now()}`;
+
+    // Start in another mission and cross a process boundary before entering
+    // ops3. This matches the campaign's frontier-save restore and authored
+    // level-transition lifecycle.
+    {
+      await using game = await GameServer.launch({
+        mission: "ops2.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 5 });
+      // Match frontier-009's raw ShodanRoom bits (1), which permits this
+      // already-reached bulkhead without pretending the objective is complete.
+      await game.quests.set("ShodanRoom", "incomplete");
+      await game.save(saveName);
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops2.mis",
+        port: basePort,
+      });
+      await game.load(saveName);
+      const [bulkhead] = await game.entities.byTemplate(OPS3_BULKHEAD);
+      assert.equal(
+        bulkhead?.name,
+        "Bulk_On_Button",
+        "expected ops2's authored ops3 bulkhead object 185",
+      );
+      await teleportVerified(game, { x: 32.244, y: -8.596, z: 16.665 });
+      await game.player.aimAt(bulkhead, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+      assert.equal(
+        (await game.info()).mission.toLowerCase(),
+        "ops3.mis",
+        "normal squeeze on the authored ops2 bulkhead must transition to ops3",
+      );
+
+      const [docile] = await game.entities.byTemplate(DOCILE);
+      const [chip] = await game.entities.byTemplate(CHIP_C);
+      const [wrench] = await game.entities.byTemplate(WRENCH);
+      assert.ok(docile, "expected ops3 Docile mission object 125");
+      assert.equal(chip?.name, "Chip C", "expected ops3 Chip C mission object 840");
+      assert.equal(wrench?.name, "Wrench", "expected ops3 Wrench mission object 1176");
+      assert.equal(await cyberModules(game), 0, "fresh character starts with 0 modules");
+
+      const containedBefore = (await game.entities.detail(docile.id)).outgoing_links.filter(
+        (link) => link.link_type.startsWith("Contains"),
+      );
+      assert.ok(
+        containedBefore.some((link) => link.target_id === chip.id),
+        "Docile must contain the authored Chip C",
+      );
+
+      // Acquire the authored world Wrench through the production flat frob
+      // edge, then use its normal first-person attack path for every hit.
+      await teleportVerified(game, {
+        x: wrench.position[0] + 1.225,
+        y: wrench.position[1] + 0.634,
+        z: wrench.position[2] + 0.917,
+      });
+      await game.player.aimAt(wrench, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+
+      const armedInventory = await game.player.inventory();
+      assert.equal(
+        armedInventory.items.find((item) => item.entity_id === wrench.id)?.location,
+        "left_hand",
+        `world-frobbing the Wrench must wield it; got ${JSON.stringify(armedInventory.items)}`,
+      );
+      assert.equal(
+        (await game.info()).player.wielded_entity_id,
+        wrench.id,
+        "the authored Wrench must drive the production attack path",
+      );
+
+      let liveDocile = await game.entities.detail(docile.id);
+      assert.equal(Number(property(liveDocile, "HitPoints")), 48);
+      await teleportVerified(game, {
+        x: liveDocile.position[0] + 0.599,
+        y: liveDocile.position[1] - 0.695,
+        z: liveDocile.position[2] - 0.865,
+      });
+
+      for (const expectedHitPoints of [42, 36, 30, 24, 18, 12, 6, 0]) {
+        await game.player.aimAt(docile, {
+          hitbox: "torso",
+          visibility: "required",
+        });
+        await swingWrench(game);
+        liveDocile = await game.entities.detail(docile.id);
+        assert.equal(
+          Number(property(liveDocile, "HitPoints")),
+          expectedHitPoints,
+          `an ordinary Wrench swing must reduce Docile to ${expectedHitPoints} HP`,
+        );
+      }
+      assert.equal(property(liveDocile, "AIBehavior"), "Dead");
+      assert.equal(
+        (await game.info()).player.hit_points,
+        30,
+        "the docile encounter should not damage the player",
+      );
+
+      // The loot action uses the same aim/squeeze edge as a real corpse frob,
+      // followed by the semantic UI click that fires both BaseButton's reward
+      // and the engine's MOVE transfer.
+      await game.player.aimAt(docile, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await squeeze(game);
+
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, "frobbing slain Docile should open its creature loot panel");
+      const chipButton = panel.elements.find(
+        (element) =>
+          element.kind === "button" &&
+          element.entity_id === chip.id &&
+          element.label === "Chip C",
+      );
+      assert.ok(chipButton, "Docile's corpse panel should expose the Chip C button");
+
+      await clickUiElement(game, chipButton);
+
+      const inventory = await game.player.inventory();
+      assert.equal(
+        inventory.items.filter(
+          (item) => item.entity_id === chip.id && item.location === "inventory",
+        ).length,
+        1,
+        `Chip C must transfer to the backpack exactly once; got ${JSON.stringify(inventory.items)}`,
+      );
+      assert.equal(
+        await cyberModules(game),
+        10,
+        "Chip C's BaseButton must fire its authored 10-module reward exactly once",
+      );
+      assert.ok(
+        !(await game.entities.detail(docile.id)).outgoing_links.some(
+          (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+        ),
+        "the transfer must remove Chip C from Docile's contents",
+      );
+      assert.ok(
+        !(await game.ui.state()).active_panel?.elements.some(
+          (element) => element.entity_id === chip.id,
+        ),
+        "the transferred Chip C must disappear from the live corpse panel",
+      );
+
+      await game.save(saveName);
+    }
+
+    // A new runtime proves both halves survive the production save format:
+    // the unique physical chip remains carried and the one-shot reward does
+    // not re-fire during load.
+    await using reloaded = await GameServer.launch({
+      mission: "ops3.mis",
+      port: basePort,
+    });
+    await reloaded.load(saveName);
+    await reloaded.step({ frames: 5 });
+
+    const inventory = await reloaded.player.inventory();
+    assert.equal(
+      inventory.items.filter(
+        (item) => item.name === "Chip C" && item.location === "inventory",
+      ).length,
+      1,
+      `fresh-runtime load must retain exactly one Chip C; got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      await cyberModules(reloaded),
+      10,
+      "fresh-runtime load must retain the single 10-module reward",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/water-exit.e2e.test.ts
+++ b/tools/shock2-sdk/test/water-exit.e2e.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function hasFrontierSave(name: string): boolean {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots.some((root) => existsSync(join(root, "saves", `${name}.sav`)));
+}
+
+// Issue #680: frontier-007 is the verified campaign state on rec1's pool
+// floor. Before water-medium locomotion and general jump mantling, the same
+// held input remained pinned at y=-8.196 below the west-wall duct.
+//
+// The copyrighted campaign save is deliberately not checked in. Developers
+// with the play-through artifacts get the full regression; other environments
+// skip this one scenario while the equivalent mechanics remain covered by
+// deterministic Rust physics tests.
+test(
+  "rec1 frontier-007 swims and mantles out of the pool",
+  {
+    skip: !e2eEnabled || !hasFrontierSave("frontier-007"),
+    timeout: 600_000,
+  },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8127),
+    });
+    assert.equal((await game.load("frontier-007")).success, true);
+    await game.step({ frames: 5 });
+
+    const before = await game.player.position();
+    assert.ok(
+      before.y < -7.5,
+      `frontier must start on the pool floor, got ${JSON.stringify(before)}`,
+    );
+
+    // The save-restored body rotation plus yaw -90 faces the west-wall duct.
+    // These are ordinary persistent input channels used by desktop/VR too:
+    // forward swims, jump swims upward, then the same held jump mantles the lip.
+    await game.input.set("head.look", [-90, 0]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.input.set("jump", 1);
+    await game.step({ frames: 140 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.input.set("jump", 0);
+    await game.step({ frames: 5 });
+
+    const after = await game.player.position();
+    assert.ok(
+      after.y > -4.5,
+      `held swim+jump must reach the dry duct height, moved ${JSON.stringify(before)} -> ${JSON.stringify(after)}`,
+    );
+    assert.ok(
+      after.x < 10,
+      `the mantle must cross the west pool wall toward the duct, ended ${JSON.stringify(after)}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #680.

Stacked on #678 (`playthrough/late-game`) because `frontier-007` depends on the Rec Crew Key progression fixed there.

## Reproduction and root cause

The verified rec1 campaign save `frontier-007` starts on the Athletics pool floor at `(12.260, -8.196, -231.100)`. Retail treats the pool as water and lets the player swim upward and mantle into the west vent; the port treated it as dry space and left normal forward/crouch input pinned on the floor.

Three omissions combined into that blocker:

- world-cell `medium`, `flags`, and `flow_group` bytes were parsed and discarded;
- WR texture ids 247/248 (the directed water-boundary surfaces) were explicitly skipped;
- player locomotion had no water state, buoyancy, jump/swim-up input, or general jump mantle outside ladder top-out.

## Change

- Preserve authored cell medium/flags/flow-group metadata and expose water cells to mission spatial queries.
- Parse `FAMILY`, `WATERBANKS`, and `FLOW_TEX`; retain 247/248 water polygons and render the authored `waterhw/BLin` / `BLout` surface with the mission's 0.35 alpha.
- Add a held jump channel across desktop (`Space`), debug runtime, and Quest (right thumbstick click); move debug-item spawn to `F10`.
- Restore the retail movement slice: neutral water buoyancy, 0.7 swim speed, held 2.5 ft/s swim-up, grounded 10 ft/s jump with 32 ft/s² gravity, and blocked-forward general mantling through the existing Dark-style preflighted top-out path.
- Add isolated parser/physics tests and an opt-in real-save SDK regression for `frontier-007`.

`CELL_MOTION` flow vectors are intentionally not applied as player current: original-source evidence supports them as portal/medium motion metadata, but their force mapping is not sufficiently established for this focused blocker fix.

## Negative-first

The parser regression initially failed because `CellMedium` and the three retained fields did not exist. The two new movement regressions initially failed because there was no water-aware update path or `PlayerMedium`; on the old build the matched 141-frame SDK input rejects `jump` and remains at `(12.2601, -8.1960, -231.1007)`.

After the fix:

- `cell_preserves_authored_medium_flags_and_flow_group` passes;
- `water_medium_suspends_gravity_and_jump_swims_upward` passes;
- `grounded_jump_has_a_ballistic_rise` passes;
- `held_jump_mantles_a_blocking_pool_lip_without_a_ladder` passes;
- the exact `frontier-007` replay reaches `(9.1601, -4.1910, -231.0967)` in the west grated vent space using only held forward+jump input.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark -p shock2vr -p desktop_runtime -p debug_runtime`
  - dark: 68 unit + 8 real-data integration passed
  - shock2vr: 355 passed
  - debug runtime: 1 passed; 1 display-only test ignored
- `cd tools/shock2-sdk && npm test` — 25 passed, 146 e2e skipped as designed
- focused real-save water-exit e2e — passed in 12.6s
- full `npm run test:e2e` — 169/171 passed, including the new water exit and all 23 mission loads

Both full-suite failures reproduce unchanged on the untouched stacked base `094c6c0`:

- Earth Psionic Training: Cryokinesis spends psi but misses the Training Droid.
- `world-aim.e2e.test.ts`: fixed-name `world-aim-e2e` save is rejected as corrupt immediately after saving.

## Campaign

Fixed-order late-game play-through campaign, iteration 007. This legacy ledger predates randomized campaign metadata, so it has no scenario/tweak/assets/seed roll to report.

## Visual verification

![rec1 water exit before/after](https://gist.githubusercontent.com/tommy-xr/201cd58e29d6cb3827f94fb2d6c543b7/raw/water-exit-before-after.gif)

<sub>The verified `frontier-007` campaign save: the base build remains pinned on the pool floor, while the fix swims up and mantles into the west vent under the same 141-frame held-input sequence. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Focused after

![water exit after](https://gist.githubusercontent.com/tommy-xr/201cd58e29d6cb3827f94fb2d6c543b7/raw/water-exit-after.gif)

### Before → after

![authored pool water restored](https://gist.githubusercontent.com/tommy-xr/201cd58e29d6cb3827f94fb2d6c543b7/raw/water-surface-before-after.png)

![pool floor to west vent](https://gist.githubusercontent.com/tommy-xr/201cd58e29d6cb3827f94fb2d6c543b7/raw/water-exit-result-before-after.png)
