### PR TITLE
fix(physics): preserve authored collider dimensions

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1015,10 +1015,19 @@ pub fn create_physics_representation(
             let qrotation = pos.rotation;
 
             let mut is_sensor = false;
-            let scale_factor = v_scale
-                .get(entity_id)
-                .map(|p| p.0)
-                .unwrap_or(vec3(1.0, 1.0, 1.0));
+            // Model scale belongs to the rendered model. An explicit
+            // P$PhysDims is already the independently authored collision
+            // volume and must not be scaled again (Shodan's window strips
+            // use a visual z-scale of 16 beside a 3.2-unit OBB). Only the
+            // model-bounds fallback needs the model's scale applied.
+            let scale_factor = if maybe_dimensions.is_some() {
+                vec3(1.0, 1.0, 1.0)
+            } else {
+                v_scale
+                    .get(entity_id)
+                    .map(|p| p.0)
+                    .unwrap_or(vec3(1.0, 1.0, 1.0))
+            };
             let _maybe_collision_prop = v_collision_type.get(entity_id);
             let maybe_trip_flags = v_trip_flags.get(entity_id);
 
@@ -1203,6 +1212,52 @@ mod tests {
     }
 
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
+    /// Model scale is a render transform, while `P$PhysDims` is the separately
+    /// authored collision volume. Shodan's long window strips make the
+    /// distinction observable: applying their visual z-scale to the OBB grows
+    /// a 3.2-unit collider to 51.2 units and seals an unrelated passage.
+    #[test]
+    fn authored_physics_dimensions_are_independent_of_model_scale() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let authored_size = vec3(3.2, 3.2, 3.2);
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(14.4, 0.0, 8.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::ORIENTED_BOUNDING_BOX,
+                num_submodels: 6,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysDimensions {
+                radius0: 0.0,
+                radius1: 0.0,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: authored_size,
+                unk1: 0,
+                unk2: 0,
+            },
+            PropScale(vec3(-0.888_888_9, 1.333_333_4, 16.0)),
+            PropImmobile(true),
+        ));
+
+        let handle = create_physics_representation(&mut world, &mut physics, &None, entity_id)
+            .expect("authored OBB should create a collider");
+        let actual_size = physics
+            .cuboid_full_size(handle)
+            .expect("authored OBB should remain a cuboid");
+
+        assert!(
+            (actual_size - authored_size).magnitude() < 0.001,
+            "render scale must not alter authored physics dimensions: expected {authored_size:?}, got {actual_size:?}"
+        );
+    }
 
     /// A climbable entity with no `PropPhysDimensions` still gets a collider,
     /// sized from the model bounds and tagged climbable (issue #589 - 24 of

--- a/tools/shock2-sdk/test/shodan-start.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-start.e2e.test.ts
@@ -67,3 +67,77 @@ test(
     );
   },
 );
