### PR TITLE
feat(ui): replay collected audio logs across missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `Space` - jump
 - `I` - move the floating inventory in front of you
 - `Alt+S` / `Alt+L` - quick save / quick load
+- `U` - replay the newest collected audio log
 - `P` - cycle the pathfinding test (set start → set goal → show path)
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,

--- a/projects/flat-ui-panels.md
+++ b/projects/flat-ui-panels.md
@@ -145,6 +145,14 @@ panel is *presentation + storage*: a reader `MediaGui`, log collection in
 `QuestInfo`, book.crf mount, audio observability. No engine unknowns. The full
 PDA browser (deck tabs, unread sort) is **out of scope this wave** — reader-only.
 
+**Implementation update (2026-07-29):** #468 shipped the entity-bound reader
+and persisted collection. The #740 follow-up adds the original player-facing
+`PlayUnreadLog` / `U` entry point, re-resolving the newest persisted `(deck,
+log)` through the source deck's localized strings and opening the same
+`MediaGui` after mission transitions. This is deliberately an extensible replay
+slice, not a substitute for the still-deferred PDA archive browser (deck tabs,
+entry selection/sorting, notes, videos).
+
 ---
 
 ## 2. Panel: Elevator

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -163,6 +163,11 @@ impl DesktopInputMapper {
                 modifier: Modifier::None,
                 action: InputAction::ToggleMap,
             },
+            Binding {
+                key: Key::U,
+                modifier: Modifier::None,
+                action: InputAction::PlayUnreadLog,
+            },
         ];
 
         Self {
@@ -227,5 +232,18 @@ mod tests {
                 .find(|binding| binding.key == key && binding.modifier == Modifier::None);
             assert_eq!(binding.map(|binding| binding.action), Some(action));
         }
+    }
+
+    #[test]
+    fn original_audio_log_replay_key_maps_to_player_action() {
+        let mapper = DesktopInputMapper::new();
+        let binding = mapper
+            .bindings
+            .iter()
+            .find(|binding| binding.key == Key::U && binding.modifier == Modifier::None);
+        assert_eq!(
+            binding.map(|binding| binding.action),
+            Some(InputAction::PlayUnreadLog)
+        );
     }
 }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -84,6 +84,10 @@ pub enum InputAction {
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key). No-op in VR. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
+
+    /// Replay the newest collected audio log in the reader MFD (the original
+    /// `play_unread_log` / `U` binding). No-op when the collection is empty.
+    PlayUnreadLog,
 }
 
 impl InputAction {
@@ -122,6 +126,7 @@ impl InputAction {
             InputAction::DebugForceChase,
             InputAction::ToggleUseMode,
             InputAction::ToggleMap,
+            InputAction::PlayUnreadLog,
         ]
     }
 
@@ -158,6 +163,7 @@ impl InputAction {
             InputAction::DebugForceChase => "DebugForceChase",
             InputAction::ToggleUseMode => "ToggleUseMode",
             InputAction::ToggleMap => "ToggleMap",
+            InputAction::PlayUnreadLog => "PlayUnreadLog",
         }
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -131,6 +131,9 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ToggleMap) {
             effects.push(Effect::ToggleMap);
         }
+        if state.just_triggered(InputAction::PlayUnreadLog) {
+            effects.push(Effect::PlayUnreadLog);
+        }
         effects
     }
 }
@@ -260,6 +263,15 @@ mod tests {
 
         let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
         assert!(matches!(effects[0], Effect::ToggleMap));
+    }
+
+    #[test]
+    fn play_unread_log_maps_to_player_replay_effect() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::PlayUnreadLog);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(matches!(effects.as_slice(), [Effect::PlayUnreadLog]));
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -377,6 +377,12 @@ pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 #[derive(Unique, Clone, Copy)]
 pub struct MapPanelEntity(pub EntityId);
 
+/// The synthetic player-owned entity hosting replayed audio logs in
+/// `MediaGui`. The physical log-disc entity belongs to its source mission, so
+/// the original `U` action needs a durable, unbound host after deck changes.
+#[derive(Unique, Clone, Copy)]
+pub struct MediaPanelEntity(pub EntityId);
+
 /// The automap location (`PropMapLoc`) of the mapped room the player most
 /// recently entered - the player's *current* map location. The automap uses it
 /// to draw that location bright (R-art) while other explored locations draw
