### PR TITLE
feat(ui): open reader for received emails

### DIFF
--- a/projects/flat-ui-panels.md
+++ b/projects/flat-ui-panels.md
@@ -563,6 +563,13 @@ QuestInfo; EmailTrap 1131 TurnOn → `EM0201` plays once, replay-deduped.
 (If audio observability proves awkward, the PR may defer audio *assertion* —
 not audio playback — and must say so.)
 
+Implemented follow-up: audio-log pickup/reader and collection shipped in #468;
+received-email presentation is completed by #494. `PlayEmail` now resolves the
+per-deck `Email*` strings onto a synthetic nonserialized `MediaGui` host and
+opens it as an unbound flat MFD with the archive-qualified `iface/email.pcx`
+backdrop. The one-shot authored `EmailTrap` can still be destroyed immediately
+without closing the reader.
+
 **PR B2 — Map panel** (~600–900 LOC, stacks on B1's QuestInfo edits)
 Files: new `scripts/gui/map.rs` (`MapGui` composing `MapChunkData` +
 `PAGE001`/decals/markers into `GuiComponent`s — port `map_renderer.rs` logic to

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -111,6 +111,10 @@ where
                 self.gui.prepare_state_on_frob(&mut self.state);
                 Effect::combine(vec![Effect::OpenPanel { entity: entity_id }, frob_effect])
             }
+            MessagePayload::OpenUnboundPanel => {
+                self.gui.prepare_state_on_frob(&mut self.state);
+                Effect::OpenUnboundPanel { entity: entity_id }
+            }
             MessagePayload::GUIHover {
                 held_entity_id,
                 screen_coordinates,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -287,6 +287,12 @@ pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 #[derive(Unique, Clone, Copy)]
 pub struct MapPanelEntity(pub EntityId);
 
+/// Synthetic host for received-email presentation. Email traps are one-shot
+/// and destroy themselves, so the flat reader binds to this unbound panel
+/// entity instead. Rebuilt on every mission load and never serialized.
+#[derive(Unique, Clone, Copy)]
+pub struct EmailPanelEntity(pub EntityId);
+
 /// The automap location (`PropMapLoc`) of the mapped room the player most
 /// recently entered - the player's *current* map location. The automap uses it
 /// to draw that location bright (R-art) while other explored locations draw
@@ -693,6 +699,27 @@ impl MissionCore {
                 },
             ));
             world.add_unique(MapPanelEntity(entity));
+
+            let entity = world.add_entity((
+                Links::empty(),
+                PropScripts {
+                    scripts: vec!["internal_media".to_owned()],
+                    inherits: false,
+                },
+                dark::properties::PropTemplateId { template_id: -1 },
+                dark::properties::PropSymName("Email Reader".to_owned()),
+                PropPosition {
+                    position: vec3(0.0, 0.0, 0.0),
+                    rotation: Quaternion {
+                        v: vec3(0.0, 0.0, 0.0),
+                        s: 1.0,
+                    },
+                    cell: 0,
+                },
+                RuntimePropTransform(Matrix4::identity()),
+                RuntimePropDoNotSerialize,
+            ));
+            world.add_unique(EmailPanelEntity(entity));
         }
 
         world.add_unique(GlobalTemplateIdMap(template_to_entity_id.clone()));
@@ -3134,6 +3161,12 @@ impl MissionCore {
                     }
                 }
 
