### PR TITLE
fix(physics): traverse diagonal low treads

### DIFF
--- a/.claude/skills/play-through/walkthroughs/earth.md
+++ b/.claude/skills/play-through/walkthroughs/earth.md
@@ -91,6 +91,12 @@ Follow the instructor prompts and demonstrate each available lesson:
    trap 379 must return the player once to approximately
    **(11.61, 24.26, 65.79)**, without an automatic re-entry loop.
 
+After that return, leave the Basic booth by walking **back/decreasing z**
+through tripwire 359 and its door leaves 358/368, then cross the hub to the
+x≈5 service passage described in Phase 4. Walking forward through the old
+Basic-entry volume is not the route to enlistment; its correctly ignored
+tripwire is not evidence that the concourse is blocked.
+
 The course begins behind timed fields. Wait for the authored delays, operate
 the highlighted Simple Button through player Frob, cross the lesson tripwires,
 climb the real ladder, and traverse the upper platform. Do not damage or
@@ -140,8 +146,9 @@ inventory; prove each exercise before leaving its room.
 Each lobby aperture has an authored **0.8-world-unit raised threshold**. Back
 off, center on the room's tripwire z coordinate, face west, and use sustained
 normal locomotion so the character controller can autostep onto it. The debug
-`/v1/player/move` helper performs a direct capsule shape cast without autostep,
-so a blocked helper move is not evidence that these entrances are impassable.
+`/v1/player/move` helper uses the same controller and step probe, but remains a
+single fixed-heading hop; a blocked direct hop is not evidence that these
+entrances are impassable without a centered or thumbstick retry.
 
 ### Weapons
 
@@ -329,9 +336,13 @@ marker is only a wiring diagnostic.
    reporting a blocker.
 3. The scripted Basic-course return must suppress stale entry-tripwire tracking.
    More than one automatic return/re-entry is a teleport-loop regression.
