### PR TITLE
feat(skill): exclude issues with active PRs

### DIFF
--- a/.claude/skills/fix-random-issues/SKILL.md
+++ b/.claude/skills/fix-random-issues/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: fix-random-issues
 description: >-
-  Randomly sample X open GitHub issues from shock2quest and process them
-  sequentially, delegating one issue at a time to an isolated agent that must
-  reproduce or confirm the problem, implement a focused fix, verify it, and open
-  a reviewable PR. Use for requests to fix, sweep, tackle, or work through a
-  bounded number of random open shock2quest issues.
+  Randomly sample X eligible open GitHub issues from shock2quest, excluding
+  issues already addressed by an open PR, and process them sequentially,
+  delegating one issue at a time to an isolated agent that must reproduce or
+  confirm the problem, implement a focused fix, verify it, and open a reviewable
+  PR. Use for requests to fix, sweep, tackle, or work through a bounded number
+  of random open shock2quest issues.
 ---
 
 # Fix random issues
@@ -22,11 +23,18 @@ before starting the next.
   `tommy-xr/shock2quest`. Honor an explicit repository override.
 - Accept an optional seed. Generate and report one when omitted.
 
+Before drawing, exclude an issue when an open PR in the repository declares
+that it closes, fixes, or resolves that issue. These issues are not part of the
+eligible pool and do not consume a sample slot. This check deliberately reads
+the open PR bodies as well as the open issue list, so stacked PRs are recognized
+even when GitHub does not populate their default-branch closing metadata.
+
 Do not silently replace skipped, closed, duplicate, already-fixed, or
 unreproducible selections. Each still consumes one sample slot. This preserves
 the random sample and makes the run produce up to X fixes rather than
-cherry-picking X easy fixes. If fewer than X issues are open, process all of
-them and report the smaller sample.
+cherry-picking X easy fixes. If fewer than X eligible issues remain, process all
+of them and report the smaller sample. If a PR begins addressing a selected
+issue after the sample is frozen, skip it without drawing a replacement.
 
 ## 1. Preflight and freeze the sample
 
@@ -45,20 +53,23 @@ them and report the smaller sample.
 
    Add `--seed <value>` when supplied. `.agents/skills` is the compatibility
    symlink to `.claude/skills`, so this command works for both Claude and Codex.
-5. Keep the emitted repository, seed, and ordered `selected` array as the run
-   ledger. Do not rerun the draw unless the user explicitly requests a new
-   sample.
+5. Keep the emitted repository, seed, `excludedActivePullRequests`, and ordered
+   `selected` array as the run ledger. Do not rerun the draw unless the user
+   explicitly requests a new sample.
 
-The selector samples all open issues without inspecting difficulty, labels, or
-assignees first. Random means random; do not quietly filter the pool.
+The selector samples all eligible open issues without inspecting difficulty,
+labels, or assignees first. The active-PR exclusion above is the only
+pre-sampling filter. Random means random; do not quietly filter the eligible
+pool further.
 
 ## 2. Process the selected issues serially
 
 For each selected issue, in emitted order:
 
 1. Re-read it with `gh issue view`, including its current state, body, comments,
-   labels, and assignees. Skip it if it is no longer open. Check current
-   `origin/main` for an existing fix or superseding PR before editing.
+   labels, and assignees. Skip it if it is no longer open or an open PR now
+   declares that it closes, fixes, or resolves the issue. Check current
+   `origin/main` for an existing fix or superseding merged PR before editing.
 2. Start one issue worker using the host's delegation tool. Prefer a
    host-provided isolated worktree. Otherwise create a unique branch/worktree
    from current `origin/main`, named along the lines of
@@ -72,7 +83,8 @@ For each selected issue, in emitted order:
 5. Record one terminal result:
    - `fixed`: reproduction/confirmation, focused fix, local verification,
      conventional commit, PR containing `Fixes #N`, and green CI.
-   - `skipped`: closed, duplicate, superseded, or already fixed on current main.
+   - `skipped`: closed, duplicate, actively addressed by an open PR, superseded,
+     or already fixed on current main.
    - `not reproduced`: reasonable evidence failed to confirm the report.
    - `blocked`: a concrete product decision, unavailable dependency/hardware,
      unsafe scope, or persistent verification/CI failure prevents completion.
