### PR TITLE
fix(gameplay): restore SHODAN computer hacking

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -257,6 +257,9 @@ pub struct PropMaterial(pub String);
 pub struct PropMapText(pub String);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropHackText(pub String);
+
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropMapObjIcon(pub String);
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
@@ -438,6 +441,8 @@ pub enum Link {
     /// particle group) to spawn when that projectile hits a descendant of the
     /// class (e.g. pistol bullets -> Hybrids spawns the blood spang).
     HitSpang(i32),
+    /// Script target activated when a tech hack succeeds.
+    Hacking,
     /// From a particle-group archetype to the object it rides
     /// ("ParticleAttachement"). On an archetype host, the engine instantiates
     /// the particle group when a concrete host is created (projectile trails,
@@ -1049,6 +1054,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         }),
         define_link("L$LandingPo", |_| Link::LandingPoint),
         define_link("L$Replicato", |_| Link::Replicator),
+        define_link("L$HackingLi", |_| Link::Hacking),
         define_link("L$SwitchLin", |_| Link::SwitchLink),
         define_link("L$Teleport", |_| Link::Teleport),
         define_link("L$TPathInit", |_| Link::TPathInit),
@@ -1304,6 +1310,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$HackDiff",
             PropHackDiff::read,
             identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$HackText",
