### PR TITLE
fix(scripts): stop earth training narrations all playing at once

### DIFF
--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -166,6 +166,16 @@ impl Script for TrapNewTripwire {
             MessagePayload::SensorEndIntersect { with } => {
                 let had_keys_before = !self.entity_in_trap.is_empty();
                 let was_reconstructed_after_load = self.reconstructed_after_load.remove(with);
+                // A scripted teleport trap yanked the entity out of this box -
+                // that departure is not a gameplay EXIT edge, the mirror of the
+                // arrival suppression above. On earth.mis the training wires
+                // switch a teleport trap *and* an inverter fanning out to a
+                // dozen Sound Traps: emitting EXIT's TurnOff here inverts into
+                // a TurnOn broadcast that starts every narration at once (and
+                // re-fires the teleport). Presence is still cleared so a later
+                // genuine re-entry sees a clean edge.
+                let departed_by_scripted_teleport =
+                    teleport_source(world, *with) == Some(TeleportSource::ScriptedTrap);
 
                 self.entity_in_trap.remove(with);
 
@@ -183,6 +193,7 @@ impl Script for TrapNewTripwire {
                 // leaving the lobby sensor. Once removed, a later genuine
                 // enter/exit pair behaves normally.
                 if !was_reconstructed_after_load
+                    && !departed_by_scripted_teleport
                     && !has_keys_now
                     && had_keys_before
                     && self.trip_flags.contains(TripFlags::EXIT)

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -124,6 +124,12 @@ impl Script for TrapNewTripwire {
                     // present. Tracking it would make walking back out emit an
                     // unbalanced EXIT TurnOff and re-trigger the earth montage
                     // loop (#515).
+                    //
+                    // NOTE: this clear is an Effect, applied only after the
+                    // whole frame's message queue has run - the SOURCE
+                    // tripwire's same-frame SensorEndIntersect (below) must
+                    // still see the marker, so the clear must never move
+                    // before message processing.
                     Some(TeleportSource::ScriptedTrap) => {
                         return Effect::ClearTeleportedMarker { entity_id: *with };
                     }
@@ -173,7 +179,9 @@ impl Script for TrapNewTripwire {
                 // dozen Sound Traps: emitting EXIT's TurnOff here inverts into
                 // a TurnOn broadcast that starts every narration at once (and
                 // re-fires the teleport). Presence is still cleared so a later
-                // genuine re-entry sees a clean edge.
+                // genuine re-entry sees a clean edge - which deliberately
+                // leaves ENTER's TurnOn without a balancing TurnOff, the same
+                // trade the arrival suppression already makes.
                 let departed_by_scripted_teleport =
                     teleport_source(world, *with) == Some(TeleportSource::ScriptedTrap);
 

--- a/shock2vr/src/scripts/trap_teleport_player.rs
+++ b/shock2vr/src/scripts/trap_teleport_player.rs
@@ -17,8 +17,15 @@ impl Script for TrapTeleportPlayer {
         entity_id: EntityId,
         world: &World,
         _physics: &PhysicsWorld,
-        _msg: &MessagePayload,
+        msg: &MessagePayload,
     ) -> Effect {
+        // Teleport on TurnOn only, like the original engine. Firing on any
+        // message meant an unrelated TurnOff (e.g. a tripwire's EXIT edge)
+        // teleported the player a second time.
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
+        }
+
         let v_position = world.borrow::<View<PropPosition>>().unwrap();
 
         let maybe_position = v_position.get(entity_id);

--- a/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
+import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
+import { teleportVerified } from "./helpers/teleport.js";
 
 // End-to-end regression for the earth.mis training-area audio cacophony.
 //
@@ -21,10 +23,13 @@ import { GameServer } from "../src/index.js";
 // intended one); post-fix exactly one plays.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
-// Stable earth.mis mission-object id of a training tripwire that links a teleport
-// trap + the silence Inverter + the narration Trigger Delay. Runtime entity ids
-// are rediscovered every launch, never hardcoded.
+// Stable earth.mis mission-object ids (the runtime reports these as
+// `template_id`, which is why they are the argument to `byTemplate` - runtime
+// entity ids are rediscovered every launch, never hardcoded). 378 is a training
+// tripwire linking the teleport trap 377, the silence Inverter, and the
+// narration Trigger Delay; 377's own position is the teleport destination pad.
 const TRAINING_TRIPWIRE_OBJ = 378;
+const TELEPORT_TRAP_OBJ = 377;
 
 test(
   "earth training: entering a teleport tripwire plays exactly one narration",
@@ -36,24 +41,18 @@ test(
     });
     await game.step({ frames: 30 });
 
-    const [tripwire] = await game.entities.byTemplate(TRAINING_TRIPWIRE_OBJ);
-    assert.ok(
-      tripwire,
-      `expected the earth.mis training tripwire for obj ${TRAINING_TRIPWIRE_OBJ}`,
-    );
-
     const audioBefore = await game.audio.recent();
     const lastAudioSequence = audioBefore.sounds.at(-1)?.sequence ?? 0;
     const messagesBefore = await game.messages.recent();
     const lastMessageSequence = messagesBefore.messages.at(-1)?.sequence ?? 0;
 
-    // Walk-in equivalent: drop the player inside the tripwire's box. A debug
-    // teleport is locomotion, so ENTER fires exactly as it does on foot.
-    await game.player.teleport({
-      x: tripwire.position[0],
-      y: tripwire.position[1],
-      z: tripwire.position[2],
-    });
+    // Enter the sensor under collision (real SensorBeginIntersect path) and
+    // verify the linked teleport actually fired.
+    await crossEarthTrainingTripwire(
+      game,
+      TRAINING_TRIPWIRE_OBJ,
+      TELEPORT_TRAP_OBJ,
+    );
     // Well past the narration Trigger Delay (~1s) so the intended clip has started.
     await game.step({ frames: 180 });
 
@@ -101,6 +100,33 @@ test(
       ["TurnOn"],
       `the teleport trap must only see the ENTER TurnOn: ` +
         JSON.stringify(teleportTrapMessages),
+    );
+
+    // Direct coverage of the TurnOn-only gate: a TurnOff injected into the
+    // teleport trap must NOT move the player (pre-fix it teleported on any
+    // message); a TurnOn must.
+    const [teleportTrap] = await game.entities.byTemplate(TELEPORT_TRAP_OBJ);
+    assert.ok(teleportTrap, `expected teleport trap ${TELEPORT_TRAP_OBJ}`);
+    const [padX, padY, padZ] = teleportTrap.position;
+    await teleportVerified(game, { x: padX, y: padY + 0.5, z: padZ - 8 });
+    const parked = await game.player.position();
+
+    await game.entities.sendMessage(teleportTrap.id, { type: "TurnOff" });
+    await game.step({ frames: 30 });
+    const afterTurnOff = await game.player.position();
+    assert.ok(
+      Math.hypot(afterTurnOff.x - parked.x, afterTurnOff.z - parked.z) < 1,
+      `TurnOff must not teleport the player: parked=${JSON.stringify(parked)} ` +
+        `after=${JSON.stringify(afterTurnOff)}`,
+    );
+
+    await game.entities.sendMessage(teleportTrap.id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+    const afterTurnOn = await game.player.position();
+    assert.ok(
+      Math.hypot(afterTurnOn.x - padX, afterTurnOn.z - padZ) < 3,
+      `TurnOn must teleport the player to the pad: pad=[${padX},${padY},${padZ}] ` +
+        `after=${JSON.stringify(afterTurnOn)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-narration.e2e.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end regression for the earth.mis training-area audio cacophony.
+//
+// Each training tripwire SwitchLinks to a Player Teleport Trap, an Inverter that
+// fans out to ~11 Sound Traps (authored so ENTER's TurnOn inverts to TurnOff and
+// SILENCES every narration), and a Trigger Delay that then plays the one local
+// narration. The teleport yanks the player straight back out of the tripwire box,
+// so Rapier reports an EXIT; the tripwire's inherited EXIT flag then sent TurnOff
+// to all links, which the Inverter flipped into a TurnOn broadcast - every
+// narration starting at once - and also re-fired the teleport trap.
+//
+// The fix suppresses the EXIT edge when the departure was caused by a scripted
+// teleport (mirror of the existing arrival suppression) and makes
+// TrapTeleportPlayer respond only to TurnOn.
+//
+// Negative-first: pre-fix this run logs 12 narrations (11 at once plus the
+// intended one); post-fix exactly one plays.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable earth.mis mission-object id of a training tripwire that links a teleport
+// trap + the silence Inverter + the narration Trigger Delay. Runtime entity ids
+// are rediscovered every launch, never hardcoded.
+const TRAINING_TRIPWIRE_OBJ = 378;
+
+test(
+  "earth training: entering a teleport tripwire plays exactly one narration",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8194),
+    });
+    await game.step({ frames: 30 });
+
+    const [tripwire] = await game.entities.byTemplate(TRAINING_TRIPWIRE_OBJ);
+    assert.ok(
+      tripwire,
+      `expected the earth.mis training tripwire for obj ${TRAINING_TRIPWIRE_OBJ}`,
+    );
+
+    const audioBefore = await game.audio.recent();
+    const lastAudioSequence = audioBefore.sounds.at(-1)?.sequence ?? 0;
+    const messagesBefore = await game.messages.recent();
+    const lastMessageSequence = messagesBefore.messages.at(-1)?.sequence ?? 0;
+
+    // Walk-in equivalent: drop the player inside the tripwire's box. A debug
+    // teleport is locomotion, so ENTER fires exactly as it does on foot.
+    await game.player.teleport({
+      x: tripwire.position[0],
+      y: tripwire.position[1],
+      z: tripwire.position[2],
+    });
+    // Well past the narration Trigger Delay (~1s) so the intended clip has started.
+    await game.step({ frames: 180 });
+
+    const narrations = (await game.audio.recent()).sounds.filter(
+      (sound) => sound.sequence > lastAudioSequence && sound.sample.startsWith("trg"),
+    );
+    assert.equal(
+      narrations.length,
+      1,
+      `expected exactly one training narration, got ${narrations.length}: ` +
+        JSON.stringify(narrations.map((s) => ({ sample: s.sample, frame: s.frame }))),
+    );
+    assert.equal(
+      narrations[0]!.still_playing,
+      true,
+      `the intended narration must not be cut short: ${JSON.stringify(narrations[0])}`,
+    );
+
+    const traced = (await game.messages.recent()).messages.filter(
+      (message) => message.sequence > lastMessageSequence,
+    );
+
+    // The Inverter's fanout is the burst: only the Trigger Delay's single
+    // narration may TurnOn a Sound Trap. (ENTER's own TurnOn arrives at the
+    // Sound Traps inverted, as TurnOff - that is the authored "silence all".)
+    const soundTrapTurnOns = traced.filter(
+      (message) => message.payload === "TurnOn" && message.to.name === "Sound Trap",
+    );
+    assert.equal(
+      soundTrapTurnOns.length,
+      1,
+      `expected a single Sound Trap TurnOn, got ${soundTrapTurnOns.length}: ` +
+        JSON.stringify(
+          soundTrapTurnOns.slice(0, 5).map((m) => ({ frame: m.frame, to: m.to.template_id })),
+        ),
+    );
+
+    // The stray EXIT edge went to the tripwire's own links, re-firing the
+    // teleport trap. Nothing should reach it but the ENTER TurnOn.
+    const teleportTrapMessages = traced.filter(
+      (message) => message.to.name === "Player Teleport Trap",
+    );
+    assert.deepEqual(
+      teleportTrapMessages.map((m) => m.payload),
+      ["TurnOn"],
+      `the teleport trap must only see the ENTER TurnOn: ` +
+        JSON.stringify(teleportTrapMessages),
+    );
+  },
+);


### PR DESCRIPTION
Stacked on #855 (uses its `/v1/audio/recent` + `/v1/messages/recent` diagnostics for verification).

## Bug

In the earth.mis training areas, stepping into a training tripwire played **a dozen audio-log narrations at once**. The authoring is interrupt-and-replace: each tripwire SwitchLinks a Player Teleport Trap, an Inverter fanning out to ~11 Sound Traps (ENTER's TurnOn arrives inverted as TurnOff = "silence every narration"), and a Trigger Delay that then starts the one local narration.

Our engine broke this because the scripted teleport yanks the player out of the tripwire's own sensor volume: Rapier reports `SensorEndIntersect`, the inherited `EXIT` flag sent TurnOff to all links, and the Inverter flipped that into a **TurnOn broadcast to every Sound Trap** — plus the stray TurnOff re-fired the teleport trap (the #515 montage-loop family; that fix suppressed teleport *arrival* edges but not *departure* edges).

## Fix

- `trap_new_tripwire.rs`: suppress the EXIT edge when the departing entity carries `PropTeleported { source: ScriptedTrap }` — the mirror of the existing #515 arrival suppression. Presence is still cleared so a later genuine re-entry sees a clean edge. Locomotion departures are unaffected (verified byte-for-byte identical message traces pre/post fix).
- `trap_teleport_player.rs`: teleport only on `TurnOn` (it previously fired on *any* message, so the stray TurnOff re-teleported the player). Canonical Dark trap behavior, same idiom as `trap_spawn` / `vaporize_inventory`.

## Evidence (via #855's diagnostics)

Pre-fix, the e2e test observes the burst — 11 narrations on one frame plus the intended one:

```
expected exactly one training narration, got 12: [{"sample":"trg0021","frame":35},{"sample":"trg0015","frame":35},
{"sample":"trg0014","frame":35},{"sample":"trg0004","frame":35},{"sample":"trg0031","frame":35},{"sample":"trg0005","frame":35},
{"sample":"trg0026","frame":35},{"sample":"trg0013","frame":35},{"sample":"trg0020","frame":35},{"sample":"trg0025","frame":35},
{"sample":"trg0030","frame":35},{"sample":"trg0006","frame":52}]
```

Post-fix: exactly one narration (`still_playing: true`), a single Sound Trap TurnOn (the Trigger Delay's), and the teleport trap sees only the ENTER TurnOn.

## Testing

- New e2e `earth-training-narration.e2e.test.ts` (`SHOCK2_E2E=1`): enters tripwire 378 under collision via `crossEarthTrainingTripwire`, asserts exactly one narration + no TurnOn burst; also covers the TurnOn-only gate directly (injected TurnOff must not move the player; TurnOn must). **Both halves verified negative-first**: reverting the tripwire hunk → 12 narrations; reverting the gate → TurnOff teleports the player.
- `missions.e2e.test.ts`: all 23 missions load. SDK unit tests green. `RUSTFLAGS="-D warnings"` check clean.
- xreview (Claude + Codex + de-dup pass): no Critical/High. Mediums addressed: gate now has direct negative-tested coverage; suppression/marker ordering invariant documented in comments (both engines confirmed the same-frame ordering is currently safe: all queued messages read the pre-effect world).

Not a visual change (audio/trigger behavior), so no capture GIF; the message/audio traces above are the observable evidence.
