### PR TITLE
fix(gameplay): honor scripted world pickup

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -456,4 +456,26 @@ mod tests {
             "a MOVE-only PropKeySrc pickup must run its injected keycard Frob path"
         );
     }
+
+    #[test]
+    fn world_use_of_authored_move_and_script_dispatches_frob() {
+        let mut world = World::new();
+        let quest_item = world.add_entity(frob_info(FrobFlag::MOVE | FrobFlag::SCRIPT));
+        let mut controller = FlatPlayerController::new();
+
+        let effects = controller.pick_up(&world, quest_item);
+
+        assert!(
+            matches!(
+                effects.as_slice(),
+                [VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                }] if *to == quest_item
+            ),
+            "an authored MOVE | SCRIPT pickup must run its Frob path exactly once; got {effects:?}"
+        );
+    }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -523,13 +523,25 @@ pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
 }
 
 /// Whether taking this world item must go through a script before the physical
-/// transfer. `PropKeySrc` items receive an `internal_keycard` script at runtime
-/// even when their authored world action is only `MOVE`.
+/// transfer. An authored `SCRIPT` world action owns its side effects and item
+/// fate (for example `FrobQB` awards a quest bit and moves the item exactly
+/// once). `PropKeySrc` items also receive an `internal_keycard` script at
+/// runtime even when their authored world action is only `MOVE`.
 pub(crate) fn uses_scripted_world_frob(world: &World, entity_id: EntityId) -> bool {
-    world
+    let has_authored_world_script = world
+        .borrow::<View<PropFrobInfo>>()
+        .map(|frob_info| {
+            frob_info
+                .get(entity_id)
+                .is_ok_and(|frob_info| frob_info.world_action.contains(FrobFlag::SCRIPT))
+        })
+        .unwrap_or(false);
+    let has_derived_keycard_script = world
         .borrow::<View<dark::properties::PropKeySrc>>()
         .map(|keycards| keycards.get(entity_id).is_ok())
-        .unwrap_or(false)
+        .unwrap_or(false);
+
+    has_authored_world_script || has_derived_keycard_script
 }
 
 /// Whether an inventory item is a wieldable weapon - a gun (`PropPlayerGun`) or

--- a/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
+++ b/tools/shock2-sdk/test/world-frob-pickup.e2e.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
@@ -45,10 +45,40 @@ test(
       );
     }
 
-    // The circuit board is MOVE | SCRIPT. Its existing FrobQB path must still
-    // both transfer the unique board and award the authored quest bit.
-    await game.entities.sendMessage(circuitBoard.id, { type: "Frob" });
+    // The circuit board is MOVE | SCRIPT. Take it through the production flat
+    // crosshair/squeeze path: the controller must route the authored SCRIPT
+    // action through FrobQB instead of bypassing it with a bare StoreItem.
+    assert.equal(await game.quests.get("note_1_10"), "unknown");
+    assert.equal(
+      (await game.physics.bodies({ entityId: circuitBoard.id })).bodies.length,
+      1,
+      "the authored circuit board should begin as a physical world item",
+    );
+    const modulesBefore = (await game.info()).player.stats?.cyber_modules;
+    assert.equal(modulesBefore, 0, "a fresh eng1 character starts with no modules");
+
+    const [boardX, boardY, boardZ] = (
+      await game.entities.detail(circuitBoard.id)
+    ).position;
+    await game.player.teleport({
+      x: boardX + 0.2,
+      y: boardY - PLAYER_EYE_HEIGHT_WORLD,
+      z: boardZ,
+    });
+    const aim = await game.player.aimAt(circuitBoard, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `the circuit board should expose a selectable surface: ${JSON.stringify(aim)}`,
+    );
+    await game.input.set("right_hand.squeeze_value", 1);
     await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 5 });
