### PR TITLE
fix(gameplay): loot a keycard through its scripted frob path

### DIFF
--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -2,7 +2,7 @@ use shipyard::{EntityId, UniqueView, World};
 
 use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
-use super::{Effect, MessagePayload, Script, script_util::set_quest_bit_effect};
+use super::{Effect, MessagePayload, Script, script_util, script_util::set_quest_bit_effect};
 
 pub struct FrobQB {}
 impl FrobQB {
@@ -40,7 +40,16 @@ impl Script for FrobQB {
                     // and leaving the object frobbable would let a second frob
                     // re-fire the other scripts attached to it - `BaseButton`
                     // resends every SwitchLink - after the bit is already set.
-                    if crate::virtual_hand::can_grab_item(world, entity_id) {
+                    //
+                    // A key source (the MedSci2 R&D card, obj 772: `MOVE |
+                    // SCRIPT` + `FrobQB` + a derived `internal_keycard`) is the
+                    // exception: its sibling keycard script registers it on the
+                    // keyring and consumes it, so awarding the bit here is all
+                    // this script does. Transferring it too would emit both a
+                    // backpack transfer and a destroy for one Frob.
+                    if crate::virtual_hand::can_grab_item(world, entity_id)
+                        && !script_util::is_key_source(world, entity_id)
+                    {
                         match world.borrow::<UniqueView<PlayerInfo>>() {
                             Ok(player) => Effect::combine(vec![
                                 quest_bit_effect,
@@ -144,6 +153,45 @@ mod tests {
                 .iter()
                 .any(|effect| matches!(effect, Effect::DestroyEntity { .. })),
             "a take-able object must not be destroyed, got {effects:?}"
+        );
+    }
+
+    /// The MedSci2 R&D card (obj 772) is `MOVE | SCRIPT` with `FrobQB` *and* a
+    /// derived `internal_keycard`. One Frob must award `rdgrab` once and leave
+    /// the card's fate to the keycard script (register-and-vanish) - emitting a
+    /// backpack transfer here would stash and destroy the same card.
+    #[test]
+    fn frobbing_a_quest_key_card_awards_its_bit_and_leaves_its_fate_to_the_keycard_script() {
+        let (mut world, object, _inventory) = quest_object_world(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        world.add_component(
+            object,
+            dark::properties::PropKeySrc(dark::properties::KeyCard {
+                is_master: false,
+                region_id: 4,
+                lock_id: 0,
+            }),
+        );
+
+        let effects = Effect::flatten(vec![FrobQB::new().handle_message(
+            object,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_1_10"
+            )),
+            "the quest bit must still be awarded, got {effects:?}"
+        );
+        assert!(
+            !effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DropEntityInfo { .. } | Effect::DestroyEntity { .. }
+            )),
+            "a key source's fate belongs to internal_keycard, got {effects:?}"
         );
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -333,6 +333,21 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         (state.clone(), Effect::NoEffect)
                     };
                 }
+                // A key source has derived `internal_keycard` behavior even
+                // when its authored frob flags otherwise look like ordinary
+                // MOVE loot. Dispatch Frob first so access and any authored
+                // quest scripts run; the keycard script owns the transfer.
+                if crate::virtual_hand::uses_scripted_world_frob(world, *ent) {
+                    return (
+                        state.clone(),
+                        Effect::Send {
+                            msg: Message {
+                                payload: MessagePayload::Frob,
+                                to: *ent,
+                            },
+                        },
+                    );
+                }
                 let inventory_entity = world
                     .borrow::<shipyard::UniqueView<crate::mission::PlayerInfo>>()
                     .map(|player| player.inventory_entity_id)
@@ -358,17 +373,19 @@ mod tests {
     use crate::gui::GuiInputInfo;
     use crate::mission::PlayerInfo;
     use cgmath::{Quaternion, point2, vec3};
-    use dark::properties::{FrobFlag, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Links, PropFrobInfo, PropKeySrc, ToLink, WrappedEntityId,
+    };
 
     /// A world with a loot container holding one iconed, grabbable item,
     /// plus the player-info unique the Take path resolves the backpack
     /// through.
-    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+    fn loot_world_with_action(world_action: FrobFlag) -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let item = world.add_entity((
             PropObjIcon("icn_psi".to_owned()),
             PropFrobInfo {
-                world_action: FrobFlag::MOVE,
+                world_action,
                 inventory_action: FrobFlag::empty(),
                 tool_action: FrobFlag::empty(),
             },
@@ -391,6 +408,10 @@ mod tests {
             inventory_entity_id: inventory,
         });
         (world, container, item, inventory)
+    }
+
+    fn loot_world() -> (World, EntityId, EntityId, EntityId) {
+        loot_world_with_action(FrobFlag::MOVE)
     }
 
     fn input_at(cursor: cgmath::Point2<f32>, pressed: bool) -> GuiInputInfo {
@@ -522,6 +543,44 @@ mod tests {
                 kinds
             );
         }
+    }
+
+    /// Rec2 card 996 is a grabbable `MOVE | SCRIPT` object inside corpse 419.
+    /// Taking it must dispatch Frob before transfer so both its authored
+    /// `FrobQB` and derived `internal_keycard` semantics run.
+    #[test]
+    fn loot_container_click_frobs_a_grabbable_keycard() {
+        let (mut world, container, item, _inventory) =
+            loot_world_with_action(FrobFlag::MOVE | FrobFlag::SCRIPT);
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+        let gui = ContainerGui::loot_container();
+
+        let (_state, effect) = gui.handle_msg(
+            container,
+            &world,
+            &ContainerGuiState {},
+            &ContainerGuiMsg::Take(item),
+        );
+
+        assert!(
+            matches!(
+                effect,
+                Effect::Send {
+                    msg: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if to == item
+            ),
+            "grabbable keycard loot must run its scripted Frob path, got {effect:?}"
+        );
     }
 
     /// Use-only objects can be contained too. Audio logs are the critical

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -3,7 +3,7 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
-use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
+use super::{Effect, MessagePayload, Script, script_util, script_util::player_carried_items};
 
 /// Implements the engine-level `PropFrobInfo.world_action = MOVE` behavior for
 /// ordinary pickup items that do not ask an authored script to handle Frob.
@@ -42,6 +42,14 @@ impl Script for InternalFrobMove {
             })
         };
         if !handles_move {
+            return Effect::NoEffect;
+        }
+
+        // Key sources (`MOVE`-only access cards) also carry a derived
+        // `internal_keycard` script, which registers them on the keyring and
+        // consumes the object. It owns the physical fate; transferring here as
+        // well would emit a backpack transfer and a destroy for one Frob.
+        if script_util::is_key_source(world, entity_id) {
             return Effect::NoEffect;
         }
 
@@ -127,6 +135,34 @@ mod tests {
                 dropped_entity_id,
             } if parent_entity_id == inventory && dropped_entity_id == item
         ));
+    }
+
+    /// A `MOVE`-only access card (the Rec2 crew card) also carries a derived
+    /// `internal_keycard` script, which registers it and consumes the object.
+    /// Transferring it here too would stash and destroy the same card.
+    #[test]
+    fn world_frob_leaves_a_key_source_to_its_keycard_script() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE, false);
+        world.add_component(
+            item,
+            dark::properties::PropKeySrc(dark::properties::KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "a key source must not also be transferred to the backpack, got {effect:?}"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/internal_keycard_script.rs
+++ b/shock2vr/src/scripts/internal_keycard_script.rs
@@ -6,6 +6,13 @@ use crate::physics::PhysicsWorld;
 
 use super::{Effect, MessagePayload, Script};
 
+/// Runtime script attached to every `PropKeySrc` object.
+///
+/// Frobbing a key source *registers* it on the player's keyring and consumes
+/// the object: access cards are logical access, not backpack inventory. This
+/// script owns the physical fate of a key source, so its sibling pickup paths
+/// (`FrobQB`, `internal_frob_move`) deliberately leave the transfer alone -
+/// otherwise a single Frob would both stash and destroy the same card.
 pub struct KeyCardScript {}
 impl KeyCardScript {
     pub fn new() -> KeyCardScript {
@@ -43,5 +50,92 @@ impl Script for KeyCardScript {
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc};
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::KeyCardScript;
+
+    fn keycard_world(world_action: FrobFlag) -> (World, shipyard::EntityId) {
+        let mut world = World::new();
+        let card = world.add_entity((
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 32,
+                lock_id: 0,
+            }),
+            PropFrobInfo {
+                world_action,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        (world, card)
+    }
+
+    /// Rec2 crew card 996 is a grabbable `MOVE` key source. Frobbing it grants
+    /// the keyring entry and consumes the object - the card is access, not a
+    /// backpack item.
+    #[test]
+    fn frobbing_a_move_keycard_registers_it_and_removes_the_object() {
+        let (world, card) = keycard_world(FrobFlag::MOVE);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            card,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AcquireKeyCard { .. })),
+            "key access must be granted, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(
+                |effect| matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == card)
+            ),
+            "the registered card must be consumed, got {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DropEntityInfo { .. })),
+            "a registered card must never be stashed in the backpack, got {effects:?}"
+        );
+    }
+
+    /// Use-only key sources (card slots, non-grabbable readers) behave the
+    /// same: register, then consume.
+    #[test]
+    fn frobbing_a_use_only_key_source_registers_and_consumes_it() {
+        let (world, card) = keycard_world(FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            card,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AcquireKeyCard { .. }))
+        );
+        assert!(effects.iter().any(
+            |effect| matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == card)
+        ));
     }
 }

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -352,6 +352,18 @@ pub fn get_first_link_of_type(
     all_links.get(0).copied()
 }
 
