### PR TITLE
fix(pathfinding): harden synthesized crossings

### DIFF
--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -888,6 +888,7 @@ pub struct DebugPathfindingStats {
     pub queries: u64,
     pub stressed_retries: u64,
     pub no_route: u64,
+    pub partial_searches: u64,
 }
 
 /// A script message a debug client can inject into a specific entity.
@@ -918,6 +919,9 @@ pub enum DebugEntityMessage {
     SetAlertness {
         level: dark::properties::AIAlertLevel,
     },
+    /// Set Dark's live `P$Locked` state. This drives the same production lock
+    /// checks and navigation-door synchronization as authored lock traps.
+    SetLocked { locked: bool },
     /// Switch-link activate (what a tripwire/button sends to its targets).
     TurnOn,
     /// Switch-link deactivate.

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1104,57 +1104,31 @@ impl MissionCore {
         }
 
         let nav_bridges = game_options.experimental_features.contains("nav_bridges");
-        // Vet nav crossings (island bridges, relaxed blocking-cell
-        // traversal) against real geometry: a torso-height ray between the
-        // two points must be clear, so routes can't run through railings,
-        // thin walls (issue #481), or furniture spanning the corridor
-        // (issue #489). Doors and creatures don't count as blockers - doors
-        // open at runtime and creatures wander off - so the ray advances
-        // past those hits (bounded).
+        if nav_bridges {
+            // Rapier normally populates its spatial-query BVH on the first
+            // physics step. Bridge validation happens during construction, so
+            // prepare the index now without advancing the mission.
+            physics.prepare_spatial_queries();
+        }
+        // Vet synthesized island crossings against real geometry with a
+        // widest-creature sphere sweep over the exact measured gap. A point
+        // ray can pass beside a railing/wall that the creature's body still
+        // clips. Doors and creatures don't count as permanent blockers:
+        // doors open at runtime and creatures wander off.
         let nav_validator = |from: cgmath::Vector3<f32>, to: cgmath::Vector3<f32>| -> bool {
-            let delta = to - from;
-            let total = delta.magnitude();
-            if total <= f32::EPSILON {
-                return true;
-            }
-            let direction = delta / total;
-            let mut origin = Point3::new(from.x, from.y, from.z);
-            let mut remaining = total;
-            // A crossing rarely stacks more than a couple of pass-through
-            // entities; bail as blocked beyond that
-            for _ in 0..4 {
-                let Some(hit) = physics.ray_cast2_as_actor(
-                    origin,
-                    direction,
-                    remaining,
-                    crate::physics::InternalCollisionGroups::WORLD
-                        | crate::physics::InternalCollisionGroups::ENTITIES,
-                    None,
-                    true,
-                ) else {
-                    return true;
-                };
-                let pass_through = hit
-                    .maybe_entity_id
-                    .map(|id| {
-                        crate::scripts::ai::ai_util::is_entity_door(&world, id)
-                            || world
-                                .borrow::<View<PropCreature>>()
-                                .map(|v| v.contains(id))
-                                .unwrap_or(false)
-                    })
-                    .unwrap_or(false);
-                if !pass_through {
-                    return false;
-                }
-                let travelled = (hit.hit_point - origin).magnitude() + 0.05;
-                if travelled >= remaining {
-                    return true;
-                }
-                remaining -= travelled;
-                origin += direction * travelled;
-            }
-            false
+            physics.actor_sweep_is_clear(
+                Point3::new(from.x, from.y, from.z),
+                Point3::new(to.x, to.y, to.z),
+                crate::physics::NAV_ACTOR_SWEEP_RADIUS_WORLD,
+                |id| {
+                    id == player_entity
+                        || crate::scripts::ai::ai_util::is_entity_door(&world, id)
+                        || world
+                            .borrow::<View<PropCreature>>()
+                            .map(|v| v.contains(id))
+                            .unwrap_or(false)
+                },
+            )
         };
         let pathfinding_service = abstract_mission.path_database.as_ref().map(|db| {
             Arc::new(PathfindingService::with_nav_options(
@@ -6597,6 +6571,11 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .run(|v: View<dark::properties::PropMaxHitPoints>| {
                 v.get(id).ok().map(|hp| hp.hit_points)
             });
+        let locked = self
+            .world
+            .run(|v: View<dark::properties::PropLocked>| v.get(id).ok().map(|value| value.0));
+        let door_blocks_pathfinding = crate::scripts::script_util::door_is_closed(&self.world, id)
+            .map(|_| crate::scripts::script_util::door_blocks_pathfinding(&self.world, id));
         // Most ecologies author no explicit P$EcoState; they behave as Normal
         // until their script's first transition creates the component.
         let ecology_state = self.world.run(
@@ -6691,6 +6670,18 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "MaxHitPoints".to_string(),
                         value: max_hit_points.to_string(),
+                    });
+                }
+                if let Some(locked) = locked {
+                    properties.push(DebugPropertyInfo {
+                        name: "Locked".to_string(),
+                        value: locked.to_string(),
+                    });
+                }
+                if let Some(blocks) = door_blocks_pathfinding {
+                    properties.push(DebugPropertyInfo {
+                        name: "DoorBlocksPathfinding".to_string(),
+                        value: blocks.to_string(),
                     });
                 }
                 if let Some(state) = ecology_state {
@@ -7593,6 +7584,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 queries: stats.queries,
                 stressed_retries: stats.stressed_retries,
                 no_route: stats.no_route,
+                partial_searches: stats.partial_searches,
             }
         })
     }
