### PR TITLE
feat(gameplay): add ordinary player jumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `W` `A` `S` `D` - move around (hold `Shift` to move faster)
 - `Q` `E` - control left hand or right hand, respectively. Mouse look will move the hand, left click will 'trigger', and right click will 'grab'.
 - `Ctrl` - crouch
+- `Space` - jump
 - `I` - move the floating inventory in front of you
 - `Alt+S` / `Alt+L` - quick save / quick load
-- `Space` - spawn a debug item
 - `P` - cycle the pathfinding test (set start → set goal → show path)
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -383,6 +383,9 @@ pub struct InputState {
     /// Crouch REQUEST (the `crouch` channel), not the resulting collider
     /// state - standing up is refused while there is no headroom.
     pub crouch: bool,
+    /// Ordinary held jump request. The physics controller launches only on
+    /// its rising edge and only while grounded.
+    pub jump: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -414,6 +417,7 @@ impl Default for InputState {
             right_hand: InputHand::default(),
             pointer: None,
             crouch: false,
+            jump: false,
         }
     }
 }

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1684,6 +1684,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
         left_hand: hand(&input.left_hand),
         right_hand: hand(&input.right_hand),
         crouch: input.crouch,
+        jump: input.jump,
     }
 }
 
@@ -1704,6 +1705,7 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
 /// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
 /// - `{left,right}_hand.thumbstick` : `[x, y]`
+/// - `jump`                         : number `0` or `1`
 /// One line describing every recognized input channel, used in error messages so
 /// a bad request is self-documenting. Includes the locomotion semantics (which
 /// stick does what) since that is the game's convention, not guessable.
@@ -1714,7 +1716,8 @@ fn input_channels_help() -> &'static str {
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
      {left,right}_hand.rotation [x,y,z,w], \
-     crouch 0|1 (stand-up refused without headroom); \
+     crouch 0|1 (stand-up refused without headroom), \
+     jump 0|1 (held; launches on the grounded rising edge); \
      locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
      left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
 }
