### PR TITLE
fix(gameplay): grant Bridge Card access

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -23,7 +23,9 @@ use crate::{
     runtime_props::RuntimePropReloading,
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
-    virtual_hand::{VirtualHandEffect, can_grab_item, is_wieldable_weapon},
+    virtual_hand::{
+        VirtualHandEffect, can_grab_item, is_wieldable_weapon, world_pickup_requires_frob,
+    },
 };
 
 /// Fallback viewmodel framing offset (look space: +x right, +y up, -z forward),
@@ -118,7 +120,9 @@ impl FlatPlayerController {
     /// Apply the original flat pickup split: weapons become the first-person
     /// viewmodel, while ordinary loot goes straight into the backpack.
     fn pick_up(&mut self, world: &World, entity_id: EntityId) -> Vec<VirtualHandEffect> {
-        if is_wieldable_weapon(world, entity_id) {
+        if world_pickup_requires_frob(world, entity_id) {
+            vec![out_message(entity_id, MessagePayload::Frob)]
+        } else if is_wieldable_weapon(world, entity_id) {
             self.wield(entity_id)
         } else {
             vec![VirtualHandEffect::StoreItem { entity_id }]
@@ -287,7 +291,15 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dark::properties::PropPlayerGun;
+    use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
+
+    fn frob_info(world_action: FrobFlag) -> PropFrobInfo {
+        PropFrobInfo {
+            world_action,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        }
+    }
 
     fn pistol() -> PropPlayerGun {
         PropPlayerGun {
@@ -307,7 +319,7 @@ mod tests {
     fn world_use_of_nonweapon_stores_it_without_displacing_wielded_weapon() {
         let mut world = World::new();
         let pistol = world.add_entity(pistol());
-        let ammo = world.add_entity(());
+        let ammo = world.add_entity(frob_info(FrobFlag::MOVE));
         let mut controller = FlatPlayerController::new();
         controller.wield(pistol);
 
@@ -342,6 +354,52 @@ mod tests {
                 [VirtualHandEffect::HoldItem { entity_id }] if *entity_id == weapon
             ),
             "weapon pickup should preserve flat auto-wield"
+        );
+    }
+
+    #[test]
+    fn world_use_of_move_and_script_item_preserves_direct_pickup_transfer() {
+        let mut world = World::new();
+        let scripted_item = world.add_entity(frob_info(FrobFlag::MOVE | FrobFlag::SCRIPT));
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, scripted_item);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::StoreItem { entity_id }] if *entity_id == scripted_item
+            ),
+            "ordinary MOVE | SCRIPT pickup must retain its direct physical transfer"
+        );
+    }
+
+    #[test]
+    fn world_use_of_move_only_keycard_dispatches_frob_for_injected_script() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            frob_info(FrobFlag::MOVE),
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+        ));
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, keycard);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                }] if *to == keycard
+            ),
+            "a MOVE-only PropKeySrc pickup must run its injected keycard Frob path"
         );
     }
 }

--- a/shock2vr/src/scripts/internal_frob_move.rs
+++ b/shock2vr/src/scripts/internal_frob_move.rs
@@ -31,6 +31,12 @@ impl Script for InternalFrobMove {
             return Effect::NoEffect;
         }
 
