### PR TITLE
fix(physics): bound ordinary jump mantle height

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1154,10 +1154,11 @@ fn plan_climb_top_out(
 /// standing pose must fit against *all* colliders, and every scripted substep
 /// still collides with parented entities. Same-height and lower landings
 /// require a genuinely clear all-world point probe above the lip, so
-/// full-height walls remain solid. An elevated landing may use Dark's
-/// parentless-terrain jump-through probe: that is what permits authored
-/// stacked corridors such as shodan's log platforms, whose upper floor is a
-/// ceiling to the lower cell.
+/// full-height walls remain solid. An elevated landing may cross the local
+/// platform lip with Dark's parentless-terrain jump-through probe, but its
+/// initial vertical rise must remain clear against all world geometry. That
+/// is what permits authored stacked corridors such as shodan's log platforms
+/// without treating a room ceiling directly overhead as an exterior landing.
 fn plan_jump_mantle(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -1199,6 +1200,7 @@ fn plan_jump_mantle(
     let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
     while rise_ss2 <= max_rise * SCALE_FACTOR + 1.0e-4 && transition.is_none() {
         let raised = head + Vector::y() * (rise_ss2 / SCALE_FACTOR);
+        let vertical_probe_clear = ray_segment_is_clear(validation_queries, head, raised);
         let mut forward_ss2 = minimum_forward * SCALE_FACTOR;
         while forward_ss2 <= PLAYER_JUMP_MANTLE_FORWARD + 1.0e-4 {
             let forward = forward_ss2 / SCALE_FACTOR;
@@ -1220,7 +1222,9 @@ fn plan_jump_mantle(
                 let nearest_floor = validation_queries
                     .cast_ray_and_get_normal(&down_ray, 2.0 * max_rise, true)
                     .map(|(_, ground)| (ground.normal.y, raised_forward.y - ground.time_of_impact));
-                let elevated_floor = nearest_floor
+                let elevated_floor = vertical_probe_clear
+                    .then_some(nearest_floor)
+                    .flatten()
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1224,8 +1224,17 @@ fn plan_jump_mantle(
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {
-                        *floor_y - current_feet_y
-                            > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                        let rise = *floor_y - current_feet_y;
+                        rise > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                            // The compressed body models Dark's discontinuous
+                            // sphere stack crossing a terrain lip; it does not
+                            // add vertical reach. Require the player's feet to
+                            // be able to reach the landing within the ordinary
+                            // ballistic apex. Otherwise an open lift shaft can
+                            // turn the room ceiling ahead into an "elevated
+                            // floor" and script the player onto its exterior
+                            // roof (#744).
+                            && rise <= max_rise
                     });
                 // A same-height floor visible above the lower candidate is the
                 // stacked-terrain signature: the continuous capsule cannot

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -10,6 +10,7 @@ const CARGO_LIFT_OBJECT = 669;
 const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
 const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
 const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+const ENGINEERING_OG_PIPE_OBJECT = 1666;
 
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
@@ -161,6 +162,99 @@ test(
       `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
         `north exit ${JSON.stringify(northExit)}, player ` +
         `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);
+
+// The Engineering campaign's authored maintenance-maze route reaches this
+// corridor from below. An idle OG-Pipe narrows the passage, but an ordinary
+// jump used to turn that local obstruction into a scripted crossing through
+// the corridor ceiling and leave the player supported on the exterior shell.
+test(
+  "ordinary jump past Engineering's OG-Pipe stays below the corridor ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG1_OG_PIPE_PORT ?? 8141),
+    });
+    await game.step({ frames: 30 });
+
+    const ogPipe = only(
+      await game.entities.byTemplate(ENGINEERING_OG_PIPE_OBJECT),
+      "maintenance-maze OG-Pipe mission object 1666",
+    );
+    assert.equal(ogPipe.name, "OG-Pipe");
+
+    // Setup only: stage at the campaign-observed interior approach, then let
+    // both player support and the authored dynamic creature settle. Starting
+    // the input edge before support is re-established after setup does not
+    // exercise a grounded production jump.
+    await game.player.teleport({
+      x: 4.4,
+      y: -15.556003,
+      z: -85.00001,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    const settledOgPipe = await game.entities.detail(ogPipe.id);
+    assert.ok(
+      Math.abs(before.x - 4.4) < 0.1 &&
+        Math.abs(before.y - -15.556003) < 0.1 &&
+        Math.abs(before.z - -85.00001) < 0.1,
+      `player should settle at the authentic maze approach, got ${JSON.stringify(before)}`,
+    );
+    assert.ok(
+      settledOgPipe.position[0] > 5 &&
+        settledOgPipe.position[0] < 7 &&
+        Math.abs(settledOgPipe.position[1] - -15.1) < 0.15 &&
+        settledOgPipe.position[2] > -86 &&
+        settledOgPipe.position[2] < -84,
+      `stable OG-Pipe 1666 should occupy the authored choke, got ` +
+        JSON.stringify(settledOgPipe.position),
+    );
+
+    // Self-check the nearby parentless world slab that bounds the corridor.
+    // The exploit exits through this ceiling and settles above its y plane.
+    const ceiling = await game.raycast({
+      start: [7.5, before.y, -84.5],
+      end: [7.5, -9, -84.5],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceiling.hit_point && Math.abs(ceiling.hit_point[1] - -12.9) < 0.1,
+      `expected maintenance-maze world ceiling at y=-12.9, got ${JSON.stringify(ceiling)}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim through the choke,
+    // hold ordinary forward locomotion, and pulse one grounded Jump edge.
+    await game.input.lookAtWorldPoint([8, before.y + 1.6, -84.5]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+    const landed = await game.player.position();
+    await game.step({ frames: 240 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceiling.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the OG-Pipe corridor ceiling ` +
+        `(${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `OG-Pipe 1666 ${JSON.stringify(settledOgPipe.position)}, player ` +
+        `${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
         `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
     );
   },

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CARGO_LIFT_OBJECT = 669;
+const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
+const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
+const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+async function pulseJump(game: GameServer): Promise<void> {
+  await game.input.setJump(true);
+  await game.step({ frames: 1 });
+  await game.input.setJump(false);
+}
+
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// reached Cargo 2B's top lift through ordinary play. Walking north from the
+// lift toward its top call button is the valid route; jumping west instead
+// exposed a collision escape onto the exterior roof.
+test(
+  "ordinary jump stays below Engineering Cargo 2B's world ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG2_CEILING_PORT ?? 8140),
+    });
+    await game.step({ frames: 5 });
+
+    const lift = only(
+      await game.entities.byTemplate(CARGO_LIFT_OBJECT),
+      "Cargo 2B East lift mission object 669",
+    );
+    const bottomButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_BOTTOM_BUTTON_OBJECT),
+      "bottom lift button mission object 480",
+    );
+    const middleButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_MIDDLE_BUTTON_OBJECT),
+      "middle lift button mission object 481",
+    );
+    const topButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_TOP_BUTTON_OBJECT),
+      "top lift button mission object 620",
+    );
+
+    // Setup only: drive the real lift along its authored 477 -> 478 -> 479
+    // path and stage at the exact campaign-observed top-stop pose.
+    await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const middleLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(middleLift.position[1] - -5.1) < 0.1,
+      `lift should reach authored middle node y=-5.1, got ${middleLift.position[1]}`,
+    );
+    await game.entities.sendMessage(middleButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const topLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(topLift.position[1] - 2.1) < 0.1,
+      `lift should reach authored top node y=2.1, got ${topLift.position[1]}`,
+    );
+
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    assert.ok(
+      Math.abs(before.x - 43.9006) < 0.1 &&
+        Math.abs(before.y - 3.144) < 0.1 &&
+        Math.abs(before.z - -168.2003) < 0.1,
+      `player should settle at the campaign lift pose, got ${JSON.stringify(before)}`,
+    );
+
+    // Control: the authored route walks north off the same top stop toward
+    // button 620. Prove it remains available, then return to the exact setup
+    // pose without carrying input or a jump edge into the regression.
+    await game.input.lookAtWorldPoint([
+      topButton.position[0],
+      before.y + 1.6,
+      topButton.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const northExit = await game.player.position();
+    assert.ok(
+      northExit.z > -166 && northExit.y < 6.8,
+      `ordinary walking should leave the lift north toward top button 620, got ` +
+        JSON.stringify(northExit),
+    );
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const jumpStart = await game.player.position();
+
+    // Self-check the parentless world slab the campaign escaped through.
+    // Probing from below sees its underside, while the reverse ray finds the
+    // exterior roof at the same y. This is level geometry, not a lift entity.
+    const ceilingUp = await game.raycast({
+      start: [41.5, jumpStart.y, -169.1],
+      end: [41.5, 10, -169.1],
+      collision_groups: ["world"],
+    });
+    const roofDown = await game.raycast({
+      start: [41.5, 10, -169.1],
+      end: [41.5, jumpStart.y, -169.1],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceilingUp.hit_point &&
+        roofDown.hit_point &&
+        Math.abs(ceilingUp.hit_point[1] - 6.8) < 0.1 &&
+        Math.abs(roofDown.hit_point[1] - 6.8) < 0.1,
+      `expected Cargo 2B world ceiling/roof at y=6.8, got ` +
+        `${JSON.stringify({ ceilingUp, roofDown })}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim west, hold ordinary
+    // forward locomotion, pulse one grounded jump edge, then release.
+    await game.input.lookAtWorldPoint([39, jumpStart.y + 1.6, -170]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 180 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 180 });
+    const landed = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceilingUp.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the Cargo 2B ceiling ` +
+        `(${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
+        `north exit ${JSON.stringify(northExit)}, player ` +
+        `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- cap ordinary-jump elevated mantle landings at the jump's ballistic apex
- require a clear head-to-raised path before any elevated mantle may use the parentless-terrain lip exception
- cover both authentic Engineering ceiling escapes: Cargo 2B in `eng2.mis` and OG-Pipe in the `eng1.mis` maintenance maze

Fixes #744.

## Stack

This PR targets `codex/fix-708-jump` / PR #714 at final commit `cd19e396`; ordinary jumping does not exist on `main` yet. The dependency chain is:

```text
main
  └─ PR #712 — original player collision footprint
       └─ PR #714 — ordinary jump
            └─ this PR — elevated-mantle ceiling containment
```

It does not include unrelated play-through fixes.

## Gameplay invariant

The jump mantle's temporary compressed body exists only to model Dark's discontinuous sphere stack crossing a local terrain lip. It must not create extra vertical reach or move the player upward through world geometry.

Two general checks now govern elevated landings:

1. The landing rise cannot exceed the ordinary jump's ballistic apex:

   ```text
   max_rise = jump_speed² / (2 × jump_gravity)
            = 28² / (2 × 40)
            = 9.8 SS2 ft
   ```

2. The initial head-to-raised route must be clear against all world geometry. The parentless-terrain exception remains available only for the subsequent horizontal compressed-body lip crossing.

This preserves intentional stacked routes and the SHODAN same-height barrier descent while rejecting ceilings selected as elevated floors. No mission-specific coordinate, object ID, or threshold is added.

## Campaign reproductions

Both cases use campaign `engineering · none · legacy · seed 1378752978` and one production `Jump` rising edge while holding forward.

### Cargo 2B exterior roof

- Mission: `eng2.mis`
- Stable objects: lift `669`; path nodes `477 → 478 → 479`; buttons `480`, `481`, `620`
- Exact launch: `(43.9006, 3.1440, -168.2003)`, aimed west toward `(39, ~3.2, -170)`
- World-only bidirectional rays verify the traversed slab at `y=6.8`

Negative on `cd19e396`:

```text
(43.900566, 3.144000, -168.200300)
  -> (34.538307, 8.043818, -171.638290)
  -> unchanged for 120 more fixed-timestep frames
```

Green with this PR:

```text
normal north exit -> (43.642235, 3.243999, -164.120060)
jump start        -> (43.900566, 3.144000, -168.200300)
settled inside    -> (28.820065, 3.244005, -174.679890)
```

### OG-Pipe maintenance-maze roof

- Mission: fresh `eng1.mis`
- Stable OG-Pipe mission object/template: `1666`
- Setup-only staging: `(4.4, -15.556003, -85.00001)`, followed by 30 fixed-timestep frames to establish authored support
- Production aim: `(8, player.y + 1.6, -84.5)`
- A world ray verifies the overhead slab at `y=-12.9`

Negative on prior PR head `125c9ac3`:

```text
(4.399970, -15.555999, -85.000010)
  -> (5.628159, -11.655860, -84.829650)
  -> stably supported on the exterior shell
```

Green with `c42bfd82`:

```text
(4.399970, -15.555999, -85.000010)
  -> approximately (5.38, -15.556, -84.7)
  -> remains contained beneath the y=-12.9 ceiling
```

Instrumentation confirmed this is the elevated branch, not the same-height branch. Its approximately `9.64 SS2 ft` roof rise is just within the ballistic cap, so the missing invariant was vertical world clearance. The same-height/lower branch remains unchanged.

## Visual verification

![Matched Cargo 2B jump before and after](https://gist.githubusercontent.com/tommy-xr/5ecdcd28b6a4c19ba80634ef371f464d/raw/cargo2-ceiling-containment.gif)

<sub>Matched fresh `eng2.mis` runs: authored lift 669 at top node 479, identical launch pose, look direction, one-frame production Jump edge, fixed-timestep stepping, and screenshot cadence. The base build crosses onto the exterior roof; the fix remains inside against the Cargo 2B crates.</sub>

### Cargo 2B before → after still

![Cargo 2B exterior escape versus contained jump](https://gist.githubusercontent.com/tommy-xr/5ecdcd28b6a4c19ba80634ef371f464d/raw/cargo2-ceiling-t10.png)

## Engineering maintenance-maze replay

![Engineering OG-Pipe ceiling containment before and after](https://gist.githubusercontent.com/tommy-xr/d7c8c139dd5a4db4fa68a4169e714eb9/raw/engineering-ogpipe-ceiling-containment.gif)

<sub>Campaign `engineering · none · legacy · seed 1378752978`; fresh `eng1.mis`; stable OG-Pipe mission object/template `1666`; matched setup-only positioning; one production `Jump` rising edge while holding forward; deterministic headless capture via `/v1/step` + `/v1/screenshot`. Exact BEFORE `125c9ac3` escapes onto the exterior shell at `(5.628, -11.656, -84.830)`; AFTER `c42bfd82` remains contained inside at `(5.385, -15.556, -84.687)`.</sub>

### OG-Pipe before → after still

![Engineering OG-Pipe exterior escape versus contained jump](https://gist.githubusercontent.com/tommy-xr/d7c8c139dd5a4db4fa68a4169e714eb9/raw/engineering-ogpipe-before-after.png)

Review stills: [BEFORE — exterior shell](https://gist.githubusercontent.com/tommy-xr/d7c8c139dd5a4db4fa68a4169e714eb9/raw/engineering-ogpipe-before-final.png) · [AFTER — contained inside](https://gist.githubusercontent.com/tommy-xr/d7c8c139dd5a4db4fa68a4169e714eb9/raw/engineering-ogpipe-after-final.png)

Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`) from force-rebuilt, SHA-distinct base/fix binaries.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` — 394 passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cd tools/shock2-sdk && npm test` — 188 total, 26 passed, 0 failed, 162 expected E2E skips
- focused Engineering ceiling SDK E2Es — 2 passed, 0 failed:
  - Cargo 2B remains contained while its normal north exit remains traversable
  - OG-Pipe remains contained beneath its within-apex maintenance-maze ceiling
- existing jump SDK E2Es — 3 passed, 0 failed:
  - SHODAN final descent
  - Engineering Cargo 2 crate stack
  - Delacroix two-platform log route
- full serial `npm run test:e2e` with legacy assets — 188 total, 185 passed, 0 failed, 3 expected SHODAN finale skips; 2,114,903 ms
