### PR TITLE
fix(gameplay): grant access for move-only keycards

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -291,7 +291,15 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::{FrobFlag, PropFrobInfo, PropPlayerGun};
+    use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
+
+    fn frob_info(world_action: FrobFlag) -> PropFrobInfo {
+        PropFrobInfo {
+            world_action,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        }
+    }
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -311,7 +319,7 @@ mod tests {
     fn world_use_of_nonweapon_stores_it_without_displacing_wielded_weapon() {
         let mut world = World::new();
         let pistol = world.add_entity(pistol());
-        let ammo = world.add_entity(());
+        let ammo = world.add_entity(frob_info(FrobFlag::MOVE));
         let mut controller = FlatPlayerController::new();
         controller.wield(pistol);
 
@@ -352,11 +360,7 @@ mod tests {
     #[test]
     fn world_use_of_scripted_pickup_dispatches_frob_instead_of_bypassing_it() {
         let mut world = World::new();
-        let keycard = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::MOVE | FrobFlag::SCRIPT,
-            inventory_action: FrobFlag::empty(),
-            tool_action: FrobFlag::empty(),
-        });
+        let keycard = world.add_entity(frob_info(FrobFlag::MOVE | FrobFlag::SCRIPT));
         let mut controller = FlatPlayerController::new();
 
         let effects = controller.pick_up(&world, keycard);
@@ -372,6 +376,35 @@ mod tests {
                 }] if *to == keycard
             ),
             "a MOVE | SCRIPT pickup must run its authored Frob path"
+        );
+    }
+
+    #[test]
+    fn world_use_of_move_only_keycard_dispatches_frob_for_injected_script() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            frob_info(FrobFlag::MOVE),
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+        ));
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, keycard);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                }] if *to == keycard
+            ),
+            "a MOVE-only PropKeySrc pickup must run its injected keycard Frob path"
         );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -512,18 +512,25 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     false
 }
 
-/// Whether taking this world item must go through its authored scripts before
-/// the physical transfer. `MOVE | SCRIPT` quest items and keycards use this
-/// route so pickup cannot bypass their quest/access side effects.
+/// Whether taking this world item must go through a script before the physical
+/// transfer. This includes authored `MOVE | SCRIPT` items and `PropKeySrc`
+/// items, whose `internal_keycard` script is injected at runtime even when the
+/// authored world action is only `MOVE`.
 pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
-    world
+    let has_authored_script = world
         .borrow::<View<PropFrobInfo>>()
         .map(|frob_info| {
             frob_info
                 .get(entity_id)
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
-        .unwrap_or(false)
+        .unwrap_or(false);
+
+    has_authored_script
+        || world
+            .borrow::<View<dark::properties::PropKeySrc>>()
+            .map(|keycards| keycards.get(entity_id).is_ok())
+            .unwrap_or(false)
 }
 
 /// Whether an authored script is already the sole owner of this item's


### PR DESCRIPTION
## Summary

- route world pickups with `PropKeySrc` through Frob even when their authored world action is `MOVE`-only
- let the injected `internal_keycard` script grant access and retain sole ownership of physical transfer
- preserve ordinary `MOVE`, weapon auto-wield, and authored `MOVE | SCRIPT` pickup behavior

Fixes #687

## Root cause

`FlatPlayerController::pick_up` only dispatched Frob when
`uses_scripted_world_frob` found an authored `SCRIPT` world-action bit. The
Command2 Bridge Card is authored with `MOVE` plus `PropKeySrc` region 8192, so
flat pickup stored the card directly and bypassed the runtime-injected
`internal_keycard` script. The physical card persisted, but `AcquireKeyCard`
never updated `QuestInfo`, and card slot 138 correctly rejected it.

The shared routing predicate now also recognizes `PropKeySrc`, which is the
general marker for the injected keycard script; there is no mission, object, or
region special case.

## Negative-first proof

Added
`flat_player_controller::tests::world_use_of_move_only_keycard_dispatches_frob_for_injected_script`.

Before the production change:

```text
a MOVE-only PropKeySrc pickup must run its injected keycard Frob path
test result: FAILED. 0 passed; 1 failed
```

After the change, all four flat pickup paths pass:

```text
ordinary MOVE: StoreItem
weapon: HoldItem
MOVE | SCRIPT: OutMessage(Frob)
MOVE-only PropKeySrc: OutMessage(Frob)
```

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 358 passed on this stacked branch
- `npm test` in `tools/shock2-sdk` — 25 passed, 147 e2e-gated tests skipped
- full `npm run test:e2e` — 170/173 passed; all relevant pickup/keycard cases and all 23 mission loads passed
  - `DebugForceChase` passed its exclusive rerun
  - the Earth Psionic Training projectile assertion and world-aim corrupt-save assertion reproduced unchanged on base commit `5c830206`

No visual artifact is required; this changes interaction state only.

## Campaign context

Play-through iteration 19, `command2`, resumed from `frontier-018`. The blocker
was validated on campaign commit `072480ca`; this PR is stacked directly on
`playthrough/water-exit-680` and contains only the fix commit.
