### PR TITLE
test(sdk): survive the Cargo 2B jump setup

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1154,10 +1154,11 @@ fn plan_climb_top_out(
 /// standing pose must fit against *all* colliders, and every scripted substep
 /// still collides with parented entities. Same-height and lower landings
 /// require a genuinely clear all-world point probe above the lip, so
-/// full-height walls remain solid. An elevated landing may use Dark's
-/// parentless-terrain jump-through probe: that is what permits authored
-/// stacked corridors such as shodan's log platforms, whose upper floor is a
-/// ceiling to the lower cell.
+/// full-height walls remain solid. An elevated landing may cross the local
+/// platform lip with Dark's parentless-terrain jump-through probe, but its
+/// initial vertical rise must remain clear against all world geometry. That
+/// is what permits authored stacked corridors such as shodan's log platforms
+/// without treating a room ceiling directly overhead as an exterior landing.
 fn plan_jump_mantle(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -1199,6 +1200,7 @@ fn plan_jump_mantle(
     let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
     while rise_ss2 <= max_rise * SCALE_FACTOR + 1.0e-4 && transition.is_none() {
         let raised = head + Vector::y() * (rise_ss2 / SCALE_FACTOR);
+        let vertical_probe_clear = ray_segment_is_clear(validation_queries, head, raised);
         let mut forward_ss2 = minimum_forward * SCALE_FACTOR;
         while forward_ss2 <= PLAYER_JUMP_MANTLE_FORWARD + 1.0e-4 {
             let forward = forward_ss2 / SCALE_FACTOR;
@@ -1220,7 +1222,9 @@ fn plan_jump_mantle(
                 let nearest_floor = validation_queries
                     .cast_ray_and_get_normal(&down_ray, 2.0 * max_rise, true)
                     .map(|(_, ground)| (ground.normal.y, raised_forward.y - ground.time_of_impact));
-                let elevated_floor = nearest_floor
+                let elevated_floor = vertical_probe_clear
+                    .then_some(nearest_floor)
+                    .flatten()
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1224,8 +1224,17 @@ fn plan_jump_mantle(
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {
-                        *floor_y - current_feet_y
-                            > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                        let rise = *floor_y - current_feet_y;
+                        rise > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                            // The compressed body models Dark's discontinuous
+                            // sphere stack crossing a terrain lip; it does not
+                            // add vertical reach. Require the player's feet to
+                            // be able to reach the landing within the ordinary
+                            // ballistic apex. Otherwise an open lift shaft can
+                            // turn the room ceiling ahead into an "elevated
+                            // floor" and script the player onto its exterior
+                            // roof (#744).
+                            && rise <= max_rise
                     });
                 // A same-height floor visible above the lower candidate is the
                 // stacked-terrain signature: the continuous capsule cannot

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -10,6 +10,7 @@ const CARGO_LIFT_OBJECT = 669;
 const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
 const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
 const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+const ENGINEERING_OG_PIPE_OBJECT = 1666;
 
 function only(matches: EntitySummary[], label: string): EntitySummary {
   assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
@@ -161,6 +162,99 @@ test(
       `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
         `north exit ${JSON.stringify(northExit)}, player ` +
         `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);
+
+// The Engineering campaign's authored maintenance-maze route reaches this
+// corridor from below. An idle OG-Pipe narrows the passage, but an ordinary
+// jump used to turn that local obstruction into a scripted crossing through
+// the corridor ceiling and leave the player supported on the exterior shell.
+test(
+  "ordinary jump past Engineering's OG-Pipe stays below the corridor ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG1_OG_PIPE_PORT ?? 8141),
+    });
+    await game.step({ frames: 30 });
+
+    const ogPipe = only(
+      await game.entities.byTemplate(ENGINEERING_OG_PIPE_OBJECT),
+      "maintenance-maze OG-Pipe mission object 1666",
+    );
+    assert.equal(ogPipe.name, "OG-Pipe");
+
+    // Setup only: stage at the campaign-observed interior approach, then let
+    // both player support and the authored dynamic creature settle. Starting
+    // the input edge before support is re-established after setup does not
+    // exercise a grounded production jump.
+    await game.player.teleport({
+      x: 4.4,
+      y: -15.556003,
+      z: -85.00001,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    const settledOgPipe = await game.entities.detail(ogPipe.id);
+    assert.ok(
+      Math.abs(before.x - 4.4) < 0.1 &&
+        Math.abs(before.y - -15.556003) < 0.1 &&
+        Math.abs(before.z - -85.00001) < 0.1,
+      `player should settle at the authentic maze approach, got ${JSON.stringify(before)}`,
+    );
+    assert.ok(
+      settledOgPipe.position[0] > 5 &&
+        settledOgPipe.position[0] < 7 &&
+        Math.abs(settledOgPipe.position[1] - -15.1) < 0.15 &&
+        settledOgPipe.position[2] > -86 &&
+        settledOgPipe.position[2] < -84,
+      `stable OG-Pipe 1666 should occupy the authored choke, got ` +
+        JSON.stringify(settledOgPipe.position),
+    );
+
+    // Self-check the nearby parentless world slab that bounds the corridor.
+    // The exploit exits through this ceiling and settles above its y plane.
+    const ceiling = await game.raycast({
+      start: [7.5, before.y, -84.5],
+      end: [7.5, -9, -84.5],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceiling.hit_point && Math.abs(ceiling.hit_point[1] - -12.9) < 0.1,
+      `expected maintenance-maze world ceiling at y=-12.9, got ${JSON.stringify(ceiling)}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim through the choke,
+    // hold ordinary forward locomotion, and pulse one grounded Jump edge.
+    await game.input.lookAtWorldPoint([8, before.y + 1.6, -84.5]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+    const landed = await game.player.position();
+    await game.step({ frames: 240 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceiling.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the OG-Pipe corridor ceiling ` +
+        `(${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `OG-Pipe 1666 ${JSON.stringify(settledOgPipe.position)}, player ` +
+        `${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
         `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
     );
   },

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -54,6 +54,14 @@ test(
       "top lift button mission object 620",
     );
 
+    // Setup only: driving the lift below costs 1200 fixed-timestep frames, and
+    // eng2's mission start leaves the player standing in a wandering ranged
+    // hybrid's line of fire, which kills an unattended player in ~14s. Park on
+    // the Cargo 2B top landing, out of that fire lane, so setup cannot decide
+    // the measurement.
+    await game.player.teleport({ x: 44, y: 5, z: -165 });
+    await game.step({ frames: 90 });
+
     // Setup only: drive the real lift along its authored 477 -> 478 -> 479
     // path and stage at the exact campaign-observed top-stop pose.
     await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
@@ -77,6 +85,12 @@ test(
       z: -168.2003,
     });
     await game.step({ frames: 30 });
+    const staged = await game.info();
+    assert.ok(
+      (staged.player.hit_points ?? 0) > 0,
+      `setup must not kill the player before the jump is measured, got ` +
+        `${staged.player.hit_points} hp (a dead player cannot walk or jump)`,
+    );
     const before = await game.player.position();
     assert.ok(
       Math.abs(before.x - 43.9006) < 0.1 &&

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CARGO_LIFT_OBJECT = 669;
+const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
+const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
+const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+async function pulseJump(game: GameServer): Promise<void> {
+  await game.input.setJump(true);
+  await game.step({ frames: 1 });
+  await game.input.setJump(false);
+}
+
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// reached Cargo 2B's top lift through ordinary play. Walking north from the
+// lift toward its top call button is the valid route; jumping west instead
+// exposed a collision escape onto the exterior roof.
+test(
+  "ordinary jump stays below Engineering Cargo 2B's world ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG2_CEILING_PORT ?? 8140),
+    });
+    await game.step({ frames: 5 });
+
+    const lift = only(
+      await game.entities.byTemplate(CARGO_LIFT_OBJECT),
+      "Cargo 2B East lift mission object 669",
+    );
+    const bottomButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_BOTTOM_BUTTON_OBJECT),
+      "bottom lift button mission object 480",
+    );
+    const middleButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_MIDDLE_BUTTON_OBJECT),
+      "middle lift button mission object 481",
+    );
+    const topButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_TOP_BUTTON_OBJECT),
+      "top lift button mission object 620",
+    );
+
+    // Setup only: drive the real lift along its authored 477 -> 478 -> 479
+    // path and stage at the exact campaign-observed top-stop pose.
+    await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const middleLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(middleLift.position[1] - -5.1) < 0.1,
+      `lift should reach authored middle node y=-5.1, got ${middleLift.position[1]}`,
+    );
+    await game.entities.sendMessage(middleButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const topLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(topLift.position[1] - 2.1) < 0.1,
+      `lift should reach authored top node y=2.1, got ${topLift.position[1]}`,
+    );
+
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    assert.ok(
+      Math.abs(before.x - 43.9006) < 0.1 &&
+        Math.abs(before.y - 3.144) < 0.1 &&
+        Math.abs(before.z - -168.2003) < 0.1,
+      `player should settle at the campaign lift pose, got ${JSON.stringify(before)}`,
+    );
+
+    // Control: the authored route walks north off the same top stop toward
+    // button 620. Prove it remains available, then return to the exact setup
+    // pose without carrying input or a jump edge into the regression.
+    await game.input.lookAtWorldPoint([
+      topButton.position[0],
+      before.y + 1.6,
+      topButton.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const northExit = await game.player.position();
+    assert.ok(
+      northExit.z > -166 && northExit.y < 6.8,
+      `ordinary walking should leave the lift north toward top button 620, got ` +
+        JSON.stringify(northExit),
+    );
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const jumpStart = await game.player.position();
+
+    // Self-check the parentless world slab the campaign escaped through.
+    // Probing from below sees its underside, while the reverse ray finds the
+    // exterior roof at the same y. This is level geometry, not a lift entity.
+    const ceilingUp = await game.raycast({
+      start: [41.5, jumpStart.y, -169.1],
+      end: [41.5, 10, -169.1],
+      collision_groups: ["world"],
+    });
+    const roofDown = await game.raycast({
+      start: [41.5, 10, -169.1],
+      end: [41.5, jumpStart.y, -169.1],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceilingUp.hit_point &&
+        roofDown.hit_point &&
+        Math.abs(ceilingUp.hit_point[1] - 6.8) < 0.1 &&
+        Math.abs(roofDown.hit_point[1] - 6.8) < 0.1,
+      `expected Cargo 2B world ceiling/roof at y=6.8, got ` +
+        `${JSON.stringify({ ceilingUp, roofDown })}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim west, hold ordinary
+    // forward locomotion, pulse one grounded jump edge, then release.
+    await game.input.lookAtWorldPoint([39, jumpStart.y + 1.6, -170]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 180 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 180 });
+    const landed = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceilingUp.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the Cargo 2B ceiling ` +
+        `(${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
+        `north exit ${JSON.stringify(northExit)}, player ` +
+        `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- park the player on the Cargo 2B top landing for the lift ride so the eng2 ceiling case's 1200-frame setup cannot kill the player it is about to measure
- assert the staged player is alive, so a future setup hazard reports itself instead of masquerading as a locomotion or mantle result

Stacked on `fix/cargo2-ceiling-escape` (PR #745), which owns the test.

## The drift

`jump-ceiling.e2e.test.ts` drives the real Cargo 2B lift (frob 480, step 600, frob 481, step 600) before teleporting the player onto its top stop. Throughout those 1200 fixed-timestep frames the player stands unattended at eng2's mission start.

Two changes have landed on `main` since the test was written:

- **#750** (`fix(ai): let hostile ranged attacks damage player`) - the wandering `OG-Shotgun` hybrid near the eng2 start now actually damages the player. Measured on `origin/main` @ `cd00795f`: it goes `Wander/Low -> RangedAttack/Moderate` around frame 305 and lands 6 damage roughly every 90 frames, taking the player from 30 hp to 0 by ~frame 865 - before the lift finishes its ride.
- **#753** (`fix(gameplay): handle player death and QBR respawn`) - a dead player's input is suppressed.

Together they make the setup fatal, and the *control* assertion is what fails:

```text
AssertionError: ordinary walking should leave the lift north toward top button 620,
got {"x":43.900566,"y":3.144,"z":-168.2003}
```

The player did not move a millimetre because it was a corpse (`life_state: "dead"`, 0 hp) - the jump under test was never exercised. This reproduces byte-identically on `origin/main` @ `cd00795f` with the test file dropped in.

## Validation

All runs `SHOCK2_E2E=1`, `DARK_ASSET_PATH` pointed at unpacked retail data.

| build | test | result |
| --- | --- | --- |
| `origin/main` @ `cd00795f` (no mantle bound) | original | FAIL on setup control - player dead, zero movement |
| `origin/main` @ `cd00795f` (no mantle bound) | **this PR** | setup + control pass, then FAILs on the real assertion: `(43.900566, 3.144, -168.2003) -> (34.538307, 8.043818, -171.638290)`, above the `y=6.8` ceiling - the guard is live |
| `fix/cargo2-ceiling-escape` @ `c42bfd82` | **this PR** | PASS, both eng2 and eng1 cases |

The staged pose settles at `(43.805, 3.244, -165.207)` on the top landing and holds 30/30 hp across the full 1200-frame ride, so the lift assertions (`y=-5.1` then `y=2.1`) and the campaign-observed jump pose are unchanged.

`npm test` (SDK unit suite): 26 pass / 0 fail. `tsc` clean on both bases. No Rust changed.