### PR TITLE
fix(ai): let hostile ranged attacks damage player

### DIFF
--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -168,24 +168,21 @@ pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaterni
     let up_offset = 0.5 / SCALE_FACTOR;
     let right_offset = 0.5 / SCALE_FACTOR;
     let forward = vec3(right_offset, up_offset, 1.0 * forward_offset);
-    let position =
-        root_transform
-            .0
-            .transform_point(point3(right_offset, up_offset, forward_offset))
-            + forward;
+    let firing_transform = root_transform.0 * Matrix4::from(rotation);
+    let muzzle_transform = firing_transform * Matrix4::from_translation(forward);
+    let position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
 
     if maybe_ranged_weapon_entity_id.is_none() {
         // Let's create the proxy entity...
         Effect::CreateEntity {
             template_id: ranged_weapon,
-            position,
-            orientation: rotation,
-            root_transform: root_transform.0,
+            position: point3(0.0, 0.0, 0.0) + forward,
+            orientation: Quaternion::from_angle_y(Deg(90.0)),
+            root_transform: firing_transform,
             options: CreateEntityOptions::default(),
         }
     } else {
-        let rot_matrix: Matrix4<f32> = rotation.into();
-        let transformed_forward = root_transform.0.transform_vector(forward);
+        let transformed_forward = firing_transform.transform_vector(forward);
         let debug_effect = Effect::DrawDebugLines {
             lines: vec![(
                 position,
@@ -208,15 +205,17 @@ pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaterni
 
         if let Some((_projectile_id, _options)) = maybe_projectile {
             let (projectile_template_id, _projectile_opts) = maybe_projectile.unwrap();
+            let projectile_transform =
+                projectile_transform_aimed_at_player(world, position, muzzle_transform);
 
             fire_effects.push(Effect::CreateEntity {
                 // Testing
                 // template_id: -1415, // rocket turret
                 // template_id: -1414, // laser turret
                 template_id: projectile_template_id,
-                position: point3(0.0, 0.0, 0.0) + forward,
+                position: point3(0.0, 0.0, 0.0),
                 orientation: Quaternion::from_angle_y(Deg(90.0)),
-                root_transform: root_transform.0 * rot_matrix,
+                root_transform: projectile_transform,
                 options: CreateEntityOptions::default(),
             });
 
@@ -242,7 +241,7 @@ pub fn fire_ranged_weapon(world: &World, entity_id: EntityId, rotation: Quaterni
                 template_id: muzzle_flash_template_id,
                 position: point3(0.0, 0.0, 0.0) + forward,
                 orientation: Quaternion::from_angle_y(Deg(90.0)),
-                root_transform: root_transform.0 * rot_matrix,
+                root_transform: firing_transform,
                 options: CreateEntityOptions::default(),
             })
         }
@@ -283,7 +282,6 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
     if let Some((projectile_id, options)) = maybe_projectile {
         let root_transform = v_transform.get(entity_id).unwrap();
         let forward = vec3(0.0, 0.0, 1.0);
-        let _up = vec3(0.0, 1.0, 0.0);
 
         let creature_type = v_creature.get(entity_id).unwrap();
         let joint_index = creature::get_creature_definition(creature_type.0)
@@ -298,36 +296,55 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
             .unwrap_or(Matrix4::identity());
 
         let transform = root_transform.0;
-        //let transform = root_transform.0 * joint_transform;
-
-        //let orientation = Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Rad(PI / 2.0));
         let position = joint_transform.transform_point(point3(0.0, 0.0, 0.0));
+        let muzzle_transform = transform * Matrix4::from_translation((position + forward).to_vec());
+        let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
+        let projectile_transform =
+            projectile_transform_aimed_at_player(world, muzzle_position, muzzle_transform);
 
-        //let rotation = Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0));
-        // TODO: This rotation is needed for some monsters? Like the droids?
-        //let _rot_matrix: Matrix4<f32> = Matrix4::from(rotation);
-
-        // panic!("creating entity: {:?}", projectile_id);
         Effect::CreateEntity {
             template_id: projectile_id,
-            position: position + forward * 1.0,
-            // position: vec3(13.11, 0.382, 16.601),
-            // orientation: rotation,
-            // Not sure why, but it seems like the orientation of the AI models is off by 90 degrees for the bin models...
-            // so we have to corect, otherwise we get sideways lasers
-            // orientation: Quaternion::from_angle_y(Deg(180.0)),
-            // orientation: Quaternion {
-            //     s: 1.0,
-            //     v: vec3(0.0, 0.0, 0.0),
-            // },
+            position: point3(0.0, 0.0, 0.0),
             orientation: Quaternion::from_angle_y(Deg(90.0)),
-            // root_transform: transform * rot_matrix,
-            root_transform: transform,
+            root_transform: projectile_transform,
             options: CreateEntityOptions::default(),
         }
     } else {
         Effect::NoEffect
     }
+}
+
+fn projectile_transform_aimed_at_player(
+    world: &World,
+    muzzle_position: Point3<f32>,
+    fallback_transform: Matrix4<f32>,
+) -> Matrix4<f32> {
+    let Ok(player) = world.borrow::<UniqueView<PlayerInfo>>() else {
+        return fallback_transform;
+    };
+    projectile_transform_aimed_at(muzzle_position, player.pos).unwrap_or(fallback_transform)
+}
+
+fn projectile_transform_aimed_at(
+    muzzle_position: Point3<f32>,
+    target_position: Vector3<f32>,
+) -> Option<Matrix4<f32>> {
+    // Fast hostile projectiles previously inherited only the attacker's yaw.
+    // Their high authored joints could therefore send a perfectly horizontal
+    // ray over the player's shorter capsule. Preserve the authored muzzle but
+    // orient +Z at the collider center so the existing velocity path includes
+    // the necessary pitch.
+    let to_player = target_position - muzzle_position.to_vec();
+    if to_player.magnitude2() <= 1.0e-12 {
+        return None;
+    }
+
+    Some(
+        Matrix4::from_translation(muzzle_position.to_vec())
+            * Matrix4::from(crate::util::get_rotation_from_forward_vector(
+                to_player.normalize(),
+            )),
+    )
 }
 
 /// Monster FOV half-angle, in degrees (matches `FovDebugConfig::monster()`).
@@ -812,6 +829,33 @@ mod separation_tests {
         assert!(
             bias.x.abs() < 1e-6,
             "symmetric neighbors cancel on x: {bias:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod projectile_aim_tests {
+    use super::*;
+    use cgmath::MetricSpace;
+
+    #[test]
+    fn hostile_projectiles_pitch_from_the_muzzle_toward_the_player() {
+        let muzzle = point3(1.0, 3.0, 5.0);
+        let player = vec3(-2.0, 1.0, -7.0);
+        let transform =
+            projectile_transform_aimed_at(muzzle, player).expect("distinct points define aim");
+
+        let spawned_at = transform.transform_point(point3(0.0, 0.0, 0.0));
+        assert!(
+            spawned_at.distance(muzzle) < 1.0e-6,
+            "aiming must preserve the authored muzzle position",
+        );
+
+        let actual_forward = transform.transform_vector(vec3(0.0, 0.0, 1.0)).normalize();
+        let expected_forward = (player - muzzle.to_vec()).normalize();
+        assert!(
+            (actual_forward - expected_forward).magnitude() < 1.0e-6,
+            "projectile direction must include pitch toward the player's collider",
         );
     }
 }

--- a/shock2vr/src/scripts/ai/turret_ai.rs
+++ b/shock2vr/src/scripts/ai/turret_ai.rs
@@ -203,6 +203,10 @@ impl TurretAI {
 impl Script for TurretAI {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
         self.initial_yaw = ai_util::current_yaw(entity_id, world);
+        // Steering returns an absolute world yaw. Seed it from the mounted
+        // orientation so the first steering update does not reinterpret zero
+        // as world-forward and turn a rotated turret away from its target.
+        self.current_heading = self.initial_yaw;
 
         // Load alertness configuration
         self.config = Self::build_config(world, entity_id);
@@ -235,7 +239,7 @@ impl Script for TurretAI {
             entity_id,
             world,
             physics,
-            -self.current_heading,
+            self.initial_yaw - self.current_heading,
             TURRET_FOV_HALF_ANGLE,
         );
 
@@ -295,7 +299,7 @@ impl Script for TurretAI {
         let fov_debug_eff = ai_debug_util::draw_debug_fov(
             world,
             entity_id,
-            -self.current_heading,
+            self.initial_yaw - self.current_heading,
             is_visible,
             &FovDebugConfig::turret(),
         );

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -175,6 +175,7 @@ fn projectile_ray_cast(
             // Sometimes, the hitbox can stick out past the bounding box...
             // so we should still check for it here
             | InternalCollisionGroups::HITBOX
+            | InternalCollisionGroups::PLAYER
             | InternalCollisionGroups::SELECTABLE
             | InternalCollisionGroups::WORLD,
     );
@@ -218,9 +219,34 @@ fn projectile_ray_cast(
 
 #[cfg(test)]
 mod tests {
-    use super::hitbox_belongs_to_entity;
+    use super::{hitbox_belongs_to_entity, projectile_ray_cast};
     use crate::creature::{HitBoxType, RuntimePropHitBox};
-    use shipyard::World;
+    use crate::physics::PhysicsWorld;
+    use cgmath::{point3, vec3};
+    use shipyard::{EntityId, World};
+
+    #[test]
+    fn projectile_raycast_hits_the_player_collider() {
+        let mut physics = PhysicsWorld::new();
+        let player_entity = EntityId::from_inner(1).unwrap();
+        let mut player = physics.create_player(vec3(0.0, 0.0, 5.0), player_entity);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let world = World::new();
+        let hit = projectile_ray_cast(
+            point3(0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 1.0),
+            &physics,
+            10.0,
+            &world,
+        );
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(player_entity),
+            "an AI/turret fast projectile must be able to hit the player's dedicated collider",
+        );
+    }
 
     #[test]
     fn refined_hitbox_must_belong_to_the_coarse_creature() {

--- a/tools/shock2-sdk/test/hostile-ranged-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/hostile-ranged-damage.e2e.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "a hostile turret tracks and damages the player",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_turret",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8574),
+    });
+
+    const hpBefore = (await game.info()).player.hit_points;
+    assert.ok(hpBefore !== null, "debug player should expose hit points");
+
+    // The authored turret takes 2.5s to open, creates its ranged-weapon proxy
+    // on the first firing tick, then fires once per second. Six seconds gives
+    // that real state machine enough time to land multiple shots.
+    await game.step({ frames: 360 });
+
+    const hpAfter = (await game.info()).player.hit_points;
+    assert.ok(hpAfter !== null, "debug player should expose hit points");
+    assert.ok(
+      hpAfter < hpBefore,
+      `the turret should damage the player after opening (${hpBefore} -> ${hpAfter})`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- include the dedicated player collision group in fast hostile projectile raycasts
- aim creature and turret projectiles from their authored muzzle toward the player's collider center, including vertical pitch
- keep turret steering/FOV headings relative to the turret's mounted yaw and place its ranged-weapon proxy at the muzzle
- add focused unit regressions and a headless debug-turret damage scenario

## Reproduction and verification

On the pre-fix main branch:

- classic and 25AE melee attacks already worked after #581: OG-Pipe and command1 Arachnightmare attacks reduced player HP in authored 10-point hits
- OG-Shotgun entered RangedAttack and crossed the authored FIRE frame, but the fast ray omitted PLAYER; after adding that group, instrumentation showed its horizontal ray still passed above the shorter player capsule
- debug_turret opened, then treated absolute steering yaw as a relative FOV offset, turned its sight away, and closed before firing

After this change:

- classic OG-Shotgun: High / RangedAttack, ogsshot3, player HP 30 -> 24
- stock 25AE OG-Shotgun: High / RangedAttack, ogsshot3, player HP 30 -> 24
- debug_turret: weapon proxy remains beside the turret, repeated laser impacts reduce player HP 30 -> 27 over six simulated seconds

## Tests

- cargo fmt --all -- --check
- cargo test -p shock2vr (383 passed)
- RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- npm test (26 passed, 158 expected e2e skips)
- focused hostile-ranged SDK e2e (passed)
- full SDK e2e: 180 passed, 3 expected skips, 1 flaky #481 alertness-churn failure; immediate isolated rerun passed

Fixes #561



## Visual verification

![Laser turret tracking and firing demo](https://gist.githubusercontent.com/tommy-xr/6c1820e8e5dc80cb88fd3b55fd3cf4ee/raw/turret-firing.gif)

<sub>The laser turret now retains its mounted heading, tracks the player after opening, and lands repeated shots. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After

![Laser turret firing](https://gist.githubusercontent.com/tommy-xr/6c1820e8e5dc80cb88fd3b55fd3cf4ee/raw/turret-after.png)

### Before → after

![Laser turret before and after](https://gist.githubusercontent.com/tommy-xr/6c1820e8e5dc80cb88fd3b55fd3cf4ee/raw/turret-before-after.png)
