### PR TITLE
fix(physics): stop dead creatures blocking players

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -869,7 +869,8 @@ fn create_physics_representation_with_options(
     // SCALE_FACTOR/6 (0.4167 world units) and make it visibly settle after
     // every load. Preserve the live creature's dynamic capsule geometry and
     // material, place it at the exact saved transform, then start it asleep.
-    // Contacts and impulses can still wake/push it.
+    // The corpse group keeps it on the world and selectable for looting without
+    // leaving a player-blocking creature capsule behind.
     if v_death_pose.get(entity_id).is_ok() {
         if let (Ok(pos), Ok(creature_type)) = (v_pos.get(entity_id), v_creature.get(entity_id)) {
             let creature_def = get_creature_definition(creature_type.0).unwrap();
@@ -885,7 +886,7 @@ fn create_physics_representation_with_options(
                 pos.rotation,
                 vec3(0.0, -creature_def.physics_offset_height, 0.0),
                 creature_shape,
-                CollisionGroup::entity(),
+                CollisionGroup::corpse(),
                 false,
                 dynamics_options,
             );

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -80,7 +80,7 @@ use crate::{
     interaction::{FlatInteraction, InteractionContext, PlayerInteraction, VrInteraction},
     inventory::PlayerInventoryEntity,
     mission::{SpatialQueryEngine, entity_populator::EntityPopulator},
-    physics::{self, PlayerHandle},
+    physics::{self, CollisionGroup, PlayerHandle},
     quest_info::QuestInfo,
     runtime_props::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
@@ -4442,15 +4442,18 @@ impl MissionCore {
                     }
                 }
                 Effect::SpawnCorpseRagdoll { entity_id, impact } => {
-                    // Death-crumple handoff (AI deaths): once the death
-                    // animation has finished, replace the animated corpse with
-                    // a physics ragdoll seeded from its final pose. Gated on
-                    // the `ragdoll` experimental flag - without it the
-                    // animated corpse entity persists exactly as before.
+                    // Death-crumple handoff (AI deaths): shortly after the
+                    // animation starts, replace the animated corpse with a
+                    // physics ragdoll seeded from its current pose. Without
+                    // the experimental flag, keep the animated corpse but
+                    // narrow its capsule to world/selectable collision: it
+                    // remains grounded and lootable without blocking the
+                    // player.
                     // (Known experimental limitations: the ragdoll corpse is
-                    // not serialized, so it vanishes on save/load; and the
-                    // creature entity is removed, which will matter once
-                    // corpse looting (`creaturecontainer`) is implemented.)
+                    // not serialized, so it vanishes on save/load; and removing
+                    // the creature entity also removes its creaturecontainer
+                    // loot target.)
+                    let mut spawned_ragdoll = false;
                     if game_options.experimental_features.contains("ragdoll") {
                         let ragdoll_id = self.spawn_ragdoll(
                             entity_id,
@@ -4461,6 +4464,7 @@ impl MissionCore {
                             // overlapping.
                             true,
                         );
+                        spawned_ragdoll = ragdoll_id.is_some();
                         // Seed the corpse with the killing blow: the struck
                         // limb gets a shove along the shot's direction, so the
                         // corpse reacts to HOW it died instead of collapsing
@@ -4472,6 +4476,14 @@ impl MissionCore {
                                 &mut self.physics,
                             );
                         }
+                    }
+                    // A successful ragdoll spawn removes the original creature
+                    // and its capsule. In the normal path (or when a model
+                    // cannot make a ragdoll), retain the corpse entity but
+                    // exclude its capsule from player/entity collision.
+                    if !spawned_ragdoll {
+                        self.physics
+                            .set_collision_group(entity_id, CollisionGroup::corpse());
                     }
                 }
                 Effect::StopSound { handle } => {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1924,6 +1924,18 @@ impl CollisionGroup {
         })
     }
 
+    /// Collision behavior for a retained non-ragdoll creature corpse. Keep the
+    /// body supported by authored world geometry and in selectable raycasts,
+    /// but do not leave its old creature capsule solid to players, living AIs,
+    /// moving terrain, or loose props.
+    pub fn corpse() -> CollisionGroup {
+        CollisionGroup(InteractionGroups {
+            memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
+            filter: InternalCollisionGroups::WORLD.bits.into(),
+            test_mode: Default::default(),
+        })
+    }
+
     /// Same collision behavior as `entity()`, plus the `CLIMBABLE` marker
     /// membership so player movement can detect ladder contact (see
     /// `PropPhysAttr.climbable`).
@@ -1991,11 +2003,7 @@ impl CollisionGroup {
     /// positions in a single step. Floor contact is what matters for a lying
     /// corpse; limb self-collision is cosmetic in that pose.
     pub fn ragdoll_no_self() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
-            memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
-            filter: InternalCollisionGroups::WORLD.bits.into(),
-            test_mode: Default::default(),
-        })
+        Self::corpse()
     }
 }
 
