### PR TITLE
fix(tweq): honor authored emitter launches

### DIFF
--- a/dark/src/properties/prop_tweq.rs
+++ b/dark/src/properties/prop_tweq.rs
@@ -188,6 +188,10 @@ pub struct PropTweqEmitterConfig {
     pub animation_config: TweqAnimationConfig,
     pub halt: TweqHalt,
 
+    /// Dark's `TWEQ_MC_RELVEL`: rotate the authored launch vector by the
+    /// emitter object's facing before launching it.
+    pub relative_velocity: bool,
+
     pub rate: Duration,
     pub max_frames: u32,
     pub emit_what: String,
@@ -205,7 +209,7 @@ impl PropTweqEmitterConfig {
         let halt_bits = read_u8(reader);
         let halt: TweqHalt = num_traits::FromPrimitive::from_u8(halt_bits).unwrap();
 
-        let _misc = read_u16(reader);
+        let misc = read_u16(reader);
         let rate = read_u16(reader);
 
         let max_frames = read_u32(reader);
@@ -216,6 +220,7 @@ impl PropTweqEmitterConfig {
         PropTweqEmitterConfig {
             animation_config,
             halt,
+            relative_velocity: misc & (1 << 8) != 0,
             rate: Duration::from_millis(rate.into()),
             max_frames,
             emit_what,
@@ -259,7 +264,7 @@ impl PropTweqDeleteConfig {
 mod tests {
     use std::io::Cursor;
 
-    use super::{PropTweqModelState, TweqAnimationState};
+    use super::{PropTweqEmitterConfig, PropTweqModelState, TweqAnimationState};
 
     #[test]
     fn model_state_reads_the_authored_frame_number() {
@@ -274,5 +279,29 @@ mod tests {
 
         assert!(state.animation_state.contains(TweqAnimationState::REVERSE));
         assert_eq!(state.frame, 4);
+    }
+
+    #[test]
+    fn emitter_config_reads_relative_velocity_misc_flag() {
+        let mut raw = vec![
+            0x00, // type
+            0x00, // curve
+            0x02, // anim config: Sim
+            0x00, // halt: DestroyObject
+            0x00, 0x01, // misc: TWEQ_MC_RELVEL (1 << 8)
+            0xf4, 0x01, // rate: 500 ms
+            0x03, 0x00, 0x00, 0x00, // max frames
+        ];
+        raw.extend_from_slice(b"grub\0\0\0\0\0\0\0\0\0\0\0\0");
+        for component in [-25.0_f32, 0.0, 0.0, 0.0, 0.0, 0.0] {
+            raw.extend_from_slice(&component.to_le_bytes());
+        }
+        let mut bytes = Cursor::new(raw);
+
+        let config = PropTweqEmitterConfig::read(&mut bytes, 64);
+
+        assert!(config.relative_velocity);
+        // `read_vec3` converts raw Dark (-X, Y, Z) into runtime (X, Z, Y).
+        assert_eq!(config.velocity, cgmath::vec3(25.0, 0.0, 0.0));
     }
 }

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -148,6 +148,10 @@ pub fn create_entity_with_position(
         world.add_component(entity_id, RuntimePropProjectileRayOrigin(origin));
     }
 
+    if additional_options.launch_projectile {
+        world.add_component(entity_id, RuntimePropLaunchedProjectile);
+    }
+
     create_entity_core(
         entity_id,
         template_id,
@@ -218,7 +222,7 @@ pub fn create_entity_core(
     entity_info: &ss2_entity_info::SystemShock2EntityInfo,
     _template_to_entity_id: &HashMap<i32, WrappedEntityId>, // realized entities from level start
     obj_map: &HashMap<i32, String>,
-    _additional_options: CreateEntityOptions,
+    additional_options: CreateEntityOptions,
 ) -> EntityCreationInfo {
     // Add template id
     world.add_component(entity_id, PropTemplateId { template_id });
@@ -272,7 +276,13 @@ pub fn create_entity_core(
 
     // Create physics representation
     let rigid_body = if has_refs(world, entity_id) {
-        create_physics_representation(world, physics, &maybe_just_model.as_ref(), entity_id)
+        create_physics_representation_with_options(
+            world,
+            physics,
+            &maybe_just_model.as_ref(),
+            entity_id,
+            additional_options.launch_projectile,
+        )
     } else {
         None
     };
@@ -755,6 +765,16 @@ pub fn create_physics_representation(
     maybe_model: &Option<&Model>,
     entity_id: EntityId,
 ) -> Option<RigidBodyHandle> {
+    create_physics_representation_with_options(world, physics, maybe_model, entity_id, false)
+}
+
+fn create_physics_representation_with_options(
+    world: &mut World,
+    physics: &mut PhysicsWorld,
+    maybe_model: &Option<&Model>,
+    entity_id: EntityId,
+    launch_projectile: bool,
+) -> Option<RigidBodyHandle> {
     // A door the authors left permanently open (no travel between its open and
     // closed endpoints, authored open) has nowhere to retract to: a collider
     // for it is a slab welded across the doorway that nothing can ever move,
@@ -769,11 +789,18 @@ pub fn create_physics_representation(
         return None;
     }
 
+    // Keep this storage out of the main borrow tuple: Shipyard 0.6 supports
+    // tuples through arity ten, and launch handling only needs membership.
+    let launched_object_is_immobile = world
+        .borrow::<View<PropImmobile>>()
+        .unwrap()
+        .contains(entity_id);
+
     let (
         v_pos,
         v_phys_attr,
         v_phys_type,
-        _v_phys_dimensions,
+        v_phys_dimensions,
         v_frob_info,
         v_hud_select,
         v_render_type,
@@ -848,6 +875,45 @@ pub fn create_physics_representation(
             physics.set_enabled_rotations(entity_id, false, false, false);
             physics.sleep_body(rigid_body_handle);
             return Some(rigid_body_handle);
+        }
+    }
+
+    // Dark's Tweq emitter hands the fresh object to launchProjectile. Preserve
+    // that explicit creation mode here: frobbable emitted objects (Ops4's Grub
+    // is one) would otherwise take the selectable-fixture branch below and
+    // replace their authored moving sphere with a kinematic model-bounds box.
+    let launched_projectile = launch_projectile
+        || world
+            .borrow::<View<RuntimePropLaunchedProjectile>>()
+            .unwrap()
+            .contains(entity_id);
+    if launched_projectile && !launched_object_is_immobile {
+        if let (Ok(pos), Ok(phys_type), Ok(dimensions)) = (
+            v_pos.get(entity_id),
+            v_phys_type.get(entity_id),
+            v_phys_dimensions.get(entity_id),
+        ) {
+            let maybe_shape = match phys_type.phys_type {
+                PhysicsModelType::ORIENTED_BOUNDING_BOX => {
+                    Some(PhysicsShape::Cuboid(dimensions.size))
+                }
+                PhysicsModelType::SPHERE => Some(PhysicsShape::Sphere(
+                    dimensions.radius0.abs().max(dimensions.radius1.abs()),
+                )),
+                _ => None,
+            };
+            if let Some(shape) = maybe_shape {
+                return Some(physics.add_dynamic(
+                    entity_id,
+                    pos.position,
+                    pos.rotation,
+                    dimensions.offset0,
+                    shape,
+                    CollisionGroup::entity(),
+                    false,
+                    dynamics_options,
+                ));
+            }
         }
     }
 
@@ -1200,6 +1266,10 @@ pub struct CreateEntityOptions {
     /// projectile. Flat firing supplies the camera origin while retaining the
     /// forward spawn clearance needed by slow physics projectiles.
     pub projectile_raycast_origin: Option<Point3<f32>>,
+    /// Create the authored physics model as a launched dynamic body. Dark's
+    /// Tweq emitter calls `launchProjectile`; this keeps frobbable emitted
+    /// archetypes from being reduced to kinematic selection colliders.
+    pub launch_projectile: bool,
 }
 
 impl Default for CreateEntityOptions {
@@ -1209,6 +1279,7 @@ impl Default for CreateEntityOptions {
             attach_to: None,
             transient_fx: false,
             projectile_raycast_origin: None,
+            launch_projectile: false,
         }
     }
 }
@@ -1381,6 +1452,59 @@ mod tests {
                 usize::from(should_have_body)
             );
         }
+    }
+
+    /// Dark's Tweq emitter launches its created object. Ops4's Grub is
+    /// frobbable for targeting, but also authors a moving sphere; the launch
+    /// path must win over the ordinary kinematic selection-collider fallback.
+    #[test]
+    fn launched_frobbable_sphere_uses_authored_dynamic_physics() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(1.0, 2.0, 3.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropHUDSelect(true),
+            PropPhysType {
+                phys_type: PhysicsModelType::SPHERE,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: true,
+            },
+            PropPhysDimensions {
+                radius0: 0.2,
+                radius1: 0.0,
+                offset0: vec3(0.0, 0.36, 0.0),
+                offset1: Vector3::zero(),
+                size: Vector3::zero(),
+                unk1: 0,
+                unk2: 0,
+            },
+        ));
+
+        create_physics_representation_with_options(
+            &mut world,
+            &mut physics,
+            &None,
+            entity_id,
+            true,
+        )
+        .expect("an authored launched sphere should get a body");
+        physics.set_velocity(entity_id, vec3(-10.0, 0.0, 0.0));
+
+        let bodies = physics.debug_list_bodies();
+        assert_eq!(bodies.len(), 1);
+        assert_eq!(bodies[0].body_type, "dynamic");
+        assert_eq!(bodies[0].linear_velocity, [-10.0, 0.0, 0.0]);
+        assert!(bodies[0].collision_groups.iter().any(|g| g == "entity"));
     }
 
     /// A non-frobbable object with a physics type but no `P$PhysDims` - the

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -84,7 +84,8 @@ use crate::{
     runtime_props::{
         RuntimePropAIBehavior, RuntimePropAttachment, RuntimePropDeathPose,
         RuntimePropDoNotSerialize, RuntimePropFlatAim, RuntimePropJointTransforms,
-        RuntimePropReloading, RuntimePropSelectedAmmo, RuntimePropTransform, RuntimePropVhots,
+        RuntimePropLaunchedProjectile, RuntimePropReloading, RuntimePropSelectedAmmo,
+        RuntimePropTransform, RuntimePropVhots,
     },
     save_load::HeldItemSaveData,
     scripts::{
@@ -356,7 +357,7 @@ pub struct GlobalAsyncPathfinding(
     pub Option<Arc<crate::pathfinding::async_queries::AsyncPathfinding>>,
 );
 
-#[derive(Unique, Clone)]
+#[derive(Unique, Clone, Default)]
 pub struct EffectQueue {
     effects: Vec<Effect>,
 }
@@ -2282,7 +2283,13 @@ impl MissionCore {
                         .borrow::<View<RuntimePropDeathPose>>()
                         .unwrap()
                         .contains(*id);
-                if !holds_terminal_death_pose {
+                let launched_with_no_root_motion = velocity.magnitude2() <= f32::EPSILON
+                    && self
+                        .world
+                        .borrow::<View<RuntimePropLaunchedProjectile>>()
+                        .unwrap()
+                        .contains(*id);
+                if !holds_terminal_death_pose && !launched_with_no_root_motion {
                     self.physics.set_velocity(*id, scaled);
                 }
             }
@@ -2514,6 +2521,23 @@ impl MissionCore {
         position: Point3<f32>,
         orientation: Quaternion<f32>,
     ) -> Option<EntityCreationInfo> {
+        self.create_entity_by_template_name_with_options(
+            asset_cache,
+            template_name,
+            position,
+            orientation,
+            CreateEntityOptions::default(),
+        )
+    }
+
+    fn create_entity_by_template_name_with_options(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        template_name: &str,
+        position: Point3<f32>,
+        orientation: Quaternion<f32>,
+        options: CreateEntityOptions,
+    ) -> Option<EntityCreationInfo> {
         let template_name_lowercase = template_name.to_ascii_lowercase();
         let maybe_template_id = self
             .template_name_to_template_id
@@ -2527,7 +2551,7 @@ impl MissionCore {
                 position,
                 orientation,
                 Matrix4::identity(),
-                CreateEntityOptions::default(),
+                options,
             ))
         } else {
             None
@@ -3736,16 +3760,30 @@ impl MissionCore {
                 }
 
                 Effect::CreateEntityByTemplateName {
+                    source_entity_id,
                     template_name,
                     position,
                     orientation,
+                    initial_velocity,
                 } => {
-                    self.create_entity_by_template_name(
+                    if let Some(created) = self.create_entity_by_template_name_with_options(
                         asset_cache,
                         &template_name,
                         position,
                         orientation,
-                    );
+                        CreateEntityOptions {
+                            launch_projectile: true,
+                            ..CreateEntityOptions::default()
+                        },
+                    ) {
+                        self.physics
+                            .set_velocity(created.entity_id, initial_velocity);
+                    } else {
+                        warn!(
+                            "Tweq emitter {:?} could not resolve authored template {:?}",
+                            source_entity_id, template_name
+                        );
+                    }
                 }
 
                 Effect::CreateEntity {

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -267,6 +267,12 @@ pub struct RuntimePropFlatAim {
 #[derive(Component, Clone, Copy, Debug)]
 pub struct RuntimePropProjectileRayOrigin(pub Point3<f32>);
 
+/// Marks an object created through Dark's `launchProjectile` path. Its
+/// authored physics model owns idle velocity; an empty skeletal animation
+/// must not zero the launch, and save/load must recreate it as a dynamic body.
+#[derive(Component, Clone, Copy)]
+pub struct RuntimePropLaunchedProjectile;
+
 // RuntimePropMapData - the automap page data for the current mission, attached
 // to the synthetic map-panel entity at mission init: the mission's level file
 // name (for the per-level `intrface/<LEVEL>/english/` art paths) and the decal

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, World};
 
 use crate::runtime_props::{
-    RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropSelectedAmmo,
+    RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropLaunchedProjectile,
+    RuntimePropSelectedAmmo,
 };
 use crate::scripts::SavedScriptState;
 
@@ -33,6 +34,11 @@ pub struct EntitySaveData {
     /// positive, mission-local object ID.
     #[serde(default)]
     pub canonical_template_ids: HashMap<u64 /* entity id */, i32>,
+    /// Entities created through Dark's `launchProjectile` path. The marker
+    /// restores dynamic authored physics and keeps empty animation players
+    /// from taking velocity ownership after load.
+    #[serde(default)]
+    pub launched_projectiles: Vec<u64 /* entity id */>,
     /// Opt-in private state owned by scripts on these entities. Registered ECS
     /// properties and links remain in their existing fields above; this is only
     /// for runtime modes, timers, latches, and similar script internals.
@@ -50,6 +56,7 @@ impl EntitySaveData {
             death_poses: HashMap::new(),
             selected_ammo: HashMap::new(),
             canonical_template_ids: HashMap::new(),
+            launched_projectiles: Vec::new(),
             script_states: Vec::new(),
         }
     }
@@ -113,6 +120,12 @@ impl EntitySaveData {
                     *new_entity_id,
                     RuntimePropCanonicalTemplateId(*canonical_template_id),
                 );
+            }
+        }
+        for old_entity_id in &self.launched_projectiles {
+            let old_entity_id = EntityId::from_inner(*old_entity_id).unwrap();
+            if let Some(new_entity_id) = old_entity_id_to_new_entity_id.get(&old_entity_id) {
+                world.add_component(*new_entity_id, RuntimePropLaunchedProjectile);
             }
         }
         (template_to_entity_id, old_entity_id_to_new_entity_id)
@@ -212,6 +225,7 @@ mod tests {
 
         assert!(data.selected_ammo.is_empty());
         assert!(data.canonical_template_ids.is_empty());
+        assert!(data.launched_projectiles.is_empty());
         assert!(data.script_states.is_empty());
     }
 
@@ -231,6 +245,24 @@ mod tests {
             .borrow::<View<RuntimePropCanonicalTemplateId>>()
             .unwrap();
         assert_eq!(canonical.get(new_entity).unwrap().0, -1358);
+    }
+
+    #[test]
+    fn instantiate_restores_launched_projectile_marker_on_the_remapped_entity() {
+        let old_entity = EntityId::new_from_index_and_gen(10, 2);
+        let mut data = EntitySaveData::empty();
+        data.all_entities.push(old_entity.inner());
+        data.launched_projectiles.push(old_entity.inner());
+        let mut world = World::new();
+
+        let (_, entity_map) = data.instantiate(&mut world);
+
+        let new_entity = entity_map[&old_entity];
+        let launched = world
+            .borrow::<View<RuntimePropLaunchedProjectile>>()
+            .unwrap();
+        assert!(launched.contains(new_entity));
+        assert!(!launched.contains(old_entity));
     }
 
     #[test]

--- a/shock2vr/src/save_load/mod.rs
+++ b/shock2vr/src/save_load/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     mission::{GlobalTemplateIdMap, PlayerInfo},
     runtime_props::{
         RuntimePropCanonicalTemplateId, RuntimePropDeathPose, RuntimePropDoNotSerialize,
-        RuntimePropSelectedAmmo,
+        RuntimePropLaunchedProjectile, RuntimePropSelectedAmmo,
     },
     scripts::{ScriptWorld, script_util},
     util::partition_map,
@@ -130,6 +130,9 @@ pub fn to_save_data_with_scripts(
     let v_canonical_templates = world
         .borrow::<View<RuntimePropCanonicalTemplateId>>()
         .unwrap();
+    let v_launched_projectiles = world
+        .borrow::<View<RuntimePropLaunchedProjectile>>()
+        .unwrap();
     let v_entities = world.borrow::<EntitiesView>().unwrap();
 
     let (all_properties, _, _) = dark::properties::get::<File>();
@@ -210,6 +213,18 @@ pub fn to_save_data_with_scripts(
         partition_map(raw_canonical_templates, |entity_id| {
             held_entities.contains(entity_id)
         });
+    let mut world_launched_projectiles = Vec::new();
+    let mut held_launched_projectiles = Vec::new();
+    for (entity_id, _) in v_launched_projectiles.iter().with_id() {
+        if entities_to_filter.contains(&entity_id.inner()) {
+            continue;
+        }
+        if held_entities.contains(&entity_id.inner()) {
+            held_launched_projectiles.push(entity_id.inner());
+        } else {
+            world_launched_projectiles.push(entity_id.inner());
+        }
+    }
     let world_entity_data = EntitySaveData {
         properties: world_serialized_properties,
         template_id_to_entity_id: template_id_to_entity_id.0.clone(),
@@ -218,6 +233,7 @@ pub fn to_save_data_with_scripts(
         death_poses: world_death_poses,
         selected_ammo: world_selected_ammo,
         canonical_template_ids: world_canonical_templates,
+        launched_projectiles: world_launched_projectiles,
         script_states: world_script_states,
     };
 
@@ -229,6 +245,7 @@ pub fn to_save_data_with_scripts(
         death_poses: held_death_poses,
         selected_ammo: held_selected_ammo,
         canonical_template_ids: held_canonical_templates,
+        launched_projectiles: held_launched_projectiles,
         script_states: held_script_states,
     };
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -298,9 +298,11 @@ pub enum Effect {
         model_name: String,
     },
     CreateEntityByTemplateName {
+        source_entity_id: EntityId,
         template_name: String,
         position: Point3<f32>,
         orientation: Quaternion<f32>,
+        initial_velocity: Vector3<f32>,
     },
 
     CreateEntity {

--- a/shock2vr/src/systems/tweq.rs
+++ b/shock2vr/src/systems/tweq.rs
@@ -1,9 +1,12 @@
 use std::time::Duration;
 
 use cgmath::{Deg, Quaternion, Rotation3};
-use dark::properties::{
-    PropPosition, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqEmitterConfig,
-    PropTweqEmitterState, PropTweqRotateState, TweqAnimationState, TweqHalt,
+use dark::{
+    SCALE_FACTOR,
+    properties::{
+        PropPosition, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqEmitterConfig,
+        PropTweqEmitterState, PropTweqRotateState, TweqAnimationState, TweqHalt,
+    },
 };
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, UniqueViewMut, View, ViewMut};
 
@@ -34,7 +37,7 @@ pub fn run_tweq(
     }
 
     // Run emit tweq
-    for (_id, (tweq_state, tweq_config, position)) in (
+    for (id, (tweq_state, tweq_config, position)) in (
         &mut v_tweq_emit_state,
         &mut v_tweq_emit_config,
         &v_prop_position,
@@ -51,10 +54,23 @@ pub fn run_tweq(
             {
                 tweq_state.num_iterations += 1;
                 tweq_state.time_since_last_event = Duration::from_secs(0);
+                // `read_vec3` has already changed the Dark vector into the
+                // runtime basis. Relative Velocity then applies the emitter's
+                // authored facing, exactly as Dark's TWEQ_MC_RELVEL path does.
+                // `angle_random` is deliberately deferred: the stock Ops4
+                // emitters author zero, while non-zero values are Dark fixed-
+                // angle ranges and need deterministic RNG/save semantics.
+                let authored_velocity = if tweq_config.relative_velocity {
+                    position.rotation * tweq_config.velocity
+                } else {
+                    tweq_config.velocity
+                };
                 effects.push(Effect::CreateEntityByTemplateName {
-                    template_name: "HE Explosion".to_string(),
+                    source_entity_id: id,
+                    template_name: tweq_config.emit_what.clone(),
                     position: vec3_to_point3(position.position),
                     orientation: position.rotation,
+                    initial_velocity: authored_velocity / SCALE_FACTOR,
                 });
             }
 
@@ -63,6 +79,9 @@ pub fn run_tweq(
                 tweq_state.animation_state = tweq_state
                     .animation_state
                     .difference(TweqAnimationState::ON);
+                if matches!(tweq_config.halt, TweqHalt::DestroyObject) {
+                    effects.push(Effect::DestroyEntity { entity_id: id });
+                }
             }
         }
     }
@@ -113,5 +132,224 @@ pub fn turn_off_tweqs(
 
     if let Ok(tweq_state) = (&mut v_tweq_delete_state).get(entity_id) {
         tweq_state.animation_state.remove(TweqAnimationState::ON);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, vec3};
+    use dark::properties::{
+        PropPosition, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqEmitterConfig,
+        PropTweqEmitterState, PropTweqRotateState, TweqAnimationConfig, TweqAnimationState,
+        TweqHalt,
+    };
+    use shipyard::{EntityId, Get, UniqueViewMut, View, World};
+
+    use super::run_tweq;
+    use crate::{mission::EffectQueue, scripts::Effect, time::Time};
+
+    fn world_with_ops4_emitter(
+        velocity: cgmath::Vector3<f32>,
+        rotation: Quaternion<f32>,
+        relative_velocity: bool,
+        max_frames: u32,
+    ) -> (World, EntityId) {
+        let mut world = World::new();
+        world.add_unique(Time {
+            elapsed: std::time::Duration::from_millis(501),
+            total: std::time::Duration::from_millis(501),
+        });
+        world.add_unique(EffectQueue::default());
+        let emitter = world.add_entity((
+            PropTweqEmitterState {
+                animation_state: TweqAnimationState::ON,
+                time_since_last_event: std::time::Duration::ZERO,
+                num_iterations: 0,
+            },
+            PropTweqEmitterConfig {
+                animation_config: TweqAnimationConfig::SIM,
+                halt: TweqHalt::DestroyObject,
+                relative_velocity,
+                rate: std::time::Duration::from_millis(500),
+                max_frames,
+                emit_what: "gRuB".to_owned(),
+                velocity,
+                angle_random: vec3(0.0, 0.0, 0.0),
+            },
+            PropPosition {
+                position: vec3(31.275366, -14.658457, -105.01082),
+                cell: u16::MAX,
+                rotation,
+            },
+        ));
+
+        // Register the other Tweq component storages borrowed by `run_tweq`.
+        world.add_entity(PropTweqRotateState {
+            animation_state: TweqAnimationState::empty(),
+            axis1_animation_state: TweqAnimationState::empty(),
+            axis2_animation_state: TweqAnimationState::empty(),
+            axis3_animation_state: TweqAnimationState::empty(),
+        });
+        world.add_entity((
+            PropTweqDeleteState {
+                animation_state: TweqAnimationState::empty(),
+                time_since_last_event: std::time::Duration::ZERO,
+                num_iterations: 0,
+            },
+            PropTweqDeleteConfig {
+                animation_config: TweqAnimationConfig::SIM,
+                halt: TweqHalt::StopTweq,
+                rate: std::time::Duration::from_secs(1),
+            },
+        ));
+        (world, emitter)
+    }
+
+    #[test]
+    fn ops4_emitter_682_uses_authored_template_world_velocity_and_destroy_completion() {
+        let (world, _) = world_with_ops4_emitter(
+            vec3(-25.0, 0.0, 0.0),
+            Quaternion::from_angle_y(Deg(-90.0)),
+            false,
+            1,
+        );
+
+        world.run(run_tweq);
+        let effects = world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+
+        assert!(matches!(
+            effects.first(),
+            Some(Effect::CreateEntityByTemplateName {
+                template_name,
+                initial_velocity,
+                ..
+            }) if template_name == "gRuB"
+                && (*initial_velocity - vec3(-10.0, 0.0, 0.0)).magnitude2() < 1.0e-6
+        ));
+        assert!(matches!(effects.get(1), Some(Effect::DestroyEntity { .. })));
+    }
+
+    #[test]
+    fn ops4_emitter_689_keeps_its_differently_rotated_world_velocity() {
+        let (world, _) = world_with_ops4_emitter(
+            vec3(10.0, 0.0, 0.0),
+            Quaternion::from_angle_y(Deg(180.0)),
+            false,
+            5,
+        );
+
+        world.run(run_tweq);
+        let effects = world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+
+        assert!(matches!(
+            effects.first(),
+            Some(Effect::CreateEntityByTemplateName {
+                initial_velocity,
+                ..
+            }) if (*initial_velocity - vec3(4.0, 0.0, 0.0)).magnitude2() < 1.0e-6
+        ));
+        assert_eq!(effects.len(), 1);
+    }
+
+    #[test]
+    fn relative_velocity_rotates_the_dark_converted_vector_by_emitter_facing() {
+        let (world, _) = world_with_ops4_emitter(
+            vec3(-25.0, 0.0, 0.0),
+            Quaternion::from_angle_y(Deg(-90.0)),
+            true,
+            3,
+        );
+
+        world.run(run_tweq);
+        let effects = world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+
+        assert!(matches!(
+            effects.first(),
+            Some(Effect::CreateEntityByTemplateName {
+                initial_velocity,
+                ..
+            }) if (*initial_velocity - vec3(0.0, 0.0, -10.0)).magnitude2() < 1.0e-6
+        ));
+    }
+
+    #[test]
+    fn mid_burst_state_roundtrip_resumes_only_the_remaining_emissions() {
+        let (world, emitter) = world_with_ops4_emitter(
+            vec3(-25.0, 0.0, 0.0),
+            Quaternion::from_angle_y(Deg(-90.0)),
+            false,
+            3,
+        );
+
+        world.run(run_tweq);
+        world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+        world.borrow::<UniqueViewMut<Time>>().unwrap().elapsed =
+            std::time::Duration::from_millis(250);
+        world.run(run_tweq);
+        assert!(
+            world
+                .borrow::<UniqueViewMut<EffectQueue>>()
+                .unwrap()
+                .flush()
+                .is_empty()
+        );
+
+        let saved_state = world
+            .borrow::<View<PropTweqEmitterState>>()
+            .unwrap()
+            .get(emitter)
+            .unwrap()
+            .clone();
+        let serialized = serde_json::to_string(&saved_state).unwrap();
+        let restored_state: PropTweqEmitterState = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(restored_state.num_iterations, 1);
+        assert_eq!(
+            restored_state.time_since_last_event,
+            std::time::Duration::from_millis(250)
+        );
+
+        let (mut restored_world, restored_emitter) = world_with_ops4_emitter(
+            vec3(-25.0, 0.0, 0.0),
+            Quaternion::from_angle_y(Deg(-90.0)),
+            false,
+            3,
+        );
+        restored_world.add_component(restored_emitter, restored_state);
+        restored_world
+            .borrow::<UniqueViewMut<Time>>()
+            .unwrap()
+            .elapsed = std::time::Duration::from_millis(251);
+
+        restored_world.run(run_tweq);
+        let effects = restored_world
+            .borrow::<UniqueViewMut<EffectQueue>>()
+            .unwrap()
+            .flush();
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            effects.first(),
+            Some(Effect::CreateEntityByTemplateName { .. })
+        ));
+        assert_eq!(
+            restored_world
+                .borrow::<View<PropTweqEmitterState>>()
+                .unwrap()
+                .get(restored_emitter)
+                .unwrap()
+                .num_iterations,
+            2
+        );
     }
 }

--- a/tools/shock2-sdk/test/ops4-tweq-emitter.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-tweq-emitter.e2e.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8188);
+
+const TRIPWIRE = 662;
+const EMITTER = 682;
+const JUNCTION = 685;
+const DESTROY_TRAP = 664;
+const BARRIERS = [545, 658, 659];
+const GRUB = -182;
+
+async function waitForGrubCount(game: GameServer, expected: number): Promise<void> {
+  for (let frame = 0; frame < 120; frame += 1) {
+    if ((await game.entities.byTemplate(GRUB)).length === expected) return;
+    await game.step({ frames: 1 });
+  }
+  assert.equal(
+    (await game.entities.byTemplate(GRUB)).length,
+    expected,
+    `expected ${expected} emitted Grubs within two seconds`,
+  );
+}
+
+test(
+  "ops4.mis: tripwire 662 emits three launched Grubs and persists completion",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const midBurstSave = `ops4_tweq_mid_${Date.now()}`;
+    const completedSave = `ops4_tweq_done_${Date.now()}`;
+
+    {
+      await using game = await GameServer.launch({
+        mission: "ops4.mis",
+        port: basePort,
+      });
+      await game.step({ frames: 5 });
+
+      assert.equal((await game.entities.byTemplate(TRIPWIRE)).length, 1);
+      assert.equal((await game.entities.byTemplate(EMITTER)).length, 1);
+      assert.equal((await game.entities.byTemplate(GRUB)).length, 0);
+      const audioBefore = await game.audio.recent();
+      const sequenceBefore = audioBefore.sounds.at(-1)?.sequence ?? 0;
+
+      // Cross the real tripwire through the same collision-valid authored
+      // corridor used by the Junction escape regression. No script message is
+      // injected into the tripwire or emitter.
+      await game.player.teleport({ x: 37.200462, y: -14.596002, z: -104.299965 });
+      await game.step({ frames: 2 });
+      for (const waypoint of [
+        { x: 36.9, y: -14.596, z: -105.43 },
+        { x: 36.1, y: -14.596, z: -105.95 },
+        { x: 35.3, y: -14.596, z: -105.51 },
+        { x: 34.3, y: -14.596, z: -104.85 },
+        { x: 32.5, y: -13.8, z: -104.32 },
+      ]) {
+        const move = await game.player.moveTo(waypoint);
+        assert.equal(move.moved, true);
+        await game.step({ frames: 2 });
+      }
+      await game.step({ frames: 5 });
+
+      const live = (await game.entities.list()).entities;
+      const junction = live.find((entity) => entity.template_id === JUNCTION);
+      const destroyTrap = live.find((entity) => entity.template_id === DESTROY_TRAP);
+      assert.ok(junction, "expected authored Junction Box 685");
+      assert.ok(destroyTrap, "expected authored Destroy Trap 664");
+      for (const objectId of BARRIERS) {
+        assert.ok(
+          live.some((entity) => entity.template_id === objectId),
+          `tripwire must deploy barrier ${objectId}`,
+        );
+      }
+
+      // Three ordinary points are the Junction's authored HP. This follows the
+      // production death-trigger link to Destroy Trap 664 and reopens the lane.
+      await game.entities.sendMessage(junction.id, { type: "Damage", amount: 3 });
+      await game.step({ frames: 4 });
+      const escapedWorld = (await game.entities.list()).entities;
+      assert.ok(!escapedWorld.some((entity) => entity.id === junction.id));
+      assert.ok(!escapedWorld.some((entity) => entity.id === destroyTrap.id));
+      for (const objectId of BARRIERS) {
+        assert.ok(
+          !escapedWorld.some((entity) => entity.template_id === objectId),
+          `Destroy Trap 664 must remove barrier ${objectId}`,
+        );
+      }
+      for (const waypoint of [
+        { x: 34.3, y: -14.596, z: -104.85 },
+        { x: 35.3, y: -14.596, z: -105.51 },
+        { x: 36.1, y: -14.596, z: -105.95 },
+      ]) {
+        const exit = await game.player.moveTo(waypoint);
+        assert.equal(exit.blocked, false, "the Junction escape lane must reopen");
+        await game.step({ frames: 2 });
+      }
+
+      await waitForGrubCount(game, 1);
+      const [firstGrub] = await game.entities.byTemplate(GRUB);
+      assert.ok(firstGrub, "the first emission must resolve case-insensitive 'grub'");
+      const bodies = await game.physics.bodies({ entityId: firstGrub.id });
+      assert.equal(bodies.bodies.length, 1, "emitted Grub must have one live physics body");
+      assert.equal(bodies.bodies[0].body_type, "dynamic");
+      const [vx, , vz] = bodies.bodies[0].velocity;
+      assert.ok(vx < -8, `emitter 682 must launch along authored world -X, got vx=${vx}`);
+      assert.ok(Math.abs(vz) < 2, `emitter 682 must not rotate velocity into Z, got vz=${vz}`);
+
+      assert.equal((await game.save(midBurstSave)).success, true);
+      const newSounds = (await game.audio.recent()).sounds.filter(
+        (sound) => sound.sequence > sequenceBefore,
+      );
+      assert.ok(
+        newSounds.every((sound) => sound.sample.toLowerCase() !== "exphe2"),
+        `Grub emission must not substitute HE audio: ${JSON.stringify(newSounds)}`,
+      );
+    }
+
+    // A fresh process must restore one consumed frame and emit only the two
+    // remaining Grubs. The completed DestroyObject emitter is absent.
+    {
+      await using game = await GameServer.launch({
+        mission: "ops1.mis",
+        port: basePort + 1,
+      });
+      assert.equal((await game.load(midBurstSave)).success, true);
+      assert.equal((await game.info()).mission, "ops4.mis");
+      const [restoredGrub] = await game.entities.byTemplate(GRUB);
+      assert.ok(restoredGrub, "the first emitted Grub must survive the save");
+      const restoredBodies = await game.physics.bodies({ entityId: restoredGrub.id });
+      assert.equal(restoredBodies.bodies.length, 1);
+      assert.equal(
+        restoredBodies.bodies[0].body_type,
+        "dynamic",
+        "the launched-physics marker must survive save/load",
+      );
+
+      await waitForGrubCount(game, 3);
+      assert.equal(
+        (await game.entities.byTemplate(EMITTER)).length,
+        0,
+        "DestroyObject completion must consume emitter 682",
+      );
+      await game.step({ frames: 120 });
+      assert.equal(
+        (await game.entities.byTemplate(GRUB)).length,
+        3,
+        "completed emitter must not produce a fourth Grub",
+      );
+      assert.equal((await game.save(completedSave)).success, true);
+    }
+
+    // Completion is persisted too: revisiting the saved state neither restores
+    // the emitter nor rearms its burst.
+    {
+      await using game = await GameServer.launch({
+        mission: "ops1.mis",
+        port: basePort + 2,
+      });
+      assert.equal((await game.load(completedSave)).success, true);
+      assert.equal((await game.entities.byTemplate(EMITTER)).length, 0);
+      assert.equal((await game.entities.byTemplate(GRUB)).length, 3);
+      await game.step({ frames: 120 });
+      assert.equal((await game.entities.byTemplate(GRUB)).length, 3);
+    }
+  },
+);


### PR DESCRIPTION
Fixes #830

## Summary

- make Tweq emitters resolve their authored `emit_what` template case-insensitively instead of substituting `HE Explosion`
- launch emitted objects with authored world-space velocity, rotating it only when `TWEQ_MC_RELVEL` is set
- honor `DestroyObject`, keep unresolved templates fail-safe, and preserve mid-burst/completed emitter state across fresh-process save/load
- keep launched frobbable objects on their authored dynamic physics model and preserve that launch marker through saves

## Source fidelity

This follows Looking Glass's `TWEQCTRL.CPP` behavior: `launchProjectile` receives the authored velocity directly unless the `TWEQ_MC_RELVEL (1 << 8)` misc flag requests emitter-relative rotation. Ops4 emitters 682 and 689 both clear that bit, so their authored `[-25, 0, 0]` and `[10, 0, 0]` vectors remain world-space after Dark-to-runtime scale conversion.

`angle_random` remains deliberately deferred. Both real Ops4 repros author zero random angle, while faithful non-zero behavior needs a verified deterministic RNG/save contract rather than an ungrounded approximation.

## Verification

- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark` (73 unit + 9 mission tests)
- `cargo test -p shock2vr` (483 tests before the latest-main rebase; focused post-rebase launch test also green)
- `npm test`
- authentic Ops4 E2E through tripwire 662, including exact three-Grub budget, world-space velocity, no `exphe2`, real Junction 685 escape, mid-burst save/load, completed save/load, and restored dynamic body
- full SDK E2E exercised all 23 missions and passed the new Ops4 regression; 202 passed / 3 skipped, with one unrelated AI-search entity lookup failing transiently and its exact isolated rerun passing

## Visual verification

Actual `ops4.mis`, actual Tweq Trap 682, identical fixed-step request sequence. The debug-skeleton overlay makes the emitted Grub's moving bones 0–3 visible in the dark launch corridor; the baseline has no authored creature.

![Ops4 Tweq emitter before/after](https://gist.githubusercontent.com/tommy-xr/b34711daec9da21a393feb0aca91779c/raw/ops4-tweq-before-after.gif)

Still: [full-resolution PNG](https://gist.githubusercontent.com/tommy-xr/b34711daec9da21a393feb0aca91779c/raw/ops4-tweq-before-after.png)

## Campaign context

`custom ops→shodan · detailed · legacy · user-directed (no random seed)`
