### PR TITLE
fix(gameplay): consume collected audio logs

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2764,6 +2764,22 @@ impl MissionCore {
         }
     }
 
+    /// Consume an audio-log pickup while retaining its ECS entity as the
+    /// backing object for the currently open reader panel. Retail SS2 destroys
+    /// the disc after copying its log identity into the player's PDA; the
+    /// reader in this port is entity-bound, so removing its world presence is
+    /// the equivalent transition without invalidating the panel mid-frob.
+    ///
+    /// `PropHasRefs(false)` persists through mission save/load, removing the
+    /// model from rendering on both the current and reconstructed mission. The
+    /// physics body and any container link must also go immediately so neither
+    /// a world ray nor a corpse/locker loot panel can frob the disc again.
+    fn consume_log_pickup(&mut self, entity_id: EntityId) {
+        self.remove_incoming_contains_links(entity_id);
+        self.world.add_component(entity_id, PropHasRefs(false));
+        self.make_un_physical(entity_id);
+    }
+
     pub fn make_physical(&mut self, entity_id: EntityId) {
         let current_entity = self.id_to_physics.get(&entity_id);
         if current_entity.is_some() {
@@ -3627,6 +3643,10 @@ impl MissionCore {
                             },
                         );
                     }
+                    // Retail copies the entry into the PDA and destroys the
+                    // pickup. Keep only the entity-bound reader state; retire
+                    // the disc from the rendered, physical, frobbable world.
+                    self.consume_log_pickup(entity_id);
                 }
 
                 Effect::ToggleMap => {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -168,9 +168,10 @@ pub enum Effect {
     },
 
     /// Record an audio log the player just frobbed into the persistent
-    /// collection (`QuestInfo`) and resolve its transcript/portrait strings onto
-    /// the disc entity (`RuntimePropLogData`) for the reader panel. Emitted by
-    /// the log disc's `MediaGui` on frob. `entity_id` is the disc; `deck`/`log`
+    /// collection (`QuestInfo`), resolve its transcript/portrait strings onto
+    /// the disc entity (`RuntimePropLogData`) for the reader panel, then retire
+    /// the pickup's world presence. Emitted by the log disc's `MediaGui` on
+    /// frob. `entity_id` is retained only as reader backing state; `deck`/`log`
     /// key the `level<deck>.str` strings.
     CollectLog {
         entity_id: EntityId,

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -6,9 +6,9 @@
 //! host's single-slot MFD), and reads its presentation strings from
 //! `RuntimePropLogData` - attached by the `Effect::CollectLog` handler when the
 //! disc is frobbed (that handler also records the log into the persistent
-//! `QuestInfo` collection and plays its audio). Deliberate deviation from the
-//! original's destroy-on-pickup: the disc survives so the reader stays bound and
-//! the code is readable in-fiction (research gap #6).
+//! `QuestInfo` collection and retires the physical pickup). The ECS entity stays
+//! alive only as reader backing state so the entity-bound panel remains valid
+//! after the retail-faithful one-shot pickup disappears from the world.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::PropLog;
@@ -264,9 +264,9 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
             log,
         };
         // The original destroyed the disc after its first frob, so its
-        // SwitchLinks fired exactly once. The disc now survives for re-reading -
-        // keep that one-shot contract by firing the links only on the frob that
-        // first collects the log (replaying audio / reopening is fine).
+        // SwitchLinks fired exactly once. The backing entity remains alive but
+        // loses all world/container presence; keep the one-shot contract even
+        // for direct debug-message replays against that internal entity.
         let already_collected = world
             .borrow::<UniqueView<QuestInfo>>()
             .map(|q| q.has_collected_log(deck, log))

--- a/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// command2's Korenchkin "re: Miracles" log is a physical, world-present
+// mission object. Runtime ids change every launch, so discover it by its stable
+// mission-object id.
+const KORENCHKIN_LOG = 1584;
+
+test(
+  "command2: collecting the Korenchkin log consumes its world pickup",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8247),
+    });
+    await game.step({ frames: 5 });
+
+    const [disc] = await game.entities.byTemplate(KORENCHKIN_LOG);
+    assert.ok(disc, "command2 should contain Korenchkin's audio-log disc");
+    assert.ok(
+      (await game.physics.bodies({ entityId: disc.id })).bodies.length > 0,
+      "the uncollected disc should have physical world presence",
+    );
+
+    await game.entities.sendMessage(disc.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 6, log: 1 }],
+      "frobbing the disc should download its log into the player's PDA state",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: disc.id })).bodies.length,
+      0,
+      "a collected log must no longer have a frobbable world body",
+    );
+
+    // The consumed state is a real mission-state transition, not a transient
+    // rendering trick: it must survive rebuilding the mission from a save.
+    await game.save("log-pickup-consumption-e2e");
+    await game.load("log-pickup-consumption-e2e");
+    await game.step({ frames: 5 });
+    const [reloadedDisc] = await game.entities.byTemplate(KORENCHKIN_LOG);
+    assert.ok(reloadedDisc, "the hidden entity remains as reader backing state");
+    assert.equal(
+      (await game.physics.bodies({ entityId: reloadedDisc.id })).bodies.length,
+      0,
+      "the collected disc must stay out of the world after save/load",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-quest-bit.e2e.test.ts
@@ -54,9 +54,8 @@ test(
       "reading the log should grant Note_4_6 as an active (INCOMPLETE) objective",
     );
 
-    // Once the player has actually completed the objective, re-reading the disc
-    // (which survives, unlike the original's destroy-on-pickup) must leave it
-    // complete.
+    // Once the player has actually completed the objective, a direct debug
+    // replay against the hidden reader-backing entity must leave it complete.
     await game.quests.set("note_4_6", "complete");
     await game.entities.sendMessage(discs[0].id, { type: "Frob" });
     await game.step({ frames: 30 });


### PR DESCRIPTION
Fixes #797

## Summary

- Keep the existing `LogDiscScript` / `CollectLog` path that records the deck/log identity and resolves the reader content.
- Retire the collected disc from rendering, physics, and corpse/locker containment immediately after collection.
- Preserve only its hidden ECS entity as backing state for the entity-bound reader panel, including across save/load.

## Fidelity

Retail SS2's `UseLog` service copies the disc's log bit into the player's PDA state and destroys the pickup. This change performs that same in-world one-shot transition through the authored log script and central effect handler; it adds no debug action or mission-specific shortcut. The hidden entity is an internal accommodation for the port's current entity-bound reader panel and is no longer player-visible or frobbable.

## Tests

- Negative-first: the new command2 Korenchkin-log scenario failed on `origin/main` because the post-frob physics body count remained `1` instead of `0`.
- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (508 passed)
- `cd tools/shock2-sdk && npm test` (26 passed; 189 opt-in e2e skipped)
- Focused log/reader/creature-loot e2e scenarios (4 passed, legacy assets)
- New consumption + save/load e2e scenario (passed with legacy and 25th Anniversary assets)

## Campaign context

- Detecting session: legacy pre-roll Operations → SHODAN · detailed run · 25th Anniversary assets · no seed (pre-roll)
- Original issue ledger: engineering-through-shodan · none · legacy assets · seed 1378752978

## PR visuals

![Collected audio log disappears from the world](https://gist.githubusercontent.com/tommy-xr/4b156b8230c13dd21f8c117b0e4b3d1e/raw/audio-log-consumed.gif)

<sub>Collecting a representative world-present Engineering audio log through its real frob/script/effect flow consumes the disc. The loop is cropped to the world pickup so an unrelated, pre-existing reader-image frame flicker does not obscure the behavior under review. Captured headlessly at a deterministic fixed timestep with 25th Anniversary assets.</sub>

### Before → after

![Before and after audio-log pickup collection](https://gist.githubusercontent.com/tommy-xr/4b156b8230c13dd21f8c117b0e4b3d1e/raw/audio-log-before-after.png)

<sub>Same camera and request sequence on `origin/main` (left) and this fix (right): the complete reader remains open in both, while only the fixed build retires the collected disc. The representative Engineering log uses the same inherited `LogDiscScript` / `CollectLog` flow as the reported Korenchkin log, whose authored spawn is occluded by its containing corpse/debris.</sub>
