### PR TITLE
fix(gameplay): preserve scripted loot transfer

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -308,17 +308,18 @@ pub fn create_entity_core(
         processed_scripts.push("internal_keycard".to_owned());
     }
 
-    // `MOVE` is an engine frob action, not an object script. Ordinary goodies
-    // such as Med Patches and armor only inherit that flag, so give them the
-    // internal handler that moves them into the backpack on Frob. Objects that
-    // also request SCRIPT keep their existing authored ownership (notably
-    // FrobQB's circuit-board/quest-item transfer).
+    // `MOVE` is an engine frob action, not an object script. Give every
+    // grabbable world-frob item the internal move handler even when it also
+    // requests SCRIPT: the authored scripts contribute side effects and the
+    // engine still performs the physical transfer. The only exceptions are
+    // paths that explicitly own transfer/consumption themselves (`FrobQB` and
+    // the injected keycard script).
     let needs_frob_move = {
         let v_frob_info = world.borrow::<View<PropFrobInfo>>().unwrap();
         v_frob_info.get(entity_id).is_ok_and(|frob| {
-            !frob.world_action.contains(FrobFlag::SCRIPT)
-                && (frob.world_action.contains(FrobFlag::MOVE)
-                    || frob.world_action.contains(FrobFlag::USE_AMMO))
+            (frob.world_action.contains(FrobFlag::MOVE)
+                || frob.world_action.contains(FrobFlag::USE_AMMO))
+                && !crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id)
         })
     };
     if needs_frob_move {

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -5,12 +5,12 @@ use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
 
-/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior for
-/// ordinary pickup items that do not ask an authored script to handle Frob.
+/// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior.
 ///
-/// `MOVE | SCRIPT` objects keep their existing scripted ownership. In
-/// particular, `FrobQB` must award the Engineering circuit board's quest bit
-/// and transfer it exactly once.
+/// `MOVE | SCRIPT` means both actions happen: authored scripts keep their side
+/// effects while this handler performs the physical transfer. Entities whose
+/// scripts explicitly own transfer/consumption (`FrobQB` and keycards) never
+/// receive this handler and are guarded here too.
 pub struct InternalFrobMove;
 
 impl InternalFrobMove {
@@ -31,14 +31,17 @@ impl Script for InternalFrobMove {
             return Effect::NoEffect;
         }
 
+        if crate::virtual_hand::scripted_world_frob_owns_transfer(world, entity_id) {
+            return Effect::NoEffect;
+        }
+
         let handles_move = {
             let frob_info = world
                 .borrow::<View<dark::properties::PropFrobInfo>>()
                 .unwrap();
             frob_info.get(entity_id).is_ok_and(|frob_info| {
-                !frob_info.world_action.contains(FrobFlag::SCRIPT)
-                    && (frob_info.world_action.contains(FrobFlag::MOVE)
-                        || frob_info.world_action.contains(FrobFlag::USE_AMMO))
+                frob_info.world_action.contains(FrobFlag::MOVE)
+                    || frob_info.world_action.contains(FrobFlag::USE_AMMO)
             })
         };
         if !handles_move {
@@ -65,7 +68,10 @@ impl Script for InternalFrobMove {
 #[cfg(test)]
 mod tests {
     use cgmath::{Quaternion, vec3};
-    use dark::properties::{FrobFlag, Link, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Link, Links, PropFrobInfo, PropKeySrc, PropScripts, ToLink,
+        WrappedEntityId,
+    };
     use shipyard::World;
 
     use crate::{
@@ -144,8 +150,8 @@ mod tests {
     }
 
     #[test]
-    fn scripted_move_remains_owned_by_the_authored_script() {
-        let (world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+    fn scripted_move_preserves_the_engine_transfer() {
+        let (world, item, inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
 
         let effect = InternalFrobMove::new().handle_message(
             item,
@@ -154,6 +160,61 @@ mod tests {
             &MessagePayload::Frob,
         );
 
-        assert!(matches!(effect, Effect::NoEffect));
+        assert!(matches!(
+            effect,
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } if parent_entity_id == inventory && dropped_entity_id == item
+        ));
+    }
+
+    #[test]
+    fn keycard_script_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "internal_keycard must remain the sole transfer owner, got {effect:?}"
+        );
+    }
+
+    #[test]
+    fn frob_qb_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE | FrobFlag::SCRIPT, false);
+        world.add_component(
+            item,
+            PropScripts {
+                scripts: vec!["BaseButton".to_owned(), "FrobQB".to_owned()],
+                inherits: true,
+            },
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "FrobQB must remain the sole transfer owner, got {effect:?}"
+        );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -526,6 +526,37 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
         .unwrap_or(false)
 }
 
+/// Whether an authored script is already the sole owner of this item's
+/// physical fate on world Frob.
+///
+/// Most `MOVE | SCRIPT` objects need both halves of `PropFrobInfo`: their
+/// scripts run side effects while the engine performs `MOVE`. Two established
+/// script paths are exceptions: keycards' injected `internal_keycard` script
+/// and `FrobQB` both deliberately transfer or consume the object themselves.
+/// Giving either the engine move handler as well would reparent or destroy the
+/// same entity twice.
+pub(crate) fn scripted_world_frob_owns_transfer(world: &World, entity_id: EntityId) -> bool {
+    let is_keycard = world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false);
+    if is_keycard {
+        return true;
+    }
+
+    world
+        .borrow::<View<dark::properties::PropScripts>>()
+        .map(|scripts| {
+            scripts.get(entity_id).is_ok_and(|scripts| {
+                scripts
+                    .scripts
+                    .iter()
+                    .any(|script| script.eq_ignore_ascii_case("frobqb"))
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
 /// a melee arm (`PropLimbModel`). Clicking one in the backpack/strip wields it
 /// (`Effect::GrabEntity`) instead of using it; shared by `ContainerGui` and the

--- a/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8194);
+
+// Stable ops3 mission-object ids. Runtime ids are rediscovered after every
+// launch and load.
+const DOCILE = 125;
+const CHIP_C = 840;
+
+const cyberModules = async (game: GameServer) =>
+  (await game.info()).player.stats?.cyber_modules;
+
+test(
+  "ops3: looting Docile's Chip C runs its reward and transfers it exactly once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `ops_chip_c_e2e_${Date.now()}`;
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops3.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 5 });
+
+      const [docile] = await game.entities.byTemplate(DOCILE);
+      const [chip] = await game.entities.byTemplate(CHIP_C);
+      assert.ok(docile, "expected ops3 Docile mission object 125");
+      assert.equal(chip?.name, "Chip C", "expected ops3 Chip C mission object 840");
+      assert.equal(await cyberModules(game), 0, "fresh character starts with 0 modules");
+
+      const containedBefore = (await game.entities.detail(docile.id)).outgoing_links.filter(
+        (link) => link.link_type.startsWith("Contains"),
+      );
+      assert.ok(
+        containedBefore.some((link) => link.target_id === chip.id),
+        "Docile must contain the authored Chip C",
+      );
+
+      // Kill only stages the production corpse flow; the assertion below uses
+      // the real creaturecontainer panel, semantic item button, BaseButton
+      // SwitchLink, EXP trap, and engine MOVE action.
+      for (let i = 0; i < 8; i++) {
+        await game.entities.sendMessage(docile.id, { type: "Damage", amount: 50 });
+        await game.step({ frames: 3 });
+      }
+      await game.step({ frames: 20 });
+
+      const corpse = await game.entities.detail(docile.id);
+      await teleportVerified(game, {
+        x: corpse.position[0] + 1.0,
+        y: corpse.position[1] + 0.5,
+        z: corpse.position[2] + 1.0,
+      });
+      await game.entities.sendMessage(docile.id, { type: "Frob" });
+      await game.step({ frames: 5 });
+
+      const panel = (await game.ui.state()).active_panel;
+      assert.ok(panel, "frobbing slain Docile should open its creature loot panel");
+      const chipButton = panel.elements.find(
+        (element) =>
+          element.kind === "button" &&
+          element.entity_id === chip.id &&
+          element.label === "Chip C",
+      );
+      assert.ok(chipButton, "Docile's corpse panel should expose the Chip C button");
+
+      await clickUiElement(game, chipButton);
+
+      const inventory = await game.player.inventory();
+      assert.equal(
+        inventory.items.filter(
+          (item) => item.entity_id === chip.id && item.location === "inventory",
+        ).length,
+        1,
+        `Chip C must transfer to the backpack exactly once; got ${JSON.stringify(inventory.items)}`,
+      );
+      assert.equal(
+        await cyberModules(game),
+        10,
+        "Chip C's BaseButton must fire its authored 10-module reward exactly once",
+      );
+      assert.ok(
+        !(await game.entities.detail(docile.id)).outgoing_links.some(
+          (link) => link.link_type.startsWith("Contains") && link.target_id === chip.id,
+        ),
+        "the transfer must remove Chip C from Docile's contents",
+      );
+      assert.ok(
+        !(await game.ui.state()).active_panel?.elements.some(
+          (element) => element.entity_id === chip.id,
+        ),
+        "the transferred Chip C must disappear from the live corpse panel",
+      );
+
+      await game.save(saveName);
+    }
+
+    // A new runtime proves both halves survive the production save format:
+    // the unique physical chip remains carried and the one-shot reward does
+    // not re-fire during load.
+    await using reloaded = await GameServer.launch({
+      mission: "ops3.mis",
+      port: basePort,
+    });
+    await reloaded.load(saveName);
+    await reloaded.step({ frames: 5 });
+
+    const inventory = await reloaded.player.inventory();
+    assert.equal(
+      inventory.items.filter(
+        (item) => item.name === "Chip C" && item.location === "inventory",
+      ).length,
+      1,
+      `fresh-runtime load must retain exactly one Chip C; got ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      await cyberModules(reloaded),
+      10,
+      "fresh-runtime load must retain the single 10-module reward",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-chip-loot.e2e.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
 import { clickUiElement } from "./helpers/ui.js";
 
@@ -12,27 +13,80 @@ const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8194);
 // launch and load.
 const DOCILE = 125;
 const CHIP_C = 840;
+const WRENCH = 1176;
+const OPS3_BULKHEAD = 185;
 
 const cyberModules = async (game: GameServer) =>
   (await game.info()).player.stats?.cyber_modules;
 
+const property = (detail: EntityDetailResult, name: string) =>
+  detail.properties.find((candidate) => candidate.name === name)?.value;
+
+const squeeze = async (game: GameServer) => {
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 8 });
+};
+
+const swingWrench = async (game: GameServer) => {
+  await game.input.set("right_hand.trigger_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger_value", 0);
+  await game.step({ frames: 20 });
+};
+
 test(
-  "ops3: looting Docile's Chip C runs its reward and transfers it exactly once",
+  "ops3: after an authored bulkhead transition, normal combat and corpse UI transfer Chip C once",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     const saveName = `ops_chip_c_e2e_${Date.now()}`;
 
+    // Start in another mission and cross a process boundary before entering
+    // ops3. This matches the campaign's frontier-save restore and authored
+    // level-transition lifecycle.
     {
       await using game = await GameServer.launch({
-        mission: "ops3.mis",
+        mission: "ops2.mis",
         port: basePort,
       });
       await game.step({ frames: 5 });
+      // Match frontier-009's raw ShodanRoom bits (1), which permits this
+      // already-reached bulkhead without pretending the objective is complete.
+      await game.quests.set("ShodanRoom", "incomplete");
+      await game.save(saveName);
+    }
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops2.mis",
+        port: basePort,
+      });
+      await game.load(saveName);
+      const [bulkhead] = await game.entities.byTemplate(OPS3_BULKHEAD);
+      assert.equal(
+        bulkhead?.name,
+        "Bulk_On_Button",
+        "expected ops2's authored ops3 bulkhead object 185",
+      );
+      await teleportVerified(game, { x: 32.244, y: -8.596, z: 16.665 });
+      await game.player.aimAt(bulkhead, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+      assert.equal(
+        (await game.info()).mission.toLowerCase(),
+        "ops3.mis",
+        "normal squeeze on the authored ops2 bulkhead must transition to ops3",
+      );
 
       const [docile] = await game.entities.byTemplate(DOCILE);
       const [chip] = await game.entities.byTemplate(CHIP_C);
+      const [wrench] = await game.entities.byTemplate(WRENCH);
       assert.ok(docile, "expected ops3 Docile mission object 125");
       assert.equal(chip?.name, "Chip C", "expected ops3 Chip C mission object 840");
+      assert.equal(wrench?.name, "Wrench", "expected ops3 Wrench mission object 1176");
       assert.equal(await cyberModules(game), 0, "fresh character starts with 0 modules");
 
       const containedBefore = (await game.entities.detail(docile.id)).outgoing_links.filter(
@@ -43,23 +97,67 @@ test(
         "Docile must contain the authored Chip C",
       );
 
-      // Kill only stages the production corpse flow; the assertion below uses
-      // the real creaturecontainer panel, semantic item button, BaseButton
-      // SwitchLink, EXP trap, and engine MOVE action.
-      for (let i = 0; i < 8; i++) {
-        await game.entities.sendMessage(docile.id, { type: "Damage", amount: 50 });
-        await game.step({ frames: 3 });
-      }
-      await game.step({ frames: 20 });
-
-      const corpse = await game.entities.detail(docile.id);
+      // Acquire the authored world Wrench through the production flat frob
+      // edge, then use its normal first-person attack path for every hit.
       await teleportVerified(game, {
-        x: corpse.position[0] + 1.0,
-        y: corpse.position[1] + 0.5,
-        z: corpse.position[2] + 1.0,
+        x: wrench.position[0] + 1.225,
+        y: wrench.position[1] + 0.634,
+        z: wrench.position[2] + 0.917,
       });
-      await game.entities.sendMessage(docile.id, { type: "Frob" });
-      await game.step({ frames: 5 });
+      await game.player.aimAt(wrench, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      await squeeze(game);
+
+      const armedInventory = await game.player.inventory();
+      assert.equal(
+        armedInventory.items.find((item) => item.entity_id === wrench.id)?.location,
+        "left_hand",
+        `world-frobbing the Wrench must wield it; got ${JSON.stringify(armedInventory.items)}`,
+      );
+      assert.equal(
+        (await game.info()).player.wielded_entity_id,
+        wrench.id,
+        "the authored Wrench must drive the production attack path",
+      );
+
+      let liveDocile = await game.entities.detail(docile.id);
+      assert.equal(Number(property(liveDocile, "HitPoints")), 48);
+      await teleportVerified(game, {
+        x: liveDocile.position[0] + 0.599,
+        y: liveDocile.position[1] - 0.695,
+        z: liveDocile.position[2] - 0.865,
+      });
+
+      for (const expectedHitPoints of [42, 36, 30, 24, 18, 12, 6, 0]) {
+        await game.player.aimAt(docile, {
+          hitbox: "torso",
+          visibility: "required",
+        });
+        await swingWrench(game);
+        liveDocile = await game.entities.detail(docile.id);
+        assert.equal(
+          Number(property(liveDocile, "HitPoints")),
+          expectedHitPoints,
+          `an ordinary Wrench swing must reduce Docile to ${expectedHitPoints} HP`,
+        );
+      }
+      assert.equal(property(liveDocile, "AIBehavior"), "Dead");
+      assert.equal(
+        (await game.info()).player.hit_points,
+        30,
+        "the docile encounter should not damage the player",
+      );
+
+      // The loot action uses the same aim/squeeze edge as a real corpse frob,
+      // followed by the semantic UI click that fires both BaseButton's reward
+      // and the engine's MOVE transfer.
+      await game.player.aimAt(docile, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      await squeeze(game);
 
       const panel = (await game.ui.state()).active_panel;
       assert.ok(panel, "frobbing slain Docile should open its creature loot panel");


### PR DESCRIPTION
## Summary

- preserve both halves of authored `MOVE | SCRIPT` frob semantics: run object scripts and perform the engine-level physical transfer
- keep `PropKeySrc`/`internal_keycard` and `FrobQB` as explicit sole transfer owners, preventing double reparent/destroy
- cover the production-faithful ops2 frontier restore → authored ops3 bulkhead → world Wrench → normal combat → Docile corpse UI flow

Fixes #682.

## Faithfulness

`cargo dq entities ops3.mis 840` shows that Chip C is authored as `MOVE | SCRIPT`, inherits `ToolConsumable`, adds `BaseButton`, and SwitchLinks to Experience Trap 1348. `BaseButton` owns the reward side effect; neither authored script owns a Frob transfer. The fix therefore lives in the existing engine `PropFrobInfo` action path rather than in an ops3-specific script or debug shim.

The existing special owners remain unchanged:

- `PropKeySrc` injects `internal_keycard`, which grants access and owns the physical item fate.
- `FrobQB` awards its quest bit and owns transfer/consumption for its quest object.
- ordinary `MOVE` continues through `internal_frob_move`.

## Campaign / stack

This is the third PR in the active late-game play-through stack and is based on `playthrough/water-exit-680` (PR #681), which itself stacks on `playthrough/late-game` (PR #678).

The PR has two logical commits:

1. `fix(gameplay): preserve scripted loot transfer`
2. `test(gameplay): exercise production Chip C loot path`

Campaign: legacy fixed-order late-game play-through, iteration 010. This ledger predates randomized campaign metadata, so it has no scenario/tweak/assets/seed roll metadata.

## Stale-binary replay correction

Iteration 010b initially appeared to reproduce the bug on this branch, but independent review has reclassified that run as `ARTIFACT`, not a current-HEAD blocker:

- frontier-009 contains no saved ops3 level state, eliminating legacy ops3 serialization as the cause
- the focused test failed before a forced rebuild, then passed as soon as rebuilding logged `InternalFrobMove` emitting the transfer effect
- three uninstrumented runs then passed against an unchanged rebuilt shared-target binary
- a cross-worktree run later reproduced the failure by reusing Cargo fingerprints in a shared target, directly confirming the stale-artifact class

Iteration 010b did not record the old executable's hash, so frontier-009 remains authoritative and must not advance until the manager performs a full replay against a hash-recorded rebuilt binary. The reviewed artifact verdict is at `/tmp/claude/playthrough/iteration-010b-ops3/review.json`.

### Exact-HEAD replay handoff

Prepared but did not launch a fresh replay binary:

- HEAD: `613b0d7e17d6c60640969ec807969cec96871baf`
- target: `/tmp/claude/playthrough/target-replay-683-613b0d7`
- binary SHA-256: `929e5cef8dfe12af09651eee843363e0e122ba5633c19fc16e5ba9001698c444`
- binary mtime: `2026-07-28T06:08:37-0700`

## Verification

### Negative-first production scenario

The hardened SDK test uses:

- an ops2 save written in one process and loaded in a fresh process
- frontier-009's `ShodanRoom=incomplete` quest state
- the authored ops2 mission-object 185 bulkhead, aimed and squeezed normally
- the authored ops3 mission-object 1176 Wrench, picked up with normal world input
- eight ordinary trigger swings against Docile with the exact HP sequence `48 → 42 → 36 → 30 → 24 → 18 → 12 → 6 → 0`
- a normal corpse aim/squeeze and one semantic Chip C UI click
- fresh-process save/load verification

Immutable target proof:

- base `d78bc16`: binary SHA-256 `11557ce43c0b73758eeddd33096f302d24005b0bb37676a335560e828952b98f` — failed at the intended assertion because the reward fired but Chip C did not enter inventory
- fix `7d0baf1`: binary SHA-256 `5eafa3ac59ae6f95176b2f9a4b66416507d6718023647f25790ef1eaf994ef35` — passed three consecutive runs with the hash unchanged
- the hardened scenario also passed in the full serialized suite in 23.9s

### Checks

- `cargo fmt --all -- --check` — passed (pre-push hook)
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed from a fresh target
- `cd tools/shock2-sdk && npm test` — 25 passed, 147 opt-in skipped
- GitHub CI — Android, macOS, Ubuntu, and Windows all passed
- full SDK E2E — 170/172 passed
  - all 23 mission loads, the hardened Chip C scenario, and every adjacent Operations/loot scenario passed
  - the two failures were reproduced identically on immutable base `d78bc16`: Earth Psionic Training's Cryokinesis projectile did not reduce the real droid's HP, and `world-aim-e2e` rejected its fixed-name save as corrupt/incompatible
- independent final review — approved with zero blocking and zero nonblocking findings

## Visual verification

![Ops3 Chip C corpse-loot transfer](https://gist.githubusercontent.com/tommy-xr/7555d952b056c0a61f3ddf936cf74707/raw/ops-chip-loot.gif)

<sub>Clicking the real Chip C corpse button runs the authored reward, clears Docile’s loot slot, and places the unique chip in the backpack. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep) using stable mission objects Docile 125 / Chip C 840 and live semantic pointer coordinates.</sub>

### After

![Chip C carried after loot](https://gist.githubusercontent.com/tommy-xr/7555d952b056c0a61f3ddf936cf74707/raw/ops-chip-loot-after.png)

### Before → after

![Base leaves Chip C in the corpse; fix moves it to the backpack](https://gist.githubusercontent.com/tommy-xr/7555d952b056c0a61f3ddf936cf74707/raw/ops-chip-loot-before-after.png)
