### PR TITLE
fix(gameplay): keep replicator output physical

### DIFF
--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -109,6 +109,20 @@ fn replicator_hack_critical_failure(entity_id: EntityId, _world: &World) -> Effe
 }
 
 impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
+    fn on_provide_for_consumption(
+        &self,
+        _entity_id: EntityId,
+        _world: &World,
+        _provided_entity_id: EntityId,
+    ) -> Option<Effect> {
+        // A replicator is a dispenser, not a container or tool receptor. In
+        // particular, output spawned at its authored hopper marker can touch
+        // RepBase immediately; refusing that ToolConsumable offer leaves the
+        // item physical for the player to pick up instead of hiding it behind
+        // a runtime Contains link.
+        Some(Effect::NoEffect)
+    }
+
     fn get_components(
         &self,
         _cursor: &Option<GuiCursor>,

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -433,8 +433,11 @@ fn effective_replicator_cost(world: &World, authored_cost: i32) -> i32 {
 mod tests {
     use super::super::keypad::{HackNode, HackPhase, base_hack_board, board_index};
     use super::*;
+    use crate::gui::GuiScript;
     use crate::mission::PlayerInfo;
+    use crate::physics::PhysicsWorld;
     use crate::runtime_props::RuntimePropTransform;
+    use crate::scripts::{MessagePayload, Script};
     use cgmath::{Matrix4, Quaternion};
     use dark::properties::{
         Link, Links, PropObjIcon, PropPosition, PropStackCount, ToLink, WrappedEntityId,
@@ -447,6 +450,26 @@ mod tests {
             Effect::Combined { effects } => effects.iter().any(creates_template),
             _ => false,
         }
+    }
+
+    #[test]
+    fn replicator_refuses_an_offered_item_instead_of_containing_it() {
+        let mut world = World::new();
+        let replicator = world.add_entity(());
+        let resonator = world.add_entity(());
+        let mut script = GuiScript::new(Box::new(ReplicatorGui));
+
+        let effect = script.handle_message(
+            replicator,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::ProvideForConsumption { entity: resonator },
+        );
+
+        assert!(
+            matches!(effect, Effect::NoEffect),
+            "a replicator is a dispenser, not a container; got {effect:?}"
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/command-resonator.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-resonator.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 import type { UiElement, UiPanel } from "../src/types.js";
 import { clickUiElement } from "./helpers/ui.js";
 
@@ -164,10 +164,115 @@ test(
     );
     await clickUiElement(game, resonatorButton);
     await game.step({ frames: 10 });
+    const resonators = await game.entities.byTemplate(SYMPATHETIC_RESONATOR);
     assert.equal(
-      (await game.entities.byTemplate(SYMPATHETIC_RESONATOR)).length,
+      resonators.length,
       1,
       "the ordinary replicator purchase should dispense template -1671",
+    );
+
+    const resonator = resonators[0];
+    const worldDetail = await game.entities.detail(resonator.id);
+    const replicatorContainsResonator = (
+      await game.entities.detail(loadedReplicator.id)
+    ).outgoing_links.some(
+      (link) =>
+        link.link_type.startsWith("Contains") &&
+        link.target_id === resonator.id,
+    );
+    assert.equal(
+      replicatorContainsResonator,
+      false,
+      "the replicator must not author a runtime Contains link to its own output",
+    );
+    assert.equal(
+      worldDetail.incoming_links.filter((link) =>
+        link.link_type.startsWith("Contains"),
+      ).length,
+      0,
+      "the replicator hopper must not convert its dispensed item into hidden containment",
+    );
+    assert.notEqual(
+      worldDetail.properties
+        .find((property) => property.name === "HasRefs")
+        ?.value.toLowerCase(),
+      "false",
+      "the world item must retain references instead of being hidden as container contents",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: resonator.id })).bodies.length,
+      1,
+      "the dispensed resonator must retain its authored world collider",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === resonator.id,
+      ),
+      false,
+      "the hopper item must remain in the world until the player picks it up",
+    );
+
+    await clickUiElement(game, button(await activePanel(game), "close"));
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.ui.state()).active_panel,
+      null,
+      "closing the replicator MFD should return control to world interaction",
+    );
+
+    const [bombX, bombY, bombZ] = worldDetail.position;
+    await game.player.teleport({
+      x: bombX + 0.2,
+      y: bombY - PLAYER_EYE_HEIGHT_WORLD,
+      z: bombZ,
+    });
+    const aim = await game.player.aimAt(resonator, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `the hopper item should expose a selectable surface: ${JSON.stringify(aim)}`,
+    );
+
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 5 });
+
+    const carried = (await game.player.inventory()).items.find(
+      (item) => item.entity_id === resonator.id,
+    );
+    assert.equal(
+      carried?.location,
+      "inventory",
+      `an ordinary visible world squeeze should pick up the resonator: ${JSON.stringify(carried)}`,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: resonator.id })).bodies.length,
+      0,
+      "the picked-up resonator should no longer retain a world body",
+    );
+
+    const pickupSave = `command_resonator_picked_up_${Date.now()}`;
+    assert.equal((await game.save(pickupSave)).success, true);
+    assert.equal((await game.load(pickupSave)).success, true);
+    await game.step({ frames: 5 });
+
+    const loadedResonators = await game.entities.byTemplate(SYMPATHETIC_RESONATOR);
+    assert.equal(
+      loadedResonators.length,
+      1,
+      "save/load must restore the unique purchased resonator",
+    );
+    const loadedInventory = await game.player.inventory();
+    assert.equal(
+      loadedInventory.items.find(
+        (item) => item.entity_id === loadedResonators[0].id,
+      )?.location,
+      "inventory",
+      `save/load must preserve the picked-up resonator: ${JSON.stringify(loadedInventory.items)}`,
     );
   },
 );