+        // `internal_keycard` grants the access state and owns the physical
+        // transfer as one operation. Do not independently reparent the card.
+        if crate::virtual_hand::world_pickup_requires_frob(world, entity_id) {
+            return Effect::NoEffect;
+        }
+
         let handles_move = {
             let frob_info = world
                 .borrow::<View<dark::properties::PropFrobInfo>>()
@@ -65,7 +71,9 @@ impl Script for InternalFrobMove {
 #[cfg(test)]
 mod tests {
     use cgmath::{Quaternion, vec3};
-    use dark::properties::{FrobFlag, Link, Links, PropFrobInfo, ToLink, WrappedEntityId};
+    use dark::properties::{
+        FrobFlag, KeyCard, Link, Links, PropFrobInfo, PropKeySrc, ToLink, WrappedEntityId,
+    };
     use shipyard::World;
 
     use crate::{
@@ -155,5 +163,30 @@ mod tests {
         );
 
         assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn keycard_script_remains_the_sole_transfer_owner() {
+        let (mut world, item, _inventory) = pickup_world(FrobFlag::MOVE, false);
+        world.add_component(
+            item,
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+        );
+
+        let effect = InternalFrobMove::new().handle_message(
+            item,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "internal_keycard must remain the sole transfer owner, got {effect:?}"
+        );
     }
 }

--- a/shock2vr/src/scripts/internal_keycard_script.rs
+++ b/shock2vr/src/scripts/internal_keycard_script.rs
@@ -1,8 +1,8 @@
 use dark::properties::PropKeySrc;
 
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
 
 use super::{Effect, MessagePayload, Script};
 
@@ -35,13 +35,119 @@ impl Script for KeyCardScript {
                     }
                 };
 
-                let destroy_self = Effect::DestroyEntity { entity_id };
-                Effect::Combined {
-                    effects: vec![acquire_key_card, destroy_self],
-                }
+                // Physical cards remain legible in the backpack after they
+                // grant access. The injected keycard script owns both effects
+                // so pickup cannot grant access without completing transfer.
+                let physical_fate = if crate::virtual_hand::can_grab_item(world, entity_id) {
+                    world
+                        .borrow::<UniqueView<PlayerInfo>>()
+                        .map(|player| Effect::DropEntityInfo {
+                            parent_entity_id: player.inventory_entity_id,
+                            dropped_entity_id: entity_id,
+                        })
+                        .unwrap_or(Effect::DestroyEntity { entity_id })
+                } else {
+                    Effect::DestroyEntity { entity_id }
+                };
+
+                Effect::combine(vec![acquire_key_card, physical_fate])
             }
             // Does turn off need to be done for email?
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{FrobFlag, KeyCard, Links, PropFrobInfo, PropKeySrc};
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::KeyCardScript;
+
+    fn keycard_world(world_action: FrobFlag) -> (World, shipyard::EntityId, shipyard::EntityId) {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+            PropFrobInfo {
+                world_action,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, keycard, inventory)
+    }
+
+    #[test]
+    fn frobbing_a_takeable_keycard_grants_access_and_stores_it() {
+        let (world, keycard, inventory) = keycard_world(FrobFlag::MOVE);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            keycard,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::AcquireKeyCard { key_card }
+                if key_card.region_id == 8192 && key_card.lock_id == 0
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::DropEntityInfo {
+                parent_entity_id,
+                dropped_entity_id,
+            } if *parent_entity_id == inventory && *dropped_entity_id == keycard
+        )));
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { .. }))
+        );
+    }
+
+    #[test]
+    fn frobbing_a_use_only_keycard_still_consumes_it() {
+        let (world, keycard, _inventory) = keycard_world(FrobFlag::SCRIPT);
+
+        let effects = Effect::flatten(vec![KeyCardScript::new().handle_message(
+            keycard,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::AcquireKeyCard { .. }))
+        );
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::DestroyEntity { entity_id } if *entity_id == keycard
+        )));
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -462,11 +462,22 @@ fn handle_empty_hand_state(
         }) = result
         {
             if can_grab_item(world, entity_id) {
-                let position = &physics.get_position(rigid_body_handle).unwrap();
-                let _dir = hand_position - position;
-                msgs.push(VirtualHandEffect::HoldItem { entity_id });
+                if world_pickup_requires_frob(world, entity_id) {
+                    // Keycards grant their access state through the injected
+                    // script, which also performs their physical transfer.
+                    msgs.push(VirtualHandEffect::OutMessage {
+                        message: Message {
+                            to: entity_id,
+                            payload: MessagePayload::Frob,
+                        },
+                    });
+                } else {
+                    let position = &physics.get_position(rigid_body_handle).unwrap();
+                    let _dir = hand_position - position;
+                    msgs.push(VirtualHandEffect::HoldItem { entity_id });
 
-                next_hand_state = HandState::Grabbing { entity_id };
+                    next_hand_state = HandState::Grabbing { entity_id };
+                }
             }
         }
     }
@@ -510,6 +521,16 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     }
 
     false
