### PR TITLE
fix(debug): report unsafe save poses

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -484,6 +484,15 @@ pub struct SaveLoadResult {
     /// load this is the restored mission; after a save it is the scene saved.
     pub mission: String,
     pub message: String,
+    /// Stable failure code. Omitted on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Human-readable refusal reason. Omitted on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Exact live pose associated with an unsafe-player-state refusal.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub player_pose: Option<shock2vr::SavePlayerPose>,
 }
 
 /// Result of a level transition (warp) request

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -355,7 +355,9 @@ async fn start_http_server(
     info!("  POST /v1/player/teleport  - Teleport player to coordinates (raw, unbounded)");
     info!("  POST /v1/player/move      - Bounded, collision-valid move toward {{x,y,z}}");
     info!("  POST /v1/control/transition-level - Warp to another level {{level, loc?}}");
-    info!("  POST /v1/save             - Save the game to a named file {{file}}");
+    info!(
+        "  POST /v1/save             - Save {{file}}; 409 JSON reports reason + player_pose when dead, unsupported, or transient"
+    );
     info!(
         "  POST /v1/load             - Load a named save (restores mission/player/quests) {{file}}"
     );
@@ -1032,13 +1034,22 @@ fn process_command(
                     message: format!("Saved '{}' ({})", file, mission),
                     file,
                     mission,
+                    error_code: None,
+                    reason: None,
+                    player_pose: None,
                 },
-                Ok(Err(error)) => commands::SaveLoadResult {
-                    success: false,
-                    message: error,
-                    file,
-                    mission: String::new(),
-                },
+                Ok(Err(error)) => {
+                    let message = error.to_string();
+                    commands::SaveLoadResult {
+                        success: false,
+                        message,
+                        file,
+                        mission: game.scene_name().to_owned(),
+                        error_code: Some(error.error_code.to_owned()),
+                        reason: Some(error.reason),
+                        player_pose: error.player_pose,
+                    }
+                }
                 Err(_) => {
                     tracing::error!("Save of '{}' panicked (caught to keep runtime alive)", file);
                     commands::SaveLoadResult {
@@ -1046,6 +1057,9 @@ fn process_command(
                         message: format!("Failed to save '{}' (see runtime log)", file),
                         file,
                         mission: String::new(),
+                        error_code: Some("save_internal_error".to_owned()),
+                        reason: Some("the save operation failed unexpectedly".to_owned()),
+                        player_pose: None,
                     }
                 }
             };
@@ -1070,6 +1084,9 @@ fn process_command(
                     message: format!("Loaded '{}' ({})", file, mission),
                     file,
                     mission,
+                    error_code: None,
+                    reason: None,
+                    player_pose: None,
                 },
                 Ok(Err(error)) => {
                     tracing::error!("Failed to load '{}': {}", file, error);
@@ -1078,6 +1095,9 @@ fn process_command(
                         message: format!("Failed to load '{}': {}", file, error),
                         file,
                         mission: String::new(),
+                        error_code: None,
+                        reason: None,
+                        player_pose: None,
                     }
                 }
                 Err(_) => {
@@ -1090,6 +1110,9 @@ fn process_command(
                         ),
                         file,
                         mission: String::new(),
+                        error_code: None,
+                        reason: None,
+                        player_pose: None,
                     }
                 }
             };
@@ -2602,35 +2625,92 @@ fn validate_save_name(file: &str) -> Result<String, (StatusCode, String)> {
     Ok(file.to_string())
 }
 
