### PR TITLE
fix(physics): center frob colliders on model bounds

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -826,10 +826,14 @@ fn create_physics_representation_with_options(
 
     let min_size = 0.5 / SCALE_FACTOR;
     let min_size_vec = vec3(min_size, min_size, min_size);
-    let dimensions = maybe_model
+    let (dimensions, model_center) = maybe_model
         .as_ref()
-        .and_then(|model| model.bounding_box().map(|bbox| bbox.max - bbox.min))
-        .unwrap_or(default_size_vec);
+        .and_then(|model| model.bounding_box())
+        .map(|bbox| {
+            let size = bbox.max - bbox.min;
+            (size, bbox.min.to_vec() + size / 2.0)
+        })
+        .unwrap_or((default_size_vec, Vector3::zero()));
     let abs_dimensions = vec3(
         dimensions.x.abs().max(min_size_vec.x),
         dimensions.y.abs().max(min_size_vec.y),
@@ -1026,7 +1030,7 @@ fn create_physics_representation_with_options(
                 entity_id,
                 pos.position,
                 qrotation,
-                Vector3::zero(),
+                model_center,
                 abs_dimensions,
                 // TODO: Kinematic experiment
                 //is_sensor,
@@ -1334,6 +1338,16 @@ mod tests {
         )
     }
 
+    /// A deliberately asymmetric model box, like `medica3.bin`'s Med Bed:
+    /// its object origin is not at the center of the rendered geometry.
+    fn asymmetric_fixture_model() -> Model {
+        Model::from_glb(
+            vec![],
+            Aabb3::new(Point3::new(-1.0, -0.5, -0.25), Point3::new(1.0, 1.5, 1.75)),
+            None,
+        )
+    }
+
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
 
     /// A wall fixture the player can frob but never pick up or move - a
@@ -1419,6 +1433,27 @@ mod tests {
             assert_eq!(bodies[0].blocks_player, should_block);
             assert_eq!(bodies[0].blocks_actor, should_block);
         }
+    }
+
+    /// A model-bounds selection collider must cover the model's actual local
+    /// bounds when the object origin is off-center. Otherwise part of the
+    /// visible object cannot be selected or frobbed (the shipped Med Bed,
+    /// Partial Med Bed, and Rick Turret models all have asymmetric bounds).
+    #[test]
+    fn frobbable_model_bounds_collider_uses_the_model_center() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = add_wall_fixture(&mut world, None);
+        let model = asymmetric_fixture_model();
+
+        create_physics_representation(&mut world, &mut physics, &Some(&model), entity_id)
+            .expect("a frobbable fixture should get a selection collider");
+
+        let collider_bounds = physics
+            .get_aabb2(entity_id)
+            .expect("the selection collider should have world bounds");
+        assert_eq!(collider_bounds.min, Point3::new(-1.0, -0.5, -0.25));
+        assert_eq!(collider_bounds.max, Point3::new(1.0, 1.5, 1.75));
     }
 
     /// Dark's pick pass weighs only objects submitted by the renderer. A


### PR DESCRIPTION
## Reproduction and audit

On current `origin/main` (`c07099afac3824a097b2949c7439c7ceb475397a`), I enumerated every gamesys archetype and every concrete entity in all 23 missions, applied the runtime's exact frobbable-branch filters, and parsed each static model's raw bounds headlessly.

- 4,979 frobbable model-bounds candidates: 3,287 kinematic fixtures and 1,692 `MOVE` objects.
- 32 candidates had asymmetric bounds, all kinematic fixtures; no `MOVE` object was asymmetric.
- The offenders use three models: `medica3` (Med Bed, center `[0, 0.20793259, 0.39521202]`), `bed02` (Partial Med Bed, center `[0, 0.19999999, 0]`), and `rickgun` (Rick Turret, center `[0.5573829, -0.1804542, 0.0077028275]`).

I then launched `medsci1.mis`, discovered mission object 1641 (Med Bed) by stable template id, and cast two selectable-only rays through its raw visible bounds in model-local space:

- local z=0.8 control: hit the Med Bed;
- local z=1.3, which is inside the visible model (`max z=1.465217`) but outside the zero-centered collider (`max z=1.070005`): no hit.

This confirms a real selectable-surface mismatch on shipped data.

## Fix

Derive the raw model bounding-box center alongside its size and pass that center as the local offset for the kinematic frobbable model-bounds collider. Dynamic `MOVE` handling is unchanged because the audit found no asymmetric movable offenders.

After the fix, both live Med Bed rays hit its selectable collider. The rendered model and pixels are unchanged, so visual capture is not applicable.

## Tests

- Negative-first unit regression: failed before the fix with collider min `[-1, -1, -1]` instead of model min `[-1, -0.5, -0.25]`; passes after the fix.
- `cargo test -p shock2vr`: 509 passed, 0 failed.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- `cd tools/shock2-sdk && npm test`: 26 passed, 0 failed, 188 e2e-only skipped.
- `cd tools/shock2-sdk && npm run test:e2e`: 210 passed, 1 failed, 3 skipped (214 total). The sole failure is the existing unrelated `a loaded corpse does not replay its death` baseline: every sample remained `Dead`, dynamic/sleeping, zero velocity, zero position/pose error, and `lastClip=ogpdie03`, while the test expects a non-null active clip. An isolated rerun reproduced the identical failure (0 passed, 1 failed).
- Post-rebase focused test, warning-free package check, formatting check, and fresh live Med Bed ray probe: passed.

Fixes #835
