### PR TITLE
fix(gameplay): stop locked buttons relaying signals

### DIFF
--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -62,14 +62,83 @@ impl Script for BaseButton {
 
             // In some places (like the computer for the engine room in eng1), invisible buttons are used as proxies -
             // there will be an actual button that sends a 'TurnOn' message to an invisible button. Not sure why
-            // this pattern is used.
-            MessagePayload::TurnOn { from: _ } => send_to_all_switch_links(
-                world,
-                entity_id,
-                MessagePayload::TurnOn { from: entity_id },
-            ),
+            // this pattern is used. A remote press still honors the proxy's lock;
+            // otherwise tripwires can relay through authored locked card slots.
+            MessagePayload::TurnOn { from: _ } if !self.is_locked(entity_id, world) => {
+                send_to_all_switch_links(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                )
+            }
 
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, PropLocked, ToLink, WrappedEntityId};
+
+    use crate::quest_info::QuestInfo;
+
+    use super::*;
+
+    fn sent_messages(effect: &Effect) -> Vec<(EntityId, MessagePayload)> {
+        match effect {
+            Effect::Send { msg } => vec![(msg.to, msg.payload.clone())],
+            Effect::Combined { effects } => effects.iter().flat_map(sent_messages).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn button_with_switch_link(world: &mut World, target: EntityId, locked: bool) -> EntityId {
+        world.add_entity((
+            PropLocked(locked),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ))
+    }
+
+    #[test]
+    fn turn_on_only_relays_when_the_button_is_unlocked() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let target = world.add_entity(());
+        let locked = button_with_switch_link(&mut world, target, true);
+        let unlocked = button_with_switch_link(&mut world, target, false);
+        let physics = PhysicsWorld::new();
+        let mut button = BaseButton::new();
+
+        let locked_effect = button.handle_message(
+            locked,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: locked },
+        );
+        assert!(
+            sent_messages(&locked_effect).is_empty(),
+            "a locked button must not relay a scripted TurnOn"
+        );
+
+        let unlocked_effect = button.handle_message(
+            unlocked,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: unlocked },
+        );
+        assert!(
+            sent_messages(&unlocked_effect)
+                .iter()
+                .any(|(to, payload)| *to == target
+                    && matches!(payload, MessagePayload::TurnOn { from } if *from == unlocked)),
+            "an unlocked proxy button must keep relaying scripted TurnOn"
+        );
     }
 }

