### PR TITLE
fix(rendering): honor mission ambient light floor

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -73,6 +73,7 @@ pub struct SystemShock2Level {
 
     pub textures: TextureList,
     pub cells: Vec<Cell>,
+    pub render_params: RenderParams,
 
     pub lightmap_atlas: TexturePacker<image::Rgb<u8>>,
 
@@ -223,7 +224,7 @@ pub fn read<T: io::Read + io::Seek>(
     );
     let all_geometry = create_geometry(asset_paths, base_path, &cells, &textures.0);
 
-    let _render_params = RenderParams::read(&table_of_contents, reader);
+    let render_params = RenderParams::read(&table_of_contents, reader);
     let room_database = RoomDatabase::read(&table_of_contents, reader);
     let song_params = SongParams::read(&table_of_contents, reader);
     let path_database = PathDatabase::read(&table_of_contents, reader);
@@ -255,6 +256,7 @@ pub fn read<T: io::Read + io::Seek>(
         bsp_tree,
         all_geometry,
         textures,
+        render_params,
         lightmap_atlas: packer,
         obj_map,
         cells,

--- a/dark/src/mission/scene_builder.rs
+++ b/dark/src/mission/scene_builder.rs
@@ -107,6 +107,7 @@ pub fn to_scene(
                 RefCell::new(engine::materials::LightmapMaterial::create(
                     lightmap_texture.clone(),
                     animated_texture,
+                    level.render_params.ambient_color,
                 ))
             }
         };

--- a/engine/src/materials/lightmap_material.rs
+++ b/engine/src/materials/lightmap_material.rs
@@ -9,6 +9,7 @@ use c_string::*;
 use cgmath::prelude::*;
 
 use cgmath::Matrix4;
+use cgmath::Vector3;
 use once_cell::sync::OnceCell;
 use std::any::Any;
 use std::rc::Rc;
@@ -56,6 +57,7 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
         // Material properties
         uniform sampler2D texture1; // lightmap
         uniform sampler2D texture2; // diffuse texture
+        uniform vec3 ambientColor;  // authored mission-wide minimum lighting
 
         // Spotlight array uniforms (up to 6 spotlights)
         uniform vec3 spotlightPos[6];
@@ -121,8 +123,9 @@ const UNIFIED_FRAGMENT_SHADER_SOURCE: &str = r#"
             vec4 lightmapColor = texture(texture1, wrappedTexCoord);
             vec4 diffuseColor = texture(texture2, texCoord);
 
-            // Base lighting from lightmap (baked static lighting)
-            vec3 finalColor = diffuseColor.rgb * lightmapColor.rgb;
+            // Dark's mission ambient is a minimum final intensity: preserve
+            // brighter authored pixels while keeping unlit surfaces legible.
+            vec3 finalColor = max(diffuseColor.rgb * lightmapColor.rgb, ambientColor);
 
             // Add dynamic spotlight contributions on top of baked lighting
             vec3 normal = normalize(worldNormal);
@@ -143,6 +146,7 @@ struct UnifiedUniforms {
     // Texture samplers
     texture1_loc: i32, // lightmap
     texture2_loc: i32, // diffuse
+    ambient_color_loc: i32,
 
     // Spotlight array uniforms (6 spotlights)
     spotlight_pos_loc: [i32; 6],
@@ -159,16 +163,19 @@ pub struct LightmapMaterial {
     has_initialized: bool,
     lightmap_texture: Rc<Texture>,
     diffuse_texture: Rc<dyn TextureTrait>,
+    ambient_color: Vector3<f32>,
 }
 
 impl LightmapMaterial {
     pub fn create(
         lightmap_texture: Rc<Texture>,
         diffuse_texture: Rc<dyn TextureTrait>,
+        ambient_color: Vector3<f32>,
     ) -> Box<dyn Material> {
         Box::new(LightmapMaterial {
             diffuse_texture,
             lightmap_texture,
+            ambient_color,
             has_initialized: false,
         })
     }
@@ -201,6 +208,12 @@ impl LightmapMaterial {
             // Set texture samplers
             gl::Uniform1i(uniforms.texture1_loc, 0); // lightmap
             gl::Uniform1i(uniforms.texture2_loc, 1); // diffuse
+            gl::Uniform3f(
+                uniforms.ambient_color_loc,
+                self.ambient_color.x,
+                self.ambient_color.y,
+                self.ambient_color.z,
+            );
 
             // Set spotlight array uniforms
             for i in 0..6 {
@@ -291,6 +304,10 @@ impl Material for LightmapMaterial {
                     // Texture samplers
                     texture1_loc: gl::GetUniformLocation(shader.gl_id, c_str!("texture1").as_ptr()),
                     texture2_loc: gl::GetUniformLocation(shader.gl_id, c_str!("texture2").as_ptr()),
+                    ambient_color_loc: gl::GetUniformLocation(
+                        shader.gl_id,
+                        c_str!("ambientColor").as_ptr(),
+                    ),
 
                     // Spotlight array uniforms (6 spotlights)
                     spotlight_pos_loc: [
@@ -443,5 +460,23 @@ impl Material for LightmapMaterial {
     ) -> bool {
         // Lightmap materials are typically opaque
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UNIFIED_FRAGMENT_SHADER_SOURCE;
+
+    #[test]
+    fn world_shader_applies_authored_ambient_as_a_floor() {
+        assert!(
+            UNIFIED_FRAGMENT_SHADER_SOURCE
+                .contains("max(diffuseColor.rgb * lightmapColor.rgb, ambientColor)"),
+            "world pixels must not render below the mission ambient"
+        );
+        assert!(
+            !UNIFIED_FRAGMENT_SHADER_SOURCE.contains("+ ambientColor"),
+            "ambient is a floor, not an additive wash over authored lighting"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- retain each mission's authored `RENDPARAMS` ambient value instead of discarding it during load
- pass that value into terrain lightmap materials and use it as the minimum final baked-lighting intensity
- preserve brighter authored lightmap output and add dynamic hand spotlights after the ambient floor as before

## Reproduction and verification

Using the hidden debug runtime with fixed 60 Hz stepping and identical camera poses:

- ENG1 Aux Storage 5: pixels at luminance ≤10 fell from 64.0% before to 0.0% after
- ENG2 central spine south: pixels at luminance ≤10 fell from 32.2% before to 1.6% after, while the median and 95th-percentile luminance remained 37 and 51
- Hydro2 authors an ambient value of zero; its before/after screenshots are byte-identical (`94005ccb91f5b0263ad00a8fd90735fa91427115451d921893339b96e504b0ee`)

This is deliberately a floor (`max(baked_output, ambient)`), not additive ambient, so normally lit surfaces are not washed out. The fragment cost is one component-wise `max`, plus one `vec3` uniform upload per terrain-material draw.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p engine`
- `cargo test -p dark`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo build -p debug_runtime`
- `cd tools/shock2-sdk && npm test`
- `cd tools/shock2-sdk && npm run test:e2e` (168/170 pass, including all 23 mission loads; both remaining failures reproduce identically on untouched `origin/main` at `2a38da7`: Earth Cryokinesis damage assertion and world-aim corrupt save/load)

Fixes #563


## Visual verification

![ENG1 ambient-floor matching-camera wipe](https://gist.githubusercontent.com/tommy-xr/7a9a2dcb4f0026cbef160591562f01d5/raw/b617d4bf42ee69343f89f7112b8febb96d34c606/ambient-floor-demo.gif)

Matching camera and deterministic simulation step in ENG1 Aux Storage 5. The wipe replaces the former pure-black terrain output with the mission-authored ambient floor.

### Before → after

![ENG1 and ENG2 deterministic before/after](https://gist.githubusercontent.com/tommy-xr/7a9a2dcb4f0026cbef160591562f01d5/raw/4874fa2db8776418b8849ebedf7ecf9bc98795d8/ambient-floor-before-after.png)

Both rows use identical poses before and after; captures are unmodified apart from layout, labels, and resizing.

