### PR TITLE
fix(gameplay): make healing items restore health

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1388,6 +1388,12 @@ impl Game {
             rotation,
             quest_info,
             player_vitals: save_load::capture_player_vitals(self.active_game_scene.world()),
+            active_healing: self
+                .active_game_scene
+                .world()
+                .borrow::<UniqueView<crate::scripts::healing_item::ActiveHealing>>()
+                .map(|active| active.clone())
+                .unwrap_or_default(),
             active_mission: self.active_game_scene.scene_name().to_string(),
             is_crouched,
         };

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -328,6 +328,13 @@ enum ComestibleUseOutcome {
     Consumed,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HealingItemUseOutcome {
+    NotUsed,
+    DecrementedStack,
+    DestroyEntity,
+}
+
 fn update_player_psi_points(world: &World, update: impl FnOnce(i32) -> i32) -> bool {
     let player_entity = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
     let mut psi_states = world
@@ -438,6 +445,70 @@ fn move_live_entity_into_container(
         world.add_component(dropped_entity_id, PropHasRefs(false));
     }
     was_able_to_drop
+}
+
+/// Start one retail timed healing course and consume exactly one carried
+/// source item. The health check, queue mutation, and stack decrement all run
+/// against live state in one effect pass, so duplicate uses safely no-op.
+fn apply_healing_item_use(
+    world: &World,
+    entity_id: EntityId,
+    total: i32,
+    pulse: i32,
+    first_pulse_secs: f32,
+    pulse_interval_secs: f32,
+) -> HealingItemUseOutcome {
+    let is_alive = world
+        .borrow::<EntitiesView>()
+        .is_ok_and(|entities| entities.is_alive(entity_id));
+    if !is_alive || !crate::scripts::script_util::player_carried_items(world).contains(&entity_id) {
+        return HealingItemUseOutcome::NotUsed;
+    }
+    let stack_count = world
+        .borrow::<View<dark::properties::PropStackCount>>()
+        .ok()
+        .and_then(|stacks| stacks.get(entity_id).ok().map(|stack| stack.0));
+    if stack_count.is_some_and(|stack| stack <= 0) {
+        return HealingItemUseOutcome::NotUsed;
+    }
+
+    let player = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
+    let current = world
+        .borrow::<View<dark::properties::PropHitPoints>>()
+        .ok()
+        .and_then(|hit_points| hit_points.get(player).ok().map(|hp| hp.hit_points));
+    let maximum = world
+        .borrow::<View<dark::properties::PropMaxHitPoints>>()
+        .ok()
+        .and_then(|max_hit_points| {
+            max_hit_points
+                .get(player)
+                .ok()
+                .map(|hp| hp.hit_points.min(i32::MAX as u32) as i32)
+        });
+    if !matches!((current, maximum), (Some(current), Some(maximum)) if current > 0 && current < maximum)
+    {
+        return HealingItemUseOutcome::NotUsed;
+    }
+
+    let queued = world
+        .borrow::<UniqueViewMut<crate::scripts::healing_item::ActiveHealing>>()
+        .is_ok_and(|mut active| active.queue(total, pulse, first_pulse_secs, pulse_interval_secs));
+    if !queued {
+        return HealingItemUseOutcome::NotUsed;
+    }
+
+    if stack_count.is_some_and(|stack| stack > 1) {
+        let mut stacks = world
+            .borrow::<ViewMut<dark::properties::PropStackCount>>()
+            .unwrap();
+        if let Ok(stack) = (&mut stacks).get(entity_id) {
+            stack.0 -= 1;
+        }
+        HealingItemUseOutcome::DecrementedStack
+    } else {
+        HealingItemUseOutcome::DestroyEntity
+    }
 }
 
 /// Restore a live hand-released item to ordinary world ownership.
@@ -1133,6 +1204,7 @@ impl MissionCore {
         world.add_unique(psi_selection);
         world.add_unique(known_powers);
         world.add_unique(crate::psi::ActivePsiPowers::default());
+        world.add_unique(crate::scripts::healing_item::ActiveHealing::default());
 
         // ** Entity creation
 
@@ -1951,6 +2023,12 @@ impl MissionCore {
         // Life-state effects go first so a scene-replacing GameOver cannot
         // clobber a same-frame quick-load arriving in `command_effects`.
         let mut effects = life_state_effects;
+        if let Some(healing) = crate::scripts::healing_item::tick_player_healing(
+            &self.world,
+            time.elapsed.as_secs_f32(),
+        ) {
+            effects.push(healing);
+        }
         effects.extend(command_effects);
 
         let player = {
@@ -4445,6 +4523,40 @@ impl MissionCore {
                         AudioHandle::new(),
                     );
                     self.destroy_entity(entity_id);
+                    if !matches!(sound, Effect::NoEffect) {
+                        effects.push_front(sound);
+                    }
+                }
+
+                Effect::UseHealingItem {
+                    entity_id,
+                    total,
+                    pulse,
+                    first_pulse_secs,
+                    pulse_interval_secs,
+                } => {
+                    let outcome = apply_healing_item_use(
+                        &self.world,
+                        entity_id,
+                        total,
+                        pulse,
+                        first_pulse_secs,
+                        pulse_interval_secs,
+                    );
+                    if outcome == HealingItemUseOutcome::NotUsed {
+                        continue;
+                    }
+
+                    let sound = crate::scripts::script_util::play_environmental_sound(
+                        &self.world,
+                        entity_id,
+                        "activate",
+                        vec![],
+                        AudioHandle::new(),
+                    );
+                    if outcome == HealingItemUseOutcome::DestroyEntity {
+                        self.destroy_entity(entity_id);
+                    }
                     if !matches!(sound, Effect::NoEffect) {
                         effects.push_front(sound);
                     }
@@ -9370,6 +9482,145 @@ mod comestible_use_tests {
             ComestibleUseOutcome::NotUsed
         );
         assert_eq!(player_hit_points(&world, player), 20);
+    }
+}
+
+#[cfg(test)]
+mod healing_item_use_tests {
+    use dark::properties::{
+        Link, Links, PropHitPoints, PropMaxHitPoints, PropStackCount, ToLink, WrappedEntityId,
+    };
+    use shipyard::{EntitiesView, Get, UniqueViewMut, View};
+
+    use super::*;
+    use crate::scripts::healing_item::{ActiveHealing, tick_player_healing};
+
+    fn world_with_player(
+        hit_points: i32,
+        stack: i32,
+        carried: bool,
+    ) -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let patch = world.add_entity(PropStackCount(stack));
+        let inventory = world.add_entity(if carried {
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(patch)),
+                    link: Link::Contains(0),
+                }],
+            }
+        } else {
+            Links::empty()
+        });
+        let player = world.add_entity((
+            PropHitPoints { hit_points },
+            PropMaxHitPoints { hit_points: 30 },
+        ));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(ActiveHealing::default());
+        (world, player, patch)
+    }
+
+    #[test]
+    fn damaged_player_queues_course_and_consumes_one_stack_unit() {
+        let (world, player, patch) = world_with_player(8, 2, true);
+
+        assert_eq!(
+            apply_healing_item_use(&world, patch, 10, 2, 0.1, 1.5),
+            HealingItemUseOutcome::DecrementedStack
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(patch)
+                .unwrap()
+                .0,
+            1
+        );
+        assert!(matches!(
+            tick_player_healing(&world, 0.1),
+            Some(Effect::AdjustHitPoints {
+                entity_id,
+                delta: 2
+            }) if entity_id == player
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<PropHitPoints>>()
+                .unwrap()
+                .get(player)
+                .unwrap()
+                .hit_points,
+            8,
+            "timed healing must not bypass the central effect handler"
+        );
+    }
+
+    #[test]
+    fn full_health_refuses_without_consuming_or_queuing() {
+        let (world, _player, patch) = world_with_player(30, 1, true);
+
+        assert_eq!(
+            apply_healing_item_use(&world, patch, 10, 2, 0.1, 1.5),
+            HealingItemUseOutcome::NotUsed
+        );
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(patch));
+        assert_eq!(
+            world
+                .borrow::<View<PropStackCount>>()
+                .unwrap()
+                .get(patch)
+                .unwrap()
+                .0,
+            1
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueViewMut<ActiveHealing>>()
+                .unwrap()
+                .advance(5.0, 30, 30),
+            0
+        );
+    }
+
+    #[test]
+    fn world_object_cannot_bypass_inventory_use() {
+        let (world, _player, patch) = world_with_player(8, 1, false);
+        assert_eq!(
+            apply_healing_item_use(&world, patch, 10, 2, 0.1, 1.5),
+            HealingItemUseOutcome::NotUsed
+        );
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(patch));
+    }
+
+    #[test]
+    fn duplicate_use_of_destroyed_source_does_not_queue_twice() {
+        let (mut world, _player, patch) = world_with_player(8, 1, true);
+        assert_eq!(
+            apply_healing_item_use(&world, patch, 10, 2, 0.1, 1.5),
+            HealingItemUseOutcome::DestroyEntity
+        );
+        world.delete_entity(patch);
+        assert_eq!(
+            apply_healing_item_use(&world, patch, 10, 2, 0.1, 1.5),
+            HealingItemUseOutcome::NotUsed
+        );
+        assert_eq!(
+            world
+                .borrow::<UniqueViewMut<ActiveHealing>>()
+                .unwrap()
+                .advance(0.1, 8, 30),
+            2
+        );
     }
 }
 

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -5,6 +5,7 @@
  */
 use super::{EntitySaveData, HeldItemSaveData, PlayerVitals};
 use crate::quest_info::QuestInfo;
