### PR TITLE
fix(scripts): restore eng2 Many ride

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -10,7 +10,7 @@ use engine::assets::asset_paths::ReadableAndSeekable;
 use cgmath::{EuclideanSpace, Zero};
 use cgmath::{
     InnerSpace, Matrix3, Matrix4, Point3, Quaternion, Rotation, Rotation3, SquareMatrix, Transform,
-    Vector2, Vector3, num_traits::ToPrimitive, vec3,
+    Vector2, Vector3, num_traits::ToPrimitive, vec2, vec3,
 };
 
 use crate::SpawnLocation;
@@ -56,7 +56,8 @@ use engine::{
     scene::{
         BillboardMaterial, ParticleSystem, SceneObject, VertexPosition, light::SpotLight, quad,
     },
-    texture::TextureTrait,
+    texture::{TextureOptions, TextureTrait, init_from_memory2},
+    texture_format::{PixelFormat, RawTextureData},
 };
 use physics::PhysicsWorld;
 use rand::{
@@ -531,6 +532,14 @@ pub struct MissionCore {
     /// canvas rendering, and the pointer -> GUIHover input mapping. Inert in
     /// VR (nothing opens a panel there). See `projects/flat-ui.md` §5.2.
     pub flat_ui: crate::mission::flat_ui_host::FlatUiHost,
+
+    /// Whether ordinary movement/hand/pointer input reaches the active player.
+    /// Authored sequences such as eng2's Many ride temporarily suppress it.
+    player_controls_enabled: bool,
+
+    /// White transition cover shared by both flat and per-eye VR rendering.
+    screen_fade_alpha: f32,
+    screen_fade_texture: Rc<dyn TextureTrait>,
 }
 
 pub struct GlobalContext {
@@ -611,6 +620,18 @@ impl MissionCore {
         let entity_info_rc = Arc::new(entity_info);
 
         let speech_registry = SpeechVoiceRegistry::from_entity_info(&entity_info_rc);
+        let screen_fade_texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
+            RawTextureData {
+                width: 1,
+                height: 1,
+                bytes: vec![255, 255, 255, 255],
+                format: PixelFormat::RGBA,
+            },
+            &TextureOptions {
+                wrap: false,
+                ..Default::default()
+            },
+        ));
 
         let mut id_to_model = HashMap::new();
         let mut id_to_animation_player = HashMap::new();
@@ -1215,6 +1236,9 @@ impl MissionCore {
             flat_melee_anim: None,
             flat_use_mode: false,
             flat_ui: crate::mission::flat_ui_host::FlatUiHost::new(),
+            player_controls_enabled: true,
+            screen_fade_alpha: 0.0,
+            screen_fade_texture,
         }
     }
 
