### PR TITLE
feat(skill): tighten random issue backlog hygiene

### DIFF
--- a/.claude/skills/fix-random-issues/SKILL.md
+++ b/.claude/skills/fix-random-issues/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: fix-random-issues
 description: >-
-  Randomly sample X eligible open GitHub issues from shock2quest, excluding
-  issues already addressed by an open PR, and process them sequentially,
-  delegating one issue at a time to an isolated agent that must reproduce or
-  confirm the problem, implement a focused fix, verify it, and open a reviewable
-  PR. Use for requests to fix, sweep, tackle, or work through a bounded number
-  of random open shock2quest issues.
+  Randomly sample X eligible owner-authored open GitHub issues from shock2quest,
+  excluding issues already addressed by an open PR, and process them
+  sequentially. Delegate one issue at a time to an isolated agent that must
+  reproduce or confirm the problem, implement a focused fix, verify it, open a
+  reviewable PR, or document and close a verified stale issue. Use for requests
+  to fix, sweep, tackle, or work through a bounded number of random open
+  shock2quest issues.
 ---
 
 # Fix random issues
@@ -21,6 +22,9 @@ before starting the next.
   positive integer.
 - Resolve the repository from the checkout, normally
   `tommy-xr/shock2quest`. Honor an explicit repository override.
+- Only issues authored by the repository owner are eligible. Exclude issues
+  opened by every other user, collaborator, organization member, or bot before
+  sampling.
 - Accept an optional seed. Generate and report one when omitted.
 
 Before drawing, exclude an issue when an open PR in the repository declares
@@ -40,7 +44,8 @@ issue after the sample is frozen, skip it without drawing a replacement.
 
 1. Read `AGENTS.md`, `README.md`, and `DEVELOPMENT.md`.
 2. Confirm `gh` authentication, repository access, and push/PR access before
-   starting a worker. Never merge a PR or close an issue directly.
+   starting a worker. Never merge a PR. Comment on and close issues only under
+   the verified-fix protocol below.
 3. Record the checkout's initial status. Preserve all existing user changes.
    Use an isolated branch/worktree for every issue; never stack unrelated issue
    fixes.
@@ -53,23 +58,26 @@ issue after the sample is frozen, skip it without drawing a replacement.
 
    Add `--seed <value>` when supplied. `.agents/skills` is the compatibility
    symlink to `.claude/skills`, so this command works for both Claude and Codex.
-5. Keep the emitted repository, seed, `excludedActivePullRequests`, and ordered
-   `selected` array as the run ledger. Do not rerun the draw unless the user
-   explicitly requests a new sample.
+5. Keep the emitted repository, seed, `totalOpenIssues`, owner-authored
+   `openIssues`, `excludedNonOwnerIssues`, `excludedActivePullRequests`, and
+   ordered `selected` array as the run ledger. Do not rerun the draw unless the
+   user explicitly requests a new sample.
 
-The selector samples all eligible open issues without inspecting difficulty,
-labels, or assignees first. The active-PR exclusion above is the only
-pre-sampling filter. Random means random; do not quietly filter the eligible
-pool further.
+The selector samples all eligible owner-authored open issues without inspecting
+difficulty, labels, or assignees first. Author and active-PR exclusions are the
+only pre-sampling filters. Random means random; do not quietly filter the
+eligible pool further.
 
 ## 2. Process the selected issues serially
 
 For each selected issue, in emitted order:
 
-1. Re-read it with `gh issue view`, including its current state, body, comments,
-   labels, and assignees. Skip it if it is no longer open or an open PR now
-   declares that it closes, fixes, or resolves the issue. Check current
-   `origin/main` for an existing fix or superseding merged PR before editing.
+1. Re-read it with `gh issue view`, including its author, current state, body,
+   comments, labels, and assignees. Stop and report a selector defect if the
+   author is not the repository owner; do not draw a replacement. Skip it if it
+   is no longer open or an open PR now declares that it closes, fixes, or
+   resolves the issue. Check current `origin/main` for an existing fix or
+   superseding merged PR before editing.
 2. Start one issue worker using the host's delegation tool. Prefer a
    host-provided isolated worktree. Otherwise create a unique branch/worktree
    from current `origin/main`, named along the lines of
