### PR TITLE
fix(gameplay): handle player death and QBR respawn

### DIFF
--- a/projects/player-death.md
+++ b/projects/player-death.md
@@ -4,9 +4,9 @@ When the player 'dies' in the VR game, we want to make them _feel_ it. The idea 
 
 If there is a revive chamber (a ResurrectionStation / ResStation - based on template -1677) and the following conditions are met:
 1. The user has _activated_ the revive station
-2. The user has 5 nanites
+2. The user has 10 nanites (the retail Normal-or-higher cost)
 
-If the revive station is available, 5 nanites should be deducted from the player balance and the player should be teleported to the revive station.
+If the revive station is available, 10 nanites should be deducted from the player balance and the player should be teleported to the revive station.
 
 ## Death Animation
 
@@ -24,121 +24,31 @@ A 'static' or 'blood' effect when the player dies would be pretty cool but not o
 
 ---
 
-## Implementation Plan
+## Gameplay implementation
 
-### Codebase Analysis Findings
+Player health is tracked by `PropHitPoints`/`PropMaxHitPoints`. All HP effects
+flow through `MissionCore::handle_effects`; lethal player damage is clamped at
+zero and enters `PlayerLifeState` exactly once.
 
-**Current Health System**:
-- Player health tracked via `PropHitPoints`/`PropMaxHitPoints` components
-- Displayed on left arm HUD (`shock2vr/src/hud/virtual_arms.rs:115-136`)
-- Death triggered by `MessagePayload::Damage` leading to `Effect::SlayEntity`
+The resurrection scanner uses the mission's existing authored flow:
 
-**Death Handling**:
-- `SlayEntity` effect processed in `mission_core.rs:751`
-- Currently removes entities via `slay_entity()` function
-- This is where we'll intercept player death
+- `Res_Station_Button` (`ResurrectMachine` + `Tweqable`) changes from `res_pad`
+  to `res_pad2` when activated.
+- The switched `PropModelName` persists in normal mission save data and is the
+  durable activation marker.
+- Its `SwitchLink` points to the authored `TrapTeleport` at the reconstruction
+  position. Death never guesses a station coordinate or uses a runtime ID.
+- With an active station and 10 carried nanites, the cost is debited atomically,
+  input is suppressed for the retail five-second delay, then the player is
+  teleported to that trap and restored to half maximum health.
+- Without an activated and affordable station, the player remains terminally
+  dead until an explicit load/restart. Dead games cannot be saved.
 
-**Camera System**:
-- `EngineRenderContext` has separate `camera_offset`/`head_offset` fields
-- Perfect foundation for adding camera override capability
+The debug runtime exposes `player.life_state` as `alive`, `dead`, or
+`respawning`, giving play-through automation an explicit loss signal.
 
-**Resurrection Station Entities**:
-- Resurrection Station template: `-1677` ("Resurrection Station", model: "resust")
-- Button template: `-4325` ("Res_Station_Button", model: "res_pad")
-- Button has `ResurrectMachine` and `Tweqable` scripts (not yet implemented)
-- Both have unparsed `P$DonorType` property (likely activation state)
+## Presentation follow-up
 