+fn save_error_result(
+    file: String,
+    mission: String,
+    error_code: &str,
+    reason: String,
+) -> commands::SaveLoadResult {
+    commands::SaveLoadResult {
+        success: false,
+        message: format!("Unable to save: {reason}"),
+        file,
+        mission,
+        error_code: Some(error_code.to_owned()),
+        reason: Some(reason),
+        player_pose: None,
+    }
+}
+
 /// HTTP handler for saving the current game to a named file. Persists a
 /// "frontier" save that a later runtime launch can reload to resume - the core
 /// of the automated play-through loop's cross-launch resume.
 async fn save_game(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
     LenientJson(request): LenientJson<SaveLoadRequest>,
-) -> Result<Json<commands::SaveLoadResult>, (StatusCode, String)> {
-    let file = validate_save_name(&request.file)?;
+) -> Result<Json<commands::SaveLoadResult>, (StatusCode, Json<commands::SaveLoadResult>)> {
+    let file = match validate_save_name(&request.file) {
+        Ok(file) => file,
+        Err((status, reason)) => {
+            return Err((
+                status,
+                Json(save_error_result(
+                    request.file,
+                    String::new(),
+                    "invalid_save_name",
+                    reason,
+                )),
+            ));
+        }
+    };
 
     let (reply_tx, reply_rx) = oneshot::channel();
     if command_tx
         .send(RuntimeCommand::SaveGame {
-            file,
+            file: file.clone(),
             reply: reply_tx,
         })
         .is_err()
     {
         tracing::error!("Failed to send SaveGame command - game loop receiver dropped");
-        return Err(game_loop_unavailable());
+        let (status, reason) = game_loop_unavailable();
+        return Err((
+            status,
+            Json(save_error_result(
+                file,
+                String::new(),
+                "game_loop_unavailable",
+                reason,
+            )),
+        ));
     }
 
     match reply_rx.await {
         Ok(result) if result.success => Ok(Json(result)),
-        // The save path unwrapped (I/O error, or a scene without player state);
-        // the game loop caught it and stayed alive, so surface a 500 here.
-        Ok(result) => Err((StatusCode::INTERNAL_SERVER_ERROR, result.message)),
+        Ok(result) => {
+            let internal_error = matches!(
+                result.error_code.as_deref(),
+                Some("save_io_error" | "save_internal_error")
+            );
+            let status = if internal_error {
+                StatusCode::INTERNAL_SERVER_ERROR
+            } else {
+                StatusCode::CONFLICT
+            };
+            Err((status, Json(result)))
+        }
         Err(_) => {
             tracing::error!("Failed to receive save result - sender dropped");
-            Err(game_loop_unavailable())
+            let (status, reason) = game_loop_unavailable();
+            Err((
+                status,
+                Json(save_error_result(
+                    file,
+                    String::new(),
+                    "game_loop_unavailable",
+                    reason,
+                )),
+            ))
         }
     }
 }

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -17,6 +17,44 @@ use crate::{
     time::Time,
 };
 
