### PR TITLE
fix(debug): report carried entity locations

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -723,6 +723,8 @@ pub struct EntitySummary {
     pub id: i32,
     pub name: String,
     pub template_id: i32,
+    /// "world", "inventory", "left_hand", or "right_hand".
+    pub location: String,
     pub position: [f32; 3],
     pub distance: f32,
     pub script_count: usize,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1603,6 +1603,7 @@ fn process_command(
                             id: e.id,
                             name: e.name,
                             template_id: e.template_id,
+                            location: e.location,
                             position: e.position,
                             distance: e.distance,
                             script_count: e.script_count,

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -276,6 +276,8 @@ pub struct DebugEntitySummary {
     pub id: i32,
     pub name: String,
     pub template_id: i32,
+    /// "world", "inventory", "left_hand", or "right_hand".
+    pub location: String,
     pub position: [f32; 3],
     pub distance: f32,
     pub script_count: usize,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -11576,6 +11576,19 @@ impl crate::game_scene::DebuggableScene for MissionCore {
         use shipyard::*;
 
         let player_pos = self.player_position();
+        let carried_locations: std::collections::HashMap<_, _> = self
+            .player_inventory()
+            .into_iter()
+            .map(|item| (item.entity_id, item.location))
+            .collect();
+        let direct_hand_entities: std::collections::HashSet<_> = {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            [player.left_hand_entity_id, player.right_hand_entity_id]
+                .into_iter()
+                .flatten()
+                .map(|entity_id| entity_id.inner() as i32)
+                .collect()
+        };
         let mut entities = Vec::new();
 
         // Query all entities with position
@@ -11600,16 +11613,20 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         }
                     }
 
-                    // Prefer the live transform; PropPosition can lag for
-                    // entities moved by animation/physics (e.g. walking AIs)
-                    let live_pos = v_transform
-                        .get(entity_id)
-                        .map(|xform| {
-                            use cgmath::Transform;
-                            let p = xform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
-                            cgmath::vec3(p.x, p.y, p.z)
-                        })
-                        .unwrap_or(pos.position);
+                    let (location, live_pos) = debug_entity_listing_location(
+                        entity_id.inner() as i32,
+                        v_transform
+                            .get(entity_id)
+                            .map(|xform| {
+                                use cgmath::Transform;
+                                let p = xform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+                                cgmath::vec3(p.x, p.y, p.z)
+                            })
+                            .unwrap_or(pos.position),
+                        player_pos,
+                        &carried_locations,
+                        &direct_hand_entities,
+                    );
                     let position = [live_pos.x, live_pos.y, live_pos.z];
                     let distance = (cgmath::Vector3::from(position) - player_pos).magnitude();
 
@@ -11636,6 +11653,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                         id: entity_id.inner() as i32,
                         name,
                         template_id,
+                        location,
                         position,
                         distance,
                         script_count,
@@ -13082,6 +13100,81 @@ impl crate::game_scene::DebuggableScene for MissionCore {
 
         self.script_world.dispatch(Message { to: id, payload });
         true
+    }
+}
+
+/// Resolve the automation-facing spatial state for one entity summary.
+///
+/// World entities use their live transform (which may differ from the authored
+/// `PropPosition`). Backpack and nested carried entities have no meaningful
+/// world transform after pickup, so expose the player's current position instead
+/// of the stale floor position retained by the entity properties. Directly held
+/// items retain their live hand/viewmodel transform, which is useful for visual
+/// automation while `location` still makes their carried state explicit.
+fn debug_entity_listing_location(
+    entity_id: i32,
+    world_position: Vector3<f32>,
+    player_position: Vector3<f32>,
+    carried_locations: &std::collections::HashMap<i32, String>,
+    direct_hand_entities: &std::collections::HashSet<i32>,
+) -> (String, Vector3<f32>) {
+    match carried_locations.get(&entity_id) {
+        Some(location) if direct_hand_entities.contains(&entity_id) => {
+            (location.clone(), world_position)
+        }
+        Some(location) => (location.clone(), player_position),
+        None => ("world".to_string(), world_position),
+    }
+}
+
+#[cfg(test)]
+mod debug_entity_listing_tests {
+    use super::debug_entity_listing_location;
+    use cgmath::vec3;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn inventory_entity_uses_inventory_location_and_player_position() {
+        let carried = HashMap::from([(42, "inventory".to_string())]);
+        let (location, position) = debug_entity_listing_location(
+            42,
+            vec3(10.0, 20.0, 30.0),
+            vec3(1.0, 2.0, 3.0),
+            &carried,
+            &HashSet::new(),
+        );
+
+        assert_eq!(location, "inventory");
+        assert_eq!(position, vec3(1.0, 2.0, 3.0));
+    }
+
+    #[test]
+    fn directly_held_entity_keeps_its_live_transform() {
+        let carried = HashMap::from([(42, "right_hand".to_string())]);
+        let (location, position) = debug_entity_listing_location(
+            42,
+            vec3(10.0, 20.0, 30.0),
+            vec3(1.0, 2.0, 3.0),
+            &carried,
+            &HashSet::from([42]),
+        );
+
+        assert_eq!(location, "right_hand");
+        assert_eq!(position, vec3(10.0, 20.0, 30.0));
+    }
+
+    #[test]
+    fn world_entity_keeps_its_live_position() {
+        let (location, position) = debug_entity_listing_location(
+            42,
+            vec3(10.0, 20.0, 30.0),
+            vec3(1.0, 2.0, 3.0),
+            &HashMap::new(),
+            &HashSet::new(),
+        );
+
+        assert_eq!(location, "world");
+        assert_eq!(position, vec3(10.0, 20.0, 30.0));
     }
 }
 

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -65,6 +65,13 @@ const detail = await game.entities.detail(doors.entities[0].id);
 // entity also reports its container's runtime id directly.
 const containerId = detail.contained_by; // number, null, or undefined on an older runtime
 
+// Summaries stay discoverable after pickup. `location` is "world",
+// "inventory", "left_hand", or "right_hand". Backpack entries report the
+// player's current position and distance 0 instead of their stale floor data;
+// directly held items retain their useful live hand/viewmodel transform.
+const pickups = await game.entities.list({ filter: "*Nanites*" });
+console.log(pickups.entities[0].location);
+
 // Inject a script message into an entity (damage, frob, AI signal)
 await game.entities.sendMessage(doors.entities[0].id, { type: "Damage", amount: 5 });
 await game.entities.sendMessage(doors.entities[0].id, { type: "Frob" });

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -167,11 +167,21 @@ export type DebugEntityMessage =
         | "Hacked";
     };
 
