### PR TITLE
fix(sdk): aim from the live crouched camera

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1952,7 +1952,11 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                     .as_ref()
                     .map(|s| s.rotation)
                     .unwrap_or([1.0, 0.0, 0.0, 0.0]),
-                camera_offset: [0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0],
+                // Match the camera and FlatInteraction ray used for this
+                // frame. A crouched player uses the compressed eye height;
+                // reporting the standing constant makes automation aim a
+                // different ray than the one production input will frob.
+                camera_offset: [0.0, game.player_eye_height() / SCALE_FACTOR, 0.0],
                 camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
                 right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -120,7 +120,8 @@ export class PlayerApi {
       this.client.get<EntityDetailResult>(`/v1/entities/${entityId}`),
       this.client.get<FrameSnapshot>("/v1/info"),
     ]);
-    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const eyeHeight =
+      options?.eyeHeight ?? snapshot.player.camera_offset?.[1] ?? 1.6;
     const eye: Vec3 = [
       snapshot.player.position[0],
       snapshot.player.position[1] + eyeHeight,
@@ -416,15 +417,16 @@ export class InputApi {
    * resulting head rotation still flows through the normal camera,
    * FlatInteraction, and weapon paths; this is aiming, not a debug hit shim.
    *
-   * `eyeHeight` defaults to the flat player's standing eye height. Pass a
-   * different value when deliberately testing crouched aiming.
+   * `eyeHeight` defaults to the runtime's live camera height, including
+   * crouch. An explicit override is measured in world units.
    */
   async lookAtWorldPoint(target: Vec3, options?: { eyeHeight?: number }): Promise<void> {
     const [{ position }, snapshot] = await Promise.all([
       this.client.get<{ position: Vec3 }>("/v1/player/position"),
       this.client.get<FrameSnapshot>("/v1/info"),
     ]);
-    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const eyeHeight =
+      options?.eyeHeight ?? snapshot.player.camera_offset?.[1] ?? 1.6;
     const localHeadRotation = headRotationForWorldPoint(
       position,
       snapshot.player.rotation,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -148,6 +148,7 @@ export type AimClassification =
 
 export interface AimOptions {
   hitbox?: AimClassification;
+  /** Override the runtime's live camera height, in world units. */
   eyeHeight?: number;
   /**
    * `required` verifies line of sight from the flat camera eye and rejects an

--- a/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "crouched flat interaction collects SHODAN Delacroix log 4",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8231),
+    });
+    await game.step({ frames: 5 });
+
+    const log = (await game.entities.list({ filter: "Audio Log", limit: 80 }))
+      .entities.find((entity) => entity.template_id === 290);
+    assert.ok(log, "shodan should contain Delacroix deck 9/log 4");
+
+    // Setup only: reproduce the campaign's stable crouched landing on the
+    // authored hidden platform. Runtime entity ids remain launch-local.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+    await teleportVerified(game, {
+      x: 31.9264,
+      y: -27.315,
+      z: 28.5662,
+    });
+    await game.step({ frames: 30 });
+
+    const aim = await game.player.aimAt(log, {
+      hitbox: "surface",
+      visibility: "required",
+    });
+    assert.ok(
+      aim.target_confirmed,
+      `production camera ray should select log 4 (${JSON.stringify(aim)})`,
+    );
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+
+    assert.ok(
+      (await game.info()).player.collected_logs.some(
+        (entry) => entry.deck === 9 && entry.log === 4,
+      ),
+      "production squeeze should collect Delacroix deck 9/log 4",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -221,6 +221,75 @@ test("aimAt uses a visible non-creature selectable surface before its center", a
   assert.equal(writes[1]?.path, "/v1/control/input");
 });
 
+test("aimAt defaults to the runtime's live crouched camera height", async () => {
+  const detail = {
+    entity_id: 290,
+    name: "Audio Log",
+    template_id: 290,
+    position: [32, -26.2, 28.4],
+    rotation: [0, 0, 0, 1],
+    inheritance_chain: [],
+    properties: [],
+    outgoing_links: [],
+    incoming_links: [],
+    aim_points: [],
+  } satisfies EntityDetailResult;
+  const snapshot = {
+    player: {
+      position: [31.9264, -27.315, 28.5662],
+      rotation: [0, 0, 0, 1],
+      camera_offset: [0, 0.48, 0],
+    },
+  } as FrameSnapshot;
+  const writes: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    get: async (path: string) => {
+      if (path === "/v1/entities/290") return detail;
+      if (path === "/v1/info") return snapshot;
+      throw new Error(`unexpected GET ${path}`);
+    },
+    post: async (path: string, body: unknown) => {
+      writes.push({ path, body });
+      if (path === "/v1/physics/raycast") {
+        return {
+          hit: true,
+          hit_point: [31.98, -26.82, 28.45],
+          hit_normal: [-1, 0, 1],
+          distance: 0.13,
+          entity_id: 290,
+          entity_name: "Audio Log",
+          collision_group: "selectable",
+          is_sensor: false,
+        };
+      }
+    },
+  };
+  const player = new PlayerApi(client as unknown as HttpClient);
+
+  const aim = await player.aimAt(290, {
+    hitbox: "surface",
+    visibility: "required",
+  });
+
+  assert.equal(aim.target_confirmed, true);
+  assert.deepEqual(
+    (writes[0]?.body as { start: Vec3 }).start,
+    [31.9264, -26.835, 28.5662],
+    "visibility must originate at the crouched production camera",
+  );
+  const input = writes.at(-1);
+  assert.equal(input?.path, "/v1/control/input");
+  assert.deepEqual(
+    (input?.body as { value: Quat }).value,
+    headRotationForWorldPoint(
+      snapshot.player.position,
+      snapshot.player.rotation,
+      aim.world_point,
+      0.48,
+    ),
+  );
+});
+
 test("aimAt reports center fallback when another entity occludes the target surface", async () => {
   const detail = {
     entity_id: 185,


### PR DESCRIPTION
Fixes #721

## What changed

- report the debug runtime's actual live camera offset in `/v1/info`, including the crouched eye height
- make SDK `aimAt` and `lookAtWorldPoint` default to that reported camera height while retaining an explicit world-unit override
- add a negative-first SHODAN scenario that discovers Delacroix log 4 by stable `template_id === 290`, stages the authentic hidden platform, and collects it through the production flat camera + squeeze path
- cover crouched camera-origin selection in the SDK unit suite

## Root cause

The log, its `LogDiscScript`, and its selectable collider were healthy. The debug runtime reported a standing `camera_offset` even while the production controller was crouched, and the SDK independently defaulted to the standing 1.6-world-unit eye height. The campaign's crouched interaction therefore verified and aimed one ray while `FlatInteraction` frobbed from another.

The original `eyeHeight: 1.2` reproduction also mixed coordinate spaces: `PLAYER_CROUCH_EYE_HEIGHT` is 1.2 SS2 feet, which is 0.48 runtime world units after `SCALE_FACTOR`. Pointing from the real 0.48-world-unit crouched eye collected the log before any script or geometry change, confirming the mismatch.

## Negative-first evidence

Before this change, the new scenario reached the visible/selectable log surface but failed:

```text
AssertionError: production squeeze should collect Delacroix deck 9/log 4
```

After the runtime and SDK use the same live camera offset:

```text
✔ crouched flat interaction collects SHODAN Delacroix log 4
```

## Validation

- `npm test` — 27 passed, 154 skipped
- focused `shodan-log4-interaction.e2e.test.ts` — passed
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- full SDK E2E — running; results will be added

## Visual verification

![Crouched SHODAN log 4 interaction before and after](https://gist.githubusercontent.com/tommy-xr/29a85d34c27f419aa3deda96c7e1f839/raw/issue-721-crouched-log4-before-after.gif)

<sub>Matched fresh `shodan.mis` runs discover template 290 dynamically, stage the same crouched hidden platform, call `aimAt` without an eye-height override, then pulse the production squeeze input. Before, the standing aim origin points the real crouched camera into darkness and collects nothing. After, the live 0.48-world-unit camera origin centers/highlights the disc, collects deck 9/log 4, and opens its reader. Captured headlessly via `/v1/step` + `/v1/screenshot` with deterministic fixed-timestep stepping.</sub>

### Aim — before → after

![Standing aim origin versus live crouched aim origin](https://gist.githubusercontent.com/tommy-xr/29a85d34c27f419aa3deda96c7e1f839/raw/issue-721-aim-before-after.png)

### Squeeze result — before → after

![No collection versus opened Delacroix log reader](https://gist.githubusercontent.com/tommy-xr/29a85d34c27f419aa3deda96c7e1f839/raw/issue-721-result-before-after.png)
