### PR TITLE
fix(gameplay): add command resonator to replicator

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4446,6 +4446,19 @@ impl MissionCore {
                         self.world.add_component(entity_id, PropObjState(state));
                     }
                 }
+                Effect::SetReplicatorHackedContents {
+                    entity_id,
+                    contents,
+                } => {
+                    let is_alive = self
+                        .world
+                        .borrow::<shipyard::EntitiesView>()
+                        .map(|entities| entities.is_alive(entity_id))
+                        .unwrap_or(false);
+                    if is_alive {
+                        self.world.add_component(entity_id, contents);
+                    }
+                }
                 Effect::SetEcologyState { entity_id, state } => {
                     let is_alive = self
                         .world

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -3,7 +3,8 @@ use dark::{
     EnvSoundQuery,
     motion::{MotionQueryItem, MotionQuerySelectionStrategy},
     properties::{
-        AIAlertLevel, AIMode, KeyCard, ObjectState, PropGunState, QuestBitValue, TeleportSource,
+        AIAlertLevel, AIMode, KeyCard, ObjectState, PropGunState, PropReplicatorHackedContents,
+        QuestBitValue, TeleportSource,
     },
 };
 use engine::audio::AudioHandle;
@@ -480,6 +481,14 @@ pub enum Effect {
     SetObjectState {
         entity_id: EntityId,
         state: ObjectState,
+    },
+
+    /// Persistently replace a replicator's hacked catalog. Retail's
+    /// `PutBombInReplicator` uses this to add the Command-deck objective item;
+    /// the registered Dark property makes the change survive save/load.
+    SetReplicatorHackedContents {
+        entity_id: EntityId,
+        contents: PropReplicatorHackedContents,
     },
 
     /// Persistently set Dark's `P$EcoState` on one live object - emitted by

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -39,6 +39,7 @@ mod picture_swap;
 pub mod player_script;
 mod psi_amp_script;
 mod psi_kit;
+mod put_bomb_in_replicator;
 mod reduce_psi;
 mod reroute_elevator_button;
 mod researchable;
@@ -115,6 +116,7 @@ use self::internal_switch_held_model::InternalSwitchHeldModelScript;
 use self::picture_swap::PictureSwap;
 use self::psi_amp_script::PsiAmpScript;
 use self::psi_kit::PsiKitScript;
+use self::put_bomb_in_replicator::PutBombInReplicator;
 use self::reduce_psi::ReducePsi;
 use self::reroute_elevator_button::RerouteElevatorButton;
 use self::researchable::ResearchableScript;
@@ -1119,7 +1121,7 @@ impl ScriptWorld {
             "trapcollideoff" => Box::new(NoopScript::new()),
             "tweqbutton" => Box::new(NoopScript::new()),
             "tweqtrap" => Box::new(NoopScript::new()),
-            "putbombinreplicator" => Box::new(NoopScript::new()),
+            "putbombinreplicator" => Box::new(PutBombInReplicator::new()),
             "trapunref" => Box::new(NoopScript::new()),
 
             // shodan
@@ -1473,6 +1475,28 @@ mod script_state_tests {
 
     fn tick(scripts: &mut ScriptWorld, world: &World) {
         scripts.update(world, &PhysicsWorld::new(), &Time::default());
+    }
+
+    #[test]
+    fn put_bomb_in_replicator_turn_on_is_not_a_noop() {
+        let mut world = World::new();
+        let replicator = world.add_entity(dark::properties::PropReplicatorHackedContents {
+            costs: [100, 75, 100, 45, 0, 0],
+            object_names: std::array::from_fn(|_| String::new()),
+        });
+        let mut script = ScriptWorld::create_script("PutBombInReplicator".to_owned());
+
+        let effect = script.handle_message(
+            replicator,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: replicator },
+        );
+
+        assert!(
+            !matches!(effect, Effect::NoEffect),
+            "the Command objective relay must add the resonator to the hacked catalog"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/put_bomb_in_replicator.rs
+++ b/shock2vr/src/scripts/put_bomb_in_replicator.rs
@@ -1,0 +1,158 @@
+use dark::properties::{ObjectState, PropObjState, PropReplicatorHackedContents};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+const RESONATOR_TEMPLATE_NAME: &str = "big bomb";
+const RESONATOR_COST: i32 = 100;
+
+/// Retail's objective-specific catalog augmentation, expressed generically as
+/// a script on whichever replicator receives `TurnOn`.
+///
+/// The original writes hacked slot 1 to `Big Bomb` at 100 nanites. If the
+/// machine was hacked before the objective fired, it resets the object to
+/// Normal so the newly authored catalog can be reached by hacking it again.
+pub struct PutBombInReplicator;
+
+impl PutBombInReplicator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for PutBombInReplicator {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
+        }
+
+        let hacked_contents = world
+            .borrow::<View<PropReplicatorHackedContents>>()
+            .ok()
+            .and_then(|contents| contents.get(entity_id).ok().cloned());
+        let Some(mut hacked_contents) = hacked_contents else {
+            return Effect::NoEffect;
+        };
+
+        hacked_contents.object_names[0] = RESONATOR_TEMPLATE_NAME.to_owned();
+        hacked_contents.costs[0] = RESONATOR_COST;
+
+        let reset_early_hack = world
+            .borrow::<View<PropObjState>>()
+            .ok()
+            .and_then(|states| states.get(entity_id).ok().copied())
+            .is_some_and(|state| state.0 == ObjectState::Hacked);
+
+        let mut effects = vec![Effect::SetReplicatorHackedContents {
+            entity_id,
+            contents: hacked_contents,
+        }];
+        if reset_early_hack {
+            effects.push(Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Normal,
+            });
+        }
+        Effect::combine(effects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scripts::Effect;
+
+    fn authored_contents() -> PropReplicatorHackedContents {
+        PropReplicatorHackedContents {
+            costs: [100, 75, 100, 45, 0, 0],
+            object_names: [
+                "emp grenade".to_owned(),
+                "timed grenade".to_owned(),
+                "incend. grenade".to_owned(),
+                "maintenance tool".to_owned(),
+                String::new(),
+                String::new(),
+            ],
+        }
+    }
+
+    fn activate(world: &World, replicator: EntityId) -> Vec<Effect> {
+        let mut script = PutBombInReplicator::new();
+        Effect::flatten(vec![script.handle_message(
+            replicator,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: replicator },
+        )])
+    }
+
+    #[test]
+    fn turn_on_replaces_only_the_first_hacked_catalog_slot() {
+        let mut world = World::new();
+        let original = authored_contents();
+        let replicator = world.add_entity(original.clone());
+
+        let effects = activate(&world, replicator);
+
+        assert_eq!(effects.len(), 1);
+        let Effect::SetReplicatorHackedContents {
+            entity_id,
+            contents,
+        } = &effects[0]
+        else {
+            panic!("expected a persistent hacked-catalog update, got {effects:?}");
+        };
+        assert_eq!(*entity_id, replicator);
+        assert_eq!(contents.object_names[0], RESONATOR_TEMPLATE_NAME);
+        assert_eq!(contents.costs[0], RESONATOR_COST);
+        assert_eq!(contents.object_names[1..], original.object_names[1..]);
+        assert_eq!(contents.costs[1..], original.costs[1..]);
+    }
+
+    #[test]
+    fn turn_on_resets_an_already_hacked_replicator_for_rehacking() {
+        let mut world = World::new();
+        let replicator = world.add_entity((authored_contents(), PropObjState(ObjectState::Hacked)));
+
+        let effects = activate(&world, replicator);
+
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetReplicatorHackedContents { entity_id, .. } if *entity_id == replicator
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetObjectState {
+                entity_id,
+                state: ObjectState::Normal,
+            } if *entity_id == replicator
+        )));
+    }
+
+    #[test]
+    fn ignores_non_turn_on_messages_and_entities_without_a_hacked_catalog() {
+        let mut world = World::new();
+        let replicator = world.add_entity(authored_contents());
+        let missing_catalog = world.add_entity(());
+        let mut script = PutBombInReplicator::new();
+
+        assert!(matches!(
+            script.handle_message(
+                replicator,
+                &world,
+                &PhysicsWorld::new(),
+                &MessagePayload::TurnOff { from: replicator },
+            ),
+            Effect::NoEffect
+        ));
+        assert!(activate(&world, missing_catalog).is_empty());
+    }
+}