@@ -1857,6 +1860,16 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
         // the player's body y (the collider center drops when crouched).
         "crouch" => {
             input.crouch = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            Ok(())
+        }
+        "jump" => {
+            input.jump = match num(channel, value)? {
                 v if v == 0.0 => false,
                 v if v == 1.0 => true,
                 v => {

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -36,11 +36,6 @@ impl DesktopInputMapper {
                 action: InputAction::PathfindingTestCycle,
             },
             Binding {
-                key: Key::Space,
-                modifier: Modifier::None,
-                action: InputAction::SpawnDebugItem,
-            },
-            Binding {
                 key: Key::I,
                 modifier: Modifier::None,
                 action: InputAction::MoveInventory,

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -684,6 +684,7 @@ fn process_events(
     }
 
     input_context.crouch = window.get_key(Key::LeftControl) == Action::Press;
+    input_context.jump = window.get_key(Key::Space) == Action::Press;
 
     // Discrete actions (spawn, save/load, inventory, pathfinding test) are
     // handled by the mapper, which edge-detects key presses.

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -337,6 +337,10 @@ fn main() {
         .create_action::<xr::Vector2f>("right_hand_thumbstick", "Right Hand Thumbstick", &[])
         .unwrap();
 
+    let jump_action = action_set
+        .create_action::<bool>("jump", "Jump", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -404,6 +408,12 @@ fn main() {
                     &right_thumbstick_action,
                     xr_instance
                         .string_to_path("/user/hand/right/input/thumbstick")
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &jump_action,
+                    xr_instance
+                        .string_to_path("/user/hand/right/input/thumbstick/click")
                         .unwrap(),
                 ),
             ],
@@ -561,6 +571,10 @@ fn main() {
             .state(&session, xr::Path::NULL)
             .unwrap()
             .current_state;
+        let jump_pressed = jump_action
+            .state(&session, xr::Path::NULL)
+            .unwrap()
+            .current_state;
 
         let left_trigger_value = left_trigger
             .state(&session, xr::Path::NULL)
@@ -627,6 +641,7 @@ fn main() {
         input_context.left_hand.squeeze_value = left_squeeze_value;
         input_context.left_hand.thumbstick =
             vec2(-left_thumbstick_value.x, left_thumbstick_value.y);
+        input_context.jump = jump_pressed;
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -24,6 +24,11 @@ pub struct InputContext {
     // is no headroom. VR leaves this false - physically crouching moves the
     // HMD instead.
     pub crouch: bool,
+
+    // Ordinary locomotion jump request. Runtimes provide this as a held
+    // button; the physics controller edge-detects it so holding the button
+    // cannot repeatedly add upward velocity.
+    pub jump: bool,
 }
 
 impl InputContext {
@@ -35,6 +40,7 @@ impl InputContext {
             right_hand: Hand::default(),
             pointer: None,
             crouch: false,
+            jump: false,
         }
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1225,9 +1225,10 @@ impl MissionCore {
                 .set_player_crouch(input_context.crouch, &mut self.player_handle);
             profile!(
                 "shock2.update.physics",
-                self.physics.update_with_facing(
+                self.physics.update_with_facing_and_jump(
                     forward + cgmath::vec3(0.0, up_value, 0.0),
                     facing,
+                    input_context.jump,
                     &mut self.player_handle,
                 )
             )

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -143,6 +143,19 @@ fn slope_ground_probe_distance(shape: &dyn Shape) -> Real {
 /// without a jump.
 const PLAYER_STEP_HEIGHT: f32 = 2.0;
 
+/// Ordinary jump launch speed and downward acceleration, in SS2 feet per
+/// second(/squared). These produce a short, fixed-height hop while preserving
+/// the existing terminal fall speed. The authored shodan.mis final barrier is
+/// deliberately taller than the 2 ft stair probe and needs this separate
+/// player action to clear.
+const PLAYER_JUMP_SPEED: f32 = 28.0;
+const PLAYER_JUMP_GRAVITY: f32 = 40.0;
+const PLAYER_MAX_FALL_SPEED: f32 = 30.0;
+/// Maximum forward search for a jump-through landing. This is deliberately a
+/// short body-scale transition, not a general wall bypass.
+const PLAYER_JUMP_MANTLE_FORWARD: f32 = 8.0;
+const PLAYER_JUMP_MANTLE_PROBE_STEP: f32 = 0.5;
+
 /// How far below the player's feet (world units) a surface still counts as the
 /// thing they are *standing on* for support-motion transfer (see
 /// [`PlayerSupport`]). Comfortably clears the controller's contact offset plus
@@ -1046,11 +1059,163 @@ fn plan_climb_top_out(
     })
 }
 
-/// Advance a compressed ladder top-out by one fixed-timestep step, checking
-/// every substep against current parented entity geometry. Parentless immutable
-/// level terrain is the narrow Dark jump-through exception. A newly-blocked
-/// route returns to its last valid standing pose before the capsule is expanded,
-/// and final standing fit is checked against every collider.
+/// Plan Dark's ordinary jump-through/mantle for a grounded player pressing
+/// into a non-climbable low obstacle.
+///
+/// Dark's sparse sphere-stack can jump through the local terrain lip after a
+/// point probe finds clearance above it. Our continuous capsule cannot occupy
+/// that intermediate pose, so this uses the same temporary head sphere and
+/// parentless-terrain exception as ladder `BreakClimb`. The transition is
+/// tightly bounded: the current frame must either be blocked by a low lip or
+/// find a walkable landing above the stair limit, the first body-scale standing
+/// pose must fit against *all* colliders, and every scripted substep still
+/// collides with parented entities. A same-height landing requires a genuinely
+/// clear all-world probe above the lip, so full-height walls remain solid. An
+/// elevated landing may use Dark's parentless-terrain jump-through probe: that
+/// is what permits authored stacked corridors such as shodan's log platforms,
+/// whose upper floor is a ceiling to the lower cell.
+fn plan_jump_mantle(
+    controller: &KinematicCharacterController,
+    validation_queries: &QueryPipeline,
+    scripted_queries: &QueryPipeline,
+    shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    desired: Vector<Real>,
+    dt: Real,
+) -> Option<PlayerMovement> {
+    let desired_h = vector![desired.x, 0.0, desired.z];
+    let desired_distance = desired_h.norm();
+    if desired_distance <= 1.0e-6 {
+        return None;
+    }
+    let direction = desired_h / desired_distance;
+    let walk = controller.move_shape(dt, validation_queries, shape, pos, desired_h, |_c| ());
+    let walk_blocked = walk.translation.dot(&direction) <= 0.25 * desired_distance;
+
+    let standing = standing_player_capsule();
+    let half_height = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR;
+    let current_feet_y = pos.translation.vector.y - half_height;
+    let head_offset = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+    let head = pos.translation.vector + Vector::y() * head_offset;
+    let max_rise =
+        (PLAYER_JUMP_SPEED * PLAYER_JUMP_SPEED) / (2.0 * PLAYER_JUMP_GRAVITY * SCALE_FACTOR);
+    let minimum_forward =
+        (2.0 * PLAYER_STANDING_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+    let mut transition = None;
+    let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
+    while rise_ss2 <= max_rise * SCALE_FACTOR + 1.0e-4 && transition.is_none() {
+        let raised = head + Vector::y() * (rise_ss2 / SCALE_FACTOR);
+        let mut forward_ss2 = minimum_forward * SCALE_FACTOR;
+        while forward_ss2 <= PLAYER_JUMP_MANTLE_FORWARD + 1.0e-4 {
+            let forward = forward_ss2 / SCALE_FACTOR;
+            let raised_forward = raised + direction * forward;
+            // Dark's sparse player spheres can pass the lip/underside of
+            // immutable level terrain during the jump-through transition.
+            // An elevated landing may therefore use the same parented-only
+            // probe as the scripted movement itself. Same-height crossings
+            // below additionally require the all-world probe to be clear, so
+            // a full-height wall with open space behind it is never a mantle.
+            let scripted_probe_clear =
+                ray_segment_is_clear(scripted_queries, raised, raised_forward);
+            let validation_probe_clear =
+                ray_segment_is_clear(validation_queries, raised, raised_forward);
+            if scripted_probe_clear {
+                // A platform above the current floor is a genuine mantle even
+                // when its underside has no blocking vertical face.
+                let down_ray = Ray::new(Point::from(raised_forward), -Vector::y());
+                let elevated_floor = validation_queries
+                    .cast_ray_and_get_normal(&down_ray, 2.0 * max_rise, true)
+                    .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+                    .map(|(_, ground)| raised_forward.y - ground.time_of_impact)
+                    .filter(|floor_y| {
+                        *floor_y - current_feet_y
+                            > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                    });
+                let final_standing = elevated_floor
+                    .map(|floor_y| {
+                        vector![
+                            raised_forward.x,
+                            floor_y
+                                + half_height
+                                + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR,
+                            raised_forward.z
+                        ]
+                    })
+                    // Otherwise, a blocked low lip crosses to the first
+                    // same-height standing pose beyond it. That destination
+                    // may open over a drop, as shodan's final descent does.
+                    .or_else(|| {
+                        (walk_blocked && validation_probe_clear)
+                            .then_some(pos.translation.vector + direction * forward)
+                    });
+                if let Some(final_standing) = final_standing {
+                    if !shape_intersects(validation_queries, final_standing, &standing) {
+                        transition = Some((raised, raised_forward, final_standing));
+                        break;
+                    }
+                }
+            }
+            forward_ss2 += PLAYER_JUMP_MANTLE_PROBE_STEP;
+        }
+        rise_ss2 += PLAYER_JUMP_MANTLE_PROBE_STEP;
+    }
+    let (raised, raised_forward, final_standing) = transition?;
+    let final_head = final_standing + Vector::y() * head_offset;
+    let waypoints = [
+        head,
+        raised,
+        raised_forward,
+        raised_forward,
+        final_head,
+        final_head,
+        final_standing,
+    ];
+
+    // Preflight the exact fixed-timestep route against every parented entity
+    // blocker. Parentless level terrain is the one Dark jump-through
+    // exception; the destination itself was validated against all colliders.
+    let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+    let mut simulated = pos.translation.vector;
+    let mut first_movement = None;
+    for waypoint in waypoints {
+        for _ in 0..512 {
+            if (waypoint - simulated).norm() <= PLAYER_MOVE_ARRIVAL_EPSILON {
+                break;
+            }
+            let movement = slide_toward(
+                controller,
+                scripted_queries,
+                &compressed,
+                simulated,
+                waypoint,
+                dt,
+            )?;
+            first_movement.get_or_insert(movement.translation);
+            simulated += movement.translation;
+        }
+        if (waypoint - simulated).norm() > PLAYER_MOVE_ARRIVAL_EPSILON {
+            return None;
+        }
+    }
+
+    Some(PlayerMovement {
+        movement: scripted_character_movement(first_movement?),
+        top_out: Some(ClimbTopOut {
+            waypoints,
+            next_waypoint: 0,
+            save_pose: pos.translation.vector,
+            reversing: false,
+        }),
+        slope_displacement: Vector::zeros(),
+    })
+}
+
+/// Advance a compressed ladder or ordinary-jump top-out by one fixed-timestep
+/// step, checking every substep against current parented entity geometry.
+/// Parentless immutable level terrain is the narrow Dark jump-through
+/// exception. A newly-blocked route returns to its last valid standing pose
+/// before the capsule is expanded, and final standing fit is checked against
+/// every collider.
 fn advance_climb_top_out(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -1147,6 +1312,10 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
 /// gravity are resolved from where the platform has taken them. A player
 /// gripping a ladder is holding the ladder, not riding the floor, so the climb
 /// branch above skips it.
+///
+/// `airborne_vertical` is one frame of an ordinary jump arc. While present it
+/// replaces the legacy constant gravity pass and disables ground snapping and
+/// stair probes; all collision casts and wall/ceiling rejection remain live.
 fn step_player_movement(
     controller: &KinematicCharacterController,
     queries: &QueryPipeline,
@@ -1157,6 +1326,7 @@ fn step_player_movement(
     dt: Real,
     gravity: Real,
     slope_displacement: Option<Vector<Real>>,
+    airborne_vertical: Option<Real>,
     climb: Option<ClimbPass<'_>>,
 ) -> PlayerMovement {
     // Ladder: the climb vector replaces both the walk and the gravity pass.
@@ -1224,7 +1394,27 @@ fn step_player_movement(
     let mut mvt = controller.move_shape(dt, queries, shape, pos, desired, |_c| ());
     let after_walk = Translation::from(mvt.translation) * pos;
     let gravity_step = Vector::y() * gravity;
-    let (fall, next_slope_displacement) = if let Some(slope_displacement) = slope_displacement {
+    // A live jump owns vertical movement until it lands. Disable the
+    // stair-sized ground snap for that pass so the initial ascent is not
+    // immediately glued back to the floor; collision, sliding, ceiling
+    // rejection, and slope classification remain the same controller path.
+    // Slope carry resumes from rest after landing instead of adding horizontal
+    // fall momentum to an independently integrated jump arc.
+    let (fall, next_slope_displacement) = if let Some(vertical) = airborne_vertical {
+        let mut airborne_controller = *controller;
+        airborne_controller.snap_to_ground = None;
+        (
+            airborne_controller.move_shape(
+                dt,
+                queries,
+                shape,
+                &after_walk,
+                Vector::y() * vertical,
+                |_collision| (),
+            ),
+            Vector::zeros(),
+        )
+    } else if let Some(slope_displacement) = slope_displacement {
         // Dark's dynamic player preserves velocity when a fall is redirected
         // by terrain. Our kinematic controller has no velocity of its own, so
         // retain only the horizontal part of a slope slide and feed it into
@@ -1334,7 +1524,7 @@ fn step_player_movement(
     // Stairs: if grounded walking was blocked, probe for a step and hop onto
     // it. (Grounded-only: an airborne player pressed against a wall must not
     // ratchet up ledges.)
-    if mvt.grounded {
+    if airborne_vertical.is_none() && mvt.grounded {
         if let Some(step) = try_step_up(
             queries,
             shape,
@@ -1644,6 +1834,14 @@ pub struct PlayerHandle {
     // collision. Carried only while gravity keeps sliding the player; flat
     // support, climbing and direct relocation clear it.
     slope_displacement: Vector<Real>,
+    // Ground contact reported by the previous character-controller frame.
+    // Unlike `support`, this includes immutable level terrain.
+    is_grounded: bool,
+    // A live ordinary jump's vertical velocity (world units / second).
+    // `None` means the legacy constant-gravity walk/fall path is active.
+    jump_velocity: Option<Real>,
+    // Held-button edge state: one press launches at most one jump.
+    jump_was_pressed: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2042,6 +2240,8 @@ impl PhysicsWorld {
     ) {
         player_handle.top_out = None;
         player_handle.slope_displacement = Vector::zeros();
+        player_handle.is_grounded = false;
+        player_handle.jump_velocity = None;
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         let shape = if player_handle.is_crouched {
             crouched_player_shared_shape()
@@ -2240,6 +2440,7 @@ impl PhysicsWorld {
         let walk_dir = vector![delta_h.x / dist, 0.0, delta_h.z / dist];
         let destination = start + walk_dir * requested_distance;
         let mut stalled_substeps = 0;
+        let mut grounded = player_handle.is_grounded;
         // Sensor volumes the player occupies, carried across the sweep. The hop
         // is committed as one jump, so without polling per substep any volume
         // entered and left between the endpoints would never be observed (#654).
@@ -2306,10 +2507,12 @@ impl PhysicsWorld {
                     dt,
                     gravity,
                     None,
+                    None,
                     // No ladder redirect: a validated move walks, it doesn't climb.
                     None,
                 )
                 .movement;
+                grounded = mvt.grounded;
 
                 let candidate = Translation::from(mvt.translation) * pos;
                 let from_start = vector![
@@ -2366,6 +2569,7 @@ impl PhysicsWorld {
         if walked {
             self.set_player_translation(new_position, player_handle);
         }
+        player_handle.is_grounded = grounded;
 
         let remaining = vector![
             destination.x - pos.translation.vector.x,
@@ -2733,6 +2937,9 @@ impl PhysicsWorld {
             top_out: None,
             support: None,
             slope_displacement: Vector::zeros(),
+            is_grounded: false,
+            jump_velocity: None,
+            jump_was_pressed: false,
         }
     }
 
@@ -3037,6 +3244,23 @@ impl PhysicsWorld {
         facing: Vector3<f32>,
         player_handle: &mut PlayerHandle,
     ) -> (Vector3<f32>, Vec<CollisionEvent>) {
+        self.update_with_facing_and_jump(desired_movement, facing, false, player_handle)
+    }
+
+    /// Update player movement with facing and a held ordinary-jump button.
+    ///
+    /// The button is edge-triggered inside [`PlayerHandle`], starts only from
+    /// controller-confirmed ground, and then follows a collision-cast ballistic
+    /// arc until landing. Keeping the request here (rather than as a debug
+    /// relocation/effect) means desktop, VR, and automated playtests all drive
+    /// the same production character controller.
+    pub fn update_with_facing_and_jump(
+        &mut self,
+        desired_movement: Vector3<f32>,
+        facing: Vector3<f32>,
+        jump_pressed: bool,
+        player_handle: &mut PlayerHandle,
+    ) -> (Vector3<f32>, Vec<CollisionEvent>) {
         // Queue every PhysAttach child at its parent's same next-frame target
         // before Rapier derives kinematic velocities. Moving-terrain assemblies
         // (tram floor + walls/buttons) therefore advance as one physical body,
@@ -3070,7 +3294,7 @@ impl PhysicsWorld {
         let desired_movement = vec_to_nvec(desired_movement);
         let facing = vec_to_nvec(facing);
         let (mut collision_events, character_body) =
-            { self.move_player(desired_movement, facing, player_handle) };
+            { self.move_player(desired_movement, facing, jump_pressed, player_handle) };
         let translation = nvec_to_cgmath(*character_body.translation());
 
         let mut additional_collision_events = { self.events.get_and_clear_events() };
@@ -3142,8 +3366,21 @@ impl PhysicsWorld {
         &mut self,
         desired_movement: Vector<Real>,
         facing: Vector<Real>,
+        jump_pressed: bool,
         player_handle: &mut PlayerHandle,
     ) -> (Vec<CollisionEvent>, &RigidBody) {
+        let jump_edge = jump_pressed && !player_handle.jump_was_pressed;
+        player_handle.jump_was_pressed = jump_pressed;
+        let launch_jump = jump_edge && player_handle.is_grounded && player_handle.top_out.is_none();
+        if launch_jump {
+            player_handle.jump_velocity = Some(PLAYER_JUMP_SPEED / SCALE_FACTOR);
+            player_handle.is_grounded = false;
+            // A jumping player has left their moving support. Its carry is
+            // already represented by the first frame's body pose; do not keep
+            // transferring later platform motion through the air.
+            player_handle.support = None;
+        }
+
         let character_body = &self.rigid_body_set[player_handle.character_handle];
         let original_position = *character_body.position();
         let character_user_data = character_body.user_data;
@@ -3164,7 +3401,9 @@ impl PhysicsWorld {
         // Flat climbing: when the player overlaps a climbable surface (ladder)
         // and pushes toward it, redirect that input to vertical movement and
         // suppress the gravity pass for this frame (see `climb_redirect`).
-        let climb_movement = {
+        let climb_movement = if player_handle.jump_velocity.is_some() {
+            None
+        } else {
             let climb_filter = QueryFilter::new()
                 .groups(InteractionGroups::new(
                     InternalCollisionGroups::PLAYER.bits.into(),
@@ -3309,24 +3548,48 @@ impl PhysicsWorld {
                     slope_displacement: Vector::zeros(),
                 }
             } else {
-                step_player_movement(
-                    &player_handle.controller,
-                    &queries,
-                    character_shape.as_ref(),
-                    &character_pos,
-                    desired_movement,
-                    carry,
-                    self.integration_parameters.dt,
-                    gravity,
-                    Some(player_handle.slope_displacement),
-                    climb_movement.map(|(movement, top_out)| ClimbPass {
-                        movement,
-                        top_out,
-                        validation_queries: queries,
-                        probe_queries: queries.with_filter(climb_pass_filter),
-                        scripted_queries: queries.with_filter(scripted_top_out_filter),
-                    }),
-                )
+                // A compressed mantle finishes by restoring the standing
+                // capsule. Keep crouched jumps ballistic so the collider flag
+                // and shape cannot diverge under low headroom.
+                let jump_mantle = (launch_jump && !player_handle.is_crouched)
+                    .then(|| {
+                        plan_jump_mantle(
+                            &player_handle.controller,
+                            &queries,
+                            &queries.with_filter(scripted_top_out_filter),
+                            character_shape.as_ref(),
+                            &character_pos,
+                            desired_movement,
+                            self.integration_parameters.dt,
+                        )
+                    })
+                    .flatten();
+                if let Some(jump_mantle) = jump_mantle {
+                    jump_mantle
+                } else {
+                    let airborne_vertical = player_handle
+                        .jump_velocity
+                        .map(|velocity| velocity * self.integration_parameters.dt);
+                    step_player_movement(
+                        &player_handle.controller,
+                        &queries,
+                        character_shape.as_ref(),
+                        &character_pos,
+                        desired_movement,
+                        carry,
+                        self.integration_parameters.dt,
+                        gravity,
+                        Some(player_handle.slope_displacement),
+                        airborne_vertical,
+                        climb_movement.map(|(movement, top_out)| ClimbPass {
+                            movement,
+                            top_out,
+                            validation_queries: queries,
+                            probe_queries: queries.with_filter(climb_pass_filter),
+                            scripted_queries: queries.with_filter(scripted_top_out_filter),
+                        }),
+                    )
+                }
             }
         });
         let was_top_out = player_handle.top_out.is_some();
@@ -3342,6 +3605,31 @@ impl PhysicsWorld {
         self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
+
+        if is_top_out {
+            player_handle.jump_velocity = None;
+            player_handle.is_grounded = false;
+        } else if let Some(mut velocity) = player_handle.jump_velocity {
+            let requested_vertical = velocity * self.integration_parameters.dt;
+            let applied_vertical = mvt.translation.y - carry.y;
+            if mvt.grounded && requested_vertical <= 0.0 {
+                player_handle.jump_velocity = None;
+                player_handle.is_grounded = true;
+            } else {
+                // A ceiling (or other overhead collision) consumes the upward
+                // cast. Cancel the rise immediately, then let the next frame's
+                // downward half of the same arc settle normally.
+                if requested_vertical > 0.0 && applied_vertical < requested_vertical * 0.5 {
+                    velocity = 0.0;
+                }
+                velocity -= PLAYER_JUMP_GRAVITY / SCALE_FACTOR * self.integration_parameters.dt;
+                player_handle.jump_velocity =
+                    Some(velocity.max(-PLAYER_MAX_FALL_SPEED / SCALE_FACTOR));
+                player_handle.is_grounded = false;
+            }
+        } else {
+            player_handle.is_grounded = mvt.grounded;
+        }
 
         // Edges already observed along a swept `move_player_validated` hop come
         // first: they happened before this frame's pose. They also leave
@@ -6230,6 +6518,343 @@ mod tests {
             max_y - start.y > 0.25,
             "the player should step onto the threshold under the ceiling, rose {}",
             max_y - start.y
+        );
+    }
+
+    /// Ordinary jump is a separate, grounded input: it clears a low obstacle
+    /// taller than the stair probe without changing automatic step height.
+    /// Negative-first: the walking control remains stopped at the 5 ft wall,
+    /// and before jump locomotion both runs ended at that same face.
+    #[test]
+    fn grounded_jump_clears_a_non_climbable_low_obstacle() {
+        let run = |jump: bool| -> (Vector3<f32>, f32) {
+            let mut world = PhysicsWorld::new();
+            world.add_kinematic(
+                EntityId::from_inner(1000).unwrap(),
+                vec3(0.0, -0.5, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(20.0, 1.0, 20.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            // 2 world units == 5 SS2 ft: taller than the 2 ft stair probe but
+            // comfortably inside the ordinary jump arc.
+            world.add_kinematic(
+                EntityId::from_inner(1001).unwrap(),
+                vec3(0.0, 1.0, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.4, 2.0, 4.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            let mut player = world.create_player(
+                vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+                EntityId::from_inner(2000).unwrap(),
+            );
+            step(&mut world, &mut player, 30);
+            let start = world.get_player_translation(&player);
+            let mut max_y = start.y;
+            for frame in 0..120 {
+                world.update_with_facing_and_jump(
+                    vec3(0.1, 0.0, 0.0),
+                    Vector3::unit_x(),
+                    jump && frame == 0,
+                    &mut player,
+                );
+                max_y = max_y.max(world.get_player_translation(&player).y);
+            }
+            (world.get_player_translation(&player), max_y - start.y)
+        };
+
+        let (walked, walked_rise) = run(false);
+        assert!(
+            walked.x < -0.3 && walked_rise < 0.1,
+            "walking must stay blocked by the over-step-height wall, ended {walked:?}, rose {walked_rise}"
+        );
+
+        let (jumped, jumped_rise) = run(true);
+        assert!(
+            jumped.x > 1.0 && jumped_rise > 2.0,
+            "jump should arc over the low wall, ended {jumped:?}, rose {jumped_rise}"
+        );
+    }
+
+    /// The authored Delacroix-log route in shodan.mis uses a platform whose
+    /// walkable top is above the stair probe but still inside the player's
+    /// ordinary jump/head reach. Unlike the final-descent lip, its underside
+    /// leaves forward walking unobstructed, so the elevated landing probe must
+    /// recognize the top rather than waiting for a blocked walk cast.
+    #[test]
+    fn grounded_jump_mantles_an_elevated_world_platform() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.5, 10.0)
+                .translation(vector![0.0, -0.5, 0.0])
+                .build(),
+        );
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            ColliderBuilder::cuboid(3.0, 1.8, 3.0)
+                .translation(vector![1.5, 1.8, 0.0])
+                .build(),
+        );
+        let mut player = world.create_player(
+            vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+
+        for frame in 0..120 {
+            world.update_with_facing_and_jump(
+                vec3(0.1, 0.0, 0.0),
+                Vector3::unit_x(),
+                frame == 0,
+                &mut player,
+            );
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            end.x > 0.0 && end.y > 4.4,
+            "jump should mantle onto the elevated platform, ended {end:?}"
+        );
+    }
+
+    /// Jump remains collision-cast locomotion: it may clear a low barrier but
+    /// cannot climb or tunnel through a full-height wall.
+    #[test]
+    fn jump_still_rejects_full_height_walls() {
+        let run = |parented: bool| {
+            let mut world = PhysicsWorld::new();
+            world.add_kinematic(
+                EntityId::from_inner(1000).unwrap(),
+                vec3(0.0, -0.5, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(20.0, 1.0, 20.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            let wall = ColliderBuilder::cuboid(0.2, 5.0, 2.0)
+                .translation(vector![0.0, 5.0, 0.0])
+                .build();
+            if parented {
+                world.add_kinematic(
+                    EntityId::from_inner(1001).unwrap(),
+                    vec3(0.0, 5.0, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.4, 10.0, 4.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            } else {
+                world.add_collider(EntityId::from_inner(1001).unwrap(), wall);
+            }
+            let mut player = world.create_player(
+                vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+                EntityId::from_inner(2000).unwrap(),
+            );
+            step(&mut world, &mut player, 30);
+            for frame in 0..180 {
+                world.update_with_facing_and_jump(
+                    vec3(0.1, 0.0, 0.0),
+                    Vector3::unit_x(),
+                    frame == 0,
+                    &mut player,
+                );
+            }
+            world.get_player_translation(&player)
+        };
+
+        for (kind, end) in [
+            ("parented entity", run(true)),
+            ("world terrain", run(false)),
+        ] {
+            assert!(
+                end.x < -0.3,
+                "jump must remain blocked by a full-height {kind} wall, ended {end:?}"
+            );
+        }
+    }
+
+    /// A held jump button is one impulse, not repeated upward thrust, and a
+    /// real low ceiling clips that impulse through the ordinary shape cast.
+    #[test]
+    fn held_jump_does_not_repeat_and_ceiling_blocks_rise() {
+        let run = |ceiling: bool| -> f32 {
+            let mut world = PhysicsWorld::new();
+            world.add_kinematic(
+                EntityId::from_inner(1000).unwrap(),
+                vec3(0.0, -0.5, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(20.0, 1.0, 20.0),
+                CollisionGroup::entity(),
+                false,
+            );
+            if ceiling {
+                world.add_kinematic(
+                    EntityId::from_inner(1001).unwrap(),
+                    vec3(0.0, 2.8, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(6.0, 0.4, 6.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            }
+            let mut player = world.create_player(
+                vec3(0.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+                EntityId::from_inner(2000).unwrap(),
+            );
+            step(&mut world, &mut player, 30);
+            let start = world.get_player_translation(&player);
+            let mut max_y = start.y;
+            for _ in 0..240 {
+                world.update_with_facing_and_jump(
+                    Vector3::new(0.0, 0.0, 0.0),
+                    Vector3::unit_x(),
+                    true,
+                    &mut player,
+                );
+                max_y = max_y.max(world.get_player_translation(&player).y);
+            }
+            max_y - start.y
+        };
+
+        let open_rise = run(false);
+        assert!(
+            open_rise > 2.0 && open_rise < 5.0,
+            "one held press should produce one bounded hop, rose {open_rise}"
+        );
+        let capped_rise = run(true);
+        assert!(
+            capped_rise < 0.15,
+            "a low ceiling must clip the jump cast, rose {capped_rise}"
+        );
+    }
+
+    /// Releasing and pressing again while airborne must not reset the vertical
+    /// velocity to a fresh launch. This covers both rapid tapping and a held
+    /// controller that bounces around its threshold during one arc.
+    #[test]
+    fn airborne_jump_edges_do_not_relaunch() {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(1000).unwrap(),
+            vec3(0.0, -0.5, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(20.0, 1.0, 20.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = world.create_player(
+            vec3(0.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        for _ in 0..5 {
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::unit_x(),
+                false,
+                &mut player,
+            );
+        }
+        let before_second_edge = player
+            .jump_velocity
+            .expect("the first jump should still be airborne");
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        let after_second_edge = player
+            .jump_velocity
+            .expect("an ignored airborne edge should leave the arc active");
+        assert!(
+            after_second_edge < before_second_edge,
+            "an airborne press must keep consuming gravity, not relaunch ({before_second_edge} -> {after_second_edge})"
+        );
+    }
+
+    /// A crouched player may hop, but must not enter the standing-only
+    /// compressed mantle path. Its collider stays crouched through the arc and
+    /// can return to the standing capsule normally once grounded in headroom.
+    #[test]
+    fn crouched_jump_preserves_collider_state_and_can_stand_after_landing() {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(1000).unwrap(),
+            vec3(0.0, -0.5, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(20.0, 1.0, 20.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.4, 2.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = world.create_player(
+            vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+        assert!(world.set_player_crouch(true, &mut player));
+
+        world.update_with_facing_and_jump(
+            vec3(0.1, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        assert!(
+            player.top_out.is_none() && player.is_crouched(),
+            "crouched jump must stay ballistic and keep the crouched collider"
+        );
+        let collider_handle = world.rigid_body_set[player.character_handle].colliders()[0];
+        let crouched = world.collider_set[collider_handle]
+            .shape()
+            .as_capsule()
+            .expect("player collider should remain a capsule");
+        assert!(
+            (2.0 * (crouched.half_height() + crouched.radius)
+                - PLAYER_CROUCH_HEIGHT / SCALE_FACTOR)
+                .abs()
+                < 1.0e-4,
+            "jump must not expand the crouched capsule"
+        );
+
+        for _ in 0..240 {
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::unit_x(),
+                false,
+                &mut player,
+            );
+        }
+        assert!(
+            !world.set_player_crouch(false, &mut player),
+            "a landed crouched player in open headroom should stand normally"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -71,11 +71,16 @@ fn standing_player_shared_shape() -> SharedShape {
 }
 
 /// The player's crouched collision capsule, in world units.
-fn crouched_player_shared_shape() -> SharedShape {
-    SharedShape::capsule_y(
+fn crouched_player_capsule() -> Capsule {
+    Capsule::new_y(
         (PLAYER_CROUCH_HEIGHT / 2.0 - PLAYER_CROUCH_RADIUS) / SCALE_FACTOR,
         PLAYER_CROUCH_RADIUS / SCALE_FACTOR,
     )
+}
+
+/// The player's crouched collision capsule, in world units.
+fn crouched_player_shared_shape() -> SharedShape {
+    SharedShape::new(crouched_player_capsule())
 }
 
 /// Gap (SS2 ft) the character controller keeps between the player collider
@@ -155,6 +160,15 @@ const PLAYER_MAX_FALL_SPEED: f32 = 30.0;
 /// short body-scale transition, not a general wall bypass.
 const PLAYER_JUMP_MANTLE_FORWARD: f32 = 8.0;
 const PLAYER_JUMP_MANTLE_PROBE_STEP: f32 = 0.5;
+/// Maximum authored drop a sparse-body jump transition may recover, in SS2
+/// feet. SHODAN's stacked final-descent cells put the lower side ring about
+/// 34 feet below the upper floor; keeping this below one room-scale span makes
+/// the exception local instead of a general search for arbitrary floors.
+const PLAYER_JUMP_MANTLE_MAX_DROP: f32 = 40.0;
+/// SHODAN's side ring is an authored 45-degree tread (normal y ~= 0.707).
+/// Rapier's default controller accepts that boundary; leave a small
+/// floating-point margin when selecting the same surface by raycast.
+const PLAYER_JUMP_DROP_MIN_GROUND_NORMAL: f32 = 0.7;
 
 /// How far below the player's feet (world units) a surface still counts as the
 /// thing they are *standing on* for support-motion transfer (see
@@ -551,6 +565,7 @@ struct ClimbTopOut {
     next_waypoint: usize,
     save_pose: Vector<Real>,
     reversing: bool,
+    is_crouched: bool,
 }
 
 struct PlayerMovement {
@@ -1054,6 +1069,7 @@ fn plan_climb_top_out(
             next_waypoint: 0,
             save_pose: pos.translation.vector,
             reversing: false,
+            is_crouched: false,
         }),
         slope_displacement: Vector::zeros(),
     })
@@ -1067,13 +1083,14 @@ fn plan_climb_top_out(
 /// that intermediate pose, so this uses the same temporary head sphere and
 /// parentless-terrain exception as ladder `BreakClimb`. The transition is
 /// tightly bounded: the current frame must either be blocked by a low lip or
-/// find a walkable landing above the stair limit, the first body-scale standing
-/// pose must fit against *all* colliders, and every scripted substep still
-/// collides with parented entities. A same-height landing requires a genuinely
-/// clear all-world probe above the lip, so full-height walls remain solid. An
-/// elevated landing may use Dark's parentless-terrain jump-through probe: that
-/// is what permits authored stacked corridors such as shodan's log platforms,
-/// whose upper floor is a ceiling to the lower cell.
+/// find a walkable landing beyond the stair limit, the first body-scale
+/// standing pose must fit against *all* colliders, and every scripted substep
+/// still collides with parented entities. Same-height and lower landings
+/// require a genuinely clear all-world point probe above the lip, so
+/// full-height walls remain solid. An elevated landing may use Dark's
+/// parentless-terrain jump-through probe: that is what permits authored
+/// stacked corridors such as shodan's log platforms, whose upper floor is a
+/// ceiling to the lower cell.
 fn plan_jump_mantle(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -1082,6 +1099,7 @@ fn plan_jump_mantle(
     pos: &Isometry<Real>,
     desired: Vector<Real>,
     dt: Real,
+    is_crouched: bool,
 ) -> Option<PlayerMovement> {
     let desired_h = vector![desired.x, 0.0, desired.z];
     let desired_distance = desired_h.norm();
@@ -1092,16 +1110,25 @@ fn plan_jump_mantle(
     let walk = controller.move_shape(dt, validation_queries, shape, pos, desired_h, |_c| ());
     let walk_blocked = walk.translation.dot(&direction) <= 0.25 * desired_distance;
 
-    let standing = standing_player_capsule();
-    let half_height = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR;
+    let final_shape = if is_crouched {
+        crouched_player_capsule()
+    } else {
+        standing_player_capsule()
+    };
+    let (body_height, body_radius) = if is_crouched {
+        (PLAYER_CROUCH_HEIGHT, PLAYER_CROUCH_RADIUS)
+    } else {
+        (PLAYER_STANDING_HEIGHT, PLAYER_STANDING_RADIUS)
+    };
+    let half_height = body_height / 2.0 / SCALE_FACTOR;
     let current_feet_y = pos.translation.vector.y - half_height;
-    let head_offset = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+    let head_offset = (body_height / 2.0 - body_radius) / SCALE_FACTOR;
     let head = pos.translation.vector + Vector::y() * head_offset;
     let max_rise =
         (PLAYER_JUMP_SPEED * PLAYER_JUMP_SPEED) / (2.0 * PLAYER_JUMP_GRAVITY * SCALE_FACTOR);
-    let minimum_forward =
-        (2.0 * PLAYER_STANDING_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
+    let minimum_forward = (2.0 * body_radius + 2.0 * PLAYER_CONTACT_OFFSET) / SCALE_FACTOR;
     let mut transition = None;
+    let mut lower_transition = None;
     let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
     while rise_ss2 <= max_rise * SCALE_FACTOR + 1.0e-4 && transition.is_none() {
         let raised = head + Vector::y() * (rise_ss2 / SCALE_FACTOR);
@@ -1123,35 +1150,103 @@ fn plan_jump_mantle(
                 // A platform above the current floor is a genuine mantle even
                 // when its underside has no blocking vertical face.
                 let down_ray = Ray::new(Point::from(raised_forward), -Vector::y());
-                let elevated_floor = validation_queries
+                let nearest_floor = validation_queries
                     .cast_ray_and_get_normal(&down_ray, 2.0 * max_rise, true)
-                    .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-                    .map(|(_, ground)| raised_forward.y - ground.time_of_impact)
+                    .map(|(_, ground)| (ground.normal.y, raised_forward.y - ground.time_of_impact));
+                let elevated_floor = nearest_floor
+                    .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+                    .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {
                         *floor_y - current_feet_y
                             > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
                     });
-                let final_standing = elevated_floor
-                    .map(|floor_y| {
-                        vector![
-                            raised_forward.x,
-                            floor_y
-                                + half_height
-                                + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR,
-                            raised_forward.z
-                        ]
+                // A same-height floor visible above the lower candidate is the
+                // stacked-terrain signature: the continuous capsule cannot
+                // descend without first clearing that overhang. An ordinary
+                // open ledge has no current-height floor at the forward probe
+                // and remains a normal ballistic fall.
+                let overhanging_current_floor = nearest_floor.is_some_and(|(normal_y, floor_y)| {
+                    normal_y > PLAYER_JUMP_DROP_MIN_GROUND_NORMAL
+                        && (floor_y - current_feet_y).abs()
+                            <= (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                });
+                let lower_probe_start = vector![
+                    raised_forward.x,
+                    current_feet_y - (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR,
+                    raised_forward.z
+                ];
+                let lower_ray = Ray::new(Point::from(lower_probe_start), -Vector::y());
+                let lower_floor = validation_probe_clear
+                    .then(|| {
+                        validation_queries
+                            .cast_ray_and_get_normal(
+                                &lower_ray,
+                                PLAYER_JUMP_MANTLE_MAX_DROP / SCALE_FACTOR,
+                                true,
+                            )
+                            .filter(|(_, ground)| {
+                                ground.normal.y > PLAYER_JUMP_DROP_MIN_GROUND_NORMAL
+                            })
+                            .map(|(_, ground)| {
+                                (
+                                    lower_probe_start - Vector::y() * ground.time_of_impact,
+                                    ground.normal,
+                                )
+                            })
+                            .filter(|(floor_point, _)| {
+                                current_feet_y - floor_point.y
+                                    > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                            })
                     })
-                    // Otherwise, a blocked low lip crosses to the first
-                    // same-height standing pose beyond it. That destination
-                    // may open over a drop, as shodan's final descent does.
-                    .or_else(|| {
-                        (walk_blocked && validation_probe_clear)
-                            .then_some(pos.translation.vector + direction * forward)
-                    });
-                if let Some(final_standing) = final_standing {
-                    if !shape_intersects(validation_queries, final_standing, &standing) {
+                    .flatten();
+                let elevated_standing = elevated_floor.map(|floor_y| {
+                    vector![
+                        raised_forward.x,
+                        floor_y
+                            + half_height
+                            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR,
+                        raised_forward.z
+                    ]
+                });
+                let lower_standing = lower_floor
+                    .map(|(floor_point, floor_normal)| {
+                        // A vertical ray identifies the exact sloped tread.
+                        // Offset the capsule along that surface normal rather
+                        // than straight up: on SHODAN's 45-degree side ring, a
+                        // vertical half-height offset embeds the bottom sphere
+                        // into the upslope half of the triangle.
+                        let segment_half = (body_height / 2.0 - body_radius) / SCALE_FACTOR;
+                        floor_point
+                            + floor_normal * ((body_radius + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR)
+                            + Vector::y() * (segment_half + PLAYER_REST_LIFT / SCALE_FACTOR)
+                    })
+                    // A normal open ledge needs no compatibility transition:
+                    // the ordinary ballistic capsule can fall beside it. Use
+                    // the sparse body only where the upper-floor ray proves
+                    // authored stacked terrain overhangs the lower landing,
+                    // and only while already crouched for that low route.
+                    .filter(|_| is_crouched && overhanging_current_floor);
+                // A blocked low lip first crosses to the same-height standing
+                // pose beyond it. That destination may itself open over a
+                // drop, as SHODAN's initial final-descent barrier does; do not
+                // skip that normal crossing in favor of a deeper landing.
+                let same_height_standing = (walk_blocked && validation_probe_clear)
+                    .then(|| pos.translation.vector + direction * forward);
+                if let Some(final_standing) = elevated_standing.or(same_height_standing) {
+                    if !shape_intersects(validation_queries, final_standing, &final_shape) {
                         transition = Some((raised, raised_forward, final_standing));
                         break;
+                    }
+                }
+                // A lower landing is a fallback for stacked geometry, never
+                // competition for an elevated/same-height mantle farther
+                // along the bounded search. Remember the first valid one and
+                // use it only if the preferred search is exhausted.
+                if lower_transition.is_none() {
+                    if let Some(final_standing) = lower_standing {
+                        if !shape_intersects(validation_queries, final_standing, &final_shape) {
+                            lower_transition = Some((raised, raised_forward, final_standing));
+                        }
                     }
                 }
             }
@@ -1159,7 +1254,7 @@ fn plan_jump_mantle(
         }
         rise_ss2 += PLAYER_JUMP_MANTLE_PROBE_STEP;
     }
-    let (raised, raised_forward, final_standing) = transition?;
+    let (raised, raised_forward, final_standing) = transition.or(lower_transition)?;
     let final_head = final_standing + Vector::y() * head_offset;
     let waypoints = [
         head,
@@ -1174,7 +1269,7 @@ fn plan_jump_mantle(
     // Preflight the exact fixed-timestep route against every parented entity
     // blocker. Parentless level terrain is the one Dark jump-through
     // exception; the destination itself was validated against all colliders.
-    let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+    let compressed = Ball::new(body_radius / SCALE_FACTOR);
     let mut simulated = pos.translation.vector;
     let mut first_movement = None;
     for waypoint in waypoints {
@@ -1205,6 +1300,7 @@ fn plan_jump_mantle(
             next_waypoint: 0,
             save_pose: pos.translation.vector,
             reversing: false,
+            is_crouched,
         }),
         slope_displacement: Vector::zeros(),
     })
@@ -1224,7 +1320,11 @@ fn advance_climb_top_out(
     mut top_out: ClimbTopOut,
     dt: Real,
 ) -> (EffectiveCharacterMovement, Option<ClimbTopOut>) {
-    let standing = standing_player_capsule();
+    let final_shape = if top_out.is_crouched {
+        crouched_player_capsule()
+    } else {
+        standing_player_capsule()
+    };
     let target = loop {
         let target = if top_out.reversing {
             match top_out.next_waypoint.checked_sub(1) {
@@ -1233,7 +1333,7 @@ fn advance_climb_top_out(
             }
         } else if let Some(target) = top_out.waypoints.get(top_out.next_waypoint) {
             *target
-        } else if shape_intersects(validation_queries, pos.translation.vector, &standing) {
+        } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape) {
             top_out.reversing = true;
             continue;
         } else {
@@ -1245,7 +1345,7 @@ fn advance_climb_top_out(
         }
         if top_out.reversing {
             if top_out.next_waypoint == 0 {
-                if shape_intersects(validation_queries, top_out.save_pose, &standing) {
+                if shape_intersects(validation_queries, top_out.save_pose, &final_shape) {
                     return (scripted_character_movement(Vector::zeros()), Some(top_out));
                 }
                 return (scripted_character_movement(Vector::zeros()), None);
@@ -1255,7 +1355,12 @@ fn advance_climb_top_out(
             top_out.next_waypoint += 1;
         }
     };
-    let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+    let compressed_radius = if top_out.is_crouched {
+        PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+    } else {
+        CLIMB_TOP_OUT_RADIUS
+    };
+    let compressed = Ball::new(compressed_radius);
     // A live entity can move into the compressed sphere between frames. The
     // forward route must stop, but refusing every cast from an overlapping
     // pose would pin the recovery forever. During reversal only, let Rapier's
@@ -3548,10 +3653,10 @@ impl PhysicsWorld {
                     slope_displacement: Vector::zeros(),
                 }
             } else {
-                // A compressed mantle finishes by restoring the standing
-                // capsule. Keep crouched jumps ballistic so the collider flag
-                // and shape cannot diverge under low headroom.
-                let jump_mantle = (launch_jump && !player_handle.is_crouched)
+                // A compressed mantle restores the same standing/crouched
+                // capsule it started with, so a player deliberately crouched
+                // for a low stacked route never expands under its ceiling.
+                let jump_mantle = launch_jump
                     .then(|| {
                         plan_jump_mantle(
                             &player_handle.controller,
@@ -3561,6 +3666,7 @@ impl PhysicsWorld {
                             &character_pos,
                             desired_movement,
                             self.integration_parameters.dt,
+                            player_handle.is_crouched,
                         )
                     })
                     .flatten();
@@ -3598,9 +3704,22 @@ impl PhysicsWorld {
         let is_top_out = player_handle.top_out.is_some();
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         if !was_top_out && is_top_out {
-            self.collider_set[collider_handle].set_shape(SharedShape::ball(CLIMB_TOP_OUT_RADIUS));
+            let compressed_radius = if player_handle
+                .top_out
+                .is_some_and(|top_out| top_out.is_crouched)
+            {
+                PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+            } else {
+                CLIMB_TOP_OUT_RADIUS
+            };
+            self.collider_set[collider_handle].set_shape(SharedShape::ball(compressed_radius));
         } else if was_top_out && !is_top_out {
-            self.collider_set[collider_handle].set_shape(standing_player_shared_shape());
+            let restored = if player_handle.is_crouched {
+                crouched_player_shared_shape()
+            } else {
+                standing_player_shared_shape()
+            };
+            self.collider_set[collider_handle].set_shape(restored);
         }
         self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
         let scripted_top_out_frame = was_top_out || is_top_out;
@@ -5760,6 +5879,7 @@ mod tests {
             next_waypoint: 2,
             save_pose: vector![-1.0, 0.0, 0.0],
             reversing: false,
+            is_crouched: false,
         };
         let first = {
             let queries = query_pipeline(&world, QueryFilter::default());
@@ -5812,6 +5932,7 @@ mod tests {
             next_waypoint: 2,
             save_pose: vector![-1.0, 0.0, 0.0],
             reversing: false,
+            is_crouched: false,
         };
         world.add_kinematic(
             EntityId::from_inner(2).unwrap(),
@@ -5845,6 +5966,39 @@ mod tests {
     }
 
     #[test]
+    fn crouched_top_out_finishes_without_expanding_into_low_headroom() {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(2).unwrap(),
+            vec3(0.0, 0.75, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 0.1, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let controller = KinematicCharacterController::default();
+        let pos = Isometry::identity();
+        let completed = ClimbTopOut {
+            waypoints: test_waypoints(),
+            next_waypoint: test_waypoints().len(),
+            save_pose: Vector::zeros(),
+            reversing: false,
+            is_crouched: true,
+        };
+
+        let (movement, active) =
+            advance_climb_top_out(&controller, &queries, &queries, &pos, completed, 1.0 / 60.0);
+
+        assert_eq!(movement.translation, Vector::zeros());
+        assert!(
+            active.is_none(),
+            "the crouched final capsule fits below headroom that blocks standing"
+        );
+    }
+
+    #[test]
     fn validated_move_refuses_a_top_out_whose_safe_pose_became_blocked() {
         let mut world = PhysicsWorld::new();
         let mut player = world.create_player(vec3(3.0, 0.5, 0.0), EntityId::from_inner(1).unwrap());
@@ -5869,6 +6023,7 @@ mod tests {
             next_waypoint: 3,
             save_pose,
             reversing: true,
+            is_crouched: false,
         });
         assert_eq!(
             world.get_player_save_translation(&player),
@@ -6790,9 +6945,10 @@ mod tests {
         );
     }
 
-    /// A crouched player may hop, but must not enter the standing-only
-    /// compressed mantle path. Its collider stays crouched through the arc and
-    /// can return to the standing capsule normally once grounded in headroom.
+    /// A crouched player may hop without ever expanding to the standing
+    /// profile. An ordinary blocked hop remains ballistic, keeps the crouched
+    /// collider, and can return to the standing capsule once grounded in open
+    /// headroom.
     #[test]
     fn crouched_jump_preserves_collider_state_and_can_stand_after_landing() {
         let mut world = PhysicsWorld::new();
@@ -6829,7 +6985,7 @@ mod tests {
         );
         assert!(
             player.top_out.is_none() && player.is_crouched(),
-            "crouched jump must stay ballistic and keep the crouched collider"
+            "this blocked crouched jump should stay ballistic and keep the crouched collider"
         );
         let collider_handle = world.rigid_body_set[player.character_handle].colliders()[0];
         let crouched = world.collider_set[collider_handle]
@@ -7325,6 +7481,7 @@ mod tests {
             next_waypoint: 3,
             save_pose,
             reversing: false,
+            is_crouched: false,
         });
 
         let result = world.move_player_validated(vec3(f32::NAN, 0.5, 0.0), &mut player);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -165,10 +165,11 @@ const PLAYER_JUMP_MANTLE_PROBE_STEP: f32 = 0.5;
 /// 34 feet below the upper floor; keeping this below one room-scale span makes
 /// the exception local instead of a general search for arbitrary floors.
 const PLAYER_JUMP_MANTLE_MAX_DROP: f32 = 40.0;
-/// SHODAN's side ring is an authored 45-degree tread (normal y ~= 0.707).
-/// Rapier's default controller accepts that boundary; leave a small
-/// floating-point margin when selecting the same surface by raycast.
-const PLAYER_JUMP_DROP_MIN_GROUND_NORMAL: f32 = 0.7;
+/// Lowest upward normal the player treats as walkable. SHODAN's side ring is
+/// an authored 45-degree tread (normal y ~= 0.707); the small margin prevents
+/// imported float normals from landing just beyond Rapier's exact pi/4
+/// climb/slide boundary.
+const PLAYER_MIN_WALKABLE_NORMAL: f32 = 0.7;
 
 /// How far below the player's feet (world units) a surface still counts as the
 /// thing they are *standing on* for support-motion transfer (see
@@ -183,6 +184,25 @@ const SUPPORT_PROBE_DISTANCE: f32 = 0.1;
 /// the controller's default 45-degree slide angle). A surface the player would
 /// slide down is not one they ride, and a wall never is.
 const SUPPORT_MIN_GROUND_NORMAL: f32 = CLIMB_TOP_OUT_MIN_GROUND_NORMAL;
+
+fn player_character_controller() -> KinematicCharacterController {
+    let mut controller = KinematicCharacterController::default();
+    controller.offset = CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
+    // Walking down stairs stays grounded (snapped onto the next tread)
+    // instead of chaining micro-falls. Deliberate tradeoff: this also
+    // absorbs any intended drop up to the step height (the player glues
+    // to <= 2 ft ledges rather than falling) - revisit when gravity
+    // becomes an integrated velocity. Stepping UP is handled by an
+    // explicit probe in `move_player` (see `try_step_up`) - Rapier's
+    // built-in autostep needs a wall-classified contact, but a capsule
+    // touching a step edge above its bottom-sphere center reads as a
+    // ceiling and never triggers it.
+    controller.snap_to_ground = Some(CharacterLength::Absolute(PLAYER_STEP_HEIGHT / SCALE_FACTOR));
+    let max_walkable_angle = PLAYER_MIN_WALKABLE_NORMAL.acos();
+    controller.max_slope_climb_angle = max_walkable_angle;
+    controller.min_slope_slide_angle = max_walkable_angle;
+    controller
+}
 
 /// Horizontal reach (world units) for ladder detection: the player grips a
 /// climbable surface when their collider, inflated by this much radially,
@@ -716,6 +736,53 @@ fn shape_intersects(queries: &QueryPipeline, position: Vector<Real>, shape: &dyn
         .is_some()
 }
 
+/// Whether an expanded player shape is genuinely resting on walkable
+/// all-collider geometry at `position`.
+///
+/// A point ray can find a finite tread beside the capsule while the capsule
+/// itself remains non-overlapping in unsupported air. Run a short sequence of
+/// the same zero-input walk/gravity passes ordinary locomotion uses, accepting
+/// only endpoints that remain grounded within the contact-sized rest band.
+fn shape_has_stable_support(
+    controller: &KinematicCharacterController,
+    queries: &QueryPipeline,
+    shape: &dyn Shape,
+    position: Vector<Real>,
+    dt: Real,
+) -> bool {
+    const SETTLE_FRAMES: usize = 96;
+
+    let mut settled = position;
+    let settle_limit = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    for _ in 0..SETTLE_FRAMES {
+        let pose = Isometry::translation(settled.x, settled.y, settled.z);
+        let support = step_player_movement(
+            controller,
+            queries,
+            shape,
+            &pose,
+            Vector::zeros(),
+            Vector::zeros(),
+            dt,
+            -0.5 / SCALE_FACTOR,
+            None,
+            None,
+            None,
+        )
+        .movement;
+        if !support.grounded {
+            return false;
+        }
+        settled += support.translation;
+        let displacement = settled - position;
+        let lateral = vector![displacement.x, 0.0, displacement.z].norm();
+        if lateral > settle_limit || displacement.y.abs() > settle_limit {
+            return false;
+        }
+    }
+    true
+}
+
 fn slide_toward(
     controller: &KinematicCharacterController,
     queries: &QueryPipeline,
@@ -1166,7 +1233,7 @@ fn plan_jump_mantle(
                 // open ledge has no current-height floor at the forward probe
                 // and remains a normal ballistic fall.
                 let overhanging_current_floor = nearest_floor.is_some_and(|(normal_y, floor_y)| {
-                    normal_y > PLAYER_JUMP_DROP_MIN_GROUND_NORMAL
+                    normal_y > PLAYER_MIN_WALKABLE_NORMAL
                         && (floor_y - current_feet_y).abs()
                             <= (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
                 });
@@ -1184,9 +1251,7 @@ fn plan_jump_mantle(
                                 PLAYER_JUMP_MANTLE_MAX_DROP / SCALE_FACTOR,
                                 true,
                             )
-                            .filter(|(_, ground)| {
-                                ground.normal.y > PLAYER_JUMP_DROP_MIN_GROUND_NORMAL
-                            })
+                            .filter(|(_, ground)| ground.normal.y > PLAYER_MIN_WALKABLE_NORMAL)
                             .map(|(_, ground)| {
                                 (
                                     lower_probe_start - Vector::y() * ground.time_of_impact,
@@ -1225,7 +1290,30 @@ fn plan_jump_mantle(
                     // the sparse body only where the upper-floor ray proves
                     // authored stacked terrain overhangs the lower landing,
                     // and only while already crouched for that low route.
-                    .filter(|_| is_crouched && overhanging_current_floor);
+                    .filter(|_| is_crouched && overhanging_current_floor)
+                    // Restore the continuous capsule an additional radius
+                    // beyond the minimum crossing distance. The first point
+                    // sample on a finite downhill tread can support the bottom
+                    // sphere while leaving its center on the boundary; one
+                    // body-radius of interior clearance selects a durable
+                    // landing without widening the bounded forward search.
+                    .filter(|_| forward >= minimum_forward + body_radius / SCALE_FACTOR)
+                    .filter(|final_standing| {
+                        // A non-overlapping capsule can still be suspended
+                        // beside the finite tread that produced the point-ray
+                        // hit. Prove the expanded body is actually supported:
+                        // repeated ordinary zero-input gravity passes must keep
+                        // it grounded without meaningful drift. Unsupported
+                        // edge candidates are skipped so the bounded search
+                        // can reach the real side-ring tread.
+                        shape_has_stable_support(
+                            controller,
+                            validation_queries,
+                            &final_shape,
+                            *final_standing,
+                            dt,
+                        )
+                    });
                 // A blocked low lip first crosses to the same-height standing
                 // pose beyond it. That destination may itself open over a
                 // drop, as SHODAN's initial final-descent barrier does; do not
@@ -3017,21 +3105,7 @@ impl PhysicsWorld {
         self.collider_set
             .insert_with_parent(collider, character_handle, &mut self.rigid_body_set);
 
-        let mut controller = KinematicCharacterController::default();
-
-        controller.offset = CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
-        // Walking down stairs stays grounded (snapped onto the next tread)
-        // instead of chaining micro-falls. Deliberate tradeoff: this also
-        // absorbs any intended drop up to the step height (the player glues
-        // to <= 2 ft ledges rather than falling) - revisit when gravity
-        // becomes an integrated velocity. Stepping UP is handled by an
-        // explicit probe in `move_player` (see `try_step_up`) - rapier's
-        // built-in autostep needs a wall-classified contact, but a capsule
-        // touching a step edge above its bottom-sphere center reads as a
-        // ceiling and never triggers it.
-        controller.snap_to_ground =
-            Some(CharacterLength::Absolute(PLAYER_STEP_HEIGHT / SCALE_FACTOR));
-
+        let controller = player_character_controller();
         self.entity_id_to_body
             .insert(player_entity, character_handle);
 
@@ -5113,6 +5187,102 @@ mod tests {
             &world.collider_set,
             filter,
         )
+    }
+
+    /// A point probe can see a narrow tread while the crouched capsule
+    /// endpoint chosen beside it is entirely unsupported. Non-overlap alone
+    /// accepted that endpoint and let the expanded body fall after top-out.
+    #[test]
+    fn jump_drop_support_rejects_pose_beside_finite_tread() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.05, 0.05, 0.05)
+                .translation(vector![0.0, -0.05, 0.0])
+                .build(),
+        );
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(1.0, 0.05, 1.0)
+                .translation(vector![2.0, -0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let shape = crouched_player_capsule();
+        let center_y = PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR;
+        let unsupported = vector![0.5, center_y, 0.0];
+        let supported = vector![2.0, center_y, 0.0];
+        let controller = player_character_controller();
+
+        assert!(
+            queries
+                .cast_ray(
+                    &Ray::new(vector![0.0, center_y, 0.0].into(), -Vector::y()),
+                    PLAYER_STEP_HEIGHT / SCALE_FACTOR,
+                    true,
+                )
+                .is_some(),
+            "the point probe must find the nearby finite tread"
+        );
+        assert!(
+            !shape_intersects(&queries, unsupported, &shape),
+            "the old non-overlap predicate must accept this unsupported endpoint"
+        );
+        assert!(
+            !shape_has_stable_support(&controller, &queries, &shape, unsupported, 1.0 / 60.0),
+            "an overlap-free pose beside the tread must not count as a landing"
+        );
+        assert!(
+            shape_has_stable_support(&controller, &queries, &shape, supported, 1.0 / 60.0),
+            "a crouched capsule centered over a broad tread must remain a valid landing"
+        );
+    }
+
+    /// Imported 45-degree treads carry tiny normal error around pi/4. The
+    /// player's walkable-normal margin must keep those authored surfaces from
+    /// turning into an automatic slide after a validated jump landing.
+    #[test]
+    fn jump_drop_support_accepts_authored_45_degree_tread() {
+        let mut world = PhysicsWorld::new();
+        let angle = std::f32::consts::FRAC_PI_4;
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(2.0, 0.05, 1.0)
+                .rotation(vector![0.0, 0.0, angle])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let shape = crouched_player_capsule();
+        let normal = vector![-angle.sin(), angle.cos(), 0.0];
+        let floor_point = normal * 0.05;
+        let segment_half = (PLAYER_CROUCH_HEIGHT / 2.0 - PLAYER_CROUCH_RADIUS) / SCALE_FACTOR;
+        let standing = floor_point
+            + normal * ((PLAYER_CROUCH_RADIUS + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR)
+            + Vector::y() * (segment_half + PLAYER_REST_LIFT / SCALE_FACTOR);
+
+        assert!(
+            !shape_intersects(&queries, standing, &shape),
+            "the capsule should begin at a collision-valid rest offset"
+        );
+        assert!(
+            shape_has_stable_support(
+                &player_character_controller(),
+                &queries,
+                &shape,
+                standing,
+                1.0 / 60.0,
+            ),
+            "an authored 45-degree tread must remain stable through the landing preflight"
+        );
     }
 
     /// Plan the standard rejection-test mantle: from the origin, facing +X,

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -408,6 +408,11 @@ export class InputApi {
     await this.client.post("/v1/control/input", { channel, value });
   }
 
+  /** Hold or release the ordinary production jump button. */
+  async setJump(pressed: boolean): Promise<void> {
+    await this.set("jump", pressed ? 1 : 0);
+  }
+
   /**
    * Point the production flat-mode camera/interaction ray at a world position.
    *

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -16,7 +16,7 @@ async function pulseJump(game: GameServer): Promise<void> {
 // collision-valid move endpoint all stop at its face; retail expects the
 // player to jump over it and land on the authored ledges below.
 test(
-  "ordinary jump crosses shodan's final descent barrier",
+  "ordinary jumps traverse shodan's final descent into the log 4 passage",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -80,6 +80,103 @@ test(
         Math.abs(supported.y - landed.y) < 0.5,
       `player should land on the first authored lower ledge ` +
         `(contact ${JSON.stringify(landed)}, after five frames ${JSON.stringify(supported)})`,
+    );
+
+    // A short diagonal jump reaches the stacked upper floor. From here the
+    // mandatory route wraps under its east lip onto a finite lower side ring;
+    // a continuous standing capsule cannot expose that ring through an
+    // ordinary ballistic edge fall.
+    await game.input.lookAtWorldPoint([31, supported.y + 1.6, 28.5]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 24 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    let position = await game.player.position();
+    assert.ok(
+      position.y > -18.2 && position.y < -17.7,
+      `diagonal jump should reach the stacked upper floor, got ${JSON.stringify(position)}`,
+    );
+
+    // Walk to the real east lip and align over the narrow z=30..32 side ring.
+    // There is no setup placement after the initial campaign frontier: every
+    // pose in the crossing is reached through production locomotion.
+    await game.input.lookAtWorldPoint([35, position.y + 1.6, 31]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 29 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    position = await game.player.position();
+    assert.ok(
+      position.x > 34.7 &&
+        position.x < 35.8 &&
+        position.z > 30.8 &&
+        position.z < 31.3,
+      `production movement should stage at the east lip, got ${JSON.stringify(position)}`,
+    );
+
+    // The lower ring immediately enters a crouch-only passage. Crouch before
+    // jumping so the bounded sparse-body transition can restore the same
+    // collision profile under the stacked upper-floor ceiling; it must never
+    // expand a standing capsule into that headroom.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+    position = await game.player.position();
+
+    // A forward jump at the parentless lip uses the bounded sparse-body
+    // transition to the first all-collider-valid crouched pose below. Before
+    // the downward transition this pulse simply landed back on y=-19.2.
+    await game.input.lookAtWorldPoint([40, position.y + 1.6, position.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    let lowerRing:
+      | Awaited<ReturnType<typeof game.player.position>>
+      | undefined;
+    for (let sample = 0; sample < 36; sample += 1) {
+      await game.step({ frames: 10 });
+      position = await game.player.position();
+      if (position.y > -32.4 && position.y < -31.3) {
+        lowerRing = position;
+        break;
+      }
+    }
+    assert.ok(
+      lowerRing &&
+        lowerRing.x > 35.2 &&
+        lowerRing.x < 36.8 &&
+        lowerRing.z > 30.2 &&
+        lowerRing.z < 31.8,
+      `jump should descend onto the finite lower side ring, got ${JSON.stringify(position)}`,
+    );
+    position = lowerRing;
+
+    // Follow the authored crouch-only continuation west from the ring toward
+    // Delacroix log 4. This proves the landing opens the real route rather than
+    // merely finding an isolated point below the upper floor.
+    await game.input.lookAtWorldPoint([
+      position.x,
+      position.y + 1.6,
+      28,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 7 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 5 });
+    position = await game.player.position();
+    await game.input.lookAtWorldPoint(
+      [30, position.y + 1.1, position.z],
+      { eyeHeight: 1.1 },
+    );
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 20 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    position = await game.player.position();
+    assert.ok(
+      position.x < 34 &&
+        position.y < -33 &&
+        position.z > 29.5 &&
+        position.z < 31.2,
+      `crouched production movement should enter the log 4 passage, got ${JSON.stringify(position)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function pulseJump(game: GameServer): Promise<void> {
+  await game.input.setJump(true);
+  await game.step({ frames: 1 });
+  await game.input.setJump(false);
+}
+
+// Issue #708: shodan.mis's mandatory final descent begins behind a low
+// non-climbable barrier at z=32. Ordinary walking, crouching, and the
+// collision-valid move endpoint all stop at its face; retail expects the
+// player to jump over it and land on the authored ledges below.
+test(
+  "ordinary jump crosses shodan's final descent barrier",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8136),
+    });
+    await game.step({ frames: 5 });
+
+    // Setup only: place the player at the campaign-confirmed approach. The
+    // crossing itself uses only the production jump and locomotion channels.
+    await game.player.teleport({
+      x: 28.14371,
+      y: -0.5959,
+      z: 31.63964,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+
+    // A save at the authored frontier must reload to a normal grounded player,
+    // not preserve a stale airborne edge or lose the newly available input.
+    await game.save("jump-shodan-final-barrier");
+    await game.step({ frames: 2 });
+    await game.load("jump-shodan-final-barrier");
+    await game.step({ frames: 30 });
+    const restored = await game.player.position();
+    assert.ok(
+      Math.hypot(restored.x - before.x, restored.z - before.z) < 0.1,
+      `save/load should preserve the jump approach (${JSON.stringify(before)} -> ` +
+        `${JSON.stringify(restored)})`,
+    );
+
+    // Face world +Z irrespective of the mission's authored pawn rotation,
+    // then press ordinary forward locomotion through the jump.
+    await game.input.lookAtWorldPoint([
+      restored.x,
+      restored.y + 1.6,
+      restored.z + 4,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 59 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    const crossed = await game.player.position();
+    assert.ok(
+      crossed.z > 32.3,
+      `jump should clear the z=32 barrier (started ${JSON.stringify(before)}, ` +
+        `ended ${JSON.stringify(crossed)})`,
+    );
+
+    // Fall straight onto the first authored sloping ledge. Contact sharply
+    // slows the old 0.2-unit/frame free fall; five more frames remain within
+    // one half unit vertically while the walkable surface slides the
+    // controller a little down-slope.
+    await game.step({ frames: 111 });
+    const landed = await game.player.position();
+    await game.step({ frames: 5 });
+    const supported = await game.player.position();
+    assert.ok(
+      landed.y > -19 && landed.y < -18 &&
+        Math.abs(supported.y - landed.y) < 0.5,
+      `player should land on the first authored lower ledge ` +
+        `(contact ${JSON.stringify(landed)}, after five frames ${JSON.stringify(supported)})`,
+    );
+  },
+);
+
+// The same ordinary jump-through semantics are also required by the optional
+// Delacroix log 2 route: the upper floors are ceilings to the stacked corridor
+// cells below. Teleport only stages the player on the real lower floor; both
+// ascents and the log frob use production input.
+test(
+  "ordinary jumps reach and collect shodan's two-platform Delacroix log",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_LOG_PORT ?? 8137),
+    });
+    await game.step({ frames: 5 });
+
+    const log = (
+      await game.entities.list({ filter: "Audio Log", limit: 80 })
+    ).entities.find((entity) => entity.template_id === 606);
+    assert.ok(log, "shodan should contain Delacroix deck 9/log 2");
+
+    await game.player.teleport({ x: 5, y: 0.2, z: 9 });
+    await game.step({ frames: 30 });
+    let position = await game.player.position();
+
+    // First authored platform: cross its south lip toward world +Z.
+    await game.input.lookAtWorldPoint([5, position.y + 1.6, 13]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 20 });
+    position = await game.player.position();
+    assert.ok(
+      position.y > 3.9 && position.y < 4.2,
+      `first jump should stand on the y=2.8 platform, got ${JSON.stringify(position)}`,
+    );
+
+    // Second platform: face the discovered log, jump toward it, and arrive on
+    // the y=6 authored floor without teleporting between platforms.
+    await game.input.lookAtWorldPoint([
+      log.position[0],
+      position.y + 1.6,
+      log.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 20 });
+    position = await game.player.position();
+    assert.ok(
+      position.y > 7.1 &&
+        position.y < 7.4 &&
+        Math.hypot(position.x - log.position[0], position.z - log.position[2]) <
+          2,
+      `second jump should reach the log platform, got ${JSON.stringify(position)}`,
+    );
+
+    // Resolve the entity again because runtime ids are launch-local, then use
+    // the normal flat crosshair + squeeze interaction to collect it.
+    const liveLog = (
+      await game.entities.list({ filter: "Audio Log", limit: 80 })
+    ).entities.find((entity) => entity.template_id === 606);
+    assert.ok(liveLog, "Delacroix log should remain present before collection");
+    await game.player.aimAt(liveLog, { visibility: "required" });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    assert.ok(
+      (await game.info()).player.collected_logs.some(
+        (entry) => entry.deck === 9 && entry.log === 2,
+      ),
+      "production squeeze should collect Delacroix deck 9/log 2",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -129,40 +129,50 @@ test(
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await pulseJump(game);
     await game.input.set("right_hand.thumbstick", [0, 0]);
-    let lowerRing:
-      | Awaited<ReturnType<typeof game.player.position>>
-      | undefined;
-    for (let sample = 0; sample < 36; sample += 1) {
-      await game.step({ frames: 10 });
-      position = await game.player.position();
-      if (position.y > -32.4 && position.y < -31.3) {
-        lowerRing = position;
-        break;
-      }
-    }
+    // Do not mistake the scripted transition passing through the ring's
+    // height for a landing. With no steering input, it must settle on authored
+    // collision for ten seconds and remain stationary for two more.
+    await game.step({ frames: 600 });
+    const lowerRing = await game.player.position();
+    await game.step({ frames: 120 });
+    const supportedLowerRing = await game.player.position();
+    const onLowerRing = (sample: typeof lowerRing): boolean =>
+      sample.x > 35.2 &&
+      sample.x < 36.8 &&
+      sample.y > -32.5 &&
+      sample.y < -31.5 &&
+      sample.z > 30.2 &&
+      sample.z < 31.8;
     assert.ok(
-      lowerRing &&
-        lowerRing.x > 35.2 &&
-        lowerRing.x < 36.8 &&
-        lowerRing.z > 30.2 &&
-        lowerRing.z < 31.8,
-      `jump should descend onto the finite lower side ring, got ${JSON.stringify(position)}`,
+      onLowerRing(lowerRing) &&
+        onLowerRing(supportedLowerRing) &&
+        Math.hypot(
+          supportedLowerRing.x - lowerRing.x,
+          supportedLowerRing.y - lowerRing.y,
+          supportedLowerRing.z - lowerRing.z,
+        ) < 0.05,
+      `jump should remain supported on the finite lower side ring ` +
+        `(${JSON.stringify(lowerRing)} -> ${JSON.stringify(supportedLowerRing)})`,
     );
-    position = lowerRing;
+    position = supportedLowerRing;
 
-    // Follow the authored crouch-only continuation west from the ring toward
-    // Delacroix log 4. This proves the landing opens the real route rather than
-    // merely finding an isolated point below the upper floor.
+    // Follow the authored crouch-only continuation around the outer north edge
+    // at z~=29, then west toward Delacroix log 4. This proves the landing opens
+    // the real route rather than merely finding an isolated point below.
     await game.input.lookAtWorldPoint([
       position.x,
       position.y + 1.6,
       28,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
-    await game.step({ frames: 7 });
+    await game.step({ frames: 18 });
     await game.input.set("right_hand.thumbstick", [0, 0]);
     await game.step({ frames: 5 });
     position = await game.player.position();
+    assert.ok(
+      position.z > 28.5 && position.z < 28.8,
+      `crouched movement should round the outer north edge, got ${JSON.stringify(position)}`,
+    );
     await game.input.lookAtWorldPoint(
       [30, position.y + 1.1, position.z],
       { eyeHeight: 1.1 },
@@ -170,13 +180,32 @@ test(
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await game.step({ frames: 20 });
     await game.input.set("right_hand.thumbstick", [0, 0]);
-    position = await game.player.position();
+    // The central passage floor is a finite authored tread at z=28.5..28.8.
+    // Release input and prove the apparent entry is support rather than a
+    // mid-fall sample over the adjacent void.
+    await game.step({ frames: 600 });
+    const passage = await game.player.position();
+    await game.step({ frames: 120 });
+    const supportedPassage = await game.player.position();
+    const inPassage = (sample: typeof passage): boolean =>
+      sample.x > 31 &&
+      sample.x < 33 &&
+      // Player positions are capsule centers: crouched half-height is 0.56
+      // world units, putting the feet on the mapped y=-33.6..-33.3 tread.
+      sample.y > -33.04 &&
+      sample.y < -32.74 &&
+      sample.z > 28.5 &&
+      sample.z < 28.8;
     assert.ok(
-      position.x < 34 &&
-        position.y < -33 &&
-        position.z > 29.5 &&
-        position.z < 31.2,
-      `crouched production movement should enter the log 4 passage, got ${JSON.stringify(position)}`,
+      inPassage(passage) &&
+        inPassage(supportedPassage) &&
+        Math.hypot(
+          supportedPassage.x - passage.x,
+          supportedPassage.y - passage.y,
+          supportedPassage.z - passage.z,
+        ) < 0.05,
+      `crouched production movement should remain supported in the log 4 passage ` +
+        `(${JSON.stringify(passage)} -> ${JSON.stringify(supportedPassage)})`,
     );
   },
 );

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -210,6 +210,123 @@ test(
   },
 );
 
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// reached this authored route from a clean playthrough. The shipped walk graph
+// continues through the Cargo 2 crate stack, but the parented mission crates
+// close its sub-player-width seam. Retail's ordinary jump is required to get
+// over the stack and continue toward Sanger on the top floor of Cargo 2B.
+test(
+  "ordinary jump clears Engineering Cargo 2's route-blocking crate stack",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG2_JUMP_PORT ?? 8138),
+    });
+    await game.step({ frames: 5 });
+
+    const entities = (await game.entities.list()).entities;
+    const bigCrate = entities.find((entity) => entity.template_id === 434);
+    const lowerSmallCrate = entities.find((entity) => entity.template_id === 435);
+    const upperSmallCrate = entities.find((entity) => entity.template_id === 436);
+    const sangerCorpse = entities.find((entity) => entity.template_id === 507);
+    assert.ok(bigCrate, "eng2 should contain mission big crate 434");
+    assert.ok(lowerSmallCrate, "eng2 should contain mission small crate 435");
+    assert.ok(upperSmallCrate, "eng2 should contain mission small crate 436");
+    assert.ok(sangerCorpse, "eng2 should contain Sanger corpse mission 507");
+
+    // Setup only: exact cold-loadable campaign frontier immediately south of
+    // the crates. Everything after settling here uses production look,
+    // locomotion, and jump channels.
+    await game.player.teleport({
+      x: 26.339931,
+      y: -11.795994,
+      z: -202.49998,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    const initialCorpseDistance = Math.hypot(
+      before.x - sangerCorpse.position[0],
+      before.z - sangerCorpse.position[2],
+    );
+
+    // Aim over the stacked small crates toward the first shipped-path point
+    // beyond them, then keep ordinary forward locomotion active for the jump.
+    await game.input.lookAtWorldPoint([
+      lowerSmallCrate.position[0],
+      before.y + 1.6,
+      -195.8,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    // The authentic stack is a two-hop route: the first jump reaches the
+    // stable top of the small crates, replacing the unavailable one-shot
+    // mantle the campaign player initially tried.
+    await pulseJump(game);
+    await game.step({ frames: 180 });
+    const onCrates = await game.player.position();
+    assert.ok(
+      onCrates.y > before.y + 2 &&
+        onCrates.z > -199 &&
+        onCrates.z < -197,
+      `first production jump should reach the stable crate-top foothold ` +
+        `(${JSON.stringify(before)} -> ${JSON.stringify(onCrates)})`,
+    );
+
+    // Jump again from that production-reached foothold into Cargo 2. No
+    // relocation or validated debug move occurs after the campaign frontier.
+    await pulseJump(game);
+    let crossed = onCrates;
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      crossed = await game.player.position();
+      if (crossed.z > -196.5) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    assert.ok(
+      crossed.z > -196.5,
+      `production jump should clear crates 434/435/436 ` +
+        `(${JSON.stringify(before)} -> ${JSON.stringify(crossed)})`,
+    );
+
+    // The crossing must finish on the ordinary supported Cargo 2 floor, not
+    // merely sample an airborne point above or beside the crates. Two long
+    // zero-input windows also make this checkpoint safe for campaign replay.
+    await game.step({ frames: 300 });
+    const landed = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+    const finalCorpseDistance = Math.hypot(
+      supported.x - sangerCorpse.position[0],
+      supported.z - sangerCorpse.position[2],
+    );
+    assert.ok(
+      landed.z > -196.5 &&
+        supported.z > -196.5 &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05 &&
+        finalCorpseDistance < initialCorpseDistance - 4,
+      `post-stack Cargo 2 checkpoint should remain supported and closer to ` +
+        `Sanger corpse 507 (${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, corpse distance ` +
+        `${initialCorpseDistance.toFixed(2)} -> ${finalCorpseDistance.toFixed(2)})`,
+    );
+    t.diagnostic(
+      `Engineering Cargo 2: frontier ${JSON.stringify(before)}, ` +
+        `crate top ${JSON.stringify(onCrates)}, crossing ${JSON.stringify(crossed)}, ` +
+        `supported ${JSON.stringify(landed)} -> ${JSON.stringify(supported)}, ` +
+        `corpse distance ${initialCorpseDistance.toFixed(2)} -> ` +
+        `${finalCorpseDistance.toFixed(2)}`,
+    );
+  },
+);
+
 // The same ordinary jump-through semantics are also required by the optional
 // Delacroix log 2 route: the upper floors are ceilings to the stacked corridor
 // cells below. Teleport only stages the player on the real lower floor; both


### PR DESCRIPTION
## Summary

- add an edge-triggered, grounded ordinary jump with fixed launch speed, gravity, terminal fall speed, live wall/ceiling collision, and no held-button relaunch
- bind the production control to desktop `Space`, Oculus right-thumbstick click, and the debug runtime/SDK held `jump` channel
- support authored traversal in both SHODAN and Engineering Cargo 2, including the mandatory SHODAN descent, the optional Delacroix log route, and Engineering's route-blocking crate stack
- validate lower sparse-body landings with the expanded player capsule against all colliders and 96 fixed zero-input locomotion/gravity frames before committing to the transition
- preserve current `main`'s downhill slope carry while an airborne jump independently owns vertical motion

This PR is stacked on `fix/707-original-player-footprint` / #712.

## Campaign evidence

`Campaign: engineering · none · legacy · seed 1378752978`

The clean campaign reached Cargo 2 at the exact cold-loadable frontier `{26.339931,-11.795994,-202.49998}`. Stable mission objects `434`/`435`/`436` are the blocking crate stack; stable mission object `507` is Sanger's corpse on the authored continuation.

The durable scenario uses only setup teleport before the frontier. Production look, locomotion, and two ordinary jump pulses then reach:

- settled frontier: `{26.266577,-11.665126,-202.53517}`
- production-reached crate top: `{24.983921,-8.31554,-198.12016}`
- upper Cargo 2 support: `{24.682234,-5.156001,-196.20673}` → unchanged after another 120 fixed frames
- distance to Sanger corpse 507: `30.30` → `24.50`

The shipped walk graph independently continues from cell 5238 through the crate coordinates into Cargo 2B. Retail documents `Spacebar` jump plus running jumps across gaps and hold-jump mantling; the original Looking Glass source binds `jump` to grounded `PhysPlayerJump`. Full source/manual/walkthrough evidence is recorded in [the campaign validation comment](https://github.com/tommy-xr/shock2quest/issues/708#issuecomment-5128002849).

## Negative-first regression

The same stable-ID Engineering scenario on rebased #712 loaded the mission, discovered all four objects, and settled at the exact frontier, then failed at the first production crossing with HTTP 400: `unknown input channel 'jump'`.

On this branch, `ordinary jump clears Engineering Cargo 2's route-blocking crate stack` passes through the authentic two-hop route and proves a stationary supported checkpoint beyond the stack. No runtime entity id is hardcoded.

## Dark terrain compatibility

SHODAN's stacked Dark cells make an upper walkable floor the lower corridor's ceiling. A continuous capsule cannot occupy the intermediate route that the original sparse player spheres traversed.

The compatibility path is deliberately narrow:

- it starts only from a grounded jump with horizontal input
- its search is capped to 8 SS2 feet forward, the physical ballistic apex, and a 40-SS2-foot lower search only under the stacked-terrain signature
- elevated and same-height routes preserve the existing standing behavior
- lower transitions require the player to already be crouched and restore the same crouched capsule under the low ceiling
- compressed substeps still collide with every parented entity; only immutable parentless terrain gets the Dark jump-through exception
- lower candidates require one crouched radius of interior tread clearance, all-collider final fit, and 96 ordinary zero-input gravity frames with no meaningful drift
- full-height terrain walls and unsupported finite edges remain solid/rejected

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- rebased #712 passed the same warning-strict check in isolation
- `cargo test -p shock2vr` — 394 passed / 0 failed
- SDK TypeScript build passed
- focused exact Engineering scenario rerun on final head `cd19e396` — 1 passed / 0 failed (`31,029 ms`), with the supported coordinates above; SDK shutdown confirmed by no port 8138 listener and no task-local debug runtime process
- full serial SDK E2E suite on the final combined stack — 186 total / 183 passed / 0 failed / 3 expected SHODAN finale skips (`1,821,939 ms`, serial concurrency 1)
- the post-suite dependency restack changes only #712's synthetic `#[cfg(test)]` ramp start; production and SDK/E2E sources are byte-identical to the full-suite head

## Visual verification

![Engineering Cargo 2 jump before and after](https://gist.githubusercontent.com/tommy-xr/03ee164de5803e36cf9d3142cda1ea05/raw/engineering-cargo-jump-before-after.gif)

<sub>Same exact Engineering frontier and deterministic 360-frame request sequence. Before, forward motion remains pinned at the crate face; after, two production jump pulses climb the stack and continue onto upper Cargo 2.</sub>

### Before → after

![Engineering Cargo 2 blocked versus jumping](https://gist.githubusercontent.com/tommy-xr/03ee164de5803e36cf9d3142cda1ea05/raw/engineering-cargo-jump-before-after.png)

Fixes #708
