### PR TITLE
fix(ai): hold fire when allies block the shot

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1173,6 +1173,7 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             |str| PropAI(str),
             accumulator::latest,
         ),
+        define_prop("P$AI_Team", PropAITeam::read, identity, accumulator::latest),
         define_prop(
             "P$AI_AlertCap",
             PropAIAlertCap::read,

--- a/dark/src/properties/prop_ai.rs
+++ b/dark/src/properties/prop_ai.rs
@@ -7,6 +7,33 @@ use shipyard::Component;
 use crate::ss2_common::{read_bytes, read_string_with_size, read_u32};
 use serde::{Deserialize, Serialize};
 
+#[repr(u32)]
+#[derive(Debug, FromPrimitive, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AITeam {
+    Good = 0,
+    Neutral = 1,
+    Bad1 = 2,
+    Bad2 = 3,
+    Bad3 = 4,
+    Bad4 = 5,
+    Bad5 = 6,
+}
+
+impl AITeam {
+    pub fn from_raw(raw: u32) -> AITeam {
+        AITeam::from_u32(raw).unwrap_or(AITeam::Bad1)
+    }
+}
+
+#[derive(Debug, Component, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PropAITeam(pub AITeam);
+
+impl PropAITeam {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropAITeam {
+        PropAITeam(AITeam::from_raw(read_u32(reader)))
+    }
+}
+
 #[derive(Debug, Component, Clone, Deserialize, Serialize)]
 pub struct PropAI(pub String);
 