--- a/tools/shock2-sdk/test/command-resonator.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-resonator.e2e.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiPanel } from "../src/types.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// Focused Command objective regression for #844. Runtime ids are discovered
+// from stable authored ids on every launch/load. The full authored relays are:
+//   tripwire 129 -> QB filter 1245 (ShuttleBBoom) -> replicator 394
+//   Shuttle B 2392 -> QB filter 1252 (InRoom)     -> replicator 394
+// This test injects their final TurnOn directly so it isolates the catalog
+// script, then uses the real MFD/HRM/purchase flow.
+//
+// Negative-first evidence (2026-08-08, origin/main c07099af): after TurnOn,
+// save/load, and a genuine successful hack, the panel still offers EMP Grenade
+// in slot 1; `buy:big bomb` is absent because PutBombInReplicator is a no-op.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const COMMAND_REPLICATOR = 394;
+const BIG_NANITE_PILE = -1591;
+const SYMPATHETIC_RESONATOR = -1671;
+
+function button(panel: UiPanel, label: string): UiElement {
+  const found = panel.elements.find(
+    (element) => element.kind === "button" && element.label === label,
+  );
+  assert.ok(
+    found,
+    `panel should expose ${label}; got ${JSON.stringify(
+      panel.elements.map((element) => element.label ?? element.texture),
+    )}`,
+  );
+  return found;
+}
+
+function hasTexture(panel: UiPanel, texture: string): boolean {
+  return panel.elements.some(
+    (element) => element.texture?.toLowerCase() === texture,
+  );
+}
+
+async function activePanel(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "replicator interaction should keep an MFD panel open");
+  return panel;
+}
+
+async function openReplicator(game: GameServer, id: number): Promise<UiPanel> {
+  await game.entities.sendMessage(id, { type: "Frob" });
+  await game.step({ frames: 5 });
+  return activePanel(game);
+}
+
+async function winHack(game: GameServer): Promise<void> {
+  const routes = [
+    ["node-2-0", "node-3-0", "node-4-0"],
+    ["node-2-1", "node-2-2", "node-2-3"],
+    ["node-0-1", "node-0-2", "node-0-3"],
+    ["node-4-0", "node-4-1", "node-4-2"],
+  ];
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    let panel = await activePanel(game);
+    if (hasTexture(panel, "winh.pcx")) return;
+    assert.ok(
+      !hasTexture(panel, "loseh.pcx"),
+      "max Hack and Cyber-Affinity should leave no critical-failure mines",
+    );
+
+    const inPlay = panel.elements.some(
+      (element) => element.label === "reset-hack",
+    );
+    const burnedOut = hasTexture(panel, "failh.pcx");
+    if (!inPlay || burnedOut) {
+      const deal = panel.elements.find(
+        (element) =>
+          element.label === "start-hack" || element.label === "reset-hack",
+      );
+      assert.ok(deal, "an unwon board should offer START/RESET");
+      await clickUiElement(game, deal);
+    }
+
+    for (const label of routes[attempt % routes.length]) {
+      panel = await activePanel(game);
+      if (hasTexture(panel, "winh.pcx")) return;
+      if (hasTexture(panel, "failh.pcx")) break;
+      await clickUiElement(game, button(panel, label));
+    }
+  }
+  assert.fail(
+    `the max-skill HRM route should win; rng=${game
+      .logs()
+      .filter((line) => line.includes("HRM rng"))
+      .slice(-8)
+      .join(" | ")}`,
+  );
+}
+
+test(
+  "command1 objective adds and dispenses the Sympathetic Resonator",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9440),
+      rustLog: "debug_runtime=info,shock2vr=debug",
+    });
+    await game.step({ frames: 5 });
+
+    await game.player.setStats({ cyber_affinity: 6, skills: { hack: 6 } });
+    for (let i = 0; i < 3; i += 1) {
+      await game.player.spawnItem(BIG_NANITE_PILE);
+    }
+
+    const [replicator] = await game.entities.byTemplate(COMMAND_REPLICATOR);
+    assert.ok(replicator, "command1 should instantiate authored replicator 394");
+    await game.entities.sendMessage(replicator.id, { type: "TurnOn" });
+    await game.step({ frames: 5 });
+
+    // The objective mutates a registered Dark property, so crossing a real
+    // save/load boundary before hacking must retain the new catalog.
+    const saveName = `command_resonator_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+
+    const [loadedReplicator] = await game.entities.byTemplate(COMMAND_REPLICATOR);
+    assert.ok(loadedReplicator, "save/load should restore authored replicator 394");
+
+    const [x, y, z] = (await game.entities.detail(loadedReplicator.id)).position;
+    await game.player.teleport({ x: x + 2, y, z: z + 2 });
+    await game.step({ frames: 5 });
+
+    const beforeOpen = await game.info();
+    assert.equal(
+      beforeOpen.player.life_state,
+      "alive",
+      `fresh Command test player must remain alive: ${JSON.stringify(beforeOpen)}`,
+    );
+
+    const normal = await openReplicator(game, loadedReplicator.id);
+    assert.ok(
+      normal.elements.some((element) => element.label === "hack-replicator"),
+      "the objective should leave a normal replicator available for hacking",
+    );
+    await clickUiElement(game, button(normal, "hack-replicator"));
+    await clickUiElement(game, button(await activePanel(game), "start-hack"));
+    await winHack(game);
+    await clickUiElement(game, button(await activePanel(game), "close"));
+
+    const hacked = await openReplicator(game, loadedReplicator.id);
+    const resonatorButton = button(hacked, "buy:big bomb");
+    assert.ok(
+      hacked.elements.some(
+        (element) => element.kind === "text" && element.text === "100",
+      ),
+      "the augmented hacked slot should retain retail's 100-nanite cost",
+    );
+
+    assert.equal(
+      (await game.entities.byTemplate(SYMPATHETIC_RESONATOR)).length,
+      0,
+      "the unique objective item should not exist before purchase",
+    );
+    await clickUiElement(game, resonatorButton);
+    await game.step({ frames: 10 });
+    assert.equal(
+      (await game.entities.byTemplate(SYMPATHETIC_RESONATOR)).length,
+      1,
+      "the ordinary replicator purchase should dispense template -1671",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #844

## Summary

- implement the retail `PutBombInReplicator` `TurnOn` behavior as a generic object script
- replace hacked catalog slot 1 with `Big Bomb` at 100 nanites and reset an already-hacked replicator to Normal so it can be hacked again
- persist the registered `P$RepHacked` property through the central effect applier and cover save/load
- add a focused Command regression that uses the real MFD, genuine paid HRM hack, and ordinary replicator purchase to dispense template `-1671`

## Root cause and fidelity

`command1.mis` authors `PutBombInReplicator` on replicator 394. Both objective filters, 1245 (`ShuttleBBoom`) and 1252 (`InRoom`), relay `TurnOn` to that replicator alongside Email 2312, QB 126, and XP 130. The port mapped the script to `NoopScript`, so the hacked catalog retained EMP Grenade and the campaign could never obtain the Sympathetic Resonator needed by generator 285.

The stock 25th Anniversary `allobjs-windows-x86_64.dll` handler sets `RepHacked / Obj 1 Name` to `Big Bomb`, cost 100, and changes `ObjState` 5 (Hacked) to 0 (Normal). The public original-script reference likewise documents `PutBombInReplicator` as a `TurnOn` catalog mutation: https://thiefmissions.com/telliamed/allscripts.html

This remains generic: there is no mission filename/object special case, debug item grant, or quest shortcut.

## Verification

- negative-first Rust factory regression failed on `origin/main`: `TurnOn` returned `Effect::NoEffect`
- negative-first 25th runtime scenario failed on `origin/main`: after save/load and a genuine successful hack, the catalog still showed EMP/timed/incendiary/maintenance and no `buy:big bomb`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- expanded warning-clean check also passed for `dark_viewer`, `dark_query`, `debug_command`, `hitbox_analyzer`, and `bench`
- `cargo test -p shock2vr` — 512 passed
- `cargo test -p shock2vr put_bomb_in_replicator` — 4 passed
- `npm test` in `tools/shock2-sdk` — 26 passed, 189 skipped
- focused 25th E2E — passed: dynamic replicator discovery → authored final `TurnOn` → save/load → real MFD/paid HRM success → Sympathetic Resonator at 100 → ordinary purchase → template `-1671`
- full serial 25th SDK E2E — 210 passed, 3 intentionally skipped, 2 unrelated failures: the corpse strict-state assertion reproduces identically on `origin/main`; the long SHODAN spike-support scenario is timing-sensitive (base passed, branch later removed the assassin after cycling) and does not exercise the changed Command script/effect

All runtime scenarios used `DARK_ASSET_PATH=/Users/bryan/ss2-25th` and dynamically resolved runtime entity IDs.

## Visual verification

![Command resonator purchase](https://gist.githubusercontent.com/tommy-xr/0159bc15fc93d9dce14f9816ca879548/raw/command-resonator-purchase.gif)

<sub>After the authored Command relay fires, a genuine HRM hack exposes the Sympathetic Resonator for 100 nanites; an ordinary replicator click dispenses it and reduces the live balance from 0147 to 0047. Captured headlessly with 25th Anniversary assets via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Command replicator hacked catalog before and after](https://gist.githubusercontent.com/tommy-xr/0159bc15fc93d9dce14f9816ca879548/raw/command-resonator-before-after.png)
