### PR TITLE
fix(physics): restore model-bounds colliders

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -977,24 +977,22 @@ pub fn create_physics_representation(
             .map(|pa| pa.climbable != 0)
             .unwrap_or(false);
 
-        // `P$PhysDims` is optional: an author who never opened the physics
-        // dimensions dialog leaves the object with only a physics *type*, and
-        // the object then got no collider at all - which is why most ladders
-        // were neither solid nor climbable (issue #589). The original engine
-        // falls back to the model's bounds, and the shipped data proves it:
-        // every ladder that *does* carry authored dimensions carries exactly
-        // its model's bbox (e.g. eng1's `Ladder 16'` #945: size
-        // (1.65, 6.40, 0.14) == ladder.bin's bounds, offset zero == its
-        // bbox center).
-        //
-        // Deliberately limited to *climbable* objects. The same fallback
-        // applied to every dimension-less physics object turns ~187 further
-        // props solid across the shipped missions (hydro2 pipe runs, station
-        // windows and crates, bar stools) - plausibly also faithful, but a
-        // separate change with its own traversal testing, not a silent
-        // side effect of a ladder fix.
+        // `P$PhysDims` is an instantiated, non-inherited property in Dark. A
+        // concrete object can therefore inherit a physics type without storing
+        // dimensions in the mission: the original PhysType listener loads its
+        // model and initializes an instance PhysDims from the scaled model
+        // bounds. Do the same here for every supported physical model, not only
+        // climbable ones (#597). Objects with PhysType `None` and model-less
+        // markers still receive no fallback.
         let maybe_dimensions = v_dimensions.get(entity_id).ok();
-        let model_bounds = if maybe_dimensions.is_none() && is_climbable {
+        let has_supported_physics_type = v_phys_type
+            .get(entity_id)
+            .map(|phys_type| {
+                phys_type.phys_type == PhysicsModelType::ORIENTED_BOUNDING_BOX
+                    || phys_type.phys_type == PhysicsModelType::SPHERE
+            })
+            .unwrap_or(false);
+        let model_bounds = if maybe_dimensions.is_none() && has_supported_physics_type {
             // Raw model bounds - deliberately NOT `abs_dimensions`, whose
             // minimum-size clamp would make a fallback ladder 41% thicker
             // than the authored ladder standing next to it. Degenerate sizes
@@ -1305,20 +1303,26 @@ mod tests {
         }
     }
 
-    /// The fallback is scoped to climbable objects: a non-climbable entity with
-    /// no `PropPhysDimensions` keeps the old behavior (no collider), so the
-    /// ladder fix does not silently turn set dressing solid.
+    /// `P$PhysDims` is an instantiated, non-inherited Dark property: a concrete
+    /// object can inherit `P$PhysType` from its archetype without carrying raw
+    /// dimensions in the mission. Dark creates those instance dimensions from
+    /// the model bounds, so ordinary OBB props need the same fallback as ladders.
     #[test]
-    fn non_climbable_without_dimensions_still_gets_no_collider() {
+    fn non_climbable_without_dimensions_gets_collider_from_model_bounds() {
         let mut world = World::new();
         let mut physics = PhysicsWorld::new();
         let entity_id = add_ladder(&mut world, PhysicsModelType::ORIENTED_BOUNDING_BOX, 0);
         let model = ladder_model();
 
-        assert!(
+        let handle =
             create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
-                .is_none(),
-            "non-climbable entities must keep their previous (collider-less) behavior"
+                .expect("an ordinary dimension-less OBB should use its model bounds");
+        let size = physics
+            .cuboid_full_size(handle)
+            .expect("the model-bounds fallback should create an OBB");
+        assert!(
+            (size - LADDER_SIZE).magnitude() < 0.01,
+            "collider should match the model bounds {LADDER_SIZE:?}, got {size:?}"
         );
     }
 
@@ -1339,6 +1343,22 @@ mod tests {
         let bodies = physics.debug_list_bodies();
         assert_eq!(bodies.len(), 1);
         assert_eq!(bodies[0].body_type, "kinematic");
+    }
+
+    /// `PhysType::NONE` means the archetype deliberately disables physical
+    /// representation. A renderable model does not override that decision.
+    #[test]
+    fn dimensionless_none_never_gets_model_bounds_collider() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_ladder(&mut world, PhysicsModelType::NONE, 0);
+        let model = ladder_model();
+
+        assert_eq!(
+            create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id),
+            None
+        );
+        assert!(physics.debug_list_bodies().is_empty());
     }
 
     fn contains_link(to: EntityId) -> ToLink {

--- a/tools/shock2-sdk/test/model-bounds-colliders.e2e.test.ts
+++ b/tools/shock2-sdk/test/model-bounds-colliders.e2e.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, PhysicsBodySummary } from "../src/types.js";
+
+// Regression coverage for #597. In the Dark Engine, P$PhysDims is an
+// instantiated, non-inherited property: mission objects can inherit P$PhysType
+// without storing dimensions of their own. The original engine materializes
+// those instance dimensions from the model bounds when it loads the object.
+//
+// Runtime entity ids vary between launches, so fixtures are discovered by the
+// stable mission-object id exposed as `template_id`.
+//
+// Negative-first: before #597, station pipe 583 and hydro2 pipe 706 had no
+// rigid body because neither stores P$PhysDims in the mission. The positive
+// assertions below therefore fail on main. Hydro2 hand rail 1007 is the
+// control: its exact PhysType is None, so its render model must not make it
+// physical.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+async function exactlyOne(
+  game: GameServer,
+  missionObjectId: number,
+  description: string,
+): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(missionObjectId);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one ${description} (mission object ${missionObjectId})`,
+  );
+  return matches[0];
+}
+
+async function modelBoundsBody(
+  game: GameServer,
+  missionObjectId: number,
+  description: string,
+): Promise<PhysicsBodySummary> {
+  const entity = await exactlyOne(game, missionObjectId, description);
+  const { bodies } = await game.physics.bodies({ entityId: entity.id });
+  assert.equal(
+    bodies.length,
+    1,
+    `${description} should receive one collider from its model bounds`,
+  );
+  const body = bodies[0];
+  assert.equal(body.entity_id, entity.id);
+  assert.equal(body.body_type, "kinematic");
+  assert.equal(body.is_enabled, true);
+  assert.equal(body.is_sensor, false);
+  assert.ok(body.collision_groups.includes("entity"));
+  return body;
+}
+
+test(
+  "station.mis: dimensionless structural pipes receive model-bounds colliders",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "station.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8188),
+    });
+    await game.step({ frames: 2 });
+
+    await modelBoundsBody(game, 583, "station Pipe 16x2");
+  },
+);
+
+test(
+  "hydro2.mis: model-bounds fallback respects supported and None physics types",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8189),
+    });
+    await game.step({ frames: 2 });
+
+    await modelBoundsBody(game, 706, "hydro2 Pipe 16x2");
+
+    const handRail = await exactlyOne(game, 1007, "hydro2 Hand Rail 8'");
+    const { bodies } = await game.physics.bodies({ entityId: handRail.id });
+    assert.equal(
+      bodies.length,
+      0,
+      "an exact PhysType None must remain bodyless even when it has a model",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #597

## Summary

- restore the model-bounds collider fallback for every supported dimensionless OBB or sphere, instead of limiting it to climbables
- preserve authored `PhysType::None`, model-less marker suppression, authored dimensions, and the existing safe kinematic policy for dimensionless spheres
- add live SDK regression coverage in Station and Hydro2, including a `PhysType::None` negative control

## Why this is faithful

The original Dark Engine source marks both PhysType and PhysDims as instantiated, non-inherited properties. Its PhysType listener creates an instance PhysDims when a concrete physical object loads, and `InitPhysProperty(PHYS_DIMS)` initializes dimensions from `ObjGetUnscaledDims` plus object scale ([source](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L117-L137), [listener](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L557-L631), [dimension initialization](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L786-L870)). Raw mission objects that inherit a physical type but omit PhysDims are therefore not intentionally nonphysical; Dark materializes their model-derived instance dimensions at load.

The fallback is gated to exact supported OBB and sphere types. Raw type 3 (`None`, currently displayed as the combined bitflags value) remains bodyless even when a model exists, avoiding the warning noise and false railing/faucet/window bodies an ungated model lookup would introduce.

## Measured scope

An instrumented all-mission audit found 261 non-climbable, non-frobbable, positioned objects with inherited PhysType, no PhysDims, and usable model bounds:

- 207 exact OBB + 6 exact sphere = 213 supported objects restored
- 48 exact `PhysType::None` objects remain bodyless
- largest deltas: Hydro2 +95, Station +46, SHODAN +23, Ops3 +12

An exact base-versus-branch runtime comparison over all 23 missions added 213 physics bodies, matching the supported audit one-for-one, with no losses or unexplained gains. All new bodies are kinematic, so dimensionless props do not unexpectedly begin falling.

## Traversal verification

- Station: opened both real Security Doors through normal aim + squeeze, walked directly beneath and around the restored pipe bank, confirmed mission object 583 owns an enabled non-sensor body, and reached the Main Hall lift boundary without a new obstruction.
- Hydro2: opened the real elevator through its button, traversed out and south to the Sector A upper route beside the 95 restored props, confirmed mission object 706 owns its body, and raycast the only stop to existing `WorldRep` geometry rather than a restored pipe. Hand Rail object 1007 remained bodyless.

## Tests

- negative-first unit: the ordinary dimensionless OBB assertion fails on base and passes with the fallback
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 398 passed
- `npm test` — 26 passed, 163 opt-in skipped
- focused live model-bounds SDK scenario — 2 passed
- full `npm run test:e2e` — 186 passed, 0 failed, 3 expected skips; all 23 missions and both new regressions passed

Post-rebase focused Rust, warning-free checks, SDK units, and both live model-bounds scenarios are also green.

## Visual verification

![Model-bounds collider restoration demo](https://gist.githubusercontent.com/tommy-xr/ea3037393a20d94db0d889fbf8ad1b10/raw/issue597-model-bounds-collision.gif)

<sub>Matched deterministic capture in `earth.mis` against Bar Stool mission object 353. From the same approach, base `2e5e394` clips through the visible stool (1.206u advanced) while fix `3524cea` stops against its restored kinematic, non-sensor collider (0.095u advanced). Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`).</sub>

### Restored behavior

![Restored solid Bar Stool](https://gist.githubusercontent.com/tommy-xr/ea3037393a20d94db0d889fbf8ad1b10/raw/issue597-fix-still.png)

### Before → after

![Before and after model-bounds collision](https://gist.githubusercontent.com/tommy-xr/ea3037393a20d94db0d889fbf8ad1b10/raw/issue597-before-after.png)
