### PR TITLE
fix(hud): localize object hover labels

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -369,6 +369,52 @@ pub struct PropObjIcon(pub String);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjName(pub String);
 
+/// How the original Shock UI substitutes placeholders in an object's localized
+/// long/short name (`P$NameType` / `ObjNameType`).
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ObjectNameType {
+    #[default]
+    Normal,
+    StackCount,
+    LogTitle,
+    Weapon,
+    /// Preserve unfamiliar retail/mod values rather than silently treating
+    /// them as one of the known formatting strategies.
+    Unknown(i32),
+}
+
+impl ObjectNameType {
+    pub fn from_raw(value: i32) -> Self {
+        match value {
+            0 => Self::Normal,
+            1 => Self::StackCount,
+            2 => Self::LogTitle,
+            3 => Self::Weapon,
+            value => Self::Unknown(value),
+        }
+    }
+
+    pub fn raw(self) -> i32 {
+        match self {
+            Self::Normal => 0,
+            Self::StackCount => 1,
+            Self::LogTitle => 2,
+            Self::Weapon => 3,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropObjectNameType(pub ObjectNameType);
+
+impl PropObjectNameType {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 4, "P$NameType must contain one signed 32-bit value");
+        Self(ObjectNameType::from_raw(read_i32(reader)))
+    }
+}
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropObjShortName(pub String);
 
@@ -1626,6 +1672,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$NameType",
+            PropObjectNameType::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$ObjState",
             PropObjState::read,
             identity,
@@ -2422,6 +2474,21 @@ pub fn define_link_with_versioned_data<TData: 'static + fmt::Debug + Send + Sync
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn object_name_type_reads_retail_variants_and_preserves_unknown_values() {
+        for (raw, expected) in [
+            (0_i32, ObjectNameType::Normal),
+            (1, ObjectNameType::StackCount),
+            (2, ObjectNameType::LogTitle),
+            (3, ObjectNameType::Weapon),
+            (17, ObjectNameType::Unknown(17)),
+        ] {
+            let parsed = PropObjectNameType::read(&mut Cursor::new(raw.to_le_bytes()), 4);
+            assert_eq!(parsed, PropObjectNameType(expected));
+            assert_eq!(parsed.0.raw(), raw);
+        }
+    }
 
     /// Build a 108-byte sStimSourceDesc payload the way shock2.gam lays it
     /// out: propagator id, intensity, unknown, then propagator params.

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -100,6 +100,13 @@ fn format_hover_label(
     }
 }
 
+fn format_inline_localized_text(text: &str) -> String {
+    text.replace("\\n", " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn localized_log_title(
     asset_cache: &mut AssetCache,
     world: &World,
@@ -117,7 +124,7 @@ fn localized_log_title(
     let strings = asset_cache.get_opt(&STRINGS_IMPORTER, &format!("level{deck:02}.str"))?;
     strings
         .get(&format!("logname{log}"))
-        .map(|name| name.replace("\\n", "\n"))
+        .map(|name| format_inline_localized_text(name))
 }
 
 fn weapon_condition_key(condition: f32) -> String {
@@ -386,6 +393,14 @@ mod tests {
                 Some("Perfect: 10"),
             ),
             "A pistol. (Perfect: 10)",
+        );
+    }
+
+    #[test]
+    fn authored_log_line_breaks_become_single_line_hover_text() {
+        assert_eq!(
+            format_inline_localized_text("SANGER 10.JUL.14\\nre: Locking Eng. Control\\n"),
+            "SANGER 10.JUL.14 re: Locking Eng. Control",
         );
     }
 

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+
 use cgmath::{Matrix4, Vector2, point2, vec2, vec3};
 use collision::{Aabb2, Aabb3};
 use dark::{
-    importers::{FONT_IMPORTER, TEXTURE_IMPORTER},
-    properties::{PropHUDSelect, PropHitPoints, PropObjName, PropStackCount, PropTemplateId},
+    importers::{FONT_IMPORTER, STRINGS_IMPORTER, TEXTURE_IMPORTER},
+    properties::{
+        ObjectNameType, PropGunState, PropHUDSelect, PropHitPoints, PropLog, PropObjName,
+        PropObjectNameType, PropStackCount, PropTemplateId,
+    },
 };
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureOptions};
 use shipyard::{EntityId, Get, View, World};
