### PR TITLE
fix(gameplay): return swapped weapons to the backpack

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -3,7 +3,7 @@
 //! The dedicated flatscreen analog of `VirtualHand`: it wields a single weapon
 //! as a first-person viewmodel, fires it on the trigger, and uses/frobs/picks
 //! up the object under the crosshair. It produces the same `VirtualHandEffect`s
-//! the VR hands do (`HoldItem`, `DropItem`, `SetPositionRotation`,
+//! the VR hands do (`HoldItem`, `StoreItem`, `SetPositionRotation`,
 //! `OutMessage { TriggerPull/Release/Frob }`), so `mission_core` processes VR
 //! and flat through one shared path, and the weapon/frob scripts run unchanged.
 //!
@@ -103,12 +103,19 @@ impl FlatPlayerController {
     }
 
     /// Wield `entity_id` as the first-person weapon. Any previously-wielded
-    /// weapon is dropped back into the world (regains physics + world model).
+    /// weapon is holstered back into the player's backpack, as the original
+    /// does - a swap never costs you the weapon (#777). Only an explicit drop
+    /// (the use-mode throw) puts a carried weapon back in the world.
     pub fn wield(&mut self, entity_id: EntityId) -> Vec<VirtualHandEffect> {
         let mut effects = Vec::new();
         if let Some(prev) = self.wielded_entity {
             if prev != entity_id {
-                effects.push(VirtualHandEffect::DropItem { entity_id: prev });
+                // `Drop` is what tells the weapon it left the hand: it restores
+                // the world model over the first-person `_h` mesh and cancels a
+                // charging psi amp. The item then goes to the backpack instead
+                // of gaining physics presence at the viewmodel's position.
+                effects.push(out_message(prev, MessagePayload::Drop));
+                effects.push(VirtualHandEffect::StoreItem { entity_id: prev });
             }
         }
         self.wielded_entity = Some(entity_id);
@@ -354,6 +361,70 @@ mod tests {
                 [VirtualHandEffect::HoldItem { entity_id }] if *entity_id == weapon
             ),
             "weapon pickup should preserve flat auto-wield"
+        );
+    }
+
+    /// #777: swapping the wielded weapon used to eject the previous one onto
+    /// the floor. The original returns it to the backpack; only an explicit
+    /// drop takes a weapon out of the player's possession.
+    #[test]
+    fn wielding_another_weapon_stores_the_displaced_one_instead_of_dropping_it() {
+        let mut world = World::new();
+        let wrench = world.add_entity(pistol());
+        let shotgun = world.add_entity(pistol());
+        let mut controller = FlatPlayerController::new();
+        controller.wield(wrench);
+
+        let effects = controller.wield(shotgun);
+
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, VirtualHandEffect::DropItem { .. })),
+            "a wield swap must never eject the displaced weapon into the world"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::StoreItem { entity_id } if *entity_id == wrench
+            )),
+            "the displaced weapon should go back to the backpack, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Drop,
+                    },
+                } if *to == wrench
+            )),
+            "the displaced weapon must still be told it left the hand (world \
+             model restore, psi-charge cancel), got {effects:?}"
+        );
+    }
+
+    /// The world-pickup auto-wield is the path the campaign session lost a
+    /// weapon on: it applies the controller's effects directly, with no
+    /// `Effect::GrabEntity` recovery behind it.
+    #[test]
+    fn world_pickup_of_a_second_weapon_stores_the_wielded_one() {
+        let mut world = World::new();
+        let carried = world.add_entity(pistol());
+        let on_the_floor = world.add_entity(pistol());
+        let mut controller = FlatPlayerController::new();
+        controller.wield(carried);
+
+        let effects = controller.pick_up(&world, on_the_floor);
+
+        assert_eq!(controller.wielded_entity(), Some(on_the_floor));
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::StoreItem { entity_id } if *entity_id == carried
+            )),
+            "picking a weapon up must holster the previous one, got {effects:?}"
         );
     }
 

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -32,7 +32,7 @@ pub enum InputAction {
     /// Cycle creatures to their next animation pose (debug hitbox/ragdoll inspection)
     DebugHitboxCyclePose,
 
-    /// Wield the next player weapon (debug: spawn-and-wield, dropping the
+    /// Wield the next player weapon (debug: spawn-and-wield, holstering the
     /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
     /// testing.
     CycleWeapon,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -893,7 +893,10 @@ impl MissionCore {
             .restore_states(&saved_script_states, &script_entity_id_map)
             .unwrap_or_else(|error| panic!("unable to restore script state: {error}"));
 
-        // If the player is holding anything, we should un-physical it
+        // If the player is holding anything, we should un-physical it.
+        // NB: these grabs discard their effects (there is no `self` yet to run
+        // them against), so a flat load of a VR two-handed save strands the
+        // displaced weapon - see #787.
 
         if let Some(entity_id) = left_hand_entity {
             interaction.grab(&world, entity_id, vr_config::Handedness::Left);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3690,12 +3690,11 @@ impl MissionCore {
                     hand,
                     current_parent_id: _,
                 } => {
-                    // What's held before the grab, so anything the grab
-                    // displaces (the flat wield swaps the viewmodel out) can
-                    // be holstered back into the backpack below. VR grabs
-                    // into an occupied hand no-op, so no displacement there.
-                    let held_before = self.interaction.held_entities();
-
+                    // A grab that displaces something (the flat wield swapping
+                    // the viewmodel out) holsters it back into the backpack
+                    // itself, via the `StoreItem` the controller returns. VR
+                    // grabs into an occupied hand no-op, so nothing is
+                    // displaced there.
                     let grab_effects = self.interaction.grab(&self.world, entity_id, hand);
                     self.process_virtual_hand_effects(asset_cache, grab_effects);
 
@@ -3721,31 +3720,6 @@ impl MissionCore {
 
                                 !is_link_to_entity
                             })
-                        }
-                    }
-
-                    // Holster anything the grab displaced (a weapon the flat
-                    // wield swapped out) back into the player's backpack -
-                    // the original returns it to the inventory grid, not the
-                    // floor at the viewmodel position.
-                    let held_after = self.interaction.held_entities();
-                    let displaced =
-                        [held_before.0, held_before.1]
-                            .into_iter()
-                            .flatten()
-                            .find(|prev| {
-                                *prev != entity_id
-                                    && held_after.0 != Some(*prev)
-                                    && held_after.1 != Some(*prev)
-                            });
-                    if let Some(prev) = displaced {
-                        let inventory_entity = self
-                            .world
-                            .borrow::<UniqueView<PlayerInfo>>()
-                            .map(|player| player.inventory_entity_id)
-                            .ok();
-                        if let Some(inventory_entity) = inventory_entity {
-                            self.drop_entity_into_container(inventory_entity, prev);
                         }
                     }
                 }