@@ -798,6 +804,30 @@ impl MissionCore {
                 },
             ));
             world.add_unique(MapPanelEntity(entity));
+
+            // Replayed logs have no current-mission world object to bind: the
+            // source disc may be several decks behind the player. A synthetic,
+            // player-owned MediaGui host lets the original `U` action reuse the
+            // production reader while remaining unbound/sticky in FlatUiHost.
+            let entity = world.add_entity((
+                Links::empty(),
+                PropScripts {
+                    scripts: vec!["internal_media".to_owned()],
+                    inherits: false,
+                },
+                dark::properties::PropTemplateId { template_id: -1 },
+                PropPosition {
+                    position: vec3(0.0, 0.0, 0.0),
+                    rotation: Quaternion {
+                        v: vec3(0.0, 0.0, 0.0),
+                        s: 1.0,
+                    },
+                    cell: 0,
+                },
+                RuntimePropTransform(Matrix4::identity()),
+                RuntimePropDoNotSerialize,
+            ));
+            world.add_unique(MediaPanelEntity(entity));
         }
 
         world.add_unique(GlobalTemplateIdMap(template_to_entity_id.clone()));
@@ -3398,6 +3428,7 @@ impl MissionCore {
                     deck,
                     log,
                 } => {
+                    let collected = crate::quest_info::CollectedLog { deck, log };
                     // Record the log identity into the persistent collection...
                     {
                         let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
@@ -3406,27 +3437,62 @@ impl MissionCore {
                     // ...and resolve the reader strings from `level<deck>.str`,
                     // caching them on the disc so the MediaGui panel can render
                     // the portrait / deck icon / header / transcript.
-                    let level_file = format!("level{deck:02}.str");
+                    let level_file = crate::scripts::gui::log_strings_file(&collected);
                     if let Some(strings) =
                         asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
                     {
-                        // The .str values carry literal backslash-n escapes
-                        // ("AMANPOUR 07.JUL.14\nre: New code\n"); unescape them
-                        // into real line breaks so the reader never draws "\n".
-                        let get = |prefix: &str| {
-                            strings
-                                .get(&format!("{prefix}{log}"))
-                                .map(|s| s.replace("\\n", "\n"))
-                        };
                         self.world.add_component(
                             entity_id,
-                            crate::runtime_props::RuntimePropLogData {
-                                name: get("logname"),
-                                text: get("logtext"),
-                                portrait: get("logportrait"),
-                                icon: get("logicon"),
-                            },
+                            crate::scripts::gui::log_data_from_strings(&collected, &strings),
                         );
+                    }
+                }
+
+                Effect::PlayUnreadLog => {
+                    // `collected_logs` is persisted in pickup order, matching
+                    // the original LOGTIMES selection. Clone the identity out
+                    // of QuestInfo before mutating the world/panel host.
+                    let latest = self
+                        .world
+                        .borrow::<UniqueView<QuestInfo>>()
+                        .ok()
+                        .and_then(|quests| quests.latest_collected_log().cloned());
+                    let Some(log) = latest else {
+                        continue;
+                    };
+
+                    // Audio replay is meaningful regardless of presentation.
+                    effects.push_front(Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        name: crate::scripts::gui::log_audio_schema(&log),
+                    });
+
+                    // The reader MFD is flat-only. Its synthetic host is rebuilt
+                    // on each mission load, while the identity stays in
+                    // QuestInfo and is localized from the *source deck* table.
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        let panel_entity = self
+                            .world
+                            .borrow::<UniqueView<MediaPanelEntity>>()
+                            .ok()
+                            .map(|panel| panel.0);
+                        if let Some(entity) = panel_entity {
+                            let level_file = crate::scripts::gui::log_strings_file(&log);
+                            if let Some(strings) =
+                                asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
+                            {
+                                self.world.add_component(
+                                    entity,
+                                    crate::scripts::gui::log_data_from_strings(&log, &strings),
+                                );
+                                self.flat_ui.open_unbound(entity);
+                            } else {
+                                warn!(
+                                    "Unable to replay collected log: missing localized table {}",
+                                    level_file
+                                );
+                            }
+                        }
                     }
                 }
 

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -95,6 +95,13 @@ impl QuestInfo {
         &self.collected_logs
     }
 
