### PR TITLE
test(psi): fix Earth Cryokinesis staging

### DIFF
--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -80,8 +80,22 @@ async function aimAtEntity(
   target: EntitySummary,
 ): Promise<EntitySummary> {
   const [tx, ty, tz] = (await game.entities.detail(target.id)).position;
-  await game.player.teleport({ x: tx - 4, y: ty, z: tz });
-  await game.step({ frames: 5 });
+  // Stand on the droid's authored platform, close enough that its torso is a
+  // clear target. The old x-4 staging was unsupported void: the player kept
+  // falling after aimAt computed its ray, so Cryokinesis hit level geometry
+  // instead of the droid and falsely looked like a damage-path bug (#696).
+  await game.player.teleport({ x: tx + 4, y: ty + 1, z: tz });
+  await game.step({ frames: 60 });
+  const supported = await game.player.position();
+  await game.step({ frames: 10 });
+  const stillSupported = await game.player.position();
+  assert.ok(
+    Math.abs(supported.y - stillSupported.y) < 0.02,
+    `target staging must be collision-supported, got ${JSON.stringify({
+      supported,
+      stillSupported,
+    })}`,
+  );
   await game.input.set("left_hand.thumbstick", [0.75, 0]);
   await game.step({ frames: 20 });
   await game.input.set("left_hand.thumbstick", [0, 0]);
@@ -101,7 +115,10 @@ async function aimAtEntity(
   // hand the live handle back so the caller's damage check follows the same
   // object.
   const live = await exactlyOne(game, target.template_id, "Training Droid");
-  const aim = await game.player.aimAt(live, { hitbox: "torso" });
+  const aim = await game.player.aimAt(live, {
+    hitbox: "torso",
+    visibility: "required",
+  });
   assert.equal(aim.entity_id, live.id);
   assert.equal(aim.classification, "torso");
   assert.equal(aim.fallback_used, false);
@@ -181,12 +198,22 @@ test(
       "normal Cryokinesis projectile should damage the real Training Droid",
     );
 
+    // aimAtEntity deliberately exercises save/load; carried entities receive
+    // fresh runtime ids on load just like the droid. Re-resolve the boosters
+    // through their stable mission template ids before using them.
+    const liveBoosters: EntitySummary[] = [];
+    for (const booster of boosters) {
+      liveBoosters.push(
+        await exactlyOne(game, booster.template_id, "loaded Psi Booster"),
+      );
+    }
+
     await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
 
     let expectedPsi = psiBeforeCast - 1;
-    let expectedBoosters = boosters.length;
-    for (const booster of boosters) {
+    let expectedBoosters = liveBoosters.length;
+    for (const booster of liveBoosters) {
       await useBooster(game, booster.id);
       expectedPsi = Math.min(expectedPsi + 20, 50);
       expectedBoosters -= 1;


### PR DESCRIPTION
## Summary

- stage the Earth Psionic Training damage check on the Training Droid's authored collision-supported platform
- require a visible torso aim point and assert the staging position remains supported before save/load and casting
- re-resolve carried Psi Boosters by stable template ID after the scenario's deliberate save/load

## Root cause

The reported Cryokinesis damage failure was a test artifact, not a production damage-path bug. The old test teleported four units to the droid's negative-x side, which is unsupported void. The player continued falling after the aim ray was computed, so the projectile hit level geometry instead of the droid. On supported ground, unchanged production code reduces the Training Droid from 20 HP to 19 HP.

Fixes #696

Campaign: SHODAN finale · Loot everything · 25th Anniversary · seed 1546344805

## Validation

- negative-first focused Earth Psionic Training e2e reproduced 20 HP remaining with the old unsupported staging
- corrected focused Earth Psionic Training e2e passes
- npm test: 172 tests, 25 passed, 147 skipped, 0 failed
- cargo fmt --all -- --check
- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- cargo test -p shock2vr: 357 passed; doc tests passed with 2 ignored
- full SDK e2e: 171/172 passed, including the corrected Earth scenario and all 23 mission loads; sole failure is the unrelated existing debug_psi synthetic-save incompatibility tracked in #698 and fixed independently by #699
