### PR TITLE
fix(debug): screenshot write verification and bounded-move step-up fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_minimal`          | Bare minimum scene for basic testing         |
    | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `CycleWeapon`) |
    | `debug_psi`              | Psi amp casting (auto-equips the amp; select powers with `CyclePsiPower`) |
+   | `debug_small_prop`       | Player faces a small climbable riser/crate 6u ahead; exercises `/v1/player/move` step-up |
 
    ```bash
    # Use with debug runtime for programmatic control

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -17,8 +17,13 @@ pub enum RuntimeCommand {
     /// Step the simulation forward by frames or time
     Step(StepSpec, oneshot::Sender<Result<StepResult, StepError>>),
 
-    /// Take a screenshot of the current frame
-    Screenshot(ScreenshotSpec, oneshot::Sender<ScreenshotResult>),
+    /// Take a screenshot of the current frame. Replies `Err(message)` when the
+    /// PNG could not be verified as fully written to disk (e.g. ENOSPC) - see
+    /// `capture_screenshot` in `main.rs`.
+    Screenshot(
+        ScreenshotSpec,
+        oneshot::Sender<Result<ScreenshotResult, String>>,
+    ),
 
     /// Perform a physics raycast
     RayCast(RayCastRequest, oneshot::Sender<RayCastResult>),

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -15,7 +15,7 @@ use cgmath::Vector3;
 use clap::Parser;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::{collections::HashSet, net::SocketAddr, time::Duration};
+use std::{collections::HashSet, io::Write, net::SocketAddr, time::Duration};
 use tokio::{signal, sync::mpsc, sync::oneshot};
 use tracing::info;
 
@@ -527,8 +527,10 @@ fn run_game_blocking(
     //   would read a stale/blank back buffer -> intermittent black screenshots).
     let mut pending_step_reply: Option<oneshot::Sender<Result<StepResult, StepError>>> = None;
     let mut frames_advanced_this_step = 0u32;
-    let mut pending_screenshots: Vec<(ScreenshotSpec, oneshot::Sender<ScreenshotResult>)> =
-        Vec::new();
+    let mut pending_screenshots: Vec<(
+        ScreenshotSpec,
+        oneshot::Sender<Result<ScreenshotResult, String>>,
+    )> = Vec::new();
 
     info!("Starting main game loop...");
     info!("Game is PAUSED by default - use /v1/step to advance frames");
@@ -3062,11 +3064,14 @@ struct ScreenshotRequest {
     filename: Option<String>,
 }
 
-/// HTTP handler for taking screenshots
+/// HTTP handler for taking screenshots. Returns 500 with an error body when
+/// the capture failed or the PNG could not be verified as fully written to
+/// disk (e.g. the volume was full - issue #781), instead of reporting success
+/// with a truncated/stub file.
 async fn take_screenshot(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
     LenientJson(request): LenientJson<ScreenshotRequest>,
-) -> Json<ScreenshotResult> {
+) -> Result<Json<ScreenshotResult>, (StatusCode, String)> {
     let (reply_tx, reply_rx) = oneshot::channel();
 
     let spec = ScreenshotSpec {
@@ -3076,33 +3081,29 @@ async fn take_screenshot(
     // Send screenshot command to game loop
     if let Err(_) = command_tx.send(RuntimeCommand::Screenshot(spec, reply_tx)) {
         tracing::error!("Failed to send Screenshot command - game loop receiver dropped");
-        return Json(ScreenshotResult {
-            filename: "error.png".to_string(),
-            full_path: "/tmp/error.png".to_string(),
-            resolution: [0, 0],
-            size_bytes: 0,
-        });
+        return Err(game_loop_unavailable());
     }
 
     // Wait for response
     match reply_rx.await {
-        Ok(result) => Json(result),
+        Ok(Ok(result)) => Ok(Json(result)),
+        Ok(Err(message)) => {
+            tracing::error!("Screenshot capture failed: {}", message);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, message))
+        }
         Err(_) => {
             tracing::error!("Failed to receive screenshot result - sender dropped");
-            Json(ScreenshotResult {
-                filename: "error.png".to_string(),
-                full_path: "/tmp/error.png".to_string(),
-                resolution: [0, 0],
-                size_bytes: 0,
-            })
+            Err(game_loop_unavailable())
         }
     }
 }
 
 /// Resolve a screenshot spec to a file path, capture the freshly-rendered frame,
 /// and build the result. Called from the game loop after `finish_render` (before
-/// the buffer swap) so it reads a complete frame.
-fn capture_screenshot_to_result(spec: ScreenshotSpec) -> ScreenshotResult {
+/// the buffer swap) so it reads a complete frame. Returns `Err` with a clear
+/// message when the capture or the write to disk failed - the caller must
+/// surface that as an HTTP error rather than a stub-file success (issue #781).
+fn capture_screenshot_to_result(spec: ScreenshotSpec) -> Result<ScreenshotResult, String> {
     let filename = spec.filename.unwrap_or_else(|| {
         format!(
             "screenshot_{}.png",
@@ -3119,21 +3120,20 @@ fn capture_screenshot_to_result(spec: ScreenshotSpec) -> ScreenshotResult {
     match capture_screenshot(&full_path, SCR_WIDTH, SCR_HEIGHT) {
         Ok(size_bytes) => {
             tracing::info!("Screenshot saved to: {}", full_path.display());
-            ScreenshotResult {
+            Ok(ScreenshotResult {
                 filename,
                 full_path: full_path.to_string_lossy().to_string(),
                 resolution: [SCR_WIDTH, SCR_HEIGHT],
                 size_bytes,
-            }
+            })
         }
         Err(e) => {
             tracing::error!("Failed to capture screenshot: {}", e);
-            ScreenshotResult {
-                filename,
-                full_path: full_path.to_string_lossy().to_string(),
-                resolution: [0, 0],
-                size_bytes: 0,
-            }
+            Err(format!(
+                "failed to write screenshot to {}: {}",
+                full_path.display(),
+                e
+            ))
         }
     }
 }
@@ -3211,11 +3211,93 @@ fn capture_screenshot(
         let img = image::RgbImage::from_vec(actual_width, actual_height, flipped_pixels)
             .ok_or("Failed to create image from pixel data")?;
 
-        img.save(path)?;
+        // Write through a `File` we keep ownership of (rather than
+        // `img.save(path)`, which only gives us its overall Ok/Err) so we can
+        // `sync_all` it afterward - see `write_png_verified` for why.
+        let file = std::fs::File::create(path)?;
+        let file = write_png_verified(&img, file)?;
+        file.sync_all()?;
 
         // Calculate file size
         let metadata = std::fs::metadata(path)?;
         Ok(metadata.len())
+    }
+}
+
+/// Encode `img` as PNG into `writer` (buffered), flush it, and hand the
+/// underlying writer back. Propagates the encoder's error if the encode
+/// itself fails, or the flush's error if the buffered write did not actually
+/// go through.
+///
+/// This exists because `image::RgbImage::save` returning `Ok` is not proof
+/// the PNG reached disk: a filesystem with delayed block allocation can
+/// accept the encoder's writes into a buffer while the volume is full and
+/// only report `ENOSPC` once that buffer is flushed. Without this check,
+/// `POST /v1/screenshot` returned 200 while writing a truncated stub PNG
+/// (issue #781). Handing back the writer lets the caller additionally
+/// `sync_all` the underlying file, which this flush alone does not
+/// guarantee.
+fn write_png_verified<W: std::io::Write + std::io::Seek>(
+    img: &image::RgbImage,
+    writer: W,
+) -> Result<W, Box<dyn std::error::Error>> {
+    let mut buffered = std::io::BufWriter::new(writer);
+    img.write_to(&mut buffered, image::ImageFormat::Png)?;
+    buffered.flush()?;
+    buffered
+        .into_inner()
+        .map_err(|e| Box::new(e.into_error()) as Box<dyn std::error::Error>)
+}
+
+#[cfg(test)]
+mod screenshot_tests {
+    use super::*;
+    use std::io;
+
+    /// A writer that accepts every `write`/`seek` (as a real buffered/
+    /// delayed-alloc filesystem would while the volume still has apparent
+    /// room) but fails `flush` - reproducing the ENOSPC-on-flush shape of
+    /// issue #781 without needing to actually fill a disk.
+    struct FailingWriter;
+
+    impl io::Write for FailingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::Other, "ENOSPC (simulated)"))
+        }
+    }
+
+    impl io::Seek for FailingWriter {
+        fn seek(&mut self, _pos: io::SeekFrom) -> io::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    fn tiny_image() -> image::RgbImage {
+        image::RgbImage::from_vec(2, 2, vec![0u8; 2 * 2 * 3]).unwrap()
+    }
+
+    // Negative first: a writer whose flush fails must surface as an Err, not
+    // be swallowed the way `image::RgbImage::save` swallowed it in #781.
+    #[test]
+    fn write_png_verified_reports_a_failed_flush() {
+        let result = write_png_verified(&tiny_image(), FailingWriter);
+        assert!(
+            result.is_err(),
+            "a writer that fails on flush must be reported as an error"
+        );
+    }
+
+    #[test]
+    fn write_png_verified_succeeds_for_a_healthy_writer() {
+        let cursor = write_png_verified(&tiny_image(), io::Cursor::new(Vec::new()))
+            .expect("healthy writer must succeed");
+        assert!(
+            !cursor.into_inner().is_empty(),
+            "a successful encode must produce bytes"
+        );
     }
 }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -606,6 +606,10 @@ struct PlayerMovement {
     /// Horizontal part of a gravity-induced slope slide, carried into the
     /// next gravity pass so a seam does not erase the player's momentum.
     slope_displacement: Vector<Real>,
+    /// Whether `try_step_up` actually fired this pass (as opposed to an
+    /// ordinary walk/slide). `move_player_validated`'s bounded-hop overshoot
+    /// guard only widens for a genuine step-up - see `step_up_allowance`.
+    stepped_up: bool,
 }
 
 /// The moving-terrain body the player is standing on, and where it was the
@@ -1151,6 +1155,7 @@ fn plan_climb_top_out(
             is_crouched: false,
         }),
         slope_displacement: Vector::zeros(),
+        stepped_up: false,
     })
 }
 