@@ -1410,7 +1434,7 @@ impl MissionCore {
         // neutral until reconstruction. Discrete quick-load remains available
         // because it arrives separately in `command_effects`.
         let suppressed_input = InputContext::default();
-        let input_context = if self.player_is_alive() {
+        let input_context = if self.player_is_alive() && self.player_controls_enabled {
             input_context
         } else {
             &suppressed_input
@@ -4413,6 +4437,18 @@ impl MissionCore {
                             .add_component(player_entity, PropTeleported::with_source(source))
                     }
                 }
+                Effect::SetPlayerRotation { rotation } => {
+                    self.world
+                        .borrow::<UniqueViewMut<PlayerInfo>>()
+                        .unwrap()
+                        .rotation = rotation;
+                }
+                Effect::SetPlayerControlsEnabled { enabled } => {
+                    self.player_controls_enabled = enabled;
+                }
+                Effect::SetScreenFade { alpha } => {
+                    self.screen_fade_alpha = alpha.clamp(0.0, 1.0);
+                }
                 Effect::ClearTeleportedMarker { entity_id } => {
                     self.world.run(
                         |mut v_teleported: ViewMut<dark::properties::PropTeleported>| {
@@ -5332,6 +5368,22 @@ impl MissionCore {
             // canvas mapping needs.
             self.flat_ui.set_screen_size(screen_size);
             ret.extend(self.flat_ui.render(asset_cache, screen_size));
+        }
+
+        // WhiteOut is a view transition, so it covers the world, viewmodel,
+        // HUD, and flat UI and is rendered once per eye in VR.
+        if self.screen_fade_alpha > 0.0 {
+            let mut fade = SceneObject::screen_space_quad2(
+                self.screen_fade_texture.clone(),
+                vec2(0.0, 0.0),
+                screen_size,
+                self.screen_fade_alpha,
+            );
+            // Some HUD bars use an opaque screen material and write depth at
+            // the same Z as this quad. Clear that UI depth before the final
+            // transparent pass so full white covers those bars as well.
+            fade.set_clear_depth(true);
+            ret.push(fade);
         }
 
         ret

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -453,6 +453,22 @@ pub enum Effect {
         source: TeleportSource,
     },
 
+    /// Set the player's pawn yaw, used by authored seating/cutscene markers.
+    SetPlayerRotation {
+        rotation: Quaternion<f32>,
+    },
+
+    /// Allow or suppress ordinary player movement and interaction channels.
+    /// Discrete recovery actions such as quick-load remain available.
+    SetPlayerControlsEnabled {
+        enabled: bool,
+    },
+
+    /// Full-screen white transition overlay (0.0 = clear, 1.0 = white).
+    SetScreenFade {
+        alpha: f32,
+    },
+
     /// Remove an entity's `PropTeleported` marker. Emitted by a tripwire once it
     /// has consumed a scripted-teleport arrival, so the ~1s marker can't also
     /// suppress a later walk-in to a *different* nearby tripwire (#515).

--- a/shock2vr/src/scripts/many_ride.rs
+++ b/shock2vr/src/scripts/many_ride.rs
@@ -1,0 +1,398 @@
+//! Scripts used by Engineering 2's scripted ride through The Many.
+//!
+//! The retail sequence is wired entirely through ordinary mission objects:
+//! `WhiteOut` hides the transition, then relays to `SitDownRightNow`,
+//! `ParalyzePlayers`, and the continuously-moving cage platform. A second
+//! white-out releases the player at the end.
+
+use dark::properties::{PropDelayTime, PropPosition};
+use serde::{Deserialize, Serialize};
+use shipyard::{EntityId, Get, View, World};
+
+use crate::{physics::PhysicsWorld, time::Time};
+
+use super::{
+    Effect, MessagePayload, Script, ScriptRestoreContext, ScriptState, ScriptStateError,
+    script_util::{get_first_entity_by_name, send_to_all_switch_links},
+};
+
+const WHITE_OUT_STATE_KEY: &str = "shock2vr.many_ride.white_out";
+const PARALYZE_STATE_KEY: &str = "shock2vr.many_ride.paralyze_players";
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+enum WhiteOutPhase {
+    #[default]
+    Idle,
+    FadingToWhite {
+        elapsed: f32,
+    },
+    FadingFromWhite {
+        elapsed: f32,
+    },
+}
+
+#[derive(Deserialize, Serialize)]
+struct WhiteOutState {
+    duration_seconds: f32,
+    phase: WhiteOutPhase,
+}
+
+/// Fade the view to white over the authored `DelayTime`, relay `TurnOn` while
+/// the screen is fully covered, then reveal the new view over the same period.
+pub struct WhiteOut {
+    duration_seconds: f32,
+    phase: WhiteOutPhase,
+}
+
+impl WhiteOut {
+    pub fn new() -> Self {
+        Self {
+            duration_seconds: 1.0,
+            phase: WhiteOutPhase::Idle,
+        }
+    }
+}
+
+impl Script for WhiteOut {
+    fn initialize(&mut self, entity_id: EntityId, world: &World) -> Effect {
+        self.duration_seconds = world
+            .borrow::<View<PropDelayTime>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|delay| delay.delay.as_secs_f32())
+            .unwrap_or(1.0)
+            .max(f32::EPSILON);
+        Effect::NoEffect
+    }
+
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if matches!(msg, MessagePayload::TurnOn { .. }) {
+            self.phase = WhiteOutPhase::FadingToWhite { elapsed: 0.0 };
+            Effect::SetScreenFade { alpha: 0.0 }
+        } else {
+            Effect::NoEffect
+        }
+    }
+
+    fn update(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        time: &Time,
+    ) -> Effect {
+        let delta = time.elapsed.as_secs_f32();
+        match self.phase {
+            WhiteOutPhase::Idle => Effect::NoEffect,
+            WhiteOutPhase::FadingToWhite { elapsed } => {
+                let elapsed = elapsed + delta;
+                let alpha = (elapsed / self.duration_seconds).clamp(0.0, 1.0);
+                if elapsed >= self.duration_seconds {
+                    self.phase = WhiteOutPhase::FadingFromWhite { elapsed: 0.0 };
+                    Effect::combine(vec![
+                        Effect::SetScreenFade { alpha: 1.0 },
+                        send_to_all_switch_links(
+                            world,
+                            entity_id,
+                            MessagePayload::TurnOn { from: entity_id },
+                        ),
+                    ])
+                } else {
+                    self.phase = WhiteOutPhase::FadingToWhite { elapsed };
+                    Effect::SetScreenFade { alpha }
+                }
+            }
+            WhiteOutPhase::FadingFromWhite { elapsed } => {
+                let elapsed = elapsed + delta;
+                let alpha = 1.0 - (elapsed / self.duration_seconds).clamp(0.0, 1.0);
+                if elapsed >= self.duration_seconds {
+                    self.phase = WhiteOutPhase::Idle;
+                } else {
+                    self.phase = WhiteOutPhase::FadingFromWhite { elapsed };
+                }
+                Effect::SetScreenFade { alpha }
+            }
+        }
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(WHITE_OUT_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &WhiteOutState {
+                duration_seconds: self.duration_seconds,
+                phase: self.phase,
+            },
+            WHITE_OUT_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: WhiteOutState = state.decode(1, WHITE_OUT_STATE_KEY)?;
+        self.duration_seconds = restored.duration_seconds.max(f32::EPSILON);
+        self.phase = restored.phase;
+        Ok(())
+    }
+}
+
+/// Seat the single supported player at the retail `Seat1` marker and suppress
+/// movement while the adjacent paralyze relay catches up.
+pub struct SitDownRightNow;
+
+impl SitDownRightNow {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for SitDownRightNow {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::TurnOn { .. }) {
+            return Effect::NoEffect;
+        }
+
+        let Some(seat) = get_first_entity_by_name(world, "Seat1") else {
+            return Effect::NoEffect;
+        };
+        let positions = world.borrow::<View<PropPosition>>().unwrap();
+        let Ok(seat_position) = positions.get(seat) else {
+            return Effect::NoEffect;
+        };
+
+        Effect::combine(vec![
+            Effect::SetPlayerPosition {
+                position: seat_position.position,
+                is_teleport: true,
+                source: dark::properties::TeleportSource::ScriptedTrap,
+            },
+            Effect::SetPlayerRotation {
+                rotation: seat_position.rotation,
+            },
+            Effect::SetPlayerControlsEnabled { enabled: false },
+        ])
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct ParalyzePlayersState {
+    paralyzed: bool,
+}
+
+/// Prevent player movement between TurnOn and TurnOff. In eng2 the seated
+/// player rests on the linked moving cage, so moving-support carry preserves
+/// the relative pose while the platform travels.
+pub struct ParalyzePlayers {
+    paralyzed: bool,
+}
+
+impl ParalyzePlayers {
+    pub fn new() -> Self {
+        Self { paralyzed: false }
+    }
+}
+
+impl Script for ParalyzePlayers {
+    fn update(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _time: &Time,
+    ) -> Effect {
+        if self.paralyzed {
+            Effect::SetPlayerControlsEnabled { enabled: false }
+        } else {
+            Effect::NoEffect
+        }
+    }
+
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TurnOn { .. } => {
+                self.paralyzed = true;
+                Effect::SetPlayerControlsEnabled { enabled: false }
+            }
+            MessagePayload::TurnOff { .. } => {
+                self.paralyzed = false;
+                Effect::SetPlayerControlsEnabled { enabled: true }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+
+    fn script_state_key(&self) -> Option<&'static str> {
+        Some(PARALYZE_STATE_KEY)
+    }
+
+    fn save_state(&self) -> Result<ScriptState, ScriptStateError> {
+        ScriptState::encode(
+            1,
+            &ParalyzePlayersState {
+                paralyzed: self.paralyzed,
+            },
+            PARALYZE_STATE_KEY,
+        )
+    }
+
+    fn restore_state(
+        &mut self,
+        state: &ScriptState,
+        _context: &ScriptRestoreContext<'_>,
+    ) -> Result<(), ScriptStateError> {
+        let restored: ParalyzePlayersState = state.decode(1, PARALYZE_STATE_KEY)?;
+        self.paralyzed = restored.paralyzed;
+        Ok(())
+    }
+}
+
+/// Release the player at the end of the ride.
+pub struct StandUpAgain;
+
+impl StandUpAgain {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for StandUpAgain {
+    fn handle_message(
+        &mut self,
+        _entity_id: EntityId,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if matches!(msg, MessagePayload::TurnOn { .. }) {
+            Effect::SetPlayerControlsEnabled { enabled: true }
+        } else {
+            Effect::NoEffect
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Link, Links, PropSymName, ToLink, WrappedEntityId};
+
+    use super::*;
+
+    fn time(seconds: f32) -> Time {
+        Time {
+            elapsed: Duration::from_secs_f32(seconds),
+            total: Duration::from_secs_f32(seconds),
+        }
+    }
+
+    #[test]
+    fn white_out_relays_only_after_reaching_full_white() {
+        let mut world = World::new();
+        let target = world.add_entity(());
+        let source = world.add_entity((
+            PropDelayTime {
+                delay: Duration::from_secs(2),
+            },
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut script = WhiteOut::new();
+        script.initialize(source, &world);
+        script.handle_message(
+            source,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: source },
+        );
+
+        let halfway = Effect::flatten(vec![script.update(source, &world, &physics, &time(1.0))]);
+        assert!(
+            halfway
+                .iter()
+                .any(|effect| matches!(effect, Effect::SetScreenFade { alpha } if *alpha == 0.5))
+        );
+        assert!(
+            !halfway
+                .iter()
+                .any(|effect| matches!(effect, Effect::Send { .. }))
+        );
+
+        let covered = Effect::flatten(vec![script.update(source, &world, &physics, &time(1.0))]);
+        assert!(
+            covered
+                .iter()
+                .any(|effect| matches!(effect, Effect::SetScreenFade { alpha } if *alpha == 1.0))
+        );
+        assert!(covered.iter().any(|effect| matches!(
+            effect,
+            Effect::Send { msg }
+                if msg.to == target && matches!(msg.payload, MessagePayload::TurnOn { .. })
+        )));
+    }
+
+    #[test]
+    fn sit_down_uses_the_single_player_seat_marker() {
+        let mut world = World::new();
+        world.add_entity((
+            PropSymName("Seat1".to_owned()),
+            PropPosition {
+                position: vec3(4.0, 5.0, 6.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut script = SitDownRightNow::new();
+        let effects = Effect::flatten(vec![script.handle_message(
+            EntityId::dead(),
+            &world,
+            &physics,
+            &MessagePayload::TurnOn {
+                from: EntityId::dead(),
+            },
+        )]);
+
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetPlayerPosition { position, .. } if *position == vec3(4.0, 5.0, 6.0)
+        )));
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                Effect::SetPlayerControlsEnabled { enabled: false }
+            ))
+        );
+    }
+}

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -31,6 +31,7 @@ mod internal_keycard_script;
 mod internal_simple_health;
 mod internal_switch_held_model;
 mod level_change_button;
+mod many_ride;
 mod melee_weapon;
 mod obj_consume_button;
 mod once_room;
@@ -145,6 +146,7 @@ use self::{
     internal_keycard_script::KeyCardScript,
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
+    many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
     melee_weapon::MeleeWeapon,
     obj_consume_button::ObjConsumeButton,
     once_room::OnceRoom,
@@ -901,7 +903,7 @@ impl ScriptWorld {
             "trapmessage" => Box::new(NoopScript {}), // eng2 - installing override. What prop for message? Where to load string?
             "charmable" => Box::new(NoopScript::new()),
             "transientcorpse" => Box::new(NoopScript::new()),
-            "whiteout" => Box::new(NoopScript::new()),
+            "whiteout" => Box::new(WhiteOut::new()),
             "vaporizeinventory" => Box::new(VaporizeInventory::new()),
 
             // Internal
@@ -1084,9 +1086,9 @@ impl ScriptWorld {
             "manybrain" => Box::new(UnimplementedScript::new(&script_name)),
             "trapsuicide" => Box::new(UnimplementedScript::new(&script_name)),
             // many ride?
-            "paralyzeplayers" => Box::new(UnimplementedScript::new(&script_name)),
-            "standupagain" => Box::new(UnimplementedScript::new(&script_name)),
-            "sitdownrightnow" => Box::new(UnimplementedScript::new(&script_name)),
+            "paralyzeplayers" => Box::new(ParalyzePlayers::new()),
+            "standupagain" => Box::new(StandUpAgain::new()),
+            "sitdownrightnow" => Box::new(SitDownRightNow::new()),
 
             // hydro1
             "transluceinout" => Box::new(UnimplementedScript::new(&script_name)),

--- a/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
+++ b/tools/shock2-sdk/test/eng2-many-ride.e2e.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Position } from "../src/index.js";
+
+// eng2's central-spine tripwire starts the authored Many ride:
+//
+//   833 -> WhiteOut 1 -> SitDownRightNow / ParalyzePlayers / Cage_Wall
+//
+// Runtime entity ids change every launch, so every object is resolved through
+// its stable mission object id (reported by the SDK as template_id).
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const TRIPWIRE = 833;
+const SEAT_1 = 870;
+const CAGE_PLATFORM = 976;
+
+async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one eng2 object ${objectId}, got ${JSON.stringify(found.map((e) => e.name))}`,
+  );
+  return found[0];
+}
+
+function distance(a: Position | readonly number[], b: Position | readonly number[]): number {
+  const av = "x" in a ? [a.x, a.y, a.z] : a;
+  const bv = "x" in b ? [b.x, b.y, b.z] : b;
+  return Math.hypot(av[0] - bv[0], av[1] - bv[1], av[2] - bv[2]);
+}
+
+test(
+  "eng2: entering the central tripwire starts the Many ride",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8158),
+    });
+    await game.step({ frames: 2 });
+
+    const [tripwire, seat, cageBefore] = await Promise.all([
+      only(game, TRIPWIRE),
+      only(game, SEAT_1),
+      only(game, CAGE_PLATFORM),
+    ]);
+
+    // Establish an outside -> inside edge through the real Rapier sensor. The
+    // debug teleport is marked as locomotion, so TrapNewTripwire receives the
+    // same SensorBeginIntersect message as an ordinary corridor crossing.
+    const [tx, ty, tz] = tripwire.position;
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz + 4.8 });
+    await game.step({ frames: 2 });
+    await game.player.teleport({ x: tx, y: ty + 0.5, z: tz });
+
+    // WhiteOut 1 uses the authored two-second DelayTime before it seats the
+    // player and starts the continuous cage elevator.
+    await game.step({ frames: 180 });
+
+    const [playerAfter, cageAfter] = await Promise.all([
+      game.player.position(),
+      only(game, CAGE_PLATFORM),
+    ]);
+    assert.ok(
+      distance(playerAfter, seat.position) < 6,
+      `player should be seated in the ride cage; player=${JSON.stringify(playerAfter)} seat=${JSON.stringify(seat.position)}`,
+    );
+    assert.ok(
+      distance(cageAfter.position, cageBefore.position) > 0.1,
+      `ride cage should have left its first waypoint; before=${JSON.stringify(cageBefore.position)} after=${JSON.stringify(cageAfter.position)}`,
+    );
+
+    // Let the seated pawn settle onto the moving platform, then hold a full
+    // strafe input for one second. ParalyzePlayers must suppress that input;
+    // the pawn may move with the cage, but not relative to it.
+    await game.step({ frames: 60 });
+    const [playerBeforeStrafe, cageBeforeStrafe] = await Promise.all([
+      game.player.position(),
+      only(game, CAGE_PLATFORM),
+    ]);
+    await game.input.set("right_hand.thumbstick", [1, 0]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const [playerAfterStrafe, cageAfterStrafe] = await Promise.all([
+      game.player.position(),
+      only(game, CAGE_PLATFORM),
+    ]);
+    const relativeBefore = {
+      x: playerBeforeStrafe.x - cageBeforeStrafe.position[0],
+      y: playerBeforeStrafe.y - cageBeforeStrafe.position[1],
+      z: playerBeforeStrafe.z - cageBeforeStrafe.position[2],
+    };
+    const relativeAfter = {
+      x: playerAfterStrafe.x - cageAfterStrafe.position[0],
+      y: playerAfterStrafe.y - cageAfterStrafe.position[1],
+      z: playerAfterStrafe.z - cageAfterStrafe.position[2],
+    };
+    assert.ok(
+      distance(relativeAfter, relativeBefore) < 1,
+      `paralyzed player should not strafe relative to the cage; before=${JSON.stringify(relativeBefore)} after=${JSON.stringify(relativeAfter)}`,
+    );
+
+    // The tripwire's second authored branch reaches WhiteOut 2 after 80
+    // seconds. Advance from five seconds into the sequence to that boundary,
+    // then through WhiteOut's two-second fade-in. A covered frame compresses
+    // much smaller than the fully revealed, textured mission frame captured
+    // after StandUpAgain has fired and the fade has completed.
+    await game.step({ frames: 4_500 });
+    await game.step({ frames: 120 });
+    const covered = await game.screenshot("eng2-many-ride-whiteout2.png");
+    await game.step({ frames: 180 });
+    const revealed = await game.screenshot("eng2-many-ride-finished.png");
+    assert.deepEqual(covered.resolution, [800, 600]);
+    assert.deepEqual(revealed.resolution, [800, 600]);
+    assert.ok(
+      revealed.size_bytes > covered.size_bytes * 2,
+      `WhiteOut 2 should clear after the ride; covered=${covered.size_bytes}B revealed=${revealed.size_bytes}B`,
+    );
+
+    // StandUpAgain runs 0.2 seconds after the fully-white relay. Once the view
+    // is revealed, the same full strafe input must move the player relative to
+    // the cage again.
+    const [playerBeforeReleaseStrafe, cageBeforeReleaseStrafe] = await Promise.all([
+      game.player.position(),
+      only(game, CAGE_PLATFORM),
+    ]);
+    await game.input.set("right_hand.thumbstick", [1, 0]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const [playerAfterReleaseStrafe, cageAfterReleaseStrafe] = await Promise.all([
+      game.player.position(),
+      only(game, CAGE_PLATFORM),
+    ]);
+    const releaseRelativeBefore = {
+      x: playerBeforeReleaseStrafe.x - cageBeforeReleaseStrafe.position[0],
+      y: playerBeforeReleaseStrafe.y - cageBeforeReleaseStrafe.position[1],
+      z: playerBeforeReleaseStrafe.z - cageBeforeReleaseStrafe.position[2],
+    };
+    const releaseRelativeAfter = {
+      x: playerAfterReleaseStrafe.x - cageAfterReleaseStrafe.position[0],
+      y: playerAfterReleaseStrafe.y - cageAfterReleaseStrafe.position[1],
+      z: playerAfterReleaseStrafe.z - cageAfterReleaseStrafe.position[2],
+    };
+    assert.ok(
+      distance(releaseRelativeAfter, releaseRelativeBefore) > 1,
+      `StandUpAgain should restore movement after WhiteOut 2; before=${JSON.stringify(releaseRelativeBefore)} after=${JSON.stringify(releaseRelativeAfter)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- implement the authored `WhiteOut`, `SitDownRightNow`, `ParalyzePlayers`, and `StandUpAgain` scripts used by Engineering 2's Many ride
- fade the complete flat/VR view to white while the player is moved to the mission-authored `Seat1` marker, lock ordinary controls during the cage ride, and release them through the authored end relay
- preserve the fade and paralyze phases across save/load, and cover the real tripwire-to-ride sequence with a deterministic SDK scenario

## Reproduction

On the pre-fix base (`607c1ce`), I launched `eng2.mis`, resolved mission object 833 by its stable template ID, teleported from outside to inside its real Rapier sensor, and stepped three seconds. The player's position remained at the tripwire (`[-0.00007, -11.556, -214.800]`), cage object 976 remained at `[94.4, -14.4, -91.0]`, and the one- and three-second screenshots were byte-identical.

The negative-first SDK scenario also failed on the base because the player never reached `Seat1`:

```text
player should be seated in the ride cage;
player={"x":-0.0000727423,"y":-11.556001,"z":-214.80003}
seat=[94.817215,-12,-91.213974]
```

Root cause: the mission's tripwire and delayed SwitchLink chain were already live, and the cage's `DontStopElevator` path was already implemented, but `WhiteOut` mapped to `NoopScript` while `SitDownRightNow`, `ParalyzePlayers`, and `StandUpAgain` mapped to `UnimplementedScript`. The first white-out therefore swallowed the relay before any seating, control lock, or cage start could occur.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed after rebase
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr --no-fail-fast` — 516 passed before rebase; focused post-rebase tests 2 passed
- `cargo fmt --all -- --check` and `git diff --check` — passed
- `npm test` — 26 passed, 191 E2E-skipped after rebase
- focused post-rebase SDK E2E — 2 passed: upstream command-resonator scenario plus the full eng2 ride (eng2: 163.54 s)
- full SDK E2E before rebase — 212 passed, 1 pre-existing failure, 3 fixture-gated skips; the eng2 ride and all 23 mission-load cases passed

The single full-suite failure (`a loaded corpse does not replay its death`) reproduces identically on a clean detached worktree at the exact pre-fix base `607c1ce`: every printed loaded-corpse sample is invariant (dead behavior, no active/queued clip, sleeping body, zero velocity, zero pose/position error), but the existing aggregate assertion fails. This change does not touch corpse, animation, or save-body code.

## Visual evidence

![eng2 Many ride white-out transition](https://gist.githubusercontent.com/tommy-xr/18feddd5b8562be8b8d0ff272c71dfb4/raw/eng2-many-ride-whiteout.gif)

<sub>Entering the real eng2 mission-object 833 tripwire fades the complete view to white, seats the player, starts the cage, and fades back out. Captured from fresh base/head launches with the identical outside→inside sensor sequence via `/v1/step` + `/v1/screenshot` (deterministic fixed 60 Hz).</sub>

### Still

![player seated in the moving eng2 Many cage](https://gist.githubusercontent.com/tommy-xr/18feddd5b8562be8b8d0ff272c71dfb4/raw/eng2-many-ride-after.png)

### Before → after

![before and after the eng2 Many ride fix](https://gist.githubusercontent.com/tommy-xr/18feddd5b8562be8b8d0ff272c71dfb4/raw/eng2-many-ride-before-after.png)

Fixes #580