+            read_variable_length_string,
+            PropHackText,
             accumulator::latest,
         ),
         define_prop(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -815,10 +815,17 @@ impl MissionCore {
 
         world.add_unique(quest_info);
 
+        crate::scripts::gui::restore_authored_computer_data(
+            &mut world,
+            &entity_info_rc,
+            &template_to_entity_id,
+        );
+
         // Preload the elevator floor labels (MISC.STR) + current mission so the
         // AssetCache-less ElevatorGui can label/gate floors at draw time.
         world.add_unique(crate::scripts::ElevatorContext::load(asset_cache, &mission));
         world.add_unique(crate::scripts::gui::TraitsContext::load(asset_cache));
+        world.add_unique(crate::scripts::gui::ComputerContext::load(asset_cache));
 
         world.add_unique(EffectQueue {
             effects: Vec::new(),

--- a/shock2vr/src/scripts/gui/computer.rs
+++ b/shock2vr/src/scripts/gui/computer.rs
@@ -1,0 +1,420 @@
+use std::collections::HashMap;
+
+use cgmath::{Vector2, Vector3, vec2};
+use dark::{
+    properties::{
+        Link, Links, ObjectState, PropHackDiff, PropHackText, PropObjState, PropTemplateId, ToLink,
+        WrappedEntityId,
+    },
+    ss2_entity_info::SystemShock2EntityInfo,
+};
+use engine::assets::asset_cache::AssetCache;
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, Unique, UniqueView, View, World};
+
+use crate::{
+    gui::{Gui, GuiComponent, GuiConfig, GuiCursor},
+    scripts::{Effect, Message, MessagePayload, script_util::*},
+};
+
+use super::keypad::{
+    HackOutcomeEffects, HackPhase, HackState, KeyPadMsg, draw_hack_board, handle_hack_msg,
+};
+
+const FALLBACK_HACK_TEXT: &str = "Complete the circuit to hack this computer.";
+const HACK_TEXT_LINE_LENGTH: usize = 25;
+
+/// Localized text displayed above Computer HRM boards. `Gui::get_components`
+/// has no asset cache, so HACKTEXT.STR is loaded once with the mission.
+#[derive(Clone, Debug, Unique)]
+pub struct ComputerContext {
+    hack_text: HashMap<String, String>,
+}
+
+impl ComputerContext {
+    pub fn load(asset_cache: &mut AssetCache) -> Self {
+        Self {
+            hack_text: asset_cache
+                .get_opt(&dark::importers::STRINGS_IMPORTER, "hacktext.str")
+                .map(|strings| (*strings).clone())
+                .unwrap_or_default(),
+        }
+    }
+
+    fn resolve(&self, key: &str) -> Option<&str> {
+        self.hack_text
+            .get(&key.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+}
+
+/// Older saves made before `P$HackText` / `L$HackingLi` were parsed cannot
+/// contain those components. Restore them from the same authored object data
+/// used for a fresh mission, so such a save retains Computer instructions and
+/// the genuine downstream hacking circuit.
+pub(crate) fn restore_authored_computer_data(
+    world: &mut World,
+    entity_info: &SystemShock2EntityInfo,
+    template_to_entity_id: &HashMap<i32, WrappedEntityId>,
+) {
+    let computers = {
+        let templates = world.borrow::<View<PropTemplateId>>().unwrap();
+        let diffs = world.borrow::<View<PropHackDiff>>().unwrap();
+        templates
+            .iter()
+            .with_id()
+            .filter(|(entity_id, _)| diffs.get(*entity_id).is_ok())
+            .map(|(entity_id, template)| (entity_id, template.template_id))
+            .collect::<Vec<_>>()
+    };
+
+    for (entity_id, template_id) in computers {
+        let has_text = world
+            .borrow::<View<PropHackText>>()
+            .unwrap()
+            .get(entity_id)
+            .is_ok();
+        if !has_text
+            && let Some(text) = hydrate_template_component::<PropHackText>(template_id, entity_info)
+        {
+            world.add_component(entity_id, text);
+        }
+
+        let has_hacking_link = world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(entity_id)
+            .is_ok_and(|links| links.to_links.iter().any(|link| link.link == Link::Hacking));
+        if has_hacking_link {
+            continue;
+        }
+
+        let mut ancestors = dark::ss2_entity_info::get_ancestors(
+            dark::ss2_entity_info::get_hierarchy(entity_info),
+            &template_id,
+        );
+        ancestors.push(template_id);
+        let authored_hacking_links = ancestors
+            .into_iter()
+            .filter_map(|ancestor| entity_info.template_to_links.get(&ancestor))
+            .flat_map(|links| &links.to_links)
+            .filter(|link| link.link == Link::Hacking)
+            .map(|link| ToLink {
+                to_template_id: link.to_template_id,
+                to_entity_id: template_to_entity_id.get(&link.to_template_id).copied(),
+                link: Link::Hacking,
+            })
+            .collect::<Vec<_>>();
+        if authored_hacking_links.is_empty() {
+            continue;
+        }
+        let mut links = world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(entity_id)
+            .cloned()
+            .unwrap_or_else(|_| Links::empty());
+        links.to_links.extend(authored_hacking_links);
+        world.add_component(entity_id, links);
+    }
+}
+
+pub struct ComputerGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct ComputerState {
+    hack: HackState,
+}
+
+#[derive(Clone)]
+pub enum ComputerMsg {
+    Hack(KeyPadMsg),
+}
+
+fn object_state(world: &World, entity_id: EntityId) -> ObjectState {
+    world
+        .borrow::<View<PropObjState>>()
+        .ok()
+        .and_then(|states| states.get(entity_id).ok().map(|state| state.0))
+        .unwrap_or(ObjectState::Normal)
+}
+
+fn hack_diff(world: &World, entity_id: EntityId) -> Option<PropHackDiff> {
+    world
+        .borrow::<View<PropHackDiff>>()
+        .ok()
+        .and_then(|diffs| diffs.get(entity_id).ok().copied())
+}
+
+fn can_hack(world: &World, entity_id: EntityId) -> bool {
+    !matches!(
+        object_state(world, entity_id),
+        ObjectState::Broken | ObjectState::Destroyed | ObjectState::Hacked
+    ) && hack_diff(world, entity_id).is_some()
+}
+
+fn computer_hack_success(entity_id: EntityId, world: &World) -> Effect {
+    let mut effects = get_all_links_of_type(world, entity_id, Link::Hacking)
+        .into_iter()
+        .map(|to| Effect::Send {
+            msg: Message {
+                to,
+                payload: MessagePayload::TurnOn { from: entity_id },
+            },
+        })
+        .collect::<Vec<_>>();
+
+    let hacked_replacement =
+        get_first_link_with_template_and_data(world, entity_id, |link| match link {
+            Link::Corpse(_) => Some(()),
+            _ => None,
+        })
+        .map(|(template_id, ())| template_id);
+    effects.push(match hacked_replacement {
+        Some(template_id) => Effect::ReplaceEntity {
+            entity_id,
+            template_id,
+        },
+        None => Effect::SetObjectState {
+            entity_id,
+            state: ObjectState::Hacked,
+        },
+    });
+    Effect::combine(effects)
+}
+
+fn computer_hack_critical_failure(entity_id: EntityId, _world: &World) -> Effect {
+    Effect::SetObjectState {
+        entity_id,
+        state: ObjectState::Broken,
+    }
+}
+
+fn authored_hack_text(world: &World, entity_id: EntityId) -> String {
+    let key = world
+        .borrow::<View<PropHackText>>()
+        .ok()
+        .and_then(|texts| texts.get(entity_id).ok().map(|text| text.0.clone()));
+    let Some(key) = key else {
+        return FALLBACK_HACK_TEXT.to_owned();
+    };
+    world
+        .borrow::<UniqueView<ComputerContext>>()
+        .ok()
+        .and_then(|context| context.resolve(&key).map(str::to_owned))
+        .unwrap_or(key)
+}
+
+fn wrap_hack_text(text: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut line = String::new();
+    for word in text.split_whitespace() {
+        if !line.is_empty() && line.len() + 1 + word.len() > HACK_TEXT_LINE_LENGTH {
+            lines.push(std::mem::take(&mut line));
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        lines.push(line);
+    }
+    lines
+}
+
+impl Gui<ComputerState, ComputerMsg> for ComputerGui {
+    fn get_components(
+        &self,
+        _cursor: &Option<GuiCursor>,
+        entity_id: EntityId,
+        world: &World,
+        state: &ComputerState,
+    ) -> Vec<GuiComponent<ComputerMsg>> {
+        let Some(diff) = hack_diff(world, entity_id) else {
+            return Vec::new();
+        };
+        let mut components = draw_hack_board(&state.hack, diff, ComputerMsg::Hack);
+        for (line, text) in wrap_hack_text(&authored_hack_text(world, entity_id))
+            .into_iter()
+            .take(3)
+            .enumerate()
+        {
+            components.push(
+                crate::gui::text(&text)
+                    .with_position(vec2(15.0, 10.0 + line as f32 * 11.0))
+                    .with_size(vec2(158.0, 11.0)),
+            );
+        }
+        components
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -1.0),
+            screen_size_in_pixels: Vector2::new(188.0, 296.0),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        state: &ComputerState,
+        msg: &ComputerMsg,
+    ) -> (ComputerState, Effect) {
+        let Some(diff) = hack_diff(world, entity_id) else {
+            return (state.clone(), Effect::NoEffect);
+        };
+        let ComputerMsg::Hack(msg) = msg;
+        let (hack, effect) = handle_hack_msg(
+            entity_id,
+            world,
+            &state.hack,
+            msg,
+            diff,
+            HackOutcomeEffects {
+                success: computer_hack_success,
+                critical_failure: computer_hack_critical_failure,
+            },
+        );
+        (ComputerState { hack }, effect)
+    }
+
+    fn opens_on_frob(&self, entity_id: EntityId, world: &World) -> bool {
+        can_hack(world, entity_id)
+    }
+
+    fn prepare_state_on_frob(&self, state: &mut ComputerState) {
+        if state.hack.phase != HackPhase::Playing {
+            *state = ComputerState::default();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{CorpseOptions, Links, ToLink, WrappedEntityId};
+    use shipyard::World;
+
+    use super::*;
+
+    fn flatten(effect: &Effect) -> Vec<&Effect> {
+        match effect {
+            Effect::Combined { effects } => effects.iter().flat_map(flatten).collect(),
+            other => vec![other],
+        }
+    }
+
+    #[test]
+    fn success_activates_hacking_links_and_uses_authored_replacement() {
+        let mut world = World::new();
+        let router = world.add_entity(());
+        let computer = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 312,
+                    to_entity_id: Some(WrappedEntityId(router)),
+                    link: Link::Hacking,
+                },
+                ToLink {
+                    to_template_id: 1269,
+                    to_entity_id: None,
+                    link: Link::Corpse(
+                        serde_json::from_str::<CorpseOptions>(r#"{"propagate_scale":false}"#)
+                            .unwrap(),
+                    ),
+                },
+            ],
+        });
+
+        let effect = computer_hack_success(computer, &world);
+        let effects = flatten(&effect);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::Send {
+                msg: Message {
+                    to,
+                    payload: MessagePayload::TurnOn { from },
+                },
+            } if *to == router && *from == computer
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::ReplaceEntity {
+                entity_id,
+                template_id: 1269,
+            } if *entity_id == computer
+        )));
+    }
+
+    #[test]
+    fn success_without_corpse_persists_hacked_state() {
+        let mut world = World::new();
+        let computer = world.add_entity(Links::empty());
+        let effects = computer_hack_success(computer, &world);
+        assert!(flatten(&effects).iter().any(|effect| matches!(
+            effect,
+            Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Hacked,
+            } if *entity_id == computer
+        )));
+    }
+
+    #[test]
+    fn critical_failure_persists_broken_state() {
+        let mut world = World::new();
+        let computer = world.add_entity(());
+        assert!(matches!(
+            computer_hack_critical_failure(computer, &world),
+            Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Broken,
+            } if entity_id == computer
+        ));
+    }
+
+    #[test]
+    fn broken_and_hacked_computers_do_not_reopen() {
+        let gui = ComputerGui;
+        for state in [ObjectState::Broken, ObjectState::Hacked] {
+            let mut world = World::new();
+            let computer = world.add_entity((
+                PropHackDiff {
+                    success_chance: 20,
+                    critical_chance: 10,
+                    cost: 3.0,
+                },
+                PropObjState(state),
+            ));
+            assert!(!gui.opens_on_frob(computer, &world));
+        }
+    }
+
+    #[test]
+    fn localized_hack_text_is_wrapped_without_losing_words() {
+        let text = "Hack all three Interlocks to disable shields.";
+        let lines = wrap_hack_text(text);
+        assert_eq!(lines.join(" "), text);
+        assert!(lines.iter().all(|line| line.len() <= HACK_TEXT_LINE_LENGTH));
+    }
+
+    #[test]
+    fn reopening_preserves_only_an_in_progress_hack() {
+        let gui = ComputerGui;
+        let mut state = ComputerState {
+            hack: HackState {
+                phase: HackPhase::Playing,
+                rng_state: 42,
+                ..HackState::default()
+            },
+        };
+        gui.prepare_state_on_frob(&mut state);
+        assert_eq!(state.hack.phase, HackPhase::Playing);
+        assert_eq!(state.hack.rng_state, 42);
+
+        state.hack.phase = HackPhase::Won;
+        gui.prepare_state_on_frob(&mut state);
+        assert_eq!(state.hack.phase, HackPhase::Unpaid);
+    }
+}

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -1,3 +1,4 @@
+mod computer;
 mod container;
 mod elevator;
 mod gamepig;