--- a/tools/shock2-sdk/test/command-locked-card-relay.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-locked-card-relay.e2e.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type {
+  EntityDetailResult,
+  EntitySummary,
+  PhysicsBodySummary,
+} from "../src/types.js";
+
+// Command's two objective gates use the same authored pattern:
+//
+//   tripwire 77/606 -> locked card slot 621 -> umbilical door 251
+//   tripwire 70/74  -> locked card slot 69  -> shuttle-bay doors 476/477
+//
+// The slots have PropLocked(true), no key destination, and TweqLockedButton.
+// A tripwire TurnOn must therefore stop at the locked button instead of
+// relaying to the doors and bypassing their authored quest-bit openers (#664).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const UMBILICAL_DOOR = 251;
+const UMBILICAL_TRIPWIRE = 77;
+const SHUTTLE_DOORS = [476, 477] as const;
+const SHUTTLE_TRIPWIRE = 70;
+
+async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one command1 object ${objectId}, got ${JSON.stringify(found.map((e) => e.name))}`,
+  );
+  return found[0];
+}
+
+async function doorState(
+  game: GameServer,
+  objectId: number,
+): Promise<{ detail: EntityDetailResult; body: PhysicsBodySummary }> {
+  const door = await only(game, objectId);
+  const [body] = (await game.physics.bodies({ entityId: door.id })).bodies;
+  assert.ok(body, `door ${objectId} must own a collider`);
+  assert.equal(body.body_type, "kinematic", `door ${objectId} collider must be kinematic`);
+  assert.equal(body.is_enabled, true, `door ${objectId} collider must be enabled`);
+  return {
+    detail: await game.entities.detail(door.id),
+    body,
+  };
+}
+
+function distance(a: readonly number[], b: readonly number[]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+async function enterTripwire(game: GameServer, objectId: number): Promise<void> {
+  const tripwire = await only(game, objectId);
+  const [x, y, z] = tripwire.position;
+  await game.player.teleport({ x, y: y + 0.5, z });
+  await game.step({ frames: 240 });
+}
+
+test(
+  "command1: locked card slots do not relay tripwire TurnOn to quest-gated doors",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8157),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal(await game.quests.get("ShuttleABoom"), "unknown");
+    assert.equal(await game.quests.get("ShuttleBBoom"), "unknown");
+    assert.equal(await game.quests.get("opscom"), "unknown");
+    assert.equal(await game.quests.get("engcom"), "unknown");
+
+    const umbilicalBefore = await doorState(game, UMBILICAL_DOOR);
+    const shuttleBefore = await Promise.all(
+      SHUTTLE_DOORS.map((door) => doorState(game, door)),
+    );
+
+    // Establish that door 251 starts physically shut, rather than merely
+    // looking displaced: it owns an enabled kinematic collider at the same
+    // live position as the rendered entity. (A Swarmer Floor Pod overlaps the
+    // approach ray here, so body inspection is the unambiguous check.)
+    assert.ok(
+      distance(umbilicalBefore.detail.position, umbilicalBefore.body.position) < 0.01,
+      "umbilical door collider must start at the rendered closed position",
+    );
+
+    // Enter the live authored tripwires without frobbing anything. Teleport is
+    // staged as locomotion and reaches TrapNewTripwire through Rapier's real
+    // SensorBeginIntersect message.
+    await enterTripwire(game, UMBILICAL_TRIPWIRE);
+    await enterTripwire(game, SHUTTLE_TRIPWIRE);
+
+    const umbilicalAfter = await doorState(game, UMBILICAL_DOOR);
+    const shuttleAfter = await Promise.all(
+      SHUTTLE_DOORS.map((door) => doorState(game, door)),
+    );
+
+    assert.ok(
+      distance(umbilicalAfter.detail.position, umbilicalAfter.body.position) < 0.01,
+      "door 251's collider must follow its live rendered position",
+    );
+    for (const [index, objectId] of SHUTTLE_DOORS.entries()) {
+      assert.ok(
+        distance(shuttleAfter[index].detail.position, shuttleAfter[index].body.position) < 0.01,
+        `door ${objectId}'s collider must follow its live rendered position`,
+      );
+    }
+
+    const changedDoors = [
+      {
+        objectId: UMBILICAL_DOOR,
+        before: umbilicalBefore.detail.position,
+        after: umbilicalAfter.detail.position,
+        bodyAfter: umbilicalAfter.body.position,
+      },
+      ...SHUTTLE_DOORS.map((objectId, index) => ({
+        objectId,
+        before: shuttleBefore[index].detail.position,
+        after: shuttleAfter[index].detail.position,
+        bodyAfter: shuttleAfter[index].body.position,
+      })),
+    ].filter(({ before, after }) => distance(before, after) >= 0.01);
+    assert.deepEqual(
+      changedDoors,
+      [],
+      `locked card slots must leave every quest-gated door closed: ${JSON.stringify(changedDoors)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- make scripted `TurnOn` honor a `BaseButton` receiver's live lock state
- preserve `TurnOn` relay behavior for unlocked proxy buttons
- cover both locked-card-slot quest bypasses in `command1.mis`

## Reproduction

On unmodified `origin/main`, the new mission scenario started with
`ShuttleABoom`, `ShuttleBBoom`, `opscom`, and `engcom` all unset.

- Door 251 started at its authored closed position
  `[-184.40205, -15.5, 12.410615]` with one enabled kinematic collider at the
  same position.
- Entering authored tripwire 77 without any frob relayed through locked,
  keyless card slot 621. Door 251 and its collider moved fully open to
  `[-184.40205, -11.9, 12.410615]` (3.6 units).
- Entering sibling tripwire 70 likewise relayed through locked, keyless card
  slot 69. Doors 476 and 477, plus their colliders, each moved fully open by
  2.2 units.

This establishes that the doors genuinely opened and carried their colliders
out of the doorway; the reported pass-through was not a missing or failed
collider.

## Root cause and fix

`BaseButton` checked `PropLocked` for player `Frob`, but its scripted `TurnOn`
branch unconditionally resent every SwitchLink. `TweqLockedButton` composes
`BaseButton`, so a tripwire could use that branch to pass through an authored
locked card slot.

The `TurnOn` relay now runs only when `is_entity_locked` is false. This uses the
same live lock state as player interaction and keeps legitimate unlocked proxy
buttons working.

## Verification

- `cargo test -p shock2vr scripts::base_button::tests::turn_on_only_relays_when_the_button_is_unlocked -- --exact`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cd tools/shock2-sdk && npm test` — 25 passed, 0 failed
- focused `command-locked-card-relay.e2e.test.ts` — passed; both quest gates and
  all three live colliders remained closed after their real tripwires fired
- full `npm run test:e2e` — 168/171 passed, including all 23 mission loads and
  every relevant button/door/tripwire/unlock scenario. The three first-pass
  failures were unrelated existing/timing-sensitive scenarios:
  - Earth Cryokinesis missed its training droid; reproduced on clean `main`
  - world-aim save/load rejected its save as incompatible; reproduced on clean
    `main`
  - DebugForceChase convergence failed once, then passed focused reruns on both
    this branch and clean `main`

## Visual evidence

![Locked card relay comparison](https://gist.githubusercontent.com/tommy-xr/511f08c109262b552a3abec3ce386a9f/raw/pr686-tripwire-door.gif)

<sub>Tripwire 77 fires with both shuttle quest bits unset: before, locked slot 621 relays and raises the umbilical door; after, the locked slot suppresses the relay and the quest gate stays closed. Red outlines show the live debug-physics colliders. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![Before base open vs after fix closed](https://gist.githubusercontent.com/tommy-xr/511f08c109262b552a3abec3ce386a9f/raw/pr686-final-state.png)

Fixes #664

