### PR TITLE
fix(input): label weapon spawning as debug-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,7 +340,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_hud`              | Test HUD rendering                           |
    | `debug_map`              | Test map/automap rendering                   |
    | `debug_minimal`          | Bare minimum scene for basic testing         |
-   | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `CycleWeapon`) |
+   | `debug_weapons`          | Flat weapon viewmodel + aim (wall ahead; cycle weapons with `DebugCycleWeapon`) |
    | `debug_psi`              | Psi amp casting (auto-equips the amp; select powers with `CyclePsiPower`) |
 
    ```bash

--- a/projects/flat-weapon-handling.md
+++ b/projects/flat-weapon-handling.md
@@ -112,7 +112,7 @@ Done:
   camera, so shots land on the crosshair and the debug-runtime camera matches
   desktop (was rendering ~1 world unit low).
 - **Tooling**: debug-runtime controllable input over HTTP (`head.look` + hand
-  trigger; the render camera now honors the input head rotation), a `CycleWeapon`
+  trigger; the render camera now honors the input head rotation), a `DebugCycleWeapon`
   action (`B` / HTTP) over the 11-weapon roster, and the `debug_weapons` scene (a
   wall straight ahead) for headless aim verification.
 
@@ -156,7 +156,7 @@ Remaining (follow-ups):
   pose. Reusable for later attached effects (shell ejection, smoke).
 - **Melee weapons** — Wrench / Electro Shock / Crystal Shard / PsiSword.
   - Done: render their `PropLimbModel` FP mesh in the flat viewmodel (they have
-    no `PropPlayerGun`), added to the CycleWeapon roster, a flat swing
+    no `PropPlayerGun`), added to the DebugCycleWeapon roster, a flat swing
     (no-projectile branch in `WeaponScript`: short raycast along the crosshair
     ray + `MELEE_DAMAGE`, damage verified on a live enemy), a closer melee
     viewmodel offset, the **idle pose**, and the **swing animation**. VR melee

--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -43,10 +43,10 @@ impl DesktopInputMapper {
             Binding {
                 key: Key::B,
                 modifier: Modifier::None,
-                action: InputAction::CycleWeapon,
+                action: InputAction::DebugCycleWeapon,
             },
             // Original System Shock 2 direct weapon bindings. These select a
-            // matching carried item; unlike CycleWeapon they never spawn one.
+            // matching carried item; unlike DebugCycleWeapon they never spawn one.
             Binding {
                 key: Key::Num1,
                 modifier: Modifier::None,

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -32,10 +32,9 @@ pub enum InputAction {
     /// Cycle creatures to their next animation pose (debug hitbox/ragdoll inspection)
     DebugHitboxCyclePose,
 
-    /// Wield the next player weapon (debug: spawn-and-wield, holstering the
-    /// previous). Cycles the full SS2 weapon roster for flat-mode aim/viewmodel
-    /// testing.
-    CycleWeapon,
+    /// Spawn and wield the next debug weapon, holstering the previous one.
+    /// Cycles the full SS2 weapon roster for flat-mode aim/viewmodel testing.
+    DebugCycleWeapon,
     /// Equip the matching weapon from the player's carried inventory. These
     /// mirror System Shock 2's original direct weapon bindings; they never
     /// create a weapon or drop the displaced weapon into the world.
@@ -98,7 +97,7 @@ impl InputAction {
             InputAction::SpawnDebugMonster,
             InputAction::MoveInventory,
             InputAction::DebugHitboxCyclePose,
-            InputAction::CycleWeapon,
+            InputAction::DebugCycleWeapon,
             InputAction::EquipWrench,
             InputAction::EquipPistol,
             InputAction::EquipShotgun,
@@ -134,7 +133,7 @@ impl InputAction {
             InputAction::SpawnDebugMonster => "SpawnDebugMonster",
             InputAction::MoveInventory => "MoveInventory",
             InputAction::DebugHitboxCyclePose => "DebugHitboxCyclePose",
-            InputAction::CycleWeapon => "CycleWeapon",
+            InputAction::DebugCycleWeapon => "DebugCycleWeapon",
             InputAction::EquipWrench => "EquipWrench",
             InputAction::EquipPistol => "EquipPistol",
             InputAction::EquipShotgun => "EquipShotgun",
@@ -213,6 +212,15 @@ mod tests {
     fn from_str_rejects_unknown_action() {
         let result = "NotARealAction".parse::<InputAction>();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn spawning_weapon_cycle_requires_an_explicit_debug_name() {
+        assert!("CycleWeapon".parse::<InputAction>().is_err());
+        assert_eq!(
+            "DebugCycleWeapon".parse::<InputAction>().unwrap(),
+            InputAction::DebugCycleWeapon
+        );
     }
 
     #[test]

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -91,7 +91,7 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::DebugHitboxCyclePose) {
             effects.push(Effect::DebugCycleHitboxPose);
         }
-        if state.just_triggered(InputAction::CycleWeapon) {
+        if state.just_triggered(InputAction::DebugCycleWeapon) {
             effects.push(Effect::DebugCycleWeapon {
                 head_rotation: input_context.head.rotation,
             });
@@ -222,6 +222,18 @@ mod tests {
                 }] if *actual == class_template_id
             ));
         }
+    }
+
+    #[test]
+    fn debug_weapon_cycle_maps_to_the_spawning_effect() {
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::DebugCycleWeapon);
+
+        let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::DebugCycleWeapon { .. }]
+        ));
     }
 
     #[test]