+                Effect::OpenUnboundPanel { entity } => {
+                    if game_options.presentation_mode == crate::PresentationMode::Flat {
+                        self.flat_ui.open_unbound(entity);
+                    }
+                }
+
                 Effect::CollectLog {
                     entity_id,
                     deck,
@@ -3162,6 +3195,7 @@ impl MissionCore {
                         self.world.add_component(
                             entity_id,
                             crate::runtime_props::RuntimePropLogData {
+                                kind: crate::runtime_props::RuntimeMediaKind::Log,
                                 name: get("logname"),
                                 text: get("logtext"),
                                 portrait: get("logportrait"),
@@ -3726,6 +3760,7 @@ impl MissionCore {
                     let has_read = quests.has_played_email(&email_file);
                     if !has_read || force {
                         quests.mark_email_as_played(&email_file);
+                        drop(quests);
                         let audio_clip =
                             asset_cache.get(&AUDIO_IMPORTER, &format!("{email_file}.wav"));
                         engine::audio::play_audio(
@@ -3741,8 +3776,47 @@ impl MissionCore {
                             vec![("kind".to_string(), "email".to_string())],
                             [0.0, 0.0, 0.0],
                         );
+
+                        // The authored trap is consumed later in this effect
+                        // batch, so flat mode renders the received email on a
+                        // synthetic unbound MediaGui host. Resolve the same
+                        // per-deck strings as the original reader overlay.
+                        if game_options.presentation_mode == crate::PresentationMode::Flat {
+                            let panel = self
+                                .world
+                                .borrow::<UniqueView<EmailPanelEntity>>()
+                                .ok()
+                                .map(|panel| panel.0);
+                            if let Some(panel) = panel {
+                                let level_file = format!("level{deck:02}.str");
+                                let strings = asset_cache
+                                    .get_opt(&dark::importers::STRINGS_IMPORTER, &level_file);
+                                let get = |prefix: &str| {
+                                    strings.as_ref().and_then(|strings| {
+                                        strings
+                                            .get(&format!("{prefix}{email}"))
+                                            .map(|s| s.replace("\\n", "\n"))
+                                    })
+                                };
+                                self.world.add_component(
+                                    panel,
+                                    crate::runtime_props::RuntimePropLogData {
+                                        kind: crate::runtime_props::RuntimeMediaKind::Email,
+                                        name: get("emailname"),
+                                        text: get("emailtext"),
+                                        portrait: get("emailportrait"),
+                                        icon: get("emailicon"),
+                                    },
+                                );
+                                self.script_world.dispatch(Message {
+                                    to: panel,
+                                    payload: MessagePayload::OpenUnboundPanel,
+                                });
+                            }
+                        }
+                    } else {
+                        drop(quests);
                     }
-                    drop(quests);
                 }
                 Effect::PlaySound { handle, name } => {
                     println!("Trying to play sound: {}", &name);

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -282,14 +282,24 @@ pub struct RuntimePropMapData {
     pub explored_rects: Vec<dark::map::MapRect>,
 }
 
-// RuntimePropLogData - the resolved presentation strings for an audio log,
-// attached to the log-disc entity when it is frobbed (collected). The reader
-// panel (`MediaGui`) reads it to render the portrait/deck-icon/name/transcript.
-// Not serialized: it is a presentation cache derived from the string tables and
-// is re-resolved on the next frob (the log identity itself persists in
-// `QuestInfo`).
+/// Which original reader-overlay presentation owns resolved media strings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RuntimeMediaKind {
+    Log,
+    Email,
+}
+
+// RuntimePropLogData - the resolved presentation strings for an audio log or
+// email. Attached to a log-disc entity when it is frobbed (collected), or to
+// the synthetic email-reader entity when an email arrives. The reader panel
+// (`MediaGui`) reads it to render the right backdrop plus the
+// portrait/deck-icon/name/transcript.
+// Not serialized: it is a presentation cache derived from the string tables
+// and is re-resolved on the next log frob or received-email event (the log
+// identity itself persists in `QuestInfo`).
 #[derive(Component, Clone, Debug)]
 pub struct RuntimePropLogData {
+    pub kind: RuntimeMediaKind,
     pub name: Option<String>,
     pub text: Option<String>,
     pub portrait: Option<String>,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -152,6 +152,12 @@ pub enum Effect {
         entity: EntityId,
     },
 
+    /// Open a flat MFD hosted by a synthetic entity with no world-object
+    /// distance behind it. It stays open until explicitly closed/replaced.
+    OpenUnboundPanel {
+        entity: EntityId,
+    },
+
     /// Record an audio log the player just frobbed into the persistent
     /// collection (`QuestInfo`) and resolve its transcript/portrait strings onto
     /// the disc entity (`RuntimePropLogData`) for the reader panel. Emitted by

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -1,14 +1,11 @@
 //! Audio-log / email reader MFD (`projects/flat-ui-panels.md` §1).
 //!
-//! The flat-mode reader panel matching the original game's email/log overlay: a
-//! `LOG.PCX` backdrop with the sender portrait, deck icon, header line and a word-wrapped,
-//! scrollable transcript. It is bound to the frobbed log-disc entity (the flat
-//! host's single-slot MFD), and reads its presentation strings from
-//! `RuntimePropLogData` - attached by the `Effect::CollectLog` handler when the
-//! disc is frobbed (that handler also records the log into the persistent
-//! `QuestInfo` collection and plays its audio). Deliberate deviation from the
-//! original's destroy-on-pickup: the disc survives so the reader stays bound and
-//! the code is readable in-fiction (research gap #6).
+//! The flat-mode reader panel matching the original game's email/log overlay:
+//! the media-specific `LOG.PCX` / `EMAIL.PCX` backdrop with the sender portrait,
+//! deck icon, header line and a word-wrapped, scrollable transcript. Logs bind
+//! to the frobbed disc; received emails bind to a synthetic unbound panel host
+//! because their one-shot trap entity is consumed. Both read resolved strings
+//! from `RuntimePropLogData`.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::PropLog;
@@ -17,7 +14,7 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::quest_info::QuestInfo;
-use crate::runtime_props::RuntimePropLogData;
+use crate::runtime_props::{RuntimeMediaKind, RuntimePropLogData};
 use crate::scripts::{
     Effect, MessagePayload,
     script_util::{send_to_all_switch_links, set_quest_bit_effect},
@@ -149,16 +146,20 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         world: &World,
         state: &MediaGuiState,
     ) -> Vec<GuiComponent<MediaGuiMsg>> {
+        let v_data = world.borrow::<View<RuntimePropLogData>>().unwrap();
+        let backdrop = match v_data.get(entity_id).map(|data| data.kind) {
+            Ok(RuntimeMediaKind::Email) => "iface/email.pcx",
+            _ => "iface/log.pcx",
+        };
         let mut components: Vec<GuiComponent<MediaGuiMsg>> = vec![
-            // Archive-qualified: obj.crf also ships a 64x64 model texture named
-            // LOG.PCX (the floppy disc art) and its mount wins the plain name -
-            // "iface/" pins the 188x296 MFD frame from the interface archive.
-            gui::image("iface/log.pcx")
+            // Archive-qualified: basenames can collide across archive mounts
+            // (notably LOG.PCX with obj.crf's floppy texture). "iface/" pins
+            // the 188x296 MFD frame from the interface archive.
+            gui::image(backdrop)
                 .with_position(vec2(0.0, 0.0))
                 .with_size(vec2(PANEL_W, PANEL_H)),
         ];
 
-        let v_data = world.borrow::<View<RuntimePropLogData>>().unwrap();
         if let Ok(data) = v_data.get(entity_id) {
             if let Some(portrait) = &data.portrait {
                 components.push(
@@ -327,9 +328,12 @@ mod tests {
 
     /// Whether a (possibly combined) effect includes opening the panel.
     fn opens_panel(effect: Effect) -> bool {
-        Effect::flatten(vec![effect])
-            .iter()
-            .any(|e| matches!(e, Effect::OpenPanel { .. }))
+        Effect::flatten(vec![effect]).iter().any(|e| {
+            matches!(
+                e,
+                Effect::OpenPanel { .. } | Effect::OpenUnboundPanel { .. }
+            )
+        })
     }
 
     /// The body text lines the reader currently draws (via the same
@@ -407,6 +411,7 @@ mod tests {
                 video: 0,
             },
             RuntimePropLogData {
+                kind: RuntimeMediaKind::Log,
                 name: None,
                 text: Some(text),
                 portrait: None,
@@ -532,6 +537,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn email_data_selects_the_email_reader_backdrop() {
+        let mut world = World::new();
+        let email = world.add_entity(RuntimePropLogData {
+            kind: RuntimeMediaKind::Email,
+            name: Some("POLITO".to_owned()),
+            text: Some("Move it!".to_owned()),
+            portrait: Some("Polito".to_owned()),
+            icon: Some("OpsIcon".to_owned()),
+        });
+
+        let components = MediaGui.get_components(&None, email, &world, &MediaGuiState::default());
+        assert!(matches!(
+            components.first(),
+            Some(GuiComponent::Image { texture, .. }) if texture == "iface/email.pcx"
+        ));
+    }
+
+    #[test]
+    fn programmatic_open_resets_received_media_to_the_first_page() {
+        let mut world = World::new();
+        let physics = PhysicsWorld::new();
+        let email = world.add_entity(RuntimePropLogData {
+            kind: RuntimeMediaKind::Email,
+            name: None,
+            text: Some(
+                (1..=20)
+                    .map(|i| format!("l{i}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ),
+            portrait: None,
+            icon: None,
+        });
+        let mut script = GuiScript::new(Box::new(MediaGui));
+        script.initialize(email, &world);
+
+        let (cx, cy) = (SCROLL_X + 9.0, PGDN_Y + 13.0);
+        script.handle_message(email, &world, &physics, &hover_at(cx, cy, false));
+        script.handle_message(email, &world, &physics, &hover_at(cx, cy, true));
+        assert_eq!(
+            drawn_lines(&mut script, email, &world, &physics)
+                .first()
+                .map(String::as_str),
+            Some("l8")
+        );
+
+        let effect =
+            script.handle_message(email, &world, &physics, &MessagePayload::OpenUnboundPanel);
+        assert!(opens_panel(effect));
+        assert_eq!(
+            drawn_lines(&mut script, email, &world, &physics)
+                .first()
+                .map(String::as_str),
+            Some("l1"),
+            "each received email should open at the top"
+        );
+    }
+
     /// Scroll clamps to the last full page: a transcript that fits on one page
     /// never scrolls, and a longer one stops at `lines - PAGE_LINES` instead of
     /// a near-empty tail page (xreview [AGREED] finding).
@@ -542,6 +606,7 @@ mod tests {
             // `line_count` one-word lines (each word fits one wrapped line).
             let text = vec!["line"; line_count].join("\n");
             let disc = world.add_entity(RuntimePropLogData {
+                kind: RuntimeMediaKind::Log,
                 name: None,
                 text: Some(text),
                 portrait: None,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -255,6 +255,9 @@ pub enum MessagePayload {
         is_grabbing: bool,
         hand: Handedness,
     },
+    /// Open a GUI-bearing entity without frobbing a world object. Used by
+    /// incoming email, whose authored trap is consumed as soon as it fires.
+    OpenUnboundPanel,
 
     // VR Interactions
     TriggerPull,    // player started pulling the trigger
@@ -556,6 +559,7 @@ impl ScriptWorld {
             "internal_collision_type" => Box::new(InternalCollisionType::new()),
             "internal_inventory" => gui_script(Box::new(ContainerGui::inv_container())),
             "internal_map" => gui_script(Box::new(MapGui)),
+            "internal_media" => gui_script(Box::new(MediaGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),

--- a/shock2vr/src/scripts/trap_email.rs
+++ b/shock2vr/src/scripts/trap_email.rs
@@ -8,6 +8,9 @@ use super::{
     script_util::{send_to_all_switch_links, set_quest_bit_effect},
 };
 
+/// Empty `PropLog` bitmasks decode as `trailing_zeros + 1 == 33`.
+const EMAIL_UNSET: u32 = 33;
+
 pub struct TrapEmail {}
 impl TrapEmail {
     pub fn new() -> TrapEmail {
@@ -27,11 +30,13 @@ impl Script for TrapEmail {
             MessagePayload::TurnOn { from: _ } => {
                 let v_log = world.borrow::<View<PropLog>>().unwrap();
                 let email_effect = match v_log.get(entity_id) {
-                    Ok(log) if log.deck > 0 && log.email > 0 => Effect::PlayEmail {
-                        deck: log.deck,
-                        email: log.email,
-                        force: false,
-                    },
+                    Ok(log) if log.deck > 0 && log.email > 0 && log.email != EMAIL_UNSET => {
+                        Effect::PlayEmail {
+                            deck: log.deck,
+                            email: log.email,
+                            force: false,
+                        }
+                    }
                     _ => Effect::NoEffect,
                 };
 
@@ -125,5 +130,27 @@ mod tests {
             plays_email(&effect),
             "the objective must be granted alongside the email, not instead of it"
         );
+    }
+
+    #[test]
+    fn unset_email_sentinel_does_not_play_email_33() {
+        let mut world = World::new();
+        let entity_id = world.add_entity(PropLog {
+            deck: 2,
+            email: EMAIL_UNSET,
+            log: 1,
+            note: 0,
+            video: 0,
+        });
+        let physics = PhysicsWorld::new();
+
+        let effect = TrapEmail::new().handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+
+        assert!(!plays_email(&effect));
     }
 }

--- a/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
@@ -85,11 +85,23 @@ test(
     await game.step({ frames: 10 });
 
     const before = await uiState();
+    // This authored route receives EM0203 beside the elevator. Incoming email
+    // owns the same single MFD slot, and frobbing the button below replaces it
+    // with ElevatorGui.
     assert.ok(
-      !before.active_panel,
-      "no panel should be active before frobbing the elevator button",
+      before.active_panel,
+      "approaching the elevator should receive its authored email",
     );
-    await game.screenshot("elevator-before-frob.png");
+    assert.equal(before.active_panel.name, "Email Reader");
+    assert.ok(
+      before.active_panel.elements.some(
+        (e) =>
+          e.kind === "text" &&
+          (e.text ?? "").toLowerCase().includes("fixing the elevators"),
+      ),
+      "EM0203 should explain how to restore elevator power",
+    );
+    await game.screenshot("elevator-email-before-frob.png");
 
     // --- Frob: the elevator panel must open, bound to the button ---
     await game.entities.sendMessage(buttonId, { type: "Frob" });

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -20,12 +20,11 @@ import { teleportVerified } from "./helpers/teleport.js";
 // "45100" IN-FICTION - by reading the log's transcript off the reader panel,
 // not by peeking at PropKeypadCode.
 //
-// Negative-first: on main, frobbing log 1608 plays LOG0220.wav and destroys
-// the disc - /v1/ui shows no panel, no transcript exists anywhere, and
-// /v1/info has no collected-log state, so every assertion below fails.
-// The review-fix assertion is also negative-verified: pre-fix, the backdrop
-// was requested as the plain "log.pcx", which obj.crf's 64x64 floppy model
-// texture wins - the archive-qualified assertions below fail on that build.
+// Negative-first for #494: on main, EmailTrap 1131 plays EM0201 but leaves
+// /v1/ui on the previously opened log panel (or empty), so the synthetic email
+// host, Polito Email* strings, and EMAIL art assertions fail. Earlier reader
+// review assertions remain here too: archive-qualified LOG art avoids the
+// colliding obj.crf floppy texture.
 //
 // Entity discovery is by stable template_id (1608 = the mission-file object
 // id); runtime entity ids are NOT stable across launches.
@@ -185,6 +184,59 @@ test(
       (s) => s.sample.toLowerCase() === "em0201",
     );
     assert.equal(afterEmail.length, 1, "EM0201 should play on TurnOn");
+
+    // Receiving an email opens the same reader overlay as a log, but with the
+    // EMAIL backdrop and Email* strings. The trap itself is consumed, so the
+    // panel is hosted by a synthetic, unbound entity rebuilt per mission.
+    const emailOpened = await game.ui.state();
+    assert.ok(
+      emailOpened.active_panel,
+      "receiving an email should open the reader MFD panel",
+    );
+    assert.equal(
+      emailOpened.active_panel.template_id,
+      -1,
+      "the email reader should be hosted by the synthetic panel entity",
+    );
+    const emailTranscript = textOf(emailOpened.active_panel);
+    assert.ok(
+      emailTranscript.toUpperCase().includes("POLITO"),
+      "the email reader header should name Polito",
+    );
+    assert.ok(
+      emailTranscript.toLowerCase().includes("depressurizing"),
+      "the reader should show EmailText1 from level02.str",
+    );
+    const emailTextures = emailOpened.active_panel.elements
+      .filter((e) => e.kind === "image")
+      .map((e) => e.texture?.toLowerCase());
+    assert.ok(
+      emailTextures.includes("iface/email.pcx"),
+      `email reader should draw the iface.crf EMAIL backdrop (images: ${emailTextures.join(", ")})`,
+    );
+    assert.ok(
+      !emailTextures.includes("iface/log.pcx"),
+      "email reader must not reuse the LOG backdrop",
+    );
+    if (hasLooseCrfArchives()) {
+      const backdrop = pcxSize(
+        readCrfEntry(path.join(dataRoot(), "res", "iface.crf"), "EMAIL.PCX"),
+      );
+      assert.deepEqual(
+        backdrop,
+        { width: 188, height: 296 },
+        "iface.crf's EMAIL.PCX should be the 188x296 MFD frame",
+      );
+    }
+    assert.ok(
+      emailTextures.includes("polito.pcx"),
+      "reader should draw the email sender portrait from book.crf",
+    );
+    assert.ok(
+      emailTextures.includes("opsicon.pcx"),
+      "reader should draw the email sender deck icon from book.crf",
+    );
+    await game.screenshot("email-reader-open.png");
 
     // --- The collection survives save/load ---
     await game.save("log-reader-e2e");

--- a/tools/shock2-sdk/test/map.e2e.test.ts
+++ b/tools/shock2-sdk/test/map.e2e.test.ts
@@ -71,12 +71,33 @@ test(
     assert.ok(markerBefore, "panel should draw the player marker (plrpip)");
 
     // Walk forward while the map is open: the unbound panel must NOT
-    // walk-away close (it has no bound world object), and the marker moves.
+    // walk-away close (it has no bound world object). After 20 frames this
+    // authored route receives EM0215, which faithfully takes over the game's
+    // single MFD slot; verify ordinary movement first, then the interruption.
     await game.input.set("right_hand.thumbstick", [0.0, 1.0]);
-    await game.step({ frames: 90 });
+    await game.step({ frames: 10 });
+    assert.ok(await marker(), "map panel must survive ordinary walking");
+    await game.step({ frames: 80 });
     await game.input.set("right_hand.thumbstick", [0.0, 0.0]);
+    const interrupted = await game.ui.state();
+    assert.ok(interrupted.active_panel, "EM0215 should open the reader");
+    assert.equal(
+      interrupted.active_panel.name,
+      "Email Reader",
+      "receiving EM0215 should replace the map in the single MFD slot",
+    );
+    assert.ok(
+      interrupted.active_panel.elements.some(
+        (e) => (e.texture ?? "").toLowerCase() === "iface/email.pcx",
+      ),
+      "the interruption should be the received-email reader",
+    );
+
+    // ToggleMap replaces the email reader with the persistent map host.
+    await game.input.trigger("ToggleMap");
+    await game.step({ frames: 5 });
     const markerAfter = await marker();
-    assert.ok(markerAfter, "map panel must survive walking (no distance close)");
+    assert.ok(markerAfter, "ToggleMap should reopen the map after email");
     const moved = Math.hypot(
       markerAfter.rect[0] - markerBefore.rect[0],
       markerAfter.rect[1] - markerBefore.rect[1],


### PR DESCRIPTION
Fixes #494

## Reproduction

On current `origin/main`, triggering medsci1's authored EmailTrap 1131 plays `EM0201`, but `PlayEmail` does no UI work. The active MFD remains the previously opened Amanpour log (template 1608), so no `EmailName1` / `EmailText1`, portrait, icon, or EMAIL backdrop is shown.

Negative-first, `log-reader.e2e.test.ts` was extended before the product change. Its real-runtime run failed after the audio assertion passed:

```text
expected synthetic panel template_id -1
actual 1608
```

## Fix

- Add a media kind to the reader's derived runtime data so the existing `MediaGui` selects archive-qualified `iface/log.pcx` or `iface/email.pcx` while reusing the faithful portrait/icon/header/word-wrapped transcript layout.
- Create one flat-only, nonserialized synthetic email-reader host per mission. Email traps remain one-shot and can destroy themselves without closing the displayed message.
- On a newly played email, resolve `EmailName<n>`, `EmailText<n>`, `EmailPortrait<n>`, and `EmailIcon<n>` from `level<deck>.str`, attach them to the host, reset the reader to page one, and open it as an unbound MFD.
- Treat decoded `PropLog.email == 33` as the unset bitmask sentinel rather than attempting `EMxx33`.
- Extend the existing log-reader scenario and update map/elevator scenarios for authentic incoming-email takeover of the game's single MFD slot (EM0215 and EM0203 respectively).

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime` ✅
- `cargo test -p shock2vr` ✅ (386 passed)
- focused `MediaGui` tests ✅ (9 passed)
- focused `TrapEmail` tests ✅ (2 passed)
- `npm test` in `tools/shock2-sdk` ✅ (26 passed; 157 e2e-gated skips)
- affected UI e2es together ✅: email/log reader, automap interruption/reopen, elevator email/replacement (3 passed)
- full serial `npm run test:e2e` ✅ (183 total; 180 passed; 0 failed; 3 expected SHODAN-finale skips; all 23 missions loaded)

## Visual evidence

![Incoming email reader demo](https://gist.githubusercontent.com/tommy-xr/617479f976d3348f9951522e5896a6d8/raw/email-reader-demo.gif)

<sub>Receiving the authored EM0201 opens the localized EMAIL reader while the one-shot trap is consumed. Captured headlessly via deterministic fixed-timestep stepping.</sub>

## Before → after

![Incoming email reader before/after](https://gist.githubusercontent.com/tommy-xr/617479f976d3348f9951522e5896a6d8/raw/email-reader-before-after.png)