@@ -84,15 +92,53 @@ For each selected issue, in emitted order:
    - `fixed`: reproduction/confirmation, focused fix, local verification,
      conventional commit, PR containing `Fixes #N`, and green CI.
    - `skipped`: closed, duplicate, actively addressed by an open PR, superseded,
-     or already fixed on current main.
+     or already fixed on current main. Apply the verified-fix protocol when the
+     issue is still open.
    - `not reproduced`: reasonable evidence failed to confirm the report.
    - `blocked`: a concrete product decision, unavailable dependency/hardware,
      unsafe scope, or persistent verification/CI failure prevents completion.
-6. Remove a temporary worktree only when it is clean and every change is safely
+6. Resolve any open, already-fixed issue under the verified-fix protocol below.
+7. Remove a temporary worktree only when it is clean and every change is safely
    committed and pushed. Otherwise preserve it and report its path.
 
 One issue is complete before the next begins. Sequential processing is a
 correctness boundary, not merely a preference.
+
+### Verified-fix protocol
+
+Use this protocol only after the selected issue's worker returns evidence about
+current `origin/main`. The manager owns comments and closure; the worker must
+not close the issue.
+
+1. Always leave one evidence-backed verification comment when an open selected
+   issue appears fixed. Include the current main SHA, the fixing commit or
+   merged PR when known, exact targeted verification and result, any remaining
+   scope, and this hidden marker:
+
+   ```html
+   <!-- fix-random-issues: appears-fixed-report -->
+   ```
+
+   Read existing comments first. Do not post or count a duplicate of the same
+   run or materially identical evidence.
+2. Treat the fix as conclusive only when:
+   - the issue's reported behavior or acceptance criteria pass a targeted test
+     or live reproduction on current main;
+   - the responsible merged change is present on current main when one exists;
+   - no acceptance criterion remains unresolved; and
+   - any adjacent product decision is explicitly out of scope or tracked
+     separately.
+
+   After posting the evidence comment, close a conclusive issue with
+   `gh issue close N --repo OWNER/REPO --reason completed`.
+3. When the issue merely appears fixed but the evidence is not conclusive, keep
+   it open. Count only three distinct evidence-backed reports from separate
+   verification runs, each carrying the marker above and identifying its tested
+   main SHA. On the third qualifying report, add a closing comment that links
+   the three reports and close the issue as completed.
+4. Never close based only on failure to reproduce, passing CI, stale evidence,
+   duplicated evidence, or an unverified code inspection. Report the remaining
+   uncertainty instead.
 
 ## Issue-worker prompt contract
 
@@ -103,7 +149,8 @@ worktree. Instruct the worker:
 Own issue #N end to end in the supplied isolated worktree.
 
 Read AGENTS.md, README.md, and DEVELOPMENT.md first. Read the full issue and
-comments. Work only on this issue; preserve unrelated changes.
+comments. Confirm the issue author is the repository owner. Work only on this
+issue; preserve unrelated changes.
 
 REPRODUCE: Confirm the reported behavior on current origin/main before changing
 code. For a feature gap, confirm the missing/stubbed behavior and investigate
@@ -124,7 +171,9 @@ DELIVER: Fetch and rebase onto current origin/main, rerun affected verification,
 push the branch, and open one conventional-title PR whose body includes
 reproduction evidence, the fix, tests, and `Fixes #N`. Watch PR checks to a
 terminal result and fix failures caused by the change. Never merge the PR or
-close the issue yourself.
+close the issue yourself. If current main already fixes the issue, return the
+evidence and a `conclusive`, `appears fixed`, or `not fixed` closure
+recommendation to the manager.
 
 Return: status; pre-fix reproduction; root cause; files changed; tests and exact
 results; commit SHA; PR URL; CI status; remaining risks. If skipped,
