### PR TITLE
feat(gameplay): implement security computer hacking

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -292,6 +292,12 @@ pub struct PropMapText(pub String);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropHackText(pub String);
 
+/// Authored security-hack duration (`P$HackTime`), in milliseconds. Dark defines
+/// this as an integer property; `SecurityComputer` scales it by Cyber before
+/// writing the resulting expiration to the player.
+#[derive(Debug, Component, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PropHackTime(pub i32);
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropMapObjIcon(pub String);
 
@@ -1578,6 +1584,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$HackText",
             read_variable_length_string,
             PropHackText,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$HackTime",
+            |reader, _len| read_i32(reader),
+            PropHackTime,
             accumulator::latest,
         ),
         define_prop(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3243,6 +3243,11 @@ impl MissionCore {
     ) -> Vec<Effect> {
         let _ = self.world.remove_unique::<Time>();
         self.world.add_unique(time.clone());
+        if time.elapsed.as_secs_f32() > 0.0
+            && let Ok(mut quests) = self.world.borrow::<UniqueViewMut<QuestInfo>>()
+        {
+            quests.advance_security_hack(time.elapsed.as_secs_f32());
+        }
 
         // Old saves can legitimately restore a zero-HP player even though
         // PlayerLifeState itself is runtime-only. Enter death on the first
@@ -7354,6 +7359,18 @@ impl MissionCore {
                         });
                         game_log!(INFO, "Psi power active: {} ({}s)", name, duration_secs);
                     }