+/** Where a carried item is held. */
+export type InventoryLocation = "inventory" | "left_hand" | "right_hand";
+
+/** Whether an entity is in the world or carried by the player. */
+export type EntityLocation = "world" | InventoryLocation;
+
 export interface EntitySummary {
   id: number;
   name: string;
   template_id: number;
+  /** Carried entities remain listed so runtime-id and template discovery continue to work. */
+  location: EntityLocation;
+  /** Live transform, or the player's current position for a backpack/nested item. */
   position: Vec3;
+  /** Distance from the player; zero for a backpack/nested item. */
   distance: number;
   script_count: number;
   link_count: number;
@@ -818,9 +828,6 @@ export interface QuestBitsResult {
   quests: QuestBitEntry[];
   count: number;
 }
-
-/** Where a carried item is held. */
-export type InventoryLocation = "inventory" | "left_hand" | "right_hand";
 
 export interface InventoryItem {
   entity_id: number;

--- a/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-world-pickup.e2e.test.ts
@@ -27,6 +27,8 @@ test(
     );
     assert.ok(pistol, "expected Earth Weapons Training pistol 246");
     assert.ok(clip, "expected Earth Weapons Training standard clip 249");
+    assert.equal(pistol.location, "world", "the pistol should initially be in the world");
+    assert.equal(clip.location, "world", "the clip should initially be in the world");
 
     await earthWorldUse(game, pistol);
     assert.equal(
@@ -59,5 +61,21 @@ test(
       0,
       "a backpack item must no longer have a world physics body",
     );
+
+    // Entity discovery remains available after the real aim+squeeze pickup,
+    // but its spatial state must follow the player rather than the old shelf.
+    const listing = await game.entities.list();
+    const listedPistol = listing.entities.find((entity) => entity.id === pistol.id);
+    const listedClip = listing.entities.find((entity) => entity.id === clip.id);
+    assert.equal(listedPistol?.location, "left_hand");
+    assert.equal(listedClip?.location, "inventory");
+    assert.ok(listedPistol, "the held pistol should remain discoverable by runtime id");
+    assert.ok(
+      listedPistol.position.every(Number.isFinite),
+      "the held pistol should retain its live viewmodel position",
+    );
+    assert.ok(listedClip, "the backpack clip should remain discoverable by runtime id");
+    assert.deepEqual(listedClip.position, listing.player_position);
+    assert.equal(listedClip.distance, 0);
   },
 );

--- a/tools/shock2-sdk/test/give-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/give-item.e2e.test.ts
@@ -28,6 +28,7 @@ test(
     const worldItems = await game.entities.byTemplate(1050);
     assert.equal(worldItems.length, 1, "expected exactly one world-placed Cryo Card");
     const item = worldItems[0];
+    assert.equal(item.location, "world", "the pickup should initially be in the world");
 
     // It should not be carried yet.
     const before = await game.player.inventory();
@@ -48,6 +49,21 @@ test(
       "inventory",
       "a given item lands in the backpack, not a hand",
     );
+
+    const afterListing = await game.entities.list();
+    const listedCarried = afterListing.entities.find((e) => e.id === item.id);
+    assert.ok(listedCarried, "the carried item should remain discoverable by runtime id");
+    assert.equal(
+      listedCarried.location,
+      "inventory",
+      "the entity listing should identify a given item as carried",
+    );
+    assert.deepEqual(
+      listedCarried.position,
+      afterListing.player_position,
+      "a carried item should not retain a stale floor position",
+    );
+    assert.equal(listedCarried.distance, 0, "a carried item is at the player, not on the floor");
 
     // A bad id is rejected without crashing the runtime.
     await assert.rejects(
@@ -78,6 +94,11 @@ test(
     assert.ok(
       sameTemplate.some((e) => e.id === item.id),
       "byTemplate should include the item among its template's instances",
+    );
+    assert.equal(
+      sameTemplate.find((e) => e.id === item.id)?.location,
+      "inventory",
+      "byTemplate should preserve the carried item's inventory state",
     );
   },
 );


### PR DESCRIPTION
## Summary

- add `location` to `/v1/entities` summaries using the existing `world` / `inventory` / `left_hand` / `right_hand` vocabulary
- report backpack and nested carried items at the current player position with distance `0` instead of their retained floor coordinates
- preserve direct hand/viewmodel live transforms and keep every entity discoverable by runtime id and `byTemplate`
- document the SDK contract and cover both debug give and real flat aim+squeeze pickup paths

## Reproduction

On current main, a runtime-discovered MedSci `20 Nanites` item (stable mission/template id `1045`) initially listed at `[-15.801491, -6.14005, 20.971342]`, distance `19.46652`, while the player was at `[-34.96759, -4.7559557, 17.85841]`.

After `POST /v1/player/give`, `/v1/player/inventory` reported the same runtime entity with `location: inventory`, but `/v1/entities` still returned the original floor position and distance unchanged.

With this change, the same transition lists the entity as `location: inventory`, position equal to the current player position, and distance `0`. The runtime id and template lookup remain available.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr -p debug_runtime` — 410 core tests and 1 debug-runtime test passed
- `npm test` — 26 passed, 0 failed; 162 opt-in e2e skipped
- focused post-fetch e2e: flat real aim+squeeze pickup, `/v1/player/give`, and muzzle/viewmodel tracking — 3 passed, 0 failed
- `npm run test:e2e` — 188 total: 185 passed, 0 failed, 3 authored SHODAN finale skips; all 23 mission loads passed

Fixes #565

## Semantics

This is a semantic change to the existing `/v1/entities` API, not just an added field: for carried items (backpack and nested containers) `position` and `distance` no longer report the retained floor coordinates - they now report the current player position and `0`. Callers that used `position`/`distance` to locate a carried item on the floor will see different values. Directly held (hand/viewmodel) items keep their live transform.