+    /// The newest collected audio log (the original `LOGTIMES` ordering used
+    /// by `play_unread_log`). Collection order is persisted with QuestInfo, so
+    /// this remains valid after a level transition or save/load.
+    pub fn latest_collected_log(&self) -> Option<&CollectedLog> {
+        self.collected_logs.last()
+    }
+
     /// The player's persistent character sheet.
     pub fn player_stats(&self) -> &PlayerStats {
         &self.player_stats
@@ -152,5 +159,36 @@ impl QuestInfo {
 
     pub fn mark_email_as_played(&mut self, email: &str) {
         self.played_emails.insert(email.to_owned());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_collected_log_is_empty_then_tracks_pickup_order() {
+        let mut quests = QuestInfo::new();
+        assert_eq!(
+            quests.latest_collected_log(),
+            None,
+            "an empty collection has no replay target"
+        );
+
+        assert!(quests.collect_log(1, 1));
+        assert!(quests.collect_log(2, 20));
+        assert_eq!(
+            quests.latest_collected_log(),
+            Some(&CollectedLog { deck: 2, log: 20 })
+        );
+
+        assert!(
+            !quests.collect_log(1, 1),
+            "collecting a duplicate must not move an older log to newest"
+        );
+        assert_eq!(
+            quests.latest_collected_log(),
+            Some(&CollectedLog { deck: 2, log: 20 })
+        );
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -169,6 +169,11 @@ pub enum Effect {
     /// VR and in scenes without a map panel. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
 
+    /// Replay the newest persisted audio-log identity through the authentic
+    /// localized reader/audio paths. This is the original `play_unread_log`
+    /// player action (`U`), not a debug lever. No-op when no log is collected.
+    PlayUnreadLog,
+
     /// Mark an automap location as explored for the current mission (persisted
     /// in `QuestInfo`, the original's mission-scoped `EXPLORED[64]` file-var).
     /// Emitted by `CoreRoom` when the player enters a room whose room object

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -2,13 +2,14 @@
 //!
 //! The flat-mode reader panel matching the original game's email/log overlay: a
 //! `LOG.PCX` backdrop with the sender portrait, deck icon, header line and a word-wrapped,
-//! scrollable transcript. It is bound to the frobbed log-disc entity (the flat
-//! host's single-slot MFD), and reads its presentation strings from
-//! `RuntimePropLogData` - attached by the `Effect::CollectLog` handler when the
-//! disc is frobbed (that handler also records the log into the persistent
-//! `QuestInfo` collection and plays its audio). Deliberate deviation from the
-//! original's destroy-on-pickup: the disc survives so the reader stays bound and
-//! the code is readable in-fiction (research gap #6).
+//! scrollable transcript. On pickup it is bound to the physical log disc; the
+//! original `play_unread_log` / `U` action instead binds the same GUI to a
+//! synthetic player-owned entity and re-resolves the latest persisted
+//! `(deck, log)` identity. Both paths read `RuntimePropLogData`, so replay uses
+//! the same authentic strings, portraits and deck icons rather than a transcript
+//! copied into code. The full PDA archive browser remains deferred.
+
+use std::collections::HashMap;
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::PropLog;
@@ -16,7 +17,7 @@ use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
-use crate::quest_info::QuestInfo;
+use crate::quest_info::{CollectedLog, QuestInfo};
 use crate::runtime_props::RuntimePropLogData;
 use crate::scripts::{
     Effect, MessagePayload,
@@ -67,6 +68,37 @@ pub struct MediaGuiState {
 pub enum MediaGuiMsg {
     PageUp,
     PageDown,
+}
+
+/// The localized string table belonging to a persisted log identity.
+pub(crate) fn log_strings_file(log: &CollectedLog) -> String {
+    format!("level{:02}.str", log.deck)
+}
+
+/// The authentic audio schema belonging to a persisted log identity.
+pub(crate) fn log_audio_schema(log: &CollectedLog) -> String {
+    format!("LOG{:02}{:02}", log.deck, log.log)
+}
+
+/// Resolve the reader's presentation cache from the per-deck localized string
+/// table. The current mission is intentionally absent: a collected deck-1 log
+/// must still resolve while the player is on deck 2.
+pub(crate) fn log_data_from_strings(
+    log: &CollectedLog,
+    strings: &HashMap<String, String>,
+) -> RuntimePropLogData {
+    let get = |prefix: &str| {
+        strings
+            .get(&format!("{prefix}{}", log.log))
+            // Retail .str values encode line breaks as literal backslash-n.
+            .map(|value| value.replace("\\n", "\n"))
+    };
+    RuntimePropLogData {
+        name: get("logname"),
+        text: get("logtext"),
+        portrait: get("logportrait"),
+        icon: get("logicon"),
+    }
 }
 
 /// Greedy word-wrap that honors explicit `\n` paragraph breaks. A single word
@@ -582,5 +614,37 @@ mod tests {
         });
         let gui = MediaGui;
         assert!(matches!(gui.on_frob(disc, &world), Effect::NoEffect));
+    }
+
+    #[test]
+    fn persisted_cross_mission_identity_resolves_localized_reader_metadata() {
+        let log = CollectedLog { deck: 1, log: 13 };
+        let strings = HashMap::from([
+            (
+                "logname13".to_owned(),
+                "SANGER 12.JUL.14\\nre: Cargo bays".to_owned(),
+            ),
+            (
+                "logtext13".to_owned(),
+                "Localized deck-one transcript".to_owned(),
+            ),
+            ("logportrait13".to_owned(), "Sanger".to_owned()),
+            ("logicon13".to_owned(), "EngIcon".to_owned()),
+        ]);
+
+        assert_eq!(log_strings_file(&log), "level01.str");
+        assert_eq!(log_audio_schema(&log), "LOG0113");
+        let data = log_data_from_strings(&log, &strings);
+        assert_eq!(
+            data.name.as_deref(),
+            Some("SANGER 12.JUL.14\nre: Cargo bays")
+        );
+        assert_eq!(data.text.as_deref(), Some("Localized deck-one transcript"));
+        assert_eq!(data.portrait.as_deref(), Some("Sanger"));
+        assert_eq!(
+            data.icon.as_deref(),
+            Some("EngIcon"),
+            "the localized deck icon must come from the collected log's deck table"
+        );
     }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -900,6 +900,7 @@ impl ScriptWorld {
             "internal_collision_type" => Box::new(InternalCollisionType::new()),
             "internal_inventory" => gui_script(Box::new(ContainerGui::inv_container())),
             "internal_map" => gui_script(Box::new(MapGui)),
+            "internal_media" => gui_script(Box::new(MediaGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -24,6 +24,7 @@ export type InputAction =
   | "Reload"
   | "CyclePsiPower"
   | "ToggleUseMode"
+  | "PlayUnreadLog"
   // Escape hatch so newly-added actions are usable before the SDK is updated.
   | (string & {});
 

--- a/tools/shock2-sdk/test/log-replay.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-replay.e2e.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, type Game } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const PLAY_UNREAD_LOG = "PlayUnreadLog";
+
+const textOf = (panel: {
+  elements: { kind: string; text: string | null }[];
+}) =>
+  panel.elements
+    .filter((element) => element.kind === "text" && element.text)
+    .map((element) => element.text)
+    .join(" ");
+
+async function closePanel(game: Game) {
+  const close = (await game.ui.state()).active_panel?.elements.find(
+    (element) => element.label === "close",
+  );
+  assert.ok(close, "the reader should expose the host close button");
+  const [x, y, width, height] = close.screen_rect;
+  await game.input.set("pointer.position", [x + width / 2, y + height / 2]);
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 1 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 1 });
+}
+
+test(
+  "PlayUnreadLog is a safe no-op when no audio log has been collected",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8188),
+    });
+    await game.step({ frames: 5 });
+
+    assert.deepEqual((await game.info()).player.collected_logs, []);
+    assert.ok(
+      (await game.input.actions()).includes(PLAY_UNREAD_LOG),
+      "the normal player log-replay action should be registered",
+    );
+
+    const priorAudioSequence =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await game.input.trigger(PLAY_UNREAD_LOG);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "an empty collection must not open a blank media panel",
+    );
+    assert.ok(
+      (await game.audio.recent()).sounds.every(
+        (sound) => sound.sequence <= priorAudioSequence,
+      ),
+      "an empty collection must not play fabricated media",
+    );
+  },
+);
+
+test(
+  "PlayUnreadLog reopens the latest authentic log after a mission transition",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8189),
+    });
+    await game.step({ frames: 5 });
+
+    // Collect the real Amanpour "New code" disc through its production frob
+    // path. Runtime ids are unstable, so identify it by stable mission object
+    // template_id 1608.
+    const logs = (await game.entities.list({ filter: "Audio Log", limit: 80 }))
+      .entities;
+    const amanpour = logs.find((entity) => entity.template_id === 1608);
+    assert.ok(amanpour, "medsci1 should contain Amanpour log object 1608");
+    const detail = await game.entities.detail(amanpour.id);
+    const [x, y, z] = detail.position;
+    await teleportVerified(game, { x, y: y + 0.5, z });
+    await game.entities.sendMessage(amanpour.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.deepEqual((await game.info()).player.collected_logs, [
+      { deck: 2, log: 20 },
+    ]);
+    await closePanel(game);
+
+    // Leave the source mission, then save/load on the destination. The physical
+    // disc and its entity-bound RuntimePropLogData no longer exist here; only
+    // the authentic persisted (deck, log) identity crosses this boundary.
+    await game.transitionLevel("eng2.mis");
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).mission, "eng2.mis");
+    await game.save("log-replay-e2e");
+    await game.load("log-replay-e2e");
+    await game.step({ frames: 5 });
+    assert.deepEqual((await game.info()).player.collected_logs, [
+      { deck: 2, log: 20 },
+    ]);
+    assert.equal((await game.ui.state()).active_panel, null);
+
+    const priorAudioSequence =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await game.input.trigger(PLAY_UNREAD_LOG);
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "U should open the collected log reader on another deck");
+    assert.equal(
+      panel.template_id,
+      -1,
+      "replay should use the synthetic player-owned panel, not a stale disc id",
+    );
+    const transcript = textOf(panel);
+    assert.ok(transcript.includes("45100"), transcript);
+    assert.ok(transcript.toUpperCase().includes("AMANPOUR"), transcript);
+
+    const textures = panel.elements
+      .filter((element) => element.kind === "image")
+      .map((element) => element.texture?.toLowerCase());
+    assert.ok(textures.includes("iface/log.pcx"));
+    assert.ok(textures.includes("amanpour.pcx"));
+    assert.ok(textures.includes("medicon.pcx"));
+
+    const replayed = (await game.audio.recent()).sounds.filter(
+      (sound) =>
+        sound.sequence > priorAudioSequence &&
+        sound.sample.toLowerCase() === "log0220",
+    );
+    assert.equal(replayed.length, 1, "U should replay authentic LOG0220 audio");
+    await game.screenshot("log-replay-cross-mission.png");
+  },
+);


