### PR TITLE
fix(physics): stop typeless frob boxes wedging the player

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -772,7 +772,7 @@ pub fn create_physics_representation(
     let (
         v_pos,
         v_phys_attr,
-        _v_phys_type,
+        v_phys_type,
         _v_phys_dimensions,
         v_frob_info,
         v_hud_select,
@@ -926,6 +926,18 @@ pub fn create_physics_representation(
                 if hud_select.0 {
                     group = CollisionGroup::selectable();
                 }
+            }
+            // This collider is the *model bounding box*, built only so the
+            // object can be frobbed and raycast - it is not an authored
+            // collision volume. Dark makes an object physical by giving it a
+            // `PhysType`; without one there is no physics model at all and
+            // the object is walk-through (its solidity in retail is the
+            // brushwork behind it). Leaving the box solid to the player fills
+            // walk-in fixtures - the hydro2 Resurrection Station alcove is a
+            // 2.2 x 4.0 x 2.5 box the player must stand inside - and wedges
+            // the capsule against its faces with no way out (#801).
+            if v_phys_type.get(entity_id).is_err() {
+                group = group.non_solid_to_player();
             }
             rigid_body_handle = physics.add_kinematic(
                 entity_id,

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1223,6 +1223,83 @@ mod tests {
 
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
 
+    /// A wall fixture the player can frob but never pick up or move - a
+    /// console, a card slot, the Resurrection Station casing. `phys_type` is
+    /// `None` for the shipped case that has no `P$PhysType` in its chain.
+    fn add_wall_fixture(world: &mut World, phys_type: Option<PhysicsModelType>) -> EntityId {
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropHUDSelect(false),
+            PropImmobile(true),
+        ));
+        if let Some(phys_type) = phys_type {
+            world.add_component(
+                entity_id,
+                PropPhysType {
+                    phys_type,
+                    num_submodels: 1,
+                    remove_on_sleep: false,
+                    is_special: false,
+                },
+            );
+        }
+        entity_id
+    }
+
+    /// A frobbable fixture's collider comes from its model bounding box, not
+    /// from an authored collision volume. Dark only builds a physics model for
+    /// an object that carries a `PhysType`, so one without any must not be
+    /// solid to the player - hydro2's Resurrection Station is a 2.2 x 4.0 x
+    /// 2.5 box around the pad the player has to stand on, and a capsule
+    /// overlapping it has no direction left to resolve into (#801). It still
+    /// gets the collider: frob and selection raycasts need it.
+    ///
+    /// Negative-first: before the fix the typeless case also blocked.
+    #[test]
+    fn a_frobbable_without_phys_type_does_not_block_the_player() {
+        for (phys_type, should_block) in [
+            (None, false),
+            (Some(PhysicsModelType::ORIENTED_BOUNDING_BOX), true),
+        ] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_wall_fixture(&mut world, phys_type);
+            let model = ladder_model();
+
+            let handle =
+                create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+                    .expect("a frobbable fixture should always get a frob collider");
+
+            assert_eq!(
+                physics.collider_blocks_player(handle),
+                should_block,
+                "phys_type {phys_type:?} should{} block the player",
+                if should_block { "" } else { " not" }
+            );
+            // Either way it stays in the world and keeps its selectable /
+            // entity membership, so nothing about frobbing changes.
+            let bodies = physics.debug_list_bodies();
+            assert_eq!(bodies.len(), 1, "expected exactly one body in the world");
+            assert!(
+                bodies[0]
+                    .collision_groups
+                    .iter()
+                    .any(|g| g == "entity" || g == "selectable"),
+                "a frob collider must stay raycastable, got {:?}",
+                bodies[0].collision_groups
+            );
+        }
+    }
+
     /// Model scale is a render transform, while `P$PhysDims` is the separately
     /// authored collision volume. Shodan's long window strips make the
     /// distinction observable: applying their visual z-scale to the OBB grows

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1239,8 +1239,14 @@ impl MissionCore {
             return;
         };
 
-        self.physics
-            .set_player_translation(position, &mut self.player_handle);
+        // The authored marker is used verbatim whenever the standing capsule
+        // fits there. Reconstruction is the one relocation the player cannot
+        // decline, so an obstructed marker would end the run outright: the
+        // character controller cannot walk out of a pose it starts inside
+        // (#801). Step aside in that case rather than strand them.
+        let position = self
+            .physics
+            .set_player_translation_unobstructed(position, &mut self.player_handle);
         let player_entity = {
             let mut player = self.world.borrow::<UniqueViewMut<PlayerInfo>>().unwrap();
             player.pos = position;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -41,10 +41,10 @@ const PLAYER_CROUCH_HEIGHT: f32 = 2.8;
 const PLAYER_CROUCH_RADIUS: f32 = 0.8;
 
 /// Widening search used to rescue an obstructed authored placement (a respawn
-/// or teleport marker whose standing capsule does not fit). The step is one
-/// standing radius, so the first ring already clears a capsule-deep overlap,
-/// and the search reaches `STEPS * STEP` = 6 SS2 ft - roughly one player
-/// height - before giving up and using the authored pose unchanged.
+/// marker whose capsule does not fit). The step is one standing radius, so two
+/// rings clear a full capsule-diameter overlap, and the search reaches
+/// `STEPS * STEP` = 6 SS2 ft - one player height - before giving up and using
+/// the authored pose unchanged.
 const PLAYER_PLACEMENT_SEARCH_STEP: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 const PLAYER_PLACEMENT_SEARCH_STEPS: u32 = 5;
 const PLAYER_PLACEMENT_SEARCH_DIRECTIONS: u32 = 8;
@@ -2459,6 +2459,21 @@ impl PhysicsWorld {
         ))
     }
 
+    /// Whether a body's collider is solid to the player capsule. Membership
+    /// alone does not say - it is the collider's *filter* that this turns on
+    /// and off (see `CollisionGroup::non_solid_to_player`).
+    #[cfg(test)]
+    pub(crate) fn collider_blocks_player(&self, handle: RigidBodyHandle) -> bool {
+        let Some(body) = self.rigid_body_set.get(handle) else {
+            return false;
+        };
+        body.colliders().iter().any(|collider_handle| {
+            self.collider_set.get(*collider_handle).is_some_and(|c| {
+                c.collision_groups().filter.bits() & InternalCollisionGroups::PLAYER.bits != 0
+            })
+        })
+    }
+
     pub fn remove_impulse_joint(&mut self, handle: ImpulseJointHandle) {
         self.impulse_joint_set.remove(handle, true);
     }
