### PR TITLE
fix(ui): key object icons by palette index

### DIFF
--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -2,7 +2,11 @@ use std::rc::Rc;
 
 use cgmath::{Deg, Matrix4, Point2, Vector2, vec2, vec3};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
-use engine::{assets::asset_cache::AssetCache, scene::SceneObject, texture::TextureTrait};
+use engine::{
+    assets::asset_cache::AssetCache,
+    scene::SceneObject,
+    texture::{TextureOptions, TextureTrait},
+};
 use shipyard::EntityId;
 
 use crate::{inventory::Inventory, vr_config::Handedness};
@@ -563,6 +567,18 @@ impl GuiComponentRenderInfo {
         }
     }
 
+    /// Entity-backed images are inventory/loot object icons. Dark keys their
+    /// paletted PCX art on palette index 0, independent of that entry's RGB.
+    pub(crate) fn transparent_index_0(&self) -> bool {
+        matches!(
+            self,
+            Self::Image {
+                entity: Some(_),
+                ..
+            }
+        )
+    }
+
     pub fn render(&self, asset_cache: &mut AssetCache) -> SceneObject {
         let scene_object = match self {
             Self::Image {
@@ -572,8 +588,16 @@ impl GuiComponentRenderInfo {
                 alpha,
                 ..
             } => {
-                let texture: Rc<dyn TextureTrait> =
-                    asset_cache.get(&TEXTURE_IMPORTER, texture).clone();
+                let texture: Rc<dyn TextureTrait> = asset_cache
+                    .get_ext(
+                        &TEXTURE_IMPORTER,
+                        texture,
+                        &TextureOptions {
+                            transparent_index_0: self.transparent_index_0(),
+                            ..Default::default()
+                        },
+                    )
+                    .clone();
                 let comp_mat = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);
                 let mut comp_obj =
                     SceneObject::new(comp_mat, Box::new(engine::scene::quad::create()));
@@ -748,5 +772,26 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_backed_object_icons_use_palette_index_zero_transparency() {
+        let entity = EntityId::from_inner(1).unwrap();
+        let component = grabbable((), ())
+            .with_entity(entity)
+            .with_image("passkey.pcx");
+
+        let render_info = component.to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
+
+        assert!(render_info.transparent_index_0());
+
+        let backdrop =
+            image::<()>("invback.pcx").to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
+        assert!(!backdrop.transparent_index_0());
     }
 }

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -673,7 +673,7 @@ impl FlatUiHost {
             // arrow (the original's `SCM_DRAGOBJ`, §2.4). Fall back to the
             // arrow when the held item has no icon or nothing is held.
             match self.cursor_item.as_ref().and_then(|c| c.icon.as_deref()) {
-                Some(icon) => canvas.image(
+                Some(icon) => canvas.object_icon(
                     Rect::new(cursor.x, cursor.y, CURSOR_ITEM_SIZE.x, CURSOR_ITEM_SIZE.y),
                     icon,
                 ),
@@ -891,7 +891,11 @@ fn draw_components(
             // alpha is a VR world-quad translucency, deliberately not
             // applied here.
             GuiComponentRenderInfo::Image { texture, .. } => {
-                canvas.image(r, texture);
+                if component.transparent_index_0() {
+                    canvas.object_icon(r, texture);
+                } else {
+                    canvas.image(r, texture);
+                }
             }
             GuiComponentRenderInfo::Text { text, font, .. } => {
                 // Render at the font's native pixel height (the Dark engine

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -143,6 +143,7 @@ enum UiElement {
         rect: Rect,
         texture: String,
         opacity: f32,
+        transparent_index_0: bool,
     },
     /// Horizontally-filling bar; `fill` (0..1) clips the texture from the left.
     Bar {
@@ -199,6 +200,19 @@ impl UiCanvas {
             rect,
             texture: texture.to_owned(),
             opacity: 1.0,
+            transparent_index_0: false,
+        });
+        self
+    }
+
+    /// Add paletted object-icon art using Dark's palette-index-0 transparency.
+    /// Ordinary UI images remain opaque through [`Self::image`].
+    pub fn object_icon(&mut self, rect: Rect, texture: &str) -> &mut Self {
+        self.elements.push(UiElement::Image {
+            rect,
+            texture: texture.to_owned(),
+            opacity: 1.0,
+            transparent_index_0: true,
         });
         self
     }
@@ -277,8 +291,16 @@ impl UiCanvas {
                     rect,
                     texture,
                     opacity,
+                    transparent_index_0,
                 } => {
-                    let tex = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options);
+                    let tex = asset_cache.get_ext(
+                        &TEXTURE_IMPORTER,
+                        texture,
+                        &TextureOptions {
+                            wrap: false,
+                            transparent_index_0: *transparent_index_0,
+                        },
+                    );
                     objs.push(SceneObject::screen_space_quad2(
                         tex.clone() as Rc<dyn TextureTrait>,
                         vec2(rect.x * scale.x + offset.x, rect.y * scale.y + offset.y),
@@ -435,5 +457,26 @@ mod tests {
             ScaleMode::PreserveAspect,
         );
         assert_eq!(p, Some(vec2(320.0, 120.0)));
+    }
+
+    #[test]
+    fn object_icon_marks_palette_index_zero_as_transparent() {
+        let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
+        canvas.image(Rect::new(0.0, 0.0, 640.0, 120.0), "invback.pcx");
+        canvas.object_icon(Rect::new(0.0, 0.0, 32.0, 32.0), "passkey.pcx");
+
+        assert!(matches!(
+            canvas.elements.as_slice(),
+            [
+                UiElement::Image {
+                    transparent_index_0: false,
+                    ..
+                },
+                UiElement::Image {
+                    transparent_index_0: true,
+                    ..
+                }
+            ]
+        ));
     }
 }


### PR DESCRIPTION
## Reproduction

`PASSKEY.PCX` is a 32x32 indexed image whose palette index 0 is RGB `(252, 0, 246)`. Index 0 appears in 559 of 1024 pixels, including all four corners. The existing RGB color key only accepts magenta when red and blue are greater than 250, so the blue value 246 remained opaque.

On current `origin/main` (`c07099afac3824a097b2949c7439c7ceb475397a`), spawning ID Cards (template `-157`) in `earth.mis` and opening use mode rendered a hot-magenta rectangle behind the keycard. The focused icon crop contained 491 bright-magenta pixels.

## Fix

- Treat entity-backed GUI images as object icons and load their indexed PCX art with palette-index-0 transparency.
- Carry the same option through the flat inventory strip and dragged-item cursor.
- Keep ordinary UI images opaque, preserving existing backdrop and screen-art behavior.

## Tests

- Negative first: the new entity-backed icon regression test failed before the implementation because `transparent_index_0` was false.
- `cargo test -p shock2vr gui::gui_component::tests::entity_backed_object_icons_use_palette_index_zero_transparency -- --exact` — 1 passed.
- `cargo test -p shock2vr ui::tests::object_icon_marks_palette_index_zero_as_transparent -- --exact` — 1 passed.
- `cargo test -p shock2vr` — 510 passed, 0 failed.
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `npm test` in `tools/shock2-sdk` — 26 passed, 188 gated e2e skipped, 0 failed.
- Focused real-runtime strip/drag scenarios — 3 passed, 0 failed.
- Full SDK e2e — 214 total: 195 passed, 16 failed, 3 skipped. Fourteen failures were a shared-host ENOSPC cascade: the first affected save returned `No space left on device (os error 28)`, then Cargo launches failed to link/copy for the same reason. Immediately afterward `df -h` reported `/dev/disk3s1` at 228 GiB total, 191 GiB used, 5.2 GiB available, 98% capacity. The remaining two were the existing loaded-corpse baseline and a transient search test; the search file passed 2/2 in isolation. All icon, inventory-strip, and drag scenarios passed before the cascade.

## Visual evidence

![Keycard palette transparency while dragged](https://gist.githubusercontent.com/tommy-xr/e3232af10ebe03c8798064abddf0efa7/raw/keycard-drag-before-after.gif)

<sub>Keycard object icons now use Dark palette-index-0 transparency in the inventory strip and while dragged. Captured headlessly via the debug runtime with deterministic fixed-timestep stepping.</sub>

### After

![Transparent keycard inventory icon](https://gist.githubusercontent.com/tommy-xr/e3232af10ebe03c8798064abddf0efa7/raw/keycard-after-still.png)

### Before → after

![Keycard transparency comparison](https://gist.githubusercontent.com/tommy-xr/e3232af10ebe03c8798064abddf0efa7/raw/keycard-before-after.png)

The deterministic 16-frame capture measured 923–935 magenta pixels in the baseline and zero in every fixed frame.

Fixes #823
