### PR TITLE
fix(gameplay): apply cursor tools in flat mode

### DIFF
--- a/projects/flat-ui.md
+++ b/projects/flat-ui.md
@@ -121,9 +121,11 @@ This left/right split matches the engine's `exclude_list_left/right` exactly
   chemical→research.
 - **ALT = split stack** (SPLIT cursor), **CTRL / "?" = query** an item; hover
   shows equipment condition.
-- **Dragging into the 3D view throws the item into the world.** An item can
-  stay on the cursor across UI states (a NewDark patch note covers
-  level-transition with an object on the cursor).
+- **LMB in the 3D view throws the cursor item into the world; RMB applies it
+  to the crosshair target** when that target explicitly accepts the item as a
+  tool. A refused/ignored item stays on the cursor. An item can stay on the
+  cursor across UI states (a NewDark patch note covers level-transition with
+  an object on the cursor).
 - Loot windows: left-click contents to take (manual p.7).
 - Audio logs: pickup downloads to the PDA; `U` plays the last unread; incoming
   **e-mail auto-plays**; BACKSPACE stops. **[unverified]** whether log *pickup*

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1756,7 +1756,8 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
 /// stick does what) since that is the game's convention, not guessable.
 fn input_channels_help() -> &'static str {
     "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
-     pointer.position [x,y] in [0,1] (origin top-left; null clears), pointer.pressed 0|1, \
+     pointer.position [x,y] in [0,1] (origin top-left; null clears), \
+     pointer.pressed 0|1, pointer.secondary_pressed 0|1, \
      {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
      {left,right}_hand.thumbstick [x,y], \
      {left,right}_hand.position [x,y,z] (pawn-local), \
@@ -1879,6 +1880,7 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
                 .get_or_insert(shock2vr::input_context::Pointer2D {
                     position: cgmath::vec2(0.0, 0.0),
                     pressed: false,
+                    secondary_pressed: false,
                 });
             pointer.position = cgmath::vec2(xy[0], xy[1]);
             Ok(())
@@ -1896,8 +1898,27 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
                 .get_or_insert(shock2vr::input_context::Pointer2D {
                     position: cgmath::vec2(0.0, 0.0),
                     pressed: false,
+                    secondary_pressed: false,
                 });
             pointer.pressed = pressed;
+            Ok(())
+        }
+        "pointer.secondary_pressed" => {
+            let pressed = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            let pointer = input
+                .pointer
+                .get_or_insert(shock2vr::input_context::Pointer2D {
+                    position: cgmath::vec2(0.0, 0.0),
+                    pressed: false,
+                    secondary_pressed: false,
+                });
+            pointer.secondary_pressed = pressed;
             Ok(())
         }
         // Crouch request: like the desktop LeftControl hold. The ACTUAL state

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -679,6 +679,7 @@ fn process_events(
             input_context.pointer = Some(shock2vr::input_context::Pointer2D {
                 position: vec2(x / SCR_WIDTH as f32, y / SCR_HEIGHT as f32),
                 pressed: window.get_mouse_button(MouseButton::Button1) == Action::Press,
+                secondary_pressed: window.get_mouse_button(MouseButton::Button2) == Action::Press,
             });
         }
     }

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -178,6 +178,10 @@ where
             _ => Effect::NoEffect,
         }
     }
+
+    fn accepts_tool(&self, entity_id: EntityId, world: &World, tool: EntityId) -> bool {
+        self.gui.accepts_tool(entity_id, world, tool)
+    }
 }
 
 pub fn gui_script<TState: Default + 'static, TMsg: Clone + 'static>(

--- a/shock2vr/src/gui/mod.rs
+++ b/shock2vr/src/gui/mod.rs
@@ -101,6 +101,19 @@ where
         }
     }
 
+    /// Whether this panel explicitly accepts `provided_entity_id` as a tool.
+    /// Flat mode queries this before sending the tool message so RMB never
+    /// takes an ordinary container-deposit path. The query must be pure; the
+    /// subsequent `on_provide_for_consumption` call owns all effects.
+    fn accepts_tool(
+        &self,
+        _entity_id: EntityId,
+        _world: &World,
+        _provided_entity_id: EntityId,
+    ) -> bool {
+        false
+    }
+
     /// An item was offered to this panel's entity (the port's tool channel:
     /// releasing a held item onto a target in VR, or a `ToolConsumable`
     /// touching it). `None` - the default - takes the ordinary deposit path,

