### PR TITLE
fix(gameplay): activate enter-room links

### DIFF
--- a/shock2vr/src/scripts/base_room.rs
+++ b/shock2vr/src/scripts/base_room.rs
@@ -1,0 +1,126 @@
+use shipyard::{EntityId, UniqueView, World};
+
+use crate::{mission::PlayerInfo, physics::PhysicsWorld};
+
+use super::{Effect, MessagePayload, Script, script_util::send_to_all_switch_links};
+
+/// The authored `BaseRoom` behavior used by `EnterRoom` objects.
+pub struct BaseRoom;
+
+impl BaseRoom {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for BaseRoom {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let player = world.borrow::<UniqueView<PlayerInfo>>();
+        match (msg, player) {
+            (MessagePayload::SensorBeginIntersect { with }, Ok(player))
+                if *with == player.entity_id =>
+            {
+                send_to_all_switch_links(
+                    world,
+                    entity_id,
+                    MessagePayload::TurnOn { from: entity_id },
+                )
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    #[test]
+    fn player_entry_turns_on_authored_switch_links() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        let destination = world.add_entity(());
+        let room = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 29,
+                to_entity_id: Some(WrappedEntityId(destination)),
+                link: Link::SwitchLink,
+            }],
+        });
+
+        let effect = BaseRoom::new().handle_message(
+            room,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::SensorBeginIntersect { with: player },
+        );
+        let messages: Vec<_> = Effect::flatten(vec![effect])
+            .into_iter()
+            .filter_map(|effect| match effect {
+                Effect::Send { msg } => Some(msg),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].to, destination);
+        assert!(matches!(
+            messages[0].payload,
+            MessagePayload::TurnOn { from } if from == room
+        ));
+    }
+
+    #[test]
+    fn non_player_and_exit_intersections_do_not_activate_the_room() {
+        let mut world = World::new();
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        let other = world.add_entity(());
+        let destination = world.add_entity(());
+        let room = world.add_entity(Links {
+            to_links: vec![ToLink {
+                to_template_id: 29,
+                to_entity_id: Some(WrappedEntityId(destination)),
+                link: Link::SwitchLink,
+            }],
+        });
+        let physics = PhysicsWorld::new();
+        let mut script = BaseRoom::new();
+
+        for payload in [
+            MessagePayload::SensorBeginIntersect { with: other },
+            MessagePayload::SensorEndIntersect { with: player },
+        ] {
+            assert!(matches!(
+                script.handle_message(room, &world, &physics, &payload),
+                Effect::NoEffect
+            ));
+        }
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -8,6 +8,7 @@ mod auto_install_soft;
 mod base_button;
 mod base_elevator;
 mod base_monster;
+mod base_room;
 mod camera_alert;
 mod chemical;
 mod choose_mission;
@@ -958,7 +959,7 @@ impl ScriptWorld {
             ])),
 
             // Rooms:
-            "baseroom" => Box::new(CoreRoom::new()),
+            "baseroom" => Box::new(base_room::BaseRoom::new()),
             "coreroom" => Box::new(CoreRoom::new()),
             "onceroom" => Box::new(OnceRoom::new()),
             "emailroom" => Box::new(TrapEmail::new()),