@@ -8,6 +9,7 @@ mod replicator;
 mod trainer;
 mod traits;
 
+pub use computer::*;
 pub use container::*;
 pub use elevator::*;
 pub use gamepig::*;

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -94,8 +94,8 @@ use self::choose_service::ChooseServiceScript;
 /// read them at draw time.
 pub use self::gui::ElevatorContext;
 use self::gui::{
-    ContainerGui, ElevatorGui, GamePigGui, KeyPadGui, MapGui, MediaGui, ReplicatorGui, TrainerGui,
-    TrainerMode, TraitGui,
+    ComputerGui, ContainerGui, ElevatorGui, GamePigGui, KeyPadGui, MapGui, MediaGui, ReplicatorGui,
+    TrainerGui, TrainerMode, TraitGui,
 };
 use self::internal_frob_move::InternalFrobMove;
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
@@ -685,7 +685,7 @@ impl ScriptWorld {
             "ectoplasm" => Box::new(UnimplementedScript::new(&script_name)),
             "medpatchscript" => Box::new(UnimplementedScript::new(&script_name)),
             "psikitscript" => Box::new(PsiKitScript::new()),
-            "computer" => Box::new(UnimplementedScript::new(&script_name)),
+            "computer" => gui_script(Box::new(ComputerGui)),
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => Box::new(UnimplementedScript::new(&script_name)),
             "turret" => Box::new(UnimplementedScript::new(&script_name)),

--- a/shock2vr/src/scripts/trap_router.rs
+++ b/shock2vr/src/scripts/trap_router.rs
@@ -18,6 +18,59 @@ impl Script for TrapRouter {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
-        send_to_all_switch_links(world, entity_id, msg.clone())
+        let routed = match msg {
+            MessagePayload::TurnOn { .. } => MessagePayload::TurnOn { from: entity_id },
+            MessagePayload::TurnOff { .. } => MessagePayload::TurnOff { from: entity_id },
+            other => other.clone(),
+        };
+        send_to_all_switch_links(world, entity_id, routed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn forwarded(effect: Effect) -> Vec<super::super::Message> {
+        Effect::flatten(vec![effect])
+            .into_iter()
+            .filter_map(|effect| match effect {
+                Effect::Send { msg } => Some(msg),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn router_rewrites_turn_sender_to_itself() {
+        let mut world = World::new();
+        let destination = world.add_entity(());
+        let router = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 2,
+                to_entity_id: Some(WrappedEntityId(destination)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let original = world.add_entity(());
+        let physics = PhysicsWorld::new();
+        let mut script = TrapRouter::new();
+
+        for payload in [
+            MessagePayload::TurnOn { from: original },
+            MessagePayload::TurnOff { from: original },
+        ] {
+            let messages = forwarded(script.handle_message(router, &world, &physics, &payload));
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].to, destination);
+            match messages[0].payload {
+                MessagePayload::TurnOn { from } | MessagePayload::TurnOff { from } => {
+                    assert_eq!(from, router)
+                }
+                ref other => panic!("expected routed switch message, got {other:?}"),
+            }
+        }
     }
 }

--- a/shock2vr/src/scripts/trigger_multi.rs
+++ b/shock2vr/src/scripts/trigger_multi.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use dark::properties::{Link, Links, ToLink};
-use shipyard::{EntityId, IntoIter, IntoWithId, View, World};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, View, ViewMut, World};
 use tracing::info;
 
 use crate::physics::PhysicsWorld;
@@ -52,7 +52,23 @@ impl Script for TriggerMulti {
     ) -> Effect {
         match msg {
             MessagePayload::TurnOn { from } => {
-                self.entities_left_to_trigger.remove(from);
+                if !self.entities_left_to_trigger.remove(from) {
+                    return Effect::NoEffect;
+                }
+                // A TriggerMulti is a one-shot "all inputs" latch. Consume the
+                // incoming SwitchLink as each source arrives so the remaining
+                // input set is part of the ordinary, save-serialized Links
+                // graph. Rebuilding this Script after a load can then resume
+                // midway through the latch instead of demanding already-used
+                // sources again.
+                if let Ok(mut links) = world.borrow::<ViewMut<Links>>()
+                    && let Ok(source_links) = (&mut links).get(*from)
+                {
+                    source_links.to_links.retain(|link| {
+                        link.link != Link::SwitchLink
+                            || link.to_entity_id.is_none_or(|to| to.0 != entity_id)
+                    });
+                }
                 let after_count = self.entities_left_to_trigger.len();
                 info!(
                     "turn on from entity {:?}, {} remaining...",
@@ -71,5 +87,71 @@ impl Script for TriggerMulti {
             }
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::WrappedEntityId;
+
+    use super::*;
+
+    #[test]
+    fn consumed_inputs_survive_script_reinitialization_through_links() {
+        let mut world = World::new();
+        let destination = world.add_entity(Links::empty());
+        let multi = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 3,
+                to_entity_id: Some(WrappedEntityId(destination)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let first = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 2,
+                to_entity_id: Some(WrappedEntityId(multi)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let second = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 2,
+                to_entity_id: Some(WrappedEntityId(multi)),
+                link: Link::SwitchLink,
+            }],
+        });
+
+        let mut before_save = TriggerMulti::new();
+        before_save.initialize(multi, &world);
+        let physics = PhysicsWorld::new();
+        assert!(matches!(
+            before_save.handle_message(
+                multi,
+                &world,
+                &physics,
+                &MessagePayload::TurnOn { from: first },
+            ),
+            Effect::NoEffect
+        ));
+
+        let mut after_load = TriggerMulti::new();
+        after_load.initialize(multi, &world);
+        let effect = after_load.handle_message(
+            multi,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: second },
+        );
+        assert!(matches!(
+            effect,
+            Effect::Combined { effects }
+                if effects.iter().any(|effect| matches!(
+                    effect,
+                    Effect::Send { msg }
+                        if msg.to == destination
+                            && matches!(msg.payload, MessagePayload::TurnOn { from } if from == multi)
+                ))
+        ));
     }
 }

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -384,6 +384,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::Replicator => "Replicator".to_string(),
                 Link::MissSpang => "MissSpang".to_string(),
                 Link::HitSpang(_) => "HitSpang".to_string(),
+                Link::Hacking => "Hacking".to_string(),
                 Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
                 Link::PhysAttach(_) => "PhysAttach".to_string(),
                 Link::TPathInit => "TPathInit".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -593,6 +593,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::Replicator => "Replicator".to_string(),
         dark::properties::Link::MissSpang => "MissSpang".to_string(),
         dark::properties::Link::HitSpang(_) => "HitSpang".to_string(),
+        dark::properties::Link::Hacking => "Hacking".to_string(),
         dark::properties::Link::ParticleAttachement(_) => "ParticleAttachement".to_string(),
         dark::properties::Link::PhysAttach(opts) => format!("PhysAttach({:?})", opts),
         dark::properties::Link::TPathInit => "TPathInit".to_string(),

--- a/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
@@ -59,7 +59,11 @@ async function approach(game: GameServer, templateId: number): Promise<void> {
     templateId === CPUS[1]
       ? [
           { x: 25.56, y: start.y, z: 62.4 },
-          { x: 25.15, y: start.y, z: 60.05 },
+          // Stay west of the corner's contact band. The original 2.4-foot
+          // player footprint cannot reach the old point at (25.15, 60.05),
+          // but this nearby pose is collision-valid for both footprints and
+          // preserves the same outer route around the shield chamber.
+          { x: 24.9, y: start.y, z: 60.25 },
           { x: 28.8, y: start.y, z: 59.84 },
           { x: 32, y: start.y, z: 59.84 },
           { x: 35.2, y: start.y, z: 59.84 },

--- a/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-computer-hacking.e2e.test.ts
@@ -1,0 +1,412 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiPanel } from "../src/types.js";
+import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// The fixture is the verified boss-entry save produced by the end-to-end
+// play-through that found #710. It is intentionally supplied out of tree:
+// retail saves contain copyrighted mission state and must not be committed.
+// The assertion itself uses production aim + squeeze from the saved position;
+// there is no debug teleport or injected Frob message.
+const bossSave = process.env.SHOCK2_SHODAN_BOSS_SAVE;
+const e2eEnabled = process.env.SHOCK2_E2E === "1" && Boolean(bossSave);
+
+const CPUS = [268, 264, 262] as const;
+const HACKED_SHODAN_COMPUTER = 1269;
+const SHODAN_HEAD = 298;
+const SHIELDS = [270, 272, 274, 275, 277, 278, 279, 280] as const;
+
+function button(panel: UiPanel, label: string): UiElement {
+  const found = panel.elements.find(
+    (element) => element.kind === "button" && element.label === label,
+  );
+  assert.ok(found, `panel should expose button ${label}`);
+  return found;
+}
+
+async function activePanel(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "computer interaction should keep an MFD panel open");
+  return panel;
+}
+
+async function closePanel(game: GameServer): Promise<void> {
+  const panel = (await game.ui.state()).active_panel;
+  const close = panel?.elements.find((element) => element.label === "close");
+  if (close) {
+    await clickUiElement(game, close);
+  }
+}
+
+async function backAwayFromComputer(game: GameServer): Promise<void> {
+  await closePanel(game);
+  // The authored hacked Corpse replacement occupies the CPU's full cabinet.
+  // Back away through ordinary locomotion before taking the next bounded
+  // collision-valid move, so the player does not begin that shape cast in
+  // contact with the freshly instantiated cabinet.
+  await game.input.set("right_hand.thumbstick", [0, -1]);
+  await game.step({ frames: 15 });
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  await game.step({ frames: 2 });
+}
+
+async function approach(game: GameServer, templateId: number): Promise<void> {
+  const start = await game.player.position();
+  const staging =
+    templateId === CPUS[1]
+      ? [
+          { x: 25.56, y: start.y, z: 62.4 },
+          { x: 25.15, y: start.y, z: 60.05 },
+          { x: 28.8, y: start.y, z: 59.84 },
+          { x: 32, y: start.y, z: 59.84 },
+          { x: 35.2, y: start.y, z: 59.84 },
+          { x: 38.51, y: start.y, z: 59.84 },
+          { x: 41.6, y: start.y, z: 61.82 },
+          { x: 43.53, y: start.y, z: 64.36 },
+          { x: 41, y: start.y, z: 65.3 },
+        ]
+      : templateId === CPUS[2]
+        ? [
+            { x: 43.53, y: start.y, z: 64.36 },
+            { x: 43.95, y: start.y, z: 65.15 },
+            { x: 44.15, y: start.y, z: 65.5 },
+            { x: 44, y: start.y, z: 68.8 },
+            { x: 44, y: start.y, z: 72 },
+            { x: 44, y: start.y, z: 75.2 },
+            { x: 42, y: start.y, z: 80 },
+          ]
+        : [];
+  for (const waypoint of staging) {
+    for (let hop = 0; hop < 6; hop += 1) {
+      const position = await game.player.position();
+      if (Math.hypot(waypoint.x - position.x, waypoint.z - position.z) < 0.2) {
+        break;
+      }
+      const moved = await game.player.moveTo(waypoint);
+      if (moved.blocked) {
+        const remaining = Math.hypot(
+          waypoint.x - moved.new_position[0],
+          waypoint.z - moved.new_position[2],
+        );
+        assert.ok(
+          remaining < 0.3,
+          `the authored outer route to computer ${templateId} should stay collision-clear; ` +
+            `waypoint=${JSON.stringify(waypoint)} result=${JSON.stringify(moved)}`,
+        );
+        break;
+      }
+    }
+  }
+  for (let hop = 0; hop < 6; hop += 1) {
+    const [entity] = await game.entities.byTemplate(templateId);
+    assert.ok(entity, `computer ${templateId} should still exist while approaching it`);
+    const detail = await game.entities.detail(entity.id);
+    const position = await game.player.position();
+    const distance = Math.hypot(
+      detail.position[0] - position.x,
+      detail.position[2] - position.z,
+    );
+    if (distance < 2.5) {
+      return;
+    }
+    const moved = await game.player.moveTo({
+      x: detail.position[0],
+      y: position.y,
+      z: detail.position[2],
+    });
+    assert.ok(
+      moved.moved || moved.blocked,
+      `bounded move toward ${templateId} should either advance or meet its surface`,
+    );
+    if (moved.blocked) {
+      return;
+    }
+  }
+}
+
+async function frobComputer(game: GameServer, templateId: number): Promise<void> {
+  await approach(game, templateId);
+  const [computer] = await game.entities.byTemplate(templateId);
+  assert.ok(computer, `authored computer ${templateId} should exist`);
+  const aim = await game.player
+    .aimAt(computer, {
+      hitbox: "center",
+      visibility: "required",
+    })
+    .catch(async (error: unknown) => {
+      throw new Error(
+        `could not see computer ${templateId} after bounded approach; ` +
+          `player=${JSON.stringify(await game.player.position())}; ` +
+          `detail=${JSON.stringify(await game.entities.detail(computer.id))}; ` +
+          `aim=${JSON.stringify(
+            error && typeof error === "object" && "result" in error
+              ? error.result
+              : String(error),
+          )}`,
+      );
+    });
+  assert.equal(aim.entity_id, computer.id);
+  assert.equal(aim.classification, "surface");
+  assert.equal(aim.visibility.state, "visible");
+
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 2 });
+
+  const panel = await activePanel(game);
+  assert.equal(panel.template_id, templateId);
+  assert.ok(
+    panel.elements.some(
+      (element) => element.texture?.toLowerCase() === "hack.pcx",
+    ),
+    "the Computer panel should render the shared authored HRM board",
+  );
+  assert.ok(
+    panel.elements.some(
+      (element) =>
+        element.kind === "text" &&
+        element.text?.includes("Hack all three Interlocks"),
+    ),
+    `the board should resolve Shield_Interlock through HACKTEXT.STR; text=${JSON.stringify(
+      panel.elements
+        .filter((element) => element.kind === "text")
+        .map((element) => element.text),
+    )}`,
+  );
+}
+
+async function playComputerHrm(
+  game: GameServer,
+  templateId: number,
+): Promise<void> {
+  await frobComputer(game, templateId);
+  const route = [
+    "node-2-0",
+    "node-3-0",
+    "node-4-0",
+    "node-2-1",
+    "node-2-2",
+    "node-2-3",
+    "node-0-1",
+    "node-1-1",
+    "node-4-1",
+    "node-0-2",
+    "node-3-2",
+    "node-4-2",
+    "node-0-3",
+    "node-1-3",
+  ];
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const unpaid = await activePanel(game);
+    const start =
+      unpaid.elements.find((element) => element.label === "start-hack") ??
+      unpaid.elements.find((element) => element.label === "reset-hack");
+    assert.ok(start, `attempt ${attempt + 1} should expose START/RESET`);
+    const nanitesBeforePayment = await carriedNaniteTotal(game);
+    await clickUiElement(game, start);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      nanitesBeforePayment - 3,
+      "each real Computer HRM attempt should debit its authored 3-nanite cost",
+    );
+
+    for (const label of route) {
+      if ((await game.entities.byTemplate(templateId)).length === 0) {
+        return;
+      }
+      const panel = await activePanel(game);
+      if (
+        panel.elements.some(
+          (element) => element.texture?.toLowerCase() === "failh.pcx",
+        )
+      ) {
+        break;
+      }
+      await clickUiElement(game, button(panel, label));
+      await game.step({ frames: 2 });
+    }
+  }
+
+  const finalPanel = (await game.ui.state()).active_panel;
+  assert.fail(
+    `five real HRM attempts did not replace computer ${templateId}; ` +
+      `textures=${JSON.stringify(finalPanel?.elements.map((element) => element.texture))}; ` +
+      `inventory=${JSON.stringify((await game.player.inventory()).items)}; rng=${game
+        .logs()
+        .filter((line) => line.includes("HRM rng"))
+        .join(" | ")}`,
+  );
+}
+
+test(
+  "SHODAN finale: hack all three interlocks through real UI, persist, expose head",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8249),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    assert.ok(bossSave);
+    assert.equal((await game.load(bossSave)).success, true);
+    await game.step({ frames: 5 });
+
+    const shieldCountBefore = (
+      await Promise.all(SHIELDS.map((template) => game.entities.byTemplate(template)))
+    ).reduce((count, shields) => count + shields.length, 0);
+    assert.equal(shieldCountBefore, SHIELDS.length, "all eight authored shields should start intact");
+    const [headBefore] = await game.entities.byTemplate(SHODAN_HEAD);
+    assert.ok(headBefore, "the authored SHODAN head should exist behind its shields");
+    for (const templateId of CPUS) {
+      const [computer] = await game.entities.byTemplate(templateId);
+      assert.ok(computer);
+      const detail = await game.entities.detail(computer.id);
+      assert.ok(
+        detail.outgoing_links.some((link) =>
+          link.link_type.toLowerCase().includes("hacking"),
+        ),
+        `loaded legacy save should restore CPU ${templateId}'s authored HackingLink; ` +
+          `links=${JSON.stringify(detail.outgoing_links)}`,
+      );
+    }
+
+    // The campaign-found boss fixture reached this room with no nanites, while
+    // retail Computer HRM charges 3 per interlock and shodan.mis places no
+    // collectible piles. Verify the genuine refusal path before staging only
+    // one genuine 20-Nanite stack (enough for bounded HRM retries). No success,
+    // Frob, script message, replacement, or shield state is injected.
+    await frobComputer(game, CPUS[0]);
+    await clickUiElement(game, button(await activePanel(game), "start-hack"));
+    const refused = await activePanel(game);
+    assert.ok(
+      refused.elements.some(
+        (element) => element.texture?.toLowerCase() === "payh.pcx",
+      ),
+      "a zero-nanite player should receive the authored PAYH refusal",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(CPUS[0])).length,
+      1,
+      "PAYH must not activate or replace the interlock",
+    );
+    await closePanel(game);
+    await game.player.spawnItem("20 Nanites");
+    assert.equal(
+      await carriedNaniteTotal(game),
+      20,
+      "fixture staging should provide one genuine, spendable 20-Nanite stack",
+    );
+
+    const hackedBefore = (
+      await game.entities.byTemplate(HACKED_SHODAN_COMPUTER)
+    ).length;
+    await playComputerHrm(game, CPUS[0]);
+    await game.step({ frames: 20 });
+    await backAwayFromComputer(game);
+    assert.equal(
+      (await game.entities.byTemplate(300)).length,
+      0,
+      "CPU1 HackingLink should route TurnOn through CPU1Router to CPU1Destroy",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(HACKED_SHODAN_COMPUTER)).length,
+      hackedBefore + 1,
+      "CPU1 should use its authored Corpse result model",
+    );
+
+    // Saving between interlocks is essential: TriggerMulti must remember the
+    // first consumed router rather than requiring its now-destroyed CPU again.
+    const midwaySave = `shodan_interlock_midway_${Date.now()}`;
+    assert.equal((await game.save(midwaySave)).success, true);
+    assert.equal((await game.load(midwaySave)).success, true);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.entities.byTemplate(CPUS[0])).length,
+      0,
+      "the first hacked interlock should remain replaced after save/load",
+    );
+
+    await playComputerHrm(game, CPUS[1]);
+    await game.step({ frames: 20 });
+    await backAwayFromComputer(game);
+    assert.equal(
+      (await game.entities.byTemplate(303)).length,
+      0,
+      "CPU2 HackingLink should route TurnOn through CPU2Router to CPU2Destroy",
+    );
+    const shieldsAfterTwo = (
+      await Promise.all(SHIELDS.map((template) => game.entities.byTemplate(template)))
+    ).reduce((count, shields) => count + shields.length, 0);
+    assert.equal(
+      shieldsAfterTwo,
+      SHIELDS.length,
+      "two interlocks must not disable SHODAN's shields early",
+    );
+
+    await playComputerHrm(game, CPUS[2]);
+    await game.step({ frames: 30 });
+    await backAwayFromComputer(game);
+    const shieldsAfterThree = (
+      await Promise.all(SHIELDS.map((template) => game.entities.byTemplate(template)))
+    ).reduce((count, shields) => count + shields.length, 0);
+    assert.equal(
+      shieldsAfterThree,
+      0,
+      `the third genuine HRM win should complete HackMultiTrigger and destroy all shields; ` +
+        `logs=${game
+          .logs()
+          .filter(
+            (line) =>
+              line.includes("turn on") ||
+              line.includes("trigger_multi") ||
+              line.includes("destroying"),
+          )
+          .join(" | ")}`,
+    );
+    assert.equal(
+      (await game.entities.byTemplate(HACKED_SHODAN_COMPUTER)).length,
+      hackedBefore + CPUS.length,
+      "all three computers should persist as their authored hacked models",
+    );
+
+    // Leave the CPU3 cabinet behind and use the now-open east side of the
+    // shield chamber for an unobstructed production view of the head.
+    const headVantageY = (await game.player.position()).y;
+    for (const waypoint of [
+      { x: 44, y: headVantageY, z: 76 },
+      { x: 44, y: headVantageY, z: 72 },
+      { x: 40.5, y: headVantageY, z: 72 },
+    ]) {
+      for (let hop = 0; hop < 3; hop += 1) {
+        const position = await game.player.position();
+        if (Math.hypot(waypoint.x - position.x, waypoint.z - position.z) < 0.3) {
+          break;
+        }
+        const moved = await game.player.moveTo(waypoint);
+        assert.ok(
+          moved.moved,
+          `post-shield route should advance toward ${JSON.stringify(waypoint)}`,
+        );
+        if (moved.blocked) {
+          break;
+        }
+      }
+    }
+
+    const [headAfter] = await game.entities.byTemplate(SHODAN_HEAD);
+    assert.ok(headAfter, "SHODAN's head should remain as the newly exposed finale target");
+    const headAim = await game.player.aimAt(headAfter, {
+      hitbox: "head",
+      visibility: "required",
+    });
+    assert.ok(
+      headAim.visibility.state === "visible",
+      "after the interlock chain, production aim should have line of sight to SHODAN's head",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse the authored `P$HackText` property and `L$HackingLi` relation, and implement the general `Computer` GUI script with the shared retail HRM board
- activate authored Hacking targets and Corpse replacements on success, persist critical failure, and hydrate newly parsed Computer data into legacy saves
- preserve `TriggerMulti` progress across save/load and make `TrapRouter` report itself as the switch source, allowing all three SHODAN interlocks to complete the authored shield circuit
- add an authentic boss-save E2E that production-frobs and plays all three computers through real UI, saves between interlocks, and verifies all eight shields are removed and SHODAN's head becomes visible

![Computer hacking interaction](https://gist.githubusercontent.com/tommy-xr/d8d6333ae5087b373320e9f6eb309851/raw/issue710-computer-hacking.gif)

<sub>SHODAN CPU1 now opens its localized Computer HRM panel and accepts real START/node input. Captured headlessly from the authentic boss save via production aim+squeeze and deterministic fixed-timestep screenshots.</sub>

## Before → after

![Before and after Computer hacking](https://gist.githubusercontent.com/tommy-xr/d8d6333ae5087b373320e9f6eb309851/raw/issue710-before-after.png)

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query`
- `cargo test -p dark`
- `cargo test -p shock2vr`
- focused Computer, TrapRouter, and TriggerMulti unit tests after final formatting
- `npm test` in `tools/shock2-sdk`
- authentic SHODAN Computer E2E: passed
- all 23 mission-load E2Es: passed
- full serial E2E: 170/173 passed; the failures were unrelated known #696 and #698 plus a one-off fleet physics catapult whose isolated rerun passed (1/1, aggregate fleet approach 54.5 units)

Fixes #710
