### PR TITLE
fix(animation): ground terminal corpse poses

### DIFF
--- a/dark/src/ss2_skeleton.rs
+++ b/dark/src/ss2_skeleton.rs
@@ -461,6 +461,99 @@ pub struct AnimationInfo<'a> {
     pub cancel_root_motion: bool,
 }
 
+/// Lowest joint depth in a posed skeleton palette.
+///
+/// Only real skeleton joints participate; unused identity slots in the fixed
+/// render palette would otherwise pin the result to zero.
+pub fn lowest_joint_y(
+    skeleton: &Skeleton,
+    transforms: &[Matrix4<f32>; MAX_SKINNED_JOINTS],
+) -> Option<f32> {
+    skeleton
+        .bones
+        .iter()
+        .filter_map(|bone| transforms.get(bone.joint_id as usize))
+        .map(|transform| transform.w.y)
+        .filter(|y| y.is_finite())
+        .reduce(f32::min)
+}
+
+/// Return a death clip whose terminal pose reaches a known floor depth.
+///
+/// The live standing pose provides the creature origin's actual floor
+/// convention. A death clip changes the limb rotations as well as lowering the
+/// root, so its own terminal lowest joint can stop above that depth even when
+/// its CAL bind-pose depth happens to match. Extend the authored descent just
+/// enough to reach the live floor. The correction follows the clip's existing
+/// root-y descent, leaving frame zero unchanged and avoiding a snap when the
+/// crumple starts. Never raise a clip that already reaches below the target.
+pub fn ground_terminal_pose_to_floor(
+    base_skeleton: &Skeleton,
+    animation_clip: &AnimationClip,
+    floor_depth: f32,
+) -> AnimationClip {
+    if base_skeleton.bones.is_empty()
+        || animation_clip.num_frames == 0
+        || animation_clip.root_transforms.is_empty()
+    {
+        return animation_clip.clone();
+    }
+
+    let terminal_skeleton = animate(
+        base_skeleton,
+        Some(AnimationInfo {
+            animation_clip,
+            frame: animation_clip.num_frames - 1,
+            fraction: 0.0,
+            wrap: false,
+            cancel_root_motion: false,
+        }),
+        &immutable::HashTrieMap::new(),
+    );
+    let Some(terminal_floor) =
+        lowest_joint_y(&terminal_skeleton, &terminal_skeleton.get_transforms())
+    else {
+        return animation_clip.clone();
+    };
+    let correction = (floor_depth - terminal_floor).min(0.0);
+
+    if !floor_depth.is_finite() || !correction.is_finite() || correction.abs() <= f32::EPSILON {
+        return animation_clip.clone();
+    }
+
+    let mut grounded = animation_clip.clone();
+    let start_y = grounded.root_transforms[0].w.y;
+    let end_y = grounded.root_transforms.last().unwrap().w.y;
+    let root_travel = end_y - start_y;
+    let last_frame = grounded.root_transforms.len().saturating_sub(1).max(1) as f32;
+    let mut corrections = Vec::with_capacity(grounded.root_transforms.len());
+
+    for (frame, transform) in grounded.root_transforms.iter_mut().enumerate() {
+        let progress = if root_travel.abs() > 1.0e-4 {
+            ((transform.w.y - start_y) / root_travel).clamp(0.0, 1.0)
+        } else {
+            frame as f32 / last_frame
+        };
+        let frame_correction = correction * progress;
+        transform.w.y += frame_correction;
+        corrections.push(frame_correction);
+    }
+    for (position, frame_correction) in grounded
+        .root_positions
+        .iter_mut()
+        .zip(corrections.into_iter())
+    {
+        position.y += frame_correction;
+    }
+
+    grounded.translation.y += correction;
+    let duration = grounded.duration.as_secs_f32();
+    if duration > f32::EPSILON {
+        grounded.sliding_velocity.y = grounded.translation.y / duration;
+    }
+    grounded
+}
+
 pub fn animate(
     base_skeleton: &Skeleton,
     animation_info: Option<AnimationInfo>,
@@ -628,6 +721,62 @@ mod tests {
             name: None,
         };
         (Skeleton::create_from_bones(bones), clip)
+    }
+
+    #[test]
+    fn terminal_pose_is_lowered_to_the_live_floor_depth() {
+        let bones = vec![
+            Bone {
+                joint_id: 0,
+                parent_id: None,
+                local_transform: Matrix4::identity(),
+            },
+            Bone {
+                joint_id: 1,
+                parent_id: Some(0),
+                local_transform: Matrix4::from_translation(Vector3::new(0.0, -1.0, 0.0)),
+            },
+            Bone {
+                joint_id: 2,
+                parent_id: Some(1),
+                local_transform: Matrix4::from_translation(Vector3::new(0.0, -1.0, 0.0)),
+            },
+        ];
+        let skeleton = Skeleton::create_from_bones(bones);
+        let mut clip = test_skeleton_and_clip().1;
+        clip.num_frames = 2;
+        clip.duration = Duration::from_millis(66);
+        clip.root_transforms = vec![
+            Matrix4::identity(),
+            Matrix4::from_translation(Vector3::new(0.0, -0.5, 0.0)),
+        ];
+        clip.root_positions = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.0, -0.5, 0.0)];
+        clip.joint_to_frame = HashMap::from([
+            (0, vec![Matrix4::identity(); 2]),
+            (
+                1,
+                vec![Matrix4::identity(), Matrix4::from_angle_z(Deg(180.0))],
+            ),
+            (2, vec![Matrix4::identity(); 2]),
+        ]);
+
+        let live_floor = -2.25;
+        let grounded = ground_terminal_pose_to_floor(&skeleton, &clip, live_floor);
+        let terminal = animate(
+            &skeleton,
+            Some(AnimationInfo {
+                animation_clip: &grounded,
+                frame: 1,
+                fraction: 0.0,
+                wrap: false,
+                cancel_root_motion: false,
+            }),
+            &immutable::HashTrieMap::new(),
+        );
+        let terminal_floor = lowest_joint_y(&terminal, &terminal.get_transforms()).unwrap();
+
+        assert!((terminal_floor - live_floor).abs() < 1.0e-5);
+        assert_eq!(grounded.root_transforms[0], Matrix4::identity());
     }
 
     #[test]

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -481,8 +481,20 @@ fn create_model(
         // historical frame-1 bake and physics behavior.
         let (model, animation_player) = {
             if let Ok(death_pose) = v_death_pose.get(entity_id) {
-                let animation_clip =
-                    asset_cache.get(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", death_pose.0));
+                let animation_clip = asset_cache.get(
+                    &ANIMATION_CLIP_IMPORTER,
+                    &format!("{}_.mc", death_pose.clip_name),
+                );
+                let animation_clip = match (model_ref.skeleton(), death_pose.floor_depth) {
+                    (Some(skeleton), Some(floor_depth)) => {
+                        Rc::new(dark::ss2_skeleton::ground_terminal_pose_to_floor(
+                            skeleton,
+                            &animation_clip,
+                            floor_depth,
+                        ))
+                    }
+                    _ => animation_clip,
+                };
                 let transformed_model = Model::transform(model_ref, transform);
                 (
                     transformed_model,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -113,6 +113,28 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 
+fn is_realtime_crumple(frame_count: f32) -> bool {
+    // `humdieup1` is an authored "already dead" pose: three frames with no
+    // fall. It shares the human crumple+die schema, but is not a real-time
+    // death and otherwise makes one in five human kills instantaneous.
+    frame_count > 3.0
+}
+
+fn select_motion_option(
+    options: &[String],
+    selection_strategy: &MotionQuerySelectionStrategy,
+) -> Option<String> {
+    if options.is_empty() {
+        return None;
+    }
+    match selection_strategy {
+        MotionQuerySelectionStrategy::Random => options.choose(&mut thread_rng()).cloned(),
+        MotionQuerySelectionStrategy::Sequential(sequence) => {
+            options.get(*sequence as usize % options.len()).cloned()
+        }
+    }
+}
+
 #[derive(Unique, Clone)]
 pub struct PlayerInfo {
     pub pos: Vector3<f32>,
@@ -1662,7 +1684,24 @@ impl MissionCore {
                     query_items.extend(actor_tags.iter().cloned());
                     let query = MotionQuery::new(actor_type, query_items)
                         .with_selection_strategy(selection_strategy.clone());
-                    let result = global_context.motiondb.query(query.clone());
+                    let result = if is_death_query {
+                        let options = global_context
+                            .motiondb
+                            .query_all(query.clone())
+                            .into_iter()
+                            .filter(|name| {
+                                is_realtime_crumple(
+                                    global_context
+                                        .motiondb
+                                        .get_mps_motions(name.clone())
+                                        .frame_count,
+                                )
+                            })
+                            .collect::<Vec<_>>();
+                        select_motion_option(&options, &selection_strategy)
+                    } else {
+                        global_context.motiondb.query(query.clone())
+                    };
                     tried_queries.push(query);
                     result
                 });
@@ -1682,6 +1721,37 @@ impl MissionCore {
                         .get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{}_.mc", next_animation));
 
                     if let Some(clip) = maybe_clip {
+                        // The live pose is already registered against the
+                        // walk surface. Preserve its lowest-joint depth as the
+                        // creature-specific floor convention: CAL bind depth
+                        // is measurably higher for real human/hybrid assets.
+                        let death_floor_depth = is_death_query
+                            .then(|| {
+                                self.id_to_model
+                                    .get(&entity_id)
+                                    .and_then(Model::skeleton)
+                                    .and_then(|skeleton| {
+                                        dark::ss2_skeleton::lowest_joint_y(
+                                            skeleton,
+                                            &player.get_transforms(skeleton),
+                                        )
+                                    })
+                            })
+                            .flatten();
+                        let clip = match (
+                            is_death_query,
+                            self.id_to_model.get(&entity_id).and_then(Model::skeleton),
+                            death_floor_depth,
+                        ) {
+                            (true, Some(skeleton), Some(floor_depth)) => {
+                                Rc::new(dark::ss2_skeleton::ground_terminal_pose_to_floor(
+                                    skeleton,
+                                    &clip,
+                                    floor_depth,
+                                ))
+                            }
+                            _ => clip,
+                        };
                         self.failed_animation_queries.remove(&entity_id);
                         *player = apply(player, clip);
 
@@ -1696,7 +1766,8 @@ impl MissionCore {
                             .and_then(|view| view.get(entity_id).ok().map(|hp| hp.hit_points <= 0))
                             .unwrap_or(false);
                         if is_death_query && is_killed {
-                            resolved_death_pose = Some(next_animation);
+                            resolved_death_pose =
+                                Some(RuntimePropDeathPose::new(next_animation, death_floor_depth));
                         }
                     } else {
                         // Report completion just like the query-miss branch
@@ -1742,9 +1813,8 @@ impl MissionCore {
             }
         }
 
-        if let Some(motion_or_tag_name) = resolved_death_pose {
-            self.world
-                .add_component(entity_id, RuntimePropDeathPose(motion_or_tag_name));
+        if let Some(death_pose) = resolved_death_pose {
+            self.world.add_component(entity_id, death_pose);
         }
     }
 
@@ -6773,6 +6843,17 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
         self.script_world.dispatch(Message { to: id, payload });
         true
+    }
+}
+
+#[cfg(test)]
+mod death_motion_tests {
+    use super::is_realtime_crumple;
+
+    #[test]
+    fn three_frame_already_dead_pose_is_not_a_realtime_crumple() {
+        assert!(!is_realtime_crumple(3.0));
+        assert!(is_realtime_crumple(79.0));
     }
 }
 

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -9,7 +9,7 @@
  */
 use cgmath::{Matrix4, Point3, Vector3};
 use dark::ss2_bin_obj_loader::Vhot;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use shipyard::Component;
 
 // RuntimePropGazeAmount - track how much the player is gazing at a prop
@@ -59,11 +59,50 @@ pub struct RuntimePropJointTransforms(pub [Matrix4<f32>; 40]);
 /// mission-placed corpse decorations untouched.
 ///
 /// The marker is attached when the random crumple query resolves. A save
-/// taken during that crumple therefore resumes at the already-selected
-/// clip's canonical final pose without replaying events. Saves created before
-/// this marker existed cannot recover which random clip had been selected.
-#[derive(Component, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RuntimePropDeathPose(pub String);
+/// taken during that crumple therefore resumes at the already-selected clip's
+/// canonical final pose without replaying events. `floor_depth` records the
+/// live pose's contact depth so the same grounding correction survives a
+/// save/load; saves from before that field existed retain their raw pose.
+#[derive(Component, Clone, Debug, Serialize, PartialEq)]
+pub struct RuntimePropDeathPose {
+    pub clip_name: String,
+    pub floor_depth: Option<f32>,
+}
+
+impl RuntimePropDeathPose {
+    pub fn new(clip_name: String, floor_depth: Option<f32>) -> Self {
+        Self {
+            clip_name,
+            floor_depth,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RuntimePropDeathPose {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StoredDeathPose {
+            Legacy(String),
+            Current {
+                clip_name: String,
+                #[serde(default)]
+                floor_depth: Option<f32>,
+            },
+        }
+
+        Ok(match StoredDeathPose::deserialize(deserializer)? {
+            StoredDeathPose::Legacy(clip_name) => Self::new(clip_name, None),
+            StoredDeathPose::Current {
+                clip_name,
+                floor_depth,
+            } => Self::new(clip_name, floor_depth),
+        })
+    }
+}
 
 #[derive(Component)]
 pub struct RuntimePropSpawnTimeInSeconds(pub f32);

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -140,7 +140,7 @@ mod tests {
         save.all_entities.push(old_entity.inner());
         save.death_poses.insert(
             old_entity.inner(),
-            RuntimePropDeathPose("resolved_death".to_owned()),
+            RuntimePropDeathPose::new("resolved_death".to_owned(), Some(-1.6)),
         );
 
         let mut loaded_world = World::new();
@@ -150,8 +150,31 @@ mod tests {
 
         assert_ne!(new_entity, old_entity);
         let poses = loaded_world.borrow::<View<RuntimePropDeathPose>>().unwrap();
-        assert_eq!(poses.get(new_entity).unwrap().0, "resolved_death");
+        assert_eq!(
+            poses.get(new_entity).unwrap(),
+            &RuntimePropDeathPose::new("resolved_death".to_owned(), Some(-1.6))
+        );
         assert!(poses.get(old_entity).is_err());
+    }
+
+    #[test]
+    fn legacy_death_pose_string_loads_without_a_floor_depth() {
+        let pose: RuntimePropDeathPose = serde_json::from_str(r#""resolved_death""#).unwrap();
+
+        assert_eq!(
+            pose,
+            RuntimePropDeathPose::new("resolved_death".to_owned(), None)
+        );
+    }
+
+    #[test]
+    fn death_pose_round_trip_preserves_the_live_floor_depth() {
+        let pose = RuntimePropDeathPose::new("resolved_death".to_owned(), Some(-1.6));
+
+        let encoded = serde_json::to_string(&pose).unwrap();
+        let decoded: RuntimePropDeathPose = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, pose);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- measure the live creature pose floor before a death clip replaces it, then lower the terminal pose to that creature-specific depth
- preserve the authored descent by blending the one-sided correction from zero at frame 0 to its exact terminal value
- reject the three-frame `humdieup1` already-dead pose from realtime crumple selection
- persist both the resolved clip and live floor depth so a loaded corpse reconstructs the same grounded pose, while accepting legacy string-only saves

## Root cause

The motion roots, CAL skeleton, and AI mesh all use the same `SCALE_FACTOR`, so this was not a unit mismatch. The affected real death clips already reached the CAL bind-pose lowest-joint depth, which made bind-based correction a no-op. The live idle pose establishes the actual model/physics origin convention and sits lower: in `debug_minimal`, `ogpdiefw` stopped at world y `0.383705` (local `-1.415157`), while the live `ogsidle1` floor was local `-1.618867`. Capturing that live depth before replacing the animation gives the death clip the missing `0.203711` descent. The three-frame `humdieup1` pose could also be randomly selected as if it were a realtime crumple.

## Verification

- negative live-asset check: the initial bind-depth implementation produced a byte-identical `ogpdiefw` endpoint to `origin/main`; changing the target to the live pre-death depth lowered it by `0.203711` and matched the idle reference within `0.00027`
- negative-first unit: terminal pose grounding failed with a no-op helper, then passed with the implementation
- negative-first unit: the three-frame pose filter failed while all candidates were accepted, then passed with the implementation
- `cargo test -p dark -p shock2vr` — 425 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed
- `cargo fmt --all -- --check` — passed
- `npm test` in `tools/shock2-sdk` — 25 passed, 145 skipped
- focused corrected SDK save/reload corpse scenario — passed in 40.8s
- corrected full SDK e2e — 168/170 passed in 26m31s, including both monster-death scenarios, both ragdoll-death scenarios, motion query/root motion, AI churn, and all 23 mission loads. The two unrelated failures were audited against clean `origin/main`: Earth psi-training also fails its Cryokinesis damage assertion there, and the fixed-name world-aim save is already corrupt there.
- refreshed PR CI — format, Android, Ubuntu, macOS, and Windows all passed

## Visuals

![Corpse grounding demo](https://gist.githubusercontent.com/tommy-xr/daf8f0c7d3b2dbea6b2ec646801a6f99/raw/corpse-grounding.gif)

<sub>The fixed OG-Pipe plays `ogpdiefw` and settles to its pre-death floor depth. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Before and after corpse grounding](https://gist.githubusercontent.com/tommy-xr/daf8f0c7d3b2dbea6b2ec646801a6f99/raw/corpse-grounding-before-after.png)

<sub>Identical pre-death save, death clip (`ogpdiefw`), camera, and 600-frame request sequence. The terminal lowest-joint depth moves from -1.415 to -1.598 local units, removing the visible floor gap.</sub>

Fixes #392