@@ -137,12 +186,15 @@ as incomplete. A PR URL alone is not completion.
 
 ## 3. Report the sweep
 
-Return the repository, seed, requested count, eligible count, actual sampled
-count, and the issues excluded because of active PRs. Then provide a table in
-sampled order with:
+Return the repository and owner, seed, requested count, total open issue count,
+owner-authored open issue count, eligible count, actual sampled count,
+non-owner exclusion count, and the issues excluded because of active PRs. Then
+provide a table in sampled order with:
 
-| Issue | Result | Evidence | Commit / PR | Verification |
-|---|---|---|---|---|
+| Issue | Result | Evidence | Issue action | Commit / PR | Verification |
+|---|---|---|---|---|---|
 
 State `fixed K of S sampled issues (X requested)`. List preserved worktree paths
-and blockers. Do not claim skipped or merely patched issues as fixed.
+and blockers. Report verification-comment and closure URLs, plus a count of
+stale fixed issues closed. Do not claim skipped, closed-as-stale, or merely
+patched issues as fixed.

--- a/.claude/skills/fix-random-issues/agents/openai.yaml
+++ b/.claude/skills/fix-random-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Fix Random Issues"
-  short_description: "Fix random issues without active PRs"
-  default_prompt: "Use $fix-random-issues to attempt 3 randomly selected eligible shock2quest issues without active PRs and process them sequentially."
+  short_description: "Sweep owner-authored issues and close stale fixes"
+  default_prompt: "Use $fix-random-issues to process 3 randomly selected owner-authored shock2quest issues, excluding active fixes and closing conclusively resolved reports."

--- a/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
+++ b/.claude/skills/fix-random-issues/scripts/select-open-issues.mjs
@@ -7,8 +7,9 @@ function usage() {
   console.log(`Usage:
   node select-open-issues.mjs <count> [--repo OWNER/REPO] [--seed VALUE]
 
-Randomly select a fixed sample of open GitHub issues. Issues addressed by an
-open pull request are excluded before sampling. Output is JSON.
+Randomly select a fixed sample of open GitHub issues authored by the repository
+owner. Issues addressed by an open pull request are excluded before sampling.
+Output is JSON.
 
 Options:
   --repo OWNER/REPO  Repository to query (default: current gh repository)
@@ -165,18 +166,28 @@ function listOpenCandidates(repository) {
   }
 
   const items = pages.flat();
-  const openIssues = items
+  const repositoryOwner = repository.split("/", 1)[0];
+  const allOpenIssues = items
     .filter((issue) => !issue.pull_request)
     .map((issue) => ({
       number: issue.number,
       title: issue.title,
       url: issue.html_url,
+      author: issue.user?.login ?? null,
       labels: (issue.labels ?? []).map((label) =>
         typeof label === "string" ? label : label.name
       ),
       assignees: (issue.assignees ?? []).map((assignee) => assignee.login),
     }))
     .sort((left, right) => left.number - right.number);
+  const openIssues = allOpenIssues.filter(
+    ({ author }) =>
+      author?.toLowerCase() === repositoryOwner.toLowerCase(),
+  );
+  const excludedNonOwnerIssues = allOpenIssues.filter(
+    ({ author }) =>
+      author?.toLowerCase() !== repositoryOwner.toLowerCase(),
+  );
   const issueNumbers = new Set(openIssues.map(({ number }) => number));
   const pullRequestsByIssue = new Map();
 
@@ -211,14 +222,25 @@ function listOpenCandidates(repository) {
     ({ number }) => !pullRequestsByIssue.has(number),
   );
 
-  return { openIssues, eligibleIssues, excludedActivePullRequests };
+  return {
+    allOpenIssues,
+    openIssues,
+    eligibleIssues,
+    excludedNonOwnerIssues,
+    excludedActivePullRequests,
+  };
 }
 
 const options = parseArgs(process.argv.slice(2));
 const repository = resolveRepository(options.repo);
 const seed = options.seed ?? randomBytes(16).toString("hex");
-const { openIssues, eligibleIssues, excludedActivePullRequests } =
-  listOpenCandidates(repository);
+const {
+  allOpenIssues,
+  openIssues,
+  eligibleIssues,
+  excludedNonOwnerIssues,
+  excludedActivePullRequests,
+} = listOpenCandidates(repository);
 const selected = shuffle(eligibleIssues, seededRandom(seed)).slice(
   0,
   options.count,
@@ -230,7 +252,9 @@ console.log(
       repository,
       seed,
       requested: options.count,
+      totalOpenIssues: allOpenIssues.length,
       openIssues: openIssues.length,
+      excludedNonOwnerIssues,
       excludedActivePullRequests,
       available: eligibleIssues.length,
       sampled: selected.length,

--- a/.claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs
+++ b/.claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,11 +16,12 @@ const selector = fileURLToPath(
   new URL("./select-open-issues.mjs", import.meta.url),
 );
 
-function issue(number) {
+function issue(number, author = "owner") {
   return {
     number,
     title: `Issue ${number}`,
     html_url: `https://github.com/owner/repo/issues/${number}`,
+    user: { login: author },
     labels: [],
     assignees: [],
   };
@@ -30,7 +37,7 @@ function pullRequest(number, body) {
   };
 }
 
