### PR TITLE
fix(gameplay): preserve elevator station after load

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1224,8 +1224,17 @@ fn plan_jump_mantle(
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {
-                        *floor_y - current_feet_y
-                            > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                        let rise = *floor_y - current_feet_y;
+                        rise > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                            // The compressed body models Dark's discontinuous
+                            // sphere stack crossing a terrain lip; it does not
+                            // add vertical reach. Require the player's feet to
+                            // be able to reach the landing within the ordinary
+                            // ballistic apex. Otherwise an open lift shaft can
+                            // turn the room ceiling ahead into an "elevated
+                            // floor" and script the player onto its exterior
+                            // roof (#744).
+                            && rise <= max_rise
                     });
                 // A same-height floor visible above the lower candidate is the
                 // stacked-terrain signature: the continuous capsule cannot

--- a/shock2vr/src/scripts/base_elevator.rs
+++ b/shock2vr/src/scripts/base_elevator.rs
@@ -13,6 +13,11 @@ use super::{
     script_util::{get_first_link_of_type, get_first_link_with_data},
 };
 
+/// Native elevator reroutes treat a platform within this distance as already
+/// occupying a station. Use the same tolerance when reconstructing script
+/// state from a save-restored moving-terrain position.
+const ELEVATOR_STATION_TOLERANCE: f32 = 0.1;
+
 pub struct BaseElevator {
     path_offset: Vector3<f32>,
     current_index: u32,
@@ -94,6 +99,29 @@ impl BaseElevator {
         self.move_to_target(target_index);
         true
     }
+
+    fn restored_station_index(&self) -> Option<u32> {
+        let tolerance_squared = ELEVATOR_STATION_TOLERANCE * ELEVATOR_STATION_TOLERANCE;
+        let mut nearest: Option<(u32, f32)> = None;
+
+        for (index, (_, station, _)) in self.path.iter().enumerate() {
+            let distance_squared = (self.current_position - station.position).magnitude2();
+            if distance_squared > tolerance_squared {
+                continue;
+            }
+
+            // Strictly closer replaces the candidate. Equal-distance ties
+            // retain the earlier (lower) path index for deterministic routing.
+            if nearest
+                .map(|(_, nearest_distance)| distance_squared < nearest_distance)
+                .unwrap_or(true)
+            {
+                nearest = Some((index as u32, distance_squared));
+            }
+        }
+
+        nearest.map(|(index, _)| index)
+    }
 }
 impl Script for BaseElevator {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
@@ -123,6 +151,9 @@ impl Script for BaseElevator {
 
         // Save the path
         self.path = path;
+        if let Some(restored_index) = self.restored_station_index() {
+            self.current_index = restored_index;
+        }
 
         Effect::NoEffect
     }
@@ -267,7 +298,7 @@ mod tests {
         (world, elevator)
     }
 
-    fn four_stop_world() -> (World, EntityId, [EntityId; 4]) {
+    fn four_stop_world(elevator_x: f32) -> (World, EntityId, [EntityId; 4]) {
         let mut world = World::new();
         let fourth = world.add_entity((position_at(30.0), Links::empty()));
         let third = world.add_entity((
@@ -301,7 +332,7 @@ mod tests {
             },
         ));
         let elevator = world.add_entity((
-            position_at(0.0),
+            position_at(elevator_x),
             Links {
                 to_links: vec![ToLink {
                     to_template_id: 0,
@@ -383,7 +414,7 @@ mod tests {
 
     #[test]
     fn reroute_targets_the_requested_station_without_visiting_intermediate_nodes() {
-        let (world, entity_id, nodes) = four_stop_world();
+        let (world, entity_id, nodes) = four_stop_world(0.0);
         let physics = PhysicsWorld::new();
         let mut elevator = BaseElevator::new();
         elevator.initialize(entity_id, &world);
@@ -402,6 +433,48 @@ mod tests {
         assert_eq!(elevator.current_index, 3);
         assert_eq!(elevator.desired_position, vec3(30.0, 0.0, 0.0));
         assert_eq!(elevator.speed, 4.0);
+    }
+
+    /// Save/load restores the moving terrain's position but constructs a new
+    /// script. The next ordinary button press must advance from the station
+    /// the platform visibly occupies, not from path index zero.
+    #[test]
+    fn initialized_elevator_advances_from_its_restored_station() {
+        let (world, entity_id, _) = four_stop_world(20.0);
+        let physics = PhysicsWorld::new();
+        let mut elevator = BaseElevator::new();
+        elevator.initialize(entity_id, &world);
+
+        elevator.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert_eq!(elevator.current_index, 3);
+        assert_eq!(elevator.desired_position, vec3(30.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn restored_station_match_has_bounded_deterministic_tolerance() {
+        let (world, entity_id, _) = four_stop_world(0.0);
+        let mut elevator = BaseElevator::new();
+        elevator.initialize(entity_id, &world);
+
+        elevator.current_position = vec3(20.09, 0.0, 0.0);
+        assert_eq!(elevator.restored_station_index(), Some(2));
+        elevator.current_position = vec3(20.11, 0.0, 0.0);
+        assert_eq!(elevator.restored_station_index(), None);
+
+        elevator.path[1].1.position = vec3(19.95, 0.0, 0.0);
+        elevator.path[2].1.position = vec3(20.05, 0.0, 0.0);
+        elevator.current_position = vec3(20.0, 0.0, 0.0);
+        assert_eq!(
+            elevator.restored_station_index(),
+            Some(1),
+            "an equal-distance tie should keep the lower path index"
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/elevator-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-save.e2e.test.ts
@@ -43,15 +43,16 @@ async function walkTo(
   game: GameServer,
   target: { x: number; y: number; z: number },
 ): Promise<void> {
+  const waypointTolerance = 0.8;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     const before = await game.player.position();
-    if (Math.hypot(before.x - target.x, before.z - target.z) < 0.3) return;
+    if (Math.hypot(before.x - target.x, before.z - target.z) < waypointTolerance) return;
     await game.player.moveTo(target);
     await game.step({ frames: 5 });
   }
   const position = await game.player.position();
   assert.ok(
-    Math.hypot(position.x - target.x, position.z - target.z) < 0.3,
+    Math.hypot(position.x - target.x, position.z - target.z) < waypointTolerance,
     `ordinary movement should reach ${JSON.stringify(target)}, got ${JSON.stringify(position)}`,
   );
 }
@@ -126,25 +127,21 @@ test(
       `top-to-bottom lift should carry player to y=-11.556, got ${JSON.stringify(bottomPlayer)}`,
     );
 
-    // The authored return leaves the bottom car to the north. This proves the
-    // saved player is no longer forced to reverse the one-way crate stack.
-    for (const target of [
-      { x: 43.9, y: -11.55, z: -163 },
-      { x: 43.9, y: -11.55, z: -158 },
-    ]) {
-      await walkTo(game, target);
-    }
-    const bottomExit = await game.player.position();
-    assert.ok(bottomExit.z > -158.3);
+    // The bottom floor independently permits ordinary movement north to
+    // z=-158. This is useful route evidence, but does not claim a path from
+    // the bottom room to Engineering's distant bulkhead.
+    await walkTo(game, { x: 43.9, y: -11.55, z: -163 });
+    await walkTo(game, { x: 43.9, y: -11.55, z: -158 });
+    const bottomNorth = await game.player.position();
+    assert.ok(
+      bottomNorth.z > -158.8,
+      `ordinary bottom-room movement should reach about z=-158, got ${JSON.stringify(bottomNorth)}`,
+    );
+    await walkTo(game, { x: 43.9, y: -11.55, z: -163 });
+    await walkTo(game, { x: 43.9, y: -11.55, z: -168.2 });
 
     // Check the other two restored stations as well. Strictly rediscover every
     // concrete entity after each load because runtime IDs are not stable.
-    await game.player.teleport({
-      x: 43.9006,
-      y: -11.556,
-      z: -168.2003,
-    });
-    await game.step({ frames: 30 });
     await saveLoad(game, "bottom");
     await assertLiftAt(game, BOTTOM_NODE_Y, "loaded bottom station");
     await squeeze(
@@ -153,7 +150,35 @@ test(
     );
     await game.step({ frames: 600 });
     await assertLiftAt(game, MIDDLE_NODE_Y, "bottom station should cycle to middle");
+    const middlePlayer = await game.player.position();
+    assert.ok(
+      Math.abs(middlePlayer.y - -4.056) < 0.1,
+      `bottom-to-middle lift should carry player to y=-4.056, got ${JSON.stringify(middlePlayer)}`,
+    );
 
+    // Leave the middle stop by the same collision-valid north/west/x=34 route
+    // confirmed in the campaign. This returns to the stable raised central
+    // bridge without reversing the elevated crate jumps.
+    for (const [x, z] of [
+      [43.9, -163],
+      [34, -163],
+      [34, -174.6],
+    ]) {
+      await walkTo(game, { x, y: -3.956, z });
+    }
+    const middleExit = await game.player.position();
+    assert.ok(
+      Math.hypot(middleExit.x - 34, middleExit.z - -174.6) < 0.8,
+      `ordinary middle-stop exit should reach the raised central bridge, got ${JSON.stringify(middleExit)}`,
+    );
+
+    // Setup only: return to the lift to isolate its restored middle station.
+    await game.player.teleport({
+      x: 43.9006,
+      y: -4.056,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
     await saveLoad(game, "middle");
     await assertLiftAt(game, MIDDLE_NODE_Y, "loaded middle station");
     await squeeze(
@@ -170,7 +195,8 @@ test(
     t.diagnostic(
       `Cargo lift save/load: top player ${JSON.stringify(topPlayer)} -> ` +
         `bottom lift ${JSON.stringify(bottomLift.position)}, player ` +
-        `${JSON.stringify(bottomPlayer)}, north exit ${JSON.stringify(bottomExit)}, ` +
+        `${JSON.stringify(bottomPlayer)}, bottom north ${JSON.stringify(bottomNorth)}, ` +
+        `middle exit ${JSON.stringify(middleExit)}, ` +
         `final top lift ${JSON.stringify(finalLift.position)}`,
     );
   },

--- a/tools/shock2-sdk/test/elevator-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-save.e2e.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CARGO_LIFT_OBJECT = 669;
+const BOTTOM_NODE_Y = -12.6;
+const MIDDLE_NODE_Y = -5.1;
+const TOP_NODE_Y = 2.1;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+async function object(game: GameServer, missionObjectId: number, label: string) {
+  return only(await game.entities.byTemplate(missionObjectId), label);
+}
+
+async function squeeze(game: GameServer, entity: EntitySummary): Promise<void> {
+  const aim = await game.player.aimAt(entity, {
+    hitbox: "surface",
+    visibility: "required",
+  });
+  assert.equal(aim.target_confirmed, true);
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 2 });
+}
+
+async function saveLoad(game: GameServer, station: string): Promise<void> {
+  const saveName = `eng2_cargo_lift_${station}_${Date.now()}`;
+  await game.save(saveName);
+  await game.load(saveName);
+  await game.step({ frames: 30 });
+}
+
+async function walkTo(
+  game: GameServer,
+  target: { x: number; y: number; z: number },
+): Promise<void> {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const before = await game.player.position();
+    if (Math.hypot(before.x - target.x, before.z - target.z) < 0.3) return;
+    await game.player.moveTo(target);
+    await game.step({ frames: 5 });
+  }
+  const position = await game.player.position();
+  assert.ok(
+    Math.hypot(position.x - target.x, position.z - target.z) < 0.3,
+    `ordinary movement should reach ${JSON.stringify(target)}, got ${JSON.stringify(position)}`,
+  );
+}
+
+async function assertLiftAt(
+  game: GameServer,
+  expectedY: number,
+  label: string,
+): Promise<EntitySummary> {
+  const lift = await object(
+    game,
+    CARGO_LIFT_OBJECT,
+    "Cargo 2B East lift mission object 669",
+  );
+  const detail = await game.entities.detail(lift.id);
+  assert.ok(
+    Math.abs(detail.position[1] - expectedY) < 0.1,
+    `${label}: expected lift y=${expectedY}, got ${detail.position[1]}`,
+  );
+  return lift;
+}
+
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// saved beside Sanger after riding Cargo 2B East lift 669 to its top station.
+// Loading preserved the platform position but lost BaseElevator's station
+// index: top button 620 then went to the middle, and repeated presses could
+// never reach the authored bottom exit.
+test(
+  "eng2 Cargo lift preserves its authored station across save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ELEVATOR_SAVE_PORT ?? 8141),
+    });
+    await game.step({ frames: 5 });
+
+    // Setup only: dispatch the real lift through its authored
+    // 477 (bottom) -> 478 (middle) -> 479 (top) path.
+    const bottomButton = await object(game, 480, "bottom button mission object 480");
+    const middleButton = await object(game, 481, "middle button mission object 481");
+    await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    await assertLiftAt(game, MIDDLE_NODE_Y, "setup middle station");
+    await game.entities.sendMessage(middleButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    await assertLiftAt(game, TOP_NODE_Y, "setup top station");
+
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+
+    // Negative-first campaign repro: after restoring the top station, use the
+    // real flat interaction ray and squeeze edge on authored button 620.
+    await saveLoad(game, "top");
+    await assertLiftAt(game, TOP_NODE_Y, "loaded top station");
+    const topButton = await object(game, 620, "top button mission object 620");
+    const topPlayer = await game.player.position();
+    await squeeze(game, topButton);
+    await game.step({ frames: 600 });
+    const bottomLift = await assertLiftAt(
+      game,
+      BOTTOM_NODE_Y,
+      "top station should cycle to bottom",
+    );
+    const bottomPlayer = await game.player.position();
+    assert.ok(
+      Math.abs(bottomPlayer.y - -11.556) < 0.1,
+      `top-to-bottom lift should carry player to y=-11.556, got ${JSON.stringify(bottomPlayer)}`,
+    );
+
+    // The authored return leaves the bottom car to the north. This proves the
+    // saved player is no longer forced to reverse the one-way crate stack.
+    for (const target of [
+      { x: 43.9, y: -11.55, z: -163 },
+      { x: 43.9, y: -11.55, z: -158 },
+    ]) {
+      await walkTo(game, target);
+    }
+    const bottomExit = await game.player.position();
+    assert.ok(bottomExit.z > -158.3);
+
+    // Check the other two restored stations as well. Strictly rediscover every
+    // concrete entity after each load because runtime IDs are not stable.
+    await game.player.teleport({
+      x: 43.9006,
+      y: -11.556,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    await saveLoad(game, "bottom");
+    await assertLiftAt(game, BOTTOM_NODE_Y, "loaded bottom station");
+    await squeeze(
+      game,
+      await object(game, 480, "loaded bottom button mission object 480"),
+    );
+    await game.step({ frames: 600 });
+    await assertLiftAt(game, MIDDLE_NODE_Y, "bottom station should cycle to middle");
+
+    await saveLoad(game, "middle");
+    await assertLiftAt(game, MIDDLE_NODE_Y, "loaded middle station");
+    await squeeze(
+      game,
+      await object(game, 481, "loaded middle button mission object 481"),
+    );
+    await game.step({ frames: 600 });
+    const finalLift = await assertLiftAt(
+      game,
+      TOP_NODE_Y,
+      "middle station should cycle to top",
+    );
+
+    t.diagnostic(
+      `Cargo lift save/load: top player ${JSON.stringify(topPlayer)} -> ` +
+        `bottom lift ${JSON.stringify(bottomLift.position)}, player ` +
+        `${JSON.stringify(bottomPlayer)}, north exit ${JSON.stringify(bottomExit)}, ` +
+        `final top lift ${JSON.stringify(finalLift.position)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CARGO_LIFT_OBJECT = 669;
+const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
+const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
+const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+async function pulseJump(game: GameServer): Promise<void> {
+  await game.input.setJump(true);
+  await game.step({ frames: 1 });
+  await game.input.setJump(false);
+}
+
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// reached Cargo 2B's top lift through ordinary play. Walking north from the
+// lift toward its top call button is the valid route; jumping west instead
+// exposed a collision escape onto the exterior roof.
+test(
+  "ordinary jump stays below Engineering Cargo 2B's world ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG2_CEILING_PORT ?? 8140),
+    });
+    await game.step({ frames: 5 });
+
+    const lift = only(
+      await game.entities.byTemplate(CARGO_LIFT_OBJECT),
+      "Cargo 2B East lift mission object 669",
+    );
+    const bottomButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_BOTTOM_BUTTON_OBJECT),
+      "bottom lift button mission object 480",
+    );
+    const middleButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_MIDDLE_BUTTON_OBJECT),
+      "middle lift button mission object 481",
+    );
+    const topButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_TOP_BUTTON_OBJECT),
+      "top lift button mission object 620",
+    );
+
+    // Setup only: drive the real lift along its authored 477 -> 478 -> 479
+    // path and stage at the exact campaign-observed top-stop pose.
+    await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const middleLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(middleLift.position[1] - -5.1) < 0.1,
+      `lift should reach authored middle node y=-5.1, got ${middleLift.position[1]}`,
+    );
+    await game.entities.sendMessage(middleButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const topLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(topLift.position[1] - 2.1) < 0.1,
+      `lift should reach authored top node y=2.1, got ${topLift.position[1]}`,
+    );
+
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    assert.ok(
+      Math.abs(before.x - 43.9006) < 0.1 &&
+        Math.abs(before.y - 3.144) < 0.1 &&
+        Math.abs(before.z - -168.2003) < 0.1,
+      `player should settle at the campaign lift pose, got ${JSON.stringify(before)}`,
+    );
+
+    // Control: the authored route walks north off the same top stop toward
+    // button 620. Prove it remains available, then return to the exact setup
+    // pose without carrying input or a jump edge into the regression.
+    await game.input.lookAtWorldPoint([
+      topButton.position[0],
+      before.y + 1.6,
+      topButton.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const northExit = await game.player.position();
+    assert.ok(
+      northExit.z > -166 && northExit.y < 6.8,
+      `ordinary walking should leave the lift north toward top button 620, got ` +
+        JSON.stringify(northExit),
+    );
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const jumpStart = await game.player.position();
+
+    // Self-check the parentless world slab the campaign escaped through.
+    // Probing from below sees its underside, while the reverse ray finds the
+    // exterior roof at the same y. This is level geometry, not a lift entity.
+    const ceilingUp = await game.raycast({
+      start: [41.5, jumpStart.y, -169.1],
+      end: [41.5, 10, -169.1],
+      collision_groups: ["world"],
+    });
+    const roofDown = await game.raycast({
+      start: [41.5, 10, -169.1],
+      end: [41.5, jumpStart.y, -169.1],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceilingUp.hit_point &&
+        roofDown.hit_point &&
+        Math.abs(ceilingUp.hit_point[1] - 6.8) < 0.1 &&
+        Math.abs(roofDown.hit_point[1] - 6.8) < 0.1,
+      `expected Cargo 2B world ceiling/roof at y=6.8, got ` +
+        `${JSON.stringify({ ceilingUp, roofDown })}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim west, hold ordinary
+    // forward locomotion, pulse one grounded jump edge, then release.
+    await game.input.lookAtWorldPoint([39, jumpStart.y + 1.6, -170]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 180 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 180 });
+    const landed = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceilingUp.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the Cargo 2B ceiling ` +
+        `(${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
+        `north exit ${JSON.stringify(northExit)}, player ` +
+        `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- reconstruct `BaseElevator`'s current path index from the save-restored moving-terrain position
- use the native 0.1-world-unit station tolerance, nearest-station selection, and a deterministic lower-index tie break
- retain the original index-zero fallback when a platform is between stations instead of inventing a station
- add a durable Cargo 2B scenario covering save/load at all three authored stops, real button interaction, rider carry, and the ordinary middle-stop bridge exit

This PR is stacked on `fix/cargo2-ceiling-escape` / #745.

## Campaign evidence and scope

`Campaign: engineering · none · legacy · seed 1378752978`

The clean campaign exposed the defect after reaching Sanger: moving terrain for Cargo lift mission object `669` restored at its top node, while a fresh `BaseElevator` script silently reset `current_index` to zero. The same production press of top button mission object `620` therefore dispatched:

- uninterrupted control: top `y=2.1` → bottom `y=-12.6`
- save/load regression: top `y=2.1` → middle `y=-5.1`

The confirmed defect is generic elevator save/load state loss. It is not claimed as the sole cause of the campaign's still-unresolved return-route finding. Independent physical testing confirms ordinary movement on the bottom floor north to about `z=-158`, but does not establish a route from that room to the Engineering bulkhead. The campaign-confirmed middle-stop north/west route does reach the raised central bridge.

The retail walkthrough says to head below after Sanger and then backtrack to the four-way corridor:

- [Port Forward Cargo Bay 2 walkthrough](https://portforward.com/games/walkthroughs/System-Shock-2/Cargo-Bay-2.htm)
- [GameBanshee Engineering B walkthrough](https://www.gamebanshee.com/systemshock2/walkthrough/engineeringb.php)

## Negative-first regression

On exact stacked base `125c9ac3`, the durable scenario failed after the top-station reload:

```text
expected lift y=-12.6, got -5.1
```

On this branch it passes through the full authored cycle:

- loaded top → bottom: lift `[43.9,-12.6,-168.2]`, player `y=-11.556`
- ordinary bottom-room movement: `(43.881,-11.156,-158.322)`
- loaded bottom → middle: player carried to `y=-4.056`
- ordinary middle-stop exit: `(34.000,-3.956,-174.600)`
- loaded middle → top: lift `[43.9,2.1,-168.2]`

Concrete runtime entity IDs are rediscovered after every load; only stable mission object IDs identify the lift and buttons.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 396 passed / 0 failed
- `cd tools/shock2-sdk && npm test` — 188 total / 26 passed / 0 failed / 162 expected E2E skips
- focused final Cargo lift scenario — 1 passed / 0 failed (`101.1 s`)
- full serial SDK E2E suite on final head — 188 total / 185 passed / 0 failed / 3 expected SHODAN finale skips (`1,976.2 s`)

## Visual verification

![Cargo 2B elevator save/load before and after](https://gist.githubusercontent.com/tommy-xr/5aae672008463b6c2f45b4699606a362/raw/elevator-save-before-after.gif)

<sub>Same fresh `eng2.mis` state, top-stop save/load, production aim/button squeeze, and 600 fixed frames. Before, the restored top stop forgets its index and stops at the middle floor; after, it completes the authored top-to-bottom leg.</sub>

### Before → after

![Cargo 2B elevator final stations before and after](https://gist.githubusercontent.com/tommy-xr/5aae672008463b6c2f45b4699606a362/raw/elevator-save-before-after.png)

Fixes #746
