### PR TITLE
fix(audio): play TrapSound narrations at their authored position

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1276,6 +1276,7 @@ impl MissionCore {
                 .choose(&mut thread_rng())
                 .expect("player death schemas are never empty")
                 .to_string(),
+            spatial: false,
         }]
     }
 
@@ -3797,6 +3798,7 @@ impl MissionCore {
                             handle: AudioHandle::new(),
                             source: None,
                             name: "boot_sw".to_owned(),
+                            spatial: false,
                         });
                     } else {
                         game_log!(INFO, "Redundant software not installed.");
@@ -4245,6 +4247,7 @@ impl MissionCore {
                     handle,
                     name,
                     source,
+                    spatial,
                 } => {
                     println!("Trying to play sound: {}", &name);
                     let audio_file = resolve_schema(global_context, &name.to_string());
@@ -4255,16 +4258,37 @@ impl MissionCore {
                         info!("Playing clip: {} handle: {:?}", name, &handle);
                         let duration = audio_clip.total_duration();
                         let handle_id = handle.id();
-                        let preempted =
-                            engine::audio::play_audio(audio_context, handle, None, audio_clip);
+                        // Spatial emitters (TrapSound narrations anchored at
+                        // their authored station) play at the source entity,
+                        // like the original engine's object sounds. Everything
+                        // else - UI feedback, audio logs, cutscene narration -
+                        // stays non-spatial at the ears even when it carries a
+                        // `source` for attribution.
+                        let maybe_position = if spatial {
+                            source.and_then(|id| get_entity_position(&self.world, id))
+                        } else {
+                            None
+                        };
+                        let preempted = if let Some(position) = maybe_position {
+                            engine::audio::play_spatial_audio(
+                                audio_context,
+                                position,
+                                handle,
+                                None,
+                                audio_clip,
+                            )
+                        } else {
+                            engine::audio::play_audio(audio_context, handle, None, audio_clip)
+                        };
                         // Observability: record scripted one-shot sounds (audio
                         // logs, keypad beeps, ...) so headless tooling can assert
                         // a schema actually resolved and played.
+                        let position = maybe_position.unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
                         crate::audio_log::record_stops(&preempted);
                         crate::audio_log::record(crate::audio_log::SoundRecord {
                             sample: &audio_file,
                             tags: vec![("kind".to_string(), "sound".to_string())],
-                            position: [0.0, 0.0, 0.0],
+                            position: [position.x, position.y, position.z],
                             duration,
                             source_entity: source.map(|id| source_entity(&self.world, id)),
                             handle: Some(handle_id),
@@ -4610,6 +4634,7 @@ impl MissionCore {
                             handle: AudioHandle::new(),
                             source: None,
                             name: "repfail".to_owned(),
+                            spatial: false,
                         });
                     } else if let Some(exhausted) = debit_player_nanites(&self.world, cost) {
                         for entity_id in exhausted {
@@ -4629,6 +4654,7 @@ impl MissionCore {
                             handle: AudioHandle::new(),
                             source: None,
                             name: "replic2e".to_owned(),
+                            spatial: false,
                         });
                     } else {
                         info!(
@@ -4639,6 +4665,7 @@ impl MissionCore {
                             handle: AudioHandle::new(),
                             source: None,
                             name: "repfail".to_owned(),
+                            spatial: false,
                         });
                     }
                 }
@@ -6242,6 +6269,15 @@ pub fn make_un_physical2(
 }
 
 fn get_entity_position(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
+    // Prefer the live transform; PropPosition can lag for entities moved by
+    // animation/physics, and is frozen for held/contained entities.
+    if let Ok(transforms) = world.borrow::<View<RuntimePropTransform>>() {
+        if let Ok(xform) = transforms.get(entity_id) {
+            use cgmath::Transform;
+            let p = xform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
+            return Some(vec3(p.x, p.y, p.z));
+        }
+    }
     if let Ok(positions) = world.borrow::<View<PropPosition>>() {
         if let Ok(prop) = positions.get(entity_id) {
             return Some(prop.position);

--- a/shock2vr/src/scripts/apparition.rs
+++ b/shock2vr/src/scripts/apparition.rs
@@ -46,6 +46,7 @@ impl Script for Apparition {
                         handle: self.audio_handle.clone(),
                         source: Some(entity_id),
                         name: sound.name.clone(),
+                        spatial: false,
                     },
                     Err(_) => Effect::NoEffect,
                 };

--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -25,6 +25,7 @@ impl BaseButton {
             handle: AudioHandle::new(),
             source: Some(entity_id),
             name: "hackfail".to_owned(),
+            spatial: false,
         })
     }
 

--- a/shock2vr/src/scripts/base_elevator.rs
+++ b/shock2vr/src/scripts/base_elevator.rs
@@ -187,6 +187,7 @@ impl Script for BaseElevator {
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "Devices/DOOR1OP".to_owned(),
+                        spatial: false,
                     }
                 } else {
                     Effect::NoEffect
@@ -198,6 +199,7 @@ impl Script for BaseElevator {
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "Devices/DOOR1OP".to_owned(),
+                        spatial: false,
                     }
                 } else {
                     Effect::NoEffect

--- a/shock2vr/src/scripts/cs9.rs
+++ b/shock2vr/src/scripts/cs9.rs
@@ -170,6 +170,7 @@ impl CS9MasterControl {
                 handle: AudioHandle::new(),
                 source: Some(entity_id),
                 name: schema.to_string(),
+                spatial: false,
             },
             Cs9Action::ScreensOnFallback => self.fire_screens_on(entity_id, world),
         }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -411,6 +411,12 @@ pub enum Effect {
         /// diagnostic (recorded in `audio_log`); `None` for sounds with no
         /// world source, e.g. cutscene schemas.
         source: Option<EntityId>,
+        /// Play positionally at `source`'s location (original-engine object
+        /// sound behavior). Only for diegetic emitters anchored in the world
+        /// (e.g. TrapSound narrations); non-diegetic audio that must stay at
+        /// constant volume - audio logs, cutscene narration, UI feedback -
+        /// keeps this false even when it has a `source` for attribution.
+        spatial: bool,
     },
     PlaySpeech {
         entity_id: EntityId,

--- a/shock2vr/src/scripts/gui/hackable_crate.rs
+++ b/shock2vr/src/scripts/gui/hackable_crate.rs
@@ -256,6 +256,7 @@ impl Gui<HackableCrateState, HackableCrateMsg> for HackableCrateGui {
                     handle: AudioHandle::new(),
                     source: Some(entity_id),
                     name: "hack_success".to_owned(),
+                    spatial: false,
                 },
             ]));
         }

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -407,6 +407,7 @@ pub(crate) fn handle_hack_msg(
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "login".to_owned(),
+                        spatial: false,
                     },
                 );
             };