--- a/shock2vr/src/scenes/debug_weapons.rs
+++ b/shock2vr/src/scenes/debug_weapons.rs
@@ -1,8 +1,8 @@
 //! Debug scene for first-person weapon work (viewmodel framing + aim).
 //!
 //! A clean, controlled environment: the player stands on a floor facing a flat
-//! wall a known distance straight ahead. Cycle weapons with `CycleWeapon`
-//! (`B` on desktop / `POST /v1/input/action {"action":"CycleWeapon"}`) and fire;
+//! wall a known distance straight ahead. Cycle weapons with `DebugCycleWeapon`
+//! (`B` on desktop / `POST /v1/input/action {"action":"DebugCycleWeapon"}`) and fire;
 //! shots land on the wall as hit-spangs, so it's easy to see whether a weapon's
 //! barrel and its projectiles track the crosshair - without a real mission's
 //! cluttered geometry hiding the viewmodel or swallowing the shot.

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -5,7 +5,7 @@ export type InputAction =
   | "QuickLoad"
   | "SpawnDebugItem"
   | "MoveInventory"
-  | "CycleWeapon"
+  | "DebugCycleWeapon"
   | "EquipWrench"
   | "EquipPistol"
   | "EquipShotgun"

--- a/tools/shock2-sdk/test/blood-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/blood-spang.e2e.test.ts
@@ -40,9 +40,9 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8100),
     });
 
-    // Wield the pistol (first CycleWeapon roster entry).
+    // Wield the pistol (first DebugCycleWeapon roster entry).
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
 
     const spawn = (await game.info()).player.position;

--- a/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
+++ b/tools/shock2-sdk/test/bullet-hole.e2e.test.ts
@@ -34,9 +34,9 @@ test(
         (e) => e.name === "Bullet Hit",
       );
 
-    // Wield the pistol (first CycleWeapon roster entry).
+    // Wield the pistol (first DebugCycleWeapon roster entry).
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
 
     // Sanity: no decals before the shot.

--- a/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
+++ b/tools/shock2-sdk/test/close-range-projectile.e2e.test.ts
@@ -191,7 +191,7 @@ test(
     // The fourth debug weapon is the laser pistol; Laser Shot velocity 40
     // follows the slow physical-projectile path rather than fast raycasting.
     for (let i = 0; i < 4; i++) {
-      await game.input.trigger("CycleWeapon");
+      await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 3 });
     }
     const player = await game.player.position();

--- a/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
+++ b/tools/shock2-sdk/test/impact-sounds.e2e.test.ts
@@ -54,9 +54,9 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8123),
     });
 
-    // Wield the pistol (first CycleWeapon roster entry).
+    // Wield the pistol (first DebugCycleWeapon roster entry).
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
 
     const spawn = (await game.info()).player.position;

--- a/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
+++ b/tools/shock2-sdk/test/muzzle-flash.e2e.test.ts
@@ -34,15 +34,15 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8094),
     });
 
-    // debug_weapons starts unarmed; CycleWeapon spawns and wields the pistol.
+    // debug_weapons starts unarmed; DebugCycleWeapon spawns and wields the pistol.
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
 
     // The wielded-entity field (new /v1/info player data) should report the pistol.
     const before = (await game.entities.list({ limit: 60 })).entities;
     const pistolId = before.find((e) => e.name === "Pistol")?.id;
-    assert.ok(pistolId !== undefined, "the pistol should exist after CycleWeapon");
+    assert.ok(pistolId !== undefined, "the pistol should exist after DebugCycleWeapon");
     const info = await game.info();
     assert.equal(
       info.player.wielded_entity_id,

--- a/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
+++ b/tools/shock2-sdk/test/projectile-trail.e2e.test.ts
@@ -27,7 +27,7 @@ test(
     // Cycle to the laser pistol (4th roster entry).
     await game.step({ frames: 5 });
     for (let i = 0; i < 4; i++) {
-      await game.input.trigger("CycleWeapon");
+      await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 3 });
     }
 

--- a/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
+++ b/tools/shock2-sdk/test/slow-projectile-spang.e2e.test.ts
@@ -30,7 +30,7 @@ test(
     // Cycle to the laser pistol (4th roster entry).
     await game.step({ frames: 5 });
     for (let i = 0; i < 4; i++) {
-      await game.input.trigger("CycleWeapon");
+      await game.input.trigger("DebugCycleWeapon");
       await game.step({ frames: 3 });
     }
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-held-model.e2e.test.ts
@@ -28,10 +28,10 @@ test(
       debugFlags: ["--vr"],
     });
 