@@ -4661,8 +4635,8 @@ impl MissionCore {
                         Matrix4::identity(),
                         CreateEntityOptions::default(),
                     );
-                    // Force-wield (unlike SpawnDebugItem): `wield` drops the
-                    // previously held weapon back into the world, so each cycle
+                    // Force-wield (unlike SpawnDebugItem): `wield` holsters the
+                    // previously held weapon into the backpack, so each cycle
                     // swaps the viewmodel. No-op in VR (wield returns nothing).
                     let msgs = self.interaction.wield(info.entity_id);
                     self.process_virtual_hand_effects(asset_cache, msgs);

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -591,8 +591,8 @@ pub enum Effect {
     },
 
     /// Debug: spawn the next player weapon in front of the player and wield it
-    /// as the flat viewmodel (dropping the previously wielded one). Cycles the
-    /// SS2 weapon roster for aim/viewmodel testing.
+    /// as the flat viewmodel (holstering the previously wielded one). Cycles
+    /// the SS2 weapon roster for aim/viewmodel testing.
     DebugCycleWeapon {
         head_rotation: Quaternion<f32>,
     },

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -66,6 +66,11 @@ pub enum VirtualHandEffect {
     /// Flat-only: move an item into the player's backpack - a world pickup of
     /// ordinary loot, or the weapon a wield swap displaced. VR preserves its
     /// physical hand-grab path and never emits this.
+    ///
+    /// Storing an item that was HELD must be paired with a preceding
+    /// `MessagePayload::Drop` to it (see `FlatPlayerController::wield`): unlike
+    /// `DropItem`, this variant does not dispatch one, so the world-model
+    /// restore and psi-charge cancel would otherwise be skipped.
     StoreItem {
         entity_id: EntityId,
     },

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -35,6 +35,7 @@ pub struct VirtualHand {
     handedness: Handedness,
 }
 
+#[derive(Debug)]
 pub enum VirtualHandEffect {
     OutMessage {
         message: Message,
@@ -62,11 +63,15 @@ pub enum VirtualHandEffect {
     HoldItem {
         entity_id: EntityId,
     },
-    /// Flat-only world pickup of ordinary loot into the player backpack.
-    /// VR preserves its physical hand-grab path and never emits this.
+    /// Flat-only: move an item into the player's backpack - a world pickup of
+    /// ordinary loot, or the weapon a wield swap displaced. VR preserves its
+    /// physical hand-grab path and never emits this.
     StoreItem {
         entity_id: EntityId,
     },
+    /// Eject an item into the world (it regains physics + its world model).
+    /// This is an explicit drop only: VR opening its hand. Losing an item to a
+    /// wield swap is a `StoreItem`, not a drop (#777).
     DropItem {
         entity_id: EntityId,
     },

--- a/tools/shock2-sdk/test/weapon-swap-holster.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-swap-holster.e2e.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable earth.mis mission-object ids for two authored Weapons Training display
+// weapons. Runtime entity ids are rediscovered every launch.
+const PISTOL_OBJ = 246;
+const LASER_PISTOL_OBJ = 253;
+
+// Regression for #777. Flat wielding a second weapon emitted
+// `VirtualHandEffect::DropItem` for the one it displaced, so the previous
+// weapon was re-physicalized at the player's feet with no HUD feedback and
+// vanished from the inventory. The original returns it to the backpack; only an
+// explicit drop takes a weapon out of the player's possession.
+//
+// This drives the world-pickup auto-wield, which applies the flat controller's
+// effects directly and had no recovery behind it.
+test(
+  "earth: picking up a second weapon holsters the wielded one instead of ejecting it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8523),
+    });
+    await game.step({ frames: 30 });
+
+    const [pistol] = await game.entities.byTemplate(PISTOL_OBJ);
+    const [laserPistol] = await game.entities.byTemplate(LASER_PISTOL_OBJ);
+    assert.ok(pistol?.name === "Pistol", "expected earth Weapons Training pistol 246");
+    assert.ok(
+      laserPistol?.name === "Laser Pistol",
+      "expected earth Weapons Training laser pistol 253",
+    );
+
+    await earthWorldUse(game, pistol);
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      pistol.id,
+      "world-use should auto-wield the first weapon",
+    );
+
+    // The swap: a second world weapon displaces the wielded pistol.
+    await earthWorldUse(game, laserPistol);
+    await game.step({ frames: 2 });
+
+    assert.equal(
+      (await game.info()).player.wielded_entity_id,
+      laserPistol.id,
+      "world-use of a second weapon should wield it",
+    );
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === laserPistol.id)?.location,
+      "left_hand",
+      `the laser pistol should be wielded, got ${JSON.stringify(inventory.items)}`,
+    );
+    // Pre-fix this was `undefined`: the displaced pistol left the player's
+    // possession entirely, ejected onto the floor.
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === pistol.id)?.location,
+      "inventory",
+      `the displaced pistol must return to the backpack, got ${JSON.stringify(inventory.items)}`,
+    );
+
+    // ...and it must not be an orphaned world object at the player's feet.
+    assert.equal(
+      (await game.physics.bodies({ entityId: pistol.id })).bodies.length,
+      0,
+      "a holstered weapon must have no world physics body",
+    );
+
+    // Explicit drop still works: lift the holstered pistol out of the use-mode
+    // strip and throw it at the bare 3D view - the original's only way to put a
+    // carried weapon back into the world.
+    const clickAt = async (screen: [number, number]) => {
+      await game.input.set("pointer.position", screen);
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 1);
+      await game.step({ frames: 2 });
+      await game.input.set("pointer.pressed", 0);
+      await game.step({ frames: 2 });
+    };
+    const clickElement = (element: UiElement) => {
+      const [x, y, width, height] = element.screen_rect;
+      return clickAt([x + width / 2, y + height / 2]);
+    };
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const ui = await game.ui.state();
+    assert.equal(ui.mode, "use");
+    const slot = ui.strip?.elements.find(
+      (element) => element.kind === "button" && element.label === "Pistol",
+    );
+    assert.ok(slot, `the holstered pistol should be in the strip, got ${JSON.stringify(ui.strip)}`);
+
+    await clickElement(slot); // lift onto the cursor
+    assert.equal(
+      (await game.ui.state()).cursor?.entity_id,
+      pistol.id,
+      "the pistol should be on the cursor",
+    );
+    await clickAt([0.5, 0.6]); // bare 3D view: throw
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.player.inventory()).items.find((item) => item.entity_id === pistol.id)
+        ?.location,
+      undefined,
+      "an explicit throw should still remove the weapon from the inventory",
+    );
+    assert.ok(
+      (await game.physics.bodies({ entityId: pistol.id })).bodies.length > 0,
+      "an explicitly thrown weapon should regain a world physics body",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #777

campaign: engineering-through-shodan · none · legacy · seed 1378752978

## Root cause (verified, not just the issue's diagnosis)

`FlatPlayerController::wield` emitted `VirtualHandEffect::DropItem { prev }` for the weapon a swap displaced. `process_virtual_hand_effects` handles that with `make_physical` + a `Drop` dispatch — i.e. it gives the weapon a fresh physics body at the viewmodel's position and leaves it there, out of the player's possession, with no HUD feedback.

The issue's report that this affects *both* swap sources needed narrowing. Only **some** paths actually lost the weapon:

| Swap source | Applies wield effects via | Pre-fix outcome |
| --- | --- | --- |
| Inventory-strip double-click / ContainerGui backpack click / the 14 direct weapon keys | `Effect::GrabEntity` | **survived** — that handler had a post-hoc "holster displaced" block that put it back |
| **World-pickup auto-wield** (crosshair + use on a weapon) | `interaction.update` → `process_virtual_hand_effects` directly | **weapon ejected onto the floor** |
| **Debug `CycleWeapon`** | `interaction.wield` directly | **weapon ejected onto the floor** |

So the campaign session lost its melee weapon by *picking a weapon up*, and the strip double-click was only saved by a duplicate recovery bolted onto one of the two call sites.

## Change

`FlatPlayerController::wield` now emits, for the displaced weapon:

- `OutMessage { Drop }` — the signal that it left the hand. This is load-bearing: `internal_switch_held_model` uses it to restore the world model over the first-person `_h` mesh, and `psi_amp_script` uses it to cancel a charging amp. `StoreItem` does not dispatch one on its own.
- `StoreItem` — the same `drop_entity_into_container(inventory, …)` path an ordinary world pickup uses. No new storage mechanism, and no capacity handling (SS2 grid capacity is not modelled anywhere in the port; out of scope here).

With the controller holstering its own displacement, the duplicate `held_before`/`held_after` recovery in the `Effect::GrabEntity` handler is redundant and is removed (~24 lines). Every `PlayerInteraction::grab` caller was audited: `VirtualHand::grab_entity` no-ops on an occupied hand, so VR never displaced anything through that block — it was flat-only.

**Explicit drop is untouched**: VR opening its hand still emits `DropItem`, and flat's use-mode lift-and-throw still goes through `throw_entity_into_world`.

## Verification

**Negative-first.** Two unit tests in `flat_player_controller.rs` and one SDK e2e were written first and confirmed red on the unmodified code:

```
test wielding_another_weapon_stores_the_displaced_one_instead_of_dropping_it ... FAILED
  a wield swap must never eject the displaced weapon into the world
test world_pickup_of_a_second_weapon_stores_the_wielded_one ... FAILED
  picking a weapon up must holster the previous one,
  got [DropItem { entity_id: EId(0.0) }, HoldItem { entity_id: EId(1.0) }]
```

`tools/shock2-sdk/test/weapon-swap-holster.e2e.test.ts` (earth.mis, both authored Weapons Training weapons, real crosshair + squeeze pickups) pre-fix:

```
AssertionError: the displaced pistol must return to the backpack,
  got [{"entity_id":70,"name":"Laser Pistol","location":"left_hand"}]
  actual: undefined,  expected: 'inventory'
```

All green with the fix. The e2e also asserts the holstered weapon has **no world physics body** (no orphan at the player's feet) and that the explicit lift-and-throw still ejects it and restores its body.

**Live runtime (hydro2.mis, production inputs).** Wield pistol → provision a wrench → Tab → double-click it in the strip:

- before the swap: strip holds the Wrench, Pistol is the viewmodel
- after the swap: `{"items":[{"entity_id":2411,"name":"Pistol","location":"inventory"},{"entity_id":2413,"name":"Wrench","location":"left_hand"}]}`, Pistol visible in the strip grid, `/v1/physics/bodies?entity_id=2411` → `total_count: 0`
- explicit drop still works: lift the Pistol out of the strip, click the bare view → it leaves the inventory and regains a physics body

**Suites.** `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`; `cargo test -p shock2vr` (425 passed); `cargo fmt --all`. SDK e2e run serially: `inventory`, `inventory-drag`, `inventory-strip`, `weapon-selection`, `flat-world-pickup`, `world-frob-pickup`, `vr-held-model`, `give-item`, `vaporize-inventory`, `save-load`, `weapon-ammo`, `psi`, plus the new one. `weapon-selection.e2e.test.ts` is the notable one — it was the *only* prior coverage of the deleted post-hoc block ("must not spawn, drop, or lose a weapon", asserting the exact carried-entity set across all 14 Equip bindings) and stays green through the new `StoreItem` path.

## Before / after

Same mission (`earth.mis`), same two production world-pickups (crosshair + use on the Weapons Training pistol, then on the laser pistol), inventory strip captured immediately after the swap. Only the build differs.

![weapon swap before/after](https://gist.githubusercontent.com/tommy-xr/fef84a6c6c53cee545e875a2dc353671/raw/swap-strip-comparison.png)

<details><summary>Full frames</summary>

**Before (`main`)** — backpack empty, `/v1/player/inventory` reports only the newly wielded laser pistol, and the displaced pistol has a world physics body (it is lying on the floor):

![before](https://gist.githubusercontent.com/tommy-xr/fef84a6c6c53cee545e875a2dc353671/raw/swap-before-main.png)

**After (this PR)** — the pistol is in the grid, `location: "inventory"`, `total_count: 0` world bodies:

![after](https://gist.githubusercontent.com/tommy-xr/fef84a6c6c53cee545e875a2dc353671/raw/swap-after-pr.png)

</details>

## Review follow-ups

Cross-engine adversarial review (Claude + Codex) found no Critical/High issues. Both independently flagged one pre-existing gap: `MissionCore`'s save restoration discards the effects returned by `interaction.grab`, so a flat load of a VR *two-handed* save strands the displaced weapon. That hole predates this change (the discarded effect used to be an equally-unapplied `DropItem`) — filed as #787 and noted at the call site rather than folded in here.

Also noted for a separate issue, not touched: in flat mode `Effect::GrabEntity` dispatches `MessagePayload::Hold` twice for the newly wielded entity (once from the `HoldItem` arm, once inline). Harmless today — both handlers are idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