-4. Low Basic-course walls require observed steering. A long held input into a wall
-   is a test-navigation failure unless bounded corrective attempts prove the
-   passage itself is impassable.
+4. Low Basic-course walls require observed steering. The two walls near
+   z≈237–241 are initially topped by authored `BlueForceField` objects 548/566;
+   lesson Destroy Trap 300 removes both after the button sequence. Trying to
+   cross them before that is a real collision, while sliding along the exposed
+   one-foot tread afterward is a controller regression. A long held input into
+   a remaining wall is a test-navigation failure unless bounded corrective
+   attempts prove the passage itself is impassable.
 5. Doors 80/81 are intentionally player-frobbed `StdDoor`s with no incoming
    SwitchLinks. Waiting for an automatic trigger is tester error; a correctly
    targeted player frob that does not move both the panel and collider is a

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -106,18 +106,27 @@ lands in `/v1/player/inventory` (a living AI's container stays closed until
 it's dead).
 
 **Navigate with `/v1/player/move`, not raw teleport.** It advances the player at
-most ~5 units toward the target and **shapecasts the player collider**, so it
-**cannot tunnel through walls or out of bounds** (returns `blocked:true`,
-`distance_moved < requested` when it hits geometry). So you walk to a place in
-short hops, checking screenshots — this is what makes it a real playtest instead
-of warping to arbitrary (often out-of-level) entity coordinates. Raw
-`/v1/player/teleport` is reserved for manager-driven setup/frontier-resume.
+most ~5 units toward the target through the real character controller, so it
+**cannot tunnel through walls or out of bounds**. Walk in short hops and check
+screenshots — this is what makes it a real playtest instead of warping to
+arbitrary (often out-of-level) entity coordinates. Raw `/v1/player/teleport` is
+reserved for manager-driven setup/frontier-resume.
 
 It **walks** the same way the player does — stairs, ramps and small ledges are
-traversed, and it climbs/descends them for you — so `blocked` means a real
-obstruction, not a step. Only the horizontal direction of the target is used;
-gravity decides the vertical, so aim at where you want to *stand*, not at a
-point in the air.
+traversed, and it climbs/descends them for you; an exposed walkable step should
+not block the hop. Only the horizontal direction of the target is used; gravity
+decides the vertical, so aim at where you want to *stand*, not at a point in the
+air.
+
+`/v1/player/move` is a **local fixed-heading walk, not a pathfinder or a
+reachability oracle**. `blocked:true` means that one bounded hop did not reach
+its requested endpoint; it does not mean there is no route around the obstacle.
+When a hop makes partial progress or stops at a visible corner, inspect the
+screenshot, try short lateral/waypoint hops, and use sustained thumbstick
+locomotion for steering-sensitive passages. Before filing an unreachable-area
+bug, corroborate the conclusion with plausible alternate lanes and available
+AIPATH data. Treat AIPATH as evidence rather than proof: it can be partitioned
+and does not account for every live door or mission object.
 
 **Ladders are not walked, they're climbed** — `/v1/player/move` never grips one.
 Aim the head with `{"head.look":[yaw_deg,pitch_deg]}` and hold

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -328,8 +328,15 @@ fn try_step_up(
         return None;
     }
     let dir = desired_h / desired_norm;
-    // Not blocked: the move achieved most of the desired horizontal distance.
-    if applied.dot(&dir) > 0.5 * desired_norm {
+    // Not blocked: the resolved horizontal vector stayed close to the input.
+    // Comparing only its projection onto `dir` masks a blocked component: a
+    // diagonal walk into a low riser can preserve most of its speed by sliding
+    // sideways along the face, so the step probe never runs even though the
+    // intended forward component was lost. A vector residual catches that
+    // deflection while the collision-checked probes below still reject an
+    // ordinary full-height wall.
+    let applied_h = vector![applied.x, 0.0, applied.z];
+    if (desired_h - applied_h).norm() <= 0.25 * desired_norm {
         return None;
     }
 
@@ -1323,25 +1330,29 @@ pub const MAX_PLAYER_MOVE_DISTANCE: f32 = 5.0;
 /// (applied once per substep, as it is once per frame) fall at the real rate.
 const PLAYER_MOVE_SUBSTEP: f32 = 25.0 / SCALE_FACTOR / 60.0;
 
-/// Fraction of a substep's attempted distance that still counts as progress.
+/// Fraction of a substep's attempted distance that still counts as movement.
 /// Below it the player is genuinely stopped (a wall, a closed door) and the
-/// move ends; above it, walking / slope handling / the step-up probe is still
-/// carrying the player toward the target.
-const PLAYER_MOVE_PROGRESS_FRACTION: f32 = 0.25;
+/// move ends; above it, walking / collision sliding / the step-up probe is
+/// still carrying the player through the world.
+const PLAYER_MOVE_MIN_ADVANCE_FRACTION: f32 = 0.25;
 
-/// Consecutive low-progress substeps tolerated before a validated move is
+/// Consecutive low-advance substeps tolerated before a validated move is
 /// considered blocked. Real locomotion keeps stepping while the capsule
 /// scrapes around a corner; a single sub-threshold frame is therefore not
 /// evidence of a wall. Three frames cover the shipped corner contacts while
 /// keeping a truly stopped move short.
 const PLAYER_MOVE_STALL_SUBSTEPS: usize = 3;
 
-/// How close to the requested distance a validated move must get to count as
-/// having arrived (world units). Also the tolerance for reporting `blocked`,
-/// and what keeps the loop from grinding on an ever-shrinking remainder (the
-/// final attempt shrinks to whatever is left, so its minimum progress shrinks
-/// with it).
+/// Geometric tolerance used by collision-checked scripted movement and by the
+/// validated move's strict horizontal-radius bound.
 const PLAYER_MOVE_ARRIVAL_EPSILON: f32 = 0.02;
+
+/// How close a validated move may finish to its bounded horizontal target and
+/// still count as successful. Collision sliding can lengthen the walked route
+/// while the API's strict radius bound prevents spending more distance than
+/// requested; a substep-scale miss is therefore an arrival, not evidence that
+/// the walkable target is unreachable.
+const PLAYER_MOVE_TARGET_EPSILON: f32 = 0.1;
 
 bitflags! {
     pub struct InternalCollisionGroups: u32 {
@@ -2102,9 +2113,9 @@ impl PhysicsWorld {
     /// player through a wall or out of bounds. Collision sliding may alter the
     /// route, but no result outside the requested horizontal radius is applied.
     ///
-    /// `blocked` means the player did not cover the requested distance: either
+    /// `blocked` means the player did not reach the target tolerance: either
     /// [`PLAYER_MOVE_STALL_SUBSTEPS`] consecutive substeps made less than
-    /// [`PLAYER_MOVE_PROGRESS_FRACTION`] of their attempts (a wall, a closed
+    /// [`PLAYER_MOVE_MIN_ADVANCE_FRACTION`] of their attempts (a wall, a closed
     /// door), the next solver result would exceed the bounded radius, or the
     /// move ran out of substeps still short of the target. A purely vertical
     /// request has nothing to walk toward and is a no-op.
@@ -2190,9 +2201,9 @@ impl PhysicsWorld {
         let dt = self.integration_parameters.dt;
         // The bounded destination (which may be short of a farther target).
         // Keep feeding the controller the same heading real thumbstick
-        // locomotion receives, but measure progress against this destination:
-        // collision sliding can alter the route, so summing only the original
-        // heading's projection overshoots the target and oscillates around it.
+        // locomotion receives, but measure the final result against this
+        // destination: collision sliding can alter the route, so summing only
+        // the original heading's projection can overshoot it.
         let start = pos.translation.vector;
         let walk_dir = vector![delta_h.x / dist, 0.0, delta_h.z / dist];
         let destination = start + walk_dir * requested_distance;
@@ -2230,13 +2241,12 @@ impl PhysicsWorld {
             observe_sensors(&pos, &mut occupied_sensors, &mut swept_sensor_events);
 
             // Walk toward the target one substep at a time. The iteration bound
-            // is the worst case a *progressing* move can need (every substep
-            // scraping by at the progress fraction, plus a few for the
-            // shrinking final attempt); running it out leaves `distance_moved`
-            // short of the request, which is reported as `blocked` below rather
-            // than passing for success.
+            // is the worst case a moving capsule can need (every substep at the
+            // minimum advance fraction, plus a few for the shrinking final
+            // attempt); running it out leaves `distance_moved` short of the
+            // request, which is reported as `blocked` below.
             let max_substeps = (requested_distance
-                / (PLAYER_MOVE_SUBSTEP * PLAYER_MOVE_PROGRESS_FRACTION))
+                / (PLAYER_MOVE_SUBSTEP * PLAYER_MOVE_MIN_ADVANCE_FRACTION))
                 .ceil() as usize
                 + 8;
             for _ in 0..max_substeps {
@@ -2246,7 +2256,7 @@ impl PhysicsWorld {
                     destination.z - pos.translation.vector.z
                 ];
                 let remaining = to_destination.norm();
-                if remaining <= PLAYER_MOVE_ARRIVAL_EPSILON {
+                if remaining <= PLAYER_MOVE_TARGET_EPSILON {
                     break;
                 }
                 let attempt = remaining.min(PLAYER_MOVE_SUBSTEP);
@@ -2280,17 +2290,16 @@ impl PhysicsWorld {
                 if from_start.norm() > requested_distance + PLAYER_MOVE_ARRIVAL_EPSILON {
                     break;
                 }
-                let after = vector![
-                    destination.x - candidate.translation.vector.x,
-                    0.0,
-                    destination.z - candidate.translation.vector.z
-                ]
-                .norm();
-                let progress = remaining - after;
+                // A wall may deflect an oblique input sideways for several
+                // frames before the capsule clears its finite end. Ordinary
+                // locomotion keeps supplying that same input; judge a stall by
+                // whether the capsule moved, not whether the deflected frame
+                // happened to reduce straight-line distance to the target.
+                let advance = vector![mvt.translation.x, 0.0, mvt.translation.z].norm();
                 pos = candidate;
                 observe_sensors(&pos, &mut occupied_sensors, &mut swept_sensor_events);
 
-                if progress < attempt * PLAYER_MOVE_PROGRESS_FRACTION {
+                if advance < attempt * PLAYER_MOVE_MIN_ADVANCE_FRACTION {
                     stalled_substeps += 1;
                     if stalled_substeps >= PLAYER_MOVE_STALL_SUBSTEPS {
                         break;
@@ -2334,7 +2343,7 @@ impl PhysicsWorld {
 
         MoveResult {
             moved,
-            blocked: remaining > PLAYER_MOVE_ARRIVAL_EPSILON,
+            blocked: remaining > PLAYER_MOVE_TARGET_EPSILON,
             new_position,
             distance_moved,
             requested_distance,
@@ -6416,6 +6425,97 @@ mod tests {
         );
     }
 
+    /// A diagonal walk into a low tread may preserve most of its speed by
+    /// sliding along the riser while losing the component that would carry it
+    /// onto the tread. The step probe must classify the resolved vector, not
+    /// just its projection onto the requested heading.
+    #[test]
+    fn diagonal_move_steps_instead_of_sliding_along_a_low_tread() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, vec![[0u32, 1, 2], [0, 2, 3]])
+                .expect("floor trimesh")
+                .build(),
+        );
+        // One-foot-high tread spanning x, with its front face at z=0.
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.0, 0.2, 2.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(100.0, 0.4, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(0.0, 1.0, -1.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        let input = vec3(2.4f32, 0.0, 1.2).normalize() * PLAYER_MOVE_SUBSTEP;
+        for _ in 0..20 {
+            world.update(input, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            end.y - start.y > 0.3 && end.z > 0.2,
+            "the diagonal walk should climb and reach the tread: {start:?} -> {end:?}"
+        );
+    }
+
+    /// A fixed heading can spend more than the three stall-tolerance frames
+    /// sliding along a finite wall before its capsule clears the end. This is
+    /// still real controller movement, even while it temporarily increases
+    /// straight-line distance to the target.
+    #[test]
+    fn validated_move_keeps_walking_while_sliding_toward_a_finite_wall_end() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, vec![[0u32, 1, 2], [0, 2, 3]])
+                .expect("floor trimesh")
+                .build(),
+        );
+        // A full-height wall at z=0 whose finite right edge is x=1. The
+        // oblique request must slide about one world unit before rounding it.
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(-49.5, 2.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(101.0, 4.0, 0.1),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(0.5, 1.0, -1.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        let result = world.move_player_validated(start + vec3(1.5, 0.0, 4.7), &mut player);
+
+        assert!(
+            result.new_position.x > 1.6 && result.new_position.z > 0.2,
+            "validated movement should round the finite wall: {result:?}"
+        );
+    }
+
     /// Sliding along a wall changes the controller's route. Progress projected
     /// only onto the requested heading can therefore consume the whole request
     /// while the net translation travels much farther; the hop must remain
@@ -6737,6 +6837,47 @@ mod tests {
             "should climb the ~1.5 ft service-hall riser, rose {} (ended {:?})",
             end.y - start.y,
             end
+        );
+    }
+
+    /// The earth.mis Basic Training course crosses from a floor at
+    /// y=20.4 onto a one-foot-higher tread at y=20.8 around z=240.4. Both
+    /// ordinary locomotion and the collision-valid debug walk used to wedge at
+    /// the riser even though it is well inside Dark's two-foot step height.
+    #[test]
+    fn player_climbs_earth_basic_training_low_wall() {
+        let Some(level) = try_load_level("earth.mis") else {
+            return;
+        };
+        let mut world = PhysicsWorld::new();
+        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        let mut player =
+            world.create_player(vec3(6.6, 22.2, 239.6), EntityId::from_inner(2).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let start = world.get_player_translation(&player);
+        let dir = vec3(2.4f32, 0.0, 1.2).normalize() * (25.0 / 60.0 / dark::SCALE_FACTOR);
+        for _ in 0..20 {
+            world.update(dir, &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            end.z > 240.8 && end.y - start.y > 0.3,
+            "should climb the one-foot Basic Training tread, moved {start:?} -> {end:?}"
+        );
+
+        let mut world = PhysicsWorld::new();
+        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        let mut player =
+            world.create_player(vec3(6.6, 22.2, 239.6), EntityId::from_inner(2).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let result = world.move_player_validated(vec3(9.0, 21.4, 240.8), &mut player);
+        assert!(
+            !result.blocked,
+            "validated walk should cross the same tread: {result:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/player-move.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-move.e2e.test.ts
@@ -203,3 +203,52 @@ test(
     );
   },
 );
+
+test(
+  "validated player move: climbs the earth Basic Training low tread",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8107),
+    });
+    await game.step({ frames: 2 });
+
+    // The course initially gates this tread with two authored force fields;
+    // Destroy Trap mission object 300 removes them after the lesson button.
+    // Reproduce that state without relying on unstable runtime entity IDs.
+    const destroyTrap = (
+      await game.entities.list({ filter: "Destroy Trap", limit: 20 })
+    ).entities.find((entity) => entity.template_id === 300);
+    assert.ok(destroyTrap, "expected Basic Training Destroy Trap 300");
+    await game.entities.sendMessage(destroyTrap.id, { type: "TurnOn" });
+    await game.step({ frames: 2 });
+    const forceFields = await game.entities.list({ filter: "BlueForceField", limit: 10 });
+    assert.equal(forceFields.entities.length, 0, "fixture fields should be destroyed");
+
+    // Regression for #517. The now-open authored route crosses diagonally from
+    // the y=20.4 floor onto a one-foot-higher tread near z=240.4. The
+    // controller used to preserve most of its speed by sliding along the
+    // riser, so the step probe missed the lost z component and stopped on the
+    // wrong side despite the tread being comfortably walkable.
+    await game.player.teleport({ x: 6.6, y: 22.2, z: 239.6 });
+    await game.step({ frames: 30 });
+    const start = await game.player.position();
+    const move = await game.player.moveTo({ x: 9, y: start.y, z: 240.8 });
+    const end = await game.player.position();
+
+    assert.equal(
+      move.blocked,
+      false,
+      `walkable tread reported blocked: ${JSON.stringify(move)}`,
+    );
+    assert.ok(
+      end.y - start.y > 0.3,
+      `player should climb the tread: ${JSON.stringify({ start, end })}`,
+    );
+    assert.ok(
+      end.z > 240.7,
+      `player should cross the riser: ${JSON.stringify({ start, end })}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- detect diagonal low-tread obstruction from the full resolved movement vector, so preserved sideways sliding no longer hides a lost component
- keep validated movement walking while the real controller is still advancing around a finite wall, while retaining the strict requested-radius safety bound
- accept a substep-scale target residual as arrival instead of reporting a crossed walkable tread as blocked
- document that `/v1/player/move` is a local fixed-heading primitive, plus the authored Earth field sequence and backward post-Basic return route

## Reproduction and diagnosis

At the Earth Basic Training tread near z 240.4, the old step test saw roughly 80 percent projected progress because the capsule slid sideways, even though it lost the entire component needed to climb. The negative-first synthetic fixture ended near y 1.004 / z -0.357 without climbing.

The validated-move loop separately treated low straight-line target progress as a stall even while the controller was moving laterally around a finite wall. The negative-first fixture stopped at x 0.855 / z -0.410; the corrected loop rounds the end to x 2.488 / z 3.398.

The Earth course initially has intentional BlueForceField mission objects 548 and 566 over the tread. The runtime regression discovers and activates Destroy Trap mission object 300 first, confirms those fields are removed, and only then checks the exposed one-foot tread. It also uses stable mission template IDs rather than runtime entity IDs.

The post-course return is authored correctly: walk back through tripwire 359 and door leaves 358/368 to the hub, then use the x approximately 5 service passage. That route is now explicit in the playtest walkthrough.

## Validation

- `cargo test -p shock2vr` — 384 passed before rebase
- post-rebase `cargo test -p shock2vr physics::tests` — 53 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- SDK `npm test` — 26 passed, 158 gated e2e skipped
- focused post-rebase player-move e2e — 3 passed
- full SDK e2e — 181 passed, 0 failed, 3 skipped

No visual capture is included because this changes invisible collision endpoint behavior; deterministic runtime positions are the review evidence.

Fixes #517