-    // CycleWeapon spawns the pistol; VR wield is a no-op so it drops to the
+    // DebugCycleWeapon spawns the pistol; VR wield is a no-op so it drops to the
     // floor in front of the player.
     await game.step({ frames: 10 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 90 });
 
     const pistol = (await game.entities.list({ limit: 100 })).entities.find(
@@ -66,10 +66,10 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8103),
     });
 
-    // In flat, CycleWeapon spawns AND wields (sends Hold), which swaps the
+    // In flat, DebugCycleWeapon spawns AND wields (sends Hold), which swaps the
     // model to the atek_h viewmodel for the first-person weapon path.
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 10 });
 
     const pistol = (await game.entities.list({ limit: 100 })).entities.find(

--- a/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo-type.e2e.test.ts
@@ -36,7 +36,7 @@ test(
     assert.equal(await ammoType(game), null, "unarmed has no ammo type");
 
     // Wield the pistol (std / he / ap).
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
     assert.equal(await ammoType(game), "std", "pistol starts on its first ammo type");
     const pistolId = (await game.info()).player.wielded_entity_id;

--- a/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-ammo.e2e.test.ts
@@ -35,9 +35,9 @@ test(
       // the first-person fire loop.
     });
 
-    // debug_weapons starts unarmed; CycleWeapon spawns + wields the pistol.
+    // debug_weapons starts unarmed; DebugCycleWeapon spawns + wields the pistol.
     await game.step({ frames: 5 });
-    await game.input.trigger("CycleWeapon");
+    await game.input.trigger("DebugCycleWeapon");
     await game.step({ frames: 5 });
 
     const pistolId = (await game.entities.list({ limit: 60 })).entities.find(

--- a/tools/shock2-sdk/test/weapon-cycle-authenticity.e2e.test.ts
+++ b/tools/shock2-sdk/test/weapon-cycle-authenticity.e2e.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "spawn-and-wield weapon cycling is explicitly debug-only",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8379),
+    });
+    await game.step({ frames: 5 });
+
+    const actions = await game.input.actions();
+    assert.ok(
+      !actions.includes("CycleWeapon"),
+      "the production-sounding CycleWeapon action must not expose a spawning cheat",
+    );
+    assert.ok(
+      actions.includes("DebugCycleWeapon"),
+      "the spawn-and-wield tool should be explicitly named as a debug action",
+    );
+
+    const before = await game.player.inventory();
+    await assert.rejects(
+      game.input.trigger("CycleWeapon"),
+      /unknown action/i,
+      "the legacy ambiguous action name should be rejected",
+    );
+    assert.deepEqual(
+      await game.player.inventory(),
+      before,
+      "rejecting the ambiguous action must preserve the exact inventory",
+    );
+
+    await game.input.trigger("DebugCycleWeapon");
+    await game.step({ frames: 2 });
+    const after = await game.player.inventory();
+    assert.equal(after.count, before.count + 1);
+    assert.equal(after.items.at(-1)?.name, "Pistol");
+  },
+);


### PR DESCRIPTION
## Reproduction

On current `origin/main` (`c07099afac3824a097b2949c7439c7ceb475397a`), I launched a fresh `command1.mis` through the SDK and exercised the public input endpoint:

- `GET /v1/input/actions` listed `CycleWeapon`.
- The player inventory initially contained 0 items.
- Triggering `CycleWeapon` four times created an Assault Rifle, Pistol, Shotgun, and Laser Pistol; the inventory count changed from 0 to 4 and the Laser Pistol became wielded.

That production-sounding action therefore exposed a spawn-and-wield debug cheat alongside the authentic, owned-item-only `Equip*` actions.

## Fix

- Rename the spawning action to `DebugCycleWeapon` across the core dispatcher, desktop debug binding, SDK type, debug scenarios, and documentation.
- Reject the old ambiguous `CycleWeapon` name instead of retaining a behavior-preserving alias.
- Keep the spawn-and-wield helper available for weapon/debug-scene work, while leaving the authentic direct `Equip*` actions unchanged.
- Add a runtime regression scenario proving the production name is absent/rejected without inventory mutation and the explicit debug name still performs the debug spawn.

## Verification

- Negative-first regression: failed on `origin/main` because `CycleWeapon` was listed; passes after the fix (`1 passed`).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p shock2vr` (`510 passed`)
- `cargo test -p desktop_runtime` (`1 passed`)
- `cargo test -p shock2vr input:: -- --nocapture` after rebase (`21 passed`)
- `npm test` in `tools/shock2-sdk` (`26 passed`, `189` opt-in E2E skipped)
- Focused owned-selection E2E (`2 passed`)
- Full SDK E2E: `215` tests; `210 passed`, `3 skipped`, `2 failed`. All affected weapon/action scenarios passed. One failure is the pre-existing corpse-load baseline reproduced unchanged on this base; the other was a transient search-entity lookup and its isolated rerun passed `2/2`.

No visual/rendering behavior changed, so visual capture is not applicable.

Fixes #814
