### PR TITLE
fix(gameplay): honor authored interaction overlays

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -14,7 +14,7 @@ use shipyard::{EntityId, Get, View, World};
 
 use dark::{
     SCALE_FACTOR,
-    properties::{PropFrobInfo, PropLimbModel, PropPlayerGun},
+    properties::{PropFrobInfo, PropLimbModel, PropPickBias, PropPlayerGun},
 };
 
 use crate::{
@@ -146,19 +146,13 @@ impl FlatPlayerController {
         // hitbox proxies to their parent, and ignoring the weapon we hold).
         let forward = look.rotate_vector(vec3(0.0, 0.0, -1.0));
         self.last_aim = Some((point3(camera_pos.x, camera_pos.y, camera_pos.z), forward));
-        let highlighted = physics
-            .ray_cast(
-                point3(camera_pos.x, camera_pos.y, camera_pos.z),
-                forward,
-                InternalCollisionGroups::ENTITY
-                    | InternalCollisionGroups::SELECTABLE
-                    | InternalCollisionGroups::WORLD
-                    | InternalCollisionGroups::UI
-                    | InternalCollisionGroups::RAYCAST,
-            )
-            .and_then(|r| r.maybe_entity_id)
-            .map(|e| resolve_proxy_entity(world, e))
-            .filter(|e| Some(*e) != self.wielded_entity && is_frobbable(world, *e));
+        let highlighted = interaction_target(
+            world,
+            physics,
+            point3(camera_pos.x, camera_pos.y, camera_pos.z),
+            forward,
+            self.wielded_entity,
+        );
 
         // Place the viewmodel + fire on the trigger edge.
         if let Some(entity_id) = self.wielded_entity {
@@ -275,6 +269,53 @@ fn out_message(to: EntityId, payload: MessagePayload) -> VirtualHandEffect {
     }
 }
 
+const INTERACTION_GROUPS: InternalCollisionGroups = InternalCollisionGroups::ENTITY
+    .union(InternalCollisionGroups::SELECTABLE)
+    .union(InternalCollisionGroups::WORLD)
+    .union(InternalCollisionGroups::UI)
+    .union(InternalCollisionGroups::RAYCAST);
+
+/// Resolve the flat crosshair's interaction target while honoring Dark's
+/// negative pick bias. The first combined hit still blocks normally. Only an
+/// explicitly de-prioritized entity is skipped, and the second cast keeps all
+/// world/entity groups enabled, so a wall or closed door behind it remains an
+/// occluder instead of allowing a through-geometry Frob.
+fn interaction_target(
+    world: &World,
+    physics: &PhysicsWorld,
+    origin: Point3<f32>,
+    forward: Vector3<f32>,
+    wielded_entity: Option<EntityId>,
+) -> Option<EntityId> {
+    let first = physics.ray_cast(origin, forward, INTERACTION_GROUPS)?;
+    let first_raw = first.maybe_entity_id?;
+    let first_entity = resolve_proxy_entity(world, first_raw);
+    if Some(first_entity) != wielded_entity && is_frobbable(world, first_entity) {
+        return Some(first_entity);
+    }
+
+    let has_negative_pick_bias = world
+        .borrow::<View<PropPickBias>>()
+        .map(|v| v.get(first_entity).is_ok_and(|bias| bias.0 < 0.0))
+        .unwrap_or(false);
+    if !has_negative_pick_bias {
+        return None;
+    }
+
+    physics
+        .ray_cast2(
+            origin,
+            forward,
+            100.0,
+            INTERACTION_GROUPS,
+            Some(first_raw),
+            true,
+        )
+        .and_then(|hit| hit.maybe_entity_id)
+        .map(|entity| resolve_proxy_entity(world, entity))
+        .filter(|entity| Some(*entity) != wielded_entity && is_frobbable(world, *entity))
+}
+
 /// Whether an entity is worth highlighting / interacting with (it has frob
 /// info), which excludes plain world geometry the ray also hits.
 fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
@@ -287,7 +328,8 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::PropPlayerGun;
+    use crate::physics::CollisionGroup;
+    use dark::properties::{FrobFlag, PropPickBias, PropPlayerGun};
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -342,6 +384,124 @@ mod tests {
                 [VirtualHandEffect::HoldItem { entity_id }] if *entity_id == weapon
             ),
             "weapon pickup should preserve flat auto-wield"
+        );
+    }
+
+    #[test]
+    fn negative_pick_bias_surface_yields_to_frobbable_overlay() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let decorative_surface = world.add_entity(PropPickBias(-2000.0));
+        let frobbable_overlay = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::SCRIPT,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let mut physics = PhysicsWorld::new();
+        let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        physics.add_kinematic(
+            decorative_surface,
+            vec3(0.0, 0.0, -1.0),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        physics.add_kinematic(
+            frobbable_overlay,
+            vec3(0.0, 0.0, -1.25),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.1),
+            CollisionGroup::selectable(),
+            false,
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &input,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            identity,
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, Some(frobbable_overlay));
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob
+                    }
+                } if *to == frobbable_overlay
+            )),
+            "the authored overlay should receive the production Frob"
+        );
+    }
+
+    #[test]
+    fn negative_pick_bias_does_not_frob_through_an_entity_blocker() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let decorative_surface = world.add_entity(PropPickBias(-2000.0));
+        let closed_door = world.add_entity(());
+        let frobbable_behind_door = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::SCRIPT,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let mut physics = PhysicsWorld::new();
+        let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        for (entity, z, group) in [
+            (decorative_surface, -1.0, CollisionGroup::entity()),
+            (closed_door, -1.25, CollisionGroup::entity()),
+            (frobbable_behind_door, -1.5, CollisionGroup::selectable()),
+        ] {
+            physics.add_kinematic(
+                entity,
+                vec3(0.0, 0.0, z),
+                identity,
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 1.0, 0.1),
+                group,
+                false,
+            );
+        }
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &input,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            identity,
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, None);
+        assert!(
+            !effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::OutMessage {
+                    message: Message {
+                        payload: MessagePayload::Frob,
+                        ..
+                    }
+                }
+            )),
+            "an ordinary entity between the biased surface and target must still occlude the Frob"
         );
     }
 }

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -360,16 +360,15 @@ fn has_hud_select(world: &World, entity_id: EntityId, expected: bool) -> bool {
         .unwrap_or(false)
 }
 
