### PR TITLE
fix(debug): preserve container loot on give

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -746,7 +746,8 @@ pub trait DebuggableScene {
 
     /// Put an existing world entity into the player's inventory (a headless
     /// "pick up" for testing). Models a pickup - the item lands in the backpack;
-    /// wielding is a separate, presentation-specific concern. Default:
+    /// wielding is a separate, presentation-specific concern. Container-held
+    /// items are rejected so tests must exercise the real loot UI. Default:
     /// unsupported.
     fn give_item(&mut self, _entity_id: EntityId) -> Result<(), String> {
         Err("scene does not support giving items".to_string())

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6619,6 +6619,32 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             return Err(format!("entity {:?} is not a pickup item", entity_id));
         }
 
+        // This debug lever is only for world-placed items. Moving an authored
+        // container's loot straight into the backpack would make
+        // `drop_entity_into_container` remove the original Contains link,
+        // permanently bypassing (and invalidating tests of) the real loot UI.
+        // Reject before mutating anything so the container remains intact.
+        let containing_entity = {
+            let links = self.world.borrow::<View<Links>>().unwrap();
+            links.iter().with_id().find_map(|(container_id, links)| {
+                links
+                    .to_links
+                    .iter()
+                    .any(|link| {
+                        matches!(link.link, Link::Contains(_))
+                            && link.to_entity_id.map(|wrapped| wrapped.0) == Some(entity_id)
+                    })
+                    .then_some(container_id)
+            })
+        };
+        if let Some(container_id) = containing_entity {
+            return Err(format!(
+                "entity {} is container-held by entity {}; loot it via the container MFD",
+                entity_id.inner(),
+                container_id.inner()
+            ));
+        }
+
         let inventory_entity = {
             let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
             player.inventory_entity_id

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -287,8 +287,9 @@ export class PlayerApi {
   /**
    * Put an existing world entity into the player's inventory - a headless
    * "pick up" for tests. `entityId` is a runtime id (see entities.list /
-   * entities.byTemplate). Throws (400) if the entity is not alive. The item
-   * lands in the backpack; wielding is a separate, presentation-specific step.
+   * entities.byTemplate). Throws (400) if the entity is not alive or is held
+   * by a container; container loot must go through the real MFD. World items
+   * land in the backpack; wielding is a separate, presentation-specific step.
    */
   async give(entityId: number): Promise<CommandResult> {
     return this.client.post<CommandResult>("/v1/player/give", {

--- a/tools/shock2-sdk/test/give-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/give-item.e2e.test.ts
@@ -24,13 +24,11 @@ test(
     });
     await game.step({ frames: 5 });
 
-    // Find a pickup item in the level (a nanite stack) by name.
-    const { entities } = await game.entities.list({
-      filter: "*Nanites*",
-      limit: 50,
-    });
-    const item = entities[0];
-    assert.ok(item, "expected to find a Nanites pickup in medsci1");
+    // Cryo Card 1050 is an authored world-placed item with no incoming
+    // Contains link (also used as the world-item control in container-loot).
+    const worldItems = await game.entities.byTemplate(1050);
+    assert.equal(worldItems.length, 1, "expected exactly one world-placed Cryo Card");
+    const item = worldItems[0];
 
     // It should not be carried yet.
     const before = await game.player.inventory();
@@ -81,6 +79,53 @@ test(
     assert.ok(
       sameTemplate.some((e) => e.id === item.id),
       "byTemplate should include the item among its template's instances",
+    );
+  },
+);
+
+test(
+  "give refuses container-held items without severing their containment",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8104),
+    });
+    await game.step({ frames: 5 });
+
+    // Male Corpse 1 (mission template 219) has exactly one authored item: a
+    // Psi Amp. Runtime ids vary between launches, so discover it through the
+    // stable container template and its live Contains link.
+    const corpses = await game.entities.byTemplate(219);
+    assert.equal(corpses.length, 1, "expected exactly one Male Corpse 1");
+    const corpse = corpses[0];
+    const before = await game.entities.detail(corpse.id);
+    const contains = before.outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.equal(contains.length, 1, "corpse should contain exactly one item");
+    const itemId = contains[0].target_id;
+
+    // Negative-first regression for #572: main accepts this request, moves the
+    // amp to the backpack, and permanently removes the corpse's Contains link.
+    await assert.rejects(
+      game.player.give(itemId),
+      /status 400.*container-held.*loot it via the container MFD/is,
+      "container-held items must be looted through the real container UI",
+    );
+
+    const after = await game.entities.detail(corpse.id);
+    const preserved = after.outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.deepEqual(
+      preserved,
+      contains,
+      "a rejected give must preserve the original Contains link exactly",
+    );
+    assert.ok(
+      !(await game.player.inventory()).items.some((item) => item.entity_id === itemId),
+      "a rejected give must not move the contained item into the backpack",
     );
   },
 );

