### PR TITLE
fix(sdk): confirm required-visibility target hits

### DIFF
--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -220,6 +220,7 @@ export class PlayerApi {
           targetIds.has(check.hit.entity_id) &&
           check.hit.hit_point !== null
         ) {
+          interactionTargetId = check.hit.entity_id;
           surfacePoint = check.hit.hit_point;
         }
       } else if (!explicitCreatureCenter) {

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -40,6 +40,8 @@ async function frobThroughReticle(
   await game.step({ frames: 3 });
   const aim = await game.player.aimAt(entity, { visibility: "required" });
   assert.equal(aim.classification, "surface", JSON.stringify(aim));
+  assert.equal(aim.interaction_target_id, entity.id, JSON.stringify(aim));
+  assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
 
   await game.input.set("right_hand.squeeze_value", 1);
   await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -329,6 +329,64 @@ test("aimAt center uses and confirms an ordinary entity's selectable surface", a
   assert.equal(writes[1]?.path, "/v1/control/input");
 });
 
+test("aimAt required visibility confirms an ordinary visible entity", async () => {
+  const detail = {
+    entity_id: 470,
+    name: "Airlock Door",
+    template_id: 470,
+    position: [30, -7, 18],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [30, -8.6, 13],
+      rotation: [0, 0, 0, 1],
+    },
+  } as FrameSnapshot;
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/470") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") {
+        return {
+          hit: true,
+          hit_point: [30, -7, 17.25],
+          hit_normal: [0, 0, -1],
+          distance: 4.25,
+          entity_id: 470,
+          entity_name: "Airlock Door",
+          collision_group: "selectable",
+          is_sensor: false,
+        };
+      }
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(470, {
+    hitbox: "center",
+    visibility: "required",
+  });
+
+  assert.equal(aim.classification, "surface");
+  assert.equal(aim.visibility.state, "visible");
+  assert.deepEqual(aim.world_point, [30, -7, 17.25]);
+  assert.equal(aim.interaction_target_id, 470);
+  assert.equal(aim.target_confirmed, true);
+  assert.equal(writes[0]?.path, "/v1/physics/raycast");
+  assert.equal(writes[1]?.path, "/v1/control/input");
+});
+
 test("aimAt visibility required skips an occluded classified proxy", async () => {
   const detail = {
     entity_id: 363,


### PR DESCRIPTION
## Summary

- copy the accepted required-visibility ray hit into `interaction_target_id` for ordinary unclassified/surface targets
- restore the documented `target_confirmed` result when that production-equivalent ray selected the requested entity
- retain the existing classified hitbox candidate selection and occlusion-error behavior
- strengthen the real Rec1 PictureSwap scenario to require a confirmed target before its production squeeze interaction

## Negative-first reproduction

The new unit fixture raycasts visible ordinary entity `470`. Before the fix, `aimAt(..., { hitbox: "center", visibility: "required" })` returned `classification: "surface"` and `visibility.state: "visible"`, but failed with:

```text
Expected values to be strictly equal:
null !== 470
```

The implementation change is one assignment in the already-validated visible-hit branch, matching the unchecked surface path without changing ray selection.

## Validation

- `npm test` in `tools/shock2-sdk` — 26 passed, 147 E2E tests skipped
- focused required-visibility unit coverage — visible ordinary target, occluded classified proxy fallback, and fully blocked classified proxy all pass
- `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/picture-swap.e2e.test.js` — passed against `rec1.mis`
- `git diff --check`

Fixes #711