@@ -7639,6 +7631,11 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             return false;
         }
 
+        if let DebugEntityMessage::SetLocked { locked } = &message {
+            crate::scripts::script_util::set_entity_locked(&mut self.world, id, *locked);
+            return true;
+        }
+
         let payload = match message {
             DebugEntityMessage::Damage {
                 amount,
@@ -7676,6 +7673,7 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             DebugEntityMessage::SetAlertness { level } => {
                 MessagePayload::SetAlertness { level, pin: false }
             }
+            DebugEntityMessage::SetLocked { .. } => unreachable!("handled above"),
             // Debug injections have no real sender; use the target itself.
             DebugEntityMessage::TurnOn => MessagePayload::TurnOn { from: id },
             DebugEntityMessage::TurnOff => MessagePayload::TurnOff { from: id },

--- a/shock2vr/src/pathfinding/mod.rs
+++ b/shock2vr/src/pathfinding/mod.rs
@@ -103,15 +103,18 @@ impl Default for PathfindingFrameBudget {
 }
 
 /// Monotonic query counters, for load measurement and budget verification.
-/// Callers diff snapshots across frames to get rates.
+/// Callers diff snapshots across frames to get rates; the number of graph
+/// searches is `queries + stressed_retries + partial_searches`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PathfindingStats {
     /// Total find_path calls
     pub queries: u64,
     /// Queries that ran the stressed second pass (first pass failed)
     pub stressed_retries: u64,
-    /// Queries that found no route at all (the most expensive outcome)
+    /// Queries whose full-route A* passes found no route
     pub no_route: u64,
+    /// Partial-route Dijkstra searches run after a full route failed
+    pub partial_searches: u64,
 }
 
 /// Outcome of an AI's most recent path query
@@ -149,6 +152,17 @@ pub struct AiSteeringDebug {
     pub stall_seconds: f32,
 }
 
+/// One directional island crossing synthesized by `nav_bridges`.
+///
+/// Dark links identify a shared edge by vertex indices. Synthesized links do
+/// not share an edge, so keep the measured exit/entry points beside the link
+/// instead of overloading the parsed database's vertex id space.
+struct SynthesizedBridge {
+    link: PathCellLink,
+    exit: Vector3<f32>,
+    entry: Vector3<f32>,
+}
+
 /// Pathfinding service for AI navigation
 ///
 /// Uses AIPATH cells for navigation mesh queries and A* pathfinding.
@@ -170,7 +184,7 @@ pub struct PathfindingService {
     effective_bits: Vec<MovementBits>,
     /// Synthesized island-crossing links (experimental `nav_bridges`),
     /// indexed after `path_database.links`
-    bridge_links: Vec<PathCellLink>,
+    bridge_links: Vec<SynthesizedBridge>,
     /// Relaxed navigation (experimental `nav_bridges`): blocking-OBB cells
     /// (furniture baked into the mesh at build time) are passable at a cost
     /// penalty - the objects are physically simulated, steering handles them
@@ -202,6 +216,7 @@ pub struct PathfindingService {
     queries: AtomicU64,
     stressed_retries: AtomicU64,
     no_route: AtomicU64,
+    partial_searches: AtomicU64,
 }
 
 impl PathfindingService {
@@ -245,10 +260,10 @@ impl PathfindingService {
         };
         for (offset, link) in bridge_links.iter().enumerate() {
             let idx = (path_database.links.len() + offset) as u32;
-            if let Some(links) = links_by_cell.get_mut(link.from_cell as usize) {
+            if let Some(links) = links_by_cell.get_mut(link.link.from_cell as usize) {
                 links.push(idx);
             }
-            effective_bits.push(link.ok_bits);
+            effective_bits.push(link.link.ok_bits);
         }
         if !bridge_links.is_empty() {
             tracing::info!(
@@ -270,6 +285,7 @@ impl PathfindingService {
             queries: AtomicU64::new(0),
             stressed_retries: AtomicU64::new(0),
             no_route: AtomicU64::new(0),
+            partial_searches: AtomicU64::new(0),
         }
     }
 
@@ -365,7 +381,7 @@ impl PathfindingService {
         if idx < n {
             &self.path_database.links[idx]
         } else {
-            &self.bridge_links[idx - n]
+            &self.bridge_links[idx - n].link
         }
     }
 
@@ -415,6 +431,7 @@ impl PathfindingService {
             queries: self.queries.load(Ordering::Relaxed),
             stressed_retries: self.stressed_retries.load(Ordering::Relaxed),
             no_route: self.no_route.load(Ordering::Relaxed),
+            partial_searches: self.partial_searches.load(Ordering::Relaxed),
         }
     }
 
@@ -521,22 +538,9 @@ impl PathfindingService {
         avoid: &std::collections::HashSet<(u32, u32)>,
     ) -> Option<Vec<Vector3<f32>>> {
         let start_cell = self.cell_from_position(start)?;
-        let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell, |&cell| {
-            self.get_successors(cell, movement_bits, avoid)
-        });
-
-        let distance_to_goal = |cell: u32| -> f32 {
-            (goal - self.path_database.cells[cell as usize].center).magnitude()
-        };
-        let mut best = start_cell;
-        let mut best_distance = distance_to_goal(start_cell);
-        for &cell in reachable.keys() {
-            let d = distance_to_goal(cell);
-            if d < best_distance {
-                best_distance = d;
-                best = cell;
-            }
-        }
+        self.partial_searches.fetch_add(1, Ordering::Relaxed);
+        let (reachable, best) =
+            self.reachable_cell_nearest_goal(start_cell, goal, movement_bits, avoid);
         if best == start_cell {
             return None;
         }
@@ -552,6 +556,34 @@ impl PathfindingService {
 
         let end = self.path_database.cells[best as usize].center;
         Some(self.waypoints_for_cell_path(&cell_path, start, end, movement_bits))
+    }
+
+    /// Explore the component reachable from `start_cell` and select the cell
+    /// whose center is nearest `goal`. The returned Dijkstra parent map lets
+    /// callers either reconstruct a partial route or use only the best cell.
+    fn reachable_cell_nearest_goal(
+        &self,
+        start_cell: u32,
+        goal: Vector3<f32>,
+        movement_bits: MovementBits,
+        avoid: &std::collections::HashSet<(u32, u32)>,
+    ) -> (HashMap<u32, (u32, u32)>, u32) {
+        let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell, |&cell| {
+            self.get_successors(cell, movement_bits, avoid)
+        });
+        let distance_to_goal = |cell: u32| -> f32 {
+            (goal - self.path_database.cells[cell as usize].center).magnitude()
+        };
+        let mut best = start_cell;
+        let mut best_distance = distance_to_goal(start_cell);
+        for &cell in reachable.keys() {
+            let distance = distance_to_goal(cell);
+            if distance < best_distance {
+                best_distance = distance;
+                best = cell;
+            }
+        }
+        (reachable, best)
     }
 
     fn find_path_with_bits(
@@ -589,27 +621,36 @@ impl PathfindingService {
         goal: Vector3<f32>,
         movement_bits: MovementBits,
     ) -> Vec<Vector3<f32>> {
-        // Collect the shared edge for each crossing
+        // Collect one portal for an authored shared-edge crossing, or two
+        // fixed portals for a synthesized gap (exit then entry).
         let mut edges = Vec::with_capacity(cell_path.len().saturating_sub(1));
         for pair in cell_path.windows(2) {
-            let edge = self
-                .link_between(pair[0], pair[1], movement_bits)
-                .and_then(|link| {
-                    let a = *self
-                        .path_database
-                        .vertices
-                        .get(link.edge_vertex_a as usize)?;
-                    let b = *self
-                        .path_database
-                        .vertices
-                        .get(link.edge_vertex_b as usize)?;
-                    Some(inset_edge(a, b))
-                });
-            edges.push(edge.unwrap_or_else(|| {
-                // No usable edge data; fall back to the destination cell center
+            let Some(link_idx) = self.link_index_between(pair[0], pair[1], movement_bits) else {
                 let center = self.path_database.cells[pair[1] as usize].center;
-                (center, center)
-            }));
+                edges.push((center, center));
+                continue;
+            };
+            let raw_link_count = self.path_database.links.len();
+            if link_idx as usize >= raw_link_count {
+                let bridge = &self.bridge_links[link_idx as usize - raw_link_count];
+                edges.push((bridge.exit, bridge.exit));
+                edges.push((bridge.entry, bridge.entry));
+            } else {
+                let edge = {
+                    let link = self.link_at(link_idx);
+                    self.path_database
+                        .vertices
+                        .get(link.edge_vertex_a as usize)
+                        .zip(self.path_database.vertices.get(link.edge_vertex_b as usize))
+                        .map(|(a, b)| inset_edge(*a, *b))
+                };
+                edges.push(edge.unwrap_or_else(|| {
+                    // Malformed authored edge data: retain the historical
+                    // destination-center fallback.
+                    let center = self.path_database.cells[pair[1] as usize].center;
+                    (center, center)
+                }));
+            }
         }
 
         // Pull the path taut: walk the edges backward, aiming each crossing
@@ -630,12 +671,12 @@ impl PathfindingService {
     }
 
     /// Find a traversable link from one cell to an adjacent cell
-    fn link_between(
+    fn link_index_between(
         &self,
         from_cell: u32,
         to_cell: u32,
         movement_bits: MovementBits,
-    ) -> Option<&PathCellLink> {
+    ) -> Option<u32> {
         self.links_by_cell
             .get(from_cell as usize)?
             .iter()
@@ -643,7 +684,6 @@ impl PathfindingService {
             .find(|&idx| {
                 self.link_at(idx).to_cell == to_cell && self.can_use_link(idx, movement_bits)
             })
-            .map(|idx| self.link_at(idx))
     }
 
     /// Find the closest reachable cell to a goal position
@@ -657,29 +697,13 @@ impl PathfindingService {
         movement_bits: MovementBits,
     ) -> Option<u32> {
         let start_cell_id = self.cell_from_position(start)?;
-
-        // Find all reachable cells using Dijkstra's algorithm
-        let reachable = pathfinding::directed::dijkstra::dijkstra_all(&start_cell_id, |&cell_id| {
-            self.get_successors(cell_id, movement_bits, &std::collections::HashSet::new())
-        });
-
-        // Find the reachable cell closest to the goal
-        let mut closest_cell = Some(start_cell_id); // Start with start cell as fallback
-        let start_center = self.path_database.cells[start_cell_id as usize].center;
-        let mut closest_distance = (goal - start_center).magnitude();
-
-        // Check all other reachable cells
-        for (cell_id, _) in reachable {
-            let cell_center = self.path_database.cells[cell_id as usize].center;
-            let distance = (goal - cell_center).magnitude();
-
-            if distance < closest_distance {
-                closest_distance = distance;
-                closest_cell = Some(cell_id);
-            }
-        }
-
-        closest_cell
+        let (_, closest) = self.reachable_cell_nearest_goal(
+            start_cell_id,
+            goal,
+            movement_bits,
+            &std::collections::HashSet::new(),
+        );
+        Some(closest)
     }
 
     /// Port of the original engine's per-link traversal check: a link is
@@ -911,14 +935,13 @@ fn is_flat_seam(db: &PathDatabase, link: &PathCellLink) -> bool {
 /// between them (stair strips and thresholds have no nav cells at all);
 /// original AI pathfinding was area-local. For full-map navigation, connect
 /// islands where two cells from different islands come within BRIDGE_MAX_GAP
-/// of each other at a walkable slope. Purely geometric - a candidate through
-/// thick geometry is possible but rare at these gates, and steering/stall
-/// handling copes with the odd bad bridge.
+/// of each other at a walkable slope and the measured crossing admits a
+/// creature-width physics sweep.
 fn compute_bridge_links(
     db: &PathDatabase,
     effective_bits: &[MovementBits],
     validator: Option<&dyn Fn(Vector3<f32>, Vector3<f32>) -> bool>,
-) -> Vec<PathCellLink> {
+) -> Vec<SynthesizedBridge> {
     // Union-find over walk-usable links to label islands
     let mut parent: Vec<u32> = (0..db.cells.len() as u32).collect();
     fn find(parent: &mut Vec<u32>, mut a: u32) -> u32 {
@@ -963,25 +986,31 @@ fn compute_bridge_links(
         buckets.entry(bucket_of(cell)).or_default().push(idx as u32);
     }
 
-    let vertex_gap = |a: &PathCell, b: &PathCell| -> f32 {
-        let mut best = f32::INFINITY;
-        for &va in &a.vertex_indices {
-            for &vb in &b.vertex_indices {
-                if let (Some(pa), Some(pb)) =
-                    (db.vertices.get(va as usize), db.vertices.get(vb as usize))
-                {
-                    best = best.min((pa - pb).magnitude());
+    let closest_vertex_pair =
+        |a: &PathCell, b: &PathCell| -> Option<(f32, Vector3<f32>, Vector3<f32>)> {
+            let mut best = f32::INFINITY;
+            let mut closest = None;
+            for &va in &a.vertex_indices {
+                for &vb in &b.vertex_indices {
+                    if let (Some(pa), Some(pb)) =
+                        (db.vertices.get(va as usize), db.vertices.get(vb as usize))
+                    {
+                        let gap = (pa - pb).magnitude();
+                        if gap < best {
+                            best = gap;
+                            closest = Some((gap, *pa, *pb));
+                        }
+                    }
                 }
             }
-        }
-        best
-    };
+            closest
+        };
 
     // Collect every qualifying candidate first, then union in a stable
     // order (shortest gap first, cell ids as tiebreak) so the synthesized
     // topology is deterministic across launches - HashMap iteration order
     // must not pick the bridges.
-    let mut candidates: Vec<(f32, u32, u32)> = Vec::new();
+    let mut candidates: Vec<(f32, u32, u32, Vector3<f32>, Vector3<f32>)> = Vec::new();
     for (&(bx, bz), cells) in &buckets {
         // Scan the 3x3 bucket neighborhood; a_id < b_id dedupes pairs
         let mut neighborhood: Vec<u32> = Vec::new();
@@ -1013,11 +1042,13 @@ fn compute_bridge_links(
                 if dy > max_dy {
                     continue;
                 }
-                let gap = vertex_gap(a, b);
+                let Some((gap, exit, entry)) = closest_vertex_pair(a, b) else {
+                    continue;
+                };
                 if gap > BRIDGE_MAX_GAP {
                     continue;
                 }
-                candidates.push((gap, a_id, b_id));
+                candidates.push((gap, a_id, b_id, exit, entry));
             }
         }
     }
@@ -1034,14 +1065,14 @@ fn compute_bridge_links(
 
     let mut rejected = 0usize;
     let mut bridges = Vec::new();
-    for (_, a_id, b_id) in candidates {
+    for (gap, a_id, b_id, a_exit, b_entry) in candidates {
         if find(&mut parent, a_id) == find(&mut parent, b_id) {
             continue;
         }
         if let Some(validate) = validator {
             let lift = Vector3::new(0.0, BRIDGE_PROBE_HEIGHT, 0.0);
-            let from = db.cells[a_id as usize].center + lift;
-            let to = db.cells[b_id as usize].center + lift;
+            let from = a_exit + lift;
+            let to = b_entry + lift;
             if !validate(from, to) {
                 rejected += 1;
                 continue;
@@ -1050,22 +1081,29 @@ fn compute_bridge_links(
         let root_a = find(&mut parent, a_id);
         parent[root_a as usize] = find(&mut parent, b_id);
         let (a, b) = (&db.cells[a_id as usize], &db.cells[b_id as usize]);
-        // Cost from center-to-center distance: the executed route runs
-        // through the cell centers (no shared edge exists), so this matches
-        // travel and keeps the center-distance A* heuristic admissible
-        let center_dist = (a.center - b.center).magnitude();
-        let cost = ((center_dist * SCALE_FACTOR) as u8).max(1);
+        // Price the route actually executed: source center to its bridge exit,
+        // across the measured gap, then entry to destination center. This is
+        // never below the center-distance heuristic (triangle inequality).
+        let crossing_dist =
+            (a.center - a_exit).magnitude() + gap + (b_entry - b.center).magnitude();
+        let cost = (crossing_dist * SCALE_FACTOR).ceil().clamp(1.0, 255.0) as u8;
         let bits = MovementBits::WALK | MovementBits::SMALL_CREATURE;
-        // No shared edge exists; u32::MAX vertex ids make waypoint
-        // building fall back to the destination cell center
-        for (from, to) in [(a_id, b_id), (b_id, a_id)] {
-            bridges.push(PathCellLink {
-                from_cell: from,
-                to_cell: to,
-                edge_vertex_a: u32::MAX,
-                edge_vertex_b: u32::MAX,
-                ok_bits: bits,
-                cost,
+        for (from, to, exit, entry) in
+            [(a_id, b_id, a_exit, b_entry), (b_id, a_id, b_entry, a_exit)]
+        {
+            bridges.push(SynthesizedBridge {
+                link: PathCellLink {
+                    from_cell: from,
+                    to_cell: to,
+                    // Retained as a sentinel for diagnostics; waypoints use
+                    // the explicit crossing geometry above.
+                    edge_vertex_a: u32::MAX,
+                    edge_vertex_b: u32::MAX,
+                    ok_bits: bits,
+                    cost,
+                },
+                exit,
+                entry,
             });
         }
     }
@@ -1178,6 +1216,24 @@ pub(crate) mod tests {
 
     fn service(db: PathDatabase) -> PathfindingService {
         PathfindingService::new(Arc::new(db))
+    }
+
+    /// Split the last cell away from the first two and make it deliberately
+    /// wide, so a bridge's measured one-unit gap is visibly different from
+    /// the destination cell center.
+    fn separated_wide_last_cell_db() -> PathDatabase {
+        let mut db = three_cell_db(PathCellFlags::empty());
+        db.links.truncate(1);
+        let first = db.vertices.len() as u32;
+        db.vertices.extend([
+            vec3(5.0, 0.0, 0.0),
+            vec3(9.0, 0.0, 0.0),
+            vec3(9.0, 0.0, 2.0),
+            vec3(5.0, 0.0, 2.0),
+        ]);
+        db.cells[2].center = vec3(7.0, 0.0, 1.0);
+        db.cells[2].vertex_indices = vec![first, first + 1, first + 2, first + 3];
+        db
     }
 
     #[test]
@@ -1307,6 +1363,57 @@ pub(crate) mod tests {
             .expect("nav_bridges must synthesize a crossing");
         assert_eq!(path[0], vec3(1.0, 0.0, 1.0));
         assert_eq!(*path.last().unwrap(), vec3(5.0, 0.0, 1.0));
+    }
+
+    #[test]
+    fn bridge_validation_uses_the_measured_crossing() {
+        use std::cell::RefCell;
+
+        let checked = RefCell::new(Vec::new());
+        let validator = |from, to| {
+            checked.borrow_mut().push((from, to));
+            true
+        };
+        let service = PathfindingService::with_nav_options(
+            Arc::new(separated_wide_last_cell_db()),
+            true,
+            Some(&validator),
+        );
+        assert_eq!(service.bridge_link_count(), 2);
+
+        let checked = checked.borrow();
+        assert_eq!(checked.len(), 1, "one undirected bridge is validated once");
+        let lift = vec3(0.0, 3.5 / SCALE_FACTOR, 0.0);
+        assert_eq!(
+            checked[0],
+            (vec3(4.0, 0.0, 0.0) + lift, vec3(5.0, 0.0, 0.0) + lift),
+            "validation must sweep the closest vertex pair, not the distant cell centers"
+        );
+    }
+
+    #[test]
+    fn bridge_waypoints_include_exit_and_entry_points() {
+        let service = PathfindingService::with_nav_options(
+            Arc::new(separated_wide_last_cell_db()),
+            true,
+            None,
+        );
+        let path = service
+            .find_path(vec3(1.0, 0.0, 1.0), vec3(8.5, 0.0, 1.0), MovementBits::WALK)
+            .expect("nav bridge should connect the separated cell");
+
+        assert!(
+            path.contains(&vec3(4.0, 0.0, 0.0)),
+            "route must leave the source cell at the measured bridge exit: {path:?}"
+        );
+        assert!(
+            path.contains(&vec3(5.0, 0.0, 0.0)),
+            "route must enter the destination cell at the measured bridge entry: {path:?}"
+        );
+        assert!(
+            !path.contains(&vec3(7.0, 0.0, 1.0)),
+            "route must not detour through the destination cell center: {path:?}"
+        );
     }
 
     #[test]
@@ -1530,7 +1637,8 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 1,
                 stressed_retries: 0,
-                no_route: 0
+                no_route: 0,
+                partial_searches: 0,
             }
         );
 
@@ -1543,7 +1651,8 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 2,
                 stressed_retries: 1,
-                no_route: 0
+                no_route: 0,
+                partial_searches: 0,
             }
         );
 
@@ -1559,8 +1668,26 @@ pub(crate) mod tests {
             PathfindingStats {
                 queries: 3,
                 stressed_retries: 2,
-                no_route: 1
+                no_route: 1,
+                partial_searches: 0,
             }
+        );
+    }
+
+    #[test]
+    fn stats_report_partial_route_searches() {
+        let mut db = three_cell_db(PathCellFlags::empty());
+        db.links.truncate(1);
+        let service = service(db);
+
+        service
+            .find_path_toward(vec3(1.0, 0.0, 1.0), vec3(5.0, 0.0, 1.0), MovementBits::WALK)
+            .expect("fixture must run a partial-route Dijkstra");
+
+        assert_eq!(
+            service.stats().partial_searches,
+            1,
+            "partial-route Dijkstra must be visible in telemetry"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -34,6 +34,11 @@ const PLAYER_STANDING_RADIUS: f32 = 1.2;
 /// axis, so "in front of the eye" is only outside the collider beyond this).
 pub const PLAYER_STANDING_RADIUS_WORLD: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 
+/// Conservative living-creature radius used to vet synthesized navigation
+/// crossings. Three Dark feet covers the widest current creature capsule and
+/// matches path waypoint corner clearance.
+pub const NAV_ACTOR_SWEEP_RADIUS_WORLD: f32 = 3.0 / SCALE_FACTOR;
+
 /// Height of the player's head sphere above the body origin (SS2 ft),
 /// `(PLAYER_HEIGHT / 2) - PLAYER_RADIUS` in the original game's collision
 /// profile. The original's first-person camera is anchored to this submodel,
@@ -4210,6 +4215,106 @@ impl PhysicsWorld {
         )
     }
 
+    /// Populate Rapier's broad-phase acceleration structure without advancing
+    /// simulation time.
+    ///
+    /// Mission construction needs spatial queries after all colliders exist
+    /// but before the first physics frame. Rapier normally builds this index
+    /// inside `PhysicsPipeline::step`; inserting only the collider AABBs keeps
+    /// load-time validation read-only and leaves both collider changes and
+    /// collision-pair events for the normal first step.
+    pub fn prepare_spatial_queries(&mut self) {
+        let aabbs: Vec<_> = self
+            .collider_set
+            .iter()
+            .filter(|(_, collider)| collider.is_enabled())
+            .map(|(handle, collider)| {
+                (
+                    handle,
+                    collider.compute_broad_phase_aabb(
+                        &self.integration_parameters,
+                        &self.rigid_body_set,
+                    ),
+                )
+            })
+            .collect();
+        for (handle, aabb) in aabbs {
+            self.broad_phase
+                .set_aabb(&self.integration_parameters, handle, aabb);
+        }
+    }
+
+    /// Whether a creature-width sphere can move between two torso-height
+    /// points without hitting actor-solid world/entity geometry.
+    ///
+    /// `pass_through` excludes transient or operable blockers such as living
+    /// creatures and doors. Collision groups still use an ACTOR membership,
+    /// so interaction-only fixtures that opt out of character collision do
+    /// not reject a navigation crossing.
+    pub fn actor_sweep_is_clear(
+        &self,
+        start: Point3<f32>,
+        end: Point3<f32>,
+        radius: f32,
+        pass_through: impl Fn(EntityId) -> bool,
+    ) -> bool {
+        let delta = end - start;
+        let distance = delta.magnitude();
+        if !radius.is_finite()
+            || radius <= 0.0
+            || !distance.is_finite()
+            || !start.x.is_finite()
+            || !start.y.is_finite()
+            || !start.z.is_finite()
+        {
+            return false;
+        }
+
+        let predicate = |_handle: ColliderHandle, collider: &Collider| {
+            if collider.is_sensor()
+                || EntityId::from_inner(collider.user_data as u64).is_some_and(&pass_through)
+            {
+                return false;
+            }
+            let aabb = collider.compute_aabb();
+            aabb.mins.iter().all(|v| v.is_finite())
+                && aabb.extents().iter().all(|e| e.is_finite() && *e > 1.0e-5)
+        };
+        let filter = QueryFilter::default()
+            .exclude_sensors()
+            .groups(InteractionGroups::new(
+                InternalCollisionGroups::ACTOR.bits.into(),
+                (InternalCollisionGroups::WORLD.bits | InternalCollisionGroups::ENTITIES.bits)
+                    .into(),
+                Default::default(),
+            ))
+            .predicate(&predicate);
+        let queries = self.broad_phase.as_query_pipeline(
+            self.narrow_phase.query_dispatcher(),
+            &self.rigid_body_set,
+            &self.collider_set,
+            filter,
+        );
+        let shape = Ball::new(radius);
+        let position = Isometry::translation(start.x, start.y, start.z);
+        if distance <= 1.0e-6 {
+            return queries.intersect_shape(position, &shape).next().is_none();
+        }
+        queries
+            .cast_shape(
+                &position,
+                &vec_to_nvec(delta / distance),
+                &shape,
+                rapier3d::parry::query::ShapeCastOptions {
+                    max_time_of_impact: distance,
+                    target_distance: 0.0,
+                    stop_at_penetration: false,
+                    compute_impact_geometry_on_penetration: true,
+                },
+            )
+            .is_none()
+    }
+
     fn ray_cast2_with_memberships(
         &self,
         query_memberships: InternalCollisionGroups,
@@ -6003,6 +6108,46 @@ mod tests {
             (end.x - start.x).abs() < 0.02,
             "player must not be dragged along by a wall they only brush: moved {} in x",
             end.x - start.x,
+        );
+    }
+
+    #[test]
+    fn actor_sweep_catches_width_obstruction_that_a_center_ray_misses() {
+        let (mut world, _player) = world_with_floor();
+        let wall_id = EntityId::from_inner(2090).unwrap();
+        world.add_kinematic(
+            wall_id,
+            vec3(0.0, 1.4, 0.8),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 3.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.prepare_spatial_queries();
+        let start = point3(-2.0, 1.4, 0.0);
+        let end = point3(2.0, 1.4, 0.0);
+        assert!(
+            world
+                .ray_cast2_as_actor(
+                    start,
+                    end - start,
+                    (end - start).magnitude(),
+                    InternalCollisionGroups::WORLD | InternalCollisionGroups::ENTITIES,
+                    None,
+                    true,
+                )
+                .is_none(),
+            "the old point-ray validator must miss this off-center obstruction"
+        );
+        assert!(
+            !world.actor_sweep_is_clear(start, end, NAV_ACTOR_SWEEP_RADIUS_WORLD, |_| false),
+            "a creature-width sweep must reject the same crossing"
+        );
+        assert!(
+            world
+                .actor_sweep_is_clear(start, end, NAV_ACTOR_SWEEP_RADIUS_WORLD, |id| id == wall_id),
+            "operable/transient entities can be explicitly passed through"
         );
     }
 

--- a/tools/shock2-sdk/src/game.ts
+++ b/tools/shock2-sdk/src/game.ts
@@ -380,7 +380,7 @@ export class EntitiesApi {
   }
 
   /**
-   * Inject a script message into an entity (damage, frob, AI signal).
+   * Inject a debug entity message (damage, frob, AI signal, lock state).
    *
    * The message is queued and delivered on the next step(); throws if the
    * entity is not found or not alive.
@@ -618,7 +618,9 @@ export class PathfindingApi {
    * Monotonic pathfinding query counters, or null when the scene has no
    * pathfinding data. Diff snapshots across steps to measure per-frame load.
    * Counts every find_path caller, including unbudgeted ones (e.g. the
-   * interactive pathfinding test).
+   * interactive pathfinding test). The number of graph searches is `queries +
+   * stressed_retries + partial_searches`; the last term counts the
+   * full-component Dijkstra fallback hidden behind an unreachable full route.
    */
   async stats(): Promise<PathfindingStats | null> {
     return this.client.get<PathfindingStats | null>("/v1/pathfinding/stats");

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -72,6 +72,7 @@ export interface PathfindingStats {
   queries: number;
   stressed_retries: number;
   no_route: number;
+  partial_searches: number;
 }
 
 export interface PathfindingTestStatus {
@@ -96,6 +97,7 @@ export type DebugEntityMessage =
   | { type: "Frob" }
   | { type: "Signal"; name: string }
   | { type: "SetAlertness"; level: "Lowest" | "Low" | "Moderate" | "High" }
+  | { type: "SetLocked"; locked: boolean }
   // Switch-link activate/deactivate - what a tripwire/button sends to its targets.
   | { type: "TurnOn" }
   | { type: "TurnOff" };

--- a/tools/shock2-sdk/test/locked-door-pathfinding.e2e.test.ts
+++ b/tools/shock2-sdk/test/locked-door-pathfinding.e2e.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Medsci's real Sci Med door (mission object 72) sits on the short route
+// between this OG-Pipe and the target point north of the threshold; a much
+// longer route around it remains available. Runtime ids vary, so both objects
+// are discovered through their stable mission-object template ids.
+const SCI_MED_DOOR = 72;
+const SOUTH_OG_PIPE = 596;
+const NORTH_OF_DOOR = { x: 23.3, y: 0.5, z: 20.0 };
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "medsci1: locking a real door removes it from a pursuing AI's route",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8148),
+    });
+    await game.step({ frames: 10 });
+
+    const [door] = await game.entities.byTemplate(SCI_MED_DOOR);
+    const [pursuer] = await game.entities.byTemplate(SOUTH_OG_PIPE);
+    assert.ok(door, `expected Sci Med door object ${SCI_MED_DOOR}`);
+    assert.ok(pursuer, `expected living OG-Pipe object ${SOUTH_OG_PIPE}`);
+
+    await game.player.teleport(NORTH_OF_DOOR);
+    await game.input.trigger("DebugForceChase");
+    await game.step({ frames: 120 });
+
+    const unlocked = (await game.pathfinding.aiPaths()).find(
+      (entry) => entry.entity_id === pursuer.id,
+    );
+    assert.equal(unlocked?.outcome, "Full", JSON.stringify(unlocked));
+    assert.ok(
+      unlocked!.waypoints.some(
+        ([x, _y, z]) => Math.hypot(x - door.position[0], z - door.position[2]) < 4.0,
+      ),
+      `unlocked route must pass the real door at ${JSON.stringify(door.position)}: ${JSON.stringify(unlocked)}`,
+    );
+
+    // Set Dark's live P$Locked property on the concrete door. The next mission
+    // update synchronizes that authored object id through GlobalTemplateIdMap
+    // into PathfindingService's door state before the AI retries its pursuit.
+    await game.entities.sendMessage(door.id, { type: "SetLocked", locked: true });
+    // An unrelated pursuing AI can already have opened the shared doorway.
+    // Drive the real StdDoor close edge as mission logic would; once closed,
+    // the lock makes its BELOW_DOOR cells impassable.
+    await game.entities.sendMessage(door.id, { type: "TurnOff" });
+    await game.step({ frames: 180 });
+
+    const lockedDoor = await game.entities.detail(door.id);
+    assert.equal(
+      lockedDoor.properties.find((property) => property.name === "Locked")?.value,
+      "true",
+    );
+    assert.equal(
+      lockedDoor.properties.find((property) => property.name === "DoorBlocksPathfinding")?.value,
+      "true",
+    );
+
+    // The pursuer may still be following the route it obtained before the
+    // lock. Restart its pursuit so the assertion observes a fresh query made
+    // against the synchronized live door state.
+    await game.input.trigger("DebugCalmAll");
+    await game.step({ frames: 30 });
+    await game.input.trigger("DebugForceChase");
+    await game.step({ frames: 120 });
+
+    const locked = (await game.pathfinding.aiPaths()).find(
+      (entry) => entry.entity_id === pursuer.id,
+    );
+    assert.ok(locked, "pursuer should publish its post-lock route attempt");
+    assert.equal(locked.outcome, "Full", JSON.stringify(locked));
+    assert.ok(
+      locked.waypoints.length > unlocked.waypoints.length,
+      `locked route must take the longer way around: ${JSON.stringify({ unlocked, locked })}`,
+    );
+    assert.ok(
+      locked.waypoints.every(
+        ([x, _y, z]) => Math.hypot(x - door.position[0], z - door.position[2]) >= 4.0,
+      ),
+      `post-lock route must not cross the door: ${JSON.stringify(locked)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Reproduction

On exact base `3ae2445d97d071c955a91867476d0909f277ddb7`, all five follow-up gaps were present:

- mission loading vetted synthesized crossings with a zero-width ray between cell centers, so an off-center obstruction inside a creature's footprint was accepted;
- synthesized links used `u32::MAX` edge sentinels, making waypoint generation fall back to the destination cell center instead of the closest-vertex crossing that qualified the bridge;
- telemetry exposed A* calls and stressed retries, but not the full-component partial-route Dijkstra hidden behind one frame-budget slot;
- `find_path_toward` and `find_closest_reachable_cell` duplicated the same `dijkstra_all` plus nearest-cell selection;
- locked-door synchronization had only synthetic unit coverage and no real mission SDK scenario.

The new bridge-geometry, obstruction, and partial-search tests were added first and failed on base: validation observed cell centers, routes omitted the measured exit/entry points, an off-center actor-width obstruction was accepted by the old point ray, and partial Dijkstra work had no counter. The real-door scenario likewise had no supported SDK lock-state setup on base.

## Fix

- Preserve each synthesized bridge's measured directional exit/entry pair and route through both points.
- Price the actual center → exit → gap → entry → center traversal.
- Prepare Rapier's load-time spatial-query BVH without advancing physics, then reject crossings that fail a widest-creature sphere sweep over the exact measured gap. Operable doors, the player, and living creatures remain transient pass-through entities.
- Add `partial_searches` to Rust/debug/SDK telemetry, making graph-search load measurable as `queries + stressed_retries + partial_searches`.
- Share one reachable-set/nearest-goal Dijkstra helper between partial routes and closest-reachable-cell queries.
- Add a real `medsci1.mis` SDK E2E: discover the authored Sci Med door and OG-Pipe by stable template IDs, prove the unlocked pursuit uses the door, lock and close it through live mission state, then prove a fresh pursuit takes the longer full route and never crosses the door.

`SetLocked` is narrowly exposed as debug scenario setup; the product behavior under test remains the real `P$Locked` property, StdDoor state, mission object-ID mapping, live door-state synchronization, and production pathfinding service.

## Benchmark

Command before and after:

```text
cargo bn path bench --all --queries 200 --seed 485 --bridges --json
```

Per-mission success/no-route counts, lookup mismatches, and bridge counts were unchanged. Representative fixed-seed results (microseconds, p50/p95/max):

| Mission | Metric | Base | Fix |
| --- | --- | ---: | ---: |
| medsci1 | find path | 470 / 727 / 2106 | 469 / 754 / 2176 |
| medsci1 | toward | 860 / 982 / 1021 | 884 / 965 / 1142 |
| medsci1 | mean / p95 inflation | 1.776581 / 3.122213 | 1.776455 / 3.122213 |
| eng1 | find path | 553 / 682 / 763 | 554 / 688 / 745 |
| eng1 | toward | 700 / 792 / 864 | 719 / 811 / 820 |
| eng1 | mean / p95 inflation | 2.363539 / 5.454073 | 2.363079 / 5.454073 |

The small timing movement is run-to-run noise; topology is stable, while mean inflation improves slightly from routing through the measured crossing geometry.

## Verification

- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — pass
- `cargo test -p shock2vr` — 522 passed, 0 failed; 2 doctests ignored
- post-rebase `cargo test -p shock2vr pathfinding::tests` — 25 passed
- post-rebase actor sweep test — 1 passed
- `npm test` — 26 passed, 0 failed; 191 opt-in scenarios skipped
- focused ladder/projectile/locked-door isolation — 6 passed, 0 failed
- post-rebase locked-door E2E — 1 passed, 0 failed
- full `npm run test:e2e` — 213 passed, 1 failed, 3 explicit SHODAN fixture skips; all 23 mission loads and every issue-relevant scenario passed. The sole failure, `a loaded corpse does not replay its death`, is unrelated and was independently reproduced on untouched base `607c1ce` during this sweep.

## Visual verification

![Matched MedSci nav bridge route](https://gist.githubusercontent.com/tommy-xr/1b7f41b75df4c5a616787b1bde180a24/raw/issue485-nav-bridge-comparison.gif)

<sub>The same deterministic MedSci route and camera pan: the base center fallback produces a sharp double-zigzag, while explicit synthesized exit/entry geometry yields one clean crossing.</sub>

### Before → after

![Before and after synthesized bridge geometry](https://gist.githubusercontent.com/tommy-xr/1b7f41b75df4c5a616787b1bde180a24/raw/issue485-nav-bridge-before-after.png)

Fixes #485
