### PR TITLE
feat(gameplay): implement Hydro Toxin-A research

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -4,7 +4,7 @@ use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
 
 use crate::{
     EnvMap, EnvSoundQuery, SoundSchema, SpeechDB, TagDatabase,
-    gamesys::params::{HrmParams, TrainerCostTables},
+    gamesys::params::{HrmParams, SkillParams, TrainerCostTables},
     properties::{LinkDefinition, LinkDefinitionWithData, PropertyDefinition},
     ss2_chunk_file_reader::{self},
     ss2_entity_info::{self, SystemShock2EntityInfo},
@@ -20,6 +20,8 @@ pub struct Gamesys {
     trainer_costs: Option<TrainerCostTables>,
     /// HRM hacking/repair/modify tuning (`HRM` file-var chunk).
     hrm_params: Option<HrmParams>,
+    /// Skill-system tuning (`SKILLPARAM` file-var chunk).
+    skill_params: Option<SkillParams>,
 }
 
 impl Gamesys {
@@ -69,6 +71,10 @@ impl Gamesys {
     pub fn hrm_params(&self) -> Option<&HrmParams> {
         self.hrm_params.as_ref()
     }
+
+    pub fn skill_params(&self) -> Option<&SkillParams> {
+        self.skill_params.as_ref()
+    }
 }
 
 pub fn read<T: io::Read + io::Seek>(
@@ -93,6 +99,7 @@ pub fn read<T: io::Read + io::Seek>(
     let speech_db = SpeechDB::read(&table_of_contents, reader);
     let trainer_costs = TrainerCostTables::read(&table_of_contents, reader);
     let hrm_params = HrmParams::read(&table_of_contents, reader);
+    let skill_params = SkillParams::read(&table_of_contents, reader);
 
     // Uncomment to output debug info for voices:
     // debug_print_voices(&sound_schema, &speech_db);
@@ -105,5 +112,6 @@ pub fn read<T: io::Read + io::Seek>(
         speech_db,
         trainer_costs,
         hrm_params,
+        skill_params,
     }
 }

--- a/dark/src/gamesys/params.rs
+++ b/dark/src/gamesys/params.rs
@@ -51,6 +51,17 @@ pub struct HrmParams {
     pub stat_break_chance: [f32; 8],
 }
 
+/// Retail `SKILLPARAM` file-var (`sSkillParams`). Research scales authored
+/// progress by `1 + research_factor * (skill - 1)^2`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillParams {
+    pub weapon_break_angle: i16,
+    pub weapon_break_factor: f32,
+    pub research_factor: f32,
+    pub damage_modifier: f32,
+    pub organ_damage: f32,
+}
+
 fn read_table<T: io::Read + io::Seek, const COLS: usize, const ROWS: usize>(
     table_of_contents: &ChunkFileTableOfContents,
     reader: &mut T,
@@ -125,5 +136,54 @@ impl HrmParams {
 
     pub fn mine_count(&self, base: i32, skill: i32, stat: i32) -> i32 {
         (base - skill * self.skill_critical_bonus - stat * self.stat_critical_bonus).max(0)
+    }
+}
+
+impl SkillParams {
+    /// Read the packed 18-byte `SKILLPARAM` chunk. Returns `None` for a
+    /// missing/truncated non-retail gamesys.
+    pub fn read<T: io::Read + io::Seek>(
+        table_of_contents: &ChunkFileTableOfContents,
+        reader: &mut T,
+    ) -> Option<Self> {
+        let chunk = table_of_contents.get_chunk("SKILLPARAM".to_owned())?;
+        if chunk.length < 18 {
+            return None;
+        }
+        reader.seek(io::SeekFrom::Start(chunk.offset)).ok()?;
+        Self::read_record(reader)
+    }
+
+    fn read_record<T: io::Read>(reader: &mut T) -> Option<Self> {
+        Some(Self {
+            weapon_break_angle: reader.read_i16::<LittleEndian>().ok()?,
+            weapon_break_factor: reader.read_f32::<LittleEndian>().ok()?,
+            research_factor: reader.read_f32::<LittleEndian>().ok()?,
+            damage_modifier: reader.read_f32::<LittleEndian>().ok()?,
+            organ_damage: reader.read_f32::<LittleEndian>().ok()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::SkillParams;
+
+    #[test]
+    fn parses_packed_retail_skill_params_layout() {
+        let mut bytes = 0_i16.to_le_bytes().to_vec();
+        for value in [0.0_f32, 1.0, 0.15, 1.25] {
+            bytes.extend(value.to_le_bytes());
+        }
+        assert_eq!(bytes.len(), 18);
+
+        let parsed = SkillParams::read_record(&mut Cursor::new(bytes)).unwrap();
+        assert_eq!(parsed.weapon_break_angle, 0);
+        assert_eq!(parsed.weapon_break_factor, 0.0);
+        assert_eq!(parsed.research_factor, 1.0);
+        assert!((parsed.damage_modifier - 0.15).abs() < f32::EPSILON);
+        assert_eq!(parsed.organ_damage, 1.25);
     }
 }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -32,6 +32,7 @@ mod prop_psi;
 mod prop_quest_bit;
 mod prop_render_type;
 mod prop_replicator;
+mod prop_research;
 mod prop_room_gravity;
 mod prop_service;
 mod prop_spawn;
@@ -73,6 +74,7 @@ pub use prop_psi::*;
 pub use prop_quest_bit::*;
 pub use prop_render_type::*;
 pub use prop_replicator::*;
+pub use prop_research::*;
 pub use prop_room_gravity::*;
 pub use prop_service::*;
 pub use prop_spawn::*;
@@ -1257,6 +1259,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$ChemNeede",
+            PropChemicalNeeded::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$Creature",
             |reader, _len| read_u32(reader),
             PropCreature,
@@ -1352,6 +1360,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$BaseGunDe",
             PropBaseGunDesc::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$BaseTechD",
+            PropBaseTechDesc::read,
             identity,
             accumulator::latest,
         ),
@@ -1523,6 +1537,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$ObjName",
             read_variable_length_string,
             PropObjName,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ObjLookS",
+            PropObjLookString::read,
+            identity,
             accumulator::latest,
         ),
         define_prop(
@@ -1735,6 +1755,30 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$RepHacked",
             PropReplicatorHackedContents::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$ReqTechDe",
+            PropRequiredTechDesc::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RsrchRep",
+            PropResearchReport::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RsrchTime",
+            PropResearchTime::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$RsrchTxt",
+            PropResearchText::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_research.rs
+++ b/dark/src/properties/prop_research.rs
@@ -1,0 +1,175 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::{read_i32, read_string_with_size, read_u32};
+
+const TECH_SKILL_COUNT: usize = 5;
+const MAX_RESEARCH_CHEMICALS: usize = 7;
+
+/// Dark's `sTechSkills`: hack, repair, modify, maintenance, research.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TechSkillValues(pub [i32; TECH_SKILL_COUNT]);
+
+impl TechSkillValues {
+    fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 20, "a tech-skill record must contain five i32 values");
+        Self(std::array::from_fn(|_| read_i32(reader)))
+    }
+
+    pub fn research(self) -> i32 {
+        self.0[4]
+    }
+}
+
+/// An object's base tech values. Research uses the research field as its
+/// required skill, defaulting to one when this property is absent.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropBaseTechDesc(pub TechSkillValues);
+
+impl PropBaseTechDesc {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(TechSkillValues::read(reader, len))
+    }
+}
+
+/// The separate required-tech record used when operating an object.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropRequiredTechDesc(pub TechSkillValues);
+
+impl PropRequiredTechDesc {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(TechSkillValues::read(reader, len))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropResearchTime(pub i32);
+
+impl PropResearchTime {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 4, "P$RsrchTime must contain one i32 second count");
+        Self(read_i32(reader))
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropResearchText(pub String);
+
+impl PropResearchText {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(read_localized_string(reader, len))
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropObjLookString(pub String);
+
+impl PropObjLookString {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        Self(read_localized_string(reader, len))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropResearchReport(pub u32);
+
+impl PropResearchReport {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(len, 4, "P$RsrchRep must contain one 32-bit report mask");
+        Self(read_u32(reader))
+    }
+
+    pub fn first_report_number(self) -> Option<u32> {
+        (self.0 != 0).then(|| self.0.trailing_zeros() + 1)
+    }
+}
+
+/// The ordered chemical gates for one researchable archetype. Thresholds are
+/// expressed in authored research seconds, before the player's skill speedup.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Component)]
+pub struct PropChemicalNeeded {
+    pub chemicals: [String; MAX_RESEARCH_CHEMICALS],
+    pub thresholds_secs: [i32; MAX_RESEARCH_CHEMICALS],
+}
+
+impl PropChemicalNeeded {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        assert_eq!(
+            len, 476,
+            "P$ChemNeede must be the retail 7*64-byte labels + 7*i32 record"
+        );
+        let chemicals = std::array::from_fn(|_| read_string_with_size(reader, 64));
+        let thresholds_secs = std::array::from_fn(|_| read_i32(reader));
+        Self {
+            chemicals,
+            thresholds_secs,
+        }
+    }
+}
+
+fn read_localized_string<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> String {
+    assert!(
+        len >= 4,
+        "localized strings include a four-byte length prefix"
+    );
+    let _stored_len = read_u32(reader);
+    read_string_with_size(reader, len as usize - 4)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn parses_tech_skills_and_research_fields() {
+        let bytes = [0_i32, 2, 3, 4, 5]
+            .into_iter()
+            .flat_map(i32::to_le_bytes)
+            .collect::<Vec<_>>();
+        let parsed = PropBaseTechDesc::read(&mut Cursor::new(bytes), 20);
+        assert_eq!(parsed.0, TechSkillValues([0, 2, 3, 4, 5]));
+        assert_eq!(parsed.0.research(), 5);
+
+        assert_eq!(
+            PropResearchTime::read(&mut Cursor::new(600_i32.to_le_bytes()), 4),
+            PropResearchTime(600)
+        );
+        assert_eq!(
+            PropResearchReport::read(&mut Cursor::new(0x10_u32.to_le_bytes()), 4)
+                .first_report_number(),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn parses_localized_string_record() {
+        let value = b"AATText: \"Toxin research text\"\0";
+        let mut bytes = (value.len() as u32).to_le_bytes().to_vec();
+        bytes.extend_from_slice(value);
+        assert_eq!(
+            PropResearchText::read(&mut Cursor::new(bytes.clone()), bytes.len() as u32).0,
+            "AATText: \"Toxin research text\""
+        );
+    }
+
+    #[test]
+    fn parses_ordered_research_chemical_layout() {
+        let mut bytes = Vec::new();
+        for name in ["Chem #4", "Chem #2", "Chem #4", "", "", "", ""] {
+            let mut field = name.as_bytes().to_vec();
+            field.resize(64, 0);
+            bytes.extend(field);
+        }
+        for threshold in [30_i32, 60, 240, 0, 0, 0, 0] {
+            bytes.extend(threshold.to_le_bytes());
+        }
+
+        let parsed = PropChemicalNeeded::read(&mut Cursor::new(bytes), 476);
+        assert_eq!(&parsed.chemicals[..3], ["Chem #4", "Chem #2", "Chem #4"]);
+        assert_eq!(&parsed.thresholds_secs[..3], [30, 60, 240]);
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -25,6 +25,7 @@ mod physics;
 pub mod player_stats;
 mod psi;
 pub mod quest_info;
+pub mod research;
 mod runtime_props;
 mod scripts;
 mod systems;

--- a/shock2vr/src/mission/entity_populator/save_file_entity_populator.rs
+++ b/shock2vr/src/mission/entity_populator/save_file_entity_populator.rs
@@ -5,7 +5,9 @@
  *
  */
 use dark::properties::{
-    Link, Links, PropEcoState, PropEcoType, PropEcology, PropSpawn, WrappedEntityId,
+    Link, Links, PropBaseTechDesc, PropChemicalNeeded, PropEcoState, PropEcoType, PropEcology,
+    PropObjLookString, PropRequiredTechDesc, PropResearchReport, PropResearchText,
+    PropResearchTime, PropSpawn, WrappedEntityId,
 };
 use shipyard::{Get, View, ViewMut, World};
 use std::collections::HashMap;
@@ -36,7 +38,7 @@ impl EntityPopulator for SaveFileEntityPopulator {
     ) -> EntityPopulation {
         let world_entity_data = &self.save_data;
         let (template_to_entity, entity_id_map) = world_entity_data.instantiate(world);
-        restore_newly_parsed_authored_ecology(
+        restore_newly_parsed_authored_data(
             gamesys_entity_info,
             level_entity_info,
             obj_name_map,
@@ -51,17 +53,17 @@ impl EntityPopulator for SaveFileEntityPopulator {
     }
 }
 
-/// Backfill retail ecology data omitted by saves written before these chunks
-/// were understood.
+/// Backfill retail data omitted by saves written before these chunks were
+/// understood.
 ///
 /// Saves deliberately own mutable runtime state, so loading cannot generally
-/// reapply the mission file over a restored entity. These four properties and
-/// `SpawnPoint` links are different: old builds could neither deserialize nor
+/// reapply the mission file over a restored entity. The ecology and research
+/// properties below are different: old builds could neither deserialize nor
 /// mutate them, and therefore could not have serialized them. Restore only a
 /// missing component/link, only for a concrete mission object which still
 /// exists in the save. Deleted generators/ecologies stay deleted, while newer
-/// saves retain their live supply, state, and spawned-child graph.
-fn restore_newly_parsed_authored_ecology(
+/// saves retain their live values and spawned-child graph.
+fn restore_newly_parsed_authored_data(
     gamesys_entity_info: &SystemShock2EntityInfo,
     level_entity_info: &SystemShock2EntityInfo,
     obj_name_map: &HashMap<i32, String>,
@@ -142,6 +144,13 @@ fn restore_newly_parsed_authored_ecology(
     restore_missing_component!(PropEcoType);
     restore_missing_component!(PropEcoState);
     restore_missing_component!(PropSpawn);
+    restore_missing_component!(PropBaseTechDesc);
+    restore_missing_component!(PropChemicalNeeded);
+    restore_missing_component!(PropObjLookString);
+    restore_missing_component!(PropRequiredTechDesc);
+    restore_missing_component!(PropResearchReport);
+    restore_missing_component!(PropResearchText);
+    restore_missing_component!(PropResearchTime);
 
     let authored_spawn_points = {
         let authored_links = authored_world.borrow::<View<Links>>().unwrap();
@@ -192,5 +201,70 @@ fn restore_newly_parsed_authored_ecology(
     }
     for (entity, links) in missing_link_components {
         world.add_component(entity, links);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dark::properties::{PropResearchReport, PropResearchText, PropResearchTime};
+
+    use super::*;
+
+    #[test]
+    fn legacy_unlooted_researchable_backfills_newly_parsed_metadata() {
+        let mut merged_entity_info = SystemShock2EntityInfo::empty();
+        merged_entity_info.entity_to_properties.insert(
+            675,
+            vec![
+                Arc::new(Box::new(PropResearchTime(600))),
+                Arc::new(Box::new(PropResearchReport(0x10))),
+                Arc::new(Box::new(PropResearchText("AATText".to_owned()))),
+            ],
+        );
+        let mut level_entity_info = SystemShock2EntityInfo::empty();
+        level_entity_info.entity_to_properties.insert(675, vec![]);
+
+        let mut world = World::new();
+        let toxin = world.add_entity(PropResearchReport(0x20));
+        let template_to_entity = HashMap::from([(675, WrappedEntityId(toxin))]);
+
+        restore_newly_parsed_authored_data(
+            &merged_entity_info,
+            &level_entity_info,
+            &HashMap::new(),
+            &template_to_entity,
+            &mut world,
+        );
+
+        assert_eq!(
+            world
+                .borrow::<View<PropResearchTime>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            600
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropResearchText>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            "AATText"
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropResearchReport>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            0x20,
+            "serialized live values must win over authored defaults"
+        );
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -415,8 +415,14 @@ impl FlatUiHost {
                 .borrow::<EntitiesView>()
                 .map(|entities| entities.is_alive(panel))
                 .unwrap_or(false);
+            // Inventory-item MFDs (research reports, readable media) remain
+            // bound while carried. Their inherited/last world position may be
+            // on the other side of the level and is no longer meaningful.
+            let carried =
+                alive && crate::scripts::script_util::player_carried_items(world).contains(&panel);
             let too_far = alive
                 && !self.sticky_panel
+                && !carried
                 && (|| {
                     let player = world.borrow::<UniqueView<PlayerInfo>>().ok()?;
                     let v_pos = world

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -781,6 +781,12 @@ impl MissionCore {
         let left_hand_entity = held_instantiation.left_hand_entity_id;
         let right_hand_entity = held_instantiation.right_hand_entity_id;
         let maybe_inventory_entity = held_instantiation.inventory_entity_id;
+        let held_entities: Vec<_> = held_instantiation.entity_id_map.values().copied().collect();
+        crate::research::backfill_legacy_held_research_components(
+            &mut world,
+            &held_entities,
+            &entity_info_rc,
+        );
         let held_script_entity_id_map = held_instantiation.entity_id_map;
         let held_saved_script_states = held_instantiation.script_states;
 
@@ -6104,10 +6110,22 @@ fn update_research(world: &World, real_seconds: f32) -> Vec<Effect> {
         return Vec::new();
     }
     game_log!(INFO, "Research complete");
-    let mut effects = vec![Effect::SetObjectState {
-        entity_id,
-        state: dark::properties::ObjectState::Normal,
-    }];
+    // Research belongs to the archetype, not one inventory instance. A legacy
+    // campaign can already carry multiple Toxin-A vials when the project
+    // completes, so normalize every live copy immediately; newly created
+    // copies are covered by ResearchableScript::initialize.
+    let canonical = world
+        .borrow::<View<crate::runtime_props::RuntimePropCanonicalTemplateId>>()
+        .unwrap();
+    let mut effects = (&canonical)
+        .iter()
+        .with_id()
+        .filter(|(_, canonical)| canonical.0 == template_id)
+        .map(|(entity_id, _)| Effect::SetObjectState {
+            entity_id,
+            state: dark::properties::ObjectState::Normal,
+        })
+        .collect::<Vec<_>>();
     if let Some(quest_bit) = crate::scripts::script_util::set_quest_bit_effect(world, entity_id) {
         effects.push(quest_bit);
     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -428,6 +428,10 @@ pub struct GlobalTrainerCosts(pub Option<dark::gamesys::TrainerCostTables>);
 #[derive(Unique, Clone)]
 pub struct GlobalHrmParams(pub Option<dark::gamesys::HrmParams>);
 
+/// Retail research-speed tuning from `SKILLPARAM`.
+#[derive(Unique, Clone)]
+pub struct GlobalSkillParams(pub Option<dark::gamesys::SkillParams>);
+
 impl GlobalTemplateHierarchy {
     /// Whether `template_id` is `class_template_id` or inherits from it.
     pub fn is_or_descends_from(&self, template_id: i32, class_template_id: i32) -> bool {
@@ -675,6 +679,7 @@ impl MissionCore {
             game_entity_info.trainer_costs().cloned(),
         ));
         world.add_unique(GlobalHrmParams(game_entity_info.hrm_params().cloned()));
+        world.add_unique(GlobalSkillParams(game_entity_info.skill_params().cloned()));
         let (mut psi_powers, psi_selection) = crate::psi::build_psi_power_registry(&entity_info_rc);
         // Player-facing discipline names come from the psihelp string table;
         // a data install without it just keeps the gamesys symbolic names.
@@ -1700,6 +1705,8 @@ impl MissionCore {
                     }
                 });
             });
+
+        effects.extend(update_research(&self.world, time.elapsed.as_secs_f32()));
 
         let (player_pos, player_rot) = {
             let player_info = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
@@ -3509,6 +3516,70 @@ impl MissionCore {
                     // flow). VR ignores it - panels are world quads there.
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui.open(entity);
+                    }
+                }
+
+                Effect::BeginResearch { entity_id } => {
+                    let carried = crate::scripts::script_util::player_carried_items(&self.world);
+                    if !carried.contains(&entity_id) {
+                        continue;
+                    }
+                    let Some(template_id) = crate::scripts::script_util::entity_class_template_id(
+                        &self.world,
+                        entity_id,
+                    ) else {
+                        continue;
+                    };
+                    let required = self
+                        .world
+                        .borrow::<View<dark::properties::PropBaseTechDesc>>()
+                        .unwrap()
+                        .get(entity_id)
+                        .map(|skills| skills.0.research().max(1))
+                        .unwrap_or(1);
+                    let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                    let skill = quests
+                        .player_stats()
+                        .skill_level(crate::player_stats::Skill::Research);
+                    let result = quests.research_mut().begin(template_id, required, skill);
+                    drop(quests);
+                    match result {
+                        crate::research::BeginResearchResult::Started => {
+                            game_log!(INFO, "Research started");
+                        }
+                        crate::research::BeginResearchResult::SkillRequired(required) => {
+                            game_log!(INFO, "Research skill {} required", required);
+                        }
+                        crate::research::BeginResearchResult::AlreadyComplete => {
+                            self.world.add_component(
+                                entity_id,
+                                PropObjState(dark::properties::ObjectState::Normal),
+                            );
+                        }
+                    }
+                }
+
+                Effect::UseResearchChemical { entity_id } => {
+                    if apply_research_chemical(&self.world, entity_id) {
+                        let stack = self
+                            .world
+                            .borrow::<View<dark::properties::PropStackCount>>()
+                            .ok()
+                            .and_then(|stacks| stacks.get(entity_id).ok().map(|stack| stack.0));
+                        if stack.unwrap_or(1) > 1 {
+                            let mut stacks = self
+                                .world
+                                .borrow::<ViewMut<dark::properties::PropStackCount>>()
+                                .unwrap();
+                            if let Ok(stack) = (&mut stacks).get(entity_id) {
+                                stack.0 -= 1;
+                            }
+                        } else {
+                            self.destroy_entity(entity_id);
+                        }
+                        game_log!(INFO, "Research chemical consumed");
+                    } else {
+                        game_log!(INFO, "That chemical is not needed");
                     }
                 }
 
@@ -5959,6 +6030,124 @@ fn option_to_vec<T>(option: Option<T>) -> Vec<T> {
         None => vec![],
         Some(v) => vec![v],
     }
+}
+
+fn carried_research_entity(world: &World, template_id: i32) -> Option<EntityId> {
+    crate::scripts::script_util::player_carried_items(world)
+        .into_iter()
+        .find(|entity| {
+            crate::scripts::script_util::entity_class_template_id(world, *entity)
+                == Some(template_id)
+        })
+}
+
+/// Advance the one active campaign research project from its carried object's
+/// live authored metadata. Keeping this central avoids multiplying progress by
+/// the number of copies/scripts in the world.
+fn update_research(world: &World, real_seconds: f32) -> Vec<Effect> {
+    if real_seconds <= 0.0 {
+        return Vec::new();
+    }
+    let active_template = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .ok()
+        .and_then(|quests| quests.research().active_template_id());
+    let Some(template_id) = active_template else {
+        return Vec::new();
+    };
+    let Some(entity_id) = carried_research_entity(world, template_id) else {
+        if let Ok(mut quests) = world.borrow::<UniqueViewMut<QuestInfo>>() {
+            quests.research_mut().suspend();
+        }
+        return Vec::new();
+    };
+
+    let total = world
+        .borrow::<View<dark::properties::PropResearchTime>>()
+        .ok()
+        .and_then(|view| view.get(entity_id).ok().map(|time| time.0 as f32));
+    let Some(total) = total else {
+        return Vec::new();
+    };
+    let chemicals = world
+        .borrow::<View<dark::properties::PropChemicalNeeded>>()
+        .ok()
+        .and_then(|view| view.get(entity_id).ok().cloned());
+    let report_mask = world
+        .borrow::<View<dark::properties::PropResearchReport>>()
+        .ok()
+        .and_then(|view| view.get(entity_id).ok().map(|report| report.0))
+        .unwrap_or(0);
+    let research_factor = world
+        .borrow::<UniqueView<GlobalSkillParams>>()
+        .ok()
+        .and_then(|params| params.0.as_ref().map(|params| params.research_factor))
+        .unwrap_or(1.0);
+
+    let outcome = {
+        let mut quests = world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+        let skill = quests
+            .player_stats()
+            .skill_level(crate::player_stats::Skill::Research);
+        quests.research_mut().advance(
+            template_id,
+            real_seconds,
+            skill,
+            research_factor,
+            total,
+            chemicals.as_ref(),
+            report_mask,
+        )
+    };
+
+    if outcome != crate::research::AdvanceResearchResult::Completed {
+        return Vec::new();
+    }
+    game_log!(INFO, "Research complete");
+    let mut effects = vec![Effect::SetObjectState {
+        entity_id,
+        state: dark::properties::ObjectState::Normal,
+    }];
+    if let Some(quest_bit) = crate::scripts::script_util::set_quest_bit_effect(world, entity_id) {
+        effects.push(quest_bit);
+    }
+    effects
+}
+
+fn apply_research_chemical(world: &World, chemical_entity: EntityId) -> bool {
+    if !crate::scripts::script_util::player_carried_items(world).contains(&chemical_entity) {
+        return false;
+    }
+    let chemical_name = world
+        .borrow::<View<dark::properties::PropSymName>>()
+        .ok()
+        .and_then(|names| names.get(chemical_entity).ok().map(|name| name.0.clone()));
+    let Some(chemical_name) = chemical_name else {
+        return false;
+    };
+    let active_template = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .ok()
+        .and_then(|quests| quests.research().active_template_id());
+    let Some(active_entity) = active_template.and_then(|id| carried_research_entity(world, id))
+    else {
+        return false;
+    };
+    let needed = world
+        .borrow::<View<dark::properties::PropChemicalNeeded>>()
+        .ok()
+        .and_then(|view| view.get(active_entity).ok().cloned());
+    let Some(needed) = needed else {
+        return false;
+    };
+    world
+        .borrow::<UniqueViewMut<QuestInfo>>()
+        .map(|mut quests| {
+            quests
+                .research_mut()
+                .provide_chemical(&chemical_name, &needed)
+        })
+        .unwrap_or(false)
 }
 
 /// Remove every `Contains` link in `links` that points at `target` - used when

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use shipyard::Unique;
 
 use crate::player_stats::PlayerStats;
+use crate::research::ResearchState;
 
 /// One audio log the player has collected (frobbed), keyed by its per-deck
 /// identity - the original stored these as `Logs<deck>` bitmasks; we keep the
@@ -43,6 +44,9 @@ pub struct QuestInfo {
     /// its reveal state. `#[serde(default)]` keeps older saves loadable.
     #[serde(default)]
     explored_maps: HashMap<String, BTreeSet<i32>>,
+    /// Campaign-wide research progress, keyed by stable gamesys archetype.
+    #[serde(default)]
+    research: ResearchState,
 }
 
 impl QuestInfo {
@@ -54,7 +58,16 @@ impl QuestInfo {
             player_stats: PlayerStats::new(),
             collected_logs: Vec::new(),
             explored_maps: HashMap::new(),
+            research: ResearchState::default(),
         }
+    }
+
+    pub fn research(&self) -> &ResearchState {
+        &self.research
+    }
+
+    pub fn research_mut(&mut self) -> &mut ResearchState {
+        &mut self.research
     }
 
     /// Mark an automap location explored for `mission` (lowercase level file

--- a/shock2vr/src/research.rs
+++ b/shock2vr/src/research.rs
@@ -1,0 +1,267 @@
+//! Persistent, campaign-wide research progress.
+//!
+//! Research is keyed by the stable gamesys archetype rather than a mission
+//! object's runtime id, so dropping an item, changing decks, or saving and
+//! loading never loses work.
+
+use std::collections::HashMap;
+
+use dark::properties::PropChemicalNeeded;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ResearchState {
+    active_template_id: Option<i32>,
+    progress: HashMap<i32, ResearchProgress>,
+    reports: u32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+struct ResearchProgress {
+    authored_seconds: f32,
+    next_chemical: usize,
+    complete: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResearchStatus {
+    pub authored_seconds: f32,
+    pub active: bool,
+    pub complete: bool,
+    pub needed_chemical: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BeginResearchResult {
+    Started,
+    SkillRequired(i32),
+    AlreadyComplete,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdvanceResearchResult {
+    InProgress,
+    ChemicalRequired,
+    Completed,
+}
+
+impl ResearchState {
+    pub fn active_template_id(&self) -> Option<i32> {
+        self.active_template_id
+    }
+
+    pub fn begin(
+        &mut self,
+        template_id: i32,
+        required_skill: i32,
+        player_skill: i32,
+    ) -> BeginResearchResult {
+        if self.is_complete(template_id) {
+            return BeginResearchResult::AlreadyComplete;
+        }
+        if player_skill < required_skill {
+            return BeginResearchResult::SkillRequired(required_skill);
+        }
+        self.progress.entry(template_id).or_default();
+        self.active_template_id = Some(template_id);
+        BeginResearchResult::Started
+    }
+
+    pub fn suspend(&mut self) {
+        self.active_template_id = None;
+    }
+
+    pub fn is_complete(&self, template_id: i32) -> bool {
+        self.progress
+            .get(&template_id)
+            .map(|progress| progress.complete)
+            .unwrap_or(false)
+    }
+
+    pub fn has_report(&self, report_mask: u32) -> bool {
+        self.reports & report_mask != 0
+    }
+
+    pub fn status(
+        &self,
+        template_id: i32,
+        chemicals: Option<&PropChemicalNeeded>,
+    ) -> ResearchStatus {
+        let progress = self.progress.get(&template_id).cloned().unwrap_or_default();
+        ResearchStatus {
+            authored_seconds: progress.authored_seconds,
+            active: self.active_template_id == Some(template_id),
+            complete: progress.complete,
+            needed_chemical: chemicals.and_then(|needed| {
+                chemical_due(&progress, needed).map(|chemical| chemical.to_owned())
+            }),
+        }
+    }
+
+    pub fn advance(
+        &mut self,
+        template_id: i32,
+        real_seconds: f32,
+        skill: i32,
+        research_factor: f32,
+        total_authored_seconds: f32,
+        chemicals: Option<&PropChemicalNeeded>,
+        report_mask: u32,
+    ) -> AdvanceResearchResult {
+        if self.active_template_id != Some(template_id) {
+            return AdvanceResearchResult::InProgress;
+        }
+        let progress = self.progress.entry(template_id).or_default();
+        if progress.complete {
+            return AdvanceResearchResult::Completed;
+        }
+        if chemicals
+            .and_then(|needed| chemical_due(progress, needed))
+            .is_some()
+        {
+            return AdvanceResearchResult::ChemicalRequired;
+        }
+
+        let skill_above_one = (skill.max(1) - 1) as f32;
+        let multiplier = 1.0 + research_factor * skill_above_one * skill_above_one;
+        progress.authored_seconds += real_seconds.max(0.0) * multiplier.max(0.0);
+
+        if let Some(threshold) = chemicals.and_then(|needed| next_threshold(progress, needed)) {
+            if progress.authored_seconds >= threshold {
+                progress.authored_seconds = threshold;
+                return AdvanceResearchResult::ChemicalRequired;
+            }
+        }
+
+        if progress.authored_seconds >= total_authored_seconds.max(0.0) {
+            progress.authored_seconds = total_authored_seconds.max(0.0);
+            progress.complete = true;
+            self.active_template_id = None;
+            self.reports |= report_mask;
+            return AdvanceResearchResult::Completed;
+        }
+        AdvanceResearchResult::InProgress
+    }
+
+    /// Consume the currently requested chemical. Wrong chemicals and uses
+    /// before the authored threshold are harmless and remain in inventory.
+    pub fn provide_chemical(
+        &mut self,
+        chemical_sym_name: &str,
+        chemicals: &PropChemicalNeeded,
+    ) -> bool {
+        let Some(template_id) = self.active_template_id else {
+            return false;
+        };
+        if !self.accepts_chemical(chemical_sym_name, chemicals) {
+            return false;
+        }
+        let Some(progress) = self.progress.get_mut(&template_id) else {
+            return false;
+        };
+        progress.next_chemical += 1;
+        true
+    }
+
+    pub fn accepts_chemical(
+        &self,
+        chemical_sym_name: &str,
+        chemicals: &PropChemicalNeeded,
+    ) -> bool {
+        let Some(template_id) = self.active_template_id else {
+            return false;
+        };
+        let Some(progress) = self.progress.get(&template_id) else {
+            return false;
+        };
+        chemical_due(progress, chemicals)
+            .map(|needed| needed.eq_ignore_ascii_case(chemical_sym_name))
+            .unwrap_or(false)
+    }
+}
+
+fn next_threshold(progress: &ResearchProgress, needed: &PropChemicalNeeded) -> Option<f32> {
+    let name = needed.chemicals.get(progress.next_chemical)?;
+    let threshold = *needed.thresholds_secs.get(progress.next_chemical)?;
+    (!name.is_empty() && threshold > 0).then_some(threshold as f32)
+}
+
+fn chemical_due<'a>(
+    progress: &ResearchProgress,
+    needed: &'a PropChemicalNeeded,
+) -> Option<&'a str> {
+    let threshold = next_threshold(progress, needed)?;
+    (progress.authored_seconds >= threshold)
+        .then(|| needed.chemicals[progress.next_chemical].as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toxin_chemicals() -> PropChemicalNeeded {
+        PropChemicalNeeded {
+            chemicals: std::array::from_fn(|index| match index {
+                0 | 2 => "Chem #4".to_owned(),
+                1 => "Chem #2".to_owned(),
+                _ => String::new(),
+            }),
+            thresholds_secs: [30, 60, 240, 0, 0, 0, 0],
+        }
+    }
+
+    #[test]
+    fn requires_skill_and_pauses_at_each_authored_chemical_gate() {
+        let mut state = ResearchState::default();
+        let chemicals = toxin_chemicals();
+        assert_eq!(
+            state.begin(-1341, 1, 0),
+            BeginResearchResult::SkillRequired(1)
+        );
+        assert_eq!(state.begin(-1341, 1, 1), BeginResearchResult::Started);
+        assert_eq!(
+            state.advance(-1341, 31.0, 1, 1.0, 600.0, Some(&chemicals), 0x10),
+            AdvanceResearchResult::ChemicalRequired
+        );
+        assert_eq!(state.status(-1341, Some(&chemicals)).authored_seconds, 30.0);
+        assert!(!state.accepts_chemical("Chem #2", &chemicals));
+        assert!(state.accepts_chemical("chem #4", &chemicals));
+        assert!(!state.provide_chemical("Chem #2", &chemicals));
+        assert!(state.provide_chemical("Chem #4", &chemicals));
+        assert_eq!(
+            state.advance(-1341, 30.0, 1, 1.0, 600.0, Some(&chemicals), 0x10),
+            AdvanceResearchResult::ChemicalRequired
+        );
+        assert_eq!(
+            state
+                .status(-1341, Some(&chemicals))
+                .needed_chemical
+                .as_deref(),
+            Some("Chem #2")
+        );
+    }
+
+    #[test]
+    fn skill_multiplier_completes_and_unlocks_report() {
+        let mut state = ResearchState::default();
+        assert_eq!(state.begin(-10, 1, 3), BeginResearchResult::Started);
+        // skill 3 -> 1 + (3 - 1)^2 = 5 authored seconds / real second.
+        assert_eq!(
+            state.advance(-10, 20.0, 3, 1.0, 100.0, None, 0x10),
+            AdvanceResearchResult::Completed
+        );
+        assert!(state.is_complete(-10));
+        assert!(state.has_report(0x10));
+        assert_eq!(state.active_template_id(), None);
+    }
+
+    #[test]
+    fn serde_round_trip_keeps_partial_and_active_progress() {
+        let mut state = ResearchState::default();
+        state.begin(-1341, 1, 1);
+        state.advance(-1341, 12.5, 1, 1.0, 600.0, None, 0x10);
+        let json = serde_json::to_string(&state).unwrap();
+        let loaded: ResearchState = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, state);
+    }
+}

--- a/shock2vr/src/research.rs
+++ b/shock2vr/src/research.rs
@@ -6,8 +6,72 @@
 
 use std::collections::HashMap;
 
-use dark::properties::PropChemicalNeeded;
+use dark::{
+    properties::{
+        PropBaseTechDesc, PropChemicalNeeded, PropObjLookString, PropObjState,
+        PropRequiredTechDesc, PropResearchReport, PropResearchText, PropResearchTime,
+    },
+    ss2_entity_info::SystemShock2EntityInfo,
+};
 use serde::{Deserialize, Serialize};
+use shipyard::{Component, EntityId, Get, View, World};
+
+use crate::{
+    runtime_props::RuntimePropCanonicalTemplateId, scripts::script_util::hydrate_template_component,
+};
+
+/// Older campaign saves serialized carried objects before research metadata
+/// became a runtime component. Restore only the newly understood properties
+/// from the stable gamesys archetype, while preserving every live serialized
+/// value that was already present in the save.
+pub(crate) fn backfill_legacy_held_research_components(
+    world: &mut World,
+    held_entities: &[EntityId],
+    entity_info: &SystemShock2EntityInfo,
+) {
+    let researchables = {
+        let canonical = world
+            .borrow::<View<RuntimePropCanonicalTemplateId>>()
+            .unwrap();
+        held_entities
+            .iter()
+            .filter_map(|entity_id| {
+                let template_id = canonical.get(*entity_id).ok()?.0;
+                hydrate_template_component::<PropResearchTime>(template_id, entity_info)
+                    .map(|_| (*entity_id, template_id))
+            })
+            .collect::<Vec<_>>()
+    };
+
+    for (entity_id, template_id) in researchables {
+        backfill_component::<PropBaseTechDesc>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropChemicalNeeded>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropObjLookString>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropObjState>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropRequiredTechDesc>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropResearchReport>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropResearchText>(world, entity_id, template_id, entity_info);
+        backfill_component::<PropResearchTime>(world, entity_id, template_id, entity_info);
+    }
+}
+
+fn backfill_component<T>(
+    world: &mut World,
+    entity_id: EntityId,
+    template_id: i32,
+    entity_info: &SystemShock2EntityInfo,
+) where
+    T: Component + Clone + Send + Sync,
+{
+    let is_missing = world
+        .borrow::<View<T>>()
+        .map(|components| components.get(entity_id).is_err())
+        .unwrap_or(true);
+    if is_missing && let Some(component) = hydrate_template_component::<T>(template_id, entity_info)
+    {
+        world.add_component(entity_id, component);
+    }
+}
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct ResearchState {
@@ -197,6 +261,14 @@ fn chemical_due<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use dark::{
+        properties::{ObjectState, PropObjState, PropResearchReport, PropResearchText},
+        ss2_entity_info::SystemShock2EntityInfo,
+    };
+    use shipyard::{Get, View, World};
+
     use super::*;
 
     fn toxin_chemicals() -> PropChemicalNeeded {
@@ -263,5 +335,55 @@ mod tests {
         let json = serde_json::to_string(&state).unwrap();
         let loaded: ResearchState = serde_json::from_str(&json).unwrap();
         assert_eq!(loaded, state);
+    }
+
+    #[test]
+    fn legacy_held_researchable_backfills_newly_parsed_template_metadata() {
+        let mut world = World::new();
+        let toxin = world.add_entity((
+            RuntimePropCanonicalTemplateId(-1341),
+            PropResearchReport(0x20),
+        ));
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        entity_info.entity_to_properties.insert(
+            -1341,
+            vec![
+                Arc::new(Box::new(PropResearchTime(600))),
+                Arc::new(Box::new(PropResearchReport(0x10))),
+                Arc::new(Box::new(PropResearchText("AATText".to_owned()))),
+                Arc::new(Box::new(PropObjState(ObjectState::Unresearched))),
+            ],
+        );
+
+        backfill_legacy_held_research_components(&mut world, &[toxin], &entity_info);
+
+        assert_eq!(
+            world
+                .borrow::<View<PropResearchTime>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            600
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropResearchReport>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            0x20,
+            "serialized live values must win over template defaults"
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropObjState>>()
+                .unwrap()
+                .get(toxin)
+                .unwrap()
+                .0,
+            ObjectState::Unresearched
+        );
     }
 }

--- a/shock2vr/src/scripts/chemical.rs
+++ b/shock2vr/src/scripts/chemical.rs
@@ -1,0 +1,28 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+pub struct ChemicalScript;
+
+impl ChemicalScript {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for ChemicalScript {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Frob => Effect::UseResearchChemical { entity_id },
+            _ => Effect::NoEffect,
+        }
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -156,6 +156,17 @@ pub enum Effect {
         entity: EntityId,
     },
 
+    /// Start or resume research on a carried researchable object.
+    BeginResearch {
+        entity_id: EntityId,
+    },
+
+    /// Offer one carried chemical to the active research project. The handler
+    /// consumes it only when it matches the currently authored gate.
+    UseResearchChemical {
+        entity_id: EntityId,
+    },
+
     /// Record an audio log the player just frobbed into the persistent
     /// collection (`QuestInfo`) and resolve its transcript/portrait strings onto
     /// the disc entity (`RuntimePropLogData`) for the reader panel. Emitted by

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -72,7 +72,7 @@ pub enum MediaGuiMsg {
 /// Greedy word-wrap that honors explicit `\n` paragraph breaks. A single word
 /// longer than `max_chars` stays on its own (over-long) line rather than being
 /// split mid-token, so codes like "45100" are never broken.
-fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
+pub(super) fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
     let mut lines = Vec::new();
     for paragraph in text.split('\n') {
         if paragraph.trim().is_empty() {

--- a/shock2vr/src/scripts/gui/mod.rs
+++ b/shock2vr/src/scripts/gui/mod.rs
@@ -7,6 +7,7 @@ mod keypad;
 mod map;
 mod media;
 mod replicator;
+mod research;
 mod trainer;
 mod traits;
 
@@ -19,5 +20,6 @@ pub use keypad::*;
 pub use map::*;
 pub use media::*;
 pub use replicator::*;
+pub use research::*;
 pub use trainer::*;
 pub use traits::*;

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -1,0 +1,237 @@
+//! Retail-shaped research MFD for carried researchable objects.
+
+use cgmath::{Vector2, Vector3, vec2};
+use dark::properties::{
+    PropBaseTechDesc, PropChemicalNeeded, PropObjLookString, PropResearchReport, PropResearchText,
+    PropResearchTime,
+};
+use shipyard::{EntityId, Get, UniqueView, View, World};
+
+use crate::{
+    gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor},
+    player_stats::Skill,
+    quest_info::QuestInfo,
+    scripts::{Effect, script_util::entity_class_template_id},
+};
+
+const PANEL_W: f32 = 188.0;
+const PANEL_H: f32 = 296.0;
+const TEXT_X: f32 = 15.0;
+const TEXT_TOP: f32 = 153.0;
+const TEXT_W: f32 = 138.0;
+const LINE_H: f32 = 11.0;
+const PAGE_LINES: usize = 10;
+const WRAP_CHARS: usize = 27;
+
+pub struct ResearchGui;
+
+#[derive(Clone, Debug, Default)]
+pub struct ResearchGuiState {
+    show_report: bool,
+}
+
+#[derive(Clone)]
+pub enum ResearchGuiMsg {
+    ToggleReport,
+}
+
+impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
+    fn get_components(
+        &self,
+        _cursor: &Option<GuiCursor>,
+        entity_id: EntityId,
+        world: &World,
+        state: &ResearchGuiState,
+    ) -> Vec<GuiComponent<ResearchGuiMsg>> {
+        let mut components = vec![
+            gui::image("iface/research.pcx")
+                .with_position(vec2(0.0, 0.0))
+                .with_size(vec2(PANEL_W, PANEL_H)),
+        ];
+
+        let Some(template_id) = entity_class_template_id(world, entity_id) else {
+            return components;
+        };
+        let chemicals_view = world.borrow::<View<PropChemicalNeeded>>().unwrap();
+        let chemicals = chemicals_view.get(entity_id).ok();
+        let required_skill = world
+            .borrow::<View<PropBaseTechDesc>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|required| required.0.research().max(1))
+            .unwrap_or(1);
+        let player_skill = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|quests| quests.player_stats().skill_level(Skill::Research))
+            .unwrap_or(0);
+        let status = world
+            .borrow::<UniqueView<QuestInfo>>()
+            .map(|quests| quests.research().status(template_id, chemicals))
+            .unwrap_or_else(|_| crate::research::ResearchStatus {
+                authored_seconds: 0.0,
+                active: false,
+                complete: false,
+                needed_chemical: None,
+            });
+        let total = world
+            .borrow::<View<PropResearchTime>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|time| time.0.max(1) as f32)
+            .unwrap_or(1.0);
+        let fraction = (status.authored_seconds / total).clamp(0.0, 1.0);
+
+        // The original overlays RESPROG on this slot; cropping is unavailable
+        // in the generic GUI primitive, so retain the authored bar art and add
+        // an exact numeric percentage for unambiguous progress feedback.
+        components.push(
+            gui::image("iface/resprog.pcx")
+                .with_position(vec2(15.0, 131.0))
+                .with_size(vec2(138.0 * fraction.max(0.01), 17.0)),
+        );
+        components.push(
+            gui::text(&format!("Research: {:.0}%", fraction * 100.0))
+                .with_position(vec2(18.0, 134.0))
+                .with_size(vec2(132.0, LINE_H)),
+        );
+
+        let report_mask = world
+            .borrow::<View<PropResearchReport>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|report| report.0)
+            .unwrap_or(0);
+        if status.complete && report_mask != 0 {
+            components.push(
+                gui::button(ResearchGuiMsg::ToggleReport)
+                    .with_image("iface/report0.pcx")
+                    .with_label("Research report")
+                    .with_position(vec2(13.0, 243.0))
+                    .with_size(vec2(142.0, 22.0)),
+            );
+        }
+
+        let body = if player_skill < required_skill && status.authored_seconds == 0.0 {
+            format!(
+                "This item requires a Research skill of {required_skill}. Use a Tech Upgrade Unit to train Research."
+            )
+        } else if let Some(chemical) = &status.needed_chemical {
+            format!(
+                "Research paused. Required chemical: {}.",
+                chemical_display_name(chemical)
+            )
+        } else if status.complete && state.show_report {
+            property_fallback(world, entity_id, true)
+        } else if status.complete {
+            "Research complete. The item is now ready for use. Select the report button to review your findings.".to_owned()
+        } else if status.active {
+            property_fallback(world, entity_id, false)
+        } else {
+            "Research suspended. Double-click this item to resume.".to_owned()
+        };
+
+        for (index, line) in wrap_text(&body, WRAP_CHARS)
+            .into_iter()
+            .take(PAGE_LINES)
+            .enumerate()
+        {
+            if !line.is_empty() {
+                components.push(
+                    gui::text(&line)
+                        .with_position(vec2(TEXT_X, TEXT_TOP + index as f32 * LINE_H))
+                        .with_size(vec2(TEXT_W, LINE_H)),
+                );
+            }
+        }
+        components
+    }
+
+    fn get_config(&self) -> GuiConfig {
+        GuiConfig {
+            world_offset: Vector3::new(0.0, 0.0, -0.1),
+            screen_size_in_pixels: Vector2::new(PANEL_W, PANEL_H),
+        }
+    }
+
+    fn handle_msg(
+        &self,
+        _entity_id: EntityId,
+        _world: &World,
+        state: &ResearchGuiState,
+        _msg: &ResearchGuiMsg,
+    ) -> (ResearchGuiState, Effect) {
+        (
+            ResearchGuiState {
+                show_report: !state.show_report,
+            },
+            Effect::NoEffect,
+        )
+    }
+
+    fn on_frob(&self, entity_id: EntityId, _world: &World) -> Effect {
+        tracing::info!(?entity_id, "researchable frob opened Research MFD");
+        Effect::BeginResearch { entity_id }
+    }
+}
+
+fn property_fallback(world: &World, entity_id: EntityId, report: bool) -> String {
+    if report {
+        world
+            .borrow::<View<PropObjLookString>>()
+            .ok()
+            .and_then(|view| {
+                view.get(entity_id)
+                    .ok()
+                    .map(|text| localized_fallback(&text.0))
+            })
+            .unwrap_or_else(|| "Research report available.".to_owned())
+    } else {
+        world
+            .borrow::<View<PropResearchText>>()
+            .ok()
+            .and_then(|view| {
+                view.get(entity_id)
+                    .ok()
+                    .map(|text| localized_fallback(&text.0))
+            })
+            .unwrap_or_else(|| "Research in progress.".to_owned())
+    }
+}
+
+fn localized_fallback(value: &str) -> String {
+    value
+        .split_once('"')
+        .and_then(|(_, tail)| tail.rsplit_once('"').map(|(text, _)| text))
+        .unwrap_or(value)
+        .replace("\\n", "\n")
+}
+
+fn chemical_display_name(sym_name: &str) -> String {
+    match sym_name.to_ascii_lowercase().as_str() {
+        "chem #2" => "Vanadium (V)".to_owned(),
+        "chem #4" => "Antimony (Sb)".to_owned(),
+        _ => sym_name.to_owned(),
+    }
+}
+
+fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    for paragraph in text.split('\n') {
+        let mut current = String::new();
+        for word in paragraph.split_whitespace() {
+            if current.is_empty() {
+                current = word.to_owned();
+            } else if current.len() + word.len() < max_chars {
+                current.push(' ');
+                current.push_str(word);
+            } else {
+                lines.push(std::mem::take(&mut current));
+                current = word.to_owned();
+            }
+        }
+        if !current.is_empty() {
+            lines.push(current);
+        }
+    }
+    lines
+}

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -20,19 +20,27 @@ const TEXT_X: f32 = 15.0;
 const TEXT_TOP: f32 = 153.0;
 const TEXT_W: f32 = 138.0;
 const LINE_H: f32 = 11.0;
-const PAGE_LINES: usize = 10;
+// Seven lines stop above the authored report button at y=243. The adjacent
+// retail page gadgets expose the remainder instead of drawing underneath it.
+const PAGE_LINES: usize = 7;
 const WRAP_CHARS: usize = 27;
+const SCROLL_X: f32 = 159.0;
+const PGUP_Y: f32 = 174.0;
+const PGDN_Y: f32 = 203.0;
 
 pub struct ResearchGui;
 
 #[derive(Clone, Debug, Default)]
 pub struct ResearchGuiState {
     show_report: bool,
+    scroll: usize,
 }
 
 #[derive(Clone)]
 pub enum ResearchGuiMsg {
     ToggleReport,
+    PageUp,
+    PageDown,
 }
 
 impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
@@ -130,18 +138,36 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
             "Research suspended. Double-click this item to resume.".to_owned()
         };
 
-        for (index, line) in wrap_text(&body, WRAP_CHARS)
-            .into_iter()
-            .take(PAGE_LINES)
-            .enumerate()
-        {
+        let lines = wrap_text(&body, WRAP_CHARS);
+        let start = if status.complete && state.show_report {
+            state.scroll.min(lines.len())
+        } else {
+            0
+        };
+        for (index, line) in lines[start..].iter().take(PAGE_LINES).enumerate() {
             if !line.is_empty() {
                 components.push(
-                    gui::text(&line)
+                    gui::text(line)
                         .with_position(vec2(TEXT_X, TEXT_TOP + index as f32 * LINE_H))
                         .with_size(vec2(TEXT_W, LINE_H)),
                 );
             }
+        }
+        if status.complete && state.show_report && lines.len() > PAGE_LINES {
+            components.push(
+                gui::button(ResearchGuiMsg::PageUp)
+                    .with_image("pgup0.pcx")
+                    .with_label("Research report previous page")
+                    .with_position(vec2(SCROLL_X, PGUP_Y))
+                    .with_size(vec2(18.0, 26.0)),
+            );
+            components.push(
+                gui::button(ResearchGuiMsg::PageDown)
+                    .with_image("pgdn0.pcx")
+                    .with_label("Research report next page")
+                    .with_position(vec2(SCROLL_X, PGDN_Y))
+                    .with_size(vec2(18.0, 26.0)),
+            );
         }
         components
     }
@@ -155,17 +181,31 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
 
     fn handle_msg(
         &self,
-        _entity_id: EntityId,
-        _world: &World,
+        entity_id: EntityId,
+        world: &World,
         state: &ResearchGuiState,
-        _msg: &ResearchGuiMsg,
+        msg: &ResearchGuiMsg,
     ) -> (ResearchGuiState, Effect) {
-        (
-            ResearchGuiState {
+        let next_state = match msg {
+            ResearchGuiMsg::ToggleReport => ResearchGuiState {
                 show_report: !state.show_report,
+                scroll: 0,
             },
-            Effect::NoEffect,
-        )
+            ResearchGuiMsg::PageUp => ResearchGuiState {
+                show_report: state.show_report,
+                scroll: state.scroll.saturating_sub(PAGE_LINES),
+            },
+            ResearchGuiMsg::PageDown => {
+                let max_scroll = wrap_text(&property_fallback(world, entity_id, true), WRAP_CHARS)
+                    .len()
+                    .saturating_sub(PAGE_LINES);
+                ResearchGuiState {
+                    show_report: state.show_report,
+                    scroll: (state.scroll + PAGE_LINES).min(max_scroll),
+                }
+            }
+        };
+        (next_state, Effect::NoEffect)
     }
 
     fn on_frob(&self, entity_id: EntityId, _world: &World) -> Effect {

--- a/shock2vr/src/scripts/gui/research.rs
+++ b/shock2vr/src/scripts/gui/research.rs
@@ -9,10 +9,13 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
     gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor},
+    mission::GlobalEntityMetadata,
     player_stats::Skill,
     quest_info::QuestInfo,
     scripts::{Effect, script_util::entity_class_template_id},
 };
+
+use super::media::wrap_text;
 
 const PANEL_W: f32 = 188.0;
 const PANEL_H: f32 = 296.0;
@@ -126,7 +129,7 @@ impl Gui<ResearchGuiState, ResearchGuiMsg> for ResearchGui {
         } else if let Some(chemical) = &status.needed_chemical {
             format!(
                 "Research paused. Required chemical: {}.",
-                chemical_display_name(chemical)
+                chemical_display_name(world, chemical)
             )
         } else if status.complete && state.show_report {
             property_fallback(world, entity_id, true)
@@ -246,32 +249,47 @@ fn localized_fallback(value: &str) -> String {
         .replace("\\n", "\n")
 }
 
-fn chemical_display_name(sym_name: &str) -> String {
-    match sym_name.to_ascii_lowercase().as_str() {
-        "chem #2" => "Vanadium (V)".to_owned(),
-        "chem #4" => "Antimony (Sb)".to_owned(),
-        _ => sym_name.to_owned(),
-    }
+fn chemical_display_name(world: &World, sym_name: &str) -> String {
+    let key = sym_name.to_ascii_lowercase();
+    world
+        .borrow::<UniqueView<GlobalEntityMetadata>>()
+        .ok()
+        .and_then(|metadata| {
+            metadata
+                .0
+                .get(&key)
+                .and_then(|chemical| chemical.obj_short_name.as_deref())
+                .map(localized_fallback)
+        })
+        .unwrap_or_else(|| sym_name.to_owned())
 }
 
-fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
-    let mut lines = Vec::new();
-    for paragraph in text.split('\n') {
-        let mut current = String::new();
-        for word in paragraph.split_whitespace() {
-            if current.is_empty() {
-                current = word.to_owned();
-            } else if current.len() + word.len() < max_chars {
-                current.push(' ');
-                current.push_str(word);
-            } else {
-                lines.push(std::mem::take(&mut current));
-                current = word.to_owned();
-            }
-        }
-        if !current.is_empty() {
-            lines.push(current);
-        }
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::mission::EntityMetadata;
+
+    use super::*;
+
+    #[test]
+    fn wrapping_preserves_blank_paragraphs() {
+        assert_eq!(wrap_text("first\n\nsecond", 20), ["first", "", "second"]);
     }
-    lines
+
+    #[test]
+    fn chemical_name_comes_from_authored_short_name() {
+        let world = World::new();
+        world.add_unique(GlobalEntityMetadata(HashMap::from([(
+            "chem #7".to_owned(),
+            EntityMetadata {
+                template_id: -144,
+                obj_icon: None,
+                obj_short_name: Some("Chem_p7: \"Californium (Cf)\"".to_owned()),
+                obj_name: None,
+            },
+        )])));
+
+        assert_eq!(chemical_display_name(&world, "Chem #7"), "Californium (Cf)");
+    }
 }

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -9,6 +9,7 @@ mod base_button;
 mod base_elevator;
 mod base_monster;
 mod camera_alert;
+mod chemical;
 mod choose_mission;
 mod choose_service;
 mod core_room;
@@ -40,6 +41,7 @@ mod psi_amp_script;
 mod psi_kit;
 mod reduce_psi;
 mod reroute_elevator_button;
+mod researchable;
 mod room_trigger;
 pub mod script_util;
 mod setup_initial_debrief;
@@ -97,6 +99,7 @@ use crate::{physics::PhysicsWorld, time::Time};
 
 use crate::gui::gui_script;
 
+use self::chemical::ChemicalScript;
 use self::choose_mission::ChooseMissionScript;
 use self::choose_service::ChooseServiceScript;
 /// Preloaded elevator floor labels (from MISC.STR) + current mission, added as
@@ -105,7 +108,7 @@ use self::choose_service::ChooseServiceScript;
 pub use self::gui::ElevatorContext;
 use self::gui::{
     ComputerGui, ContainerGui, ElevatorGui, GamePigGui, HackableCrateGui, KeyPadGui, MapGui,
-    MediaGui, ReplicatorGui, TrainerGui, TrainerMode, TraitGui,
+    MediaGui, ReplicatorGui, ResearchGui, TrainerGui, TrainerMode, TraitGui,
 };
 use self::internal_frob_move::InternalFrobMove;
 use self::internal_switch_held_model::InternalSwitchHeldModelScript;
@@ -114,6 +117,7 @@ use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
 use self::reduce_psi::ReducePsi;
 use self::reroute_elevator_button::RerouteElevatorButton;
+use self::researchable::ResearchableScript;
 use self::trap_signal::TrapSignal;
 use self::{
     auto_install_soft::AutoInstallSoft,
@@ -1135,12 +1139,15 @@ impl ScriptWorld {
             "censor" => Box::new(UnimplementedScript::new(&script_name)),
             "censorme" => Box::new(UnimplementedScript::new(&script_name)),
             "creaturecontainer" => gui_script(Box::new(ContainerGui::loot_creature())),
-            "chemical" => Box::new(NoopScript::new()),
+            "chemical" => Box::new(ChemicalScript::new()),
             "chooseservice" => Box::new(ChooseServiceScript::new()),
             "infocomputer" => Box::new(UnimplementedScript::new(&script_name)),
             "reducepsi" => Box::new(ReducePsi::new()),
             "replicatorscript" => gui_script(Box::new(ReplicatorGui)),
-            "researchablescript" => Box::new(UnimplementedScript::new(&script_name)),
+            "researchablescript" => Box::new(CompositeScript::new(vec![
+                Box::new(ResearchableScript::new()),
+                gui_script(Box::new(ResearchGui)),
+            ])),
             "setupinitialdebrief" => {
                 Box::new(setup_initial_debrief::SetupInitialDebriefScript::new())
             }

--- a/shock2vr/src/scripts/obj_consume_button.rs
+++ b/shock2vr/src/scripts/obj_consume_button.rs
@@ -1,4 +1,6 @@
-use dark::properties::{PropConsumeType, PropSymName};
+use dark::properties::{
+    ObjectState, PropConsumeType, PropModelName, PropObjState, PropSymName, PropTweqModelConfig,
+};
 use engine::audio::AudioHandle;
 use shipyard::{EntityId, Get, View, World};
 
@@ -61,6 +63,28 @@ fn consume(world: &World, entity_id: EntityId, entity_to_consume: EntityId) -> E
 }
 
 fn can_consume_entity(world: &World, self_id: EntityId, entity_to_consume_id: EntityId) -> bool {
+    let already_used = {
+        let models = world.borrow::<View<PropModelName>>().unwrap();
+        let configs = world.borrow::<View<PropTweqModelConfig>>().unwrap();
+        match (models.get(self_id), configs.get(self_id)) {
+            (Ok(model), Ok(config)) => model_is_final(&model.0, &config.model_names),
+            _ => false,
+        }
+    };
+    if already_used {
+        return false;
+    }
+
+    let unresearched = world
+        .borrow::<View<PropObjState>>()
+        .unwrap()
+        .get(entity_to_consume_id)
+        .map(|state| state.0 == ObjectState::Unresearched)
+        .unwrap_or(false);
+    if unresearched {
+        return false;
+    }
+
     let v_consume_type = world.borrow::<View<PropConsumeType>>().unwrap();
     let v_sym_name = world.borrow::<View<PropSymName>>().unwrap();
 
@@ -71,4 +95,43 @@ fn can_consume_entity(world: &World, self_id: EntityId, entity_to_consume_id: En
         return consume_type.0.eq_ignore_ascii_case(&sym_name.0);
     }
     false
+}
+
+fn model_is_final(current: &str, frames: &[String]) -> bool {
+    frames
+        .last()
+        .map(|last| current.eq_ignore_ascii_case(last))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropConsumeType, PropModelName, PropObjState, PropSymName};
+    use shipyard::World;
+
+    use super::*;
+
+    #[test]
+    fn unresearched_candidate_is_rejected() {
+        let mut world = World::new();
+        let receptor = world.add_entity(PropConsumeType("AAToxin".to_owned()));
+        let toxin = world.add_entity((
+            PropSymName("AAToxin".to_owned()),
+            PropObjState(ObjectState::Unresearched),
+        ));
+        assert!(!can_consume_entity(&world, receptor, toxin));
+
+        world.add_component(toxin, PropObjState(ObjectState::Normal));
+        assert!(can_consume_entity(&world, receptor, toxin));
+    }
+
+    #[test]
+    fn final_tweq_model_marks_receptor_used() {
+        let frames = vec!["air_reof".to_owned(), "air_re".to_owned()];
+        assert!(!model_is_final("air_reof", &frames));
+        assert!(model_is_final("AIR_RE", &frames));
+
+        // A model without frames cannot accidentally become one-shot.
+        assert!(!model_is_final(&PropModelName("air_re".to_owned()).0, &[]));
+    }
 }

--- a/shock2vr/src/scripts/obj_consume_button.rs
+++ b/shock2vr/src/scripts/obj_consume_button.rs
@@ -2,16 +2,65 @@ use dark::properties::{
     ObjectState, PropConsumeType, PropModelName, PropObjState, PropSymName, PropTweqModelConfig,
 };
 use engine::audio::AudioHandle;
+use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, View, World};
 
-use crate::{physics::PhysicsWorld, scripts::script_util::play_environmental_sound};
+use crate::{physics::PhysicsWorld, scripts::script_util::play_environmental_sound, time::Time};
 
-use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links_and_self};
+use super::{
+    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    script_util::send_to_all_switch_links_and_self,
+};
 
-pub struct ObjConsumeButton;
+const SCRIPT_STATE_KEY: &str = "shock2vr.obj_consume_button";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+enum OneShotPhase {
+    #[default]
+    Idle,
+    PendingDelivery,
+    AwaitingFinalModel,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ObjConsumeButtonState {
+    one_shot_phase: OneShotPhase,
+}
+
+pub struct ObjConsumeButton {
+    one_shot_phase: OneShotPhase,
+    activation_sent: bool,
+}
 impl ObjConsumeButton {
     pub fn new() -> ObjConsumeButton {
-        ObjConsumeButton
+        ObjConsumeButton {
+            one_shot_phase: OneShotPhase::Idle,
+            activation_sent: false,
+        }
+    }
+
+    fn consume_if_eligible(
+        &mut self,
+        world: &World,
+        receptor: EntityId,
+        candidate: EntityId,
+    ) -> Effect {
+        let one_shot = receptor_has_final_model(world, receptor);
+        if (one_shot && self.one_shot_phase != OneShotPhase::Idle)
+            || !can_consume_entity(world, receptor, candidate)
+        {
+            return Effect::NoEffect;
+        }
+
+        // The TurnOn/model-change effects apply after this message batch. Latch
+        // immediately so two VR hands cannot provision distinct vials before
+        // the authored final model becomes observable in the ECS. Reusable
+        // consumers without a final model retain their original behavior.
+        if one_shot {
+            self.one_shot_phase = OneShotPhase::PendingDelivery;
+            self.activation_sent = true;
+        }
+        consume(world, receptor, candidate)
     }
 }
 impl Script for ObjConsumeButton {
@@ -25,26 +74,89 @@ impl Script for ObjConsumeButton {
         match msg {
             // VR: the player holds a specific item against the receptor.
             MessagePayload::ProvideForConsumption { entity } => {
-                if can_consume_entity(world, entity_id, *entity) {
-                    consume(world, entity_id, *entity)
-                } else {
-                    Effect::NoEffect
-                }
+                self.consume_if_eligible(world, entity_id, *entity)
             }
             // Flat: frobbing the receptor consumes the first matching item the
             // player carries (no hold-item-near-the-receptor step - that is
             // VR-only, handled above).
             MessagePayload::Frob => {
+                if self.one_shot_phase != OneShotPhase::Idle {
+                    return Effect::NoEffect;
+                }
                 match super::script_util::player_carried_items(world)
                     .into_iter()
                     .find(|item| can_consume_entity(world, entity_id, *item))
                 {
-                    Some(item) => consume(world, entity_id, item),
+                    Some(item) => self.consume_if_eligible(world, entity_id, item),
                     None => Effect::NoEffect,
                 }
             }
+            MessagePayload::TurnOn { from }
+                if *from == entity_id && self.one_shot_phase == OneShotPhase::PendingDelivery =>
+            {
+                // This acknowledgement is handled in the same batch as every
+                // linked recipient. Persist it separately from the final model
+                // so a mid-animation save does not replay the plot activation.
+                self.one_shot_phase = OneShotPhase::AwaitingFinalModel;
+                Effect::NoEffect
+            }
             _ => Effect::NoEffect,
         }
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        match self.one_shot_phase {
+            OneShotPhase::Idle => Effect::NoEffect,
+            OneShotPhase::PendingDelivery if self.activation_sent => Effect::NoEffect,
+            OneShotPhase::PendingDelivery => {
+                // A save can capture the consumed item after DestroyEntity but
+                // before the deferred TurnOn is delivered. Re-emit that
+                // activation once after restoring the pending delivery.
+                self.activation_sent = true;
+                send_to_all_switch_links_and_self(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                )
+            }
+            OneShotPhase::AwaitingFinalModel if receptor_is_used(world, entity_id) => {
+                self.one_shot_phase = OneShotPhase::Idle;
+                self.activation_sent = false;
+                Effect::NoEffect
+            }
+            OneShotPhase::AwaitingFinalModel => Effect::NoEffect,
+        }
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SCRIPT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &ObjConsumeButtonState {
+                one_shot_phase: self.one_shot_phase,
+            },
+            SCRIPT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: ObjConsumeButtonState = state.decode(1, SCRIPT_STATE_KEY)?;
+        self.one_shot_phase = restored.one_shot_phase;
+        self.activation_sent = false;
+        Ok(())
     }
 }
 
@@ -63,15 +175,7 @@ fn consume(world: &World, entity_id: EntityId, entity_to_consume: EntityId) -> E
 }
 
 fn can_consume_entity(world: &World, self_id: EntityId, entity_to_consume_id: EntityId) -> bool {
-    let already_used = {
-        let models = world.borrow::<View<PropModelName>>().unwrap();
-        let configs = world.borrow::<View<PropTweqModelConfig>>().unwrap();
-        match (models.get(self_id), configs.get(self_id)) {
-            (Ok(model), Ok(config)) => model_is_final(&model.0, &config.model_names),
-            _ => false,
-        }
-    };
-    if already_used {
+    if receptor_is_used(world, self_id) {
         return false;
     }
 
@@ -97,6 +201,24 @@ fn can_consume_entity(world: &World, self_id: EntityId, entity_to_consume_id: En
     false
 }
 
+fn receptor_has_final_model(world: &World, entity_id: EntityId) -> bool {
+    let models = world.borrow::<View<PropModelName>>().unwrap();
+    let configs = world.borrow::<View<PropTweqModelConfig>>().unwrap();
+    models.get(entity_id).is_ok()
+        && configs
+            .get(entity_id)
+            .is_ok_and(|config| !config.model_names.is_empty())
+}
+
+fn receptor_is_used(world: &World, entity_id: EntityId) -> bool {
+    let models = world.borrow::<View<PropModelName>>().unwrap();
+    let configs = world.borrow::<View<PropTweqModelConfig>>().unwrap();
+    match (models.get(entity_id), configs.get(entity_id)) {
+        (Ok(model), Ok(config)) => model_is_final(&model.0, &config.model_names),
+        _ => false,
+    }
+}
+
 fn model_is_final(current: &str, frames: &[String]) -> bool {
     frames
         .last()
@@ -106,10 +228,149 @@ fn model_is_final(current: &str, frames: &[String]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use dark::properties::{PropConsumeType, PropModelName, PropObjState, PropSymName};
-    use shipyard::World;
+    use std::{cell::Cell, collections::HashMap, rc::Rc};
+
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{
+        Link, Links, PropConsumeType, PropModelName, PropObjState, PropSymName,
+        PropTweqModelConfig, ToLink, TweqAnimationConfig, TweqHalt, WrappedEntityId,
+    };
+    use shipyard::{IntoIter, World};
+
+    use crate::{
+        mission::{GlobalTemplateIdMap, PlayerInfo},
+        save_load::{EntitySaveData, to_save_data_with_scripts},
+        scripts::{Message, ScriptWorld},
+    };
 
     use super::*;
+
+    fn one_shot_receptor(world: &mut World) -> EntityId {
+        world.add_entity((
+            PropConsumeType("AAToxin".to_owned()),
+            PropModelName("air_reof".to_owned()),
+            PropTweqModelConfig {
+                animation_config: TweqAnimationConfig::empty(),
+                halt: TweqHalt::StopTweq,
+                model_names: vec!["air_reof".to_owned(), "air_re".to_owned()],
+            },
+        ))
+    }
+
+    struct TurnOnRecorder(Rc<Cell<u32>>);
+
+    impl Script for TurnOnRecorder {
+        fn handle_message(
+            &mut self,
+            _entity_id: EntityId,
+            _world: &World,
+            _physics: &PhysicsWorld,
+            msg: &MessagePayload,
+        ) -> Effect {
+            if matches!(msg, MessagePayload::TurnOn { .. }) {
+                self.0.set(self.0.get() + 1);
+            }
+            Effect::NoEffect
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum SaveWindow {
+        BeforeDelivery,
+        AfterDelivery,
+        AfterFinalModel,
+    }
+
+    fn round_trip_consumption_at(window: SaveWindow) -> (u32, u32) {
+        let mut world = World::new();
+        let receptor = one_shot_receptor(&mut world);
+        let objective = world.add_entity(());
+        world.add_component(
+            receptor,
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 42,
+                    to_entity_id: Some(WrappedEntityId(objective)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        );
+        let toxin = world.add_entity(PropSymName("AAToxin".to_owned()));
+        let player = world.add_entity(());
+        let inventory = world.add_entity(Links::empty());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        world.add_unique(GlobalTemplateIdMap(HashMap::from([
+            (1001, WrappedEntityId(receptor)),
+            (1002, WrappedEntityId(objective)),
+        ])));
+
+        let before_count = Rc::new(Cell::new(0));
+        let mut scripts = ScriptWorld::new();
+        scripts.add_entity2(receptor, Box::new(ObjConsumeButton::new()));
+        scripts.add_entity2(objective, Box::new(TurnOnRecorder(before_count.clone())));
+        scripts.dispatch(Message {
+            to: receptor,
+            payload: MessagePayload::ProvideForConsumption { entity: toxin },
+        });
+        let effects = scripts.update(&world, &PhysicsWorld::new(), &Time::default());
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::DestroyEntity { entity_id } if *entity_id == toxin
+        )));
+        world.delete_entity(toxin);
+
+        if matches!(
+            window,
+            SaveWindow::AfterDelivery | SaveWindow::AfterFinalModel
+        ) {
+            scripts.update(&world, &PhysicsWorld::new(), &Time::default());
+            assert_eq!(before_count.get(), 1);
+        }
+        if matches!(window, SaveWindow::AfterFinalModel) {
+            world.add_component(receptor, PropModelName("air_re".to_owned()));
+            scripts.update(&world, &PhysicsWorld::new(), &Time::default());
+        }
+
+        let (saved_world, _) = to_save_data_with_scripts(&world, Some(&scripts));
+        let saved_world: EntitySaveData =
+            serde_json::from_value(serde_json::to_value(saved_world).unwrap()).unwrap();
+        assert!(!saved_world.all_entities.contains(&toxin.inner()));
+
+        let mut loaded_world = World::new();
+        let (_, entity_map) = saved_world.instantiate(&mut loaded_world);
+        assert!(!entity_map.contains_key(&toxin));
+        assert!(
+            loaded_world
+                .borrow::<View<PropSymName>>()
+                .unwrap()
+                .iter()
+                .all(|name| !name.0.eq_ignore_ascii_case("AAToxin"))
+        );
+        let loaded_receptor = entity_map[&receptor];
+        let loaded_objective = entity_map[&objective];
+        let after_count = Rc::new(Cell::new(0));
+        let mut loaded_scripts = ScriptWorld::new();
+        loaded_scripts.add_entity2(loaded_receptor, Box::new(ObjConsumeButton::new()));
+        loaded_scripts.add_entity2(
+            loaded_objective,
+            Box::new(TurnOnRecorder(after_count.clone())),
+        );
+        loaded_scripts
+            .restore_states(&saved_world.script_states, &entity_map)
+            .unwrap();
+
+        for _ in 0..3 {
+            loaded_scripts.update(&loaded_world, &PhysicsWorld::new(), &Time::default());
+        }
+        (before_count.get(), after_count.get())
+    }
 
     #[test]
     fn unresearched_candidate_is_rejected() {
@@ -133,5 +394,97 @@ mod tests {
 
         // A model without frames cannot accidentally become one-shot.
         assert!(!model_is_final(&PropModelName("air_re".to_owned()).0, &[]));
+    }
+
+    #[test]
+    fn two_same_tick_provisions_consume_only_the_first_item() {
+        let mut world = World::new();
+        let receptor = one_shot_receptor(&mut world);
+        let first_toxin = world.add_entity(PropSymName("AAToxin".to_owned()));
+        let second_toxin = world.add_entity(PropSymName("AAToxin".to_owned()));
+        let physics = PhysicsWorld::new();
+        let mut script = ObjConsumeButton::new();
+
+        let first = Effect::flatten(vec![script.handle_message(
+            receptor,
+            &world,
+            &physics,
+            &MessagePayload::ProvideForConsumption {
+                entity: first_toxin,
+            },
+        )]);
+        let second = Effect::flatten(vec![script.handle_message(
+            receptor,
+            &world,
+            &physics,
+            &MessagePayload::ProvideForConsumption {
+                entity: second_toxin,
+            },
+        )]);
+
+        assert!(first.iter().any(|effect| matches!(
+            effect,
+            Effect::DestroyEntity { entity_id } if *entity_id == first_toxin
+        )));
+        assert!(
+            !second.iter().any(|effect| matches!(
+                effect,
+                Effect::DestroyEntity { entity_id } if *entity_id == second_toxin
+            )),
+            "the receptor must latch before its deferred model change, got {second:?}"
+        );
+    }
+
+    #[test]
+    fn consumer_without_a_final_model_remains_reusable() {
+        let mut world = World::new();
+        let receptor = world.add_entity(PropConsumeType("AccessCard".to_owned()));
+        let first_card = world.add_entity(PropSymName("AccessCard".to_owned()));
+        let second_card = world.add_entity(PropSymName("AccessCard".to_owned()));
+        let physics = PhysicsWorld::new();
+        let mut script = ObjConsumeButton::new();
+
+        let first = Effect::flatten(vec![script.handle_message(
+            receptor,
+            &world,
+            &physics,
+            &MessagePayload::ProvideForConsumption { entity: first_card },
+        )]);
+        let second = Effect::flatten(vec![script.handle_message(
+            receptor,
+            &world,
+            &physics,
+            &MessagePayload::ProvideForConsumption {
+                entity: second_card,
+            },
+        )]);
+
+        assert!(first.iter().any(|effect| matches!(
+            effect,
+            Effect::DestroyEntity { entity_id } if *entity_id == first_card
+        )));
+        assert!(second.iter().any(|effect| matches!(
+            effect,
+            Effect::DestroyEntity { entity_id } if *entity_id == second_card
+        )));
+    }
+
+    #[test]
+    fn consumption_save_windows_preserve_exactly_one_activation() {
+        for window in [
+            SaveWindow::BeforeDelivery,
+            SaveWindow::AfterDelivery,
+            SaveWindow::AfterFinalModel,
+        ] {
+            let (before, after) = round_trip_consumption_at(window);
+            assert_eq!(
+                (before, after),
+                match window {
+                    SaveWindow::BeforeDelivery => (0, 1),
+                    SaveWindow::AfterDelivery | SaveWindow::AfterFinalModel => (1, 0),
+                },
+                "activation count mismatch for {window:?}"
+            );
+        }
     }
 }

--- a/shock2vr/src/scripts/researchable.rs
+++ b/shock2vr/src/scripts/researchable.rs
@@ -1,5 +1,5 @@
-use dark::properties::{ObjectState, PropObjState};
-use shipyard::{EntityId, Get, World};
+use dark::properties::ObjectState;
+use shipyard::{EntityId, World};
 
 use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
 
@@ -31,19 +31,7 @@ impl Script for ResearchableScript {
                 state: ObjectState::Normal,
             }
         } else {
-            let unresearched = world
-                .borrow::<shipyard::View<PropObjState>>()
-                .ok()
-                .and_then(|states| states.get(entity_id).ok().map(|state| state.0))
-                == Some(ObjectState::Unresearched);
-            if unresearched {
-                Effect::NoEffect
-            } else {
-                Effect::SetObjectState {
-                    entity_id,
-                    state: ObjectState::Unresearched,
-                }
-            }
+            Effect::NoEffect
         }
     }
 
@@ -55,5 +43,28 @@ impl Script for ResearchableScript {
         _msg: &MessagePayload,
     ) -> Effect {
         Effect::NoEffect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{ObjectState, PropObjState};
+
+    use crate::runtime_props::RuntimePropCanonicalTemplateId;
+
+    use super::*;
+
+    #[test]
+    fn incomplete_research_preserves_authored_object_state() {
+        let mut world = World::new();
+        let entity_id = world.add_entity((
+            RuntimePropCanonicalTemplateId(-1341),
+            PropObjState(ObjectState::Normal),
+        ));
+        world.add_unique(QuestInfo::new());
+
+        let effect = ResearchableScript::new().initialize(entity_id, &world);
+
+        assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/researchable.rs
+++ b/shock2vr/src/scripts/researchable.rs
@@ -1,0 +1,59 @@
+use dark::properties::{ObjectState, PropObjState};
+use shipyard::{EntityId, Get, World};
+
+use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
+
+use super::{Effect, MessagePayload, Script, script_util::entity_class_template_id};
+
+/// Keeps newly-created copies of a campaign-researched archetype usable. The
+/// Research MFD itself handles frobs; this script only reconciles persistent
+/// campaign state onto the live Dark object state during initialization.
+pub struct ResearchableScript;
+
+impl ResearchableScript {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for ResearchableScript {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        let Some(template_id) = entity_class_template_id(world, entity_id) else {
+            return Effect::NoEffect;
+        };
+        let researched = world
+            .borrow::<shipyard::UniqueView<QuestInfo>>()
+            .map(|quests| quests.research().is_complete(template_id))
+            .unwrap_or(false);
+        if researched {
+            Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Normal,
+            }
+        } else {
+            let unresearched = world
+                .borrow::<shipyard::View<PropObjState>>()
+                .ok()
+                .and_then(|states| states.get(entity_id).ok().map(|state| state.0))
+                == Some(ObjectState::Unresearched);
+            if unresearched {
+                Effect::NoEffect
+            } else {
+                Effect::SetObjectState {
+                    entity_id,
+                    state: ObjectState::Unresearched,
+                }
+            }
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _msg: &MessagePayload,
+    ) -> Effect {
+        Effect::NoEffect
+    }
+}

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -2,25 +2,34 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { UiElement } from "../src/types.js";
+import type { UiElement, UiState } from "../src/types.js";
 import { clickUiElement } from "./helpers/ui.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
-// Hydroponics' authored Toxin-A research objective. The test deliberately
-// starts the vial through the production flat inventory interaction (Tab/use
-// mode, cursor lift, second-click use), rather than injecting a script message.
-// Runtime entity ids are discovered every launch.
+// Hydroponics' authored Toxin-A research objective. Every player-facing use
+// travels through production interactions: the inventory strip double-click,
+// the Hydro 2 Tech Trainer, real carried chemical entities, and Hydro 1's ACR1
+// regulator. Runtime ids are discovered each time (including after save/load).
 //
-// Negative-first evidence for #763: on origin/main at 5ebca74d the second
-// inventory click reaches the `ResearchableScript` stub, leaving
-// `/v1/ui.active_panel` null. The first panel assertion below therefore fails.
+// Negative-first evidence for #763: on origin/main at 5ebca74d the first
+// Toxin-A double-click reaches the `ResearchableScript` stub, leaving
+// `/v1/ui.active_panel` null. The first research-panel assertion therefore
+// fails before the implementation.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function ensureUseMode(game: GameServer): Promise<void> {
+  if ((await game.ui.state()).mode !== "use") {
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+  }
+}
 
 async function useInventoryItem(
   game: GameServer,
   entityId: number,
 ): Promise<void> {
+  await ensureUseMode(game);
   const ui = await game.ui.state();
-  assert.equal(ui.mode, "use", "inventory use requires the live use-mode strip");
   const element = ui.strip?.elements.find(
     (candidate: UiElement) => candidate.entity_id === entityId,
   );
@@ -41,37 +50,229 @@ async function useInventoryItem(
   await game.step({ frames: 5 });
 }
 
+function panelTexts(ui: UiState): string[] {
+  return (
+    ui.active_panel?.elements
+      .filter((element) => element.kind === "text")
+      .flatMap((element) => (element.text ? [element.text] : [])) ?? []
+  );
+}
+
+async function carriedNamed(game: GameServer, name: string) {
+  return (await game.player.inventory()).items.find((item) => item.name === name);
+}
+
+async function researchPanel(game: GameServer): Promise<UiState> {
+  const ui = await game.ui.state();
+  assert.ok(ui.active_panel, "Toxin-A should have an open Research MFD");
+  assert.ok(
+    ui.active_panel.elements.some((element) =>
+      element.texture?.toLowerCase().endsWith("research.pcx"),
+    ),
+    "the panel should use the retail RESEARCH.PCX backdrop",
+  );
+  return ui;
+}
+
 test(
-  "hydro2.mis: Toxin-A starts research through the real flat inventory",
+  "Hydro Toxin-A: train, research with chemicals, persist, and use ACR once",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
+    const saveName = `hydro_research_${Date.now()}`;
     await using game = await GameServer.launch({
       mission: "hydro2.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
     });
     await game.step({ frames: 5 });
 
-    const toxin = (
+    // Pick up an authored Hydro 2 vial, then prove Hydro 1's real regulator
+    // refuses it while its Dark object state is still Unresearched.
+    const authoredToxin = (
       await game.entities.list({ filter: "Anti-Annelid Toxin", limit: 20 })
     ).entities[0];
-    assert.ok(toxin, "Hydro 2 should contain an authored Toxin-A vial");
-    await game.player.give(toxin.id);
-
-    await game.input.trigger("ToggleUseMode");
+    assert.ok(authoredToxin, "Hydro 2 should contain an authored Toxin-A vial");
+    await game.player.give(authoredToxin.id);
+    await game.transitionLevel("hydro1.mis");
     await game.step({ frames: 5 });
-    await useInventoryItem(game, toxin.id);
-
-    const opened = await game.ui.state();
-    assert.ok(
-      opened.active_panel,
-      "using unresearched Toxin-A should open the research panel",
+    const acr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR1",
     );
-    assert.equal(opened.active_panel.entity_id, toxin.id);
+    assert.ok(acr1, "Hydro 1 should contain the authored ACR1 regulator");
+    await game.entities.sendMessage(acr1.id, { type: "Frob" });
+    await game.step({ frames: 30 });
     assert.ok(
-      opened.active_panel.elements.some(
-        (element) => element.texture?.toLowerCase() === "research.pcx",
+      await carriedNamed(game, "Anti-Annelid Toxin"),
+      "ACR1 must not consume unresearched toxin",
+    );
+    assert.notEqual(
+      await game.quests.get("ACR1"),
+      "complete",
+      "rejected toxin must not advance the ACR objective",
+    );
+
+    await game.transitionLevel("hydro2.mis");
+    await game.step({ frames: 5 });
+    let toxin = await carriedNamed(game, "Anti-Annelid Toxin");
+    assert.ok(toxin, "Toxin-A should remain carried after returning to Hydro 2");
+
+    // Double-click through the production inventory. With no Research skill,
+    // the MFD opens but explicitly refuses to begin.
+    await useInventoryItem(game, toxin.entity_id);
+    let panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Research skill of 1")),
+      `untrained panel should explain the requirement; got ${JSON.stringify(panelTexts(panel))}`,
+    );
+
+    // Fund and use Hydro 2's authored Tech Trainer, purchasing Research 0->1
+    // for the retail WTECHCOST price of ten modules.
+    await game.player.setStats({ cyber_modules: 10 });
+    const techTrainer = (
+      await game.entities.list({ filter: "Tech Trainer", limit: 20 })
+    ).entities.find((entity) => entity.template_id === 966);
+    assert.ok(techTrainer, "Hydro 2 should contain its authored Tech Trainer");
+    const [tx, ty, tz] = (await game.entities.detail(techTrainer.id)).position;
+    await teleportVerified(game, { x: tx, y: ty + 0.5, z: tz + 1.2 });
+    await game.step({ frames: 20 });
+    await game.entities.sendMessage(techTrainer.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const trainer = await game.ui.state();
+    const researchRow = trainer.active_panel?.elements.find(
+      (element) => element.kind === "button" && element.label === "Research",
+    );
+    assert.ok(researchRow, "Tech Trainer should expose the Research row");
+    await clickUiElement(game, researchRow);
+    await game.step({ frames: 3 });
+    const trained = (await game.info()).player.stats!;
+    assert.equal(trained.skills.research, 1, "real trainer purchase grants Research 1");
+    assert.equal(trained.cyber_modules, 0, "Research 1 spends ten cyber modules");
+
+    // Raise only for test-time acceleration after proving the real purchase;
+    // the state-machine unit test covers the exact skill multiplier. At skill
+    // 6, the retail formula advances 26 authored seconds per real second.
+    await game.player.setStats({ skills: { research: 6 } });
+    toxin = await carriedNamed(game, "Anti-Annelid Toxin");
+    assert.ok(toxin);
+    await useInventoryItem(game, toxin.entity_id);
+    await game.step({ frames: 75 });
+    panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Antimony (Sb)")),
+      `first gate should request antimony; got ${JSON.stringify(panelTexts(panel))}`,
+    );
+
+    // Carry the actual authored Hydro chemical objects. Wrong Vanadium is
+    // refused and remains; Antimony is consumed, reaching the second gate.
+    const antimonyWorld = (
+      await game.entities.list({ filter: "Chem #4", limit: 30 })
+    ).entities.slice(0, 2);
+    const vanadiumWorld = (
+      await game.entities.list({ filter: "Chem #2", limit: 30 })
+    ).entities[0];
+    assert.equal(antimonyWorld.length, 2, "Hydro 2 should author two Antimony doses");
+    assert.ok(vanadiumWorld, "Hydro 2 should author a Vanadium dose");
+    for (const chemical of [...antimonyWorld, vanadiumWorld]) {
+      await game.player.give(chemical.id);
+    }
+
+    let vanadium = await carriedNamed(game, "Chem #2");
+    assert.ok(vanadium);
+    await useInventoryItem(game, vanadium.entity_id);
+    assert.ok(await carriedNamed(game, "Chem #2"), "wrong chemical must remain carried");
+
+    let antimony = await carriedNamed(game, "Chem #4");
+    assert.ok(antimony);
+    await useInventoryItem(game, antimony.entity_id);
+    await game.step({ frames: 75 });
+    panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Vanadium (V)")),
+      `second gate should request vanadium; got ${JSON.stringify(panelTexts(panel))}`,
+    );
+
+    // Save/load while paused at a chemical gate, then reopen the carried item:
+    // active partial progress and the pending chemical must survive.
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    toxin = await carriedNamed(game, "Anti-Annelid Toxin");
+    assert.ok(toxin, "Toxin-A survives save/load");
+    await useInventoryItem(game, toxin.entity_id);
+    panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Vanadium (V)")),
+      "the pending second chemical survives save/load",
+    );
+
+    vanadium = await carriedNamed(game, "Chem #2");
+    assert.ok(vanadium);
+    await useInventoryItem(game, vanadium.entity_id);
+    await game.step({ frames: 430 });
+    panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Antimony (Sb)")),
+      "the authored 240-second gate requests the second Antimony dose",
+    );
+
+    antimony = await carriedNamed(game, "Chem #4");
+    assert.ok(antimony);
+    await useInventoryItem(game, antimony.entity_id);
+    await game.step({ frames: 850 });
+    panel = await researchPanel(game);
+    assert.ok(
+      panelTexts(panel).some((text) => text.includes("Research complete")),
+      `completion should be player-visible; got ${JSON.stringify(panelTexts(panel))}`,
+    );
+    assert.equal(
+      await game.quests.get("Note_3_2"),
+      "complete",
+      "Toxin-A completion grants its authored research quest bit",
+    );
+
+    const report = panel.active_panel!.elements.find(
+      (element) => element.label === "Research report",
+    );
+    assert.ok(report, "completed research unlocks report #5");
+    await clickUiElement(game, report);
+    await game.step({ frames: 3 });
+    assert.ok(
+      panelTexts(await game.ui.state()).some((text) => text.includes("Summary:")),
+      "the report button reveals the authored analysis",
+    );
+
+    // A researched vial is accepted once by ACR1. After its authored model
+    // tweq reaches the used frame, another researched vial is left untouched.
+    await game.transitionLevel("hydro1.mis");
+    await game.step({ frames: 5 });
+    const liveAcr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR1",
+    );
+    assert.ok(liveAcr1);
+    toxin = await carriedNamed(game, "Anti-Annelid Toxin");
+    assert.ok(toxin);
+    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === toxin!.entity_id,
       ),
-      "the panel should use the retail RESEARCH.PCX backdrop",
+      "ACR1 consumes the researched vial",
+    );
+    assert.equal(
+      await game.quests.get("ACR1"),
+      "incomplete",
+      "the authored ACR1-Activate trap marks this regulator active",
+    );
+
+    const secondToxin = await game.player.spawnItem(-1341);
+    await game.step({ frames: 5 });
+    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
+    await game.step({ frames: 30 });
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === secondToxin.entity_id,
+      ),
+      "an already-used ACR must not consume another vial",
     );
   },
 );

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -62,6 +62,10 @@ async function carriedNamed(game: GameServer, name: string) {
   return (await game.player.inventory()).items.find((item) => item.name === name);
 }
 
+async function carriedItemsNamed(game: GameServer, name: string) {
+  return (await game.player.inventory()).items.filter((item) => item.name === name);
+}
+
 async function researchPanel(game: GameServer): Promise<UiState> {
   const ui = await game.ui.state();
   assert.ok(ui.active_panel, "Toxin-A should have an open Research MFD");
@@ -75,7 +79,7 @@ async function researchPanel(game: GameServer): Promise<UiState> {
 }
 
 test(
-  "Hydro Toxin-A: train, research with chemicals, persist, and use ACR once",
+  "Hydro Toxin-A: train, research with chemicals, persist, and use both ACRs",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     const saveName = `hydro_research_${Date.now()}`;
@@ -87,11 +91,17 @@ test(
 
     // Pick up an authored Hydro 2 vial, then prove Hydro 1's real regulator
     // refuses it while its Dark object state is still Unresearched.
-    const authoredToxin = (
+    const authoredToxins = (
       await game.entities.list({ filter: "Anti-Annelid Toxin", limit: 20 })
-    ).entities[0];
-    assert.ok(authoredToxin, "Hydro 2 should contain an authored Toxin-A vial");
-    await game.player.give(authoredToxin.id);
+    ).entities.slice(0, 2);
+    assert.equal(
+      authoredToxins.length,
+      2,
+      "Hydro 2 should contain both authored Toxin-A vials",
+    );
+    for (const authoredToxin of authoredToxins) {
+      await game.player.give(authoredToxin.id);
+    }
     await game.transitionLevel("hydro1.mis");
     await game.step({ frames: 5 });
     const acr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
@@ -101,8 +111,8 @@ test(
     await game.entities.sendMessage(acr1.id, { type: "Frob" });
     await game.step({ frames: 30 });
     assert.ok(
-      await carriedNamed(game, "Anti-Annelid Toxin"),
-      "ACR1 must not consume unresearched toxin",
+      (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length === 2,
+      "ACR1 must not consume either unresearched toxin",
     );
     assert.notEqual(
       await game.quests.get("ACR1"),
@@ -235,28 +245,49 @@ test(
     assert.ok(report, "completed research unlocks report #5");
     await clickUiElement(game, report);
     await game.step({ frames: 3 });
+    let reportPanel = await game.ui.state();
     assert.ok(
-      panelTexts(await game.ui.state()).some((text) => text.includes("Summary:")),
+      panelTexts(reportPanel).some((text) => text.includes("Summary:")),
       "the report button reveals the authored analysis",
     );
 
-    // A researched vial is accepted once by ACR1. After its authored model
-    // tweq reaches the used frame, another researched vial is left untouched.
+    // The report is longer than the safe text region. Page through the retail
+    // scroll gadget and prove the late recommendation is reachable rather
+    // than silently truncated or drawn under the report button.
+    for (let page = 0; page < 8; page += 1) {
+      if (panelTexts(reportPanel).some((text) => text.includes("Recommendation:"))) {
+        break;
+      }
+      const nextPage = reportPanel.active_panel?.elements.find(
+        (element) => element.label === "Research report next page",
+      );
+      assert.ok(nextPage, "a long research report should expose next-page navigation");
+      await clickUiElement(game, nextPage);
+      await game.step({ frames: 3 });
+      reportPanel = await game.ui.state();
+    }
+    assert.ok(
+      panelTexts(reportPanel).some((text) => text.includes("Recommendation:")),
+      `late report recommendation should be reachable; got ${JSON.stringify(panelTexts(reportPanel))}`,
+    );
+
+    // Both vials predated completion, so both must be normalized to researched
+    // and accepted by Hydro's two independent, cross-deck regulators.
     await game.transitionLevel("hydro1.mis");
     await game.step({ frames: 5 });
     const liveAcr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
       (entity) => entity.name === "ACR1",
     );
     assert.ok(liveAcr1);
-    toxin = await carriedNamed(game, "Anti-Annelid Toxin");
-    assert.ok(toxin);
+    let carriedToxins = await carriedItemsNamed(game, "Anti-Annelid Toxin");
+    assert.equal(carriedToxins.length, 2, "both preexisting vials survive research");
     await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
     await game.step({ frames: 600 });
-    assert.ok(
-      !(await game.player.inventory()).items.some(
-        (item) => item.entity_id === toxin!.entity_id,
-      ),
-      "ACR1 consumes the researched vial",
+    carriedToxins = await carriedItemsNamed(game, "Anti-Annelid Toxin");
+    assert.equal(
+      carriedToxins.length,
+      1,
+      "ACR1 consumes one researched preexisting vial",
     );
     assert.equal(
       await game.quests.get("ACR1"),
@@ -264,9 +295,32 @@ test(
       "the authored ACR1-Activate trap marks this regulator active",
     );
 
+    // ACR2 is the second real regulator in Hydro 2, not another Hydro 1
+    // object. Follow the authored cross-deck objective before using it.
+    await game.transitionLevel("hydro2.mis");
+    await game.step({ frames: 5 });
+    const liveAcr2 = (await game.entities.list({ filter: "ACR2", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR2",
+    );
+    assert.ok(liveAcr2, "Hydro 2 should contain the authored ACR2 regulator");
+    await game.entities.sendMessage(liveAcr2.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    assert.equal(
+      (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length,
+      0,
+      "ACR2 consumes the other researched preexisting vial",
+    );
+    assert.equal(
+      await game.quests.get("ACR2"),
+      "incomplete",
+      "the authored ACR2-Activate trap marks the second regulator active",
+    );
+
+    // After its authored model tweq reaches the used frame, another researched
+    // vial is left untouched by an already-used regulator.
     const secondToxin = await game.player.spawnItem(-1341);
     await game.step({ frames: 5 });
-    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
+    await game.entities.sendMessage(liveAcr2.id, { type: "Frob" });
     await game.step({ frames: 30 });
     assert.ok(
       (await game.player.inventory()).items.some(

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -16,6 +16,8 @@ import { teleportVerified } from "./helpers/teleport.js";
 // `/v1/ui.active_panel` null. The first research-panel assertion therefore
 // fails before the implementation.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const TOXIN_DESKS = [675, 713];
+const CHEMICAL_DESK = 354;
 
 async function ensureUseMode(game: GameServer): Promise<void> {
   if ((await game.ui.state()).mode !== "use") {
@@ -48,6 +50,48 @@ async function useInventoryItem(
     "second click should use the item and clear the cursor",
   );
   await game.step({ frames: 5 });
+}
+
+async function lootContainerItems(
+  game: GameServer,
+  containerTemplateId: number,
+  itemNames: string[],
+): Promise<void> {
+  const containers = await game.entities.byTemplate(containerTemplateId);
+  assert.equal(
+    containers.length,
+    1,
+    `expected one authored container ${containerTemplateId}`,
+  );
+  const container = containers[0];
+  await teleportVerified(game, {
+    x: container.position[0] + 1.0,
+    y: container.position[1] + 0.5,
+    z: container.position[2] + 1.0,
+  });
+  await game.entities.sendMessage(container.id, { type: "Frob" });
+  await game.step({ frames: 5 });
+
+  for (const itemName of itemNames) {
+    const panel = (await game.ui.state()).active_panel;
+    assert.equal(
+      panel?.entity_id,
+      container.id,
+      `container ${containerTemplateId} should open its loot MFD`,
+    );
+    const item = panel.elements.find(
+      (element) => element.kind === "button" && element.label === itemName,
+    );
+    assert.ok(item, `container ${containerTemplateId} should contain ${itemName}`);
+    await clickUiElement(game, item);
+  }
+
+  const close = (await game.ui.state()).active_panel?.elements.find(
+    (element) => element.label === "close",
+  );
+  if (close) {
+    await clickUiElement(game, close);
+  }
 }
 
 function panelTexts(ui: UiState): string[] {
@@ -89,41 +133,34 @@ test(
     });
     await game.step({ frames: 5 });
 
-    // Pick up an authored Hydro 2 vial, then prove Hydro 1's real regulator
-    // refuses it while its Dark object state is still Unresearched.
-    const authoredToxins = (
-      await game.entities.list({ filter: "Anti-Annelid Toxin", limit: 20 })
-    ).entities.slice(0, 2);
-    assert.equal(
-      authoredToxins.length,
-      2,
-      "Hydro 2 should contain both authored Toxin-A vials",
-    );
-    for (const authoredToxin of authoredToxins) {
-      await game.player.give(authoredToxin.id);
+    // Loot two authored Hydro 2 vials, then prove Hydro 2's real regulator
+    // refuses them while their Dark object state is still Unresearched.
+    for (const desk of TOXIN_DESKS) {
+      await lootContainerItems(game, desk, ["Anti-Annelid Toxin"]);
     }
-    await game.transitionLevel("hydro1.mis");
-    await game.step({ frames: 5 });
-    const acr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
-      (entity) => entity.name === "ACR1",
+    assert.equal(
+      (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length,
+      2,
+      "two authored Toxin-A vials should be looted from Hydro 2 desks",
     );
-    assert.ok(acr1, "Hydro 1 should contain the authored ACR1 regulator");
-    await game.entities.sendMessage(acr1.id, { type: "Frob" });
+    const acr2 = (await game.entities.list({ filter: "ACR2", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR2",
+    );
+    assert.ok(acr2, "Hydro 2 should contain the authored ACR2 regulator");
+    await game.entities.sendMessage(acr2.id, { type: "Frob" });
     await game.step({ frames: 30 });
     assert.ok(
       (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length === 2,
-      "ACR1 must not consume either unresearched toxin",
+      "ACR2 must not consume either unresearched toxin",
     );
     assert.notEqual(
-      await game.quests.get("ACR1"),
+      await game.quests.get("ACR2"),
       "complete",
       "rejected toxin must not advance the ACR objective",
     );
 
-    await game.transitionLevel("hydro2.mis");
-    await game.step({ frames: 5 });
     let toxin = await carriedNamed(game, "Anti-Annelid Toxin");
-    assert.ok(toxin, "Toxin-A should remain carried after returning to Hydro 2");
+    assert.ok(toxin, "Toxin-A should remain carried after ACR2 rejects it");
 
     // Double-click through the production inventory. With no Research skill,
     // the MFD opens but explicitly refuses to begin.
@@ -173,20 +210,18 @@ test(
 
     // Carry the actual authored Hydro chemical objects. Wrong Vanadium is
     // refused and remains; Antimony is consumed, reaching the second gate.
-    const antimonyWorld = (
-      await game.entities.list({ filter: "Chem #4", limit: 30 })
-    ).entities.slice(0, 2);
-    const vanadiumWorld = (
-      await game.entities.list({ filter: "Chem #2", limit: 30 })
-    ).entities[0];
-    assert.equal(antimonyWorld.length, 2, "Hydro 2 should author two Antimony doses");
-    assert.ok(vanadiumWorld, "Hydro 2 should author a Vanadium dose");
-    for (const chemical of [...antimonyWorld, vanadiumWorld]) {
-      await game.player.give(chemical.id);
-    }
+    await lootContainerItems(game, CHEMICAL_DESK, ["Chem #2"]);
+    await lootContainerItems(game, CHEMICAL_DESK, ["Chem #4"]);
+    await lootContainerItems(game, CHEMICAL_DESK, ["Chem #4"]);
+    toxin = await carriedNamed(game, "Anti-Annelid Toxin");
+    assert.ok(toxin);
+    await useInventoryItem(game, toxin.entity_id);
 
     let vanadium = await carriedNamed(game, "Chem #2");
-    assert.ok(vanadium);
+    assert.ok(
+      vanadium,
+      `the authored Vanadium should be carried; got ${JSON.stringify((await game.player.inventory()).items)}`,
+    );
     await useInventoryItem(game, vanadium.entity_id);
     assert.ok(await carriedNamed(game, "Chem #2"), "wrong chemical must remain carried");
 
@@ -272,55 +307,55 @@ test(
     );
 
     // Both vials predated completion, so both must be normalized to researched
-    // and accepted by Hydro's two independent, cross-deck regulators.
-    await game.transitionLevel("hydro1.mis");
-    await game.step({ frames: 5 });
-    const liveAcr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
-      (entity) => entity.name === "ACR1",
-    );
-    assert.ok(liveAcr1);
+    // and accepted by Hydro's two independent, cross-deck regulators. Use ACR2
+    // before leaving Hydro 2, keeping transition-revisit coverage isolated in
+    // its dedicated #770 regression test.
     let carriedToxins = await carriedItemsNamed(game, "Anti-Annelid Toxin");
     assert.equal(carriedToxins.length, 2, "both preexisting vials survive research");
-    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
+    const liveAcr2 = (await game.entities.list({ filter: "ACR2", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR2",
+    );
+    assert.ok(liveAcr2, "Hydro 2 should still contain the authored ACR2 regulator");
+    await game.entities.sendMessage(liveAcr2.id, { type: "Frob" });
     await game.step({ frames: 600 });
     carriedToxins = await carriedItemsNamed(game, "Anti-Annelid Toxin");
     assert.equal(
       carriedToxins.length,
       1,
-      "ACR1 consumes one researched preexisting vial",
-    );
-    assert.equal(
-      await game.quests.get("ACR1"),
-      "incomplete",
-      "the authored ACR1-Activate trap marks this regulator active",
-    );
-
-    // ACR2 is the second real regulator in Hydro 2, not another Hydro 1
-    // object. Follow the authored cross-deck objective before using it.
-    await game.transitionLevel("hydro2.mis");
-    await game.step({ frames: 5 });
-    const liveAcr2 = (await game.entities.list({ filter: "ACR2", limit: 30 })).entities.find(
-      (entity) => entity.name === "ACR2",
-    );
-    assert.ok(liveAcr2, "Hydro 2 should contain the authored ACR2 regulator");
-    await game.entities.sendMessage(liveAcr2.id, { type: "Frob" });
-    await game.step({ frames: 600 });
-    assert.equal(
-      (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length,
-      0,
-      "ACR2 consumes the other researched preexisting vial",
+      "ACR2 consumes one researched preexisting vial",
     );
     assert.equal(
       await game.quests.get("ACR2"),
       "incomplete",
-      "the authored ACR2-Activate trap marks the second regulator active",
+      "the authored ACR2-Activate trap marks this regulator active",
+    );
+
+    // Follow the authored cross-deck objective to Hydro 1 and consume the
+    // remaining researched vial in the independent ACR1 regulator.
+    await game.transitionLevel("hydro1.mis");
+    await game.step({ frames: 5 });
+    const liveAcr1 = (await game.entities.list({ filter: "ACR1", limit: 30 })).entities.find(
+      (entity) => entity.name === "ACR1",
+    );
+    assert.ok(liveAcr1, "Hydro 1 should contain the authored ACR1 regulator");
+    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    assert.equal(
+      (await carriedItemsNamed(game, "Anti-Annelid Toxin")).length,
+      0,
+      "ACR1 consumes the other researched preexisting vial",
+    );
+    assert.equal(
+      await game.quests.get("ACR1"),
+      "incomplete",
+      "the authored ACR1-Activate trap marks the second regulator active",
     );
 
     // After its authored model tweq reaches the used frame, another researched
     // vial is left untouched by an already-used regulator.
     const secondToxin = await game.player.spawnItem(-1341);
     await game.step({ frames: 5 });
-    await game.entities.sendMessage(liveAcr2.id, { type: "Frob" });
+    await game.entities.sendMessage(liveAcr1.id, { type: "Frob" });
     await game.step({ frames: 30 });
     assert.ok(
       (await game.player.inventory()).items.some(

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// Hydroponics' authored Toxin-A research objective. The test deliberately
+// starts the vial through the production flat inventory interaction (Tab/use
+// mode, cursor lift, second-click use), rather than injecting a script message.
+// Runtime entity ids are discovered every launch.
+//
+// Negative-first evidence for #763: on origin/main at 5ebca74d the second
+// inventory click reaches the `ResearchableScript` stub, leaving
+// `/v1/ui.active_panel` null. The first panel assertion below therefore fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function useInventoryItem(
+  game: GameServer,
+  entityId: number,
+): Promise<void> {
+  const ui = await game.ui.state();
+  assert.equal(ui.mode, "use", "inventory use requires the live use-mode strip");
+  const element = ui.strip?.elements.find(
+    (candidate: UiElement) => candidate.entity_id === entityId,
+  );
+  assert.ok(element, `strip should expose carried item ${entityId}`);
+
+  await clickUiElement(game, element);
+  assert.equal(
+    (await game.ui.state()).cursor?.entity_id,
+    entityId,
+    "first click should lift the item onto the cursor",
+  );
+  await clickUiElement(game, element);
+  assert.equal(
+    (await game.ui.state()).cursor,
+    null,
+    "second click should use the item and clear the cursor",
+  );
+  await game.step({ frames: 5 });
+}
+
+test(
+  "hydro2.mis: Toxin-A starts research through the real flat inventory",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
+    });
+    await game.step({ frames: 5 });
+
+    const toxin = (
+      await game.entities.list({ filter: "Anti-Annelid Toxin", limit: 20 })
+    ).entities[0];
+    assert.ok(toxin, "Hydro 2 should contain an authored Toxin-A vial");
+    await game.player.give(toxin.id);
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    await useInventoryItem(game, toxin.id);
+
+    const opened = await game.ui.state();
+    assert.ok(
+      opened.active_panel,
+      "using unresearched Toxin-A should open the research panel",
+    );
+    assert.equal(opened.active_panel.entity_id, toxin.id);
+    assert.ok(
+      opened.active_panel.elements.some(
+        (element) => element.texture?.toLowerCase() === "research.pcx",
+      ),
+      "the panel should use the retail RESEARCH.PCX backdrop",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse the retail research properties and skill-timing parameters needed by Toxin-A
- implement campaign-persistent research with Research-skill gating, authored Sb → V → Sb pauses, retail timing, reports, and completion quest bits
- add the retail-shaped Research MFD with visible progress, localized chemical guidance sourced from `PropObjShortName`, and paged Summary/Analysis/Recommendation text
- prevent unresearched toxin, already-used regulators, and same-tick dual-hand provisioning from bypassing the objective; migrate both carried and unlooted legacy researchables without overwriting saved or authored object state
- cover the real Hydro objects across both decks: inventory double-click, Tech Trainer purchase, chemicals, research gates, two authored vials, ACR1, ACR2, and repeat-use refusal

The independent mission-revisit panic from #770 is split into #832.

## Player-observable result

Before, a normal inventory double-click cleared the cursor but opened no research UI or project:

![Before: Toxin-A inventory use is a no-op](https://gist.githubusercontent.com/tommy-xr/015e0053d8169579f064dd7b27ae31a8/raw/hydro-research-no-op.png)

After, the same carried item exposes research progress, pauses for its authored chemicals, completes, and pages through the full report:

![After: Hydro Toxin-A research from chemical gates through the paged report](https://gist.githubusercontent.com/tommy-xr/144b8124fd3859d7269c597926cde3e6/raw/hydro-research-progress.gif)

The late Recommendation remains reachable without overlapping the report control:

![Paged Toxin-A Recommendation](https://gist.githubusercontent.com/tommy-xr/144b8124fd3859d7269c597926cde3e6/raw/hydro-research-recommendation.png)

This is a net-new Research interface, so there is no base-branch rendering of the panel to capture; the issue's corrected no-op reproduction is the player-observable before state.

### Review follow-up: authored chemical label

![Toxin-A research advances to the authored Antimony gate](https://gist.githubusercontent.com/tommy-xr/7999b6e30579131a5f9418dc537b7083/raw/hydro-research-antimony.gif)

<sub>Toxin-A research advances to the authored Antimony gate; chemical labels now come from `PropObjShortName`. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Toxin-A research paused at the authored Antimony gate](https://gist.githubusercontent.com/tommy-xr/7999b6e30579131a5f9418dc537b7083/raw/hydro-research-antimony.png)

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p dark` — 77 unit + 9 mission integration tests passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` — 501 passed, 0 failed
- `npm test` in `tools/shock2-sdk` — 26 passed, 0 failed
- focused `hydro-research.e2e.test.ts` on the latest rebased code — 1 passed, 0 failed in 124.15s
- full serial SDK E2E completed on the preceding reviewed head — 202 passed, 3 skipped; the 3 reported failures were triaged as pre-existing/environmental (the occupied-port QBR case passed in isolation, the corpse-save assertion also fails on `origin/main`, and the AI-search case alternates pass/fail on `origin/main`)

Fixes #763
