### PR TITLE
fix(ai): re-acquire visible players after alertness decay

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -78,6 +78,27 @@ fn default_alert_cap() -> PropAIAlertCap {
     }
 }
 
+/// Whether a creature that can currently see the player should turn to face
+/// it, overriding the heading its own behavior asked for.
+///
+/// Sight is the only thing that escalates alertness, but the behaviors an
+/// unaware creature runs steer by their own agenda - wander picks a random
+/// destination, patrol follows its route, search walks to a stale position -
+/// so a creature that spots the player promptly turns away, loses the
+/// contact before it can escalate, and decays back to calm. It then stands
+/// facing wherever it stopped, permanently blind to a player outside that
+/// cone: the "never re-acquires after alertness decays" loop of #791.
+/// Orienting on what it can see lets the normal escalation ladder finish.
+///
+/// Pursuing levels (Moderate and up) are excluded because their behaviors
+/// already steer at their target, and a running scripted sequence owns its
+/// actor's heading.
+fn should_orient_on_target(level: AIAlertLevel, is_visible: bool, scripted: ScriptedState) -> bool {
+    is_visible
+        && matches!(level, AIAlertLevel::Lowest | AIAlertLevel::Low)
+        && scripted != ScriptedState::Running
+}
+
 /// Forward-speed multiplier for a given heading error: 1.0 facing the
 /// travel direction, ramping down to a third by 60 degrees of error and
 /// flooring there. The floor is never zero - steering chains (collision
@@ -946,6 +967,20 @@ impl Script for AnimatedMonsterAI {
                 Effect::NoEffect,
             ));
 
+        // Keep looking at a player this creature can actually see, so the
+        // sighting survives long enough to escalate (see
+        // `should_orient_on_target`). The behavior's own steering effects
+        // still apply - only the heading is overridden.
+        let steering_output = if should_orient_on_target(
+            self.alertness.current_level,
+            is_visible,
+            self.current_behavior.borrow().scripted_state(),
+        ) {
+            orient_toward_player(world, entity_id).unwrap_or(steering_output)
+        } else {
+            steering_output
+        };
+
         let rotation_effect = self.apply_steering_output(steering_output, time, entity_id);
 
         // A finished scripted sequence (its final queued effects were drained
@@ -1342,6 +1377,16 @@ impl Script for AnimatedMonsterAI {
     }
 }
 
