### PR TITLE
fix(rendering): cull Dark object backfaces

### DIFF
--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -12,7 +12,10 @@ use cgmath::{Point3, point3, prelude::*, vec3};
 use collision::Aabb3;
 use engine::{
     assets::asset_cache::AssetCache,
-    scene::{SceneObject, VertexPositionTextureNormal, VertexPositionTextureSkinnedNormal},
+    scene::{
+        FrontFaceWinding, SceneObject, VertexPositionTextureNormal,
+        VertexPositionTextureSkinnedNormal,
+    },
     texture::{AnimatedTexture, TextureTrait},
 };
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -29,6 +32,9 @@ use crate::{
     ss2_skeleton::{Bone, Skeleton},
     util::load_multiple_textures_for_model,
 };
+
+// Dark LGMD polygons use clockwise front faces.
+const DARK_OBJECT_FRONT_FACE: FrontFaceWinding = FrontFaceWinding::Clockwise;
 
 #[derive(FromPrimitive, ToPrimitive, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum VhotType {
@@ -232,7 +238,7 @@ pub fn to_scene_objects(
             };
 
             let material = RefCell::new(mat);
-            let mut so = engine::scene::scene_object::SceneObject::create(material, geometry);
+            let mut so = create_dark_object_scene_object(material, geometry);
 
             so.set_skinning_data(skeleton.get_transforms());
 
@@ -256,6 +262,15 @@ pub fn to_scene_objects(
 
     mesh_objects.append(&mut vhot_objs);
     (mesh_objects, skeleton)
+}
+
+fn create_dark_object_scene_object(
+    material: RefCell<Box<dyn engine::scene::Material>>,
+    geometry: Rc<Box<dyn engine::scene::Geometry>>,
+) -> SceneObject {
+    let mut scene_object = SceneObject::create(material, geometry);
+    scene_object.set_backface_culling(Some(DARK_OBJECT_FRONT_FACE));
+    scene_object
 }
 
 // Data