+use crate::scripts::healing_item::ActiveHealing;
 use cgmath::{Quaternion, Vector3};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -46,6 +47,11 @@ pub struct GlobalData {
     /// the pre-existing template/career initialization behavior.
     #[serde(default)]
     pub player_vitals: Option<PlayerVitals>,
+    /// In-progress retail healing timers. This is global because the source
+    /// item is consumed when a course starts and cannot own script state.
+    /// Ordinary level transitions intentionally start with an empty queue.
+    #[serde(default)]
+    pub active_healing: ActiveHealing,
     pub active_mission: String,
     /// Whether the player was crouched at save time. Defaults false for
     /// saves that predate crouch.
@@ -66,6 +72,7 @@ mod tests {
             quest_info: QuestInfo::new(),
             held_items: HeldItemSaveData::empty(),
             player_vitals,
+            active_healing: ActiveHealing::default(),
             active_mission: "earth.mis".to_owned(),
             is_crouched: false,
         }
@@ -105,5 +112,23 @@ mod tests {
         let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
 
         assert_eq!(decoded.player_vitals, None);
+    }
+
+    #[test]
+    fn active_healing_round_trips_and_older_saves_default_empty() {
+        let mut original = global_data(Some(sample_vitals()));
+        assert!(original.active_healing.queue(10, 2, 0.1, 1.5));
+        let encoded = serde_json::to_value(&original).unwrap();
+        let decoded: GlobalData = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(decoded.active_healing, original.active_healing);
+
+        let mut legacy = encoded;
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("active_healing")
+            .unwrap();
+        let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
+        assert_eq!(decoded.active_healing, ActiveHealing::default());
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -352,6 +352,7 @@ pub fn load_mission_from_save_data(
     game_options: &GameOptions,
 ) -> (Mission, HashMap<String, EntitySaveData>) {
     let current_mission = save_data.global_data.active_mission.clone();
+    let active_healing = save_data.global_data.active_healing.clone();
 
     let populator: Box<dyn EntityPopulator> = {
         if let Some(save_data) = save_data
@@ -386,6 +387,13 @@ pub fn load_mission_from_save_data(
         &active_mission.mission_core.world,
         save_data.global_data.player_vitals,
     );
+    if let Ok(mut healing) = active_mission
+        .mission_core
+        .world
+        .borrow::<shipyard::UniqueViewMut<crate::scripts::healing_item::ActiveHealing>>()
+    {
+        *healing = active_healing;
+    }
 
     // A loaded mission rebuilds Rapier from scratch. Mark the restored player
     // so the first BeginIntersect events reconstruct already-existing sensor

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -257,6 +257,16 @@ pub enum Effect {
         hit_points: i32,
     },
 
+    /// Consume one Med Patch / Medical Kit and queue its retail timed healing
+    /// course. Invalid and full-health uses leave the source item untouched.
+    UseHealingItem {
+        entity_id: EntityId,
+        total: i32,
+        pulse: i32,
+        first_pulse_secs: f32,
+        pulse_interval_secs: f32,
+    },
+
     /// Install a soft on the character sheet and consume the object it came
     /// from. Emitted by `scripts::auto_install_soft` when a soft is frobbed in
     /// the world or taken from a container. The applier does the atomic

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -12,7 +12,7 @@
 //! `QuestInfo`, so it survives save/load and deck re-entry), and
 //! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
 //! implemented for the subset with existing consumers (Tank, Naturally Able,
-//! Replicator Expert - see [`live_effect_note`]); everything else stays visible
+//! Pharmo-Friendly, Replicator Expert - see [`live_effect_note`]); everything else stays visible
 //! but cannot consume a one-shot machine or trait slot until its effect exists.
 
 use cgmath::{Vector2, Vector3, vec2};
@@ -49,6 +49,7 @@ pub const OS_TRAITS: [(u8, &str); 16] = [
 
 /// Retail trait ids with live gameplay effects here (see the effect handler).
 pub const TRAIT_NATURALLY_ABLE: u8 = 6;
+pub const TRAIT_PHARMO_FRIENDLY: u8 = 2;
 pub const TRAIT_TANK: u8 = 8;
 pub const TRAIT_REPLICATOR_EXPERT: u8 = 13;
 
@@ -398,6 +399,7 @@ pub fn live_effect_note(trait_id: u8) -> Option<&'static str> {
     match trait_id {
         TRAIT_TANK => Some("+5 max hit points"),
         TRAIT_NATURALLY_ABLE => Some("+8 cyber modules"),
+        TRAIT_PHARMO_FRIENDLY => Some("20% healing-item bonus"),
         TRAIT_REPLICATOR_EXPERT => Some("20% replicator discount"),
         _ => None,
     }

--- a/shock2vr/src/scripts/healing_item.rs
+++ b/shock2vr/src/scripts/healing_item.rs
@@ -1,0 +1,334 @@
+use dark::properties::{PropHitPoints, PropMaxHitPoints};
+use serde::{Deserialize, Serialize};
+use shipyard::{Get, Unique, UniqueView, View, World};
+
+use crate::{mission::PlayerInfo, physics::PhysicsWorld, quest_info::QuestInfo};
+
+use super::{Effect, MessagePayload, Script};
+use crate::scripts::gui::TRAIT_PHARMO_FRIENDLY;
+
+/// Retail `MedPatchScript` / `MedKitScript` cadence recovered from the shipped
+/// `allobjs.osm`: `DoHeal` first runs after 0.1s, then reschedules every 1.5s
+/// until the item's healing budget has been spent.
+pub const HEALING_FIRST_PULSE_SECS: f32 = 0.1;
+pub const HEALING_PULSE_INTERVAL_SECS: f32 = 1.5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HealingItemKind {
+    MedPatch,
+    MedicalKit,
+}
+
+impl HealingItemKind {
+    fn base_total(self) -> i32 {
+        match self {
+            Self::MedPatch => 10,
+            Self::MedicalKit => 200,
+        }
+    }
+
+    fn base_pulse(self) -> i32 {
+        match self {
+            Self::MedPatch => 2,
+            Self::MedicalKit => 5,
+        }
+    }
+}
+
+/// The retail healing-item scripts share one implementation and override only
+/// their healing budget and pulse size.
+pub struct HealingItemScript {
+    kind: HealingItemKind,
+}
+
+impl HealingItemScript {
+    pub fn new(kind: HealingItemKind) -> Self {
+        Self { kind }
+    }
+
+    fn pharmo_friendly(world: &World) -> bool {
+        world
+            .borrow::<UniqueView<QuestInfo>>()
+            .is_ok_and(|quests| quests.player_stats().has_os_trait(TRAIT_PHARMO_FRIENDLY))
+    }
+
+    /// The original multiplies both values by 1.2 and converts back to an
+    /// integer. Integer arithmetic preserves that truncation exactly.
+    fn retail_amount(base: i32, pharmo_friendly: bool) -> i32 {
+        if pharmo_friendly {
+            base.saturating_mul(6) / 5
+        } else {
+            base
+        }
+    }
+}
+
+impl Script for HealingItemScript {
+    fn handle_message(
+        &mut self,
+        entity_id: shipyard::EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) {
+            return Effect::NoEffect;
+        }
+
+        let pharmo_friendly = Self::pharmo_friendly(world);
+        Effect::UseHealingItem {
+            entity_id,
+            total: Self::retail_amount(self.kind.base_total(), pharmo_friendly),
+            pulse: Self::retail_amount(self.kind.base_pulse(), pharmo_friendly),
+            first_pulse_secs: HEALING_FIRST_PULSE_SECS,
+            pulse_interval_secs: HEALING_PULSE_INTERVAL_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct HealingDose {
+    remaining: i32,
+    pulse: i32,
+    seconds_until_pulse: f32,
+    pulse_interval_secs: f32,
+}
+
+/// Timed healing already applied to the player. This intentionally lives in
+/// global save data rather than the source item's script namespace: retail
+/// consumes the source as soon as it starts the timer course, so no item
+/// remains to own the continuing state.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Unique)]
+pub struct ActiveHealing {
+    doses: Vec<HealingDose>,
+}
+
+impl ActiveHealing {
+    pub fn queue(
+        &mut self,
+        total: i32,
+        pulse: i32,
+        first_pulse_secs: f32,
+        pulse_interval_secs: f32,
+    ) -> bool {
+        if total <= 0
+            || pulse <= 0
+            || !first_pulse_secs.is_finite()
+            || first_pulse_secs < 0.0
+            || !pulse_interval_secs.is_finite()
+            || pulse_interval_secs <= 0.0
+        {
+            return false;
+        }
+        self.doses.push(HealingDose {
+            remaining: total,
+            pulse,
+            seconds_until_pulse: first_pulse_secs,
+            pulse_interval_secs,
+        });
+        true
+    }
+
+    fn prune_invalid(&mut self) {
+        self.doses.retain(|dose| {
+            dose.remaining > 0
+                && dose.pulse > 0
+                && dose.seconds_until_pulse.is_finite()
+                && dose.pulse_interval_secs.is_finite()
+                && dose.pulse_interval_secs > 0.0
+        });
+    }
+
+    /// Advance every active course and return the HP delta to send through the
+    /// mission's central `AdjustHitPoints` handler. Pulse budgets are spent at
+    /// the maximum too, so later damage cannot resurrect healing that retail
+    /// already capped away.
+    pub fn advance(&mut self, elapsed_secs: f32, current_hp: i32, maximum_hp: i32) -> i32 {
+        // Saves are user-editable and older experimental builds wrote this
+        // global state. Reject zero pulses/intervals and non-finite timers
+        // before entering the pulse loop so corrupt data cannot hang a load.
+        self.prune_invalid();
+        if !elapsed_secs.is_finite() || elapsed_secs <= 0.0 {
+            return 0;
+        }
+
+        let maximum_hp = maximum_hp.max(0);
+        let mut live_hp = current_hp.min(maximum_hp);
+        for dose in &mut self.doses {
+            dose.seconds_until_pulse -= elapsed_secs;
+            while dose.remaining > 0 && dose.seconds_until_pulse <= 0.0 {
+                let budget = dose.pulse.min(dose.remaining);
+                let missing = (maximum_hp - live_hp).max(0);
+                live_hp += budget.min(missing);
+                dose.remaining -= budget;
+                dose.seconds_until_pulse += dose.pulse_interval_secs;
+            }
+        }
+        self.doses.retain(|dose| dose.remaining > 0);
+        live_hp - current_hp
+    }
+}
+
+/// Advance the live player's retail course and produce one ordinary health
+/// effect. `MissionCore` remains the only place that mutates HP, preserving its
+/// player-death guard and the shared HP trace.
+pub fn tick_player_healing(world: &World, elapsed_secs: f32) -> Option<Effect> {
+    let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?.entity_id;
+    let current = world
+        .borrow::<View<PropHitPoints>>()
+        .ok()
+        .and_then(|hit_points| hit_points.get(player).ok().map(|hp| hp.hit_points))?;
+    let maximum = world
+        .borrow::<View<PropMaxHitPoints>>()
+        .ok()
+        .and_then(|max_hit_points| {
+            max_hit_points
+                .get(player)
+                .ok()
+                .map(|hp| hp.hit_points.min(i32::MAX as u32) as i32)
+        })?;
+    let delta = world
+        .borrow::<shipyard::UniqueViewMut<ActiveHealing>>()
+        .ok()
+        .map(|mut active| active.advance(elapsed_secs, current, maximum))
+        .unwrap_or(0);
+    (delta > 0).then_some(Effect::AdjustHitPoints {
+        entity_id: player,
+        delta,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        quest_info::QuestInfo,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::{
+        ActiveHealing, HEALING_FIRST_PULSE_SECS, HEALING_PULSE_INTERVAL_SECS, HealingItemKind,
+        HealingItemScript,
+    };
+
+    #[test]
+    fn med_patch_frob_uses_retail_budget_and_cadence() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let patch = world.add_entity(());
+        let effect = HealingItemScript::new(HealingItemKind::MedPatch).handle_message(
+            patch,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UseHealingItem {
+                entity_id,
+                total: 10,
+                pulse: 2,
+                first_pulse_secs: HEALING_FIRST_PULSE_SECS,
+                pulse_interval_secs: HEALING_PULSE_INTERVAL_SECS,
+            } if entity_id == patch
+        ));
+    }
+
+    #[test]
+    fn medical_kit_uses_retail_override() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let kit = world.add_entity(());
+        let effect = HealingItemScript::new(HealingItemKind::MedicalKit).handle_message(
+            kit,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UseHealingItem {
+                entity_id,
+                total: 200,
+                pulse: 5,
+                ..
+            } if entity_id == kit
+        ));
+    }
+
+    #[test]
+    fn pharmo_friendly_uses_the_retail_twenty_percent_integer_bonus() {
+        let mut world = World::new();
+        let mut quests = QuestInfo::new();
+        assert!(quests.player_stats_mut().add_os_trait(2));
+        world.add_unique(quests);
+        let kit = world.add_entity(());
+        let effect = HealingItemScript::new(HealingItemKind::MedicalKit).handle_message(
+            kit,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UseHealingItem {
+                total: 240,
+                pulse: 6,
+                ..
+            }
+        ));
+
+        let patch = world.add_entity(());
+        let effect = HealingItemScript::new(HealingItemKind::MedPatch).handle_message(
+            patch,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+        assert!(matches!(
+            effect,
+            Effect::UseHealingItem {
+                total: 12,
+                // 2 * 1.2 truncates back to 2 in the original.
+                pulse: 2,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn active_healing_obeys_initial_delay_interval_total_and_cap() {
+        let mut active = ActiveHealing::default();
+        assert!(active.queue(10, 2, 0.1, 1.5));
+        assert_eq!(active.advance(0.099, 8, 30), 0);
+        assert_eq!(active.advance(0.002, 8, 30), 2);
+        assert_eq!(active.advance(6.0, 10, 30), 8);
+
+        assert!(active.queue(200, 5, 0.1, 1.5));
+        assert_eq!(active.advance(8.0, 1, 30), 29);
+    }
+
+    #[test]
+    fn queue_rejects_non_finite_timing() {
+        let mut active = ActiveHealing::default();
+        assert!(!active.queue(10, 2, f32::NAN, 1.5));
+        assert!(!active.queue(10, 2, 0.1, f32::INFINITY));
+        assert_eq!(active, ActiveHealing::default());
+    }
+
+    #[test]
+    fn corrupt_restored_doses_are_pruned_without_looping() {
+        let mut active: ActiveHealing = serde_json::from_value(json!({
+            "doses": [
+                { "remaining": 10, "pulse": 0, "seconds_until_pulse": -1.0, "pulse_interval_secs": 0.0 },
+                { "remaining": 10, "pulse": 2, "seconds_until_pulse": 0.0, "pulse_interval_secs": 0.0 }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(active.advance(60.0, 8, 30), 0);
+        assert_eq!(active, ActiveHealing::default());
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -26,6 +26,7 @@ mod energy_weapon;
 mod exp_cookie;
 mod frob_qb;
 pub mod gui;
+pub mod healing_item;
 mod internal_collision_type;
 mod internal_explosion;
 pub mod internal_fast_projectile;
@@ -117,6 +118,7 @@ use self::gui::{
     ComputerGui, ContainerGui, ElevatorGui, GamePigGui, HackableCrateGui, KeyPadGui, MapGui,
     MediaGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui,
 };
+use self::healing_item::{HealingItemKind, HealingItemScript};
 use self::internal_frob_move::InternalFrobMove;
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::picture_swap::PictureSwap;
@@ -1045,9 +1047,9 @@ impl ScriptWorld {
 
             //goodies:
             "expcookie" => Box::new(ExpCookie::new()), // cyber modules
-            "medkitscript" => Box::new(UnimplementedScript::new(&script_name)), // cyber modules
+            "medkitscript" => Box::new(HealingItemScript::new(HealingItemKind::MedicalKit)),
             "speedpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
-            "radpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
+            "radpatch" => Box::new(UnimplementedScript::new(&script_name)),   // speed boost
             "autoinstallsoft" => Box::new(AutoInstallSoft::new()), // auto install software
             "strboost" => Box::new(UnimplementedScript::new(&script_name)), // strength boost
             "intboost" => Box::new(UnimplementedScript::new(&script_name)),
@@ -1063,7 +1065,7 @@ impl ScriptWorld {
                 Box::new(apparition::Apparition::new()),
             ])),
             "ectoplasm" => Box::new(UnimplementedScript::new(&script_name)),
-            "medpatchscript" => Box::new(UnimplementedScript::new(&script_name)),
+            "medpatchscript" => Box::new(HealingItemScript::new(HealingItemKind::MedPatch)),
             "psikitscript" => Box::new(PsiKitScript::new()),
             "computer" => gui_script(Box::new(ComputerGui)),
             "lightsoundon" => Box::new(NoopScript::new()),

--- a/tools/shock2-sdk/test/healing-items.e2e.test.ts
+++ b/tools/shock2-sdk/test/healing-items.e2e.test.ts
@@ -1,0 +1,587 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// End-to-end regression for #668, reproducing the campaign's exact production
+// path before covering the sibling item and flat presentation:
+//
+//   medsci2 Desk 471 --Contains--> Med Patch 1054
+//   hand trigger -> loot panel -> backpack -> MoveInventory -> left squeeze
+//   held-item trigger -> authored Frob -> timed retail healing course
+//
+// Retail allobjs.osm behavior is data-driven by the two script names:
+// MedPatchScript restores 10 HP in 2-HP pulses; MedKitScript restores 200 HP
+// in 5-HP pulses. Both wait 0.1s before the first pulse and then 1.5s between
+// pulses, preserve the item at full health, and receive Pharmo-Friendly's 20%
+// integer bonus.
+//
+// Negative-first on campaign HEAD 9698555b: both script names resolve to
+// UnimplementedScript. The authentic trigger reaches Med Patch 1054, but HP
+// remains unchanged and the exact held entity survives.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const MEDSCI2_DESK_WITH_PATCH = 471;
+const MEDSCI2_PATCH = 1054;
+const PANEL_PIXEL_TO_WORLD = 1 / 250;
+const LOOT_PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
+const VR_BACKPACK_SCALE = 0.55;
+
+function hp(info: Awaited<ReturnType<GameServer["info"]>>): number {
+  assert.notEqual(
+    info.player.hit_points,
+    null,
+    "mission player should have HP",
+  );
+  return info.player.hit_points as number;
+}
+
+async function exactMissionEntity(
+  game: GameServer,
+  missionObjectId: number,
+  label: string,
+): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(missionObjectId);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one ${label} (${missionObjectId}), got ${JSON.stringify(matches)}`,
+  );
+  return matches[0];
+}
+
+function canvasPointWorld(
+  panel: { position: Vec3; rotation: [number, number, number, number] },
+  panelPixels: Vec3,
+  pointPixels: Vec3,
+  worldScale: number,
+): Vec3 {
+  const panelSize: Vec3 = [
+    panelPixels[0] * PANEL_PIXEL_TO_WORLD * worldScale,
+    panelPixels[1] * PANEL_PIXEL_TO_WORLD * worldScale,
+    0,
+  ];
+  const u = pointPixels[0] / panelPixels[0];
+  const v = pointPixels[1] / panelPixels[1];
+  const local: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  return add(panel.position, quatRotate(panel.rotation, local));
+}
+
+async function onlyUiPanel(game: GameServer, context: string) {
+  const panels = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  assert.equal(
+    panels.length,
+    1,
+    `${context} must expose exactly one world panel`,
+  );
+  return panels[0];
+}
+
+async function stripItem(
+  game: GameServer,
+  entityId: number,
+): Promise<UiElement> {
+  const ui = await game.ui.state();
+  assert.equal(
+    ui.mode,
+    "use",
+    "flat healing-item use must happen in live use mode",
+  );
+  const item = ui.strip?.elements.find(
+    (candidate) => candidate.entity_id === entityId,
+  );
+  assert.ok(
+    item,
+    `inventory strip should expose carried healing item ${entityId}`,
+  );
+  return item;
+}
+
+async function useFlatInventoryItem(
+  game: GameServer,
+  entityId: number,
+): Promise<void> {
+  const item = await stripItem(game, entityId);
+  await clickUiElement(game, item);
+  assert.equal((await game.ui.state()).cursor?.entity_id, entityId);
+  await clickUiElement(game, item);
+  assert.equal((await game.ui.state()).cursor, null);
+}
+
+async function buyPharmoFriendly(game: GameServer): Promise<void> {
+  const machines = (await game.entities.list({ filter: "Trait Machine" }))
+    .entities;
+  const machine = machines.find((entity) => entity.template_id === 133);
+  assert.ok(machine, "medsci2 should contain Trait Machine mission object 133");
+  await teleportVerified(game, {
+    x: machine.position[0] + 1.2,
+    y: machine.position[1] + 0.5,
+    z: machine.position[2],
+  });
+  await game.entities.sendMessage(machine.id, { type: "Frob" });
+  await game.step({ frames: 5 });
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "the real Trait Machine should open its panel");
+  const pharmo = panel.elements.find(
+    (element) =>
+      element.kind === "button" && element.label === "Pharmo-Friendly",
+  );
+  assert.ok(pharmo, "Trait Machine must expose the Pharmo-Friendly choice");
+  await clickUiElement(game, pharmo);
+  await game.step({ frames: 3 });
+  assert.deepEqual(
+    (await game.info()).player.stats?.os_traits,
+    [2],
+    "the real machine must acquire Pharmo-Friendly (trait 2)",
+  );
+}
+
+test(
+  "medsci2 VR Desk 471 Med Patch heals through backpack, held trigger, and save/load",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8668),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const initial = await game.info();
+    assert.equal(hp(initial), 30);
+    assert.equal(initial.player.max_hit_points, 30);
+    const playerId = initial.player.entity_id;
+    assert.notEqual(playerId, null, "medsci2 should have a live player");
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 10 });
+    await game.step({ frames: 2 });
+    assert.equal(hp(await game.info()), 20);
+
+    const desk = await exactMissionEntity(
+      game,
+      MEDSCI2_DESK_WITH_PATCH,
+      "medsci2 Desk with Med Patch",
+    );
+    const deskDetail = await game.entities.detail(desk.id);
+    const contains = deskDetail.outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.equal(
+      contains.length,
+      1,
+      "Desk 471 should contain exactly its Med Patch",
+    );
+    assert.equal(contains[0].target_name, "Med Patch");
+    assert.equal(
+      typeof contains[0].contains_ordinal,
+      "number",
+      `Desk link must expose its exact slot: ${JSON.stringify(contains[0])}`,
+    );
+    const patchId = contains[0].target_id;
+    const exactPatch = await exactMissionEntity(
+      game,
+      MEDSCI2_PATCH,
+      "Desk 471 Med Patch",
+    );
+    assert.equal(
+      exactPatch.id,
+      patchId,
+      "mission object 1054 must be Desk 471's loot",
+    );
+
+    await teleportVerified(game, {
+      x: desk.position[0] + 1.2,
+      y: desk.position[1] + 0.5,
+      z: desk.position[2] + 1.2,
+    });
+    await game.step({ frames: 5 });
+    const deskAim = await game.player.aimAt(desk, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      deskAim.target_confirmed,
+      true,
+      "Desk 471 must be physically reachable",
+    );
+    await aimVrHandAt(game, deskAim.world_point);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    const lootPanel = await onlyUiPanel(game, "Desk 471 frob");
+    // Desk 471 is yawed in the mission. Stand on the panel's authored front
+    // normal instead of remaining on top of the desk, so the controller ray
+    // crosses its face (rather than grazing the thin collider edge).
+    const panelFront = quatRotate(lootPanel.rotation, [0, 0, -1]);
+    const eyeHeight = (await game.info()).player.camera_offset[1];
+    await teleportVerified(game, {
+      x: lootPanel.position[0] + panelFront[0] * 1.25,
+      y: lootPanel.position[1] - eyeHeight,
+      z: lootPanel.position[2] + panelFront[2] * 1.25,
+    });
+    await game.step({ frames: 3 });
+    const lootUi = (await game.ui.state()).active_panel;
+    assert.ok(lootUi, "Desk 471's VR panel must be introspectable");
+    const lootElement = lootUi.elements.find(
+      (element) => element.entity_id === patchId,
+    );
+    assert.ok(
+      lootElement,
+      `the real panel must render exact Med Patch ${patchId}: ${JSON.stringify(lootUi)}`,
+    );
+    const [lootX, lootY, lootW, lootH] = lootElement.rect;
+    const lootSlot = canvasPointWorld(
+      lootPanel,
+      LOOT_PANEL_SIZE_PX,
+      [lootX + lootW / 2, lootY + lootH / 2, 0],
+      1,
+    );
+    const lootAim = await aimVrHandAt(game, lootSlot, 0.35);
+    const lootHit = await game.raycast({
+      start: lootAim.start,
+      end: lootAim.target,
+      collision_groups: ["ui"],
+      max_distance: 1,
+    });
+    assert.equal(
+      lootHit.entity_id,
+      lootPanel.entity_id,
+      "the hand ray must hit the patch slot",
+    );
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === patchId,
+      )?.location,
+      "right_hand",
+      "squeezing the real loot icon must retrieve the exact patch from Desk 471",
+    );
+    assert.equal(
+      (await game.entities.detail(desk.id)).outgoing_links.some(
+        (link) =>
+          link.target_id === patchId && link.link_type.startsWith("Contains"),
+      ),
+      false,
+      "physical loot must sever Desk 471's exact Contains link",
+    );
+
+    // Close the Desk panel without releasing the physical patch. Drop it into
+    // the world, then use the ordinary world-trigger pickup path that stores
+    // MOVE items in the backpack. This mirrors the campaign's physical-loot ->
+    // stored-item sequence without a debug Give/provisioning shortcut.
+    await teleportVerified(game, {
+      x: initial.player.position[0],
+      y: initial.player.position[1],
+      z: initial.player.position[2],
+    });
+    await game.step({ frames: 5 });
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.physics.bodies()).bodies.filter((body) =>
+        body.collision_groups.includes("ui"),
+      ).length,
+      0,
+      "the production action must close the transient panel before the drop",
+    );
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    const droppedBody = (await game.physics.bodies({ entityId: patchId }))
+      .bodies;
+    assert.equal(
+      droppedBody.length,
+      1,
+      "the exact released patch must regain one world body",
+    );
+    const pickupAim = await aimVrHandAt(game, droppedBody[0].position, 0.35);
+    const pickupHit = await game.raycast({
+      start: pickupAim.start,
+      end: pickupAim.target,
+      collision_groups: ["entity", "selectable", "world", "raycast"],
+      max_distance: 1,
+      ignore_sensors: true,
+    });
+    assert.equal(
+      pickupHit.entity_id,
+      patchId,
+      "the production ray must select the dropped patch",
+    );
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === patchId,
+      )?.location,
+      "inventory",
+      "world-trigger pickup must store the exact patch in the backpack",
+    );
+    const backpackId = (await game.info()).player.inventory_entity_id;
+    assert.notEqual(backpackId, null);
+    const backpackLink = (
+      await game.entities.detail(backpackId!)
+    ).outgoing_links.find(
+      (link) =>
+        link.target_id === patchId && link.link_type.startsWith("Contains"),
+    );
+    assert.ok(
+      backpackLink,
+      "the exact patch must own a backpack Contains slot",
+    );
+    assert.equal(typeof backpackLink.contains_ordinal, "number");
+
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    const backpackPanel = await onlyUiPanel(game, "MoveInventory retrieval");
+    const backpackUi = (await game.ui.state()).active_panel;
+    assert.ok(backpackUi, "the backpack world panel must be introspectable");
+    const backpackElement = backpackUi.elements.find(
+      (element) => element.entity_id === patchId,
+    );
+    assert.ok(
+      backpackElement,
+      `the backpack must visibly render exact patch ${patchId}: ${JSON.stringify(backpackUi)}`,
+    );
+    const [backpackX, backpackY, backpackW, backpackH] = backpackElement.rect;
+    const backpackSlot = canvasPointWorld(
+      backpackPanel,
+      BACKPACK_PANEL_SIZE_PX,
+      [backpackX + backpackW / 2, backpackY + backpackH / 2, 0],
+      VR_BACKPACK_SCALE,
+    );
+    const panelAim = await aimVrHandAt(game, backpackSlot, 0.35);
+    const inputResponse = await fetch(`${game.baseUrl}/v1/control/input`);
+    assert.equal(inputResponse.ok, true);
+    const input = (await inputResponse.json()) as {
+      right_hand: {
+        position: Vec3;
+        rotation: [number, number, number, number];
+      };
+    };
+    await game.input.set("left_hand.position", input.right_hand.position);
+    await game.input.set("left_hand.rotation", input.right_hand.rotation);
+    await game.input.set("left_hand.trigger", 0);
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 3 });
+    const panelHit = await game.raycast({
+      start: panelAim.start,
+      end: panelAim.target,
+      collision_groups: ["ui"],
+      max_distance: 1,
+    });
+    assert.equal(panelHit.entity_id, backpackPanel.entity_id);
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (item) => item.entity_id === patchId,
+      )?.location,
+      "left_hand",
+      "left squeeze must retrieve the exact rendered patch into the left hand",
+    );
+
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+    await game.input.set("left_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    const messages = (await game.messages.recent()).messages.filter(
+      (message) => message.to.entity_id === patchId,
+    );
+    assert.ok(messages.some((message) => message.payload === "Frob"));
+    assert.ok(!messages.some((message) => message.payload === "TriggerPull"));
+    assert.equal(
+      hp(await game.info()),
+      20,
+      "retail healing must not be instantaneous",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(MEDSCI2_PATCH)).length,
+      0,
+      "a successful below-max use must consume the exact mission entity",
+    );
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === patchId,
+      ),
+      "consumption must clear the exact patch from every carried location",
+    );
+
+    await game.step({ frames: 7 });
+    assert.equal(
+      hp(await game.info()),
+      22,
+      "the first pulse restores exactly 2 HP after 0.1s",
+    );
+    await game.screenshot("issue668-vr-medpatch-first-pulse.png");
+
+    const saveName = `issue668_vr_medpatch_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 80 });
+    assert.equal(
+      hp(await game.info()),
+      22,
+      "load must preserve the next-pulse delay",
+    );
+    await game.step({ frames: 15 });
+    assert.equal(
+      hp(await game.info()),
+      24,
+      "the saved course must resume at 1.5s cadence",
+    );
+    await game.step({ frames: 300 });
+    assert.equal(
+      hp(await game.info()),
+      30,
+      "one Med Patch must spend exactly its 10-HP budget",
+    );
+    assert.equal((await game.entities.byTemplate(MEDSCI2_PATCH)).length, 0);
+    await game.screenshot("issue668-vr-medpatch-complete.png");
+  },
+);
+
+test(
+  "flat Medical Kit heals to full while full-health Med Patch is preserved",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8669),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+    });
+    await game.step({ frames: 5 });
+    const initial = await game.info();
+    const playerId = initial.player.entity_id;
+    assert.notEqual(playerId, null);
+    const maxHp = initial.player.max_hit_points;
+    const psi = initial.player.psi_points;
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 29 });
+    await game.step({ frames: 2 });
+    assert.equal(hp(await game.info()), 1);
+
+    const kit = await game.player.spawnItem("Medical Kit");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await useFlatInventoryItem(game, kit.entity_id);
+    assert.equal(
+      hp(await game.info()),
+      1,
+      "Medical Kit use must not heal instantly",
+    );
+    await game.step({ frames: 5 });
+    assert.equal(
+      hp(await game.info()),
+      6,
+      "the delayed first pulse must restore exactly 5 HP",
+    );
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === kit.entity_id,
+      ),
+      "a successful kit use must consume its source entity",
+    );
+    await game.step({ frames: 80 });
+    assert.equal(
+      hp(await game.info()),
+      6,
+      "the next pulse must not arrive before 1.5s",
+    );
+    await game.step({ frames: 15 });
+    assert.equal(
+      hp(await game.info()),
+      11,
+      "Medical Kit must continue in exact 5-HP pulses",
+    );
+    await game.step({ frames: 405 });
+    const healed = await game.info();
+    assert.equal(hp(healed), maxHp);
+    assert.equal(healed.player.max_hit_points, maxHp);
+    assert.equal(healed.player.psi_points, psi);
+
+    const unused = await game.player.spawnItem("Med Patch");
+    await useFlatInventoryItem(game, unused.entity_id);
+    await game.step({ frames: 120 });
+    assert.equal(hp(await game.info()), maxHp);
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === unused.entity_id,
+      ),
+      "full-health inventory use must preserve the exact patch",
+    );
+    const saveName = `issue668_full_health_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.name === "Med Patch",
+      ),
+      "full-health refusal must survive save/load",
+    );
+  },
+);
+
+test(
+  "Pharmo-Friendly gives Med Patch the retail 12-HP integer budget",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8670),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+    });
+    await game.step({ frames: 5 });
+    await buyPharmoFriendly(game);
+
+    await game.transitionLevel("earth.mis");
+    await game.step({ frames: 5 });
+    assert.deepEqual(
+      (await game.info()).player.stats?.os_traits,
+      [2],
+      "Pharmo-Friendly must survive the ordinary cross-mission character path",
+    );
+
+    const playerId = (await game.info()).player.entity_id;
+    assert.notEqual(playerId, null);
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 20 });
+    await game.step({ frames: 2 });
+    assert.equal(hp(await game.info()), 10);
+    const patch = await game.player.spawnItem("Med Patch");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    if ((await game.ui.state()).mode === "shooter") {
+      // The first toggle dismisses the still-open Trait Machine MFD; the
+      // second enters the ordinary inventory use mode.
+      await game.input.trigger("ToggleUseMode");
+      await game.step({ frames: 5 });
+    }
+    await useFlatInventoryItem(game, patch.entity_id);
+    await game.step({ frames: 500 });
+    assert.equal(
+      hp(await game.info()),
+      22,
+      "Pharmo-Friendly must increase a patch's 10-HP budget to exactly 12",
+    );
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === patch.entity_id,
+      ),
+    );
+  },
+);


### PR DESCRIPTION
Fixes #668

> **Stack dependency:** this PR is based on [#975](https://github.com/tommy-xr/shock2quest/pull/975) (`fix/974-vr-released-item-physics`). The review order is #967 → #968 → #975 → **#755** → #980 → #986. Review only commit `d2f6eae6`; its diff against #975 is the nine-file healing change.

## Campaign evidence

`earth → medsci* → eng* → hydro → ops* · VR · --auto · --restart · seed 976894603`

The exact MedSci2 replay at campaign head `9698555b` physically opened Desk mission object 471, looted its contained Med Patch mission object 1054 through the real world panel, opened the X backpack, retrieved the patch into the left hand, and pulled the held trigger. At `pt028` / `pt031` / `pt032`, HP remained **29/35** and the patch survived. The production trigger delivered the patch's authored `Frob`; the current gamesys mapping still resolved `medpatchscript` to `UnimplementedScript`.

Run evidence: `.claude/skills/play-through/runs/earth-ops-vr-seed-976894603-iter-3-medsci2-replay-02/`.

The finding is a valid high-value gameplay gap but not a campaign blocker: recovery is materially constrained, while evasion and alternate routes remain possible.

## What changed

- map the authored `medpatchscript` and `medkitscript` names to one shared, data-driven healing implementation
- reproduce retail behavior recovered from shipped `allobjs.osm`:
  - Med Patch: 10 HP budget, 2-HP pulses
  - Medical Kit: 200 HP budget, 5-HP pulses
  - first pulse after 0.1 seconds, then every 1.5 seconds
- consume exactly one stack unit only when use starts below maximum HP; preserve the item at full health
- apply Pharmo-Friendly's retail 20% integer bonus
- route every timed pulse through the central `Effect::AdjustHitPoints` handler, preserving death guards and HP tracing
- serialize the active timer course for same-mission save/load and reject corrupt/non-finite saved doses without looping

The active course is intentionally global player state: the source item is destroyed as soon as use succeeds, so no surviving object script can own the timer. Ordinary mission transitions start a fresh course; persistent same-mission saves restore it.

## Negative-first and regression coverage

Before implementation, the durable MedSci2 VR scenario failed at the intended assertion: the exact Desk 471 patch remained alive and HP never changed after the production held-trigger `Frob`.

The final stacked head now verifies:

- real MedSci2 VR Desk panel → physical loot → world drop → trigger storage → X backpack → left squeeze → held trigger
- no debug-only shortcut and no `TriggerPull` substitution for the patch's authored `Frob`
- 2-HP timed pulses, exact 10-HP budget, entity/stack consumption, and mid-course save/load cadence
- flat Medical Kit 5-HP pulses to the authored maximum
- full-health Med Patch preservation across save/load
- Pharmo-Friendly purchase, cross-mission persistence, and exact 12-HP patch budget
- #975's real MedSci2 two-drop/card/save-load path still passes on the healing head

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- full core unit suite on the exact campaign integration: **694 passed, 0 failed**
- final stacked SDK unit run: **261 total, 26 passed, 235 E2E-skipped, 0 failed**
- final stacked `healing-items.e2e.test.ts`: **3 passed, 0 failed**
- final stacked `medsci2-vr-released-item.e2e.test.ts`: **1 passed, 0 failed**
- exact-campaign healing commit `18524291`; campaign continuation cherry-pick `48a75b97`
- review commit `72a2dd53` on exact #975 head `82f40001`

No Oculus/OpenXR runtime code changed, so no headset install cycle was required. The production VR hand path is covered by the real debug-runtime VR scenarios; Android CI is required to pass before merge.

## Player-observable evidence

![VR Med Patch timed healing](https://gist.githubusercontent.com/tommy-xr/09ae745590c0e1f3fa3169894c380714/raw/issue668-medpatch-vr.gif)

<sub>The real MedSci2 Desk 471 Med Patch is looted through the VR backpack and used from the left hand. Exact base `9698555b` leaves HP at 20/30 and keeps the item held; fixed `6c1799bd` consumes it and visibly advances 20 → 22 → 24 → 26 → 28 → 30 on the retail cadence.</sub>

### Before → after at the first pulse

![Base vs fixed at first retail pulse](https://gist.githubusercontent.com/tommy-xr/09ae745590c0e1f3fa3169894c380714/raw/issue668-medpatch-before-after.png)

### Full 10-HP course

![Full 10 HP course](https://gist.githubusercontent.com/tommy-xr/09ae745590c0e1f3fa3169894c380714/raw/issue668-medpatch-course-complete.png)

[Full-resolution media and capture details](https://gist.github.com/tommy-xr/09ae745590c0e1f3fa3169894c380714). The matched runs use the same deterministic `/v1/step` and `/v1/screenshot` sequence; hosted bytes were hash-verified against the inspected local GIF/PNGs.