+/// Why the player's current state cannot be represented by a durable save.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlayerSavePoseError {
+    NoPlayer,
+    PlayerNotAlive,
+    TransientSlopeMotion,
+    BlockedRecoveryPose,
+    UnsupportedPose,
+}
+
+impl PlayerSavePoseError {
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::NoPlayer => "no_player_pose",
+            Self::PlayerNotAlive => "player_not_alive",
+            Self::TransientSlopeMotion => "transient_player_motion",
+            Self::BlockedRecoveryPose => "blocked_recovery_pose",
+            Self::UnsupportedPose => "unsupported_player_pose",
+        }
+    }
+
+    pub(crate) fn reason(self) -> &'static str {
+        match self {
+            Self::NoPlayer => "the active scene has no player pose",
+            Self::PlayerNotAlive => "the player is not alive",
+            Self::TransientSlopeMotion => {
+                "the player is still carrying transient slope displacement"
+            }
+            Self::BlockedRecoveryPose => {
+                "the player's last collision-valid recovery pose is blocked"
+            }
+            Self::UnsupportedPose => {
+                "the player pose has no walkable support and is outside the authored level cells"
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct AmbientAudioState {
     pub player_position: Vector3<f32>,
@@ -98,10 +136,11 @@ pub trait GameScene {
         false
     }
 
-    /// Collision-valid standing position to serialize for the player. Mission
-    /// scenes override this while transient locomotion compresses the collider.
-    fn player_save_position(&self) -> Option<Vector3<f32>> {
-        None
+    /// Collision-valid, supported position to serialize for the player.
+    /// Mission scenes return a specific refusal reason while transient
+    /// locomotion, death, or unsupported space makes a durable save unsafe.
+    fn player_save_position(&self) -> Result<Vector3<f32>, PlayerSavePoseError> {
+        Err(PlayerSavePoseError::NoPlayer)
     }
 
     /// Get lighting information for VR enhancement

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -458,6 +458,32 @@ pub struct PlayerStateSnapshot {
     pub explored_map_locations: Vec<i32>,
 }
 
+/// Live player pose attached to a save refusal so automation can diagnose and
+/// recover from the exact state that could not be persisted.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SavePlayerPose {
+    pub position: [f32; 3],
+    pub rotation: [f32; 4],
+    pub is_crouched: bool,
+}
+
+/// A save failure with a stable machine-readable code and, for unsafe player
+/// state, the live pose that was refused.
+#[derive(Clone, Debug)]
+pub struct SaveGameError {
+    pub error_code: &'static str,
+    pub reason: String,
+    pub player_pose: Option<SavePlayerPose>,
+}
+
+impl std::fmt::Display for SaveGameError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "Unable to save: {}", self.reason)
+    }
+}
+
+impl std::error::Error for SaveGameError {}
+
 impl Game {
     /// True while a deferred level transition (`--experimental loading_screen`)
     /// is in flight. `update` is what advances it (`pending_transition.frames_shown`
@@ -820,7 +846,7 @@ impl Game {
     /// exact current/maximum player vitals.
     /// Returns the scene name that was saved so the caller can report it, or
     /// an error when transient locomotion has no collision-valid standing pose.
-    pub fn save_game(&mut self, file: String) -> Result<String, String> {
+    pub fn save_game(&mut self, file: String) -> Result<String, SaveGameError> {
         let path = save_file_path(&file);
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -1191,13 +1217,8 @@ impl Game {
         }
     }
 
-    fn save_to_file(&self, file_name: String) -> Result<(), String> {
-        let Some(save_data) = self.build_save_data() else {
-            return Err(format!(
-                "Unable to save '{}': no collision-valid standing player pose is currently available",
-                file_name
-            ));
-        };
+    fn save_to_file(&self, file_name: String) -> Result<(), SaveGameError> {
+        let save_data = self.build_save_data()?;
         // Saves live in `<data_root>/saves`, which may not exist yet on a fresh
         // install - a quicksave must create it rather than fail (and a failure
         // must not take the game down).
@@ -1206,15 +1227,22 @@ impl Game {
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
         {
-            std::fs::create_dir_all(parent)
-                .map_err(|error| format!("Unable to create '{}': {}", parent.display(), error))?;
+            std::fs::create_dir_all(parent).map_err(|error| SaveGameError {
+                error_code: "save_io_error",
+                reason: format!("unable to create '{}': {}", parent.display(), error),
+                player_pose: None,
+            })?;
         }
         let mut zip_file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .open(path)
-            .map_err(|error| format!("Unable to save '{}': {}", file_name, error))?;
+            .map_err(|error| SaveGameError {
+                error_code: "save_io_error",
+                reason: format!("unable to write '{}': {}", file_name, error),
+                player_pose: None,
+            })?;
         save_data.write(&mut zip_file);
         Ok(())
     }
@@ -1261,10 +1289,21 @@ impl Game {
     /// Player transform with the center normalized to a collision-valid
     /// standing pose. Both persistent saves and debug reloads recreate a
     /// standing capsule, so neither may use a transient compressed mantle pose.
-    /// `None` defers the operation when a live blocker has occupied the
+    /// An error defers the operation when a live blocker has occupied the
     /// mantle's cached recovery pose.
-    fn player_standing_transform(&self) -> Option<(Vector3<f32>, Quaternion<f32>)> {
-        let safe_position = self.active_game_scene.player_save_position()?;
+    fn player_standing_transform(&self) -> Result<(Vector3<f32>, Quaternion<f32>), SaveGameError> {
+        let safe_position = self
+            .active_game_scene
+            .player_save_position()
+            .map_err(|error| SaveGameError {
+                error_code: error.code(),
+                reason: error.reason().to_owned(),
+                player_pose: self.player_state().map(|state| SavePlayerPose {
+                    position: state.position,
+                    rotation: state.rotation,
+                    is_crouched: self.active_game_scene.player_is_crouched(),
+                }),
+            })?;
         let (position, rotation) = {
             let player_info = self
                 .active_game_scene
@@ -1278,10 +1317,10 @@ impl Game {
         } else {
             position
         };
-        Some((position, rotation))
+        Ok((position, rotation))
     }
 
-    fn build_save_data(&self) -> Option<SaveData> {
+    fn build_save_data(&self) -> Result<SaveData, SaveGameError> {
         let mut level_data = self.mission_to_save_data.clone();
 
         let (save_data, held_items) = save_load::to_save_data_with_scripts(
@@ -1311,7 +1350,7 @@ impl Game {
             is_crouched,
         };
 
-        Some(SaveData {
+        Ok(SaveData {
             global_data,
             level_data,
         })
@@ -1357,11 +1396,12 @@ impl Game {
                 }
             }
             GlobalEffect::TestReload => {
-                let Some((position, rotation)) = self.player_standing_transform() else {
-                    warn!(
-                        "Unable to reload level: no collision-valid standing player pose is currently available"
-                    );
-                    return;
+                let (position, rotation) = match self.player_standing_transform() {
+                    Ok(transform) => transform,
+                    Err(error) => {
+                        warn!("Unable to reload level: {}", error.reason);
+                        return;
+                    }
                 };
                 let level_name = self.active_game_scene.scene_name().to_string();
                 let spawn_loc = SpawnLocation::PositionRotation(position, rotation);

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -73,6 +73,7 @@ use crate::{
     GameOptions,
     creature::{HitBoxManager, RagDollManager, get_creature_definition},
     game_scene::AmbientAudioState,
+    game_scene::PlayerSavePoseError,
     gui::GuiManager,
     hud::{draw_item_name, draw_item_outline},
     input_context::{self, InputContext},
@@ -5712,12 +5713,31 @@ impl MissionCore {
         self.player_handle.is_crouched()
     }
 
-    pub fn player_save_position(&self) -> Option<Vector3<f32>> {
+    pub fn player_save_position(&self) -> Result<Vector3<f32>, PlayerSavePoseError> {
         if !self.player_is_alive() {
-            return None;
+            return Err(PlayerSavePoseError::PlayerNotAlive);
         }
-        self.physics
+        match self
+            .physics
             .get_player_save_translation(&self.player_handle)
+        {
+            Err(PlayerSavePoseError::UnsupportedPose) => {
+                let position = self.physics.get_player_translation(&self.player_handle);
+                let inside_authored_cell = self.spatial_data.as_ref().is_some_and(|spatial| {
+                    (0..spatial.get_cell_count()).any(|index| {
+                        spatial.get_cell_by_index(index).is_some_and(|cell| {
+                            (position - cell.center).magnitude2() <= cell.radius * cell.radius
+                        })
+                    })
+                });
+                if inside_authored_cell {
+                    Ok(position)
+                } else {
+                    Err(PlayerSavePoseError::UnsupportedPose)
+                }
+            }
+            result => result,
+        }
     }
 
     /// Re-apply a crouch recorded in save data. The save stores the

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -251,7 +251,7 @@ impl crate::game_scene::GameScene for Mission {
         self.mission_core.player_is_crouched()
     }
 
-    fn player_save_position(&self) -> Option<Vector3<f32>> {
+    fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.mission_core.player_save_position()
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -19,6 +19,8 @@ use rapier3d::{
 };
 use shipyard::EntityId;
 
+use crate::game_scene::PlayerSavePoseError;
+
 use physics_events::*;
 
 use self::debug_render_pipeline::DebugRenderer;
@@ -2758,6 +2760,33 @@ impl PhysicsWorld {
         self.standing_player_pose_is_clear(nvec_to_cgmath(top_out.save_pose), player_handle)
     }
 
+    /// Whether the live pose has nearby walkable ground to settle onto. The
+    /// last movement frame's `is_grounded` flag is the fast path, but a fresh
+    /// mission spawn can still be a fraction above its authored floor while
+    /// the controller settles. Accept ground within one standing body height;
+    /// that short fall is faithfully restorable, unlike a pose over a void.
+    fn player_save_pose_has_support(&self, player_handle: &PlayerHandle) -> bool {
+        if player_handle.is_grounded {
+            return true;
+        }
+        let position = vec_to_nvec(self.get_player_translation(player_handle));
+        let half_height = if player_handle.is_crouched {
+            PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+        } else {
+            PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+        };
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            player_pose_filter(player_handle.character_handle),
+        );
+        let down = Ray::new(Point::from(position), -Vector::y());
+        queries
+            .cast_ray_and_get_normal(&down, half_height + PLAYER_PLACEMENT_MAX_DROP, true)
+            .is_some_and(|(_, hit)| hit.normal.y >= SUPPORT_MIN_GROUND_NORMAL)
+    }
+
     /// Position safe to serialize for the player. A compressed mantle can
     /// occupy places where the standing capsule does not fit, so persist its
     /// last valid standing start instead of an in-flight waypoint. A live
@@ -2768,7 +2797,7 @@ impl PhysicsWorld {
     pub fn get_player_save_translation(
         &self,
         player_handle: &PlayerHandle,
-    ) -> Option<Vector3<f32>> {
+    ) -> Result<Vector3<f32>, PlayerSavePoseError> {
         // This short-lived displacement is the kinematic equivalent of
         // in-flight velocity. Loading only a transform in the middle of a
         // chained slope would erase it and can strand the player on an
@@ -2776,14 +2805,17 @@ impl PhysicsWorld {
         if player_handle.slope_displacement.norm_squared()
             > PLAYER_SLOPE_DISPLACEMENT_EPSILON_SQUARED
         {
-            return None;
+            return Err(PlayerSavePoseError::TransientSlopeMotion);
         }
         match player_handle.top_out {
             Some(top_out) if self.top_out_save_pose_is_clear(player_handle, top_out) => {
-                Some(nvec_to_cgmath(top_out.save_pose))
+                Ok(nvec_to_cgmath(top_out.save_pose))
             }
-            Some(_) => None,
-            None => Some(self.get_player_translation(player_handle)),
+            Some(_) => Err(PlayerSavePoseError::BlockedRecoveryPose),
+            None if !self.player_save_pose_has_support(player_handle) => {
+                Err(PlayerSavePoseError::UnsupportedPose)
+            }
+            None => Ok(self.get_player_translation(player_handle)),
         }
     }
 
@@ -5604,25 +5636,42 @@ mod tests {
 
     #[test]
     fn player_save_waits_for_transient_slope_displacement() {
-        let mut world = PhysicsWorld::new();
-        let mut player =
-            world.create_player(vec3(0.0, 3.0, 0.0), EntityId::from_inner(2102).unwrap());
+        let (mut world, mut player) = world_with_floor();
+        world.set_player_translation(vec3(0.0, 2.0, 0.0), &mut player);
+        step(&mut world, &mut player, 30);
         assert!(
-            world.get_player_save_translation(&player).is_some(),
+            world.get_player_save_translation(&player).is_ok(),
             "a stationary player should be saveable"
         );
 
         player.slope_displacement = vector![0.1, 0.0, 0.0];
         assert_eq!(
             world.get_player_save_translation(&player),
-            None,
+            Err(PlayerSavePoseError::TransientSlopeMotion),
             "a transform-only save must not erase active slope carry"
         );
 
-        world.set_player_translation(vec3(1.0, 3.0, 0.0), &mut player);
+        let current = world.get_player_translation(&player);
+        world.set_player_translation(current + vec3(1.0, 0.0, 0.0), &mut player);
+        step(&mut world, &mut player, 2);
         assert!(
-            world.get_player_save_translation(&player).is_some(),
+            world.get_player_save_translation(&player).is_ok(),
             "an explicit relocation clears the transient carry"
+        );
+    }
+
+    #[test]
+    fn player_save_rejects_an_unsupported_void_pose() {
+        let mut world = PhysicsWorld::new();
+        let mut player =
+            world.create_player(vec3(0.0, -100.0, 0.0), EntityId::from_inner(2106).unwrap());
+
+        step(&mut world, &mut player, 3);
+
+        assert_eq!(
+            world.get_player_save_translation(&player),
+            Err(PlayerSavePoseError::UnsupportedPose),
+            "a falling player with no walkable support must not brick a save slot"
         );
     }
 
@@ -6655,7 +6704,7 @@ mod tests {
         player.top_out = Some(reversing);
         assert_eq!(
             world.get_player_save_translation(&player),
-            Some(vec3(-1.0, 0.0, 0.0)),
+            Ok(vec3(-1.0, 0.0, 0.0)),
             "an in-flight save must serialize the last standing pose"
         );
     }
@@ -6765,7 +6814,7 @@ mod tests {
         });
         assert_eq!(
             world.get_player_save_translation(&player),
-            None,
+            Err(PlayerSavePoseError::BlockedRecoveryPose),
             "a blocker occupying the cached standing pose must defer saving"
         );
 

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -264,7 +264,7 @@ impl GameScene for DebugScene {
         self.core.player_is_crouched()
     }
 
-    fn player_save_position(&self) -> Option<Vector3<f32>> {
+    fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.core.player_save_position()
     }
 
@@ -484,7 +484,7 @@ impl<H: DebugSceneHooks> GameScene for HookedDebugScene<H> {
         self.core.player_is_crouched()
     }
 
-    fn player_save_position(&self) -> Option<Vector3<f32>> {
+    fn player_save_position(&self) -> Result<Vector3<f32>, crate::game_scene::PlayerSavePoseError> {
         self.core.player_save_position()
     }
 

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -720,6 +720,9 @@ export class Game {
    * separators - e.g. "frontier"). Persists the active mission, player
    * position/rotation, quest bits, and held items. The save survives across
    * runtime relaunches, so a later `load(file)` in a fresh session resumes it.
+   * Rejects with HTTP 409 while the live player is dead, unsupported/falling,
+   * or in transient locomotion that cannot be represented safely. That JSON
+   * error body includes `error_code`, `reason`, and the exact `player_pose`.
    */
   async save(file: string): Promise<SaveLoadResult> {
     return this.client.post<SaveLoadResult>("/v1/save", { file });

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -481,6 +481,16 @@ export interface SaveLoadResult {
   /** Active scene after the operation, e.g. "medsci1.mis". */
   mission: string;
   message: string;
+  /** Stable machine-readable failure code; absent on success. */
+  error_code?: string;
+  /** Human-readable failure reason; absent on success. */
+  reason?: string;
+  /** Exact live player pose when save safety refused the request. */
+  player_pose?: {
+    position: Vec3;
+    rotation: Quat;
+    is_crouched: boolean;
+  };
 }
 
 /** The 3-state value of a quest bit (objective flag). */

--- a/tools/shock2-sdk/test/hydro-research.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro-research.e2e.test.ts
@@ -132,6 +132,7 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
     });
     await game.step({ frames: 5 });
+    const supportedSavePosition = await game.player.position();
 
     // Loot two authored Hydro 2 vials, then prove Hydro 2's real regulator
     // refuses them while their Dark object state is still Unresearched.
@@ -236,7 +237,11 @@ test(
     );
 
     // Save/load while paused at a chemical gate, then reopen the carried item:
-    // active partial progress and the pending chemical must survive.
+    // active partial progress and the pending chemical must survive. The
+    // interaction helpers intentionally stage beside data-authored objects,
+    // including spots outside playable cell geometry; return to the supported
+    // mission spawn before exercising the production save guard.
+    await game.player.teleport(supportedSavePosition);
     assert.equal((await game.save(saveName)).success, true);
     assert.equal((await game.load(saveName)).success, true);
     await game.step({ frames: 5 });

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -61,6 +61,7 @@ test(
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8153),
     });
     await game.step({ frames: 5 });
+    const supportedSavePosition = await game.player.position();
 
     const pictures = (
       await game.entities.list({ filter: CODE_PIC_1, limit: 20 })
@@ -82,6 +83,10 @@ test(
       "PictureSwap should retain static for the authored one-second delay",
     );
     const saveName = `picture_swap_mid_static_${Date.now()}`;
+    // The reticle helper stages beside the authored picture in non-playable
+    // geometry. Restore the supported spawn without stepping so the exact
+    // one-second PictureSwap timer remains the behavior under test.
+    await game.player.teleport(supportedSavePosition);
     assert.equal((await game.save(saveName)).success, true);
     assert.equal((await game.load(saveName)).success, true);
     const restoredPictures = (

--- a/tools/shock2-sdk/test/save-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/save-load.e2e.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { GameServer, HttpError, findRepoRoot } from "../src/index.js";
@@ -222,6 +222,63 @@ test(
       (await game.info()).mission,
       "medsci1.mis",
       "runtime should stay live on medsci1 after a failed load",
+    );
+  },
+);
+
+test(
+  "saving an unsupported player returns a structured pose refusal",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `unsupported_save_e2e_${Date.now()}`;
+    t.after(() => {
+      const path = findSavePath(saveName);
+      if (path) rmSync(path, { force: true });
+    });
+
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort + 5,
+    });
+    await game.step({ frames: 5 });
+
+    const start = await game.player.position();
+    await game.player.teleport({ x: start.x, y: -100, z: start.z });
+    await game.step({ frames: 3 });
+    const unsupported = await game.player.position();
+
+    await assert.rejects(
+      game.save(saveName),
+      (error: unknown) => {
+        if (!(error instanceof HttpError) || error.status !== 409) return false;
+        const body = JSON.parse(error.body) as {
+          success: boolean;
+          error_code: string;
+          reason: string;
+          player_pose: {
+            position: [number, number, number];
+            is_crouched: boolean;
+          };
+        };
+        assert.equal(body.success, false);
+        assert.equal(body.error_code, "unsupported_player_pose");
+        assert.match(body.reason, /support/i);
+        assert.equal(body.player_pose.is_crouched, false);
+        assert.ok(
+          Math.abs(body.player_pose.position[0] - unsupported.x) < 0.01 &&
+            Math.abs(body.player_pose.position[1] - unsupported.y) < 0.01 &&
+            Math.abs(body.player_pose.position[2] - unsupported.z) < 0.01,
+          `refusal must report the live pose: ${JSON.stringify(body.player_pose)} vs ${JSON.stringify(unsupported)}`,
+        );
+        return true;
+      },
+      "an unsupported pose must be an explicit 409 with its reason and live pose",
+    );
+
+    assert.equal(
+      (await game.info()).mission,
+      "medsci1.mis",
+      "a refused save must leave the runtime live",
     );
   },
 );


### PR DESCRIPTION
## Summary

- preserve specific player-pose save refusal reasons through the game and debug runtime
- return HTTP 409 JSON from `/v1/save` with `error_code`, `reason`, and the exact live `player_pose`
- reject unsupported poses outside authored level cells while preserving valid crouched and in-level saves
- document the response in endpoint help and SDK types/docs

## Reproduction

On `origin/main` at `c07099a`, the negative physics test accepted a falling void pose: expected `None`, got `Some(Vector3 [0.0, -100.399994, 0.0])`. Existing player-state refusal responses were a generic plain-text HTTP 500 whose reason collapsed to no collision-valid standing pose.

The added SDK scenario teleports below MedSci, steps the simulation, and verifies that save refuses the unsafe pose without taking down the runtime.

## Verification

- `cargo test -p shock2vr`: 509 passed, 0 failed; doctests 2 ignored
- `RUSTFLAGS=-D warnings CARGO_INCREMENTAL=0 cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- `npm test`: 26 passed, 0 failed, 189 E2E skipped
- focused automap + unsupported-save E2E: 2 passed, 0 failed
- focused save-load E2E: 4 passed, 0 failed
- focused crouched low-headroom E2E: 1 passed, 0 failed
- full SDK E2E: 215 total, 211 passed, 3 skipped, 1 pre-existing failure

The sole full-suite failure is `a loaded corpse does not replay its death`. The exact test also fails on a clean detached `origin/main` build (0 passed, 1 failed) with every logged corpse state field stable, establishing that it predates this change.

No visual output changed.

Fixes #804