### PR TITLE
feat(gameplay): auto-install software on pickup

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -218,6 +218,20 @@ pub struct PropExp(pub i32);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropStackCount(pub i32);
 
+/// The version of a piece of software (`P$SoftLevel`, 1..=3). Authored on the
+/// `Softs` base archetype as 1 and overridden by the V2/V3 archetypes, so a
+/// V1 soft inherits the base value. Read by the `AutoInstallSoft` script.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropSoftLevel(pub i32);
+
+/// Which software slot a soft installs into (`P$SoftType`). Authored on the
+/// four soft class archetypes: 1 = Hack, 2 = Modify, 3 = Repair, 4 = Research
+/// (the `PDA Soft` archetype carries 0, i.e. no slot). The numbering matches
+/// the `SoftUpgrade0..3` message order in `res/strings/MISC.STR`, offset by
+/// one.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropSoftType(pub i32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropLimbModel(pub String);
 
@@ -1300,6 +1314,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$StackCoun",
             |reader, _len| read_i32(reader),
             PropStackCount,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$SoftLevel",
+            |reader, _len| read_i32(reader),
+            PropSoftLevel,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$SoftType",
+            |reader, _len| read_i32(reader),
+            PropSoftType,
             accumulator::latest,
         ),
         define_prop("P$Spawn", PropSpawn::read, identity, accumulator::latest),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3562,6 +3562,47 @@ impl MissionCore {
                     }
                 }
 
+                Effect::InstallSoftware {
+                    entity_id,
+                    software,
+                    level,
+                } => {
+                    // Two frobs of the same soft can be queued before either
+                    // effect runs (both VR hands in one frame); the second must
+                    // not report the soft it already installed as redundant.
+                    let is_alive = self
+                        .world
+                        .borrow::<EntitiesView>()
+                        .is_ok_and(|entities| entities.is_alive(entity_id));
+                    if !is_alive {
+                        continue;
+                    }
+                    // Atomic compare-and-install against live state: the sheet
+                    // keeps the higher version, so a soft picked up after a
+                    // better one is redundant (retail MISC.STR `SoftUseless`).
+                    // Either way the soft is consumed - it never occupies
+                    // inventory.
+                    let installed = self
+                        .world
+                        .borrow::<UniqueViewMut<QuestInfo>>()
+                        .unwrap()
+                        .player_stats_mut()
+                        .install_software(software, level);
+                    if installed {
+                        // Retail reports MISC.STR `SoftUpgrade0..3` here and
+                        // `SoftUseless` below; the port has no player-facing
+                        // message facility yet, so both go to the game log.
+                        game_log!(INFO, "{:?} software upgraded to level {}", software, level);
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            name: "boot_sw".to_owned(),
+                        });
+                    } else {
+                        game_log!(INFO, "Redundant software not installed.");
+                    }
+                    self.destroy_entity(entity_id);
+                }
+
                 Effect::ActivatePsiPower {
                     template_id,
                     name,

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -102,6 +102,53 @@ impl SkillLevels {
     }
 }
 
+/// The four kinds of software the player can install, in the original's
+/// `P$SoftType` order (1 = Hack, 2 = Modify, 3 = Repair, 4 = Research). The
+/// same order indexes the `SoftUpgrade0..3` strings in `res/strings/MISC.STR`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Software {
+    Hack,
+    Modify,
+    Repair,
+    Research,
+}
+
+impl Software {
+    /// Resolve the authored `P$SoftType` value. `0` (the unused `PDA Soft`
+    /// archetype) and anything out of range have no slot.
+    pub fn from_soft_type(soft_type: i32) -> Option<Software> {
+        match soft_type {
+            1 => Some(Software::Hack),
+            2 => Some(Software::Modify),
+            3 => Some(Software::Repair),
+            4 => Some(Software::Research),
+            _ => None,
+        }
+    }
+}
+
+/// Installed software versions, one per [`Software`] slot. `0` means no
+/// software of that kind is installed; installing only ever raises the value
+/// (a V2 soft supersedes V1, a V1 soft found after V2 is redundant).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SoftwareVersions {
+    pub hack: i32,
+    pub modify: i32,
+    pub repair: i32,
+    pub research: i32,
+}
+
+impl SoftwareVersions {
+    fn get_mut(&mut self, software: Software) -> &mut i32 {
+        match software {
+            Software::Hack => &mut self.hack,
+            Software::Modify => &mut self.modify,
+            Software::Repair => &mut self.repair,
+            Software::Research => &mut self.research,
+        }
+    }
+}
+
 /// The player's persistent character sheet: primary stats, trained skills, and
 /// mastered psi disciplines, plus the set of training years already granted
 /// (so a tour reward applies exactly once per year even if a tour marker
