### PR TITLE
fix(rendering): honor LGMD material texture redirects

### DIFF
--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -24,13 +24,14 @@ use tracing::{trace, warn};
 
 use crate::{
     SCALE_FACTOR,
+    importers::TEXTURE_IMPORTER,
     ss2_bin_header::SystemShock2BinHeader,
     ss2_common::{
         self, read_array_u16, read_bytes, read_i16, read_i32, read_matrix, read_packed_normal,
         read_point3, read_single, read_string_with_size, read_u8, read_u16, read_u32, read_vec3,
     },
     ss2_skeleton::{Bone, Skeleton},
-    util::load_multiple_textures_for_model,
+    util::{load_multiple_textures_for_model, resolve_object_material_texture_name},
 };
 
 // Dark LGMD polygons use clockwise front faces.
@@ -164,16 +165,19 @@ pub fn to_scene_objects(
                 tex_path = "soft12 .pcx".to_owned();
             }
 
-            let maybe_texture = crate::util::load_texture_with_fallback(asset_cache, &tex_path);
-
-            if maybe_texture.is_none() {
+            let Some(resolved_tex_path) =
+                resolve_object_material_texture_name(asset_cache, &tex_path)
+            else {
                 // Dropping the slot here makes part (or all) of a prop silently
                 // vanish from the world, so it is worth surfacing.
                 warn!("no texture for material \"{tex_path}\"; dropping mesh slot {slot}");
                 return None;
-            }
+            };
 
-            let texture = maybe_texture.unwrap();
+            let Some(texture) = asset_cache.get_opt(&TEXTURE_IMPORTER, &resolved_tex_path) else {
+                warn!("could not load resolved texture \"{resolved_tex_path}\"; dropping mesh slot {slot}");
+                return None;
+            };
 
             let geometry: Rc<Box<dyn engine::scene::Geometry>> = if is_skinned {
                 Rc::new(Box::new(engine::scene::mesh::create(verts)))

--- a/dark/src/util/mod.rs
+++ b/dark/src/util/mod.rs
@@ -4,7 +4,7 @@ use cgmath::{InnerSpace, Point3, point3};
 use collision::Sphere;
 pub use merge_maps::*;
 
-use std::{path::Path, rc::Rc};
+use std::{io::Read, path::Path, rc::Rc};
 
 use engine::{assets::asset_cache::AssetCache, texture::Texture};
 use tracing::trace;
@@ -54,6 +54,108 @@ pub fn resolve_texture_name(asset_cache: &AssetCache, requested: &str) -> Option
         trace!("texture {requested} resolved to {resolved}");
     }
     Some(resolved)