@@ -30,11 +35,111 @@ pub(crate) fn is_hud_selectable(world: &World, entity_id: EntityId) -> bool {
         .unwrap_or(false)
 }
 
+const LOG_UNSET: u32 = 33;
+
+fn resolve_localized_property_string(raw: &str, strings: &HashMap<String, String>) -> String {
+    let (key, fallback) = match raw.split_once(':') {
+        Some((key, remainder)) => {
+            let remainder = remainder.trim();
+            let fallback = match remainder.strip_prefix('"') {
+                Some(quoted) => quoted.split_once('"').map_or("", |(value, _)| value),
+                None => remainder,
+            };
+            (key.trim(), fallback)
+        }
+        None => (raw.trim(), ""),
+    };
+
+    strings
+        .get(&key.to_ascii_lowercase())
+        .map(String::as_str)
+        .unwrap_or(fallback)
+        .to_owned()
+}
+
 fn format_stack_aware_item_name(item_name: &str, stack_count: Option<i32>) -> String {
     match stack_count {
         Some(count) => item_name.replace("%d", &count.to_string()),
         None => item_name.to_owned(),
     }
+}
+
+fn format_typed_item_name(
+    item_name: &str,
+    name_type: ObjectNameType,
+    stack_count: Option<i32>,
+    log_title: Option<&str>,
+    weapon_condition: Option<&str>,
+) -> String {
+    match name_type {
+        ObjectNameType::StackCount => format_stack_aware_item_name(item_name, stack_count),
+        ObjectNameType::LogTitle => log_title
+            .map(|title| item_name.replace("%s", title))
+            .unwrap_or_else(|| item_name.to_owned()),
+        ObjectNameType::Weapon => weapon_condition
+            .map(|condition| item_name.replace("%s", condition))
+            .unwrap_or_else(|| item_name.to_owned()),
+        ObjectNameType::Normal | ObjectNameType::Unknown(_) => item_name.to_owned(),
+    }
+}
+
+fn format_hover_label(
+    item_name: &str,
+    hit_points: Option<i32>,
+    debug_identity: Option<(&str, u64)>,
+) -> String {
+    match (hit_points, debug_identity) {
+        (Some(hit_points), Some((template_id, entity_id))) => {
+            format!("{item_name} | {hit_points} (Tem {template_id}| Ent {entity_id})")
+        }
+        (None, Some((template_id, entity_id))) => {
+            format!("{item_name} (Tem {template_id}| Ent {entity_id})")
+        }
+        (Some(hit_points), None) => format!("{item_name} | {hit_points}"),
+        (None, None) => item_name.to_owned(),
+    }
+}
+
+fn localized_log_title(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    entity_id: EntityId,
+) -> Option<String> {
+    let (deck, log) = {
+        let logs = world.borrow::<View<PropLog>>().ok()?;
+        let log = logs.get(entity_id).ok()?;
+        (log.deck, log.log)
+    };
+    if deck == 0 || log == 0 || log == LOG_UNSET {
+        return None;
+    }
+
+    let strings = asset_cache.get_opt(&STRINGS_IMPORTER, &format!("level{deck:02}.str"))?;
+    strings
+        .get(&format!("logname{log}"))
+        .map(|name| name.replace("\\n", "\n"))
+}
+
+fn weapon_condition_key(condition: f32) -> String {
+    // Looking Glass's GunGetConditionString truncates the 0..100 condition,
+    // divides it into ten buckets, and fetches GunCondVal1..10.
+    let bucket = ((condition as i32) / 10).clamp(0, 9) + 1;
+    format!("guncondval{bucket}")
+}
+
+fn localized_weapon_condition(
+    asset_cache: &mut AssetCache,
+    world: &World,
+    entity_id: EntityId,
+) -> Option<String> {
+    let condition = {
+        let gun_states = world.borrow::<View<PropGunState>>().ok()?;
+        gun_states.get(entity_id).ok()?.condition
+    };
+    asset_cache
+        .get_opt(&STRINGS_IMPORTER, "weapon.str")?
+        .get(&weapon_condition_key(condition))
+        .cloned()
 }
 
 pub fn draw_item_name(
@@ -54,54 +159,69 @@ pub fn draw_item_name(
         return vec![];
     }
 
-    let v_prop_obj_short_name = world.borrow::<View<PropObjName>>().unwrap();
-    let maybe_prop_obj_short_name = v_prop_obj_short_name.get(entity_id);
+    let v_prop_obj_name = world.borrow::<View<PropObjName>>().unwrap();
+    let maybe_prop_obj_name = v_prop_obj_name.get(entity_id);
 
-    if maybe_prop_obj_short_name.is_err() {
+    if maybe_prop_obj_name.is_err() {
         return vec![];
     }
 
-    let prop_obj_short_name = maybe_prop_obj_short_name.unwrap();
+    let prop_obj_name = maybe_prop_obj_name.unwrap();
 
-    if prop_obj_short_name.0.is_empty() {
+    if prop_obj_name.0.is_empty() {
         return vec![];
     }
 
+    let object_name_strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
+    let localized_name = resolve_localized_property_string(&prop_obj_name.0, &object_name_strings);
+    if localized_name.is_empty() {
+        return vec![];
+    }
+
+    let name_type = world
+        .borrow::<View<PropObjectNameType>>()
+        .unwrap()
+        .get(entity_id)
+        .map(|name_type| name_type.0)
+        .unwrap_or_default();
     let stack_count = world
         .borrow::<View<PropStackCount>>()
         .unwrap()
         .get(entity_id)
         .map(|stack| stack.0)
         .ok();
-    let item_name = format_stack_aware_item_name(&prop_obj_short_name.0, stack_count);
+    let log_title = (name_type == ObjectNameType::LogTitle)
+        .then(|| localized_log_title(asset_cache, world, entity_id))
+        .flatten();
+    let weapon_condition = (name_type == ObjectNameType::Weapon)
+        .then(|| localized_weapon_condition(asset_cache, world, entity_id))
+        .flatten();
+    let item_name = format_typed_item_name(
+        &localized_name,
+        name_type,
+        stack_count,
+        log_title.as_deref(),
+        weapon_condition.as_deref(),
+    );
 
     let aabb = maybe_bbox.unwrap();
     let font = asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
     let extents = project_aabb3(&aabb, view, projection, screen_size);
 
     let v_prop_hitpoints = world.borrow::<View<PropHitPoints>>().unwrap();
-    let maybe_hitpoints = v_prop_hitpoints
-        .get(entity_id)
-        .map(|hp| hp.hit_points.to_string())
-        .unwrap_or("?".to_string());
-
-    let text_content = if debug_show_ids {
-        let template_id = world
+    let hit_points = v_prop_hitpoints.get(entity_id).map(|hp| hp.hit_points).ok();
+    let template_id = debug_show_ids.then(|| {
+        world
             .borrow::<View<PropTemplateId>>()
             .unwrap()
             .get(entity_id)
             .map(|prop| prop.template_id.to_string())
-            .unwrap_or_else(|_| "runtime".to_owned());
-        format!(
-            "{} | {} (Tem {}| Ent {})",
-            item_name,
-            &maybe_hitpoints,
-            template_id,
-            entity_id.inner(),
-        )
-    } else {
-        format!("{} | {}", item_name, &maybe_hitpoints,)
-    };
+            .unwrap_or_else(|_| "runtime".to_owned())
+    });
+    let debug_identity = template_id
+        .as_deref()
+        .map(|template_id| (template_id, entity_id.inner()));
+    let text_content = format_hover_label(&item_name, hit_points, debug_identity);
 
     let text_obj_0_0 = SceneObject::screen_space_text(
         &text_content,
@@ -119,7 +239,7 @@ pub fn draw_item_name(
 mod tests {
     use super::*;
     use crate::flat_player_controller::is_frobbable;
-    use dark::properties::{FrobFlag, PropFrobInfo};
+    use dark::properties::{FrobFlag, ObjectNameType, PropFrobInfo};
 
     fn frob_info() -> PropFrobInfo {
         PropFrobInfo {
@@ -170,6 +290,113 @@ mod tests {
 
         assert!(!is_frobbable(&world, id));
         assert!(!is_hud_selectable(&world, id));
+    }
+
+    #[test]
+    fn object_name_resource_reference_uses_localized_value() {
+        let strings = HashMap::from([(
+            "elevator_button".to_string(),
+            "Localized elevator button".to_string(),
+        )]);
+
+        assert_eq!(
+            resolve_localized_property_string(
+                r#"Elevator_Button: "A two-state button.""#,
+                &strings,
+            ),
+            "Localized elevator button",
+        );
+    }
+
+    #[test]
+    fn object_name_resource_reference_uses_embedded_fallback() {
+        assert_eq!(
+            resolve_localized_property_string(r#"HumanCorpses: "A corpse.""#, &HashMap::new(),),
+            "A corpse.",
+        );
+    }
+
+    #[test]
+    fn object_name_resource_key_without_fallback_uses_localized_value() {
+        let strings = HashMap::from([("basketball".to_string(), "A basketball.".to_string())]);
+
+        assert_eq!(
+            resolve_localized_property_string("Basketball", &strings),
+            "A basketball.",
+        );
+    }
+
+    #[test]
+    fn hover_label_omits_unknown_hit_points() {
+        assert_eq!(format_hover_label("A corpse.", None, None), "A corpse.");
+    }
+
+    #[test]
+    fn hover_label_keeps_meaningful_hit_points_and_debug_identity() {
+        assert_eq!(
+            format_hover_label("A turret.", Some(12), Some(("-1778", 42))),
+            "A turret. | 12 (Tem -1778| Ent 42)",
+        );
+    }
+
+    #[test]
+    fn hover_label_falls_back_to_runtime_identity_without_a_template() {
+        assert_eq!(
+            format_hover_label("A corpse.", None, Some(("runtime", 7))),
+            "A corpse. (Tem runtime| Ent 7)",
+        );
+    }
+
+    #[test]
+    fn localized_stack_name_replaces_decimal_placeholder() {
+        let strings =
+            HashMap::from([("nanites".to_string(), "%d translated nanites.".to_string())]);
+        let localized = resolve_localized_property_string(r#"Nanites: "%d nanites.""#, &strings);
+
+        assert_eq!(
+            format_typed_item_name(
+                &localized,
+                ObjectNameType::StackCount,
+                Some(250),
+                None,
+                None,
+            ),
+            "250 translated nanites.",
+        );
+    }
+
+    #[test]
+    fn log_and_weapon_name_types_replace_string_placeholder() {
+        assert_eq!(
+            format_typed_item_name(
+                "An audio log: %s.",
+                ObjectNameType::LogTitle,
+                None,
+                Some("SANGER"),
+                None,
+            ),
+            "An audio log: SANGER.",
+        );
+        assert_eq!(
+            format_typed_item_name(
+                "A pistol. (%s)",
+                ObjectNameType::Weapon,
+                None,
+                None,
+                Some("Perfect: 10"),
+            ),
+            "A pistol. (Perfect: 10)",
+        );
+    }
+
+    #[test]
+    fn weapon_condition_uses_original_ten_point_buckets() {
+        assert_eq!(weapon_condition_key(-1.0), "guncondval1");
+        assert_eq!(weapon_condition_key(0.0), "guncondval1");
+        assert_eq!(weapon_condition_key(9.9), "guncondval1");
+        assert_eq!(weapon_condition_key(10.0), "guncondval2");
+        assert_eq!(weapon_condition_key(50.0), "guncondval6");
+        assert_eq!(weapon_condition_key(100.0), "guncondval10");
     }
 
     #[test]

--- a/tools/shock2-sdk/test/hover-label-localization.e2e.test.ts
+++ b/tools/shock2-sdk/test/hover-label-localization.e2e.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const SANGER_LOG_OBJECT = 451;
+
+test(
+  "eng1.mis: authored audio-log hover label renders through the production reticle",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
+    });
+    await game.step({ frames: 5 });
+
+    const logs = await game.entities.byTemplate(SANGER_LOG_OBJECT);
+    assert.equal(logs.length, 1, "expected eng1 mission object 451 (Sanger audio log)");
+    const log = logs[0];
+    const [x, y, z] = log.position;
+
+    // Stage nearby, then use the production world-aim path to select the
+    // physical disc. Do not squeeze: the hover label should render without
+    // collecting or mutating the log.
+    await game.player.teleport({ x: x - 1.5, y: y - 1.6, z });
+    await game.step({ frames: 3 });
+    const aim = await game.player.aimAt(log, {
+      hitbox: "center",
+      visibility: "required",
+      // Use the debug runtime's flat-camera eye offset for this low ceiling;
+      // it centers the disc rather than merely confirming its surface ray.
+      eyeHeight: 1.4,
+    });
+    assert.equal(aim.interaction_target_id, log.id, JSON.stringify(aim));
+    assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+    await game.step({ frames: 1 });
+
+    // This is a real-mission render smoke and visual artifact capture. The
+    // negative-first semantic assertions for OBJNAME.STR resolution, LogTitle
+    // substitution, and omission of `| ?` live beside the renderer in
+    // item_outline.rs.
+    const shot = await game.screenshot("eng1-sanger-localized-hover-label.png");
+    assert.deepEqual(shot.resolution, [800, 600]);
+    assert.ok(shot.size_bytes > 10_000);
+
+    assert.equal(
+      (await game.info()).player.collected_logs.some(
+        (collected) => collected.deck === 1 && collected.log === 13,
+      ),
+      false,
+      "rendering the localized label must not collect the authored log",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #739

campaign: engineering · none · legacy · seed 1378752978

## Root cause

The HUD loaded `OBJNAME.STR` but discarded it, then rendered serialized `PropObjName` values such as `AudioLog: "An audio log: %s"` directly. `P$NameType` was also unparsed, so the original stack/log-title/weapon substitution flow could not run. The suffix unconditionally emitted `| ?` when hit points were absent.

## Design

- Parse the authored `P$NameType` property, preserving unknown raw values.
- Resolve `PropObjName` through the real `OBJNAME.STR` resource with its embedded fallback.
- Apply the original NameType substitutions through authored `levelNN.str` log names, stack counts, and `weapon.str` gun-condition strings.
- Show `| HP` only when an object actually has a hit-point property; preserve debug entity IDs without inventing an unknown condition.
- Add a real `eng1.mis` SDK scenario that discovers the Sanger log by stable template, selects it through the production reticle, captures the rendered label, and proves hovering does not collect it.

This follows the original Looking Glass resource flow rather than introducing a debug-only name table or presentation shim:
- [GameStrings parsing](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/framewrk/gamestr.cpp)
- [object-name substitutions](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkprop.cpp)
- [weapon condition buckets](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkgun.cpp)

## Verification

- Negative-first HUD tests failed on missing localization/formatting helpers before implementation.
- `cargo test -p dark object_name_type_reads_retail_variants_and_preserves_unknown_values`
- `cargo test -p shock2vr hud::item_outline::tests` (12 passed)
- `cargo test -p shock2vr` (390 passed)
- `RUSTFLAGS="-D warnings -C debuginfo=0" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test` (26 passed, 158 skipped)
- focused authored `eng1.mis` hover-label e2e passed
- full SDK e2e on the final commit: 184 tests — 181 passed, 0 failed, 3 expected skipped

## Visual evidence

![Localized Sanger hover label loop](https://gist.githubusercontent.com/tommy-xr/b225b4441994cd4f934c392eedf9a586/raw/localized-hover-label.gif)

<sub>The authored Sanger audio-log disc falls under mission physics while the production reticle tracks it; the localized title stays resolved and the unknown `| ?` suffix is gone. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Final still

![Localized Sanger hover label](https://gist.githubusercontent.com/tommy-xr/b225b4441994cd4f934c392eedf9a586/raw/localized-hover-label.png)

### Before → after

![Serialized hover property before and localized log title after](https://gist.githubusercontent.com/tommy-xr/b225b4441994cd4f934c392eedf9a586/raw/localized-hover-label-before-after.png)