### PR TITLE
fix(vr): anchor tracked poses at the feet and true world scale

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -608,16 +608,23 @@ fn main() {
             right_aim_location.pose.orientation.z,
         );
 
-        let right_hand_position = vec3(
-            right_aim_location.pose.position.x,
-            right_aim_location.pose.position.y,
-            right_aim_location.pose.position.z,
+        let center_above_floor = game.player_center_above_floor();
+        let right_hand_position = stage_to_pawn(
+            vec3(
+                right_aim_location.pose.position.x,
+                right_aim_location.pose.position.y,
+                right_aim_location.pose.position.z,
+            ),
+            center_above_floor,
         );
 
-        let left_hand_position = vec3(
-            left_aim_location.pose.position.x,
-            left_aim_location.pose.position.y,
-            left_aim_location.pose.position.z,
+        let left_hand_position = stage_to_pawn(
+            vec3(
+                left_aim_location.pose.position.x,
+                left_aim_location.pose.position.y,
+                left_aim_location.pose.position.z,
+            ),
+            center_above_floor,
         );
         let left_hand_rotation = cgmath::Quaternion::new(
             left_aim_location.pose.orientation.w,
@@ -1003,6 +1010,18 @@ fn create_projection_matrix(fov: &xr::Fovf, near_z: f32, far_z: f32) -> cgmath::
     )
 }
 
+/// Convert a floor-origin STAGE-space position (meters) into the game's pawn
+/// space (world units, origin at the player collider's center): scale meters
+/// to world units, then move the anchor from the physical floor up to the
+/// collider center, so a tracked eye or hand N meters above the real floor
+/// lands the equivalent height above the in-game floor. Without this the raw
+/// meters were added to the collider CENTER unscaled, placing the standing
+/// eye ~1.8 SS2 ft above the original game's eye line (and world scale ~31%
+/// large).
+fn stage_to_pawn(position_meters: Vector3<f32>, center_above_floor: f32) -> Vector3<f32> {
+    position_meters / shock2vr::METERS_PER_WORLD_UNIT - vec3(0.0, center_above_floor, 0.0)
+}
+
 fn render_swapchain(
     game: &mut Game,
     engine: &Box<dyn engine::Engine>,
@@ -1026,11 +1045,13 @@ fn render_swapchain(
     let width = swapchain.width;
     let height = swapchain.height;
 
-    let head_offset = cgmath::Vector3::new(
-        view.pose.position.x,
-        view.pose.position.y,
-        view.pose.position.z,
-        //0.0, 0.0, 5.0,
+    let head_offset = stage_to_pawn(
+        cgmath::Vector3::new(
+            view.pose.position.x,
+            view.pose.position.y,
+            view.pose.position.z,
+        ),
+        game.player_center_above_floor(),
     );
     let head_rotation = cgmath::Quaternion::new(
         view.pose.orientation.w,

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -72,6 +72,13 @@ pub const PLAYER_EYE_HEIGHT: f32 = physics::PLAYER_HEAD_POS + physics::PLAYER_EY
 /// cannot poke through a low ceiling the collider clears.
 pub const PLAYER_CROUCH_EYE_HEIGHT: f32 = 1.2;
 
+/// Real-world meters per world unit: 1 world unit is `dark::SCALE_FACTOR`
+/// (2.5) SS2 feet, and an SS2 foot is a real foot (0.3048 m). VR runtimes
+/// divide floor-relative tracked poses (meters) by this before feeding them
+/// to the game so the world renders at true scale and a tracked eye N meters
+/// above the physical floor lands the equivalent height above the game floor.
+pub const METERS_PER_WORLD_UNIT: f32 = 0.3048 * dark::SCALE_FACTOR;
+
 /// The single mapping from crouch state to eye height. The render camera and
 /// the flat controller's shot/viewmodel origin must both go through this (or
 /// [`Game::player_eye_height`], which wraps it) so shots stay on the
@@ -1432,6 +1439,14 @@ impl Game {
     /// view matches the flat controller's shot origin.
     pub fn player_eye_height(&self) -> f32 {
         player_eye_height_for(self.active_game_scene.player_is_crouched())
+    }
+
+    /// Height (world units) of the player collider's center above the surface
+    /// it stands on, for the current stance. VR runtimes subtract this from
+    /// the pawn position returned by [`Game::render`] to anchor floor-relative
+    /// tracked poses at the player's feet instead of the collider center.
+    pub fn player_center_above_floor(&self) -> f32 {
+        physics::player_center_above_floor(self.active_game_scene.player_is_crouched())
     }
 
     pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -91,6 +91,19 @@ pub fn player_crouch_center_shift() -> f32 {
     (PLAYER_STANDING_HEIGHT - PLAYER_CROUCH_HEIGHT) / 2.0 / SCALE_FACTOR
 }
 
+/// Height (world units) of the collider CENTER above the surface the player
+/// stands on, per stance: half the capsule height plus the resting gap the
+/// character controller maintains. VR runtimes subtract this from the body
+/// position to get the feet/floor anchor for floor-relative tracked poses.
+pub fn player_center_above_floor(crouched: bool) -> f32 {
+    let height = if crouched {
+        PLAYER_CROUCH_HEIGHT
+    } else {
+        PLAYER_STANDING_HEIGHT
+    };
+    (height / 2.0 + PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR
+}
+
 /// The player's standing collision capsule, in world units.
 fn standing_player_capsule() -> Capsule {
     Capsule::new_y(


### PR DESCRIPTION
## Summary

- convert OpenXR STAGE-space tracked positions (meters) to world units (1 wu = 2.5 SS2 ft) before they enter the game
- re-anchor the per-eye view poses and both hand poses from the player collider's **center** to the **feet**, via a new stance-aware `Game::player_center_above_floor()`
- net effect: a tracked eye N meters above the physical floor lands at the equivalent height above the in-game floor

## Problem

The Oculus runtime added raw STAGE poses (meters, floor origin) on top of the collider center (3.11 SS2 ft above the game floor) with no unit conversion. For a ~1.7 m player that put the standing eye ~7.4 SS2 ft above the game floor — ~1.8 ft above the original game's 5.6 ft standing eye line — varying with the player's real-world height, and rendered the world ~31% oversized (tracked meters used 1:1 as world units also inflated the stereo baseline). Hands ran through the same composition (`virtual_hand` anchors them at the pawn position plus the raw tracked offset), so they carried the same error.

Flat runtimes are untouched: they compose the camera from `player_eye_height()` and never use tracked poses.

## Change

`stage_to_pawn()` in the Oculus runtime scales meters → world units and drops the anchor from the physical floor to the collider center, applied identically at both ingestion points (per-eye `head_offset` in `render_swapchain`, hand poses feeding `InputContext`) so view and hands stay attached. `physics::player_center_above_floor(crouched)` exposes the stance-aware capsule-center height (half height + resting gap); `shock2vr::METERS_PER_WORLD_UNIT` is the single unit constant.

Physical crouch now tracks 1:1 through the camera. The collider itself still does not crouch in VR — that remains #512 / #675, and this change is a prerequisite for #675's camera behaving sanely (it removes the capsule-center anchor that caused the double-lowered crouch view flagged in its review).

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean
- `cargo test -p shock2vr` — passed
- `cargo apk build --release` — built and signed
- **Quest 3 on-device**: medsci1 at steady 90 Hz (frame ~11.1 ms, 0 skipped), XR session FOCUSED; standing eye verified on the retail eye line, world scale reads life-sized, hand reach matches proprioception, physical crouch tracks the view naturally.