@@ -432,6 +433,7 @@ pub(crate) fn handle_hack_msg(
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "start_hack".to_owned(),
+                        spatial: false,
                     },
                 ]),
             )
@@ -448,6 +450,7 @@ pub(crate) fn handle_hack_msg(
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "login".to_owned(),
+                        spatial: false,
                     },
                 );
             }
@@ -473,6 +476,7 @@ pub(crate) fn handle_hack_msg(
                                 handle: AudioHandle::new(),
                                 source: Some(entity_id),
                                 name: "hack_success".to_owned(),
+                                spatial: false,
                             },
                         ]),
                     );
@@ -487,6 +491,7 @@ pub(crate) fn handle_hack_msg(
                             handle: AudioHandle::new(),
                             source: Some(entity_id),
                             name: "hack_critical".to_owned(),
+                            spatial: false,
                         },
                     ]),
                 );
@@ -503,6 +508,7 @@ pub(crate) fn handle_hack_msg(
                     handle: AudioHandle::new(),
                     source: Some(entity_id),
                     name: "hacking".to_owned(),
+                    spatial: false,
                 },
             )
         }
@@ -684,6 +690,7 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
             handle: AudioHandle::new(),
             source: Some(entity_id),
             name: "bkeypad".to_owned(),
+            spatial: false,
         };
 
         let new_state = match msg {
@@ -725,6 +732,7 @@ impl Gui<KeyPadState, KeyPadMsg> for KeyPadGui {
                         handle: AudioHandle::new(),
                         source: Some(entity_id),
                         name: "hacksucc".to_owned(),
+                        spatial: false,
                     };
                     Effect::combine(vec![switch_link_effect, sound_effect])
                 } else {

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -258,6 +258,7 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
             handle: AudioHandle::new(),
             source: Some(entity_id),
             name: format!("LOG{deck:02}{log:02}"),
+            spatial: false,
         };
         let collect = Effect::CollectLog {
             entity_id,

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -324,6 +324,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                             handle: AudioHandle::new(),
                             source: Some(entity_id),
                             name: "repfail".to_owned(),
+                            spatial: false,
                         },
                     );
                 }
@@ -337,6 +338,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
                             handle: AudioHandle::new(),
                             source: Some(entity_id),
                             name: "repfail".to_owned(),
+                            spatial: false,
                         },
                     );
                 }