+}
+
+/// Resolve the diffuse texture used by a Dark LGMD object material.
+///
+/// 25th Anniversary replacement models can attach a `.mtl` render-material
+/// script to the material name. The primary pass may select a different
+/// texture from the same-named bitmap.
+pub fn resolve_object_material_texture_name(
+    asset_cache: &AssetCache,
+    requested: &str,
+) -> Option<String> {
+    let redirected = object_material_primary_texture(asset_cache, requested);
+    let texture_name = redirected.as_deref().unwrap_or(requested);
+    let resolved = resolve_texture_name(asset_cache, texture_name);
+
+    if redirected.is_some() && resolved.is_none() {
+        return resolve_texture_name(asset_cache, requested);
+    }
+
+    resolved
+}
+
+fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) -> Option<String> {
+    let stem = Path::new(requested).with_extension("");
+    let stem = stem.to_str()?.to_ascii_lowercase();
+    let candidates = [
+        format!("{TEXTURE_SUBDIR}/{stem}.mtl"),
+        format!("{stem}.mtl"),
+    ];
+    let script_name = asset_cache
+        .asset_paths()
+        .resolve_first(asset_cache.base_path().to_owned(), &candidates)?;
+
+    let reader = asset_cache.get_raw_reader(&script_name)?;
+    let mut script = String::new();
+    reader.borrow_mut().read_to_string(&mut script).ok()?;
+    let texture = primary_render_pass_texture(&script)?;
+    trace!("object material {requested} primary pass redirects to {texture}");
+    Some(texture)
+}
+
+fn primary_render_pass_texture(script: &str) -> Option<String> {
+    let mut in_render_pass = false;
+    let mut saw_open_brace = false;
+    let mut brace_depth = 0_i32;
+
+    for raw_line in script.lines() {
+        let line = raw_line
+            .split_once("//")
+            .map_or(raw_line, |(code, _)| code)
+            .trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if !in_render_pass {
+            let directive = line.split_whitespace().next()?;
+            if !directive.eq_ignore_ascii_case("render_pass") {
+                continue;
+            }
+            in_render_pass = true;
+        }
+
+        let mut fields = line.split_whitespace();
+        if fields
+            .next()
+            .is_some_and(|field| field.eq_ignore_ascii_case("texture"))
+        {
+            let texture = fields.next()?.trim_matches('"');
+            if texture.eq_ignore_ascii_case("$texture") {
+                return None;
+            }
+            return normalize_material_texture_reference(texture);
+        }
+
+        brace_depth += line.chars().filter(|character| *character == '{').count() as i32;
+        if line.contains('{') {
+            saw_open_brace = true;
+        }
+        brace_depth -= line.chars().filter(|character| *character == '}').count() as i32;
+        if saw_open_brace && brace_depth <= 0 {
+            return None;
+        }
+    }
+
+    None
+}
+
+fn normalize_material_texture_reference(reference: &str) -> Option<String> {
+    let normalized = reference.replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+    let relative = if lower.starts_with("obj/txt16/") {
+        &normalized["obj/txt16/".len()..]
+    } else if lower.starts_with("obj/") {
+        &normalized["obj/".len()..]
+    } else if lower.starts_with("fam/") {
+        &normalized["fam/".len()..]
+    } else {
+        &normalized
+    };
+
+    (!relative.is_empty()).then(|| relative.to_owned())
 }
 
 /// Family archives keep their textures in this subdirectory (`obj/txt16/...`,
