### PR TITLE
fix(gameplay): restore close-range projectile hits

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -144,6 +144,10 @@ pub fn create_entity_with_position(
         world.add_component(entity_id, crate::runtime_props::RuntimePropTransientFx);
     }
 
+    if let Some(origin) = additional_options.projectile_raycast_origin {
+        world.add_component(entity_id, RuntimePropProjectileRayOrigin(origin));
+    }
+
     create_entity_core(
         entity_id,
         template_id,
@@ -1113,6 +1117,10 @@ pub struct CreateEntityOptions {
     /// it is destroyed once its one-shot particle burst expires. Used for
     /// impact spangs so they don't accumulate at every bullet hole.
     pub transient_fx: bool,
+    /// Override the collision-ray origin when this entity resolves as a fast
+    /// projectile. Flat firing supplies the camera origin while retaining the
+    /// forward spawn clearance needed by slow physics projectiles.
+    pub projectile_raycast_origin: Option<Point3<f32>>,
 }
 
 impl Default for CreateEntityOptions {
@@ -1121,6 +1129,7 @@ impl Default for CreateEntityOptions {
             force_visible: false,
             attach_to: None,
             transient_fx: false,
+            projectile_raycast_origin: None,
         }
     }
 }

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -258,6 +258,15 @@ pub struct RuntimePropFlatAim {
     pub forward: Vector3<f32>,
 }
 
