### PR TITLE
fix(physics): remove invented marker colliders

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -750,8 +750,9 @@ pub fn create_physics_representation(
     let (
         v_pos,
         v_phys_attr,
-        _v_phys_type,
-        _v_phys_dimensions,
+        v_phys_type,
+        v_phys_dimensions,
+        v_model_name,
         v_frob_info,
         v_hud_select,
         v_creature,
@@ -763,6 +764,7 @@ pub fn create_physics_representation(
             View<PropPhysAttr>,
             View<PropPhysType>,
             View<PropPhysDimensions>,
+            View<PropModelName>,
             View<PropFrobInfo>,
             View<PropHUDSelect>,
             View<PropCreature>,
@@ -829,6 +831,23 @@ pub fn create_physics_representation(
 
     // Frobbable item, let's see what we can do...
     if let (Ok(pos), Ok(frob_info)) = (v_pos.get(entity_id), v_frob_info.get(entity_id)) {
+        // An inherited FrobInfo alone is not authored collision geometry. A
+        // script-only marker with no model and no physics properties has no
+        // shape to select or collide with; the old default-size fallback
+        // invented one anyway. eng1 object 181 ("Ectoplasm") is such a marker:
+        // it only relays its AIWatchObj action to the Radapp apparition, and
+        // the invented cube partially blocked the doorway (#564).
+        //
+        // Keep the fallback for renderable frob targets (including bitmaps,
+        // whose PropModelName does not load through MODELS_IMPORTER) and for
+        // explicitly physical invisible objects.
+        let has_model = maybe_model.is_some() || v_model_name.get(entity_id).is_ok();
+        let has_authored_physics =
+            v_phys_type.get(entity_id).is_ok() || v_phys_dimensions.get(entity_id).is_ok();
+        if !has_model && !has_authored_physics {
+            return None;
+        }
+
         let qrotation = pos.rotation;
 
         let _is_sensor = true;
@@ -1176,6 +1195,39 @@ mod tests {
     }
 
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
+    /// Script-only markers can inherit frob/select properties through their
+    /// archetype even though they have no visual or authored physics. The
+    /// eng1 Ectoplasm marker (object 181) is one such object: it only relays an
+    /// AIWatchObj action to the apparition, so inventing a default selectable
+    /// cube for it partially blocks the doorway (#564).
+    #[test]
+    fn model_less_frobbable_without_authored_physics_gets_no_collider() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(21.19, -15.22, -44.78),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropHUDSelect(true),
+            PropRenderType(RenderType::NoRender),
+            PropImmobile(false),
+        ));
+
+        assert_eq!(
+            create_physics_representation(&mut world, &mut physics, &None, entity_id),
+            None,
+            "a marker with no model or authored physics must not get an invented collider"
+        );
+        assert!(physics.debug_list_bodies().is_empty());
+    }
 
     /// A climbable entity with no `PropPhysDimensions` still gets a collider,
     /// sized from the model bounds and tagged climbable (issue #589 - 24 of

--- a/tools/shock2-sdk/test/eng1-ectoplasm.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng1-ectoplasm.e2e.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "eng1 Ectoplasm marker does not create a doorway-blocking collider",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: 8464,
+    });
+    await game.step({ frames: 2 });
+
+    // Runtime IDs change every launch. Mission object 181 is the durable
+    // identity of the Ectoplasm marker that relays the nearby watch action to
+    // Radapp; it has no model or authored physics of its own.
+    const { entities } = await game.entities.list({ filter: "Ectoplasm" });
+    const ectoplasm = entities.find((entity) => entity.template_id === 181);
+    assert.ok(ectoplasm, "expected eng1 mission object 181 (Ectoplasm)");
+
+    const { bodies } = await game.physics.bodies({ entityId: ectoplasm.id });
+    assert.deepEqual(
+      bodies,
+      [],
+      "script-only Ectoplasm marker must not obstruct the doorway",
+    );
+  },
+);


### PR DESCRIPTION
## Reproduction

On current main, `eng1.mis` mission object 181 (`Ectoplasm`) at `(21.1938, -15.2194, -44.7814)` instantiated as one kinematic, non-sensor body in the `selectable` group. Static data shows that it is a `NoRender` script marker with no model and no authored physics; it only relays its `AIWatchObj` action to `Radapp`.

A negative unit test for that data shape failed before the fix because `create_physics_representation` returned a body.

## Fix

Treat inherited `FrobInfo` as interaction behavior, not authored collision geometry. Frobbable entities with neither a model reference nor `PhysType`/`PhysDimensions` now get no invented default collider. Rendered objects, bitmap-backed targets, and explicitly physical invisible objects retain the existing fallback behavior.

Added a durable SDK scenario that discovers Ectoplasm by mission object/template id 181 and verifies it owns no physics bodies.

## Verification

- `cargo test -p shock2vr model_less_frobbable_without_authored_physics_gets_no_collider -- --nocapture` — pass (negative-first: failed before fix)
- `SHOCK2_E2E=1 node --test dist/test/eng1-ectoplasm.e2e.test.js` — pass
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — pass
- `cargo fmt --all -- --check` — pass
- `npm test` — pass (25 passed, 148 opt-in skipped)
- Full `npm run test:e2e` — 171/173 passed, including the new Ectoplasm scenario and all 23 mission-load tests. The two failures reproduce identically on clean unmodified `origin/main`: Earth Cryokinesis does not damage the Training Droid, and `world-aim-e2e` cannot reload its newly-created save as compatible.

## Visual evidence

No rendered appearance changes: Ectoplasm is explicitly `NoRender`; this removes only its invisible collision body, so screenshot/GIF evidence would be identical.

Fixes #564