@@ -146,5 +173,21 @@ impl PropAISignalResponse {
             priority,
             actions,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn ai_team_decodes_dark_team_enum() {
+        let mut good = Cursor::new(0_u32.to_le_bytes());
+        let mut bad4 = Cursor::new(5_u32.to_le_bytes());
+
+        assert_eq!(PropAITeam::read(&mut good, 4), PropAITeam(AITeam::Good));
+        assert_eq!(PropAITeam::read(&mut bad4, 4), PropAITeam(AITeam::Bad4));
+        assert_eq!(AITeam::from_raw(u32::MAX), AITeam::Bad1);
     }
 }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -13,7 +13,7 @@ use crate::{
     creature,
     mission::{PlayerInfo, entity_creator::CreateEntityOptions},
     physics::{InternalCollisionGroups, PhysicsWorld},
-    runtime_props::{RuntimePropJointTransforms, RuntimePropTransform},
+    runtime_props::{RuntimePropJointTransforms, RuntimePropProxyEntity, RuntimePropTransform},
     scripts::{
         Effect,
         script_util::{get_first_link_of_type, get_first_link_with_template_and_data},
@@ -268,7 +268,11 @@ fn find_first_entity_by_template_id(world: &World, ranged_weapon: i32) -> Option
 /// Handles firing a projectile from a ranged weapon, when that weapon is own directly by the creature.
 /// Used by most creatures (robots, hybrids, midwives, etc)
 ///
-pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
+pub fn fire_ranged_projectile(
+    world: &World,
+    physics: &PhysicsWorld,
+    entity_id: EntityId,
+) -> Effect {
     let maybe_projectile =
         get_first_link_with_template_and_data(world, entity_id, |link| match link {
             Link::AIProjectile(data) => Some(*data),
@@ -299,6 +303,23 @@ pub fn fire_ranged_projectile(world: &World, entity_id: EntityId) -> Effect {
         let position = joint_transform.transform_point(point3(0.0, 0.0, 0.0));
         let muzzle_transform = transform * Matrix4::from_translation((position + forward).to_vec());
         let muzzle_position = muzzle_transform.transform_point(point3(0.0, 0.0, 0.0));
+        let Some((target_entity, target_position)) = world
+            .borrow::<UniqueView<PlayerInfo>>()
+            .ok()
+            .map(|player| (player.entity_id, player.pos))
+        else {
+            return Effect::NoEffect;
+        };
+        if !has_line_of_fire_from(
+            entity_id,
+            muzzle_position,
+            target_entity,
+            world,
+            physics,
+            target_position,
+        ) {
+            return Effect::NoEffect;
+        }
         let projectile_transform =
             projectile_transform_aimed_at_player(world, muzzle_position, muzzle_transform);
 
@@ -632,10 +653,9 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
 /// because projectiles collide with those - an AI allowed to stop and
 /// shoot through a closed door or a crate stands rooted firing into it
 /// for as long as its target stays known (issue #481's stand-and-shoot
-/// freeze). A living creature as the first hit still counts as clear:
-/// allies wander off on their own, and refusing to stand behind one would
-/// flap the chase/attack transition every time the ally shifts (holding
-/// fire while an ally blocks the shot is #614).
+/// freeze). Living allies block the shot, while an enemy creature or the
+/// intended target counts as clear. This preserves pursuit/attack against
+/// enemies without letting converged ranged AIs shoot through their own side.
 pub fn has_line_of_fire(
     from_entity: EntityId,
     world: &World,
@@ -652,7 +672,35 @@ pub fn has_line_of_fire(
         return false;
     };
     let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
+    let Some(target_entity) = world
+        .borrow::<UniqueView<PlayerInfo>>()
+        .ok()
+        .map(|player| player.entity_id)
+    else {
+        return false;
+    };
+    has_line_of_fire_from(
+        from_entity,
+        start_point,
+        target_entity,
+        world,
+        physics,
+        target,
+    )
+}
+
+fn has_line_of_fire_from(
+    from_entity: EntityId,
+    start_point: Point3<f32>,
+    target_entity: EntityId,
+    world: &World,
+    physics: &PhysicsWorld,
+    target: Vector3<f32>,
+) -> bool {
     let end_point = point3(0.0, 0.0, 0.0) + target;
+    if (end_point - start_point).magnitude2() <= 1.0e-12 {
+        return true;
+    }
     let direction = (end_point - start_point).normalize();
     let distance = (end_point - start_point).magnitude();
     let result = physics.ray_cast2(
@@ -670,13 +718,47 @@ pub fn has_line_of_fire(
         Some(hit) => hit
             .maybe_entity_id
             .map(|id| {
-                world
+                let id = world
+                    .borrow::<View<RuntimePropProxyEntity>>()
+                    .ok()
+                    .and_then(|v| v.get(id).ok().map(|proxy| proxy.0))
+                    .unwrap_or(id);
+                if target_entity == id {
+                    return true;
+                }
+
+                let is_creature = world
                     .borrow::<View<PropCreature>>()
                     .map(|v| v.contains(id))
-                    .unwrap_or(false)
+                    .unwrap_or(false);
+                if !is_creature {
+                    return false;
+                }
+                let is_living = world
+                    .borrow::<View<PropHitPoints>>()
+                    .ok()
+                    .and_then(|v| v.get(id).ok().map(|hp| hp.hit_points > 0))
+                    .unwrap_or(true);
+                if !is_living {
+                    return true;
+                }
+
+                ai_team(world, id) != ai_team(world, from_entity)
             })
             .unwrap_or(false),
     }
+}
+
+/// Dark defaults ordinary AIs to Bad 1; Good/Neutral/other Bad teams are
+/// explicit `P$AI_Team` overrides (including the shipped Good Guy and Charmed
+/// metaproperties). Equal teams are allies; a living creature on another team
+/// is a valid hostile obstruction and does not suppress the shot.
+fn ai_team(world: &World, entity_id: EntityId) -> AITeam {
+    world
+        .borrow::<View<PropAITeam>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|team| team.0))
+        .unwrap_or(AITeam::Bad1)
 }
 
 /// Check if the player is visible from an entity within a field of view
@@ -857,5 +939,130 @@ mod projectile_aim_tests {
             (actual_forward - expected_forward).magnitude() < 1.0e-6,
             "projectile direction must include pitch toward the player's collider",
         );
+    }
+}
+
+#[cfg(test)]
+mod line_of_fire_tests {
+    use super::*;
+    use crate::{
+        mission::PlayerInfo, physics::CollisionGroup, runtime_props::RuntimePropTransform,
+    };
+
+    fn identity_rotation() -> Quaternion<f32> {
+        Quaternion::from_sv(1.0, vec3(0.0, 0.0, 0.0))
+    }
+
+    fn line_of_fire_through(blocker_team: AITeam, blocker_hit_points: i32) -> bool {
+        let mut world = World::new();
+        let shooter = world.add_entity((
+            PropCreature(0),
+            PropAITeam(AITeam::Bad1),
+            PropHitPoints { hit_points: 10 },
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: identity_rotation(),
+            },
+            RuntimePropTransform(Matrix4::from_translation(vec3(0.0, 0.0, 0.0))),
+        ));
+        let blocker = world.add_entity((
+            PropCreature(0),
+            PropAITeam(blocker_team),
+            PropHitPoints {
+                hit_points: blocker_hit_points,
+            },
+            PropPosition {
+                position: vec3(0.0, 0.0, 5.0),
+                cell: 0,
+                rotation: identity_rotation(),
+            },
+            RuntimePropTransform(Matrix4::from_translation(vec3(0.0, 0.0, 5.0))),
+        ));
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 10.0),
+            rotation: identity_rotation(),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            blocker,
+            vec3(0.0, 0.0, 5.0),
+            identity_rotation(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 2.0, 1.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player_handle = physics.create_player(vec3(50.0, 50.0, 50.0), player);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        has_line_of_fire(shooter, &world, &physics, vec3(0.0, 0.0, 10.0))
+    }
+
+    #[test]
+    fn living_ally_blocks_line_of_fire() {
+        assert!(!line_of_fire_through(AITeam::Bad1, 10));
+    }
+
+    #[test]
+    fn living_enemy_does_not_block_line_of_fire() {
+        assert!(line_of_fire_through(AITeam::Good, 10));
+    }
+
+    #[test]
+    fn dead_ally_does_not_block_line_of_fire() {
+        assert!(line_of_fire_through(AITeam::Bad1, 0));
+    }
+
+    #[test]
+    fn intended_target_does_not_block_its_own_line_of_fire() {
+        let mut world = World::new();
+        let shooter = world.add_entity((
+            PropCreature(0),
+            PropAITeam(AITeam::Bad1),
+            PropHitPoints { hit_points: 10 },
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: identity_rotation(),
+            },
+        ));
+        let target = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 5.0),
+            rotation: identity_rotation(),
+            entity_id: target,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, 0.0, 5.0),
+            identity_rotation(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 2.0, 1.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player_handle = physics.create_player(vec3(50.0, 50.0, 50.0), target);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        assert!(has_line_of_fire(
+            shooter,
+            &world,
+            &physics,
+            vec3(0.0, 0.0, 5.0),
+        ));
     }
 }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -1392,7 +1392,7 @@ impl Script for AnimatedMonsterAI {
                     if self.is_dead || is_killed(entity_id, world) {
                         return Effect::NoEffect;
                     }
-                    fire_ranged_projectile(world, entity_id)
+                    fire_ranged_projectile(world, physics, entity_id)
                 } else if motion_flags.contains(MotionFlags::MELEE_CONTACT_START) {
                     // The swing reached its authored contact frame - resolve
                     // the hit through the attacker's melee weapon archetype.

--- a/tools/shock2-sdk/test/ally-line-of-fire.e2e.test.ts
+++ b/tools/shock2-sdk/test/ally-line-of-fire.e2e.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function numericProp(detail: EntityDetailResult, name: string): number {
+  const value = detail.properties.find((property) => property.name === name)?.value;
+  assert.ok(value !== undefined, `${detail.name} ${detail.entity_id} has no ${name}`);
+  return Number(value);
+}
+
+function distance(
+  position: [number, number, number],
+  target: { x: number; y: number; z: number },
+): number {
+  return Math.hypot(position[0] - target.x, position[1] - target.y, position[2] - target.z);
+}
+
+test(
+  "ranged AIs do not hurt allies during a pinned corridor convergence",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8146),
+      experimental: ["nav_bridges"],
+    });
+
+    await game.step({ frames: 10 });
+    const player = { x: -14.0, y: 0.5, z: -30.0 };
+    await game.player.teleport(player);
+    await game.step({ frames: 10 });
+
+    const hybrids = (await game.entities.list({ filter: "OG-", limit: 20 })).entities.filter(
+      (entity) => entity.name.startsWith("OG-"),
+    );
+    assert.ok(hybrids.length >= 2, `expected medsci1 hybrids, got ${hybrids.length}`);
+
+    const initialHealth = new Map<number, number>();
+    for (const hybrid of hybrids) {
+      const detail = await game.entities.detail(hybrid.id);
+      initialHealth.set(hybrid.id, numericProp(detail, "HitPoints"));
+    }
+
+    // The issue's authored reproduction funnels melee and ranged hybrids onto
+    // the same player down a narrow corridor. The player never attacks, so any
+    // health loss during this sequence is friendly projectile damage.
+    await game.input.trigger("DebugAlertAll");
+    await game.step({ frames: 630 });
+    await game.input.trigger("DebugForceChase");
+    await game.step({ frames: 1800 });
+
+    let closestShotgun = Infinity;
+    const damaged: string[] = [];
+    for (const hybrid of hybrids) {
+      const detail = await game.entities.detail(hybrid.id);
+      if (hybrid.name === "OG-Shotgun") {
+        closestShotgun = Math.min(closestShotgun, distance(detail.position, player));
+      }
+      const before = initialHealth.get(hybrid.id)!;
+      const after = numericProp(detail, "HitPoints");
+      if (after < before) {
+        damaged.push(`${hybrid.name} ${hybrid.id}: ${before} -> ${after}`);
+      }
+    }
+
+    assert.ok(
+      closestShotgun < 6.0,
+      `the fixture must bring a ranged AI into engagement range (closest ${closestShotgun.toFixed(2)})`,
+    );
+    assert.deepEqual(
+      damaged,
+      [],
+      `hybrids took damage while only their allies were firing:\n${damaged.join("\n")}`,
+    );
+  },
+);


