### PR TITLE
feat(oculus): add Quest profiling baseline

### DIFF
--- a/.claude/skills/oculus-profiling/SKILL.md
+++ b/.claude/skills/oculus-profiling/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: oculus-profiling
+description: >-
+  Measure shock2quest startup, frame/update/render timings, compositor
+  performance, memory, and Adreno GPU counters on an adb-attached Meta Quest.
+  Use to baseline missions, diagnose missed VR frame budgets, compare OpenXR or
+  rendering changes, evaluate FFR or multiview, and require measured device
+  evidence for optimization claims.
+---
+
+# Oculus profiling
+
+Measure before optimizing. Use the `vr-device-loop` skill first to build,
+install, focus, and visually verify a release APK.
+
+Desktop and device measurements answer different questions:
+
+| Surface | Evidence |
+| --- | --- |
+| Desktop tests/benchmarks | correctness and host CPU behavior |
+| `SHOCK2QUEST_PERF` | game update and render-stage CPU wall time on Quest |
+| VrApi telemetry | delivered FPS, App/compositor time, stale frames, CPU/GPU load |
+| `ovrgpuprofiler` | Adreno stage split, stalls, cache behavior, work volume |
+| Device PNG/MP4 | the measured workload actually rendered correctly |
+
+Never use a debug APK for performance claims. Confirm with:
+
+```sh
+adb shell dumpsys package com.tommybuilds.shock2quest | grep 'flags='
+```
+
+## Run mission baselines
+
+Test the parser first, then measure one mission or all installed missions:
+
+```sh
+node --test \
+  .claude/skills/oculus-profiling/scripts/quest-benchmark.test.mjs
+
+node .claude/skills/oculus-profiling/scripts/quest-benchmark.mjs \
+  --mission medsci1.mis --warmup 10 --seconds 30
+
+node .claude/skills/oculus-profiling/scripts/quest-benchmark.mjs \
+  --all --warmup 5 --seconds 10 --output /tmp/quest-all-levels
+```
+
+The sweep restarts the APK per mission, waits for the first submitted XR frame,
+waits for focus, warms up, samples telemetry, records memory, then extracts a
+focused device PNG for each successful run. It uses a direct compositor
+screenshot first and falls back to a frame from a short Quest recording. The
+sweep continues after a mission or visual failure and writes:
+
+- `results.json` for machine comparison;
+- `report.md` for review;
+- one JSON, runtime log, raw telemetry log, and optional PNG per mission.
+
+The startup fields deliberately separate `Game::init` from host-observed
+launch-to-focused. The latter includes Android activity startup, OpenXR/EGL
+setup, mission initialization, session focus, swapchain allocation, and the
+first render.
+
+Use identical release builds, headset refresh rate, device power state, mission
+selector, spawn point, warmup, and interval for comparisons. Repeat noisy
+results; do not compare a cold first run against a warmed asset cache without
+labeling it.
+
+## Read engine telemetry
+
+`SHOCK2QUEST_PERF` aggregates one-second windows:
+
+- `fps` / `frame_ms`: paced rendered-frame rate and interval;
+- `skipped`: frames for which OpenXR said not to render;
+- `update_ms`: `Game::update`;
+- `scene_ms`: shared `Game::render` scene preparation;
+- `left_eye_ms`, `right_eye_ms`: per-eye scene generation plus GLES rendering;
+- `submit_ms`: OpenXR `FrameStream::end`.
+
+The two eye timings are currently sequential. Their sum is the direct CPU/GPU
+submission cost exposed to the app, but GPU execution can overlap; use VrApi
+and hardware counters before calling it pure GPU time.
+
+Always report VrApi minimum FPS and stale/torn frame counts beside mean
+presentation FPS. Compositor presentation at the selected refresh rate can
+still reuse an old application frame; it is not evidence that every frame was
+fresh. Current Horizon OS emits paired `Fov=0D` and `Fov=0` records per
+interval; the benchmark uses only the primary-display `Fov=0D` series so the
+compositor and app telemetry cover the same number of one-second windows.
+
+Per-frame logging invalidates CPU measurements. Keep device logs aggregated and
+structured.
+
+## Collect Adreno counters
+
+Quest provides `/system_ext/bin/ovrgpuprofiler`; no app instrumentation is
+needed:
+
+```sh
+D=SERIAL
+adb -s "$D" shell ovrgpuprofiler -m
+adb -s "$D" shell 'ovrgpuprofiler --realtime="24,31,16,18,22,7,8,9,6,21,25,32,27,38"'
+```
+
+Bound realtime capture from the host and interrupt it after a settled interval.
+Useful counters:
+
+| IDs | Question |
+| --- | --- |
+| 24, 31 | vertex vs fragment share |
+| 16, 18, 22 | shader busy, ALU use, occupancy |
+| 7, 8, 9, 21 | texture stalls, L1/L2 misses, texture-pipe pressure |
+| 6 | vertex-fetch stalls |
+| 25, 32 | vertices and fragments per second |
+| 27, 38 | textures per vertex/fragment |
+
+For a detailed render-stage trace:
+
+```sh
+adb -s "$D" shell ovrgpuprofiler -e
+# Relaunch after enabling detailed mode.
+adb -s "$D" shell ovrgpuprofiler -t 1.0
+adb -s "$D" shell ovrgpuprofiler -d
+```
+
+Derive per-frame work using the measured FPS:
+
+```text
+vertices/frame  = vertices/second / fps
+fragments/frame = fragments/second / fps
+overdraw         = fragments/frame / (2 * eye_width * eye_height)
+stage_ms         = App_ms * stage_percent / 100
+```
+
+## Decide what to optimize
+
+Evaluate each idea as an A/B on the same mission set and retain device visuals.
+
+- **FFR:** prioritize when fragment share, texture-fetch stalls, GPU load, or
+  overdraw dominate. OpenXR requires `XR_FB_foveation`,
+  `XR_FB_swapchain_update_state`, the OpenGL ES swapchain-update extension, and
+  foveation-capable swapchain creation. Compare off/low/medium/high, including
+  peripheral visual quality.
+- **Multiview:** prioritize when two per-eye timings dominate and the scene
+  performs duplicate draw submission, culling, state changes, or vertex work.
+  It requires texture-array swapchains/framebuffers and multiview-capable
+  shaders; it does not remove genuinely eye-dependent work.
+- **CPU/game update:** prioritize when `update_ms` is high even while GPU App
+  time has margin. Profile physics, scripts, AI/pathfinding, visibility, and
+  allocation hot paths.
+- **Scene/render preparation:** prioritize when `scene_ms` or both eye CPU
+  timings are high. Avoid regenerating identical eye-independent scene data and
+  repeated asset/material work.
+- **Resolution/material work:** prioritize only with fragment/bandwidth
+  evidence. Texture-fetch stalls with low ALU use favor fewer/localized fetches;
+  high fragment work favors FFR, overdraw reduction, and cheaper materials.
+
+An exact desktop result cannot prove Quest GPU parity.
+
+## Report
+
+Lead with budget status and the slowest missions. Include:
+
+1. Device, OS, APK profile/commit, refresh rate, and eye resolution.
+2. Startup and steady-state tables, including minimum FPS, stale frames, torn
+   frames, and skipped app frames.
+3. Engine timings beside VrApi and memory.
+4. GPU counter interpretation, clearly separating measurement from inference.
+5. Device PNG/MP4 evidence, including failures and visual tradeoffs.
+6. Ranked next steps tied to the metric that justifies each.
+
+Include negative results; they prevent repeated dead ends.
+
+## Finish cleanly
+
+Disable detailed GPU mode if used and restore proximity automation:
+
+```sh
+adb -s "$D" shell ovrgpuprofiler -d
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs \
+  --serial "$D" restore
+```

--- a/.claude/skills/oculus-profiling/agents/openai.yaml
+++ b/.claude/skills/oculus-profiling/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Oculus Profiling"
+  short_description: "Profile shock2quest on a Meta Quest"
+  default_prompt: "Use $oculus-profiling to benchmark missions and diagnose this Quest performance issue."