-### Phase 1: Engine Camera Override System
-
-**Files to modify:**
-- `engine/src/engine.rs` - Add `CameraOverride` to `EngineRenderContext`
-- VR runtime files - Update camera calculation logic
-
-**Implementation:**
-1. Add `CameraOverride` struct to `engine/src/engine.rs`:
-```rust
-pub struct CameraOverride {
-    pub transition: f32,    // 0.0 = VR position, 1.0 = override position
-    pub position: Vector3<f32>,
-    pub forward: Vector3<f32>,
-    pub up: Vector3<f32>,
-}
-```
-
-2. Add `camera_override: Option<CameraOverride>` to `EngineRenderContext`
-
-3. Update VR runtimes to interpolate between VR head position and override when present
-
-### Phase 2: Player Death Detection
-
-**Files to modify:**
-- `shock2vr/src/mission/mission_core.rs` - Modify `slay_entity` function
-- `shock2vr/src/mission/player_info.rs` - Track player death state
-
-**Implementation:**
-1. Detect when player entity is slayed in `mission_core.rs:751`
-2. Check if slayed entity is the player (compare with `PlayerInfo.entity_id`)
-3. Trigger death sequence instead of normal entity removal
-
-### Phase 3: Death Animation System
-
-**Files to create/modify:**
-- `shock2vr/src/systems/player_death.rs` - New system for death animation
-- `shock2vr/src/game_scene.rs` - Update render to use camera override
-
-**Implementation:**
-1. Create `PlayerDeathState` component:
-```rust
-pub struct PlayerDeathState {
-    pub start_time: f32,
-    pub start_position: Vector3<f32>,
-    pub target_position: Vector3<f32>, // Floor position
-    pub duration: f32,
-}
-```
-
-2. Death animation lerps camera from current VR position to floor over 2-3 seconds
-3. Calculate floor position using physics raycast downward
-4. Add random facing direction (forward/backward)
-
-### Phase 4: Resurrection System
-
-**Files to create/modify:**
-- `shock2vr/src/scripts/resurrect_machine.rs` - Implement ResurrectMachine script
-- `shock2vr/src/mission/nanites.rs` - Nanite currency management
-
-**Implementation:**
-1. Create ResurrectMachine script that handles:
-   - Button frob detection
-   - Player death state check
-   - Nanite balance verification (5 nanites required)
-   - Teleportation to resurrection station location
-
-2. Add nanite management system:
-   - Track player nanite count
-   - Deduct 5 nanites on resurrection
-   - Store in player properties or separate component
-
-### Phase 5: Integration and Polish
-
-**Files to modify:**
-- Mission scene render logic
-- Input handling during death state
-- UI feedback for resurrection availability
-
-**Implementation:**
-1. Disable player input during death animation
-2. Show resurrection prompt if available
-3. Handle respawn at resurrection station position
-4. Reset player health to full on resurrection
-5. Clear death state and restore normal camera control
-
-### Recommended Implementation Order
-
-1. **Start with Phase 1** - Camera override system (foundational)
-2. **Phase 2** - Player death detection (core logic)
-3. **Phase 3** - Death animation (visual feedback)
-4. **Phase 4** - Resurrection system (gameplay mechanics)
-5. **Phase 5** - Polish and integration
-
-Each phase builds on the previous and can be tested independently. The camera override system from Phase 1 will be reusable for other features like cutscenes or forced camera movements.
+The functional lifecycle does not yet force the VR camera into a collapse pose
+or draw a dedicated death overlay. A future presentation pass can add those
+effects without changing the authoritative HP/QBR state machine above.

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -648,6 +648,8 @@ pub struct PlayerInfo {
     pub entity_id: Option<i32>,
     pub position: [f32; 3],
     pub rotation: [f32; 4], // quaternion
+    /// "alive", terminally "dead", or waiting for QBR reconstruction.
+    pub life_state: String,
     pub camera_offset: [f32; 3],
     pub camera_rotation: [f32; 4], // quaternion
     /// The wielded/first-person weapon in flatscreen mode (the player's left-hand

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1953,6 +1953,10 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                     .as_ref()
                     .map(|s| s.rotation)
                     .unwrap_or([1.0, 0.0, 0.0, 0.0]),
+                life_state: state
+                    .as_ref()
+                    .map(|s| s.life_state.clone())
+                    .unwrap_or_else(|| "alive".to_owned()),
                 camera_offset: [0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0],
                 camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -397,6 +397,9 @@ pub struct PlayerStateSnapshot {
     pub entity_id: i32,
     pub position: [f32; 3],
     pub rotation: [f32; 4],
+    /// "alive", terminally "dead", or waiting for an activated QBR while
+    /// "respawning". This is the automation-visible loss signal.
+    pub life_state: String,
     pub wielded_entity_id: Option<i32>,
     pub right_hand_entity_id: Option<i32>,
     /// Whether the wielded weapon is mid-reload, and (if so) the current
@@ -414,8 +417,8 @@ pub struct PlayerStateSnapshot {
     /// is only one (it just cannot be cycled).
     pub wielded_ammo_type: Option<String>,
     /// The player's hit points (current, max), or `None` when the player has
-    /// no health pool. Seeded from `The Player` template; drained by psi
-    /// burnout (real damage handling is still TODO).
+    /// no health pool. Seeded from `The Player` template and consumed by every
+    /// damage path, with zero entering the player death lifecycle.
     pub hit_points: Option<(i32, i32)>,
     /// The player's psi pool (current, max), or `None` when the player has no
     /// psi state (e.g. gamesys not loaded).
@@ -471,6 +474,10 @@ impl Game {
                 info.rotation.v.z,
                 info.rotation.s,
             ],
+            life_state: world
+                .borrow::<shipyard::UniqueView<crate::mission::PlayerLifeState>>()
+                .map(|life| life.as_str().to_owned())
+                .unwrap_or_else(|_| "alive".to_owned()),
             wielded_entity_id: info.left_hand_entity_id.map(|e| e.inner() as i32),
             right_hand_entity_id: info.right_hand_entity_id.map(|e| e.inner() as i32),
             reloading: reload.is_some(),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -42,8 +42,9 @@ use dark::{
         PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
         PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropTeleported,
-        PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState, PropertyDefinition, RenderType,
-        TeleportSource, ToLink, TripFlags, TweqAnimationState, WrappedEntityId,
+        PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqModelConfig,
+        PropertyDefinition, RenderType, TeleportSource, ToLink, TripFlags, TweqAnimationState,
+        WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -144,6 +145,95 @@ pub struct PlayerInfo {
     pub left_hand_entity_id: Option<EntityId>,
     pub right_hand_entity_id: Option<EntityId>,
     pub inventory_entity_id: EntityId,
+}
+
+/// The live player's death/reconstruction lifecycle.
+///
+/// This is mission-local runtime state: a dead game cannot be saved (see
+/// `player_save_position`), so only the player's persistent vitals and an
+/// activated station's authored model state need serialization.
+#[derive(Unique, Clone, Debug, PartialEq)]
+pub enum PlayerLifeState {
+    Alive,
+    /// No activated/affordable QBR exists in this mission. The player remains
+    /// terminally dead until a load or level restart replaces the scene.
+    Dead,
+    /// The retail five-second death pause before a QBR reconstruction.
+    Respawning {
+        elapsed_seconds: f32,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+    },
+}
+
+impl PlayerLifeState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PlayerLifeState::Alive => "alive",
+            PlayerLifeState::Dead => "dead",
+            PlayerLifeState::Respawning { .. } => "respawning",
+        }
+    }
+
+    fn is_alive(&self) -> bool {
+        matches!(self, PlayerLifeState::Alive)
+    }
+}
+
+const PLAYER_RESPAWN_DELAY_SECONDS: f32 = 5.0;
+const PLAYER_RESPAWN_NANITE_COST: i32 = 10;
+
+/// Resolve the active QBR's authored teleport trap. `ResurrectMachine` uses
+/// the scanner's model tweq as its durable activation state: the initial
+/// `res_pad` becomes the config's final model (`res_pad2`) when frobbed, and
+/// `PropModelName` already persists with the rest of the mission.
+fn active_resurrection_target(world: &World) -> Option<(Vector3<f32>, Quaternion<f32>)> {
+    let scripts = world.borrow::<View<PropScripts>>().ok()?;
+    let models = world.borrow::<View<PropModelName>>().ok()?;
+    let tweq_configs = world.borrow::<View<PropTweqModelConfig>>().ok()?;
+    let links = world.borrow::<View<Links>>().ok()?;
+    let positions = world.borrow::<View<PropPosition>>().ok()?;
+
+    for (button, (button_scripts, model, config)) in
+        (&scripts, &models, &tweq_configs).iter().with_id()
+    {
+        let is_resurrection_button = button_scripts
+            .scripts
+            .iter()
+            .any(|script| script.eq_ignore_ascii_case("resurrectmachine"));
+        let is_active = config
+            .model_names
+            .last()
+            .is_some_and(|active_model| model.0.eq_ignore_ascii_case(active_model));
+        if !is_resurrection_button || !is_active {
+            continue;
+        }
+
+        let Some(button_links) = links.get(button).ok() else {
+            continue;
+        };
+        for link in &button_links.to_links {
+            if !matches!(link.link, Link::SwitchLink) {
+                continue;
+            }
+            let Some(target) = link.to_entity_id.map(|target| target.0) else {
+                continue;
+            };
+            let target_is_teleport = scripts.get(target).is_ok_and(|target_scripts| {
+                target_scripts
+                    .scripts
+                    .iter()
+                    .any(|script| script.eq_ignore_ascii_case("trapteleport"))
+            });
+            if target_is_teleport {
+                if let Ok(position) = positions.get(target) {
+                    return Some((position.position, position.rotation));
+                }
+            }
+        }
+    }
+
+    None
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -812,6 +902,7 @@ impl MissionCore {
             right_hand_entity_id: None,
             inventory_entity_id: inventory,
         });
+        world.add_unique(PlayerLifeState::Alive);
 
         world.add_unique(quest_info);
 
@@ -1055,6 +1146,112 @@ impl MissionCore {
         }
     }
 
