### PR TITLE
fix(scripts): damage no-HP TriggerDestroy props

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -49,6 +49,14 @@ pub struct EntityCreationInfo {
     pub scripts: Vec<String>,
 }
 
+fn needs_internal_simple_health(
+    has_hit_points: bool,
+    is_creature: bool,
+    _authored_scripts: &[String],
+) -> bool {
+    has_hit_points && !is_creature
+}
+
 pub fn create_entity_with_position(
     template_id: i32,
     position: Point3<f32>,
@@ -322,7 +330,11 @@ pub fn create_entity_core(
     let v_hp = world.borrow::<View<PropHitPoints>>().unwrap();
     // If there is hitpoint, but the item is not a creature, just use the simple damage method...
     // Otherwise, the hitbox / creature logic will take care of handling damage
-    if v_hp.get(entity_id).is_ok() && v_creature.get(entity_id).is_err() {
+    if needs_internal_simple_health(
+        v_hp.get(entity_id).is_ok(),
+        v_creature.get(entity_id).is_ok(),
+        &processed_scripts,
+    ) {
         processed_scripts.push("internal_simple_health".to_owned());
     }
 
@@ -1335,6 +1347,28 @@ mod tests {
     }
 
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
+    #[test]
+    fn trigger_destroy_prop_without_hit_points_still_owns_weapon_damage() {
+        let trigger_destroy = vec!["TriggerDestroy".to_owned()];
+
+        assert!(
+            needs_internal_simple_health(false, false, &trigger_destroy),
+            "a non-creature TriggerDestroy prop must translate Damage into Slay"
+        );
+        assert!(
+            needs_internal_simple_health(true, false, &[]),
+            "ordinary HP-bearing props keep incremental simple health"
+        );
+        assert!(
+            !needs_internal_simple_health(false, false, &[]),
+            "ordinary non-creatures without HP or TriggerDestroy stay unaffected"
+        );
+        assert!(
+            !needs_internal_simple_health(true, true, &trigger_destroy),
+            "creatures retain ownership of their hitbox damage path"
+        );
+    }
 
     /// A wall fixture the player can frob but never pick up or move - a
     /// console, a card slot, the Resurrection Station casing. `phys_type` is

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -52,9 +52,13 @@ pub struct EntityCreationInfo {
 fn needs_internal_simple_health(
     has_hit_points: bool,
     is_creature: bool,
-    _authored_scripts: &[String],
+    authored_scripts: &[String],
 ) -> bool {
-    has_hit_points && !is_creature
+    !is_creature
+        && (has_hit_points
+            || authored_scripts
+                .iter()
+                .any(|script| script.eq_ignore_ascii_case("TriggerDestroy")))
 }
 
 pub fn create_entity_with_position(
@@ -328,8 +332,9 @@ pub fn create_entity_core(
 
     let v_creature = world.borrow::<View<PropCreature>>().unwrap();
     let v_hp = world.borrow::<View<PropHitPoints>>().unwrap();
-    // If there is hitpoint, but the item is not a creature, just use the simple damage method...
-    // Otherwise, the hitbox / creature logic will take care of handling damage
+    // Ordinary HP-bearing props use simple health. Authored TriggerDestroy props
+    // without HP use its existing no-HP fallback (Damage -> Slay), so their
+    // destruction links can fire. Creatures keep damage ownership in hitboxes.
     if needs_internal_simple_health(
         v_hp.get(entity_id).is_ok(),
         v_creature.get(entity_id).is_ok(),

--- a/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/types.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+// Command's Shuttle B is an authored destroyable prop with TriggerDestroy and
+// nine SwitchLinks, but deliberately no HitPoints. The original simple-health
+// path treats that absence as a one-hit Slay. Before #868, however, the entity
+// creator only installed that path on props which *did* author HitPoints, so a
+// real weapon impact had no script owner and the objective chain never fired.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const SHIELD_DESTROY_TRAP = 280;
+const SHUTTLE_SHIELD = 278;
+const SHUTTLE_B = 2392;
+const DIRECT_EXPLOSION_TWEQS = [157, 460, 482] as const;
+const PISTOL_TEMPLATE = -17;
+const SMALL_AP_CLIP_TEMPLATE = -1360;
+
+async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one command1 object ${objectId}, got ${JSON.stringify(found)}`,
+  );
+  return found[0];
+}
+
+function ammoOf(detail: EntityDetailResult): number {
+  const ammo = detail.properties.find((property) => property.name === "Ammo");
+  assert.ok(ammo, "the provisioned pistol must expose its live magazine count");
+  return Number(ammo.value);
+}
+
+test(
+  "command1: one visible AP hit destroys no-HP Shuttle B and fires its objective chain",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `command_shuttle_b_destroyed_${Date.now()}`;
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8618),
+    });
+    await game.step({ frames: 5 });
+
+    const shuttle = await only(game, SHUTTLE_B);
+    const shuttleDetail = await game.entities.detail(shuttle.id);
+    const switchLinks = shuttleDetail.outgoing_links.filter(
+      (link) => link.link_type === "SwitchLink",
+    );
+    assert.equal(switchLinks.length, 9, "Shuttle B must retain all nine authored branches");
+    assert.ok(
+      shuttleDetail.properties.some(
+        (property) => property.name === "Scripts" && property.value.includes("TriggerDestroy"),
+      ),
+      "mission object 2392 must exercise the authored TriggerDestroy path",
+    );
+    assert.ok(
+      !shuttleDetail.properties.some((property) => property.name === "HitPoints"),
+      "the regression requires Shuttle B's deliberate no-HP fallback",
+    );
+
+    assert.equal(await game.quests.get("ShuttleBBoom"), "unknown");
+    assert.equal(await game.quests.get("HackEXP"), "unknown");
+    assert.equal(await game.quests.get("Note_6_6"), "unknown");
+    const modulesBefore = (await game.info()).player.stats?.cyber_modules;
+    assert.equal(modulesBefore, 0, "fresh Command character starts with no cyber modules");
+
+    // Isolate the already-completed objective precondition by firing Command's
+    // authored DestroyTrap280. It removes the real Shield278 entity; the weapon
+    // shot below is therefore genuinely unshielded rather than bypassing a
+    // collision volume or mutating Shuttle2392 itself.
+    const shieldDestroyTrap = await only(game, SHIELD_DESTROY_TRAP);
+    await game.entities.sendMessage(shieldDestroyTrap.id, { type: "TurnOn" });
+    await game.step({ frames: 30 });
+    assert.equal(
+      (await game.entities.byTemplate(SHUTTLE_SHIELD)).length,
+      0,
+      "authored DestroyTrap280 setup must remove Shuttle Shield278",
+    );
+
+    // The QB filter is conditional on the player being in the objective room.
+    // Establish only that authored precondition through the debug setup API;
+    // every action under test below is the production weapon/impact/script path.
+    await game.quests.set("InRoom", "complete");
+
+    const pistol = await game.player.spawnItem(PISTOL_TEMPLATE);
+    await game.player.setStats({ skills: { standard_weapons: 6 } });
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    const stripPistol = (await game.ui.state()).strip?.elements.find(
+      (element) => element.kind === "button" && element.label === "Pistol",
+    );
+    assert.ok(stripPistol, "the provisioned pistol must appear in the inventory strip");
+    await clickUiElement(game, stripPistol);
+    await clickUiElement(game, stripPistol);
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.wielded_entity_id, pistol.entity_id);
+
+    // A freshly provisioned pistol carries standard rounds and faithfully
+    // refuses to transmute a loaded magazine. Empty it away from the objective,
+    // provision a real AP clip, then select and reload AP through normal inputs.
+    const standardAmmo = ammoOf(await game.entities.detail(pistol.entity_id));
+    for (let round = 0; round < standardAmmo; round += 1) {
+      await fireOnce(game);
+    }
+    assert.equal(ammoOf(await game.entities.detail(pistol.entity_id)), 0);
+    await game.player.spawnItem(SMALL_AP_CLIP_TEMPLATE);
+    await game.input.trigger("CycleAmmo");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.wielded_ammo_type, "ap");
+    await game.input.trigger("Reload");
+    await game.step({ frames: 130 });
+    const ammoBefore = ammoOf(await game.entities.detail(pistol.entity_id));
+    assert.ok(ammoBefore > 0, "the provisioned pistol must start loaded");
+
+    // Teleport only stages the shooter on the supported bay floor. Acquisition
+    // is visibility-checked and the hit itself comes from one real trigger edge.
+    await game.player.teleport({ x: -294.55, y: -7.796, z: 87.2 });
+    await game.step({ frames: 10 });
+    const aim = await game.player.aimAt(shuttle, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(aim.entity_id, shuttle.id, JSON.stringify(aim));
+    assert.equal(aim.visibility.state, "visible", JSON.stringify(aim));
+    await fireOnce(game);
+    assert.equal(
+      ammoOf(await game.entities.detail(pistol.entity_id)),
+      ammoBefore - 1,
+      "the regression must consume exactly one AP round",
+    );
+    await game.step({ frames: 180 });
+
+    assert.equal(
+      (await game.entities.byTemplate(SHUTTLE_B)).length,
+      0,
+      "one unshielded AP impact must remove Shuttle B",
+    );
+    assert.equal(await game.quests.get("ShuttleBBoom"), "incomplete");
+    assert.equal(await game.quests.get("HackEXP"), "incomplete");
+    assert.equal(await game.quests.get("Note_6_6"), "incomplete");
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      modulesBefore + 20,
+      "the InRoom QB-filter branch must award the authored 20 modules",
+    );
+    for (const objectId of DIRECT_EXPLOSION_TWEQS) {
+      assert.equal(
+        (await game.entities.byTemplate(objectId)).length,
+        0,
+        `direct explosion Tweq${objectId} must have received the shuttle TurnOn`,
+      );
+    }
+    assert.equal(
+      (await game.entities.byTemplate(394)).length,
+      1,
+      "the same QB-filter fanout must preserve its Replicator394 target",
+    );
+
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    assert.equal((await game.entities.byTemplate(SHUTTLE_B)).length, 0);
+    assert.equal(await game.quests.get("ShuttleBBoom"), "incomplete");
+    assert.equal(await game.quests.get("HackEXP"), "incomplete");
+    assert.equal(await game.quests.get("Note_6_6"), "incomplete");
+    assert.equal((await game.info()).player.stats?.cyber_modules, modulesBefore + 20);
+  },
+);

--- a/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-shuttle-destroy.e2e.test.ts
@@ -16,7 +16,8 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const SHIELD_DESTROY_TRAP = 280;
 const SHUTTLE_SHIELD = 278;
 const SHUTTLE_B = 2392;
-const DIRECT_EXPLOSION_TWEQS = [157, 460, 482] as const;
+const EXPLOSION_TWEQS = [157, 460, 482, 632, 500, 524, 516, 499, 521] as const;
+const DELAYED_SLAY_TARGET = 808;
 const PISTOL_TEMPLATE = -17;
 const SMALL_AP_CLIP_TEMPLATE = -1360;
 
@@ -67,6 +68,7 @@ test(
     assert.equal(await game.quests.get("ShuttleBBoom"), "unknown");
     assert.equal(await game.quests.get("HackEXP"), "unknown");
     assert.equal(await game.quests.get("Note_6_6"), "unknown");
+    assert.equal(await game.quests.get("Note_6_7"), "unknown");
     const modulesBefore = (await game.info()).player.stats?.cyber_modules;
     assert.equal(modulesBefore, 0, "fresh Command character starts with no cyber modules");
 
@@ -84,9 +86,12 @@ test(
     );
 
     // The QB filter is conditional on the player being in the objective room.
-    // Establish only that authored precondition through the debug setup API;
-    // every action under test below is the production weapon/impact/script path.
+    // The later delayed filter likewise expects Shuttle A's preceding objective
+    // to be done. Establish only those authored campaign preconditions through
+    // the debug setup API; every action under test below is the production
+    // weapon/impact/script path.
     await game.quests.set("InRoom", "complete");
+    await game.quests.set("ShuttleABoom", "incomplete");
 
     const pistol = await game.player.spawnItem(PISTOL_TEMPLATE);
     await game.player.setStats({ skills: { standard_weapons: 6 } });
@@ -106,10 +111,22 @@ test(
     // refuses to transmute a loaded magazine. Empty it away from the objective,
     // provision a real AP clip, then select and reload AP through normal inputs.
     const standardAmmo = ammoOf(await game.entities.detail(pistol.entity_id));
+    const drainPosition = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      drainPosition.x,
+      drainPosition.y + 1.04,
+      drainPosition.z - 100,
+    ]);
+    await game.step({ frames: 1 });
     for (let round = 0; round < standardAmmo; round += 1) {
       await fireOnce(game);
     }
     assert.equal(ammoOf(await game.entities.detail(pistol.entity_id)), 0);
+    assert.equal(
+      (await game.entities.byTemplate(SHUTTLE_B)).length,
+      1,
+      "standard-magazine setup must fire away from Shuttle B",
+    );
     await game.player.spawnItem(SMALL_AP_CLIP_TEMPLATE);
     await game.input.trigger("CycleAmmo");
     await game.step({ frames: 2 });
@@ -121,7 +138,10 @@ test(
 
     // Teleport only stages the shooter on the supported bay floor. Acquisition
     // is visibility-checked and the hit itself comes from one real trigger edge.
-    await game.player.teleport({ x: -294.55, y: -7.796, z: 87.2 });
+    // This is the supported side-on firing lane from the accepted iteration27
+    // save; it keeps the pistol muzzle clear of the bay-floor lip as well as
+    // giving the camera ray an unobstructed shuttle surface.
+    await game.player.teleport({ x: -286.4, y: -7.156, z: 91.0 });
     await game.step({ frames: 10 });
     const aim = await game.player.aimAt(shuttle, {
       hitbox: "center",
@@ -129,6 +149,12 @@ test(
     });
     assert.equal(aim.entity_id, shuttle.id, JSON.stringify(aim));
     assert.equal(aim.visibility.state, "visible", JSON.stringify(aim));
+    // aimAt's ordinary-object acquisition deliberately picks the nearest
+    // selectable surface. Refine the production camera/weapon to the authored
+    // center after that visibility gate so the projectile ray continues
+    // through the hull instead of grazing a close surface edge.
+    await game.input.lookAtWorldPoint(shuttleDetail.position);
+    await game.step({ frames: 1 });
     await fireOnce(game);
     assert.equal(
       ammoOf(await game.entities.detail(pistol.entity_id)),
@@ -144,19 +170,34 @@ test(
     );
     assert.equal(await game.quests.get("ShuttleBBoom"), "incomplete");
     assert.equal(await game.quests.get("HackEXP"), "incomplete");
-    assert.equal(await game.quests.get("Note_6_6"), "incomplete");
+    const note66After = await game.quests.get("Note_6_6");
+    assert.notEqual(
+      note66After,
+      "unknown",
+      "the InRoom QB-filter branch must grant the authored shuttle email objective",
+    );
+    assert.equal(
+      await game.quests.get("Note_6_7"),
+      "complete",
+      "the two-second delay branch must reach its ShuttleABoom filter",
+    );
     assert.equal(
       (await game.info()).player.stats?.cyber_modules,
       modulesBefore + 20,
       "the InRoom QB-filter branch must award the authored 20 modules",
     );
-    for (const objectId of DIRECT_EXPLOSION_TWEQS) {
+    for (const objectId of EXPLOSION_TWEQS) {
       assert.equal(
         (await game.entities.byTemplate(objectId)).length,
         0,
-        `direct explosion Tweq${objectId} must have received the shuttle TurnOn`,
+        `direct or delayed explosion Tweq${objectId} must receive the shuttle TurnOn`,
       );
     }
+    assert.equal(
+      (await game.entities.byTemplate(DELAYED_SLAY_TARGET)).length,
+      0,
+      "the half-second delay branch must relay through TrapSlayer631 to Window808",
+    );
     assert.equal(
       (await game.entities.byTemplate(394)).length,
       1,
@@ -169,7 +210,8 @@ test(
     assert.equal((await game.entities.byTemplate(SHUTTLE_B)).length, 0);
     assert.equal(await game.quests.get("ShuttleBBoom"), "incomplete");
     assert.equal(await game.quests.get("HackEXP"), "incomplete");
-    assert.equal(await game.quests.get("Note_6_6"), "incomplete");
+    assert.equal(await game.quests.get("Note_6_6"), note66After);
+    assert.equal(await game.quests.get("Note_6_7"), "complete");
     assert.equal((await game.info()).player.stats?.cyber_modules, modulesBefore + 20);
   },
 );


### PR DESCRIPTION
Fixes #868

## Summary

- instantiate InternalSimpleHealth for non-creature props that author TriggerDestroy even when they deliberately omit HitPoints
- reuse the existing no-HP Damage-to-Slay fallback so TriggerDestroy can relay every authored SwitchLink
- leave HP-bearing incremental damage and creature hitbox ownership unchanged
- add a negative-first fresh Command regression for Shuttle2392 through a real visible AP weapon hit and save/load

## Production regression

The command1 scenario removes the authored Shield278 entity through DestroyTrap280 setup, provisions and genuinely wields a pistol, empties its standard magazine, loads a real AP clip, visibility-checks Shuttle2392, and fires one trigger edge. It asserts one consumed AP round, shuttle removal, all nine authored outgoing branches, ShuttleBBoom/HackEXP/Note_6_6, the 20-module award, explosion Tweqs, Replicator394 preservation, and the destroyed state after save/load.

## Validation

- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- cargo test -p shock2vr: 515 passed
- SDK unit suite: 26 passed, 190 opt-in skipped
- fresh Command Shuttle2392 production E2E: passed
- all 23 shipped mission load/step smoke scenarios: passed
- focused HP-bearing prop, explosion, flinderize, and live-creature death E2Es: passed

The loaded-corpse half of monster-death.e2e still exposes the clean-main actor-to-entity collision-group mismatch already tracked by open PR #685; pose, behavior, sleep, position, and mass remain stable and the live-creature death half passes.

## Visuals

![Command Shuttle B destruction demo](https://gist.githubusercontent.com/tommy-xr/a70da951d0839bd47b79226ed3923aed/raw/command-shuttle-destroy.gif)

<sub>A genuine, visibility-checked AP trigger edge consumes exactly one round (6 → 5); Shuttle B disappears and its authored delayed explosion sequence fires. Captured headlessly in fresh `command1.mis` via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Clean main leaves Shuttle B intact; PR #869 destroys it and fires explosions](https://gist.githubusercontent.com/tommy-xr/a70da951d0839bd47b79226ed3923aed/raw/command-shuttle-before-after.png)