--- a/.claude/skills/oculus-profiling/scripts/quest-benchmark.mjs
+++ b/.claude/skills/oculus-profiling/scripts/quest-benchmark.mjs
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import {
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  PACKAGE,
+  adb,
+  assertRuntimeFocused,
+  captureFocusedFrame,
+  launchMission,
+  missionSelection,
+  resolveSerial,
+  restoreMissionSelection,
+  restoreProximityAutomation,
+  stopApp,
+  validateMission,
+} from "../../vr-device-loop/scripts/quest-device.mjs";
+
+const delay = (milliseconds) =>
+  new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+
+export function parseArgs(argv) {
+  const options = {
+    missions: [],
+    all: false,
+    warmup: 5,
+    seconds: 10,
+    timeout: 120,
+    capture: true,
+    keepAwake: false,
+    output: resolve(
+      "/tmp",
+      `shock2quest-quest-benchmark-${new Date().toISOString().replaceAll(":", "-")}`,
+    ),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--all") options.all = true;
+    else if (argument === "--no-capture") options.capture = false;
+    else if (argument === "--keep-awake") options.keepAwake = true;
+    else {
+      const value = argv[++index];
+      if (value === undefined) throw new Error(`${argument} requires a value`);
+      if (argument === "--mission") options.missions.push(validateMission(value));
+      else if (argument === "--warmup") options.warmup = Number(value);
+      else if (argument === "--seconds") options.seconds = Number(value);
+      else if (argument === "--timeout") options.timeout = Number(value);
+      else if (argument === "--output") options.output = resolve(value);
+      else if (argument === "--serial") options.serial = value;
+      else throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+
+  if (options.all && options.missions.length > 0) {
+    throw new Error("use either --all or --mission, not both");
+  }
+  if (!options.all && options.missions.length === 0) {
+    throw new Error("pass --all or at least one --mission");
+  }
+  for (const [name, value, minimum] of [
+    ["warmup", options.warmup, 0],
+    ["seconds", options.seconds, 3],
+    ["timeout", options.timeout, 1],
+  ]) {
+    if (!Number.isFinite(value) || value < minimum) {
+      throw new Error(`--${name} must be at least ${minimum}`);
+    }
+  }
+  if (!Number.isInteger(options.seconds)) {
+    throw new Error("--seconds must be a whole number of one-second samples");
+  }
+  return options;
+}
+
+function escapeRegularExpression(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function numericField(line, name) {
+  const escapedName = escapeRegularExpression(name);
+  const match = line.match(
+    new RegExp(`(?:^|[ ,])${escapedName}=(-?[0-9.]+)`),
+  );
+  return match ? Number(match[1]) : undefined;
+}
+
+export function summarize(values) {
+  if (values.length === 0) return undefined;
+  const sorted = values.toSorted((left, right) => left - right);
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    mean: Number((total / values.length).toFixed(3)),
+    min: sorted[0],
+    p5: sorted[Math.floor((sorted.length - 1) * 0.05)],
+    p95: sorted[Math.ceil(sorted.length * 0.95) - 1],
+    max: sorted.at(-1),
+  };
+}
+
+function valuesFor(lines, name) {
+  return lines
+    .map((line) => numericField(line, name))
+    .filter((value) => value !== undefined);
+}
+
+function sumObserved(lines, name) {
+  const values = valuesFor(lines, name);
+  return values.length !== lines.length
+    ? undefined
+    : values.reduce((sum, value) => sum + value, 0);
+}
+
+export function parseVrApiTelemetry(text, expectedSamples) {
+  const allLines = text.split("\n").filter((line) => line.includes("FPS="));
+  // Current Horizon OS emits a primary-display (`Fov=0D`) record and a second
+  // `Fov=0` record for each interval. Treating both as independent samples
+  // double-counts the window and mixes distinct CPU&GPU values. Prefer the
+  // primary-display series when present, while retaining compatibility with
+  // OS versions that emit only one record class.
+  const primaryDisplayLines = allLines.filter((line) =>
+    line.includes("Fov=0D"),
+  );
+  const sampleLines =
+    primaryDisplayLines.length > 0 ? primaryDisplayLines : allLines;
+  const lines =
+    expectedSamples === undefined
+      ? sampleLines.length > 2
+        ? sampleLines.slice(1)
+        : sampleLines
+      : sampleLines.slice(-expectedSamples);
+  if (lines.length === 0) return undefined;
+  return {
+    samples: lines.length,
+    fps: summarize(valuesFor(lines, "FPS")),
+    app_ms: summarize(valuesFor(lines, "App")),
+    compositor_ms: summarize(valuesFor(lines, "TW")),
+    cpu_gpu_ms: summarize(valuesFor(lines, "CPU&GPU")),
+    gpu_load: summarize(valuesFor(lines, "GPU%")),
+    cpu_load: summarize(valuesFor(lines, "CPU%")),
+    temperature_c: summarize(valuesFor(lines, "Temp")),
+    stale_frames: sumObserved(lines, "Stale"),
+    torn_frames: sumObserved(lines, "Tear"),
+  };
+}
+
+export function parseEngineTelemetry(text, expectedSamples) {
+  const allLines = text
+    .split("\n")
+    .filter((line) => line.includes("SHOCK2QUEST_PERF"));
+  const lines =
+    expectedSamples === undefined
+      ? allLines.length > 2
+        ? allLines.slice(1)
+        : allLines
+      : allLines.slice(-expectedSamples);
+  if (lines.length === 0) return undefined;
+  return {
+    samples: lines.length,
+    focused_samples: lines.filter((line) => line.includes("focused=true"))
+      .length,
+    unfocused_samples: lines.filter((line) => line.includes("focused=false"))
+      .length,
+    skipped_frames: valuesFor(lines, "skipped").reduce(
+      (sum, value) => sum + value,
+      0,
+    ),
+    fps: summarize(valuesFor(lines, "fps")),
+    frame_ms: summarize(valuesFor(lines, "frame_ms")),
+    update_ms: summarize(valuesFor(lines, "update_ms")),
+    scene_ms: summarize(valuesFor(lines, "scene_ms")),
+    left_eye_ms: summarize(valuesFor(lines, "left_eye_ms")),
+    right_eye_ms: summarize(valuesFor(lines, "right_eye_ms")),
+    submit_ms: summarize(valuesFor(lines, "submit_ms")),
+  };
+}
+
+function parseMemory(text) {
+  const number = (pattern) => {
+    const match = text.match(pattern);
+    return match ? Number(match[1]) : undefined;
+  };
+  const mebibytes = (kilobytes) =>
+    kilobytes === undefined
+      ? undefined
+      : Number((kilobytes / 1024).toFixed(1));
+  return {
+    total_pss_mib: mebibytes(number(/TOTAL PSS:\s+(\d+)/)),
+    total_rss_mib: mebibytes(number(/TOTAL RSS:\s+(\d+)/)),
+    graphics_pss_mib: mebibytes(number(/Graphics:\s+(\d+)/)),
+  };
+}
+
+function markerField(text, marker, name) {
+  const line = text.split("\n").find((entry) => entry.includes(marker));
+  return line ? numericField(line, name) : undefined;
+}
+
+function readyInfo(text) {
+  const line = text
+    .split("\n")
+    .find((entry) => entry.includes("SHOCK2QUEST_READY"));
+  if (!line) return undefined;
+  return {
+    refresh_hz: numericField(line, "refresh_hz"),
+    eye_width: numericField(line, "eye_width"),
+    eye_height: numericField(line, "eye_height"),
+  };
+}
+
+async function collectTelemetry(serial, seconds) {
+  const child = spawn(
+    "adb",
+    [
+      "-s",
+      serial,
+      "logcat",
+      "-v",
+      "raw",
+      "VrApi:I",
+      "RustStdoutStderr:V",
+      "*:S",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let output = "";
+  let errors = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+
+  // The first one-second record may straddle the sampling boundary. Collect an
+  // extra second and let both parsers discard that first bucket.
+  await delay((seconds + 1) * 1_000);
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolveClose) => child.once("close", resolveClose)),
+    delay(2_000),
+  ]);
+  if (errors) output += `\nADB_LOGCAT_STDERR ${errors}`;
+  return output;
+}
+
+function installedMissions(serial) {
+  return adb(serial, ["shell", "ls", "/sdcard/shock2quest"])
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.endsWith(".mis"))
+    .sort();
+}
+
+async function benchmarkMission(serial, mission, options, device) {
+  const launched = await launchMission(
+    serial,
+    mission,
+    options.timeout * 1_000,
+  );
+  await delay(options.warmup * 1_000);
+  assertRuntimeFocused(serial, mission);
+  const rawTelemetry = await collectTelemetry(serial, options.seconds);
+  const slug = mission.replace(/[^A-Za-z0-9_-]/g, "_");
+  writeFileSync(
+    resolve(options.output, `${slug}.telemetry.log`),
+    rawTelemetry,
+  );
+  const engineTelemetry = parseEngineTelemetry(rawTelemetry, options.seconds);
+  const compositorTelemetry = parseVrApiTelemetry(
+    rawTelemetry,
+    options.seconds,
+  );
+  if (!engineTelemetry || engineTelemetry.samples !== options.seconds) {
+    throw new Error(
+      `expected ${options.seconds} advancing SHOCK2QUEST_PERF samples, got ${engineTelemetry?.samples ?? 0}`,
+    );
+  }
+  if (!compositorTelemetry || compositorTelemetry.samples !== options.seconds) {
+    throw new Error(
+      `expected ${options.seconds} primary-display VrApi samples, got ${compositorTelemetry?.samples ?? 0}`,
+    );
+  }
+  if (
+    engineTelemetry.focused_samples !== engineTelemetry.samples ||
+    engineTelemetry.unfocused_samples > 0
+  ) {
+    throw new Error(
+      `XR session was not focused for the full interval (${engineTelemetry.focused_samples}/${engineTelemetry.samples} focused samples)`,
+    );
+  }
+  assertRuntimeFocused(serial, mission);
+  const runtimeLogs = adb(serial, [
+    "logcat",
+    "-d",
+    "-v",
+    "raw",
+    "RustStdoutStderr:V",
+    "*:S",
+  ]);
+  let screenshot;
+  let visual_error;
+  if (options.capture) {
+    try {
+      screenshot = captureFocusedFrame(
+        serial,
+        resolve(options.output, `${slug}.png`),
+        mission,
+      );
+    } catch (error) {
+      visual_error = error instanceof Error ? error.message : String(error);
+    }
+  }
+  const result = {
+    status: visual_error ? "visual_failed" : "ok",
+    mission,
+    device,
+    sample: {
+      warmup_seconds: options.warmup,
+      duration_seconds: options.seconds,
+    },
+    startup: {
+      game_init_ms: markerField(
+        launched.logs,
+        "SHOCK2QUEST_STARTUP",
+        "init_ms",
+      ),
+      launch_to_focused_ms: launched.launchMilliseconds,
+    },
+    ready: readyInfo(launched.logs),
+    engine: engineTelemetry,
+    vrapi: compositorTelemetry,
+    memory: parseMemory(
+      adb(serial, ["shell", "dumpsys", "meminfo", PACKAGE]),
+    ),
+    screenshot,
+    visual_error,
+  };
+  writeFileSync(resolve(options.output, `${slug}.log`), runtimeLogs);
+  writeFileSync(
+    resolve(options.output, `${slug}.json`),
+    `${JSON.stringify(result, null, 2)}\n`,
+  );
+  return result;
+}
+
+function metricMean(metric, suffix = "") {
+  return metric?.mean === undefined ? "n/a" : `${metric.mean}${suffix}`;
+}
+
+export function renderMarkdown(results, metadata) {
+  const lines = [
+    "# Quest mission baseline",
+    "",
+    `- Device: ${metadata.model} (${metadata.serial})`,
+    `- Android: ${metadata.android}`,
+    `- APK: release, ${PACKAGE}`,
+    `- APK SHA-256: ${metadata.apk_sha256}`,
+    `- Sample: ${metadata.seconds}s after ${metadata.warmup}s warmup per mission`,
+    "",
+    "| Mission | Init | Focused | FPS mean/min | Stale | Torn | App | Update | Scene | Eyes | GPU load | PSS | Visual |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+  ];
+  for (const result of results) {
+    if (result.status === "failed") {
+      lines.push(
+        `| ${result.mission} | n/a | n/a | failed | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | ${result.error} |`,
+      );
+      continue;
+    }
+    const eyes =
+      result.engine?.left_eye_ms && result.engine?.right_eye_ms
+        ? `${(
+            result.engine.left_eye_ms.mean + result.engine.right_eye_ms.mean
+          ).toFixed(3)} ms`
+        : "n/a";
+    const visual =
+      result.status === "visual_failed"
+        ? `failed: ${result.visual_error}`
+        : result.screenshot
+          ? `[PNG](${result.screenshot.replaceAll(" ", "%20")})`
+          : "not captured";
+    const fps = result.vrapi?.fps ?? result.engine?.fps;
+    const fpsSummary = fps
+      ? `${fps.mean}/${fps.min}`
+      : "n/a";
+    lines.push(
+      `| ${result.mission} | ${result.startup.game_init_ms?.toFixed(1) ?? "n/a"} ms | ${result.startup.launch_to_focused_ms} ms | ${fpsSummary} | ${result.vrapi?.stale_frames ?? "n/a"} | ${result.vrapi?.torn_frames ?? "n/a"} | ${metricMean(result.vrapi?.app_ms, " ms")} | ${metricMean(result.engine?.update_ms, " ms")} | ${metricMean(result.engine?.scene_ms, " ms")} | ${eyes} | ${metricMean(result.vrapi?.gpu_load)} | ${result.memory.total_pss_mib ?? "n/a"} MiB | ${visual} |`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    "Engine timings are one-second in-app means. VrApi values use the primary-display (`Fov=0D`) one-second record when Horizon OS emits paired records. VrApi FPS is compositor presentation rate; stale/torn counts identify intervals that were not fresh application frames. Visual paths have passed an automated non-black check only and still require human review. `n/a` means the current OS did not emit that field.",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  const serial = resolveSerial(options.serial);
+  const packageInfo = adb(serial, ["shell", "dumpsys", "package", PACKAGE]);
+  if (/\bDEBUGGABLE\b/.test(packageInfo)) {
+    throw new Error(
+      "installed APK is debuggable; install a cargo apk --release build",
+    );
+  }
+
+  mkdirSync(options.output, { recursive: true });
+  const missions = options.all ? installedMissions(serial) : options.missions;
+  const previousMissionSelection = missionSelection(serial);
+  const apkPath = adb(serial, ["shell", "pm", "path", PACKAGE]).replace(
+    /^package:/,
+    "",
+  );
+  const device = {
+    serial,
+    model: adb(serial, ["shell", "getprop", "ro.product.model"]),
+    android: adb(serial, ["shell", "getprop", "ro.build.version.release"]),
+    apk_sha256: adb(serial, ["shell", "sha256sum", apkPath]).split(/\s+/)[0],
+  };
+  const results = [];
+  try {
+    for (const mission of missions) {
+      process.stdout.write(`Benchmarking ${mission}...\n`);
+      try {
+        const result = await benchmarkMission(
+          serial,
+          mission,
+          options,
+          device,
+        );
+        results.push(result);
+        process.stdout.write(
+          `  ${metricMean(result.vrapi?.fps ?? result.engine?.fps)} FPS, ${metricMean(result.engine?.update_ms, " ms")} update, ${result.screenshot ?? `visual failed: ${result.visual_error}`}\n`,
+        );
+      } catch (error) {
+        const failure = {
+          status: "failed",
+          mission,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        results.push(failure);
+        process.stderr.write(`  failed: ${failure.error}\n`);
+      }
+    }
+  } finally {
+    try {
+      restoreMissionSelection(serial, previousMissionSelection);
+    } finally {
+      if (!options.keepAwake) {
+        try {
+          stopApp(serial);
+        } finally {
+          restoreProximityAutomation(serial);
+        }
+      }
+    }
+  }
+
+  const metadata = {
+    ...device,
+    warmup: options.warmup,
+    seconds: options.seconds,
+  };
+  const report = renderMarkdown(results, metadata);
+  writeFileSync(
+    resolve(options.output, "results.json"),
+    `${JSON.stringify({ metadata, results }, null, 2)}\n`,
+  );
+  writeFileSync(resolve(options.output, "report.md"), report);
+  process.stdout.write(`\n${report}\nArtifacts: ${options.output}\n`);
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      `quest-benchmark: ${error instanceof Error ? error.message : error}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/.claude/skills/oculus-profiling/scripts/quest-benchmark.test.mjs
+++ b/.claude/skills/oculus-profiling/scripts/quest-benchmark.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseArgs,
+  parseEngineTelemetry,
+  parseVrApiTelemetry,
+  renderMarkdown,
+  summarize,
+} from "./quest-benchmark.mjs";
+
+test("summarize reports the distribution used in benchmark tables", () => {
+  assert.deepEqual(summarize([3, 1, 2, 4]), {
+    mean: 2.5,
+    min: 1,
+    p5: 1,
+    p95: 4,
+    max: 4,
+  });
+});
+
+test("parses VrApi one-second telemetry buckets", () => {
+  const telemetry = parseVrApiTelemetry(`
+FPS=90,App=5.0,TW=2.0,CPU&GPU=6.0,GPU%=0.5,CPU%=0.4,Stale=0,Tear=0
+FPS=89,App=6.0,TW=2.5,CPU&GPU=7.0,GPU%=0.6,CPU%=0.5,Stale=1,Tear=0
+FPS=88,App=7.0,TW=3.0,CPU&GPU=8.0,GPU%=0.7,CPU%=0.6,Stale=0,Tear=1
+`);
+
+  assert.equal(telemetry.samples, 2);
+  assert.equal(telemetry.fps.mean, 88.5);
+  assert.equal(telemetry.app_ms.mean, 6.5);
+  assert.equal(telemetry.stale_frames, 1);
+  assert.equal(telemetry.torn_frames, 1);
+});
+
+test("uses one primary-display VrApi record per interval", () => {
+  const telemetry = parseVrApiTelemetry(
+    `
+FPS=90,Fov=0D,App=5.0,CPU&GPU=6.0,Stale=0,Tear=0
+FPS=10,Fov=0,App=50.0,CPU&GPU=60.0,Stale=9,Tear=9
+FPS=89,Fov=0D,App=6.0,CPU&GPU=7.0,Stale=1,Tear=0
+FPS=10,Fov=0,App=60.0,CPU&GPU=70.0,Stale=9,Tear=9
+FPS=88,Fov=0D,App=7.0,CPU&GPU=8.0,Stale=0,Tear=1
+FPS=10,Fov=0,App=70.0,CPU&GPU=80.0,Stale=9,Tear=9
+`,
+    2,
+  );
+
+  assert.equal(telemetry.samples, 2);
+  assert.equal(telemetry.fps.mean, 88.5);
+  assert.equal(telemetry.app_ms.mean, 6.5);
+  assert.equal(telemetry.cpu_gpu_ms.mean, 7.5);
+  assert.equal(telemetry.stale_frames, 1);
+  assert.equal(telemetry.torn_frames, 1);
+});
+
+test("does not report missing compositor freshness fields as zero", () => {
+  const telemetry = parseVrApiTelemetry(`
+FPS=90,Fov=0D,App=5.0
+FPS=90,Fov=0D,App=5.0
+FPS=90,Fov=0D,App=5.0
+`);
+
+  assert.equal(telemetry.stale_frames, undefined);
+  assert.equal(telemetry.torn_frames, undefined);
+});
+
+test("does not report partially observed freshness fields as zero", () => {
+  const telemetry = parseVrApiTelemetry(
+    `
+FPS=90,Fov=0D,App=5.0,Stale=0,Tear=0
+FPS=90,Fov=0D,App=5.0
+FPS=90,Fov=0D,App=5.0,Stale=0,Tear=0
+`,
+    3,
+  );
+
+  assert.equal(telemetry.stale_frames, undefined);
+  assert.equal(telemetry.torn_frames, undefined);
+});
+
+test("requires a whole number of one-second samples", () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        "--mission",
+        "earth.mis",
+        "--seconds",
+        "3.5",
+      ]),
+    /whole number of one-second samples/,
+  );
+});
+
+test("parses Shock2Quest engine timing records", () => {
+  const telemetry = parseEngineTelemetry(`
+SHOCK2QUEST_PERF mission=earth.mis focused=false samples=40 skipped=2 fps=40 frame_ms=25 update_ms=8 scene_ms=8 left_eye_ms=8 right_eye_ms=8 submit_ms=1
+SHOCK2QUEST_PERF mission=earth.mis focused=true samples=90 skipped=0 fps=90 frame_ms=11.1 update_ms=1.0 scene_ms=2.0 left_eye_ms=3.0 right_eye_ms=3.1 submit_ms=0.1
+SHOCK2QUEST_PERF mission=earth.mis focused=true samples=89 skipped=1 fps=89 frame_ms=11.2 update_ms=1.2 scene_ms=2.2 left_eye_ms=3.2 right_eye_ms=3.3 submit_ms=0.2
+`);
+
+  assert.equal(telemetry.samples, 2);
+  assert.equal(telemetry.focused_samples, 2);
+  assert.equal(telemetry.unfocused_samples, 0);
+  assert.equal(telemetry.skipped_frames, 1);
+  assert.equal(telemetry.fps.mean, 89.5);
+  assert.equal(telemetry.update_ms.mean, 1.1);
+  assert.equal(telemetry.right_eye_ms.max, 3.3);
+});
+
+test("benchmark report exposes compositor freshness failures", () => {
+  const report = renderMarkdown(
+    [
+      {
+        status: "ok",
+        mission: "earth.mis",
+        startup: { game_init_ms: 1000, launch_to_focused_ms: 1500 },
+        ready: { refresh_hz: 90 },
+        engine: {
+          update_ms: { mean: 1 },
+          scene_ms: { mean: 2 },
+          left_eye_ms: { mean: 3 },
+          right_eye_ms: { mean: 4 },
+        },
+        vrapi: {
+          fps: { mean: 90, min: 88 },
+          stale_frames: 2,
+          torn_frames: 1,
+          app_ms: { mean: 5 },
+          gpu_load: { mean: 0.5 },
+        },
+        memory: { total_pss_mib: 300 },
+      },
+    ],
+    {
+      model: "Quest",
+      serial: "test",
+      android: "14",
+      apk_sha256: "abc",
+      seconds: 5,
+      warmup: 3,
+    },
+  );
+
+  assert.match(report, /\| earth\.mis .* \| 90\/88 \| 2 \| 1 \|/);
+  assert.match(report, /stale\/torn counts identify/);
+});

--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: vr-device-loop
+description: >-
+  Build, install, launch, select missions, inspect, capture, troubleshoot, and
+  verify shock2quest on an adb-attached Meta Quest. Use for Oculus/OpenXR runtime
+  changes, unattended headset testing, device screenshots or recordings,
+  mission launch failures, controller/proximity launch gates, and device
+  verification of rendering or performance work.
+---
+
+# VR device loop
+
+Treat the Quest as the acceptance environment for Oculus runtime changes. Read
+`README.md`, `DEVELOPMENT.md`, `runtimes/oculus_runtime/Cargo.toml`, and the
+relevant portion of `runtimes/oculus_runtime/src/lib.rs` before changing the
+pipeline.
+
+Use `scripts/quest-device.mjs` for repeatable device lifecycle operations:
+
+```sh
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs status
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs launch medsci1.mis
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs capture /tmp/medsci1.png
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs record /tmp/medsci1.mp4 8
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs restore
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs reset-mission
+```
+
+Pass `--serial SERIAL` before the command when more than one device is attached.
+
+## Preserve the runtime contract
+
+- Keep game behavior in `shock2vr`; keep OpenXR session, EGL/GLES swapchains,
+  tracked poses, compositor submission, and device lifecycle in
+  `runtimes/oculus_runtime`.
+- Keep mission names data-relative. The device runtime reads
+  `/sdcard/shock2quest/vr-mission.txt`; the helper validates and pushes this
+  file before launch.
+- Use `shock2vr::paths::data_root()` in Rust. Android resolves it to
+  `/sdcard/shock2quest`.
+- Use release APKs for performance claims and verify the installed package does
+  not contain the `DEBUGGABLE` flag.
+- Never commit keystore paths, credentials, or device-specific serials.
+
+## Preflight
+
+Resolve the device and confirm required game data:
+
+```sh
+adb devices -l
+adb -s SERIAL shell ls -l \
+  /sdcard/shock2quest/shock2.gam \
+  /sdcard/shock2quest/motiondb.bin \
+  /sdcard/shock2quest/earth.mis
+```
+
+The repository data and device data must describe the same workload. Sync the
+retail game data before interpreting visual or performance differences.
+
+## Build and install
+
+Build from the runtime directory so its FFmpeg and signing paths resolve:
+
+```sh
+cd runtimes/oculus_runtime
+export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+source ./set_up_android_sdk.sh
+cargo apk build --release
+adb -s SERIAL install -r ../../target/release/apk/shock2quest.apk
+```
+
+Locate the emitted APK from the final `cargo apk` line instead of assuming the
+path when the local Cargo target directory differs. After any Oculus Rust or
+manifest change, rebuild and reinstall.
+
+## Establish an unattended XR session
+
+Quest rendering cannot run as a normal background process: the activity must
+own a visible, focused OpenXR session. “Headless” here means unattended and
+ADB-driven.
+
+`quest-device.mjs launch` performs these steps:
+
+1. Push the selected mission.
+2. Pause Guardian dialogs, wake the device, and send the proximity-close
+   automation broadcast.
+3. Clear logcat, stop the old process, and start `android.app.NativeActivity`.
+4. Poll for `SHOCK2QUEST_READY`, which is emitted only after the first submitted
+   XR frame, then require `SHOCK2QUEST_XR_STATE ... state=FOCUSED`.
+
+The APK declares optional `oculus.software.handtracking`. Without this,
+Horizon OS may intercept an unattended launch with a disabled “Switch to
+Controllers” dialog before the app process exists.
+
+Expect these structured records:
+
+```text
+SHOCK2QUEST_STARTUP mission=medsci1.mis init_ms=...
+SHOCK2QUEST_READY mission=medsci1.mis refresh_hz=... eye_width=... eye_height=...
+SHOCK2QUEST_XR_STATE mission=medsci1.mis state=FOCUSED
+SHOCK2QUEST_PERF mission=medsci1.mis focused=true samples=... skipped=... fps=...
+```
+
+An `am start` success or a live PID does not prove XR is rendering. Require
+the first-frame marker, a focused XR state, a top-resumed activity, and
+advancing focused performance samples.
+
+## Capture device visuals every iteration
+
+Capture from the Quest for every implementation iteration, including failed
+launches:
+
+```sh
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs \
+  capture /tmp/quest-after.png
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs \
+  capture-focused medsci1.mis /tmp/quest-focused.png
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs \
+  record /tmp/quest-after.mp4 8
+file /tmp/quest-after.png /tmp/quest-after.mp4
+```
+
+Read the still and decode the video before using them as evidence. Require
+visible stereo content, the intended mission, plausible disparity, no system
+dialog, and no fallback/missing assets. `capture-focused` asserts the named
+mission is focused before and after a direct compositor screenshot, rejects
+fully black images, and falls back to a short device recording only when the
+direct capture fails. A human or image-capable reviewer must still reject Quest
+Loft, void, or badly aimed captures. `adb screencap` is compositor evidence; a
+future raw-eye endpoint should capture the application swapchains before
+distortion for renderer diagnosis.
+
+When opening or updating a PR, use the `pr-visuals` hosting and embedding
+workflow, but use these Quest artifacts whenever the claim depends on device
+behavior. Include before/after device captures for visual modifications.
+
+## Toward a device debug runtime
+
+Prefer a thin loopback-only HTTP server reached through `adb forward`, sharing
+wire types and behavior with `runtimes/debug_runtime`, rather than a separate
+automation model. Add it incrementally:
+
+1. `GET /v1/info` and `GET /v1/metrics` for mission, session state, frame
+   counter, views, and aggregate timings.
+2. `POST /v1/screenshot` for a raw left/right swapchain capture.
+3. Existing input actions and control channels.
+4. Entity/physics inspection only after the common interface is extracted.
+
+Keep OpenXR rendering focused while serving requests. A server that responds
+while the XR session is idle must report that state and reject captures rather
+than returning stale pixels.
+
+## Troubleshoot
+
+- **“Switch to Controllers” before PID exists:** inspect
+  `ActivityLaunchInterceptorController`; verify the optional hand-tracking
+  manifest feature is present in the installed APK.
+- **PID exists, no READY marker:** inspect `RustStdoutStderr`, OpenXR session
+  transitions, storage permission, and data sentinels.
+- **Home remains visible:** repeat proximity-close and start with `-S`; inspect
+  the top-resumed activity with `dumpsys activity activities`.
+- **Immediate native crash:** use
+  `adb logcat RustStdoutStderr:V AndroidRuntime:E DEBUG:E '*:S'`.
+- **Bad performance:** confirm release packaging, stop broad logcat consumers,
+  settle the mission, then use the `oculus-profiling` skill.
+
+## Finish cleanly
+
+Always restore the device:
+
+```sh
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs stop
+node .claude/skills/vr-device-loop/scripts/quest-device.mjs restore
+```
+
+The restore command re-enables Guardian before disabling proximity automation.
+Benchmark sweeps snapshot and restore the previous mission selector. For manual
+work, use `reset-mission` to return to the runtime default.
+Report the device/model, APK profile, mission, view size, refresh rate, capture
+paths, and whether automation was restored.

--- a/.claude/skills/vr-device-loop/agents/openai.yaml
+++ b/.claude/skills/vr-device-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "VR Device Loop"
+  short_description: "Build, drive, capture, and verify Quest"
+  default_prompt: "Use $vr-device-loop to run and verify this shock2quest change on an attached Quest."

--- a/.claude/skills/vr-device-loop/scripts/quest-device.mjs
+++ b/.claude/skills/vr-device-loop/scripts/quest-device.mjs
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PACKAGE = "com.tommybuilds.shock2quest";
+export const ACTIVITY = `${PACKAGE}/android.app.NativeActivity`;
+export const MISSION_CONFIG = "/sdcard/shock2quest/vr-mission.txt";
+
+const delay = (milliseconds) =>
+  new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+
+export function adb(serial, args, options = {}) {
+  const output = execFileSync("adb", ["-s", serial, ...args], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+  return typeof output === "string" ? output.trim() : output;
+}
+
+export function resolveSerial(explicitSerial) {
+  const lines = execFileSync("adb", ["devices", "-l"], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const devices = lines
+    .filter((line) => /\sdevice(?:\s|$)/.test(line))
+    .map((line) => line.split(/\s+/)[0]);
+
+  if (explicitSerial) {
+    if (!devices.includes(explicitSerial)) {
+      throw new Error(
+        `requested device ${explicitSerial} is not attached and authorized`,
+      );
+    }
+    return explicitSerial;
+  }
+  if (devices.length !== 1) {
+    throw new Error(
+      `expected exactly one attached device, found ${devices.length}; pass --serial`,
+    );
+  }
+  return devices[0];
+}
+
+export function validateMission(mission) {
+  const trimmed = mission.trim();
+  const validCharacters = /^[A-Za-z0-9_.-]+$/.test(trimmed);
+  const validName = trimmed.startsWith("debug_") || trimmed.endsWith(".mis");
+  if (!trimmed || !validCharacters || !validName) {
+    throw new Error(`invalid mission name: ${JSON.stringify(mission)}`);
+  }
+  return trimmed;
+}
+
+export function selectMission(serial, mission) {
+  const selected = validateMission(mission);
+  writeMissionSelection(serial, `${selected}\n`);
+  return selected;
+}
+
+function writeMissionSelection(serial, contents) {
+  const temporaryDirectory = mkdtempSync(
+    resolve(tmpdir(), "shock2quest-mission-"),
+  );
+  const localPath = resolve(temporaryDirectory, "vr-mission.txt");
+  try {
+    writeFileSync(localPath, contents);
+    adb(serial, ["shell", "mkdir", "-p", dirname(MISSION_CONFIG)]);
+    adb(serial, ["push", localPath, MISSION_CONFIG]);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+export function missionSelection(serial) {
+  try {
+    return {
+      exists: true,
+      contents: adb(serial, ["exec-out", "cat", MISSION_CONFIG], {
+        encoding: null,
+      }),
+    };
+  } catch {
+    return { exists: false, contents: Buffer.alloc(0) };
+  }
+}
+
+export function restoreMissionSelection(serial, selection) {
+  if (selection.exists) {
+    writeMissionSelection(serial, selection.contents);
+  } else {
+    adb(serial, ["shell", "rm", "-f", MISSION_CONFIG]);
+  }
+}
+
+export function wakeDevice(serial) {
+  adb(serial, ["shell", "setprop", "debug.oculus.guardian_pause", "1"]);
+  adb(serial, ["shell", "input", "keyevent", "KEYCODE_WAKEUP"]);
+  adb(serial, [
+    "shell",
+    "am",
+    "broadcast",
+    "-a",
+    "com.oculus.vrpowermanager.prox_close",
+  ]);
+}
+
+export function restoreProximityAutomation(serial) {
+  adb(serial, ["shell", "setprop", "debug.oculus.guardian_pause", "0"]);
+  adb(serial, [
+    "shell",
+    "am",
+    "broadcast",
+    "-a",
+    "com.oculus.vrpowermanager.automation_disable",
+  ]);
+}
+
+export function runtimeLogs(serial) {
+  return adb(serial, [
+    "logcat",
+    "-d",
+    "-v",
+    "raw",
+    "RustStdoutStderr:V",
+    "ActivityLaunchInterceptorController:I",
+    "AndroidRuntime:E",
+    "DEBUG:E",
+    "*:S",
+  ]);
+}
+
+export function assertRuntimeFocused(serial, mission) {
+  const processId = adb(serial, ["shell", "pidof", PACKAGE]);
+  if (!processId) throw new Error("runtime process is not running");
+
+  const activities = adb(serial, ["shell", "dumpsys", "activity", "activities"]);
+  const resumed = activities
+    .split("\n")
+    .find((line) => /topResumedActivity|mResumedActivity/.test(line));
+  if (!resumed) {
+    throw new Error("could not find Android's top resumed activity");
+  }
+  if (!resumed.includes(PACKAGE)) {
+    throw new Error(`runtime is not the top resumed activity: ${resumed.trim()}`);
+  }
+
+  const logs = runtimeLogs(serial);
+  const states = logs
+    .split("\n")
+    .filter((line) =>
+      line.includes(`SHOCK2QUEST_XR_STATE mission=${mission} state=`),
+    );
+  const latestState = states.at(-1);
+  if (!latestState) {
+    throw new Error(`no XR session state found for ${mission}`);
+  }
+  if (!latestState.endsWith("state=FOCUSED")) {
+    throw new Error(`runtime XR session is not focused: ${latestState}`);
+  }
+
+  const performance = logs
+    .split("\n")
+    .filter((line) =>
+      line.includes(`SHOCK2QUEST_PERF mission=${mission} `),
+    );
+  const latestPerformance = performance.at(-1);
+  if (!latestPerformance) {
+    throw new Error(`no advancing performance sample found for ${mission}`);
+  }
+  if (!latestPerformance.includes("focused=true")) {
+    throw new Error(`runtime is not rendering while focused: ${latestPerformance}`);
+  }
+
+  return {
+    processId,
+    resumed,
+    latestState,
+    performanceSamples: performance.length,
+  };
+}
+
+export async function waitForMarker(
+  serial,
+  marker,
+  timeoutMilliseconds = 120_000,
+) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  let logs = "";
+  while (Date.now() < deadline) {
+    logs = runtimeLogs(serial);
+    if (logs.includes(marker)) return logs;
+    if (logs.includes("RequiresControllersLaunchInterceptor")) {
+      throw new Error(
+        "Horizon OS blocked launch for sleeping controllers; verify optional oculus.software.handtracking in the installed manifest",
+      );
+    }
+
+    let pid = "";
+    try {
+      pid = adb(serial, ["shell", "pidof", PACKAGE]);
+    } catch {
+      // pidof exits non-zero until Android has started the process.
+    }
+    if (!pid && logs.includes("FATAL EXCEPTION")) {
+      break;
+    }
+    await delay(250);
+  }
+  const tail = logs.split("\n").slice(-30).join("\n");
+  throw new Error(`timed out waiting for ${marker}\n${tail}`);
+}
+
+export async function launchMission(
+  serial,
+  mission,
+  timeoutMilliseconds = 120_000,
+) {
+  const selected = selectMission(serial, mission);
+  wakeDevice(serial);
+  try {
+    adb(serial, ["logcat", "-c"]);
+    adb(serial, ["shell", "am", "force-stop", PACKAGE]);
+    const launchStarted = Date.now();
+    adb(serial, ["shell", "am", "start", "-S", "-n", ACTIVITY]);
+    const firstFrameLogs = await waitForMarker(
+      serial,
+      `SHOCK2QUEST_READY mission=${selected}`,
+      timeoutMilliseconds,
+    );
+    const focusedLogs = await waitForMarker(
+      serial,
+      `SHOCK2QUEST_XR_STATE mission=${selected} state=FOCUSED`,
+      timeoutMilliseconds,
+    );
+    const launchMilliseconds = Date.now() - launchStarted;
+    const performanceLogs = await waitForMarker(
+      serial,
+      `SHOCK2QUEST_PERF mission=${selected} focused=true`,
+      timeoutMilliseconds,
+    );
+    assertRuntimeFocused(serial, selected);
+    return {
+      mission: selected,
+      launchMilliseconds,
+      logs: `${firstFrameLogs}\n${focusedLogs}\n${performanceLogs}`,
+    };
+  } catch (error) {
+    try {
+      stopApp(serial);
+    } finally {
+      restoreProximityAutomation(serial);
+    }
+    throw error;
+  }
+}
+
+export function stopApp(serial) {
+  adb(serial, ["shell", "am", "force-stop", PACKAGE]);
+}
+
+export function captureScreenshot(
+  serial,
+  outputPath,
+  { focusedMission } = {},
+) {
+  if (focusedMission) assertRuntimeFocused(serial, focusedMission);
+  const absolutePath = resolve(outputPath);
+  const bytes = adb(serial, ["exec-out", "screencap", "-p"], {
+    encoding: null,
+  });
+  writeFileSync(absolutePath, bytes);
+  if (focusedMission) {
+    assertRuntimeFocused(serial, focusedMission);
+    validateScreenshot(absolutePath);
+  }
+  return absolutePath;
+}
+
+export function captureFocusedFrame(serial, outputPath, mission) {
+  const absolutePath = resolve(outputPath);
+  try {
+    return captureScreenshot(serial, absolutePath, {
+      focusedMission: mission,
+    });
+  } catch (screenshotError) {
+    assertRuntimeFocused(serial, mission);
+    return captureFocusedFrameFromRecording(
+      serial,
+      absolutePath,
+      mission,
+      screenshotError,
+    );
+  }
+}
+
+function captureFocusedFrameFromRecording(
+  serial,
+  absolutePath,
+  mission,
+  screenshotError,
+) {
+  const focusedBefore = assertRuntimeFocused(serial, mission);
+  const temporaryDirectory = mkdtempSync(
+    resolve(tmpdir(), "shock2quest-focused-capture-"),
+  );
+  const videoPath = resolve(temporaryDirectory, "capture.mp4");
+  try {
+    recordVideo(serial, videoPath, 2);
+    execFileSync(
+      "ffmpeg",
+      [
+        "-y",
+        "-v",
+        "error",
+        "-ss",
+        "1",
+        "-i",
+        videoPath,
+        "-frames:v",
+        "1",
+        absolutePath,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    const focusedAfter = assertRuntimeFocused(serial, mission);
+    if (focusedAfter.performanceSamples <= focusedBefore.performanceSamples) {
+      throw new Error("performance samples did not advance during recording");
+    }
+    validateScreenshot(absolutePath);
+    return absolutePath;
+  } catch (recordingError) {
+    throw new Error(
+      `focused screencap failed (${
+        screenshotError instanceof Error ? screenshotError.message : screenshotError
+      }); recording fallback failed (${
+        recordingError instanceof Error ? recordingError.message : recordingError
+      })`,
+    );
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function validateScreenshot(path) {
+  try {
+    const pixels = execFileSync(
+      "ffmpeg",
+      [
+        "-v",
+        "error",
+        "-i",
+        path,
+        "-vf",
+        "scale=64:32",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "pipe:1",
+      ],
+      { encoding: null, maxBuffer: 1024 * 1024 },
+    );
+    let sum = 0;
+    let sumSquares = 0;
+    for (const value of pixels) {
+      sum += value;
+      sumSquares += value * value;
+    }
+    const mean = sum / pixels.length;
+    const variance = sumSquares / pixels.length - mean * mean;
+    if (mean < 1 && variance < 1) {
+      unlinkSync(path);
+      throw new Error("captured compositor frame is effectively black");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("effectively black")) {
+      throw error;
+    }
+    throw new Error(
+      `could not validate captured compositor frame with ffmpeg: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+}
+
+export function recordVideo(serial, outputPath, seconds = 8) {
+  if (!Number.isInteger(seconds) || seconds < 1 || seconds > 180) {
+    throw new Error("recording duration must be an integer from 1 to 180 seconds");
+  }
+  const absolutePath = resolve(outputPath);
+  const remotePath = `/sdcard/shock2quest-profile-${process.pid}.mp4`;
+  try {
+    adb(
+      serial,
+      [
+        "shell",
+        "screenrecord",
+        "--time-limit",
+        String(seconds),
+        remotePath,
+      ],
+      { timeout: (seconds + 15) * 1_000 },
+    );
+    adb(serial, ["pull", remotePath, absolutePath]);
+  } finally {
+    adb(serial, ["shell", "rm", "-f", remotePath]);
+  }
+  return absolutePath;
+}
+
+export function deviceStatus(serial) {
+  let pid = "";
+  try {
+    pid = adb(serial, ["shell", "pidof", PACKAGE]);
+  } catch {
+    // An absent process is a valid status.
+  }
+  let mission = "";
+  try {
+    mission = adb(serial, ["shell", "cat", MISSION_CONFIG]);
+  } catch {
+    // A missing selector means the runtime will use its default.
+  }
+  return {
+    serial,
+    model: adb(serial, ["shell", "getprop", "ro.product.model"]),
+    package: PACKAGE,
+    pid: pid || null,
+    mission: mission || null,
+  };
+}
+
+function usage() {
+  return `Usage:
+  quest-device.mjs [--serial SERIAL] status
+  quest-device.mjs [--serial SERIAL] select MISSION
+  quest-device.mjs [--serial SERIAL] launch MISSION
+  quest-device.mjs [--serial SERIAL] capture OUTPUT.png
+  quest-device.mjs [--serial SERIAL] capture-focused MISSION OUTPUT.png
+  quest-device.mjs [--serial SERIAL] record OUTPUT.mp4 [SECONDS]
+  quest-device.mjs [--serial SERIAL] stop
+  quest-device.mjs [--serial SERIAL] restore
+  quest-device.mjs [--serial SERIAL] reset-mission`;
+}
+
+async function main(argv) {
+  const args = [...argv];
+  let explicitSerial;
+  if (args[0] === "--serial") {
+    explicitSerial = args[1];
+    args.splice(0, 2);
+  }
+  const serial = resolveSerial(explicitSerial);
+  const [command, ...values] = args;
+
+  if (command === "status") {
+    process.stdout.write(`${JSON.stringify(deviceStatus(serial), null, 2)}\n`);
+  } else if (command === "select" && values[0]) {
+    process.stdout.write(`${selectMission(serial, values[0])}\n`);
+  } else if (command === "launch" && values[0]) {
+    const result = await launchMission(serial, values[0]);
+    const { logs: _logs, ...summary } = result;
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else if (command === "capture" && values[0]) {
+    process.stdout.write(`${captureScreenshot(serial, values[0])}\n`);
+  } else if (
+    command === "capture-focused" &&
+    values[0] &&
+    values[1]
+  ) {
+    process.stdout.write(
+      `${captureFocusedFrame(serial, values[1], values[0])}\n`,
+    );
+  } else if (command === "record" && values[0]) {
+    const seconds = values[1] === undefined ? 8 : Number(values[1]);
+    process.stdout.write(`${recordVideo(serial, values[0], seconds)}\n`);
+  } else if (command === "stop") {
+    stopApp(serial);
+  } else if (command === "restore") {
+    restoreProximityAutomation(serial);
+  } else if (command === "reset-mission") {
+    restoreMissionSelection(serial, { exists: false, contents: "" });
+  } else {
+    throw new Error(usage());
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      `quest-device: ${error instanceof Error ? error.message : error}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/projects/quest-profiling.md
+++ b/projects/quest-profiling.md
@@ -1,0 +1,184 @@
+# Quest profiling
+
+## Initial mission-spawn baseline
+
+Measured July 28, 2026 on a Quest 3 running Android 14 with a release APK from
+this change. Each mission was launched in a fresh process, allowed to warm up
+for three seconds after reaching the OpenXR `FOCUSED` state, then sampled for
+five seconds. The runtime rendered at 1680x1760 per eye and 90 Hz. Human review
+accepted identifiable mission content for 19 captures. `eng1.mis`, `eng2.mis`,
+`hydro3.mis`, and `ops4.mis` produced valid focused telemetry but only
+environment/void frames, including direct focused recapture attempts.
+
+This is a stationary initial-spawn baseline. It proves that every mission
+loads, reaches a focused XR session, and submits stereo frames at its spawn. It
+does not represent combat, populated sight lines, effects-heavy rooms, or a
+thermally settled long play session. Compositor stale-frame counts also mean
+the near-90 Hz presentation rate must not be interpreted as every frame being
+fresh application work.
+
+| Mission | Game init | Focused | FPS mean/min | Stale | App | Update | Scene | Both eyes | GPU load | PSS | Visual |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| command1.mis | 3405.4 ms | 4658 ms | 90.000/89 | 7 | 3.940 ms | 2.679 ms | 0.328 ms | 3.663 ms | 0.498 | 370.4 MiB | pass |
+| command2.mis | 5004.8 ms | 6490 ms | 90.200/89 | 4 | 2.238 ms | 2.994 ms | 0.352 ms | 3.874 ms | 0.340 | 410.9 MiB | pass |
+| earth.mis | 2346.6 ms | 3904 ms | 90.400/90 | 2 | 5.514 ms | 1.495 ms | 0.769 ms | 4.129 ms | 0.640 | 345.2 MiB | pass |
+| eng1.mis | 5056.9 ms | 6513 ms | 90.400/90 | 5 | 4.480 ms | 3.208 ms | 0.401 ms | 4.316 ms | 0.536 | 405.8 MiB | environment/void |
+| eng2.mis | 3779.5 ms | 5228 ms | 89.800/88 | 14 | 5.090 ms | 3.541 ms | 0.343 ms | 3.312 ms | 0.600 | 384.2 MiB | environment/void |
+| hydro1.mis | 2180.3 ms | 3462 ms | 90.600/90 | 5 | 2.476 ms | 2.043 ms | 0.609 ms | 4.000 ms | 0.364 | 351.9 MiB | pass |
+| hydro2.mis | 4360.1 ms | 5607 ms | 90.000/89 | 9 | 2.242 ms | 3.173 ms | 0.486 ms | 4.251 ms | 0.340 | 410.7 MiB | pass |
+| hydro3.mis | 1453.8 ms | 3039 ms | 90.200/90 | 1 | 1.630 ms | 1.153 ms | 0.371 ms | 2.282 ms | 0.284 | 328.4 MiB | environment/void |
+| many.mis | 4007.5 ms | 5660 ms | 90.400/90 | 5 | 1.826 ms | 3.527 ms | 0.352 ms | 3.241 ms | 0.302 | 381.2 MiB | pass |
+| medsci1.mis | 4634.3 ms | 6065 ms | 90.800/90 | 5 | 2.340 ms | 2.861 ms | 0.487 ms | 4.104 ms | 0.348 | 416.8 MiB | pass |
+| medsci2.mis | 4264.9 ms | 5569 ms | 90.400/90 | 3 | 2.510 ms | 2.619 ms | 0.328 ms | 3.710 ms | 0.370 | 401.6 MiB | pass |
+| ops1.mis | 790.6 ms | 2128 ms | 90.800/90 | 1 | 3.866 ms | 0.899 ms | 0.298 ms | 1.400 ms | 0.488 | 312.6 MiB | pass |
+| ops2.mis | 3255.7 ms | 4716 ms | 90.600/90 | 7 | 2.356 ms | 2.475 ms | 0.490 ms | 3.999 ms | 0.350 | 383.3 MiB | pass |
+| ops3.mis | 2640.0 ms | 3892 ms | 90.600/90 | 7 | 2.198 ms | 2.534 ms | 0.453 ms | 3.663 ms | 0.330 | 380.0 MiB | pass |
+| ops4.mis | 2772.2 ms | 4251 ms | 90.400/90 | 4 | 1.148 ms | 2.998 ms | 0.248 ms | 1.315 ms | 0.240 | 371.8 MiB | environment/void |
+| rec1.mis | 4280.2 ms | 5619 ms | 90.400/90 | 8 | 2.406 ms | 2.875 ms | 0.362 ms | 3.864 ms | 0.360 | 402.9 MiB | pass |
+| rec2.mis | 3790.9 ms | 5157 ms | 90.600/90 | 5 | 1.752 ms | 2.399 ms | 0.376 ms | 3.908 ms | 0.304 | 384.0 MiB | pass |
+| rec3.mis | 3211.5 ms | 4764 ms | 89.600/89 | 7 | 2.244 ms | 2.364 ms | 0.363 ms | 3.986 ms | 0.342 | 371.6 MiB | pass |
+| rick1.mis | 4618.7 ms | 6011 ms | 90.400/90 | 15 | 2.174 ms | 3.356 ms | 0.554 ms | 4.838 ms | 0.332 | 417.2 MiB | pass |
+| rick2.mis | 1202.9 ms | 2583 ms | 90.200/90 | 1 | 1.462 ms | 1.528 ms | 0.313 ms | 1.847 ms | 0.272 | 329.7 MiB | pass |
+| rick3.mis | 2333.5 ms | 3920 ms | 90.400/90 | 2 | 3.130 ms | 1.446 ms | 0.365 ms | 3.097 ms | 0.420 | 340.1 MiB | pass |
+| shodan.mis | 2049.6 ms | 3438 ms | 90.600/90 | 0 | 1.608 ms | 1.314 ms | 0.304 ms | 2.681 ms | 0.282 | 332.4 MiB | pass |
+| station.mis | 2272.4 ms | 3844 ms | 90.200/89 | 4 | 2.262 ms | 1.875 ms | 0.658 ms | 3.955 ms | 0.342 | 350.0 MiB | pass |
+
+`Game init` measures `Game::init`. `Focused` is host-observed activity launch
+through both the first submitted XR frame and the OpenXR `FOCUSED` transition.
+Engine stage values are means of five one-second focused windows. Compositor
+values use the last five primary-display (`Fov=0D`) records; current Horizon OS
+also emits a paired `Fov=0` line that is not a second independent sample. `App`,
+presentation rate, stale frames, and GPU load are independent compositor
+telemetry. `Both eyes` is the sum of sequential left- and right-eye wall times;
+GPU execution can overlap that CPU interval. The app profiler reported zero
+skipped render frames for every mission. VrApi reported zero torn frames in
+this run.
+
+### Findings
+
+- All 23 missions loaded, reached `FOCUSED`, and emitted complete app and
+  compositor telemetry. Mean presentation stayed close to 90 Hz, but 22
+  missions reported 1-15 stale frames during the five-second sample.
+  `eng2.mis` had the lowest observed interval at 88 FPS; `rick1.mis` had the
+  most stale frames at 15. This short sample establishes a regression baseline,
+  not flawless frame delivery.
+- The highest mean compositor app time was `earth.mis` at 5.514 ms, followed by
+  `eng2.mis` at 5.090 ms and `eng1.mis` at 4.480 ms. These stationary spawns
+  retain apparent headroom inside the 11.11 ms 90 Hz interval, but longer
+  thermally settled gameplay samples are needed to explain the stale frames.
+- Startup is the clearest measured issue. `eng1.mis`, `medsci1.mis`,
+  `rick1.mis`, and `command2.mis` take 6.01-6.51 seconds to reach the first
+  submitted frame and focused session. `Game::init` accounts for 4.62-5.06
+  seconds of those launches.
+- The highest mean update values are `eng2.mis` (3.541 ms), `many.mis`
+  (3.527 ms), `rick1.mis` (3.356 ms), `eng1.mis` (3.208 ms), and
+  `hydro2.mis` (3.173 ms).
+- The largest mean combined eye-render time is `rick1.mis` at 4.838 ms,
+  followed by `eng1.mis` at 4.316 ms and `hydro2.mis` at 4.251 ms.
+- Total PSS ranges from 312.6 MiB to 417.2 MiB. `rick1.mis`, `medsci1.mis`,
+  `command2.mis`, and `hydro2.mis` are the largest stationary spawns.
+- Human review validated identifiable mission content for 19 missions. Direct
+  focused recaptures recovered `command1.mis`, `earth.mis`, and `ops1.mis`, but
+  `eng1.mis`, `eng2.mis`, `hydro3.mis`, and `ops4.mis` still showed only the
+  environment/void. Their numeric telemetry remains valid because the runtime
+  independently reported a focused, advancing session. This is the concrete
+  reason a raw-eye capture endpoint belongs in the next device-control
+  increment; do not use those four rows for render-quality or render-cost
+  comparisons until a raw-eye capture confirms the submitted workload.
+
+## Optimization decisions
+
+### Fixed foveated rendering
+
+The headset runtime reports support for `XR_FB_foveation`,
+`XR_FB_foveation_configuration`, `XR_FB_swapchain_update_state`, and the
+OpenGL ES swapchain-update extension. FFR is therefore implementable, but the
+stationary baseline does not yet demonstrate a frame-budget failure.
+
+Capture Adreno vertex/fragment share, texture stalls, and overdraw on
+`earth.mis`, `eng2.mis`, `rick3.mis`, and an effects-heavy gameplay scenario
+before prioritizing it. If those workloads are fragment-bound, compare
+off/low/medium/high with matched raw-eye and compositor visuals. Prefer dynamic
+FFR only after fixed levels establish the quality/performance curve.
+
+### Multiview
+
+The runtime currently creates two independent single-layer swapchains and runs
+`game.render_per_eye` plus engine submission sequentially for each eye.
+Multiview can remove duplicated draw submission, state changes, and vertex
+work, so it is the stronger architectural candidate even though the stationary
+spawn fits budget. It requires:
+
+1. a texture-array OpenXR swapchain and multiview framebuffer;
+2. multiview-capable vertex shaders and eye-indexed view/projection data;
+3. separation of eye-independent scene preparation from genuinely
+   eye-dependent HUD/hand work;
+4. an A/B benchmark over the same missions and scripted gameplay workloads.
+
+Adreno counters should determine whether the expected gain is mainly CPU draw
+submission, vertex work, or both.
+
+### Other measured targets
+
+1. Add staged startup spans around mission parse/merge, asset decode/upload,
+   entity instantiation, physics creation, and OpenXR/EGL setup.
+2. Profile update systems on `rick1`, `many`, `eng2`, and `hydro2`, starting
+   with scripts, physics, AI/pathfinding, visibility, and allocation counts.
+3. Split `render_per_eye`, engine submission, GPU execution, and
+   `finish_render` more precisely; the second-eye wall time currently includes
+   end-of-frame work.
+4. Add deterministic device scenarios for locomotion, combat, particle-heavy
+   rooms, and populated sight lines, with longer thermally settled samples.
+5. Track peak and retained asset memory, not only process PSS.
+
+## Quest debug-runtime direction
+
+Quest automation still needs a visible, focused OpenXR session; “headless”
+means unattended and ADB-driven rather than background rendering. Add a thin
+loopback HTTP server and reach it with `adb forward`, reusing the desktop debug
+runtime's wire types:
+
+1. `GET /v1/info` and `GET /v1/metrics` for mission, XR session state, frame
+   counter, views, and aggregate timings;
+2. `POST /v1/screenshot` for undistorted left/right swapchain images;
+3. existing discrete input actions and continuous control channels;
+4. mission transitions and deterministic scripted benchmark scenarios;
+5. shared entity/physics inspection after extracting a runtime-neutral
+   interface.
+
+The server must report an idle or unfocused XR session explicitly and reject
+stale captures. This makes a loopback API useful for debugging without
+pretending Quest rendering is independent of headset lifecycle.
+
+## OpenXR fork removal
+
+The Oculus runtime still depends on the repository's OpenXR 0.16 fork. That
+fork originally supplied OpenGL ES and Meta extensions that are present in
+current upstream `openxr`. Migrate to current crates.io OpenXR in a separate,
+small PR:
+
+1. switch the dependency and adapt compile-time API changes;
+2. build, install, and verify session focus, tracking, input, swapchains, and
+   all 23 mission spawns on device;
+3. compare startup, frame telemetry, memory, and device visuals against this
+   baseline;
+4. remove `vendor/openxrs` only after the device comparison passes.
+
+Keeping the dependency migration separate makes the large vendored deletion
+reviewable and preserves this baseline as a clean comparison point.
+
+## Reproduce
+
+From the repository root with a release APK installed and a Quest attached:
+
+```sh
+node --test \
+  .claude/skills/oculus-profiling/scripts/quest-benchmark.test.mjs
+
+node .claude/skills/oculus-profiling/scripts/quest-benchmark.mjs \
+  --all --warmup 3 --seconds 5 --output /tmp/quest-all-levels
+```
+
+Use a longer warmup and interval for optimization decisions. The short sweep
+above was selected to establish device interaction and cover every mission
+without claiming a thermally stable performance certification.

--- a/projects/quest-profiling.md
+++ b/projects/quest-profiling.md
@@ -3,12 +3,21 @@
 ## Initial mission-spawn baseline
 
 Measured July 28, 2026 on a Quest 3 running Android 14 with a release APK from
-this change. Each mission was launched in a fresh process, allowed to warm up
-for three seconds after reaching the OpenXR `FOCUSED` state, then sampled for
-five seconds. The runtime rendered at 1680x1760 per eye and 90 Hz. Human review
+this change (SHA-256
+`9aeb725f044f1f51bb1d688d291216786382c28872918e142fe628c29b333d3c`).
+Each mission was launched in a fresh process, allowed to warm up for three
+seconds after reaching the OpenXR `FOCUSED` state, then sampled for five
+seconds. The runtime rendered at 1680x1760 per eye and 90 Hz. Human review
 accepted identifiable mission content for 19 captures. `eng1.mis`, `eng2.mis`,
 `hydro3.mis`, and `ops4.mis` produced valid focused telemetry but only
 environment/void frames, including direct focused recapture attempts.
+
+The final focus-transition window hardening was rebuilt as APK SHA-256
+`b67a75354cd9509ef9abdf4efb56cce11180a5367e6d947301c20fed65f59f19`.
+An additional three-second focused `earth.mis` smoke run with that exact APK
+reported 90.333 FPS, 0 stale frames, 0 torn frames, and a fresh stereo device
+capture. The hardening resets incomplete buckets only when focus changes and
+does not alter continuous focused intervals in the all-mission baseline.
 
 This is a stationary initial-spawn baseline. It proves that every mission
 loads, reaches a focused XR session, and submits stereo frames at its spawn. It

--- a/runtimes/oculus_runtime/Cargo.toml
+++ b/runtimes/oculus_runtime/Cargo.toml
@@ -37,6 +37,10 @@ name = "android.permission.WRITE_EXTERNAL_STORAGE"
 [[package.metadata.android.uses_permission]]
 name = "android.permission.READ_EXTERNAL_STORAGE"
 
+[[package.metadata.android.uses_feature]]
+name = "oculus.software.handtracking"
+required = false
+
 [[package.metadata.android.application.activity.intent_filter]]
 actions = ["android.intent.action.MAIN"]
 categories = [

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavcodec.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavcodec.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libavcodec
 Description: FFmpeg codec library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavdevice.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavdevice.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libavdevice
 Description: FFmpeg device handling library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavfilter.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavfilter.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libavfilter
 Description: FFmpeg audio/video filtering library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavformat.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavformat.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libavformat
 Description: FFmpeg container format library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavutil.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libavutil.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libavutil
 Description: FFmpeg utility library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libswresample.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libswresample.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libswresample
 Description: FFmpeg audio resampling library

--- a/runtimes/oculus_runtime/ffmpeg/pkgconfig/libswscale.pc
+++ b/runtimes/oculus_runtime/ffmpeg/pkgconfig/libswscale.pc
@@ -1,7 +1,7 @@
-prefix=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg
+prefix=${pcfiledir}/..
 exec_prefix=${prefix}
-libdir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/lib/arm64-v8a
-includedir=/Users/bryphe/shock2quest/runtimes/oculus_runtime/ffmpeg/include
+libdir=${pcfiledir}/../../lib/arm64-v8a
+includedir=${prefix}/include
 
 Name: libswscale
 Description: FFmpeg image rescaling library

--- a/runtimes/oculus_runtime/set_up_android_sdk.sh
+++ b/runtimes/oculus_runtime/set_up_android_sdk.sh
@@ -6,6 +6,7 @@ export JAVA_HOME="/Applications/Android Studio.app/Contents/jre/Contents/Home"
 export NDK="${SDK}/ndk/24.0.8215888"
 export ANDROID_NDK_ROOT="${NDK}"
 export ARM64_TOOLCHAIN="${NDK}/toolchains/llvm/prebuilt/darwin-x86_64"
+export FFMPEG_ROOT="$(pwd)/ffmpeg"
 export CC="${ARM64_TOOLCHAIN}/bin/aarch64-linux-android26-clang"
 export CCP="${ARM64_TOOLCHAIN}/bin/aarch64-linux-android26-clang++"
 export SYSROOT="${ARM64_TOOLCHAIN}/sysroot"
@@ -52,15 +53,17 @@ alias cargo_android='unset CC && cargo'
 export PATH="$PATH:${SDK}/platform-tools"
 
 # FFmpeg cross-compilation setup
-export FFMPEG_ROOT="$(pwd)/ffmpeg"
 export PKG_CONFIG_ALLOW_CROSS=1
 export PKG_CONFIG_PATH="${FFMPEG_ROOT}/pkgconfig"
-export PKG_CONFIG_SYSROOT_DIR="${FFMPEG_ROOT}"
+unset PKG_CONFIG_SYSROOT_DIR
+# Avoid resolving the host macOS libbz2 through pkg-config during the Android
+# build; bzip2-sys will compile its bundled source for the target instead.
+export BZIP2_NO_PKG_CONFIG=1
 
 # Set target-specific pkg-config variables
 export PKG_CONFIG_ALLOW_CROSS_aarch64_linux_android=1
 export PKG_CONFIG_PATH_aarch64_linux_android="${FFMPEG_ROOT}/pkgconfig"
-export PKG_CONFIG_SYSROOT_DIR_aarch64_linux_android="${FFMPEG_ROOT}"
+unset PKG_CONFIG_SYSROOT_DIR_aarch64_linux_android
 
 echo "FFmpeg cross-compilation environment configured:"
 echo "  FFMPEG_ROOT: ${FFMPEG_ROOT}"

--- a/runtimes/oculus_runtime/src/frame_profiler.rs
+++ b/runtimes/oculus_runtime/src/frame_profiler.rs
@@ -1,0 +1,205 @@
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FrameTimings {
+    pub frame: Duration,
+    pub update: Duration,
+    pub scene: Duration,
+    pub left_eye: Duration,
+    pub right_eye: Duration,
+    pub submit: Duration,
+}
+
+impl FrameTimings {
+    #[cfg(test)]
+    fn from_frame_duration(frame: Duration) -> Self {
+        Self {
+            frame,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FrameReport {
+    pub frames: u64,
+    pub skipped_frames: u64,
+    pub fps: f64,
+    pub frame_ms: f64,
+    pub update_ms: f64,
+    pub scene_ms: f64,
+    pub left_eye_ms: f64,
+    pub right_eye_ms: f64,
+    pub submit_ms: f64,
+}
+
+#[derive(Debug)]
+pub struct FrameProfiler {
+    report_interval: Duration,
+    elapsed: Duration,
+    frames: u64,
+    skipped_frames: u64,
+    update: Duration,
+    scene: Duration,
+    left_eye: Duration,
+    right_eye: Duration,
+    submit: Duration,
+}
+
+impl FrameProfiler {
+    pub fn new(report_interval: Duration) -> Self {
+        assert!(!report_interval.is_zero());
+        Self {
+            report_interval,
+            elapsed: Duration::ZERO,
+            frames: 0,
+            skipped_frames: 0,
+            update: Duration::ZERO,
+            scene: Duration::ZERO,
+            left_eye: Duration::ZERO,
+            right_eye: Duration::ZERO,
+            submit: Duration::ZERO,
+        }
+    }
+
+    pub fn record(&mut self, timings: FrameTimings) -> Option<FrameReport> {
+        self.frames += 1;
+        self.record_sample(timings)
+    }
+
+    pub fn record_skipped(&mut self, frame: Duration, update: Duration) -> Option<FrameReport> {
+        self.skipped_frames += 1;
+        self.record_sample(FrameTimings {
+            frame,
+            update,
+            ..FrameTimings::default()
+        })
+    }
+
+    pub fn reset(&mut self) {
+        self.elapsed = Duration::ZERO;
+        self.frames = 0;
+        self.skipped_frames = 0;
+        self.update = Duration::ZERO;
+        self.scene = Duration::ZERO;
+        self.left_eye = Duration::ZERO;
+        self.right_eye = Duration::ZERO;
+        self.submit = Duration::ZERO;
+    }
+
+    fn record_sample(&mut self, timings: FrameTimings) -> Option<FrameReport> {
+        self.elapsed += timings.frame;
+        self.update += timings.update;
+        self.scene += timings.scene;
+        self.left_eye += timings.left_eye;
+        self.right_eye += timings.right_eye;
+        self.submit += timings.submit;
+
+        if self.elapsed < self.report_interval {
+            return None;
+        }
+
+        let elapsed_seconds = self.elapsed.as_secs_f64();
+        let frames = self.frames;
+        let attempts = frames + self.skipped_frames;
+        let rendered_divisor = frames.max(1) as f64;
+        let update_divisor = attempts as f64;
+        let report = FrameReport {
+            frames,
+            skipped_frames: self.skipped_frames,
+            fps: frames as f64 / elapsed_seconds,
+            frame_ms: self.elapsed.as_secs_f64() * 1_000.0 / rendered_divisor,
+            update_ms: self.update.as_secs_f64() * 1_000.0 / update_divisor,
+            scene_ms: self.scene.as_secs_f64() * 1_000.0 / rendered_divisor,
+            left_eye_ms: self.left_eye.as_secs_f64() * 1_000.0 / rendered_divisor,
+            right_eye_ms: self.right_eye.as_secs_f64() * 1_000.0 / rendered_divisor,
+            submit_ms: self.submit.as_secs_f64() * 1_000.0 / rendered_divisor,
+        };
+
+        self.reset();
+
+        Some(report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FrameProfiler, FrameTimings};
+    use std::time::Duration;
+
+    #[test]
+    fn reports_mean_timings_when_the_window_elapses() {
+        let mut profiler = FrameProfiler::new(Duration::from_millis(20));
+        let timings = FrameTimings {
+            frame: Duration::from_millis(10),
+            update: Duration::from_millis(1),
+            scene: Duration::from_millis(2),
+            left_eye: Duration::from_millis(3),
+            right_eye: Duration::from_millis(3),
+            submit: Duration::from_millis(1),
+        };
+
+        assert!(profiler.record(timings).is_none());
+        let report = profiler.record(timings).expect("window should report");
+
+        assert_eq!(report.frames, 2);
+        assert_eq!(report.skipped_frames, 0);
+        assert_eq!(report.fps, 100.0);
+        assert_eq!(report.frame_ms, 10.0);
+        assert_eq!(report.update_ms, 1.0);
+        assert_eq!(report.scene_ms, 2.0);
+        assert_eq!(report.left_eye_ms, 3.0);
+        assert_eq!(report.right_eye_ms, 3.0);
+        assert_eq!(report.submit_ms, 1.0);
+    }
+
+    #[test]
+    fn resets_after_emitting_a_report() {
+        let mut profiler = FrameProfiler::new(Duration::from_millis(10));
+        let first = FrameTimings::from_frame_duration(Duration::from_millis(10));
+        let second = FrameTimings::from_frame_duration(Duration::from_millis(20));
+
+        assert!(profiler.record(first).is_some());
+        let report = profiler
+            .record(second)
+            .expect("second window should report");
+
+        assert_eq!(report.frames, 1);
+        assert_eq!(report.fps, 50.0);
+        assert_eq!(report.frame_ms, 20.0);
+    }
+
+    #[test]
+    fn skipped_frames_reduce_rendered_fps_and_are_reported() {
+        let mut profiler = FrameProfiler::new(Duration::from_millis(30));
+        let rendered = FrameTimings {
+            frame: Duration::from_millis(10),
+            update: Duration::from_millis(2),
+            ..FrameTimings::default()
+        };
+
+        assert!(profiler.record(rendered).is_none());
+        assert!(
+            profiler
+                .record_skipped(Duration::from_millis(10), Duration::from_millis(1))
+                .is_none()
+        );
+        let report = profiler.record(rendered).expect("window should report");
+
+        assert_eq!(report.frames, 2);
+        assert_eq!(report.skipped_frames, 1);
+        assert!((report.fps - 66.666_666).abs() < 0.001);
+        assert_eq!(report.frame_ms, 15.0);
+        assert!((report.update_ms - 1.666_666).abs() < 0.001);
+    }
+
+    #[test]
+    fn reset_discards_an_incomplete_window() {
+        let mut profiler = FrameProfiler::new(Duration::from_millis(20));
+        let timing = FrameTimings::from_frame_duration(Duration::from_millis(10));
+
+        assert!(profiler.record(timing).is_none());
+        profiler.reset();
+        assert!(profiler.record(timing).is_none());
+    }
+}

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -20,6 +20,8 @@ use std::env;
 use tracing;
 
 mod android_permissions;
+mod frame_profiler;
+mod quest_config;
 
 use tokio::runtime::Runtime;
 
@@ -421,22 +423,26 @@ fn main() {
     let mut swapchain = None;
     let mut event_storage = xr::EventDataBuffer::new();
     let mut session_running = false;
-    // Index of the current frame, wrapped by PIPELINE_DEPTH. Not to be confused with the
-    // swapchain image index.
-    let mut frame = 0;
     let now = Instant::now();
     let engine = engine::android();
     let bundle_storage = engine.get_storage();
-    let mut experimental_features = HashSet::new();
+    let experimental_features = HashSet::new();
     // experimental_features.insert("gui".to_owned());
+    let mission = quest_config::configured_mission();
+    let game_init_started = Instant::now();
     let options: GameOptions = GameOptions {
         render_particles: false,
-        mission: "debug_gloves".to_string(),
+        mission: mission.clone(),
         experimental_features,
         debug_skeletons: false,
         ..GameOptions::default()
     };
     let mut game = shock2vr::Game::init(options, bundle_storage);
+    println!(
+        "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",
+        mission,
+        game_init_started.elapsed().as_secs_f64() * 1_000.0
+    );
 
     // No discrete actions are mapped for VR controllers yet; this stays empty
     // until an OculusInputMapper is added.
@@ -446,10 +452,11 @@ fn main() {
 
     let render_time = Instant::now();
     let mut last_update_time = render_time;
+    let mut frame_profiler = frame_profiler::FrameProfiler::new(Duration::from_secs(1));
+    let mut display_refresh_rate = None;
+    let mut ready_reported = false;
+    let mut session_focused = false;
     'main_loop: loop {
-        frame = frame + 1;
-
-        println!("Starting frame: {}", frame);
         // println!(
         //     " - Before polling events: {}",
         //     render_time.elapsed().as_secs_f32()
@@ -461,11 +468,26 @@ fn main() {
                     // Session state change is where we can begin and end sessions, as well as
                     // find quit messages!
                     println!("entered state {:?}", e.state());
+                    println!(
+                        "SHOCK2QUEST_XR_STATE mission={} state={:?}",
+                        mission,
+                        e.state()
+                    );
+                    let next_session_focused = e.state() == xr::SessionState::FOCUSED;
+                    if next_session_focused != session_focused {
+                        // Never emit a one-second bucket containing samples from
+                        // both sides of a focus transition.
+                        frame_profiler.reset();
+                    }
+                    session_focused = next_session_focused;
                     match e.state() {
                         xr::SessionState::READY => {
                             session.begin(VIEW_TYPE).unwrap();
                             session_running = true;
-                            let _refresh_rate = session.get_display_refresh_rate().unwrap();
+                            display_refresh_rate = session.get_display_refresh_rate().ok();
+                            ready_reported = false;
+                            last_update_time = Instant::now();
+                            frame_profiler.reset();
 
                             // let available_rates =
                             //     session.enumerate_display_refresh_rates().unwrap();
@@ -477,6 +499,8 @@ fn main() {
                         xr::SessionState::STOPPING => {
                             session.end().unwrap();
                             session_running = false;
+                            last_update_time = Instant::now();
+                            frame_profiler.reset();
                         }
                         xr::SessionState::EXITING | xr::SessionState::LOSS_PENDING => {
                             break 'main_loop;
@@ -600,7 +624,9 @@ fn main() {
         input_context.left_hand.squeeze_value = left_squeeze_value;
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
+        let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
+        let update_elapsed = update_started.elapsed();
 
         // Must be called before any rendering is done!
         frame_stream.begin().unwrap();
@@ -619,6 +645,9 @@ fn main() {
                     &[],
                 )
                 .unwrap();
+            if let Some(report) = frame_profiler.record_skipped(elapsed_time, update_elapsed) {
+                print_frame_report(&mission, session_focused, report);
+            }
             continue;
         }
 
@@ -764,10 +793,13 @@ fn main() {
             )
             .unwrap();
 
+        let scene_started = Instant::now();
         let (scene, camera_pos, camera_rot) = game.render();
+        let scene_elapsed = scene_started.elapsed();
 
         // Render to each eye
         let time = now.elapsed().as_secs_f32();
+        let left_eye_started = Instant::now();
         render_swapchain(
             &mut game,
             &engine,
@@ -780,6 +812,8 @@ fn main() {
             &scene,
             false,
         );
+        let left_eye_elapsed = left_eye_started.elapsed();
+        let right_eye_started = Instant::now();
         render_swapchain(
             &mut game,
             &engine,
@@ -792,6 +826,7 @@ fn main() {
             &scene,
             true,
         );
+        let right_eye_elapsed = right_eye_started.elapsed();
 
         let swap1 = &swapchain[0].handle.borrow();
         let rect = xr::Rect2Di {
@@ -811,6 +846,7 @@ fn main() {
         let sub2 = xr::SwapchainSubImage::new()
             .swapchain(swap2)
             .image_rect(rect);
+        let submit_started = Instant::now();
         frame_stream
             .end(
                 xr_frame_state.predicted_display_time,
@@ -829,6 +865,29 @@ fn main() {
                 ],
             )
             .unwrap();
+        let submit_elapsed = submit_started.elapsed();
+
+        if !ready_reported {
+            println!(
+                "SHOCK2QUEST_READY mission={} refresh_hz={:.3} eye_width={} eye_height={}",
+                mission,
+                display_refresh_rate.unwrap_or_default(),
+                swapchain[0].width,
+                swapchain[0].height
+            );
+            ready_reported = true;
+        }
+
+        if let Some(report) = frame_profiler.record(frame_profiler::FrameTimings {
+            frame: elapsed_time,
+            update: update_elapsed,
+            scene: scene_elapsed,
+            left_eye: left_eye_elapsed,
+            right_eye: right_eye_elapsed,
+            submit: submit_elapsed,
+        }) {
+            print_frame_report(&mission, session_focused, report);
+        }
 
         // let mut printed = false;
         // if right_aim.is_active(&session, xr::Path::NULL).unwrap() {
@@ -861,6 +920,23 @@ fn main() {
     //             reqs.max_api_version_supported.major() + 1
     //         );
     //     }
+}
+
+fn print_frame_report(mission: &str, focused: bool, report: frame_profiler::FrameReport) {
+    println!(
+        "SHOCK2QUEST_PERF mission={} focused={} samples={} skipped={} fps={:.3} frame_ms={:.3} update_ms={:.3} scene_ms={:.3} left_eye_ms={:.3} right_eye_ms={:.3} submit_ms={:.3}",
+        mission,
+        focused,
+        report.frames,
+        report.skipped_frames,
+        report.fps,
+        report.frame_ms,
+        report.update_ms,
+        report.scene_ms,
+        report.left_eye_ms,
+        report.right_eye_ms,
+        report.submit_ms
+    );
 }
 
 use cgmath::{Vector3, vec3};
@@ -997,7 +1073,6 @@ fn render_swapchain(
         game.finish_render(view_matrix, projection_matrix, screen_size);
     }
 
-    println!("-- Finished rendering");
     xr_swapchain.release_image().unwrap();
 }
 

--- a/runtimes/oculus_runtime/src/quest_config.rs
+++ b/runtimes/oculus_runtime/src/quest_config.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+pub const DEFAULT_MISSION: &str = "earth.mis";
+pub const MISSION_CONFIG_PATH: &str = "/sdcard/shock2quest/vr-mission.txt";
+
+pub fn configured_mission() -> String {
+    match fs::read_to_string(MISSION_CONFIG_PATH) {
+        Ok(raw) => match parse_mission(&raw) {
+            Some(mission) => mission,
+            None => {
+                println!(
+                    "SHOCK2QUEST_CONFIG invalid_mission={:?} fallback={DEFAULT_MISSION}",
+                    raw.trim()
+                );
+                DEFAULT_MISSION.to_owned()
+            }
+        },
+        Err(error) => {
+            println!(
+                "SHOCK2QUEST_CONFIG mission_file={MISSION_CONFIG_PATH} error={error} fallback={DEFAULT_MISSION}"
+            );
+            DEFAULT_MISSION.to_owned()
+        }
+    }
+}
+
+fn parse_mission(raw: &str) -> Option<String> {
+    let mission = raw.trim();
+    let valid_characters = mission
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'));
+    let valid_name = mission.starts_with("debug_") || mission.ends_with(".mis");
+
+    (!mission.is_empty() && valid_characters && valid_name).then(|| mission.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_mission;
+
+    #[test]
+    fn accepts_missions_and_debug_scenes() {
+        assert_eq!(parse_mission(" medsci1.mis\n"), Some("medsci1.mis".into()));
+        assert_eq!(parse_mission("debug_weapons"), Some("debug_weapons".into()));
+    }
+
+    #[test]
+    fn rejects_paths_and_unrecognized_names() {
+        assert_eq!(parse_mission("../earth.mis"), None);
+        assert_eq!(parse_mission("/sdcard/earth.mis"), None);
+        assert_eq!(parse_mission("earth"), None);
+        assert_eq!(parse_mission("earth.mis --flag"), None);
+    }
+}


### PR DESCRIPTION
## Summary

- add focused Quest mission selection and structured startup/frame telemetry to the Oculus runtime
- adapt the `vr-device-loop` and `oculus-profiling` skills for repeatable build, launch, focus, capture, and benchmark workflows
- record a Quest 3 initial-spawn baseline for all 23 missions
- document the next device-debug increment: a loopback HTTP API over `adb forward`, including raw-eye capture

## Baseline

Measured on Quest 3 / Android 14 with a release APK at 1680x1760 per eye and 90 Hz. Each mission used a fresh process, 3 seconds of focused warmup, and five one-second samples.

- 23/23 missions loaded, reached OpenXR `FOCUSED`, and produced complete engine and compositor telemetry
- 19/23 device captures showed identifiable mission content
- `eng1`, `eng2`, `hydro3`, and `ops4` produced valid focused telemetry but only environment/void compositor captures; the report excludes those visuals as rendering-quality evidence
- app-reported skipped render frames: 0 across the sweep
- compositor stale frames: 0-15 per five-second sample; no torn frames
- slowest launch-to-focused: `eng1` 6.513 s, `command2` 6.490 s, `medsci1` 6.065 s, `rick1` 6.011 s
- highest mean update: `eng2` 3.541 ms, `many` 3.527 ms, `rick1` 3.356 ms

The full methodology, table, limitations, and optimization analysis are in `projects/quest-profiling.md`.

## Conclusions

- these short stationary spawns retain apparent 90 Hz budget headroom, but stale compositor frames and the lack of thermal/gameplay coverage prevent a flawless-performance claim
- startup instrumentation is the clearest immediate optimization target
- multiview is the stronger architectural candidate because the current runtime submits two eyes sequentially
- FFR is supported by the runtime, but should be prioritized only after Adreno counters show fragment-bound workloads
- migrate away from the vendored OpenXR fork in a separate PR and compare that build against this device baseline
- add the Oculus debug-runtime equivalent incrementally: focused visible XR plus loopback `/v1/info`, `/v1/metrics`, raw-eye screenshot, input/control, then shared entity inspection

## Validation

- `RUSTFLAGS="-D warnings" cargo apk build --release`
- `cargo fmt --all -- --check`
- 8/8 benchmark parser/report tests
- both imported skills pass `quick_validate.py`
- exact final APK device smoke: Earth focused at 90.33 FPS over three buckets, 0 stale, 0 torn, with a fresh stereo device capture
- full SDK e2e: 168/173 passed and all 23 mission-load cases passed; five failures reproduced as unrelated existing/flaky desktop scenarios (alertness churn, Earth psi training, flat power cell, user quicksave dependency, stale named-save world aim)
- independent and Codex adversarial review: no remaining Critical, High, or Medium findings

## Device visuals

### Before: unattended launch blocker

![Quest controller prompt blocking unattended launch](https://gist.githubusercontent.com/tommy-xr/d4f52b095137e6a8cc1116f9e6fa3121/raw/compositor-launch-blocker.png)

<sub>The first on-device attempt remained in Quest Loft behind the controller-switch dialog, so it was not valid app evidence. This capture made the unattended-launch gate visible and drove the focused-launch checks in the device workflow.</sub>

### After: focused mission rendering

![Rick1 focused on-device recording](https://gist.githubusercontent.com/tommy-xr/d4f52b095137e6a8cc1116f9e6fa3121/raw/rick1-focused-device.gif)

<sub>Eight-second looping Rick1 recording captured from the Quest after the app reached OpenXR `FOCUSED`; this is device compositor output, not the desktop debug runtime.</sub>

![Rick1 focused on-device still](https://gist.githubusercontent.com/tommy-xr/d4f52b095137e6a8cc1116f9e6fa3121/raw/rick1-focused-frame.png)

<sub>Rick1 focused still from the same device verification session.</sub>

![Earth strict-focused on-device still](https://gist.githubusercontent.com/tommy-xr/d4f52b095137e6a8cc1116f9e6fa3121/raw/earth-strict-focus-final.png)

<sub>Earth strict-focus smoke capture, accepted only after the live PID, resumed activity, latest XR state, and focused performance sample checks passed.</sub>

### All-level visual review

![Human-reviewed Quest mission contact sheet](https://gist.githubusercontent.com/tommy-xr/d4f52b095137e6a8cc1116f9e6fa3121/raw/contact-sheet-human-reviewed.png)

<sub>Human-reviewed Quest contact sheet: 19 mission captures contain identifiable mission content. `eng1`, `eng2`, `hydro3`, and `ops4` are explicitly marked **NO IDENTIFIABLE MISSION CONTENT**; their focused numeric telemetry remains valid, but those compositor captures are not rendering-quality evidence.</sub>


