### PR TITLE
fix(hud): fit the Research MFD progress line's % glyph

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -898,6 +898,12 @@ impl Game {
                 // Log/email sender portraits + deck icons (the reader panel art).
                 ZipAssetPath::new(resource_path("res/book.crf")),
                 ZipAssetPath::new(resource_path("res/fam.crf")),
+                // The canonical font family. iface.crf also bundles a "fonts/"
+                // subfolder sharing most of these basenames (mostly identical,
+                // but its MAINFONT.FON/MAINAA.FON are stripped copies missing
+                // glyph data for '%' and '&' - a 1px-wide blank cell instead of
+                // the real bitmap), so this must be mounted first to win.
+                ZipAssetPath::new(resource_path("res/fonts.crf")),
                 // Also mounted under the "iface/" namespace: iface.crf shares seven
                 // basenames with the obj/bitmap mounts above (access/block/log/
                 // plant1/repair/stats.pcx + palette1.pal), and first-mount-wins

--- a/shock2vr/src/zip_asset_path.rs
+++ b/shock2vr/src/zip_asset_path.rs
@@ -172,3 +172,58 @@ impl AbstractAssetPath for ZipAssetPath {
         Some(RefCell::new(Box::new(Cursor::new(file_contents))))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::assets::asset_paths::AssetPath;
+
+    /// `res/iface.crf` bundles its own `fonts/` subfolder sharing most
+    /// basenames with `res/fonts.crf` (the canonical font family) - almost all
+    /// byte-identical, but its `MAINFONT.FON`/`MAINAA.FON` are stripped copies
+    /// missing glyph data for `%` and `&` (a 1px-wide blank cell instead of the
+    /// real bitmap - shock2quest issue #778, the Research MFD's "Research: 5%"
+    /// progress line rendering as "Research: 5"). `fonts.crf` must be mounted
+    /// ahead of `iface.crf` (as `Game::init` does) so the bare "mainfont.fon"
+    /// lookup resolves to the complete font, not the archive that merely
+    /// happens to also carry a `fonts/` subfolder.
+    #[test]
+    fn fonts_crf_outranks_iface_crfs_bundled_fonts_folder() {
+        let root = std::env::var("DARK_ASSET_PATH").unwrap_or_else(|_| "../Data".to_owned());
+        let fonts_crf = format!("{root}/res/fonts.crf");
+        let iface_crf = format!("{root}/res/iface.crf");
+        if !std::path::Path::new(&fonts_crf).exists() || !std::path::Path::new(&iface_crf).exists()
+        {
+            eprintln!("skipping: res/fonts.crf or res/iface.crf not found under {root}");
+            return;
+        }
+
+        // Same relative order as the `Game::init` mount list: fonts.crf first.
+        let mounts = AssetPath::combine(vec![
+            ZipAssetPath::new(fonts_crf.clone()),
+            ZipAssetPath::with_namespace(iface_crf, "iface"),
+        ]);
+        let reader = mounts
+            .get_reader(String::new(), "mainfont.fon".to_owned())
+            .expect("mainfont.fon should resolve from either mount");
+        let mut bytes = Vec::new();
+        reader.borrow_mut().read_to_end(&mut bytes).unwrap();
+
+        // fonts.crf's MAINFONT.FON is 1737 bytes; iface.crf's stripped copy is
+        // 1715. Confirms the resolved bytes came from fonts.crf, not iface.crf.
+        let expected = std::fs::read(&fonts_crf)
+            .ok()
+            .and_then(|zip_bytes| {
+                let mut archive = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes)).ok()?;
+                let mut file = archive.by_name("MAINFONT.FON").ok()?;
+                let mut out = Vec::new();
+                file.read_to_end(&mut out).ok()?;
+                Some(out)
+            })
+            .expect("fonts.crf should contain MAINFONT.FON directly");
+        assert_eq!(
+            bytes, expected,
+            "mainfont.fon must resolve to fonts.crf's complete copy, not iface.crf's stripped one"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The Research MFD's progress line (`"Research: N%"`) rendered with the `%`
  glyph completely missing (`"Research: 5"` instead of `"Research: 5%"`),
  reproduced live via the debug runtime (hydro2.mis, Anti-Annelid Toxin,
  Research skill 1, use-mode double-click).
- Root cause: **not** a layout/rect clipping bug - `GET /v1/ui` already
  reported the correct full string, and the flat-mode text renderer draws
  left-aligned with no scissor/clip against its box. It's a font **asset
  mount priority** bug: `res/iface.crf` bundles its own `fonts/` subfolder
  that shares most basenames with the canonical `res/fonts.crf` family
  (byte-identical for `keyfont`/`numfont`/`keyfonta`/`bignum`/`boldaa`), but
  its `MAINFONT.FON` and `MAINAA.FON` are older, stripped copies with a
  corrupted `%` glyph cell (1px wide, entirely blank in the source bitmap -
  same for `&`). `res/fonts.crf` (the intact copy, `%` glyph width 10-11px)
  was never mounted at all in `Game::init`'s classic-install asset path
  list, so the bare `"mainfont.fon"` lookup fell through to `iface.crf`'s
  broken copy via its basename-collapsing.

## Root cause detail

```
res/fonts.crf  MAINFONT.FON         1737 bytes  '%' glyph width = 10px  (correct)
res/iface.crf  fonts/MAINFONT.FON   1715 bytes  '%' glyph width =  1px, blank (corrupt)
```

Confirmed byte-for-byte against the unpacked data tree and by decoding the
packed 1bpp glyph bitmaps directly - the `iface.crf` copy's `%` and `&`
cells are genuinely blank in the source data, not a parsing bug in the
`.FON` reader (`dark::font`). The mount list in `shock2vr/src/lib.rs`
already mounts one archive per resource family (`obj.crf`, `bitmap.crf`,
`book.crf`, `fam.crf`, `mesh.crf`, ...) - `fonts.crf` was simply missing
from that list.

## Change

- `shock2vr/src/lib.rs`: mount `res/fonts.crf` ahead of `res/iface.crf` in
  the classic-install mount list, so it wins the existing
  mount-first-wins resolution for the shared basenames.
- `shock2vr/src/zip_asset_path.rs`: regression test
  `fonts_crf_outranks_iface_crfs_bundled_fonts_folder` - mounts `fonts.crf`
  then `iface.crf` in the same relative order as `Game::init` and asserts
  the bare `"mainfont.fon"` lookup resolves to `fonts.crf`'s bytes, not
  `iface.crf`'s stripped copy. Guarded by real-asset presence (no-ops
  without game data). Verified negative-first: swapping the mount order
  back to iface-first reproduces the assertion failure before being
  reverted to the fix.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean.
- `cargo test -p shock2vr` - 492 passed, 0 failed.
- `cargo fmt --all`.
- Reproduced live before the fix and confirmed fixed after: debug runtime,
  hydro2.mis, spawned the Anti-Annelid Toxin (`template_id: -1341`), set
  Research skill to 1, entered use mode, double-clicked the vial in the
  inventory strip. See before/after below.

## Visual verification

![Research MFD before/after - '%' glyph missing vs fixed](https://gist.githubusercontent.com/tommy-xr/4ced0c612fdf6471964876c30a114ac3/raw/research_mfd_beforeafter.png)

<sub>Live in-game capture via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), same repro sequence on both builds: hydro2.mis, spawn the Anti-Annelid Toxin, set Research skill 1, enter use mode, frob the vial to open the Research MFD.</sub>

![fonts.crf vs iface.crf MAINFONT.FON glyph decode - '%' and '&' cells](https://gist.githubusercontent.com/tommy-xr/4ced0c612fdf6471964876c30a114ac3/raw/glyph_comparison.png)

<sub>Root-cause evidence: the packed 1bpp glyph bitmaps decoded directly from both archives' MAINFONT.FON (offsets/format per `dark::font`). `iface.crf`'s copy has genuinely blank `%`/`&` cells in the source data - not a rendering or parsing bug.</sub>

campaign: engineering-through-shodan · none · legacy · seed 1378752978

Fixes #778

