### PR TITLE
fix(sdk): reap prior owned debug runtimes

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -346,8 +346,11 @@ campaign just launches mission 0 with no frontier to load, which is harmless.
    and creates the ledger on the first iteration, keeps the roll after), then
    `show` → read the frontier + NEXT action (goal, tweak, `DARK_ASSET_PATH`).
 2. **Resume:** build the runtime from the **`fix_branch`** (so accrued fixes are
-   in), launch it **with the campaign's `DARK_ASSET_PATH`**, and `POST /v1/load
-   {file: frontier.save}` — or launch the first mission fresh at iteration 0.
+   in), launch it **with the campaign's `DARK_ASSET_PATH`** on a stable,
+   campaign-owned port via `GameServer.launch({ mission, port, reapPrevious:
+   true })`, and `POST /v1/load {file: frontier.save}` — or launch the first
+   mission fresh at iteration 0. The exact-ID reap prevents a dead iteration's
+   runtime from accumulating without touching another checkout's runtime.
 3. **Playtest** from here toward the goal (the `playtest` primitive), passing the
    campaign goal + the tweak instructions into the playtest prompt → `data.json`.
 4. **Review** the session (§2). Shallow/invalid → re-playtest with guidance.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -27,8 +27,11 @@ manager validates, files, and delegates its fix in parallel. Continue to record
 the finding in the final `data.json`.
 
 ## Reach the start state
-- **Fresh:** launch the runtime on the mission (SDK `GameServer.launch`, or
-  `cargo dbgr --mission <m>.mis --port <p>`), `step 5` to settle.
+- **Fresh:** launch the runtime on the mission with a stable, session-owned port
+  and stale-instance reaping
+  (`GameServer.launch({ mission, port, reapPrevious: true })`), then `step 5` to
+  settle. Prefer this SDK lifecycle over raw `cargo dbgr` for agent sessions:
+  reaping requires the SDK's checkout-local lease and exact runtime instance ID.
 - **Resume at a frontier** (the manager passes one): warp with
   `POST /v1/control/transition-level {level, loc}` and/or `teleport {x,y,z}` to
   where the last session stalled, so you don't replay solved parts. (`QuickLoad`

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -126,6 +126,11 @@ const game = await GameServer.connect("http://127.0.0.1:8080");
 - `GameServer.launch` finds the cargo workspace by walking up from `cwd`;
   pass `repoRoot` to override. First launch may take minutes while cargo
   compiles; the default readiness timeout is 5 minutes.
+- Long-lived automation should use a stable dedicated port and pass
+  `reapPrevious: true`. Before launch, the SDK then reaps only a prior runtime
+  whose checkout-local lease, requested port, and live random instance ID all
+  match. The option is off by default so concurrent tests asking for the same
+  port continue to use separate free ports rather than stopping each other.
 - Injected actions apply on the next game update, which runs even while
   paused (with zero delta time).
 - `game.logs()` returns recent runtime output (also included in launch

--- a/tools/shock2-sdk/src/server.ts
+++ b/tools/shock2-sdk/src/server.ts
@@ -1,8 +1,17 @@
-import { type ChildProcess, spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:net";
-import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
 import { HttpClient } from "./client.js";
 import { Game } from "./game.js";
@@ -32,6 +41,13 @@ export interface LaunchOptions {
   rustLog?: string;
   /** Echo runtime output to this process's stderr (default false). */
   echoLogs?: boolean;
+  /**
+   * Reap a prior SDK-owned runtime on the requested port before launching.
+   * Ownership must be proven by this checkout's lease and the runtime's exact
+   * instance id. Disabled by default so concurrent callers keep independent
+   * runtimes and use the next free port as usual.
+   */
+  reapPrevious?: boolean;
 }
 
 /** Walk up from a directory until a cargo workspace root is found. */
@@ -39,7 +55,10 @@ export function findRepoRoot(startDir: string): string | undefined {
   let dir = startDir;
   for (;;) {
     const manifest = join(dir, "Cargo.toml");
-    if (existsSync(manifest) && readFileSync(manifest, "utf8").includes("[workspace]")) {
+    if (
+      existsSync(manifest) &&
+      readFileSync(manifest, "utf8").includes("[workspace]")
+    ) {
       return dir;
     }
     const parent = dirname(dir);
@@ -58,6 +77,190 @@ const MAX_LOG_LINES = 2000;
  * but whose child hasn't bound yet (cargo may compile for minutes first).
  */
 const reservedPorts = new Set<number>();
+
+interface RuntimeLease {
+  port: number;
+  instanceId: string;
+  pid: number;
+}
+
+function canonicalRepoRoot(repoRoot: string): string {
+  try {
+    return realpathSync.native(repoRoot);
+  } catch {
+    return resolve(repoRoot);
+  }
+}
+
+function runtimeLeaseDirectory(repoRoot: string, port: number): string {
+  const checkout = createHash("sha256")
+    .update(canonicalRepoRoot(repoRoot))
+    .digest("hex")
+    .slice(0, 24);
+  return join(tmpdir(), "shock2-sdk-runtime-leases", checkout, String(port));
+}
+
+/** @internal Exported for ownership-safety tests. */
+export function runtimeLeasePath(
+  repoRoot: string,
+  port: number,
+  instanceId: string,
+): string {
+  return join(runtimeLeaseDirectory(repoRoot, port), `${instanceId}.json`);
+}
+
+function writeRuntimeLease(repoRoot: string, lease: RuntimeLease): string {
+  const path = runtimeLeasePath(repoRoot, lease.port, lease.instanceId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  return path;
+}
+
+function removeRuntimeLease(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw error;
+  }
+}
+
+function readRuntimeLeases(
+  repoRoot: string,
+  port: number,
+): Array<{
+  lease: RuntimeLease;
+  path: string;
+}> {
+  const directory = runtimeLeaseDirectory(repoRoot, port);
+  let names: string[];
+  try {
+    names = readdirSync(directory);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+
+  const leases: Array<{ lease: RuntimeLease; path: string }> = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const path = join(directory, name);
+    try {
+      const value = JSON.parse(
+        readFileSync(path, "utf8"),
+      ) as Partial<RuntimeLease>;
+      if (
+        value.port === port &&
+        typeof value.instanceId === "string" &&
+        Number.isSafeInteger(value.pid) &&
+        (value.pid ?? 0) > 0
+      ) {
+        leases.push({ lease: value as RuntimeLease, path });
+      }
+    } catch {
+      // A corrupt lease cannot prove ownership, so leave it untouched.
+    }
+  }
+  return leases;
+}
+
+async function runtimeInstanceId(port: number): Promise<string | undefined> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/health`, {
+      signal: AbortSignal.timeout(1_000),
+    });
+    if (!response.ok) return undefined;
+    const health = (await response.json()) as { instance_id?: unknown };
+    return typeof health.instance_id === "string"
+      ? health.instance_id
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function waitForPortToBeFree(
+  port: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (await portIsFree(port)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } while (Date.now() < deadline);
+  return false;
+}
+
+function killLeasedProcessTree(pid: number): void {
+  if (process.platform === "win32") {
+    const result = spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+    });
+    if (result.error !== undefined || result.status !== 0) {
+      throw result.error ?? new Error(`taskkill exited with ${result.status}`);
+    }
+    return;
+  }
+  // launch() creates a detached process group whose leader is this pid.
+  process.kill(-pid, "SIGKILL");
+}
+
+export type ReapResult = "none" | "preserved" | "reaped";
+
+/**
+ * Reap the prior runtime only when a checkout-local lease and live instance id
+ * agree. A port occupied by any other instance is deliberately preserved.
+ */
+export async function reapPreviousRuntime(
+  repoRoot: string,
+  port: number,
+): Promise<ReapResult> {
+  const leases = readRuntimeLeases(repoRoot, port);
+  if (leases.length === 0) return "none";
+
+  const liveInstanceId = await runtimeInstanceId(port);
+  const owned = leases.find(({ lease }) => lease.instanceId === liveInstanceId);
+  if (owned === undefined) {
+    if (liveInstanceId === undefined && (await portIsFree(port))) {
+      for (const entry of leases) removeRuntimeLease(entry.path);
+      return "none";
+    }
+    return "preserved";
+  }
+
+  try {
+    await fetch(`http://127.0.0.1:${port}/v1/shutdown`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ instance_id: owned.lease.instanceId }),
+      signal: AbortSignal.timeout(2_000),
+    });
+  } catch {
+    // The runtime can close the connection while processing shutdown. Treat
+    // this as ambiguous and check the port before deciding whether to escalate.
+  }
+  if (!(await waitForPortToBeFree(port, 2_000))) {
+    // Recheck immediately before terminating the recorded process tree. This
+    // prevents a stale lease from targeting a runtime that replaced it.
+    if ((await runtimeInstanceId(port)) !== owned.lease.instanceId) {
+      return "preserved";
+    }
+    killLeasedProcessTree(owned.lease.pid);
+    if (!(await waitForPortToBeFree(port, 5_000))) {
+      throw new Error(
+        `owned debug_runtime ${owned.lease.instanceId} on port ${port} did not exit`,
+      );
+    }
+  }
+
+  for (const entry of leases) removeRuntimeLease(entry.path);
+  return "reaped";
+}
 
 /** Children that must not outlive this process (see hookSignalCleanup). */
 const liveServers = new Set<GameServer>();
