### PR TITLE
fix(gameplay): keep hidden relays out of interaction

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -776,6 +776,7 @@ pub fn create_physics_representation(
         _v_phys_dimensions,
         v_frob_info,
         v_hud_select,
+        v_render_type,
         v_creature,
         v_creature_pose,
         v_death_pose,
@@ -787,6 +788,7 @@ pub fn create_physics_representation(
             View<PropPhysDimensions>,
             View<PropFrobInfo>,
             View<PropHUDSelect>,
+            View<PropRenderType>,
             View<PropCreature>,
             View<PropCreaturePose>,
             View<RuntimePropDeathPose>,
@@ -851,6 +853,21 @@ pub fn create_physics_representation(
 
     // Frobbable item, let's see what we can do...
     if let (Ok(pos), Ok(frob_info)) = (v_pos.get(entity_id), v_frob_info.get(entity_id)) {
+        // Dark chooses frob targets from the objects submitted by its render
+        // pipeline. A NoRender object is never submitted, regardless of an
+        // inherited FrobInfo or model, so it cannot be picked directly. Keep
+        // authored invisible physics (tripwires and other sensors have an
+        // explicit PhysType), but do not invent the model-bounds selection
+        // collider that exists here only to make a visible, typeless object
+        // raycastable. Otherwise hidden switch relays can eclipse their
+        // co-located visible control and bypass the authored link chain (#827).
+        let is_no_render = v_render_type
+            .get(entity_id)
+            .is_ok_and(|render_type| render_type.0 == RenderType::NoRender);
+        if is_no_render && v_phys_type.get(entity_id).is_err() {
+            return None;
+        }
+
         let qrotation = pos.rotation;
 
         let _is_sensor = true;
@@ -1323,6 +1340,39 @@ mod tests {
                     .any(|g| g == "entity" || g == "selectable"),
                 "a frob collider must stay raycastable, got {:?}",
                 bodies[0].collision_groups
+            );
+        }
+    }
+
+    /// Dark's pick pass weighs only objects submitted by the renderer. A
+    /// NoRender relay with inherited FrobInfo must therefore remain callable
+    /// by scripts/links without gaining this engine's synthetic frob body.
+    /// Authored invisible physics is independent and must survive: tripwires
+    /// use NoRender + PhysType for their sensor volumes.
+    #[test]
+    fn no_render_frob_collider_requires_authored_phys_type() {
+        for (phys_type, should_have_body) in [
+            (None, false),
+            (Some(PhysicsModelType::ORIENTED_BOUNDING_BOX), true),
+        ] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_wall_fixture(&mut world, phys_type);
+            world.add_component(entity_id, PropRenderType(RenderType::NoRender));
+            let model = ladder_model();
+
+            let handle =
+                create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id);
+
+            assert_eq!(
+                handle.is_some(),
+                should_have_body,
+                "NoRender fixture with PhysType {phys_type:?} should{} keep a body",
+                if should_have_body { "" } else { " not" }
+            );
+            assert_eq!(
+                physics.debug_list_bodies().len(),
+                usize::from(should_have_body)
             );
         }
     }

--- a/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops-bulkhead-button.e2e.test.ts
@@ -19,6 +19,117 @@ import { GameServer } from "../src/index.js";
 // stable *mission object id*, reported in the `template_id` field.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
