### PR TITLE
feat(sdk): reap stale/orphaned debug runtimes on launch

### DIFF
--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -126,6 +126,21 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
 - `GameServer.launch` finds the cargo workspace by walking up from `cwd`;
   pass `repoRoot` to override. First launch may take minutes while cargo
   compiles; the default readiness timeout is 5 minutes.
+- **Lifecycle / reaping stale runtimes**: a long automation session that dies
+  without reaching `/v1/shutdown` (a crashed agent, a killed test runner)
+  leaves its `debug_runtime` orphaned - still bound to its port and burning a
+  CPU core. To guard against that, `launch()` reaps (SIGKILL) any
+  `debug_runtime` already bound to the requested port *before* starting a new
+  one, by default. This only ever targets the exact port you asked for
+  (`port ?? 8080`) - never a fallback port picked by the bind-race retry loop,
+  and never a process that isn't a `debug_runtime` by command line, and never
+  a port a live `GameServer` in *this* process already owns (that one is
+  skipped as "not stale," not killed). It does **not** distinguish an actual
+  orphan from another agent's currently-running session that happens to share
+  the same port - if you rely on the existing walk-up-to-a-free-port behavior
+  to coexist with concurrent runs on a shared default port, pass an explicit
+  unique `port` per run, or set `reapStale: false` to fall back to walk-up
+  instead of killing what's there.
 - Injected actions apply on the next game update, which runs even while
   paused (with zero delta time).
 - `game.logs()` returns recent runtime output (also included in launch

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -1,8 +1,9 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
+import { promisify } from "node:util";
 
 import { HttpClient } from "./client.js";
 import { Game } from "./game.js";
@@ -32,6 +33,15 @@ export interface LaunchOptions {
   rustLog?: string;
   /** Echo runtime output to this process's stderr (default false). */
   echoLogs?: boolean;
+  /**
+   * Reap (SIGKILL) a stale `debug_runtime` already bound to the requested
+   * launch port before starting - e.g. an orphan left by a prior agent
+   * session that died without reaching `/v1/shutdown` (see #786). Only ever
+   * targets the exact port this launch asked for (`port ?? 8080`); a
+   * fallback port picked by the free-port walk-up on a bind race is never
+   * touched. Default true.
+   */
+  reapStale?: boolean;
 }
 
 /** Walk up from a directory until a cargo workspace root is found. */
@@ -115,6 +125,131 @@ export async function findFreePort(start: number): Promise<number> {
   );
 }
 