-/// Whether an entity is worth highlighting / interacting with. Empty authored
-/// FrobInfo overrides deliberately suppress an inherited world action, so
-/// property presence by itself is not enough.
+/// Whether an entity is worth highlighting / interacting with (it has frob
+/// info), which excludes plain world geometry the ray also hits. Some scripted
+/// world objects (including StdDoor leaves) have an empty world-action mask but
+/// still consume Frob messages, so property presence is the compatibility
+/// boundary here.
 fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<View<PropFrobInfo>>()
-        .map(|v| {
-            v.get(entity_id)
-                .is_ok_and(|frob| !frob.world_action.is_empty())
-        })
+        .map(|v| v.get(entity_id).is_ok())
         .unwrap_or(false)
 }
 
@@ -441,20 +440,6 @@ mod tests {
             ),
             "weapon pickup should preserve flat auto-wield"
         );
-    }
-
-    #[test]
-    fn empty_or_inventory_only_frob_info_is_not_world_frobbable() {
-        let mut world = World::new();
-        let empty = world.add_entity(frob_info(FrobFlag::empty()));
-        let inventory_only = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::empty(),
-            inventory_action: FrobFlag::SCRIPT,
-            tool_action: FrobFlag::empty(),
-        });
-
-        assert!(!is_frobbable(&world, empty));
-        assert!(!is_frobbable(&world, inventory_only));
     }
 
     #[test]

--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -9,12 +9,12 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slices 5-6).
 