+}
+
+/// Whether physically taking this world item must first run an injected Frob
+/// script. `PropKeySrc` is the data-driven marker for `internal_keycard`, even
+/// when the authored world action is only `MOVE`.
+pub(crate) fn world_pickup_requires_frob(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<View<dark::properties::PropKeySrc>>()
+        .map(|keycards| keycards.get(entity_id).is_ok())
+        .unwrap_or(false)
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or
@@ -559,5 +580,80 @@ fn resolve_hit_proxy_entity(world: &World, ray_cast_result: RayCastResult) -> Ra
     RayCastResult {
         maybe_entity_id: maybe_new_entity_id,
         ..ray_cast_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc};
+
+    use super::*;
+    use crate::physics::CollisionGroup;
+
+    #[test]
+    fn only_keycard_world_pickups_require_injected_frob() {
+        let mut world = World::new();
+        let ordinary = world.add_entity(());
+        let keycard = world.add_entity(PropKeySrc(KeyCard {
+            is_master: false,
+            region_id: 8192,
+            lock_id: 0,
+        }));
+
+        assert!(!world_pickup_requires_frob(&world, ordinary));
+        assert!(world_pickup_requires_frob(&world, keycard));
+    }
+
+    #[test]
+    fn vr_grip_of_keycard_dispatches_frob_instead_of_bypassing_access() {
+        let mut world = World::new();
+        let keycard = world.add_entity((
+            PropKeySrc(KeyCard {
+                is_master: false,
+                region_id: 8192,
+                lock_id: 0,
+            }),
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+        ));
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            keycard,
+            vec3(0.0, 0.0, -1.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Vector3::zero(),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        let player_entity = world.add_entity(());
+        let mut player = physics.create_player(vec3(100.0, 100.0, 100.0), player_entity);
+        physics.update(Vector3::zero(), &mut player);
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+
+        let (hand, effects) = handle_empty_hand_state(
+            Handedness::Right,
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            None,
+            &world,
+            &physics,
+            &input,
+        );
+
+        assert_eq!(hand.get_held_entity(), None);
+        assert!(matches!(
+            effects.as_slice(),
+            [VirtualHandEffect::OutMessage {
+                message: Message {
+                    to,
+                    payload: MessagePayload::Frob,
+                },
+            }] if *to == keycard
+        ));
     }
 }

--- a/tools/shock2-sdk/test/command2-bridge-card.e2e.test.ts
+++ b/tools/shock2-sdk/test/command2-bridge-card.e2e.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable command2 mission-object ids. Runtime entity ids are rediscovered on
+// every launch and are never used as durable identities.
+const BRIDGE_CARD = 135;
+const CARD_SLOT = 138;
+const BRIDGE_DOOR = 144;
+const EYE_HEIGHT = 1.6;
+
+async function only(game: GameServer, missionObjectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(missionObjectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected one command2 object ${missionObjectId}, got ${JSON.stringify(found)}`,
+  );
+  return found[0];
+}
+
+/** Stage near an authored object, acquire a verified crosshair target, and use
+ * the normal flat squeeze edge. The candidate offsets handle which side of a
+ * wall-mounted object is open without weakening the required visibility check. */
+async function worldUse(game: GameServer, target: EntitySummary): Promise<void> {
+  const [x, y, z] = (await game.entities.detail(target.id)).position;
+  const offsets = [
+    [0, 1.2],
+    [0, -1.2],
+    [1.2, 0],
+    [-1.2, 0],
+  ] as const;
+
+  let lastError: unknown;
+  for (const [dx, dz] of offsets) {
+    await game.player.teleport({ x: x + dx, y: y - EYE_HEIGHT, z: z + dz });
+    try {
+      const aim = await game.player.aimAt(target, {
+        hitbox: "center",
+        visibility: "required",
+      });
+      if (!aim.target_confirmed) {
+        continue;
+      }
+      await game.input.set("right_hand.squeeze_value", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("right_hand.squeeze_value", 0);
+      await game.step({ frames: 2 });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `could not stage a visible use ray to ${target.name} (${target.template_id}): ${String(lastError)}`,
+  );
+}
+
+test(
+  "command2: picking up the Bridge Card grants access to its authored slot",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8201),
+    });
+    await game.step({ frames: 5 });
+
+    const bridgeCard = await only(game, BRIDGE_CARD);
+    const cardSlot = await only(game, CARD_SLOT);
+    const bridgeDoor = await only(game, BRIDGE_DOOR);
+    assert.equal(bridgeCard.name, "Bridge Card");
+    assert.equal(cardSlot.name, "Card slot");
+    assert.equal(bridgeDoor.name, "Security Door");
+
+    const doorBefore = await game.entities.detail(bridgeDoor.id);
+
+    // This is the production flat pickup path that regressed: object 135 is
+    // authored MOVE-only, but PropKeySrc must still run internal_keycard.
+    await worldUse(game, bridgeCard);
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === bridgeCard.id)?.location,
+      "inventory",
+      `the physical Bridge Card must remain in the backpack: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: bridgeCard.id })).bodies.length,
+      0,
+      "the stored Bridge Card must no longer have a world body",
+    );
+
+    // Slot 138 requires KeyDst region 8192 and SwitchLinks to door 144. Its
+    // normal use proves that pickup acquired the matching persistent key state.
+    await worldUse(game, cardSlot);
+    await game.step({ frames: 120 });
+
+    const doorAfter = await game.entities.detail(bridgeDoor.id);
+    assert.ok(
+      Math.abs(doorAfter.position[1] - doorBefore.position[1]) > 1,
+      `the Bridge Card slot must open door 144, before=${JSON.stringify(doorBefore.position)}, after=${JSON.stringify(doorAfter.position)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- route any world pickup carrying `PropKeySrc` through the runtime-injected `internal_keycard` Frob path, including flat world use and VR grip
- grant the key region and retain physical MOVE keycards in the backpack as one scripted operation
- keep the injected keycard script as sole transfer owner while preserving ordinary MOVE, weapon, and MOVE | SCRIPT pickup behavior
- exercise the real Command2 Bridge Card, authored slot, and linked security door through production flat input

## Root cause

Command2 mission object 135 inherits `PropFrobInfo.world_action = MOVE` and carries `PropKeySrc` region 8192. `FlatPlayerController::pick_up` stored every non-weapon directly, so the injected keycard script never received Frob and `AcquireKeyCard` never updated `QuestInfo`. The physical Bridge Card survived in inventory, but slot 138 correctly rejected region 8192 and left door 144 closed.

The same bypass existed for a VR grip: it emitted `HoldItem` without running the injected script. Both pickup surfaces now use `PropKeySrc` as the general data-driven discriminator. There are no mission, object, region, or runtime-ID special cases in the product fix.

## Relationship to #688

PR #688 implemented the routing predicate on the non-default `playthrough/water-exit-680` stack, whose base already contained broader keycard-transfer and scripted-loot changes. It never reached `main`, and its two-file diff alone would destroy physical cards on current main. This PR reimplements the focused fix against current main: physical keycard transfer, sole ownership, and flat/VR routing are included, while the unrelated stacked MOVE | SCRIPT composition remains unchanged.

## Negative-first proof

Before the production change:

```text
cargo test -p shock2vr world_use_of_move_only_keycard_dispatches_frob_for_injected_script -- --nocapture
FAILED: a MOVE-only PropKeySrc pickup must run its injected keycard Frob path
```

After the fix, focused tests cover ordinary MOVE, weapon, ordinary MOVE | SCRIPT, MOVE-only keycard, VR grip routing, physical/use-only keycard fate, and sole transfer ownership.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 388 passed
- `cd tools/shock2-sdk && npm test` — 26 passed, 158 opt-in tests skipped
- focused `command2-bridge-card.e2e.test.ts` — passed; real card pickup retained the card, removed its world body, and the real slot opened linked door 144
- full serialized SDK e2e — 180 passed, 3 expected SHODAN fixture skips, all 23 missions and the new Command2 scenario passed; the sole failure was unrelated `DebugForceChase` async pathfinding divergence, which passed its immediate exclusive rerun on the unchanged commit

No visual capture is required; this changes interaction/access state without altering rendered output.

Fixes #687