### PR DESCRIPTION
Fixes #740

Campaign: `engineering · none · legacy · seed 1378752978`

## Original behavior and gap

The retail [System Shock 2 manual, pp. 8–9](https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/238210/manuals/System%20Shock%202%20-%20Manual.pdf?t=1760115651) says collected logs are retained by the PDA and `U` plays the last log picked up. The original `shkpda.cpp` implementation stores pickup order in campaign `LOGTIMES`; `ShockPDAPlayUnreadLog` selects the newest unread persisted identity, then `ShockPDAUseLog` opens the normal localized reader and plays its audio.

#468 already shipped the authentic reader, pickup collection, and audio, but deliberately bound `MediaGui` to the physical disc and left `U`/the PDA out of scope. Once the player changed missions, `QuestInfo.collected_logs` survived while no player-facing action could rematerialize the transcript.

## Faithful scoped implementation

- Adds the normal `InputAction::PlayUnreadLog`, dispatched through the shared action/effect architecture and bound to the original desktop `U` key. It is also available to the debug runtime/SDK like every ordinary input action; there is no debug-only shortcut.
- Uses `QuestInfo`'s persisted pickup order to select the newest collected `(deck, log)` identity. Empty collections are a safe no-op.
- Re-resolves `level<deck>.str` from the **source deck**, including `LogName`, `LogText`, `LogPortrait`, and `LogIcon`, then opens the existing `MediaGui` on a synthetic player-owned, unbound entity rebuilt each mission. No transcript, Sanger/Amanpour identity, or mission object id is hardcoded in production code.
- Replays the authentic `LOG<deck><log>` schema through the existing `PlaySound` path.
- Documents `U` in README and the follow-up scope in `projects/flat-ui-panels.md`.

