### PR TITLE
fix(cutscene): resolve anniversary video layers

### DIFF
--- a/engine_ffmpeg/src/audio_player.rs
+++ b/engine_ffmpeg/src/audio_player.rs
@@ -9,7 +9,7 @@ pub struct AudioPlayer;
 impl AudioPlayer {
     pub fn from_filename(filename: &str) -> Result<AudioClip, ffmpeg::Error> {
         // 2. Open the media file
-        let mut ictx = ffmpeg::format::input(&filename).unwrap();
+        let mut ictx = ffmpeg::format::input(&filename)?;
 
         // 3. Find the audio stream
         let input = ictx
@@ -51,11 +51,11 @@ impl AudioPlayer {
         let mut decoded_audio_samples: Vec<i16> = Vec::new();
 
         for (stream, packet) in ictx.packets() {
-            if stream.index() == audio_stream_index {
-                audio_decoder.send_packet(&packet).unwrap();
+            if stream.index() == audio_stream_index && packet_has_payload(&packet) {
+                audio_decoder.send_packet(&packet)?;
                 let mut audio_frame = ffmpeg::util::frame::audio::Audio::empty();
 
-                while audio_decoder.receive_frame(&mut audio_frame).is_ok() {
+                while let Ok(()) = audio_decoder.receive_frame(&mut audio_frame) {
                     let mut decoded_audio_frame = ffmpeg::util::frame::audio::Audio::empty();
                     audio_frame.set_channel_layout(ChannelLayout::STEREO);
                     let _option_delay = swr.run(&audio_frame, &mut decoded_audio_frame).unwrap();
@@ -88,5 +88,19 @@ impl AudioPlayer {
 
         let clip = AudioClip::from_raw(target_channel_count, target_sample_rate, remapped_samples);
         Ok(clip)
+    }
+}
+
+fn packet_has_payload(packet: &ffmpeg::Packet) -> bool {
+    packet.size() > 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_empty_ogg_end_of_stream_packets() {
+        assert!(!packet_has_payload(&ffmpeg::Packet::empty()));
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -111,6 +111,7 @@ pub struct SceneInitResult {
 }
 
 const ENDING_CUTSCENE_CANDIDATES: &[&str] = &["enhanced/cs3.ogv", "cs3.avi", "cs3.ogv"];
+const ANNIVERSARY_CUTSCENE_LAYERS: &[&str] = &["enhanced", "original", "kex"];
 
 /// How a debug scene is built. Every entry in [`DEBUG_SCENES`] has this shape,
 /// so a scene that needs none of the arguments simply ignores them.
@@ -209,7 +210,7 @@ pub fn create_initial_scene(
     global_context: &GlobalContext,
     options: &GameOptions,
 ) -> SceneInitResult {
-    if is_cutscene_mission(&options.mission) {
+    if is_cutscene_file(&options.mission) {
         let mission_name = options.mission.clone();
         let cutscene_path = resolve_cutscene_path(&mission_name);
         let cutscene_path_string = cutscene_path.to_string_lossy().into_owned();
@@ -367,12 +368,17 @@ pub fn load_mission_from_save_data(
     (active_mission, save_data.level_data)
 }
 
-fn is_cutscene_mission(name: &str) -> bool {
+pub fn is_cutscene_file(name: &str) -> bool {
     let normalized = name.trim().to_ascii_lowercase();
     normalized.ends_with(".avi") || normalized.ends_with(".ogv")
 }
 
-fn resolve_cutscene_path(name: &str) -> PathBuf {
+/// Resolve a classic or 25th Anniversary cutscene name to a loose video file.
+///
+/// Exact paths retain priority. When a classic `.avi` is absent, Anniversary
+/// `.ogv` files are searched in the game's preferred layer order: enhanced
+/// videos first, then original, then KEX-specific videos.
+pub fn resolve_cutscene_path(name: &str) -> PathBuf {
     resolve_cutscene_path_from(&paths::data_root(), name)
 }
 
@@ -381,18 +387,79 @@ fn resolve_cutscene_path_from(data_root: &Path, name: &str) -> PathBuf {
     let raw_path = Path::new(trimmed);
 
     if raw_path.is_absolute() {
-        return raw_path.to_path_buf();
+        return find_requested_cutscene(raw_path).unwrap_or_else(|| raw_path.to_path_buf());
     }
 
-    let begins_with_cutscenes = raw_path
-        .components()
-        .next()
-        .is_some_and(|component| component.as_os_str().eq_ignore_ascii_case("cutscenes"));
-    if begins_with_cutscenes {
-        data_root.join(raw_path)
-    } else {
-        data_root.join("cutscenes").join(raw_path)
+    // dark_viewer historically accepts a path relative to its working
+    // directory. Keep that behavior in the shared resolver so the tool and
+    // game select the same file for any given request.
+    if let Some(path) = find_requested_cutscene(raw_path) {
+        return path;
     }
+
+    let mut components = raw_path.components();
+    let relative_cutscene_path = if components
+        .next()
+        .is_some_and(|component| component.as_os_str().eq_ignore_ascii_case("cutscenes"))
+    {
+        components.as_path()
+    } else {
+        raw_path
+    };
+    let rooted_path = data_root.join("cutscenes").join(relative_cutscene_path);
+
+    if let Some(path) = find_requested_cutscene(&rooted_path) {
+        return path;
+    }
+
+    // An explicit layer remains explicit. Layer fallback is only for the
+    // classic bare names authored by the game, such as `Intro.avi`.
+    if relative_cutscene_path.components().count() == 1
+        && is_cutscene_file(relative_cutscene_path.to_string_lossy().as_ref())
+    {
+        let file_stem = relative_cutscene_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let anniversary_name = format!("{file_stem}.ogv");
+
+        for layer in ANNIVERSARY_CUTSCENE_LAYERS {
+            let candidate = data_root
+                .join("cutscenes")
+                .join(layer)
+                .join(&anniversary_name);
+            if let Some(path) = find_file_ignoring_ascii_case(&candidate) {
+                return path;
+            }
+        }
+    }
+
+    rooted_path
+}
+
+fn find_requested_cutscene(path: &Path) -> Option<PathBuf> {
+    find_file_ignoring_ascii_case(path).or_else(|| {
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("avi"))
+            .then(|| path.with_extension("ogv"))
+            .and_then(|candidate| find_file_ignoring_ascii_case(&candidate))
+    })
+}
+
+fn find_file_ignoring_ascii_case(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+
+    let requested_name = path.file_name()?;
+    path.parent()?
+        .read_dir()
+        .ok()?
+        .filter_map(Result::ok)
+        .find(|entry| entry.file_name().eq_ignore_ascii_case(requested_name))
+        .map(|entry| entry.path())
 }
 
 /// Resolve the retail ending for both 25th Anniversary (`enhanced/cs3.ogv`)
@@ -446,11 +513,41 @@ mod tests {
         );
     }
 
+    /// A scratch data root that removes itself after each resolver test.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir()
+                .join(format!("shock2vr-cutscenes-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn write(&self, relative_path: &str) -> PathBuf {
+            let path = self.0.join(relative_path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"cutscene fixture").unwrap();
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
     #[test]
     fn recognizes_classic_and_enhanced_cutscene_extensions() {
-        assert!(is_cutscene_mission("cs3.avi"));
-        assert!(is_cutscene_mission("enhanced/cs3.ogv"));
-        assert!(!is_cutscene_mission("shodan.mis"));
+        assert!(is_cutscene_file("cs3.avi"));
+        assert!(is_cutscene_file("enhanced/cs3.ogv"));
+        assert!(!is_cutscene_file("shodan.mis"));
     }
 
     #[test]
@@ -465,5 +562,25 @@ mod tests {
             resolve_cutscene_path_from(root, "cutscenes/enhanced/cs3.ogv"),
             root.join("cutscenes/enhanced/cs3.ogv")
         );
+    }
+
+    #[test]
+    fn classic_name_resolves_to_anniversary_ogv_counterpart() {
+        let root = TempDir::new("anniversary-counterpart");
+        let expected = root.write("cutscenes/original/intro.ogv");
+
+        assert_eq!(
+            resolve_cutscene_path_from(root.path(), "Intro.avi"),
+            expected
+        );
+    }
+
+    #[test]
+    fn enhanced_anniversary_layer_precedes_original() {
+        let root = TempDir::new("anniversary-precedence");
+        let expected = root.write("cutscenes/enhanced/cs1.ogv");
+        root.write("cutscenes/original/cs1.ogv");
+
+        assert_eq!(resolve_cutscene_path_from(root.path(), "cs1.avi"), expected);
     }
 }

--- a/tools/dark_viewer/src/main.rs
+++ b/tools/dark_viewer/src/main.rs
@@ -33,6 +33,7 @@ use engine::scene::SceneObject;
 use engine::scene::TextVertex;
 use shock2vr::GameOptions;
 use shock2vr::paths;
+use shock2vr::scenes::{is_cutscene_file, resolve_cutscene_path};
 use tracing::trace;
 
 extern crate gl;
@@ -58,7 +59,7 @@ const SCR_HEIGHT: u32 = 600;
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Shock Engine tooling viewer", long_about = None)]
 struct Cli {
-    /// Asset to preview (video .avi, object .bin, font .fon, GLB .glb)
+    /// Asset to preview (video .avi/.ogv, object .bin, font .fon, GLB .glb)
     filename: String,
 
     /// One or more animation clips, comma separated.
@@ -181,34 +182,6 @@ fn camera_update_mouse(camera: &mut CameraContext, x_pos: f32, y_pos: f32) -> Mo
     }
 }
 
-fn find_video_file(filename: &str) -> Option<String> {
-    let requested = Path::new(filename);
-    let data_root = paths::data_root();
-
-    let mut candidates = vec![requested.to_path_buf()];
-    if requested.is_relative() {
-        candidates.push(data_root.join(requested));
-        if let Some(file_name) = requested.file_name() {
-            candidates.push(data_root.join("cutscenes").join(file_name));
-            candidates.push(Path::new("cutscenes").join(file_name));
-        }
-    }
-
-    for candidate in candidates {
-        if candidate.exists() {
-            println!("Found video at: {}", candidate.display());
-            return Some(candidate.to_string_lossy().into_owned());
-        }
-    }
-
-    println!(
-        "Could not find video file {} in any of the expected locations (searched under {} and current directory)",
-        filename,
-        data_root.display()
-    );
-    None
-}
-
 fn create_scene(
     filename: &str,
     animations: &[String],
@@ -219,11 +192,18 @@ fn create_scene(
     debug_hit_boxes: bool,
 ) -> Result<Box<dyn ToolScene>, Box<dyn std::error::Error>> {
     let lower = filename.to_ascii_lowercase();
-    if lower.ends_with(".avi") {
-        if let Some(video_path) = find_video_file(filename) {
-            let scene = VideoPlayerScene::from_file(video_path)?;
+    if is_cutscene_file(&lower) {
+        let video_path = resolve_cutscene_path(filename);
+        if video_path.is_file() {
+            println!("Found video at: {}", video_path.display());
+            let scene = VideoPlayerScene::from_file(video_path.to_string_lossy().into_owned())?;
             Ok(Box::new(scene))
         } else {
+            println!(
+                "Could not find video file {} in any of the expected locations (searched under {} and current directory)",
+                filename,
+                paths::data_root().display()
+            );
             Err(format!("Could not find video file: {}", filename).into())
         }
     } else if lower.ends_with(".bin") {
@@ -259,7 +239,7 @@ fn create_scene(
         Err("Animation preview is only supported for .bin AI meshes.".into())
     } else {
         Err(format!(
-            "Unsupported file type: {}. Supported file types: .avi (video), .bin (3D model), .fon (font), .glb (GLB/GLTF 3D model)",
+            "Unsupported file type: {}. Supported file types: .avi/.ogv (video), .bin (3D model), .fon (font), .glb (GLB/GLTF 3D model)",
             filename
         )
         .into())


### PR DESCRIPTION
## Reproduction

With the 25th Anniversary install selected, the classic authored name could not reach its layered OGV counterpart:

```console
$ DARK_ASSET_PATH=/Users/bryan/ss2-25th cargo dv Intro.avi --debug-no-render
Could not find video file Intro.avi in any of the expected locations
```

`ffprobe` also confirms that `original/intro.ogv` has an unsupported data stream before its Theora video and Vorbis audio streams, and its final audio packet is a zero-byte Ogg EOS marker. Before this change, discovery failed; when opened directly, that EOS marker made `AudioPlayer` panic with FFmpeg `Invalid argument`.

## Fix

- share cutscene extension/path resolution between the game and dark_viewer
- preserve exact/classic files, then map missing classic `.avi` names to layered `.ogv` files with `enhanced`, `original`, `kex` precedence
- accept direct `.ogv` input in dark_viewer and the game
- select the actual audio stream by media type/index as before, while skipping zero-byte Ogg EOS packets rather than submitting them to the Vorbis decoder

The enhanced-first policy follows the existing ending resolver introduced in #731. The 25AE campaign layout then naturally falls back to `original/intro.ogv`, while the remaining campaign videos resolve under `enhanced/`.

## Verification

- negative-first resolver tests failed on base, then passed after the fix
- `DARK_ASSET_PATH=/Users/bryan/ss2-25th cargo dv Intro.avi --debug-no-render` — resolves `original/intro.ogv`; scene creation succeeds
- `DARK_ASSET_PATH=/Users/bryan/ss2-25th cargo dv cs1.avi --debug-no-render` — resolves `enhanced/cs1.ogv`; scene creation succeeds
- `cargo test -p engine_ffmpeg` — 2 passed
- `cargo test -p shock2vr` — 383 passed
- `RUSTFLAGS="-D warnings" cargo check -p engine_ffmpeg -p shock2vr -p dark_viewer -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cd tools/shock2-sdk && npm run test:e2e` — 180 passed, 0 failed, 3 expected private-save skips

Fixes #660

## Visual verification

![Classic Intro.avi anniversary cutscene demo](https://gist.githubusercontent.com/tommy-xr/40ec4c83bb40a7fcd61ef11cadada89d/raw/classic-intro-anniversary.gif)

<sub>The classic Intro.avi request now resolves and plays the shipped 25th Anniversary original/intro.ogv (Theora/Vorbis), including its leading data stream. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After still

![Classic Intro.avi anniversary cutscene still](https://gist.githubusercontent.com/tommy-xr/40ec4c83bb40a7fcd61ef11cadada89d/raw/intro-after.png)