### PR TITLE
fix(physics): put the player camera at the head sphere

### DIFF
--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -106,7 +106,8 @@ Done:
   rotation — applying it over-rotates each gun by exactly its heading — so it is
   deliberately unused.
 - **Eye-height alignment** — the shot origin + viewmodel use the shared
-  `shock2vr::PLAYER_EYE_HEIGHT` (4.0 SS2 units), matching every runtime's render
+  `shock2vr::PLAYER_EYE_HEIGHT` (the original engine's `PLAYER_HEAD` sphere,
+  1.8 SS2 units above the body origin), matching every runtime's render
   camera, so shots land on the crosshair and the debug-runtime camera matches
   desktop (was rendering ~1 world unit low).
 - **Tooling**: debug-runtime controllable input over HTTP (`head.look` + hand

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -106,8 +106,9 @@ Done:
   rotation — applying it over-rotates each gun by exactly its heading — so it is
   deliberately unused.
 - **Eye-height alignment** — the shot origin + viewmodel use the shared
-  `shock2vr::PLAYER_EYE_HEIGHT` (the original engine's `PLAYER_HEAD` sphere,
-  1.8 SS2 units above the body origin), matching every runtime's render
+  `shock2vr::PLAYER_EYE_HEIGHT` (the original game's camera placement: the
+  head sphere 1.8 SS2 units above the body origin plus the 0.8 eye offset =
+  2.6, i.e. 5.6 ft above the floor), matching every runtime's render
   camera, so shots land on the crosshair and the debug-runtime camera matches
   desktop (was rendering ~1 world unit low).
 - **Tooling**: debug-runtime controllable input over HTTP (`head.look` + hand

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1970,7 +1970,9 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
                     .as_ref()
                     .map(|s| s.life_state.clone())
                     .unwrap_or_else(|| "alive".to_owned()),
-                camera_offset: [0.0, shock2vr::PLAYER_EYE_HEIGHT / SCALE_FACTOR, 0.0],
+                // The LIVE eye height, not the standing constant: automation
+                // aims from this, and a crouched player's camera is lower.
+                camera_offset: [0.0, game.player_eye_height() / SCALE_FACTOR, 0.0],
                 camera_rotation: [1.0, 0.0, 0.0, 0.0], // TODO: Get camera rotation
                 wielded_entity_id: state.as_ref().and_then(|s| s.wielded_entity_id),
                 right_hand_entity_id: state.as_ref().and_then(|s| s.right_hand_entity_id),

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -52,15 +52,17 @@ pub use mission::visibility_engine::CullingInfo;
 /// this for [`PLAYER_CROUCH_EYE_HEIGHT`] - flat runtimes should use
 /// [`Game::player_eye_height`] rather than reading the constants directly.
 ///
-/// This is the original engine's `PLAYER_HEAD` sphere: Dark's first-person
-/// camera IS that submodel's location (`CameraUpdate` calls
-/// `PhysGetSubModLocation(objid, 0 /* PLAYER_HEAD */)`), and the sphere sits at
-/// `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS` above the body
-/// origin. Deriving it from the collision profile keeps the eye *inside* the
-/// standing collider: an eye above the crown starts the crosshair ray outside
-/// any room whose ceiling the body itself clears, so the ray hits that ceiling
-/// from above and nothing in the room can be highlighted or frobbed (#795).
-pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS;
+/// This follows the original game's camera placement: the viewpoint is
+/// anchored to the player's head sphere - `(PLAYER_HEIGHT / 2) -
+/// PLAYER_RADIUS` = 1.8 ft above the body origin - and then raised by the
+/// default eye offset ("eyeloc") of 0.8 ft, for a standing eye 2.6 ft above
+/// the body center, i.e. 5.6 ft above the floor. Deriving it from the
+/// collision profile keeps the eye *inside* the standing collider (2.6 ft is
+/// below the 3.0 ft capsule crown): an eye above the crown starts the
+/// crosshair ray outside any room whose ceiling the body itself clears, so the
+/// ray hits that ceiling from above and nothing in the room can be highlighted
+/// or frobbed (#795).
+pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EYE_OFFSET;
 
 /// Crouched eye height above the (crouched) body position, in SS2 units.
 /// The crouched capsule is 2.8 ft tall with its center 1.4 ft above the feet;

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -51,9 +51,16 @@ pub use mission::visibility_engine::CullingInfo;
 /// the debug runtime renders at a different height than desktop. Crouch swaps
 /// this for [`PLAYER_CROUCH_EYE_HEIGHT`] - flat runtimes should use
 /// [`Game::player_eye_height`] rather than reading the constants directly.
-/// The standing footprint resize deliberately leaves this body-relative Dark
-/// offset unchanged, so the camera, crosshair ray and viewmodel remain aligned.
-pub const PLAYER_EYE_HEIGHT: f32 = 4.0;
+///
+/// This is the original engine's `PLAYER_HEAD` sphere: Dark's first-person
+/// camera IS that submodel's location (`CameraUpdate` calls
+/// `PhysGetSubModLocation(objid, 0 /* PLAYER_HEAD */)`), and the sphere sits at
+/// `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS` above the body
+/// origin. Deriving it from the collision profile keeps the eye *inside* the
+/// standing collider: an eye above the crown starts the crosshair ray outside
+/// any room whose ceiling the body itself clears, so the ray hits that ceiling
+/// from above and nothing in the room can be highlighted or frobbed (#795).
+pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS;
 
 /// Crouched eye height above the (crouched) body position, in SS2 units.
 /// The crouched capsule is 2.8 ft tall with its center 1.4 ft above the feet;

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2718,7 +2718,10 @@ impl MissionCore {
     /// frozen mid-air.
     fn throw_entity_into_world(&mut self, entity_id: EntityId) {
         /// How far ahead of the camera the item materializes (world units).
-        const THROW_SPAWN_DISTANCE: f32 = 0.5;
+        /// The eye sits on the standing capsule's axis, so this must clear the
+        /// capsule's radius or a downward throw spawns the item inside the
+        /// player's own collider and gets ejected.
+        const THROW_SPAWN_DISTANCE: f32 = crate::physics::PLAYER_STANDING_RADIUS_WORLD + 0.2;
         /// Launch speed along the view ray (world units/sec).
         const THROW_SPEED: f32 = 6.0;
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -29,6 +29,11 @@ use self::debug_render_pipeline::DebugRenderer;
 const PLAYER_STANDING_HEIGHT: f32 = 6.0;
 const PLAYER_STANDING_RADIUS: f32 = 1.2;
 
+/// The standing collider's radius in world units, for callers that must place
+/// something outside the player's own body (the camera sits on the capsule
+/// axis, so "in front of the eye" is only outside the collider beyond this).
+pub const PLAYER_STANDING_RADIUS_WORLD: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
+
 /// Height of the player's head sphere above the body origin (SS2 ft), the
 /// original engine's `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS`
 /// (`src/physics/physapi.h`). Dark places the first-person camera at exactly
@@ -4996,13 +5001,18 @@ mod tests {
         world.add_collider(EntityId::from_inner(2199).unwrap(), collider);
     }
 
-    /// The eye is the head sphere's center, so it is always inside the standing
-    /// collider. A camera above the crown is outside every room whose ceiling
-    /// the body itself clears.
+    /// The standing eye is the original engine's `PLAYER_HEAD` sphere center,
+    /// which is inside the collider by construction - a camera above the crown
+    /// would be outside every room whose ceiling the body itself clears.
     #[test]
-    fn standing_eye_stays_inside_the_standing_collider() {
-        let crown = PLAYER_STANDING_HEIGHT / 2.0;
+    fn standing_eye_is_the_head_sphere_inside_the_collider() {
         let eye = crate::player_eye_height_for(false);
+        assert_eq!(
+            eye,
+            PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS,
+            "the standing eye must be Dark's PLAYER_HEAD_POS"
+        );
+        let crown = PLAYER_STANDING_HEIGHT / 2.0;
         assert!(
             eye <= crown,
             "the standing eye ({eye} ft) must not sit above the collider crown ({crown} ft)"
@@ -5045,6 +5055,13 @@ mod tests {
         assert!(
             (body.y - PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR).abs() < 0.2,
             "the standing player should fit in a seven-foot room; got {body:?}"
+        );
+
+        // Fixture precondition: this room must actually be one the old 4.0 ft
+        // eye escaped, or the test would pass on the buggy build too.
+        assert!(
+            body.y + 4.0 / SCALE_FACTOR > ROOM_HEIGHT,
+            "the pre-fix eye must be above this ceiling for the repro to bite"
         );
 
         let eye = point3(

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -29,6 +29,14 @@ use self::debug_render_pipeline::DebugRenderer;
 const PLAYER_STANDING_HEIGHT: f32 = 6.0;
 const PLAYER_STANDING_RADIUS: f32 = 1.2;
 
+/// Height of the player's head sphere above the body origin (SS2 ft), the
+/// original engine's `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS`
+/// (`src/physics/physapi.h`). Dark places the first-person camera at exactly
+/// this submodel, so it is also the eye height ([`crate::PLAYER_EYE_HEIGHT`]);
+/// deriving it here keeps the camera tied to the collision profile, inside the
+/// capsule rather than above its crown.
+pub const PLAYER_HEAD_POS: f32 = PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS;
+
 /// Crouched capsule height (SS2 ft). The original engine's crouched COLLISION
 /// profile (a stack of two 1.2 ft spheres, body-bottom -1.8 to head-top +1.0
 /// around the object origin) is ~2.8 ft tall - its taller "crouch height" is
@@ -4965,6 +4973,106 @@ mod tests {
             test_mode: Default::default(),
         });
         world.collider_set.insert(collider);
+    }
+
+    /// A room's level geometry: a floor quad at `floor_y` and a ceiling quad at
+    /// `ceiling_y`, in ONE `ALL_COLLIDABLE` trimesh, exactly as
+    /// [`PhysicsWorld::add_level_geometry`] builds `WorldRep`.
+    fn add_level_room(world: &mut PhysicsWorld, floor_y: f32, ceiling_y: f32, half: f32) {
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        for y in [floor_y, ceiling_y] {
+            let base = vertices.len() as u32;
+            vertices.push(point![-half, y, -half]);
+            vertices.push(point![-half, y, half]);
+            vertices.push(point![half, y, -half]);
+            vertices.push(point![half, y, half]);
+            indices.push([base, base + 1, base + 3]);
+            indices.push([base, base + 3, base + 2]);
+        }
+        let collider = ColliderBuilder::trimesh(vertices, indices)
+            .expect("valid room mesh")
+            .build();
+        world.add_collider(EntityId::from_inner(2199).unwrap(), collider);
+    }
+
+    /// The eye is the head sphere's center, so it is always inside the standing
+    /// collider. A camera above the crown is outside every room whose ceiling
+    /// the body itself clears.
+    #[test]
+    fn standing_eye_stays_inside_the_standing_collider() {
+        let crown = PLAYER_STANDING_HEIGHT / 2.0;
+        let eye = crate::player_eye_height_for(false);
+        assert!(
+            eye <= crown,
+            "the standing eye ({eye} ft) must not sit above the collider crown ({crown} ft)"
+        );
+    }
+
+    /// The crosshair ray must reach a frobbable object in a room the player can
+    /// stand in. hydro2's Hydro Card B corpse (#795) lies under a seven-foot
+    /// ceiling: the six-foot body clears it, but an eye above the crown put the
+    /// ray origin *above* the ceiling, so every aim point hit that ceiling from
+    /// outside the room instead of the container - no highlight, no frob.
+    ///
+    /// Negative-first: with the previous `PLAYER_EYE_HEIGHT` of 4.0 ft this
+    /// resolves to the one-sided ceiling rather than the container.
+    #[test]
+    fn standing_crosshair_reaches_a_container_under_a_seven_foot_ceiling() {
+        // hydro2's corpse alcove: a flat floor with a one-sided level ceiling
+        // seven feet above it, which the six-foot standing body clears.
+        const ROOM_HEIGHT: f32 = 7.0 / SCALE_FACTOR;
+        let mut world = PhysicsWorld::new();
+        add_level_room(&mut world, 0.0, ROOM_HEIGHT, 20.0);
+
+        // A frobbable container resting on the floor, two units ahead.
+        let container = EntityId::from_inner(2201).unwrap();
+        let container_pos = vec3(2.0, 0.2, 0.0);
+        world.add_kinematic(
+            container,
+            container_pos,
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.8, 0.4, 0.8),
+            CollisionGroup::selectable(),
+            false,
+        );
+
+        let mut player =
+            world.create_player(vec3(0.0, 2.0, 0.0), EntityId::from_inner(2200).unwrap());
+        step(&mut world, &mut player, 120);
+        let body = world.get_player_translation(&player);
+        assert!(
+            (body.y - PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR).abs() < 0.2,
+            "the standing player should fit in a seven-foot room; got {body:?}"
+        );
+
+        let eye = point3(
+            body.x,
+            body.y + crate::player_eye_height_for(false) / SCALE_FACTOR,
+            body.z,
+        );
+        // The exact mask the flat controller's crosshair raycast uses.
+        let direction =
+            (point3(container_pos.x, container_pos.y, container_pos.z) - eye).normalize();
+        let hit = world
+            .ray_cast(
+                eye,
+                direction,
+                InternalCollisionGroups::ENTITY
+                    | InternalCollisionGroups::SELECTABLE
+                    | InternalCollisionGroups::WORLD
+                    | InternalCollisionGroups::UI
+                    | InternalCollisionGroups::RAYCAST,
+            )
+            .expect("the crosshair ray should hit something");
+        assert_eq!(
+            hit.maybe_entity_id,
+            Some(container),
+            "the crosshair should select the container, not the ceiling; hit {:?} at {:?}",
+            hit.maybe_entity_id,
+            hit.hit_point
+        );
     }
 
     /// Falling onto a steep face carries the resulting downslope momentum

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -34,13 +34,21 @@ const PLAYER_STANDING_RADIUS: f32 = 1.2;
 /// axis, so "in front of the eye" is only outside the collider beyond this).
 pub const PLAYER_STANDING_RADIUS_WORLD: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 
-/// Height of the player's head sphere above the body origin (SS2 ft), the
-/// original engine's `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS`
-/// (`src/physics/physapi.h`). Dark places the first-person camera at exactly
-/// this submodel, so it is also the eye height ([`crate::PLAYER_EYE_HEIGHT`]);
-/// deriving it here keeps the camera tied to the collision profile, inside the
-/// capsule rather than above its crown.
+/// Height of the player's head sphere above the body origin (SS2 ft),
+/// `(PLAYER_HEIGHT / 2) - PLAYER_RADIUS` in the original game's collision
+/// profile. The original's first-person camera is anchored to this submodel,
+/// so deriving it here keeps the camera tied to the collision profile rather
+/// than floating free of it.
 pub const PLAYER_HEAD_POS: f32 = PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS;
+
+/// Eye offset above the head sphere center (SS2 ft). The original game does
+/// not put the camera at the head sphere center: after locating the head it
+/// raises the viewpoint by this default eye offset (configurable as
+/// "eyeloc"; our data ships no override). Head sphere (1.8) + this (0.8) puts
+/// the standing eye 2.6 ft above the body center - 5.6 ft above the floor -
+/// and still 0.4 ft below the capsule crown, so the camera stays inside the
+/// collider by construction. See [`crate::PLAYER_EYE_HEIGHT`].
+pub const PLAYER_EYE_OFFSET: f32 = 0.8;
 
 /// Crouched capsule height (SS2 ft). The original engine's crouched COLLISION
 /// profile (a stack of two 1.2 ft spheres, body-bottom -1.8 to head-top +1.0
@@ -5001,21 +5009,21 @@ mod tests {
         world.add_collider(EntityId::from_inner(2199).unwrap(), collider);
     }
 
-    /// The standing eye is the original engine's `PLAYER_HEAD` sphere center,
-    /// which is inside the collider by construction - a camera above the crown
-    /// would be outside every room whose ceiling the body itself clears.
+    /// The standing eye is the head sphere center plus the original game's eye
+    /// offset, which stays inside the collider by construction - a camera above
+    /// the crown would be outside every room whose ceiling the body clears.
     #[test]
-    fn standing_eye_is_the_head_sphere_inside_the_collider() {
+    fn standing_eye_is_the_head_sphere_plus_eye_offset_inside_the_collider() {
         let eye = crate::player_eye_height_for(false);
         assert_eq!(
             eye,
-            PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS,
-            "the standing eye must be Dark's PLAYER_HEAD_POS"
+            PLAYER_HEAD_POS + PLAYER_EYE_OFFSET,
+            "the standing eye must be the head sphere plus the eye offset"
         );
         let crown = PLAYER_STANDING_HEIGHT / 2.0;
         assert!(
-            eye <= crown,
-            "the standing eye ({eye} ft) must not sit above the collider crown ({crown} ft)"
+            eye < crown,
+            "the standing eye ({eye} ft) must sit below the collider crown ({crown} ft)"
         );
     }
 

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -50,12 +50,26 @@ impl Script for InternalFastProjectileScript {
         let current_position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
         // let forward = xform.transform_vector(vec3(0.0, 0.0, -1.0));
         let forward = self.velocity.normalize();
-        let start_point = world
+        let maybe_camera_origin = world
             .borrow::<View<RuntimePropProjectileRayOrigin>>()
             .ok()
-            .and_then(|origins| origins.get(entity_id).ok().map(|origin| origin.0))
-            .unwrap_or(current_position - forward * SCALE_FACTOR * 0.25);
-        let maybe_hit_spot = projectile_ray_cast(start_point, forward, physics, distance, world);
+            .and_then(|origins| origins.get(entity_id).ok().map(|origin| origin.0));
+        let start_point =
+            maybe_camera_origin.unwrap_or(current_position - forward * SCALE_FACTOR * 0.25);
+        // A camera-origin ray starts at the player's eye, which is INSIDE the
+        // player's own capsule (the eye is the head sphere). Rapier's solid
+        // raycast reports a shape containing the origin as a hit at
+        // distance 0, so keeping `PLAYER` in the mask would make every flat
+        // shot hit the shooter instead of what the crosshair is on.
+        let can_hit_player = maybe_camera_origin.is_none();
+        let maybe_hit_spot = projectile_ray_cast(
+            start_point,
+            forward,
+            physics,
+            distance,
+            world,
+            can_hit_player,
+        );
 
         if let Some(RayCastResult {
             hit_point,
@@ -167,7 +181,13 @@ fn projectile_ray_cast(
     physics: &PhysicsWorld,
     distance: f32,
     world: &World,
+    can_hit_player: bool,
 ) -> Option<RayCastResult> {
+    let player_group = if can_hit_player {
+        InternalCollisionGroups::PLAYER
+    } else {
+        InternalCollisionGroups::empty()
+    };
     let mut maybe_hit_spot = physics.ray_cast(
         start_point,
         forward * distance,
@@ -175,7 +195,7 @@ fn projectile_ray_cast(
             // Sometimes, the hitbox can stick out past the bounding box...
             // so we should still check for it here
             | InternalCollisionGroups::HITBOX
-            | InternalCollisionGroups::PLAYER
+            | player_group
             | InternalCollisionGroups::SELECTABLE
             | InternalCollisionGroups::WORLD,
     );
@@ -222,7 +242,8 @@ mod tests {
     use super::{hitbox_belongs_to_entity, projectile_ray_cast};
     use crate::creature::{HitBoxType, RuntimePropHitBox};
     use crate::physics::PhysicsWorld;
-    use cgmath::{point3, vec3};
+    use cgmath::{Quaternion, point3, vec3};
+    use dark::SCALE_FACTOR;
     use shipyard::{EntityId, World};
 
     #[test]
@@ -239,12 +260,53 @@ mod tests {
             &physics,
             10.0,
             &world,
+            true,
         );
 
         assert_eq!(
             hit.and_then(|result| result.maybe_entity_id),
             Some(player_entity),
             "an AI/turret fast projectile must be able to hit the player's dedicated collider",
+        );
+    }
+
+    /// The flat crosshair ray starts at the player's eye, which is inside the
+    /// player's own capsule (the eye is the head sphere). A solid raycast
+    /// reports a containing shape as a distance-0 hit, so the player's own
+    /// collider must be excluded or every flat shot hits the shooter.
+    #[test]
+    fn camera_origin_projectile_shoots_past_the_shooters_own_collider() {
+        let mut physics = PhysicsWorld::new();
+        let player_entity = EntityId::from_inner(1).unwrap();
+        let mut player = physics.create_player(vec3(0.0, 0.0, 0.0), player_entity);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        // The eye: on the capsule axis, inside the player's own collider.
+        let body = physics.get_player_translation(&player);
+        let eye = point3(
+            body.x,
+            body.y + crate::PLAYER_EYE_HEIGHT / SCALE_FACTOR,
+            body.z,
+        );
+
+        let target = EntityId::from_inner(2).unwrap();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, eye.y, 5.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 2.0, 2.0),
+            crate::physics::CollisionGroup::selectable(),
+            false,
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let world = World::new();
+        let hit = projectile_ray_cast(eye, vec3(0.0, 0.0, 1.0), &physics, 10.0, &world, false);
+
+        assert_eq!(
+            hit.and_then(|result| result.maybe_entity_id),
+            Some(target),
+            "a shot fired from the player's own eye must reach the target, not the shooter",
         );
     }
 

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -40,6 +40,15 @@ import type {
   Vec3,
 } from "./types.js";
 
+/**
+ * Standing eye height above the player's body position, in world units:
+ * the Rust `PLAYER_EYE_HEIGHT` (the original engine's `PLAYER_HEAD` sphere,
+ * `(PLAYER_HEIGHT / 2) - PLAYER_RADIUS` = 1.8 SS2 ft) divided by
+ * `dark::SCALE_FACTOR` (2.5). Only a fallback: aiming prefers the live
+ * `camera_offset` the runtime reports in `/v1/info`.
+ */
+export const PLAYER_EYE_HEIGHT_WORLD = 0.72;
+
 /** Error thrown when the game reports a command failed (success: false). */
 export class CommandError extends Error {
   constructor(public readonly result: CommandResult) {
@@ -120,7 +129,8 @@ export class PlayerApi {
       this.client.get<EntityDetailResult>(`/v1/entities/${entityId}`),
       this.client.get<FrameSnapshot>("/v1/info"),
     ]);
-    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const eyeHeight =
+      options?.eyeHeight ?? snapshot.player.camera_offset?.[1] ?? PLAYER_EYE_HEIGHT_WORLD;
     const eye: Vec3 = [
       snapshot.player.position[0],
       snapshot.player.position[1] + eyeHeight,
@@ -430,7 +440,8 @@ export class InputApi {
       this.client.get<{ position: Vec3 }>("/v1/player/position"),
       this.client.get<FrameSnapshot>("/v1/info"),
     ]);
-    const eyeHeight = options?.eyeHeight ?? 1.6;
+    const eyeHeight =
+      options?.eyeHeight ?? snapshot.player.camera_offset?.[1] ?? PLAYER_EYE_HEIGHT_WORLD;
     const localHeadRotation = headRotationForWorldPoint(
       position,
       snapshot.player.rotation,
@@ -482,7 +493,7 @@ export function headRotationForWorldPoint(
   playerPosition: Vec3,
   playerRotation: Quat,
   target: Vec3,
-  eyeHeight = 1.6,
+  eyeHeight = PLAYER_EYE_HEIGHT_WORLD,
 ): Quat {
   const worldLook = lookQuat([
     target[0] - playerPosition[0],

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -42,12 +42,13 @@ import type {
 
 /**
  * Standing eye height above the player's body position, in world units:
- * the Rust `PLAYER_EYE_HEIGHT` (the original engine's `PLAYER_HEAD` sphere,
- * `(PLAYER_HEIGHT / 2) - PLAYER_RADIUS` = 1.8 SS2 ft) divided by
- * `dark::SCALE_FACTOR` (2.5). Only a fallback: aiming prefers the live
- * `camera_offset` the runtime reports in `/v1/info`.
+ * the Rust `PLAYER_EYE_HEIGHT` (head sphere at `(PLAYER_HEIGHT / 2) -
+ * PLAYER_RADIUS` = 1.8 SS2 ft, plus the original game's 0.8 ft eye offset =
+ * 2.6 SS2 ft, i.e. 5.6 ft above the floor) divided by `dark::SCALE_FACTOR`
+ * (2.5). Only a fallback: aiming prefers the live `camera_offset` the runtime
+ * reports in `/v1/info`.
  */
-export const PLAYER_EYE_HEIGHT_WORLD = 0.72;
+export const PLAYER_EYE_HEIGHT_WORLD = 1.04;
 
 /** Error thrown when the game reports a command failed (success: false). */
 export class CommandError extends Error {

--- a/tools/shock2-sdk/src/index.ts
+++ b/tools/shock2-sdk/src/index.ts
@@ -8,6 +8,7 @@ export {
   headRotationForWorldPoint,
   InputApi,
   PathfindingTestApi,
+  PLAYER_EYE_HEIGHT_WORLD,
   PlayerApi,
   UiApi,
 } from "./game.js";

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { GameServer } from "../src/index.js";
 
 // End-to-end test for data-driven impact spangs: a projectile spawns the spang
 // its authored links say, not a hardcoded effect.
@@ -64,9 +64,7 @@ test(
     );
     assert.ok(og, `expected the corridor OG-Pipe near the anchor (got: ${JSON.stringify(ogs.map((e) => e.position))})`);
 
-    // Stand ~4.5 units south (+z) of it, then aim at its chest from the live
-    // positions. Empirical debug-runtime look mapping: yaw 0 faces -x, yaw 90
-    // faces -z (yaw = atan2(-dz, -dx)); positive pitch aims down.
+    // Stand ~4.5 units south (+z) of it, then aim at its torso.
     await game.player.teleport({
       x: og.position[0],
       y: og.position[1] + 0.8,
@@ -74,23 +72,11 @@ test(
     });
     await game.step({ frames: 15 }); // settle on the floor
 
-    const player = (await game.info()).player;
-    const target = (await game.entities.detail(og.id)).position;
-    const eye = [
-      player.position[0],
-      player.position[1] + PLAYER_EYE_HEIGHT_WORLD,
-      player.position[2],
-    ];
-    const d = [
-      target[0] - eye[0],
-      target[1] + 0.7 - eye[1], // chest height above the entity origin
-      target[2] - eye[2],
-    ];
-    const yawDeg = (Math.atan2(-d[2], -d[0]) * 180) / Math.PI;
-    const pitchDeg =
-      (Math.atan2(-d[1], Math.hypot(d[0], d[2])) * 180) / Math.PI;
 
-    await game.input.set("head.look", [yawDeg, pitchDeg]);
+    const target = (await game.entities.detail(og.id)).position;
+    // Production aim at the live torso proxy (reads the runtime camera
+    // height, so it survives changes to the player eye).
+    await game.player.aimAt(og.id, { hitbox: "torso" });
     await game.step({ frames: 3 });
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 
 // End-to-end test for data-driven impact spangs: a projectile spawns the spang
 // its authored links say, not a hardcoded effect.
@@ -30,7 +30,6 @@ import { GameServer } from "../src/index.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
 
 test(
   "projectile impacts spawn the authored spangs (terrain + blood)",

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 import type { EntitySummary } from "../src/index.js";
 
 // End-to-end test for flat (desktop-style) ladder climbing.
@@ -265,7 +265,7 @@ test(
     // room using only ordinary locomotion.
     await game.input.lookAtWorldPoint([
       stable.x,
-      stable.y + 1.6,
+      stable.y + PLAYER_EYE_HEIGHT_WORLD,
       ladder.z + 4,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -282,7 +282,7 @@ test(
 
     await game.input.lookAtWorldPoint([
       deckSide.x + 8,
-      deckSide.y + 1.6,
+      deckSide.y + PLAYER_EYE_HEIGHT_WORLD,
       deckSide.z,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);

--- a/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
@@ -77,10 +77,10 @@ test(
       y: keypadY - 1,
       z: keypadZ + 3.25,
     });
-    // Earth spawns facing the opposite body heading from the accepted manual
-    // route; -154.5deg is the same world ray as that route's +25.5deg head
-    // yaw after its 180deg body turn.
-    await game.input.set("head.look", [-154.5, 10]);
+    // Aim through the production look-at (it accounts for Earth's authored
+    // body heading and reads the live camera height) rather than a fixed
+    // pitch tuned to one camera position.
+    await game.input.lookAtWorldPoint(keypadDetail.position);
     await game.step({ frames: 2 });
     await game.input.set("right_hand.squeeze", 1);
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
+++ b/tools/shock2-sdk/test/energy-weapon-recharge.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { rotateByInverse } from "../src/anim-metrics.js";
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { fireOnce } from "./helpers/weapon.js";
 
@@ -27,7 +27,6 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const LASER_PISTOL_OBJECT = 253;
 const RECHARGING_STATION_OBJECT = 258;
 const LASER_AUTHORED_CAPACITY = 100;
-const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
 
 function ammoOf(detail: {
   properties: { name: string; value: string }[];

--- a/tools/shock2-sdk/test/helpers/earth-world-use.ts
+++ b/tools/shock2-sdk/test/helpers/earth-world-use.ts
@@ -1,3 +1,4 @@
+import { PLAYER_EYE_HEIGHT_WORLD } from "../../src/index.js";
 import type { GameServer } from "../../src/index.js";
 import type { EntitySummary } from "../../src/types.js";
 
@@ -18,9 +19,8 @@ const DEFAULT_STAGING: EarthWorldUseStaging = {
   pitchDeg: undefined,
 };
 
-/** Eye height above the player's body position, in world units:
- * `PLAYER_EYE_HEIGHT` (4.0) divided by `dark::SCALE_FACTOR` (2.5). */
-const EYE_HEIGHT = 1.6;
+/** Eye height above the player's body position, in world units. */
+const EYE_HEIGHT = PLAYER_EYE_HEIGHT_WORLD;
 
 /**
  * Aim at and world-use an authored entity through the normal flat crosshair

--- a/tools/shock2-sdk/test/helpers/earth-world-use.ts
+++ b/tools/shock2-sdk/test/helpers/earth-world-use.ts
@@ -13,7 +13,8 @@ export interface EarthWorldUseStaging {
 
 const DEFAULT_STAGING: EarthWorldUseStaging = {
   horizontalOffset: 0.1,
-  verticalOffset: -1.6,
+  // Stage the body so the CAMERA lands level with the item.
+  verticalOffset: -PLAYER_EYE_HEIGHT_WORLD,
   // Ignored unless `pitchDeg` is given explicitly - the aim is computed from the
   // measured camera position instead. See below.
   pitchDeg: undefined,

--- a/tools/shock2-sdk/test/hydro2-corpse-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-corpse-frob.e2e.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable hydro2 mission-object ids (runtime entity ids are rediscovered every
+// launch and must never be hardcoded).
+const HYD_MALE_CORPSE = 754; // Contains -> Hydro Card B
+const CORPSE_ROOM_STANDING_SPOT = { x: 73.08, y: -0.76, z: -14.92 };
+
+// #795: this corpse lies in an alcove with a SEVEN-FOOT ceiling. The six-foot
+// standing body clears it, but the camera used to sit 7.0 ft above the feet -
+// ABOVE that ceiling - so the crosshair ray started outside the room and hit
+// the ceiling plane 0.05 units in front of the eye. No highlight, no frob, and
+// with it the Hydro Card B chain (hydro1/hydro3 bulkheads, ACR1/ACR4).
+//
+// Negative-first: with the previous `PLAYER_EYE_HEIGHT` of 4.0 ft the aim +
+// squeeze below opens no panel at all.
+test(
+  "hydro2: the crosshair frobs the Hydro Card B corpse under its seven-foot ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8231),
+    });
+    await game.step({ frames: 5 });
+
+    const [corpse] = await game.entities.byTemplate(HYD_MALE_CORPSE);
+    assert.ok(corpse, "expected hydro2 HYD Male Corpse obj 754");
+    const contains = (await game.entities.detail(corpse.id)).outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.ok(
+      contains.some((link) => link.target_name.includes("Hydro Card B")),
+      `corpse 754 should contain Hydro Card B; got ${JSON.stringify(contains)}`,
+    );
+
+    // Stand where the campaign playthrough stood, under the low ceiling.
+    await teleportVerified(game, CORPSE_ROOM_STANDING_SPOT);
+    await game.step({ frames: 30 });
+
+    // Fixture sanity: this really is the low alcove the bug depends on - a
+    // ceiling barely above the standing body (6.0 SS2 ft / 2.4 world units).
+    const { player } = await game.info();
+    const ceiling = await game.raycast({
+      start: [player.position[0], player.position[1], player.position[2]],
+      end: [player.position[0], player.position[1] + 12, player.position[2]],
+      ignore_sensors: true,
+      collision_groups: ["world", "entity", "selectable"],
+    });
+    assert.ok(ceiling.hit, "expected a ceiling above the corpse alcove");
+    const clearance = ceiling.hit_point![1] - (player.position[1] - 1.2);
+    assert.ok(
+      clearance > 2.4 && clearance < 3.0,
+      `the corpse alcove should be a low room the body just clears; got ${clearance} world units`,
+    );
+
+    await game.screenshot("hydro2-corpse-aim.png");
+
+    // Production interaction: real crosshair aim, real use button.
+    await game.player.aimAt(corpse, { hitbox: "center" });
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+
+    const ui = await game.ui.state();
+    assert.ok(
+      ui.active_panel,
+      `aiming at the corpse and squeezing should open its loot MFD (got ${JSON.stringify(ui)})`,
+    );
+    assert.equal(
+      ui.active_panel.entity_id,
+      corpse.id,
+      "the active panel should be bound to the corpse entity",
+    );
+    assert.ok(
+      ui.active_panel.elements.some(
+        (element) => element.kind === "button" && element.label === "Hydro Card B",
+      ),
+      `the loot panel should list Hydro Card B (got ${JSON.stringify(ui.active_panel.elements)})`,
+    );
+    await game.screenshot("hydro2-corpse-panel.png");
+  },
+);

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 import type { PlayedSound } from "../src/types.js";
 
 // End-to-end test for weapon impact sounds: a bullet hit plays the
@@ -28,7 +28,6 @@ import type { PlayedSound } from "../src/types.js";
 //   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-const PLAYER_EYE_HEIGHT_WORLD = 1.6; // 4 SS2 units / SCALE_FACTOR
 
 function tagValue(sound: PlayedSound, tag: string): string | undefined {
   return sound.tags.find(([t]) => t === tag)?.[1];

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { GameServer } from "../src/index.js";
 import type { PlayedSound } from "../src/types.js";
 
 // End-to-end test for weapon impact sounds: a bullet hit plays the
@@ -78,9 +78,7 @@ test(
     );
     assert.ok(og, `expected the corridor OG-Pipe near the anchor (got: ${JSON.stringify(ogs.map((e) => e.position))})`);
 
-    // Stand ~4.5 units south (+z) of it, then aim at its chest from the live
-    // positions. Empirical debug-runtime look mapping: yaw 0 faces -x, yaw 90
-    // faces -z (yaw = atan2(-dz, -dx)); positive pitch aims down.
+    // Stand ~4.5 units south (+z) of it, then aim at its torso.
     await game.player.teleport({
       x: og.position[0],
       y: og.position[1] + 0.8,
@@ -88,26 +86,14 @@ test(
     });
     await game.step({ frames: 15 }); // settle on the floor
 
-    const player = (await game.info()).player;
-    const target = (await game.entities.detail(og.id)).position;
-    const eye = [
-      player.position[0],
-      player.position[1] + PLAYER_EYE_HEIGHT_WORLD,
-      player.position[2],
-    ];
-    const d = [
-      target[0] - eye[0],
-      target[1] + 0.7 - eye[1], // chest height above the entity origin
-      target[2] - eye[2],
-    ];
-    const yawDeg = (Math.atan2(-d[2], -d[0]) * 180) / Math.PI;
-    const pitchDeg =
-      (Math.atan2(-d[1], Math.hypot(d[0], d[2])) * 180) / Math.PI;
 
     const beforeCreature =
       (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
 
-    await game.input.set("head.look", [yawDeg, pitchDeg]);
+    const target = (await game.entities.detail(og.id)).position;
+    // Production aim at the live torso proxy (reads the runtime camera
+    // height, so it survives changes to the player eye).
+    await game.player.aimAt(og.id, { hitbox: "torso" });
     await game.step({ frames: 3 });
     await game.input.set("right_hand.trigger", 1.0);
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/jump.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
@@ -52,7 +52,7 @@ test(
     // then press ordinary forward locomotion through the jump.
     await game.input.lookAtWorldPoint([
       restored.x,
-      restored.y + 1.6,
+      restored.y + PLAYER_EYE_HEIGHT_WORLD,
       restored.z + 4,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -86,7 +86,7 @@ test(
     // mandatory route wraps under its east lip onto a finite lower side ring;
     // a continuous standing capsule cannot expose that ring through an
     // ordinary ballistic edge fall.
-    await game.input.lookAtWorldPoint([31, supported.y + 1.6, 28.5]);
+    await game.input.lookAtWorldPoint([31, supported.y + PLAYER_EYE_HEIGHT_WORLD, 28.5]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await pulseJump(game);
     await game.step({ frames: 24 });
@@ -101,7 +101,7 @@ test(
     // Walk to the real east lip and align over the narrow z=30..32 side ring.
     // There is no setup placement after the initial campaign frontier: every
     // pose in the crossing is reached through production locomotion.
-    await game.input.lookAtWorldPoint([35, position.y + 1.6, 31]);
+    await game.input.lookAtWorldPoint([35, position.y + PLAYER_EYE_HEIGHT_WORLD, 31]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await game.step({ frames: 29 });
     await game.input.set("right_hand.thumbstick", [0, 0]);
@@ -125,7 +125,7 @@ test(
     // A forward jump at the parentless lip uses the bounded sparse-body
     // transition to the first all-collider-valid crouched pose below. Before
     // the downward transition this pulse simply landed back on y=-19.2.
-    await game.input.lookAtWorldPoint([40, position.y + 1.6, position.z]);
+    await game.input.lookAtWorldPoint([40, position.y + PLAYER_EYE_HEIGHT_WORLD, position.z]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await pulseJump(game);
     await game.input.set("right_hand.thumbstick", [0, 0]);
@@ -161,7 +161,7 @@ test(
     // the real route rather than merely finding an isolated point below.
     await game.input.lookAtWorldPoint([
       position.x,
-      position.y + 1.6,
+      position.y + PLAYER_EYE_HEIGHT_WORLD,
       28,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -254,7 +254,7 @@ test(
     // beyond them, then keep ordinary forward locomotion active for the jump.
     await game.input.lookAtWorldPoint([
       lowerSmallCrate.position[0],
-      before.y + 1.6,
+      before.y + PLAYER_EYE_HEIGHT_WORLD,
       -195.8,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -351,7 +351,7 @@ test(
     let position = await game.player.position();
 
     // First authored platform: cross its south lip toward world +Z.
-    await game.input.lookAtWorldPoint([5, position.y + 1.6, 13]);
+    await game.input.lookAtWorldPoint([5, position.y + PLAYER_EYE_HEIGHT_WORLD, 13]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
     await pulseJump(game);
     await game.step({ frames: 90 });
@@ -367,7 +367,7 @@ test(
     // the y=6 authored floor without teleporting between platforms.
     await game.input.lookAtWorldPoint([
       log.position[0],
-      position.y + 1.6,
+      position.y + PLAYER_EYE_HEIGHT_WORLD,
       log.position[2],
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);

--- a/tools/shock2-sdk/test/world-aim.test.ts
+++ b/tools/shock2-sdk/test/world-aim.test.ts
@@ -4,6 +4,7 @@ import {
   AimOcclusionError,
   headRotationForWorldPoint,
   HttpClient,
+  PLAYER_EYE_HEIGHT_WORLD,
   PlayerApi,
 } from "../src/index.js";
 import type {
@@ -12,6 +13,11 @@ import type {
   RayCastResult,
   Vec3,
 } from "../src/index.js";
+
+/** Distance from the default standing eye of the fixture player at (62, -15.8, 83). */
+function distanceFromEye([x, y, z]: Vec3): number {
+  return Math.hypot(x - 62, y - (-15.8 + PLAYER_EYE_HEIGHT_WORLD), z - 83);
+}
 
 type Quat = [number, number, number, number];
 
@@ -43,7 +49,8 @@ test("world aim cancels a non-identity save-restored pawn rotation", () => {
 
 test("world aim rejects an undefined zero-length direction", () => {
   assert.throws(
-    () => headRotationForWorldPoint([1, 2, 3], [0, 0, 0, 1], [1, 3.6, 3]),
+    () =>
+      headRotationForWorldPoint([1, 2, 3], [0, 0, 0, 1], [1, 2 + PLAYER_EYE_HEIGHT_WORLD, 3]),
     /target must differ/,
   );
 });
@@ -63,7 +70,8 @@ function rotateVec(q: Quat, v: Vec3): Vec3 {
 }
 
 test("world aim keeps the horizon level for every direction, including world +z", () => {
-  const eye: Vec3 = [0, -1.6, 0]; // eye height 1.6 lands the eye at the origin
+  // The default eye height lands the eye at the origin.
+  const eye: Vec3 = [0, -PLAYER_EYE_HEIGHT_WORLD, 0];
   const pitches = [-80, -45, -10, 0, 10, 45, 80];
   for (let yawDeg = 0; yawDeg < 360; yawDeg += 15) {
     for (const pitchDeg of pitches) {
@@ -104,7 +112,7 @@ test("world aim keeps the horizon level for every direction, including world +z"
 });
 
 test("world aim picks a stable yaw when looking straight up or down", () => {
-  const eye: Vec3 = [0, -1.6, 0];
+  const eye: Vec3 = [0, -PLAYER_EYE_HEIGHT_WORLD, 0];
   for (const y of [10, -10]) {
     const head = headRotationForWorldPoint(eye, [0, 0, 0, 1], [0, y, 0]);
     const forward = rotateVec(head, [0, 0, -1]);
@@ -116,7 +124,7 @@ test("world aim picks a stable yaw when looking straight up or down", () => {
 });
 
 test("world aim still honors a near-vertical direction's tiny yaw", () => {
-  const eye: Vec3 = [0, -1.6, 0];
+  const eye: Vec3 = [0, -PLAYER_EYE_HEIGHT_WORLD, 0];
   const head = headRotationForWorldPoint(eye, [0, 0, 0, 1], [1e-10, 10, 0]);
   const forward = rotateVec(head, [0, 0, -1]);
   assert.ok(forward[0] > 0, `tiny +x yaw must survive, got forward ${forward}`);
@@ -469,7 +477,9 @@ test("aimAt visibility required skips an occluded classified proxy", async () =>
   assert.equal(aim.visibility.state, "visible");
   assert.equal(aim.visibility.origin, "view");
   assert.equal(aim.visibility.blocker, null);
-  assert.ok(Math.abs(aim.visibility.target_distance - 5.8558) < 0.001);
+  assert.ok(
+    Math.abs(aim.visibility.target_distance - distanceFromEye([56.5, -14, 81])) < 0.001,
+  );
   assert.equal(
     writes.filter(({ path }) => path === "/v1/physics/raycast").length,
     2,
@@ -545,7 +555,9 @@ test("aimAt visibility required reports the blocker when every proxy is occluded
       assert.equal(error.result.visibility.state, "blocked");
       assert.equal(error.result.visibility.origin, "view");
       assert.ok(
-        Math.abs(error.result.visibility.target_distance - 5.5317) < 0.001,
+        Math.abs(
+          error.result.visibility.target_distance - distanceFromEye([56.8, -13.2, 81.4]),
+        ) < 0.001,
       );
       assert.deepEqual(error.result.visibility.blocker, {
         entity_id: 77,


### PR DESCRIPTION
## Summary

hydro2's `HYD Male Corpse` (mission object 754, holds **Hydro Card B**) could not be highlighted or frobbed by the flat interaction ray. The container logic was never at fault - a debug `Frob` opened it fine.

Root cause: **the player's camera sat above the player's own head.** `PLAYER_EYE_HEIGHT` was a magic `4.0` SS2 ft above the body origin, but the standing collision capsule is `6.0` ft tall, so its crown is at `+3.0`. The eye was therefore **1.0 ft above the collider crown — 7.1 ft above the feet for a 6-foot body.** That corpse lies in an alcove with a **7-foot ceiling** (floor `-1.96`, ceiling `0.80`): the body clears it, the camera does not. The eye lands at `0.844`, *outside* the room, so the crosshair ray starts above the ceiling and hits it `0.05` units in front of the eye. Nothing in that alcove can be selected, and the view renders from above the slab.

The fix derives the eye from the original game's camera placement instead of a magic constant. The original anchors the first-person viewpoint to the player's **head sphere** — `PLAYER_HEAD_POS = (PLAYER_HEIGHT / 2) - PLAYER_RADIUS` = **1.8 ft** above the body origin, from the same `PLAYER_RADIUS 1.2` / `PLAYER_HEIGHT 6.0` collision profile this repo already matches — and then raises it by a separate **default eye offset of 0.8 ft** (configurable as `"eyeloc"`; our data ships no override). Standing eye = 1.8 + 0.8 = **2.6 ft above the body center, i.e. 5.6 ft above the floor**.

Both halves are named constants (`physics::PLAYER_HEAD_POS`, `physics::PLAYER_EYE_OFFSET`) and the head half is derived from the collision profile, so the camera stays *inside* the capsule by construction: 2.6 ft is still 0.4 ft below the 3.0 ft crown, and a future footprint change cannot push the eye back through ceilings.

Two consequences of moving the eye *into* the capsule are handled in the second commit:

- The flat projectile ray starts at the camera and includes the `PLAYER` group (so AI shots can hit the player). With the eye inside the capsule, Rapier's solid raycast reported the shooter's own collider as a distance-0 hit and **every flat shot resolved on the player** (terrain spangs, metal impact sounds). A camera-origin ray is by definition the player's own shot, so it now drops `PLAYER`; AI/turret projectiles keep it.
- `THROW_SPAWN_DISTANCE` (0.5) no longer cleared the capsule radius (0.48) for a downward throw; it is now derived from that radius.

## Regression window

Not #767 (`fix(physics): restore model-bounds colliders`) as the issue suspected - **it is #712** (`fix(physics): restore original player footprint`, `962a2a2b`). The eye offset is measured from the capsule **center**, so restoring the standing capsule from 4.8 ft to the authentic 6.0 ft raised the camera 0.6 ft and pushed it over this 7-foot ceiling.

Same deterministic probe (17 standing aim points ringing the corpse, production camera height, crosshair ray with the flat controller's mask):

| build | camera y | corpse selected |
| --- | --- | --- |
| `962a2a2b~1` (before #712) | 0.604 | **yes** (8/17, incl. ang 0 @ 1.5u) |
| `cd00795f~1` (after #712, before #767) | 0.844 | **no** at every level-floor point; ray stops on the ceiling at 0.051u |
| `cd00795f` (main, after #767) | 0.844 | **no** - byte-identical to the line above, so #767 is exonerated |
| this branch | 0.284 | **yes** |

Camera y for this branch is measured from the runtime (`/v1/info`): body center `-0.756` + the live `camera_offset` `1.04` world units (= 2.6 SS2 ft / 2.5), i.e. `2.24` world units (5.6 ft) above the `-1.96` floor and `0.52` units below the `0.80` ceiling. (An earlier revision of this table listed `0.684` for this row; that probe added the eye offset to a position that already included it.)

## Tests

- **Negative-first unit** (`shock2vr/src/physics/mod.rs`): a seven-foot room built from real `WorldRep`-style level geometry, a `selectable` container on the floor, and the flat controller's exact crosshair mask. With the old 4.0 ft eye it resolves to the ceiling (`hit ... at Point3 [0.033, 2.8, 0.0]`); with the fix it resolves to the container. A fixture precondition asserts the pre-fix eye really would have escaped this room, so the repro can't silently stop biting. A second test pins the eye to `PLAYER_HEAD_POS + PLAYER_EYE_OFFSET` and asserts it sits strictly below the capsule crown.
- **Negative-first unit** (`internal_fast_projectile.rs`): a shot fired from the player's own eye reaches the target, not the shooter; the existing "an AI/turret projectile must be able to hit the player" test still passes.
- **Negative-first e2e** (`tools/shock2-sdk/test/hydro2-corpse-frob.e2e.test.ts`): stands at the campaign repro spot, aims with the production `aimAt`, squeezes, and asserts the loot MFD opens bound to the corpse and lists Hydro Card B. On `cd00795f~1`: `active_panel: null`. On this branch: passes.
- `cargo fmt --all`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, `cargo test -p shock2vr` (426 passed), SDK `npm test` (26 passed), full `npm run test:e2e`.
- Several SDK aim fixtures encoded the old camera height (hardcoded `body + 1.6` look targets, a fixed keypad pitch, the Earth world-use staging offset). They now use the exported `PLAYER_EYE_HEIGHT_WORLD` (0.72 -> **1.04** world units with the eye offset) or the production `aimAt`, and `/v1/info` now reports the **live** eye height so automation aims correctly while crouched too.

Fixes #795

campaign: engineering-through-shodan · none · legacy · seed 1378752978


## Visual verification

![camera head-sphere fix demo](https://gist.githubusercontent.com/tommy-xr/11ef64edf489402756a226b81e7947eb/raw/camera_head_fix.gif)

<sub>hydro2 alcove, this branch: the camera pans down onto the <code>HYD Male Corpse</code>, which now highlights (hover label + selection brackets), and a frob opens the SEARCH loot MFD listing <b>Hydro Card B</b>. Captured headlessly via the debug runtime (<code>/v1/step</code> + <code>/v1/screenshot</code>, deterministic fixed-timestep). <b>Note:</b> these captures predate the eye-offset commit, so they show the camera 0.8 ft (0.32 world units) lower than the current build; the alcove is reachable at both heights and the e2e frob test passes on the current build.</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/11ef64edf489402756a226b81e7947eb/raw/camera_head_beforeafter.png)

<sub>Same position and the same aim quaternion on both builds. Before (<code>origin/main~</code>): the eye is above the alcove's 7-ft ceiling, so the view is the featureless top of the ceiling slab and the crosshair ray never reaches the room — <code>/v1/ui</code> stays <code>active_panel: null</code> after a frob. After: the eye is at the original's standing height (head sphere + eye offset), inside the capsule and inside the alcove.</sub>