@@ -125,8 +137,9 @@ as incomplete. A PR URL alone is not completion.
 
 ## 3. Report the sweep
 
-Return the repository, seed, requested count, actual sampled count, and a table
-in sampled order with:
+Return the repository, seed, requested count, eligible count, actual sampled
+count, and the issues excluded because of active PRs. Then provide a table in
+sampled order with:
 
 | Issue | Result | Evidence | Commit / PR | Verification |
 |---|---|---|---|---|

--- a/.claude/skills/fix-random-issues/agents/openai.yaml
+++ b/.claude/skills/fix-random-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Fix Random Issues"
-  short_description: "Fix random open issues one at a time"
-  default_prompt: "Use $fix-random-issues to attempt 3 randomly selected open shock2quest issues sequentially."
+  short_description: "Fix random issues without active PRs"
+  default_prompt: "Use $fix-random-issues to attempt 3 randomly selected eligible shock2quest issues without active PRs and process them sequentially."

--- a/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
+++ b/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
@@ -7,7 +7,8 @@ function usage() {
   console.log(`Usage:
   node select-open-issues.mjs <count> [--repo OWNER/REPO] [--seed VALUE]
 
-Randomly select a fixed sample of open GitHub issues. Output is JSON.
+Randomly select a fixed sample of open GitHub issues. Issues addressed by an
+open pull request are excluded before sampling. Output is JSON.
 
 Options:
   --repo OWNER/REPO  Repository to query (default: current gh repository)
@@ -134,7 +135,22 @@ function shuffle(values, random) {
   return result;
 }
 
-function listOpenIssues(repository) {
+function closingIssueNumbers(body, repository) {
+  const numbers = new Set();
+  const closingReference =
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:(?:https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/issues\/)|(?:([^#\s]+\/[^#\s]+)#)|#)(\d+)\b/gi;
+
+  for (const match of body?.matchAll(closingReference) ?? []) {
+    const referencedRepository = match[1] ?? match[2] ?? repository;
+    if (referencedRepository.toLowerCase() === repository.toLowerCase()) {
+      numbers.add(Number(match[3]));
+    }
+  }
+
+  return numbers;
+}
+
+function listOpenCandidates(repository) {
   const endpoint = `repos/${repository}/issues?state=open&per_page=100`;
   const raw = runGh(["api", "--paginate", "--slurp", endpoint]);
   let pages;
@@ -148,8 +164,8 @@ function listOpenIssues(repository) {
     fail("GitHub response was not a paginated issue list");
   }
 
-  return pages
-    .flat()
+  const items = pages.flat();
+  const openIssues = items
     .filter((issue) => !issue.pull_request)
     .map((issue) => ({
       number: issue.number,
@@ -161,13 +177,52 @@ function listOpenIssues(repository) {
       assignees: (issue.assignees ?? []).map((assignee) => assignee.login),
     }))
     .sort((left, right) => left.number - right.number);
+  const issueNumbers = new Set(openIssues.map(({ number }) => number));
+  const pullRequestsByIssue = new Map();
+
+  for (const pullRequest of items.filter((item) => item.pull_request)) {
+    for (const issueNumber of closingIssueNumbers(pullRequest.body, repository)) {
+      if (!issueNumbers.has(issueNumber)) {
+        continue;
+      }
+      const pullRequests = pullRequestsByIssue.get(issueNumber) ?? [];
+      pullRequests.push({
+        number: pullRequest.number,
+        title: pullRequest.title,
+        url: pullRequest.html_url,
+      });
+      pullRequestsByIssue.set(issueNumber, pullRequests);
+    }
+  }
+
+  for (const pullRequests of pullRequestsByIssue.values()) {
+    pullRequests.sort((left, right) => left.number - right.number);
+  }
+
+  const excludedActivePullRequests = openIssues
+    .filter(({ number }) => pullRequestsByIssue.has(number))
+    .map((issue) => ({
+      issueNumber: issue.number,
+      issueTitle: issue.title,
+      issueUrl: issue.url,
+      pullRequests: pullRequestsByIssue.get(issue.number),
+    }));
+  const eligibleIssues = openIssues.filter(
+    ({ number }) => !pullRequestsByIssue.has(number),
+  );
+
+  return { openIssues, eligibleIssues, excludedActivePullRequests };
 }
 
 const options = parseArgs(process.argv.slice(2));
 const repository = resolveRepository(options.repo);
 const seed = options.seed ?? randomBytes(16).toString("hex");
-const openIssues = listOpenIssues(repository);
-const selected = shuffle(openIssues, seededRandom(seed)).slice(0, options.count);
+const { openIssues, eligibleIssues, excludedActivePullRequests } =
+  listOpenCandidates(repository);
+const selected = shuffle(eligibleIssues, seededRandom(seed)).slice(
+  0,
+  options.count,
+);
 
 console.log(
   JSON.stringify(
@@ -175,7 +230,9 @@ console.log(
       repository,
       seed,
       requested: options.count,
-      available: openIssues.length,
+      openIssues: openIssues.length,
+      excludedActivePullRequests,
+      available: eligibleIssues.length,
       sampled: selected.length,
       selected,
     },

--- a/.claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs
+++ b/.claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const selector = fileURLToPath(
+  new URL("./select-open-issues.mjs", import.meta.url),
+);
+
+function issue(number) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    html_url: `https://github.com/owner/repo/issues/${number}`,
+    labels: [],
+    assignees: [],
+  };
+}
+
+function pullRequest(number, body) {
+  return {
+    number,
+    title: `PR ${number}`,
+    html_url: `https://github.com/owner/repo/pull/${number}`,
+    body,
+    pull_request: {},
+  };
+}
+
+test("excludes issues addressed by an open pull request before sampling", () => {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "select-open-issues-"),
+  );
+  const fakeGh = path.join(temporaryDirectory, "gh");
+  writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env node
+if (process.argv[2] !== "api") {
+  process.stderr.write("unexpected gh command");
+  process.exit(2);
+}
+process.stdout.write(process.env.FAKE_GH_RESPONSE);
+`,
+  );
+  chmodSync(fakeGh, 0o755);
+
+  try {
+    const response = [
+      [
+        issue(10),
+        issue(11),
+        issue(12),
+        issue(13),
+        issue(14),
+        pullRequest(90, "Fixes #11"),
+        pullRequest(91, "Related context: #10"),
+        pullRequest(92, "Resolves owner/repo#12"),
+        pullRequest(
+          93,
+          "Closes https://github.com/owner/repo/issues/13",
+        ),
+        pullRequest(94, "Fixes someone/else#14"),
+        pullRequest(95, "Fixes #11"),
+      ],
+    ];
+    const result = spawnSync(
+      process.execPath,
+      [selector, "5", "--repo", "owner/repo", "--seed", "active-pr-test"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_RESPONSE: JSON.stringify(response),
+          PATH: `${temporaryDirectory}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.openIssues, 5);
+    assert.equal(output.available, 2);
+    assert.deepEqual(
+      output.selected
+        .map(({ number }) => number)
+        .sort((left, right) => left - right),
+      [10, 14],
+    );
+    assert.deepEqual(
+      output.excludedActivePullRequests.map(({ issueNumber, pullRequests }) => ({
+        issueNumber,
+        pullRequests: pullRequests.map(({ number }) => number),
+      })),
+      [
+        { issueNumber: 11, pullRequests: [90, 95] },
+        { issueNumber: 12, pullRequests: [92] },
+        { issueNumber: 13, pullRequests: [93] },
+      ],
+    );
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- exclude issues addressed by an open pull request before freezing the random sample
- recognize local, repository-qualified, and full-URL closing references in open PR bodies
- report excluded issues and their active PRs in the selector ledger
- document the pre-sampling eligibility rule and the post-sampling race check

## Negative-first

The new selector regression failed on the original implementation because all five open issues remained in the pool and no active-PR exclusion ledger existed. It passes after the filter, leaving only the two eligible issues.

The fixture also proves that ordinary issue mentions and closing references to another repository do not exclude a local issue.

## Verification

- `node --test .claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs`
- `node --check .claude/skills/fix-random-issues/scripts/select-open-issues.mjs`
- `node --check .claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs`
- `quick_validate.py .claude/skills/fix-random-issues` — Skill is valid
- `git diff --check`

The existing frozen draw that prompted this improvement was not rerun.