@@ -1403,6 +1408,7 @@ fn plan_jump_mantle(
             is_crouched,
         }),
         slope_displacement: Vector::zeros(),
+        stepped_up: false,
     })
 }
 
@@ -1576,6 +1582,7 @@ fn step_player_movement(
                 movement: mvt,
                 top_out: None,
                 slope_displacement: Vector::zeros(),
+                stepped_up: false,
             };
         }
     }
@@ -1729,6 +1736,7 @@ fn step_player_movement(
     // Stairs: if grounded walking was blocked, probe for a step and hop onto
     // it. (Grounded-only: an airborne player pressed against a wall must not
     // ratchet up ledges.)
+    let mut stepped_up = false;
     if airborne_vertical.is_none() && mvt.grounded {
         if let Some(step) = try_step_up(
             queries,
@@ -1738,6 +1746,7 @@ fn step_player_movement(
             mvt.translation,
         ) {
             mvt.translation += step;
+            stepped_up = true;
         }
     }
     // The caller applies one translation from the ORIGINAL pose, so fold the
@@ -1748,6 +1757,7 @@ fn step_player_movement(
         movement: mvt,
         top_out: None,
         slope_displacement: next_slope_displacement,
+        stepped_up,
     }
 }
 
@@ -2715,7 +2725,7 @@ impl PhysicsWorld {
                     break;
                 }
                 let attempt = remaining.min(PLAYER_MOVE_SUBSTEP);
-                let mvt = step_player_movement(
+                let substep = step_player_movement(
                     &player_handle.controller,
                     &queries,
                     character_shape.as_ref(),
@@ -2731,8 +2741,8 @@ impl PhysicsWorld {
                     None,
                     // No ladder redirect: a validated move walks, it doesn't climb.
                     None,
-                )
-                .movement;
+                );
+                let mvt = substep.movement;
                 grounded = mvt.grounded;
 
                 let candidate = Translation::from(mvt.translation) * pos;
@@ -2742,14 +2752,19 @@ impl PhysicsWorld {
                     candidate.translation.vector.z - start.z
                 ];
                 // A collision slide may alter the route, but this API promises
-                // a bounded hop: bound it to the request, with a floor of
-                // `step_up_allowance` so a legitimate step-up (itself
+                // a bounded hop: bound it to the request. The one exception is
+                // a genuine step-up (`substep.stepped_up`) - itself
                 // collision-checked and safe, just geometrically wider than a
-                // short request) is never discarded outright - see the
-                // `step_up_allowance` comment above.
-                if from_start.norm()
-                    > requested_distance.max(step_up_allowance) + PLAYER_MOVE_ARRIVAL_EPSILON
-                {
+                // short request - which gets the `step_up_allowance` floor
+                // instead, so it is never discarded outright. An ordinary
+                // walk/slide substep (issue #599's wall-slide overshoot) stays
+                // held to the request even when it is short.
+                let overshoot_bound = if substep.stepped_up {
+                    requested_distance.max(step_up_allowance)
+                } else {
+                    requested_distance
+                };
+                if from_start.norm() > overshoot_bound + PLAYER_MOVE_ARRIVAL_EPSILON {
                     break;
                 }
                 let after = vector![
@@ -2797,12 +2812,24 @@ impl PhysicsWorld {
         }
         player_handle.is_grounded = grounded;
 
-        let remaining = vector![
+        let to_destination = vector![
             destination.x - pos.translation.vector.x,
             0.0,
             destination.z - pos.translation.vector.z
-        ]
-        .norm();
+        ];
+        // A completed step-up's fixed forward clearance can carry the player
+        // PAST `destination` on a short request (see `step_up_allowance`
+        // above). Past that point a plain Euclidean distance-to-destination
+        // grows again with the overshoot, which would wrongly report
+        // `blocked: true, distance_moved: 0` on a call that actually
+        // succeeded - exactly the symptom this fix resolves. Detect
+        // "reached or passed" via the signed progress along the requested
+        // heading instead of unsigned distance.
+        let remaining = if to_destination.dot(&walk_dir) <= 0.0 {
+            0.0
+        } else {
+            to_destination.norm()
+        };
         let distance_moved = (requested_distance - remaining).clamp(0.0, requested_distance);
 
         MoveResult {
@@ -3758,6 +3785,7 @@ impl PhysicsWorld {
                     movement,
                     top_out,
                     slope_displacement: Vector::zeros(),
+                    stepped_up: false,
                 }
             } else {
                 // A compressed mantle restores the same standing/crouched
@@ -7660,6 +7688,20 @@ mod tests {
             } else {
                 consecutive_blocked = 0;
             }
+            // A completed step-up can carry the player past this call's
+            // `destination` (the step's fixed forward clearance can exceed
+            // the 0.3wu request). That must be reported as real progress,
+            // not wrapped back into `blocked: true, distance_moved: 0` -
+            // the exact signature issue #782 describes, now on a call that
+            // actually advanced the player.
+            let advanced = (world.get_player_translation(&player) - current).x.abs();
+            assert!(
+                !(result.blocked && advanced > 0.5),
+                "a call that substantially advanced the player must not report blocked \
+                 with no distance credited: advanced={advanced} distance_moved={} blocked={}",
+                result.distance_moved,
+                result.blocked
+            );
         }
         let end = world.get_player_translation(&player);
 
@@ -7723,6 +7765,59 @@ mod tests {
             vec3(translated.x, 0.0, translated.z).magnitude()
                 <= result.requested_distance + PLAYER_MOVE_ARRIVAL_EPSILON,
             "validated movement must remain inside its requested radius: {result:?}"
+        );
+    }
+
+    /// The `step_up_allowance` floor added for issue #782 must only widen the
+    /// overshoot guard for a genuine, completed step-up - an ordinary
+    /// collision slide (issue #599) against a plain wall must stay held
+    /// tightly to a SHORT request, not opportunistically use the wider
+    /// step-up allowance (~0.6-0.8wu) just because the request was small.
+    /// Same fixture as `validated_move_stays_bounded_while_sliding_along_a_wall`,
+    /// but with a 0.3wu request - well under the step-up allowance - so a
+    /// regression that widened the guard unconditionally would let this slide
+    /// travel much farther than requested.
+    #[test]
+    fn validated_move_short_request_stays_bounded_while_sliding_along_a_wall() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, vec![[0u32, 1, 2], [0, 2, 3]])
+                .expect("floor trimesh")
+                .build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(-1.0, 2.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(1.28, 4.0, 100.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(0.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+
+        let start = world.get_player_translation(&player);
+        let direction = vec3(-0.5, 0.0, -f32::sqrt(3.0) / 2.0);
+        let result = world.move_player_validated(start + direction * 0.3, &mut player);
+        let translated = result.new_position - start;
+
+        assert!(
+            vec3(translated.x, 0.0, translated.z).magnitude()
+                <= result.requested_distance + PLAYER_MOVE_ARRIVAL_EPSILON,
+            "a short request sliding along a wall must stay inside its OWN \
+             requested radius, not opportunistically use the wider step-up \
+             allowance: {result:?}"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -354,6 +354,23 @@ const PROBE_SKIN: f32 = PLAYER_CONTACT_OFFSET / 2.0;
 /// input; the guard is against deflecting on noise, not against large angles.
 const MIN_SLIDE_FRACTION: f32 = 0.2;
 
+/// How far forward of a blocked position [`try_step_up`] must plant the
+/// capsule axis to stand on a riser's tread: the capsule radius plus a
+/// margin of contact-offset gaps. Shared with [`PhysicsWorld::move_player_validated`],
+/// whose bounded-hop overshoot guard must not reject a completed step-up
+/// just because it needed more room than a short request budgeted (issue
+/// #782) - this fixed, small quantity (not the walk distance) is the true
+/// bound on how far a step can outrun the request.
+fn step_up_forward_clearance(shape: &dyn Shape) -> f32 {
+    let contact_offset = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    let capsule_radius = shape
+        .as_capsule()
+        .map_or(PLAYER_STANDING_RADIUS / SCALE_FACTOR, |capsule| {
+            capsule.radius
+        });
+    capsule_radius + 4.0 * contact_offset
+}
+
 /// Step-up probe (the original engine's stair-climbing approach: probe up,
 /// forward, then down from the blocked position). Called when the player's
 /// horizontal movement was mostly blocked; returns the extra translation that
@@ -396,12 +413,7 @@ fn try_step_up(
     // Far enough forward that the capsule axis (its lowest point) stands on
     // the tread: the capsule radius, the gap to the riser (which can exceed
     // the contact offset when the walk stalled early), and margin on top.
-    let capsule_radius = shape
-        .as_capsule()
-        .map_or(PLAYER_STANDING_RADIUS / SCALE_FACTOR, |capsule| {
-            capsule.radius
-        });
-    let forward = capsule_radius + 4.0 * contact_offset;
+    let forward = step_up_forward_clearance(shape);
     // Full-width cast, used for the LANDING sweep: the tread height it
     // measures depends on the real capsule bottom, and its `target_distance`
     // is the contact offset so the player comes to rest at the normal gap
@@ -2617,6 +2629,22 @@ impl PhysicsWorld {
         let character_body = &self.rigid_body_set[player_handle.character_handle];
         let character_collider = &self.collider_set[character_body.colliders()[0]];
         let character_shape = character_collider.shared_shape().clone();
+        // A step-up's own forward clearance requirement (a small, fixed
+        // geometric quantity - see `step_up_forward_clearance`) can exceed a
+        // short `requested_distance`. Real per-frame walking has no
+        // per-call distance budget at all, so it climbs the same riser fine;
+        // the bounded hop's overshoot guard below must not reject an
+        // otherwise-valid, fully collision-checked step-up just because the
+        // caller asked for less room than a step needs (issue #782 - without
+        // this, automation stepping toward a target in short hops could get
+        // permanently wedged against a climbable riser/small prop).
+        //
+        // The substep that triggers the step-up also carries its own partial
+        // walk contribution (`step_player_movement` returns walk + step as one
+        // translation) - up to one `PLAYER_MOVE_SUBSTEP` on top of the step's
+        // own forward clearance - so the allowance must cover both.
+        let step_up_allowance =
+            PLAYER_MOVE_SUBSTEP + step_up_forward_clearance(character_shape.as_ref());
         let mut pos = *character_body.position();
         let gravity = player_gravity_step(character_body);
         let player_id = EntityId::from_inner(character_body.user_data as u64);
@@ -2714,9 +2742,14 @@ impl PhysicsWorld {
                     candidate.translation.vector.z - start.z
                 ];
                 // A collision slide may alter the route, but this API promises
-                // a bounded hop. Never commit a solver result outside the
-                // requested horizontal radius.
-                if from_start.norm() > requested_distance + PLAYER_MOVE_ARRIVAL_EPSILON {
+                // a bounded hop: bound it to the request, with a floor of
+                // `step_up_allowance` so a legitimate step-up (itself
+                // collision-checked and safe, just geometrically wider than a
+                // short request) is never discarded outright - see the
+                // `step_up_allowance` comment above.
+                if from_start.norm()
+                    > requested_distance.max(step_up_allowance) + PLAYER_MOVE_ARRIVAL_EPSILON
+                {
                     break;
                 }
                 let after = vector![
@@ -7563,6 +7596,81 @@ mod tests {
         assert!(
             wall_x < 0.8,
             "a validated move must not pass into a wall, advanced {wall_x}"
+        );
+    }
+
+    /// An automation client that steers toward a distant goal in short
+    /// (sub-clearance) hops must not get permanently wedged against a small,
+    /// climbable riser/crate the way one long hop already proves is
+    /// steppable. Each `move_player_validated` call only requested 0.3wu -
+    /// less than the ~0.64wu of forward clearance a step-up needs to land -
+    /// so the bounded-hop overshoot guard used to discard the completed,
+    /// fully collision-checked step outright and report `blocked` forever.
+    /// (Negative-first: before the `step_up_allowance` floor on the overshoot
+    /// guard, this looped at the riser's near face with `distance_moved`
+    /// pinned at 0 for the rest of the 40 requests - issue #782.)
+    #[test]
+    fn validated_move_climbs_a_riser_via_short_requests_without_wedging() {
+        let mut world = PhysicsWorld::new();
+        let floor_verts = vec![
+            point![-100.0, 0.0, -100.0],
+            point![100.0, 0.0, -100.0],
+            point![100.0, 0.0, 100.0],
+            point![-100.0, 0.0, 100.0],
+        ];
+        let floor_tris = vec![[0u32, 1, 2], [0, 2, 3]];
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::trimesh(floor_verts, floor_tris)
+                .expect("floor trimesh")
+                .build(),
+        );
+        // A small crate-sized DYNAMIC prop (real in-mission crates are
+        // dynamic bodies, added via `add_dynamic`), 0.6wu tall - the same
+        // walkable riser height `validated_move_steps_up_stairs_but_not_walls`
+        // already proves climbable with long hops.
+        let obstacle_height = 0.6;
+        world.add_dynamic(
+            EntityId::from_inner(2001).unwrap(),
+            vec3(-3.0, obstacle_height / 2.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(2.0, obstacle_height, 2.0)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        let mut player =
+            world.create_player(vec3(-6.0, 1.0, 0.0), EntityId::from_inner(2000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+
+        // Walk in short 0.3wu increments (below the step-up's own forward
+        // clearance requirement) all the way past the crate.
+        let start = world.get_player_translation(&player);
+        let mut consecutive_blocked = 0;
+        let mut max_consecutive_blocked = 0;
+        for _ in 0..40 {
+            let current = world.get_player_translation(&player);
+            let result = world.move_player_validated(current + vec3(0.3, 0.0, 0.0), &mut player);
+            if result.blocked {
+                consecutive_blocked += 1;
+                max_consecutive_blocked = max_consecutive_blocked.max(consecutive_blocked);
+            } else {
+                consecutive_blocked = 0;
+            }
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            end.x - start.x > 10.0,
+            "short-hop navigation should cross the crate and keep going, advanced {}",
+            end.x - start.x
+        );
+        assert!(
+            max_consecutive_blocked <= 3,
+            "must not wedge indefinitely against a climbable crate: {max_consecutive_blocked} consecutive blocked calls"
         );
     }
 

--- a/shock2vr/src/scenes/debug_small_prop.rs
+++ b/shock2vr/src/scenes/debug_small_prop.rs
@@ -1,0 +1,94 @@
+//! Debug scene for exercising `/v1/player/move`'s bounded-hop step-up against
+//! a small, climbable floor prop (crate/riser-sized obstacle) - see issue
+//! #782. The player spawns a known distance from the near face of the prop,
+//! facing it; automation can approach it via `/v1/player/move` in short hops
+//! and confirm it climbs over instead of wedging (or via
+//! `/v1/control/input` + `/v1/step` to compare against production
+//! locomotion).
+
+use cgmath::{Deg, Quaternion, Rotation3, vec3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
+use rapier3d::prelude::{ColliderBuilder, Isometry, SharedShape};
+use shipyard::EntityId;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::InputContext,
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
+    physics::CollisionGroup,
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    },
+    time::Time,
+};
+
+/// Height (world units) of the prop - a typical walkable stair riser/crate,
+/// matching the height `validated_move_steps_up_stairs_but_not_walls` and
+/// `validated_move_climbs_a_riser_via_short_requests_without_wedging`
+/// (shock2vr/src/physics/mod.rs) already prove climbable with a long hop.
+pub const PROP_HEIGHT: f32 = 0.6;
+
+/// Distance (world units) from the player spawn to the near face of the
+/// prop, straight ahead (-X, the default view forward).
+pub const PROP_DISTANCE: f32 = 6.0;
+
+#[derive(Default)]
+struct SmallPropHooks;
+
+impl SmallPropHooks {
+    fn initialize(&mut self, core: &mut MissionCore) {
+        // A separate static body (not baked into the level's compound
+        // collider), matching how a real in-mission crate is its own
+        // physics body rather than part of the level mesh.
+        let center_x = -PROP_DISTANCE - 2.0;
+        let isometry = Isometry::translation(center_x, PROP_HEIGHT / 2.0, 0.0);
+        let handle = core.physics.create_static_body(isometry, None);
+        let shape = SharedShape::cuboid(2.0, PROP_HEIGHT / 2.0, 2.0);
+        core.physics
+            .attach_collider(handle, shape, 1.0, CollisionGroup::entity());
+    }
+}
+
+impl DebugSceneHooks for SmallPropHooks {
+    fn before_update(
+        &mut self,
+        _core: &mut MissionCore,
+        _time: &Time,
+        _input_context: &InputContext,
+        _asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+    ) {
+    }
+}
+
+pub fn create_debug_small_prop_scene(
+    global_context: &GlobalContext,
+    game_options: &GameOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> Box<dyn GameScene> {
+    // Floor only - top at y=0. The prop is added separately below.
+    let floor_collider = ColliderBuilder::new(SharedShape::cuboid(20.0, 0.5, 20.0))
+        .position(Isometry::translation(0.0, -0.5, 0.0))
+        .build();
+
+    let builder = DebugSceneBuilder::new("debug_small_prop")
+        .with_spawn_location(SpawnLocation::PositionRotation(
+            vec3(0.0, 2.0, 0.0),
+            Quaternion::from_angle_y(Deg(0.0)),
+        ))
+        .with_physics_geometry(floor_collider);
+
+    let build_options = DebugSceneBuildOptions {
+        global_context,
+        game_options,
+        asset_cache,
+        audio_context,
+    };
+
+    let mut core = builder.build_core(build_options);
+    let mut hooks = SmallPropHooks;
+    hooks.initialize(&mut core);
+    Box::new(HookedDebugScene::new(core, hooks))
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -30,6 +30,7 @@ pub mod debug_minimal;
 pub mod debug_particles;
 pub mod debug_psi;
 pub mod debug_ragdoll;
+pub mod debug_small_prop;
 pub mod debug_teleport;
 pub mod debug_turret;
 pub mod debug_weapons;
@@ -47,6 +48,7 @@ pub use debug_minimal::DebugMinimalScene;
 pub use debug_particles::DebugParticlesScene;
 pub use debug_psi::create_debug_psi_scene;
 pub use debug_ragdoll::DebugRagdollScene;
+pub use debug_small_prop::create_debug_small_prop_scene;
 pub use debug_teleport::DebugTeleportScene;
 pub use debug_turret::DebugTurretScene;
 pub use debug_weapons::create_debug_weapons_scene;
@@ -111,6 +113,18 @@ pub fn create_initial_scene(
                 asset_cache,
                 audio_context,
             )),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("debug_small_prop") {
+        return SceneInitResult {
+            scene: create_debug_small_prop_scene(
+                global_context,
+                options,
+                asset_cache,
+                audio_context,
+            ),
             mission_save_data: HashMap::new(),
         };
     }

--- a/tools/shock2-sdk/test/player-move.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-move.e2e.test.ts
@@ -207,3 +207,55 @@ test(
     );
   },
 );
+
+test(
+  "validated player move: short hops climb a small prop instead of wedging",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    // Regression for #782: an automation client that steers toward a distant
+    // goal in short (sub-clearance) hops - e.g. 0.3u increments, well under
+    // the ~0.64u of forward clearance a step-up needs to land - used to get
+    // permanently wedged against a small, climbable riser/crate: the bounded
+    // hop's overshoot guard discarded the completed, fully collision-checked
+    // step outright because it was wider than the tiny request, and every
+    // later call reported `blocked: true, distance_moved: 0` forever.
+    //
+    // `debug_small_prop` (shock2vr/src/scenes/debug_small_prop.rs) spawns the
+    // player facing a 0.6u-tall, 4u-wide prop 6u ahead - the same riser
+    // height the wall/stairs test above already proves climbable with a long
+    // hop.
+    await using game = await GameServer.launch({
+      mission: "debug_small_prop",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8108),
+    });
+    await game.step({ frames: 30 });
+
+    const start = await game.player.position();
+    let maxConsecutiveBlocked = 0;
+    let consecutiveBlocked = 0;
+    for (let i = 0; i < 40; i++) {
+      const current = await game.player.position();
+      const result = await game.player.moveTo({
+        x: current.x - 0.3,
+        y: current.y,
+        z: current.z,
+      });
+      if (result.blocked) {
+        consecutiveBlocked++;
+        maxConsecutiveBlocked = Math.max(maxConsecutiveBlocked, consecutiveBlocked);
+      } else {
+        consecutiveBlocked = 0;
+      }
+    }
+    const end = await game.player.position();
+
+    assert.ok(
+      start.x - end.x > 10,
+      `short-hop navigation should cross the prop and keep going, advanced ${start.x - end.x}u`,
+    );
+    assert.ok(
+      maxConsecutiveBlocked <= 3,
+      `must not wedge indefinitely against a climbable prop: ${maxConsecutiveBlocked} consecutive blocked calls`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Two debug_runtime HTTP tooling defects found by campaign automation.

**#781 — `POST /v1/screenshot` silently writes stub PNGs when the disk is full.**
`image::RgbImage::save()` can return `Ok` even though the write never actually
reached disk (a filesystem with delayed block allocation accepts the encoder's
writes into a buffer and only reports `ENOSPC` once that buffer is flushed).
The endpoint now routes the encode through an owned `File`, flushes the
buffered writer, and calls `sync_all()`; any failure now surfaces as an HTTP
500 with a clear message instead of a 200 + truncated file.

**#782 — `POST /v1/player/move` reports false dead-ends on small climbable props.**
Automation stepping toward a goal in short (sub-clearance) hops - e.g. 0.3
world-unit increments - got permanently wedged against a small riser/crate:
the step-up maneuver's own forward-clearance requirement (~0.64wu for the
default capsule) exceeded the caller's tiny `requested_distance`, so the
bounded hop's overshoot guard discarded the completed, fully
collision-checked step every time and reported `blocked: true,
distance_moved: 0` forever - even though the same riser is climbable with one
long hop, or with ordinary thumbstick locomotion (which has no such per-call
distance budget at all).

Fixed by flooring the overshoot guard at the step-up's actual required room
(forward clearance + the substep's own partial walk contribution), but
*only* for substeps where a step-up genuinely fired (threaded back via a new
`PlayerMovement::stepped_up` flag) - an ordinary wall-slide substep (issue
#599's concern) stays held tightly to the request even when it's short.

Two issues surfaced during investigation and were fixed as part of the same
change (both caught by an adversarial cross-engine review, not by the
original repro):
- A step-up overshooting a short request's destination point made the
  (unsigned) distance-to-destination grow again, wrongly reporting
  `blocked: true, distance_moved: 0` on a call that had actually advanced
  and unblocked the player - detected via signed progress along the walk
  heading instead.
- The overshoot-guard floor was originally applied to every substep, not
  just genuine step-ups, which could have weakened issue #599's wall-slide
  overshoot protection on short requests.

## Changes

- `runtimes/debug_runtime/src/main.rs` / `commands.rs`: verified screenshot
  writes (`write_png_verified` + `sync_all`), `Screenshot` command now
  replies `Result<ScreenshotResult, String>`, HTTP handler returns 500 on
  failure. Unit tests with an injectable failing writer.
- `shock2vr/src/physics/mod.rs`: `step_up_forward_clearance` helper shared
  between `try_step_up` and `move_player_validated`; `step_up_allowance`
  floor on the bounded-hop overshoot guard, gated to genuine step-ups via
  `PlayerMovement::stepped_up`; signed-progress fix for `distance_moved`/
  `blocked` on overshoot. New/updated regression tests in `physics::tests`.
- `shock2vr/src/scenes/debug_small_prop.rs` (new): minimal debug scene - a
  small climbable riser/crate 6u ahead of spawn - for reproducible testing.
  Registered in `shock2vr/src/scenes/mod.rs`; documented in `AGENTS.md`.
- `tools/shock2-sdk/test/player-move.e2e.test.ts`: new e2e test walking into
  `debug_small_prop` in 0.3u increments (fails before the fix, passes after).

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- [x] `cargo test -p shock2vr` - 425 passed
- [x] `cargo test -p debug_runtime --bin debug_runtime screenshot_tests` - 2 passed (negative-first verified: fails without the fix)
- [x] `cargo fmt --all -- --check` - clean
- [x] Negative-first verified for both `shock2vr` regression tests (fail without the fix, pass with it) and for the SDK e2e test, including live end-to-end confirmation against a running debug_runtime over real HTTP
- [x] `npm run test:e2e` (SDK e2e suite) - `missions.e2e.test.ts` (all 23 missions) and `player-move.e2e.test.ts` (all 4 tests) pass; full suite run in progress, will report before merge
- [x] Adversarial cross-engine review (Claude subagent + Codex) - both independently found and both findings were fixed

campaign: engineering-through-shodan · none · legacy · seed 1378752978

Fixes #781
Fixes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)