-use cgmath::{Deg, Point3, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
+use cgmath::{Deg, InnerSpace, Point3, Quaternion, Rotation, Rotation3, Vector3, point3, vec3};
 use shipyard::{EntityId, Get, View, World};
 
 use dark::{
     SCALE_FACTOR,
-    properties::{PropFrobInfo, PropLimbModel, PropPickBias, PropPlayerGun},
+    properties::{PropFrobInfo, PropHUDSelect, PropLimbModel, PropPickBias, PropPlayerGun},
 };
 
 use crate::{
@@ -275,11 +275,21 @@ const INTERACTION_GROUPS: InternalCollisionGroups = InternalCollisionGroups::ENT
     .union(InternalCollisionGroups::UI)
     .union(InternalCollisionGroups::RAYCAST);
 
+/// HUD-hidden computer shells and their invisible frob overlays are authored
+/// at the same origin. Keep the tolerance tight enough that a nearby control
+/// cannot become the shell's accidental target.
+const HUD_OVERLAY_POSITION_EPSILON: f32 = 0.05;
+/// The selectable overlay may sit just inside the decorative shell's collider,
+/// but it must still be part of the same visible surface rather than an object
+/// farther into the room.
+const HUD_OVERLAY_SURFACE_GAP: f32 = 0.5;
+
 /// Resolve the flat crosshair's interaction target while honoring Dark's
-/// negative pick bias. The first combined hit still blocks normally. Only an
-/// explicitly de-prioritized entity is skipped, and the second cast keeps all
-/// world/entity groups enabled, so a wall or closed door behind it remains an
-/// occluder instead of allowing a through-geometry Frob.
+/// authored selection priority. The first combined hit still blocks normally.
+/// Only an explicitly de-prioritized entity or a tightly matched HUD-hidden
+/// shell is skipped, and the second cast keeps all world/entity groups enabled,
+/// so a wall or closed door behind it remains an occluder instead of allowing a
+/// through-geometry Frob.
 fn interaction_target(
     world: &World,
     physics: &PhysicsWorld,
@@ -290,7 +300,8 @@ fn interaction_target(
     let first = physics.ray_cast(origin, forward, INTERACTION_GROUPS)?;
     let first_raw = first.maybe_entity_id?;
     let first_entity = resolve_proxy_entity(world, first_raw);
-    if Some(first_entity) != wielded_entity && is_frobbable(world, first_entity) {
+    let hud_hidden = has_hud_select(world, first_entity, false);
+    if !hud_hidden && Some(first_entity) != wielded_entity && is_frobbable(world, first_entity) {
         return Some(first_entity);
     }
 
@@ -298,30 +309,67 @@ fn interaction_target(
         .borrow::<View<PropPickBias>>()
         .map(|v| v.get(first_entity).is_ok_and(|bias| bias.0 < 0.0))
         .unwrap_or(false);
-    if !has_negative_pick_bias {
+    if !has_negative_pick_bias && !hud_hidden {
         return None;
     }
 
-    physics
-        .ray_cast2(
-            origin,
-            forward,
-            100.0,
-            INTERACTION_GROUPS,
-            Some(first_raw),
-            true,
-        )
-        .and_then(|hit| hit.maybe_entity_id)
-        .map(|entity| resolve_proxy_entity(world, entity))
-        .filter(|entity| Some(*entity) != wielded_entity && is_frobbable(world, *entity))
+    let second = physics.ray_cast2(
+        origin,
+        forward,
+        100.0,
+        INTERACTION_GROUPS,
+        Some(first_raw),
+        true,
+    )?;
+    let second_raw = second.maybe_entity_id?;
+    let second_entity = resolve_proxy_entity(world, second_raw);
+    if Some(second_entity) == wielded_entity || !is_frobbable(world, second_entity) {
+        return None;
+    }
+
+    // Explicit negative pick bias keeps its existing general-purpose behavior.
+    if has_negative_pick_bias {
+        return Some(second_entity);
+    }
+
+    // HUDSelect(false) alone is narrower: it represents a decorative shell
+    // that may yield only to its co-located HUDSelect(true) frob overlay. The
+    // combined recast above ensures a wall, closed door, or unrelated entity
+    // between them remains the immediate hit and blocks the interaction.
+    // Require direct entity colliders before comparing body origins: a damage
+    // proxy's rigid body is not located at its resolved parent entity.
+    if first_raw != first_entity
+        || second_raw != second_entity
+        || !has_hud_select(world, second_entity, true)
+    {
+        return None;
+    }
+    let first_position = physics.get_position(first.maybe_rigid_body_handle?)?;
+    let second_position = physics.get_position(second.maybe_rigid_body_handle?)?;
+    let co_located = (first_position - second_position).magnitude2()
+        <= HUD_OVERLAY_POSITION_EPSILON * HUD_OVERLAY_POSITION_EPSILON;
+    let close_surface = (first.hit_point - second.hit_point).magnitude2()
+        <= HUD_OVERLAY_SURFACE_GAP * HUD_OVERLAY_SURFACE_GAP;
+    (co_located && close_surface).then_some(second_entity)
 }
 
-/// Whether an entity is worth highlighting / interacting with (it has frob
-/// info), which excludes plain world geometry the ray also hits.
+fn has_hud_select(world: &World, entity_id: EntityId, expected: bool) -> bool {
+    world
+        .borrow::<View<PropHUDSelect>>()
+        .map(|v| v.get(entity_id).is_ok_and(|select| select.0 == expected))
+        .unwrap_or(false)
+}
+
+/// Whether an entity is worth highlighting / interacting with. Empty authored
+/// FrobInfo overrides deliberately suppress an inherited world action, so
+/// property presence by itself is not enough.
 fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
     world
         .borrow::<View<PropFrobInfo>>()
-        .map(|v| v.get(entity_id).is_ok())
+        .map(|v| {
+            v.get(entity_id)
+                .is_ok_and(|frob| !frob.world_action.is_empty())
+        })
         .unwrap_or(false)
 }
 
@@ -329,7 +377,15 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 mod tests {
     use super::*;
     use crate::physics::CollisionGroup;
-    use dark::properties::{FrobFlag, PropPickBias, PropPlayerGun};
+    use dark::properties::{FrobFlag, PropHUDSelect, PropPickBias, PropPlayerGun};
+
+    fn frob_info(world_action: FrobFlag) -> PropFrobInfo {
+        PropFrobInfo {
+            world_action,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        }
+    }
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -388,15 +444,25 @@ mod tests {
     }
 
     #[test]
+    fn empty_or_inventory_only_frob_info_is_not_world_frobbable() {
+        let mut world = World::new();
+        let empty = world.add_entity(frob_info(FrobFlag::empty()));
+        let inventory_only = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::empty(),
+            inventory_action: FrobFlag::SCRIPT,
+            tool_action: FrobFlag::empty(),
+        });
+
+        assert!(!is_frobbable(&world, empty));
+        assert!(!is_frobbable(&world, inventory_only));
+    }
+
+    #[test]
     fn negative_pick_bias_surface_yields_to_frobbable_overlay() {
         let mut world = World::new();
         let player = world.add_entity(());
         let decorative_surface = world.add_entity(PropPickBias(-2000.0));
-        let frobbable_overlay = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::SCRIPT,
-            inventory_action: FrobFlag::empty(),
-            tool_action: FrobFlag::empty(),
-        });
+        let frobbable_overlay = world.add_entity(frob_info(FrobFlag::SCRIPT));
         let mut physics = PhysicsWorld::new();
         let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
@@ -448,16 +514,193 @@ mod tests {
     }
 
     #[test]
+    fn hud_hidden_surface_yields_to_colocated_selectable_overlay() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let decorative_surface =
+            world.add_entity((PropHUDSelect(false), frob_info(FrobFlag::empty())));
+        let frobbable_overlay =
+            world.add_entity((PropHUDSelect(true), frob_info(FrobFlag::SCRIPT)));
+        let mut physics = PhysicsWorld::new();
+        let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        physics.add_kinematic(
+            decorative_surface,
+            vec3(0.0, 0.0, -1.0),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        physics.add_kinematic(
+            frobbable_overlay,
+            vec3(0.0, 0.0, -1.0),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.1),
+            CollisionGroup::selectable(),
+            false,
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &input,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            identity,
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, Some(frobbable_overlay));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            VirtualHandEffect::OutMessage {
+                message: Message {
+                    to,
+                    payload: MessagePayload::Frob
+                }
+            } if *to == frobbable_overlay
+        )));
+    }
+
+    #[test]
+    fn hud_hidden_surface_does_not_frob_through_an_entity_blocker() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let decorative_surface = world.add_entity(PropHUDSelect(false));
+        let closed_door = world.add_entity(());
+        let frobbable_overlay =
+            world.add_entity((PropHUDSelect(true), frob_info(FrobFlag::SCRIPT)));
+        let mut physics = PhysicsWorld::new();
+        let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        for (entity, z, depth, group) in [
+            (decorative_surface, -1.0, 0.2, CollisionGroup::entity()),
+            (closed_door, -0.925, 0.02, CollisionGroup::entity()),
+            (frobbable_overlay, -1.0, 0.1, CollisionGroup::selectable()),
+        ] {
+            physics.add_kinematic(
+                entity,
+                vec3(0.0, 0.0, z),
+                identity,
+                vec3(0.0, 0.0, 0.0),
+                vec3(1.0, 1.0, depth),
+                group,
+                false,
+            );
+        }
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        let first = physics
+            .ray_cast(
+                point3(0.0, 0.0, 0.0),
+                vec3(0.0, 0.0, -1.0),
+                INTERACTION_GROUPS,
+            )
+            .expect("the hidden shell should be the first combined hit");
+        assert_eq!(first.maybe_entity_id, Some(decorative_surface));
+        let second = physics
+            .ray_cast2(
+                point3(0.0, 0.0, 0.0),
+                vec3(0.0, 0.0, -1.0),
+                100.0,
+                INTERACTION_GROUPS,
+                Some(decorative_surface),
+                true,
+            )
+            .expect("the door should block the recast behind the shell");
+        assert_eq!(second.maybe_entity_id, Some(closed_door));
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &input,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            identity,
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, None);
+        assert!(!effects.iter().any(|effect| matches!(
+            effect,
+            VirtualHandEffect::OutMessage {
+                message: Message {
+                    payload: MessagePayload::Frob,
+                    ..
+                }
+            }
+        )));
+    }
+
+    #[test]
+    fn hud_hidden_surface_does_not_frob_an_unrelated_selectable() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let decorative_surface = world.add_entity(PropHUDSelect(false));
+        let unrelated_control =
+            world.add_entity((PropHUDSelect(true), frob_info(FrobFlag::SCRIPT)));
+        let mut physics = PhysicsWorld::new();
+        let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        physics.add_kinematic(
+            decorative_surface,
+            vec3(0.0, 0.0, -1.0),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        physics.add_kinematic(
+            unrelated_control,
+            vec3(0.0, 0.0, -1.3),
+            identity,
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 1.0, 0.1),
+            CollisionGroup::selectable(),
+            false,
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &input,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            identity,
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, None);
+        assert!(!effects.iter().any(|effect| matches!(
+            effect,
+            VirtualHandEffect::OutMessage {
+                message: Message {
+                    payload: MessagePayload::Frob,
+                    ..
+                }
+            }
+        )));
+    }
+
+    #[test]
     fn negative_pick_bias_does_not_frob_through_an_entity_blocker() {
         let mut world = World::new();
         let player = world.add_entity(());
         let decorative_surface = world.add_entity(PropPickBias(-2000.0));
         let closed_door = world.add_entity(());
-        let frobbable_behind_door = world.add_entity(PropFrobInfo {
-            world_action: FrobFlag::SCRIPT,
-            inventory_action: FrobFlag::empty(),
-            tool_action: FrobFlag::empty(),
-        });
+        let frobbable_behind_door = world.add_entity(frob_info(FrobFlag::SCRIPT));
         let mut physics = PhysicsWorld::new();
         let mut player_handle = physics.create_player(vec3(1000.0, 1000.0, 1000.0), player);
         let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);