-test("excludes issues addressed by an open pull request before sampling", () => {
+test("samples only owner issues without an active closing pull request", () => {
   const temporaryDirectory = mkdtempSync(
     path.join(tmpdir(), "select-open-issues-"),
   );
@@ -55,6 +62,7 @@ process.stdout.write(process.env.FAKE_GH_RESPONSE);
         issue(12),
         issue(13),
         issue(14),
+        issue(15, "community-member"),
         pullRequest(90, "Fixes #11"),
         pullRequest(91, "Related context: #10"),
         pullRequest(92, "Resolves owner/repo#12"),
@@ -81,8 +89,16 @@ process.stdout.write(process.env.FAKE_GH_RESPONSE);
 
     assert.equal(result.status, 0, result.stderr);
     const output = JSON.parse(result.stdout);
+    assert.equal(output.totalOpenIssues, 6);
     assert.equal(output.openIssues, 5);
     assert.equal(output.available, 2);
+    assert.deepEqual(
+      output.excludedNonOwnerIssues.map(({ number, author }) => ({
+        number,
+        author,
+      })),
+      [{ number: 15, author: "community-member" }],
+    );
     assert.deepEqual(
       output.selected
         .map(({ number }) => number)
@@ -103,4 +119,16 @@ process.stdout.write(process.env.FAKE_GH_RESPONSE);
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }
+});
+
+test("documents evidence comments and controlled issue closure", () => {
+  const skill = readFileSync(
+    fileURLToPath(new URL("../SKILL.md", import.meta.url)),
+    "utf8",
+  );
+
+  assert.match(skill, /Only issues authored by the repository owner/i);
+  assert.match(skill, /Always leave one evidence-backed verification comment/i);
+  assert.match(skill, /three distinct evidence-backed reports/i);
+  assert.match(skill, /gh issue close .*--reason completed/);
 });


### PR DESCRIPTION
## Summary

- restrict the random-issue selector to issues authored by the repository owner before shuffling
- expose total, owner-authored, and excluded non-owner issue counts in the frozen ledger
- require an evidence-backed comment when a sampled issue appears fixed
- close conclusively fixed issues immediately, or close after three distinct verification reports when evidence remains non-conclusive
- keep issue closure with the manager while workers return a closure recommendation and concrete evidence

## Motivation

The sweep of #389 found that merged PR #581 had already fixed the reported player-damage gap, but the issue remained open. The workflow should clean up conclusively stale issues without treating an inability to reproduce as proof, and it should keep random sweeps focused on the owner's intended backlog.

## Verification

- `node --test .claude/skills/fix-random-issues/scripts/select-open-issues.test.mjs` — 2 passed
- skill `quick_validate.py` — valid
- `git diff --check origin/main...HEAD` — clean
- pre-push `cargo fmt --all -- --check` — passed