### PR DESCRIPTION
## Reproduction

On current `origin/main` (`c07099afac3824a097b2949c7439c7ceb475397a`), I launched `medsci1.mis` with `nav_bridges`, teleported the player to `(-14, 0.5, -30)`, advanced 10 frames, triggered `DebugAlertAll`, advanced 630 frames, triggered `DebugForceChase`, and advanced 1800 frames.

The player never attacked. A converged `OG-Shotgun` (mission template 613) ended at `[-10.227456, 0.0988639, -25.77282]` with 15/24 HP while in `RangedAttack`: 9 HP of friendly projectile damage.

The data audit found `P$AI_Team` is the Dark 4-byte `Good, Neutral, Bad1..Bad5` enum. Retail `shock2.gam` gives the `Good Guy` and `Charmed` metaproperties explicit `Good` values; ordinary AIs use the Dark default, `Bad1`.

## Root cause

The existing line-of-fire gate deliberately treated every living `PropCreature` as clear while #614 was deferred. The authored FIRE event also created the projectile without rechecking from the actual muzzle, so a ranged AI behind a same-team creature fired through it.

## Fix

- Parse and inherit the authored `P$AI_Team` property, defaulting missing/unknown data to Dark's `Bad1` default.
- Resolve hitbox proxies to their parent creature when classifying the first projectile-ray hit.
- Hold fire for a living creature on the shooter's exact team. Preserve shots through a corpse, a different-team creature, or the intended player target.
- Recheck from the authored muzzle at the FIRE animation event so movement after behavior selection cannot reintroduce the unsafe shot. A blocked AI emits no projectile and remains free to chase/strafe.
- Add an authored medsci1 SDK regression that requires a shotgun hybrid to reach engagement range while all six OG hybrids retain their starting health.

