### PR TITLE
fix(ai): start authored patrol routes without an alert

### DIFF
--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -256,11 +256,16 @@ impl AnimatedMonsterAI {
         Some(MonsterConfig { alert_cap, timings })
     }
 
-    /// Get the appropriate behavior for the current alertness level
+    /// Get the appropriate behavior for the current alertness level.
+    ///
+    /// `physics` is optional because `initialize` has none: without it the
+    /// High arm falls back to its chase, which is where a High AI out of
+    /// reach belongs anyway - the attack swap happens on arrival, through
+    /// `ChaseBehavior::next_behavior`.
     fn behavior_for_alertness(
         &self,
         world: &World,
-        _physics: &PhysicsWorld,
+        physics: Option<&PhysicsWorld>,
         entity_id: EntityId,
     ) -> Box<RefCell<dyn Behavior>> {
         match self.alertness.current_level {
@@ -272,7 +277,8 @@ impl AnimatedMonsterAI {
                 // distance (ChaseBehavior::next_behavior escalates back to
                 // an attack on arrival via the same shared helper). Without
                 // the range check, a far-away High AI stood still swinging.
-                attack_behavior_for_distance(world, _physics, entity_id)
+                physics
+                    .and_then(|physics| attack_behavior_for_distance(world, physics, entity_id))
                     .unwrap_or_else(|| Box::new(RefCell::new(ChaseBehavior::new())))
             }
         }
@@ -500,7 +506,7 @@ impl AnimatedMonsterAI {
         self.alertness.visible_time = 0.0;
         self.alertness.hidden_time = 0.0;
 
-        self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
+        self.current_behavior = self.behavior_for_alertness(world, Some(physics), entity_id);
         alertness::sync_alertness_effect(entity_id, &self.alertness)
     }
 
@@ -733,23 +739,6 @@ impl Script for AnimatedMonsterAI {
         // Load alertness configuration from entity properties
         self.config = Self::build_config(world, entity_id);
 
-        // Choose the calm behavior now, not just on the first alertness
-        // transition. A behavior is otherwise only picked when alertness
-        // CHANGES level, and both constructors seed a plain `IdleBehavior`, so
-        // a creature that spawns calm and is never alerted keeps that idle for
-        // the whole mission - including one flagged to patrol, which then
-        // never takes a step of its authored route (#807). Spawn alertness is
-        // always the `Lowest` clamp below (no shipped object authors
-        // `P$AI_AlertCap`, and its default `min_level` is `Lowest`), which is
-        // exactly what `idle_behavior` covers - the calm arm of
-        // `behavior_for_alertness`, minus its physics dependency, which
-        // `initialize` has no access to.
-        //
-        // This is also what holds a creature excluded from awareness entirely
-        // (an apparition - see `build_config`) still: `idle_behavior` gives it
-        // the non-scanning idle rather than the constructor's scanning one.
-        self.current_behavior = self.idle_behavior(world, entity_id);
-
         // Initialize alertness state
         let alertness_effect = if let Some(config) = &self.config {
             let initial_level = alertness::clamp_level(AIAlertLevel::Lowest, &config.alert_cap);
@@ -758,6 +747,23 @@ impl Script for AnimatedMonsterAI {
         } else {
             Effect::NoEffect
         };
+
+        // Pick the behavior matching that starting alertness now, rather than
+        // only on the first transition. A behavior is otherwise chosen only
+        // when alertness CHANGES level, and both constructors seed a plain
+        // `IdleBehavior`, so a creature that spawns calm and is never alerted
+        // keeps that idle for the whole mission - including one flagged to
+        // patrol, which then never takes a step of its authored route (#807).
+        // (Selecting AFTER seeding alertness also keeps the two in step for a
+        // hypothetical `P$AI_AlertCap` whose `min_level` is above `Lowest`;
+        // no shipped object authors that property, so in practice every
+        // creature starts on the calm arm.)
+        //
+        // This also holds a creature excluded from awareness entirely (an
+        // apparition - see `build_config`) still, which the previous
+        // `config.is_none()` special case did: `idle_behavior` gives it the
+        // non-scanning idle rather than the constructor's scanning one.
+        self.current_behavior = self.behavior_for_alertness(world, None, entity_id);
 
         let is_locomotion = self.current_behavior.borrow().is_locomotion();
         let selection_strategy = self.next_selection(is_locomotion);
@@ -919,10 +925,12 @@ impl Script for AnimatedMonsterAI {
                             Some(goal) => Some(Box::new(RefCell::new(SearchBehavior::new(goal)))),
                             // Never actually saw the player (e.g. aggroed by
                             // damage from behind) - nothing to investigate
-                            None => Some(self.behavior_for_alertness(world, physics, entity_id)),
+                            None => {
+                                Some(self.behavior_for_alertness(world, Some(physics), entity_id))
+                            }
                         }
                     } else {
-                        Some(self.behavior_for_alertness(world, physics, entity_id))
+                        Some(self.behavior_for_alertness(world, Some(physics), entity_id))
                     };
                     // Fully calmed: a sighting from this engagement must not
                     // trigger a cross-map search minutes later
@@ -1021,19 +1029,20 @@ impl Script for AnimatedMonsterAI {
         // are) hands control back to the alertness-appropriate behavior. This
         // runs every frame, so it also covers sequences ended by the
         // watchdog, where no further AnimationCompleted may ever arrive.
-        let handback_effect =
-            if self.current_behavior.borrow().scripted_state() == ScriptedState::Finished {
-                self.current_behavior = self.behavior_for_alertness(world, physics, entity_id);
-                let is_locomotion = self.current_behavior.borrow().is_locomotion();
-                let selection_strategy = self.next_selection(is_locomotion);
-                Effect::PlayAnimationBySchema {
-                    entity_id,
-                    motion_queries: self.current_behavior.borrow().animation_queries(),
-                    selection_strategy,
-                }
-            } else {
-                Effect::NoEffect
-            };
+        let handback_effect = if self.current_behavior.borrow().scripted_state()
+            == ScriptedState::Finished
+        {
+            self.current_behavior = self.behavior_for_alertness(world, Some(physics), entity_id);
+            let is_locomotion = self.current_behavior.borrow().is_locomotion();
+            let selection_strategy = self.next_selection(is_locomotion);
+            Effect::PlayAnimationBySchema {
+                entity_id,
+                motion_queries: self.current_behavior.borrow().animation_queries(),
+                selection_strategy,
+            }
+        } else {
+            Effect::NoEffect
+        };
 
         let sensor_effect = self.try_tickle_sensor(world, physics, entity_id);
 
@@ -1635,7 +1644,8 @@ mod tests {
     /// A creature excluded from awareness entirely (an apparition - see
     /// `build_config`) holds its authored mark even when it is flagged to
     /// patrol and a route exists: leaving the mark is exactly what its
-    /// scripted performance must not do.
+    /// scripted performance must not do. It must get the STILL idle, not
+    /// merely a non-patrol one, so it doesn't scan off its mark either.
     #[test]
     fn apparition_holds_its_mark_even_when_flagged_to_patrol() {
         let (mut world, entity_id) =
@@ -1647,6 +1657,16 @@ mod tests {
 
         assert!(monster.config.is_none(), "apparitions process no alertness");
         assert_eq!(monster.current_behavior.borrow().name(), "Idle");
+
+        // Well past the idle scan's dwell and a full sweep.
+        for _ in 0..200 {
+            let effects = step(&mut monster, &world, entity_id);
+            let heading = commanded_heading(&effects).expect("the AI steers every frame");
+            assert!(
+                (heading.0.abs() - 180.0).abs() < 1.0,
+                "an apparition must hold its authored heading, got {heading:?}",
+            );
+        }
     }
 
     /// The counterpart: sight still gates the turn. A creature facing away has

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -733,13 +733,22 @@ impl Script for AnimatedMonsterAI {
         // Load alertness configuration from entity properties
         self.config = Self::build_config(world, entity_id);
 
-        // A creature with no config is excluded from awareness entirely (an
-        // apparition - see `build_config`). It never runs an alertness
-        // transition, so it would otherwise sit in the constructor's
-        // scanning idle for its whole life; `idle_behavior` holds it still.
-        if self.config.is_none() {
-            self.current_behavior = self.idle_behavior(world, entity_id);
-        }
+        // Choose the calm behavior now, not just on the first alertness
+        // transition. A behavior is otherwise only picked when alertness
+        // CHANGES level, and both constructors seed a plain `IdleBehavior`, so
+        // a creature that spawns calm and is never alerted keeps that idle for
+        // the whole mission - including one flagged to patrol, which then
+        // never takes a step of its authored route (#807). Spawn alertness is
+        // always the `Lowest` clamp below (no shipped object authors
+        // `P$AI_AlertCap`, and its default `min_level` is `Lowest`), which is
+        // exactly what `idle_behavior` covers - the calm arm of
+        // `behavior_for_alertness`, minus its physics dependency, which
+        // `initialize` has no access to.
+        //
+        // This is also what holds a creature excluded from awareness entirely
+        // (an apparition - see `build_config`) still: `idle_behavior` gives it
+        // the non-scanning idle rather than the constructor's scanning one.
+        self.current_behavior = self.idle_behavior(world, entity_id);
 
         // Initialize alertness state
         let alertness_effect = if let Some(config) = &self.config {
@@ -1550,6 +1559,94 @@ mod tests {
                 "an apparition must hold its authored heading, got {heading:?}",
             );
         }
+    }
+
+    /// Flag `entity_id` as a patroller and (when `with_route`) lay down a
+    /// two-point `AIPatrol` loop 10 units down +X for it to walk.
+    fn make_patroller(world: &mut World, entity_id: EntityId, with_route: bool) {
+        world.add_component(entity_id, dark::properties::PropAIPatrol(true));
+        if !with_route {
+            return;
+        }
+        let mut point = |x: f32| {
+            world.add_entity((
+                crate::runtime_props::RuntimePropTransform(cgmath::Matrix4::from_translation(
+                    vec3(x, 0.0, 0.0),
+                )),
+                dark::properties::Links::empty(),
+            ))
+        };
+        let first = point(10.0);
+        let second = point(20.0);
+        let mut v_links = world
+            .borrow::<shipyard::ViewMut<dark::properties::Links>>()
+            .unwrap();
+        for (from, to) in [(first, second), (second, first)] {
+            (&mut v_links)
+                .get(from)
+                .unwrap()
+                .to_links
+                .push(dark::properties::ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(dark::properties::WrappedEntityId(to)),
+                    link: Link::AIPatrol,
+                });
+        }
+    }
+
+    /// #807: a creature flagged to patrol must walk its authored route from
+    /// spawn. Behavior is otherwise only chosen on an alertness LEVEL CHANGE,
+    /// so a patroller that is never alerted stood on its spawn point for the
+    /// whole mission - patrol only ever started after an alert had come and
+    /// gone.
+    #[test]
+    fn patroller_starts_its_route_without_ever_being_alerted() {
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(180.0));
+        make_patroller(&mut world, entity_id, true);
+
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        assert_eq!(
+            monster.alertness.current_level,
+            AIAlertLevel::Lowest,
+            "the patroller must not need an alert first",
+        );
+        assert_eq!(
+            monster.current_behavior.borrow().name(),
+            "Patrol",
+            "a flagged patroller with a reachable route patrols from spawn",
+        );
+    }
+
+    /// ...but the flag alone is not enough: a mission with no patrol network
+    /// leaves the creature on the ordinary idle (which, post-#791, scans).
+    #[test]
+    fn a_patroller_with_no_route_stands_idle() {
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(180.0));
+        make_patroller(&mut world, entity_id, false);
+
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        assert_eq!(monster.current_behavior.borrow().name(), "Idle");
+    }
+
+    /// A creature excluded from awareness entirely (an apparition - see
+    /// `build_config`) holds its authored mark even when it is flagged to
+    /// patrol and a route exists: leaving the mark is exactly what its
+    /// scripted performance must not do.
+    #[test]
+    fn apparition_holds_its_mark_even_when_flagged_to_patrol() {
+        let (mut world, entity_id) =
+            world_with_creature_and_player(Deg(180.0), "creaturetype apparition");
+        make_patroller(&mut world, entity_id, true);
+
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        assert!(monster.config.is_none(), "apparitions process no alertness");
+        assert_eq!(monster.current_behavior.borrow().name(), "Idle");
     }
 
     /// The counterpart: sight still gates the turn. A creature facing away has

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, Vector3};
+use cgmath::{Deg, EuclideanSpace, Vector3};
 use dark::SCALE_FACTOR;
 use dark::motion::MotionQueryItem;
 use shipyard::{EntityId, World};
@@ -25,6 +25,23 @@ const PATROL_ARRIVE_DISTANCE: f32 = 4.0 / SCALE_FACTOR;
 /// ...and within this height difference (patrol markers sit near the floor).
 /// Standing under a marker on a walkway above is not arrival.
 const PATROL_ARRIVE_HEIGHT: f32 = 6.0 / SCALE_FACTOR;
+/// The route point the AI happens to be nearest is not always one it can
+/// walk to: A* can report no route at all (the point sits in a disconnected
+/// part of the navigation graph), and the fallback whisker steering then just
+/// presses the body into the geometry in between. Giving up after this long
+/// without covering ground - the patrol-scale counterpart of the path
+/// follower's own per-waypoint stall watchdog, which cannot see a route that
+/// never existed - keeps the route moving instead of walking into a wall for
+/// the rest of the mission.
+const PATROL_STALL_SECONDS: f32 = 5.0;
+/// Ground covered (XZ, 2 Dark feet) that counts as progress and re-anchors
+/// the stall watchdog. A patrolling AI clears this in a fraction of a second,
+/// so only a body that is genuinely going nowhere trips the timer.
+const PATROL_STALL_PROGRESS: f32 = 2.0 / SCALE_FACTOR;
+/// Points skipped in a row, without reaching one in between, after which the
+/// AI stops patrolling altogether and hands back to idle - rather than
+/// shuffling forever between points it has no route to.
+const PATROL_MAX_SKIPPED_POINTS: u32 = 3;
 
 /// Walk an authored patrol route: head to the current patrol point, and on
 /// arrival advance to the next one along the `AIPatrol` link chain. Routes are
@@ -39,8 +56,15 @@ pub struct PatrolBehavior {
     steering_strategy: Box<dyn SteeringStrategy>,
     /// Set when the route dead-ends (a chain that isn't a loop): the AI has
     /// reached the final point and there is nowhere further to go, so it stops
-    /// patrolling and hands back to idle.
+    /// patrolling and hands back to idle. Also set once the AI has skipped
+    /// PATROL_MAX_SKIPPED_POINTS unreachable points in a row.
     finished: bool,
+    /// Stall watchdog: where the AI was when the timer was last re-anchored,
+    /// and how long it has been stuck within PATROL_STALL_PROGRESS of it.
+    stall_anchor: Option<Vector3<f32>>,
+    stall_seconds: f32,
+    /// Points given up on since the last one actually reached.
+    skipped_points: u32,
 }
 
 impl PatrolBehavior {
@@ -50,6 +74,9 @@ impl PatrolBehavior {
             goal,
             steering_strategy: Self::steering_to(goal),
             finished: false,
+            stall_anchor: None,
+            stall_seconds: 0.0,
+            skipped_points: 0,
         }
     }
 
@@ -62,12 +89,44 @@ impl PatrolBehavior {
         ])
     }
 
