### PR TITLE
fix(physics): keep lift passengers on clear support

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1199,7 +1199,23 @@ fn create_physics_representation_with_options(
                 && maybe_dimensions.is_none()
                 && !immobile
                 && !is_climbable;
-            let group = if is_unsimulated_debris {
+            // An explicit SPHERE with no usable radius has no authored
+            // collision volume. `add_dynamic` still sanitizes it to a tiny
+            // ball because Rapier cannot index a degenerate AABB, but that
+            // crash guard is not level geometry: leaving it solid turns a
+            // dimensionless point into an invisible character obstacle. This
+            // is especially destructive above moving terrain, where the point
+            // can deflect a carried capsule off its support (#592).
+            //
+            // Keep the body and ENTITY membership for save/physics identity,
+            // raycasts, and script effects. Only character solidity changes;
+            // positive authored spheres remain ordinary solid dynamic props.
+            let is_dimensionless_authored_sphere = phys_type.phys_type == PhysicsModelType::SPHERE
+                && maybe_dimensions.is_some_and(|dimensions| {
+                    let radius = dimensions.radius0.abs().max(dimensions.radius1.abs());
+                    !radius.is_finite() || radius <= 0.0
+                });
+            let group = if is_unsimulated_debris || is_dimensionless_authored_sphere {
                 group.non_solid_to_characters()
             } else {
                 group
@@ -1534,6 +1550,31 @@ mod tests {
         entity_id
     }
 
+    fn add_authored_sphere(world: &mut World, radius: f32) -> EntityId {
+        world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::SPHERE,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysDimensions {
+                radius0: radius,
+                radius1: 0.0,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: Vector3::zero(),
+                unk1: 0,
+                unk2: 0,
+            },
+        ))
+    }
+
     /// `eggbit.bin`'s bounds, the annelid gib a smashed Floor Pod flinderizes
     /// into: measured live off its collider at 0.66 x 0.74 x 0.31 wu.
     fn gib_model() -> Model {
@@ -1597,6 +1638,45 @@ mod tests {
             );
             assert_eq!(bodies[0].blocks_player, should_block);
             assert_eq!(bodies[0].blocks_actor, should_block);
+        }
+    }
+
+    /// A zero-radius authored SPHERE has no collision volume. Physics keeps a
+    /// tiny sanitized body so Rapier never sees a degenerate AABB, but that
+    /// implementation detail must not turn the point into solid geometry for
+    /// character capsules. Positive authored spheres remain ordinary solid
+    /// dynamic props.
+    ///
+    /// Negative-first: before the fix both cases blocked characters.
+    #[test]
+    fn authored_zero_radius_sphere_does_not_block_characters() {
+        for (radius, should_block) in [(0.0, false), (0.25, true)] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_authored_sphere(&mut world, radius);
+
+            let handle = create_physics_representation(&mut world, &mut physics, &None, entity_id)
+                .expect("an authored sphere should retain its runtime body");
+
+            assert_eq!(
+                physics.collider_blocks_player(handle),
+                should_block,
+                "radius {radius} should{} block the player",
+                if should_block { "" } else { " not" }
+            );
+            assert_eq!(
+                physics.collider_blocks_actor(handle),
+                should_block,
+                "radius {radius} should{} block actors",
+                if should_block { "" } else { " not" }
+            );
+            let bodies = physics.debug_list_bodies();
+            assert_eq!(bodies.len(), 1);
+            assert_eq!(bodies[0].body_type, "dynamic");
+            assert!(
+                bodies[0].collision_groups.iter().any(|g| g == "entity"),
+                "the sphere must remain raycastable"
+            );
         }
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -448,7 +448,7 @@ fn try_step_up(
             rapier3d::parry::query::ShapeCastOptions {
                 max_time_of_impact: max_dist,
                 target_distance: target,
-                stop_at_penetration: false,
+                stop_at_penetration: true,
                 compute_impact_geometry_on_penetration: true,
             },
         )
@@ -717,6 +717,42 @@ fn detect_support(
     })
 }
 
