### PR TITLE
fix(gameplay): run periodic radius stim sources

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -670,13 +670,30 @@ pub enum StimPropagator {
 pub struct StimSourceOptions {
     pub intensity: f32,
     pub propagator: StimPropagator,
+    /// The temporal portion of the source descriptor. Radius sources use this
+    /// to fire once at birth and then at the authored cadence.
+    #[serde(default)]
+    pub lifecycle: StimSourceLifecycle,
+}
+
+/// Dark Engine's standard periodic source lifecycle (`sPeriodicLifeCycle`).
+/// The values occupy the first 16 bytes of the 32-byte lifecycle block in an
+/// `sStimSourceDesc` record.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StimSourceLifecycle {
+    pub period: Duration,
+    pub max_firings: i32,
+    pub no_max_firings: bool,
+    pub destroy_on_completion: bool,
+    pub intensity_slope: f32,
 }
 
 impl StimSourceOptions {
-    pub fn read(reader: &mut Box<dyn ReadAndSeek>, _len: u32) -> StimSourceOptions {
+    pub fn read(reader: &mut Box<dyn ReadAndSeek>, len: u32) -> StimSourceOptions {
         // sStimSourceDesc (108 bytes): propagator id, intensity, then
-        // propagator-specific params (a redundant propagator name string sits
-        // at +76). Only the fields the game consumes are parsed.
+        // a 32-byte shape block and 32-byte lifecycle block. A redundant
+        // propagator name string sits at +76. Radius shape data starts at +12;
+        // the standard periodic lifecycle is flags/period/max/slope at +44.
         let propagator_id = read_u32(reader);
         let intensity = read_single(reader);
         let _unknown = read_u32(reader);
@@ -688,9 +705,23 @@ impl StimSourceOptions {
             },
             other => StimPropagator::Unknown(other),
         };
+        let lifecycle = if len >= 60 {
+            reader.seek(io::SeekFrom::Start(44)).unwrap();
+            let flags = read_u32(reader);
+            StimSourceLifecycle {
+                no_max_firings: flags & 1 != 0,
+                destroy_on_completion: flags & 2 != 0,
+                period: Duration::from_millis(read_u32(reader).into()),
+                max_firings: read_i32(reader),
+                intensity_slope: read_single(reader),
+            }
+        } else {
+            StimSourceLifecycle::default()
+        };
         StimSourceOptions {
             intensity,
             propagator,
+            lifecycle,
         }
     }
 }
@@ -2316,6 +2347,30 @@ mod tests {
 
         let null = read_stim_source(stim_source_payload(0, 16.0, 0.0));
         assert_eq!(null.propagator, StimPropagator::Null);
+    }
+
+    #[test]
+    fn stim_source_preserves_periodic_lifecycle_data() {
+        let mut one_second = stim_source_payload(2, 5.0, 6.0);
+        one_second[44..48].copy_from_slice(&3u32.to_le_bytes());
+        one_second[48..52].copy_from_slice(&1_000u32.to_le_bytes());
+        one_second[52..56].copy_from_slice(&3i32.to_le_bytes());
+        one_second[56..60].copy_from_slice(&0.25f32.to_le_bytes());
+
+        let mut five_seconds = one_second.clone();
+        five_seconds[48..52].copy_from_slice(&5_000u32.to_le_bytes());
+
+        let parsed = read_stim_source(one_second.clone());
+        assert_eq!(parsed.lifecycle.period, Duration::from_secs(1));
+        assert_eq!(parsed.lifecycle.max_firings, 3);
+        assert!(parsed.lifecycle.no_max_firings);
+        assert!(parsed.lifecycle.destroy_on_completion);
+        assert_eq!(parsed.lifecycle.intensity_slope, 0.25);
+        assert_ne!(
+            read_stim_source(one_second),
+            read_stim_source(five_seconds),
+            "authored lifecycle timing must survive parsing"
+        );
     }
 
     /// Build an 88-byte sReceptron payload the way shock2.gam lays it out:

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -329,29 +329,31 @@ pub fn create_entity_core(
         processed_scripts.push("internal_frob_move".to_owned());
     }
 