Because #468 deliberately auto-opens/auto-plays logs on pickup (where retail pickup only marked them unread), this scoped action preserves the player-visible intent as replaying the newest collected entry. It does not introduce a contradictory read flag that would make `U` immediately inert after the port's pickup-time playback.

## Deferred PDA scope

This is an architecturally extensible replay slice, not a simulated archive. The full PDA browser remains deferred: deck tabs, archive entry selection and timestamp sorting, unread/read presentation, notes, videos, and the received-email overlay tracked by #494.

## Negative-first and verification

The new SDK scenario was written and run against `origin/main` first:

- empty eng2 start: `PlayUnreadLog` absent from `/v1/input/actions`;
- authentic Amanpour pickup in fresh medsci1 -> eng2 transition: persisted `{deck:2, log:20}` existed, but the normal action was rejected and no cross-mission panel opened.

On this branch, `log-replay.e2e.test.ts` proves:

- an empty collection opens no blank panel and plays no fabricated media;
- a fresh runtime frobs the authentic mission-object-1608 disc, transitions to eng2, saves/loads there, invokes the normal `PlayUnreadLog` action, and sees the existing reader with localized AMANPOUR header, transcript code `45100`, portrait, MED/SCI deck icon, and one new `LOG0220` audio event;
- the replay panel is synthetic/unbound (`template_id: -1`), not a stale entity id from medsci1.