+const execFileAsync = promisify(execFile);
+
+/** A live process with a listening socket on a port, as reported by the OS. */
+export interface PortProcess {
+  pid: number;
+  /** Full command line (not the truncated program name `lsof` reports). */
+  command: string;
+}
+
+/**
+ * Finds processes with a listening TCP socket on `port`, via `lsof` (pid
+ * discovery) + `ps` (full command line - `lsof`'s COMMAND column truncates to
+ * 9 characters and drops arguments, so it can't be used to confirm this is a
+ * `debug_runtime` bound to the port we think it is). Best-effort: returns []
+ * if either tool is unavailable or reports nothing, rather than throwing -
+ * callers treat that the same as "no stale process found".
+ */
+export async function findProcessesOnPort(port: number): Promise<PortProcess[]> {
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync("lsof", [
+      "-nP",
+      `-iTCP:${port}`,
+      "-sTCP:LISTEN",
+      "-t",
+    ]));
+  } catch {
+    // No listener on the port (lsof exits non-zero), or lsof isn't installed.
+    return [];
+  }
+  const pids = [...new Set(stdout.split("\n").map((line) => line.trim()).filter(Boolean))].map(
+    Number,
+  );
+
+  const processes: PortProcess[] = [];
+  for (const pid of pids) {
+    try {
+      const { stdout: command } = await execFileAsync("ps", ["-p", String(pid), "-o", "command="]);
+      processes.push({ pid, command: command.trim() });
+    } catch {
+      // Process exited between the lsof snapshot and this lookup - skip it.
+    }
+  }
+  return processes;
+}
+
+/**
+ * True when `command` is a `debug_runtime` invocation bound to exactly
+ * `port` - checked by tokenizing the full command line (not a raw substring
+ * match, which a name like `debug_runtime_proxy` or a `--port 8080` vs.
+ * `--port 808` collision could fool): the executable's basename must be
+ * exactly `debug_runtime`, and its args must contain the literal token pair
+ * `--port <port>`.
+ */
+function isDebugRuntimeOnPort(command: string, port: number): boolean {
+  const argv = command.trim().split(/\s+/);
+  const exe = argv[0]?.split("/").pop();
+  if (exe !== "debug_runtime") return false;
+  const portFlagIndex = argv.indexOf("--port");
+  return portFlagIndex !== -1 && argv[portFlagIndex + 1] === String(port);
+}
+
+/**
+ * Kill any `debug_runtime` process bound to `port` (see
+ * `isDebugRuntimeOnPort` for the exact match criteria - never kills an
+ * unrelated process, or a `debug_runtime` that merely mentions this port
+ * without actually being bound to it). Best-effort: swallows discovery/kill
+ * errors, since a permission failure or the process exiting mid-reap just
+ * means the subsequent bind proceeds normally (or fails loudly on its own).
+ *
+ * Returns the pids it killed, mainly for tests.
+ */
+export async function reapStaleRuntimeOnPort(
+  port: number,
+  deps: {
+    findProcesses?: (port: number) => Promise<PortProcess[]>;
+    kill?: (pid: number, signal: NodeJS.Signals) => void;
+  } = {},
+): Promise<number[]> {
+  const findProcesses = deps.findProcesses ?? findProcessesOnPort;
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+
+  let candidates: PortProcess[];
+  try {
+    candidates = await findProcesses(port);
+  } catch {
+    return [];
+  }
+
+  const toKill = candidates.filter((p) => isDebugRuntimeOnPort(p.command, port));
+
+  const killed: number[] = [];
+  for (const { pid } of toKill) {
+    try {
+      kill(pid, "SIGKILL");
+      killed.push(pid);
+    } catch {
+      // Already gone, or no permission - nothing more we can do.
+    }
+  }
+  if (killed.length > 0) {
+    // Wait for the OS to actually release the socket before returning, so
+    // the caller's very next bind probe (`findFreePort`) sees the port as
+    // free instead of racing the kill - a fixed short sleep isn't reliably
+    // enough under load (see #786 PR discussion), so poll with a bound.
+    const deadline = Date.now() + 2000;
+    while (!(await portIsFree(port)) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  return killed;
+}
+
+/**
+ * Indirection for `GameServer.launch`'s reap call, so tests can swap it out
+ * without spawning a real runtime. ES module exports are read-only live
+ * bindings (reassigning the `reapStaleRuntimeOnPort` export from outside
+ * this module throws), so a plain mutable object is the seam instead - only
+ * the property write needs to be assignable, not the export itself. Not
+ * meant to be used outside tests.
+ */
+export const reapHooks = {
+  reapStaleRuntimeOnPort,
+};
+
 /**
  * Pick the most useful slice of runtime output for an error message.
  *
@@ -191,6 +326,16 @@ export class GameServer extends Game implements AsyncDisposable {
    */
   static async launch(options: LaunchOptions): Promise<GameServer> {
     const hint = options.port ?? 8080;
+    // Only the exact requested port - never a fallback port from the
+    // bind-race retry loop below (see reapStale's doc comment). Skip
+    // entirely when THIS process already reserved the port for a live
+    // sibling GameServer (findFreePort below, `reservedPorts`) - that's not
+    // a stale orphan, it's our own in-flight launch, and killing it would
+    // destroy a live instance for no benefit (the walk-up below would still
+    // skip the port via `reservedPorts` regardless of whether we killed it).
+    if ((options.reapStale ?? true) && !reservedPorts.has(hint)) {
+      await reapHooks.reapStaleRuntimeOnPort(hint);
+    }
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
       try {

--- a/tools/shock2-sdk/test/reap-stale.e2e.test.ts
+++ b/tools/shock2-sdk/test/reap-stale.e2e.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { findRepoRoot, reapStaleRuntimeOnPort } from "../src/server.js";
+
+// Verifies the real (unmocked) reap path end-to-end: a genuinely orphaned
+// debug_runtime - one whose process outlives the harness that spawned it,
+// e.g. a crashed agent that never reached /v1/shutdown (#786) - gets killed
+// and its port reclaimed by the next launch(), rather than launch() quietly
+// walking up to a different port and leaving the orphan running.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const PORT = Number(process.env.SHOCK2_E2E_PORT ?? 8580);
+
+interface Orphan {
+  child: ChildProcess;
+  instanceId: string;
+}
+
+/**
+ * Spawns a debug_runtime directly (bypassing GameServer.launch entirely) so
+ * it is untracked by the SDK's own in-process port bookkeeping
+ * (`reservedPorts`) - a genuine orphan is a process from a *different* Node
+ * invocation, so going through the SDK's own launch() here would exercise a
+ * same-process bookkeeping guard instead of the real reap path.
+ */
+function spawnOrphan(port: number, repoRoot: string): Orphan {
+  const instanceId = randomUUID();
+  const child = spawn(
+    "cargo",
+    [
+      "run",
+      "-p",
+      "debug_runtime",
+      "--",
+      "--mission",
+      "medsci1.mis",
+      "--port",
+      String(port),
+      "--instance-id",
+      instanceId,
+    ],
+    { cwd: repoRoot, stdio: "ignore", detached: true },
+  );
+  return { child, instanceId };
+}
+
+/**
+ * Waits for our own orphan to come up, identified by `/v1/health`'s
+ * `instance_id` - not merely "some healthy service answered on this port".
+ * On a shared dev host, this port could already be held by an unrelated
+ * runtime (another agent's session); if the caller proceeded to treat that
+ * as "our fixture is ready" it could reap or otherwise mistreat a foreign
+ * process later in the test. Fails loudly instead of guessing.
+ */
+async function waitUntilOwnedHealthy(
+  port: number,
+  expectedInstanceId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/health`);
+      if (res.ok) {
+        const body = (await res.json()) as { instance_id?: string | null };
+        if (body.instance_id === expectedInstanceId) return;
+        throw new Error(
+          `port ${port} is held by a different instance (expected ${expectedInstanceId}, got ${body.instance_id ?? "none"}) - refusing to proceed against an unrelated runtime`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith("port ")) throw error;
+      // Connection refused / not up yet - keep waiting.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`orphan debug_runtime on port ${port} never became healthy`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+/** Kill our directly-spawned orphan by pid (belt-and-suspenders cleanup). */
+function killOrphanProcessGroup(orphan: Orphan): void {
+  if (orphan.child.pid === undefined) return;
+  try {
+    process.kill(-orphan.child.pid, "SIGKILL");
+  } catch {
+    // Already gone.
+  }
+}
+
+test(
+  "launch() reaps a genuinely orphaned debug_runtime and rebinds its exact port",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "expected to find the cargo workspace root");
+
+    const orphan = spawnOrphan(PORT, repoRoot);
+    let successor: GameServer | undefined;
+    try {
+      await waitUntilOwnedHealthy(PORT, orphan.instanceId, 300_000);
+
+      // Default reapStale: true should kill the orphan and reclaim PORT
+      // exactly, rather than the pre-existing find-a-free-port walk-up
+      // landing on PORT + 1.
+      successor = await GameServer.launch({ mission: "medsci1.mis", port: PORT });
+      assert.equal(
+        new URL(successor.baseUrl).port,
+        String(PORT),
+        "expected the successor to reclaim the exact orphaned port, not walk up",
+      );
+      await successor.info(); // confirm it's genuinely up, not just bound
+    } finally {
+      await successor?.shutdown();
+      // Belt-and-suspenders: if the assertion above failed (reap didn't
+      // work), don't leave the orphan running on the dev machine.
+      killOrphanProcessGroup(orphan);
+      await reapStaleRuntimeOnPort(PORT);
+    }
+  },
+);
+
+test(
+  "launch() with reapStale: false leaves an orphan running and walks up to a free port",
+  { skip: !e2eEnabled, timeout: 300_000 },
+  async () => {
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot, "expected to find the cargo workspace root");
+
+    const orphanPort = PORT + 10;
+    const orphan = spawnOrphan(orphanPort, repoRoot);
+    let successor: GameServer | undefined;
+    try {
+      await waitUntilOwnedHealthy(orphanPort, orphan.instanceId, 300_000);
+
+      successor = await GameServer.launch({
+        mission: "medsci1.mis",
+        port: orphanPort,
+        reapStale: false,
+      });
+      assert.notEqual(
+        new URL(successor.baseUrl).port,
+        String(orphanPort),
+        "reapStale: false must not touch the orphan - launch should walk up instead",
+      );
+      // The orphan itself must still be alive and still OUR instance.
+      const stillUp = await fetch(`http://127.0.0.1:${orphanPort}/v1/health`);
+      assert.ok(stillUp.ok, "the orphan should be untouched and still serving");
+      const body = (await stillUp.json()) as { instance_id?: string | null };
+      assert.equal(body.instance_id, orphan.instanceId, "the untouched orphan should still be ours");
+    } finally {
+      await successor?.shutdown();
+      killOrphanProcessGroup(orphan);
+      await reapStaleRuntimeOnPort(orphanPort);
+    }
+  },
+);

--- a/tools/shock2-sdk/test/unit.test.ts
+++ b/tools/shock2-sdk/test/unit.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
 import { test } from "node:test";
 
 import { Game, findRepoRoot } from "../src/index.js";
@@ -75,4 +76,173 @@ test("findFreePort skips ports that are already bound", async () => {
   } finally {
     await new Promise((resolve) => blocker.close(resolve));
   }
+});
+
+test("reapStaleRuntimeOnPort kills a debug_runtime bound to the port", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+  const killed: Array<{ pid: number; signal: string }> = [];
+
+  const result = await reapStaleRuntimeOnPort(8080, {
+    findProcesses: async (port) => {
+      assert.equal(port, 8080);
+      return [{ pid: 4242, command: "target/debug/debug_runtime --mission medsci1.mis --port 8080" }];
+    },
+    kill: (pid, signal) => killed.push({ pid, signal }),
+  });
+
+  assert.deepEqual(result, [4242]);
+  assert.deepEqual(killed, [{ pid: 4242, signal: "SIGKILL" }]);
+});
+
+test("reapStaleRuntimeOnPort never kills a process that isn't debug_runtime", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+  const killed: number[] = [];
+
+  const result = await reapStaleRuntimeOnPort(8080, {
+    findProcesses: async () => [
+      { pid: 111, command: "com.docker.backend --some-flag" },
+      { pid: 222, command: "node dist/some-other-server.js --port 8080" },
+    ],
+    kill: (pid) => killed.push(pid),
+  });
+
+  assert.deepEqual(result, []);
+  assert.deepEqual(killed, []);
+});
+
+test("reapStaleRuntimeOnPort only kills the candidate whose args exactly name --port <port>", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+  const killed: number[] = [];
+
+  // Two debug_runtime processes turn up (e.g. a stale entry mid-lsof-vs-ps
+  // race) - only the one that actually names this port should be killed.
+  const result = await reapStaleRuntimeOnPort(9001, {
+    findProcesses: async () => [
+      { pid: 1, command: "target/debug/debug_runtime --mission medsci1.mis --port 9002" },
+      { pid: 2, command: "target/debug/debug_runtime --mission earth.mis --port 9001" },
+    ],
+    kill: (pid) => killed.push(pid),
+  });
+
+  assert.deepEqual(result, [2]);
+  assert.deepEqual(killed, [2]);
+});
+
+test("reapStaleRuntimeOnPort rejects substring look-alikes (executable name and port)", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+  const killed: number[] = [];
+
+  const result = await reapStaleRuntimeOnPort(808, {
+    findProcesses: async () => [
+      // Not our binary, despite containing "debug_runtime" as a substring.
+      { pid: 1, command: "/opt/tools/debug_runtime_proxy --port 808" },
+      // Right binary, but "--port 8080" is not the literal token "808".
+      { pid: 2, command: "target/debug/debug_runtime --mission medsci1.mis --port 8080" },
+    ],
+    kill: (pid) => killed.push(pid),
+  });
+
+  assert.deepEqual(result, [], "neither look-alike should be treated as a match");
+  assert.deepEqual(killed, []);
+});
+
+test("reapStaleRuntimeOnPort is a no-op when nothing is listening", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+  const killed: number[] = [];
+
+  const result = await reapStaleRuntimeOnPort(8080, {
+    findProcesses: async () => [],
+    kill: (pid) => killed.push(pid),
+  });
+
+  assert.deepEqual(result, []);
+  assert.deepEqual(killed, []);
+});
+
+test("reapStaleRuntimeOnPort tolerates a kill failing (process already gone)", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+
+  const result = await reapStaleRuntimeOnPort(8080, {
+    findProcesses: async () => [
+      { pid: 4242, command: "target/debug/debug_runtime --mission medsci1.mis --port 8080" },
+    ],
+    kill: () => {
+      throw new Error("ESRCH: no such process");
+    },
+  });
+
+  assert.deepEqual(result, [], "a failed kill isn't reported as killed");
+});
+
+test("reapStaleRuntimeOnPort swallows discovery errors", async () => {
+  const { reapStaleRuntimeOnPort } = await import("../src/server.js");
+
+  const result = await reapStaleRuntimeOnPort(8080, {
+    findProcesses: async () => {
+      throw new Error("lsof not found");
+    },
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test("GameServer.launch reaps only the requested launch port, never a fallback port", async () => {
+  const { GameServer, reapHooks } = await import("../src/server.js");
+  const requestedPorts: number[] = [];
+  const originalReap = reapHooks.reapStaleRuntimeOnPort;
+
+  // Stub out the reap hook to observe what port(s) launch() asks it to
+  // check, without spawning a real debug_runtime. This exercises the option
+  // plumbing added for #786: `reapStale` gating the call, and the call
+  // always targeting the literal requested port hint - never `hint + attempt`
+  // from the bind-race retry loop.
+  reapHooks.reapStaleRuntimeOnPort = async (port: number) => {
+    requestedPorts.push(port);
+    return [];
+  };
+  try {
+    // repoRoot points at a real directory with no Cargo.toml, so `cargo run`
+    // fails near-instantly ("could not find Cargo.toml") instead of actually
+    // compiling/running debug_runtime - fast and side-effect-free, while
+    // still exercising the real launch()/launchOnce() code path around the
+    // reap call.
+    await assert.rejects(
+      GameServer.launch({
+        mission: "medsci1.mis",
+        port: 47001,
+        launchTimeoutMs: 2000,
+        repoRoot: tmpdir(),
+      }),
+    );
+  } finally {
+    reapHooks.reapStaleRuntimeOnPort = originalReap;
+  }
+
+  assert.deepEqual(requestedPorts, [47001], "reaps exactly the requested port, once");
+});
+
+test("GameServer.launch skips reaping when reapStale is false", async () => {
+  const { GameServer, reapHooks } = await import("../src/server.js");
+  const requestedPorts: number[] = [];
+  const originalReap = reapHooks.reapStaleRuntimeOnPort;
+
+  reapHooks.reapStaleRuntimeOnPort = async (port: number) => {
+    requestedPorts.push(port);
+    return [];
+  };
+  try {
+    await assert.rejects(
+      GameServer.launch({
+        mission: "medsci1.mis",
+        port: 47002,
+        launchTimeoutMs: 2000,
+        repoRoot: tmpdir(),
+        reapStale: false,
+      }),
+    );
+  } finally {
+    reapHooks.reapStaleRuntimeOnPort = originalReap;
+  }
+
+  assert.deepEqual(requestedPorts, [], "reapStale: false must not call the reap hook at all");
 });


### PR DESCRIPTION
## Summary

- **Fixes #786**: `GameServer.launch` now reaps (SIGKILL) a stale `debug_runtime` already bound to the requested launch port before starting a new one, by default (`reapStale?: boolean`, default `true`). Long automation campaigns accumulate orphaned `debug_runtime` processes when an agent dies without reaching `/v1/shutdown` - a 10-hour orphan at ~100% CPU was found during the #783 investigation, with five runtimes alive at once.
- Only ever targets the **exact requested port** (`port ?? 8080`) - never a fallback port from the existing bind-race retry loop (`hint + attempt`), and never a port a live `GameServer` in the *same* process already owns (that's an in-flight sibling launch, not an orphan - the pre-existing `reservedPorts` in-process bookkeeping already makes the free-port walk-up skip it, so reaping it would only destroy a live instance for no benefit).
- Discovery: `lsof` for candidate pids bound to the port, then `ps -o command=` for each one's full command line (`lsof`'s own `COMMAND` column truncates to 9 chars and drops args, so it can't check for `--port <port>` in argv). A candidate is only killed if its executable basename is exactly `debug_runtime` **and** its args contain the literal token pair `--port <port>` - tokenized matching, not a raw substring check, so e.g. `debug_runtime_proxy` or a `--port 8080` vs. `--port 808` collision can't be mistaken for a match.
- Passing `reapStale: false` restores the old behavior (walk up to the next free port, never touch what's already there).

## Test plan

- [x] `npx tsc --noEmit` - clean
- [x] `npm test` (unit, 35 pass / 0 fail) - includes:
  - `reapStaleRuntimeOnPort` core logic: kills a matching candidate, never kills a non-`debug_runtime`, only kills the candidate with the exact matching `--port`, rejects substring look-alikes (executable name and port), no-op when nothing's listening, tolerates a kill failing, swallows discovery errors
  - Option plumbing (mocked): `GameServer.launch` calls the reap hook exactly once with the literal requested port; `reapStale: false` skips it entirely
- [x] `npm run test:e2e`'s new `reap-stale.e2e.test.ts` (`SHOCK2_E2E=1`, real processes, no mocking): spawns a genuine orphan `debug_runtime` directly via `child_process` (bypassing `GameServer.launch`, since going through it would register the port in the SDK's own same-process bookkeeping instead of exercising the real cross-process reap path), verifies the default path reaps it and the successor reclaims the *exact* port; a second test verifies `reapStale: false` leaves the orphan alone and walks up instead. Both verify ownership via `/v1/health`'s `instance_id` to stay safe on a shared/busy dev host. **Both pass.**
- [x] `cargo fmt --all` - no Rust files touched, no-op
- [x] README's lifecycle section updated to document reaping and its scope/risk

## Review

Cross-engine adversarial review (`/xreview`: Claude subagent + Codex CLI) both independently flagged that the initial version would kill *any* `debug_runtime` on the port including a live sibling launched by the same process - fixed via the `reservedPorts` same-process guard above. Both also converged on tightening the process-match from substring to exact-token matching - done. A follow-up Codex pass flagged the e2e test could mistake an unrelated pre-existing service on the port for its own fixture - fixed via the `instance_id` ownership check. Remaining lower-severity notes (a theoretical PID-reuse race between `lsof` and `kill`, and best-effort discovery failures degrading silently to the pre-existing walk-up behavior) were judged acceptable residual risk for a local dev-automation tool rather than requiring further complexity.

campaign: engineering-through-shodan · none · legacy · seed 1378752978

🤖 Generated with [Claude Code](https://claude.com/claude-code)