+                }
+
+                Effect::ActivateSecurityHack { duration_seconds } => {
+                    self.world
+                        .borrow::<UniqueViewMut<QuestInfo>>()
+                        .unwrap()
+                        .activate_security_hack(duration_seconds);
+                    game_log!(
+                        INFO,
+                        "Security devices disabled for {} seconds.",
+                        duration_seconds
+                    );
                 }
 
                 Effect::AwardXP { amount } => {

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -53,6 +53,12 @@ pub struct QuestInfo {
     /// Campaign-wide research progress, keyed by stable gamesys archetype.
     #[serde(default)]
     research: ResearchState,
+    /// Remaining global security-hack window in seconds. Retail stores the
+    /// absolute expiration on the player (`HackTime`) and makes that player
+    /// invisible to camera-class device vision; remaining time is the
+    /// save/load-safe equivalent for this runtime's reset-on-load clock.
+    #[serde(default)]
+    security_hack_seconds_remaining: f32,
 }
 
 impl QuestInfo {
@@ -65,7 +71,25 @@ impl QuestInfo {
             collected_logs: Vec::new(),
             explored_maps: HashMap::new(),
             research: ResearchState::default(),
+            security_hack_seconds_remaining: 0.0,
         }
+    }
+
+    pub fn activate_security_hack(&mut self, duration_seconds: f32) {
+        self.security_hack_seconds_remaining = duration_seconds.max(0.0);
+    }
+
+    pub fn advance_security_hack(&mut self, elapsed_seconds: f32) {
+        self.security_hack_seconds_remaining =
+            (self.security_hack_seconds_remaining - elapsed_seconds.max(0.0)).max(0.0);
+    }
+
+    pub fn security_hack_seconds_remaining(&self) -> f32 {
+        self.security_hack_seconds_remaining
+    }
+
+    pub fn security_hack_active(&self) -> bool {
+        self.security_hack_seconds_remaining > 0.0
     }
 
     pub fn research(&self) -> &ResearchState {
@@ -331,5 +355,40 @@ mod log_tests {
                 read: false
             }
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QuestInfo;
+
+    #[test]
+    fn security_hack_timer_expires_after_its_remaining_duration() {
+        let mut quests = QuestInfo::new();
+        quests.activate_security_hack(12.0);
+        quests.advance_security_hack(4.5);
+        assert_eq!(quests.security_hack_seconds_remaining(), 7.5);
+        assert!(quests.security_hack_active());
+
+        quests.advance_security_hack(8.0);
+        assert_eq!(quests.security_hack_seconds_remaining(), 0.0);
+        assert!(!quests.security_hack_active());
+    }
+
+    #[test]
+    fn security_hack_timer_survives_save_round_trip_and_old_saves_default_inactive() {
+        let mut quests = QuestInfo::new();
+        quests.activate_security_hack(42.25);
+        let encoded = serde_json::to_value(&quests).unwrap();
+        let restored: QuestInfo = serde_json::from_value(encoded.clone()).unwrap();
+        assert_eq!(restored.security_hack_seconds_remaining(), 42.25);
+
+        let mut legacy = encoded;
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("security_hack_seconds_remaining");
+        let restored: QuestInfo = serde_json::from_value(legacy).unwrap();
+        assert!(!restored.security_hack_active());
     }
 }

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -9,7 +9,7 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::{
     mission::PlayerInfo,
     physics::PhysicsWorld,
-    scripts::{Effect, ai::ai_util, speech_util},
+    scripts::{Effect, ai::ai_util, security_computer, speech_util},
     time::Time,
 };
 
@@ -447,13 +447,14 @@ impl Script for CameraAI {
             let effective_heading = Deg(self.state.view_angle + 90.0);
 
             // Check visibility with FOV constraint
-            is_visible = ai_util::is_player_visible_in_fov(
-                entity_id,
-                world,
-                physics,
-                effective_heading,
-                CAMERA_FOV_HALF_ANGLE,
-            );
+            is_visible = security_computer::security_devices_can_detect_player(world)
+                && ai_util::is_player_visible_in_fov(
+                    entity_id,
+                    world,
+                    physics,
+                    effective_heading,
+                    CAMERA_FOV_HALF_ANGLE,
+                );
 
             if is_visible {
                 let v_pos = world.borrow::<View<PropPosition>>().unwrap();

--- a/shock2vr/src/scripts/ai/turret_ai.rs
+++ b/shock2vr/src/scripts/ai/turret_ai.rs
@@ -11,6 +11,7 @@ use super::{
     alertness::{self, AlertnessState, AlertnessTimings},
     steering::{ChasePlayerSteeringStrategy, SteeringStrategy},
 };
+use crate::scripts::security_computer;
 
 pub enum TurretState {
     Closed,
@@ -235,13 +236,14 @@ impl Script for TurretAI {
         // Turret FOV is 30 degrees half-angle (matches FovDebugConfig::turret())
         // Turret uses joint transforms for rotation, negate heading to match visual direction
         const TURRET_FOV_HALF_ANGLE: f32 = 30.0;
-        let is_visible = ai_util::is_player_visible_in_fov(
-            entity_id,
-            world,
-            physics,
-            self.initial_yaw - self.current_heading,
-            TURRET_FOV_HALF_ANGLE,
-        );
+        let is_visible = security_computer::security_devices_can_detect_player(world)
+            && ai_util::is_player_visible_in_fov(
+                entity_id,
+                world,
+                physics,
+                self.initial_yaw - self.current_heading,
+                TURRET_FOV_HALF_ANGLE,
+            );
 
         // Update alertness state
         let alertness_effect = if let Some(config) = &self.config {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -488,6 +488,14 @@ pub enum Effect {
         duration_secs: f32,
     },
 
+    /// Apply the retail global security-hack window. The authored
+    /// `SecurityComputer` duration has already been scaled by Cyber; while the
+    /// window is active, camera-class security devices cannot detect the
+    /// player.
+    ActivateSecurityHack {
+        duration_seconds: f32,
+    },
+
     /// Set the psi amp's hold-to-overload meter state
     /// (`RuntimePropPsiCharge`) on the amp entity - drives the HUD meter and
     /// debug introspection while a charge is in progress or flashing its

--- a/shock2vr/src/scripts/gui/computer.rs
+++ b/shock2vr/src/scripts/gui/computer.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use cgmath::{Vector2, Vector3, vec2};
 use dark::{
     properties::{
-        Link, Links, ObjectState, PropHackDiff, PropHackText, PropTemplateId, ToLink,
+        Link, Links, ObjectState, PropHackDiff, PropHackText, PropHackTime, PropTemplateId, ToLink,
         WrappedEntityId,
     },
     ss2_entity_info::SystemShock2EntityInfo,
@@ -13,7 +13,7 @@ use shipyard::{EntityId, Get, IntoIter, IntoWithId, Unique, UniqueView, View, Wo
 
 use crate::{
     gui::{Gui, GuiComponent, GuiConfig, GuiCursor},
-    scripts::{Effect, Message, MessagePayload, script_util::*},
+    scripts::{Effect, Message, MessagePayload, script_util::*, security_computer},
 };
 
 use super::keypad::{
@@ -48,7 +48,7 @@ impl ComputerContext {
     }
 }
 
-/// Older saves made before `P$HackText` / `L$HackingLi` were parsed cannot
+/// Older saves made before `P$HackText` / `P$HackTime` / `L$HackingLi` were parsed cannot
 /// contain those components. Restore them from the same authored object data
 /// used for a fresh mission, so such a save retains Computer instructions and
 /// the genuine downstream hacking circuit.
@@ -78,6 +78,18 @@ pub(crate) fn restore_authored_computer_data(
             && let Some(text) = hydrate_template_component::<PropHackText>(template_id, entity_info)
         {
             world.add_component(entity_id, text);
+        }
+
+        let has_hack_time = world
+            .borrow::<View<PropHackTime>>()
+            .unwrap()
+            .get(entity_id)
+            .is_ok();
+        if !has_hack_time
+            && let Some(hack_time) =
+                hydrate_template_component::<PropHackTime>(template_id, entity_info)
+        {
+            world.add_component(entity_id, hack_time);
         }
 
         let has_hacking_link = world
@@ -119,7 +131,36 @@ pub(crate) fn restore_authored_computer_data(
     }
 }
 
-pub struct ComputerGui;
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ComputerKind {
+    #[default]
+    Ordinary,
+    Security,
+}
+
+pub struct ComputerGui {
+    kind: ComputerKind,
+}
+
+impl ComputerGui {
+    pub fn new() -> Self {
+        Self {
+            kind: ComputerKind::Ordinary,
+        }
+    }
+
+    pub fn security() -> Self {
+        Self {
+            kind: ComputerKind::Security,
+        }
+    }
+}
+
+impl Default for ComputerGui {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct ComputerState {
@@ -252,18 +293,25 @@ impl Gui<ComputerState, ComputerMsg> for ComputerGui {
             return (state.clone(), Effect::NoEffect);
         };
         let ComputerMsg::Hack(msg) = msg;
-        let (hack, effect) = handle_hack_msg(
-            entity_id,
-            world,
-            &state.hack,
-            msg,
-            diff,
-            HackOutcomeEffects {
+        let outcomes = match self.kind {
+            ComputerKind::Ordinary => HackOutcomeEffects {
                 success: computer_hack_success,
                 critical_failure: computer_hack_critical_failure,
             },
-        );
+            ComputerKind::Security => HackOutcomeEffects {
+                success: security_computer::successful_hack,
+                critical_failure: security_computer::critical_failure,
+            },
+        };
+        let (hack, effect) = handle_hack_msg(entity_id, world, &state.hack, msg, diff, outcomes);
         (ComputerState { hack }, effect)
+    }
+
+    fn on_frob(&self, entity_id: EntityId, world: &World) -> Effect {
+        match self.kind {
+            ComputerKind::Ordinary => Effect::NoEffect,
+            ComputerKind::Security => security_computer::normal_frob(world, entity_id),
+        }
     }
 
     fn opens_on_frob(&self, entity_id: EntityId, world: &World) -> bool {
@@ -363,7 +411,7 @@ mod tests {
 
     #[test]
     fn broken_and_hacked_computers_do_not_reopen() {
-        let gui = ComputerGui;
+        let gui = ComputerGui::new();
         for state in [ObjectState::Broken, ObjectState::Hacked] {
             let mut world = World::new();
             let computer = world.add_entity((
@@ -388,7 +436,7 @@ mod tests {
 
     #[test]
     fn reopening_preserves_only_an_in_progress_hack() {
-        let gui = ComputerGui;
+        let gui = ComputerGui::new();
         let mut state = ComputerState {
             hack: HackState {
                 phase: HackPhase::Playing,

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -56,6 +56,7 @@ mod reroute_elevator_button;
 mod researchable;
 mod room_trigger;
 pub mod script_util;
+mod security_computer;
 mod setup_initial_debrief;
 mod std_door;
 mod tool_consumable;
@@ -1105,7 +1106,7 @@ impl ScriptWorld {
             // partially implemented:
             "keypadunhackable" => gui_script(Box::new(KeyPadGui)),
             "keypad" => gui_script(Box::new(KeyPadGui)),
-            "securitycomputer" => Box::new(UnimplementedScript::new(&script_name)),
+            "securitycomputer" => gui_script(Box::new(ComputerGui::security())),
             "resurrectmachine" => Box::new(BaseButton {}),
             "twostatebutton" => Box::new(BaseButton::new()),
 
@@ -1154,7 +1155,7 @@ impl ScriptWorld {
             "medpatchscript" => Box::new(HealingItemScript::new(HealingItemKind::MedPatch)),
             "psikitscript" => Box::new(PsiKitScript::new()),
             "psimine" => Box::new(PsiMine::new()),
-            "computer" => gui_script(Box::new(ComputerGui)),
+            "computer" => gui_script(Box::new(ComputerGui::new())),
             "lightsoundon" => Box::new(NoopScript::new()),
             "hackablecrate" => gui_script(Box::new(HackableCrateGui::new())),
             "turret" => Box::new(UnimplementedScript::new(&script_name)),

--- a/shock2vr/src/scripts/security_computer.rs
+++ b/shock2vr/src/scripts/security_computer.rs
@@ -1,0 +1,180 @@
+use dark::properties::{Link, ObjectState, PropEcoState, PropEcology, PropHackTime, PropObjState};
+use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
+
+use crate::quest_info::QuestInfo;
+
+use super::{Effect, Message, MessagePayload, script_util::get_all_links_of_type};
+
+const ECOLOGY_STATE_ALERT: i32 = 2;
+
+pub(crate) fn reset_active_alarms(world: &World, sender: EntityId) -> Effect {
+    let Ok((ecologies, states)) = world.borrow::<(View<PropEcology>, View<PropEcoState>)>() else {
+        return Effect::NoEffect;
+    };
+    Effect::combine(
+        (&ecologies, &states)
+            .iter()
+            .with_id()
+            .filter(|(_, (_, state))| state.0 == ECOLOGY_STATE_ALERT)
+            .map(|(ecology, _)| Effect::Send {
+                msg: Message {
+                    to: ecology,
+                    payload: MessagePayload::Reset { from: sender },
+                },
+            })
+            .collect(),
+    )
+}
+
+pub(crate) fn normal_frob(world: &World, computer: EntityId) -> Effect {
+    let state = world
+        .borrow::<View<PropObjState>>()
+        .ok()
+        .and_then(|states| states.get(computer).ok().map(|state| state.0))
+        .unwrap_or(ObjectState::Normal);
+    if state == ObjectState::Normal {
+        reset_active_alarms(world, computer)
+    } else {
+        Effect::NoEffect
+    }
+}
+
+pub(crate) fn successful_hack(computer: EntityId, world: &World) -> Effect {
+    let authored_seconds = world
+        .borrow::<View<PropHackTime>>()
+        .ok()
+        .and_then(|times| times.get(computer).ok().map(|time| time.0))
+        .unwrap_or_default();
+    let cyber = world
+        .borrow::<UniqueView<QuestInfo>>()
+        .ok()
+        .map(|quest| quest.player_stats().cyber_affinity)
+        .unwrap_or(1);
+    let duration_seconds = authored_seconds.saturating_mul(cyber).max(0) as f32 / 1_000.0;
+
+    Effect::combine(vec![
+        reset_active_alarms(world, computer),
+        Effect::ActivateSecurityHack { duration_seconds },
+    ])
+}
+
+pub(crate) fn critical_failure(computer: EntityId, world: &World) -> Effect {
+    let mut effects = vec![Effect::SetObjectState {
+        entity_id: computer,
+        state: ObjectState::Broken,
+    }];
+    effects.extend(
+        get_all_links_of_type(world, computer, Link::SwitchLink)
+            .into_iter()
+            .map(|to| Effect::Send {
+                msg: Message {
+                    to,
+                    payload: MessagePayload::Alarm { from: computer },
+                },
+            }),
+    );
+    Effect::combine(effects)
+}
+
+pub(crate) fn security_devices_can_detect_player(world: &World) -> bool {
+    world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|quest| !quest.security_hack_active())
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use dark::properties::{
+        Link, Links, PropEcoState, PropEcology, PropHackTime, ToLink, WrappedEntityId,
+    };
+    use shipyard::World;
+
+    use super::*;
+    use crate::scripts::MessagePayload;
+
+    fn ecology() -> PropEcology {
+        PropEcology {
+            period_seconds: 15.0,
+            min_count: [0; 3],
+            max_count: [0; 3],
+            recovery_seconds: [0.0, 0.0, 30.0],
+            random_chance: [0; 3],
+        }
+    }
+
+    #[test]
+    fn global_alarm_reset_targets_only_alert_ecologies() {
+        let mut world = World::new();
+        let sender = world.add_entity(());
+        let alert = world.add_entity((ecology(), PropEcoState(2)));
+        let _normal = world.add_entity((ecology(), PropEcoState(0)));
+
+        let effects = Effect::flatten(vec![reset_active_alarms(&world, sender)]);
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            &effects[0],
+            Effect::Send { msg }
+                if msg.to == alert
+                    && matches!(msg.payload, MessagePayload::Reset { from } if from == sender)
+        ));
+    }
+
+    #[test]
+    fn critical_failure_breaks_the_computer_and_alarms_authored_switch_links() {
+        let mut world = World::new();
+        let ecology = world.add_entity(());
+        let computer = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 341,
+                to_entity_id: Some(WrappedEntityId(ecology)),
+                link: Link::SwitchLink,
+            }],
+        });
+
+        let effects = Effect::flatten(vec![critical_failure(computer, &world)]);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetObjectState { entity_id, state: dark::properties::ObjectState::Broken }
+                if *entity_id == computer
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::Send { msg }
+                if msg.to == ecology
+                    && matches!(msg.payload, MessagePayload::Alarm { from } if from == computer)
+        )));
+    }
+
+    #[test]
+    fn successful_hack_scales_authored_seconds_by_cyber_and_resets_alarm() {
+        let mut world = World::new();
+        let mut quest = QuestInfo::new();
+        quest.player_stats_mut().cyber_affinity = 3;
+        world.add_unique(quest);
+        let computer = world.add_entity(PropHackTime(30_000));
+        let alert = world.add_entity((ecology(), PropEcoState(2)));
+
+        let effects = Effect::flatten(vec![successful_hack(computer, &world)]);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::ActivateSecurityHack { duration_seconds } if *duration_seconds == 90.0
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::Send { msg }
+                if msg.to == alert
+                    && matches!(msg.payload, MessagePayload::Reset { from } if from == computer)
+        )));
+    }
+
+    #[test]
+    fn active_security_hack_hides_player_from_security_devices() {
+        let world = World::new();
+        let mut quest = QuestInfo::new();
+        assert!(security_devices_can_detect_player(&world));
+        quest.activate_security_hack(10.0);
+        world.add_unique(quest);
+        assert!(!security_devices_can_detect_player(&world));
+    }
+}

--- a/tools/shock2-sdk/test/ops3-security-computer.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops3-security-computer.e2e.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, UiElement, UiPanel } from "../src/types.js";
+import { carriedNaniteTotal } from "./helpers/earth-replicator.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// Real Operations fixture from the detailed 25th-anniversary play-through:
+// Security Comp 346 --SwitchLink--> Ecology 341 --SwitchLink--> Camera 350.
+// Runtime ids are discovered every launch; the constants are stable authored
+// mission-object/template ids. On pre-fix main, the production aim + squeeze
+// reaches object 346 at 1.39 units, but SecurityComputer is unimplemented and
+// `/v1/ui.active_panel` remains null.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const SECURITY_COMPUTER = 346;
+const ECOLOGY = 341;
+const CAMERA = 350;
+
+function property(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((candidate) => candidate.name === name)?.value;
+}
+
+function button(panel: UiPanel, label: string): UiElement {
+  const found = panel.elements.find(
+    (element) => element.kind === "button" && element.label === label,
+  );
+  assert.ok(found, `security HRM should expose ${label}`);
+  return found;
+}
+
+function hasTexture(panel: UiPanel, texture: string): boolean {
+  return panel.elements.some(
+    (element) => element.texture?.toLowerCase() === texture,
+  );
+}
+
+async function activePanel(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "production frob should keep the Security Computer MFD open");
+  return panel;
+}
+
+async function playSecurityHrmToWin(game: GameServer): Promise<UiPanel> {
+  const routes = [
+    ["node-2-0", "node-3-0", "node-4-0"],
+    ["node-2-1", "node-2-2", "node-2-3"],
+    ["node-0-1", "node-0-2", "node-0-3"],
+    ["node-4-0", "node-4-1", "node-4-2"],
+    ["node-0-3", "node-1-3", "node-2-3"],
+  ];
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    let panel = await activePanel(game);
+    if (hasTexture(panel, "winh.pcx")) return panel;
+    assert.ok(
+      !hasTexture(panel, "loseh.pcx"),
+      "max Hack/Cyber should avoid terminal critical failure in this bounded run",
+    );
+    const inPlay = panel.elements.some((element) => element.label === "reset-hack");
+    if (!inPlay || hasTexture(panel, "failh.pcx")) {
+      const deal = panel.elements.find(
+        (element) =>
+          element.label === "start-hack" || element.label === "reset-hack",
+      );
+      assert.ok(deal, "an unwon board should offer START/RESET");
+      await clickUiElement(game, deal);
+      assert.ok(
+        !hasTexture(await activePanel(game), "payh.pcx"),
+        "the provisioned authored nanite stack should cover every retry",
+      );
+    }
+    for (const label of routes[attempt % routes.length]!) {
+      panel = await activePanel(game);
+      if (hasTexture(panel, "winh.pcx")) return panel;
+      if (hasTexture(panel, "failh.pcx") || hasTexture(panel, "loseh.pcx")) break;
+      await clickUiElement(game, button(panel, label));
+    }
+  }
+  assert.fail(
+    `real Security Computer HRM did not win; rng=${game.logs()
+      .filter((line) => line.includes("HRM rng"))
+      .slice(-8)
+      .join(" | ")}`,
+  );
+}
+
+test(
+  "ops3 Security Computer resets alarm and applies a saved timed device hack",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops3.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8743),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    await game.step({ frames: 10 });
+
+    const [computer] = await game.entities.byTemplate(SECURITY_COMPUTER);
+    const [ecology] = await game.entities.byTemplate(ECOLOGY);
+    const [camera] = await game.entities.byTemplate(CAMERA);
+    assert.ok(computer && ecology && camera, "ops3 authored security circuit must exist");
+    const computerDetail = await game.entities.detail(computer.id);
+    assert.ok(
+      computerDetail.outgoing_links.some(
+        (link) => link.link_type === "SwitchLink" && link.target_id === ecology.id,
+      ),
+      "Security Comp 346 must exercise its authored ecology SwitchLink",
+    );
+    // First stand in camera 350's open scan area so ordinary perception raises
+    // its real ecology alarm. The console itself occludes the camera's ray to
+    // the finding's closer frob point, so alarm setup and production frob use
+    // two nearby, independently verified clear positions.
+    await teleportVerified(game, { x: 54, y: -8.356, z: 159.75 });
+    for (let poll = 0; poll < 20; poll += 1) {
+      const cameraDetail = await game.entities.detail(camera.id);
+      const ecologyDetail = await game.entities.detail(ecology.id);
+      if (
+        property(cameraDetail, "AIAlertness") === "High" &&
+        property(ecologyDetail, "EcologyState") === "Alert"
+      ) {
+        break;
+      }
+      await game.step({ frames: 120 });
+    }
+    assert.equal(property(await game.entities.detail(camera.id), "AIAlertness"), "High");
+    assert.equal(property(await game.entities.detail(ecology.id), "EcologyState"), "Alert");
+
+    // Production interaction: visibility-required aim at the rendered console,
+    // then the same squeeze channel used by ordinary flat play. No Frob message
+    // is injected.
+    await teleportVerified(game, { x: 57, y: -8.356, z: 161 });
+    const aim = await game.player.aimAt(computer, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(aim.entity_id, computer.id);
+    assert.equal(aim.visibility.state, "visible");
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 4 });
+
+    const board = await activePanel(game);
+    assert.equal(board.template_id, SECURITY_COMPUTER);
+    assert.ok(hasTexture(board, "hack.pcx"), "Security Computer should open the shared HRM board");
+    assert.equal(
+      property(await game.entities.detail(ecology.id), "EcologyState"),
+      "Normal",
+      "normal frob should reset the active global alarm before opening the overlay",
+    );
+
+    // Provision only the player prerequisites; success still travels through
+    // the genuine HRM UI and authored difficulty/cost.
+    await game.player.setStats({ cyber_affinity: 6, skills: { hack: 6 } });
+    await game.player.spawnItem(-1591); // authored Big Nanite Pile
+    const nanitesBefore = await carriedNaniteTotal(game);
+    assert.ok(nanitesBefore >= 45, "wallet should cover all 15 bounded retries");
+    const won = await playSecurityHrmToWin(game);
+    assert.ok(hasTexture(won, "winh.pcx"), "genuine HRM success art should remain visible");
+    assert.ok(
+      (await carriedNaniteTotal(game)) < nanitesBefore,
+      "real HRM attempts should spend the authored three-nanite cost",
+    );
+
+    // Cyber 6 scales ops3's 55,000ms HackTime to 330 seconds. Save immediately
+    // after success; after reload the camera must still be blind at 300s, then
+    // reacquire once the remaining window expires.
+    await teleportVerified(game, { x: 54, y: -8.356, z: 159.75 });
+    const saveName = `ops3_security_hack_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    for (let interval = 0; interval < 30; interval += 1) {
+      await game.step({ frames: 10 * 60 });
+    }
+    assert.equal(
+      property(await game.entities.detail((await game.entities.byTemplate(CAMERA))[0]!.id), "AIAlertness"),
+      "Lowest",
+      "saved active security hack should keep camera 350 blind before 330 seconds",
+    );
+    for (let interval = 0; interval < 4; interval += 1) {
+      await game.step({ frames: 10 * 60 });
+    }
+    const reloadedCamera = (await game.entities.byTemplate(CAMERA))[0]!;
+    const reloadedEcology = (await game.entities.byTemplate(ECOLOGY))[0]!;
+    for (let poll = 0; poll < 20; poll += 1) {
+      if (property(await game.entities.detail(reloadedCamera.id), "AIAlertness") === "High") break;
+      await game.step({ frames: 120 });
+    }
+    assert.equal(
+      property(await game.entities.detail(reloadedCamera.id), "AIAlertness"),
+      "High",
+      "camera 350 should detect the still-present player after the timed hack expires",
+    );
+    assert.equal(
+      property(await game.entities.detail(reloadedEcology.id), "EcologyState"),
+      "Alert",
+      "restored camera detection should raise the authored ecology again",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- replace the inert `SecurityComputer` registry entry with the shared retail HRM panel and security-specific success/failure outcomes
- reset every actively alerted authored ecology on normal frob and hack success, while preserving critical-failure `Alarm` delivery through the computer's authored `SwitchLink`s
- parse authored `P$HackTime`, apply its Cyber-scaled global device-visibility window to cameras and turrets, and persist remaining time through `QuestInfo` save/load
- cover the ops3 `Security Comp` 346 → ecology 341 → camera 350 circuit with production aim/squeeze, real paid HRM input, save/load, and timed reacquisition

## Retail mapping

The implementation follows the original engine rather than a mission-specific device toggle:

- `ShockAlarmDisableAll` iterates alert ecology objects and sends each `Reset`; the Rust script produces those ordinary `MessagePayload::Reset` effects.
- Dark defines `HackTime` as a four-byte integer. ops3 object 346 authors `55,000` ms; success multiplies that value by Cyber before activating the window.
- Retail stores the absolute expiry and `HackVisi=0` on the player, and player stat recalculation applies that value to camera-class AI visibility. This runtime's simulation clock starts fresh on load, so a remaining-seconds field in established, serialized `QuestInfo` is the save-compatible equivalent. CameraAI and TurretAI read it as a pure visibility gate; scripts do not add ad hoc ECS state.
- Critical failure retains the HRM's Broken object state and sends `Alarm` through the computer's authored `SwitchLink`, so ops3 naturally reaches ecology 341.

Reference source: Looking Glass engine [`shkalarm.cpp`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkalarm.cpp), [`shkprop.cpp`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkprop.cpp), and [`shkplayr.cpp`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkplayr.cpp).

## Campaign evidence

- Campaign: Operations → SHODAN
- Pass: detailed
- Assets: 25th Anniversary (`/Users/bryan/ss2-25th` locally; no retail assets committed)
- Ledger: legacy pre-roll, no seed
- Finding: at `(57, -8.356, 161)`, visibility-required aim reaches ops3 object 346, but pre-fix production squeeze leaves `active_panel: null` because `securitycomputer` mapped to `UnimplementedScript`.

## Validation

- Negative-first: new alarm-reset and critical-link tests failed against the inert stubs, then passed with the implementation.
- `cargo fmt --check --all`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (514 passed)
- `cd tools/shock2-sdk && npm test` (26 passed, 189 E2E skipped by default)
- `DARK_ASSET_PATH=/Users/bryan/ss2-25th SHOCK2_E2E=1 node --test dist/test/ops3-security-computer.e2e.test.js` (production camera alarm → visibility-required aim/squeeze → paid HRM win → save/load → camera blind through 300s → expiry/reacquire at 330s; passed in 429s using bounded fixed-step chunks)

## Visual evidence

![Security Computer production frob opens the HRM](https://gist.githubusercontent.com/tommy-xr/e97dcd6e2c3240acfe554e1503bff8a7/raw/pr842-security-computer.gif)

<sub>ops3 authored Security Comp 346: production visibility-required aim + squeeze now slides in the genuine HACK MFD. Captured headlessly with 25th-anniversary assets via deterministic fixed-timestep stepping.</sub>

### Before → after

![Before: no panel; after: Security Computer HRM](https://gist.githubusercontent.com/tommy-xr/e97dcd6e2c3240acfe554e1503bff8a7/raw/pr842-security-computer-before-after.png)

Fixes #735