@@ -2475,6 +2483,24 @@ impl PhysicsWorld {
             &mut self.multibody_joint_set,
             true,
         );
+    }
+
+    /// Replace the collision groups on every collider owned by an entity's
+    /// primary body. This preserves the body's pose, material, sleep state,
+    /// and world contacts while changing which actors it can obstruct.
+    pub fn set_collision_group(&mut self, entity_id: EntityId, group: CollisionGroup) {
+        let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
+            return;
+        };
+        let Some(body) = self.rigid_body_set.get(handle) else {
+            return;
+        };
+        let collider_handles = body.colliders().to_vec();
+        for collider_handle in collider_handles {
+            if let Some(collider) = self.collider_set.get_mut(collider_handle) {
+                collider.set_collision_groups(group.0);
+            }
+        }
     }
 
     /// Resize every cuboid collider attached to a kinematic body. GUI panels
@@ -5289,6 +5315,64 @@ mod tests {
             obstacle.0.test(generic_entity_ray),
             "selection/projectile rays must still hit the obstacle"
         );
+    }
+
+    #[test]
+    fn corpse_body_stays_grounded_and_selectable_without_blocking_characters() {
+        let mut world = PhysicsWorld::new();
+        let corpse_id = EntityId::from_inner(1).unwrap();
+        let handle = world.add_dynamic(
+            corpse_id,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Capsule {
+                height: 1.0,
+                radius: 0.5,
+            },
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+
+        world.set_collision_group(corpse_id, CollisionGroup::corpse());
+
+        let collider = &world.collider_set[world.rigid_body_set[handle].colliders()[0]];
+        let corpse = collider.collision_groups();
+        let player = InteractionGroups::new(
+            InternalCollisionGroups::PLAYER.bits.into(),
+            InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            Default::default(),
+        );
+        let live_creature = CollisionGroup::actor().0;
+        let terrain = InteractionGroups::new(
+            InternalCollisionGroups::WORLD.bits.into(),
+            InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            Default::default(),
+        );
+        let selectable_query = InteractionGroups::new(
+            InternalCollisionGroups::ALL.bits.into(),
+            InternalCollisionGroups::SELECTABLE.bits.into(),
+            Default::default(),
+        );
+
+        assert!(
+            !corpse.test(player),
+            "corpse capsule must not block the player"
+        );
+        assert!(
+            !corpse.test(live_creature),
+            "corpse capsule must not block living creatures"
+        );
+        assert!(
+            corpse.test(terrain),
+            "corpse must remain supported by terrain"
+        );
+        assert!(
+            corpse.test(selectable_query),
+            "corpse must remain selectable for looting"
+        );
+        assert!(!collider.is_sensor(), "world support uses a solid collider");
     }
 
     /// AI movement probes must use the actor membership, not a generic ray:

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -797,9 +797,10 @@ impl Script for AnimatedMonsterAI {
                 self.death_elapsed += time.elapsed.as_secs_f32();
             }
             // Near-instant handoff: once the death animation has had a few
-            // frames, offer the corpse to physics (no-op without the
-            // `ragdoll` experimental flag; a successful spawn removes this
-            // entity, so at most one emission ever matters).
+            // frames, offer the corpse to physics. With ragdolls disabled the
+            // handler makes the animated capsule non-blocking; a successful
+            // ragdoll spawn removes this entity, so at most one emission ever
+            // matters.
             let handoff_effect = if self.is_dead
                 && !self.handoff_emitted
                 && self.death_elapsed >= CRUMPLE_HANDOFF_SECONDS

--- a/tools/shock2-sdk/test/monster-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/monster-death.e2e.test.ts
@@ -105,11 +105,21 @@ test(
     // measurement (observed 0.74 against a 0.5 threshold). Rest is a physics
     // fact, so ask the body. If it never sleeps, fall through and let the
     // assertion report the real motion rather than masking it.
+    let corpseBody:
+      | Awaited<ReturnType<typeof game.physics.bodies>>["bodies"][number]
+      | undefined;
     for (let i = 0; i < 60; i++) {
       const [body] = (await game.physics.bodies({ entityId: monster.id })).bodies;
+      corpseBody = body;
       if (body?.is_sleeping) break;
       await game.step({ frames: 10 });
     }
+    assert.ok(corpseBody, "corpse should retain its body for interaction");
+    assert.deepEqual(
+      corpseBody.collision_groups,
+      ["selectable"],
+      "a non-ragdoll corpse must stay selectable without entity/player collision",
+    );
     const deadPos = (await game.entities.detail(monster.id)).position;
     for (let i = 0; i < 5; i++) {
       await game.step({ frames: 120 });
@@ -182,6 +192,11 @@ test(
     );
     assert.ok(savedBody, "terminal corpse body should be sleeping");
     assert.equal(savedBody.body_type, "dynamic");
+    assert.deepEqual(
+      savedBody.collision_groups,
+      ["selectable"],
+      "a non-ragdoll corpse must stay selectable without entity/player collision",
+    );
     const savedCorpse = await game.entities.detail(monster.id);
     assert.equal(aiProp(savedCorpse, "AIBehavior"), "Dead");
     assert.equal(savedAnimation.clip, null, "death animation should be complete");

--- a/tools/shock2-sdk/test/ops2-corpse-corridor.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-corpse-corridor.e2e.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// This regression depends on a deep campaign save, which contains player state
+// and retail-derived mission data and therefore cannot live in the repository.
+// Opt in by naming the locally preserved save (without `.sav`):
+//
+//   SHOCK2_CORPSE_BLOCK_SAVE=campaign_ops_shodan_25th_iter03_corpse_block_20260808 \
+//     SHOCK2_E2E=1 node --test dist/test/ops2-corpse-corridor.e2e.test.js
+const saveName = process.env.SHOCK2_CORPSE_BLOCK_SAVE;
+const e2eEnabled = process.env.SHOCK2_E2E === "1" && saveName !== undefined;
+
+// Stable mission-object id, not a runtime entity id: the Protocol Droid that
+// died across ops2's Crew-lower catwalk near (63.25, -9.50, 107.33).
+const CATWALK_PROTOCOL_DROID = 354;
+
+test(
+  "ops2 exact save: the retained Protocol Droid corpse does not seal the Crew catwalk",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8491),
+    });
+
+    const loaded = await game.load(saveName!);
+    assert.equal(loaded.success, true);
+    assert.equal(loaded.mission, "ops2.mis");
+    await game.step({ frames: 5 });
+
+    const matches = await game.entities.byTemplate(CATWALK_PROTOCOL_DROID);
+    assert.equal(
+      matches.length,
+      1,
+      `expected the saved Protocol Droid object ${CATWALK_PROTOCOL_DROID}`,
+    );
+    const corpse = matches[0]!;
+    const detail = await game.entities.detail(corpse.id);
+    assert.equal(
+      detail.properties.find((property) => property.name === "AIBehavior")?.value,
+      "Dead",
+      "the preserved droid must be a terminal corpse, not a live obstruction",
+    );
+
+    const bodies = await game.physics.bodies({ entityId: corpse.id });
+    assert.equal(bodies.bodies.length, 1, "the corpse keeps one grounded interaction body");
+    assert.equal(
+      bodies.bodies[0]!.blocks_player,
+      false,
+      "a retained corpse body must not stop the player capsule",
+    );
+
+    // Production interaction still sees and frobs the corpse: use the real
+    // camera ray and squeeze edge, then require its ordinary (empty) SEARCH
+    // panel. This is the player-observable guard that the fix did not delete
+    // the terminal pose or its creaturecontainer target.
+    await game.player.aimAt(corpse, { hitbox: "center", visibility: "required" });
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    const ui = await game.ui.state();
+    assert.ok(ui.active_panel, "the retained corpse should still open its SEARCH panel");
+    assert.equal(ui.active_panel.entity_id, corpse.id);
+    await game.screenshot("ops2-corpse-corridor-search.png");
+
+    // Dismiss the SEARCH panel through the normal bare-view click, then walk
+    // straight through the only route. The railings close both edges, so
+    // reaching z<106.4 proves normal movement crossed the corpse's old capsule.
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 2 });
+    const start = (await game.info()).player.position;
+    const move = await game.player.moveTo({ x: start[0], y: start[1], z: 104.8 });
+    await game.step({ frames: 10 });
+    const end = (await game.info()).player.position;
+    assert.equal(move.blocked, false, `corpse crossing was blocked: ${JSON.stringify(move)}`);
+    assert.ok(
+      end[2] < 106.4,
+      `the player must cross south of the corpse: z ${start[2]} -> ${end[2]}`,
+    );
+    await game.screenshot("ops2-corpse-corridor-crossed.png");
+
+    const stillThere = await game.entities.byTemplate(CATWALK_PROTOCOL_DROID);
+    assert.equal(stillThere.length, 1, "crossing must not delete the corpse entity");
+    assert.equal(stillThere[0]!.id, corpse.id);
+  },
+);