@@ -2502,16 +2517,21 @@ impl PhysicsWorld {
         self.refresh_player_support(player_handle);
     }
 
-    /// Place the player at an authored pose, stepping aside only when the
-    /// standing capsule does not fit there.
+    /// Place the player at an authored pose, stepping aside only when their
+    /// capsule does not fit there.
     ///
-    /// Respawn and scripted-teleport markers are authored coordinates, so the
-    /// authored pose is used verbatim whenever it is free - this never
-    /// second-guesses level data. It exists because a marker that *is*
-    /// obstructed leaves the player permanently immobile: the character
-    /// controller has no depenetration pass, so every cast from inside a
-    /// collider returns a zero-length move in every direction and no input can
-    /// recover (#801). Returns the position actually used.
+    /// A respawn marker is an authored coordinate, so it is used verbatim
+    /// whenever it is free - this never second-guesses level data. It exists
+    /// because a marker that *is* obstructed leaves the player permanently
+    /// immobile: the character controller has no depenetration pass, so every
+    /// cast from inside a collider returns a zero-length move in every
+    /// direction and no input can recover (#801). Returns the position
+    /// actually used.
+    ///
+    /// Only QBR reconstruction routes through here. Scripted teleports and the
+    /// debug teleport still write the body directly: those are triggered, and
+    /// a player who walks into a bad trap can at least reload - reconstruction
+    /// is the relocation they cannot decline.
     pub fn set_player_translation_unobstructed(
         &mut self,
         position: Vector3<f32>,
@@ -2537,33 +2557,60 @@ impl PhysicsWorld {
         placed
     }
 
-    /// Whether the standing player capsule fits at `position` without
-    /// overlapping blocking geometry (the player's own body excluded).
-    pub fn standing_player_pose_is_clear(
+    /// Whether the player's *current* capsule - crouched or standing, since
+    /// nothing uncrouches them on the way to a respawn - fits at `position`
+    /// without overlapping blocking geometry (their own body excluded).
+    fn player_pose_is_clear(&self, position: Vector3<f32>, player_handle: &PlayerHandle) -> bool {
+        let capsule = if player_handle.is_crouched {
+            crouched_player_capsule()
+        } else {
+            standing_player_capsule()
+        };
+        self.pose_is_clear(position, player_handle, &capsule)
+    }
+
+    /// Whether the STANDING capsule fits at `position`, whatever the player is
+    /// doing right now. Used where the pose has to be valid for an upright
+    /// player later (the climb top-out's saved pose), and by the tests.
+    fn standing_player_pose_is_clear(
         &self,
         position: Vector3<f32>,
         player_handle: &PlayerHandle,
     ) -> bool {
-        let standing = standing_player_capsule();
+        self.pose_is_clear(position, player_handle, &standing_player_capsule())
+    }
+
+    fn pose_is_clear(
+        &self,
+        position: Vector3<f32>,
+        player_handle: &PlayerHandle,
+        shape: &dyn Shape,
+    ) -> bool {
         let queries = self.broad_phase.as_query_pipeline(
             self.narrow_phase.query_dispatcher(),
             &self.rigid_body_set,
             &self.collider_set,
             player_pose_filter(player_handle.character_handle),
         );
-        !shape_intersects(&queries, vec_to_nvec(position), &standing)
+        !shape_intersects(&queries, vec_to_nvec(position), shape)
     }
 
     /// Whether a *substitute* pose is somewhere the player can actually be
     /// left: the capsule fits AND there is ground within one player height
     /// below it. The clearance test alone is happy in mid-air and over a
     /// void, which would trade one stranding for another.
+    ///
+    /// There is deliberately no "is the route there clear" test: the only
+    /// geometry between an obstructed marker and any escape from it is the
+    /// obstruction itself, so such a test would reject every candidate it was
+    /// meant to vet. The bounded search radius is what keeps a substitute
+    /// near the marker instead.
     fn placement_candidate_is_usable(
         &self,
         position: Vector3<f32>,
         player_handle: &PlayerHandle,
     ) -> bool {
-        if !self.standing_player_pose_is_clear(position, player_handle) {
+        if !self.player_pose_is_clear(position, player_handle) {
             return false;
         }
         let queries = self.broad_phase.as_query_pipeline(
@@ -2573,7 +2620,11 @@ impl PhysicsWorld {
             player_pose_filter(player_handle.character_handle),
         );
         let down = Ray::new(Point::from(vec_to_nvec(position)), -Vector::y());
-        let to_feet = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR;
+        let to_feet = if player_handle.is_crouched {
+            PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+        } else {
+            PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+        };
         queries
             .cast_ray(&down, to_feet + PLAYER_PLACEMENT_MAX_DROP, true)
             .is_some()
@@ -2591,7 +2642,7 @@ impl PhysicsWorld {
         position: Vector3<f32>,
         player_handle: &PlayerHandle,
     ) -> Option<Vector3<f32>> {
-        if self.standing_player_pose_is_clear(position, player_handle) {
+        if self.player_pose_is_clear(position, player_handle) {
             return Some(position);
         }
         // A single small lift covers the common near-miss - a marker sunk into
@@ -7332,8 +7383,8 @@ mod tests {
     /// Build a floor whose top face is flush with the bottom of a walk-in
     /// fixture's model-bounds box - hydro2's Resurrection Station casing sits
     /// on the alcove floor exactly like this - and return the world plus the
-    /// box's -x/-z corner in world coordinates.
-    fn frob_box_fixture(solid: bool) -> (PhysicsWorld, f32, f32, f32) {
+    /// y a standing capsule rests at on that floor.
+    fn frob_box_fixture(solid: bool) -> (PhysicsWorld, f32) {
         let mut world = PhysicsWorld::new();
         // Floor: 40x40, 1 thick, centred on the origin -> top face at y = 0.5.
         world.add_kinematic(
@@ -7375,7 +7426,7 @@ mod tests {
             },
             false,
         );
-        (world, 0.9, -1.25, 1.7)
+        (world, 1.7)
     }
 
     /// Furthest the player gets from `start` over `HEADINGS` compass
@@ -7386,7 +7437,7 @@ mod tests {
         let mut best: f32 = 0.0;
         for heading in 0..HEADINGS {
             let angle = std::f32::consts::TAU * heading as f32 / HEADINGS as f32;
-            let (mut world, _, _, _) = frob_box_fixture(solid);
+            let (mut world, _) = frob_box_fixture(solid);
             let mut player = world.create_player(start, EntityId::from_inner(2000).unwrap());
             for _ in 0..30 {
                 world.update(vec3(0.0, 0.0, 0.0), &mut player);
@@ -7414,7 +7465,7 @@ mod tests {
     /// `non_solid_to_player` half changes behavior.
     #[test]
     fn a_non_solid_frob_box_never_wedges_the_player() {
-        let (_, _, _, stand_y) = frob_box_fixture(true);
+        let (_, stand_y) = frob_box_fixture(true);
         // Poses inside the slot, the way the reported wedge sat between the
         // casing and the alcove's step.
         let starts = [
@@ -7429,7 +7480,7 @@ mod tests {
             .fold(f32::INFINITY, f32::min);
         assert!(
             worst_when_solid < 0.25,
-            "a solid frob box should still pin the capsule in the slot, best walk {worst_when_solid}"
+            "at least one slot pose should still be pinned by a solid frob box, best walk over all of them was {worst_when_solid}"
         );
 
         for start in starts {
@@ -7447,7 +7498,7 @@ mod tests {
     /// above - so reconstruction would end the run outright (#801).
     #[test]
     fn an_obstructed_authored_placement_steps_aside() {
-        let (mut world, _, _, stand_y) = frob_box_fixture(true);
+        let (mut world, stand_y) = frob_box_fixture(true);
         let mut player = world.create_player(
             vec3(-8.0, stand_y, 0.0),
             EntityId::from_inner(2000).unwrap(),

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -40,6 +40,19 @@ const PLAYER_CROUCH_HEIGHT: f32 = 2.8;
 /// does not.
 const PLAYER_CROUCH_RADIUS: f32 = 0.8;
 
+/// Widening search used to rescue an obstructed authored placement (a respawn
+/// or teleport marker whose standing capsule does not fit). The step is one
+/// standing radius, so the first ring already clears a capsule-deep overlap,
+/// and the search reaches `STEPS * STEP` = 6 SS2 ft - roughly one player
+/// height - before giving up and using the authored pose unchanged.
+const PLAYER_PLACEMENT_SEARCH_STEP: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
+const PLAYER_PLACEMENT_SEARCH_STEPS: u32 = 5;
+const PLAYER_PLACEMENT_SEARCH_DIRECTIONS: u32 = 8;
+/// How far below a substitute pose's feet ground may be before it counts as
+/// mid-air or a void. One player height: enough for the ordinary "the pose is
+/// a little above its pad" case, short of dropping the player down a shaft.
+const PLAYER_PLACEMENT_MAX_DROP: f32 = PLAYER_STANDING_HEIGHT / SCALE_FACTOR;
+
 /// Margin (SS2 ft) for the stand-up headroom test capsule: its radius is
 /// shrunk by this and its pose lifted by it, keeping the test top exactly at
 /// the standing crown while floating the test bottom off the floor. Without
@@ -724,6 +737,19 @@ fn scripted_character_movement(translation: Vector<Real>) -> EffectiveCharacterM
         grounded: false,
         is_sliding_down_slope: false,
     }
+}
+
+/// Query filter for testing a player pose against everything that blocks the
+/// player, excluding the player's own body.
+fn player_pose_filter<'a>(character_handle: RigidBodyHandle) -> QueryFilter<'a> {
+    QueryFilter::new()
+        .groups(InteractionGroups::new(
+            InternalCollisionGroups::PLAYER.bits.into(),
+            InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
+            Default::default(),
+        ))
+        .exclude_rigid_body(character_handle)
+        .exclude_sensors()
 }
 
 fn shape_intersects(queries: &QueryPipeline, position: Vector<Real>, shape: &dyn Shape) -> bool {
@@ -1871,6 +1897,26 @@ impl CollisionGroup {
         })
     }
 
+    /// The same membership as this group, with `PLAYER` dropped from the
+    /// filter so the player capsule never collides with it.
+    ///
+    /// Dark only instantiates a physics model for an object that carries a
+    /// `PhysType` (`phprop.cpp`'s PhysType listener is what creates the
+    /// instance `PhysDims`). An object with no `PhysType` anywhere in its
+    /// inheritance chain - a wall console, a card slot, a button, the
+    /// Resurrection Station's own casing - is therefore never solid in
+    /// retail; its physical presence is the brushwork behind it. This engine
+    /// still needs a collider there so the object stays frobbable and
+    /// raycastable, so keep the collider and only take the player out of it.
+    pub fn non_solid_to_player(self) -> CollisionGroup {
+        let filter = self.0.filter.bits() & !InternalCollisionGroups::PLAYER.bits;
+        CollisionGroup(InteractionGroups {
+            memberships: self.0.memberships,
+            filter: filter.into(),
+            test_mode: self.0.test_mode,
+        })
+    }
+
     /// Collision group for ragdoll limb bodies. Members are `SELECTABLE` (so
     /// they remain raycast/selectable) and collide with `WORLD` geometry *and*
     /// each other (`SELECTABLE`), so limbs don't pass through the torso/head.
@@ -2456,6 +2502,120 @@ impl PhysicsWorld {
         self.refresh_player_support(player_handle);
     }
 
+    /// Place the player at an authored pose, stepping aside only when the
+    /// standing capsule does not fit there.
+    ///
+    /// Respawn and scripted-teleport markers are authored coordinates, so the
+    /// authored pose is used verbatim whenever it is free - this never
+    /// second-guesses level data. It exists because a marker that *is*
+    /// obstructed leaves the player permanently immobile: the character
+    /// controller has no depenetration pass, so every cast from inside a
+    /// collider returns a zero-length move in every direction and no input can
+    /// recover (#801). Returns the position actually used.
+    pub fn set_player_translation_unobstructed(
+        &mut self,
+        position: Vector3<f32>,
+        player_handle: &mut PlayerHandle,
+    ) -> Vector3<f32> {
+        let placed = match self.nearest_unobstructed_player_pose(position, player_handle) {
+            Some(placed) => placed,
+            None => {
+                // Nothing within a player height of the marker fits. The
+                // authored pose is still the best answer available - the
+                // alternatives (leaving the player dead, or inventing a
+                // coordinate) are worse - but it means the level data and the
+                // engine disagree somewhere, so say so loudly.
+                tracing::warn!(
+                    "no unobstructed standing pose within {} wu of authored placement {:?}; using it as authored",
+                    PLAYER_PLACEMENT_SEARCH_STEP * PLAYER_PLACEMENT_SEARCH_STEPS as f32,
+                    position
+                );
+                position
+            }
+        };
+        self.set_player_translation(placed, player_handle);
+        placed
+    }
+
+    /// Whether the standing player capsule fits at `position` without
+    /// overlapping blocking geometry (the player's own body excluded).
+    pub fn standing_player_pose_is_clear(
+        &self,
+        position: Vector3<f32>,
+        player_handle: &PlayerHandle,
+    ) -> bool {
+        let standing = standing_player_capsule();
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            player_pose_filter(player_handle.character_handle),
+        );
+        !shape_intersects(&queries, vec_to_nvec(position), &standing)
+    }
+
+    /// Whether a *substitute* pose is somewhere the player can actually be
+    /// left: the capsule fits AND there is ground within one player height
+    /// below it. The clearance test alone is happy in mid-air and over a
+    /// void, which would trade one stranding for another.
+    fn placement_candidate_is_usable(
+        &self,
+        position: Vector3<f32>,
+        player_handle: &PlayerHandle,
+    ) -> bool {
+        if !self.standing_player_pose_is_clear(position, player_handle) {
+            return false;
+        }
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            player_pose_filter(player_handle.character_handle),
+        );
+        let down = Ray::new(Point::from(vec_to_nvec(position)), -Vector::y());
+        let to_feet = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR;
+        queries
+            .cast_ray(&down, to_feet + PLAYER_PLACEMENT_MAX_DROP, true)
+            .is_some()
+    }
+
+    /// The authored pose if the standing capsule fits there, otherwise the
+    /// closest usable pose on a widening deterministic search around it, or
+    /// `None` when nothing within the search fits.
+    ///
+    /// The authored pose only has to be *clear* - a marker over an authored
+    /// drop is level data, not a mistake. A pose this code invents has to
+    /// stand up to more than that; see `placement_candidate_is_usable`.
+    fn nearest_unobstructed_player_pose(
+        &self,
+        position: Vector3<f32>,
+        player_handle: &PlayerHandle,
+    ) -> Option<Vector3<f32>> {
+        if self.standing_player_pose_is_clear(position, player_handle) {
+            return Some(position);
+        }
+        // A single small lift covers the common near-miss - a marker sunk into
+        // its own pad - and is deliberately not widened: a taller lift would
+        // perch the player on the roof of whatever they were placed inside.
+        // Everything past that slides out horizontally, nearest ring first.
+        let lift = position + vec3(0.0, PLAYER_PLACEMENT_SEARCH_STEP, 0.0);
+        if self.placement_candidate_is_usable(lift, player_handle) {
+            return Some(lift);
+        }
+        for step in 1..=PLAYER_PLACEMENT_SEARCH_STEPS {
+            let distance = PLAYER_PLACEMENT_SEARCH_STEP * step as f32;
+            for compass in 0..PLAYER_PLACEMENT_SEARCH_DIRECTIONS {
+                let angle = std::f32::consts::TAU * compass as f32
+                    / PLAYER_PLACEMENT_SEARCH_DIRECTIONS as f32;
+                let slide = position + vec3(angle.cos() * distance, 0.0, angle.sin() * distance);
+                if self.placement_candidate_is_usable(slide, player_handle) {
+                    return Some(slide);
+                }
+            }
+        }
+        None
+    }
+
     /// The character body's current translation, without stepping the
     /// simulation. Used while time is frozen (debug-runtime pause) so
     /// teleports - which write the physics body directly - are still
@@ -2473,22 +2633,7 @@ impl PhysicsWorld {
         player_handle: &PlayerHandle,
         top_out: ClimbTopOut,
     ) -> bool {
-        let standing = standing_player_capsule();
-        let filter = QueryFilter::new()
-            .groups(InteractionGroups::new(
-                InternalCollisionGroups::PLAYER.bits.into(),
-                InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
-                Default::default(),
-            ))
-            .exclude_rigid_body(player_handle.character_handle)
-            .exclude_sensors();
-        let queries = self.broad_phase.as_query_pipeline(
-            self.narrow_phase.query_dispatcher(),
-            &self.rigid_body_set,
-            &self.collider_set,
-            filter,
-        );
-        !shape_intersects(&queries, top_out.save_pose, &standing)
+        self.standing_player_pose_is_clear(nvec_to_cgmath(top_out.save_pose), player_handle)
     }
 
     /// Position safe to serialize for the player. A compressed mantle can
@@ -7181,6 +7326,175 @@ mod tests {
         assert!(
             !world.set_player_crouch(false, &mut player),
             "a landed crouched player in open headroom should stand normally"
+        );
+    }
+
+    /// Build a floor whose top face is flush with the bottom of a walk-in
+    /// fixture's model-bounds box - hydro2's Resurrection Station casing sits
+    /// on the alcove floor exactly like this - and return the world plus the
+    /// box's -x/-z corner in world coordinates.
+    fn frob_box_fixture(solid: bool) -> (PhysicsWorld, f32, f32, f32) {
+        let mut world = PhysicsWorld::new();
+        // Floor: 40x40, 1 thick, centred on the origin -> top face at y = 0.5.
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(40.0, 1.0, 40.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        // A wall, standing on the floor with its +x face at x = 0.5 - the
+        // alcove's authored step, which the hydro2 wedge also grazed.
+        world.add_kinematic(
+            EntityId::from_inner(1002).unwrap(),
+            vec3(-0.5, 2.5, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.0, 4.0, 20.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        // The casing, at the Resurrection Station's real model-bounds extents,
+        // standing on the floor: x in [0.9, 3.1], y in [0.5, 4.5], z in
+        // [-1.25, 1.25]. That leaves a 0.4-wide slot against the wall - half a
+        // capsule diameter - so a pose inside it is pinned between two
+        // opposing faces with no direction left to resolve into.
+        let casing = CollisionGroup::entity();
+        world.add_kinematic(
+            EntityId::from_inner(1003).unwrap(),
+            vec3(2.0, 2.5, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(2.2, 4.0, 2.5),
+            if solid {
+                casing
+            } else {
+                casing.non_solid_to_player()
+            },
+            false,
+        );
+        (world, 0.9, -1.25, 1.7)
+    }
+
+    /// Furthest the player gets from `start` over `HEADINGS` compass
+    /// directions of ordinary locomotion input - the same probe the issue used
+    /// against the live level.
+    fn best_walk_from(solid: bool, start: Vector3<f32>) -> f32 {
+        const HEADINGS: usize = 8;
+        let mut best: f32 = 0.0;
+        for heading in 0..HEADINGS {
+            let angle = std::f32::consts::TAU * heading as f32 / HEADINGS as f32;
+            let (mut world, _, _, _) = frob_box_fixture(solid);
+            let mut player = world.create_player(start, EntityId::from_inner(2000).unwrap());
+            for _ in 0..30 {
+                world.update(vec3(0.0, 0.0, 0.0), &mut player);
+            }
+            let from = world.get_player_translation(&player);
+            let step = vec3(angle.cos() * 0.05, 0.0, angle.sin() * 0.05);
+            for _ in 0..120 {
+                world.update(step, &mut player);
+            }
+            let to = world.get_player_translation(&player);
+            best = best.max(((to.x - from.x).powi(2) + (to.z - from.z).powi(2)).sqrt());
+        }
+        best
+    }
+
+    /// A walk-in fixture's model-bounds box - built only so the object can be
+    /// frobbed, for an object Dark never gives a physics model - must not be
+    /// solid to the player. While it was, a capsule overlapping the corner of
+    /// two of its faces had no way out: the character controller has no
+    /// depenetration pass, so every cast returns toi=0 and the resolved
+    /// translation is exactly zero in every direction (hydro2's Resurrection
+    /// Station alcove, #801).
+    ///
+    /// Negative-first: the `solid` half is the bug and still freezes; only the
+    /// `non_solid_to_player` half changes behavior.
+    #[test]
+    fn a_non_solid_frob_box_never_wedges_the_player() {
+        let (_, _, _, stand_y) = frob_box_fixture(true);
+        // Poses inside the slot, the way the reported wedge sat between the
+        // casing and the alcove's step.
+        let starts = [
+            vec3(0.75, stand_y, 0.0),
+            vec3(0.85, stand_y, 0.0),
+            vec3(0.85, stand_y, 0.6),
+        ];
+
+        let worst_when_solid = starts
+            .iter()
+            .map(|start| best_walk_from(true, *start))
+            .fold(f32::INFINITY, f32::min);
+        assert!(
+            worst_when_solid < 0.25,
+            "a solid frob box should still pin the capsule in the slot, best walk {worst_when_solid}"
+        );
+
+        for start in starts {
+            let walked = best_walk_from(false, start);
+            assert!(
+                walked > 1.0,
+                "a non-solid frob box must leave {start:?} walkable, moved {walked}"
+            );
+        }
+    }
+
+    /// An authored placement (a QBR marker, a teleport trap) is used verbatim
+    /// when the standing capsule fits, and only steps aside when it does not.
+    /// An obstructed placement is unrecoverable otherwise - see the wedge
+    /// above - so reconstruction would end the run outright (#801).
+    #[test]
+    fn an_obstructed_authored_placement_steps_aside() {
+        let (mut world, _, _, stand_y) = frob_box_fixture(true);
+        let mut player = world.create_player(
+            vec3(-8.0, stand_y, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        for _ in 0..10 {
+            world.update(vec3(0.0, 0.0, 0.0), &mut player);
+        }
+
+        let free = vec3(-4.0, stand_y, 0.0);
+        assert_eq!(
+            world.set_player_translation_unobstructed(free, &mut player),
+            free,
+            "a free authored placement must be used exactly, never nudged"
+        );
+
+        let obstructed = vec3(2.0, stand_y, 0.0);
+        assert!(
+            !world.standing_player_pose_is_clear(obstructed, &player),
+            "the fixture interior should be obstructed for the standing capsule"
+        );
+        let placed = world.set_player_translation_unobstructed(obstructed, &mut player);
+        assert_ne!(placed, obstructed);
+        assert!(
+            world.standing_player_pose_is_clear(placed, &player),
+            "reconstruction must land somewhere the standing capsule fits, got {placed:?}"
+        );
+
+        // The casing is still solid in this fixture, so escape is measured the
+        // way the issue measured it: the best of eight compass headings.
+        let mut walked: f32 = 0.0;
+        for heading in 0..8 {
+            let angle = std::f32::consts::TAU * heading as f32 / 8.0;
+            world.set_player_translation(placed, &mut player);
+            for _ in 0..30 {
+                world.update(vec3(0.0, 0.0, 0.0), &mut player);
+            }
+            let from = world.get_player_translation(&player);
+            let step = vec3(angle.cos() * 0.05, 0.0, angle.sin() * 0.05);
+            for _ in 0..120 {
+                world.update(step, &mut player);
+            }
+            let to = world.get_player_translation(&player);
+            walked = walked.max(((to.x - from.x).powi(2) + (to.z - from.z).powi(2)).sqrt());
+        }
+        assert!(
+            walked > 1.0,
+            "a reconstructed player must be able to walk away, moved {walked}"
         );
     }
 

--- a/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
@@ -26,16 +26,13 @@ const RESURRECTION_TARGET = 570;
 const RESURRECTION_COST = 10;
 const RESPAWN_DELAY_FRAMES = 5 * 60;
 
-// The wedge reported in #801, and a control one metre away on the pad where
-// movement always worked.
+// The wedge reported in #801, and the reconstruction pad one metre away. The
+// pad is NOT an outside-the-box control - it is the box's own x/z centre. It
+// moved fine even on main because a capsule buried deep inside a convex box
+// finds no contact at all; only poses straddling a face freeze. Asserting both
+// keeps the fix honest in either regime.
 const WEDGE = { x: 43.72, y: 3.69, z: 31.32 };
 const PAD = { x: 44.8, y: 3.7, z: 32.4 };
-
-type LifeState = "alive" | "dead" | "respawning";
-
-function lifeState(player: object): LifeState | undefined {
-  return (player as { life_state?: LifeState }).life_state;
-}
 
 function planarDistance(
   a: [number, number, number],
@@ -100,10 +97,12 @@ test(
       "the Resurrection Station must keep its frob collider",
     );
     // ...and that collider must still answer the mask the frob/selection ray
-    // uses, or the machine would become impossible to interact with.
+    // uses, or the machine would become impossible to interact with. Cast from
+    // just outside its -x face (past the Regen_Hologram, which is a typeless
+    // frobbable too and would otherwise be hit first) into the casing.
     const hit = await game.raycast({
-      start: [station.position[0] - 4, station.position[1], station.position[2]],
-      end: [station.position[0] + 1, station.position[1], station.position[2]],
+      start: [43.4, station.position[1], station.position[2]],
+      end: [station.position[0], station.position[1], station.position[2]],
       collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
       ignore_sensors: true,
     });
@@ -116,7 +115,7 @@ test(
     const padWalk = await bestWalkDistance(game, PAD);
     assert.ok(
       padWalk > 1,
-      `the reconstruction pad has always been walkable: moved ${padWalk}`,
+      `the reconstruction pad must stay walkable: moved ${padWalk}`,
     );
 
     const wedgeWalk = await bestWalkDistance(game, WEDGE);
@@ -166,11 +165,11 @@ test(
       amount: (before.player.hit_points ?? 0) + 100,
     });
     await game.step({ frames: 1 });
-    assert.equal(lifeState((await game.info()).player), "respawning");
+    assert.equal((await game.info()).player.life_state, "respawning");
 
     await game.step({ frames: RESPAWN_DELAY_FRAMES });
     const revived = await game.info();
-    assert.equal(lifeState(revived.player), "alive");
+    assert.equal(revived.player.life_state, "alive");
     // The authored marker is free, so reconstruction must use it verbatim -
     // in all three axes, so a vertical nudge cannot pass unnoticed. (The
     // tolerance covers the settling that follows reconstruction, not a

--- a/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
+
+// Regression coverage for #801. The hydro2 Resurrection Station is a walk-in
+// fixture: the player stands inside its casing on the reconstruction pad. Its
+// template carries no P$PhysType anywhere in its inheritance chain, so Dark
+// never gives it a physics model - it is decoration in front of the brushwork.
+// This engine still builds a model-bounds box for it so it stays frobbable,
+// and while that box was solid to the player it filled the whole alcove
+// (2.2 x 4.0 x 2.5 world units). The character controller has no
+// depenetration pass, so a capsule overlapping one of its faces resolved every
+// direction to a zero-length move and no input could recover.
+//
+// Negative-first: on main both the raw-input and bounded-move assertions below
+// report 0 at the wedge coordinates from the issue.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8206);
+
+// Stable mission-object ids (`template_id`), not runtime entity ids.
+const RESURRECTION_STATION = 423;
+const RESURRECTION_BUTTON = 858;
+const RESURRECTION_TARGET = 570;
+const RESURRECTION_COST = 10;
+const RESPAWN_DELAY_FRAMES = 5 * 60;
+
+// The wedge reported in #801, and a control one metre away on the pad where
+// movement always worked.
+const WEDGE = { x: 43.72, y: 3.69, z: 31.32 };
+const PAD = { x: 44.8, y: 3.7, z: 32.4 };
+
+type LifeState = "alive" | "dead" | "respawning";
+
+function lifeState(player: object): LifeState | undefined {
+  return (player as { life_state?: LifeState }).life_state;
+}
+
+function planarDistance(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[2] - b[2]);
+}
+
+function distance(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/**
+ * Drive real locomotion input across `headings` compass directions and report
+ * the furthest the player got from where they started. This is the production
+ * path (thumbstick -> character controller), not the debug mover.
+ */
+async function bestWalkDistance(
+  game: GameServer,
+  from: { x: number; y: number; z: number },
+  headings = 8,
+): Promise<number> {
+  let best = 0;
+  for (let i = 0; i < headings; i += 1) {
+    const angle = (2 * Math.PI * i) / headings;
+    await game.player.teleport(from);
+    await game.step({ frames: 5 });
+    const start = (await game.info()).player.position;
+    await game.input.set("right_hand.thumbstick", [
+      Math.sin(angle),
+      Math.cos(angle),
+    ]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const end = (await game.info()).player.position;
+    best = Math.max(best, planarDistance(start, end));
+  }
+  return best;
+}
+
+test(
+  "hydro2: the QBR alcove floor is walkable and its casing stays frobbable",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 5 });
+
+    // The casing keeps its collider - it must stay selectable and raycastable,
+    // it just must not block the player capsule.
+    const [station] = await game.entities.byTemplate(RESURRECTION_STATION);
+    assert.ok(station, "hydro2 should contain its authored Resurrection Station");
+    const { bodies } = await game.physics.bodies({ entityId: station.id });
+    assert.equal(
+      bodies.length,
+      1,
+      "the Resurrection Station must keep its frob collider",
+    );
+    // ...and that collider must still answer the mask the frob/selection ray
+    // uses, or the machine would become impossible to interact with.
+    const hit = await game.raycast({
+      start: [station.position[0] - 4, station.position[1], station.position[2]],
+      end: [station.position[0] + 1, station.position[1], station.position[2]],
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      ignore_sensors: true,
+    });
+    assert.equal(
+      hit.entity_id,
+      station.id,
+      `the selection ray must still hit the Resurrection Station: ${JSON.stringify(hit)}`,
+    );
+
+    const padWalk = await bestWalkDistance(game, PAD);
+    assert.ok(
+      padWalk > 1,
+      `the reconstruction pad has always been walkable: moved ${padWalk}`,
+    );
+
+    const wedgeWalk = await bestWalkDistance(game, WEDGE);
+    assert.ok(
+      wedgeWalk > 1,
+      `the alcove floor beside the pad must be walkable too: moved ${wedgeWalk}`,
+    );
+
+    // The bounded mover is the same character-controller step, so it agrees.
+    await game.player.teleport(WEDGE);
+    await game.step({ frames: 10 });
+    const here = await game.player.position();
+    const hop = await game.player.moveTo({ ...here, x: here.x + 1 });
+    assert.ok(
+      hop.distance_moved > 0,
+      `a bounded move out of the alcove must make progress: ${JSON.stringify(hop)}`,
+    );
+  },
+);
+
+test(
+  "hydro2: QBR reconstruction leaves the player able to move",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: basePort + 1,
+    });
+    await game.step({ frames: 5 });
+
+    await game.player.spawnItem("20 Nanites");
+    assert.ok((await carriedNaniteTotal(game)) >= RESURRECTION_COST);
+
+    const [button] = await game.entities.byTemplate(RESURRECTION_BUTTON);
+    assert.ok(button, "hydro2 should contain its authored QBR scanner button");
+    const [target] = await game.entities.byTemplate(RESURRECTION_TARGET);
+    assert.ok(target, "the QBR button should link to its authored teleport target");
+    const targetPosition = (await game.entities.detail(target.id)).position;
+
+    await game.entities.sendMessage(button.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+
+    const before = await game.info();
+    assert.ok(before.player.entity_id !== null, "mission should expose the player entity");
+    await game.entities.sendMessage(before.player.entity_id, {
+      type: "Damage",
+      amount: (before.player.hit_points ?? 0) + 100,
+    });
+    await game.step({ frames: 1 });
+    assert.equal(lifeState((await game.info()).player), "respawning");
+
+    await game.step({ frames: RESPAWN_DELAY_FRAMES });
+    const revived = await game.info();
+    assert.equal(lifeState(revived.player), "alive");
+    // The authored marker is free, so reconstruction must use it verbatim -
+    // in all three axes, so a vertical nudge cannot pass unnoticed. (The
+    // tolerance covers the settling that follows reconstruction, not a
+    // deliberate step-aside.)
+    assert.ok(
+      distance(revived.player.position, targetPosition) < 0.25,
+      `reconstruction should use the authored marker: target=${JSON.stringify(targetPosition)} actual=${JSON.stringify(revived.player.position)}`,
+    );
+
+    const spawn = revived.player.position;
+    const walked = await bestWalkDistance(game, {
+      x: spawn[0],
+      y: spawn[1],
+      z: spawn[2],
+    });
+    assert.ok(
+      walked > 1,
+      `a reconstructed player must be able to walk away: moved ${walked}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #801

campaign: engineering-through-shodan · none · legacy · seed 1378752978

## Summary

- stop fabricating a **player-solid** collider for objects Dark never gives a physics model — an object with no `P$PhysType` keeps its model-bounds box for frobbing/raycasts, but the player capsule no longer collides with it
- validate the **QBR reconstruction pose**: the authored marker is used verbatim when the standing capsule fits there, and only steps aside when it does not
- negative-first coverage: two physics unit tests plus an SDK e2e that teleports to the reported wedge coordinates in hydro2

## Root cause

The hydro2 Resurrection Station (`hydro2.mis` object 423, template `-1677` → `Functional` → `Physical` → `Object`) carries **no `P$PhysType` and no `P$PhysDims` anywhere in its inheritance chain**. It still received a collider, because `entity_creator.rs`'s *frobbable item* branch builds a solid kinematic cuboid from the raw **model bounding box** for any entity that has `P$FrobInfo`, without consulting `PhysType` at all.

Measured live with `/v1/physics/raycast` (binary search on the collider boundary):

```
Resurrection Station collider AABB: x[43.697, 45.903] y[2.400, 6.403] z[31.126, 33.674]
  size 2.206 x 4.003 x 2.548, centre (44.800, 4.401, 32.400)
```

That is a solid box filling the entire walk-in alcove — including the reconstruction pad the player is *required* to stand on. The alcove floor is at y 2.40, exactly the box's bottom face, so a standing capsule there is inside the box in y and straddling its `-x`/`-z` faces, pinched between the box and the alcove's authored step at x≈43.3 in a gap narrower than the capsule diameter.

Rapier's `KinematicCharacterController` has **no depenetration pass** — `check_and_fix_penetrations()` is a no-op in rapier 0.31 — so every shape cast from a penetrating pose returns `time_of_impact = 0`, `handle_slopes` strips the remaining direction, and the loop exits with a translation of exactly zero. In every direction. Forever.

Why this is faithful: in the original engine `PhysType` is what makes an object physical — its PhysType listener is what creates the instance `PhysDims` from the scaled model bounds ([phprop.cpp](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/phprop.cpp#L557-L631)). #597/#767 already codified exactly this rule for the non-frobbable branch, deliberately leaving `PhysType::None` and typeless objects bodyless. The frobbable branch contradicted that policy; this change makes the two consistent *for the player* while keeping the collider so nothing about frobbing, selection, projectiles or AI changes.

No authored collider is deleted and no coordinate is hardcoded.

## Pocket map

Probe: teleport to each cell at y = 3.69, settle 20 frames, then a bounded 1.0 wu move in ±x/±z. Cell = `settled-y / best distance moved`.

**Before (`origin/main`)**

```
  x\z |   30.60    |   30.90    |   31.20    |   31.50    |   31.80    |   32.10    |   32.40    |   32.70    |   33.00
 42.80| 3.60/ 1.00| 3.68/ 1.00| 3.76/ 0.99| 3.77/ 0.70| 3.77/ 0.76| 3.77/ 0.98| 3.56/ 0.91| 3.77/ 0.14| 3.60/ 0.76
 43.10| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00
 43.40| 3.69/ 0.00| 3.69/ 0.00| 3.69/ 0.00| 3.75/ 0.00| 3.75/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.08
 43.70| 3.69/ 0.00| 3.69/ 0.00| 3.69/ 0.00| 3.65/ 0.00| 3.64/ 0.00| 3.69/ 0.00| 3.64/ 0.00| 3.69/ 0.00| 3.64/ 0.33
 44.00| 3.69/ 0.00| 3.69/ 0.00| 3.64/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.30| 3.77/ 0.00| 3.77/ 0.00| 3.65/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.60| 3.77/ 0.00| 3.77/ 0.00| 3.69/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.90| 3.77/ 0.73| 3.77/ 0.00| 3.69/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 45.20| 3.77/ 0.90| 3.77/ 0.00| 3.64/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
```

**After**

```
  x\z |   30.60    |   30.90    |   31.20    |   31.50    |   31.80    |   32.10    |   32.40    |   32.70    |   33.00
 42.80| 3.60/ 1.00| 3.68/ 1.00| 3.76/ 0.99| 3.77/ 0.98| 3.77/ 0.98| 3.77/ 0.98| 3.55/ 1.00| 3.59/ 1.00| 3.60/ 1.00
 43.10| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00| 3.77/ 0.00
 43.40| 3.69/ 0.00| 3.64/ 0.72| 3.64/ 0.85| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 43.70| 3.69/ 0.00| 3.64/ 0.96| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.00| 3.69/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.30| 3.77/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.60| 3.77/ 0.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 44.90| 3.77/ 0.73| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
 45.20| 3.77/ 0.90| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00| 3.64/ 1.00
```

The two remaining zero columns/rows are genuine level brushwork, confirmed by world-only raycast: `x ≈ 43.1` is a floor step (world surface at y 3.20 instead of 2.40, so a capsule teleported to y 3.69 is buried in it) and `z = 30.60` is the alcove's authored wall (`ent 2080` = the level trimesh). Neither is reachable by walking.

At the exact coordinates from the issue, `(43.72, 3.69, 31.32)`:

| probe | before | after |
| --- | --- | --- |
| bounded move, best of 8 directions | **0.000** | **1.000** |
| raw thumbstick, 12 headings × 60 frames | **0.0001** | **7.05** |

Walking in from the free floor also used to strand the player — the endpoints reachable by ordinary locomotion input escaped 0.36 / 0.50 wu before, and 6.29 / 6.79 wu after.

## Not fixed here: #803

[#803](https://github.com/tommy-xr/shock2quest/issues/803) reports the same *symptom* (a capsule with nowhere to resolve to) from Eggbit gibs and corpses, but not the same cause: `Eggbit` inherits `PropPhysType { phys_type: SPHERE }` from `Monster Parts` (`-2182`), so it is a genuinely physical object and goes down the #597/#767 model-bounds path, untouched by this change. The shared substrate — rapier's missing depenetration pass — is real, but recovering *any* penetrating capsule is a change to the core movement step for every mission, not a fix for this alcove. #803 needs separate treatment.

## QBR reconstruction

Hydro2's authored marker (`Teleport Trap`, object 570, linked from `Res_Station_Button` 858) is at `(44.8, 4.0, 32.4)`, which *is* free — so the verdict on placement is: the marker is fine, and the wedge was the collider, not the coordinates. Reconstruction still uses the authored pose verbatim; the new `set_player_translation_unobstructed` only steps aside when the standing capsule does not fit, because that one relocation is the one the player cannot decline and there is no way to walk out of an obstructed pose.

The authored pose only has to be *clear* (a marker over an authored drop is level data, not a mistake). A pose the engine invents has to also have ground within one player height below it, so a substitute can't be mid-air or over a void. The search is one small lift — the "marker sunk into its own pad" case, deliberately not widened so the player is never perched on a fixture's roof — then horizontal rings out to 6 SS2 ft. If nothing fits it falls back to the authored pose with a `warn!`, so it is never worse than today.

## Scope

In hydro2, 36 of 777 player-blocking bodies come from templates with no `PhysType`: `Card slot` ×6, `Bulk_Off_Button` ×4, `RepBase` ×3, `Audio Log` ×2, `Bulk_On_Button` ×2, `Big_Orange_Button` ×2, and one each of `Regen_Hologram`, `Trait Machine`, `Psi Trainer`, `Tech Trainer`, `Millerecto`, `Millerbutton`, `Pic 01`, `Master Elevator Button`, `Debris #2`, `Debris #3`, `Res_Station_Button`, `Resurrection Station` and five `SecurityNComputer`s.

Across all 23 shipped missions the set `{objects with inherited P$FrobInfo} − {objects with inherited P$PhysType}` is **912 objects**, and every one is a button, card slot, wall computer, keypad, audio log, trainer / `RepBase` / `Trait Machine`, `Regen_Hologram`, picture, debris pile, ectoplasm or apparition. **No doors, elevators, lifts, platforms, crates, ladders or stairs are in it** — every Airlock / Sci Med / Hydro door and `medsci1`'s Security Door carries `PropPhysType` and is untouched, and `command1`'s only door-looking hit (#200 `B_Sci_Med_Door`) is an elevator button. Nothing gating is in the set.

The trade-off, stated plainly: the player can now clip *into* the visual volume of those wall and floor fixtures instead of being stopped by an invisible box around them. That is what the original engine does — no `PhysType`, no physics model — and it is the price of not converting a mis-sized decoration box into a softlock.

They all keep their colliders and stay frobbable, selectable and shootable: every `ray_cast` site builds `InteractionGroups::new(ALL, groups)`, so `ALL & filter` is still non-zero once `PLAYER` is dropped — frob/selection (`virtual_hand.rs`, `flat_player_controller.rs`), melee (`weapon_script.rs`) and projectiles (`internal_fast_projectile.rs`) are unaffected, and the e2e asserts the selection ray still hits the QBR casing. AI is also unaffected (`ENTITY` ↔ `ENTITY` is untouched), which does introduce a deliberate asymmetry: an AI can no longer follow the player through a fixture the player now walks through.

`PhysType`-carrying objects (crates, corpses, pipes, railings, everything from #597/#767) are untouched, as is the dynamic pickup branch.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean; also clean for CI's package set with `--all-targets`
- `cargo test -p shock2vr` — 425 passed
- `cargo fmt --all -- --check` — clean
- `entity_creator::tests::a_frobbable_without_phys_type_does_not_block_the_player` covers the shipped conditional itself (CI does not run the e2e suite, so the behaviour change needed a unit test). **Negative-first verified** — with the new branch disabled it fails on `phys_type None should not block the player`
- `physics::tests::a_non_solid_frob_box_never_wedges_the_player` (its `solid` half still reproduces the freeze, so it carries its own negative control) and `physics::tests::an_obstructed_authored_placement_steps_aside`
- new `tools/shock2-sdk/test/qbr-alcove-clearance.e2e.test.ts`; **negative-first verified** — on `origin/main` it fails with `the alcove floor beside the pad must be walkable too: moved 0.000008062257745569701`
- re-ran the movement- and frob-adjacent e2e after the change: `climbing`, `jump`, `player-move`, `crouch-shaft`, `world-frob-pickup`, `door-frob`, `keypad`, `model-bounds-colliders` (#597/#767) and `player-death` (#753) — all green, plus the full `SHOCK2_E2E=1 npm run test:e2e`

## Review

Both `/xreview` engines were run over the diff. Their agreed finding — a substitute pose validated only for overlap can be mid-air or over a void — is fixed (ground check, capped lift). A route check between the authored pose and a candidate is deliberately *not* added: the only geometry between an obstructed marker and any escape from it is the obstruction itself, so such a test would reject every candidate it was meant to vet; the bounded search radius is what keeps a substitute near the marker instead.
