### PR TITLE
fix(doors): animate rotating doors at authored hinges

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -103,7 +103,7 @@ use std::{
 };
 
 use crate::{SCALE_FACTOR, ss2_common::*};
-use cgmath::{Deg, InnerSpace, Quaternion, Rotation3, Vector3, vec3};
+use cgmath::{Deg, InnerSpace, Quaternion, Rad, Rotation, Rotation3, Vector3, vec3};
 use shipyard::{
     Component, EntityId, Get, IntoIter, IntoWithId, TupleAddComponent, View, ViewMut, World,
 };
@@ -1134,6 +1134,135 @@ pub struct PropTranslatingDoor {
     pub base_location: Vector3<f32>,
 }
 
+/// Optional automatic-close delay for doors, in seconds.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropDoorTimer(pub i32);
+
+/// Dark's `P$RotDoor` (`sRotDoorProp`, version 1001).
+///
+/// A rotating door can also inherit `P$TransDoor` from its door archetype.
+/// Looking Glass's `GetDoorProperty` deliberately preferred RotDoor in that
+/// case; runtime door code must do the same or the inherited zero translating
+/// endpoints can move the object to world origin (#861).
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropRotatingDoor {
+    pub door_type: i32,
+    /// Authored angle in degrees at the closed endpoint.
+    pub closed: f32,
+    /// Authored angle in degrees at the open endpoint.
+    pub open: f32,
+    /// Angular speed in radians per second (not a world-space distance).
+    pub speed: f32,
+    pub axis: i32,
+    /// Dark's DOOR_STATE: 0=closed, 1=open, 2=closing, 3=opening, 4=halted.
+    pub state: i32,
+    pub clockwise: bool,
+    pub base_closed_location: Vector3<f32>,
+    pub base_open_location: Vector3<f32>,
+    /// Authored base position used to derive the endpoint physics locations.
+    pub base_location: Vector3<f32>,
+    /// Authored base orientation around which the hinge axis is transformed.
+    pub base_rotation: Quaternion<f32>,
+    pub base_closed_rotation: Quaternion<f32>,
+    pub base_open_rotation: Quaternion<f32>,
+    /// Normalized closed-to-open progress, persisted with the property by this
+    /// runtime. The retail payload has no explicit progress field.
+    #[serde(default)]
+    pub progress: f32,
+}
+
+impl PropRotatingDoor {
+    /// Signed opening travel, following Dark's clockwise flag. Rotating doors
+    /// can deliberately take the long way around through the 0/360 seam.
+    pub fn travel_degrees(&self) -> f32 {
+        let mut travel = self.open - self.closed;
+        if travel.abs() <= f32::EPSILON {
+            return 0.0;
+        }
+        if self.clockwise {
+            while travel > 0.0 {
+                travel -= 360.0;
+            }
+        } else {
+            while travel < 0.0 {
+                travel += 360.0;
+            }
+        }
+        travel
+    }
+
+    pub fn has_travel(&self) -> bool {
+        self.travel_degrees().abs() > 1e-4
+    }
+
+    pub fn initial_pose(&self) -> (Vector3<f32>, Quaternion<f32>) {
+        match self.state {
+            0 => (self.base_closed_location, self.base_closed_rotation),
+            1 => (self.base_open_location, self.base_open_rotation),
+            _ => (self.base_location, self.base_rotation),
+        }
+    }
+
+    /// Pose the door along the authored hinge arc. Endpoint locations already
+    /// encode Dark's physics center-of-gravity offset. Recovering the fixed
+    /// pivot from those two endpoints keeps the intermediate center on the
+    /// same circular arc without coupling the script to physics internals.
+    pub fn pose_at_progress(&self, progress: f32) -> (Vector3<f32>, Quaternion<f32>) {
+        let progress = progress.clamp(0.0, 1.0);
+        if progress <= f32::EPSILON || !self.has_travel() {
+            return (self.base_closed_location, self.base_closed_rotation);
+        }
+        if (1.0 - progress) <= f32::EPSILON {
+            return (self.base_open_location, self.base_open_rotation);
+        }
+
+        let total_angle = Rad(self.travel_degrees().to_radians());
+        let local_axis = rotating_door_local_axis(self.axis);
+        let world_axis = self.base_rotation.rotate_vector(local_axis).normalize();
+        let displacement = self.base_open_location - self.base_closed_location;
+        let axial = world_axis * displacement.dot(world_axis);
+        let perpendicular = displacement - axial;
+        let alpha = total_angle.0.cos() - 1.0;
+        let beta = total_angle.0.sin();
+        let denominator = alpha * alpha + beta * beta;
+
+        let position = if denominator > 1e-6 {
+            let radius =
+                (perpendicular * alpha - world_axis.cross(perpendicular) * beta) / denominator;
+            let partial = Quaternion::from_axis_angle(world_axis, total_angle * progress);
+            self.base_closed_location + partial.rotate_vector(radius) - radius + axial * progress
+        } else {
+            // Degenerate/full-circle authored motion has no unique pivot from
+            // its coincident endpoints. Preserve endpoints and interpolate the
+            // tiny residual instead of producing an unstable huge radius.
+            self.base_closed_location + displacement * progress
+        };
+        let rotation = Quaternion::from_axis_angle(world_axis, total_angle * progress)
+            * self.base_closed_rotation;
+        (position, rotation.normalize())
+    }
+}
+
+fn rotating_door_local_axis(axis: i32) -> Vector3<f32> {
+    // Dark angle vectors map (x,y,z) to this runtime's (-x,z,y).
+    match axis {
+        0 => vec3(-1.0, 0.0, 0.0),
+        1 => vec3(0.0, 0.0, 1.0),
+        2 => vec3(0.0, 1.0, 0.0),
+        _ => vec3(0.0, 1.0, 0.0),
+    }
+}
+
+fn rotating_door_rotation(
+    base_rotation: Quaternion<f32>,
+    axis: i32,
+    angle_degrees: f32,
+) -> Quaternion<f32> {
+    (base_rotation
+        * Quaternion::from_axis_angle(rotating_door_local_axis(axis), Deg(angle_degrees)))
+    .normalize()
+}
+
 impl PropTranslatingDoor {
     /// The world position this door should occupy at load time, per its
     /// authored state. In-motion/halted states resume from the authored
@@ -2038,6 +2167,18 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
+            "P$RotDoor",
+            read_prop_rotating_door,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$DoorTimer",
+            |reader, _len| read_i32(reader),
+            PropDoorTimer,
+            accumulator::latest,
+        ),
+        define_prop(
             "P$TransDoor",
             read_prop_translating_door,
             identity,
@@ -2192,6 +2333,68 @@ fn read_prop_translating_door<T: io::Read + io::Seek>(
         base_location,
         axis,
         speed,
+    }
+}
+
+fn read_prop_rotating_door<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropRotatingDoor {
+    let door_type = read_i32(reader);
+    let closed = read_single(reader);
+    let open = read_single(reader);
+    let speed = read_single(reader);
+    let axis = read_i32(reader);
+    let state = read_i32(reader);
+    let _hard_limits = read_bool(reader);
+    let _sound_blocking = read_single(reader);
+    let _vision_blocking = read_bool(reader);
+    let _push_mass = read_single(reader);
+    let base_closed_location = read_vec3(reader) / SCALE_FACTOR;
+    let base_open_location = read_vec3(reader) / SCALE_FACTOR;
+    let base_location = read_vec3(reader) / SCALE_FACTOR;
+    let base_rotation = quat_from_facing_vector(read_u16_vec3(reader));
+    let _base = read_single(reader);
+    let _room1 = read_i32(reader);
+    let _room2 = read_i32(reader);
+    let clockwise = read_bool(reader);
+
+    // Version 1001 appended the two endpoint facings (6 bytes each). Older
+    // version-1000 payloads stop at byte 98; derive equivalent facings from
+    // the authored base angle and endpoint angles in that case.
+    let (base_closed_rotation, base_open_rotation, consumed) = if len >= 110 {
+        (
+            quat_from_facing_vector(read_u16_vec3(reader)),
+            quat_from_facing_vector(read_u16_vec3(reader)),
+            110,
+        )
+    } else {
+        (
+            rotating_door_rotation(base_rotation, axis, closed),
+            rotating_door_rotation(base_rotation, axis, open),
+            98,
+        )
+    };
+    if len > consumed {
+        read_bytes(reader, (len - consumed) as usize);
+    }
+
+    let progress = match state {
+        1 => 1.0,
+        _ => 0.0,
+    };
+    PropRotatingDoor {
+        door_type,
+        closed,
+        open,
+        speed,
+        axis,
+        state,
+        clockwise,
+        base_closed_location,
+        base_open_location,
+        base_location,
+        base_rotation,
+        base_closed_rotation,
+        base_open_rotation,
+        progress,
     }
 }
 