@@ -175,4 +277,85 @@ pub fn compute_bounding_sphere(vertices: &Vec<Point3<f32>>) -> Sphere<f32> {
     }
 
     sphere
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::HashMap, io::Cursor};
+
+    use engine::assets::{
+        asset_cache::AssetCache,
+        asset_paths::{AbstractAssetPath, ReadableAndSeekable},
+    };
+
+    use super::resolve_object_material_texture_name;
+
+    struct FakeAssetPath(HashMap<String, Vec<u8>>);
+
+    impl AbstractAssetPath for FakeAssetPath {
+        fn exists(&self, _base_path: String, asset_name: String) -> bool {
+            self.0.contains_key(&asset_name)
+        }
+
+        fn get_reader(
+            &self,
+            _base_path: String,
+            asset_name: String,
+        ) -> Option<RefCell<Box<dyn ReadableAndSeekable>>> {
+            let bytes = self.0.get(&asset_name)?.clone();
+            Some(RefCell::new(Box::new(Cursor::new(bytes))))
+        }
+    }
+
+    fn cache(assets: &[(&str, &[u8])]) -> AssetCache {
+        let assets = assets
+            .iter()
+            .map(|(name, bytes)| ((*name).to_owned(), bytes.to_vec()))
+            .collect();
+        AssetCache::new(String::new(), Box::new(FakeAssetPath(assets)))
+    }
+
+    #[test]
+    fn object_material_uses_primary_mtl_render_pass_texture() {
+        let asset_cache = cache(&[
+            (
+                "txt16/nd-airlock_scr.mtl",
+                b"render_material_only 1\nrender_pass\n{\n texture OBJ\\TXT16\\ND-airlock_2\n shaded 0\n}\n",
+            ),
+            ("txt16/nd-airlock_scr.dds", b"magenta helper"),
+            ("txt16/nd-airlock_2.dds", b"opaque door atlas"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "ND-airlock_scr"),
+            Some("txt16/nd-airlock_2.dds".to_owned())
+        );
+    }
+
+    #[test]
+    fn object_material_without_mtl_keeps_ordinary_opaque_texture() {
+        let asset_cache = cache(&[("txt16/panel.dds", b"opaque panel")]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/panel.dds".to_owned())
+        );
+    }
+
+    #[test]
+    fn object_material_texture_macro_keeps_the_authored_default() {
+        let asset_cache = cache(&[
+            (
+                "txt16/panel.mtl",
+                b"render_pass\n{\n texture $TEXTURE\n}\nrender_pass\n{\n texture OBJ\\TXT16\\reflection\n}\n",
+            ),
+            ("txt16/panel.dds", b"opaque panel"),
+            ("txt16/reflection.dds", b"reflection map"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/panel.dds".to_owned())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- honor explicit primary-pass texture redirects from 25th Anniversary `.mtl` scripts for LGMD object materials
- preserve the ordinary same-name texture for no-script and `$TEXTURE` primary-pass materials
- keep the change scoped to object-model loading, leaving terrain and UI texture defaults unchanged

## Root cause

The reported magenta slabs are material slot 1 of the 25th Anniversary replacement `AIR002.BIN`. Its LGMD material name is `ND-airlock_scr`, while `ND-airlock_scr.mtl` declares `OBJ\TXT16\ND-airlock_2` as the first render pass's texture. The loader ignored that script and resolved the same-stem `ND-airlock_scr.dds`, which is an opaque 32×32 magenta helper texture.

The issue's original palette-index hypothesis was falsified during triage: legacy is already correct, the active 25th assets are DDS, and both PCX index-alpha and generic chroma-key experiments left the scene unchanged. Issue #837 has been corrected to document the proven asset flow.

## Verification

- Negative-first: `object_material_uses_primary_mtl_render_pass_texture` selected `txt16/nd-airlock_scr.dds` on base, then `txt16/nd-airlock_2.dds` with this change.
- Controls: ordinary opaque/no-script materials and `$TEXTURE` primary-pass materials retain their default texture.
- `cargo fmt --check --all`
- `RUSTFLAGS='-D warnings' cargo check -p dark -p shock2vr -p desktop_runtime -p debug_runtime -p dark_viewer -p dark_query`
- `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked RUSTFLAGS='-D warnings' cargo test -p dark -p shock2vr` (80 dark + 9 mission-loading + 508 shock2vr tests)
- Deterministic `ops2.mis` debug-runtime capture at `(30.20, -8.36, 7.30)` on base and fix refs with the identical `/v1/step` + `/v1/screenshot` request sequence.
- Legacy control remained visually unchanged (one-pixel raster jitter); 25th changed only around the affected replacement display and adjacent atlas surface.

## Campaign context

Operations → SHODAN · detailed · 25th Anniversary assets · legacy pre-roll / no seed.

## Visual assessment

Player-visible rendering change: **yes**. A looping GIF and labeled before/after PNG were captured headlessly with the deterministic debug runtime and are embedded below.

![25th Anniversary airlock material redirect demo](https://gist.githubusercontent.com/tommy-xr/af6d039350d8f98d61ffe2fe98230a88/raw/pr837-lgmd-mtl-demo.gif)

<sub>The replacement airlock display alternates between the ignored-material-script result and the authored primary-pass texture. Captured headlessly in `ops2.mis` via deterministic fixed-timestep `/v1/step` + `/v1/screenshot` requests.</sub>

### Before → after

![Before and after: magenta helper DDS replaced by readable airlock display](https://gist.githubusercontent.com/tommy-xr/af6d039350d8f98d61ffe2fe98230a88/raw/pr837-lgmd-mtl-before-after.png)

Fixes #837