Unit coverage pins empty/latest collection ordering, action dispatch, original `U` desktop binding, and cross-mission identity -> `level01.str` / `LOG0113` -> localized transcript/portrait/deck metadata.

## Visual evidence

![cross-mission audio-log replay](https://gist.githubusercontent.com/tommy-xr/d2f45106a542ad7e04b71411fcbbfa4e/raw/log-replay.gif)

<sub>A fresh medsci1 pickup persists through the eng2 transition; pressing the normal U action reopens the authentic localized reader and replays its audio. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![before and after: U unavailable versus reader reopened](https://gist.githubusercontent.com/tommy-xr/d2f45106a542ad7e04b71411fcbbfa4e/raw/before-after.png)

<sub>Identical fresh pickup → eng2 → `PlayUnreadLog` request sequence. On `origin/main`, the action is unknown and no panel appears; on this branch, the same action opens `MediaGui` with Amanpour portrait, MED/SCI deck icon, and the localized 45100 transcript.</sub>

## Validation

- `cargo fmt --check --all` ✅
- `cargo check -p shock2vr -p desktop_runtime -p debug_runtime` ✅
- `cargo test -p shock2vr` ✅ (384 passed)
- `cargo test -p desktop_runtime input_mapper::tests::original_audio_log_replay_key_maps_to_player_action` ✅
- SDK `log-replay.e2e.test.ts` ✅ (2 passed; negative-verified against `origin/main`)
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_viewer -p dark_query -p debug_command -p hitbox_analyzer -p bench` ✅
- SDK `npm test` ✅ (26 passed; 159 e2e-gated skips)
- Full serial SDK `npm run test:e2e` with legacy assets ✅ (185 total; 182 passed; 0 failed; 3 expected SHODAN-finale skips; all 23 missions loaded)

