### PR TITLE
fix(debug-runtime): throttle idle main loop, demote NoopScript log spam

### DIFF
--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -15,7 +15,7 @@ use cgmath::Vector3;
 use clap::Parser;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::{collections::HashSet, net::SocketAddr, time::Duration};
+use std::{collections::HashSet, net::SocketAddr, thread, time::Duration};
 use tokio::{signal, sync::mpsc, sync::oneshot};
 use tracing::info;
 
@@ -157,6 +157,15 @@ static INSTANCE_ID: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::n
 /// time-based stepping advance a deterministic, wall-clock-independent amount of
 /// simulation time (60 Hz, matching the game's target frame rate).
 const FIXED_STEP_DT: f32 = 1.0 / 60.0;
+
+/// How long to sleep at the end of an idle loop iteration (paused, no step in
+/// progress). Without this the loop spins as fast as possible - no swap
+/// interval is set anywhere and the window is hidden, so `swap_buffers` never
+/// blocks - pinning a CPU core even when nothing is happening (see #784). The
+/// sleep only delays how soon the next iteration polls the command channel,
+/// so it caps `/v1/step` and `/v1/screenshot` latency at this duration; a few
+/// ms is a no-op for automation but returns the core the rest of the time.
+const IDLE_SLEEP: Duration = Duration::from_millis(4);
 
 /// Head rotation for a yaw/pitch (degrees), matching the desktop runtime's
 /// camera convention (`camera_forward` / `camera_rotation`): at `yaw=pitch=0`
@@ -562,7 +571,9 @@ fn run_game_blocking(
         // Process commands from HTTP server. Step and Screenshot replies are
         // deferred (see below) so callers observe a complete, post-render frame;
         // every other command is handled synchronously here.
+        let mut had_command_this_iteration = false;
         while let Ok(command) = command_rx.try_recv() {
+            had_command_this_iteration = true;
             match command {
                 RuntimeCommand::Step(step_spec, reply) => {
                     if pending_step_reply.is_some() {
@@ -635,6 +646,36 @@ fn run_game_blocking(
                     );
                 }
             }
+        }
+
+        // Throttle: paused, no step in progress, no command arrived this
+        // iteration, nothing queued to render for, and no deferred level
+        // transition (--experimental loading_screen) needs frames pumped.
+        // Without this the loop spins as fast as possible - no swap interval
+        // is set anywhere and the window is hidden, so `swap_buffers` never
+        // blocks - pinning a CPU core running an unchanged frame's
+        // update/render even when nothing is happening (see #784). Skipping
+        // straight back to the top (rather than sleeping and still
+        // rendering) also means an idle runtime does no GL work at all until
+        // there's something to do. `/v1/step` and `/v1/screenshot` are
+        // unaffected: both arrive as a command, which sets
+        // `had_command_this_iteration` and falls through to the normal
+        // update/render path below in the same iteration they land in.
+        // Stepping (fixed timestep) and any future free-running mode are
+        // also unaffected - both keep `step_requested` or `is_paused` out of
+        // this condition so they always fall through. The pending-transition
+        // check matters because `pending_transition.frames_shown` only
+        // advances inside `game.update` - without it, a transition that's
+        // still in flight when stepping ends (back to paused) would freeze
+        // instead of finishing.
+        if is_paused
+            && !step_requested
+            && !had_command_this_iteration
+            && pending_screenshots.is_empty()
+            && !game.has_pending_transition()
+        {
+            thread::sleep(IDLE_SLEEP);
+            continue;
         }
 
         // Only update the game if not paused or if step was requested

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -450,6 +450,16 @@ pub struct PlayerStateSnapshot {
 }
 
 impl Game {
+    /// True while a deferred level transition (`--experimental loading_screen`)
+    /// is in flight. `update` is what advances it (`pending_transition.frames_shown`
+    /// and the background parse-completion check), so a caller that only calls
+    /// `update` on activity - e.g. the debug runtime's idle-throttled loop
+    /// (#784) - needs this to know a transition still needs frames pumped even
+    /// while otherwise idle.
+    pub fn has_pending_transition(&self) -> bool {
+        self.pending_transition.is_some()
+    }
+
     /// A snapshot of the player (position, look rotation, held/wielded entities)
     /// for debug tooling, or `None` if the active scene has no player (e.g. a
     /// menu). Reads the `PlayerInfo` unique from the active world.

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -88,7 +88,7 @@ pub use effect::*;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use shipyard::{EntityId, World};
-use tracing::{Level, info, span, warn};
+use tracing::{Level, info, span, trace, warn};
 
 use crate::util::debug_entity;
 use crate::vr_config::Handedness;
@@ -793,7 +793,7 @@ impl Script for NoopScript {
         _physics: &PhysicsWorld,
         _msg: &MessagePayload,
     ) -> Effect {
-        warn!("message {:?} sent to NoopScript, unhandled", _msg);
+        trace!("message {:?} sent to NoopScript, unhandled", _msg);
         Effect::NoEffect
     }
 }


### PR DESCRIPTION
## Summary

- **Fixes #784**: throttles the `debug_runtime` main game loop while paused and idle. Previously the loop ran `game.update`/`render`/`render_per_eye`/`engine.render`/`finish_render`/`swap_buffers` on every iteration regardless of pause state - no swap interval is set anywhere and the window is hidden, so `swap_buffers` never blocks. Measured 92-99% CPU sustained during 18 minutes of pure idle (see the measurement-based diagnosis in #783). Now: on an iteration that is paused, not stepping, and had no HTTP command to react to, the loop skips update/render/swap entirely, sleeps 4ms, and retries. `/v1/step` and `/v1/screenshot` are unaffected - both arrive as a command, which falls through to the normal path in the same iteration they land in. Stepping keeps its fixed 60Hz timestep untouched. Also guards a deferred level transition (`--experimental loading_screen`) from stalling, since its frame-pump only happens inside `game.update` - a review round caught that the idle-skip could otherwise freeze an in-flight transition after stepping ends paused.
- **Fixes #785**: demotes the per-frame `warn!("message {:?} sent to NoopScript, unhandled")` (`shock2vr/src/scripts/mod.rs`) to `trace!` - it was 95.8% of a 25-minute session's log output (612k/638k lines), 80% of it a single `AnimationFlagTriggered` payload fired per-entity per-frame.

## Measurements (release build, medsci1.mis, this repo's `/Users/bryan/ss2-data-unpacked` assets)

| | Before | After |
|---|---|---|
| Idle CPU% (paused, no requests) | 97-100% | 0.1-0.2% |
| 600-frame `/v1/step` wall time | ~1.9-2.4s (3 runs) | ~2.1-2.4s (3 runs) |

Stepping wall time is noise-level identical before/after, confirming determinism and step performance are unaffected.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` - clean
- [x] `cargo test -p shock2vr` - 423 passed, 0 failed
- [x] `cargo fmt --all -- --check` - clean
- [x] Full SDK e2e suite (`npm run test:e2e`, 194 tests): **191 passed, 0 failed, 3 skipped** (skips are gated behind an unrelated optional save fixture env var, `SHOCK2_SHODAN_AVATAR_SAVE`, not present in this environment)
- [x] Manual idle-CPU and step-timing measurements above (baseline vs. fixed release binaries, same mission, same machine)
- [x] Cross-engine adversarial review (`/xreview`: Claude subagent + Codex CLI) - one agreed Medium/High finding (the loading-screen transition stall) found and fixed before landing; no other Critical/High findings

campaign: engineering-through-shodan · none · legacy · seed 1378752978

🤖 Generated with [Claude Code](https://claude.com/claude-code)