+/// Whether the complete character shape can follow `translation` without a
+/// raw geometric collision. The ordinary controller intentionally casts with
+/// its contact offset, but an already-supported passenger can begin inside
+/// that margin at a tight station lip. In that case a tangential platform
+/// carry is still physically clear and must not turn the margin into a
+/// sideways slide.
+fn raw_character_sweep_is_clear(
+    queries: &QueryPipeline,
+    shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    translation: Vector<Real>,
+    moving_support: RigidBodyHandle,
+) -> bool {
+    let distance = translation.norm();
+    if distance <= Real::EPSILON {
+        return true;
+    }
+    let direction = translation / distance;
+    let not_moving_support =
+        |_handle: ColliderHandle, collider: &Collider| collider.parent() != Some(moving_support);
+    queries
+        .with_filter(queries.filter.predicate(&not_moving_support))
+        .cast_shape(
+            pos,
+            &direction,
+            shape,
+            rapier3d::parry::query::ShapeCastOptions {
+                max_time_of_impact: distance,
+                target_distance: 0.0,
+                stop_at_penetration: false,
+                compute_impact_geometry_on_penetration: true,
+            },
+        )
+        .is_none()
+}
+
 /// Distance along a horizontal ray at which it exits a climbable AABB expanded
 /// by the player's required clearance. `None` means the ray never crosses the
 /// expanded box.
