### PR TITLE
feat(gameplay): end terminal death at a game-over screen

### DIFF
--- a/projects/player-death.md
+++ b/projects/player-death.md
@@ -41,14 +41,39 @@ The resurrection scanner uses the mission's existing authored flow:
 - With an active station and 10 carried nanites, the cost is debited atomically,
   input is suppressed for the retail five-second delay, then the player is
   teleported to that trap and restored to half maximum health.
-- Without an activated and affordable station, the player remains terminally
-  dead until an explicit load/restart. Dead games cannot be saved.
+- Without an activated and affordable station, death is terminal: the authored
+  player death vocalization (`PlayerDeath0..4`, the gamesys SPEECH_TRIGGERS
+  schemas) plays, input stays suppressed for a three-second death sequence, and
+  the mission is then replaced by the game-over screen. Dead games cannot be
+  saved.
 
-The debug runtime exposes `player.life_state` as `alive`, `dead`, or
-`respawning`, giving play-through automation an explicit loss signal.
+## Game over
+
+Retail death without reconstruction ends the run at the Tri-Optimum archive
+database - the load-game screen - so that is where this port lands too.
+`scenes::GameOverScene` draws the original `GAMELOD.PCX` backdrop on the shared
+`UiCanvas`, positioned by the authored `GAMELODR.BIN` widget rects (header,
+archive list, and the two right-hand buttons), and shows:
+
+- "YOU HAVE DIED" in the archive header,
+- the most recent save in `<data_root>/saves` (or `GAMELOD.STR`'s `< EMPTY >`),
+- "LOAD", which emits `GlobalEffect::Load` for that save, and "QUIT".
+
+"LOAD" is inert and dimmed when no save exists, so the screen never offers a
+recovery it cannot perform. Quicksaves resolve through `save_file_path`, so they
+land in the same directory and are offered like any other save.
+
+A full save browser (selecting among slots, the retail list widget) is deferred;
+the screen offers the most recent save, which is the port's existing quick-load
+idiom. Like the main menu, it is pointer-driven, so it is a flatscreen path
+until VR gets a pointer.
+
+The debug runtime exposes `player.life_state` as `alive`, `dead`, `game_over`,
+or `respawning`, and `mission` becomes `game_over` on the screen, giving
+play-through automation an explicit loss signal.
 
 ## Presentation follow-up
 
 The functional lifecycle does not yet force the VR camera into a collapse pose
-or draw a dedicated death overlay. A future presentation pass can add those
-effects without changing the authoritative HP/QBR state machine above.
+during the death sequence. A future presentation pass can add that without
+changing the authoritative HP/QBR state machine above.

--- a/projects/player-death.md
+++ b/projects/player-death.md
@@ -43,7 +43,8 @@ The resurrection scanner uses the mission's existing authored flow:
   teleported to that trap and restored to half maximum health.
 - Without an activated and affordable station, death is terminal: the authored
   player death vocalization (`PlayerDeath0..4`, the gamesys SPEECH_TRIGGERS
-  schemas) plays, input stays suppressed for a three-second death sequence, and
+  schemas) plays, continuous input stays suppressed (discrete actions such as
+  quick-load deliberately keep working) for a three-second death sequence, and
   the mission is then replaced by the game-over screen. Dead games cannot be
   saved.
 
@@ -65,8 +66,9 @@ land in the same directory and are offered like any other save.
 
 A full save browser (selecting among slots, the retail list widget) is deferred;
 the screen offers the most recent save, which is the port's existing quick-load
-idiom. Like the main menu, it is pointer-driven, so it is a flatscreen path
-until VR gets a pointer.
+idiom. Like the main menu, its buttons are pointer-driven, so clicking is a
+flatscreen path until VR gets a pointer; the screen also forwards discrete input
+actions (quick-load, quick-save), so every runtime keeps a way out.
 
 The debug runtime exposes `player.life_state` as `alive`, `dead`, `game_over`,
 or `respawning`, and `mission` becomes `game_over` on the screen, giving

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -12,7 +12,17 @@ const DEBUG_SPAWN_TEMPLATE_ID: i32 = -17;
 /// Template spawned by InputAction::SpawnDebugMonster (grunt og-pipe)
 const DEBUG_MONSTER_TEMPLATE_ID: i32 = -397;
 
-const QUICK_SAVE_FILE: &str = "save1.sav";
+/// Bare name of the quick save slot. It resolves through
+/// [`crate::save_file_path`] so quicksaves land beside every other named save
+/// in `<data_root>/saves`, which is the directory the load/game-over screens
+/// search for a save to offer.
+const QUICK_SAVE_NAME: &str = "save1";
+
+fn quick_save_file() -> String {
+    crate::save_file_path(QUICK_SAVE_NAME)
+        .to_string_lossy()
+        .into_owned()
+}
 
 /// Original System Shock 2 direct-weapon bindings. The input action describes
 /// the semantic selection; desktop keys are mapped separately by
@@ -51,12 +61,12 @@ impl ActionDispatcher {
         }
         if state.just_triggered(InputAction::QuickSave) {
             effects.push(Effect::GlobalEffect(GlobalEffect::Save {
-                file_name: QUICK_SAVE_FILE.to_owned(),
+                file_name: quick_save_file(),
             }));
         }
         if state.just_triggered(InputAction::QuickLoad) {
             effects.push(Effect::GlobalEffect(GlobalEffect::Load {
-                file_name: QUICK_SAVE_FILE.to_owned(),
+                file_name: quick_save_file(),
             }));
         }
         if state.just_triggered(InputAction::SpawnDebugItem) {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -283,7 +283,7 @@ pub fn resource_path(str: &str) -> String {
 /// reloaded in a later launch (frontier persistence for automated play-through
 /// loops).
 pub fn save_file_path(name: &str) -> std::path::PathBuf {
-    paths::data_root().join("saves").join(format!("{name}.sav"))
+    save_load::save_directory().join(format!("{name}.sav"))
 }
 
 /// How the game is presented and controlled.
@@ -1179,12 +1179,23 @@ impl Game {
                 file_name
             ));
         };
+        // Saves live in `<data_root>/saves`, which may not exist yet on a fresh
+        // install - a quicksave must create it rather than fail (and a failure
+        // must not take the game down).
+        let path = Path::new(&file_name);
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("Unable to create '{}': {}", parent.display(), error))?;
+        }
         let mut zip_file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(file_name)
-            .unwrap();
+            .open(path)
+            .map_err(|error| format!("Unable to save '{}': {}", file_name, error))?;
         save_data.write(&mut zip_file);
         Ok(())
     }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -36,8 +36,8 @@ mod vr_config;
 pub mod zip_asset_path;
 
 use scenes::{
-    CutscenePlayerScene, SceneInitResult, create_initial_scene, load_mission_from_save_data,
-    resolve_ending_cutscene,
+    CutscenePlayerScene, GameOverScene, SceneInitResult, create_initial_scene,
+    load_mission_from_save_data, resolve_ending_cutscene,
 };
 
 pub use mission::SpawnLocation;