@@ -141,6 +188,11 @@ pub struct PlayerStats {
     /// `scripts::gui::traits` for names and which traits have live effects.
     #[serde(default)]
     pub os_traits: Vec<u8>,
+    /// Installed software versions (hack/modify/repair/research), raised by
+    /// picking up a soft (`scripts::auto_install_soft`). `#[serde(default)]`
+    /// keeps saves written before this field existed loadable.
+    #[serde(default)]
+    pub software: SoftwareVersions,
 }
 
 /// The player has four O/S trait slots (one per single-use machine in the game).
@@ -163,6 +215,7 @@ impl Default for PlayerStats {
             cyber_modules: 0,
             psi_tier: 0,
             os_traits: Vec::new(),
+            software: SoftwareVersions::default(),
         }
     }
 }
@@ -231,6 +284,18 @@ impl PlayerStats {
     /// Raise a trainable skill by one level (a trainer purchase).
     pub fn raise_skill(&mut self, skill: Skill) {
         *self.skills.get_mut(skill) += 1;
+    }
+
+    /// Install a soft. The original keeps the higher of the installed and
+    /// picked-up version (a V2 supersedes V1); a version at or below the
+    /// installed one is redundant. Returns `true` when the sheet was raised.
+    pub fn install_software(&mut self, software: Software, level: i32) -> bool {
+        let slot = self.software.get_mut(software);
+        if level <= *slot {
+            return false;
+        }
+        *slot = level;
+        true
     }
 
     /// Whether an O/S trait (retail id 1..=16) is owned.
@@ -543,6 +608,56 @@ mod tests {
         let legacy = r#"{"strength":1,"endurance":1,"agility":1,"psionic_ability":1,"cyber_affinity":1,"skills":{"standard_weapons":0,"energy_weapons":0,"heavy_weapons":0,"exotic_weapons":0,"hack":0,"repair":0,"modify":0,"maintenance":0,"research":0},"psi_disciplines":[],"granted_years":[]}"#;
         let loaded: PlayerStats = serde_json::from_str(legacy).unwrap();
         assert_eq!(loaded.cyber_modules, 0);
+    }
+
+    #[test]
+    fn installing_software_keeps_the_higher_version() {
+        let mut stats = PlayerStats::new();
+        assert_eq!(stats.software.hack, 0);
+
+        // A V2 soft installs over nothing...
+        assert!(stats.install_software(Software::Hack, 2));
+        assert_eq!(stats.software.hack, 2);
+        // ...a V1 found afterwards is redundant...
+        assert!(!stats.install_software(Software::Hack, 1));
+        // ...as is a second copy of the same version...
+        assert!(!stats.install_software(Software::Hack, 2));
+        assert_eq!(stats.software.hack, 2);
+        // ...and a V3 supersedes it.
+        assert!(stats.install_software(Software::Hack, 3));
+        assert_eq!(stats.software.hack, 3);
+
+        // Slots are independent.
+        assert!(stats.install_software(Software::Research, 1));
+        assert_eq!(stats.software.research, 1);
+        assert_eq!(stats.software.hack, 3);
+        assert_eq!(stats.software.modify, 0);
+        assert_eq!(stats.software.repair, 0);
+    }
+
+    #[test]
+    fn soft_type_maps_to_the_authored_software_slots() {
+        // P$SoftType on the four soft class archetypes (-321..-324); the
+        // unused PDA Soft archetype authors 0 (no slot).
+        assert_eq!(Software::from_soft_type(1), Some(Software::Hack));
+        assert_eq!(Software::from_soft_type(2), Some(Software::Modify));
+        assert_eq!(Software::from_soft_type(3), Some(Software::Repair));
+        assert_eq!(Software::from_soft_type(4), Some(Software::Research));
+        assert_eq!(Software::from_soft_type(0), None);
+        assert_eq!(Software::from_soft_type(5), None);
+    }
+
+    #[test]
+    fn software_survives_serde_and_defaults_for_old_saves() {
+        let mut stats = PlayerStats::new();
+        stats.install_software(Software::Repair, 3);
+        let back: PlayerStats =
+            serde_json::from_str(&serde_json::to_string(&stats).unwrap()).expect("round trip");
+        assert_eq!(back.software.repair, 3);
+        // A save written before this field existed loads with no software.
+        let legacy = r#"{"strength":1,"endurance":1,"agility":1,"psionic_ability":1,"cyber_affinity":1,"skills":{"standard_weapons":0,"energy_weapons":0,"heavy_weapons":0,"exotic_weapons":0,"hack":0,"repair":0,"modify":0,"maintenance":0,"research":0},"psi_disciplines":[],"granted_years":[]}"#;
+        let loaded: PlayerStats = serde_json::from_str(legacy).unwrap();
+        assert_eq!(loaded.software, SoftwareVersions::default());
     }
 
     #[test]

--- a/shock2vr/src/scripts/auto_install_soft.rs
+++ b/shock2vr/src/scripts/auto_install_soft.rs
@@ -1,0 +1,166 @@
+use dark::properties::{PropSoftLevel, PropSoftType};
+use shipyard::{EntityId, Get, View, World};
+use tracing::warn;
+
+use crate::physics::PhysicsWorld;
+use crate::player_stats::Software;
+
+use super::{Effect, MessagePayload, Script};
+
+/// The retail `AutoInstallSoft` script, carried by every `Softs` archetype
+/// (hack / modify / repair / research softs, V1-V3).
+///
+/// Softs are not carryable items: the `Softs` archetype authors a `SCRIPT`
+/// world *and* inventory frob action, so frobbing one in the world - or
+/// clicking it in a container's loot MFD, which routes a use-only item's click
+/// to a `Frob` - installs it and consumes the object rather than moving it
+/// into the backpack.
+///
+/// The soft to install is read from the object: `P$SoftType` selects the
+/// software slot and `P$SoftLevel` its version. The compare-and-install (and
+/// the consumption) is the applier's job - see `Effect::InstallSoftware` - so
+/// this script stays pure.
+pub struct AutoInstallSoft;
+
+impl AutoInstallSoft {
+    pub fn new() -> AutoInstallSoft {
+        AutoInstallSoft
+    }
+}
+
+impl Script for AutoInstallSoft {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) {
+            return Effect::NoEffect;
+        }
+
+        let soft_type = world
+            .borrow::<View<PropSoftType>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).map(|p| p.0).ok())
+            .unwrap_or(0);
+        let Some(software) = Software::from_soft_type(soft_type) else {
+            // The unused `PDA Soft` archetype authors SoftType 0 - it installs
+            // nothing, so leave the object alone rather than consuming it.
+            warn!("AutoInstallSoft: no software slot for P$SoftType {soft_type}");
+            return Effect::NoEffect;
+        };
+
+        // Every soft archetype inherits `P$SoftLevel` (the `Softs` base
+        // authors 1), so a missing value means unreadable data - treat it as
+        // the base version rather than dropping the pickup.
+        let level = world
+            .borrow::<View<PropSoftLevel>>()
+            .ok()
+            .and_then(|v| v.get(entity_id).map(|p| p.0).ok())
+            .unwrap_or(1);
+
+        Effect::InstallSoftware {
+            entity_id,
+            software,
+            level,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{PropSoftLevel, PropSoftType};
+    use shipyard::World;
+
+    use crate::{
+        physics::PhysicsWorld,
+        player_stats::Software,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::AutoInstallSoft;
+
+    fn soft(soft_type: i32, level: Option<i32>) -> (World, shipyard::EntityId) {
+        let mut world = World::new();
+        let entity = world.add_entity(PropSoftType(soft_type));
+        if let Some(level) = level {
+            world.add_component(entity, PropSoftLevel(level));
+        }
+        (world, entity)
+    }
+
+    fn frob(world: &World, entity: shipyard::EntityId) -> Effect {
+        AutoInstallSoft::new().handle_message(
+            entity,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )
+    }
+
+    #[test]
+    fn frobbing_a_hack_soft_v2_requests_its_install() {
+        // Hack Soft V2 (template -1123): P$SoftType 1, P$SoftLevel 2.
+        let (world, entity) = soft(1, Some(2));
+        assert!(matches!(
+            frob(&world, entity),
+            Effect::InstallSoftware {
+                entity_id,
+                software: Software::Hack,
+                level: 2,
+            } if entity_id == entity
+        ));
+    }
+
+    #[test]
+    fn soft_type_selects_the_software_slot() {
+        for (soft_type, expected) in [
+            (1, Software::Hack),
+            (2, Software::Modify),
+            (3, Software::Repair),
+            (4, Software::Research),
+        ] {
+            let (world, entity) = soft(soft_type, Some(3));
+            let Effect::InstallSoftware { software, .. } = frob(&world, entity) else {
+                panic!("expected an install for P$SoftType {soft_type}");
+            };
+            assert_eq!(software, expected);
+        }
+    }
+
+    #[test]
+    fn a_soft_without_an_authored_level_installs_the_base_version() {
+        let (world, entity) = soft(4, None);
+        assert!(matches!(
+            frob(&world, entity),
+            Effect::InstallSoftware { level: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn a_soft_with_no_software_slot_is_left_alone() {
+        // The unused PDA Soft archetype (-500) authors P$SoftType 0.
+        let (world, entity) = soft(0, Some(1));
+        assert!(matches!(frob(&world, entity), Effect::NoEffect));
+
+        // An entity with no P$SoftType at all (e.g. restored from a save
+        // written before the property was parsed) is likewise left alone.
+        let mut world = World::new();
+        let entity = world.add_entity(PropSoftLevel(3));
+        assert!(matches!(frob(&world, entity), Effect::NoEffect));
+    }
+
+    #[test]
+    fn unrelated_messages_do_nothing() {
+        let (world, entity) = soft(1, Some(2));
+        let effect = AutoInstallSoft::new().handle_message(
+            entity,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: entity },
+        );
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -210,6 +210,18 @@ pub enum Effect {
         amount: i32,
     },
 
+    /// Install a soft on the character sheet and consume the object it came
+    /// from. Emitted by `scripts::auto_install_soft` when a soft is frobbed in
+    /// the world or taken from a container. The applier does the atomic
+    /// compare (installing only ever raises the version) so a redundant soft
+    /// is reported rather than downgrading the sheet; either way the object is
+    /// consumed - softs never occupy inventory.
+    InstallSoftware {
+        entity_id: EntityId,
+        software: crate::player_stats::Software,
+        level: i32,
+    },
+
     /// Activate (or refresh) a sustained psi power on the player for
     /// `duration_secs` (`ActivePsiPowers` unique). Emitted by the psi amp
     /// when a sustained (activation type 1) power is cast; a per-frame tick

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -4,6 +4,7 @@ pub mod speech_registry;
 pub mod speech_util;
 
 mod apparition;
+mod auto_install_soft;
 mod base_button;
 mod base_elevator;
 mod base_monster;
@@ -115,6 +116,7 @@ use self::reduce_psi::ReducePsi;
 use self::reroute_elevator_button::RerouteElevatorButton;
 use self::trap_signal::TrapSignal;
 use self::{
+    auto_install_soft::AutoInstallSoft,
     base_button::BaseButton,
     base_elevator::BaseElevator,
     base_monster::BaseMonster,
@@ -1023,8 +1025,8 @@ impl ScriptWorld {
             "medkitscript" => Box::new(UnimplementedScript::new(&script_name)), // cyber modules
             "speedpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
             "radpatch" => Box::new(UnimplementedScript::new(&script_name)), // speed boost
-            "autoinstallsoft" => Box::new(UnimplementedScript::new(&script_name)), // auto install software
-            "strboost" => Box::new(UnimplementedScript::new(&script_name)),        // strength boost
+            "autoinstallsoft" => Box::new(AutoInstallSoft::new()), // auto install software
+            "strboost" => Box::new(UnimplementedScript::new(&script_name)), // strength boost
             "intboost" => Box::new(UnimplementedScript::new(&script_name)),
             "statboostimplant" => Box::new(UnimplementedScript::new(&script_name)),
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -412,6 +412,18 @@ export interface PlayerStats {
   /** O/S upgrade traits acquired at trait machines, by retail trait id
    * (1..=16, TRAITS.STR order), in acquisition order; at most 4. */
   os_traits: number[];
+  /** Installed software versions, raised by picking up a soft (softs
+   * auto-install and never enter inventory). 0 = none installed. */
+  software: SoftwareVersions;
+}
+
+/** Installed software versions, one per soft class. Installing keeps the
+ * higher of the installed and picked-up version (a V2 supersedes a V1). */
+export interface SoftwareVersions {
+  hack: number;
+  modify: number;
+  repair: number;
+  research: number;
 }
 
 export interface FrameSnapshot {

--- a/tools/shock2-sdk/test/auto-install-soft.e2e.test.ts
+++ b/tools/shock2-sdk/test/auto-install-soft.e2e.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// End-to-end test for auto-installing software (issue #812).
+//
+// Softs (`AutoInstallSoft`) are not carryable: the retail `Softs` archetype
+// authors a SCRIPT world *and* inventory frob action, so picking one up
+// installs it on the character sheet and consumes the object. The sheet keeps
+// the higher version (a V3 supersedes a V2).
+//
+// command1 is the one mission that carries both placements of the same soft
+// class, so a single launch covers both entry points:
+//   - Hack Soft V2 (obj 131): world-placed, no incoming Contains -> world frob
+//   - Hack Soft V3 (obj 2095): inside "Female Corpse 1" (obj 2255) -> loot MFD
+//
+// Negative-first: on main `autoinstallsoft` maps to `UnimplementedScript`, so
+// the world frob logs "Unimplemented script" and leaves the soft in the world
+// (`software.hack` stays 0), and the loot-MFD click routes a use-only item's
+// click to that same no-op script - the reported symptom, "10 clicks in the
+// container MFD do nothing".
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const HACK_SOFT_V2 = 131; // world-placed
+const CORPSE_WITH_HACK_SOFT_V3 = 2255; // Female Corpse 1 -> Contains -> obj 2095
+
+test(
+  "command1: softs auto-install on pickup instead of entering inventory",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9241),
+    });
+    await game.step({ frames: 5 });
+
+    const software = async () => {
+      const stats = (await game.info()).player.stats;
+      assert.ok(stats, "the mission should expose a character sheet");
+      return stats.software;
+    };
+    const byTemplate = async (templateId: number, what: string) => {
+      const matches = await game.entities.byTemplate(templateId);
+      assert.equal(matches.length, 1, `expected exactly one ${what} (mission id ${templateId})`);
+      return matches[0];
+    };
+
+    assert.deepEqual(
+      await software(),
+      { hack: 0, modify: 0, repair: 0, research: 0 },
+      "a fresh character has no software installed",
+    );
+
+    // --- (i) world pickup: frobbing a world-placed soft installs it ---
+    const worldSoft = await byTemplate(HACK_SOFT_V2, "Hack Soft V2");
+    assert.equal(worldSoft.name, "Hack Soft V2");
+    await game.entities.sendMessage(worldSoft.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await software()).hack,
+      2,
+      "frobbing Hack Soft V2 must raise the installed hack software to version 2",
+    );
+    // NEGATIVE KEY: a soft never occupies inventory - it is consumed.
+    const afterWorldPickup = await game.player.inventory();
+    assert.ok(
+      !afterWorldPickup.items.some((i) => i.entity_id === worldSoft.id),
+      `an installed soft must not enter the inventory (got ${JSON.stringify(afterWorldPickup.items)})`,
+    );
+    assert.equal(
+      (await game.entities.byTemplate(HACK_SOFT_V2)).length,
+      0,
+      "the installed soft is consumed - it no longer exists in the world",
+    );
+    assert.deepEqual(
+      { modify: (await software()).modify, repair: (await software()).repair },
+      { modify: 0, repair: 0 },
+      "installing a hack soft must not touch the other software slots",
+    );
+
+    // --- (ii) container MFD: taking a soft installs it, superseding V2 ---
+    const corpse = await byTemplate(CORPSE_WITH_HACK_SOFT_V3, "Female Corpse 1");
+    const contained = (await game.entities.detail(corpse.id)).outgoing_links.filter((l) =>
+      l.link_type.startsWith("Contains"),
+    );
+    const softLink = contained.find((l) => l.target_name.includes("Hack Soft V3"));
+    assert.ok(softLink, `corpse 2255 should contain a Hack Soft V3 (got ${JSON.stringify(contained)})`);
+
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.0,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.0,
+    });
+    await game.step({ frames: 5 });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "frobbing the corpse should open its loot MFD panel");
+    const softElement = panel.elements.find((e) => e.entity_id === softLink.target_id);
+    assert.ok(
+      softElement,
+      `the loot panel should expose the Hack Soft V3 (got ${JSON.stringify(panel.elements)})`,
+    );
+    await game.screenshot("soft-loot-panel.png");
+
+    await clickUiElement(game, softElement);
+
+    assert.equal(
+      (await software()).hack,
+      3,
+      "taking Hack Soft V3 from the corpse must supersede the installed version 2",
+    );
+    const afterTake = await game.player.inventory();
+    assert.ok(
+      !afterTake.items.some((i) => i.entity_id === softLink.target_id),
+      `a looted soft must not enter the inventory (got ${JSON.stringify(afterTake.items)})`,
+    );
+    const afterPanel = (await game.ui.state()).active_panel;
+    assert.ok(
+      !afterPanel?.elements.some((e) => e.entity_id === softLink.target_id),
+      "the installed soft disappears from the loot panel",
+    );
+    await game.screenshot("soft-loot-taken.png");
+
+    // --- (iii) the installed version persists through save/load ---
+    const saveName = `auto_install_soft_e2e_${Date.now()}`;
+    await game.save(saveName);
+    await game.load(saveName);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await software()).hack,
+      3,
+      "the installed software version must survive save/load",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #812

## Problem

Every soft (`Hack`/`Modify`/`Repair`/`Research Soft`, V1-V3) carries the retail
`AutoInstallSoft` script, which mapped to `UnimplementedScript`. The `Softs`
archetype (`-320`) authors `P$FrobInfo` with a **SCRIPT** world *and* inventory
action and **no MOVE**, so nothing on the pickup path can move a soft by itself:

- the container loot MFD (`scripts/gui/container.rs`, the `Take` arm) sees a
  non-grabbable, use-only item and routes the click to `MessagePayload::Frob`;
- the flat world-frob path (`flat_player_controller.rs`) does the same.

Both landed on the no-op script - hence "10 clicks in the container MFD do
nothing", while an AP Clip (MOVE) beside it transfers on the first click. The
whole Softs item class was unobtainable.

## Authored data

Decoded from `shock2.gam` - both chunks were previously unparsed:

| Chunk | Meaning | Values |
| --- | --- | --- |
| `P$SoftType` | which software slot | `1` Hack (`-321`), `2` Modify (`-323`), `3` Repair (`-322`), `4` Research (`-324`), `0` on the unused `PDA Soft` (`-500`) |
| `P$SoftLevel` | version | authored `1` on the `Softs` base, overridden to `2`/`3` on the V2/V3 archetypes (a V1 soft inherits the base 1) |

The `SoftType` numbering matches the `SoftUpgrade0..3` message order in
`res/strings/MISC.STR`, offset by one. The retail script's string table in
`allobjs.osm` (`SoftType`, `SoftLevel`, `Player`, `SoftUpgrade`, `boot_sw`,
`SoftUseless`, `Contains`, `HasRefs`, `TakeSoft`) confirms the flow: read the
object's type/level, compare against the player's installed version, report
either `SoftUpgrade<n>` ("Hacking sofware upgraded to level %d!") with the
`boot_sw` schema or `SoftUseless` ("Redundant software not installed."), then
remove the object either way - a soft never occupies inventory.

## Change

- **`dark`**: parse `P$SoftLevel` / `P$SoftType` as `PropSoftLevel` /
  `PropSoftType` (plain `i32`s, `accumulator::latest`, so archetype inheritance
  resolves V1 from the base and V2/V3 from their own rows).
- **`PlayerStats.software`** (`SoftwareVersions { hack, modify, repair,
  research }`, `#[serde(default)]`): the character sheet already rides
  `QuestInfo`, so installed versions persist across level transitions and
  save/load for free, exactly like `cyber_modules` / `os_traits`.
  `install_software` keeps the **higher** of the installed and picked-up
  version.
- **`scripts::auto_install_soft`**: pure - on `Frob` it reads the object's
  `P$SoftType`/`P$SoftLevel` and returns
  `Effect::InstallSoftware { entity_id, software, level }`. A `SoftType` with no
  slot (the unused PDA Soft) is left alone.
- **`Effect::InstallSoftware` applier** (`mission_core::handle_effects`): does
  the atomic compare-and-install against live state (the same shape as
  `TrainerPurchase` / `AcquireOsTrait` / `UsePsiKit`), logs the retail MISC.STR
  message, plays the `boot_sw` schema on an upgrade, and consumes the object in
  both cases.
- **SDK**: `PlayerStats.software` added to the TS types.

## What consumes software versions today

Nothing yet - the field is storage-only for now, called out here deliberately.
The hacking board derives its odds from the Hack **skill** and Cyber Affinity
only (`scripts/gui/keypad.rs::effective_hack_values` ->
`HrmParams::success_chance(base, skill, stat)`); repair/modify/research have no
systems in the port at all. Installing faithfully now means the value is on the
sheet and in saves when those consumers land (`ResearchSoftNeeded` in MISC.STR
is the first one that will need it), and it unblocks the item class immediately:
softs can be looted again instead of jamming a container panel.

## Verification

`RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`,
`cargo test -p shock2vr` (431 pass), `cargo fmt --all`, SDK `npm test` + `tsc`.

**Unit tests** (`scripts/auto_install_soft.rs`, `player_stats.rs`): the emitted
effect for each `SoftType`, the base-version fallback, the no-slot case, the
max-keeping install semantics, and serde round-trip / legacy-save default.

**e2e** `tools/shock2-sdk/test/auto-install-soft.e2e.test.ts` - command1, the one
mission carrying both a world-placed and a corpse-contained soft of the same
class, so a single launch covers both entry points: world-frob `Hack Soft V2`
(obj 131) -> `software.hack` 0 -> 2, item not in inventory and gone from the
world; loot `Hack Soft V3` (obj 2095) out of Female Corpse 1 (obj 2255) through
the MFD -> 2 -> 3, still never in inventory, gone from the panel; version
survives save/load.

Negative-first, same test against the unpatched build:

```
✖ AssertionError: frobbing Hack Soft V2 must raise the installed hack software to version 2
  undefined !== 2
```

and with the world section relaxed so the container path is reached (the loot
panel does render the soft and the click is delivered - it is the script that
no-ops, exactly as reported):

```
✖ AssertionError: taking Hack Soft V3 from the corpse must supersede the installed version 2
  undefined !== 3
```

Full `SHOCK2_E2E=1 npm run test:e2e`: 185/192 green on the first pass; the 7
failures were all `debug_runtime failed to start` in one contiguous ~2 s window
caused by editing the source tree mid-run (a transient compile error), not by
this change. Re-run against the final tree, all 7 plus the new test pass:
`ops-bulkhead-button`, `ops2-aim-visibility`, `ops4-door-save`,
`ops4-trigger-destroy`, `os-traits`, `pathfinding-budget`,
`auto-install-soft` - 9/9.

## Review

Two independent adversarial reviewers (Claude subagent + Codex CLI) found no
Critical/High issues. Applied: a liveness guard so two frobs of the same soft
queued in one batch cannot report the soft they just installed as redundant;
dropped an unused accessor and the four-arm message formatter (the log line uses
the slot's `Debug` name and cites the MISC.STR keys in a comment); reused the
existing `clickUiElement` test helper; added a unit case for a soft with no
`P$SoftType` component at all. One finding was rejected with evidence - the
`PDA Soft` archetype (-500) *does* author `P$SoftType = 0` (verified by decoding
the chunk rows directly out of `shock2.gam`), so the comments are accurate.

campaign: engineering-through-shodan · none · legacy · seed 1378752978