@@ -147,6 +350,7 @@ export class GameServer extends Game implements AsyncDisposable {
     private readonly logLines: string[],
     private readonly instanceId: string | undefined,
     private readonly port: number | undefined,
+    private readonly leasePath: string | undefined,
   ) {
     super(client);
   }
@@ -164,6 +368,9 @@ export class GameServer extends Game implements AsyncDisposable {
       reservedPorts.delete(this.port);
     }
     liveServers.delete(this);
+    if (this.leasePath !== undefined) {
+      removeRuntimeLease(this.leasePath);
+    }
   }
 
   /** Recent stdout/stderr from the spawned runtime (ring buffer). */
@@ -178,7 +385,14 @@ export class GameServer extends Game implements AsyncDisposable {
 
   /** Connect to an already-running debug runtime. shutdown() will stop it; dispose will not spawn-kill anything. */
   static async connect(baseUrl = "http://127.0.0.1:8080"): Promise<GameServer> {
-    const server = new GameServer(new HttpClient(baseUrl), undefined, [], undefined, undefined);
+    const server = new GameServer(
+      new HttpClient(baseUrl),
+      undefined,
+      [],
+      undefined,
+      undefined,
+      undefined,
+    );
     await server.health();
     return server;
   }
@@ -191,10 +405,19 @@ export class GameServer extends Game implements AsyncDisposable {
    */
   static async launch(options: LaunchOptions): Promise<GameServer> {
     const hint = options.port ?? 8080;
+    const repoRoot = options.repoRoot ?? findRepoRoot(process.cwd());
+    if (repoRoot === undefined) {
+      throw new Error(
+        "Could not find cargo workspace root; pass repoRoot explicitly",
+      );
+    }
+    if (options.reapPrevious) {
+      await reapPreviousRuntime(repoRoot, hint);
+    }
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        return await GameServer.launchOnce(options, hint + attempt);
+        return await GameServer.launchOnce(options, repoRoot, hint + attempt);
       } catch (error) {
         lastError = error;
         const message = String(error);
@@ -214,15 +437,10 @@ export class GameServer extends Game implements AsyncDisposable {
 
   private static async launchOnce(
     options: LaunchOptions,
+    repoRoot: string,
     portHint: number,
   ): Promise<GameServer> {
     const port = await findFreePort(portHint);
-    const repoRoot = options.repoRoot ?? findRepoRoot(process.cwd());
-    if (repoRoot === undefined) {
-      throw new Error(
-        "Could not find cargo workspace root; pass repoRoot explicitly",
-      );
-    }
 
     // Identifies OUR runtime: /v1/health echoes it, and readiness checks
     // reject a different instance on the same port (e.g. another agent's
@@ -265,6 +483,28 @@ export class GameServer extends Game implements AsyncDisposable {
       detached: true,
     });
 
+    let leasePath: string;
+    try {
+      if (child.pid === undefined) {
+        throw new Error("spawned debug_runtime has no process id");
+      }
+      leasePath = writeRuntimeLease(repoRoot, {
+        port,
+        instanceId,
+        pid: child.pid,
+      });
+    } catch (error) {
+      if (child.pid !== undefined) {
+        try {
+          killLeasedProcessTree(child.pid);
+        } catch {
+          // Preserve the lease error, which is the actionable launch failure.
+        }
+      }
+      reservedPorts.delete(port);
+      throw error;
+    }
+
     const capture = (chunk: Buffer) => {
       for (const line of chunk.toString().split("\n")) {
         if (line.length === 0) continue;
@@ -282,6 +522,7 @@ export class GameServer extends Game implements AsyncDisposable {
       logLines,
       instanceId,
       port,
+      leasePath,
     );
     liveServers.add(server);
     hookSignalCleanup();

--- a/tools/shock2-sdk/test/runtime-reap.e2e.test.ts
+++ b/tools/shock2-sdk/test/runtime-reap.e2e.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { test } from "node:test";
+
+import { HttpClient } from "../src/client.js";
+import { GameServer } from "../src/index.js";
+import { findRepoRoot, runtimeLeasePath } from "../src/server.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+interface OwnedRuntime {
+  baseUrl: string;
+  instanceId: string;
+  pid: number;
+}
+
+async function launchOrphan(port: number): Promise<OwnedRuntime> {
+  const source = [
+    'import { GameServer } from "./dist/src/index.js";',
+    `const game = await GameServer.launch({ mission: "debug_minimal", port: ${port} });`,
+    "const health = await fetch(`${game.baseUrl}/v1/health`).then((response) => response.json());",
+    'process.stdout.write(JSON.stringify({ baseUrl: game.baseUrl, instanceId: health.instance_id, pid: game.child.pid }) + "\\n", () => process.exit(0));',
+  ].join("\n");
+  const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+  child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
+  assert.equal(exitCode, 0, `orphan launcher failed:\n${stderr}`);
+  return JSON.parse(stdout.trim()) as OwnedRuntime;
+}
+
+async function health(runtime: OwnedRuntime): Promise<{ instance_id: string }> {
+  return new HttpClient(runtime.baseUrl).get<{ instance_id: string }>(
+    "/v1/health",
+  );
+}
+
+async function stopOwnedRuntime(runtime: OwnedRuntime): Promise<void> {
+  const client = new HttpClient(runtime.baseUrl);
+  try {
+    await client.post("/v1/shutdown", { instance_id: runtime.instanceId });
+  } catch {
+    // The runtime can close the connection while processing the command.
+  }
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    let live: { instance_id: string };
+    try {
+      live = await health(runtime);
+    } catch {
+      return;
+    }
+    assert.equal(
+      live.instance_id,
+      runtime.instanceId,
+      "refusing to clean up a replacement runtime",
+    );
+  }
+
+  if (process.platform === "win32") {
+    const result = spawnSync(
+      "taskkill",
+      ["/pid", String(runtime.pid), "/T", "/F"],
+      { stdio: "ignore" },
+    );
+    assert.equal(result.status, 0, `failed to stop owned pid ${runtime.pid}`);
+  } else {
+    process.kill(-runtime.pid, "SIGKILL");
+  }
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    try {
+      await client.get("/v1/health");
+    } catch {
+      return;
+    }
+  }
+  throw new Error(
+    `owned runtime ${runtime.instanceId} did not exit after kill`,
+  );
+}
+
+test(
+  "launch can reap the exact prior SDK-owned runtime on its requested port",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const port = Number(process.env.SHOCK2_E2E_PORT ?? 8786);
+    const orphan = await launchOrphan(port);
+    let replacement: GameServer | undefined;
+    try {
+      assert.equal((await health(orphan)).instance_id, orphan.instanceId);
+
+      // Use a variable so this negative-first test compiles on the parent SDK,
+      // where the option is not declared and is simply ignored at runtime.
+      const options = { mission: "debug_minimal", port, reapPrevious: true };
+      replacement = await GameServer.launch(options);
+      assert.equal(
+        replacement.baseUrl,
+        orphan.baseUrl,
+        "the prior owned runtime should be reaped instead of accumulating on the next port",
+      );
+      const replacementHealth = await new HttpClient(replacement.baseUrl).get<{
+        instance_id: string;
+      }>("/v1/health");
+      assert.notEqual(replacementHealth.instance_id, orphan.instanceId);
+    } finally {
+      await replacement?.shutdown();
+      await stopOwnedRuntime(orphan);
+    }
+  },
+);
+
+test(
+  "launch preserves a runtime whose live instance id does not match the lease",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const port = Number(process.env.SHOCK2_E2E_PORT ?? 8786) + 2;
+    const repoRoot = findRepoRoot(process.cwd());
+    assert.ok(repoRoot);
+    const orphan = await launchOrphan(port);
+    const realLease = runtimeLeasePath(repoRoot, port, orphan.instanceId);
+    const unrelatedInstanceId = randomUUID();
+    const unrelatedLease = runtimeLeasePath(
+      repoRoot,
+      port,
+      unrelatedInstanceId,
+    );
+    unlinkSync(realLease);
+    mkdirSync(dirname(unrelatedLease), { recursive: true });
+    writeFileSync(
+      unrelatedLease,
+      `${JSON.stringify({ port, instanceId: unrelatedInstanceId, pid: orphan.pid })}\n`,
+      { mode: 0o600 },
+    );
+
+    let replacement: GameServer | undefined;
+    try {
+      replacement = await GameServer.launch({
+        mission: "debug_minimal",
+        port,
+        reapPrevious: true,
+      });
+      assert.notEqual(
+        replacement.baseUrl,
+        orphan.baseUrl,
+        "a runtime without an exact matching lease must be preserved",
+      );
+      assert.equal((await health(orphan)).instance_id, orphan.instanceId);
+    } finally {
+      await replacement?.shutdown();
+      await stopOwnedRuntime(orphan);
+      unlinkSync(unrelatedLease);
+    }
+  },
+);

--- a/tools/shock2-sdk/test/unit.test.ts
+++ b/tools/shock2-sdk/test/unit.test.ts
@@ -1,9 +1,17 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
 
 import { Game, findRepoRoot } from "../src/index.js";
 import { HttpClient } from "../src/client.js";
-import { formatCrashOutput } from "../src/server.js";
+import {
+  formatCrashOutput,
+  reapPreviousRuntime,
+  runtimeLeasePath,
+} from "../src/server.js";
 
 test("formatCrashOutput keeps the panic message and backtrace together", () => {
   const lines = [
@@ -16,10 +24,17 @@ test("formatCrashOutput keeps the panic message and backtrace together", () => {
     "   1: dark::mission::path_database::PathDatabase::read",
   ];
   const output = formatCrashOutput(lines);
-  assert.match(output, /starting level load/, "includes context before the panic");
+  assert.match(
+    output,
+    /starting level load/,
+    "includes context before the panic",
+  );
   assert.match(output, /panicked at/);
   assert.match(output, /PathDatabase::read/, "includes backtrace frames");
-  assert.ok(!output.includes("startup line 10"), "drops unrelated early output");
+  assert.ok(
+    !output.includes("startup line 10"),
+    "drops unrelated early output",
+  );
 });
 
 test("formatCrashOutput falls back to the tail when there is no panic", () => {
@@ -32,7 +47,10 @@ test("formatCrashOutput falls back to the tail when there is no panic", () => {
 test("findRepoRoot locates the cargo workspace from the SDK directory", () => {
   const root = findRepoRoot(import.meta.dirname);
   assert.ok(root, "expected to find a workspace root above the SDK");
-  assert.ok(!root.includes("shock2-sdk"), "workspace root should be above the SDK package");
+  assert.ok(
+    !root.includes("shock2-sdk"),
+    "workspace root should be above the SDK package",
+  );
 });
 
 test("waitFor resolves with the first truthy value", async () => {
@@ -74,5 +92,49 @@ test("findFreePort skips ports that are already bound", async () => {
     assert.ok(free > taken, `expected a port above ${taken}, got ${free}`);
   } finally {
     await new Promise((resolve) => blocker.close(resolve));
+  }
+});
+
+test("reapPreviousRuntime preserves a mismatched live instance", async () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "shock2-sdk-reap-test-"));
+  let shutdownRequests = 0;
+  const foreignInstanceId = "foreign-instance";
+  const server = createServer((request, response) => {
+    response.setHeader("Content-Type", "application/json");
+    if (request.method === "GET" && request.url === "/v1/health") {
+      response.end(JSON.stringify({ instance_id: foreignInstanceId }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/v1/shutdown") {
+      shutdownRequests += 1;
+    }
+    response.end("{}");
+  });
+  await new Promise<void>((resolve) =>
+    server.listen({ port: 0, host: "127.0.0.1" }, resolve),
+  );
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const leasePath = runtimeLeasePath(repoRoot, address.port, "owned-instance");
+  mkdirSync(dirname(leasePath), { recursive: true });
+  writeFileSync(
+    leasePath,
+    `${JSON.stringify({
+      port: address.port,
+      instanceId: "owned-instance",
+      pid: 2_147_483_000,
+    })}\n`,
+  );
+
+  try {
+    assert.equal(
+      await reapPreviousRuntime(repoRoot, address.port),
+      "preserved",
+    );
+    assert.equal(shutdownRequests, 0);
+  } finally {
+    unlinkSync(leasePath);
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
   }
 });


### PR DESCRIPTION
## Summary

- add opt-in `reapPrevious` support to `GameServer.launch`
- record each SDK launch in a checkout-scoped temporary lease keyed by requested port and random runtime instance ID
- gracefully stop, then terminate the detached process tree only while the live port still reports the exact leased instance ID
- preserve mismatched/unleased runtimes and retain the normal next-free-port behavior
- document the safe reap lifecycle for long-running playtest/play-through campaigns

This addresses the owner feedback on closed PR #793: reaping is not a process-name/default operation and cannot select another checkout's runtime. It is opt-in for a stable, caller-owned port.

## Reproduction

On current main, two separate owned SDK launches both requested port 17860. The first remained healthy at 17860 and the second remained healthy at 17861 (`bothAlive: true`), demonstrating that a dead automation owner would silently accumulate a runtime.

The new negative-first real-process test then failed on main because the replacement bound 8787 rather than reclaiming the orphan's 8786.

## Safety

- lease namespace includes the canonical checkout path
- a candidate must match requested port and the live `/v1/health` random instance ID
- graceful `/v1/shutdown` includes that exact ID
- force termination occurs only after an immediate second identity check
- mismatched IDs receive no shutdown request and are covered by unit and real-process tests
- no process-name scan or broad debug-runtime kill is used

## Verification

- `npm test`: 27 passed, 0 failed (190 e2e skips)
- focused real-process reap suite: 2 passed, 0 failed
  - exact prior orphan was reaped and the same port reused
  - mismatched lease/runtime stayed healthy while the replacement used the next port
- full SDK e2e: 213 passed, 1 failed, 3 conditional skips (217 total, 45m26s)
  - sole failure: existing `a loaded corpse does not replay its death` assertion
  - isolated branch run failed identically (30.60s)
  - untouched origin/main c07099a failed identically (46.55s)
  - all recorded corpse frames were Dead, sleeping, zero velocity, and zero position/pose error
- Prettier check: passed
- `git diff --check`: passed
- push hook `cargo fmt --all -- --check`: passed

No visual capture is applicable; this changes SDK process lifecycle only.

All issue-owned test runtimes were shut down or reaped and ports 8786-8789 were clear afterward. Pre-existing runtimes on unrelated ports were not targeted.

Fixes #786
