### PR TITLE
fix(physics): acquire ladders before descent lips

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -244,6 +244,13 @@ fn player_character_controller() -> KinematicCharacterController {
 /// collider and the rungs, so the un-inflated shapes never intersect.
 const CLIMB_REACH: f32 = 1.0 / SCALE_FACTOR;
 
+/// How far ahead a downward-pitched approach may acquire a ladder.
+/// Hydro2 Sector C's office landing leaves about one player footprint between
+/// its edge and the nearest Rick Ladder grip. Looking down and walking toward
+/// it must preserve descent intent across that gap, before gravity wins the
+/// race to ordinary contact.
+const CLIMB_DESCENT_ACQUIRE_FORWARD: f32 = 2.0 * PLAYER_STANDING_RADIUS / SCALE_FACTOR;
+
 /// Climb speed as a fraction of walk speed (the into-ladder input component is
 /// redirected to vertical movement at this scale).
 const CLIMB_SPEED_SCALE: f32 = 0.6;
@@ -608,6 +615,7 @@ fn try_step_up(
 struct ClimbPass<'a> {
     movement: Vector<Real>,
     top_out: Option<(Vector<Real>, Real)>,
+    descent_approach: bool,
     validation_queries: QueryPipeline<'a>,
     probe_queries: QueryPipeline<'a>,
     scripted_queries: QueryPipeline<'a>,
@@ -1596,6 +1604,7 @@ fn step_player_movement(
     if let Some(ClimbPass {
         movement: climb,
         top_out,
+        descent_approach,
         validation_queries,
         probe_queries: climb_queries,
         scripted_queries,
@@ -1617,7 +1626,11 @@ fn step_player_movement(
                 return top_out;
             }
         }
-        let mvt = controller.move_shape(dt, &climb_queries, shape, pos, climb, |_c| ());
+        // Ground snapping belongs to ordinary stair/ledge walking. At a
+        // descent lip it can add a step-sized drop to the controlled redirect.
+        let mut climb_controller = *controller;
+        climb_controller.snap_to_ground = None;
+        let mvt = climb_controller.move_shape(dt, &climb_queries, shape, pos, climb, |_c| ());
         let climbed = mvt.translation.y * climb.y.signum();
         if climbed > CLIMB_MIN_PROGRESS_FRACTION * climb.y.abs() {
             return PlayerMovement {
@@ -1625,6 +1638,33 @@ fn step_player_movement(
                 top_out: None,
                 slope_displacement: Vector::zeros(),
             };
+        }
+        if descent_approach && climb.y < 0.0 {
+            // A descent probe can acquire the ladder while the capsule is
+            // still supported by the adjacent landing. Downward travel is
+            // blocked there, so preserve the grip (and suppress gravity) while
+            // collision-checked horizontal input carries the body to the lip.
+            // Once the floor clears, the vertical redirect above takes over.
+            let desired_h = vector![desired.x, 0.0, desired.z];
+            let approach_distance = desired_h.norm();
+            if approach_distance > 1.0e-6 {
+                let approach_mvt = climb_controller.move_shape(
+                    dt,
+                    &validation_queries,
+                    shape,
+                    pos,
+                    desired_h,
+                    |_c| (),
+                );
+                let progress = approach_mvt.translation.dot(&desired_h) / approach_distance;
+                if progress > CLIMB_MIN_PROGRESS_FRACTION * approach_distance {
+                    return PlayerMovement {
+                        movement: approach_mvt,
+                        top_out: None,
+                        slope_displacement: Vector::zeros(),
+                    };
+                }
+            }
         }
     }
     // Support motion first: the platform underfoot took the player with it
@@ -3907,58 +3947,73 @@ impl PhysicsWorld {
                 // (The collider-center direction is wrong when the player is
                 // off-center: it tilts away from the face, which under-reads
                 // the into-ladder push the grip test and climb speed use.)
-                let mut nearest: Option<(f32, Vector<Real>)> = None;
-                for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
-                    let contact = rapier3d::parry::query::contact(
-                        &character_pos,
-                        character_shape.as_ref(),
-                        collider.position(),
-                        collider.shape(),
-                        CLIMB_REACH,
-                    );
-                    if let Ok(Some(contact)) = contact {
-                        // normal1 points from the player toward the climbable.
-                        let toward_h = vector![contact.normal1.x, 0.0, contact.normal1.z];
-                        let toward_norm = toward_h.norm();
-                        // A mostly-vertical normal means the player is on top of
-                        // (or under) the surface - that's standing, not climbing.
-                        if toward_norm > 0.5 && nearest.is_none_or(|(d, _)| contact.dist < d) {
-                            let toward = toward_h / toward_norm;
-                            nearest = Some((contact.dist, toward));
+                let nearest_at = |probe_pos: &Isometry<Real>| {
+                    let mut nearest: Option<(f32, Vector<Real>)> = None;
+                    for (_handle, collider) in queries.intersect_shape(*probe_pos, &inflated) {
+                        let contact = rapier3d::parry::query::contact(
+                            probe_pos,
+                            character_shape.as_ref(),
+                            collider.position(),
+                            collider.shape(),
+                            CLIMB_REACH,
+                        );
+                        if let Ok(Some(contact)) = contact {
+                            // normal1 points from the player toward the climbable.
+                            let toward_h = vector![contact.normal1.x, 0.0, contact.normal1.z];
+                            let toward_norm = toward_h.norm();
+                            // A mostly-vertical normal means the player is on top of
+                            // (or under) the surface - that's standing, not climbing.
+                            if toward_norm > 0.5 && nearest.is_none_or(|(d, _)| contact.dist < d) {
+                                let toward = toward_h / toward_norm;
+                                nearest = Some((contact.dist, toward));
+                            }
                         }
                     }
-                }
-                nearest.and_then(|(_, toward)| {
-                    climb_redirect(desired_movement, toward).map(|movement| {
-                        let top_out = if near_column_top && !player_handle.is_crouched {
-                            climb_top_out_direction(desired_movement, facing).map(|direction| {
-                                // Stay compressed until projected facing has
-                                // exited every horizontally-expanded climbable
-                                // AABB in this ladder column.
-                                let capsule_clearance =
-                                    capsule.radius + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
-                                let minimum_clear_forward = queries
-                                    .intersect_shape(character_pos, &column_probe)
-                                    .filter_map(|(_, collider)| {
-                                        climbable_aabb_exit_distance(
-                                            character_pos.translation.vector,
-                                            direction,
-                                            &collider.compute_aabb(),
-                                            capsule_clearance,
-                                        )
-                                    })
-                                    .fold(0.0, f32::max);
-                                (direction, minimum_clear_forward)
-                            })
-                        } else {
-                            None
-                        };
-                        (movement, top_out)
-                    })
+                    nearest
+                };
+
+                let direct_grip = nearest_at(&character_pos)
+                    .and_then(|(_, toward)| climb_redirect(desired_movement, toward));
+                let descent_grip = vector![desired_movement.x, 0.0, desired_movement.z]
+                    .try_normalize(1.0e-6)
+                    .and_then(|direction| {
+                        let probe_pos =
+                            Translation::from(direction * CLIMB_DESCENT_ACQUIRE_FORWARD)
+                                * character_pos;
+                        nearest_at(&probe_pos).and_then(|(_, toward)| {
+                            climb_redirect(desired_movement, toward)
+                                .filter(|movement| movement.y < 0.0)
+                        })
+                    });
+                let grip = direct_grip.or(descent_grip);
+                grip.map(|movement| {
+                    let top_out = if near_column_top && !player_handle.is_crouched {
+                        climb_top_out_direction(desired_movement, facing).map(|direction| {
+                            // Stay compressed until projected facing has
+                            // exited every horizontally-expanded climbable
+                            // AABB in this ladder column.
+                            let capsule_clearance =
+                                capsule.radius + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+                            let minimum_clear_forward = queries
+                                .intersect_shape(character_pos, &column_probe)
+                                .filter_map(|(_, collider)| {
+                                    climbable_aabb_exit_distance(
+                                        character_pos.translation.vector,
+                                        direction,
+                                        &collider.compute_aabb(),
+                                        capsule_clearance,
+                                    )
+                                })
+                                .fold(0.0, f32::max);
+                            (direction, minimum_clear_forward)
+                        })
+                    } else {
+                        None
+                    };
+                    (movement, top_out, movement.y < 0.0)
                 })
             })
         };
-
         // The climb cast collides with everything the walk does EXCEPT the
         // climbable surfaces themselves - see `ClimbPass`. Membership is checked
         // by predicate rather than by group filter because a ladder is also an
@@ -4044,9 +4099,10 @@ impl PhysicsWorld {
                         gravity,
                         Some(player_handle.slope_displacement),
                         airborne_vertical,
-                        climb_movement.map(|(movement, top_out)| ClimbPass {
+                        climb_movement.map(|(movement, top_out, descent_approach)| ClimbPass {
                             movement,
                             top_out,
+                            descent_approach,
                             validation_queries: queries,
                             probe_queries: queries.with_filter(climb_pass_filter),
                             scripted_queries: queries.with_filter(scripted_top_out_filter),
@@ -7222,6 +7278,71 @@ mod tests {
         assert!(
             end.y < PLAYER_HALF_HEIGHT + 0.1,
             "the descent must carry the player to the shaft floor, ended {end:?}"
+        );
+    }
+
+    /// Issue #802: hydro2's lower Sector C office landing ends about one player
+    /// footprint before its Rick Ladder can qualify for an ordinary contact
+    /// grip. A downward approach must preserve descent intent across that lip,
+    /// instead of letting gravity accelerate the player before contact.
+    #[test]
+    fn player_acquires_hydro2_office_ladder_before_lip_fall() {
+        let quad = |z0: f32, z1: f32, y: f32| {
+            let verts = vec![
+                point![-100.0, y, z0],
+                point![100.0, y, z0],
+                point![100.0, y, z1],
+                point![-100.0, y, z1],
+            ];
+            ColliderBuilder::trimesh(verts, vec![[0u32, 1, 2], [0, 2, 3]]).expect("trimesh")
+        };
+
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            quad(-100.0, 100.0, -2.0).build(),
+        );
+        // Exact authored relationship from the returning office route: floor
+        // y=2.4, edge z=23.8, rung center z=22.2. The rung is wide on x, thin
+        // on z, and its zero authored height is clamped to 0.01.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            quad(23.8, 100.0, 2.4).build(),
+        );
+        for rung in 0..11 {
+            world.add_kinematic(
+                EntityId::from_inner(2001 + rung).unwrap(),
+                vec3(0.0, -2.0 + 0.8 * rung as f32, 22.2),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(3.2, 0.01, 0.2),
+                CollisionGroup::climbable_entity(),
+                false,
+            );
+        }
+
+        let mut player =
+            world.create_player(vec3(0.0, 3.644, 24.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let descend = Vector3::new(0.0, -walk * 0.6, -walk * 0.8);
+        let start = world.get_player_translation(&player);
+        let mut previous = world.get_player_translation(&player);
+        let mut max_frame_drop = 0.0f32;
+        for _ in 0..60 {
+            world.update(descend, &mut player);
+            let current = world.get_player_translation(&player);
+            max_frame_drop = max_frame_drop.max(previous.y - current.y);
+            previous = current;
+        }
+        let acquired = world.get_player_translation(&player);
+
+        assert!(
+            start.y - acquired.y > 2.0 && (acquired.z - 22.2).abs() < 1.2 && max_frame_drop < 0.1,
+            "the office-lip approach must descend at climb speed instead of free-falling before contact, started {start:?}, ended {acquired:?}, max frame drop {max_frame_drop}"
         );
     }
 

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -90,6 +90,80 @@ test(
   },
 );
 
+// Issue #802: after Sector C's ladder top-out, the returning office route
+// leaves about one player footprint between the landing edge and the first
+// contact-qualified rung. A downward approach must preserve descent intent
+// across that gap instead of accelerating under gravity before it grips.
+test(
+  "flat climbing: hydro2 Sector C office lip starts a controlled descent",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    const rungs = (
+      await game.entities.list({ filter: "Rick Ladder", limit: 100 })
+    ).entities;
+    const anchor = rungs.find((entity) => entity.template_id === 551);
+    assert.ok(anchor, "hydro2 should contain Sector C Rick Ladder object 551");
+    const [ladderX, , ladderZ] = anchor.position;
+    const column = rungs.filter(
+      (entity) =>
+        entity.name === "Rick Ladder" &&
+        Math.hypot(
+          entity.position[0] - ladderX,
+          entity.position[2] - ladderZ,
+        ) < 0.05,
+    );
+    const ladderBottom = Math.min(...column.map((entity) => entity.position[1]));
+    assert.equal(column.length, 11, "expected the authored Sector C rung stack");
+
+    // Geometry-relative setup on the lower office floor reached by PR #679's
+    // campaign top-out. Teleport is setup only; approach, acquisition, and
+    // descent all use ordinary production look/locomotion input.
+    await game.player.teleport({
+      x: ladderX,
+      y: ladderBottom + 5.644,
+      z: ladderZ + 1.8,
+    });
+    await game.step({ frames: 30 });
+    const start = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      ladderX,
+      ladderBottom - 2,
+      ladderZ - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    const hpBefore = (await game.info()).player.hit_points;
+
+    let previous = start;
+    let maxFrameDrop = 0;
+    for (let frame = 0; frame < 60; frame += 1) {
+      await game.step({ frames: 1 });
+      const current = await game.player.position();
+      maxFrameDrop = Math.max(maxFrameDrop, previous.y - current.y);
+      previous = current;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const descended = previous;
+    const hpAfter = (await game.info()).player.hit_points;
+
+    assert.ok(
+      start.y - descended.y > 3 &&
+        Math.abs(descended.z - ladderZ) < 1.2 &&
+        maxFrameDrop < 0.1 &&
+        hpAfter === hpBefore,
+      `the office-lip approach must descend at climb speed without health loss; ` +
+        `ladder=(${ladderX.toFixed(2)}, ${ladderBottom.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
+        `start=${JSON.stringify(start)}, ended=${JSON.stringify(descended)}, ` +
+        `maxFrameDrop=${maxFrameDrop.toFixed(3)}, hp=${hpBefore}->${hpAfter}`,
+    );
+  },
+);
+
 // Issue #626: rick1's opening ladder extends above the upper-deck landing.
 // Vertical-only climbing reaches the cap at about (20.4, 19.2, 2.0), but
 // ordinary collision then keeps the standing capsule on the shaft side. This


### PR DESCRIPTION
## Reproduction

Hydro2 mission object 551 anchors the authored 11-rung Sector C Rick Ladder at `(59.6, -2.0, 22.2)`. Returning from the lower office puts the player at `(59.600, 3.644, 24.000)`, about one player footprint before ordinary contact reach. Looking down and holding normal forward input produced an uncontrolled pre-grip drop: the live replay fell as much as **0.397 world units in one frame** before contact, and the matched negative unit fixture measured **0.368 world units/frame** with the preview absent. Once contact finally qualified, descent settled to the intended **0.081 world units/frame** climb rate.

Current `main` has no ordinary fall-damage emitter, so the issue's historical 6 HP loss itself no longer changes HP (30 -> 30 in the replay); the unsafe movement precursor is still reproducible and is what this fixes.

## Root cause

Ladder acquisition only inspected the player capsule at its current pose. The office landing ends before the nearest rung can qualify for contact, so several normal movement/gravity frames ran before the ladder grip took over. Ground snapping could add another step-sized drop at the transition.

## Fix

- Preview climbable contact one player footprint ahead, only for downward-pitched movement.
- Preserve descent intent with collision-checked horizontal approach while the landing still blocks vertical travel.
- Disable ordinary ground snapping during the climb/descent pass.
- Keep direct contact authoritative and retain the existing blocked-climb walking fallback.

## Tests

- Negative-first Hydro2 geometry fixture: failed at max frame drop `0.368280`; passes with the fix below `0.1`.
- Authored Hydro2 SDK replay: descends more than 3 world units, stays at the rung stack, max frame drop below `0.1`, HP unchanged.
- 10/10 repeated authored replays: y `3.644071 -> -0.527185`, max frame drop `0.0805405`, HP `30 -> 30`.
- `cargo test -p shock2vr`: 509 passed before rebase; focused post-rebase climb 20/20 and ladder 6/6 passed.
- `RUSTFLAGS="-D warnings" CARGO_INCREMENTAL=0 cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed before and after rebase.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `npm test`: 26 passed before rebase; 26 passed post-rebase.
- Focused authored SDK E2E: passed before and after rebase.
- Full SDK E2E: 211 passed, 3 skipped, 1 unrelated failure in `a loaded corpse does not replay its death` (same stable corpse assertion reproduced on clean `origin/main`; all 23 mission loads passed).

## Visual evidence

![Synchronized before and after Hydro2 Sector C ladder descent](https://gist.githubusercontent.com/tommy-xr/65d23eda2d1a26468414bf68d1c4aff2/raw/sector-c-ladder-descent.gif)

<sub>The same ordinary lower-office approach is replayed against `main` and the fix. Baseline falls 0.397 world units in one frame before gripping; the fix limits every frame to 0.081 or less. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Consecutive-frame before and after comparison](https://gist.githubusercontent.com/tommy-xr/65d23eda2d1a26468414bf68d1c4aff2/raw/sector-c-ladder-before-after.png)

<sub>Frames 5 and 6 are consecutive 1/60-second samples from the identical request sequence: the baseline lurches 0.397 units while the fixed controller moves only 0.037 units.</sub>

<details>
<summary>Individual consecutive-frame stills</summary>

#### Before — uncontrolled pre-grip drop

![Baseline consecutive frames](https://gist.githubusercontent.com/tommy-xr/65d23eda2d1a26468414bf68d1c4aff2/raw/sector-c-ladder-before.png)

#### After — controlled ladder acquisition

![Fixed consecutive frames](https://gist.githubusercontent.com/tommy-xr/65d23eda2d1a26468414bf68d1c4aff2/raw/sector-c-ladder-after.png)

</details>

Fixes #802