+/// Whether this object is a key source (`PropKeySrc`), which the runtime gives
+/// an `internal_keycard` script. Frobbing one registers it on the keyring and
+/// consumes the object, so `internal_keycard` owns its physical fate: the
+/// generic pickup paths (`FrobQB`, `internal_frob_move`) must not also transfer
+/// it to the backpack, or one Frob would both stash and destroy the same card.
+pub fn is_key_source(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|key_sources| key_sources.get(entity_id).is_ok())
+        .unwrap_or(false)
+}
+
 /// Every item the player is currently carrying: each wielded/hand-held entity
 /// plus everything nested under it, and the backpack (inventory) entity's
 /// contents - following `Contains` links to depth 2 (mirrors the item set the

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -568,12 +568,7 @@ pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bo
                 .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
         })
         .unwrap_or(false);
-    let has_derived_keycard_script = world
-        .borrow::<View<dark::properties::PropKeySrc>>()
-        .map(|keycards| keycards.get(entity_id).is_ok())
-        .unwrap_or(false);
-
-    has_authored_world_script || has_derived_keycard_script
+    has_authored_world_script || crate::scripts::script_util::is_key_source(world, entity_id)
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or

--- a/tools/shock2-sdk/test/rec2-crew-keycard.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec2-crew-keycard.e2e.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// 25th Anniversary campaign regression for #583. The copyrighted frontier
+// save remains outside the repository; when present it reproduces the exact
+// Recreation route immediately before the crew access card trip.
+const FIXTURE_SAVE =
+  "campaign_recreation_25th_iter10_rec2_beyond_midwife_before_card_trip_20260808";
+const FIXTURE_SHA256 =
+  "d9e77ae096e8711c8d3d6d017a6e43a8ea91eff38e30d95b01e7ac00eb6d859d";
+const CORPSE = 419;
+const CREW_CARD = 996;
+const CREW_SLOT = 293;
+const CREW_DOORS = [1580, 1582] as const;
+
+function savePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+const fixturePath = savePath(FIXTURE_SAVE);
+const e2eEnabled = process.env.SHOCK2_E2E === "1" && Boolean(fixturePath);
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8583);
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+// Registering a key source consumes the object: access lives on the player's
+// keyring, not in the backpack. So the card must be gone once it is taken.
+async function assertCardRegisteredAndConsumed(game: GameServer): Promise<void> {
+  // `/v1/entities` enumerates contained items too (that is how the card is
+  // found inside corpse 419 before the take), so an empty result also proves
+  // the card was not stashed in the backpack.
+  assert.equal(
+    (await game.entities.byTemplate(CREW_CARD)).length,
+    0,
+    "a registered crew card must no longer exist as an object, in world or backpack",
+  );
+}
+
+test(
+  "Rec2 corpse loot registers the crew card and grants quest reward and persistent Rec1 access",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    assert.ok(fixturePath);
+    assert.equal(
+      createHash("sha256").update(readFileSync(fixturePath)).digest("hex"),
+      FIXTURE_SHA256,
+      "the regression must use the reviewed campaign frontier",
+    );
+
+    const persistedSave = `rec2_crew_keycard_e2e_${Date.now()}`;
+    t.after(() => {
+      const path = savePath(persistedSave);
+      if (path) rmSync(path, { force: true });
+    });
+
+    let expectedModules: number;
+
+    // Session 1: resume the exact Rec2 frontier and perform the real player
+    // interaction: bounded movement, corpse surface aim/squeeze, then the
+    // authentic Container MFD card button through pointer input.
+    {
+      await using game = await GameServer.launch({
+        mission: "rec2.mis",
+        port: basePort,
+        echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+      });
+      assert.equal((await game.load(FIXTURE_SAVE)).success, true);
+      await game.step({ frames: 5 });
+
+      assert.equal(await game.quests.get("crewcahd"), "unknown");
+      const modulesBefore = (await game.info()).player.stats?.cyber_modules;
+      assert.notEqual(modulesBefore, undefined);
+      const corpse = only(await game.entities.byTemplate(CORPSE), "Rec2 corpse 419");
+      const card = only(await game.entities.byTemplate(CREW_CARD), "Rec2 card 996");
+
+      await game.player.moveTo({ x: 96.0, y: -8.756, z: -54.0 });
+      await game.step({ frames: 8 });
+      await game.player.moveTo({ x: 97.7, y: -8.756, z: -54.0 });
+      await game.step({ frames: 8 });
+      const aim = await game.player.aimAt(corpse.id, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+      await game.input.set("right_hand.squeeze_value", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("right_hand.squeeze_value", 0);
+      await game.step({ frames: 5 });
+
+      const panel = (await game.ui.state()).active_panel;
+      assert.equal(panel?.entity_id, corpse.id, "corpse 419 must open its real loot MFD");
+      const cardButton = panel.elements.find(
+        (element) => element.kind === "button" && element.entity_id === card.id,
+      );
+      assert.ok(cardButton, "corpse 419 must expose contained card 996");
+      await clickUiElement(game, cardButton);
+      await game.step({ frames: 30 });
+
+      await assertCardRegisteredAndConsumed(game);
+      assert.equal(
+        await game.quests.get("crewcahd"),
+        "incomplete",
+        "FrobQB must set the authored crew-access quest bit",
+      );
+      expectedModules = (modulesBefore as number) + 20;
+      assert.equal(
+        (await game.info()).player.stats?.cyber_modules,
+        expectedModules,
+        "the crewcahd trigger must award exactly 20 cyber modules",
+      );
+      await game.step({ frames: 120 });
+      assert.equal(
+        (await game.info()).player.stats?.cyber_modules,
+        expectedModules,
+        "the one-shot experience trap must not pay twice",
+      );
+      assert.equal((await game.save(persistedSave)).success, true);
+    }
+
+    // Session 2: a fresh process reloads the result, then visits Rec1. The
+    // level warp and nearby placement are setup only; the card slot itself is
+    // aimed and squeezed through normal production input.
+    {
+      await using game = await GameServer.launch({
+        mission: "rec1.mis",
+        port: basePort + 1,
+        echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+      });
+      assert.equal((await game.load(persistedSave)).success, true);
+      await game.step({ frames: 5 });
+      assert.equal((await game.info()).mission, "rec2.mis");
+      await assertCardRegisteredAndConsumed(game);
+      assert.equal(await game.quests.get("crewcahd"), "incomplete");
+      assert.equal((await game.info()).player.stats?.cyber_modules, expectedModules);
+
+      assert.equal((await game.transitionLevel("rec1.mis")).success, true);
+      await game.step({ frames: 10 });
+      await assertCardRegisteredAndConsumed(game);
+
+      const slot = only(await game.entities.byTemplate(CREW_SLOT), "Rec1 crew card slot 293");
+      const doors = await Promise.all(
+        CREW_DOORS.map(async (templateId) =>
+          only(await game.entities.byTemplate(templateId), `Rec1 crew door ${templateId}`),
+        ),
+      );
+      const before = await Promise.all(
+        doors.map(async (door) => (await game.entities.detail(door.id)).position),
+      );
+      const soundSequence = (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+
+      await game.player.teleport({ x: 12.05, y: -3.956, z: -142.5 });
+      await game.step({ frames: 3 });
+      const aim = await game.player.aimAt(slot.id, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+      await game.input.set("right_hand.squeeze_value", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("right_hand.squeeze_value", 0);
+      await game.step({ frames: 180 });
+
+      const after = await Promise.all(
+        doors.map(async (door) => (await game.entities.detail(door.id)).position),
+      );
+      assert.ok(
+        after.some((position, index) => distance(position, before[index]) > 0.5),
+        `region-32 access must open the linked Rec1 doors: before=${JSON.stringify(before)}, after=${JSON.stringify(after)}`,
+      );
+      const played = (await game.audio.recent()).sounds
+        .filter((sound) => sound.sequence > soundSequence)
+        .map((sound) => sound.sample.toLowerCase());
+      assert.ok(
+        !played.includes("hackfail"),
+        `the acquired crew card must not be refused: ${JSON.stringify(played)}`,
+      );
+    }
+  },
+);


### PR DESCRIPTION
Fixes #583.

## The bug

Taking a key source out of a corpse or container went through the Container MFD's generic **Take** path, which just re-parents the object into the backpack. The object's `Frob` never ran, so `internal_keycard` never registered the card on the keyring — the Rec2 crew card (obj 996, inside corpse 419) gave no Recreation access — and the card's authored `FrobQB` quest bit (`crewcahd`, worth 20 cyber modules) never fired either.

## The fix

1. **Container Take dispatches Frob for scripted objects.** `ContainerGui`'s `Take` now sends `MessagePayload::Frob` when `uses_scripted_world_frob` holds — an authored `SCRIPT` world action *or* a derived `internal_keycard` (any `PropKeySrc`). The object's own script then decides what happens to it, the same as frobbing it in the world.

2. **A key source keeps its engine fate: register and vanish.** `internal_keycard` grants `AcquireKeyCard` and destroys the object. Access cards are logical access, not backpack inventory — this is unchanged from `main` (an earlier revision of this PR made cards backpack-retained; that is reverted).

3. **One Frob, one owner of the card's fate.** Registering-and-consuming collides with the generic pickup transfer on objects that are both: the MedSci2 R&D card (obj 772) is `MOVE | SCRIPT` with `FrobQB` *and* a derived `internal_keycard`, so a single Frob emitted a backpack `DropEntityInfo` **and** a `DestroyEntity` for the same card. `FrobQB` and `internal_frob_move` now skip the transfer for key sources — `FrobQB` still awards its quest bit — leaving the physical fate to `internal_keycard`. The check is one shared helper, `script_util::is_key_source`, which `uses_scripted_world_frob` also now reuses.

## Verification

- `cargo fmt`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr` — 721 passed. New/updated unit tests cover: container Take dispatching Frob for a grabbable keycard; `internal_keycard` registering *and* consuming both `MOVE` and use-only key sources; `FrobQB` awarding `rdgrab` while emitting neither a transfer nor a destroy for a key source; `internal_frob_move` returning `NoEffect` for a key source.
- SDK `npm test` (unit + typecheck) — pass.
- e2e (`SHOCK2_E2E=1`): `container-loot`, `hydro2-keycard-gates`, `command-locked-card-relay` — pass.
- `tools/shock2-sdk/test/rec2-crew-keycard.e2e.test.ts` (new): resumes the Rec2 campaign frontier, aims and squeezes at corpse 419, clicks the card button in the real loot MFD, then asserts the card object is gone (registered, not stashed), `crewcahd` is set, and exactly 20 cyber modules are paid once; a second process reloads the save, transitions to `rec1.mis`, frobs the crew card slot and asserts the linked crew doors open with no `hackfail`. It self-skips without the copyrighted campaign frontier save, which is not present in this environment.

No visual change (script/effect logic only).