@@ -889,6 +904,39 @@ fn convert_skinned_vertices_to_static_vertices(
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    /// S_HIVOLT.BIN contains two coplanar, opposite-wound faces with inverse U
+    /// mappings. Only its authored clockwise face reads left-to-right from the
+    /// affected command1 placement; rendering both lets the mirrored face win
+    /// the depth test.
+    #[test]
+    fn dark_object_culling_selects_the_readable_sign_face() {
+        let sign_faces = [
+            (FrontFaceWinding::CounterClockwise, 1.0_f32, 0.0_f32),
+            (FrontFaceWinding::Clockwise, 0.0_f32, 1.0_f32),
+        ];
+
+        let (_, left_u, right_u) = sign_faces
+            .into_iter()
+            .find(|(winding, _, _)| *winding == DARK_OBJECT_FRONT_FACE)
+            .expect("the configured winding should match an authored sign face");
+
+        assert!(
+            left_u < right_u,
+            "the selected sign face must not be mirrored"
+        );
+    }
+
+    #[test]
+    fn dark_object_scene_objects_enable_clockwise_culling() {
+        let material = RefCell::new(engine::scene::color_material::create(vec3(1.0, 1.0, 1.0)));
+        let geometry: Rc<Box<dyn engine::scene::Geometry>> =
+            Rc::new(Box::new(engine::scene::geometry::EmptyMesh));
+
+        let object = create_dark_object_scene_object(material, geometry);
+
+        assert_eq!(object.backface_culling(), Some(FrontFaceWinding::Clockwise));
+    }
 
     fn material(name: &str) -> SystemShock2MeshMaterial {
         SystemShock2MeshMaterial {

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -24,7 +24,7 @@ mod billboard_material;
 pub use billboard_material::*;
 
 pub mod scene_object;
-pub use scene_object::SceneObject;
+pub use scene_object::{FrontFaceWinding, SceneObject};
 
 pub mod renderable;
 pub use renderable::{

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -30,6 +30,12 @@ use super::quad;
 use super::skinned_material::SkinnedMaterial;
 use crate::materials;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrontFaceWinding {
+    Clockwise,
+    CounterClockwise,
+}
+
 #[derive(Clone)]
 pub struct SceneObject {
     pub material: Rc<RefCell<Box<dyn Material>>>,
@@ -48,6 +54,9 @@ pub struct SceneObject {
     /// a lasting material-level override would bleed between entities; instead
     /// this is applied to the material only around this object's own draw.
     pub transparency_override: Option<f32>,
+    /// Front-face winding used to cull backfaces for this object. Most engine
+    /// geometry remains double-sided; imported Dark models opt in explicitly.
+    backface_culling: Option<FrontFaceWinding>,
 }
 
 impl SceneObject {
@@ -223,6 +232,7 @@ impl SceneObject {
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
+            backface_culling: None,
         }
     }
 
@@ -261,7 +271,7 @@ impl SceneObject {
             &self.skinning_data,
             lights,
         ) {
-            self.geometry.draw();
+            self.draw_geometry();
         }
         if self.transparency_override.is_some() {
             self.material.borrow_mut().set_transparency_override(None);
@@ -291,7 +301,7 @@ impl SceneObject {
             &self.skinning_data,
             lights,
         ) {
-            self.geometry.draw();
+            self.draw_geometry();
         }
         if self.transparency_override.is_some() {
             self.material.borrow_mut().set_transparency_override(None);
@@ -352,6 +362,7 @@ impl SceneObject {
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
+            backface_culling: None,
         }
     }
 
@@ -365,6 +376,7 @@ impl SceneObject {
             depth_write: self.depth_write,
             clear_depth: self.clear_depth,
             transparency_override: self.transparency_override,
+            backface_culling: self.backface_culling,
         }
     }
 
@@ -374,6 +386,38 @@ impl SceneObject {
 
     pub fn set_clear_depth(&mut self, enabled: bool) {
         self.clear_depth = enabled;
+    }
+
+    pub fn set_backface_culling(&mut self, front_face: Option<FrontFaceWinding>) {
+        self.backface_culling = front_face;
+    }
+
+    pub fn backface_culling(&self) -> Option<FrontFaceWinding> {
+        self.backface_culling
+    }
+
+    fn draw_geometry(&self) {
+        if let Some(front_face) = self.backface_culling {
+            unsafe {
+                gl::Enable(gl::CULL_FACE);
+                gl::CullFace(gl::BACK);
+                gl::FrontFace(match front_face {
+                    FrontFaceWinding::Clockwise => gl::CW,
+                    FrontFaceWinding::CounterClockwise => gl::CCW,
+                });
+            }
+        }
+
+        self.geometry.draw();
+
+        if self.backface_culling.is_some() {
+            // Culling is an explicit per-object opt-in; restore the default for
+            // world, procedural, and UI geometry drawn afterward.
+            unsafe {
+                gl::Disable(gl::CULL_FACE);
+                gl::FrontFace(gl::CCW);
+            }
+        }
     }
 
     pub fn set_skinned_transparency(&mut self, transparency: Option<f32>) {
@@ -395,5 +439,20 @@ impl SceneObject {
     /// objects sharing the same material are unaffected.
     pub fn set_transparency(&mut self, transparency: Option<f32>) {
         self.transparency_override = transparency;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_scene_objects_are_double_sided_by_default() {
+        let object = SceneObject::new(
+            super::super::color_material::create(vec3(1.0, 1.0, 1.0)),
+            Box::new(super::super::geometry::EmptyMesh),
+        );
+
+        assert_eq!(object.backface_culling(), None);
     }
 }


### PR DESCRIPTION
## Summary

- honor Dark LGMD's clockwise front-face convention for imported object meshes
- scope culling per `SceneObject`, leaving world, procedural, vhot-debug, and UI geometry double-sided
- cover the affected two-sided sign geometry with an orientation regression test

## Root cause

`S_HIVOLT.BIN` authors the sign as two coplanar, opposite-wound faces with inverse UV mappings. Backface culling was disabled, so the first coplanar face won the depth test from either side. Placements viewed from the other authored face therefore displayed mirrored text. This follows the format's winding convention instead of flipping UVs or textures globally.

## Verification

- negative-first regression: failed with Dark-object culling disabled, passes with clockwise front faces
- deterministic command1 replay: `Danger Hi Voltage` mission object 727 by tram button 199 reads **HIGH VOLTAGE**
- deterministic station replay: `Danger Hi Voltage` mission object 503 reads **HIGH VOLTAGE**
- command1 mission object 453, which was already readable from its authored side, remains readable
- `cargo fmt --all -- --check`
- `cargo test -p engine` (32 passed)
- `cargo test -p dark` (72 unit + 9 mission integration passed)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cd tools/shock2-sdk && npm run test:e2e` (185 passed, 3 skipped, 0 failed; all 23 missions loaded)

## Visual proof

![Danger Hi Voltage decal orientation demo](https://gist.githubusercontent.com/tommy-xr/d313cb1a0dd762ec8f7e8a8384222cbe/raw/decal-mirroring-demo.gif)

<sub>command1 mission object 727 by tram button 199: base `736b8fc` displays mirrored `HGIH / EGATLOV`; head `13abb6f` displays readable `HIGH / VOLTAGE`. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Danger Hi Voltage decal before and after](https://gist.githubusercontent.com/tommy-xr/d313cb1a0dd762ec8f7e8a8384222cbe/raw/decal-mirroring-before-after.png)

<details>
<summary>Additional placement checks</summary>

![Station correction and command1 existing-correct control](https://gist.githubusercontent.com/tommy-xr/d313cb1a0dd762ec8f7e8a8384222cbe/raw/supporting-placements-before-after.png)

<sub>station mission object 503 changes from mirrored to readable; command1 mission object 453 remains readable from +X.</sub>

</details>

Fixes #671