+
     const inventory = await game.player.inventory();
     assert.equal(
       inventory.items.find((entry) => entry.entity_id === circuitBoard.id)
@@ -60,6 +90,37 @@ test(
       await game.quests.get("note_1_10"),
       "complete",
       "circuit board FrobQB must still award note_1_10",
+    );
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      10,
+      "the same single Frob should relay the authored +10 module reward exactly once",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: circuitBoard.id })).bodies.length,
+      0,
+      "the collected circuit board should no longer have a world body",
+    );
+
+    const saveName = `world_frob_scripted_pickup_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+
+    const [loadedBoard] = await game.entities.byTemplate(CIRCUIT_BOARD_OBJ);
+    assert.ok(loadedBoard, "save/load should restore the unique circuit board");
+    assert.equal(
+      (await game.player.inventory()).items.find(
+        (entry) => entry.entity_id === loadedBoard.id,
+      )?.location,
+      "inventory",
+      "save/load must preserve the scripted pickup in the backpack",
+    );
+    assert.equal(await game.quests.get("note_1_10"), "complete");
+    assert.equal(
+      (await game.info()).player.stats?.cyber_modules,
+      10,
+      "save/load must preserve one reward without replaying the pickup",
     );
   },
 );


### PR DESCRIPTION
Fixes #579

## Problem

Flat crosshair pickup treated every ordinary movable object as a direct `StoreItem`. That bypassed an authored `PropFrobInfo` world `SCRIPT` action, so `FrobQB` never ran for quest pickups such as Engineering's circuit board 705 or Command's Sympathetic Resonator.

The item still appeared in the backpack, which hid the lost quest and linked effects.

## Fix

- Route authored world `SCRIPT` actions through the normal `Frob` message.
- Preserve the existing derived `PropKeySrc` route for MOVE-only keycards.
- Emit no parallel `StoreItem`; the authored script remains the sole owner of transfer and side effects.

The VR trigger path already emits `Frob`, so authored scripted use is available there. Physical VR squeeze/grip remains `HoldItem`; changing that distinct interaction into automatic backpack storage would alter tool and held-object semantics.

## Negative-first evidence

At the test-only commit, both regressions failed before the implementation:

- Fresh `eng1.mis`: a visibility-confirmed two-frame squeeze moved circuit board 705 into inventory but left `note_1_10` unknown and awarded zero modules.
- Local-only integration on PR #875: a real Command purchase and visible squeeze moved the Resonator into inventory but left `note_6_7` unknown instead of incomplete.

Both pass with this fix. The committed Engineering scenario is main-only and independent of #875; the Command integration ref was not pushed.

## Validation

- `cargo test -p shock2vr` — 519 passed
- `npm test` in `tools/shock2-sdk` — 26 passed, 190 E2E-gated
- Focused production E2Es: container loot, ordinary flat world pickup, scripted world pickup — 3 passed
- Scripted circuit-board E2E verifies exact-once +10 modules, quest completion, inventory/body transition, and cold save/load persistence
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --check --all`
- `git diff --check`
- Full SDK run — 212 passed, 3 intentionally gated SHODAN scenarios skipped, 1 pre-existing baseline failure: `a loaded corpse does not replay its death` fails identically on this head and exact `origin/main` (`3ae2445d`); the new scripted-pickup scenario passes in the full run

Campaign diagnostic retained locally only: `campaign_cmd25_i37_command1_bomb_inventory_hp7_ap2_20260810.sav`, 13,758,986 bytes, SHA-256 `554570ddab9e17e4f2ad7292c5ba014276facaed26d7645c49657185a6371cb9`.

## Visuals

![Scripted circuit-board pickup demo](https://gist.githubusercontent.com/tommy-xr/0a8316f6d7177fd72c7bf368808a3a7e/raw/scripted-world-pickup.gif)

<sub>Fresh `eng1.mis`, circuit board 705: the same visibility-confirmed surface aim and exact two-frame flat squeeze stores the item on both refs; the fix also runs authored `FrobQB`, completing the objective and awarding 10 cyber modules. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Scripted circuit-board pickup before/after](https://gist.githubusercontent.com/tommy-xr/0a8316f6d7177fd72c7bf368808a3a7e/raw/scripted-world-pickup-before-after.png)