-    fn arrived(&self, world: &World, entity_id: EntityId) -> bool {
-        let (position, _) = ai_util::get_position_and_forward(world, entity_id);
+    fn arrived(&self, position: Vector3<f32>) -> bool {
         let dx = position.x - self.goal.x;
         let dz = position.z - self.goal.z;
         (dx * dx + dz * dz).sqrt() < PATROL_ARRIVE_DISTANCE
             && (position.y - self.goal.y).abs() < PATROL_ARRIVE_HEIGHT
+    }
+
+    /// Advance to the next point on the route; a closed loop repeats. A
+    /// dead-end (no next link) ends the patrol.
+    fn advance(&mut self, world: &World) {
+        match ai_util::next_patrol_point(world, self.target_point) {
+            Some((next, goal)) => {
+                self.target_point = next;
+                self.goal = goal;
+                self.steering_strategy = Self::steering_to(goal);
+                self.stall_anchor = None;
+                self.stall_seconds = 0.0;
+            }
+            None => self.finished = true,
+        }
+    }
+
+    /// Whether the AI has failed to cover ground for PATROL_STALL_SECONDS.
+    /// Re-anchors (and reports false) as soon as it moves.
+    fn stalled(&mut self, position: Vector3<f32>, time: &Time) -> bool {
+        let moved = self
+            .stall_anchor
+            .map(|anchor| {
+                (position.x - anchor.x).hypot(position.z - anchor.z) >= PATROL_STALL_PROGRESS
+            })
+            .unwrap_or(true);
+        if moved {
+            self.stall_anchor = Some(position);
+            self.stall_seconds = 0.0;
+            return false;
+        }
+        self.stall_seconds += time.elapsed.as_secs_f32();
+        self.stall_seconds >= PATROL_STALL_SECONDS
     }
 }
 