--- a/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-drag.e2e.test.ts
@@ -223,10 +223,10 @@ test(
     });
     await game.step({ frames: 5 });
 
-    // Give the player a carried item (source doesn't matter here).
-    const { entities: nanites } = await game.entities.list({ filter: "*Nanites*", limit: 10 });
-    assert.ok(nanites[0], "expected a Nanites pickup in medsci1");
-    await game.player.give(nanites[0].id);
+    // Provision a fresh carried item (source doesn't matter here). Do not pick
+    // an arbitrary mission Nanites entity: some are authored container loot,
+    // which `/v1/player/give` intentionally refuses to preserve containment.
+    await game.player.spawnItem("Nanites");
 
     // Tab into use mode and lift the item onto the cursor.
     await game.input.trigger("ToggleUseMode");

--- a/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
+++ b/tools/shock2-sdk/test/inventory-strip.e2e.test.ts
@@ -23,7 +23,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 //
 // Item acquisition is honest where it matters: the Wrench is looted from MS
 // Male Corpse 1177 via the PR 3 loot panel (the authored first MedSci
-// interaction); the Nanites use the debug give lever as test setup.
+// interaction); the Nanites use debug template provisioning as test setup.
 //
 // Negative-first: on main, Tab already flips /v1/ui mode to "use" (the PR 1
 // mode flag) but NO inventory strip exists - `strip` is absent/null and no
@@ -55,13 +55,8 @@ test(
     };
 
     // --- Setup: give the player a couple of items ---
-    // Nanites via the debug give lever (plain test setup)...
-    const { entities: nanites } = await game.entities.list({
-      filter: "*Nanites*",
-      limit: 10,
-    });
-    assert.ok(nanites[0], "expected a Nanites pickup in medsci1");
-    await game.player.give(nanites[0].id);
+    // Fresh Nanites via debug template provisioning (plain test setup)...
+    await game.player.spawnItem("Nanites");
 
     // ...and the Wrench looted honestly through the PR 3 loot MFD.
     const corpses = await game.entities.byTemplate(CORPSE_WRENCH);


### PR DESCRIPTION
## Summary

- reject `POST /v1/player/give` before mutation when the target has an incoming `Contains` link
- return an actionable 400 naming both runtime entities and directing automation through the container MFD
- keep ordinary world-item give behavior covered and move unrelated UI setup away from arbitrary mission loot

## Reproduction

On base `736b8fc`, the new negative-first SDK scenario discovered the Psi Amp through Male Corpse 1's live `Contains` link and `/v1/player/give` accepted it instead of rejecting it:

```text
AssertionError: Missing expected rejection: container-held items must be looted through the real container UI
```

`MissionCore::give_item` passed every grabbable entity directly to `drop_entity_into_container`, whose legitimate reparenting behavior removes all prior incoming `Contains` links. That made the debug shortcut permanently empty the authored container.

## Fix

`give_item` now scans the live concrete links for an incoming `Contains` relationship after pickup eligibility is established and before any inventory or physics mutation. It returns:

```text
entity <item> is container-held by entity <container>; loot it via the container MFD
```

The regression asserts the exact original link remains unchanged and the item never enters the backpack. A separate control gives the known world-placed MedSci Cryo Card successfully.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr -p debug_runtime` — shock2vr 407/407, debug_runtime 1/1 (one display-only test ignored)
- `npm test` in `tools/shock2-sdk` — 26 passed, 0 failed
- focused give-item e2e — 2 passed, 0 failed
- full SDK e2e — 181 passed initially, 5 exact failures rerun green, 3 existing skips; final accounting 186 passed, 0 unresolved failures, all 23 missions loaded
  - two failures were invalid arbitrary-Nanites `/give` setup and pass after provisioning fresh Nanites instead
  - two launches hit `ENOSPC` and pass after generated incremental artifacts were cleared
  - the unrelated #481 alertness-churn route observation passed its isolated rerun

## Visual proof

Non-renderable: this changes only the debug HTTP endpoint's error contract and whether an internal `Contains` link is mutated. A rendered frame cannot expose either the 400 response or link preservation. The player-facing loot MFD and ordinary world pickup presentation are intentionally unchanged; their existing e2e scenarios pass. The deterministic SDK before/after assertion is the direct proof for this tooling-only behavior.

Fixes #572