+/// Camera-origin ray for a fast projectile fired through the flat crosshair.
+///
+/// Flat projectiles still spawn ahead of the camera so slow physics projectiles
+/// clear the player. Fast projectiles consume this origin instead of deriving a
+/// shorter ray start from that forward spawn offset, keeping hitscan collision
+/// aligned with the crosshair all the way down to contact range.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RuntimePropProjectileRayOrigin(pub Point3<f32>);
+
 // RuntimePropMapData - the automap page data for the current mission, attached
 // to the synthetic map-panel entity at mission init: the mission's level file
 // name (for the per-level `intrface/<LEVEL>/english/` art paths) and the decal

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -10,7 +10,7 @@ use crate::{
     creature::RuntimePropHitBox,
     mission::entity_creator::CreateEntityOptions,
     physics::{InternalCollisionGroups, PhysicsWorld, RayCastResult},
-    runtime_props::RuntimePropTransform,
+    runtime_props::{RuntimePropProjectileRayOrigin, RuntimePropTransform},
     scripts::{
         Message,
         ai::ai_util::does_entity_have_hitboxes,
@@ -50,7 +50,11 @@ impl Script for InternalFastProjectileScript {
         let current_position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
         // let forward = xform.transform_vector(vec3(0.0, 0.0, -1.0));
         let forward = self.velocity.normalize();
-        let start_point = current_position - forward * SCALE_FACTOR * 0.25;
+        let start_point = world
+            .borrow::<View<RuntimePropProjectileRayOrigin>>()
+            .ok()
+            .and_then(|origins| origins.get(entity_id).ok().map(|origin| origin.0))
+            .unwrap_or(current_position - forward * SCALE_FACTOR * 0.25);
         let maybe_hit_spot = projectile_ray_cast(start_point, forward, physics, distance, world);
 
         if let Some(RayCastResult {
@@ -147,6 +151,16 @@ impl Script for InternalFastProjectileScript {
     }
 }
 
+fn hitbox_belongs_to_entity(world: &World, hitbox_entity: EntityId, parent: EntityId) -> bool {
+    world
+        .borrow::<View<RuntimePropHitBox>>()
+        .is_ok_and(|hitboxes| {
+            hitboxes
+                .get(hitbox_entity)
+                .is_ok_and(|hitbox| hitbox.parent_entity_id == parent)
+        })
+}
+
 fn projectile_ray_cast(
     start_point: Point3<f32>,
     forward: cgmath::Vector3<f32>,
@@ -171,13 +185,27 @@ fn projectile_ray_cast(
 
         if let Some(hit_entity_id) = &hit_spot.maybe_entity_id {
             if does_entity_have_hitboxes(world, *hit_entity_id) {
-                maybe_hit_spot = physics.ray_cast(
+                let refined_hit = physics.ray_cast(
                     start_point,
                     forward * distance,
                     InternalCollisionGroups::HITBOX
                         | InternalCollisionGroups::SELECTABLE
                         | InternalCollisionGroups::WORLD,
                 );
+                // Prefer the authored damage proxy when the ray intersects one.
+                // If the coarse creature capsule surrounds the ray origin but
+                // its proxies do not cover that exact line, retain the coarse
+                // entity hit instead of turning a contact-range shot into a
+                // terrain impact beyond the creature.
+                let refined_hits_target_hitbox = refined_hit
+                    .as_ref()
+                    .and_then(|hit| hit.maybe_entity_id)
+                    .is_some_and(|entity_id| {
+                        hitbox_belongs_to_entity(world, entity_id, *hit_entity_id)
+                    });
+                if refined_hits_target_hitbox {
+                    maybe_hit_spot = refined_hit;
+                }
             }
         }
     }
@@ -186,4 +214,44 @@ fn projectile_ray_cast(
     // This should be called recursively with some limit (ie, depth=3) to handle those cases
 
     maybe_hit_spot
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hitbox_belongs_to_entity;
+    use crate::creature::{HitBoxType, RuntimePropHitBox};
+    use shipyard::World;
+
+    #[test]
+    fn refined_hitbox_must_belong_to_the_coarse_creature() {
+        let mut world = World::new();
+        let coarse_creature = world.add_entity(());
+        let overlapping_creature = world.add_entity(());
+        let coarse_hitbox = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: coarse_creature,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 1,
+        });
+        let overlapping_hitbox = world.add_entity(RuntimePropHitBox {
+            parent_entity_id: overlapping_creature,
+            hit_box_type: HitBoxType::Body,
+            joint_id: 1,
+        });
+
+        assert!(hitbox_belongs_to_entity(
+            &world,
+            coarse_hitbox,
+            coarse_creature,
+        ));
+        assert!(!hitbox_belongs_to_entity(
+            &world,
+            overlapping_hitbox,
+            coarse_creature,
+        ));
+        assert!(!hitbox_belongs_to_entity(
+            &world,
+            coarse_creature,
+            coarse_creature,
+        ));
+    }
 }

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -347,6 +347,7 @@ pub(super) fn create_projectile(
                 root_transform: Matrix4::from_translation(origin.to_vec()) * rot,
                 options: CreateEntityOptions {
                     force_visible: true,
+                    projectile_raycast_origin: Some(aim.origin),
                     ..CreateEntityOptions::default()
                 },
             };

--- a/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
+++ b/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { AimOcclusionError, GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// Flat fast projectiles used to spawn SCALE_FACTOR (2.5 world units) ahead of
+// the camera, then raycast back only SCALE_FACTOR * 0.25. The resulting ray
+// began 1.875 units ahead of the eye, so an enemy already at melee range was
+// behind the shot and could not be damaged (#669).
+//
+// Earth's stationary Training Droid makes the range boundary deterministic:
+// both staging points are on its authored platform, and the target cannot
+// chase the player between shots.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const TRAINING_DROID = 593;
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8469);
+
+function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find(
+    (candidate) => candidate.name === "HitPoints",
+  );
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+async function stageAndAim(
+  game: GameServer,
+  targetId: number,
+  horizontalDistance: number,
+): Promise<number> {
+  const [tx, ty, tz] = (await game.entities.detail(targetId)).position;
+  await game.player.teleport({
+    x: tx + horizontalDistance,
+    y: ty + 1,
+    z: tz,
+  });
+  await game.step({ frames: 60 });
+
+  const settled = await game.player.position();
+  await game.step({ frames: 10 });
+  const stillSettled = await game.player.position();
+  assert.ok(
+    Math.abs(settled.y - stillSettled.y) < 0.02,
+    `range staging must be collision-supported: ${JSON.stringify({
+      settled,
+      stillSettled,
+    })}`,
+  );
+
+  const aim = await game.player.aimAt(targetId, {
+    hitbox: "torso",
+    visibility: "required",
+  });
+  assert.equal(aim.entity_id, targetId);
+  assert.equal(aim.classification, "torso");
+  assert.equal(aim.fallback_used, false);
+  await game.step({ frames: 3 });
+  return aim.visibility.target_distance;
+}
+
+test(
+  "flat projectiles damage targets at melee-close and ordinary ranges",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    // SpawnDebugItem provisions and auto-wields the standard pistol.
+    await game.input.trigger("SpawnDebugItem");
+    await game.step({ frames: 10 });
+    assert.ok(
+      (await game.info()).player.wielded_entity_id !== null,
+      "the test needs a wielded flat-mode firearm",
+    );
+
+    const [droid] = await game.entities.byTemplate(TRAINING_DROID);
+    assert.ok(droid, "Earth should contain its authored Training Droid");
+
+    let hp = hitPoints(await game.entities.detail(droid.id));
+    const closeDistance = await stageAndAim(game, droid.id, 1.2);
+    assert.ok(
+      closeDistance < 1.8,
+      `close-range regression must exercise the old blind zone, got ${closeDistance.toFixed(3)}`,
+    );
+    await fireOnce(game);
+    await game.step({ frames: 5 });
+    const afterClose = hitPoints(await game.entities.detail(droid.id));
+    assert.ok(
+      afterClose < hp,
+      `a close-range torso shot should damage the droid (distance=${closeDistance.toFixed(3)}, hp=${hp}->${afterClose})`,
+    );
+
+    hp = afterClose;
+    const ordinaryDistance = await stageAndAim(game, droid.id, 4);
+    assert.ok(
+      ordinaryDistance > 2.5,
+      `ordinary-range control must be outside the old blind zone, got ${ordinaryDistance.toFixed(3)}`,
+    );
+    await fireOnce(game);
+    await game.step({ frames: 5 });
+    const afterOrdinary = hitPoints(await game.entities.detail(droid.id));
+    assert.ok(
+      afterOrdinary < hp,
+      `an ordinary-range torso shot should still damage the droid (distance=${ordinaryDistance.toFixed(3)}, hp=${hp}->${afterOrdinary})`,
+    );
+  },
+);
+
+test(
+  "a wall inside flat muzzle clearance still blocks a fast projectile",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 1,
+    });
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("SpawnDebugItem");
+    await game.step({ frames: 5 });
+
+    const known = new Set(
+      (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities.map(
+        (entity) => entity.id,
+      ),
+    );
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 10 });
+    const monster = (
+      await game.entities.list({ filter: "OG-Pipe", limit: 50 })
+    ).entities.find((entity) => !known.has(entity.id));
+    assert.ok(monster, "SpawnDebugMonster should create a target");
+
+    // Put the scene's wall at x=-12 between the camera at x=-14 and the
+    // monster spawned near x=-4. Its near face is only ~1.5 units from the
+    // camera: inside the 2.5-unit flat projectile spawn clearance. Starting a
+    // fast ray at the spawned projectile would skip this cover.
+    const player = await game.player.position();
+    await game.player.teleport({ x: -14, y: player.y, z: 0 });
+    await game.step({ frames: 5 });
+
+    let aim;
+    try {
+      await game.player.aimAt(monster, {
+        hitbox: "torso",
+        visibility: "required",
+      });
+      assert.fail("the close wall should occlude the monster");
+    } catch (error) {
+      assert.ok(error instanceof AimOcclusionError);
+      aim = error.result;
+    }
+    assert.equal(aim.visibility.state, "blocked");
+    assert.ok(
+      (aim.visibility.blocker?.distance ?? Number.POSITIVE_INFINITY) < 2.5,
+      `the regression requires cover inside muzzle clearance: ${JSON.stringify(aim.visibility)}`,
+    );
+    // Required visibility intentionally refuses to move the production camera.
+    // Aim along the rejected world ray anyway so firing exercises collision
+    // against the reported blocker rather than a different direction.
+    await game.input.set("head.rotation", aim.head_rotation);
+    await game.step({ frames: 3 });
+
+    const hpBefore = hitPoints(await game.entities.detail(monster.id));
+    await fireOnce(game);
+    await game.step({ frames: 5 });
+    assert.equal(
+      hitPoints(await game.entities.detail(monster.id)),
+      hpBefore,
+      "camera-origin collision must stop the shot at close cover",
+    );
+  },
+);
+
+test(
+  "flat slow physical projectiles retain forward spawn clearance",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_weapons",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 5 });
+
+    // The fourth debug weapon is the laser pistol; Laser Shot velocity 40
+    // follows the slow physical-projectile path rather than fast raycasting.
+    for (let i = 0; i < 4; i++) {
+      await game.input.trigger("CycleWeapon");
+      await game.step({ frames: 3 });
+    }
+    const player = await game.player.position();
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    const shot = (
+      await game.entities.list({ filter: "Laser Shot", limit: 20 })
+    ).entities.find((entity) => entity.name === "Laser Shot");
+    assert.ok(shot, "the slow laser projectile should remain live after one frame");
+    assert.equal(
+      (await game.physics.bodies({ entityId: shot.id })).bodies.length,
+      1,
+      "Laser Shot should use the physical projectile path",
+    );
+    assert.ok(
+      player.x - shot.position[0] > 2,
+      `slow flat projectiles must still spawn ahead of the player to clear their collider (player x=${player.x}, shot x=${shot.position[0]})`,
+    );
+    await game.input.set("right_hand.trigger", 0);
+  },
+);


### PR DESCRIPTION
## Summary

- carry the flat camera origin onto fast projectiles so collision covers the complete crosshair ray down to contact range
- keep the existing forward entity spawn clearance for slow physical projectiles
- retain a coarse creature hit when proxy refinement misses, while accepting only proxies owned by that creature
- add negative-first runtime coverage for close/ordinary damage, close cover, and slow-projectile spawn behavior

## Validation

- negative-first on `origin/main`: visible Training Droid torso at 1.087u remained 20 HP after firing
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (358 passed)
- `cd tools/shock2-sdk && npm test` (25 passed, 150 opt-in skipped)
- focused E2E file (3 passed): close + ordinary damage, wall inside muzzle clearance, slow physical Laser Shot clearance
- full serial SDK E2E (173/175 passed): only the two known unrelated stale test fixtures failed: #696 fixed by PR #701, and #698 fixed by PR #699; all 23 missions and every projectile-neighboring scenario passed

## Play-through campaign

- invocation: `--auto --restart`
- seed: `1546344805`
- scenario: SHODAN finale
- goal: verify end-game/final boss, especially SHODAN AI
- tweak: Loot everything
- assets: 25th Anniversary (`DARK_ASSET_PATH=/Users/bryan/ss2-25th`)

Fixes #669