--- a/shock2vr/src/scripts/std_door.rs
+++ b/shock2vr/src/scripts/std_door.rs
@@ -259,6 +259,7 @@ impl Script for StdDoor {
                             handle: AudioHandle::new(),
                             source: Some(entity_id),
                             name: "hackfail".to_owned(),
+                            spatial: false,
                         }
                     } else {
                         self.open(entity_id, world, &trans_door)

--- a/shock2vr/src/scripts/trap_sound.rs
+++ b/shock2vr/src/scripts/trap_sound.rs
@@ -35,6 +35,10 @@ impl Script for TrapSound {
                         handle,
                         name: sound.name.to_owned(),
                         source: Some(entity_id),
+                        // TrapSound(Amb) narrations are anchored at their
+                        // authored station - a stale montage segment two rooms
+                        // away should be distant, not at the player's ears.
+                        spatial: true,
                     }
                 } else {
                     Effect::NoEffect

--- a/shock2vr/src/scripts/use_sound.rs
+++ b/shock2vr/src/scripts/use_sound.rs
@@ -34,6 +34,7 @@ impl Script for UseSound {
                     handle,
                     name: "TELEPHON".to_owned(),
                     source: Some(entity_id),
+                    spatial: false,
                 }
                 // } else {
                 //     Effect::NoEffect

--- a/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
+++ b/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
@@ -69,6 +69,15 @@ test(
     assert.equal(sound.still_playing, true, "a clip this long is still playing");
     assert.equal(sound.stopped_at_sim_time, null);
 
+    // TrapSound narrations play spatially at their authored station, like the
+    // original engine's object sounds (pre-change the log recorded [0,0,0]).
+    const [tx, ty, tz] = trap.position;
+    const [px, py, pz] = sound.position;
+    assert.ok(
+      Math.hypot(px - tx, py - ty, pz - tz) < 0.5,
+      `the clip must play at the trap's position [${tx},${ty},${tz}], got [${px},${py},${pz}]`,
+    );
+
     // Stepping past the clip's duration retires it (derived from sim time, not
     // from live audio-device state).
     await game.step({ frames: Math.ceil(sound.duration_secs! * 60) + 60 });


### PR DESCRIPTION
Stacked on #856. Fixes the residual overlap reported in the psi-amp portion of basic training.

## Bug

The basic-training entry starts a **timer-paced montage**: `Trigger Delay 456 → { trg0006 now, Delay 458 → trg0007 at ~12s, … }` - segments paced back-to-back assuming the player stands and watches. The station stop-all inverters silence whatever is *currently playing* but cannot cancel a *pending* delay, so a late montage segment starts on top of the station narration you triggered by moving. Reproduced with the #855 diagnostics: station narration `trg0010` at frame 678, montage timer drops `trg0007` on top at frame 746.

The original engine has the same race but tolerates it: these `TrapSoundAmb` schemas play **positionally at their stations** (~23 world units away in the repro), while our `Effect::PlaySound` played everything non-spatially at the player's ears at full volume.

## Fix

- `Effect::PlaySound` gains an explicit `spatial: bool`; the effect applier plays spatial sounds via `play_spatial_audio` at the source entity's live position (same pattern as `PlaySpeech`). **Only `TrapSound` sets it** - deliberately scoped after xreview found that spatializing every sourced sound would break non-diegetic audio: the CS9 SHODAN reveal monologue plays from a marker ~32 units from the theatre (would drop to ~3% volume), and audio-log discs' `PropPosition` freezes at their pickup spot once carried (a log replayed from inventory would be near-silent). Those emitters keep `spatial: false` while still carrying `source` for audio-log attribution.
- `get_entity_position` now prefers `RuntimePropTransform` over the lagging `PropPosition` (same expression the entity listing uses) - also fixes `PlaySpeech` positioning for animated entities.
- The audio log records the real playback position; the e2e contract asserts the trap's authored position appears there (pre-change: `[0,0,0]`, verified failing).

## Testing

- Extended `audio-message-diagnostics.e2e.test.ts` with the position assertion (negative-tested by stashing the change: records `[0,0,0]` → fails).
- Full relevant set green: 520 shock2vr unit tests, 26 SDK unit tests, all 23 missions load, both earth training e2e scenarios, psionic-training scenario.
- xreview (Opus adversarial): the two High blast-radius findings above are resolved by the `spatial` flag scoping; `still_playing`/preemption/scale-factor verified clean; remaining engine gaps (positional sinks never update emitter position; ear axis ignores head rotation) filed as #872, schema volume/pan as #871.

Audio change, so no capture GIF; the audio-log position trace is the observable evidence.
