### PR TITLE
fix(interaction): bound frob to retail reach

### DIFF
--- a/shock2vr/src/flat_player_controller.rs
+++ b/shock2vr/src/flat_player_controller.rs
@@ -24,7 +24,7 @@ use crate::{
     scripts::{Message, MessagePayload},
     util::resolve_proxy_entity,
     virtual_hand::{
-        VirtualHandEffect, can_grab_item, is_wieldable_weapon, uses_scripted_world_frob,
+        FROB_REACH, VirtualHandEffect, can_grab_item, is_wieldable_weapon, uses_scripted_world_frob,
     },
 };
 
@@ -158,14 +158,17 @@ impl FlatPlayerController {
         let forward = look.rotate_vector(vec3(0.0, 0.0, -1.0));
         self.last_aim = Some((point3(camera_pos.x, camera_pos.y, camera_pos.z), forward));
         let highlighted = physics
-            .ray_cast(
+            .ray_cast2(
                 point3(camera_pos.x, camera_pos.y, camera_pos.z),
                 forward,
+                FROB_REACH,
                 InternalCollisionGroups::ENTITIES
                     | InternalCollisionGroups::SELECTABLE
                     | InternalCollisionGroups::WORLD
                     | InternalCollisionGroups::UI
                     | InternalCollisionGroups::RAYCAST,
+                None,
+                true,
             )
             .and_then(|r| r.maybe_entity_id)
             .map(|e| resolve_proxy_entity(world, e))
@@ -299,6 +302,8 @@ fn is_frobbable(world: &World, entity_id: EntityId) -> bool {
 mod tests {
     use super::*;
     use dark::properties::{FrobFlag, KeyCard, PropFrobInfo, PropKeySrc, PropPlayerGun};
+
+    use crate::physics::CollisionGroup;
 
     fn frob_info(world_action: FrobFlag) -> PropFrobInfo {
         PropFrobInfo {
@@ -476,6 +481,58 @@ mod tests {
                 }] if *to == quest_item
             ),
             "an authored MOVE | SCRIPT pickup must run its Frob path exactly once; got {effects:?}"
+        );
+    }
+
+    /// Retail `GAMEPARAM` authors `Frob Dist = 50`, which the original picker
+    /// treats as squared SS2 units. After this engine's 2.5 world-scale divide,
+    /// a surface farther than `sqrt(50) / 2.5` must not highlight or frob.
+    #[test]
+    fn crosshair_does_not_frob_a_visible_entity_beyond_retail_reach() {
+        let mut world = World::new();
+        let target = world.add_entity(frob_info(FrobFlag::SCRIPT));
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, 0.0, -4.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+        let mut player = physics.create_player(
+            vec3(100.0, 100.0, 100.0),
+            EntityId::from_inner(1000).unwrap(),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+
+        let ray_hit = physics
+            .ray_cast(
+                point3(0.0, 0.0, 0.0),
+                vec3(0.0, 0.0, -1.0),
+                InternalCollisionGroups::SELECTABLE,
+            )
+            .expect("the fixture target must remain visible to an unbounded ray");
+        assert_eq!(ray_hit.maybe_entity_id, Some(target));
+
+        let (effects, highlighted) = FlatPlayerController::new().update(
+            &Hand {
+                squeeze_value: 1.0,
+                ..Hand::default()
+            },
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            0.0,
+            &world,
+            &physics,
+        );
+
+        assert_eq!(highlighted, None, "out-of-reach objects must not highlight");
+        assert!(
+            effects.is_empty(),
+            "out-of-reach use must emit no frob effects, got {effects:?}"
         );
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -1,7 +1,10 @@
 // Helper to convert the input context to a form more useful for gameplay / interacting with the world
 
 use cgmath::{InnerSpace, Matrix4, Quaternion, Rotation, Vector3, Zero, point3, vec3};
-use dark::properties::{FrobFlag, PropFrobInfo, PropModelName};
+use dark::{
+    SCALE_FACTOR,
+    properties::{FrobFlag, PropFrobInfo, PropModelName},
+};
 use engine::scene::SceneObject;
 use engine::script_log;
 
@@ -19,6 +22,12 @@ use crate::{
 };
 
 const HAND_OFFSET: Vector3<f32> = vec3(0.0, 0.0, 0.0);
+
+/// Maximum world-space distance from the hand/eye to a frob target's visible
+/// surface. Retail `shock2.gam` authors `GAMEPARAM.Frob Dist = 50`; the
+/// original `PickSetFocus` treats that as squared SS2 units, while this engine
+/// divides authored world geometry by [`SCALE_FACTOR`].
+pub(crate) const FROB_REACH: f32 = 7.071_068 / SCALE_FACTOR;
 
 #[derive(Clone)]
 pub struct VirtualHand {
@@ -665,7 +674,6 @@ fn interaction_ray_cast(
     forward: Vector3<f32>,
     entity_to_ignore: Option<EntityId>,
 ) -> Option<RayCastResult> {
-    const MAX_INTERACTION_DISTANCE: f32 = 100.0;
     let ordinary_groups = InternalCollisionGroups::ENTITIES
         | InternalCollisionGroups::SELECTABLE
         | InternalCollisionGroups::WORLD
@@ -673,7 +681,7 @@ fn interaction_ray_cast(
     let ui_hit = physics.ray_cast2(
         ray_start,
         forward,
-        MAX_INTERACTION_DISTANCE,
+        FROB_REACH,
         InternalCollisionGroups::UI,
         entity_to_ignore,
         true,
@@ -711,7 +719,7 @@ fn interaction_ray_cast(
             .ray_cast2(
                 ray_start,
                 forward,
-                MAX_INTERACTION_DISTANCE,
+                FROB_REACH,
                 ordinary_groups | InternalCollisionGroups::UI,
                 entity_to_ignore,
                 true,
@@ -1140,6 +1148,83 @@ mod tests {
         assert!(
             frobbed_second,
             "a new target under the hand must be Frobbed even though squeeze never released, got {effects:?}"
+        );
+    }
+
+    fn frob_fixture(distance: f32) -> (World, PhysicsWorld, EntityId) {
+        let mut world = World::new();
+        let target = world.add_entity(PropFrobInfo {
+            world_action: FrobFlag::SCRIPT,
+            inventory_action: FrobFlag::empty(),
+            tool_action: FrobFlag::empty(),
+        });
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, 0.0, -distance),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+        let mut player = physics.create_player(
+            vec3(100.0, 100.0, 100.0),
+            EntityId::from_inner(1000).unwrap(),
+        );
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+        (world, physics, target)
+    }
+
+    /// Retail `GAMEPARAM` authors `Frob Dist = 50`, which the original picker
+    /// treats as squared SS2 units. After this engine's 2.5 world-scale divide,
+    /// a surface farther than `sqrt(50) / 2.5` must not highlight or frob.
+    #[test]
+    fn vr_hand_only_frobs_within_retail_reach() {
+        let input = Hand {
+            trigger_value: 1.0,
+            ..Hand::default()
+        };
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+
+        let (far_world, far_physics, _) = frob_fixture(4.0);
+        let (far_hand, far_effects) = VirtualHand::update(
+            &VirtualHand::new(Handedness::Right),
+            &far_physics,
+            &far_world,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            &input,
+            None,
+        );
+        assert_eq!(far_hand.get_raytraced_entity(), None);
+        assert!(
+            far_effects.is_empty(),
+            "an out-of-reach VR trigger must not frob, got {far_effects:?}"
+        );
+
+        let (near_world, near_physics, near_target) = frob_fixture(2.5);
+        let (near_hand, near_effects) = VirtualHand::update(
+            &VirtualHand::new(Handedness::Right),
+            &near_physics,
+            &near_world,
+            vec3(0.0, 0.0, 0.0),
+            identity,
+            &input,
+            None,
+        );
+        assert_eq!(near_hand.get_raytraced_entity(), Some(near_target));
+        assert!(
+            near_effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::OutMessage {
+                    message: Message {
+                        to,
+                        payload: MessagePayload::Frob,
+                    },
+                } if *to == near_target
+            )),
+            "an in-reach VR trigger should preserve frob behavior, got {near_effects:?}"
         );
     }
 }

--- a/tools/shock2-sdk/test/door-frob.e2e.test.ts
+++ b/tools/shock2-sdk/test/door-frob.e2e.test.ts
@@ -22,6 +22,15 @@ function distanceSquared(entity: EntitySummary, target: Vec3): number {
   );
 }
 
+async function distanceFromCamera(game: GameServer, point: Vec3): Promise<number> {
+  const { player } = await game.info();
+  return Math.hypot(
+    point[0] - player.position[0],
+    point[1] - (player.position[1] + player.camera_offset[1]),
+    point[2] - player.position[2],
+  );
+}
+
 test(
   "earth.mis: StdDoor Frob opens and closes its collider",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -61,9 +70,14 @@ test(
     const beforeBodies = (await game.physics.bodies({ entityId: door.id })).bodies;
     assert.equal(beforeBodies.length, 1, "the door should own one kinematic body");
 
-    const aim = await game.player.aimAt(door);
+    const aim = await game.player.aimAt(door, { visibility: "required" });
     assert.equal(aim.classification, "surface", JSON.stringify(aim));
     assert.equal(aim.entity_id, door.id);
+    assert.equal(aim.target_confirmed, true, JSON.stringify(aim));
+    assert.ok(
+      (await distanceFromCamera(game, aim.world_point)) < 2.83,
+      `closed door surface must be inside retail frob reach: ${JSON.stringify(aim)}`,
+    );
     await game.input.set("right_hand.squeeze_value", 1);
     await game.step({ frames: 2 });
     await game.input.set("right_hand.squeeze_value", 0);
@@ -80,7 +94,18 @@ test(
       "the kinematic collider must follow the opened door transform",
     );
 
-    await game.player.aimAt(door);
+    // The original staging point is over the recruitment-center pit once the
+    // leaf opens, so the player falls away during the one-second door motion.
+    // Restage just outside the open collider before testing the reverse frob.
+    await game.player.teleport({ x: 5.0, y: 24.0, z: 55.8 });
+    const openAim = await game.player.aimAt(door, { visibility: "required" });
+    assert.equal(openAim.classification, "surface", JSON.stringify(openAim));
+    assert.equal(openAim.entity_id, door.id);
+    assert.equal(openAim.target_confirmed, true, JSON.stringify(openAim));
+    assert.ok(
+      (await distanceFromCamera(game, openAim.world_point)) < 2.83,
+      `open door surface must be inside retail frob reach: ${JSON.stringify(openAim)}`,
+    );
     await game.input.set("right_hand.squeeze_value", 1);
     await game.step({ frames: 2 });
     await game.input.set("right_hand.squeeze_value", 0);

--- a/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-hacking.e2e.test.ts
@@ -73,14 +73,24 @@ test(
     // message would not prove an ordinary player can reach the feature.
     const [keypadX, keypadY, keypadZ] = keypadDetail.position;
     await teleportVerified(game, {
-      x: keypadX - 1.63,
+      // Preserve the existing clear approach vector while keeping the
+      // selectable surface inside retail's sqrt(50) / 2.5 frob reach.
+      x: keypadX - 0.98,
       y: keypadY - 1,
-      z: keypadZ + 3.25,
+      z: keypadZ + 1.95,
     });
     // Aim through the production look-at (it accounts for Earth's authored
     // body heading and reads the live camera height) rather than a fixed
     // pitch tuned to one camera position.
-    await game.input.lookAtWorldPoint(keypadDetail.position);
+    const keypadAim = await game.player.aimAt(keypad, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      keypadAim.target_confirmed,
+      true,
+      `keypad staging must expose its selectable surface: ${JSON.stringify(keypadAim)}`,
+    );
     await game.step({ frames: 2 });
     await game.input.set("right_hand.squeeze", 1);
     await game.step({ frames: 2 });

--- a/tools/shock2-sdk/test/frob-range.e2e.test.ts
+++ b/tools/shock2-sdk/test/frob-range.e2e.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Stable hydro2 mission-object id for the bulkhead button leading to hydro1.
+// Runtime entity ids are rediscovered on every launch.
+const HYDRO1_BULKHEAD_BUTTON = 998;
+
+async function pulseUse(game: GameServer): Promise<void> {
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 30 });
+}
+
+test(
+  "hydro2: a visible bulkhead button only frobs within the retail reach",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8237),
+    });
+    await game.step({ frames: 5 });
+
+    const [button] = await game.entities.byTemplate(HYDRO1_BULKHEAD_BUTTON);
+    assert.ok(button, "expected hydro2 Bulk_On_Button object 998");
+
+    // Retail GAMEPARAM authors Frob Dist = 50, interpreted by PickSetFocus as
+    // squared SS2 units. In this engine's /2.5 world scale that is
+    // sqrt(50) / 2.5 = 2.828 world units. Stage along the button's clear face
+    // beyond that reach, while keeping it visible and centered under the real
+    // flat crosshair.
+    await game.player.teleport({
+      x: button.position[0] - 4.5,
+      y: button.position[1],
+      z: button.position[2],
+    });
+    await game.step({ frames: 5 });
+    const farAim = await game.player.aimAt(button, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(farAim.target_confirmed, true, "far button must be unobstructed");
+    const farPlayer = await game.info();
+    const farDistance = Math.hypot(
+      farAim.world_point[0] - farPlayer.player.position[0],
+      farAim.world_point[1] -
+        (farPlayer.player.position[1] + farPlayer.player.camera_offset[1]),
+      farAim.world_point[2] - farPlayer.player.position[2],
+    );
+    assert.ok(
+      farDistance > 2.83,
+      `fixture must put the visible button beyond retail frob reach, got ${farDistance}`,
+    );
+
+    await pulseUse(game);
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "hydro2.mis",
+      "ordinary use must not trigger a visible but out-of-reach level transition",
+    );
+
+    // The same production aim/use path must remain functional at arm's reach.
+    await game.player.teleport({
+      x: button.position[0] - 2.5,
+      y: button.position[1],
+      z: button.position[2],
+    });
+    await game.step({ frames: 5 });
+    const nearAim = await game.player.aimAt(button, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(nearAim.target_confirmed, true, "near button must be unobstructed");
+    const nearPlayer = await game.info();
+    const nearDistance = Math.hypot(
+      nearAim.world_point[0] - nearPlayer.player.position[0],
+      nearAim.world_point[1] -
+        (nearPlayer.player.position[1] + nearPlayer.player.camera_offset[1]),
+      nearAim.world_point[2] - nearPlayer.player.position[2],
+    );
+    assert.ok(
+      nearDistance < 2.83,
+      `fixture must put the visible button within retail frob reach, got ${nearDistance}`,
+    );
+
+    await pulseUse(game);
+    assert.equal(
+      (await game.info()).mission.toLowerCase(),
+      "hydro1.mis",
+      "the same bulkhead button should transition when used within reach",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/picture-swap.e2e.test.ts
+++ b/tools/shock2-sdk/test/picture-swap.e2e.test.ts
@@ -34,9 +34,10 @@ async function frobThroughReticle(
   entity: { id: number; position: [number, number, number] },
 ): Promise<void> {
   // This side of rec1's picture has an unobstructed selectable surface. The
-  // teleport only stages the player; aim and frob use production paths.
+  // teleport only stages the player inside retail frob reach; aim and frob
+  // use production paths.
   await game.player.teleport({
-    x: entity.position[0] + 3,
+    x: entity.position[0] + 2.5,
     y: entity.position[1] - 1,
     z: entity.position[2],
   });


### PR DESCRIPTION
## Reproduction

On `origin/main` (`3ae2445`), I launched `hydro2.mis`, rediscovered mission object 998 (`Bulk_On_Button` leading to Hydro1), and staged the flat player at its clear face. The production aim helper confirmed the button was visible/selectable, with its hit surface beyond 2.83 runtime world units. An ordinary right-hand squeeze transitioned immediately to `hydro1.mis`; the negative-first E2E therefore failed with `actual hydro1.mis`, `expected hydro2.mis`.

The underlying flat and VR interaction paths both called the generic `PhysicsWorld::ray_cast`, whose 100-unit maximum made frob/highlight acquisition effectively unlimited.

## Faithful reach

Retail `shock2.gam`'s 76-byte `GAMEPARAM` chunk contains `Overlay Dist = 175` and `Frob Dist = 50`. The original Shock picker passes that value to `PickSetFocus`, stores it as its maximum distance squared, and rejects candidates when `(center distance - object radius)^2` exceeds it. Because shock2quest divides authored world geometry by `dark::SCALE_FACTOR` (2.5), the equivalent surface reach is `sqrt(50) / 2.5 = 2.828427` runtime world units.

## Fix

- Define that retail-derived world-space frob reach once and use bounded `ray_cast2` queries for both flat crosshair and VR hand selection/frob paths.
- Preserve the existing selectable/world/UI occlusion groups and sensor filtering.
- Leave flat weapon aim and projectile/fire rays unchanged.
- Add flat and VR regression tests, plus a real Hydro2 far-reject/near-accept SDK scenario.
- Restage three existing physical-frob E2E fixtures inside the now-enforced reach; each continues to use production aiming/input and explicitly verifies visibility where applicable.

This changes interaction eligibility rather than rendered output, so deterministic runtime evidence is more useful than a visual capture.

## Verification

- Negative-first Hydro2 E2E: **failed before the fix** by transitioning from Hydro2 to Hydro1 at the far staging point.
- Focused Hydro2 E2E after fix: **1 passed, 0 failed** (far squeeze remains Hydro2; near squeeze transitions Hydro1).
- Focused Rust reach tests: **2 passed, 0 failed** (flat + VR).
- `cargo test -p shock2vr`: **520 passed, 0 failed**.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: **passed**.
- `cargo fmt --all -- --check`: **passed**.
- SDK fast suite: **217 total, 26 passed, 191 E2E skipped, 0 failed**.
- Full SDK E2E rerun: **217 total, 212 passed, 2 failed, 3 skipped**. The new Hydro2 scenario, all three adjusted frob fixtures, all direct/relay level-transition tests, and all 23 mission loads passed. The two failures are outside this change:
  - existing corpse save/load mismatch: collision group restores as `entity` instead of the saved `actor`; reproduced standalone twice while behavior, pose, position, sleep, and mass remained exact;
  - intermittent AI search fixture: one aggregate run and one isolated retry received a null entity detail after the spawned monster disappeared. The same test passed the first aggregate run, a subsequent isolated branch retry, and an isolated clean detached `origin/main` (`3ae2445`) run.

Fixes #611
