### PR TITLE
fix(physics): keep jump mantles inside world ceilings

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1180,10 +1180,11 @@ fn plan_climb_top_out(
 /// standing pose must fit against *all* colliders, and every scripted substep
 /// still collides with parented entities. Same-height and lower landings
 /// require a genuinely clear all-world point probe above the lip, so
-/// full-height walls remain solid. An elevated landing may use Dark's
-/// parentless-terrain jump-through probe: that is what permits authored
-/// stacked corridors such as shodan's log platforms, whose upper floor is a
-/// ceiling to the lower cell.
+/// full-height walls remain solid. An elevated landing may cross the local
+/// platform lip with Dark's parentless-terrain jump-through probe, but its
+/// initial vertical rise must remain clear against all world geometry. That
+/// is what permits authored stacked corridors such as shodan's log platforms
+/// without treating a room ceiling directly overhead as an exterior landing.
 fn plan_jump_mantle(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -1225,6 +1226,7 @@ fn plan_jump_mantle(
     let mut rise_ss2 = PLAYER_JUMP_MANTLE_PROBE_STEP;
     while rise_ss2 <= max_rise * SCALE_FACTOR + 1.0e-4 && transition.is_none() {
         let raised = head + Vector::y() * (rise_ss2 / SCALE_FACTOR);
+        let vertical_probe_clear = ray_segment_is_clear(validation_queries, head, raised);
         let mut forward_ss2 = minimum_forward * SCALE_FACTOR;
         while forward_ss2 <= PLAYER_JUMP_MANTLE_FORWARD + 1.0e-4 {
             let forward = forward_ss2 / SCALE_FACTOR;
@@ -1246,12 +1248,23 @@ fn plan_jump_mantle(
                 let nearest_floor = validation_queries
                     .cast_ray_and_get_normal(&down_ray, 2.0 * max_rise, true)
                     .map(|(_, ground)| (ground.normal.y, raised_forward.y - ground.time_of_impact));
-                let elevated_floor = nearest_floor
+                let elevated_floor = vertical_probe_clear
+                    .then_some(nearest_floor)
+                    .flatten()
                     .filter(|(normal_y, _)| *normal_y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
                     .map(|(_, floor_y)| floor_y)
                     .filter(|floor_y| {
-                        *floor_y - current_feet_y
-                            > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                        let rise = *floor_y - current_feet_y;
+                        rise > (PLAYER_STEP_HEIGHT + PLAYER_CONTACT_OFFSET) / SCALE_FACTOR
+                            // The compressed body models Dark's discontinuous
+                            // sphere stack crossing a terrain lip; it does not
+                            // add vertical reach. Require the player's feet to
+                            // be able to reach the landing within the ordinary
+                            // ballistic apex. Otherwise an open lift shaft can
+                            // turn the room ceiling ahead into an "elevated
+                            // floor" and script the player onto its exterior
+                            // roof (#744).
+                            && rise <= max_rise
                     });
                 // A same-height floor visible above the lower candidate is the
                 // stacked-terrain signature: the continuous capsule cannot
@@ -7157,6 +7170,101 @@ mod tests {
         assert!(
             end.x > 0.0 && end.y > 4.4,
             "jump should mantle onto the elevated platform, ended {end:?}"
+        );
+    }
+
+    /// The compressed compatibility body may cross a local terrain lip, but it
+    /// must not add vertical reach beyond the ordinary ballistic jump. A roof
+    /// above that apex is not a mantle landing even when its top is visible to
+    /// the elevated-floor probe (#744).
+    #[test]
+    fn jump_mantle_rejects_a_platform_above_the_ballistic_apex() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.5, 10.0)
+                .translation(vector![0.0, -0.5, 0.0])
+                .build(),
+        );
+        // Top at y=4.5: 4.4 world units above the player's resting feet,
+        // beyond the 3.92-world-unit / 9.8-SS2-foot ballistic apex.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            ColliderBuilder::cuboid(10.0, 2.25, 3.0)
+                .translation(vector![8.5, 2.25, 0.0])
+                .build(),
+        );
+        let mut player = world.create_player(
+            vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+
+        for frame in 0..180 {
+            world.update_with_facing_and_jump(
+                vec3(0.1, 0.0, 0.0),
+                Vector3::unit_x(),
+                frame == 0,
+                &mut player,
+            );
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            end.y < 4.5,
+            "an above-apex platform must not become a scripted mantle landing, ended {end:?}"
+        );
+    }
+
+    /// A parented body can block a corridor without making the parentless room
+    /// ceiling above it a valid mantle destination. This is the deterministic
+    /// equivalent of the campaign's retained-body choke: the initial rise must
+    /// remain collision-checked against world geometry before the narrow lip
+    /// exception is allowed for the later horizontal crossing (#744).
+    #[test]
+    fn dynamic_obstacle_does_not_turn_the_world_ceiling_into_a_mantle() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.5, 10.0)
+                .translation(vector![0.0, -0.5, 0.0])
+                .build(),
+        );
+        // Parentless room slab: underside y=3.6, exterior roof y=3.8. The roof
+        // is within the ballistic apex, so the vertical-clearance invariant is
+        // what distinguishes it from a genuine elevated platform ahead.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.1, 10.0)
+                .translation(vector![0.0, 3.7, 0.0])
+                .build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1002).unwrap(),
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.8, 2.0, 3.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = world.create_player(
+            vec3(-2.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+
+        for frame in 0..180 {
+            world.update_with_facing_and_jump(
+                vec3(0.1, 0.0, 0.0),
+                Vector3::unit_x(),
+                frame == 0,
+                &mut player,
+            );
+        }
+        let end = world.get_player_translation(&player);
+        assert!(
+            end.y < 3.6,
+            "an obstacle below a world ceiling must not script the player onto its exterior, ended {end:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
+++ b/tools/shock2-sdk/test/jump-ceiling.e2e.test.ts
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CARGO_LIFT_OBJECT = 669;
+const CARGO_LIFT_BOTTOM_BUTTON_OBJECT = 480;
+const CARGO_LIFT_MIDDLE_BUTTON_OBJECT = 481;
+const CARGO_LIFT_TOP_BUTTON_OBJECT = 620;
+const ENGINEERING_OG_PIPE_OBJECT = 1666;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+async function pulseJump(game: GameServer): Promise<void> {
+  await game.input.setJump(true);
+  await game.step({ frames: 1 });
+  await game.input.setJump(false);
+}
+
+// Engineering campaign `engineering · none · legacy · seed 1378752978`
+// reached Cargo 2B's top lift through ordinary play. Walking north from the
+// lift toward its top call button is the valid route; jumping west instead
+// exposed a collision escape onto the exterior roof.
+test(
+  "ordinary jump stays below Engineering Cargo 2B's world ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG2_CEILING_PORT ?? 8140),
+    });
+    await game.step({ frames: 5 });
+
+    const lift = only(
+      await game.entities.byTemplate(CARGO_LIFT_OBJECT),
+      "Cargo 2B East lift mission object 669",
+    );
+    const bottomButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_BOTTOM_BUTTON_OBJECT),
+      "bottom lift button mission object 480",
+    );
+    const middleButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_MIDDLE_BUTTON_OBJECT),
+      "middle lift button mission object 481",
+    );
+    const topButton = only(
+      await game.entities.byTemplate(CARGO_LIFT_TOP_BUTTON_OBJECT),
+      "top lift button mission object 620",
+    );
+
+    // Setup only: board the lift at its authored bottom node, then drive the
+    // real 477 -> 478 -> 479 path. Riding it keeps the fresh-mission player
+    // alive and proves current-main moving-terrain support on the way to the
+    // exact campaign-observed top-stop pose.
+    await game.player.teleport({
+      x: 43.9,
+      y: -11.556,
+      z: -168.2,
+    });
+    await game.step({ frames: 30 });
+    await game.entities.sendMessage(bottomButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const middleLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(middleLift.position[1] - -5.1) < 0.1,
+      `lift should reach authored middle node y=-5.1, got ${middleLift.position[1]}`,
+    );
+    await game.entities.sendMessage(middleButton.id, { type: "Frob" });
+    await game.step({ frames: 600 });
+    const topLift = await game.entities.detail(lift.id);
+    assert.ok(
+      Math.abs(topLift.position[1] - 2.1) < 0.1,
+      `lift should reach authored top node y=2.1, got ${topLift.position[1]}`,
+    );
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    assert.ok(
+      Math.abs(before.x - 43.9006) < 0.1 &&
+        Math.abs(before.y - 3.144) < 0.1 &&
+        Math.abs(before.z - -168.2003) < 0.1,
+      `player should settle at the campaign lift pose, got ${JSON.stringify(before)}`,
+    );
+
+    // Control: the authored route walks north off the same top stop toward
+    // button 620. Prove it remains available, then return to the exact setup
+    // pose without carrying input or a jump edge into the regression.
+    await game.input.lookAtWorldPoint([
+      topButton.position[0],
+      before.y + 1.6,
+      topButton.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const northExit = await game.player.position();
+    assert.ok(
+      northExit.z > -166 && northExit.y < 6.8,
+      `ordinary walking should leave the lift north toward top button 620, got ` +
+        JSON.stringify(northExit),
+    );
+    await game.player.teleport({
+      x: 43.9006,
+      y: 3.144,
+      z: -168.2003,
+    });
+    await game.step({ frames: 30 });
+    const jumpStart = await game.player.position();
+
+    // Self-check the parentless world slab the campaign escaped through.
+    // Probing from below sees its underside, while the reverse ray finds the
+    // exterior roof at the same y. This is level geometry, not a lift entity.
+    const ceilingUp = await game.raycast({
+      start: [41.5, jumpStart.y, -169.1],
+      end: [41.5, 10, -169.1],
+      collision_groups: ["world"],
+    });
+    const roofDown = await game.raycast({
+      start: [41.5, 10, -169.1],
+      end: [41.5, jumpStart.y, -169.1],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceilingUp.hit_point &&
+        roofDown.hit_point &&
+        Math.abs(ceilingUp.hit_point[1] - 6.8) < 0.1 &&
+        Math.abs(roofDown.hit_point[1] - 6.8) < 0.1,
+      `expected Cargo 2B world ceiling/roof at y=6.8, got ` +
+        `${JSON.stringify({ ceilingUp, roofDown })}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim west, hold ordinary
+    // forward locomotion, pulse one grounded jump edge, then release.
+    await game.input.lookAtWorldPoint([39, jumpStart.y + 1.6, -170]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 180 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 180 });
+    const landed = await game.player.position();
+    await game.step({ frames: 120 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceilingUp.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the Cargo 2B ceiling ` +
+        `(${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `Cargo 2B ceiling: lift ${JSON.stringify(topLift.position)}, ` +
+        `north exit ${JSON.stringify(northExit)}, player ` +
+        `${JSON.stringify(jumpStart)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);
+
+// The Engineering campaign's authored maintenance-maze route reaches this
+// corridor from below. An idle OG-Pipe narrows the passage, but an ordinary
+// jump used to turn that local obstruction into a scripted crossing through
+// the corridor ceiling and leave the player supported on the exterior shell.
+test(
+  "ordinary jump past Engineering's OG-Pipe stays below the corridor ceiling",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_ENG1_OG_PIPE_PORT ?? 8141),
+    });
+    await game.step({ frames: 30 });
+
+    const ogPipe = only(
+      await game.entities.byTemplate(ENGINEERING_OG_PIPE_OBJECT),
+      "maintenance-maze OG-Pipe mission object 1666",
+    );
+    assert.equal(ogPipe.name, "OG-Pipe");
+
+    // Setup only: stage at the campaign-observed interior approach, then let
+    // both player support and the authored dynamic creature settle. Starting
+    // the input edge before support is re-established after setup does not
+    // exercise a grounded production jump.
+    await game.player.teleport({
+      x: 4.4,
+      y: -15.556003,
+      z: -85.00001,
+    });
+    await game.step({ frames: 30 });
+    const before = await game.player.position();
+    const settledOgPipe = await game.entities.detail(ogPipe.id);
+    assert.ok(
+      Math.abs(before.x - 4.4) < 0.1 &&
+        Math.abs(before.y - -15.556003) < 0.1 &&
+        Math.abs(before.z - -85.00001) < 0.1,
+      `player should settle at the authentic maze approach, got ${JSON.stringify(before)}`,
+    );
+    assert.ok(
+      settledOgPipe.position[0] > 5 &&
+        settledOgPipe.position[0] < 7 &&
+        Math.abs(settledOgPipe.position[1] - -15.1) < 0.15 &&
+        settledOgPipe.position[2] > -86 &&
+        settledOgPipe.position[2] < -84,
+      `stable OG-Pipe 1666 should occupy the authored choke, got ` +
+        JSON.stringify(settledOgPipe.position),
+    );
+
+    // Self-check the nearby parentless world slab that bounds the corridor.
+    // The exploit exits through this ceiling and settles above its y plane.
+    const ceiling = await game.raycast({
+      start: [7.5, before.y, -84.5],
+      end: [7.5, -9, -84.5],
+      collision_groups: ["world"],
+    });
+    assert.ok(
+      ceiling.hit_point && Math.abs(ceiling.hit_point[1] - -12.9) < 0.1,
+      `expected maintenance-maze world ceiling at y=-12.9, got ${JSON.stringify(ceiling)}`,
+    );
+
+    // Exact product-input sequence from the campaign: aim through the choke,
+    // hold ordinary forward locomotion, and pulse one grounded Jump edge.
+    await game.input.lookAtWorldPoint([8, before.y + 1.6, -84.5]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await pulseJump(game);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+    const landed = await game.player.position();
+    await game.step({ frames: 240 });
+    const supported = await game.player.position();
+
+    const ceilingY = ceiling.hit_point[1];
+    assert.ok(
+      landed.y < ceilingY &&
+        supported.y < ceilingY &&
+        Math.hypot(
+          supported.x - landed.x,
+          supported.y - landed.y,
+          supported.z - landed.z,
+        ) < 0.05,
+      `one ordinary jump must remain inside below the OG-Pipe corridor ceiling ` +
+        `(${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, ceiling y=${ceilingY})`,
+    );
+    t.diagnostic(
+      `OG-Pipe 1666 ${JSON.stringify(settledOgPipe.position)}, player ` +
+        `${JSON.stringify(before)} -> ${JSON.stringify(landed)} -> ` +
+        `${JSON.stringify(supported)}, world ceiling y=${ceilingY}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- cap elevated ordinary-jump mantle landings at the jump's ballistic apex
- require the initial upward route to be clear against all world geometry before the parentless-terrain lip exception can apply
- preserve the authored Cargo 2B, Engineering OG-Pipe, SHODAN descent, Cargo crate-stack, and Delacroix-platform routes

Fixes #744

## Campaign

`custom ops→shodan · detailed · legacy · user-directed (no random seed)`

The current-main replay surfaced the Operations variant in `ops3.mis` Data Storage after retained Docile/Shotgun Hybrid bodies blocked bounded movement. One ordinary forward jump crossed the authored floor and fell below the world. The invalid state was discarded and the real Chip C / `SimComp_1` route was completed on a clean replay. Corpse solidity remains tracked separately by #562; alive below-world recovery remains #724.

## Why this is the faithful boundary

Looking Glass's original `CheckMantle` first raycasts upward from the player head against both terrain and OBBs. Any hit aborts the mantle before its forward and downward probes. The port's compressed compatibility body intentionally models Dark's sparse sphere-stack crossing a local terrain lip, but the parentless-terrain exception had been applied to the initial rise too. That let a room ceiling become an exterior landing whenever a nearby object blocked ordinary movement.

This restores two general constraints, without mission coordinates or object special cases:

1. The initial head-to-raised path must be clear in the all-world query. The parentless-terrain exception remains limited to the subsequent horizontal lip crossing.
2. The landing rise must not exceed the ordinary jump's ballistic apex: `28² / (2 × 40) = 9.8 SS2 ft`.

PR #745 previously implemented the same invariants on stale base `codex/fix-708-jump`. Its merge commit `c3b14bd8` is not an ancestor of current `main`; this PR ports only the independently reviewed physics hunk and updates its tests for current-main moving-terrain behavior.

## Negative-first evidence

On untouched current `origin/main`:

- deterministic above-apex fixture settled on the scripted exterior at `y=5.7439`
- deterministic parented-obstacle/world-ceiling fixture settled on the exterior at `y=5.0439`
- the real Cargo 2B route escaped from `y=3.144` through the authored `y=6.8` roof and remained supported at `y=8.0438175`

The stable unit fixture represents the Ops3 retained-body relationship without relying on combat, corpse timing, or insertion order: a parented body blocks the aisle beneath parentless room geometry, and a normal grounded jump must remain inside.

## Authored-route verification

The Cargo regression now boards real lift object 669 at its bottom node and drives it through authored buttons 480 and 481 to top node 479. This both avoids an unrelated fresh-mission death during long setup stepping and exercises current-main moving-terrain support before the exact production jump.

After the fix:

- Cargo 2B stays inside at `y=3.2440052`; the ordinary north exit remains walkable
- Engineering OG-Pipe object 1666 stays below its `y=-12.9` corridor ceiling
- SHODAN final descent still reaches the log 4 passage
- Engineering Cargo 2's crate stack remains jumpable
- SHODAN's Delacroix two-platform log remains reachable and collectable

## Player-observable evidence

![Cargo 2B mantle-floor clearance comparison](https://gist.githubusercontent.com/tommy-xr/067283a2980d678e8ca2199c32619ff2/raw/cargo-2b-mantle-fix.gif)

<sub>The same fresh Engineering Cargo 2B lift ride and production Jump edge: current main escapes above the world ceiling; the fix remains inside. Captured headlessly via the debug runtime with deterministic fixed-timestep stepping.</sub>

### Before → after

![Cargo 2B before/after](https://gist.githubusercontent.com/tommy-xr/067283a2980d678e8ca2199c32619ff2/raw/cargo-2b-before-after.png)

[Full-resolution media and review stills](https://gist.github.com/tommy-xr/067283a2980d678e8ca2199c32619ff2).

## Verification

- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr`: 479 passed
- focused unit regressions: 2 passed
- focused ceiling + preserved authored jump SDK scenarios: 5 passed
- `npm test` in `tools/shock2-sdk`: 26 passed; E2E skipped as designed
- full `npm run test:e2e`: 202 passed, 3 skipped, 2 unrelated flaky failures; every mantle/jump scenario passed
  - `living SHODAN assassin remains supported when corridor spikes activate` passed on isolated rerun
  - `losing sight of the player triggers a search of the last-known position` failed twice on the PR branch with a null entity and reproduced identically on untouched `origin/main` (base sample: 2 passed, 1 failed)