### PR DESCRIPTION
Fixes #874

## Summary

- make replicator panels refuse `ProvideForConsumption` offers because they are dispensers, not containers or tool receptors
- keep purchased `ToolConsumable` output physical at the authored hopper marker instead of creating a hidden runtime `Contains` link
- extend the fresh Command resonator scenario through real hack and purchase, visible world pickup, and save/load

## Root cause

The purchased Sympathetic Resonator spawns at the replicator output marker and immediately collides with `RepBase`. `ToolConsumable` sends `ProvideForConsumption` to the replicator GUI. The generic GUI fallback treated that offer as a container deposit, adding `Contains(0)`, setting `HasRefs=false`, and removing the physics body. A replicator-specific refusal preserves the shared fallback for actual containers and the tool hook for real receptors.

## Negative-first evidence

- unit: current main returned `DropEntityInfo { parent: RepBase, item: resonator }`, expected refusal
- fresh `command1.mis`: current main added a runtime `RepBase -> Contains -> Big Bomb` link and reported zero physics bodies after the real HRM hack and purchase

## Validation

- `cargo fmt --check --all`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (519 passed)
- `npm test` in `tools/shock2-sdk` (26 passed, 190 E2E skipped)
- serial production E2Es: Command resonator, container loot, Earth replicator economy, Earth replicator hacking, Hydro hackable crate (5 passed)
- fresh Command scenario proves no replicator containment or `HasRefs=false`, one authored physics body, visibility-confirmed surface aim, ordinary squeeze pickup into inventory, and post-pickup save/load persistence

## Visuals

![Command replicator physical output demo](https://gist.githubusercontent.com/tommy-xr/57c4c899aaf588bfcc72f83943c34c1c/raw/command-bigbomb-pickup.gif)

<sub>Fresh <code>command1.mis</code>: stable Replicator394 objective relay, max-skill genuine HRM hack, real <code>buy:big bomb</code> purchase, MFD close, then an ordinary two-frame world squeeze. Base stays empty because the output is hidden in containment; the fix leaves the Resonator physical in the hopper and the squeeze picks it into inventory. Captured headlessly via deterministic <code>/v1/step</code> + <code>/v1/screenshot</code>.</sub>

### Before → after

![Base hidden output versus fixed physical Resonator in hopper](https://gist.githubusercontent.com/tommy-xr/57c4c899aaf588bfcc72f83943c34c1c/raw/command-bigbomb-before-after.png)

<sub>Left: exact base <code>3ae2445d</code> (empty hopper, runtime <code>Contains</code>, zero bodies). Right: exact head <code>8ba5eed0</code> (visible Resonator, no replicator containment, one selectable body).</sub>