--- a/shock2vr/src/scripts/trap_email.rs
+++ b/shock2vr/src/scripts/trap_email.rs
@@ -1,7 +1,7 @@
 use dark::properties::PropLog;
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::physics::PhysicsWorld;
+use crate::{physics::PhysicsWorld, quest_info::QuestInfo};
 
 use super::{
     Effect, MessagePayload, Script,
@@ -13,6 +13,23 @@ impl TrapEmail {
     pub fn new() -> TrapEmail {
         TrapEmail {}
     }
+}
+
+/// Whether the trap's authored objective effect would move existing campaign
+/// progress backwards. Late-arriving legacy saves can legitimately contain a
+/// completed objective while this one-shot email trap is still alive.
+fn is_quest_bit_downgrade(world: &World, effect: &Effect) -> bool {
+    let Effect::SetQuestBit {
+        quest_bit_name,
+        quest_bit_value,
+    } = effect
+    else {
+        return false;
+    };
+    world
+        .borrow::<UniqueView<QuestInfo>>()
+        .map(|quests| quests.read_quest_bit_value(quest_bit_name).bits() > quest_bit_value.bits())
+        .unwrap_or(false)
 }
 
 impl Script for TrapEmail {
@@ -38,8 +55,9 @@ impl Script for TrapEmail {
                 // The email trap also carries the objective it hands out
                 // (PropQuestBitName/PropQuestBitValue) - the email and the
                 // objective it describes are authored on the same entity.
-                let quest_bit_effect =
-                    set_quest_bit_effect(world, entity_id).unwrap_or(Effect::NoEffect);
+                let quest_bit_effect = set_quest_bit_effect(world, entity_id)
+                    .filter(|effect| !is_quest_bit_downgrade(world, effect))
+                    .unwrap_or(Effect::NoEffect);
 
                 let switchlink_effects = send_to_all_switch_links(
                     world,
@@ -47,12 +65,11 @@ impl Script for TrapEmail {
                     MessagePayload::TurnOn { from: entity_id },
                 );
 
-                // The trap is consumed once it fires. The tripwires that feed
-                // these traps fire on every crossing, and re-applying the quest
-                // bit would knock an already-COMPLETE objective back to
-                // INCOMPLETE (QuestInfo::set_quest_bit_value overwrites).
-                // has_played_email only suppresses the audio, not the objective
-                // or the switch-link relay.
+                // The trap is consumed once it fires. A late legacy save can
+                // already have completed this objective while the email trap
+                // remains alive, so suppress only the backward quest-bit write;
+                // the email, switch-link relay, and one-shot consumption still
+                // occur normally.
                 Effect::Combined {
                     effects: vec![
                         email_effect,
@@ -70,7 +87,11 @@ impl Script for TrapEmail {
 
 #[cfg(test)]
 mod tests {
-    use dark::properties::{PropQuestBitName, PropQuestBitValue, QuestBitValue};
+    use dark::properties::{
+        Link, Links, PropQuestBitName, PropQuestBitValue, QuestBitValue, ToLink, WrappedEntityId,
+    };
+
+    use crate::quest_info::QuestInfo;
 
     use super::*;
 
@@ -125,5 +146,57 @@ mod tests {
             plays_email(&effect),
             "the objective must be granted alongside the email, not instead of it"
         );
+    }
+
+    #[test]
+    fn completed_objective_is_not_downgraded_but_email_still_fires_and_consumes() {
+        let mut world = World::new();
+        let mut quests = QuestInfo::new();
+        quests.set_quest_bit_value("Note_5_7", QuestBitValue::COMPLETE);
+        world.add_unique(quests);
+        let destination = world.add_entity(());
+        let entity_id = world.add_entity((
+            PropLog {
+                deck: 5,
+                email: 9,
+                log: 33,
+                note: 0,
+                video: 0,
+            },
+            PropQuestBitName("Note_5_7".to_owned()),
+            PropQuestBitValue(QuestBitValue::INCOMPLETE),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 27,
+                    to_entity_id: Some(WrappedEntityId(destination)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+
+        let effect = TrapEmail::new().handle_message(
+            entity_id,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+        let flattened = Effect::flatten(vec![effect.clone()]);
+
+        assert!(
+            quest_bits(&effect).is_empty(),
+            "an arrival email must not regress a completed objective"
+        );
+        assert!(
+            plays_email(&effect),
+            "the late arrival email must still play"
+        );
+        assert!(
+            flattened
+                .iter()
+                .any(|effect| matches!(effect, Effect::Send { msg } if msg.to == destination))
+        );
+        assert!(flattened.iter().any(
+            |effect| matches!(effect, Effect::DestroyEntity { entity_id: destroyed } if *destroyed == entity_id)
+        ));
     }
 }

--- a/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import { test } from "node:test";
+import { join } from "node:path";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Position } from "../src/types.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+// Stateful retail save supplied locally by the play-through campaign. The
+// binary is intentionally not committed or uploaded; pass its bare logical
+// name after copying it under DARK_ASSET_PATH/saves.
+const arrivalSave = process.env.SHOCK2_REC_ARRIVAL_SAVE;
+
+const ELEVATOR_BUTTON = 545;
+const ARRIVAL_TRIPWIRE = 752;
+const ARRIVAL_DOORS = [1922, 1923] as const;
+const ARRIVAL_ONCE_ROUTER = 29;
+
+async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one rec1 object ${objectId}, got ${JSON.stringify(found)}`,
+  );
+  return found[0];
+}
+
+async function walkTo(game: GameServer, target: Position): Promise<void> {
+  let position = await game.player.position();
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await game.player.moveTo(target);
+    await game.step({ frames: 30 });
+    position = await game.player.position();
+    if (Math.hypot(position.x - target.x, position.z - target.z) < 0.4) break;
+  }
+  assert.ok(
+    Math.hypot(position.x - target.x, position.z - target.z) < 0.4,
+    `bounded movement should reach ${JSON.stringify(target)}, got ${JSON.stringify(position)}`,
+  );
+}
+
+function playedEmails(saveName: string): string[] {
+  const dataRoot = process.env.DARK_ASSET_PATH;
+  assert.ok(dataRoot, "DARK_ASSET_PATH is required for the stateful arrival-room E2E");
+  const save = JSON.parse(
+    readFileSync(join(dataRoot, "saves", `${saveName}.sav`), "utf8"),
+  ) as { global_data: { quest_info: { played_emails: string[] } } };
+  return save.global_data.quest_info.played_emails;
+}
+
+test(
+  "rec1: entering the arrival room activates the authored objective chain (#859)",
+  { skip: !e2eEnabled || arrivalSave === undefined, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
+    });
+    assert.ok(arrivalSave);
+    assert.equal((await game.load(arrivalSave)).success, true);
+    await game.step({ frames: 1 });
+
+    assert.equal(await game.quests.get("note_4_4"), "unknown");
+    assert.equal(await game.quests.get("note_5_7"), "unknown");
+    assert.equal(await game.quests.get("reprogram"), "incomplete");
+    assert.equal(await game.quests.get("shodanroom"), "incomplete");
+
+    // Leave the real main-elevator car through its four authored doors. This
+    // is a production aim + squeeze interaction, not an injected Frob.
+    const elevatorButton = await only(game, ELEVATOR_BUTTON);
+    await game.player.aimAt(elevatorButton, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 60 });
+
+    for (const target of [
+      { x: -4.5, y: -3.956, z: -128.9 },
+      { x: -2.5, y: -3.956, z: -128.9 },
+      { x: -1.5, y: -3.956, z: -131.0 },
+      { x: -2.0, y: -3.956, z: -134.0 },
+      { x: -6.5, y: -3.956, z: -137.75 },
+    ]) {
+      await walkTo(game, target);
+    }
+
+    // Enter Tripwire 752 by bounded locomotion. It opens the real 1922/1923
+    // door pair, which proves the route rather than teleporting into the room.
+    await walkTo(game, { x: -8.47, y: -3.956, z: -137.87 });
+    await game.step({ frames: 180 });
+    const afterDoors = await Promise.all(
+      ARRIVAL_DOORS.map(async (objectId) => (await only(game, objectId)).position),
+    );
+    assert.ok(
+      Math.abs(afterDoors[0][2] - afterDoors[1][2]) > 5,
+      `arrival doors should be physically spread open through Tripwire ${ARRIVAL_TRIPWIRE}, ` +
+        `got z=${afterDoors[0][2]} / ${afterDoors[1][2]}`,
+    );
+
+    await walkTo(game, { x: -9.5, y: -3.956, z: -137.8 });
+    await walkTo(game, { x: -11.75, y: -3.956, z: -137.6 });
+    await game.step({ frames: 180 });
+
+    assert.equal(await game.quests.get("note_4_4"), "complete");
+    assert.equal(await game.quests.get("note_5_7"), "incomplete");
+    assert.equal(
+      (await game.entities.byTemplate(ARRIVAL_ONCE_ROUTER)).length,
+      0,
+      "the room entry should consume its authored OnceRouter after firing",
+    );
+
+    const firstEntrySave = `rec_arrival_first_entry_${Date.now()}`;
+    assert.equal((await game.save(firstEntrySave)).success, true);
+    const firstEmails = playedEmails(firstEntrySave);
+    assert.equal(firstEmails.filter((email) => email === "EM0509").length, 1);
+    assert.equal(firstEmails.includes("EM0511"), false);
+
+    // Walk fully out of the ROOM_DB volume, then back in. OnceRouter 29 and
+    // Buffy/TrapSlayer make the authored objective/email chain one-shot.
+    for (const target of [
+      { x: -9.5, y: -3.956, z: -137.8 },
+      { x: -8.47, y: -3.956, z: -137.87 },
+      { x: -6.5, y: -3.956, z: -137.75 },
+    ]) {
+      await walkTo(game, target);
+    }
+    await game.step({ frames: 60 });
+    for (const target of [
+      { x: -8.47, y: -3.956, z: -137.87 },
+      { x: -9.5, y: -3.956, z: -137.8 },
+      { x: -11.75, y: -3.956, z: -137.6 },
+    ]) {
+      await walkTo(game, target);
+    }
+    await game.step({ frames: 180 });
+
+    assert.equal(await game.quests.get("note_4_4"), "complete");
+    assert.equal(await game.quests.get("note_5_7"), "incomplete");
+    const secondEntrySave = `rec_arrival_second_entry_${Date.now()}`;
+    assert.equal((await game.save(secondEntrySave)).success, true);
+    const secondEmails = playedEmails(secondEntrySave);
+    assert.equal(secondEmails.filter((email) => email === "EM0509").length, 1);
+    assert.equal(secondEmails.includes("EM0511"), false);
+
+    const dataRoot = process.env.DARK_ASSET_PATH!;
+    rmSync(join(dataRoot, "saves", `${firstEntrySave}.sav`));
+    rmSync(join(dataRoot, "saves", `${secondEntrySave}.sav`));
+  },
+);

--- a/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec-arrival-room.e2e.test.ts
@@ -11,11 +11,16 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 // binary is intentionally not committed or uploaded; pass its bare logical
 // name after copying it under DARK_ASSET_PATH/saves.
 const arrivalSave = process.env.SHOCK2_REC_ARRIVAL_SAVE;
+const commandArrivalSave = process.env.SHOCK2_COMMAND_ARRIVAL_SAVE;
 
 const ELEVATOR_BUTTON = 545;
 const ARRIVAL_TRIPWIRE = 752;
 const ARRIVAL_DOORS = [1922, 1923] as const;
 const ARRIVAL_ONCE_ROUTER = 29;
+const ARRIVAL_ROUTER = 26;
+const ARRIVAL_EMAIL_TRAP = 171;
+const COMMAND_RETURN_BUTTON = 422;
+const COMMAND_ELEVATOR_BUTTON = 512;
 
 async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
   const found = await game.entities.byTemplate(objectId);
@@ -28,17 +33,42 @@ async function only(game: GameServer, objectId: number): Promise<EntitySummary> 
 }
 
 async function walkTo(game: GameServer, target: Position): Promise<void> {
+  const arrivalTolerance = 0.8;
   let position = await game.player.position();
   for (let attempt = 0; attempt < 3; attempt++) {
     await game.player.moveTo(target);
     await game.step({ frames: 30 });
     position = await game.player.position();
-    if (Math.hypot(position.x - target.x, position.z - target.z) < 0.4) break;
+    if (
+      Math.hypot(position.x - target.x, position.z - target.z) < arrivalTolerance
+    )
+      break;
   }
-  assert.ok(
-    Math.hypot(position.x - target.x, position.z - target.z) < 0.4,
-    `bounded movement should reach ${JSON.stringify(target)}, got ${JSON.stringify(position)}`,
+  if (
+    Math.hypot(position.x - target.x, position.z - target.z) < arrivalTolerance
+  )
+    return;
+  const nearby = (await game.entities.list({ limit: 12 })).entities.map(
+    ({ name, template_id, position }) => ({ name, template_id, position }),
   );
+  assert.fail(
+    `bounded movement should reach ${JSON.stringify(target)}, got ${JSON.stringify(position)}; ` +
+      `nearby=${JSON.stringify(nearby)}`,
+  );
+}
+
+async function squeezeButton(
+  game: GameServer,
+  objectId: number,
+): Promise<void> {
+  const button = await only(game, objectId);
+  await game.player.aimAt(button, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
 }
 
 function playedEmails(saveName: string): string[] {
@@ -69,14 +99,7 @@ test(
 
     // Leave the real main-elevator car through its four authored doors. This
     // is a production aim + squeeze interaction, not an injected Frob.
-    const elevatorButton = await only(game, ELEVATOR_BUTTON);
-    await game.player.aimAt(elevatorButton, {
-      hitbox: "center",
-      visibility: "required",
-    });
-    await game.input.set("right_hand.squeeze_value", 1);
-    await game.step({ frames: 2 });
-    await game.input.set("right_hand.squeeze_value", 0);
+    await squeezeButton(game, ELEVATOR_BUTTON);
     await game.step({ frames: 60 });
 
     for (const target of [
@@ -150,5 +173,87 @@ test(
     const dataRoot = process.env.DARK_ASSET_PATH!;
     rmSync(join(dataRoot, "saves", `${firstEntrySave}.sav`));
     rmSync(join(dataRoot, "saves", `${secondEntrySave}.sav`));
+  },
+);
+
+test(
+  "rec1: a late Command return does not regress a completed objective (#859)",
+  { skip: !e2eEnabled || commandArrivalSave === undefined, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8198),
+    });
+    assert.ok(commandArrivalSave);
+    assert.equal((await game.load(commandArrivalSave)).success, true);
+    await game.step({ frames: 1 });
+
+    assert.equal((await game.info()).mission, "command1.mis");
+    assert.equal(await game.quests.get("note_4_4"), "unknown");
+    assert.equal(await game.quests.get("note_5_7"), "complete");
+
+    // Operate Command's real return-elevator button. It synchronously runs
+    // SimpleLevelChangeButton's authored rec1 / loc 65 transition.
+    await squeezeButton(game, COMMAND_RETURN_BUTTON);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).mission, "rec1.mis");
+
+    // Open the real Recreation command-elevator doors, then traverse the
+    // shipped navigation corridor to the arrival vestibule by locomotion.
+    await squeezeButton(game, COMMAND_ELEVATOR_BUTTON);
+    await game.step({ frames: 60 });
+    for (const target of [
+      { x: 35.8, y: -3.956, z: -113.8 },
+      { x: 32.9, y: -3.956, z: -113.8 },
+      { x: 31.1, y: -3.956, z: -112.0 },
+      { x: 28.1, y: -3.956, z: -115.0 },
+      { x: 24.4, y: -3.956, z: -114.8 },
+      { x: 20.5, y: -3.956, z: -114.8 },
+      { x: 20.2, y: -3.956, z: -115.8 },
+      { x: 16.1, y: -3.956, z: -116.4 },
+      { x: 12.1, y: -3.956, z: -117.05 },
+      { x: 7.7, y: -3.956, z: -119.45 },
+      { x: 7.7, y: -3.956, z: -125.5 },
+      { x: 7.7, y: -3.956, z: -131.7 },
+      { x: 6.0, y: -3.956, z: -135.4 },
+      { x: 4.2, y: -3.956, z: -136.6 },
+      { x: 3.85, y: -3.956, z: -136.98 },
+      { x: 3.72, y: -3.956, z: -137.02 },
+      { x: 3.6, y: -3.956, z: -137.7 },
+      { x: -2.3, y: -3.956, z: -138.2 },
+      { x: -6.5, y: -3.956, z: -137.75 },
+      { x: -8.47, y: -3.956, z: -137.87 },
+    ]) {
+      await walkTo(game, target);
+    }
+    await game.step({ frames: 180 });
+    await walkTo(game, { x: -9.5, y: -3.956, z: -137.8 });
+    await walkTo(game, { x: -11.75, y: -3.956, z: -137.6 });
+    await game.step({ frames: 180 });
+
+    assert.equal(await game.quests.get("note_4_4"), "complete");
+    assert.equal(
+      await game.quests.get("note_5_7"),
+      "complete",
+      "late arrival must not overwrite the already-completed objective",
+    );
+    for (const consumed of [
+      ARRIVAL_ROUTER,
+      ARRIVAL_ONCE_ROUTER,
+      ARRIVAL_EMAIL_TRAP,
+    ]) {
+      assert.equal(
+        (await game.entities.byTemplate(consumed)).length,
+        0,
+        `authored one-shot object ${consumed} should be consumed`,
+      );
+    }
+
+    const lateEntrySave = `rec_arrival_late_command_entry_${Date.now()}`;
+    assert.equal((await game.save(lateEntrySave)).success, true);
+    const emails = playedEmails(lateEntrySave);
+    assert.equal(emails.filter((email) => email === "EM0509").length, 1);
+    assert.equal(emails.includes("EM0511"), false);
+    rmSync(join(process.env.DARK_ASSET_PATH!, "saves", `${lateEntrySave}.sav`));
   },
 );


### PR DESCRIPTION
## Summary

- implement the missing generic `BaseRoom` entry behavior for authored `EnterRoom` mission objects
- relay player `SensorBeginIntersect` as `TurnOn { from: room }` to real SwitchLinks, without activating on other bodies or room exit
- keep gravity and automap behavior isolated in the existing inherited `CoreRoom` script
- preserve completed objectives when a legacy-save `TrapEmail` fires late, while still playing its email, relaying its links, and consuming the trap
- cover both the generic relay and the backward-save edge with negative-first unit tests plus genuine stateful SDK routes

Fixes #859.

## Root cause

ROOM_DB collision and forwarding were already healthy:

`Rapier BeginIntersect → internal_room_trigger → SensorBeginIntersect → BaseRoom/CoreRoom`

But both `BaseRoom` and `CoreRoom` were mapped to `CoreRoom`, whose only responsibilities are gravity and automap reveal. It never emitted the `TurnOn` edge required by authored `OnceRouter` / quest-filter links, so every `EnterRoom` chain stopped at the room object.

This change separates the two scripts: inherited `CoreRoom` keeps gravity/map handling, while `BaseRoom` handles only the player-entry edge.

The accepted Command campaign frontier predates that behavior fix: `note_5_7` is already complete while the Recreation arrival EmailTrap remains alive. Its authored incomplete write would otherwise regress that completed objective on a late return. `TrapEmail` now suppresses only downward quest-bit writes; its email, SwitchLinks, and one-shot consumption are unchanged.

## Verification

- negative-first BaseRoom unit: before the implementation, player entry produced 0 authored sends; after, it produces exactly one `TurnOn` with the room as sender
- negative-first TrapEmail unit: before compatibility handling, a completed `note_5_7` emitted an incomplete overwrite; after, that write is absent while PlayEmail, SwitchLink relay, and DestroyEntity remain
- exact hashed 25th Anniversary pre-boundary save (kept local; not uploaded):
  - ordinary aim+squeeze on real elevator button 545
  - bounded collision-valid movement through moving elevator doors
  - real Tripwire 752 opens doors 1922/1923
  - bounded movement into QBopsdone room 167
  - `note_4_4 = complete`, `note_5_7 = incomplete`
  - serialized `played_emails` contains exactly one `EM0509` and no `EM0511`
  - exit/re-enter preserves exactly one `EM0509`; OnceRouter 29 remains consumed
- exact hashed accepted Command frontier (kept local; not uploaded):
  - ordinary aim+squeeze on Command return button 422 → authored `rec1` loc 65 transition
  - ordinary aim+squeeze on Recreation command-elevator button 512
  - 72 m collision-bounded corridor and vestibule traversal into room 167
  - `note_4_4 = complete`; preexisting `note_5_7` remains complete
  - Router 26, OnceRouter 29, and EmailTrap 171 are consumed
  - serialized `played_emails` contains exactly one `EM0509` and no `EM0511`
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (511 passed)
- `cd tools/shock2-sdk && npm test` (216 total; 26 passed, 190 E2E skipped)
- both exact real-save E2Es together (2 passed, 91.16 s)

Visual evidence is embedded below.

## Campaign

Operations → Recreation full-campaign continuation · detailed test run · 25th Anniversary assets · legacy fixed campaign ledger (no random seed recorded).

## Visual assessment

Player-observable objective/email behavior changes at the Recreation arrival boundary, so this PR requires headless before/after evidence. Capture completed with identical production framebuffer pixels because the outcome is script/audio/objective state and no email or objective panel auto-opens; the final media therefore labels the exact observed state result without implying a rendered HUD delta.

![Recreation arrival-room relay demo](https://gist.githubusercontent.com/tommy-xr/c1345a0a01c5c37c2b662434f1ea0143/raw/pr860-rec-arrival-demo.gif)

<sub>Genuine route: real elevator button 545 → bounded movement → Tripwire 752 → QBopsdone room. The animation explicitly labels observed runtime state; native framebuffer pixels do not change because EM0509 is audio-only and no email/objective panel auto-opens.</sub>

## Before → after

![Recreation arrival-room before and after](https://gist.githubusercontent.com/tommy-xr/c1345a0a01c5c37c2b662434f1ea0143/raw/pr860-rec-arrival-before-after.png)

<sub>Same hashed 25th Anniversary save and identical 150-request sequence from fresh baseline/fixed launches. Before: `note_4_4` remains unknown and OnceRouter 29 remains present. After: `note_4_4` completes and OnceRouter 29 is consumed. The raw game frames are byte-identical, so the labels report the exact runtime quest/entity observations without implying a rendered HUD delta.</sub>