--- a/shock2vr/src/input_context.rs
+++ b/shock2vr/src/input_context.rs
@@ -52,6 +52,9 @@ impl InputContext {
 pub struct Pointer2D {
     pub position: Vector2<f32>,
     pub pressed: bool,
+    /// Secondary flat-pointer button. In gameplay this is RMB, the existing
+    /// flat "use/frob" gesture; menus may ignore it.
+    pub secondary_pressed: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -74,11 +74,13 @@ const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
 /// cursor), so it is always reachable and serializes correctly on
 /// save/transition. Only committing the drag reaches the world: **Throw**
 /// detaches it and gives it world presence with an impulse along the view ray;
+/// **Apply** offers it to an explicitly accepting crosshair target;
 /// **Wield** equips/uses it (a double-click) via the same effect as a backpack
 /// click, acting on the still-contained item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlatUiDragAction {
     Throw(EntityId),
+    Apply(EntityId),
     Wield(EntityId),
     /// Cycle the empty wielded weapon's ammo type (the AMMOFULL cycle button
     /// was clicked). Not tied to a cursor item - the caller maps it to
@@ -146,6 +148,7 @@ pub struct FlatUiHost {
     cursor_canvas: Option<Vector2<f32>>,
     hover_close: bool,
     last_pointer_pressed: bool,
+    last_secondary_pointer_pressed: bool,
     /// Last known render-target size, for pointer->canvas letterbox mapping
     /// (updated every rendered frame; 4:3 default until the first render).
     screen_size: Vector2<f32>,
@@ -175,6 +178,7 @@ impl FlatUiHost {
             cursor_canvas: None,
             hover_close: false,
             last_pointer_pressed: false,
+            last_secondary_pointer_pressed: false,
             screen_size: CANVAS_SIZE,
         }
     }
@@ -382,11 +386,12 @@ impl FlatUiHost {
 
     /// Per-frame pointer processing while in flat presentation. Returns the
     /// `GUIHover` messages to dispatch to the strip/panel entity plus any
-    /// cursor-drag [`FlatUiDragAction`]s (lift/place/throw) for the caller to
+    /// cursor-drag [`FlatUiDragAction`]s (lift/place/apply/throw) for the caller to
     /// apply. Handles the close gestures (close button, LMB on the bare view,
     /// walk-away, entity gone) and the cursor-is-the-item drag (§1.5/§2.4):
     /// LMB on a strip item lifts it onto the cursor, LMB on another slot
-    /// places/swaps, LMB on the bare view throws it into the world. A
+    /// places/swaps, LMB on the bare view throws it into the world, and RMB
+    /// on the bare view offers it to the crosshair target. A
     /// bare-view click closes the MFD panel but never the strip - use mode is
     /// left by Tab (projects/flat-ui.md §5.2).
     pub fn update(
@@ -397,6 +402,9 @@ impl FlatUiHost {
         let pressed = pointer.map(|p| p.pressed).unwrap_or(false);
         let pressed_edge = pressed && !self.last_pointer_pressed;
         self.last_pointer_pressed = pressed;
+        let secondary_pressed = pointer.map(|p| p.secondary_pressed).unwrap_or(false);
+        let secondary_pressed_edge = secondary_pressed && !self.last_secondary_pointer_pressed;
+        self.last_secondary_pointer_pressed = secondary_pressed;
 
         // Age out the double-click window since the last lift.
         if let Some(mark) = self.last_lift.as_mut() {
@@ -459,8 +467,13 @@ impl FlatUiHost {
         }
 
         // A press fully outside the canvas (letterbox bars) is a bare-view
-        // click: throw a held item, else close the panel.
+        // click: RMB applies a held item, LMB throws it (or closes the panel).
         let Some(canvas_pos) = canvas_pos else {
+            if secondary_pressed_edge {
+                if let Some(held) = self.cursor_item.as_ref() {
+                    return (Vec::new(), vec![FlatUiDragAction::Apply(held.entity)]);
+                }
+            }
             if pressed_edge {
                 if let Some(held) = self.cursor_item.take() {
                     return (Vec::new(), vec![FlatUiDragAction::Throw(held.entity)]);
@@ -489,10 +502,16 @@ impl FlatUiHost {
             .unwrap_or(false);
 
         // --- Cursor-is-the-item drag: while an item rides the cursor, LMB
-        // places/swaps/throws it and never routes to a GuiScript (protecting
-        // the held item - the original blocks losing `drag_obj`). ---
+        // places/swaps/throws it. RMB over the bare view asks mission_core to
+        // apply it to the crosshair target, but deliberately keeps it on the
+        // cursor until the target actually consumes/destroys it. ---
         if self.cursor_item.is_some() {
             self.hover_close = false;
+            if secondary_pressed_edge && !over_strip && !over_panel && !over_ammo {
+                let held = self.cursor_item.as_ref().unwrap().entity;
+                self.last_lift = None;
+                return (Vec::new(), vec![FlatUiDragAction::Apply(held)]);
+            }
             if !pressed_edge {
                 return (Vec::new(), Vec::new());
             }
@@ -1156,6 +1175,7 @@ mod tests {
         let bare_view_pressed = Pointer2D {
             position: vec2(0.9, 0.9),
             pressed: true,
+            secondary_pressed: false,
         };
         host.update(&world, Some(bare_view_pressed));
         assert!(
@@ -1168,6 +1188,7 @@ mod tests {
             Some(Pointer2D {
                 position: vec2(0.9, 0.9),
                 pressed: false,
+                secondary_pressed: false,
             }),
         );
         host.update(&world, Some(bare_view_pressed));
@@ -1249,6 +1270,7 @@ mod tests {
         let over_strip = Pointer2D {
             position: vec2(0.5, 0.125),
             pressed: false,
+            secondary_pressed: false,
         };
         let (msgs, _) = host.update(&world, Some(over_strip));
         assert_eq!(msgs.len(), 1);
@@ -1258,6 +1280,7 @@ mod tests {
         let over_panel = Pointer2D {
             position: vec2(96.0 / 640.0, 272.0 / 480.0),
             pressed: false,
+            secondary_pressed: false,
         };
         let (msgs, _) = host.update(&world, Some(over_panel));
         assert_eq!(msgs.len(), 1);
@@ -1294,6 +1317,7 @@ mod tests {
             Some(Pointer2D {
                 position: bare,
                 pressed: false,
+                secondary_pressed: false,
             }),
         );
         host.update(
@@ -1301,6 +1325,7 @@ mod tests {
             Some(Pointer2D {
                 position: bare,
                 pressed: true,
+                secondary_pressed: false,
             }),
         );
         assert!(
@@ -1319,6 +1344,7 @@ mod tests {
             Some(Pointer2D {
                 position: bare,
                 pressed: false,
+                secondary_pressed: false,
             }),
         );
         host.update(
@@ -1326,6 +1352,7 @@ mod tests {
             Some(Pointer2D {
                 position: bare,
                 pressed: true,
+                secondary_pressed: false,
             }),
         );
         assert_eq!(host.strip_entity(), Some(inventory));
@@ -1421,6 +1448,7 @@ mod tests {
             Some(Pointer2D {
                 position: norm(canvas.0, canvas.1),
                 pressed: false,
+                secondary_pressed: false,
             }),
         );
         let (_msgs, actions) = host.update(
@@ -1428,6 +1456,31 @@ mod tests {
             Some(Pointer2D {
                 position: norm(canvas.0, canvas.1),
                 pressed: true,
+                secondary_pressed: false,
+            }),
+        );
+        actions
+    }
+
+    fn secondary_press_edge(
+        host: &mut FlatUiHost,
+        world: &World,
+        canvas: (f32, f32),
+    ) -> Vec<FlatUiDragAction> {
+        host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: false,
+                secondary_pressed: false,
+            }),
+        );
+        let (_msgs, actions) = host.update(
+            world,
+            Some(Pointer2D {
+                position: norm(canvas.0, canvas.1),
+                pressed: false,
+                secondary_pressed: true,
             }),
         );
         actions
@@ -1587,6 +1640,21 @@ mod tests {
         let actions = press_edge(&mut host, &world, (320.0, 300.0));
         assert_eq!(actions, vec![FlatUiDragAction::Throw(wrench)]);
         assert!(host.cursor_debug().is_none(), "throwing clears the cursor");
+    }
+
+    #[test]
+    fn secondary_clicking_the_bare_view_offers_but_keeps_the_item() {
+        let (world, mut host, wrench, _inv) = drag_world();
+        press_edge(&mut host, &world, (23.5, 34.0)); // lift
+
+        let actions = secondary_press_edge(&mut host, &world, (320.0, 300.0));
+
+        assert_eq!(actions, vec![FlatUiDragAction::Apply(wrench)]);
+        assert_eq!(
+            host.cursor_debug().map(|cursor| cursor.entity_id),
+            Some(wrench.inner() as i32),
+            "application keeps the item until a target actually consumes it",
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2787,7 +2787,9 @@ impl MissionCore {
     /// Apply a cursor-is-the-item drag action from the `FlatUiHost` (§1.5/§2.4).
     /// Lift/place/swap never reach here: a lifted item stays in the backpack
     /// container (the host just hides it from the strip), so only committing
-    /// the drag touches the world. `Throw` detaches + launches; `Wield`
+    /// the drag touches the world. `Throw` detaches + launches; `Apply`
+    /// offers the held item to an explicitly accepting crosshair target;
+    /// `Wield`
     /// produces the same effect a backpack click does (returned for the normal
     /// effect pipeline, which has `asset_cache` for the grab).
     fn apply_flat_drag_action(
@@ -2799,6 +2801,24 @@ impl MissionCore {
             FlatUiDragAction::Throw(entity_id) => {
                 self.throw_entity_into_world(entity_id);
                 Vec::new()
+            }
+            FlatUiDragAction::Apply(entity_id) => {
+                let Some(target) = self.interaction.highlighted_entities().into_iter().next()
+                else {
+                    return Vec::new();
+                };
+                if !self
+                    .script_world
+                    .accepts_tool(target, &self.world, entity_id)
+                {
+                    return Vec::new();
+                }
+                vec![Effect::Send {
+                    msg: Message {
+                        payload: MessagePayload::ProvideForConsumption { entity: entity_id },
+                        to: target,
+                    },
+                }]
             }
             // The AMMOFULL cycle button: advance the wielded weapon's ammo type
             // via the same effect as the CycleAmmo key/action.

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -330,6 +330,7 @@ mod tests {
         Some(Pointer2D {
             position: vec2(center.x / CANVAS_W, center.y / CANVAS_H),
             pressed,
+            secondary_pressed: false,
         })
     }
 

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -295,6 +295,7 @@ mod tests {
         Some(Pointer2D {
             position: vec2(x, y),
             pressed,
+            secondary_pressed: false,
         })
     }
 

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -264,6 +264,15 @@ impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
         // again. An open crate falls through and accepts the deposit normally.
         (!is_open(world, entity_id)).then_some(Effect::NoEffect)
     }
+
+    fn accepts_tool(
+        &self,
+        entity_id: EntityId,
+        world: &World,
+        provided_entity_id: EntityId,
+    ) -> bool {
+        can_hack(world, entity_id) && is_free_hack_tool(world, provided_entity_id)
+    }
 }
 
 #[cfg(test)]
@@ -536,6 +545,11 @@ mod tests {
         let pick = ice_pick(&mut world);
         let gui = HackableCrateGui::new();
 
+        assert!(
+            gui.accepts_tool(security_crate, &world, pick),
+            "flat mode should discover the authored FreeHack acceptance"
+        );
+
         let effect = gui
             .on_provide_for_consumption(security_crate, &world, pick)
             .expect("an ICE Pick should be claimed as a tool, not deposited");
@@ -570,6 +584,11 @@ mod tests {
         let (mut world, security_crate, _clip) = crate_world();
         let wrench = world.add_entity(PropObjIcon("icn_wrench".to_owned()));
         let gui = HackableCrateGui::new();
+
+        assert!(
+            !gui.accepts_tool(security_crate, &world, wrench),
+            "flat mode must leave a rejected item on the cursor"
+        );
 
         let effects = Effect::flatten(vec![
             gui.on_provide_for_consumption(security_crate, &world, wrench)

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -498,6 +498,14 @@ pub trait Script {
         Effect::NoEffect
     }
 
+    /// Whether this target explicitly handles an item on the tool channel.
+    /// Flat mode asks before dispatching `ProvideForConsumption`, so an RMB
+    /// application never falls into a container's ordinary deposit behavior
+    /// and never steals an item from a target that ignores it.
+    fn accepts_tool(&self, _entity_id: EntityId, _world: &World, _tool: EntityId) -> bool {
+        false
+    }
+
     /// Stable opt-in identity for private runtime state. Entity properties and
     /// links do not belong here: they are already serialized by the ECS save
     /// layer. Return a key only for state owned exclusively by this script.
@@ -679,6 +687,12 @@ impl Script for CompositeScript {
             .collect();
 
         Effect::combine(effects)
+    }
+
+    fn accepts_tool(&self, entity_id: EntityId, world: &World, tool: EntityId) -> bool {
+        self.scripts
+            .iter()
+            .any(|instance| instance.script.accepts_tool(entity_id, world, tool))
     }
 
     fn initialize_after_hydration(
@@ -1186,6 +1200,16 @@ impl ScriptWorld {
         self.message_queue.push(message);
     }
 
+    /// Query the target's scripts without mutating either target or tool.
+    /// Only an explicit opt-in makes flat RMB send the tool message.
+    pub fn accepts_tool(&self, target: EntityId, world: &World, tool: EntityId) -> bool {
+        self.entity_to_scripts.get(&target).is_some_and(|scripts| {
+            scripts
+                .iter()
+                .any(|instance| instance.script.accepts_tool(target, world, tool))
+        })
+    }
+
     /// Snapshot all opting-in private script state. The output is sorted so
     /// identical worlds produce reviewable, deterministic save JSON despite
     /// `HashMap` iteration order.
@@ -1392,6 +1416,30 @@ mod script_state_tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
+
+    struct ToolAcceptance(bool);
+
+    impl Script for ToolAcceptance {
+        fn accepts_tool(&self, _entity_id: EntityId, _world: &World, _tool: EntityId) -> bool {
+            self.0
+        }
+    }
+
+    #[test]
+    fn tool_application_requires_an_explicit_target_script_opt_in() {
+        let mut world = World::new();
+        let accepting = world.add_entity(());
+        let refusing = world.add_entity(());
+        let unscripted = world.add_entity(());
+        let tool = world.add_entity(());
+        let mut scripts = ScriptWorld::new();
+        scripts.add_entity2(accepting, Box::new(ToolAcceptance(true)));
+        scripts.add_entity2(refusing, Box::new(ToolAcceptance(false)));
+
+        assert!(scripts.accepts_tool(accepting, &world, tool));
+        assert!(!scripts.accepts_tool(refusing, &world, tool));
+        assert!(!scripts.accepts_tool(unscripted, &world, tool));
+    }
 
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     struct TestState {

--- a/shock2vr/src/scripts/obj_consume_button.rs
+++ b/shock2vr/src/scripts/obj_consume_button.rs
@@ -104,6 +104,11 @@ impl Script for ObjConsumeButton {
         }
     }
 
+    fn accepts_tool(&self, entity_id: EntityId, world: &World, tool: EntityId) -> bool {
+        (!receptor_has_final_model(world, entity_id) || self.one_shot_phase == OneShotPhase::Idle)
+            && can_consume_entity(world, entity_id, tool)
+    }
+
     fn update(
         &mut self,
         entity_id: EntityId,

--- a/tools/shock2-sdk/test/flat-tool-application.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-tool-application.e2e.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement, UiState } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+
+// Flat tool delivery (#817): while an inventory item rides the use-mode
+// cursor, RMB on the bare world view offers it to the crosshair target. LMB
+// remains the ordinary throw gesture (covered by inventory-drag.e2e.test.ts).
+//
+// Negative-first (verified against main, c07099af): the debug runtime rejects
+// `pointer.secondary_pressed` because no flat secondary gesture exists. The
+// only current bare-view click is LMB, which inventory-drag proves clears the
+// cursor and gives the item a world physics body instead of sending
+// ProvideForConsumption.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const ICE_PICK = -73;
+const SECURITY_CRATE = 325;
+
+function stripItem(ui: UiState, name: string): UiElement {
+  const item = ui.strip?.elements.find(
+    (element) => element.kind === "button" && element.label === name,
+  );
+  assert.ok(
+    item,
+    `inventory strip should contain ${name}; got ${JSON.stringify(
+      ui.strip?.elements.map((element) => element.label ?? element.texture),
+    )}`,
+  );
+  return item;
+}
+
+async function secondaryClickBareView(game: GameServer): Promise<void> {
+  // The center of the world view is below the top inventory strip and outside
+  // the left MFD slot. Pulse the secondary button through real pointer input.
+  await game.input.set("pointer.position", [0.5, 0.6]);
+  await game.input.set("pointer.secondary_pressed", 0);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.secondary_pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.secondary_pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+async function primaryClickBareView(game: GameServer): Promise<void> {
+  await game.input.set("pointer.position", [0.5, 0.6]);
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 2 });
+}
+
+test(
+  "flat cursor applies an ICE Pick to its crosshair target without hijacking rejected items",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9817),
+    });
+    await game.step({ frames: 5 });
+
+    const [crate] = await game.entities.byTemplate(SECURITY_CRATE);
+    assert.ok(crate, "hydro1 should contain security crate 325");
+    const [x, y, z] = crate.position;
+    await teleportVerified(game, { x: x + 1.2, y: y + 0.5, z: z + 1.2 });
+    await game.player.aimAt(crate, { hitbox: "center", visibility: "required" });
+    await game.step({ frames: 3 });
+
+    const amp = await game.player.spawnItem("Psi Amp");
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    // A target-side refusal must not drop, throw, deposit, or consume the
+    // cursor item. The sealed HackableCrate explicitly refuses a Psi Amp.
+    let ui = await game.ui.state();
+    await clickUiElement(game, stripItem(ui, "Psi Amp"));
+    await secondaryClickBareView(game);
+    ui = await game.ui.state();
+    assert.equal(
+      ui.cursor?.entity_id,
+      amp.entity_id,
+      "a rejected tool must remain on the cursor",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === amp.entity_id,
+      ),
+      "a rejected tool must remain in the backpack",
+    );
+
+    // LMB remains the ordinary throw path. It clears the cursor, detaches the
+    // item from the backpack, and gives it world physics.
+    await game.input.set("head.look", [180, 0]);
+    await game.step({ frames: 3 });
+    await primaryClickBareView(game);
+    assert.ok(!(await game.ui.state()).cursor);
+    assert.ok(
+      (await game.physics.bodies({ entityId: amp.entity_id })).bodies.length > 0,
+      "LMB should still throw the cursor item into the world",
+    );
+
+    // Reacquire the crate, provision the ICE Pick into the now-free backpack
+    // slot, then apply it with RMB. The crate claims FreeHack, becomes Hacked,
+    // and destroys the consumed Pick; destruction clears the host cursor.
+    await teleportVerified(game, { x: x + 1.2, y: y + 0.5, z: z + 1.2 });
+    await game.player.aimAt(crate, { hitbox: "center", visibility: "required" });
+    await game.step({ frames: 3 });
+    const pick = await game.player.spawnItem(ICE_PICK);
+    await game.step({ frames: 5 });
+    ui = await game.ui.state();
+    await clickUiElement(game, stripItem(ui, "ICE Pick"));
+    assert.equal((await game.ui.state()).cursor?.entity_id, pick.entity_id);
+    await secondaryClickBareView(game);
+    await game.step({ frames: 3 });
+
+    ui = await game.ui.state();
+    assert.ok(!ui.cursor, "the consumed ICE Pick should leave the cursor");
+    assert.ok(
+      !(await game.player.inventory()).items.some(
+        (item) => item.entity_id === pick.entity_id,
+      ),
+      "the crate should consume the ICE Pick",
+    );
+
+    // Opening the crate through its normal frob flow proves the target-side
+    // state change: Hacked crates show the loot face instead of the hack board.
+    await game.entities.sendMessage(crate.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "the applied ICE Pick should leave the crate openable");
+    assert.ok(
+      panel.elements.some(
+        (element) => element.texture?.toLowerCase() === "contain.pcx",
+      ),
+      "the ICE Pick should open the crate directly to its loot face",
+    );
+    assert.ok(
+      !panel.elements.some(
+        (element) => element.texture?.toLowerCase() === "hack.pcx",
+      ),
+      "the applied ICE Pick should bypass the hack board",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- add a flat-mode RMB gesture that applies the cursor-held item to the current crosshair target while preserving LMB throw
- require an explicit, pure target-side tool-acceptance opt-in before sending `ProvideForConsumption`, so ignored/refused items stay on the cursor and ordinary container deposits are never triggered accidentally
- wire the existing HackableCrate/ICE Pick and ObjConsumeButton handlers into that acceptance path, expose the secondary pointer in desktop/debug runtimes, and document/test the gesture

## Reproduction

On current `origin/main` (`c07099afac3824a097b2949c7439c7ceb475397a`):

- `cargo dq templates 73` reports the ICE Pick (`-73`) with `FreeHack` and `PropFrobInfo { world_action: MOVE, inventory_action: SCRIPT, tool_action: SCRIPT }`.
- Hydro1 security crate mission object `325` has the live `HackableCrate` target handler from #816.
- The existing real `inventory-drag` scenario passed and showed that LMB on the bare view clears the cursor and creates a physics body: the Pick is thrown, never offered to the crate.
- The new negative-first Hydro1 scenario failed before the product change with HTTP 400: `unknown input channel 'pointer.secondary_pressed'`; flat mode had no secondary apply gesture or `ProvideForConsumption` sender.

## Fix

RMB is the existing flat use/frob button, so it now means "apply cursor item to crosshair target" while in the inventory drag state. LMB remains the documented throw gesture.

`Script::accepts_tool` is false by default. `GuiScript` delegates to a pure `Gui::accepts_tool` hook, HackableCrate accepts only a still-hackable crate plus an authored `FreeHack` item, and ObjConsumeButton accepts only its authored eligible consumable. Mission code sends `ProvideForConsumption` only after that opt-in. The cursor itself is not cleared; a successful target destroys/consumes the item through the normal effects pipeline, while ignored/refused targets leave it in the backpack and on the cursor.

## Verification

- `cargo test -p shock2vr` — **510 passed, 0 failed**
- focused Rust drag/acceptance/HackableCrate tests — **4 passed, 0 failed**
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — **passed**
- `cargo fmt --all -- --check` and `git diff --check` — **passed**
- `cd tools/shock2-sdk && npm test` — **26 passed, 189 e2e-gated/skipped, 0 failed**
- focused real Hydro1 SDK scenario — **1 passed, 0 failed**; verifies rejected Psi Amp retention, unchanged LMB throw/physics, ICE Pick RMB consumption, and `CONTAIN.PCX` instead of `HACK.PCX`
- full serial SDK e2e — **211 passed, 1 failed, 3 suite-gated/skipped** in 45m44s. The sole failure was the pre-existing `a loaded corpse does not replay its death` exact-comparison case; isolated runs failed identically on this branch and detached current `origin/main`, with all five printed samples stable (`Dead`, no clip/queue, sleeping dynamic body, zero velocity/position/pose error).
- informational full Clippy audit remains baseline-red (22 existing `engine` lints; `shock2vr --no-deps` likewise reports existing legacy lints); no changed-path compile warning appears in the required `-D warnings` check.

## Visual verification

![Flat ICE Pick application](https://gist.githubusercontent.com/tommy-xr/f0fff9420df5f6c54bade7cdc203c1b7/raw/ice-pick-tool-application.gif)

<sub>Flat-mode RMB now applies a cursor-held ICE Pick to the targeted security crate. On `origin/main`, LMB throws the Pick and the crate still opens `HACK.PCX`; on the branch, RMB consumes the Pick and the frob opens `CONTAIN.PCX`. Captured headlessly with deterministic fixed-timestep stepping.</sub>

### After

![ICE Pick applied to security crate](https://gist.githubusercontent.com/tommy-xr/f0fff9420df5f6c54bade7cdc203c1b7/raw/ice-pick-after-still.png)

### Before → after

![Thrown versus applied ICE Pick](https://gist.githubusercontent.com/tommy-xr/f0fff9420df5f6c54bade7cdc203c1b7/raw/ice-pick-before-after.png)

Fixes #817