@@ -2633,6 +2836,72 @@ mod tests {
 
         assert!(property.active);
         assert!(!property.previous_active);
+    }
+
+    fn rotating_door_definition() -> Box<dyn PropertyDefinition<Box<dyn ReadAndSeek>>> {
+        let (properties, _, _) = get::<Box<dyn ReadAndSeek>>();
+        properties
+            .into_iter()
+            .find(|property| property.name() == "P$RotDoor")
+            .expect("P$RotDoor must be a registered Dark property")
+    }
+
+    #[test]
+    fn rotating_door_reads_version_1001_payload() {
+        // eng1 Floor Hatch obj 85 authors this 110-byte layout. Leaving it
+        // unparsed makes its inherited zero P$TransDoor win and StdDoor moves
+        // the hatch to world origin (#861).
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0i32.to_le_bytes()); // rotating
+        bytes.extend_from_slice(&0.0f32.to_le_bytes()); // closed angle
+        bytes.extend_from_slice(&90.0f32.to_le_bytes()); // open angle
+        bytes.extend_from_slice(&45.0f32.to_le_bytes()); // raw angular speed
+        bytes.extend_from_slice(&1i32.to_le_bytes()); // Dark Y -> world Z
+        bytes.extend_from_slice(&0i32.to_le_bytes()); // closed state
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // hard limits
+        bytes.extend_from_slice(&0.75f32.to_le_bytes()); // sound blocking
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // vision blocking
+        bytes.extend_from_slice(&30.0f32.to_le_bytes()); // push mass
+        for file_vector in [
+            [-2.5f32, 7.5, 5.0],  // world (1,2,3), closed
+            [-2.5f32, 10.0, 5.0], // world (1,2,4), open
+            [-2.5f32, 7.5, 5.0],  // authored base/current
+        ] {
+            for value in file_vector {
+                bytes.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+        bytes.extend_from_slice(&[0; 6]); // base facing
+        bytes.extend_from_slice(&0.0f32.to_le_bytes()); // base angle scalar
+        bytes.extend_from_slice(&(-1i32).to_le_bytes()); // room 1
+        bytes.extend_from_slice(&(-1i32).to_le_bytes()); // room 2
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // counter-clockwise
+        bytes.extend_from_slice(&[0; 6]); // closed facing
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // open x
+        bytes.extend_from_slice(&0x4000u16.to_le_bytes()); // open Dark y = 90 degrees
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // open z
+        assert_eq!(bytes.len(), 110);
+
+        let mut cursor: Box<dyn ReadAndSeek> = Box::new(Cursor::new(bytes));
+        let property = rotating_door_definition().read(&mut cursor, 110);
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        property.initialize(&mut world, entity);
+
+        let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+        let door = doors.get(entity).unwrap();
+        assert_eq!(door.door_type, 0);
+        assert_eq!(door.speed, 45.0, "angular speed must not be world-scaled");
+        assert_eq!(door.axis, 1);
+        assert!(!door.clockwise);
+        assert_eq!(door.base_closed_location, vec3(1.0, 2.0, 3.0));
+        assert_eq!(door.base_open_location, vec3(1.0, 2.0, 4.0));
+        assert_eq!(door.initial_pose().0, vec3(1.0, 2.0, 3.0));
+        let expected_open = Quaternion::from_angle_z(Deg(90.0));
+        assert!(
+            door.base_open_rotation.dot(expected_open).abs() > 0.9999,
+            "open facing should preserve Dark's angle-axis mapping"
+        );
     }
 
     #[test]

--- a/shock2vr/src/mission/entity_populator/save_file_entity_populator.rs
+++ b/shock2vr/src/mission/entity_populator/save_file_entity_populator.rs
@@ -5,9 +5,9 @@
  *
  */
 use dark::properties::{
-    Link, Links, PropBaseTechDesc, PropChemicalNeeded, PropEcoState, PropEcoType, PropEcology,
-    PropObjLookString, PropRequiredTechDesc, PropResearchReport, PropResearchText,
-    PropResearchTime, PropSpawn, WrappedEntityId,
+    Link, Links, PropBaseTechDesc, PropChemicalNeeded, PropDoorTimer, PropEcoState, PropEcoType,
+    PropEcology, PropObjLookString, PropRequiredTechDesc, PropResearchReport, PropResearchText,
+    PropResearchTime, PropRotatingDoor, PropSpawn, WrappedEntityId,
 };
 use shipyard::{Get, View, ViewMut, World};
 use std::collections::HashMap;
@@ -59,10 +59,12 @@ impl EntityPopulator for SaveFileEntityPopulator {
 /// Saves deliberately own mutable runtime state, so loading cannot generally
 /// reapply the mission file over a restored entity. The ecology and research
 /// properties below are different: old builds could neither deserialize nor
-/// mutate them, and therefore could not have serialized them. Restore only a
-/// missing component/link, only for a concrete mission object which still
-/// exists in the save. Deleted generators/ecologies stay deleted, while newer
-/// saves retain their live values and spawned-child graph.
+/// mutate them, and therefore could not have serialized them. This includes
+/// RotDoor/DoorTimer data needed to repair transforms already serialized by an
+/// old runtime. Restore only a missing component/link, only for a concrete
+/// mission object which still exists in the save. Deleted generators/ecologies
+/// stay deleted, while newer saves retain their live values and spawned-child
+/// graph.
 fn restore_newly_parsed_authored_data(
     gamesys_entity_info: &SystemShock2EntityInfo,
     level_entity_info: &SystemShock2EntityInfo,
@@ -151,6 +153,8 @@ fn restore_newly_parsed_authored_data(
     restore_missing_component!(PropResearchReport);
     restore_missing_component!(PropResearchText);
     restore_missing_component!(PropResearchTime);
+    restore_missing_component!(PropRotatingDoor);
+    restore_missing_component!(PropDoorTimer);
 
     let authored_spawn_points = {
         let authored_links = authored_world.borrow::<View<Links>>().unwrap();
@@ -208,7 +212,10 @@ fn restore_newly_parsed_authored_data(
 mod tests {
     use std::sync::Arc;
 
-    use dark::properties::{PropResearchReport, PropResearchText, PropResearchTime};
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{
+        PropResearchReport, PropResearchText, PropResearchTime, PropRotatingDoor,
+    };
 
     use super::*;
 
@@ -266,5 +273,49 @@ mod tests {
             0x20,
             "serialized live values must win over authored defaults"
         );
+    }
+
+    #[test]
+    fn legacy_rotating_door_backfills_newly_parsed_authored_motion() {
+        let mut merged_entity_info = SystemShock2EntityInfo::empty();
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        merged_entity_info.entity_to_properties.insert(
+            85,
+            vec![Arc::new(Box::new(PropRotatingDoor {
+                door_type: 0,
+                closed: 0.0,
+                open: 95.0,
+                speed: 1.0,
+                axis: 0,
+                state: 0,
+                clockwise: false,
+                base_closed_location: vec3(0.1, -12.75, -23.7),
+                base_open_location: vec3(0.1, -11.9, -24.7),
+                base_location: vec3(0.1, -12.75, -23.7),
+                base_rotation: identity,
+                base_closed_rotation: identity,
+                base_open_rotation: identity,
+                progress: 0.0,
+            }))],
+        );
+        let mut level_entity_info = SystemShock2EntityInfo::empty();
+        level_entity_info.entity_to_properties.insert(85, vec![]);
+
+        let mut world = World::new();
+        let hatch = world.add_entity(());
+        let template_to_entity = HashMap::from([(85, WrappedEntityId(hatch))]);
+
+        restore_newly_parsed_authored_data(
+            &merged_entity_info,
+            &level_entity_info,
+            &HashMap::new(),
+            &template_to_entity,
+            &mut world,
+        );
+
+        let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+        let restored = doors.get(hatch).unwrap();
+        assert_eq!(restored.base_closed_location, vec3(0.1, -12.75, -23.7));
+        assert_eq!(restored.open, 95.0);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -8480,6 +8480,20 @@ impl MissionCore {
                         .push(text, now);
                 }
 
+                Effect::SetRotatingDoorState {
+                    entity_id,
+                    state,
+                    progress,
+                } => {
+                    let mut v_rot_door = self
+                        .world
+                        .borrow::<ViewMut<dark::properties::PropRotatingDoor>>()
+                        .unwrap();
+                    if let Ok(door) = (&mut v_rot_door).get(entity_id) {
+                        door.state = state;
+                        door.progress = progress;
+                    }
+                }
                 Effect::SetQuestBit {
                     quest_bit_name,
                     quest_bit_value,

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -406,9 +406,9 @@ pub fn yaw_between_vectors(a: Vector3<f32>, b: Vector3<f32>) -> Deg<f32> {
 
 pub(crate) fn is_entity_door(world: &shipyard::World, entity_id: shipyard::EntityId) -> bool {
     let v_door_prop = world.borrow::<View<PropTranslatingDoor>>().unwrap();
-    //let v_rot_door_prop = world.borrow::<View<PropRotating>>.unwrap();
+    let v_rot_door_prop = world.borrow::<View<PropRotatingDoor>>().unwrap();
 
-    v_door_prop.contains(entity_id)
+    v_rot_door_prop.contains(entity_id) || v_door_prop.contains(entity_id)
 }
 
 /// Fire Ranged Weapon

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -838,6 +838,15 @@ pub enum Effect {
         base_location: Vector3<f32>,
     },
 
+    /// Persistently set Dark's `P$RotDoor` motion fields on one live object.
+    /// Keeping normalized progress lets an interrupted hinged motion resume
+    /// faithfully after a save/load.
+    SetRotatingDoorState {
+        entity_id: EntityId,
+        state: i32,
+        progress: f32,
+    },
+
     ResetGravity {
         entity_id: EntityId,
     },

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -182,12 +182,20 @@ pub fn set_entity_locked(world: &mut World, entity_id: EntityId, locked: bool) {
     }
 }
 
-/// Whether a translating door is closed (i.e. worth opening): normally that
-/// means it is nearer its closed endpoint than its open one, but a door with
-/// no travel - whose endpoints coincide, so position says nothing - answers
-/// from its authored state. `None` for entities that aren't translating doors.
+/// Whether a supported door is closed (i.e. worth opening). RotDoor takes
+/// precedence over an inherited TransDoor, matching Dark's GetDoorProperty.
 pub fn door_is_closed(world: &World, entity_id: EntityId) -> Option<bool> {
     use cgmath::InnerSpace;
+    let v_rot_door = world
+        .borrow::<View<dark::properties::PropRotatingDoor>>()
+        .unwrap();
+    if let Ok(door) = v_rot_door.get(entity_id) {
+        if !door.has_travel() {
+            return Some(door.state != 1);
+        }
+        return Some(door.progress <= 0.5);
+    }
+
     // A door with no travel can never leave its authored pose, and both
     // endpoints sit on top of each other - the distance test below is
     // degenerate there (equal distances always read as "closed"). Answer from
@@ -254,18 +262,24 @@ pub fn door_open_progress(world: &World, entity_id: EntityId) -> Option<(f32, f3
 
 /// Whether a cell-gating entity is an obstacle A* must not cross.
 ///
-/// Closed-but-unlocked translating doors stay pathable because a pursuing AI
-/// opens them on arrival. Entities that are not translating doors cannot be
-/// operated by `StdDoor`, so they remain walls.
+/// Closed-but-unlocked runtime doors stay pathable because a pursuing AI opens
+/// them on arrival. Entities without a supported door property remain walls.
 pub fn door_blocks_pathfinding(world: &World, entity_id: EntityId) -> bool {
     match door_is_closed(world, entity_id) {
         Some(true) => {
             let permanently_closed = world
-                .borrow::<View<dark::properties::PropTranslatingDoor>>()
+                .borrow::<View<dark::properties::PropRotatingDoor>>()
                 .unwrap()
                 .get(entity_id)
-                .map(|door| door.is_permanently_closed())
-                .unwrap_or(false);
+                .map(|door| !door.has_travel())
+                .unwrap_or_else(|_| {
+                    world
+                        .borrow::<View<dark::properties::PropTranslatingDoor>>()
+                        .unwrap()
+                        .get(entity_id)
+                        .map(|door| door.is_permanently_closed())
+                        .unwrap_or(false)
+                });
             permanently_closed || is_entity_locked(world, entity_id)
         }
         Some(false) => false,

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -1,13 +1,16 @@
 use cgmath::{InnerSpace, Vector3, Zero};
-use dark::properties::{Link, Links, PropKeypadCode, PropTranslatingDoor};
+use dark::properties::{
+    Link, Links, PropDoorTimer, PropKeypadCode, PropRotatingDoor, PropTranslatingDoor,
+};
 use engine::audio::AudioHandle;
+use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, IntoIter, View, World};
 use tracing::trace;
 
 use crate::{physics::PhysicsWorld, time::Time};
 
 use super::{
-    Effect, Message, MessagePayload, Script,
+    Effect, Message, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
     script_util::{is_entity_locked, play_environmental_sound},
 };
 
@@ -29,11 +32,26 @@ fn has_incoming_keypad_switch(world: &World, door: EntityId) -> bool {
     })
 }
 
+const SCRIPT_STATE_KEY: &str = "std_door";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct StdDoorState {
+    current_position: Vector3<f32>,
+    desired_position: Vector3<f32>,
+    is_moving: bool,
+    rotation_progress: f32,
+    rotation_target_open: bool,
+    auto_close_remaining: Option<f32>,
+}
+
 pub struct StdDoor {
     audio_handle: AudioHandle,
     current_position: Vector3<f32>,
     desired_position: Vector3<f32>,
     is_moving: bool,
+    rotation_progress: f32,
+    rotation_target_open: bool,
+    auto_close_remaining: Option<f32>,
 }
 
 impl StdDoor {
@@ -43,12 +61,25 @@ impl StdDoor {
             current_position: Vector3::zero(),
             desired_position: Vector3::zero(),
             is_moving: false,
+            rotation_progress: 0.0,
+            rotation_target_open: false,
+            auto_close_remaining: None,
         }
     }
 
     fn target_is_open(&self, trans_door: &PropTranslatingDoor) -> bool {
         (self.desired_position - trans_door.base_open_location).magnitude2()
             < (self.desired_position - trans_door.base_closed_location).magnitude2()
+    }
+
+    fn automatic_close_delay(world: &World, entity_id: EntityId) -> Option<f32> {
+        world
+            .borrow::<View<PropDoorTimer>>()
+            .ok()?
+            .get(entity_id)
+            .ok()
+            .map(|timer| timer.0 as f32)
+            .filter(|seconds| *seconds > 0.0)
     }
 
     /// Door motion is persisted through the effect pipeline (applied by
@@ -58,6 +89,68 @@ impl StdDoor {
             entity_id,
             state,
             base_location: position,
+        }
+    }
+
+    fn persist_rotation(entity_id: EntityId, state: i32, progress: f32) -> Effect {
+        Effect::SetRotatingDoorState {
+            entity_id,
+            state,
+            progress,
+        }
+    }
+
+    fn open_rotation(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _rot_door: &PropRotatingDoor,
+    ) -> Effect {
+        if self.rotation_target_open {
+            return Effect::NoEffect;
+        }
+
+        self.rotation_target_open = true;
+        self.is_moving = true;
+        self.auto_close_remaining = None;
+        Effect::Combined {
+            effects: vec![
+                Self::persist_rotation(entity_id, 3, self.rotation_progress),
+                play_environmental_sound(
+                    world,
+                    entity_id,
+                    "statechange",
+                    vec![("openstate", "opening"), ("oldopenstate", "closed")],
+                    self.audio_handle.clone(),
+                ),
+            ],
+        }
+    }
+
+    fn close_rotation(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _rot_door: &PropRotatingDoor,
+    ) -> Effect {
+        if !self.rotation_target_open {
+            return Effect::NoEffect;
+        }
+
+        self.rotation_target_open = false;
+        self.is_moving = true;
+        self.auto_close_remaining = None;
+        Effect::Combined {
+            effects: vec![
+                Self::persist_rotation(entity_id, 2, self.rotation_progress),
+                play_environmental_sound(
+                    world,
+                    entity_id,
+                    "statechange",
+                    vec![("openstate", "closing"), ("oldopenstate", "open")],
+                    self.audio_handle.clone(),
+                ),
+            ],
         }
     }
 
@@ -111,6 +204,45 @@ impl StdDoor {
 }
 impl Script for StdDoor {
     fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        let rot_door = {
+            let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
+        if let Some(rot_door) = rot_door {
+            // Dark's GetDoorProperty chooses RotDoor before TransDoor. That
+            // precedence matters because rotating doors commonly inherit a
+            // zero-filled translating property from StdDoor (#861).
+            self.rotation_progress = match rot_door.state {
+                0 => 0.0,
+                1 => 1.0,
+                _ => rot_door.progress.clamp(0.0, 1.0),
+            };
+            self.rotation_target_open = match rot_door.state {
+                1 | 3 => true,
+                0 | 2 => false,
+                _ => self.rotation_progress >= 0.5,
+            };
+            self.is_moving = matches!(rot_door.state, 2 | 3);
+            self.auto_close_remaining = if rot_door.state == 1 {
+                Self::automatic_close_delay(world, entity_id)
+            } else {
+                None
+            };
+            let (position, rotation) = rot_door.pose_at_progress(self.rotation_progress);
+            self.current_position = position;
+            self.desired_position = if self.rotation_target_open {
+                rot_door.base_open_location
+            } else {
+                rot_door.base_closed_location
+            };
+
+            return Effect::SetPositionRotation {
+                entity_id,
+                position,
+                rotation,
+            };
+        }
+
         let trans_door = {
             let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
             doors.get(entity_id).ok().cloned()
@@ -151,8 +283,98 @@ impl Script for StdDoor {
         _physics: &PhysicsWorld,
         time: &Time,
     ) -> Effect {
-        //println!("Updating door: {:?}", entity_id);
-        let _lerpval = (f32::cos(time.total.as_secs_f32()) + 1.0) * 0.5;
+        let rot_door = {
+            let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
+        if let Some(rot_door) = rot_door {
+            self.rotation_progress = rot_door.progress.clamp(0.0, 1.0);
+            self.rotation_target_open = matches!(rot_door.state, 1 | 3);
+            self.is_moving = matches!(rot_door.state, 2 | 3);
+            if !self.is_moving {
+                if rot_door.state == 1
+                    && let Some(remaining) = self.auto_close_remaining
+                {
+                    let remaining = remaining - time.elapsed.as_secs_f32();
+                    if remaining <= 0.0 {
+                        self.auto_close_remaining = None;
+                        return self.close_rotation(entity_id, world, &rot_door);
+                    }
+                    self.auto_close_remaining = Some(remaining);
+                }
+                return Effect::NoEffect;
+            }
+
+            let target = if self.rotation_target_open { 1.0 } else { 0.0 };
+            let remaining = (target - self.rotation_progress).abs();
+            let travel_radians = rot_door.travel_degrees().to_radians().abs();
+            let step = if travel_radians > f32::EPSILON {
+                time.elapsed.as_secs_f32() * rot_door.speed.abs() / travel_radians
+            } else {
+                0.0
+            };
+            if step <= f32::EPSILON {
+                return Effect::NoEffect;
+            }
+
+            let reached_endpoint = remaining <= step.max(0.0001);
+            if reached_endpoint {
+                self.rotation_progress = target;
+                self.is_moving = false;
+                self.auto_close_remaining = if self.rotation_target_open {
+                    Self::automatic_close_delay(world, entity_id)
+                } else {
+                    None
+                };
+            } else {
+                self.rotation_progress += (target - self.rotation_progress).signum() * step;
+            }
+
+            let (position, rotation) = rot_door.pose_at_progress(self.rotation_progress);
+            self.current_position = position;
+            let state = if reached_endpoint {
+                if self.rotation_target_open { 1 } else { 0 }
+            } else if self.rotation_target_open {
+                3
+            } else {
+                2
+            };
+            let mut effects = vec![
+                Effect::SetPositionRotation {
+                    entity_id,
+                    position,
+                    rotation,
+                },
+                Self::persist_rotation(entity_id, state, self.rotation_progress),
+            ];
+            if reached_endpoint {
+                let reached_open = self.rotation_target_open;
+                effects.push(play_environmental_sound(
+                    world,
+                    entity_id,
+                    "statechange",
+                    if reached_open {
+                        vec![("openstate", "open"), ("oldopenstate", "opening")]
+                    } else {
+                        vec![("openstate", "closed"), ("oldopenstate", "closing")]
+                    },
+                    self.audio_handle.clone(),
+                ));
+                effects.push(Effect::Send {
+                    msg: Message {
+                        to: entity_id,
+                        payload: MessagePayload::Signal {
+                            name: if reached_open {
+                                "DoorOpen".to_string()
+                            } else {
+                                "DoorClose".to_string()
+                            },
+                        },
+                    },
+                });
+            }
+            return Effect::Combined { effects };
+        }
 
         let trans_door = {
             let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
@@ -250,6 +472,42 @@ impl Script for StdDoor {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
+        let rot_door = {
+            let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+            doors.get(entity_id).ok().cloned()
+        };
+        if let Some(rot_door) = rot_door {
+            self.rotation_progress = rot_door.progress.clamp(0.0, 1.0);
+            self.rotation_target_open = matches!(rot_door.state, 1 | 3);
+            self.is_moving = matches!(rot_door.state, 2 | 3);
+            if !rot_door.has_travel() {
+                return Effect::NoEffect;
+            }
+            return match msg {
+                MessagePayload::Frob => {
+                    if self.rotation_target_open {
+                        self.close_rotation(entity_id, world, &rot_door)
+                    } else if is_entity_locked(world, entity_id) {
+                        Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            source: Some(entity_id),
+                            name: "hackfail".to_owned(),
+                            spatial: false,
+                        }
+                    } else {
+                        self.open_rotation(entity_id, world, &rot_door)
+                    }
+                }
+                MessagePayload::TurnOn { from: _ } => {
+                    self.open_rotation(entity_id, world, &rot_door)
+                }
+                MessagePayload::TurnOff { from: _ } => {
+                    self.close_rotation(entity_id, world, &rot_door)
+                }
+                _ => Effect::NoEffect,
+            };
+        }
+
         let trans_door = {
             let doors = world.borrow::<View<PropTranslatingDoor>>().unwrap();
             doors.get(entity_id).ok().cloned()
@@ -301,13 +559,47 @@ impl Script for StdDoor {
             Effect::NoEffect
         }
     }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(SCRIPT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &StdDoorState {
+                current_position: self.current_position,
+                desired_position: self.desired_position,
+                is_moving: self.is_moving,
+                rotation_progress: self.rotation_progress,
+                rotation_target_open: self.rotation_target_open,
+                auto_close_remaining: self.auto_close_remaining,
+            },
+            SCRIPT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: StdDoorState = state.decode(1, SCRIPT_STATE_KEY)?;
+        self.current_position = restored.current_position;
+        self.desired_position = restored.desired_position;
+        self.is_moving = restored.is_moving;
+        self.rotation_progress = restored.rotation_progress;
+        self.rotation_target_open = restored.rotation_target_open;
+        self.auto_close_remaining = restored.auto_close_remaining;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
-    use cgmath::{Matrix4, vec3};
+    use cgmath::{Deg, Matrix4, Quaternion, Rotation3, vec3};
     use dark::properties::{
         KeyCard, Link, Links, PropClassTag, PropKeyDst, PropKeypadCode, PropLocked, ToLink,
         WrappedEntityId,
@@ -351,6 +643,48 @@ mod tests {
             quest.add_key_card(key_card());
         }
         world.add_unique(quest);
+        (world, entity_id)
+    }
+
+    fn rotating_world() -> (World, EntityId) {
+        let mut world = World::new();
+        let closed = vec3(5.0, 6.0, 7.0);
+        let open = vec3(5.0, 7.0, 8.0);
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let entity_id = world.add_entity((
+            PropRotatingDoor {
+                door_type: 0,
+                closed: 0.0,
+                open: 90.0,
+                speed: 1.0,
+                axis: 0,
+                state: 0,
+                clockwise: false,
+                base_closed_location: closed,
+                base_open_location: open,
+                base_location: closed,
+                base_rotation: identity,
+                base_closed_rotation: identity,
+                base_open_rotation: Quaternion::from_angle_x(Deg(-90.0)),
+                progress: 0.0,
+            },
+            // Real RotDoors inherit this unusable zero property. The rotating
+            // component must win exactly as Dark's GetDoorProperty did.
+            PropTranslatingDoor {
+                door_type: 1,
+                closed: 0.0,
+                open: 0.0,
+                speed: 0.0,
+                axis: 0,
+                state: 0,
+                base_closed_location: Vector3::zero(),
+                base_open_location: Vector3::zero(),
+                base_location: Vector3::zero(),
+            },
+            PropClassTag::from_string("doortype hatch"),
+            RuntimePropTransform(Matrix4::from_translation(closed)),
+        ));
+        world.add_unique(QuestInfo::new());
         (world, entity_id)
     }
 
@@ -509,25 +843,129 @@ mod tests {
         }
     }
 
-    /// Stand-in for `mission_core`'s `Effect::SetTranslatingDoorState` handler -
-    /// the script only emits the effect, the world write happens here.
+    /// Stand-in for mission_core's persistent door-state effect handlers - the
+    /// script only emits effects, and the world writes happen here.
     fn apply(world: &World, effect: Effect) {
         for effect in Effect::flatten(vec![effect]) {
-            if let Effect::SetTranslatingDoorState {
-                entity_id,
-                state,
-                base_location,
-            } = effect
-            {
-                let mut doors = world
-                    .borrow::<shipyard::ViewMut<PropTranslatingDoor>>()
-                    .unwrap();
-                if let Ok(door) = (&mut doors).get(entity_id) {
-                    door.state = state;
-                    door.base_location = base_location;
+            match effect {
+                Effect::SetTranslatingDoorState {
+                    entity_id,
+                    state,
+                    base_location,
+                } => {
+                    let mut doors = world
+                        .borrow::<shipyard::ViewMut<PropTranslatingDoor>>()
+                        .unwrap();
+                    if let Ok(door) = (&mut doors).get(entity_id) {
+                        door.state = state;
+                        door.base_location = base_location;
+                    }
                 }
+                Effect::SetRotatingDoorState {
+                    entity_id,
+                    state,
+                    progress,
+                } => {
+                    let mut doors = world
+                        .borrow::<shipyard::ViewMut<PropRotatingDoor>>()
+                        .unwrap();
+                    if let Ok(door) = (&mut doors).get(entity_id) {
+                        door.state = state;
+                        door.progress = progress;
+                    }
+                }
+                _ => {}
             }
         }
+    }
+
+    #[test]
+    fn rotating_door_initialization_ignores_inherited_zero_translation() {
+        let (world, entity_id) = rotating_world();
+        let mut door = StdDoor::new();
+
+        let effect = door.initialize(entity_id, &world);
+
+        match effect {
+            Effect::SetPositionRotation {
+                entity_id: id,
+                position,
+                rotation,
+            } => {
+                assert_eq!(id, entity_id);
+                assert_eq!(position, vec3(5.0, 6.0, 7.0));
+                assert!(rotation.s > 0.999);
+            }
+            unexpected => panic!("expected rotating pose, got {unexpected:?}"),
+        }
+    }
+
+    #[test]
+    fn rotating_door_open_and_closed_endpoints_are_persisted() {
+        let (world, entity_id) = rotating_world();
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        let effect = door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(2.0));
+        apply(&world, effect);
+        {
+            let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+            let saved = doors.get(entity_id).unwrap();
+            assert_eq!(saved.state, 1);
+            assert_eq!(saved.progress, 1.0);
+        }
+
+        let effect = door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOff { from: entity_id },
+        );
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(2.0));
+        apply(&world, effect);
+        let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+        let saved = doors.get(entity_id).unwrap();
+        assert_eq!(saved.state, 0);
+        assert_eq!(saved.progress, 0.0);
+    }
+
+    #[test]
+    fn rotating_door_closes_after_its_authored_timer() {
+        let (mut world, entity_id) = rotating_world();
+        world.add_component(entity_id, PropDoorTimer(1));
+        let physics = PhysicsWorld::new();
+        let mut door = initialized_door(entity_id, &world);
+
+        let effect = door.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity_id },
+        );
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(2.0));
+        apply(&world, effect);
+        let effect = door.update(entity_id, &world, &physics, &step(1.1));
+        apply(&world, effect);
+
+        {
+            let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+            assert_eq!(doors.get(entity_id).unwrap().state, 2);
+        }
+
+        let effect = door.update(entity_id, &world, &physics, &step(2.0));
+        apply(&world, effect);
+        let doors = world.borrow::<View<PropRotatingDoor>>().unwrap();
+        assert_eq!(doors.get(entity_id).unwrap().state, 0);
+        assert_eq!(doors.get(entity_id).unwrap().progress, 0.0);
     }
 
     #[test]
@@ -566,6 +1004,24 @@ mod tests {
                 _ => None,
             });
         assert_eq!(persisted, Some((3, vec3(1.0, 2.0, 3.0))));
+    }
+
+    #[test]
+    fn translating_door_private_motion_survives_script_state_round_trip() {
+        let (world, entity_id) = test_world(false, false);
+        let physics = PhysicsWorld::new();
+        let mut before = initialized_door(entity_id, &world);
+        before.handle_message(entity_id, &world, &physics, &MessagePayload::Frob);
+
+        let state = before.save_state().unwrap();
+        let mut after = StdDoor::new();
+        let entity_map = HashMap::new();
+        let context = ScriptRestoreContext::new(&entity_map);
+        after.restore_state(&state, &context).unwrap();
+
+        assert_eq!(after.current_position, before.current_position);
+        assert_eq!(after.desired_position, before.desired_position);
+        assert_eq!(after.is_moving, before.is_moving);
     }
 
     #[test]

--- a/shock2vr/src/scripts/trap_new_tripwire.rs
+++ b/shock2vr/src/scripts/trap_new_tripwire.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use dark::properties::{
-    PropLocalPlayer, PropTeleported, PropTranslatingDoor, PropTripFlags, TeleportSource, TripFlags,
+    PropLocalPlayer, PropRotatingDoor, PropTeleported, PropTranslatingDoor, PropTripFlags,
+    TeleportSource, TripFlags,
 };
 use shipyard::{EntityId, Get, View, World};
 use tracing::info;
@@ -82,11 +83,13 @@ impl TrapNewTripwire {
         let links = get_all_switch_links(world, entity_id);
 
         let v_simple_door = world.borrow::<View<PropTranslatingDoor>>().unwrap();
+        let v_rot_door = world.borrow::<View<PropRotatingDoor>>().unwrap();
 
         // Are there any links that are a simple door?
         // TODO: Make sure it is _simple_ - ie, not locked
-        // TODO: Handle rotating doors?
-        links.iter().any(|link| v_simple_door.get(*link).is_ok())
+        links
+            .iter()
+            .any(|link| v_rot_door.get(*link).is_ok() || v_simple_door.get(*link).is_ok())
     }
 }
 impl Script for TrapNewTripwire {

--- a/tools/shock2-sdk/test/rotating-door.e2e.test.ts
+++ b/tools/shock2-sdk/test/rotating-door.e2e.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary, Quat, Vec3 } from "../src/types.js";
+
+// The late-Engineering Floor Hatch is a real rotating door controlled by two
+// ordinary BaseButtons:
+//
+//   button 130 ---SwitchLink---> Floor Hatch 85 <---SwitchLink--- button 152
+//
+// Object 85 also inherits a zero-valued P$TransDoor. RotDoor must take
+// precedence, exactly as Looking Glass's GetDoorProperty did. Before #861 the
+// unparsed P$RotDoor left StdDoor to initialize from the zero translation,
+// moving both the hatch and its body to world origin.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const exactCampaignSave = process.env.SHOCK2_ROTDOOR_EXACT_SAVE;
+const HATCH = 85;
+const SECOND_SHIPPED_HATCH = 462;
+const UPPER_CONTROL = 152;
+const AUTHORED_CLOSED: Vec3 = [0.114864826, -12.75, -23.712574];
+const SECOND_AUTHORED_CLOSED: Vec3 = [44.72176, -8.258417, -33.899513];
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function rotationDistance(a: Quat, b: Quat): number {
+  const dot = Math.abs(a.reduce((sum, value, axis) => sum + value * b[axis], 0));
+  return 1 - Math.min(1, dot);
+}
+
+async function byMissionId(
+  game: GameServer,
+  missionId: number,
+  label: string,
+): Promise<EntitySummary> {
+  const matches = (await game.entities.list({ limit: 5_000 })).entities.filter(
+    (entity) => entity.template_id === missionId,
+  );
+  assert.equal(matches.length, 1, `expected exactly one ${label} (${missionId})`);
+  return matches[0];
+}
+
+async function hatchDetail(game: GameServer): Promise<EntityDetailResult> {
+  return game.entities.detail((await byMissionId(game, HATCH, "Floor Hatch")).id);
+}
+
+async function pressUpperControl(game: GameServer): Promise<void> {
+  const control = await byMissionId(game, UPPER_CONTROL, "upper hatch control");
+  const link = (await game.entities.detail(control.id)).outgoing_links.find(
+    (candidate) => candidate.link_type === "SwitchLink",
+  );
+  const hatch = await byMissionId(game, HATCH, "Floor Hatch");
+  assert.equal(link?.target_id, hatch.id, "the real upper control must target Hatch 85");
+
+  // Setup only: stand on the authored upper side. Interaction itself is the
+  // production flat camera + ordinary squeeze rising edge, not a message.
+  await game.player.teleport({ x: -3, y: -12, z: -22.3 });
+  await game.step({ frames: 1 });
+  const aim = await game.player.aimAt(control, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+  await game.input.set("right_hand.squeeze_value", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze_value", 0);
+  // The 95-degree swing completes in about 1.7 seconds. Stop well before the
+  // hatch's authored 10-second DoorTimer closes it again.
+  await game.step({ frames: 180 });
+}
+
+async function assertBodyFollows(game: GameServer, hatch: EntitySummary): Promise<void> {
+  const body = (await game.physics.bodies({ entityId: hatch.id })).bodies;
+  assert.equal(body.length, 1, "Floor Hatch should own one kinematic body");
+  assert.ok(
+    distance(body[0].position, hatch.position) < 0.01,
+    `hatch body must follow its live transform: ${JSON.stringify(body[0].position)} vs ${JSON.stringify(hatch.position)}`,
+  );
+}
+
+test(
+  "eng1.mis: linked control rotates Floor Hatch 85 and open/closed saves restore",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8185),
+    });
+    await game.step({ frames: 30 });
+
+    const closed = await hatchDetail(game);
+    assert.ok(
+      distance(closed.position, AUTHORED_CLOSED) < 0.01,
+      `Hatch 85 must initialize at its authored shaft, got ${JSON.stringify(closed.position)}`,
+    );
+    await assertBodyFollows(game, await byMissionId(game, HATCH, "Floor Hatch"));
+
+    // A second concrete shipped P$RotDoor must take precedence too. This
+    // catches a Hatch-85-only exception even if the campaign blocker passes.
+    const second = await byMissionId(game, SECOND_SHIPPED_HATCH, "second Floor Hatch");
+    assert.ok(
+      distance(second.position, SECOND_AUTHORED_CLOSED) < 0.01,
+      `eng1 Hatch 462 must also initialize from P$RotDoor, got ${JSON.stringify(second.position)}`,
+    );
+    await assertBodyFollows(game, second);
+
+    const closedSave = `rotating-door-closed-${process.pid}`;
+    assert.equal((await game.save(closedSave)).success, true);
+
+    await pressUpperControl(game);
+    const open = await hatchDetail(game);
+    assert.ok(
+      rotationDistance(open.rotation, closed.rotation) > 0.1,
+      `linked control must rotate the hatch: ${JSON.stringify(closed.rotation)} -> ${JSON.stringify(open.rotation)}`,
+    );
+    await assertBodyFollows(game, await byMissionId(game, HATCH, "Floor Hatch"));
+
+    const openSave = `rotating-door-open-${process.pid}`;
+    assert.equal((await game.save(openSave)).success, true);
+    assert.equal((await game.load(openSave)).success, true);
+    await game.step({ frames: 30 });
+    const restoredOpen = await hatchDetail(game);
+    assert.ok(distance(restoredOpen.position, open.position) < 0.01);
+    assert.ok(rotationDistance(restoredOpen.rotation, open.rotation) < 0.001);
+
+    // The same production press starts the authored 10-second door cycle;
+    // after its hold, StdDoor closes the hatch rotationally without a debug
+    // message or synthetic TurnOff.
+    await game.step({ frames: 660 });
+    const reclosed = await hatchDetail(game);
+    assert.ok(distance(reclosed.position, closed.position) < 0.01);
+    assert.ok(rotationDistance(reclosed.rotation, closed.rotation) < 0.001);
+
+    assert.equal((await game.load(closedSave)).success, true);
+    await game.step({ frames: 30 });
+    const restoredClosed = await hatchDetail(game);
+    assert.ok(distance(restoredClosed.position, closed.position) < 0.01);
+    assert.ok(rotationDistance(restoredClosed.rotation, closed.rotation) < 0.001);
+    await assertBodyFollows(game, await byMissionId(game, HATCH, "Floor Hatch"));
+  },
+);
+
+test(
+  "exact campaign frontier: the supported upper approach opens Hatch 85",
+  { skip: !e2eEnabled || !exactCampaignSave, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8185) + 1,
+    });
+    assert.equal((await game.load(exactCampaignSave!)).success, true);
+    await game.step({ frames: 30 });
+    assert.equal((await game.info()).mission, "eng1.mis");
+
+    const closed = await hatchDetail(game);
+    assert.ok(distance(closed.position, AUTHORED_CLOSED) < 0.01);
+    await assertBodyFollows(game, await byMissionId(game, HATCH, "Floor Hatch"));
+
+    // Walk from the saved supported frontier around the hatch lip to the same
+    // upper-side control approach. The bounded SDK primitive shape-casts the
+    // real player capsule; it cannot cross the sealed hatch or world geometry.
+    const approach = await game.player.moveTo({ x: -3, y: -12, z: -22.3 });
+    assert.ok(
+      approach.distance_moved > 2,
+      `saved player must walk toward the upper control: ${JSON.stringify(approach)}`,
+    );
+    const control = await byMissionId(game, UPPER_CONTROL, "upper hatch control");
+    const aim = await game.player.aimAt(control, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `saved frontier must have a production interaction ray to control 152: ${JSON.stringify(aim)}`,
+    );
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 180 });
+
+    const open = await hatchDetail(game);
+    assert.ok(rotationDistance(open.rotation, closed.rotation) > 0.1);
+    await assertBodyFollows(game, await byMissionId(game, HATCH, "Floor Hatch"));
+  },
+);


