### PR TITLE
fix(ui): gate elevator floors on power state

### DIFF
--- a/shock2vr/src/scripts/gui/elevator.rs
+++ b/shock2vr/src/scripts/gui/elevator.rs
@@ -79,16 +79,12 @@ impl ElevatorContext {
 /// 1 = partial ("worm goo") lockout, 2 = fully accessible
 /// (projects/flat-ui-panels.md §2.1).
 ///
-/// We deliberately treat the **unset/0 default as fully accessible** rather
-/// than "no power": the shipped, hands-on-verified behavior is an ungated
-/// elevator, and shipping ungated is "strictly more playable" (doc §7.3 #2).
-/// Only an explicit partial-lockout value (`INCOMPLETE`, raw 1) gates - it
-/// seals deck 1 (Engineering), leaving decks >= 2 reachable, matching the
-/// original's "only buttons >= deck 2 work" rule.
 fn is_floor_available(elev_state: u32, deck: usize) -> bool {
     match elev_state {
-        1 => deck >= 2,
-        _ => true,
+        0 => false,
+        1 => deck <= 3,
+        2 => true,
+        _ => false,
     }
 }
 
@@ -136,11 +132,23 @@ impl Gui<ElevatorGuiState, ElevatorGuiMsg> for ElevatorGui {
                 )
             });
 
-        // ElevState quest bit (raw): 1 = partial lockout, else accessible.
+        // ElevState quest bit (raw): 0 = no power, 1 = lower three decks,
+        // 2 = every deck.
         let elev_state = world
             .borrow::<UniqueView<QuestInfo>>()
             .map(|q| q.read_quest_bit_value("ElevState").bits())
             .unwrap_or(0);