@@ -810,6 +846,7 @@ fn shape_has_stable_support(
             &pose,
             Vector::zeros(),
             Vector::zeros(),
+            None,
             dt,
             -0.5 / SCALE_FACTOR,
             None,
@@ -1564,7 +1601,8 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
 /// (see [`PlayerSupport`]); it is applied first, so the player's own input and
 /// gravity are resolved from where the platform has taken them. A player
 /// gripping a ladder is holding the ladder, not riding the floor, so the climb
-/// branch above skips it.
+/// branch above skips it. `carry_support` identifies that owned body so a raw
+/// safety sweep can ignore the deck itself while retaining every other solid.
 ///
 /// `airborne_vertical` is one frame of an ordinary jump arc. While present it
 /// replaces the legacy constant gravity pass and disables ground snapping and
@@ -1576,6 +1614,7 @@ fn step_player_movement(
     pos: &Isometry<Real>,
     desired: Vector<Real>,
     carry: Vector<Real>,
+    carry_support: Option<RigidBodyHandle>,
     dt: Real,
     gravity: Real,
     slope_displacement: Option<Vector<Real>>,
@@ -1633,9 +1672,13 @@ fn step_player_movement(
     // along it instead of pushing them through it. Everything below then
     // resolves the player's own movement from where the platform left them.
     let carried = if carry != Vector::zeros() {
-        controller
+        let swept = controller
             .move_shape(dt, queries, shape, pos, carry, |_c| ())
-            .translation
+            .translation;
+        let raw_clear = carry_support.is_some_and(|support| {
+            raw_character_sweep_is_clear(queries, shape, pos, carry, support)
+        });
+        if raw_clear { carry } else { swept }
     } else {
         Vector::zeros()
     };
@@ -2964,6 +3007,7 @@ impl PhysicsWorld {
                     // has moved since the last one; the support is refreshed
                     // at the end of the hop instead.
                     Vector::zeros(),
+                    None,
                     dt,
                     gravity,
                     None,
@@ -3984,14 +4028,14 @@ impl PhysicsWorld {
         // advanced it to this frame's pose, so this is exactly the platform's
         // displacement for this frame. A support that has been removed simply
         // stops carrying.
-        let carry = player_handle
+        let (carry_support, carry) = player_handle
             .support
             .and_then(|support| {
                 self.rigid_body_set
                     .get(support.body)
-                    .map(|body| body.translation() - support.translation)
+                    .map(|body| (Some(support.body), body.translation() - support.translation))
             })
-            .unwrap_or_else(Vector::zeros);
+            .unwrap_or((None, Vector::zeros()));
 
         let player_movement = profile!(scope: "physics", level: TRACE, "physics.move_player", {
             let queries = self.player_movement_queries(dispatcher, movement_filter);
@@ -4040,6 +4084,7 @@ impl PhysicsWorld {
                         &character_pos,
                         desired_movement,
                         carry,
+                        carry_support,
                         self.integration_parameters.dt,
                         gravity,
                         Some(player_handle.slope_displacement),
@@ -5966,6 +6011,91 @@ mod tests {
             (end.y - start.y - platform_travel).abs() < 0.02,
             "player should ride the lift all {platform_travel} units up: moved {} (from {start:?} to {end:?})",
             end.y - start.y,
+        );
+    }
+
+    /// A lift deck can be authored flush with a station opening whose shaft is
+    /// only just wider than the player's physical capsule.  Once the deck has
+    /// acquired the player as its support, rising through that opening must
+    /// preserve the support's exact translation instead of letting a grazing
+    /// controller contact with the stationary lip slide the passenger into a
+    /// wall and off the deck.
+    #[test]
+    fn vertical_platform_carries_player_through_a_tight_station_lip() {
+        let mut world = PhysicsWorld::new();
+        let platform = world.add_kinematic(
+            EntityId::from_inner(2000).unwrap(),
+            vec3(0.0, -0.1, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 0.2, 1.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = world.create_player(
+            vec3(0.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2200).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+        let player_start = world.get_player_translation(&player);
+        let platform_start = world.get_position(platform).unwrap();
+
+        // The lower edge of a slightly tilted shaft face is geometrically
+        // clear of the capsule but inside the controller offset. Upward carry
+        // approaches that face by less than the raw clearance in one frame;
+        // the exact endpoint still fits, while a contact-offset cast slides.
+        world.add_collider(
+            EntityId::from_inner(2100).unwrap(),
+            ColliderBuilder::cuboid(0.05, 0.2, 5.0)
+                .translation(vector![0.59, player_start.y, 0.0])
+                .rotation(vector![0.0, 0.0, 0.3])
+                .build(),
+        );
+
+        world.set_translation(platform, platform_start + vec3(0.0, 0.04, 0.0));
+        step(&mut world, &mut player, 1);
+        // One more frame lands at the kinematic next pose written above.
+        step(&mut world, &mut player, 1);
+
+        let player_end = world.get_player_translation(&player);
+        let platform_end = world.get_position(platform).unwrap();
+        let platform_travel = platform_end.y - platform_start.y;
+        assert!(
+            (player_end.y - player_start.y - platform_travel).abs() < 0.02,
+            "passenger must rise exactly with the deck through the station lip: player {player_start:?} -> {player_end:?}, platform moved {platform_travel}"
+        );
+        assert!(
+            player_end.x.abs() < 1.0e-5 && player_end.z.abs() < 1.0e-5,
+            "a geometrically clear station lip must not deflect the passenger sideways: {player_end:?}"
+        );
+    }
+
+    /// The zero-offset proof only bypasses the controller's contact margin;
+    /// it must not bypass an actual obstruction in the platform's path.
+    #[test]
+    fn moving_platform_does_not_carry_player_through_a_real_wall() {
+        let (mut world, mut player, platform) = world_with_kinematic_platform();
+        let player_start = world.get_player_translation(&player);
+        let platform_start = world.get_position(platform).unwrap();
+        let wall_near_face = player_start.x + 0.65;
+        world.add_collider(
+            EntityId::from_inner(2101).unwrap(),
+            ColliderBuilder::cuboid(0.1, 5.0, 5.0)
+                .translation(vector![wall_near_face + 0.1, player_start.y, 0.0])
+                .build(),
+        );
+
+        world.set_translation(platform, platform_start + vec3(0.4, 0.0, 0.0));
+        step(&mut world, &mut player, 2);
+
+        let player_end = world.get_player_translation(&player);
+        assert!(
+            player_end.x < player_start.x + 0.25,
+            "a real wall must clip platform carry instead of being bypassed: {player_start:?} -> {player_end:?}"
+        );
+        assert!(
+            player_end.x + PLAYER_STANDING_RADIUS_WORLD <= wall_near_face + 1.0e-4,
+            "the carried capsule must remain outside the wall: {player_end:?}, wall face {wall_near_face}"
         );
     }
 

--- a/tools/shock2-sdk/test/ops4-lift-passenger.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-lift-passenger.e2e.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+// Bare save name copied into DARK_ASSET_PATH/saves by the caller. Retail save
+// payloads are copyrighted and intentionally remain outside the repository.
+const ops4LiftSave = process.env.SHOCK2_OPS4_LIFT_SAVE;
+const saveE2eEnabled = e2eEnabled && Boolean(ops4LiftSave);
+
+// Stable mission identities (`cargo dq entities ops4.mis <id>`). Runtime ids
+// are assigned afresh on every load and must be discovered each trial.
+const LIFT = 572;
+const LIFT_WALLS = 129;
+const UPPER_BUTTON = 600;
+const LOWER_BUTTON = 599;
+
+function onlyEntity(entities: EntitySummary[], templateId: number): EntitySummary {
+  assert.equal(
+    entities.length,
+    1,
+    `expected one live entity for template ${templateId}, got ${JSON.stringify(entities)}`,
+  );
+  return entities[0];
+}
+
+async function entity(game: GameServer, templateId: number): Promise<EntitySummary> {
+  return onlyEntity(await game.entities.byTemplate(templateId), templateId);
+}
+
+async function squeeze(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+}
+
+/**
+ * Regression for #592: Ops4 mission object 129 authors SPHERE physics with an
+ * explicit zero radius. The runtime must keep its crash-safe tiny body out of
+ * character collision; otherwise a centered passenger reaches that invisible
+ * point around ascent frame 80, is deflected sideways, loses lift support, and
+ * falls back to the lower station.
+ */
+test(
+  "Ops4 Lift 1 carries a centered passenger past dimensionless Lift 1 Walls",
+  { skip: !saveE2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "ops4.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8489),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    for (let trial = 1; trial <= 4; trial += 1) {
+      await game.load(ops4LiftSave!);
+      await game.step({ frames: 1 });
+
+      const lift = await entity(game, LIFT);
+      const walls = await entity(game, LIFT_WALLS);
+      const upperButton = await entity(game, UPPER_BUTTON);
+      const lowerButton = await entity(game, LOWER_BUTTON);
+
+      const wallsBodies = await game.physics.bodies({ entityId: walls.id });
+      assert.equal(wallsBodies.bodies.length, 1, "Lift 1 Walls should retain one body");
+      assert.equal(
+        wallsBodies.bodies[0].blocks_player,
+        false,
+        "zero-radius Lift 1 Walls must not become solid to the player",
+      );
+      assert.equal(
+        wallsBodies.bodies[0].blocks_actor,
+        false,
+        "zero-radius Lift 1 Walls must not become solid to actors",
+      );
+
+      // Deterministically exercise the authored elevator/button scripts while
+      // the player remains away from the shaft: send the lift down, then make
+      // one empty up/down round trip. This preserves the clean point body that
+      // earlier diagnostics accidentally knocked away before boarding.
+      await game.entities.sendMessage(upperButton.id, { type: "Frob" });
+      await game.step({ frames: 300 });
+      await game.entities.sendMessage(lowerButton.id, { type: "Frob" });
+      await game.step({ frames: 300 });
+      await game.entities.sendMessage(lowerButton.id, { type: "Frob" });
+      await game.step({ frames: 300 });
+
+      const lowerLift = await entity(game, LIFT);
+      assert.ok(
+        Math.abs(lowerLift.position[1] + 15.8) < 0.01,
+        `trial ${trial}: lift must be at the lower station, got ${lowerLift.position[1]}`,
+      );
+
+      // Match the clean campaign evidence exactly. The final activation is a
+      // genuine surface aim + production squeeze, not a script-message bypass.
+      await game.player.teleport({ x: 45.3, y: -14.356001, z: -106.0 });
+      const aim = await game.player.aimAt(lowerButton, {
+        hitbox: "surface",
+        visibility: "required",
+      });
+      assert.equal(aim.target_confirmed, true, `trial ${trial}: lower button aim`);
+      await game.step({ frames: 2 });
+      await squeeze(game);
+
+      let elapsed = 0;
+      for (const target of [15, 30, 60, 90, 120, 300]) {
+        await game.step({ frames: target - elapsed });
+        elapsed = target;
+      }
+
+      const finalPlayer = await game.player.position();
+      const finalLift = await entity(game, LIFT);
+      const horizontalDrift = Math.hypot(
+        finalPlayer.x - finalLift.position[0],
+        finalPlayer.z - finalLift.position[2],
+      );
+      const supportOffset = finalPlayer.y - finalLift.position[1];
+
+      assert.ok(
+        finalLift.position[1] > -11.0,
+        `trial ${trial}: lift should reach the upper station, got ${finalLift.position[1]}`,
+      );
+      assert.ok(
+        horizontalDrift < 0.05,
+        `trial ${trial}: passenger drifted off center by ${horizontalDrift}`,
+      );
+      assert.ok(
+        Math.abs(supportOffset - 1.444) < 0.05,
+        `trial ${trial}: passenger lost support (offset ${supportOffset})`,
+      );
+    }
+  },
+);

--- a/tools/shock2-sdk/test/ops4-lift-passenger.e2e.test.ts
+++ b/tools/shock2-sdk/test/ops4-lift-passenger.e2e.test.ts
@@ -16,6 +16,10 @@ const LIFT = 572;
 const LIFT_WALLS = 129;
 const UPPER_BUTTON = 600;
 const LOWER_BUTTON = 599;
+const OUTER_DOORS = [547, 192] as const;
+const INNER_DOORS = [193, 194] as const;
+
+type Point = { x: number; y: number; z: number };
 
 function onlyEntity(entities: EntitySummary[], templateId: number): EntitySummary {
   assert.equal(
@@ -36,99 +40,214 @@ async function squeeze(game: GameServer): Promise<void> {
   await game.input.set("right_hand.squeeze_value", 0);
 }
 
+async function frob(
+  game: GameServer,
+  templateId: number,
+  label: string,
+): Promise<void> {
+  const target = await entity(game, templateId);
+  const aim = await game.player
+    .aimAt(target, {
+      hitbox: "surface",
+      visibility: "required",
+    })
+    .catch(async (error: unknown) => {
+      const position = await game.player.position();
+      throw new Error(`${label} from ${JSON.stringify(position)}: ${String(error)}`, {
+        cause: error,
+      });
+    });
+  assert.equal(aim.target_confirmed, true, `${label}: surface aim`);
+  assert.equal(aim.entity_id, target.id, `${label}: aimed runtime entity`);
+  await game.step({ frames: 2 });
+  await squeeze(game);
+}
+
+async function moveAndSettle(
+  game: GameServer,
+  target: Point,
+  label: string,
+  allowBlocked = false,
+) {
+  const result = await game.player.moveTo(target);
+  // Match the campaign playtest primitive exactly: every bounded movement is
+  // followed by eight ordinary production frames before the next action.
+  await game.step({ frames: 8 });
+  if (!allowBlocked) {
+    assert.equal(result.blocked, false, `${label}: ${JSON.stringify(result)}`);
+    const position = await game.player.position();
+    assert.ok(
+      Math.hypot(position.x - target.x, position.z - target.z) < 0.1,
+      `${label}: did not reach waypoint: ${JSON.stringify({ target, result, position })}`,
+    );
+  }
+  return result;
+}
+
+async function traverseToUpperLift(game: GameServer, trial: number): Promise<void> {
+  for (const door of OUTER_DOORS) {
+    await frob(game, door, `trial ${trial}: outer door ${door}`);
+  }
+  await game.step({ frames: 25 });
+
+  // The preserved campaign save contains a Red Assassin corpse in this
+  // doorway. Crouched bounded locomotion walks around its edge; the midpoint
+  // may report blocked after making useful progress, exactly as in playtest.
+  await game.input.set("crouch", 1);
+  await game.step({ frames: 3 });
+  await moveAndSettle(game, { x: 65, y: -9.556, z: -97.8 }, "outer threshold");
+  await moveAndSettle(
+    game,
+    { x: 65, y: -9.556, z: -99.5 },
+    "corpse edge",
+    true,
+  );
+  await moveAndSettle(game, { x: 65, y: -9.556, z: -101 }, "past corpse");
+  await moveAndSettle(game, { x: 62, y: -9.556, z: -102.2 }, "inner doors");
+  await game.input.set("crouch", 0);
+  await game.step({ frames: 3 });
+
+  // Crossing the authored New Tripwire at the inner threshold opens both
+  // linked panels. Let that real sensor/door path finish before walking on;
+  // directly frobbing the already-moving panels is timing-dependent because
+  // their selectable centers slide behind the doorway brush.
+  for (const door of INNER_DOORS) await entity(game, door);
+  await game.step({ frames: 25 });
+  let through = await moveAndSettle(
+    game,
+    { x: 60.7, y: -9.556, z: -102.4 },
+    "inner threshold",
+    true,
+  );
+  if (through.blocked) {
+    // A final bounded retry covers arriving during the last closing fraction;
+    // setup still uses only the authored tripwire and ordinary simulation.
+    await game.step({ frames: 25 });
+    through = await moveAndSettle(
+      game,
+      { x: 60.7, y: -9.556, z: -102.4 },
+      "inner threshold retry",
+    );
+  }
+  assert.equal(through.blocked, false, `trial ${trial}: pass inner doors`);
+
+  for (const [index, waypoint] of [
+    { x: 59.5, y: -9.556, z: -102.4 },
+    { x: 56, y: -9.556, z: -102.4 },
+    { x: 51, y: -9.556, z: -102.4 },
+    { x: 51, y: -9.556, z: -106 },
+    { x: 49.8, y: -9.556, z: -106 },
+    { x: 48, y: -9.556, z: -106 },
+    { x: 45.3, y: -9.556, z: -106 },
+  ].entries()) {
+    await moveAndSettle(game, waypoint, `trial ${trial}: upper approach ${index}`);
+  }
+}
+
+async function runTrial(trial: number, port: number): Promise<void> {
+  await using game = await GameServer.launch({
+    mission: "ops4.mis",
+    port,
+    echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+  });
+
+  assert.equal((await game.load(ops4LiftSave!)).success, true);
+  await game.step({ frames: 1 });
+
+  const walls = await entity(game, LIFT_WALLS);
+  const wallsBodies = await game.physics.bodies({ entityId: walls.id });
+  assert.equal(wallsBodies.bodies.length, 1, "Lift 1 Walls should retain one body");
+  assert.equal(
+    wallsBodies.bodies[0].blocks_player,
+    false,
+    "zero-radius Lift 1 Walls must not become solid to the player",
+  );
+  assert.equal(
+    wallsBodies.bodies[0].blocks_actor,
+    false,
+    "zero-radius Lift 1 Walls must not become solid to actors",
+  );
+
+  await traverseToUpperLift(game, trial);
+
+  // Ride down through the genuine upper button, walk clear of the deck, then
+  // use the real lower button for an empty up/down cycle. This preserves the
+  // exact clean campaign state that exposed the intermittent ascent failure.
+  await frob(game, UPPER_BUTTON, `trial ${trial}: upper lift button`);
+  await game.step({ frames: 300 });
+  const lowerLift = await entity(game, LIFT);
+  assert.ok(
+    Math.abs(lowerLift.position[1] + 15.8) < 0.01,
+    `trial ${trial}: lift must reach lower station, got ${lowerLift.position[1]}`,
+  );
+  await moveAndSettle(
+    game,
+    { x: 47.5, y: -14.356, z: -104.5 },
+    `trial ${trial}: leave lower deck`,
+  );
+  await frob(game, LOWER_BUTTON, `trial ${trial}: send empty lift up`);
+  await game.step({ frames: 300 });
+  await frob(game, LOWER_BUTTON, `trial ${trial}: call empty lift down`);
+  await game.step({ frames: 300 });
+
+  // Board through the production bounded movement API and retain its required
+  // eight-frame settle. No teleport or injected script message participates.
+  await moveAndSettle(
+    game,
+    { x: 45.3, y: -14.356, z: -106 },
+    `trial ${trial}: board exact center`,
+  );
+  const boarded = await game.player.position();
+  assert.ok(
+    Math.hypot(boarded.x - 45.3, boarded.z + 106) < 0.02,
+    `trial ${trial}: bounded boarding must reach lift center: ${JSON.stringify(boarded)}`,
+  );
+
+  await frob(game, LOWER_BUTTON, `trial ${trial}: passenger ascent`);
+  let elapsed = 0;
+  let maxDrift = 0;
+  for (const target of [0, 15, 30, 60, 75, 78, 80, 90, 120, 300]) {
+    if (target > elapsed) await game.step({ frames: target - elapsed });
+    elapsed = target;
+    const player = await game.player.position();
+    const lift = await entity(game, LIFT);
+    const drift = Math.hypot(
+      player.x - lift.position[0],
+      player.z - lift.position[2],
+    );
+    maxDrift = Math.max(maxDrift, drift);
+  }
+
+  const finalPlayer = await game.player.position();
+  const finalLift = await entity(game, LIFT);
+  const supportOffset = finalPlayer.y - finalLift.position[1];
+  assert.ok(
+    finalLift.position[1] > -11.0,
+    `trial ${trial}: lift should reach upper station, got ${finalLift.position[1]}`,
+  );
+  assert.ok(
+    maxDrift < 0.05,
+    `trial ${trial}: passenger drifted off center by ${maxDrift}`,
+  );
+  assert.ok(
+    Math.abs(supportOffset - 1.444) < 0.05,
+    `trial ${trial}: passenger lost support (offset ${supportOffset})`,
+  );
+}
+
 /**
- * Regression for #592: Ops4 mission object 129 authors SPHERE physics with an
- * explicit zero radius. The runtime must keep its crash-safe tiny body out of
- * character collision; otherwise a centered passenger reaches that invisible
- * point around ascent frame 80, is deflected sideways, loses lift support, and
- * falls back to the lower station.
+ * Regression for #592: a genuine bounded-board passenger must survive Ops4's
+ * clean Lift 1 ascent. Mission object 129 authors a dimensionless sphere, and
+ * the shaft lip sits within the controller's contact margin; neither may turn
+ * a geometrically clear moving-support transfer into a lateral ejection.
  */
 test(
   "Ops4 Lift 1 carries a centered passenger past dimensionless Lift 1 Walls",
   { skip: !saveE2eEnabled, timeout: 600_000 },
   async () => {
-    await using game = await GameServer.launch({
-      mission: "ops4.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8489),
-      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
-    });
-
+    const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8489);
     for (let trial = 1; trial <= 4; trial += 1) {
-      await game.load(ops4LiftSave!);
-      await game.step({ frames: 1 });
-
-      const lift = await entity(game, LIFT);
-      const walls = await entity(game, LIFT_WALLS);
-      const upperButton = await entity(game, UPPER_BUTTON);
-      const lowerButton = await entity(game, LOWER_BUTTON);
-
-      const wallsBodies = await game.physics.bodies({ entityId: walls.id });
-      assert.equal(wallsBodies.bodies.length, 1, "Lift 1 Walls should retain one body");
-      assert.equal(
-        wallsBodies.bodies[0].blocks_player,
-        false,
-        "zero-radius Lift 1 Walls must not become solid to the player",
-      );
-      assert.equal(
-        wallsBodies.bodies[0].blocks_actor,
-        false,
-        "zero-radius Lift 1 Walls must not become solid to actors",
-      );
-
-      // Deterministically exercise the authored elevator/button scripts while
-      // the player remains away from the shaft: send the lift down, then make
-      // one empty up/down round trip. This preserves the clean point body that
-      // earlier diagnostics accidentally knocked away before boarding.
-      await game.entities.sendMessage(upperButton.id, { type: "Frob" });
-      await game.step({ frames: 300 });
-      await game.entities.sendMessage(lowerButton.id, { type: "Frob" });
-      await game.step({ frames: 300 });
-      await game.entities.sendMessage(lowerButton.id, { type: "Frob" });
-      await game.step({ frames: 300 });
-
-      const lowerLift = await entity(game, LIFT);
-      assert.ok(
-        Math.abs(lowerLift.position[1] + 15.8) < 0.01,
-        `trial ${trial}: lift must be at the lower station, got ${lowerLift.position[1]}`,
-      );
-
-      // Match the clean campaign evidence exactly. The final activation is a
-      // genuine surface aim + production squeeze, not a script-message bypass.
-      await game.player.teleport({ x: 45.3, y: -14.356001, z: -106.0 });
-      const aim = await game.player.aimAt(lowerButton, {
-        hitbox: "surface",
-        visibility: "required",
-      });
-      assert.equal(aim.target_confirmed, true, `trial ${trial}: lower button aim`);
-      await game.step({ frames: 2 });
-      await squeeze(game);
-
-      let elapsed = 0;
-      for (const target of [15, 30, 60, 90, 120, 300]) {
-        await game.step({ frames: target - elapsed });
-        elapsed = target;
-      }
-
-      const finalPlayer = await game.player.position();
-      const finalLift = await entity(game, LIFT);
-      const horizontalDrift = Math.hypot(
-        finalPlayer.x - finalLift.position[0],
-        finalPlayer.z - finalLift.position[2],
-      );
-      const supportOffset = finalPlayer.y - finalLift.position[1];
-
-      assert.ok(
-        finalLift.position[1] > -11.0,
-        `trial ${trial}: lift should reach the upper station, got ${finalLift.position[1]}`,
-      );
-      assert.ok(
-        horizontalDrift < 0.05,
-        `trial ${trial}: passenger drifted off center by ${horizontalDrift}`,
-      );
-      assert.ok(
-        Math.abs(supportOffset - 1.444) < 0.05,
-        `trial ${trial}: passenger lost support (offset ${supportOffset})`,
-      );
+      await runTrial(trial, basePort + trial - 1);
     }
   },
 );


### PR DESCRIPTION
Fixes #592

## Summary

- keep a crash-safe body for authored SPHERE physics with an explicit zero radius, but make that implementation-only point non-solid to players and living actors
- preserve exact moving-support translation when a zero-offset full-capsule sweep proves the path geometrically clear
- retain the ordinary contact-offset controller as the fallback for real walls, ceilings, and other obstructions
- replace the invalid setup-only lift test with four fresh-process campaign trials using real tripwires, paired doors, upper/lower button squeezes, bounded boarding, and the playtester's eight-frame settle

## Root cause

Two generic collision-boundary defects combined in the clean Ops4 state.

First, mission object 129 (Lift 1 Walls) explicitly authors a SPHERE with radius zero. Rapier cannot index a truly degenerate AABB, so the runtime correctly retains a sanitized 0.005-radius body, but incorrectly made that implementation-only point solid to character capsules. The first commit preserves entity/raycast/script/save identity while removing only character collision from explicit zero-radius spheres.

That correction exposed a second failure in the genuine bounded-boarding route. Internal traces showed that moving support never switched to static BSP or None: the rider retained Lift 1 body 599 / collider 600 at frames 0, 15, and 30. Instead, the character controller's intentional contact-offset sweep treated the tight station lip as a grazing hit even though the raw standing capsule and its complete carry path were geometrically clear. Its slide response introduced lateral drift, which accumulated until the rider left the deck.

The fix keeps the controller result unless a second zero-offset full-capsule sweep, excluding only the already-owned support body, proves the entire carry path clear. A clear path receives the support's exact translation. A true obstruction still uses the controller's clipped/sliding result, so authored geometry remains solid.

## Negative-first coverage

- tight station-lip fixture: baseline carry deflected the rider by x = -0.00015855 in one 0.04-unit lift frame; fixed carry preserves x/z exactly
- real-wall control: the raw proof rejects an actual wall and the controller keeps the full capsule outside it
- explicit zero-radius sphere: baseline blocked a player; fixed body remains present/raycastable but is non-solid to characters
- adjacent positive-radius sphere and dimensionless-debris controls remain solid/non-solid according to their authored geometry

## Exact campaign verification

Save: `campaign_ops_shodan_25th_iter06_ops4_chipb_checkpoint_20260808.sav`  
SHA-256: `759672bdba0ccc25c5b4029c04c63b23077b2856fe650721b4ae3c163b8a7fed`

The final E2E passed 4/4 fresh debug-runtime processes with 25th Anniversary assets. Every trial used:

1. authored tripwire/paired-door traversal from the saved frontier
2. genuine surface aim + squeeze on upper button 600 and lower button 599
3. bounded movement from off-platform to exact center, followed by the same eight-frame settle used by playtest
4. chunked ascent samples at frames 0/15/30/60/75/78/80/90/120/300

No teleport or injected script message participates. All trials kept maximum horizontal drift below 0.05, reached the upper station, and preserved the approximately 1.444 standing support offset.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 511 passed
- moving-platform subset — 9 passed
- SDK TypeScript/unit suite — 26 passed, 189 E2E skipped
- exact Ops4 campaign E2E — 4/4 fresh-process trials passed

## Visual evidence

![Ops4 Lift 1 passenger before and after](https://gist.githubusercontent.com/tommy-xr/f56f7afaa65a286afe9f60d09e2adde0/raw/ops4-lift-passenger.gif)

<sub>Before, the centered passenger is ejected as the lift reaches the station lip. After, the same production route carries the passenger cleanly to the upper station. Captured headlessly via the debug runtime with deterministic fixed-timestep stepping.</sub>

### Before → after at ascent frame 90

![Ops4 Lift 1 frame 90 before and after](https://gist.githubusercontent.com/tommy-xr/f56f7afaa65a286afe9f60d09e2adde0/raw/ops4-lift-before-after.png)

<sub>Exact 25th Anniversary save (SHA-256 `759672bdba0ccc25c5b4029c04c63b23077b2856fe650721b4ae3c163b8a7fed`), authored tripwire/door traversal, genuine upper/lower button surface aim + squeeze, bounded center boarding, and eight-frame settle; no teleport or injected messages. Baseline frame 90: drift 0.061 / support offset 0.980; fixed maximum drift 0.000028 / final support offset 1.444.</sub>