@@ -1345,6 +1345,14 @@ impl Game {
                 } else {
                     self.switch_mission(level_name, spawn_loc, PlayerVitalsTransition::Preserve);
                 }
+            }
+            GlobalEffect::GameOver => {
+                // The run is over, so the dead mission is deliberately NOT
+                // written back to the in-memory level ledger: the only way
+                // forward is the screen's own recovery path (reload a save),
+                // which replaces the ledger wholesale.
+                self.pending_transition = None;
+                self.active_game_scene = Box::new(GameOverScene::new());
             }
             GlobalEffect::CompleteCampaign => {
                 // Preserve the destroyed head and the rest of the finale state

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -149,9 +149,12 @@ pub struct PlayerInfo {
 
 /// The live player's death/reconstruction lifecycle.
 ///
-/// This is mission-local runtime state: a dead game cannot be saved (see
+/// This is runtime state, never serialized: a dead game cannot be saved (see
 /// `player_save_position`), so only the player's persistent vitals and an
-/// activated station's authored model state need serialization.
+/// activated station's authored model state need serialization. Missions own
+/// the full state machine; the game-over screen carries the terminal
+/// `GameOver` value so automation still sees the loss after the mission is
+/// gone.
 #[derive(Unique, Clone, Debug, PartialEq)]
 pub enum PlayerLifeState {
     Alive,
@@ -1478,8 +1481,10 @@ impl MissionCore {
                 }
             }
         }
-        let mut effects = command_effects;
-        effects.append(&mut life_state_effects);
+        // Life-state effects go first so a scene-replacing GameOver cannot
+        // clobber a same-frame quick-load arriving in `command_effects`.
+        let mut effects = life_state_effects;
+        effects.extend(command_effects);
 
         let player = {
             let player_info = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -155,9 +155,15 @@ pub struct PlayerInfo {
 #[derive(Unique, Clone, Debug, PartialEq)]
 pub enum PlayerLifeState {
     Alive,
-    /// No activated/affordable QBR exists in this mission. The player remains
-    /// terminally dead until a load or level restart replaces the scene.
-    Dead,
+    /// No activated/affordable QBR exists in this mission. The authored death
+    /// sequence plays out for [`PLAYER_DEATH_SEQUENCE_SECONDS`], then the
+    /// mission is replaced by the game-over screen.
+    Dead {
+        elapsed_seconds: f32,
+    },
+    /// The death sequence finished and the game-over screen has been
+    /// requested, so it is never requested twice.
+    GameOver,
     /// The retail five-second death pause before a QBR reconstruction.
     Respawning {
         elapsed_seconds: f32,
@@ -170,7 +176,8 @@ impl PlayerLifeState {
     pub fn as_str(&self) -> &'static str {
         match self {
             PlayerLifeState::Alive => "alive",
-            PlayerLifeState::Dead => "dead",
+            PlayerLifeState::Dead { .. } => "dead",
+            PlayerLifeState::GameOver => "game_over",
             PlayerLifeState::Respawning { .. } => "respawning",
         }
     }
@@ -182,6 +189,19 @@ impl PlayerLifeState {
 
 const PLAYER_RESPAWN_DELAY_SECONDS: f32 = 5.0;
 const PLAYER_RESPAWN_NANITE_COST: i32 = 10;
+/// How long terminal death lingers in the mission before the game-over screen
+/// takes over - the beat where the authored death vocalization plays and the
+/// player sees where they fell.
+const PLAYER_DEATH_SEQUENCE_SECONDS: f32 = 3.0;
+/// The retail player death vocalizations (`PlayerDeath0..4`, SPEECH_TRIGGERS
+/// schemas in the gamesys); one is chosen per death, as the original does.
+const PLAYER_DEATH_SCHEMAS: [&str; 5] = [
+    "PlayerDeath0",
+    "PlayerDeath1",
+    "PlayerDeath2",
+    "PlayerDeath3",
+    "PlayerDeath4",
+];
 
 /// Resolve the active QBR's authored teleport trap. `ResurrectMachine` uses
 /// the scanner's model tweq as its durable activation state: the initial
@@ -1174,11 +1194,13 @@ impl MissionCore {
 
     /// Enter the death state once. An active QBR is usable only when the
     /// player can atomically pay the retail 10-nanite reconstruction cost;
-    /// otherwise death is terminal and the scene remains available for an
-    /// explicit quick-load/restart.
-    fn begin_player_death(&mut self) {
+    /// otherwise death is terminal and runs the death sequence that ends in
+    /// the game-over screen.
+    ///
+    /// Returns the death feedback to play (the authored death vocalization).
+    fn begin_player_death(&mut self) -> Vec<Effect> {
         if !self.player_is_alive() {
-            return;
+            return Vec::new();
         }
 
         let paid_respawn = active_resurrection_target(&self.world).and_then(|target| {
@@ -1204,19 +1226,36 @@ impl MissionCore {
             }
         } else {
             info!("Player died: no activated and affordable QBR");
-            PlayerLifeState::Dead
+            PlayerLifeState::Dead {
+                elapsed_seconds: 0.0,
+            }
         };
 
         *self
             .world
             .borrow::<UniqueViewMut<PlayerLifeState>>()
             .unwrap() = next_state;
+
+        vec![Effect::PlaySound {
+            handle: AudioHandle::new(),
+            name: PLAYER_DEATH_SCHEMAS
+                .choose(&mut thread_rng())
+                .expect("player death schemas are never empty")
+                .to_string(),
+        }]
     }
 
-    /// Advance the retail death pause and perform the reconstruction when its
-    /// five seconds have elapsed.
-    fn update_player_life_state(&mut self, elapsed_seconds: f32) {
-        let respawn = {
+    /// Advance the death pause: perform the QBR reconstruction once its retail
+    /// five seconds elapse, or hand a terminal death off to the game-over
+    /// screen once its death sequence elapses.
+    fn update_player_life_state(&mut self, elapsed_seconds: f32) -> Vec<Effect> {
+        enum DeathPause {
+            Pending,
+            Reconstruct(Vector3<f32>, Quaternion<f32>),
+            GameOver,
+        }
+
+        let pause = {
             let mut life = self
                 .world
                 .borrow::<UniqueViewMut<PlayerLifeState>>()
@@ -1228,15 +1267,37 @@ impl MissionCore {
                     rotation,
                 } => {
                     *elapsed += elapsed_seconds;
-                    (*elapsed + f32::EPSILON >= PLAYER_RESPAWN_DELAY_SECONDS)
-                        .then_some((*position, *rotation))
+                    if *elapsed + f32::EPSILON >= PLAYER_RESPAWN_DELAY_SECONDS {
+                        DeathPause::Reconstruct(*position, *rotation)
+                    } else {
+                        DeathPause::Pending
+                    }
                 }
-                PlayerLifeState::Alive | PlayerLifeState::Dead => None,
+                PlayerLifeState::Dead {
+                    elapsed_seconds: elapsed,
+                } => {
+                    *elapsed += elapsed_seconds;
+                    if *elapsed + f32::EPSILON >= PLAYER_DEATH_SEQUENCE_SECONDS {
+                        DeathPause::GameOver
+                    } else {
+                        DeathPause::Pending
+                    }
+                }
+                PlayerLifeState::Alive | PlayerLifeState::GameOver => DeathPause::Pending,
             }
         };
 
-        let Some((position, rotation)) = respawn else {
-            return;
+        let (position, rotation) = match pause {
+            DeathPause::Pending => return Vec::new(),
+            DeathPause::GameOver => {
+                info!("Player death is terminal: showing the game-over screen");
+                *self
+                    .world
+                    .borrow::<UniqueViewMut<PlayerLifeState>>()
+                    .unwrap() = PlayerLifeState::GameOver;
+                return vec![Effect::GlobalEffect(GlobalEffect::GameOver)];
+            }
+            DeathPause::Reconstruct(position, rotation) => (position, rotation),
         };
 
         self.physics
@@ -1269,6 +1330,7 @@ impl MissionCore {
             .borrow::<UniqueViewMut<PlayerLifeState>>()
             .unwrap() = PlayerLifeState::Alive;
         info!("Player reconstructed at QBR {:?}", position);
+        Vec::new()
     }
 
     pub fn update(
@@ -1298,10 +1360,11 @@ impl MissionCore {
                 })
                 .unwrap_or(false)
         };
+        let mut life_state_effects = Vec::new();
         if self.player_is_alive() && player_health_depleted {
-            self.begin_player_death();
+            life_state_effects.append(&mut self.begin_player_death());
         }
-        self.update_player_life_state(time.elapsed.as_secs_f32());
+        life_state_effects.append(&mut self.update_player_life_state(time.elapsed.as_secs_f32()));
 
         // A dead player's physical head can still look around in VR, but all
         // actionable movement, hand, trigger, crouch, and pointer channels are
@@ -1416,6 +1479,7 @@ impl MissionCore {
             }
         }
         let mut effects = command_effects;
+        effects.append(&mut life_state_effects);
 
         let player = {
             let player_info = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
@@ -3278,7 +3342,9 @@ impl MissionCore {
                             hp
                         );
                         if entity_id == player_entity && previous > 0 && hp == 0 {
-                            self.begin_player_death();
+                            for death_effect in self.begin_player_death() {
+                                effects.push_back(death_effect);
+                            }
                         }
                     }
                 }

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -2,11 +2,13 @@ mod entity_save_data;
 mod held_item_save_data;
 mod player_vitals;
 mod save_data;
+mod save_files;
 
 pub use entity_save_data::*;
 pub use held_item_save_data::*;
 pub use player_vitals::*;
 pub use save_data::*;
+pub use save_files::*;
 
 use std::{
     collections::{HashMap, HashSet},

--- a/shock2vr/src/save_load/save_files.rs
+++ b/shock2vr/src/save_load/save_files.rs
@@ -1,0 +1,111 @@
+//! Discovery of saved games on disk.
+//!
+//! Named saves live in `<data_root>/saves/<name>.sav` (see
+//! [`crate::save_file_path`]). Screens that offer a reload - today the
+//! game-over screen after a terminal death - need to know what is actually
+//! available without hardcoding a file name, so they ask here.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use crate::paths;
+
+/// A saved game found on disk.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SaveFile {
+    /// The bare save name (file stem), as shown to the player.
+    pub name: String,
+    pub path: PathBuf,
+    /// Write time, used to order "most recent first".
+    pub modified: SystemTime,
+}
+
+/// The directory holding named saves.
+pub fn save_directory() -> PathBuf {
+    paths::data_root().join("saves")
+}
+
+/// The most recently written save, or `None` when nothing has been saved yet.
+pub fn latest_save() -> Option<SaveFile> {
+    latest_save_in(&save_directory())
+}
+
+/// [`latest_save`] against an explicit directory (missing directory -> `None`).
+pub fn latest_save_in(directory: &Path) -> Option<SaveFile> {
+    fs::read_dir(directory)
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.extension().is_some_and(|ext| ext == "sav") {
+                return None;
+            }
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some(SaveFile {
+                name: path.file_stem()?.to_string_lossy().into_owned(),
+                path,
+                modified,
+            })
+        })
+        // Ties (same-second writes on coarse filesystems) resolve by name so
+        // the choice is deterministic rather than directory-order dependent.
+        .max_by(|a, b| {
+            a.modified
+                .cmp(&b.modified)
+                .then_with(|| a.name.cmp(&b.name))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn scratch_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("shock2vr_save_files_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_save(dir: &Path, name: &str) {
+        fs::write(dir.join(name), b"save").unwrap();
+    }
+
+    #[test]
+    fn missing_directory_has_no_latest_save() {
+        assert_eq!(
+            latest_save_in(Path::new("/nonexistent/shock2vr/saves")),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_directory_has_no_latest_save() {
+        let dir = scratch_dir("empty");
+        assert_eq!(latest_save_in(&dir), None);
+    }
+
+    #[test]
+    fn non_save_files_are_ignored() {
+        let dir = scratch_dir("filter");
+        write_save(&dir, "notes.txt");
+        assert_eq!(latest_save_in(&dir), None);
+    }
+
+    #[test]
+    fn the_most_recently_written_save_wins() {
+        let dir = scratch_dir("recency");
+        write_save(&dir, "old.sav");
+        // Sleep past the filesystem's mtime granularity before the newer write.
+        std::thread::sleep(Duration::from_millis(20));
+        write_save(&dir, "new.sav");
+
+        let latest = latest_save_in(&dir).expect("a save should be found");
+        assert_eq!(latest.name, "new");
+        assert_eq!(latest.path, dir.join("new.sav"));
+    }
+}

--- a/shock2vr/src/save_load/save_files.rs
+++ b/shock2vr/src/save_load/save_files.rs
@@ -34,7 +34,7 @@ pub fn latest_save() -> Option<SaveFile> {
 }
 
 /// [`latest_save`] against an explicit directory (missing directory -> `None`).
-pub fn latest_save_in(directory: &Path) -> Option<SaveFile> {
+fn latest_save_in(directory: &Path) -> Option<SaveFile> {
     fs::read_dir(directory)
         .ok()?
         .flatten()

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -10,8 +10,6 @@
 //! Structurally it is a sibling of [`crate::scenes::MainMenuScene`]: a pointer
 //! driven `GameScene` that emits a `GlobalEffect` on click.
 
-use std::collections::HashMap;
-
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
 use engine::{
@@ -25,11 +23,7 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
-    inventory::PlayerInventoryEntity,
-    mission::{
-        GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo, PlayerLifeState,
-    },
-    quest_info::QuestInfo,
+    mission::{GlobalContext, PlayerLifeState},
     save_load::{SaveFile, latest_save},
     scripts::{Effect, GlobalEffect},
     time::Time,
@@ -53,7 +47,7 @@ const DEATH_MESSAGE: &str = "YOU HAVE DIED";
 const NO_SAVE_LABEL: &str = "< EMPTY >";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum GameOverAction {
+enum GameOverAction {
     /// Reload the most recent save and resume play.
     Load,
     Quit,
@@ -143,32 +137,10 @@ pub struct GameOverScene {
 
 impl GameOverScene {
     pub fn new() -> Self {
-        // Mirror `MainMenuScene`'s minimal world so the shared save/transition
-        // machinery has the uniques it expects.
-        let mut world = World::new();
-
-        let player_entity = world.add_entity(());
-        let inventory_entity = PlayerInventoryEntity::create(&mut world);
-        PlayerInventoryEntity::set_position_rotation(
-            &mut world,
-            vec3(0.0, -1000.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        );
-        world.add_unique(PlayerInfo {
-            pos: vec3(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            entity_id: player_entity,
-            left_hand_entity_id: None,
-            right_hand_entity_id: None,
-            inventory_entity_id: inventory_entity,
-        });
+        let world = super::ui_scene_world();
         // Keep the lifecycle signal (`/v1/info` player.life_state) honest once
         // the mission is gone: the run is over, not alive.
         world.add_unique(PlayerLifeState::GameOver);
-        world.add_unique(QuestInfo::new());
-        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
-        world.add_unique(GlobalEntityMetadata(HashMap::new()));
-        world.add_unique(Time::default());
 
         Self {
             world,
@@ -194,11 +166,20 @@ impl GameScene for GameOverScene {
         input_context: &InputContext,
         asset_cache: &mut AssetCache,
         _game_options: &GameOptions,
-        _command_effects: Vec<Effect>,
+        command_effects: Vec<Effect>,
     ) -> Vec<Effect> {
         if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
             *world_time = time.clone();
         }
+
+        // Discrete input actions (quick-load above all) must keep working here:
+        // this screen is the only thing left, so swallowing them would restore
+        // the dead end it exists to remove. Only global effects are meaningful
+        // without a mission; the rest have nothing to act on.
+        let mut effects: Vec<Effect> = command_effects
+            .into_iter()
+            .filter(|effect| matches!(effect, Effect::GlobalEffect(_)))
+            .collect();
 
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
@@ -214,19 +195,17 @@ impl GameScene for GameOverScene {
         self.last_pressed = last_pressed;
 
         match action {
-            Some(GameOverAction::Load) => self
-                .save
-                .as_ref()
-                .map(|save| {
-                    Effect::GlobalEffect(GlobalEffect::Load {
+            Some(GameOverAction::Load) => {
+                if let Some(save) = &self.save {
+                    effects.push(Effect::GlobalEffect(GlobalEffect::Load {
                         file_name: save.path.to_string_lossy().into_owned(),
-                    })
-                })
-                .into_iter()
-                .collect(),
-            Some(GameOverAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
-            None => Vec::new(),
+                    }));
+                }
+            }
+            Some(GameOverAction::Quit) => effects.push(Effect::GlobalEffect(GlobalEffect::Quit)),
+            None => {}
         }
+        effects
     }
 
     fn render(

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -1,0 +1,441 @@
+//! Game-over screen.
+//!
+//! Where terminal death lands. In the original, dying with no active
+//! Quantum Bio-Reconstruction machine ends the run and hands the player back
+//! to the Tri-Optimum archive database (the load-game screen) to pick a save;
+//! this screen is that destination in this port's idiom - the original
+//! `GAMELOD.PCX` backdrop and `GAMELODR.BIN` widget rects, showing the death
+//! message plus the most recent save, with "Load" and "Quit".
+//!
+//! Structurally it is a sibling of [`crate::scenes::MainMenuScene`]: a pointer
+//! driven `GameScene` that emits a `GlobalEffect` on click.
+
+use std::collections::HashMap;
+
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, light::SpotLight},
+};
+use shipyard::{EntityId, UniqueViewMut, World};
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::{InputContext, Pointer2D},
+    inventory::PlayerInventoryEntity,
+    mission::{
+        GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo, PlayerLifeState,
+    },
+    quest_info::QuestInfo,
+    save_load::{SaveFile, latest_save},
+    scripts::{Effect, GlobalEffect},
+    time::Time,
+    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+};
+
+/// The screen is authored on the original 640x480 `GAMELOD.PCX` canvas.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
+/// The original load screen's widget layout - LTRB rects (`UI_LAYOUT_IMPORTER`).
+const LAYOUT_FILE: &str = "GAMELODR.BIN";
+/// Same display font the main menu uses (`res/intrface/METAFONT.FON`).
+const MENU_FONT: &str = "metafont.fon";
+/// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// Death message shown in the archive header.
+const DEATH_MESSAGE: &str = "YOU HAVE DIED";
+/// `GAMELOD.STR`'s `unused` string - shown when there is nothing to load.
+const NO_SAVE_LABEL: &str = "< EMPTY >";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GameOverAction {
+    /// Reload the most recent save and resume play.
+    Load,
+    Quit,
+}
+
+/// Indices into the `GAMELODR.BIN` rect list, in the screen's authored order.
+const HEADER_RECT_INDEX: usize = 0;
+const LIST_RECT_INDEX: usize = 1;
+const LOAD_RECT_INDEX: usize = 2;
+const QUIT_RECT_INDEX: usize = 3;
+
+/// Decoded `GAMELODR.BIN` values, used when the layout file is absent.
+const FALLBACK_RECTS: [Rect; 4] = [
+    Rect::new(261.0, 31.0, 202.0, 20.0),
+    Rect::new(261.0, 54.0, 202.0, 290.0),
+    Rect::new(527.0, 161.0, 96.0, 62.0),
+    Rect::new(527.0, 405.0, 95.0, 62.0),
+];
+
+/// Resolve the screen's widget rects from `GAMELODR.BIN`, falling back to the
+/// decoded values when it is absent.
+fn screen_rects(layout: Option<&[MapRect]>) -> [Rect; 4] {
+    let mut rects = FALLBACK_RECTS;
+    for (index, rect) in rects.iter_mut().enumerate() {
+        if let Some(r) = layout.and_then(|rects| rects.get(index)) {
+            *rect = Rect::new(
+                r.ul_x as f32,
+                r.ul_y as f32,
+                r.width() as f32,
+                r.height() as f32,
+            );
+        }
+    }
+    rects
+}
+
+/// Pure click resolution: on a rising press edge over an enabled button,
+/// return its action. Also returns the new `last_pressed` for the next frame.
+/// `can_load` disables "Load" when no save exists, so the screen never offers
+/// a recovery it cannot perform.
+fn resolve_click(
+    pointer: Option<Pointer2D>,
+    last_pressed: bool,
+    screen_size: Vector2<f32>,
+    rects: &[Rect; 4],
+    can_load: bool,
+) -> (Option<GameOverAction>, bool) {
+    let Some(p) = pointer else {
+        return (None, false);
+    };
+    if !p.pressed || last_pressed {
+        return (None, p.pressed);
+    }
+
+    let action = pointer_to_canvas(
+        vec2(CANVAS_W, CANVAS_H),
+        p.position,
+        screen_size,
+        SCALE_MODE,
+    )
+    .and_then(|c| {
+        if can_load && rects[LOAD_RECT_INDEX].contains(c) {
+            Some(GameOverAction::Load)
+        } else if rects[QUIT_RECT_INDEX].contains(c) {
+            Some(GameOverAction::Quit)
+        } else {
+            None
+        }
+    });
+    (action, p.pressed)
+}
+
+pub struct GameOverScene {
+    world: World,
+    scene_name: String,
+    /// The save offered by "Load", resolved once when the screen opens so the
+    /// label and the click agree.
+    save: Option<SaveFile>,
+    /// Pointer from the latest update, used for hover highlighting in render.
+    pointer: Option<Pointer2D>,
+    /// Whether the pointer was pressed last frame (for rising-edge clicks).
+    last_pressed: bool,
+    /// Screen size from the latest render, so `update` maps the pointer into
+    /// canvas space consistently with how the canvas is drawn.
+    last_screen_size: Vector2<f32>,
+}
+
+impl GameOverScene {
+    pub fn new() -> Self {
+        // Mirror `MainMenuScene`'s minimal world so the shared save/transition
+        // machinery has the uniques it expects.
+        let mut world = World::new();
+
+        let player_entity = world.add_entity(());
+        let inventory_entity = PlayerInventoryEntity::create(&mut world);
+        PlayerInventoryEntity::set_position_rotation(
+            &mut world,
+            vec3(0.0, -1000.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        );
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player_entity,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory_entity,
+        });
+        // Keep the lifecycle signal (`/v1/info` player.life_state) honest once
+        // the mission is gone: the run is over, not alive.
+        world.add_unique(PlayerLifeState::GameOver);
+        world.add_unique(QuestInfo::new());
+        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
+        world.add_unique(GlobalEntityMetadata(HashMap::new()));
+        world.add_unique(Time::default());
+
+        Self {
+            world,
+            scene_name: "game_over".to_owned(),
+            save: latest_save(),
+            pointer: None,
+            last_pressed: false,
+            last_screen_size: vec2(CANVAS_W, CANVAS_H),
+        }
+    }
+}
+
+impl Default for GameOverScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameScene for GameOverScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+        _command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+
+        self.pointer = input_context.pointer;
+        let (action, last_pressed) = resolve_click(
+            input_context.pointer,
+            self.last_pressed,
+            self.last_screen_size,
+            &rects,
+            self.save.is_some(),
+        );
+        self.last_pressed = last_pressed;
+
+        match action {
+            Some(GameOverAction::Load) => self
+                .save
+                .as_ref()
+                .map(|save| {
+                    Effect::GlobalEffect(GlobalEffect::Load {
+                        file_name: save.path.to_string_lossy().into_owned(),
+                    })
+                })
+                .into_iter()
+                .collect(),
+            Some(GameOverAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
+            None => Vec::new(),
+        }
+    }
+
+    fn render(
+        &mut self,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        // Drawn in screen space in `render_per_eye`; the 3D scene is empty.
+        (
+            Vec::new(),
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        )
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        _options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        self.last_screen_size = screen_size;
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let pointer_canvas = self.pointer.and_then(|p| {
+            pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            )
+        });
+
+        canvas.text_native(
+            rects[HEADER_RECT_INDEX],
+            DEATH_MESSAGE,
+            MENU_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+
+        // The archive list holds the one save "Load" will restore (or the
+        // original's empty-slot label when there is nothing to restore).
+        let save_label = match &self.save {
+            Some(save) => save.name.as_str(),
+            None => NO_SAVE_LABEL,
+        };
+        let list = rects[LIST_RECT_INDEX];
+        canvas.text_native(
+            Rect::new(list.x, list.y, list.w, 20.0),
+            save_label,
+            MENU_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+
+        for (index, label) in [(LOAD_RECT_INDEX, "LOAD"), (QUIT_RECT_INDEX, "QUIT")] {
+            let rect = rects[index];
+            let enabled = index != LOAD_RECT_INDEX || self.save.is_some();
+            let hovered = enabled && pointer_canvas.is_some_and(|p| rect.contains(p));
+            canvas
+                .text_native(rect, label, MENU_FONT, HAlign::Center, VAlign::Middle)
+                .opacity(match (enabled, hovered) {
+                    (false, _) => 0.3,
+                    (true, false) => 0.6,
+                    (true, true) => 1.0,
+                });
+        }
+
+        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+    }
+
+    fn handle_effects(
+        &mut self,
+        effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        _asset_cache: &mut AssetCache,
+        _audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        effects
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::GlobalEffect(g) => Some(g),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn wants_pointer(&self) -> bool {
+        true
+    }
+
+    fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
+        Vec::new()
+    }
+
+    fn world(&self) -> &World {
+        &self.world
+    }
+
+    fn scene_name(&self) -> &str {
+        &self.scene_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The runtimes render 4:3, so PreserveAspect maps normalized coordinates
+    /// straight onto the 640x480 canvas.
+    const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
+
+    fn pointer_at(rect: Rect, pressed: bool) -> Option<Pointer2D> {
+        let center = rect.center();
+        Some(Pointer2D {
+            position: vec2(center.x / CANVAS_W, center.y / CANVAS_H),
+            pressed,
+        })
+    }
+
+    #[test]
+    fn clicking_load_with_a_save_reloads() {
+        let rects = screen_rects(None);
+        let (action, last) = resolve_click(
+            pointer_at(rects[LOAD_RECT_INDEX], true),
+            false,
+            SCREEN,
+            &rects,
+            true,
+        );
+        assert_eq!(action, Some(GameOverAction::Load));
+        assert!(last);
+    }
+
+    #[test]
+    fn load_is_inert_without_a_save() {
+        let rects = screen_rects(None);
+        let (action, _) = resolve_click(
+            pointer_at(rects[LOAD_RECT_INDEX], true),
+            false,
+            SCREEN,
+            &rects,
+            false,
+        );
+        assert_eq!(action, None);
+    }
+
+    #[test]
+    fn quit_is_always_available() {
+        let rects = screen_rects(None);
+        let (action, _) = resolve_click(
+            pointer_at(rects[QUIT_RECT_INDEX], true),
+            false,
+            SCREEN,
+            &rects,
+            false,
+        );
+        assert_eq!(action, Some(GameOverAction::Quit));
+    }
+
+    #[test]
+    fn held_press_does_not_re_activate() {
+        let rects = screen_rects(None);
+        let (action, last) = resolve_click(
+            pointer_at(rects[LOAD_RECT_INDEX], true),
+            true,
+            SCREEN,
+            &rects,
+            true,
+        );
+        assert_eq!(action, None);
+        assert!(last);
+    }
+
+    #[test]
+    fn clicking_outside_the_buttons_does_nothing() {
+        let rects = screen_rects(None);
+        let (action, _) = resolve_click(
+            pointer_at(rects[LIST_RECT_INDEX], true),
+            false,
+            SCREEN,
+            &rects,
+            true,
+        );
+        assert_eq!(action, None);
+    }
+
+    #[test]
+    fn screen_rects_prefer_the_layout_file() {
+        let layout: Vec<MapRect> = (0..4)
+            .map(|i| MapRect::new(10, i * 70, 110, i * 70 + 50))
+            .collect();
+        let rects = screen_rects(Some(&layout));
+        assert_eq!(rects[LOAD_RECT_INDEX], Rect::new(10.0, 140.0, 100.0, 50.0));
+        assert_eq!(screen_rects(None), FALLBACK_RECTS);
+    }
+
+    #[test]
+    fn world_supports_transition_save_data() {
+        // The transition machinery calls `to_save_data` on the outgoing scene's
+        // world, so the game-over world must support it.
+        let scene = GameOverScene::new();
+        let _ = crate::save_load::to_save_data(scene.world());
+    }
+}

--- a/shock2vr/src/scenes/loading.rs
+++ b/shock2vr/src/scenes/loading.rs
@@ -14,8 +14,6 @@
 //! driven by `progress`: `new_demo()` sweeps it for visual inspection via the
 //! `debug_loading` scene; real background loading (PR 3) calls `set_progress`.
 
-use std::collections::HashMap;
-
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
 use engine::{
@@ -29,9 +27,7 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     input_context::InputContext,
-    inventory::PlayerInventoryEntity,
-    mission::{GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
-    quest_info::QuestInfo,
+    mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{Rect, ScaleMode, UiCanvas},
@@ -97,29 +93,7 @@ impl LoadingScene {
     }
 
     fn build(demo: bool) -> Self {
-        // Mirror `MainMenuScene`'s minimal world so the transition machinery
-        // (`switch_mission` -> `to_save_data` on the outgoing scene) has the uniques
-        // it expects.
-        let mut world = World::new();
-        let player_entity = world.add_entity(());
-        let inventory_entity = PlayerInventoryEntity::create(&mut world);
-        PlayerInventoryEntity::set_position_rotation(
-            &mut world,
-            vec3(0.0, -1000.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        );
-        world.add_unique(PlayerInfo {
-            pos: vec3(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            entity_id: player_entity,
-            left_hand_entity_id: None,
-            right_hand_entity_id: None,
-            inventory_entity_id: inventory_entity,
-        });
-        world.add_unique(QuestInfo::new());
-        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
-        world.add_unique(GlobalEntityMetadata(HashMap::new()));
-        world.add_unique(Time::default());
+        let world = super::ui_scene_world();
 
         Self {
             world,

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -8,8 +8,6 @@
 //!
 //! See `projects/flatscreen-and-vr-architecture.md` (Slice 3).
 
-use std::collections::HashMap;
-
 use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use dark::{importers::UI_LAYOUT_IMPORTER, map::MapRect};
 use engine::{
@@ -23,9 +21,7 @@ use crate::{
     GameOptions,
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
-    inventory::PlayerInventoryEntity,
-    mission::{GlobalContext, GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
-    quest_info::QuestInfo,
+    mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
@@ -148,29 +144,7 @@ pub struct MainMenuScene {
 
 impl MainMenuScene {
     pub fn new() -> Self {
-        let mut world = World::new();
-
-        let player_entity = world.add_entity(());
-
-        let inventory_entity = PlayerInventoryEntity::create(&mut world);
-        PlayerInventoryEntity::set_position_rotation(
-            &mut world,
-            vec3(0.0, -1000.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        );
-
-        world.add_unique(PlayerInfo {
-            pos: vec3(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            entity_id: player_entity,
-            left_hand_entity_id: None,
-            right_hand_entity_id: None,
-            inventory_entity_id: inventory_entity,
-        });
-        world.add_unique(QuestInfo::new());
-        world.add_unique(GlobalTemplateIdMap(HashMap::new()));
-        world.add_unique(GlobalEntityMetadata(HashMap::new()));
-        world.add_unique(Time::default());
+        let world = super::ui_scene_world();
 
         Self {
             world,

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -33,6 +33,7 @@ pub mod debug_ragdoll;
 pub mod debug_teleport;
 pub mod debug_turret;
 pub mod debug_weapons;
+pub mod game_over;
 pub mod loading;
 pub mod main_menu;
 
@@ -50,6 +51,7 @@ pub use debug_ragdoll::DebugRagdollScene;
 pub use debug_teleport::DebugTeleportScene;
 pub use debug_turret::DebugTurretScene;
 pub use debug_weapons::create_debug_weapons_scene;
+pub use game_over::GameOverScene;
 pub use loading::LoadingScene;
 pub use main_menu::MainMenuScene;
 

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -55,6 +55,44 @@ pub use game_over::GameOverScene;
 pub use loading::LoadingScene;
 pub use main_menu::MainMenuScene;
 
+/// The minimal world a non-mission screen (menu, loading, game over) needs.
+///
+/// These scenes have no simulation, but the shared save/transition machinery
+/// still runs `to_save_data` on the outgoing scene's world, so the uniques it
+/// reads must exist.
+pub(crate) fn ui_scene_world() -> shipyard::World {
+    use cgmath::{Quaternion, vec3};
+
+    use crate::{
+        inventory::PlayerInventoryEntity,
+        mission::{GlobalEntityMetadata, GlobalTemplateIdMap, PlayerInfo},
+        quest_info::QuestInfo,
+        time::Time,
+    };
+
+    let mut world = shipyard::World::new();
+    let player_entity = world.add_entity(());
+    let inventory_entity = PlayerInventoryEntity::create(&mut world);
+    PlayerInventoryEntity::set_position_rotation(
+        &mut world,
+        vec3(0.0, -1000.0, 0.0),
+        Quaternion::new(1.0, 0.0, 0.0, 0.0),
+    );
+    world.add_unique(PlayerInfo {
+        pos: vec3(0.0, 0.0, 0.0),
+        rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        entity_id: player_entity,
+        left_hand_entity_id: None,
+        right_hand_entity_id: None,
+        inventory_entity_id: inventory_entity,
+    });
+    world.add_unique(QuestInfo::new());
+    world.add_unique(GlobalTemplateIdMap(HashMap::new()));
+    world.add_unique(GlobalEntityMetadata(HashMap::new()));
+    world.add_unique(Time::default());
+    world
+}
+
 pub struct SceneInitResult {
     pub scene: Box<dyn GameScene>,
     pub mission_save_data: HashMap<String, EntitySaveData>,

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -51,6 +51,10 @@ pub enum GlobalEffect {
     // Test the reload functionality (as if saving + loading)
     TestReload,
 
+    /// The player died with no reconstruction available: replace the mission
+    /// with the game-over screen, which offers the load/quit recovery path.
+    GameOver,
+
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -323,9 +323,10 @@ export interface PlayerSnapshot {
   entity_id: number | null;
   position: Vec3;
   rotation: [number, number, number, number];
-  /** Current player lifecycle. `dead` is terminal until a load/restart;
-   * `respawning` is the five-second QBR reconstruction delay. */
-  life_state: "alive" | "dead" | "respawning";
+  /** Current player lifecycle. `dead` is the terminal death sequence (no
+   * activated QBR), which hands off to the `game_over` screen after three
+   * seconds; `respawning` is the five-second QBR reconstruction delay. */
+  life_state: "alive" | "dead" | "game_over" | "respawning";
   camera_offset: Vec3;
   camera_rotation: [number, number, number, number];
   /** The wielded/first-person weapon in flatscreen mode; null when unarmed. */

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -12,7 +12,7 @@ const RESURRECTION_TARGET = 187;
 const RESURRECTION_COST = 10;
 const RESPAWN_DELAY_FRAMES = 5 * 60;
 
-type LifeState = "alive" | "dead" | "respawning";
+type LifeState = "alive" | "dead" | "game_over" | "respawning";
 
 function lifeState(player: object): LifeState | undefined {
   return (player as { life_state?: LifeState }).life_state;
@@ -161,9 +161,14 @@ test(
     const dead = await game.info();
     assert.equal(lifeState(dead.player), "dead");
     assert.equal(dead.mission, "medsci1.mis", "the death sequence plays out in the mission");
+    // The authored `PlayerDeath0..4` schemas resolve to the retail player death
+    // samples (`XXpdieNN`), so assert on the resolved sample, not just a count.
+    const played = (await game.audio.recent()).sounds.slice(audioBefore);
     assert.ok(
-      (await game.audio.recent()).sounds.length > audioBefore,
-      "death should play the authored player death vocalization",
+      played.some((sound) => /pdie/i.test(sound.sample)),
+      `death should play the authored player death vocalization, got ${JSON.stringify(
+        played.map((sound) => sound.sample),
+      )}`,
     );
 
     // The death sequence hands off to the game-over screen.
@@ -189,5 +194,38 @@ test(
     );
     assert.equal(lifeState(resumed.player), "alive");
     assert.ok((resumed.player.hit_points ?? 0) > 0, "the resumed player is alive with health");
+  },
+);
+
+test(
+  "the game-over screen still honors the quick-load action (the runtime-agnostic way out)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 3,
+    });
+    await game.step({ frames: 5 });
+
+    // Quick-save writes `<data>/saves/save1.sav`, creating the directory if the
+    // install has never saved.
+    await game.input.trigger("QuickSave");
+    await game.step({ frames: 2 });
+
+    await killPlayer(game);
+    await game.step({ frames: DEATH_SEQUENCE_FRAMES + 30 });
+    assert.equal((await game.info()).mission, "game_over");
+
+    // The screen's buttons are pointer-driven, but a headset has no pointer, so
+    // discrete actions must still reach the global effect handler.
+    await game.input.trigger("QuickLoad");
+    await game.step({ frames: 5 });
+    const resumed = await game.info();
+    assert.equal(
+      resumed.mission,
+      "medsci1.mis",
+      "quick-load on the game-over screen must restore the quick save",
+    );
+    assert.equal(lifeState(resumed.player), "alive");
   },
 );

--- a/tools/shock2-sdk/test/player-death.e2e.test.ts
+++ b/tools/shock2-sdk/test/player-death.e2e.test.ts
@@ -124,3 +124,70 @@ test(
     );
   },
 );
+
+// The game-over screen is the original load-game screen (`GAMELOD.PCX`), so
+// its "Load" button sits at the `GAMELODR.BIN` rect [527, 161, 96x62] on the
+// 640x480 canvas. The runtime renders 4:3, so aspect-preserving placement maps
+// canvas coordinates straight onto normalized screen coordinates.
+const GAME_OVER_LOAD_BUTTON: [number, number] = [(527 + 96 / 2) / 640, (161 + 62 / 2) / 480];
+const DEATH_SEQUENCE_FRAMES = 3 * 60;
+
+async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", [x, y]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+test(
+  "terminal death reaches the game-over screen, whose load path resumes play",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 2,
+    });
+    await game.step({ frames: 5 });
+
+    // The screen offers the most recent save, so make ours the newest one.
+    const saveName = `player_death_game_over_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+
+    const audioBefore = (await game.audio.recent()).sounds.length;
+    await killPlayer(game);
+
+    const dead = await game.info();
+    assert.equal(lifeState(dead.player), "dead");
+    assert.equal(dead.mission, "medsci1.mis", "the death sequence plays out in the mission");
+    assert.ok(
+      (await game.audio.recent()).sounds.length > audioBefore,
+      "death should play the authored player death vocalization",
+    );
+
+    // The death sequence hands off to the game-over screen.
+    await game.step({ frames: DEATH_SEQUENCE_FRAMES + 30 });
+    const gameOver = await game.info();
+    assert.equal(
+      gameOver.mission,
+      "game_over",
+      "terminal death must reach the game-over screen instead of hanging in the dead mission",
+    );
+    assert.equal(lifeState(gameOver.player), "game_over");
+
+    // ... and its "Load" button is a real recovery path back into play. The
+    // screen restores the most recent save in the shared `<data>/saves`
+    // directory, so assert on being playable again rather than on which
+    // mission another test's save may have left as the newest.
+    await click(game, GAME_OVER_LOAD_BUTTON);
+    const resumed = await game.info();
+    assert.notEqual(
+      resumed.mission,
+      "game_over",
+      "loading from the game-over screen must return to a playable mission",
+    );
+    assert.equal(lifeState(resumed.player), "alive");
+    assert.ok((resumed.player.hit_points ?? 0) > 0, "the resumed player is alive with health");
+  },
+);

--- a/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
+++ b/tools/shock2-sdk/test/quickload-missing.e2e.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, renameSync } from "node:fs";
 import { test } from "node:test";
 import { join } from "node:path";
 
@@ -7,34 +7,51 @@ import { GameServer, findRepoRoot } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
+/**
+ * Where an in-game quicksave lands: `<data_root>/saves/save1.sav` (the same
+ * directory every named save uses). The runtime resolves its data root from
+ * `DARK_ASSET_PATH`, falling back to `<repo>/Data`.
+ */
+function quickSavePath(): string {
+  const dataRoot =
+    process.env.DARK_ASSET_PATH ??
+    join(findRepoRoot(process.cwd()) ?? process.cwd(), "Data");
+  return join(dataRoot, "saves", "save1.sav");
+}
+
 test(
   "QuickLoad without a session quicksave leaves the runtime healthy",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await GameServer.launch({
-      mission: "debug_minimal",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
-    });
+    // Establish the precondition without destroying a real quicksave: move it
+    // aside for the duration and put it back afterwards.
+    const quickSave = quickSavePath();
+    const parked = `${quickSave}.quickload-missing-test`;
+    const hadQuickSave = existsSync(quickSave);
+    if (hadQuickSave) renameSync(quickSave, parked);
 
-    // Establish the precondition without deleting or overwriting a user's
-    // quicksave. A stale save1.sav should fail rather than mask the regression.
-    const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
-    assert.equal(
-      existsSync(join(repoRoot, "save1.sav")),
-      false,
-      "the test requires a worktree with no pre-existing session quicksave",
-    );
+    try {
+      await using game = await GameServer.launch({
+        mission: "debug_minimal",
+        port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
+      });
 
-    await game.input.trigger("QuickLoad");
-    await game.step({ frames: 1 });
+      await game.input.trigger("QuickLoad");
+      await game.step({ frames: 1 });
 
-    assert.equal((await game.health()).status, "ok");
-    assert.equal((await game.info()).mission, "debug_minimal");
-    assert.ok(
-      game
-        .logs()
-        .some((line) => line.includes("Unable to load save 'save1.sav'")),
-      "missing QuickLoad should be recorded in the runtime log",
-    );
+      assert.equal((await game.health()).status, "ok");
+      assert.equal((await game.info()).mission, "debug_minimal");
+      assert.ok(
+        game
+          .logs()
+          .some(
+            (line) =>
+              line.includes("Unable to load save") && line.includes("save1.sav"),
+          ),
+        "missing QuickLoad should be recorded in the runtime log",
+      );
+    } finally {
+      if (hadQuickSave) renameSync(parked, quickSave);
+    }
   },
 );


### PR DESCRIPTION
## Summary

Dying with no activated Resurrection Station was a silent dead end: no death sequence, no message, no way back. The session just sat in the dead mission (the no-QBR branch from #753 was marked intentional-for-now), and only an out-of-band quick-load escaped.

Terminal death now runs the authored death sequence and ends at a real recovery screen:

- **Death feedback** — one of the gamesys' authored player death vocalizations (`PlayerDeath0..4`, SPEECH_TRIGGERS schemas, resolving to the retail `XXpdieNN` samples) plays on death.
- **Death sequence** — the player stays in the mission, input suppressed, for three seconds, so death reads as a beat rather than a cut.
- **Game over** — the mission is then replaced by a `GameOverScene`. Retail death without reconstruction hands the player back to the Tri-Optimum archive database (the load-game screen), so that is the destination here too: the original `GAMELOD.PCX` backdrop laid out by the authored `GAMELODR.BIN` widget rects, with the death message in the archive header, the most recent save in the list, and the art's own two buttons wired to **LOAD** and **QUIT**.

`GlobalEffect::GameOver` carries the handoff, so the mission stays effects-pure and the scene swap happens in the one place that owns scenes (`Game::handle_global_effect`). The dead mission is deliberately *not* written back to the level ledger.

Quicksaves now resolve through `save_file_path`, so they land in `<data_root>/saves` beside every other named save and are discoverable by the screen's "most recent save" lookup (previously they were written to the process CWD). `save_to_file` creates that directory and no longer unwraps its I/O.

![terminal death to game-over screen](https://gist.githubusercontent.com/tommy-xr/06ffbe8d5e6f36dbffe878257e98eb58/raw/death-flow.gif)

<sub>medsci1, no activated QBR: lethal damage, the three-second death sequence in the dead mission (which is where the session used to stay forever), the game-over screen, then clicking LOAD back into play. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![game-over screen](https://gist.githubusercontent.com/tommy-xr/06ffbe8d5e6f36dbffe878257e98eb58/raw/gameover_still.png)

<sub>The screen itself: `GAMELOD.PCX` laid out by `GAMELODR.BIN` - death message in the archive header, the most recent save in the list, LOAD and QUIT on the art's own buttons.</sub>

## Scope: what is faithful now, what is deferred

Faithful now: the authored death vocalization, a death beat before the handoff, and the retail post-death destination (the archive-database load screen) with a working reload.

Deferred, and called out rather than faked:

- **A full save browser.** The screen offers the most recent save, which is this port's existing quick-load idiom (the issue explicitly allows it). Selecting among slots — and the authored `GAMELOD.STR` `"Load Failed"` feedback — comes with a real load screen, which the main menu will want too.
- **The retail death movie / camera collapse.** `projects/player-death.md` already tracks the VR camera-collapse presentation; this change adds no camera work.
- **VR clicking.** Like the existing main menu, the buttons are pointer-driven, and no VR runtime produces a pointer yet. The screen therefore also forwards discrete input actions, so **quick-load still works on it in every runtime** — there is no runtime where death is a dead end.

## Before -> after

![before/after](https://gist.githubusercontent.com/tommy-xr/06ffbe8d5e6f36dbffe878257e98eb58/raw/beforeafter.png)

<sub>Same request sequence on both refs: lethal damage in medsci1 with no activated QBR, then six seconds of stepping. On `main` the dead mission is still all there is (and stays that way); on this branch the death sequence has handed off to the game-over screen.</sub>

## Verification

Negative-first: the new e2e test was run against `origin/main` (with only the test file applied) and fails — no death vocalization, and the game never leaves the dead mission. It passes on this branch.

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` and the CI package set (`engine`, `dark_viewer`, `dark_query`, `debug_command`)
- `cargo test -p shock2vr` — 434 passed (adds unit coverage for the game-over click resolution, its layout fallbacks, and save discovery)
- SDK `npm test` — 26 passed
- SDK `test/player-death.e2e.test.ts` — 4 passed, including the two pre-existing #753 tests (terminal death state and the 10-nanite QBR reconstruction) unchanged
- Full SDK `npm run test:e2e` - 192 passed, 3 gated-skip, 1 failure that this branch caused and fixes: `quickload-missing.e2e.test.ts` asserted its "no quicksave exists" precondition against the process CWD, which is no longer where a quicksave lands; it now parks any real quicksave in `<data_root>/saves` for the duration instead

Runtime evidence (debug runtime, medsci1): kill the player with no activated QBR → `/v1/audio/recent` reports the resolved `XXpdie03` sample → after the death sequence `/v1/info` reports `mission: "game_over"`, `life_state: "game_over"` → clicking LOAD returns to `medsci1.mis`, alive, at the saved position. Triggering the `QuickLoad` action on the screen does the same.

Reviewed with `/xreview`; both engines agreed on the quicksave-directory defect (fixed here), and the swallowed command effects, same-frame quick-load ordering, and menu-scene duplication were all addressed.

campaign: engineering-through-shodan · none · legacy · seed 1378752978

Fixes #792