+
+        // The original replaces the entire elevator backdrop with POWER.PCX
+        // while the elevator is unpowered. Qualify the archive because
+        // objicon also contains a different 32x32 POWER.PCX.
+        if elev_state == 0 {
+            return vec![
+                gui::image("iface/power.pcx")
+                    .with_position(vec2(0.0, 0.0))
+                    .with_size(vec2(188.0, 296.0)),
+            ];
+        }
 
         let mut components: Vec<GuiComponent<ElevatorGuiMsg>> = vec![
             gui::image("elev.pcx")
@@ -241,23 +249,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_and_full_power_unlock_every_floor() {
-        // Unset (0) and fully-powered (COMPLETE, 2) leave every deck reachable -
-        // the shipped playable behavior.
-        for state in [0u32, 2] {
-            for deck in 1..=5 {
-                assert!(is_floor_available(state, deck), "state {state} deck {deck}");
-            }
+    fn no_power_blocks_every_floor() {
+        for deck in 1..=5 {
+            assert!(
+                !is_floor_available(0, deck),
+                "unpowered deck {deck} must stay unavailable"
+            );
         }
     }
 
     #[test]
-    fn partial_lockout_seals_only_engineering() {
-        // INCOMPLETE (1) is the "worm goo" partial lockout: deck 1 sealed,
-        // decks >= 2 reachable.
-        assert!(!is_floor_available(1, 1));
-        for deck in 2..=5 {
-            assert!(is_floor_available(1, deck), "deck {deck} should stay open");
+    fn partial_power_reaches_only_engineering_through_hydroponics() {
+        for deck in 1..=3 {
+            assert!(is_floor_available(1, deck), "deck {deck} should be open");
+        }
+        for deck in 4..=5 {
+            assert!(!is_floor_available(1, deck), "deck {deck} should be sealed");
+        }
+    }
+
+    #[test]
+    fn full_power_unlocks_every_floor() {
+        for deck in 1..=5 {
+            assert!(is_floor_available(2, deck), "deck {deck} should be open");
         }
     }
 }

--- a/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/elevator-panel.e2e.test.ts
@@ -9,18 +9,19 @@ import { teleportVerified } from "./helpers/teleport.js";
 // §2, PR A - "flat UI 6a"): frobbing the medsci1 Master Elevator Button opens
 // ElevatorGui in the left MFD, whose floor buttons are now semantically
 // labeled from MISC.STR (`ElevLevel<n>`), the current deck is lit + inert, and
-// floors gate on the `ElevState` quest bit. Clicking an available floor
-// transitions the game to that mission (marker StartLoc 22).
+// floors gate on the `ElevState` quest bit. With no power the original draws
+// POWER.PCX instead of any floor controls; partial power reaches decks 1..=3;
+// full power reaches all five. Clicking an available floor transitions the
+// game to that mission (marker StartLoc 22).
 //
 // Entity discovery is by NAME at run time (runtime entity ids are NOT stable
 // across launches): the "Master Elevator Button" (medsci1 mission id 1041,
 // script ElevatorButton). The floor labels/decks are global data (the gamesys
 // `Elev` file-var), so the button carries no floor links.
 //
-// Negative-first: on main the floor buttons render with `label: null` (the
-// host only knew the keypad's art-derived labels), so the "button labeled
-// 'Engineering (1)'" assertion fails; the fix adds the generic button-label
-// field + MISC.STR floor names.
+// Issue #593 negative-first: current main renders the normal ELEV.PCX panel
+// and exposes every non-current floor while ElevState is unset. It also gates
+// partial power backwards, exposing decks 4..=5 instead of decks 1..=3.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // The five floor labels ElevatorGui reads from MISC.STR (deck 1..5). Med / Sci
@@ -42,6 +43,11 @@ const OPERATIONS: Floor = {
   deck: 4,
   describe: "Operations (deck 4)",
 };
+const HYDROPONICS: Floor = {
+  name: /hydroponics/i,
+  deck: 3,
+  describe: "Hydroponics (deck 3)",
+};
 const MED_SCI: Floor = {
   name: /med\s*\/?\s*sci/i,
   deck: 2,
@@ -57,7 +63,7 @@ const floorButton = (state: UiState, floor: Floor): UiElement | undefined =>
   );
 
 test(
-  "flat elevator MFD: labeled floors, current-floor inert, ElevState gating, click transitions",
+  "flat elevator MFD: power states, labeled floors, current-floor inert, click transitions",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -106,46 +112,56 @@ test(
       "the active panel should be bound to the elevator button entity",
     );
 
-    // --- Floor buttons must be semantically labeled (THE fix; negative on main) ---
+    // --- No power: retail shows only POWER.PCX, with no floor controls. ---
     assert.ok(
-      floorButton(opened, ENGINEERING),
-      `panel should expose a floor button labeling ${ENGINEERING.describe} (on main labels are null)`,
+      opened.active_panel.elements.some(
+        (element) => element.texture === "iface/power.pcx",
+      ),
+      "an unset ElevState should draw the archive-qualified no-power panel",
     );
-    assert.ok(
-      floorButton(opened, OPERATIONS),
-      `panel should expose a floor button labeling ${OPERATIONS.describe}`,
+    assert.deepEqual(
+      opened.active_panel.elements
+        .filter((element) => element.kind === "button")
+        .map((element) => element.label),
+      ["close"],
+      "an unpowered elevator should expose no floor buttons",
     );
-    // The current deck (Med / Sci, deck 2) is lit + inert - never a clickable
-    // button.
-    assert.ok(
-      !floorButton(opened, MED_SCI),
-      "the current floor should be inert (not a clickable button)",
-    );
-    await game.screenshot("elevator-panel-open.png");
+    await game.screenshot("elevator-panel-unpowered.png");
 
-    // --- Gating: ElevState = INCOMPLETE seals deck 1 (Engineering) ---
+    // --- Partial power: decks 1..=3 work; decks 4..=5 remain blocked. ---
     await game.quests.set("ElevState", "incomplete");
     await game.step({ frames: 5 });
-    const gated = await uiState();
-    assert.ok(gated.active_panel, "panel should stay open across the gate change");
+    const partial = await uiState();
     assert.ok(
-      !floorButton(gated, ENGINEERING),
-      "with ElevState=incomplete, Engineering (deck 1) must be sealed (no button)",
+      partial.active_panel,
+      "panel should stay open across the power change",
     );
     assert.ok(
-      floorButton(gated, OPERATIONS),
-      "with ElevState=incomplete, decks >= 2 (e.g. Operations) stay available",
+      floorButton(partial, ENGINEERING),
+      "with partial power, Engineering (deck 1) should be available",
+    );
+    assert.ok(
+      floorButton(partial, HYDROPONICS),
+      "with partial power, Hydroponics (deck 3) should be available",
+    );
+    assert.ok(
+      !floorButton(partial, OPERATIONS),
+      "with partial power, Operations (deck 4) should remain sealed",
+    );
+    assert.ok(
+      !floorButton(partial, MED_SCI),
+      "the current floor should remain inert (not a clickable button)",
     );
     await game.screenshot("elevator-panel-gated.png");
 
-    // --- Ungate and click Engineering: the game transitions to eng1.mis ---
-    await game.quests.set("ElevState", "unknown");
+    // --- Full power and click Engineering: transition to eng1.mis. ---
+    await game.quests.set("ElevState", "complete");
     await game.step({ frames: 5 });
-    const ungated = await uiState();
-    const engineering = floorButton(ungated, ENGINEERING);
+    const fullyPowered = await uiState();
+    const engineering = floorButton(fullyPowered, ENGINEERING);
     assert.ok(
       engineering,
-      "ungating should restore the Engineering floor button",
+      "full power should retain the Engineering floor button",
     );
 
     assert.equal(


### PR DESCRIPTION
Fixes #593

## Reproduction

The issue's primary "no panel" report no longer reproduces on current `origin/main`: the Engineering Master Elevator Button opens `ElevatorGui` both before and after the authored power chain. I verified this against the campaign's real saves:

- `iter13_pre_master_power_hp6`: both nacelles completed, `ElevState` unset; the panel opened but incorrectly exposed Med/Sci, Hydroponics, Operations, and Recreation.
- `iter13_pre_east_hybrid_hp6`: the real Master Power interaction had set `CorePower` and `ElevState` to raw 1; the panel opened but still exposed all four other decks.

The secondary gating report does reproduce. The original Dark Engine source (`shkelev.cpp`) treats `ElevState` as:

- 0: draw only `POWER.PCX`; no floor selection
- 1: allow UI button indices 2..=4, which map through the inverted layout to decks 3..=1 (Engineering through Hydroponics)
- 2: allow every deck

Current main deliberately treated 0 as fully accessible and mapped 1 to decks >= 2, the reverse of the original partial-power range.

Negative-first results:

- `cargo test -p shock2vr scripts::gui::elevator::tests -- --nocapture`: 2 failed / 1 passed (`unpowered deck 1 must stay unavailable`; `deck 1 should be open`).
- Focused SDK runtime scenario: failed `an unset ElevState should draw the archive-qualified no-power panel`.

Original source reference: https://github.com/infernuslord/DarkEngine/blob/c8542d03825bc650bfd6944dc03da5b793c92c19/cam/src/shock/shkelev.cpp

## Fix

- Render the retail 188x296 `iface/power.pcx` panel while `ElevState` is unset/0. The archive-qualified name avoids the unrelated 32x32 `objicon/POWER.PCX` collision.
- Gate partial power to decks 1 through 3 and full power to all five decks.
- Fail closed for invalid raw quest values.
- Extend the existing real-runtime elevator scenario across no-power, partial-power, and full-power states before exercising the actual level transition.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 384 passed
- `cd tools/shock2-sdk && npm test` — 26 passed, 157 expected e2e skips
- focused elevator SDK e2e — passed
- full SDK e2e — 175 passed, 5 launch failures, 3 expected skips; all five failures were `No space left on device (os error 28)` before their runtimes started
- isolated rerun of the five ENOSPC-affected scenarios — 5 passed

## Visual evidence

![Elevator power-state gating demo](https://gist.githubusercontent.com/tommy-xr/0434b48f0fb84d37c1a8549647574918/raw/pr764-elevator-power-states.gif)

<sub>Fresh no-power state shows the retail power warning; partial and full power reveal only the decks allowed by ElevState.</sub>

<sub>Captured headlessly in `medsci1.mis` via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Matched ElevState 0 before/after](https://gist.githubusercontent.com/tommy-xr/0434b48f0fb84d37c1a8549647574918/raw/pr764-elevator-before-after.png)

<sub>Matched fresh-launch sequence: `main` at `5ebca74` → PR head at `2fa5dc6`; discover the Master Elevator Button by name, teleport beside it, frob, and step 5 frames.</sub>
