### PR TITLE
fix(physics): keep a loaded crouch under a low ceiling

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2068,6 +2068,10 @@ pub struct PhysicsWorld {
     physics_pipeline: PhysicsPipeline,
     island_manager: IslandManager,
     broad_phase: DefaultBroadPhase,
+    /// Whether the pipeline has stepped at least once. Rapier builds the
+    /// broad-phase BVH inside `PhysicsPipeline::step`, so until this is true
+    /// every spatial query against this world matches nothing at all.
+    has_stepped: bool,
     narrow_phase: NarrowPhase,
     impulse_joint_set: ImpulseJointSet,
     multibody_joint_set: MultibodyJointSet,
@@ -3215,7 +3219,21 @@ impl PhysicsWorld {
                     },
                 )
                 .is_some();
-            let blocked = overlaps_final_pose || blocked_by_crown_sweep;
+            // Both probes above are spatial queries, and Rapier only builds the
+            // broad-phase BVH inside `PhysicsPipeline::step`. On a world that
+            // has never been stepped they therefore match nothing and report
+            // "clear" everywhere, which is not an answer - it is the absence of
+            // one. Refuse to expand into geometry we cannot see yet: the very
+            // next frame has a populated broad phase and re-decides normally.
+            //
+            // This is exactly the load frame. `Game::load_from_file` rebuilds
+            // the world, re-applies the saved crouch, and then runs a frame
+            // whose crouch input is released - which used to stand the player
+            // up inside the ceiling they had saved under (hydro2's "Low Head
+            // Room" ledge, issue #773). A standing capsule embedded in level
+            // geometry is unrecoverable: the character controller resolves zero
+            // movement in every direction for the rest of the session.
+            let blocked = !self.has_stepped || overlaps_final_pose || blocked_by_crown_sweep;
 
             if !blocked {
                 self.collider_set[collider_handle].set_shape(standing_player_shared_shape());
@@ -3263,6 +3281,7 @@ impl PhysicsWorld {
             physics_pipeline,
             island_manager,
             broad_phase,
+            has_stepped: false,
             narrow_phase,
             impulse_joint_set,
             multibody_joint_set,
@@ -3468,6 +3487,7 @@ impl PhysicsWorld {
                 &self.events,
             )
         });
+        self.has_stepped = true;
 
         // Update character controller
         let desired_movement = vec_to_nvec(desired_movement);
@@ -5175,6 +5195,9 @@ mod tests {
         world.set_player_translation(vec3(1.0, 2.0, 3.0), &mut player);
         assert_player_capsule_dimensions(&world, &player, 2.8, 1.6);
 
+        // Standing up runs a headroom query, which only has an answer once the
+        // pipeline has stepped and built its broad phase.
+        step(&mut world, &mut player, 1);
         assert!(!world.set_player_crouch(false, &mut player));
         assert_player_capsule_dimensions(&world, &player, 6.0, 2.4);
     }