## Verification

- Negative-first fixture: `living_ally_blocks_line_of_fire` failed before the classification change; the different-team control already passed.
- `cargo test -p dark ai_team_decodes_dark_team_enum`: 1 passed.
- `cargo test -p shock2vr line_of_fire_tests`: 4 passed.
- `cargo test -p dark`: 78 unit + 9 mission-loading tests passed.
- `cargo test -p shock2vr`: 512 passed, 0 failed; 2 doctests ignored.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- SDK `npm test`: 26 passed, 189 opt-in e2e tests skipped.
- Focused `ally-line-of-fire.e2e.test.ts`: passed before and after rebase (78.1s / 79.6s). Post-fix all six OGs remained at max HP and continued in `Chase`; the chokepoint shotgun was 24/24 at `[-12.492, 0.099, -26.633]`.
- Full SDK e2e: 215 total, 209 passed, 3 failed, 3 skipped in 2,862.8s. Failure classification against current main:
  - `a loaded corpse does not replay its death` fails repeatably on both this branch and `origin/main` with the same stable-state aggregate assertion.
  - `losing sight of the player triggers a search of the last-known position` passed isolated on branch and `origin/main`; its full-run entity-disappearance failure did not reproduce.
  - `living SHODAN assassin remains supported when corridor spikes activate` passed isolated on branch and `origin/main`; its full-run fall did not reproduce.

No visual assets, rendering, UI, or presentation code changed. The behavioral result is covered deterministically by projectile-ray fixtures and health/state telemetry, so a rendering GIF is not applicable.

Fixes #614