--- a/tools/shock2-sdk/test/shodan-corpse-drift.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-corpse-drift.e2e.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const LIVE_RED_ASSASSINS = [643, 644, 649, 678] as const;
+const ASSASSIN_CORRIDOR_SPIKES = [1226, 1227, 1309] as const;
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((property) => property.name === name)?.value;
+}
+
+function distance3(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+test(
+  "newly killed SHODAN assassins stop at their terminal death pose",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8460),
+    });
+
+    await game.step({ frames: 10 });
+
+    const assassins = await Promise.all(
+      LIVE_RED_ASSASSINS.map(async (templateId) => {
+        const matches = await game.entities.byTemplate(templateId);
+        assert.equal(
+          matches.length,
+          1,
+          `expected one Red Assassin mission object ${templateId}`,
+        );
+        return matches[0]!;
+      }),
+    );
+    const deathPositions = new Map(
+      assassins.map((assassin) => [assassin.id, assassin.position] as const),
+    );
+
+    for (const assassin of assassins) {
+      await game.entities.sendMessage(assassin.id, {
+        type: "Damage",
+        amount: 1000,
+      });
+    }
+
+    // Wait for every randomly selected one-shot crumple to drain. The
+    // terminal pose is the ownership boundary: authored root motion may move
+    // the creature during the crumple, but no motion may survive afterwards.
+    const terminalPositions = new Map<number, [number, number, number]>();
+    for (
+      let attempt = 0;
+      attempt < 120 && terminalPositions.size < assassins.length;
+      attempt += 1
+    ) {
+      await game.step({ frames: 5 });
+      for (const assassin of assassins) {
+        if (terminalPositions.has(assassin.id)) continue;
+        const animation = await game.entities.animation(assassin.id);
+        if (
+          animation?.clip === null &&
+          animation.last_clip &&
+          animation.queue.length === 0
+        ) {
+          const detail = await game.entities.detail(assassin.id);
+          assert.equal(aiProp(detail, "AIBehavior"), "Dead");
+          const deathPosition = deathPositions.get(assassin.id)!;
+          const crumpleTravel = distance3(deathPosition, detail.position);
+          assert.ok(
+            crumpleTravel < 3,
+            `dying Assassin ${assassin.template_id} traveled ${crumpleTravel.toFixed(3)} units from ${JSON.stringify(deathPosition)} to terminal pose ${JSON.stringify(detail.position)}`,
+          );
+          terminalPositions.set(assassin.id, detail.position);
+        }
+      }
+    }
+    assert.equal(
+      terminalPositions.size,
+      assassins.length,
+      "all Assassin death animations should reach their terminal poses",
+    );
+
+    // The east-loop tripwire activates these authored DataShape elevators
+    // beside the Assassin group. Injecting the same TurnOn payload directly
+    // is focused fixture setup: it preserves the production moving-terrain
+    // and corpse physics paths without replaying the whole traversal.
+    for (const templateId of ASSASSIN_CORRIDOR_SPIKES) {
+      const matches = await game.entities.byTemplate(templateId);
+      assert.equal(
+        matches.length,
+        1,
+        `expected moving Spike mission object ${templateId}`,
+      );
+      await game.entities.sendMessage(matches[0]!.id, { type: "TurnOn" });
+    }
+    await game.step({ frames: 600 });
+
+    for (const assassin of assassins) {
+      const terminal = terminalPositions.get(assassin.id)!;
+      const detail = await game.entities.detail(assassin.id);
+      const drift = distance3(terminal, detail.position);
+      assert.equal(aiProp(detail, "AIBehavior"), "Dead");
+      assert.ok(
+        drift < 0.1,
+        `dead Assassin ${assassin.template_id} drifted ${drift.toFixed(3)} units from ${JSON.stringify(terminal)} to ${JSON.stringify(detail.position)}`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
Fixes #562
Fixes #716

## Reproduction

### Exact Operations blocker

Campaign: `custom Operations→SHODAN · detailed · System Shock 2: 25th Anniversary Remaster assets · legacy pre-randomization ledger (no seed)`

On unmodified baseline `c07099af`, cold-load the locally retained save `campaign_ops_shodan_25th_iter03_corpse_block_20260808` (3,090,510 bytes; SHA-256 `6576c87093e72a865ce27b85e0077e4c96ad422eebef0dce4e77fdda261969e8`). The save is intentionally not published because it contains player/campaign state and retail-derived data.

The normally killed Protocol Droid (stable ops2 mission object `354`) lies transversely across the only ~2.5-unit Crew-lower catwalk near `(63.25, -9.50, 107.33)`. It remains visibly present and its empty SEARCH panel opens normally, but its one sleeping dynamic body reports `blocks_player: true` and `blocks_actor: true`.

From the saved player position `(64.25889, -9.95597, 108.02995)`:

- Collision-checked movement toward five center/edge lanes beyond the corpse advances only ~0.000–0.006 units and never crosses south of `z=106.4`.
- 180 fixed frames of normal production thumbstick input likewise stop at `z=108.02429`.
- Railings and walls close both edges, so there is no player-sized route around it.

The new exact-save E2E failed negative-first on main at `blocks_player true !== false`.

### Restarted Engineering campaign revalidation

Campaign: `engineering · verify-camera-alarms · 25th · seed 839293941`

A fresh `eng1.mis` run killed the authored OG-Pipes (stable mission objects `924` and `1670`) through ordinary `Damage`. On current `origin/main` (`ff09cde1`), the focused negative-first check retained the living `actor` collision group. The rebased fix leaves both corpses present and dead while reporting `blocks_player: false`, `blocks_actor: false`, and collision group `selectable`. The same result holds after loading the locally retained reproduction save `pt-eng-iter0-corpse-choke-repro` (SHA-256 `723672f4811b84bec72e1c3e935b8b28b39071e07f2c678fa7ee176146974884`). The save is intentionally not published because it contains player/campaign state and retail-derived data.

Adversarial review downgraded this occurrence from blocker to playable/non-blocking: an ordinary jump plus forward movement clears the narrow coolant-pipe choke on unmodified main. The retained collider is still a real defect covered by #562, but it did not gate campaign progress and this PR was not stacked onto the campaign branch.

### Other generic reproductions

- A fresh killed OG-Pipe retained the same solid capsule before and after save/load.
- SHODAN's moving corridor spikes swept retained Assassin corpses more than ten units from their terminal poses.
- Earlier Engineering and Operations runs found the same collider in narrow coolant/Data Storage routes.

## Root cause

AI death deliberately retains the creature entity for its authored terminal pose, scripts, persistence, and `creaturecontainer` looting. With experimental ragdolls disabled, `SpawnCorpseRagdoll` was a no-op, so a fresh corpse kept the living `ACTOR` capsule forever. Save/load independently recreated a terminal `RuntimePropDeathPose` with a fully solid `ENTITY` capsule.

The shipped ops2 droid is a normal `PropCreature` with an authored two-submodel SPHERE physics model and remains a searchable corpse after death. The public openDarkEngine physics declarations also keep AI collision as an explicit model concern. Because this port currently represents a non-ragdoll creature with one retained capsule, the faithful inference is to preserve world support and ray/search selection while dropping character, moving-terrain, and loose-prop contacts at the death transition—not delete the corpse or its container data.

## Fix

- Add a retained-corpse collision group with `SELECTABLE` membership and a `WORLD`-only filter.
- Apply it at the ordinary animated death handoff, including the fallback when an experimental ragdoll cannot be created.
- Recreate save-loaded terminal corpses with the same group.
- Preserve the body, completed death pose, creature scripts, SEARCH target, and contained loot.
- Keep successful experimental ragdoll spawning unchanged: it still replaces the original capsule with articulated limbs.
- Restacked on current `origin/main` (`ff09cde1`) following #826, with focused coverage proving corpses block neither players nor living creatures.

## Verification

- Negative-first on current `origin/main` (`ff09cde1`): the fresh killed OG-Pipe assertion failed with collision group `actor` instead of `selectable`.
- Rebased fix (`b513813d`): focused corpse collision unit passed; fresh and save-loaded 25th-assets OG-Pipe E2Es passed (2/2).
- Restarted Engineering evidence passed both fresh-death and local-save checks for mission objects `924` and `1670`: present + dead, `blocks_player: false`, `blocks_actor: false`, group `selectable`.
- Focused 25th-assets E2E gate — **5/5 passed**: fresh death, loaded corpse, creature loot, exact ops2 crossing/search, and SHODAN moving-terrain drift.
- `cargo test -p shock2vr` — **537 passed**.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- SDK units — **26 passed**, 201 expected E2E skips.
- GitHub Actions — all five required checks green on restacked commit `b513813d`.

## Player-observable evidence

![SHODAN corpse drift before/after](https://gist.githubusercontent.com/tommy-xr/914068ea6474e9c77ba3ab16e90619de/raw/issue-716-corpse-drift-before-after.gif)

<sub>Matched fresh `shodan.mis` runs: template 643 was killed through normal `Damage`, its terminal animation queue was allowed to drain, and authored Spike movers 1226/1227/1309 were activated. Over the same 240 fixed frames, main's corpse was swept 10.262 units while the fix held it at 0.000 drift. Captured headlessly through `/v1/step` + `/v1/screenshot`.</sub>

### Start — terminal pose

![SHODAN corpse drift comparison at start](https://gist.githubusercontent.com/tommy-xr/914068ea6474e9c77ba3ab16e90619de/raw/issue-716-start.png)

### End — 240 fixed frames

![SHODAN corpse drift comparison after 240 fixed frames](https://gist.githubusercontent.com/tommy-xr/914068ea6474e9c77ba3ab16e90619de/raw/issue-716-end.png)

### Exact Operations blocker — before → after

![Ops2 corpse corridor exact-save before/after](https://gist.githubusercontent.com/tommy-xr/70145d7b077c34bb97040386b74e3a75/raw/ops2-corpse-corridor-before-after.gif)

<sub>Same validated save and identical 1.8 seconds of production locomotion: main is deflected into the railings and remains on the starting side at z=108.21; PR #685 passes the dead Protocol Droid and reaches z=103.57. The opening and closing SEARCH views show that the corpse remains visible and frobbable. Captured headlessly via `/v1/step` + `/v1/screenshot` at a fixed 60 Hz timestep.</sub>

#### Final SEARCHable corpse

![Ops2 corpse corridor blocked versus crossed still](https://gist.githubusercontent.com/tommy-xr/70145d7b077c34bb97040386b74e3a75/raw/ops2-corpse-corridor-before-after.png)

<sub>Baseline remains pressed against the corpse; the fixed build looks back from beyond it while the same empty SEARCH panel is open.</sub>



