### PR TITLE
fix(gameplay): relay TriggerDamage switch links

### DIFF
--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -71,6 +71,7 @@ mod trap_trip_level;
 mod trap_tweq;
 mod trap_unlock;
 mod trigger_collide;
+mod trigger_damage;
 mod trigger_destroy;
 mod trigger_ecology;
 mod trigger_multi;
@@ -172,6 +173,7 @@ use self::{
     trap_tweq::TrapTweq,
     trap_unlock::TrapUnlock,
     trigger_collide::TriggerCollide,
+    trigger_damage::TriggerDamage,
     trigger_destroy::TriggerDestroy,
     trigger_ecology::TriggerEcology,
     trigger_multi::TriggerMulti,
@@ -878,7 +880,7 @@ impl ScriptWorld {
             "cs9_shodanscreen" => Box::new(CS9ShodanScreen::new()),
             "sitdownrightnowmp" => Box::new(SitDownRightNowMP::new()),
             "trapdestroyteleport" => Box::new(TrapDestroyTeleport::new()),
-            "triggerdamage" => Box::new(NoopScript::new()),
+            "triggerdamage" => Box::new(TriggerDamage::new()),
             // many.micontain
             "brain" => Box::new(NoopScript::new()),
             "wormheartimplant" => Box::new(NoopScript::new()),

--- a/shock2vr/src/scripts/trigger_damage.rs
+++ b/shock2vr/src/scripts/trigger_damage.rs
@@ -1,0 +1,114 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+
+pub struct TriggerDamage;
+
+impl TriggerDamage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for TriggerDamage {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::Damage { .. } => send_to_all_switch_links(
+                world,
+                entity_id,
+                MessagePayload::TurnOn { from: entity_id },
+            ),
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    #[test]
+    fn damage_relays_turn_on_to_every_switch_link() {
+        let mut world = World::new();
+        let first = world.add_entity(());
+        let second = world.add_entity(());
+        let unrelated = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![
+                ToLink {
+                    to_template_id: 1,
+                    to_entity_id: Some(WrappedEntityId(first)),
+                    link: Link::SwitchLink,
+                },
+                ToLink {
+                    to_template_id: 2,
+                    to_entity_id: Some(WrappedEntityId(second)),
+                    link: Link::SwitchLink,
+                },
+                ToLink {
+                    to_template_id: 3,
+                    to_entity_id: Some(WrappedEntityId(unrelated)),
+                    link: Link::Contains(0),
+                },
+            ],
+        });
+        let mut script = TriggerDamage::new();
+
+        let effect = script.handle_message(
+            trigger,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Damage {
+                amount: 1.0,
+                impact: None,
+            },
+        );
+        let effects = match effect {
+            Effect::Combined { effects } => effects,
+            other => panic!("expected relayed messages, got {other:?}"),
+        };
+
+        assert_eq!(effects.len(), 2);
+        for (effect, target) in effects.iter().zip([first, second]) {
+            match effect {
+                Effect::Send { msg } => {
+                    assert_eq!(msg.to, target);
+                    assert!(matches!(
+                        msg.payload,
+                        MessagePayload::TurnOn { from } if from == trigger
+                    ));
+                }
+                other => panic!("expected TurnOn message, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn non_damage_messages_are_inert() {
+        let mut world = World::new();
+        let target = world.add_entity(());
+        let trigger = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 1,
+                to_entity_id: Some(WrappedEntityId(target)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let mut script = TriggerDamage::new();
+
+        let effect =
+            script.handle_message(trigger, &world, &PhysicsWorld::new(), &MessagePayload::Frob);
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/tools/shock2-sdk/test/ops2-trigger-damage.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops2-trigger-damage.e2e.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const RED_ASSASSIN = 254;
+const NINJA_RUN_01 = 385;
+const NINJA_RUN_02 = 386;
+const NINJA_RUN_TRAP = 388;
+const DESTROY_NINJA_TRAP = 389;
+
+function only<T>(matches: T[], label: string): T {
+  assert.equal(matches.length, 1, `expected one ${label}`);
+  return matches[0]!;
+}
+
+function prop(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((property) => property.name === name)?.value;
+}
+
+function horizontalDistance(a: number[], b: number[]): number {
+  return Math.hypot(a[0]! - b[0]!, a[2]! - b[2]!);
+}
+
+test(
+  "ops2: damaging the Red Assassin starts its authored Ninja Run sequence",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8486),
+    });
+    await game.step({ frames: 5 });
+
+    // Concrete mission-object ids are stable handles; runtime entity ids are
+    // discovered afresh on every launch.
+    const assassin = only(
+      await game.entities.byTemplate(RED_ASSASSIN),
+      "Red Assassin mission object 254",
+    );
+    const waypoint01 = only(
+      await game.entities.byTemplate(NINJA_RUN_01),
+      "Ninja Run 01 mission object 385",
+    );
+    only(
+      await game.entities.byTemplate(NINJA_RUN_02),
+      "Ninja Run 02 mission object 386",
+    );
+    only(
+      await game.entities.byTemplate(NINJA_RUN_TRAP),
+      "Ninja Run Trap mission object 388",
+    );
+    only(
+      await game.entities.byTemplate(DESTROY_NINJA_TRAP),
+      "Destroy Ninja Trap mission object 389",
+    );
+
+    const before = await game.entities.detail(assassin.id);
+    const hitPointsBefore = Number(prop(before, "HitPoints"));
+    const initialDistance01 = horizontalDistance(before.position, waypoint01.position);
+    assert.equal(prop(before, "AIBehavior"), "Idle");
+    assert.ok(Number.isFinite(hitPointsBefore));
+
+    // Stay at the untouched mission spawn, before proximity tripwire 378.
+    // Damage is the production payload a successful weapon hit delivers; this
+    // scenario deliberately isolates the script/trap chain from aiming and
+    // projectile collision.
+    await game.entities.sendMessage(assassin.id, { type: "Damage", amount: 1 });
+    await game.step({ frames: 6 });
+
+    const afterDamage = await game.entities.detail(assassin.id);
+    assert.equal(Number(prop(afterDamage, "HitPoints")), hitPointsBefore - 1);
+    assert.equal(
+      prop(afterDamage, "AIBehavior"),
+      "ScriptedSequence",
+      "TriggerDamage must relay TurnOn to trap 388, which signals Ninja Run",
+    );
+
+    let closestDistance01 = initialDistance01;
+    let signalTrapDestroyed = false;
+    const samples: EntitySummary[] = [];
+
+    // Follow the real two-waypoint sequence through its authored final Frob.
+    // Sample coarsely because A* queries complete on a worker thread.
+    for (let second = 0; second < 75; second += 1) {
+      await game.step({ frames: 60 });
+      const current = only(
+        await game.entities.byTemplate(RED_ASSASSIN),
+        "living Red Assassin mission object 254",
+      );
+      samples.push(current);
+      closestDistance01 = Math.min(
+        closestDistance01,
+        horizontalDistance(current.position, waypoint01.position),
+      );
+      signalTrapDestroyed =
+        (await game.entities.byTemplate(NINJA_RUN_TRAP)).length === 0;
+      if (signalTrapDestroyed) break;
+    }
+
+    assert.ok(
+      closestDistance01 < initialDistance01 - 1.5,
+      `assassin must make progress toward Ninja Run 01; initial=${initialDistance01}, closest=${closestDistance01}, samples=${JSON.stringify(
+        samples.map((sample) => sample.position),
+      )}`,
+    );
+    assert.equal(
+      signalTrapDestroyed,
+      true,
+      "the sequence's authored Destroy Ninja Trap Frob must consume trap 388",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- replace the `TriggerDamage` no-op registration with an ordinary pure script
- relay `TurnOn` to every authored `SwitchLink` on `Damage`, preserving the damaged entity as the sender
- keep unrelated messages inert and avoid mission-, creature-, or AI-sequence-specific behavior
- add an ops2 runtime regression that follows the authored Red Assassin → Ninja Run Trap → AI signal → scripted waypoint/Frob flow

## Faithfulness

This does not invoke Ninja Run directly or special-case Operations' Red Assassin. Mission object 254's authored `TriggerDamage` sends through its existing SwitchLink to trap 388; `TrapSignal` then delivers the existing `Ninja Run` signal and the assassin's authored response owns the visible behavior.

The runtime scenario starts from a fresh `ops2.mis` spawn before proximity tripwire 378, discovers mission object 254's runtime entity dynamically, and injects one nonlethal `Damage` message. That is the production script payload delivered by a successful weapon hit, but the scenario intentionally isolates TriggerDamage/trap behavior and does not claim generic weapon aiming or collision coverage.

## Testing

- negative-first: focused unit test failed with `NoEffect` before implementation
- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (510 passed)
- `npm test` in `tools/shock2-sdk` (26 passed, 189 opt-in tests skipped)
- focused `ops2-trigger-damage.e2e.test.ts` with 25th Anniversary assets (passed)

## Visual evidence

Captured from identical fresh `ops2.mis` request sequences with 25th Anniversary assets. The baseline uses ordinary Chase after damage; the fix runs the real authored Ninja Run response.

![TriggerDamage authored response before and after](https://gist.githubusercontent.com/tommy-xr/582a7004aab15e81e49dd26164b5a4f3/raw/trigger-damage-before-after.gif)

<sub>Same fresh mission, camera, Damage message, and fixed-timestep stepping. Captured headlessly through `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Before ordinary Chase; after authored Ninja Run](https://gist.githubusercontent.com/tommy-xr/582a7004aab15e81e49dd26164b5a4f3/raw/trigger-damage-before-after.png)

Fixes #836