+    fn player_is_alive(&self) -> bool {
+        self.world
+            .borrow::<UniqueView<PlayerLifeState>>()
+            .map(|life| life.is_alive())
+            .unwrap_or(true)
+    }
+
+    /// Enter the death state once. An active QBR is usable only when the
+    /// player can atomically pay the retail 10-nanite reconstruction cost;
+    /// otherwise death is terminal and the scene remains available for an
+    /// explicit quick-load/restart.
+    fn begin_player_death(&mut self) {
+        if !self.player_is_alive() {
+            return;
+        }
+
+        let paid_respawn = active_resurrection_target(&self.world).and_then(|target| {
+            crate::scripts::script_util::debit_player_nanites(
+                &self.world,
+                PLAYER_RESPAWN_NANITE_COST,
+            )
+            .map(|exhausted| (target, exhausted))
+        });
+
+        let next_state = if let Some(((position, rotation), exhausted)) = paid_respawn {
+            for entity_id in exhausted {
+                self.destroy_entity(entity_id);
+            }
+            info!(
+                "Player died: QBR reconstruction queued at {:?} (-{} nanites)",
+                position, PLAYER_RESPAWN_NANITE_COST
+            );
+            PlayerLifeState::Respawning {
+                elapsed_seconds: 0.0,
+                position,
+                rotation,
+            }
+        } else {
+            info!("Player died: no activated and affordable QBR");
+            PlayerLifeState::Dead
+        };
+
+        *self
+            .world
+            .borrow::<UniqueViewMut<PlayerLifeState>>()
+            .unwrap() = next_state;
+    }
+
+    /// Advance the retail death pause and perform the reconstruction when its
+    /// five seconds have elapsed.
+    fn update_player_life_state(&mut self, elapsed_seconds: f32) {
+        let respawn = {
+            let mut life = self
+                .world
+                .borrow::<UniqueViewMut<PlayerLifeState>>()
+                .unwrap();
+            match &mut *life {
+                PlayerLifeState::Respawning {
+                    elapsed_seconds: elapsed,
+                    position,
+                    rotation,
+                } => {
+                    *elapsed += elapsed_seconds;
+                    (*elapsed + f32::EPSILON >= PLAYER_RESPAWN_DELAY_SECONDS)
+                        .then_some((*position, *rotation))
+                }
+                PlayerLifeState::Alive | PlayerLifeState::Dead => None,
+            }
+        };
+
+        let Some((position, rotation)) = respawn else {
+            return;
+        };
+
+        self.physics
+            .set_player_translation(position, &mut self.player_handle);
+        let player_entity = {
+            let mut player = self.world.borrow::<UniqueViewMut<PlayerInfo>>().unwrap();
+            player.pos = position;
+            player.rotation = rotation;
+            player.entity_id
+        };
+        self.world.add_component(
+            player_entity,
+            PropTeleported::with_source(TeleportSource::ScriptedTrap),
+        );
+        self.world.run(
+            |mut hit_points: ViewMut<PropHitPoints>,
+             max_hit_points: View<dark::properties::PropMaxHitPoints>| {
+                let maximum = max_hit_points
+                    .get(player_entity)
+                    .map(|max| max.hit_points as i32)
+                    .unwrap_or(1)
+                    .max(1);
+                if let Ok(hit_points) = (&mut hit_points).get(player_entity) {
+                    hit_points.hit_points = (maximum / 2).max(1);
+                }
+            },
+        );
+        *self
+            .world
+            .borrow::<UniqueViewMut<PlayerLifeState>>()
+            .unwrap() = PlayerLifeState::Alive;
+        info!("Player reconstructed at QBR {:?}", position);
+    }
+
     pub fn update(
         &mut self,
         time: &Time,
@@ -1065,6 +1262,38 @@ impl MissionCore {
     ) -> Vec<Effect> {
         let _ = self.world.remove_unique::<Time>();
         self.world.add_unique(time.clone());
+
+        // Old saves can legitimately restore a zero-HP player even though
+        // PlayerLifeState itself is runtime-only. Enter death on the first
+        // update in that case, then advance any pending QBR reconstruction.
+        let player_health_depleted = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            self.world
+                .borrow::<View<PropHitPoints>>()
+                .ok()
+                .and_then(|hit_points| {
+                    hit_points
+                        .get(player.entity_id)
+                        .ok()
+                        .map(|hit_points| hit_points.hit_points <= 0)
+                })
+                .unwrap_or(false)
+        };
+        if self.player_is_alive() && player_health_depleted {
+            self.begin_player_death();
+        }
+        self.update_player_life_state(time.elapsed.as_secs_f32());
+
+        // A dead player's physical head can still look around in VR, but all
+        // actionable movement, hand, trigger, crouch, and pointer channels are
+        // neutral until reconstruction. Discrete quick-load remains available
+        // because it arrives separately in `command_effects`.
+        let suppressed_input = InputContext::default();
+        let input_context = if self.player_is_alive() {
+            input_context
+        } else {
+            &suppressed_input
+        };
         // Refill the per-frame AI pathfind budget - only on advancing frames,
         // so paused zero-dt ticks (debug runtime introspection) can't grant
         // extra query slots between stepped frames
@@ -3003,13 +3232,20 @@ impl MissionCore {
                 }
 
                 Effect::AdjustHitPoints { entity_id, delta } => {
+                    // Once death has started, stray queued damage/healing must
+                    // not churn the terminal pool or revive the player outside
+                    // the reconstruction path.
+                    if entity_id == player_entity && !self.player_is_alive() {
+                        continue;
+                    }
                     let mut v_hit_points = self
                         .world
                         .borrow::<ViewMut<dark::properties::PropHitPoints>>()
                         .unwrap();
 
                     if let Ok(hit_points) = (&mut v_hit_points).get(entity_id) {
-                        hit_points.hit_points += delta;
+                        let previous = hit_points.hit_points;
+                        hit_points.hit_points = hit_points.hit_points.saturating_add(delta).max(0);
                         // Every HP change flows through here (weapon, stim,
                         // collision damage) - trace it with the resulting
                         // total so a mysterious death is attributable.
@@ -3021,6 +3257,9 @@ impl MissionCore {
                             delta,
                             hp
                         );
+                        if entity_id == player_entity && previous > 0 && hp == 0 {
+                            self.begin_player_death();
+                        }
                     }
                 }
 
@@ -5215,6 +5454,9 @@ impl MissionCore {
     }
 
     pub fn player_save_position(&self) -> Option<Vector3<f32>> {
+        if !self.player_is_alive() {
+            return None;
+        }
         self.physics
             .get_player_save_translation(&self.player_handle)
     }
@@ -6997,6 +7239,67 @@ mod death_motion_tests {
     fn three_frame_already_dead_pose_is_not_a_realtime_crumple() {
         assert!(!is_realtime_crumple(3.0));
         assert!(is_realtime_crumple(79.0));
+    }
+}
+
+#[cfg(test)]
+mod player_death_tests {
+    use dark::properties::{PropTweqModelConfig, TweqAnimationConfig, TweqHalt};
+
+    use super::*;
+
+    fn resurrection_world(model: &str) -> (World, Vector3<f32>, Quaternion<f32>) {
+        let mut world = World::new();
+        let target_position = vec3(4.0, 5.0, 6.0);
+        let target_rotation = Quaternion::from_angle_y(cgmath::Deg(90.0));
+        let target = world.add_entity((
+            PropScripts {
+                scripts: vec!["TrapTeleport".to_owned()],
+                inherits: true,
+            },
+            PropPosition {
+                position: target_position,
+                rotation: target_rotation,
+                cell: 0,
+            },
+        ));
+        world.add_entity((
+            PropScripts {
+                scripts: vec!["ResurrectMachine".to_owned(), "Tweqable".to_owned()],
+                inherits: true,
+            },
+            PropModelName(model.to_owned()),
+            PropTweqModelConfig {
+                animation_config: TweqAnimationConfig::SIM,
+                halt: TweqHalt::StopTweq,
+                model_names: vec!["res_pad".to_owned(), "res_pad2".to_owned()],
+            },
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        (world, target_position, target_rotation)
+    }
+
+    #[test]
+    fn inactive_resurrection_scanner_has_no_respawn_target() {
+        let (world, _, _) = resurrection_world("res_pad");
+
+        assert_eq!(active_resurrection_target(&world), None);
+    }
+
+    #[test]
+    fn activated_scanner_resolves_its_linked_teleport_target() {
+        let (world, expected_position, expected_rotation) = resurrection_world("res_pad2");
+
+        assert_eq!(
+            active_resurrection_target(&world),
+            Some((expected_position, expected_rotation))
+        );
     }
 }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -323,6 +323,9 @@ export interface PlayerSnapshot {
   entity_id: number | null;
   position: Vec3;
   rotation: [number, number, number, number];
+  /** Current player lifecycle. `dead` is terminal until a load/restart;
+   * `respawning` is the five-second QBR reconstruction delay. */
+  life_state: "alive" | "dead" | "respawning";
   camera_offset: Vec3;
   camera_rotation: [number, number, number, number];
   /** The wielded/first-person weapon in flatscreen mode; null when unarmed. */

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8198);
+
+const RESURRECTION_BUTTON = 909;
+const RESURRECTION_TARGET = 187;
+const RESURRECTION_COST = 10;
+const RESPAWN_DELAY_FRAMES = 5 * 60;
+
+type LifeState = "alive" | "dead" | "respawning";
+
+function lifeState(player: object): LifeState | undefined {
+  return (player as { life_state?: LifeState }).life_state;
+}
+
+async function killPlayer(game: GameServer): Promise<void> {
+  const before = await game.info();
+  assert.ok(before.player.entity_id !== null, "mission should expose the player entity");
+  assert.ok(before.player.hit_points !== null, "player should have hit points");
+  await game.entities.sendMessage(before.player.entity_id, {
+    type: "Damage",
+    amount: before.player.hit_points + 100,
+  });
+  await game.step({ frames: 1 });
+}
+
+test(
+  "player death becomes terminal without an activated resurrection station",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    await killPlayer(game);
+    const dead = await game.info();
+    assert.equal(dead.player.hit_points, 0, "lethal damage should clamp HP at zero");
+    assert.equal(
+      lifeState(dead.player),
+      "dead",
+      "death without an active QBR must expose a terminal loss signal",
+    );
+
+    const deathPosition = dead.player.position;
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const afterInput = await game.info();
+    assert.equal(lifeState(afterInput.player), "dead");
+    assert.ok(
+      Math.hypot(
+        afterInput.player.position[0] - deathPosition[0],
+        afterInput.player.position[1] - deathPosition[1],
+        afterInput.player.position[2] - deathPosition[2],
+      ) < 0.001,
+      `dead players must not keep moving: before=${JSON.stringify(deathPosition)} after=${JSON.stringify(afterInput.player.position)}`,
+    );
+  },
+);
+
+test(
+  "an activated resurrection station revives the player after charging 10 nanites",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 1,
+    });
+    await game.step({ frames: 5 });
+
+    await game.player.spawnItem("20 Nanites");
+    const nanitesBefore = await carriedNaniteTotal(game);
+    assert.ok(nanitesBefore >= RESURRECTION_COST);
+
+    const [button] = await game.entities.byTemplate(RESURRECTION_BUTTON);
+    assert.ok(button, "medsci1 should contain its authored QBR scanner button");
+    const [target] = await game.entities.byTemplate(RESURRECTION_TARGET);
+    assert.ok(target, "QBR button should link to its authored teleport target");
+    const targetPosition = (await game.entities.detail(target.id)).position;
+
+    await game.entities.sendMessage(button.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+
+    // Activation is the scanner's authored switched model, which must survive
+    // a save/load before a later death can rely on it.
+    const saveName = `player_death_qbr_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 2 });
+
+    await killPlayer(game);
+
+    const dying = await game.info();
+    assert.equal(lifeState(dying.player), "respawning");
+    assert.equal(dying.player.hit_points, 0);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      nanitesBefore - RESURRECTION_COST,
+      "death should charge the retail 10-nanite reconstruction cost once",
+    );
+
+    await game.step({ frames: RESPAWN_DELAY_FRAMES });
+    const revived = await game.info();
+    assert.equal(lifeState(revived.player), "alive");
+    assert.equal(
+      revived.player.hit_points,
+      Math.floor((revived.player.max_hit_points ?? 0) / 2),
+      "QBR reconstruction should restore half of maximum health",
+    );
+    assert.ok(
+      Math.hypot(
+        revived.player.position[0] - targetPosition[0],
+        revived.player.position[1] - targetPosition[1],
+        revived.player.position[2] - targetPosition[2],
+      ) < 0.25,
+      `player should respawn at the QBR teleport target: target=${JSON.stringify(targetPosition)} actual=${JSON.stringify(revived.player.position)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- clamp lethal player damage at zero and enter an explicit alive/dead/respawning lifecycle
- use each activated Resurrection Station scanner model and its authored SwitchLink teleport target to reconstruct after five seconds
- atomically charge the retail 10-nanite cost, restore half maximum health, suppress dead-player input, and refuse saves while dead
- expose `player.life_state` through the debug runtime/SDK and cover terminal death plus save-persistent QBR activation end to end
- update the player-death design note to describe the implemented lifecycle and remaining presentation work

## Reproduction

Before this change, the new negative-first runtime scenario sent lethal Damage to the real MedSci player and observed `-100` HP with no lifecycle/loss state. Activating the authored QBR scanner did not change that: life state was absent and reconstruction never occurred.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (383 passed)
- `cargo test -p shock2vr player_death_tests --lib` (2 passed, post-rebase)
- SDK `npm test` (26 passed, 159 opt-in skipped)
- focused player-death e2e (2 passed, post-rebase)
- full SDK `npm run test:e2e` (182 passed, 0 failed, 3 explicitly gated finale tests skipped; all 23 missions loaded)

Strict Clippy was also attempted, but the unchanged `engine` crate currently has baseline `-D warnings` failures such as `module_inception` and `new_ret_no_self`.

## Remaining risk

This implements the authoritative gameplay lifecycle and automation-visible loss signal. A dedicated death overlay or VR camera-collapse presentation remains a follow-up; this change adds no rendering path. Difficulty selection is not implemented in the current game, so the retail Normal-or-higher cost of 10 nanites is used.

Fixes #670