+/// Steering that faces the player's current position.
+fn orient_toward_player(world: &World, entity_id: EntityId) -> Option<SteeringOutput> {
+    let player_pos = world.borrow::<UniqueView<PlayerInfo>>().ok()?.pos;
+    let (position, _) = get_position_and_forward(world, entity_id);
+    Some(Steering::turn_to_point(
+        position,
+        crate::util::vec3_to_point3(player_pos),
+    ))
+}
+
 fn player_is_within_watch_obj(world: &World, entity_id: EntityId, radius: f32) -> bool {
     let u_player = world.borrow::<shipyard::UniqueView<PlayerInfo>>().unwrap();
     let v_current_pos = world.borrow::<View<PropPosition>>().unwrap();
@@ -1367,6 +1412,130 @@ fn is_attack_animation(motion_query_items: &[MotionQueryItem]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A live monster at the origin, turned `heading` degrees off +Z, with the
+    /// player standing 10 units down +Z. The physics world is empty, so
+    /// line-of-sight is always clear and only the FOV cone gates visibility.
+    fn world_with_monster_and_player(heading: Deg<f32>) -> (World, EntityId) {
+        let mut world = World::new();
+        let rotation = Quaternion::from_angle_y(heading);
+        let entity_id = world.add_entity((
+            dark::properties::PropHitPoints { hit_points: 12 },
+            dark::properties::PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation,
+                cell: 0,
+            },
+            crate::runtime_props::RuntimePropTransform(cgmath::Matrix4::from(rotation)),
+        ));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 10.0),
+            rotation: Quaternion::from_angle_y(Deg(0.0)),
+            entity_id: EntityId::dead(),
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: EntityId::dead(),
+        });
+        (world, entity_id)
+    }
+
+    /// The yaw (degrees off +Z) the monster asked the world to set this frame.
+    fn commanded_heading(effects: &[Effect]) -> Option<Deg<f32>> {
+        effects.iter().find_map(|effect| match effect {
+            Effect::SetRotation { rotation, .. } => {
+                Some(Deg(2.0 * rotation.v.y.atan2(rotation.s).to_degrees()))
+            }
+            _ => None,
+        })
+    }
+
+    fn step(monster: &mut AnimatedMonsterAI, world: &World, entity_id: EntityId) -> Vec<Effect> {
+        let physics = PhysicsWorld::new();
+        let time = Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_millis(100),
+        };
+        Effect::flatten(vec![monster.update(entity_id, world, &physics, &time)])
+    }
+
+    /// #791: a calm creature that can see the player must turn to look at it.
+    /// Its idle/wander/patrol steering has its own agenda, so without this the
+    /// sighting is dropped before alertness can escalate and the creature ends
+    /// up parked facing away, unable to ever re-acquire.
+    #[test]
+    fn calm_monster_turns_toward_a_visible_player() {
+        // 45 degrees off the player: inside the 60-degree FOV half-angle, so
+        // the player is plainly visible.
+        let (world, entity_id) = world_with_monster_and_player(Deg(45.0));
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+        assert_eq!(monster.alertness.current_level, AIAlertLevel::Lowest);
+
+        let effects = step(&mut monster, &world, entity_id);
+
+        let heading = commanded_heading(&effects).expect("the AI steers every frame");
+        assert!(
+            heading.0 < 44.0,
+            "a calm AI that sees the player should turn toward it (0 degrees), got {heading:?}",
+        );
+    }
+
+    /// The counterpart: sight still gates the turn. A creature facing away has
+    /// no idea the player is there and must not swivel onto them.
+    #[test]
+    fn calm_monster_ignores_a_player_outside_its_fov() {
+        // Turned 180 degrees from the player - well outside the FOV cone.
+        let (world, entity_id) = world_with_monster_and_player(Deg(180.0));
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        let effects = step(&mut monster, &world, entity_id);
+
+        let heading = commanded_heading(&effects).expect("the AI steers every frame");
+        assert!(
+            (heading.0.abs() - 180.0).abs() < 1.0,
+            "an AI that cannot see the player must hold its heading, got {heading:?}",
+        );
+    }
+
+    #[test]
+    fn orienting_on_target_needs_sight_and_a_non_pursuing_unscripted_ai() {
+        use ScriptedState::*;
+        // Sighted while unaware or merely suspicious: look at it.
+        assert!(should_orient_on_target(
+            AIAlertLevel::Lowest,
+            true,
+            NotScripted
+        ));
+        assert!(should_orient_on_target(
+            AIAlertLevel::Low,
+            true,
+            NotScripted
+        ));
+        // No sight, no turn.
+        assert!(!should_orient_on_target(
+            AIAlertLevel::Lowest,
+            false,
+            NotScripted
+        ));
+        // Pursuing behaviors steer at their own target.
+        assert!(!should_orient_on_target(
+            AIAlertLevel::Moderate,
+            true,
+            NotScripted
+        ));
+        assert!(!should_orient_on_target(
+            AIAlertLevel::High,
+            true,
+            NotScripted
+        ));
+        // A running scripted sequence owns its actor's heading.
+        assert!(!should_orient_on_target(
+            AIAlertLevel::Lowest,
+            true,
+            Running
+        ));
+    }
 
     #[test]
     fn killed_monster_initializes_inert_without_replaying_death_effects() {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -282,6 +282,14 @@ impl AnimatedMonsterAI {
     /// it is flagged to and a route exists, otherwise stand idle. Falls back to
     /// idle when the mission has no patrol network reachable from here.
     fn idle_behavior(&self, world: &World, entity_id: EntityId) -> Box<RefCell<dyn Behavior>> {
+        // A creature excluded from awareness entirely (an apparition - see
+        // `build_config`) can never see the player, so it has nothing to
+        // look around for and no reason to leave its mark: it holds the
+        // heading its authored performance was staged with. This also covers
+        // the handback after a scripted sequence finishes.
+        if self.config.is_none() {
+            return Box::new(RefCell::new(IdleBehavior::holding_post()));
+        }
         if is_patroller(world, entity_id) {
             let (position, _) = get_position_and_forward(world, entity_id);
             if let Some((point, goal)) = nearest_patrol_point(world, position.to_vec()) {
@@ -724,6 +732,14 @@ impl Script for AnimatedMonsterAI {
 
         // Load alertness configuration from entity properties
         self.config = Self::build_config(world, entity_id);
+
+        // A creature with no config is excluded from awareness entirely (an
+        // apparition - see `build_config`). It never runs an alertness
+        // transition, so it would otherwise sit in the constructor's
+        // scanning idle for its whole life; `idle_behavior` holds it still.
+        if self.config.is_none() {
+            self.current_behavior = self.idle_behavior(world, entity_id);
+        }
 
         // Initialize alertness state
         let alertness_effect = if let Some(config) = &self.config {
@@ -1513,6 +1529,27 @@ mod tests {
             (heading.0 - 45.0).abs() < 1.0,
             "an apparition must hold its authored heading, got {heading:?}",
         );
+    }
+
+    /// ...and it must keep holding it: the idle scan that lets a posted
+    /// creature look around (#791) must not reach a creature excluded from
+    /// awareness, or a ghost slowly swings off its authored mark.
+    #[test]
+    fn apparition_holds_its_heading_instead_of_scanning() {
+        let (world, entity_id) =
+            world_with_creature_and_player(Deg(180.0), "creaturetype apparition");
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        // Well past the idle scan's dwell and a full sweep.
+        for _ in 0..200 {
+            let effects = step(&mut monster, &world, entity_id);
+            let heading = commanded_heading(&effects).expect("the AI steers every frame");
+            assert!(
+                (heading.0.abs() - 180.0).abs() < 1.0,
+                "an apparition must hold its authored heading, got {heading:?}",
+            );
+        }
     }
 
     /// The counterpart: sight still gates the turn. A creature facing away has

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -91,10 +91,17 @@ fn default_alert_cap() -> PropAIAlertCap {
 /// Orienting on what it can see lets the normal escalation ladder finish.
 ///
 /// Pursuing levels (Moderate and up) are excluded because their behaviors
-/// already steer at their target, and a running scripted sequence owns its
-/// actor's heading.
-fn should_orient_on_target(level: AIAlertLevel, is_visible: bool, scripted: ScriptedState) -> bool {
-    is_visible
+/// already steer at their target, a running scripted sequence owns its
+/// actor's heading, and a creature with no alertness config at all (an
+/// apparition - see `build_config`) must never notice the player.
+fn should_orient_on_target(
+    processes_alertness: bool,
+    level: AIAlertLevel,
+    is_visible: bool,
+    scripted: ScriptedState,
+) -> bool {
+    processes_alertness
+        && is_visible
         && matches!(level, AIAlertLevel::Lowest | AIAlertLevel::Low)
         && scripted != ScriptedState::Running
 }
@@ -972,6 +979,7 @@ impl Script for AnimatedMonsterAI {
         // `should_orient_on_target`). The behavior's own steering effects
         // still apply - only the heading is overridden.
         let steering_output = if should_orient_on_target(
+            self.config.is_some(),
             self.alertness.current_level,
             is_visible,
             self.current_behavior.borrow().scripted_state(),
@@ -1417,10 +1425,15 @@ mod tests {
     /// player standing 10 units down +Z. The physics world is empty, so
     /// line-of-sight is always clear and only the FOV cone gates visibility.
     fn world_with_monster_and_player(heading: Deg<f32>) -> (World, EntityId) {
+        world_with_creature_and_player(heading, "creaturetype hybrid")
+    }
+
+    fn world_with_creature_and_player(heading: Deg<f32>, class_tag: &str) -> (World, EntityId) {
         let mut world = World::new();
         let rotation = Quaternion::from_angle_y(heading);
         let entity_id = world.add_entity((
             dark::properties::PropHitPoints { hit_points: 12 },
+            dark::properties::PropClassTag::from_string(class_tag),
             dark::properties::PropPosition {
                 position: vec3(0.0, 0.0, 0.0),
                 rotation,
@@ -1473,10 +1486,32 @@ mod tests {
 
         let effects = step(&mut monster, &world, entity_id);
 
+        // 100ms at the 180 deg/s turn speed closes 18 of the 45 degrees.
         let heading = commanded_heading(&effects).expect("the AI steers every frame");
         assert!(
-            heading.0 < 44.0,
+            (26.0..28.0).contains(&heading.0),
             "a calm AI that sees the player should turn toward it (0 degrees), got {heading:?}",
+        );
+    }
+
+    /// Apparitions replay an authored performance and are excluded from
+    /// alertness entirely (`build_config` returns no config for them), so the
+    /// player they "see" must not turn their head either - a ghost that
+    /// tracked the player would face away from its mark.
+    #[test]
+    fn apparition_does_not_track_a_visible_player() {
+        let (world, entity_id) =
+            world_with_creature_and_player(Deg(45.0), "creaturetype apparition");
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+        assert!(monster.config.is_none(), "apparitions process no alertness");
+
+        let effects = step(&mut monster, &world, entity_id);
+
+        let heading = commanded_heading(&effects).expect("the AI steers every frame");
+        assert!(
+            (heading.0 - 45.0).abs() < 1.0,
+            "an apparition must hold its authored heading, got {heading:?}",
         );
     }
 
@@ -1503,37 +1538,50 @@ mod tests {
         use ScriptedState::*;
         // Sighted while unaware or merely suspicious: look at it.
         assert!(should_orient_on_target(
+            true,
             AIAlertLevel::Lowest,
             true,
             NotScripted
         ));
         assert!(should_orient_on_target(
+            true,
             AIAlertLevel::Low,
             true,
             NotScripted
         ));
         // No sight, no turn.
         assert!(!should_orient_on_target(
+            true,
             AIAlertLevel::Lowest,
             false,
             NotScripted
         ));
         // Pursuing behaviors steer at their own target.
         assert!(!should_orient_on_target(
+            true,
             AIAlertLevel::Moderate,
             true,
             NotScripted
         ));
         assert!(!should_orient_on_target(
+            true,
             AIAlertLevel::High,
             true,
             NotScripted
         ));
         // A running scripted sequence owns its actor's heading.
         assert!(!should_orient_on_target(
+            true,
             AIAlertLevel::Lowest,
             true,
             Running
+        ));
+        // A creature that processes no alertness notices nothing.
+        assert!(!should_orient_on_target(
+            false,
+            AIAlertLevel::Lowest,
+            true,
+            NotScripted
         ));
     }
 

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -172,7 +172,7 @@ impl AnimatedMonsterAI {
             handoff_emitted: false,
             death_impact: None,
             took_damage: false,
-            current_behavior: Box::new(RefCell::new(IdleBehavior)),
+            current_behavior: Box::new(RefCell::new(IdleBehavior::new())),
             current_heading: Deg(0.0),
             animation_seq: 0,
             locomotion_seq: 0,
@@ -196,7 +196,7 @@ impl AnimatedMonsterAI {
             death_impact: None,
             took_damage: false,
             // Start with IdleBehavior - alertness will drive behavior changes
-            current_behavior: Box::new(RefCell::new(IdleBehavior)),
+            current_behavior: Box::new(RefCell::new(IdleBehavior::new())),
             current_heading: Deg(0.0),
             animation_seq: 0,
             locomotion_seq: 0,
@@ -288,7 +288,7 @@ impl AnimatedMonsterAI {
                 return Box::new(RefCell::new(PatrolBehavior::new(point, goal)));
             }
         }
-        Box::new(RefCell::new(IdleBehavior))
+        Box::new(RefCell::new(IdleBehavior::new()))
     }
 
     fn apply_steering_output(

--- a/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
@@ -42,8 +42,18 @@ const SCAN_HALF_ARC_DEGREES: f32 = 90.0;
 /// itself is relaxed - the creature still only ever sees what is genuinely
 /// in front of it and unoccluded.
 pub struct IdleBehavior {
+    /// Whether this creature looks around at all. Creatures excluded from
+    /// awareness entirely never do - see `holding_post`.
+    scans: bool,
     /// The heading the creature took its post with. Latched on the first
     /// steer, because the script - not the behavior - owns the heading.
+    ///
+    /// Not persisted across save/load (the script persists no behavior state
+    /// at all today - alertness and last-known position reset too), so a
+    /// reloaded creature re-anchors on whatever heading it was saved
+    /// mid-sweep with, rotating which wedge behind it is blind. It keeps its
+    /// post position and still sweeps 300 degrees, so it is never blind in
+    /// one direction forever - see #791 follow-up.
     post_heading: Option<Deg<f32>>,
     /// Current sweep offset from `post_heading`, in degrees.
     offset: f32,
@@ -69,6 +79,7 @@ impl IdleBehavior {
             -1.0
         };
         IdleBehavior {
+            scans: true,
             post_heading: None,
             offset: 0.0,
             target: direction * SCAN_HALF_ARC_DEGREES,
@@ -77,9 +88,30 @@ impl IdleBehavior {
         }
     }
 
+    /// Standing still: holds the heading it is given and never looks around.
+    ///
+    /// For creatures excluded from awareness entirely - apparitions, which
+    /// have no alertness config at all (see
+    /// `AnimatedMonsterAI::build_config`). They can never see the player, so
+    /// they have nothing to look for, and swinging them off the heading
+    /// their authored performance was staged with would face a ghost away
+    /// from its mark.
+    pub fn holding_post() -> IdleBehavior {
+        IdleBehavior {
+            scans: false,
+            post_heading: None,
+            offset: 0.0,
+            target: 0.0,
+            dwell: 0.0,
+        }
+    }
+
     /// Advance the scan by `delta` seconds, returning the offset from the
     /// post heading to face.
     fn advance(&mut self, delta: f32) -> f32 {
+        if !self.scans {
+            return 0.0;
+        }
         if self.dwell > 0.0 {
             self.dwell -= delta;
             return self.offset;
@@ -132,15 +164,19 @@ impl Behavior for IdleBehavior {
 mod tests {
     use super::*;
 
-    fn steer_for(behavior: &mut IdleBehavior, post: Deg<f32>, seconds: f32) -> f32 {
-        let world = World::new();
-        let physics = PhysicsWorld::new();
+    fn steer_for(
+        behavior: &mut IdleBehavior,
+        world: &World,
+        physics: &PhysicsWorld,
+        post: Deg<f32>,
+        seconds: f32,
+    ) -> f32 {
         let time = Time {
             elapsed: std::time::Duration::from_secs_f32(seconds),
             total: std::time::Duration::from_secs_f32(seconds),
         };
         behavior
-            .steer(post, &world, &physics, EntityId::dead(), &time)
+            .steer(post, world, physics, EntityId::dead(), &time)
             .expect("idle always steers")
             .0
             .desired_heading
@@ -167,6 +203,7 @@ mod tests {
     /// everything outside that one direction permanently invisible to it.
     #[test]
     fn idle_sweeps_its_heading_to_both_sides_of_its_post() {
+        let (world, physics) = (World::new(), PhysicsWorld::new());
         let mut behavior = IdleBehavior::new();
         let post = Deg(30.0);
 
@@ -174,7 +211,7 @@ mod tests {
         let mut max_offset: f32 = 0.0;
         // Two full sweeps' worth of dwell + travel, at 60Hz.
         for _ in 0..1200 {
-            let offset = steer_for(&mut behavior, post, 1.0 / 60.0) - post.0;
+            let offset = steer_for(&mut behavior, &world, &physics, post, 1.0 / 60.0) - post.0;
             min_offset = min_offset.min(offset);
             max_offset = max_offset.max(offset);
         }
@@ -193,14 +230,32 @@ mod tests {
     /// drifts off the heading it was left with.
     #[test]
     fn idle_sweep_stays_within_its_arc() {
+        let (world, physics) = (World::new(), PhysicsWorld::new());
         let mut behavior = IdleBehavior::new();
         let post = Deg(-140.0);
 
         for _ in 0..1800 {
-            let offset = steer_for(&mut behavior, post, 1.0 / 60.0) - post.0;
+            let offset = steer_for(&mut behavior, &world, &physics, post, 1.0 / 60.0) - post.0;
             assert!(
                 offset.abs() <= SCAN_HALF_ARC_DEGREES + 0.01,
                 "idle swept {offset} degrees off its post",
+            );
+        }
+    }
+
+    /// A creature excluded from awareness never looks around: it holds the
+    /// heading its authored performance was staged with.
+    #[test]
+    fn a_still_idle_holds_its_heading_forever() {
+        let (world, physics) = (World::new(), PhysicsWorld::new());
+        let mut behavior = IdleBehavior::holding_post();
+        let post = Deg(-15.0);
+
+        for _ in 0..1200 {
+            let heading = steer_for(&mut behavior, &world, &physics, post, 1.0 / 60.0);
+            assert!(
+                (heading - post.0).abs() < f32::EPSILON,
+                "a still idle must not turn, got {heading}",
             );
         }
     }
@@ -210,10 +265,11 @@ mod tests {
     /// beat instead of immediately turning away.
     #[test]
     fn idle_holds_its_post_before_the_first_sweep() {
+        let (world, physics) = (World::new(), PhysicsWorld::new());
         let mut behavior = IdleBehavior::new();
         let post = Deg(75.0);
 
-        let heading = steer_for(&mut behavior, post, 0.1);
+        let heading = steer_for(&mut behavior, &world, &physics, post, 0.1);
         assert!(
             (heading - post.0).abs() < f32::EPSILON,
             "the first frame should hold the post heading, got {heading}",

--- a/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/idle_behavior.rs
@@ -1,8 +1,102 @@
+use cgmath::Deg;
 use dark::motion::MotionQueryItem;
+use rand::Rng;
+use shipyard::{EntityId, World};
+
+use crate::{
+    physics::PhysicsWorld,
+    scripts::{
+        Effect,
+        ai::steering::{Steering, SteeringOutput},
+    },
+    time::Time,
+};
 
 use super::Behavior;
 
-pub struct IdleBehavior;
+/// How long an idle creature holds a heading before sweeping to the next one.
+const SCAN_DWELL_SECONDS: f32 = 2.5;
+
+/// How fast the scan heading sweeps, in degrees per second. Well under the
+/// 180 deg/s turn speed, so the body follows the sweep exactly instead of
+/// snapping between poses.
+const SCAN_SWEEP_DEGREES_PER_SECOND: f32 = 45.0;
+
+/// How far to either side of its post the sweep reaches. Combined with the
+/// 60-degree FOV half-angle this covers 300 degrees around the post and
+/// leaves a blind wedge directly behind it, so sneaking up from straight
+/// back still works.
+const SCAN_HALF_ARC_DEGREES: f32 = 90.0;
+
+/// Standing watch: the creature holds its post, but looks around.
+///
+/// Sight is the only thing that escalates a calm creature's alertness, and
+/// the cone it sees through is fixed to its heading. A creature that never
+/// turns is therefore permanently blind to everything outside that one cone -
+/// the "never re-acquires the player" half of #791. The hydro2 Midwife that
+/// reopened the issue is the clearest case: it takes up its post facing a
+/// ledge wall 1.6 units away, so with a fixed heading no line of sight to it
+/// can ever exist. Sweeping the heading back and forth over the post (Dark's
+/// idle AIs look around the same way) lets the normal FOV + line-of-sight
+/// check eventually see what is really there. Nothing about the sight test
+/// itself is relaxed - the creature still only ever sees what is genuinely
+/// in front of it and unoccluded.
+pub struct IdleBehavior {
+    /// The heading the creature took its post with. Latched on the first
+    /// steer, because the script - not the behavior - owns the heading.
+    post_heading: Option<Deg<f32>>,
+    /// Current sweep offset from `post_heading`, in degrees.
+    offset: f32,
+    /// The end of the sweep currently being travelled to, in degrees.
+    target: f32,
+    /// Seconds left of the pause at this end of the sweep.
+    dwell: f32,
+}
+
+impl Default for IdleBehavior {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdleBehavior {
+    pub fn new() -> IdleBehavior {
+        // Randomize which way the first sweep goes so creatures posted
+        // together don't scan in lockstep.
+        let direction = if rand::thread_rng().gen_bool(0.5) {
+            1.0
+        } else {
+            -1.0
+        };
+        IdleBehavior {
+            post_heading: None,
+            offset: 0.0,
+            target: direction * SCAN_HALF_ARC_DEGREES,
+            // Settle onto the post before the first sweep.
+            dwell: SCAN_DWELL_SECONDS,
+        }
+    }
+
+    /// Advance the scan by `delta` seconds, returning the offset from the
+    /// post heading to face.
+    fn advance(&mut self, delta: f32) -> f32 {
+        if self.dwell > 0.0 {
+            self.dwell -= delta;
+            return self.offset;
+        }
+
+        let step = SCAN_SWEEP_DEGREES_PER_SECOND * delta;
+        if (self.target - self.offset).abs() <= step {
+            // Reached this end of the sweep: pause, then head for the other.
+            self.offset = self.target;
+            self.target = -self.target;
+            self.dwell = SCAN_DWELL_SECONDS;
+        } else {
+            self.offset += step * (self.target - self.offset).signum();
+        }
+        self.offset
+    }
+}
 
 impl Behavior for IdleBehavior {
     fn name(&self) -> &'static str {
@@ -16,15 +110,46 @@ impl Behavior for IdleBehavior {
     fn animation_queries(&self) -> Vec<Vec<MotionQueryItem>> {
         vec![self.animation(), vec![MotionQueryItem::new("stand")]]
     }
+
+    fn steer(
+        &mut self,
+        current_heading: Deg<f32>,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _entity_id: EntityId,
+        time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        let post = *self.post_heading.get_or_insert(current_heading);
+        let offset = self.advance(time.elapsed.as_secs_f32());
+        Some((
+            Steering::from_current(Deg(post.0 + offset)),
+            Effect::NoEffect,
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn steer_for(behavior: &mut IdleBehavior, post: Deg<f32>, seconds: f32) -> f32 {
+        let world = World::new();
+        let physics = PhysicsWorld::new();
+        let time = Time {
+            elapsed: std::time::Duration::from_secs_f32(seconds),
+            total: std::time::Duration::from_secs_f32(seconds),
+        };
+        behavior
+            .steer(post, &world, &physics, EntityId::dead(), &time)
+            .expect("idle always steers")
+            .0
+            .desired_heading
+            .0
+    }
+
     #[test]
     fn idle_prefers_gesture_then_stand() {
-        let queries = IdleBehavior.animation_queries();
+        let queries = IdleBehavior::new().animation_queries();
         let tags = queries
             .iter()
             .map(|query| {
@@ -36,5 +161,62 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(tags, vec![vec!["idlegesture"], vec!["stand"]]);
+    }
+
+    /// #791: an idle creature must look around, or its fixed FOV cone leaves
+    /// everything outside that one direction permanently invisible to it.
+    #[test]
+    fn idle_sweeps_its_heading_to_both_sides_of_its_post() {
+        let mut behavior = IdleBehavior::new();
+        let post = Deg(30.0);
+
+        let mut min_offset: f32 = 0.0;
+        let mut max_offset: f32 = 0.0;
+        // Two full sweeps' worth of dwell + travel, at 60Hz.
+        for _ in 0..1200 {
+            let offset = steer_for(&mut behavior, post, 1.0 / 60.0) - post.0;
+            min_offset = min_offset.min(offset);
+            max_offset = max_offset.max(offset);
+        }
+
+        assert!(
+            max_offset >= SCAN_HALF_ARC_DEGREES - 0.01,
+            "idle should sweep a full arc to one side, reached {max_offset}",
+        );
+        assert!(
+            min_offset <= -(SCAN_HALF_ARC_DEGREES - 0.01),
+            "idle should sweep a full arc to the other side, reached {min_offset}",
+        );
+    }
+
+    /// The sweep is anchored on the post, so a creature standing watch never
+    /// drifts off the heading it was left with.
+    #[test]
+    fn idle_sweep_stays_within_its_arc() {
+        let mut behavior = IdleBehavior::new();
+        let post = Deg(-140.0);
+
+        for _ in 0..1800 {
+            let offset = steer_for(&mut behavior, post, 1.0 / 60.0) - post.0;
+            assert!(
+                offset.abs() <= SCAN_HALF_ARC_DEGREES + 0.01,
+                "idle swept {offset} degrees off its post",
+            );
+        }
+    }
+
+    /// It settles onto its post before the first sweep, so a creature that
+    /// just took up a heading (e.g. after losing the player) holds it for a
+    /// beat instead of immediately turning away.
+    #[test]
+    fn idle_holds_its_post_before_the_first_sweep() {
+        let mut behavior = IdleBehavior::new();
+        let post = Deg(75.0);
+
+        let heading = steer_for(&mut behavior, post, 0.1);
+        assert!(
+            (heading - post.0).abs() < f32::EPSILON,
+            "the first frame should hold the post heading, got {heading}",
+        );
     }
 }

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -113,7 +113,7 @@ impl Behavior for PatrolBehavior {
         _entity_id: EntityId,
     ) -> NextBehavior {
         if self.finished {
-            NextBehavior::Next(Box::new(RefCell::new(IdleBehavior)))
+            NextBehavior::Next(Box::new(RefCell::new(IdleBehavior::new())))
         } else {
             NextBehavior::Stay
         }

--- a/shock2vr/src/scripts/ai/behavior/search_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/search_behavior.rs
@@ -143,7 +143,7 @@ impl Behavior for SearchBehavior {
             .ok()
             .and_then(|v| v.get(entity_id).ok().map(|a| a.level));
         if matches!(level, Some(AIAlertLevel::Lowest)) {
-            NextBehavior::Next(Box::new(RefCell::new(IdleBehavior)))
+            NextBehavior::Next(Box::new(RefCell::new(IdleBehavior::new())))
         } else {
             NextBehavior::Next(Box::new(RefCell::new(WanderBehavior::new())))
         }

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -219,10 +219,12 @@ test(
       "setup: the player must start unseen",
     );
 
-    // One full scan cycle is well under 20 sim-seconds.
+    // A worst-case cycle is ~10s of scanning (the first sweep may go the
+    // other way) plus 1.5s of held sight to reach a pursuing level.
     const trace: string[] = [];
     let reacquired: EntityDetailResult | undefined;
-    for (let tick = 0; tick < 40 && !reacquired; tick++) {
+    let controlSawPlayer: string | undefined;
+    for (let tick = 0; tick < 60 && !reacquired; tick++) {
       await game.step({ frames: 30 }); // 0.5 sim-seconds
       const d = await game.entities.detail(midwife.id);
       trace.push(
@@ -230,13 +232,35 @@ test(
           ` vis=${aiProp(d, "AITargetVisible")} facing=${facingErrorDeg(d, player).toFixed(0)}deg`,
       );
       if (PURSUING.has(aiProp(d, "AIBehavior") ?? "")) reacquired = d;
+      // The control scans too, so check it at every heading it takes, not
+      // just at the end.
+      const c = await game.entities.detail(control.id);
+      if (aiProp(c, "AITargetVisible") === "true") {
+        controlSawPlayer ??= `at ${((tick + 1) * 0.5).toFixed(1)}s`;
+      }
     }
     assert.ok(
       reacquired,
       `the posted AI never scanned around to find the player: ${trace.join(", ")}`,
     );
 
-    // Still no omniscience: the AI across the deck saw nothing.
+    // Give the control a full scan cycle of its own (the main loop stops as
+    // soon as the Midwife re-acquires, which can be well before the control
+    // has swept its whole arc).
+    for (let tick = 0; tick < 34; tick++) {
+      await game.step({ frames: 30 });
+      const c = await game.entities.detail(control.id);
+      if (aiProp(c, "AITargetVisible") === "true") {
+        controlSawPlayer ??= `after ${(tick * 0.5).toFixed(1)}s of its own sweep`;
+      }
+    }
+
+    // Still no omniscience: scanning only changes where an AI looks, so one
+    // with no line of sight to the player never sees it, at any heading.
+    assert.ok(
+      !controlSawPlayer,
+      `an AI behind geometry must never see the player, but did ${controlSawPlayer}`,
+    );
     assert.equal(
       aiProp(await game.entities.detail(control.id), "AIAlertness"),
       "Lowest",

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -162,3 +162,85 @@ test(
     );
   },
 );
+
+// The reopened half of #791 (campaign iteration 22): the AI above is looked at
+// while it can already see the player. The hydro2 Midwife that reopened the
+// issue never could - it takes up its post facing a ledge wall 1.6 units away,
+// so with a fixed heading no line of sight to it can ever exist and the fix
+// above is never reached. A calm creature has to look around.
+test(
+  "a calm native AI scans until it finds a player outside its cone (#791)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT_SCAN ?? 8593),
+    });
+
+    await game.step({ frames: 60 });
+
+    // The Midwife from the issue, found by its stable template id (runtime
+    // entity ids are reassigned every launch).
+    const listed = await game.entities.list({ filter: "Midwife", limit: 50 });
+    const midwife = listed.entities.find((e) => e.template_id === 1676);
+    assert.ok(midwife, "expected hydro2's Midwife (template 1676)");
+
+    // Never engaged: fully calm, and posted facing the ledge (-X).
+    let detail = await game.entities.detail(midwife.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
+    assert.equal(aiProp(detail, "AIBehavior"), "Idle");
+    assert.notEqual(
+      aiProp(detail, "AITargetVisible"),
+      "true",
+      "setup: the Midwife must start unable to see the player",
+    );
+
+    // A control: another native Midwife across the deck, out of sight.
+    const control = listed.entities.find(
+      (e) => e.template_id === 2156, // MidwifeLucy, ~40 units away behind geometry
+    );
+    assert.ok(control, "expected MidwifeLucy for the control");
+
+    // Stand due north of it: clear line of sight, but 90 degrees off its
+    // heading - outside the 60-degree FOV half-angle. Nothing but scanning
+    // can bring the player into view.
+    await game.player.teleport({ x: 80, y: -1, z: 37 });
+    await game.step({ frames: 30 });
+    const player = await game.player.position();
+    detail = await game.entities.detail(midwife.id);
+    const initialFacing = facingErrorDeg(detail, player);
+    assert.ok(
+      initialFacing > 60,
+      `setup: the player must start outside the FOV cone, got ${initialFacing.toFixed(0)} degrees`,
+    );
+    assert.notEqual(
+      aiProp(detail, "AITargetVisible"),
+      "true",
+      "setup: the player must start unseen",
+    );
+
+    // One full scan cycle is well under 20 sim-seconds.
+    const trace: string[] = [];
+    let reacquired: EntityDetailResult | undefined;
+    for (let tick = 0; tick < 40 && !reacquired; tick++) {
+      await game.step({ frames: 30 }); // 0.5 sim-seconds
+      const d = await game.entities.detail(midwife.id);
+      trace.push(
+        `${((tick + 1) * 0.5).toFixed(1)}s ${aiProp(d, "AIAlertness")}/${aiProp(d, "AIBehavior")}` +
+          ` vis=${aiProp(d, "AITargetVisible")} facing=${facingErrorDeg(d, player).toFixed(0)}deg`,
+      );
+      if (PURSUING.has(aiProp(d, "AIBehavior") ?? "")) reacquired = d;
+    }
+    assert.ok(
+      reacquired,
+      `the posted AI never scanned around to find the player: ${trace.join(", ")}`,
+    );
+
+    // Still no omniscience: the AI across the deck saw nothing.
+    assert.equal(
+      aiProp(await game.entities.detail(control.id), "AIAlertness"),
+      "Lowest",
+      "an AI that cannot see the player must stay calm",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -61,6 +61,11 @@ test(
       (e) => e.name === "OG-Pipe" && known.has(e.id) && e.distance > 10,
     );
     assert.ok(control, "expected a native OG-Pipe out of sight for the control");
+    assert.notEqual(
+      aiProp(await game.entities.detail(control.id), "AITargetVisible"),
+      "true",
+      "setup: the control AI must not be able to see the player",
+    );
 
     // The issue's state: a hostile that engaged the player earlier and has
     // since fully calmed down. SetAlertness is scenario setup only - what is

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end regression for #791: a hostile whose alertness decayed back to
+// Lowest/Idle never re-acquired the player, because nothing made it look at
+// what it could see - it turned away mid-detection and calmed down again.
+//
+// Opt-in (needs Data/ assets + compiles the runtime): npm run test:e2e
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+const PURSUING = new Set(["Chase", "MeleeAttack", "RangedAttack"]);
+
+/** Degrees between where `detail` faces and the direction to `target` (XZ plane). */
+function facingErrorDeg(
+  detail: EntityDetailResult,
+  target: { x: number; z: number },
+): number {
+  const [, y, , w] = detail.rotation;
+  const yaw = 2 * Math.atan2(y, w);
+  const dx = target.x - detail.position[0];
+  const dz = target.z - detail.position[2];
+  const len = Math.hypot(dx, dz) || 1;
+  const dot = (Math.sin(yaw) * dx + Math.cos(yaw) * dz) / len;
+  return (Math.acos(Math.max(-1, Math.min(1, dot))) * 180) / Math.PI;
+}
+
+test(
+  "a decayed AI re-acquires a player standing in its field of view (#791)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8592),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a monster in front of the player, identifying it by diffing the
+    // entity list across the spawn (medsci1 has native OG-Pipes too).
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((e) => e.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && !known.has(e.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    // A control: a native AI elsewhere on the deck, behind geometry. It must
+    // stay calm throughout - re-acquisition is driven by sight, not by
+    // proximity to a fight.
+    const control = postSpawn.entities.find(
+      (e) => e.name === "OG-Pipe" && known.has(e.id) && e.distance > 10,
+    );
+    assert.ok(control, "expected a native OG-Pipe out of sight for the control");
+
+    // The issue's state: a hostile that engaged the player earlier and has
+    // since fully calmed down. SetAlertness is scenario setup only - what is
+    // asserted below is what sight alone does from there.
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    await game.step({ frames: 5 });
+    await game.entities.sendMessage(monster.id, {
+      type: "SetAlertness",
+      level: "Lowest",
+    });
+    await game.step({ frames: 10 });
+    let detail = await game.entities.detail(monster.id);
+    assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
+    assert.equal(aiProp(detail, "AIBehavior"), "Idle");
+
+    // Step off the creature's axis - still well inside its 60-degree FOV, so
+    // it can plainly see the player, but no longer square-on. A calm AI holds
+    // whatever heading it stopped on, so only one that actually looks at what
+    // it sees ends up facing the player again.
+    const start = await game.player.position();
+    const dx = start.x - detail.position[0];
+    const dz = start.z - detail.position[2];
+    const distance = Math.hypot(dx, dz);
+    const offset = distance * Math.tan((30 * Math.PI) / 180);
+    let player = start;
+    for (const sign of [1, -1]) {
+      await game.player.moveTo({
+        x: start.x + (sign * -dz * offset) / distance,
+        y: start.y,
+        z: start.z + (sign * dx * offset) / distance,
+      });
+      await game.step({ frames: 5 });
+      player = await game.player.position();
+      if (Math.hypot(player.x - start.x, player.z - start.z) > offset * 0.7) break;
+      await game.player.moveTo(start);
+      await game.step({ frames: 5 });
+    }
+    detail = await game.entities.detail(monster.id);
+    const offAxis = facingErrorDeg(detail, player);
+    assert.ok(
+      offAxis > 10,
+      `setup: the player should end up off the AI's axis, got ${offAxis.toFixed(0)} degrees`,
+    );
+    assert.equal(
+      aiProp(detail, "AITargetVisible"),
+      "true",
+      "setup: the player must still be plainly visible to the AI",
+    );
+
+    // Sight must now drive it back up the escalation ladder: look at the
+    // player, and with the contact held, escalate (Lowest -> Low -> Moderate
+    // is 1.5s of continuous sight by default).
+    const trace: string[] = [];
+    let reacquired: EntityDetailResult | undefined;
+    let lookedAway: string | undefined;
+    for (let tick = 0; tick < 8 && !reacquired; tick++) {
+      await game.step({ frames: 30 }); // 0.5 sim-seconds
+      const d = await game.entities.detail(monster.id);
+      const visible = aiProp(d, "AITargetVisible");
+      const facing = facingErrorDeg(d, player);
+      trace.push(
+        `${((tick + 1) * 0.5).toFixed(1)}s ${aiProp(d, "AIAlertness")}/${aiProp(d, "AIBehavior")}` +
+          ` vis=${visible} facing=${facing.toFixed(0)}deg`,
+      );
+      if (PURSUING.has(aiProp(d, "AIBehavior") ?? "")) {
+        reacquired = d;
+        break;
+      }
+      // Pre-pursuit only: the pursuing behaviors own the heading from here.
+      if (visible !== "true" || facing > 10) lookedAway ??= trace[trace.length - 1];
+    }
+    assert.ok(
+      !lookedAway,
+      `the AI failed to keep looking at a player it could see: ${trace.join(", ")}`,
+    );
+    assert.ok(
+      reacquired,
+      `the decayed AI never re-acquired the visible player: ${trace.join(", ")}`,
+    );
+    const level = aiProp(reacquired, "AIAlertness");
+    assert.ok(
+      level === "Moderate" || level === "High",
+      `expected a pursuing alertness level, got ${level}`,
+    );
+
+    // No over-correction: the out-of-sight AI never noticed a thing.
+    assert.equal(
+      aiProp(await game.entities.detail(control.id), "AIAlertness"),
+      "Lowest",
+      "an AI that cannot see the player must stay calm",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #791

campaign: engineering-through-shodan · none · legacy · seed 1378752978

## Attempt 2 — what the first attempt missed

The first two commits make a calm creature **track a player it can already see**, and that is real and still needed. But campaign iteration 22 found a hydro2 Midwife that never re-acquired even with them in, so the orient code was never being reached.

**It was not the visibility evaluation.** Traced on this branch with the debug runtime, on the creature from the report (hydro2 `Midwife`, template 1676, posted at `(80.0, -1.5, 32.0)`):

- Standing the player **1.2 / 1.5 units directly in front of it** — inside the cone, clear line of sight — flips `AITargetVisible` to `true` at `Lowest` alertness, exactly as it should. The FOV / line-of-sight / psi-invisibility gates all work.
- The reason the campaign never saw that: **the Midwife takes up its post facing a ledge wall 1.6 units away.** A `world`-group raycast along its facing vector hits level geometry at 1.6 units, and the ground beyond the ledge drops to `y = -5.2`. So a player anywhere past that wall genuinely has no line of sight, at any distance. (The report's "confirmed line of sight" was measured with the debug raycast API's *default* collision groups, `["entity", "level"]` — and `"level"` is not a group name the runtime knows, so it is silently dropped. That call cannot see level geometry at all. Filed separately.)
- The "stale `AILastKnown`" in the report is not evidence of a prior engagement either. On a freshly loaded hydro2, before a single frame is stepped, this Midwife already reports `AITargetVisible: true` / `AILastKnown: [5.20, -0.20, -1.60]` — the player's entry point, 82 units away through the whole deck: its cone happens to point that way and the occlusion raycast finds nothing on frame 0. One step later it is `false` again and the stale last-known simply sticks, because it is only cleared on an alertness transition and this creature never has one. The reported precondition is reproducible on an untouched mission load.

**The real gap: a calm creature never looks around.** `IdleBehavior` had no `steer`, so it held one heading forever, and the FOV cone is rigidly attached to that heading. Everything outside one 120° wedge was permanently invisible to it — which is the issue's "never re-acquires", and no amount of orient-on-sight can help a creature that can never get sight in the first place.

## Change (third commit)

An idle creature sweeps its heading **±90° around the heading it took its post with**, at 45°/s with a 2.5 s dwell at each end, starting from a dwell so a creature that just lost the player holds that heading for a beat. With the 60° FOV half-angle that covers 300° around the post; the 60° wedge directly behind stays blind, so sneaking up from straight back still works.

Nothing about the sight test is relaxed — FOV, line-of-sight and psi-invisibility gate detection exactly as before, and the creature never leaves its post. Creatures excluded from awareness entirely (apparitions — no alertness config) get the still variant of idle and never scan, on both the initial and the post-scripted-sequence path, so the invariant from the second commit keeps holding.

## Before / after — the exact failing context

hydro2, the reported Midwife, player standing due north of it at `(80, -1.95, 37)`: clear line of sight, 90° off its heading. Same script both runs, sampled once a second.

**Before** (this branch at `c3b68d1`, i.e. with the first attempt in):

```
t+ 1s heading=-90.0 alert=Lowest behav=Idle vis=false
t+ 5s heading=-90.0 alert=Lowest behav=Idle vis=false
t+10s heading=-90.0 alert=Lowest behav=Idle vis=false
t+15s heading=-90.0 alert=Lowest behav=Idle vis=false
t+20s heading=-90.0 alert=Lowest behav=Idle vis=false
```

**After**:

```
t+ 1s heading= -90.0 alert=Lowest   behav=Idle    vis=false
t+ 3s heading=-156.7 alert=Lowest   behav=Idle    vis=false   <- sweeps one way
t+ 6s heading=-180.0 alert=Lowest   behav=Idle    vis=false   <- dwells
t+ 8s heading= -91.5 alert=Lowest   behav=Idle    vis=false   <- sweeps back
t+ 9s heading=  -8.2 alert=Lowest   behav=Idle    vis=true    <- sees the player
t+10s heading=   0.7 alert=Low      behav=Wander  vis=true
t+11s heading=  15.3 alert=Moderate behav=Chase   vis=true
t+12s heading=  13.5 alert=High     behav=Chase   vis=true
```

## Tests

Negative-first, all verified red on `c3b68d1` and green after:

- `idle_sweeps_its_heading_to_both_sides_of_its_post` — the exact failing gate: without a `steer`, the commanded heading never leaves the post (`reached 0`).
- `idle_sweep_stays_within_its_arc`, `idle_holds_its_post_before_the_first_sweep`, `a_still_idle_holds_its_heading_forever` — the sweep's shape and the still variant.
- `apparition_holds_its_heading_instead_of_scanning` — 200 frames; red without the apparition guard (`got 184.5°`).
- `ai-reacquire.e2e.test.ts` gains **"a calm native AI scans until it finds a player outside its cone"** — hydro2, the reported Midwife found by its stable template id, player positioned with real line of sight but 90° outside the cone. Red on `c3b68d1` with a 40-sample trace of `Lowest/Idle vis=false facing=90deg`, green with the fix. Its control (another native Midwife behind geometry) is asserted to never see the player at **any** heading it sweeps through, including a full scan cycle of its own.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 432 passed
- `cargo fmt --all`
- Full SDK e2e suite (`npm run test:e2e`) — 196 tests, 193 pass, 0 fail, 3 pre-existing skips
- No pr-visuals capture: like the first commit, this changes only an AI's heading — no rendering, material, HUD or animation surface. The player-observable effect (a posted creature slowly looking around) is captured by the alertness/heading traces above.
- Cross-engine adversarial review (`/xreview`): both engines independently flagged the apparition gap (fixed in the third commit) and the control-AI assertion (strengthened). Both also flagged that the sweep phase is not persisted across save/load, so a reloaded creature re-anchors its sweep on whatever heading it was saved mid-sweep with — that rotates which wedge behind it is blind, but it keeps its post and still sweeps 300°, and `AnimatedMonsterAI` persists no behavior state at all today (alertness and last-known position reset on load too). Left as a follow-up rather than adding a save hook for this one field.

## Known follow-ups (filed separately)

- #806 — the debug raycast API silently drops unknown collision-group names, and its own default mask uses `"level"`, which is not one, so the default raycast cannot see level geometry. This is what produced the misleading "confirmed line of sight" in the report.
- #807 — a patroller that spawns at `Lowest` and is never alerted never reaches `behavior_for_alertness`, so it never starts its route (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