-    // Explosion SFX templates (class tag "explosiontype", e.g. HE / Incendiary
-    // Explosion) with radius stim sources (arSrcDesc) blast once on spawn.
-    // Radius sources WITHOUT the tag (electrical sparks, Swarm, Rad Burst) are
-    // periodic emitters in the original engine - not one-shot blasts - and are
-    // not handled yet.
-    let is_explosion = {
+    // Radius stim sources with an "explosiontype" class tag blast once on
+    // spawn. Other radius sources (electrical sparks, Swarm, Rad Burst) use
+    // their authored periodic lifecycle.
+    let (is_explosion, is_periodic_stim_emitter) = {
         let v_class_tag = world.borrow::<View<PropClassTag>>().unwrap();
         let v_links = world.borrow::<View<Links>>().unwrap();
-        v_class_tag
+        let has_explosion_tag = v_class_tag
             .get(entity_id)
             .map(|tag| tag.class_tags().iter().any(|(k, _)| *k == "explosiontype"))
-            .unwrap_or(false)
-            && v_links.get(entity_id).is_ok_and(|links| {
-                links.to_links.iter().any(|l| {
-                    matches!(
-                        l.link,
-                        Link::StimSource(StimSourceOptions {
-                            propagator: StimPropagator::Radius { .. },
-                            ..
-                        })
-                    )
-                })
+            .unwrap_or(false);
+        let has_radius_source = v_links.get(entity_id).is_ok_and(|links| {
+            links.to_links.iter().any(|l| {
+                matches!(
+                    l.link,
+                    Link::StimSource(StimSourceOptions {
+                        propagator: StimPropagator::Radius { .. },
+                        ..
+                    })
+                )
             })
+        });
+        (
+            has_explosion_tag && has_radius_source,
+            !has_explosion_tag && has_radius_source,
+        )
     };
     // Release the property views before add_component below needs the world
     // mutably; nothing after this point reads them.
@@ -367,6 +369,9 @@ pub fn create_entity_core(
         // (has_fired) is not persisted, so a saved mid-animation explosion
         // would re-detonate on every load.
         world.add_component(entity_id, RuntimePropDoNotSerialize);
+    }
+    if is_periodic_stim_emitter {
+        processed_scripts.push("internal_periodic_stim".to_owned());
     }
 
     // ...and remove any duplicates!

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2073,12 +2073,10 @@ impl MissionCore {
         did_slay
     }
 
-    /// Apply a radius stim blast (Effect::RadiusBlast): every entity with hit
-    /// points in range receives the stim at linear-falloff intensity, and its
-    /// receptrons decide the damage (no receptron for the stim = no response -
-    /// the type-effectiveness mechanism: EMP does nothing to organics).
-    /// Dynamic bodies in range are shoved outward regardless.
-    fn radius_blast(
+    /// Apply a radius stimulus: every entity with hit points in range receives
+    /// the stim at linear-falloff intensity, and its receptrons decide the
+    /// damage (no receptron for the stim = no response).
+    fn radius_stim(
         &mut self,
         center: Vector3<f32>,
         radius: f32,
@@ -2102,6 +2100,23 @@ impl MissionCore {
                     in_range.push((entity_id, intensity * falloff));
                 }
             }
+
+            // The player is represented by the physics character and keeps
+            // its live position in PlayerInfo, not RuntimePropTransform. Add
+            // it explicitly so environmental radius sources can reach the
+            // player's receptrons too.
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            if v_hit_points.get(player.entity_id).is_ok()
+                && !in_range
+                    .iter()
+                    .any(|(entity_id, _)| *entity_id == player.entity_id)
+            {
+                let distance = (player.pos - center).magnitude();
+                if distance < radius {
+                    let falloff = 1.0 - distance / radius;
+                    in_range.push((player.entity_id, intensity * falloff));
+                }
+            }
         }
 
         for (entity_id, felt_intensity) in in_range {
@@ -2115,16 +2130,18 @@ impl MissionCore {
                 stim_template_id,
                 felt_intensity,
             );
-            // Explosions only ever deal damage: dispatch a Damage message only
-            // for a positive result. A zero amount (fully shielded) would still
-            // read as "took damage" and aggro AI; a negative one (a heal
-            // receptron) has no meaning through the damage path.
+            // Radius stims currently expose only the damage response path:
+            // dispatch a Damage message only for a positive result. A zero
+            // amount (fully shielded) would still read as "took damage" and
+            // aggro AI; a negative one (a heal receptron) has no meaning
+            // through the damage path.
             if let Some(amount) = maybe_damage {
                 if amount > 0.0 {
                     self.script_world.dispatch(Message {
                         to: entity_id,
-                        // No impact vector: the blast's physical push is
-                        // applied radially to bodies by radius_blast itself.
+                        // Stim propagation has no directional impact; an
+                        // explosive source applies its physical push
+                        // separately in radius_blast.
                         payload: MessagePayload::Damage {
                             amount,
                             impact: None,
@@ -2133,7 +2150,17 @@ impl MissionCore {
                 }
             }
         }
+    }
 
+    /// Apply an explosive radius stimulus, then shove nearby dynamic bodies.
+    fn radius_blast(
+        &mut self,
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+        stim_template_id: i32,
+    ) {
+        self.radius_stim(center, radius, intensity, stim_template_id);
         self.physics.apply_radial_impulse(
             center,
             radius,
@@ -3066,6 +3093,15 @@ impl MissionCore {
                     stim_template_id,
                 } => {
                     self.radius_blast(center, radius, intensity, stim_template_id);
+                }
+
+                Effect::RadiusStim {
+                    center,
+                    radius,
+                    intensity,
+                    stim_template_id,
+                } => {
+                    self.radius_stim(center, radius, intensity, stim_template_id);
                 }
 
                 Effect::RaiseNoise { origin, radius } => {

--- a/shock2vr/src/mission/stim_response.rs
+++ b/shock2vr/src/mission/stim_response.rs
@@ -302,6 +302,7 @@ mod tests {
             link: Link::StimSource(StimSourceOptions {
                 intensity,
                 propagator,
+                lifecycle: Default::default(),
             }),
         }
     }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -247,6 +247,16 @@ pub enum Effect {
         force: Vector3<f32>,
     },
 
+    /// A radius stimulus without explosion physics (environmental sparks,
+    /// swarms, radiation sources). Entities in range resolve the authored stim
+    /// through their receptrons; dynamic bodies are not pushed.
+    RadiusStim {
+        center: Vector3<f32>,
+        radius: f32,
+        intensity: f32,
+        stim_template_id: i32,
+    },
+
     /// A radius stim blast (explosions): entities within `radius` of `center`
     /// receive the stim at `intensity` with linear distance falloff - damage
     /// is resolved per target through its receptrons for `stim_template_id`

--- a/shock2vr/src/scripts/internal_explosion.rs
+++ b/shock2vr/src/scripts/internal_explosion.rs
@@ -58,6 +58,7 @@ impl Script for InternalExplosion {
             StimSourceOptions {
                 intensity,
                 propagator,
+                ..
             },
         ) in radius_sources
         {

--- a/shock2vr/src/scripts/internal_periodic_stim.rs
+++ b/shock2vr/src/scripts/internal_periodic_stim.rs
@@ -1,0 +1,191 @@
+use std::time::Duration;
+
+use cgmath::{Transform, point3};
+use dark::properties::{Link, StimPropagator, StimSourceLifecycle, StimSourceOptions};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+use crate::runtime_props::RuntimePropTransform;
+use crate::time::Time;
+use crate::util::point3_to_vec3;
+
+use super::{Effect, Script, script_util::get_all_links_with_template};
+
+const MINIMUM_PERIOD: Duration = Duration::from_millis(1);
+
+#[derive(Clone, Copy, Debug)]
+struct PeriodicSourceState {
+    stim_template_id: i32,
+    intensity: f32,
+    radius: f32,
+    lifecycle: StimSourceLifecycle,
+    age: Duration,
+    next_firing: Duration,
+    firings: u32,
+}
+
+impl PeriodicSourceState {
+    fn new(stim_template_id: i32, options: StimSourceOptions) -> Option<Self> {
+        let StimPropagator::Radius { radius } = options.propagator else {
+            return None;
+        };
+        Some(Self {
+            stim_template_id,
+            intensity: options.intensity,
+            radius,
+            lifecycle: options.lifecycle,
+            age: Duration::ZERO,
+            next_firing: Duration::ZERO,
+            firings: 0,
+        })
+    }
+
+    fn can_fire(&self) -> bool {
+        self.lifecycle.no_max_firings
+            || u32::try_from(self.lifecycle.max_firings).is_ok_and(|maximum| self.firings < maximum)
+    }
+
+    /// Advance the source and return the intensity of every firing whose time
+    /// was crossed, plus whether this firing completed a destroy-on-finish
+    /// lifecycle. Sources fire at birth, then once per authored period.
+    fn advance(&mut self, elapsed: Duration) -> (Vec<f32>, bool) {
+        self.age += elapsed;
+        let period = self.lifecycle.period.max(MINIMUM_PERIOD);
+        let mut intensities = Vec::new();
+
+        while self.next_firing <= self.age && self.can_fire() {
+            intensities.push(self.intensity + self.firings as f32 * self.lifecycle.intensity_slope);
+            self.firings += 1;
+            self.next_firing += period;
+        }
+
+        let completed_now = !intensities.is_empty()
+            && self.lifecycle.destroy_on_completion
+            && !self.lifecycle.no_max_firings
+            && u32::try_from(self.lifecycle.max_firings)
+                .is_ok_and(|maximum| self.firings >= maximum);
+        (intensities, completed_now)
+    }
+}
+
+/// Runs inherited non-explosion radius stimulus sources according to their
+/// authored periodic lifecycle (electrical sparks, swarms, Rad Burst, etc.).
+pub struct InternalPeriodicStim {
+    sources: Vec<PeriodicSourceState>,
+}
+
+impl InternalPeriodicStim {
+    pub fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+}
+
+impl Script for InternalPeriodicStim {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        self.sources = get_all_links_with_template(world, entity_id, |link| match link {
+            Link::StimSource(options) => Some(*options),
+            _ => None,
+        })
+        .into_iter()
+        .filter_map(|(stim_template_id, options)| {
+            PeriodicSourceState::new(stim_template_id, options)
+        })
+        .collect();
+        Effect::NoEffect
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let center = world
+            .borrow::<View<RuntimePropTransform>>()
+            .ok()
+            .and_then(|transforms| {
+                transforms.get(entity_id).ok().map(|transform| {
+                    point3_to_vec3(transform.0.transform_point(point3(0.0, 0.0, 0.0)))
+                })
+            });
+
+        let mut effects = Vec::new();
+        let mut destroy_on_completion = false;
+        for source in &mut self.sources {
+            let (intensities, completed) = source.advance(time.elapsed);
+            destroy_on_completion |= completed;
+            if let Some(center) = center {
+                effects.extend(intensities.into_iter().map(|intensity| Effect::RadiusStim {
+                    center,
+                    radius: source.radius,
+                    intensity,
+                    stim_template_id: source.stim_template_id,
+                }));
+            }
+        }
+        if destroy_on_completion {
+            effects.push(Effect::DestroyEntity { entity_id });
+        }
+
+        if effects.is_empty() {
+            Effect::NoEffect
+        } else {
+            Effect::combine(effects)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(lifecycle: StimSourceLifecycle) -> PeriodicSourceState {
+        PeriodicSourceState::new(
+            -378,
+            StimSourceOptions {
+                intensity: 5.0,
+                propagator: StimPropagator::Radius { radius: 2.4 },
+                lifecycle,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn infinite_source_fires_at_birth_and_each_period() {
+        let mut source = source(StimSourceLifecycle {
+            period: Duration::from_secs(5),
+            max_firings: 0,
+            no_max_firings: true,
+            destroy_on_completion: false,
+            intensity_slope: 0.0,
+        });
+
+        assert_eq!(source.advance(Duration::ZERO), (vec![5.0], false));
+        assert_eq!(
+            source.advance(Duration::from_millis(4_999)),
+            (vec![], false)
+        );
+        assert_eq!(source.advance(Duration::from_millis(1)), (vec![5.0], false));
+    }
+
+    #[test]
+    fn finite_source_applies_slope_and_destroys_after_its_last_firing() {
+        let mut source = source(StimSourceLifecycle {
+            period: Duration::from_millis(100),
+            max_firings: 3,
+            no_max_firings: false,
+            destroy_on_completion: true,
+            intensity_slope: 0.25,
+        });
+
+        assert_eq!(
+            source.advance(Duration::from_millis(250)),
+            (vec![5.0, 5.25, 5.5], true)
+        );
+        assert_eq!(source.advance(Duration::from_secs(1)), (vec![], false));
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -25,6 +25,7 @@ mod internal_explosion;
 pub mod internal_fast_projectile;
 mod internal_frob_move;
 mod internal_keycard_script;
+mod internal_periodic_stim;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
@@ -128,6 +129,7 @@ use self::{
     internal_collision_type::InternalCollisionType,
     internal_explosion::InternalExplosion,
     internal_keycard_script::KeyCardScript,
+    internal_periodic_stim::InternalPeriodicStim,
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     melee_weapon::MeleeWeapon,
@@ -560,6 +562,7 @@ impl ScriptWorld {
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),
             "internal_keycard" => Box::new(KeyCardScript::new()),
+            "internal_periodic_stim" => Box::new(InternalPeriodicStim::new()),
             "internal_room_trigger" => Box::new(RoomTrigger::new()),
             "internal_simple_health" => Box::new(InternalSimpleHealth::new()),
             // Implemented

--- a/tools/shock2-sdk/test/periodic-stim.e2e.test.ts
+++ b/tools/shock2-sdk/test/periodic-stim.e2e.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// command2 contains two concrete descendants of the gamesys `electrical
+// sparks` source. Its inherited arSrcDesc emits Electricity at intensity 5 in
+// a 2.4-world-unit radius immediately, then every 5 seconds. The player's
+// Human Vulnerability has an Electricity damage receptron at x1.
+test(
+  "Periodic stim: electrical sparks damage on their authored five-second cadence",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8365),
+    });
+
+    // Initialize source scripts while the player is away from the sparks. The
+    // birth firing is deliberately not replayed when the player later enters.
+    await game.step({ frames: 2 });
+    const sparks = (
+      await game.entities.list({ filter: "electrical sparks", limit: 20 })
+    ).entities.find((entity) => entity.name === "electrical sparks");
+    assert.ok(sparks !== undefined, "expected a concrete electrical-sparks source");
+
+    const [x, y, z] = sparks.position;
+    // Hold the raw debug fly channel at the value that cancels the fixed
+    // character-controller gravity step, keeping the player at the source
+    // center instead of dropping to the deck below it.
+    await game.input.set("left_hand.thumbstick", [0, 0.5]);
+    await game.player.teleport({ x, y, z });
+    await game.step({ frames: 1 });
+    const hpBefore = (await game.info()).player.hit_points;
+    assert.notEqual(hpBefore, null, "player should have a hit-point pool");
+
+    // Four seconds is still before the next authored pulse.
+    await game.step({ frames: 240 });
+    assert.equal(
+      (await game.info()).player.hit_points,
+      hpBefore,
+      "sparks should not damage continuously between pulses",
+    );
+
+    // Crossing five seconds emits Electricity 5 at the source center.
+    await game.step({ frames: 90 });
+    assert.equal(
+      (await game.info()).player.hit_points,
+      (hpBefore as number) - 5,
+      "the first five-second pulse should deal the authored five damage",
+    );
+
+    // The next pulse uses the same cadence rather than firing every frame.
+    await game.step({ frames: 240 });
+    assert.equal((await game.info()).player.hit_points, (hpBefore as number) - 5);
+    await game.step({ frames: 90 });
+    assert.equal(
+      (await game.info()).player.hit_points,
+      (hpBefore as number) - 10,
+      "the second five-second pulse should deal another five damage",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse the periodic lifecycle fields from Dark Engine stimulus source descriptors
- attach a scheduler to inherited non-explosion radius sources and emit their authored stim at birth/cadence, including finite firing counts, intensity slopes, and destroy-on-completion
- route radius stimuli through receptrons without explosion impulse, including the transform-less player entity
- cover the scheduler with unit tests and command2 electrical-sparks behavior with a real-runtime SDK scenario

## Reproduction

Before this change, command2 electrical sparks never changed player HP: entity creation explicitly excluded non-explosion radius sources, and the source lifecycle bytes were discarded. The parser regression test was first run against the old behavior and failed because descriptors with different authored periods parsed identically.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark` (70 unit + 9 mission-loading tests)
- `cargo test -p shock2vr` (383 tests)
- `cd tools/shock2-sdk && npm test` (26 passed, 158 e2e-gated)
- targeted `periodic-stim.e2e.test.ts` (passed)
- `cd tools/shock2-sdk && npm run test:e2e` (181 passed, 0 failed, 3 existing gated skips; all 23 missions loaded)

Fixes #390