### PR TITLE
fix(rendering): hide permanently open door leaves

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -242,12 +242,21 @@ pub fn create_entity_core(
     //     world,
     // );
 
+    // A zero-travel door authored open has no retracted transform at which to
+    // draw its leaf. Keep the logical entity and scripts, but omit its visual
+    // just as its permanently-open state omits the collider (#608).
+    let create_visual = should_create_visual(world, entity_id);
+
     // Create model, if we can
-    let maybe_model = create_model(world, asset_cache, entity_id);
+    let maybe_model = if create_visual {
+        create_model(world, asset_cache, entity_id)
+    } else {
+        None
+    };
     let maybe_just_model = maybe_model.clone().map(|m| m.0);
 
     // Create bitmap animation, if no model
-    let bitmap_animation = if maybe_model.is_none() {
+    let bitmap_animation = if create_visual && maybe_model.is_none() {
         create_bitmap(world, asset_cache, entity_id)
     } else {
         None
@@ -386,6 +395,15 @@ pub fn create_entity_core(
         rigid_body,
         scripts: output_scripts,
     }
+}
+
+fn should_create_visual(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<PropTranslatingDoor>>()
+        .unwrap()
+        .get(entity_id)
+        .map(|door| !door.is_permanently_open())
+        .unwrap_or(true)
 }
 
 fn initialize_sym_name_from_obj_map(
@@ -1338,6 +1356,21 @@ mod tests {
             create_physics_representation(&mut world, &mut physics, &None, door),
             None
         );
+    }
+
+    #[test]
+    fn a_permanently_open_door_gets_no_visual() {
+        // The authored open and closed locations of hydro2 obj 135 coincide,
+        // so there is no retracted transform at which its leaf can be drawn.
+        let mut world = World::new();
+        let at = vec3(18.0, -0.4, 41.8);
+        let permanently_open = add_door(&mut world, at, at, at, 1);
+        let permanently_closed = add_door(&mut world, at, at, at, 0);
+        let ordinary = add_door(&mut world, at, at, at + vec3(0.0, 0.0, 2.4), 0);
+
+        assert!(!should_create_visual(&world, permanently_open));
+        assert!(should_create_visual(&world, permanently_closed));
+        assert!(should_create_visual(&world, ordinary));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- suppress model and bitmap creation for zero-travel translating doors authored in the open state
- preserve the logical entity, scripts, and normal rendering for permanently closed and ordinary traveling doors
- cover the Hydroponics authored-data regression with a focused unit test

## Reproduction and root cause

In `hydro2.mis`, object 135 (`HydroDoorWide`) is authored with state 1 while its closed, open, base, and initial locations all coincide. The object therefore has no retracted transform, but the mission loader still instantiated its `hydo5` leaf model in the doorway. Issue #607 already omitted the collider for this permanent-open state; the visible leaf needed the corresponding render-side treatment.

The issue was reproduced with stable mission object/template ID 135, teleporting to `[14.0, 0.1, 41.8]`, looking at yaw 0, stepping 10 fixed frames, and capturing the rendered frame.

## Verification

- negative-first: `cargo test -p shock2vr --lib mission::entity_creator::tests::a_permanently_open_door_gets_no_visual -- --exact` failed before the implementation, then passed
- `cargo test -p shock2vr` — 382 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cd tools/shock2-sdk && npm test` — 26 passed, 157 gated e2e cases skipped
- `cd tools/shock2-sdk && npm run test:e2e` — 180 passed, 0 failed, 3 expected SHODAN skips
- deterministic before/after visual capture for Hydroponics object 135

Fixes #608

## Visual verification

![Permanently-open Hydroponics door walkthrough](https://gist.githubusercontent.com/tommy-xr/71b6e67d8ba3e6cc06c44a9a6709ae2c/raw/hydro2-open-door-demo.gif)

<sub>Permanently-open Hydroponics door no longer draws its leaf; ordinary traveling doors remain visible. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After still

![Open Hydroponics doorway](https://gist.githubusercontent.com/tommy-xr/71b6e67d8ba3e6cc06c44a9a6709ae2c/raw/hydro2-open-door-after.png)

### Before → after

![Hydroponics permanently-open door before and after](https://gist.githubusercontent.com/tommy-xr/71b6e67d8ba3e6cc06c44a9a6709ae2c/raw/hydro2-open-door-before-after.png)