@@ -7968,6 +7991,114 @@ mod tests {
         assert!(
             crouched_world.set_player_crouch(false, &mut crouched_player),
             "standing must be refused under the five-foot ceiling"
+        );
+    }
+
+    /// A crawlspace whose 3.875 ft clearance admits the 2.8 ft crouched body
+    /// but not the 6 ft standing one, entered at the standing-equivalent
+    /// collider centre a save file stores (`GlobalData::position`).
+    fn world_with_low_ceiling_crawlspace() -> (PhysicsWorld, PlayerHandle) {
+        let mut world = PhysicsWorld::new();
+        for (entity, y) in [(1000u64, 0.0), (1001, 1.55)] {
+            world.add_collider(
+                EntityId::from_inner(entity).unwrap(),
+                ColliderBuilder::trimesh(
+                    vec![
+                        point![-50.0, y, -50.0],
+                        point![50.0, y, -50.0],
+                        point![50.0, y, 50.0],
+                        point![-50.0, y, 50.0],
+                    ],
+                    vec![[0u32, 1, 2], [0, 2, 3]],
+                )
+                .expect("crawlspace trimesh")
+                .build(),
+            );
+        }
+        let player = world.create_player(
+            vec3(0.0, PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        (world, player)
+    }
+
+    /// Loading a save taken while crouched must not expand the player into the
+    /// ceiling they were crouched under on the very first frame.
+    ///
+    /// `Game::load_from_file` builds a fresh world, re-applies the saved crouch
+    /// (`Mission::restore_saved_crouch`) and then runs a frame whose crouch
+    /// input is released, so the stand-up headroom probes run before the world
+    /// has ever been stepped - i.e. against a broad phase Rapier has not built.
+    ///
+    /// Negative-first: those probes used to report "clear" (they match nothing
+    /// at all), standing the 6 ft capsule up inside a 3.875 ft clearance. An
+    /// embedded capsule is unrecoverable - the character controller resolves
+    /// zero movement in every direction - which is the permanently stuck hydro2
+    /// "Low Head Room" pose reported in issue #773.
+    #[test]
+    fn first_frame_after_load_keeps_a_crouch_the_ceiling_requires() {
+        let (mut world, mut player) = world_with_low_ceiling_crawlspace();
+        // What `Mission::restore_saved_crouch` does at load, on a world the
+        // physics pipeline has not stepped yet.
+        assert!(
+            world.set_player_crouch(true, &mut player),
+            "the saved crouch must shrink the collider"
+        );
+        // Frame 1: the crouch key is not held.
+        assert!(
+            world.set_player_crouch(false, &mut player),
+            "standing must stay refused before the world can answer a query"
+        );
+
+        // ...and the player is still free to crawl back out.
+        step(&mut world, &mut player, 10);
+        let start = world.get_player_translation(&player);
+        for _ in 0..60 {
+            world.update(vec3(-10.0 / 60.0, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            start.x - end.x > 2.0,
+            "a loaded crouched player must still move, went {start:?} -> {end:?}"
+        );
+        assert!(
+            player.is_crouched(),
+            "the ceiling must still refuse standing once the world is queryable"
+        );
+    }
+
+    /// The same first-frame load against the real hydro2 geometry and the exact
+    /// pose stored in the issue #773 save (`(84.37742, 4.044117, 20.42488)`,
+    /// `is_crouched: true`): the "Low Head Room" ledge under the Sector C
+    /// window row, where the brush ceiling sits 1.55 wu above the y=2.8 floor.
+    /// Skipped when the game data is absent (CI); the synthetic fixture above
+    /// covers the same regression there.
+    #[test]
+    fn hydro2_low_head_room_save_pose_stays_crouched_on_load() {
+        let Some(level) = try_load_level("hydro2.mis") else {
+            return;
+        };
+        let mut world = PhysicsWorld::new();
+        world.add_level_geometry(EntityId::from_inner(1).unwrap(), &level);
+        let mut player = world.create_player(
+            vec3(84.37742, 4.044117, 20.42488),
+            EntityId::from_inner(2).unwrap(),
+        );
+        assert!(world.set_player_crouch(true, &mut player));
+        assert!(
+            world.set_player_crouch(false, &mut player),
+            "the hydro2 ledge has no standing headroom, so the load frame must stay crouched"
+        );
+
+        step(&mut world, &mut player, 10);
+        let start = world.get_player_translation(&player);
+        for _ in 0..90 {
+            world.update(vec3(-10.0 / 60.0, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            start.x - end.x > 2.0,
+            "the loaded player must be able to crawl back along the ledge, went {start:?} -> {end:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/crouch-load-headroom.e2e.test.ts
+++ b/tools/shock2-sdk/test/crouch-load-headroom.e2e.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
+import { test } from "node:test";
+import { join } from "node:path";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Locate the on-disk .sav for a save name (mirrors shock2vr::save_file_path =
+// <data_root>/saves/<name>.sav; data_root is DARK_ASSET_PATH or a ./Data search
+// relative to the repo root), so the test can clean up after itself.
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((d): d is string => Boolean(d));
+  for (const root of roots) {
+    const p = join(root, "saves", `${saveName}.sav`);
+    if (existsSync(p)) return p;
+  }
+  return undefined;
+}
+
+// Regression test for #773: loading a save taken while crouched under a low
+// ceiling must not stand the player up into it.
+//
+// The load path re-applies the saved crouch, then runs a frame whose crouch
+// input is released. Standing up is gated on a headroom shape query, and Rapier
+// only rebuilds the broad-phase BVH inside its pipeline step - so on the first
+// frame of a freshly built world the query matched nothing, the check read
+// "clear", and the six-foot capsule expanded into the ceiling. Once embedded in
+// level geometry the character controller resolves no movement at all, in any
+// direction, for the rest of the session.
+//
+// The fixture is hydro2's "Low Head Room" ledge above the Sector C window row
+// (floor y=2.8, brush ceiling y~=4.35 - 1.55 wu, less than the 2.4 wu standing
+// body), which is where the campaign play-through hit this.
+test(
+  "a save taken crouched under a low ceiling reloads crouched and mobile",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `crouch_load_headroom_e2e_${Date.now()}`;
+    t.after(() => {
+      const path = findSavePath(saveName);
+      if (path) rmSync(path, { force: true });
+    });
+
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8237),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    // Stand on the open (six-foot-clearance) end of the ledge, then crawl into
+    // the low-headroom pocket with ordinary locomotion input.
+    await teleportVerified(game, { x: 83.67, y: 4.04, z: 19.7 });
+    await game.step({ frames: 10 });
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 10 });
+    await game.input.set("head.look", [90, 0]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 40 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    const preSave = await game.player.position();
+    const ceiling = await game.raycast({
+      start: [preSave.x, preSave.y, preSave.z],
+      end: [preSave.x, preSave.y + 6.0, preSave.z],
+      collision_groups: ["world"],
+    });
+    // Feet are half a crouched body (0.56 wu) below the collider center; the
+    // standing body is 2.4 wu tall, so anything under 2.4 wu of clearance is
+    // crouch-only.
+    assert.ok(
+      ceiling.hit_point && ceiling.hit_point[1] - (preSave.y - 0.56) < 2.4,
+      `setup must be under a crouch-only ceiling: ${JSON.stringify(ceiling)} over feet y=${(preSave.y - 0.56).toFixed(2)}`,
+    );
+
+    await game.save(saveName);
+
+    // Release crouch BEFORE loading: this is the cold-load case (nothing is
+    // holding the crouch key when the restored world runs its first frame).
+    await game.input.set("crouch", 0);
+    await game.load(saveName);
+    await game.step({ frames: 30 });
+
+    const loaded = await game.player.position();
+    assert.ok(
+      Math.abs(loaded.y - preSave.y) < 0.2,
+      `loading must keep the crouched pose the ceiling requires ` +
+        `(y ${preSave.y.toFixed(3)} -> ${loaded.y.toFixed(3)}; standing would be +0.64)`,
+    );
+
+    // ...and the player must still be able to crawl back out under production
+    // locomotion. An embedded capsule reports exactly zero displacement here.
+    await game.input.set("head.look", [270, 0]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const walked = await game.player.position();
+    assert.ok(
+      loaded.z - walked.z > 2.0,
+      `a loaded crouched player must still move ` +
+        `(${JSON.stringify(loaded)} -> ${JSON.stringify(walked)})`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #773

campaign: engineering-through-shodan · none · legacy · seed 1378752978

## What actually blocks the campaign save

Loading `iter17_hydro_dark_descent_blocked.sav` leaves the player **completely
immobile — in every direction, forever**, not just toward the alleged descent.
That is a real player-physics defect, and it is what the issue's "Actual"
section describes ("Ordinary crouch plus thumbstick, jump-forward, and
collision-valid short move attempts all reproduce the same cap").

Root cause:

- The save records `is_crouched: true` and stores the **standing-equivalent**
  collider centre (`GlobalData::position` = `(84.37742, 4.044117, 20.42488)`).
- `Game::load_from_file` builds a fresh `PhysicsWorld`, creates the standing
  capsule there and calls `Mission::restore_saved_crouch()` — correct so far,
  the player is crouched at y 3.404 immediately after load.
- Frame 1 then runs with the crouch key released, so `set_player_crouch(false)`
  runs its **stand-up headroom test**. That test is a shape query, and Rapier
  only rebuilds the broad-phase BVH inside `PhysicsPipeline::step` — which had
  not run yet, because `mission_core` applied the crouch *before*
  `PhysicsWorld::update_with_facing_and_jump`.
- With an empty BVH the query matches nothing, the check reads "clear", and the
  6 ft capsule expands into a ceiling 1.55 wu above the floor. The kinematic
  character controller can no longer resolve any motion, so every subsequent
  input produces exactly zero displacement.

Measured directly on the runtime (`/v1/physics/raycast` immediately after
`POST /v1/load`, before any `/v1/step`):

```
raycast down through the player column, right after load : {"hit":false}
the same raycast after one /v1/step                      : hit at y=4.350243
```

## The fix

Track whether the pipeline has stepped, and treat the stand-up probes as
**blocked** until it has. That is the whole change — 4 production lines. No
coordinates, no shims, and no behaviour change on any other frame: the next
frame has a populated broad phase and decides normally, and the guard can only
ever keep the *smaller* capsule, never expand into geometry it cannot see. A
fresh mission start is unaffected (the player is already standing, so the
request is a no-op).

```rust
let blocked = !self.has_stepped || overlaps_final_pose || blocked_by_crown_sweep;
```

Considered and rejected: deferring the crouch until after the step (so the
headroom test always sees the current frame's broad phase). It fixes #773 too,
but it moves a body-pose write between two steps — Rapier syncs a parented
collider's world pose to its body only inside its step, while `move_player`
reads the **collider** pose and writes back to the **body**, so a crouching,
standing-still player fell through the floor. Even with that repaired it
perturbed every crouch decision on the map: `jump.e2e.test.ts`'s shodan
log-4 descent drifted 0.03 wu past its authored tread window. Priming the world
with an extra step at load has the same "changes every load" problem. Refusing
to answer an unanswerable query touches only the frame that was broken.

## Before / after

Same binary invocation both sides, same save, same production input: cold-load
the campaign save, then hold ordinary locomotion for 120 fixed frames.

| | `origin/main` | this branch |
| --- | --- | --- |
| pose after load | standing, y 4.044 (embedded in the ceiling) | crouched, y 3.404 |
| after 120 frames of forward input | `(84.377, 4.044, 20.425)` — **0.000 wu** | `(84.413, 3.404, 6.780)` — **13.16 wu** |

| before (origin/main) | after |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/1c06dae173369d91cc20efa2663a5922/raw/fix773-before.gif) | ![after](https://gist.githubusercontent.com/tommy-xr/1c06dae173369d91cc20efa2663a5922/raw/fix773-after.gif) |
| ![before still](https://gist.githubusercontent.com/tommy-xr/1c06dae173369d91cc20efa2663a5922/raw/fix773-before-still.png) | ![after still](https://gist.githubusercontent.com/tommy-xr/1c06dae173369d91cc20efa2663a5922/raw/fix773-after-still.png) |

Continuing with production locomotion from the same save on this branch walks
the frontier back out of the pocket and across the deck — the player also
stands up again by itself as soon as there is headroom:

```
loaded              (84.377, 3.404, 20.424)   crouched
north along ledge   (84.371, 3.404, 10.591)
west along ledge    (69.607, 4.044, 10.433)   <- stands up where headroom allows
north               (69.441, 4.044,  7.438)
west                (54.696, 4.044,  7.571)
west                (49.949, 4.044,  7.494)
```

## Faithfulness gate: the "dark descent" itself is authored-closed

The issue asks for the y=2.8 ledge at x 84–85 to open onto the y=0.8 floor at
z ≥ 21.75. It does not, and no code change should make it. Read-only evidence:

- **Vertical column probes at x=84.4** (repeated raycasts down the column,
  collecting every face): z=20.25 → `4.4 / 2.8 / 0.8 / -1.87`;
  z=20.5 → `4.2 / 2.8 / 0.6 / -1.73`; z=20.75 → `3.7 / 2.8 / 0.1 / -1.4`;
  z=21.0 → `3.2 / 2.8 / -0.4 / -1.07`; z=21.25 and z=21.5 → **no faces at all
  (solid)**; z=21.75 → `0.8 / 0.4 / -2.4`. The sloped brush ceiling descends
  2 units per unit of z and **wedges onto the y=2.8 floor at z ≈ 21.2**. The
  crouched capsule stopping at z ≈ 20.42–20.49 is that wedge, not a lip.
- **Horizontal probes** at x=84.4 find a full-height brush face at **z = 21.6**
  from y=-2.3 up to y=4.2. There is no aperture at any height.
- **AIPATH** (`cargo bn path cell hydro2.mis`): the ledge cells under the player
  (2342 @ `(82.30, 2.80, 20.60)`, 2352 @ `(84.60, 2.80, 18.40)`) have **no WALK
  links at all**, while the lower floor cell 2283 @ `(85.20, 0.80, 22.80)` sits
  in a different walk component — the same one that contains the ACR3 area cell
  1957 @ `(75.03, 3.20, 23.40)`. Nothing authored crosses that wall.
- The **"Low Head Room" sign** the issue anchors on (`hydro2` id 433) is at
  `(85.0, -0.4, 21.616)`, i.e. mounted on that z=21.6 wall at y=-0.4 — it
  belongs to the *lower* passage (floor y≈-1.1…-2.4), two storeys below the
  y=2.8 ledge. Same for `Infectious Biohazard` id 18 at `(86.6, -0.4, 21.63)`.
- Cold storage is nowhere near here: ACR2 is `hydro2` id 913 @
  `(33.4, -6.0, -50.0)` and the Hydro A card is in corpse id 1297 @
  `(46.1, -8.6, -39.4)`, reached through the `FrostedGlass1` id 795 breach @
  `(28.4, 3.6, -46.4)`. The blocked pose is at x=84, z=20 — the opposite corner
  of the deck.

So the ledge is a dead end by design; the campaign blocker was the wedged
capsule, and the frontier is reachable again once the player can move.

## Coverage

Negative-first, all red before the change and green after:

- `shock2vr` `first_frame_after_load_keeps_a_crouch_the_ceiling_requires` —
  synthetic 3.875 ft crawlspace, runs on CI without game data.
- `shock2vr` `hydro2_low_head_room_save_pose_stays_crouched_on_load` — the exact
  pose from the issue save against real `hydro2.mis` geometry; skipped when
  `Data/` is absent.
- `tools/shock2-sdk/test/crouch-load-headroom.e2e.test.ts` — crawls onto the
  ledge with production locomotion, saves, releases crouch, reloads. Red on
  `origin/main`: `loading must keep the crouched pose the ceiling requires
  (y 3.404 -> 4.044; standing would be +0.64)`.

`player_capsule_uses_original_standing_and_existing_crouched_footprints` now
steps once before its stand-up assertion, since that branch needs a world that
can answer a query.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo check -p dark_viewer -p dark_query -p debug_command -p bench`
- `cargo test -p shock2vr` — 426 passed (incl. the existing crouch / ladder /
  mantle suites)
- `cargo fmt --all`
- SDK e2e suite (`SHOCK2_E2E=1 npm run test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