+
+test(
+  "shodan.mis: the Citadel-memory portal is open while its window stays solid",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233) + 1,
+    });
+
+    // Resume the reviewed campaign frontier immediately before the portal.
+    // Relocation is setup only: both legs through the opening are
+    // collision-valid production movement.
+    await game.player.teleport({ x: 12.0, y: -2.196, z: -14.0 });
+    await game.step({ frames: 10 });
+    const start = await game.player.position();
+    const east = await game.player.moveTo({
+      x: 13.5,
+      y: start.y,
+      z: start.z,
+    });
+    assert.ok(
+      !east.blocked && east.new_position[0] > 13.3,
+      `window collision must not extend into the portal approach, got ${JSON.stringify(east)}`,
+    );
+
+    const beforeCrossing = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      beforeCrossing.x,
+      beforeCrossing.y,
+      -20.0,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 120 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+
+    const across = await game.player.position();
+    assert.ok(
+      across.z < -18.0 && Math.abs(across.y - start.y) < 0.25,
+      `ordinary walking should cross onto the supported floor, got ${JSON.stringify({
+        start,
+        across,
+      })}`,
+    );
+
+    // The fix narrows the collision to the authored 3.2-unit OBB; it does not
+    // make the unbreakable window itself non-solid.
+    const windows = await game.entities.list({
+      filter: "UBWin_6x9",
+      limit: 100,
+    });
+    const window = windows.entities.find(
+      (entity) => entity.template_id === 1288,
+    );
+    assert.ok(window, "expected Shodan mission object 1288 (UBWin_6x9)");
+    const windowHit = await game.raycast({
+      start: [10.0, 0.0, 8.0],
+      end: [18.0, 0.0, 8.0],
+      collision_groups: ["entity"],
+      ignore_sensors: true,
+    });
+    assert.equal(
+      windowHit.entity_id,
+      window.id,
+      `authored window footprint should stay solid, got ${JSON.stringify(windowHit)}`,
+    );
+    assert.ok(
+      windowHit.hit_point !== null &&
+        Math.abs(windowHit.hit_point[0] - 12.8) < 0.02,
+      `window west face should use its authored OBB at x=12.8, got ${JSON.stringify(windowHit)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- keep explicit `P$PhysDims` collision volumes independent from render `PropScale`
- retain `PropScale` for the model-bounds fallback when no physics dimensions are authored
- cover the Shodan Citadel-memory portal and the window's intended local collision

## Root cause

Shodan mission object 1288 (`UBWin_6x9`) uses model `wnd_69u`, whose raw bounds are `3.6 × 2.4 × 0.2`. Its render scale `0.888889 × 1.333333 × 16` produces a visible `3.2 × 3.2 × 3.2` window, matching its separately authored `P$PhysDims`.

The physics builder applied that render scale a second time to `P$PhysDims`, producing a `2.844 × 4.267 × 51.2` collider. That collider extended from the distant window into the campaign route and sealed the authored AIPATH opening against the neighboring WorldRep face.

## Source and corpus validation

The original Dark Engine establishes that explicit physics dimensions are final:

- [`phprop.cpp` initialization](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L823-L847) multiplies the unscaled object bounds by object scale when creating `P$PhysDims`.
- [`UpdatePhysModel`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L1178-L1190) later passes the stored `P$PhysDims.size` directly to `SetEdgeLengths`, without scaling it again.

A full shipped-entity audit also rejected a loaded-model-bounds discriminator: mounted replacement assets changed the classification for 70 entities (22 flipped the scaled-bounds match), and even `wnd_69u` appears with both raw- and scaled-looking authored conventions. Collision semantics therefore cannot depend on the currently mounted visual model. The durable rule is the source-faithful one in this PR: explicit dimensions are final; only a missing-dimensions model fallback receives `PropScale`.

The audit also exposed the independent standing-player footprint bug tracked in #707. That work is delegated separately and does not change this PR's collider semantics.

## Verification

- negative-first unit regression: failed before the fix with `2.844 × 4.267 × 51.2`, passes with the authored `3.2 × 3.2 × 3.2`
- exact campaign `frontier` save: collision-valid east move reaches `x=13.500`; ordinary thumbstick locomotion crosses and settles at `(13.508, -2.196, -31.640)`
- retained window collision: entity-only ray hits stable mission object 1288's authored west face at `x=12.800`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (363 passed)
- `shodan-start.e2e.test.ts` (#694 opening chute and #702 portal/window both pass)
- complete SDK E2E: **171/174 passed**, **0 cancelled**, **0 skipped**
  - **all 23 mission-load scenarios passed**, including `shodan.mis`
  - the only failures are independently tracked: #707 (standing-player footprint), stacked #696 (Cryokinesis damage), and stacked #698 (world-aim save compatibility)

Campaign: **SHODAN finale · Loot everything · 25th Anniversary · seed 1546344805**

Stacked on #697 / `playthrough/shodan-1546344805`.

Fixes #702

## Visual verification

![Citadel-memory portal traversal](https://gist.githubusercontent.com/tommy-xr/a61e40d95411e5ed65fb95b1134fc660/raw/portal-crossing.gif)

<sub>Collision-valid movement from the real campaign frontier through the authored portal. Captured headlessly via the debug runtime with deterministic fixed-timestep stepping.</sub>

### Before → after

![Blocked before and safely crossed after](https://gist.githubusercontent.com/tommy-xr/a61e40d95411e5ed65fb95b1134fc660/raw/before-after.png)