### PR DESCRIPTION
Fixes #861

## Summary

- parse the full version-1001 `P$RotDoor` payload plus authored `P$DoorTimer`, and give rotating doors the same precedence over inherited `P$TransDoor` as Dark's `GetDoorProperty`
- initialize, open, close, auto-close, and persist rotating doors through the existing StdDoor/effect/physics pipeline, including center-of-gravity motion around the authored hinge
- backfill newly understood rotating-door data into legacy saves only when those components are absent, so the retained campaign frontier repairs its stale `(0,0,0)` transform while newer live save state still wins
- recognize rotating doors in AI/path/tripwire helpers and add shipped-mission SDK coverage for Hatch 85, Hatch 462, real control interaction, body motion, and open/closed save restoration

## Negative-first evidence

- parser unit initially failed with `P$RotDoor must be a registered Dark property`
- shipped eng1 scenario initially failed with `Hatch 85 must initialize at its authored shaft, got [0,0,0]`
- exact legacy-save scenario then exposed the old serialized zero transform until the missing-authored-data backfill was added

## Validation

- `cargo test -p dark` — 78 unit + 9 mission tests passed
- `cargo test -p shock2vr` — 513 passed
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cd tools/shock2-sdk && npm test` — 26 passed, 190 opt-in E2Es skipped
- rotating door + ordinary TransDoor SDK E2Es — 3/3 passed
- all-mission SDK load suite — 23/23 passed
- exact retained save SHA-256 `a6e77f3ef81aef23b9c91b0c55e3cf9380689e0362b9ceb7afee6f7331ff12f4` — collision-checked approach, real upper control aim/squeeze, rotational open/body follow passed (save is local-only and not uploaded)

## Visual evidence

![eng1 Floor Hatch 85 opening](https://gist.githubusercontent.com/tommy-xr/72d2f116403eeedb37f62713a337da70/raw/eng1-floor-hatch-85.gif)

<sub>Fresh `eng1.mis`: the real upper-side control (mission object 152) is aimed at and squeezed through the production interaction path, then Floor Hatch 85 visibly rotates around its authored hinge to uncover the ladder. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![Floor Hatch 85 before and after](https://gist.githubusercontent.com/tommy-xr/72d2f116403eeedb37f62713a337da70/raw/eng1-floor-hatch-85-before-after.png)

<sub>Matching fresh-launch request sequence and lower-side camera: `main` leaves the authored shaft empty because the hatch was moved to world origin; this PR places the closed hatch at the shipped hinge before it opens.</sub>