@@ -84,17 +143,23 @@ impl Behavior for PatrolBehavior {
         entity_id: EntityId,
         time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
-        if !self.finished && self.arrived(world, entity_id) {
-            // Advance to the next point on the route; a closed loop repeats.
-            // A dead-end (no next link) ends the patrol - stop and hand back to
-            // idle via next_behavior, rather than walking in place forever.
-            match ai_util::next_patrol_point(world, self.target_point) {
-                Some((next, goal)) => {
-                    self.target_point = next;
-                    self.goal = goal;
-                    self.steering_strategy = Self::steering_to(goal);
+        if !self.finished {
+            let (position, _) = ai_util::get_position_and_forward(world, entity_id);
+            let position = position.to_vec();
+            if self.arrived(position) {
+                self.skipped_points = 0;
+                self.advance(world);
+            } else if self.stalled(position, time) {
+                // Going nowhere: give up on this point and try the next one.
+                // Enough of those in a row and the whole route is out of
+                // reach, so stop patrolling and hand back to idle via
+                // next_behavior rather than walking in place forever.
+                self.skipped_points += 1;
+                if self.skipped_points >= PATROL_MAX_SKIPPED_POINTS {
+                    self.finished = true;
+                } else {
+                    self.advance(world);
                 }
-                None => self.finished = true,
             }
         }
 
@@ -131,5 +196,111 @@ impl Behavior for PatrolBehavior {
 
     fn is_locomotion(&self) -> bool {
         !self.finished
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_props::RuntimePropTransform;
+    use cgmath::{Matrix4, vec3};
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+    use shipyard::{Get, ViewMut};
+
+    /// A world with a creature pinned at the origin and a three-point
+    /// `AIPatrol` loop 100 units away that it can never reach.
+    fn world_with_unreachable_route() -> (World, EntityId, EntityId, Vector3<f32>) {
+        let mut world = World::new();
+        let creature = world.add_entity(RuntimePropTransform(Matrix4::from_scale(1.0)));
+        let points: Vec<EntityId> = (0..3)
+            .map(|i| {
+                world.add_entity((
+                    RuntimePropTransform(Matrix4::from_translation(vec3(
+                        100.0 + i as f32,
+                        0.0,
+                        100.0,
+                    ))),
+                    Links::empty(),
+                ))
+            })
+            .collect();
+        {
+            let mut v_links = world.borrow::<ViewMut<Links>>().unwrap();
+            for (index, point) in points.iter().enumerate() {
+                (&mut v_links).get(*point).unwrap().to_links.push(ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(points[(index + 1) % points.len()])),
+                    link: Link::AIPatrol,
+                });
+            }
+        }
+        (world, creature, points[0], vec3(100.0, 0.0, 100.0))
+    }
+
+    /// A patroller that cannot reach its route must not walk into the
+    /// geometry forever. The nearest point is chosen geometrically, so it can
+    /// sit in a disconnected part of the navigation graph - A* then returns
+    /// no route at all, which the path follower's own per-waypoint watchdog
+    /// cannot see, and the whisker fallback just presses the body onward.
+    #[test]
+    fn a_patroller_that_cannot_reach_its_route_gives_up() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(first, goal);
+
+        // 20 simulated seconds without the body ever moving - four times the
+        // stall window, so every point on the loop gets its turn.
+        let mut elapsed = 0.0;
+        for _ in 0..200 {
+            let time = Time {
+                elapsed: std::time::Duration::from_millis(100),
+                total: std::time::Duration::from_millis(0),
+            };
+            patrol.steer(Deg(0.0), &world, &physics, creature, &time);
+            elapsed += 0.1;
+            if patrol.finished {
+                break;
+            }
+        }
+
+        assert!(
+            patrol.finished,
+            "a patroller going nowhere should give up, still patrolling after {elapsed}s",
+        );
+        assert!(
+            matches!(
+                patrol.next_behavior(&world, &physics, creature),
+                NextBehavior::Next(_)
+            ),
+            "giving up should hand back to idle",
+        );
+    }
+
+    /// ...but only when it is genuinely going nowhere: an AI that keeps
+    /// covering ground toward a point it has not reached yet stays on route.
+    #[test]
+    fn a_patroller_making_progress_keeps_its_route() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(first, goal);
+
+        for step in 0..200 {
+            // Walk 1 unit per tick toward the goal (never arriving).
+            world.run(|mut v_xform: ViewMut<RuntimePropTransform>| {
+                (&mut v_xform).get(creature).unwrap().0 =
+                    Matrix4::from_translation(vec3(step as f32, 0.0, 0.0));
+            });
+            let time = Time {
+                elapsed: std::time::Duration::from_millis(100),
+                total: std::time::Duration::from_millis(0),
+            };
+            patrol.steer(Deg(0.0), &world, &physics, creature, &time);
+        }
+
+        assert!(
+            !patrol.finished,
+            "a moving patroller must stay on its route"
+        );
+        assert_eq!(patrol.target_point, first, "and keep the same point");
     }
 }

--- a/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ai-reacquire.e2e.test.ts
@@ -165,9 +165,15 @@ test(
 
 // The reopened half of #791 (campaign iteration 22): the AI above is looked at
 // while it can already see the player. The hydro2 Midwife that reopened the
-// issue never could - it takes up its post facing a ledge wall 1.6 units away,
-// so with a fixed heading no line of sight to it can ever exist and the fix
-// above is never reached. A calm creature has to look around.
+// issue never could - it holds one heading, so with no line of sight to it the
+// fix above is never reached. A calm creature has to look around.
+//
+// The subject is MidwifeLucy rather than the Midwife from the report: that one
+// is authored `P$AI_Patrol` with a route beside its post, so since #807 it
+// walks that route instead of holding a post, and a patroller is not what this
+// test is about. Lucy carries no patrol flag - she really is posted - and
+// reproduces the same failure shape: a fixed heading, a player with clear line
+// of sight 90 degrees off it.
 test(
   "a calm native AI scans until it finds a player outside its cone (#791)",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -179,13 +185,13 @@ test(
 
     await game.step({ frames: 60 });
 
-    // The Midwife from the issue, found by its stable template id (runtime
-    // entity ids are reassigned every launch).
+    // Found by stable template id (runtime entity ids are reassigned every
+    // launch).
     const listed = await game.entities.list({ filter: "Midwife", limit: 50 });
-    const midwife = listed.entities.find((e) => e.template_id === 1676);
-    assert.ok(midwife, "expected hydro2's Midwife (template 1676)");
+    const midwife = listed.entities.find((e) => e.template_id === 2156);
+    assert.ok(midwife, "expected hydro2's MidwifeLucy (template 2156)");
 
-    // Never engaged: fully calm, and posted facing the ledge (-X).
+    // Never engaged: fully calm, and posted facing -X.
     let detail = await game.entities.detail(midwife.id);
     assert.equal(aiProp(detail, "AIAlertness"), "Lowest");
     assert.equal(aiProp(detail, "AIBehavior"), "Idle");
@@ -195,16 +201,17 @@ test(
       "setup: the Midwife must start unable to see the player",
     );
 
-    // A control: another native Midwife across the deck, out of sight.
+    // A control: another posted native Midwife ~60 units across the deck,
+    // behind geometry (and likewise not a patroller, so it stays put).
     const control = listed.entities.find(
-      (e) => e.template_id === 2156, // MidwifeLucy, ~40 units away behind geometry
+      (e) => e.template_id === 1711, // Midwife_ChemRoom
     );
-    assert.ok(control, "expected MidwifeLucy for the control");
+    assert.ok(control, "expected Midwife_ChemRoom for the control");
 
-    // Stand due north of it: clear line of sight, but 90 degrees off its
-    // heading - outside the 60-degree FOV half-angle. Nothing but scanning
+    // Stand 5 units due south of it: clear line of sight, but 90 degrees off
+    // its heading - outside the 60-degree FOV half-angle. Nothing but scanning
     // can bring the player into view.
-    await game.player.teleport({ x: 80, y: -1, z: 37 });
+    await game.player.teleport({ x: -3, y: 0.3, z: -46.4 });
     await game.step({ frames: 30 });
     const player = await game.player.position();
     detail = await game.entities.detail(midwife.id);

--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -109,3 +109,105 @@ test(
     );
   },
 );
+
+// #807: the test above starts its patroller with a SetAlertness, and that
+// forced transition is the ONLY reason patrol used to engage - behavior was
+// picked exclusively on an alertness LEVEL CHANGE, so a creature that spawns
+// calm and is never alerted kept the constructor's Idle for the whole mission.
+// This one never touches the AI: it loads the level and watches.
+//
+// medsci1's OG-Pipe object 163 is a native patroller whose route is the
+// two-point AIPatrol loop of "Patrol Path" markers beside it. Object ids are
+// stable (`template_id` in the runtime's entity list); runtime entity ids are
+// not, so it is discovered by that.
+const MEDSCI1_PATROLLER_OBJ = 163;
+/** Close enough to count as having reached a route point (arrival is ~0.3). */
+const WAYPOINT_REACHED = 3.0;
+
+test(
+  "a patroller starts its authored route on a fresh load, unalerted (#807)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8162),
+    });
+
+    // Move the player off the deck before anything can be seen, so the run is
+    // unambiguously about an AI nobody ever alerted. No alertness is forced
+    // here, and none is expected: the assertions below check it stays Lowest.
+    await game.player.teleport({ x: 300, y: 0, z: 300 });
+    await game.step({ frames: 60 });
+
+    const pipes = await game.entities.list({ filter: "OG-Pipe", limit: 100 });
+    const patroller = pipes.entities.find(
+      (e) => e.template_id === MEDSCI1_PATROLLER_OBJ,
+    );
+    assert.ok(
+      patroller,
+      `medsci1 should have its native patroller (object ${MEDSCI1_PATROLLER_OBJ})`,
+    );
+
+    // Its authored route: the marker it is posted on, plus whatever its
+    // AIPatrol link chains to - the route as the mission authored it, not a
+    // guess from proximity (medsci1 has unrelated markers on the walkway
+    // above).
+    const first = (await game.entities.list({ limit: 5000 })).entities
+      .filter((e) => e.name === "Patrol Path")
+      .sort(
+        (a, b) =>
+          distXZ(a.position, patroller.position) -
+          distXZ(b.position, patroller.position),
+      )[0];
+    assert.ok(first, "medsci1 should have a patrol network");
+    const firstDetail = await game.entities.detail(first.id);
+    const nextId = firstDetail.outgoing_links.find(
+      (l) => l.link_type === "AIPatrol",
+    )?.target_id;
+    assert.ok(nextId, "the route point should chain to the next one");
+    const markers = [firstDetail, await game.entities.detail(nextId)];
+
+    let detail = await game.entities.detail(patroller.id);
+    assert.equal(
+      aiProp(detail, "AIAlertness"),
+      "Lowest",
+      "setup: the patroller must never have been alerted",
+    );
+    assert.equal(
+      aiProp(detail, "AIBehavior"),
+      "Patrol",
+      "a flagged patroller with a route patrols straight out of the load",
+    );
+
+    // ...and it actually walks it: reaching BOTH ends of the loop is what
+    // separates a route being followed from a creature milling on the spot.
+    const reached = markers.map(() => false);
+    let prev = detail.position;
+    let traveled = 0;
+    for (let tick = 0; tick < 40 && !reached.every(Boolean); tick++) {
+      await game.step({ frames: 120 });
+      detail = await game.entities.detail(patroller.id);
+      traveled += distXZ(detail.position, prev);
+      prev = detail.position;
+      markers.forEach((m, i) => {
+        if (distXZ(detail.position, m.position) < WAYPOINT_REACHED)
+          reached[i] = true;
+      });
+      assert.equal(
+        aiProp(detail, "AIAlertness"),
+        "Lowest",
+        "nothing should have alerted the patroller",
+      );
+      assert.equal(
+        aiProp(detail, "AIBehavior"),
+        "Patrol",
+        "an unalerted patroller should stay on its route",
+      );
+    }
+
+    assert.ok(
+      reached.every(Boolean),
+      `patroller should visit both route points; reached ${JSON.stringify(reached)} after traveling ${traveled.toFixed(1)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -22,6 +22,13 @@ function distXZ(
   return Math.hypot(a[0] - b[0], a[2] - b[2]);
 }
 
+function dist3(
+  a: [number, number, number],
+  b: [number, number, number],
+): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
 // eng1's native AI archetypes that carry patrol flags
 const CREATURE_NAMES = ["OG-Pipe", "OG-Shotgun", "Blue Monkey"];
 
@@ -148,23 +155,29 @@ test(
       `medsci1 should have its native patroller (object ${MEDSCI1_PATROLLER_OBJ})`,
     );
 
-    // Its authored route: the marker it is posted on, plus whatever its
-    // AIPatrol link chains to - the route as the mission authored it, not a
-    // guess from proximity (medsci1 has unrelated markers on the walkway
-    // above).
-    const first = (await game.entities.list({ limit: 5000 })).entities
-      .filter((e) => e.name === "Patrol Path")
-      .sort(
-        (a, b) =>
-          distXZ(a.position, patroller.position) -
-          distXZ(b.position, patroller.position),
-      )[0];
-    assert.ok(first, "medsci1 should have a patrol network");
-    const firstDetail = await game.entities.detail(first.id);
+    // Its authored route, resolved the way ai_util::nearest_patrol_point
+    // does: the 3D-nearest marker that actually has an outgoing AIPatrol link
+    // (so the chain can be walked from it), then whatever that link chains to.
+    // Following the link matters - medsci1 has unrelated markers on the
+    // walkway above that a proximity guess would pick up.
+    const candidates = await Promise.all(
+      (await game.entities.list({ limit: 5000 })).entities
+        .filter((e) => e.name === "Patrol Path")
+        .sort(
+          (a, b) =>
+            dist3(a.position, patroller.position) -
+            dist3(b.position, patroller.position),
+        )
+        .slice(0, 8)
+        .map((e) => game.entities.detail(e.id)),
+    );
+    const firstDetail = candidates.find((d) =>
+      d.outgoing_links.some((l) => l.link_type === "AIPatrol"),
+    );
+    assert.ok(firstDetail, "medsci1 should have a patrol network beside it");
     const nextId = firstDetail.outgoing_links.find(
       (l) => l.link_type === "AIPatrol",
-    )?.target_id;
-    assert.ok(nextId, "the route point should chain to the next one");
+    )!.target_id;
     const markers = [firstDetail, await game.entities.detail(nextId)];
 
     let detail = await game.entities.detail(patroller.id);


### PR DESCRIPTION
Fixes #807

campaign: engineering-through-shodan · none · legacy · seed 1378752978

> **Stacked on #794** (`fix/791-ai-reacquire`), which is its base — like #774 is stacked on #745. The diff below is only this branch's three commits; merge #794 first.

## Root cause

`AnimatedMonsterAI` picked a behavior in exactly two places: the *level changed* branch of `process_alertness_update`, and the handback after a scripted sequence finishes. Both constructors (`new()` / `idle()`) seed a plain `IdleBehavior`.

A creature that spawns at `Lowest` and is never alerted runs **no transition at all**, so it keeps that idle for the whole mission. `idle_behavior` — the only thing that ever constructs `PatrolBehavior` — was therefore unreachable at load, and an AI flagged `P$AI_Patrol` with a route beside it stood on its spawn point instead of walking it. Patrol only ever engaged after a creature had been alerted once and calmed back down.

The data confirms these are real authored patrollers, not an edge case: `P$AI_Patrol(true)` appears on native creatures across the game (medsci1 has 2 hybrids, eng1 6 creatures + generators, hydro2 11, rec1 7, command1 3, …), each with a chain of `Patrol Path` markers linked by `L$AIPatrol` beside its post. medsci1 object 163 (`OG-Pipe`) sits 1.3 units from marker 287, whose `AIPatrol` link closes a two-point loop with marker 235, 12 units away.

## Change

`initialize` now picks the behavior matching the AI's starting alertness, right after seeding it, instead of waiting for a transition. For every shipped object that is the calm arm — `idle_behavior` — so a flagged patroller with a route gets `PatrolBehavior`, and everything else the ordinary idle. (`behavior_for_alertness` takes `Option<&PhysicsWorld>` now, because `initialize` has none; without it the High arm falls back to its chase, which is where an out-of-reach High AI belongs anyway.)

The second commit is the case adversarial review turned up: `nearest_patrol_point` picks the geometrically closest route point, which is not always one the AI has a route to. A* then reports no route **at all** — which the path follower's own per-waypoint stall watchdog cannot see, since it never had a path — and the chained whisker fallback just presses the body at the goal. `PatrolBehavior` now watches its own displacement: 5 s without covering 2 Dark feet gives up on the point and moves to the next one along the chain; three give-ups in a row with nothing reached in between end the patrol and hand back to idle, exactly as a dead-ended route already does.

### Patrol vs. the idle scan from #794 — how they compose

They are alternatives on the same calm arm, and `idle_behavior` is the single place that decides:

| Creature | Calm behavior | Why |
| --- | --- | --- |
| `P$AI_Patrol` + a route | `PatrolBehavior` | It walks its circuit; its heading is its travel direction, so it sweeps the level by *moving*. No scan on top — a patroller is not posted. |
| Everything else | `IdleBehavior::new()` (scanning) | #794's ±90° sweep: a posted creature holds its spot and looks around. |
| No alertness config (apparition) | `IdleBehavior::holding_post()` | Never notices the player, never leaves its authored mark, never scans. |

The apparition invariant from #794 keeps holding, and now by construction rather than by special case: the `config.is_none()` early return in `idle_behavior` sits **before** the `is_patroller` check, so an apparition can never patrol on any path — initial, or the post-scripted-sequence handback. `initialize`'s old `if self.config.is_none()` block is gone because the unconditional call subsumes it. There is a unit test asserting an apparition flagged to patrol still holds its heading for 200 frames.

## Before / after — medsci1's native patroller

medsci1 object 163 (`OG-Pipe`, `P$AI_Patrol(true)`), route = markers 287 `(-8.8, 41.9)` ↔ 235 `(-7.4, 30.0)`. Fresh load, player never near it, nothing alerted. `moved` is distance from its spawn point.

**Before** (`c8d24348`, i.e. #794 as it stands):

```
t+ 0s pos=( -9.98, 42.17) moved=0.00 alert=Lowest behav=Idle
t+ 5s pos=( -9.99, 42.77) moved=0.60 alert=Lowest behav=Idle
t+10s pos=(-10.04, 42.84) moved=0.67 alert=Lowest behav=Idle
t+20s pos=(-10.11, 42.40) moved=0.27 alert=Lowest behav=Idle
t+30s pos=(-10.38, 41.88) moved=0.49 alert=Lowest behav=Idle
```

Thirty seconds inside a 0.8-unit circle, `Idle` throughout — it never leaves its spawn point.

**After** — it walks the loop, `goal` flipping between the two authored markers:

```
t+ 0s pos=( -7.02, 36.24) goal=( -8.8, 41.9) behav=Patrol
t+ 3s pos=( -8.79, 39.95) goal=( -8.8, 41.9) behav=Patrol   <- reaches marker 287
t+ 5s pos=( -6.58, 31.02) goal=( -8.8, 41.9) behav=Patrol
t+ 7s pos=( -7.73, 38.98) goal=( -7.4, 30.0) behav=Patrol   <- reaches 235, turns back
t+11s pos=( -6.39, 31.57) goal=( -8.8, 41.9) behav=Patrol
t+27s pos=( -7.19, 33.52) goal=( -7.4, 30.0) behav=Patrol
t+36s pos=( -6.61, 31.05) goal=( -8.8, 41.9) behav=Patrol
t+53s pos=( -8.06, 32.00) goal=( -8.8, 41.9) behav=Patrol
```

Lap after lap, alertness `Lowest` the whole time.

### ...and the unreachable-route case (eng1, second commit)

Six eng1 patrollers, distance from spawn, 60 s from a fresh load:

```
        obj 728    obj 1201   obj 164    obj 781    obj 1273   obj 850
t+ 10s  Patrol@37  Patrol@10  Patrol@24  Patrol@ 1  Patrol@ 3  Patrol@5.4   <- 850 wedged, no route
t+ 20s  Patrol@37  Patrol@10  Patrol@25  Patrol@17  Patrol@ 3  Idle  @5.3   <- gives up
t+ 40s  Patrol@14  Idle  @10  Patrol@41  Patrol@ 7  Patrol@ 2  Idle  @5.1
t+ 60s  Patrol@37  Idle  @11  Patrol@51  Patrol@ 3  Patrol@ 3  Idle  @5.1
```

Object 850 (`GET /v1/ai/paths` → `outcome: "Failed"`, no waypoints) walked ~3 units and, without the watchdog, stayed frozen in `Patrol` with its walk clip playing through t=60 s. It now gives up at ~20 s and settles; 1201 likewise at ~40 s. The routable ones keep going — 728 walks a 37-unit loop and returns to 0.4, 164 covers 51 units.

## Tests

Negative-first, each verified red on `c8d24348` (or on the branch without the specific hunk) and green after:

- `patroller_starts_its_route_without_ever_being_alerted` — the exact gate; red with `left: "Idle", right: "Patrol"`.
- `a_patroller_with_no_route_stands_idle` and `apparition_holds_its_mark_even_when_flagged_to_patrol` — the two ways the patrol arm must *not* be taken; the apparition one steps 200 frames and asserts the heading never leaves its mark, so it distinguishes the still idle from the scanning one.
- `a_patroller_that_cannot_reach_its_route_gives_up` — 20 simulated seconds with a body pinned at the origin and a route 100 units away; red without the watchdog (still patrolling after 20 s). Its control `a_patroller_making_progress_keeps_its_route` walks 1 unit a tick and must stay on the same point.
- `patrol.e2e.test.ts` gains **"a patroller starts its authored route on a fresh load, unalerted (#807)"** — medsci1's patroller found by its stable object id, its route resolved by following the `AIPatrol` link the same way `nearest_patrol_point` does. It never sends an alert (and asserts `Lowest`/`Patrol` on every sample), and requires the AI to reach **both** ends of the loop. Red on `c8d24348`: `'Idle' !== 'Patrol'` at the first sample.

### One existing test needed retargeting

#794's scan test used hydro2's Midwife 1676 as its "posted" creature. That object is authored `P$AI_Patrol` with a route beside its post — it is a patroller whose patrol was broken by #807, not a posted creature, and with this fix it walks that route. Retargeted at `MidwifeLucy` (template 2156), which carries no patrol flag and really is posted, with `Midwife_ChemRoom` (1711) — also posted, ~60 units away behind geometry — as the control. Same failure shape, verified on hydro2:

```
0.5s Lowest/Idle vis=false face= 90deg
3.5s Lowest/Idle vis=false face=180deg   <- sweeps away
6.0s Lowest/Idle vis=false face=160deg   <- and back
8.5s Lowest/Idle vis=true  face= 11deg   <- finds the player
9.0s Low/Wander  vis=true  face=  0deg
10.0s Moderate/Chase vis=true face= 7deg
```

The control never sees the player at any heading it sweeps through.

## Note for reviewers: staged AIs now leave their marks

`base_monster` routes AIs with a `PropAISignalResponse` or an `AIWatchObj` link to `AnimatedMonsterAI::idle()`, which is byte-identical to `new()` — so a staged AI that is *also* flagged to patrol now walks. Concretely, medsci1 object 596 (`OG-Pipe`, `AIWatchObj -> Card slot` **and** `P$AI_Patrol`) leaves its authored ambush post. `AIWatchObj` fires on *player* proximity to the watched object, so the sequence still triggers — just from wherever the AI has walked to. Dark's `AI_Patrol` does patrol from spawn, so this looks engine-faithful, but it changes staged scenes across the game and is worth a second opinion.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr --lib` — 437 passed
- `cargo fmt --all`
- AI-related SDK e2e suites, each on its own port: `patrol`, `ai-reacquire`, `ai-alertness`, `alertness-churn`, `chase-last-seen`, `search-behavior`, `damage-alert`, `force-chase`, `sound-awareness`, `security-ecology`, `monster-death` — all pass
- `missions.e2e.test.ts` — 23/23 missions load (this change runs at entity init, so it is the relevant safety net)
- No pr-visuals capture: like #794, this changes only where an AI walks — no rendering, material, HUD or animation surface. The player-observable effect (a guard walking its circuit) is the position/goal traces above.
- Cross-engine adversarial review (`/xreview`): both engines independently flagged the unreachable-patrol-point jam and the select-before-seed-alertness ordering. Both are fixed in the third commit, with the eng1 measurement above as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