--- a/tools/shock2-sdk/test/eng1-fluidics.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng1-fluidics.e2e.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable eng1 mission-object ids. Runtime ids are rediscovered every launch.
+const FLUIDIC_BUTTON_OBJECT = 1114;
+const FLUIDIC_COMP_OBJECT = 1152;
+const OFFLINE_EMAIL_TRAP_OBJECT = 651;
+
+// Negative-first: Fluidic Comp is authored HUDSelect(false) with PickBias
+// -2000, immediately in front of the invisible HUDSelect(true) button overlay.
+// Flat interaction used to stop at the computer's non-frobbable ENTITY
+// collider, then filter it out, so a normal squeeze could never reach the
+// overlay or fire the offline response.
+test(
+  "eng1: production crosshair frobs the Fluidics overlay behind its biased computer",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
+    });
+    await game.step({ frames: 2 });
+
+    const [button] = await game.entities.byTemplate(FLUIDIC_BUTTON_OBJECT);
+    const [computer] = await game.entities.byTemplate(FLUIDIC_COMP_OBJECT);
+    const [offlineEmail] = await game.entities.byTemplate(OFFLINE_EMAIL_TRAP_OBJECT);
+    assert.ok(button?.name === "Fluidic Button", "expected the Fluidics button overlay");
+    assert.ok(computer?.name === "Fluidic Comp", "expected the Fluidics computer");
+    assert.ok(offlineEmail, "expected the one-shot offline email response");
+
+    // Setup only: use the real campaign standing position, then drive the
+    // production camera and squeeze path for the interaction under test.
+    await game.player.teleport({ x: 0.956, y: -1.556, z: -175.278 });
+    await game.step({ frames: 2 });
+    const aim = await game.player.aimAt(button, { hitbox: "center" });
+    assert.equal(
+      aim.interaction_target_id,
+      computer.id,
+      "the unprioritized combined ray should document the computer occluder",
+    );
+    assert.equal(aim.target_confirmed, false);
+
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.entities.byTemplate(OFFLINE_EMAIL_TRAP_OBJECT)).length,
+      0,
+      "the production Frob should relay through the button and consume the offline email trap",
+    );
+    assert.equal(
+      await game.quests.get("note_1_13"),
+      "incomplete",
+      "the offline response should grant its authored objective",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/eng1-master-power.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng1-master-power.e2e.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable eng1 mission-object ids. Runtime ids are rediscovered every launch.
+const MASTER_POWER_BUTTON_OBJECT = 1870;
+const MASTER_POWER_COMP_OBJECT = 1103;
+const MASTER_POWER_ROUTER_OBJECT = 878;
+const ELEVATOR_DOOR_CONTROL_OBJECT = 990;
+
+async function lastSoundSequence(game: GameServer): Promise<number> {
+  const { sounds } = await game.audio.recent();
+  return sounds.length === 0 ? 0 : sounds[sounds.length - 1].sequence;
+}
+
+async function pressRefused(game: GameServer, entityId: number): Promise<boolean> {
+  const since = await lastSoundSequence(game);
+  await game.entities.sendMessage(entityId, { type: "Frob" });
+  await game.step({ frames: 5 });
+  const { sounds } = await game.audio.recent();
+  return sounds.some(
+    ({ sequence, sample }) =>
+      sequence > since && sample.toLowerCase() === "hackfail",
+  );
+}
+
+// Negative-first: Master Power Comp is authored HUDSelect(false) with empty
+// FrobInfo immediately in front of an invisible HUDSelect(true) button overlay.
+// Unlike Fluidic Comp it has no negative PickBias, so the flat crosshair used to
+// stop on the decorative shell and never reach the production button.
+test(
+  "eng1: production crosshair frobs the Master Power overlay behind its non-selectable computer",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8195),
+    });
+    await game.step({ frames: 2 });
+
+    const [button] = await game.entities.byTemplate(MASTER_POWER_BUTTON_OBJECT);
+    const [computer] = await game.entities.byTemplate(MASTER_POWER_COMP_OBJECT);
+    const [router] = await game.entities.byTemplate(MASTER_POWER_ROUTER_OBJECT);
+    const [elevatorControl] = await game.entities.byTemplate(
+      ELEVATOR_DOOR_CONTROL_OBJECT,
+    );
+    assert.ok(button?.name === "Master Power Button", "expected the button overlay");
+    assert.ok(computer?.name === "Master Power Comp", "expected the computer shell");
+    assert.ok(router?.name === "Once Router", "expected the one-shot success router");
+    assert.ok(
+      elevatorControl?.name === "Elevator Button",
+      "expected the locked elevator control",
+    );
+
+    // Setup only: satisfy the authored nacelle filter and stand at the exact
+    // campaign position, then drive the production camera and squeeze path.
+    await game.quests.set("NacellesFrobbed", "incomplete");
+    assert.equal(
+      await pressRefused(game, elevatorControl.id),
+      true,
+      "the authored elevator control should begin locked",
+    );
+    await game.player.teleport({ x: 1.5, y: 4.444, z: -19.72 });
+    await game.step({ frames: 2 });
+    const aim = await game.player.aimAt(button, { hitbox: "center" });
+    assert.equal(
+      aim.interaction_target_id,
+      computer.id,
+      "the unprioritized combined ray should document the computer occluder",
+    );
+    assert.equal(aim.target_confirmed, false);
+
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 30 });
+
+    const [poweredComputer] = await game.entities.byTemplate(
+      MASTER_POWER_COMP_OBJECT,
+    );
+    assert.ok(poweredComputer, "the Master Power computer should remain in the mission");
+    assert.equal(
+      (await game.entities.detail(poweredComputer.id)).properties.find(
+        ({ name }) => name === "Model",
+      )?.value,
+      "engon",
+      "the production Frob should switch the Master Power display on",
+    );
+    assert.equal(await game.quests.get("CorePower"), "incomplete");
+    assert.equal(await game.quests.get("note_1_5"), "complete");
+    assert.equal(await game.quests.get("note_1_1"), "complete");
+    assert.equal(await game.quests.get("ElevState"), "incomplete");
+    assert.equal(
+      (await game.entities.byTemplate(MASTER_POWER_ROUTER_OBJECT)).length,
+      0,
+      "the successful production Frob should consume the one-shot power router",
+    );
+    assert.equal(
+      await pressRefused(game, elevatorControl.id),
+      false,
+      "restoring Master Power should unlock the elevator control",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- honor authored negative `P$PickBias` when the flat crosshair first hits the Fluidics computer shell
- let a `HUDSelect(false)` visual shell yield only to its direct, co-located `HUDSelect(true)` interaction overlay, with tight body-origin and surface-gap bounds
- keep the combined recast's ENTITY/WORLD/UI/RAYCAST blockers, so walls, closed doors, and unrelated controls still occlude interaction
- preserve Dark's compatibility rule that any `P$FrobInfo` marks an interactable object: scripted objects such as `StdDoor` can consume `Frob` even with an empty world-action mask
- cover Fluidics and Master Power through the production camera + squeeze path, plus the existing Earth door path

Fixes #751

## Player-observable evidence

### Fluidics Control

![eng1 Fluidics Control interaction demo](https://gist.githubusercontent.com/tommy-xr/6c164c7de355a45ac43853cc923008b7/raw/fluidics-interaction.gif)

At the same production crosshair pose, the fix exposes the authored Fluidics hover target and the following production squeeze consumes the one-shot offline EmailTrap. [Full-resolution source stills and binary media](https://gist.github.com/tommy-xr/6c164c7de355a45ac43853cc923008b7).

![eng1 Fluidics Control before and after](https://gist.githubusercontent.com/tommy-xr/6c164c7de355a45ac43853cc923008b7/raw/fluidics-before-after.png)

### Master Power

![eng1 Master Power interaction demo](https://gist.githubusercontent.com/tommy-xr/113cd5337096d5e57f88fcc688a8a6a1/raw/master-power-extension.gif)

From the same Engine Core fixture and camera/squeeze sequence, the base stays `ENG. CORE OFFLINE`; the fix reaches the authored overlay and powers it to `ENG. CORE ONLINE`. [Full-resolution source stills and binary media](https://gist.github.com/tommy-xr/113cd5337096d5e57f88fcc688a8a6a1).

![eng1 Master Power before and after](https://gist.githubusercontent.com/tommy-xr/113cd5337096d5e57f88fcc688a8a6a1/raw/master-power-before-after.png)

Both captures use matched pre-fix/fixed debug-runtime binaries, fresh or cold campaign fixtures, rediscovered runtime entity IDs, and deterministic `/v1/step` + `/v1/screenshot` sequences.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` — 386 passed
- `env -u SHOCK2_E2E npm test` in `tools/shock2-sdk` — 26 passed, 159 E2E scenarios skipped as designed
- focused runtime regression set: Earth `StdDoor`, eng1 Fluidics, eng1 Master Power — 3 passed
- full `npm run test:e2e` — 182 passed, 0 failed, 3 intentionally skipped

The Master Power E2E starts from fresh eng1, satisfies only the prior nacelle condition, then uses production `aimAt` + squeeze and verifies the display, `CorePower`, linked notes, one-shot router consumption, and elevator unlock.