+// The player pose observed in #827 immediately before the ordinary production
+// squeeze. The button position itself comes from the runtime entity so the
+// interaction follows the authored mission object rather than a debug Frob.
+const OPS4_BUTTON_PLAYER_POSE = {
+  x: 53.47933,
+  y: -7.8612247,
+  z: -6.4060183,
+};
+
+async function squeezeVisibleOps4Button(game: GameServer): Promise<void> {
+  const [button] = await game.entities.byTemplate(404);
+  assert.ok(button, "expected the visible ops2 Ops 4 bulkhead button");
+
+  await game.player.teleport(OPS4_BUTTON_PLAYER_POSE);
+  await game.step({ frames: 2 });
+  await game.input.lookAtWorldPoint(button.position);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  await game.step({ frames: 30 });
+}
+
+test(
+  "ops2: the visible Ops 4 button cannot directly select its hidden pre-reveal relay",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8128),
+    });
+    await game.step({ frames: 2 });
+    assert.equal(await game.quests.get("ShodanRoom"), "unknown");
+
+    // ops2 object 999 is the NoRender, PickBias=-2000 level-change relay.
+    // Dark never offers NoRender objects to the render-driven pick system, so
+    // an object with no authored PhysType must not gain a synthetic frob body.
+    const [hiddenRelay] = await game.entities.byTemplate(999);
+    assert.ok(hiddenRelay, "expected the hidden ops2 Ops 4 relay");
+    assert.equal(
+      (await game.physics.bodies({ entityId: hiddenRelay.id })).total_count,
+      0,
+      "the NoRender relay must remain script-addressable without becoming a direct interaction target",
+    );
+
+    await squeezeVisibleOps4Button(game);
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops2.mis",
+      "the visible button's authored QB filter must block Ops 4 before the SHODAN reveal",
+    );
+  },
+);
+
+test(
+  "ops1 reveal keeps its NoRender sensor and unlocks the visible ops2 Ops 4 button",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8129),
+    });
+    await game.step({ frames: 2 });
+
+    // Enter the real reveal tripwire (ops1 object 204). It is also NoRender,
+    // but unlike the hidden relay it has an authored PhysType and therefore
+    // must keep the sensor body that drives TrapNewTripwire.
+    const [revealTripwire] = await game.entities.byTemplate(204);
+    assert.ok(revealTripwire, "expected the ops1 SHODAN reveal tripwire");
+    const revealBodies = await game.physics.bodies({
+      entityId: revealTripwire.id,
+    });
+    assert.ok(
+      revealBodies.bodies.some((body) => body.is_sensor),
+      "the authored NoRender reveal sensor must remain physical",
+    );
+
+    await game.player.teleport({
+      x: revealTripwire.position[0] + 2,
+      y: revealTripwire.position[1],
+      z: revealTripwire.position[2],
+    });
+    await game.step({ frames: 2 });
+    await game.player.teleport({
+      x: revealTripwire.position[0],
+      y: revealTripwire.position[1],
+      z: revealTripwire.position[2],
+    });
+    await game.step({ frames: 5 });
+    assert.equal(
+      await game.quests.get("ShodanRoom"),
+      "incomplete",
+      "entering the authored reveal tripwire should establish ShodanRoom",
+    );
+
+    // Preserve the quest state while returning to ops2; the interaction below
+    // is still the ordinary production aim/squeeze and the hidden changer is
+    // reached only through visible button -> QB filter -> SwitchLink.
+    await game.transitionLevel("ops2.mis");
+    await game.step({ frames: 2 });
+    await squeezeVisibleOps4Button(game);
+
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "ops4.mis",
+      "after the genuine reveal flow, the authored visible-button relay chain should reach Ops 4",
+    );
+  },
+);
+
 test(
   "ops2: frobbing the visible bulkhead button relays TurnOn and transitions to ops3",
   { skip: !e2eEnabled, timeout: 600_000 },


### PR DESCRIPTION
## Summary

- keep `PropRenderType(NoRender)` entities without an authored `PropPhysType` out of direct flat interaction by not inventing a model-bounds frob collider for them
- preserve authored invisible physics for real tripwires/sensors and preserve all ECS scripts, switch links, and legitimate `LevelChangeButton` message behavior
- cover the fresh pre-reveal gate and the real ops1 reveal → ops2 → ops4 progression with production camera aim and squeeze input

Fixes #827

## Campaign

`custom ops→shodan · detailed · legacy · user-directed (no random seed)`

## Faithful behavior

Looking Glass's original pick pass calls `PickWeighObject` from the rendered-object callback. Its `Weight` function applies `PickBias` to every screen-space bounding-box edge and rejects a candidate when any biased edge falls outside the focus point. A `NoRender` object is never submitted to that callback at all; ops2 object 999's authored `PickBias=-2000` would also make it unpickable.

The port diverged by synthesizing a model-bounds selection collider for every inherited `FrobInfo`, including NoRender object 999, despite that relay having no authored physics. This change restores the original boundary at entity creation: only the synthetic collider is omitted. A NoRender entity with an authored `PhysType` still gets its physical body, so ops1's reveal tripwire remains a live sensor. Hidden relays remain script-addressable and continue to receive `TurnOn` over their real switch links.

This is complementary to #751 / PR #752. That sibling work resolves visible, rendered low-bias/HUD shells and co-located interaction overlays. This PR handles a hidden relay that should never enter the direct pick candidate set.

## Reproduction and regression

Fresh legacy `ops2.mis`, no quest bits:

1. stand at `[53.47933, -7.8612247, -6.4060183]`
2. aim the production camera at visible object 404 at `[52.9, -7.9, -8.2]`
3. pulse the ordinary right-hand squeeze edge

Before this change the co-located hidden object 999 had a selectable synthetic body and could receive the `Frob` directly, transitioning to `ops4` before `ShodanRoom`. After the change the visible object receives the interaction and its authored `BaseButton → QB filters → hidden relay` chain correctly blocks the transition.

The positive progression regression starts fresh in `ops1`, enters authored NoRender/PhysType tripwire 204, verifies it remains a sensor and establishes `ShodanRoom=incomplete`, carries that state back to `ops2`, and uses the same production interaction. The visible button then passes the QB filter and reaches the hidden changer only through its switch link, transitioning to `ops4`.

Negative-first evidence: the new focused E2E failed on `origin/main` because the hidden relay had one physics body (`1 !== 0`). It passes after the entity-creation fix.

## Player-observable evidence

![Ops 2 gated button production interaction](https://gist.githubusercontent.com/tommy-xr/3df0c89860d8c763d59e54ab3bd3726a/raw/ops2-gated-button.gif)

<sub>The visible Ops 4 button highlights and animates under the normal production squeeze, while the unrevealed player remains in Ops 2. Captured headlessly with deterministic fixed-timestep `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Before: hidden relay skips to Ops 4; after: visible gate keeps the player in Ops 2](https://gist.githubusercontent.com/tommy-xr/3df0c89860d8c763d59e54ab3bd3726a/raw/ops2-before-after.png)

[Full-resolution stills and binary media](https://gist.github.com/tommy-xr/3df0c89860d8c763d59e54ab3bd3726a).

## Verification

- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- focused unit: `no_render_frob_collider_requires_authored_phys_type`
- focused `ops-bulkhead-button.e2e.test.ts`: 5 passed, including the two #827 production regressions
- `cargo test -p shock2vr`: 478 passed
- `npm test` in `tools/shock2-sdk`: 26 passed, E2E scenarios skipped as designed
- full `npm run test:e2e`: 201 passed, 3 skipped, 3 failed outside this interaction path; isolated reruns passed the force-chase and SHODAN-assassin scenarios, while the remaining search-behavior null-entity failure reproduced identically on untouched `origin/main`
