### PR TITLE
fix(debug): validate raycast collision groups

### DIFF
--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -144,10 +144,10 @@ const screenshot = await game.screenshot('test.png');
 console.log(`Saved to ${screenshot.fullPath}`);
 
 // Physics queries
-const hit = await game.physics.raycast({
+const hit = await game.raycast({
   start: [0, 0, 0],
   end: [10, 0, 0],
-  groups: ['entity', 'level'],
+  collision_groups: ['world', 'entity'],
 });
 
 // Cleanup
@@ -281,13 +281,18 @@ curl -X POST http://127.0.0.1:8080/v1/player/teleport \
 # Raycast
 curl -X POST http://127.0.0.1:8080/v1/physics/raycast \
   -H "Content-Type: application/json" \
-  -d '{"start": [0,0,0], "end": [10,0,0], "collision_groups": ["entity", "level"]}'
+  -d '{"start": [0,0,0], "end": [10,0,0], "collision_groups": ["world", "entity"]}'
 
 # Screenshot
 curl -X POST http://127.0.0.1:8080/v1/screenshot \
   -H "Content-Type: application/json" \
   -d '{"filename": "test.png"}'
 ```
+
+Omitting `collision_groups` defaults to `["world", "entity"]`. Supported
+names are `world`, `entity`, `selectable`, `player`, `ui`, `hitbox`, `raycast`,
+and `all`; the older documented name `level` is accepted as an alias for
+`world`. Unknown names and explicit empty masks return HTTP 400.
 
 ## Key Files
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -905,7 +905,7 @@ fn process_command(
                 let mask = RaycastMask {
                     groups: request
                         .collision_groups
-                        .unwrap_or_else(|| vec!["entity".to_string(), "level".to_string()]),
+                        .unwrap_or_else(|| vec!["world".to_string(), "entity".to_string()]),
                     ignore_sensors: request.ignore_sensors.unwrap_or(false),
                 };
 
@@ -2923,16 +2923,64 @@ async fn list_transitions(
 }
 
 /// HTTP handler for physics raycast
+fn normalize_raycast_collision_groups(
+    collision_groups: Option<Vec<String>>,
+) -> Result<Vec<String>, (StatusCode, String)> {
+    const VALID_GROUPS: [&str; 8] = [
+        "world",
+        "entity",
+        "selectable",
+        "player",
+        "ui",
+        "hitbox",
+        "raycast",
+        "all",
+    ];
+
+    let Some(collision_groups) = collision_groups else {
+        return Ok(vec!["world".to_string(), "entity".to_string()]);
+    };
+    if collision_groups.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "collision_groups must contain at least one group".to_string(),
+        ));
+    }
+
+    collision_groups
+        .into_iter()
+        .map(|group| {
+            if group == "level" {
+                Ok("world".to_string())
+            } else if VALID_GROUPS.contains(&group.as_str()) {
+                Ok(group)
+            } else {
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "unknown collision group '{}'; expected one of: {} (level is an alias for world)",
+                        group,
+                        VALID_GROUPS.join(", ")
+                    ),
+                ))
+            }
+        })
+        .collect()
+}
+
 async fn perform_raycast(
     State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
-    LenientJson(request): LenientJson<RayCastRequest>,
-) -> Json<RayCastResult> {
+    LenientJson(mut request): LenientJson<RayCastRequest>,
+) -> Result<Json<RayCastResult>, (StatusCode, String)> {
+    request.collision_groups = Some(normalize_raycast_collision_groups(
+        request.collision_groups,
+    )?);
     let (reply_tx, reply_rx) = oneshot::channel();
 
     // Send raycast command to game loop
     if let Err(_) = command_tx.send(RuntimeCommand::RayCast(request, reply_tx)) {
         tracing::error!("Failed to send RayCast command - game loop receiver dropped");
-        return Json(RayCastResult {
+        return Ok(Json(RayCastResult {
             hit: false,
             hit_point: None,
             hit_normal: None,
@@ -2942,15 +2990,15 @@ async fn perform_raycast(
             body_id: None,
             collision_group: None,
             is_sensor: false,
-        });
+        }));
     }
 
     // Wait for response
     match reply_rx.await {
-        Ok(result) => Json(result),
+        Ok(result) => Ok(Json(result)),
         Err(_) => {
             tracing::error!("Failed to receive raycast result - sender dropped");
-            Json(RayCastResult {
+            Ok(Json(RayCastResult {
                 hit: false,
                 hit_point: None,
                 hit_normal: None,
@@ -2960,7 +3008,7 @@ async fn perform_raycast(
                 body_id: None,
                 collision_group: None,
                 is_sensor: false,
-            })
+            }))
         }
     }
 }
@@ -3563,5 +3611,37 @@ mod shutdown_tests {
             command_rx.try_recv(),
             Ok(RuntimeCommand::Shutdown)
         ));
+    }
+
+    #[test]
+    fn raycast_collision_groups_default_to_world_and_entity() {
+        assert_eq!(
+            normalize_raycast_collision_groups(None).unwrap(),
+            ["world", "entity"]
+        );
+    }
+
+    #[test]
+    fn raycast_collision_groups_preserve_level_as_world_alias() {
+        assert_eq!(
+            normalize_raycast_collision_groups(Some(vec!["level".to_string()])).unwrap(),
+            ["world"]
+        );
+    }
+
+    #[test]
+    fn raycast_collision_groups_reject_unknown_and_empty_masks() {
+        let unknown =
+            normalize_raycast_collision_groups(Some(vec!["bogus".to_string()])).unwrap_err();
+        assert_eq!(unknown.0, StatusCode::BAD_REQUEST);
+        assert!(unknown.1.contains("unknown collision group 'bogus'"));
+
+        let empty = normalize_raycast_collision_groups(Some(vec![])).unwrap_err();
+        assert_eq!(empty.0, StatusCode::BAD_REQUEST);
+        assert!(
+            empty
+                .1
+                .contains("collision_groups must contain at least one group")
+        );
     }
 }

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -108,12 +108,21 @@ await game.waitFor(
 
 // Screenshots and physics
 await game.screenshot("test.png");
-await game.raycast({ start: [0, 0, 0], end: [10, 0, 0] });
+await game.raycast({
+  start: [0, 0, 0],
+  end: [10, 0, 0],
+  collision_groups: ["world", "entity"],
+});
 
 // Recently played environmental sounds (resolved schema sample + query tags) -
 // the headless way to assert audio, e.g. weapon impact sounds.
 const { sounds } = await game.audio.recent();
 ```
+
+Raycasts default to `world` and `entity`. Supported groups are `world`,
+`entity`, `selectable`, `player`, `ui`, `hitbox`, `raycast`, and `all`;
+`level` remains accepted as an alias for `world`. Unknown groups and explicit
+empty masks are rejected with HTTP 400 instead of being reported as clear rays.
 
 To attach to a runtime you started yourself (`cargo dbgr -- --mission ... --port 8080`):
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -260,10 +260,23 @@ export interface ScreenshotResult {
   size_bytes: number;
 }
 
+export type RayCastCollisionGroup =
+  | "world"
+  | "entity"
+  | "selectable"
+  | "player"
+  | "ui"
+  | "hitbox"
+  | "raycast"
+  | "all"
+  /** Backward-compatible alias for `world`. */
+  | "level";
+
 export interface RayCastRequest {
   start: Vec3;
   end: Vec3;
-  collision_groups?: string[];
+  /** Defaults to `["world", "entity"]`; an explicit empty list is invalid. */
+  collision_groups?: RayCastCollisionGroup[];
   max_distance?: number;
   ignore_sensors?: boolean;
 }

--- a/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
+++ b/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  GameServer,
+  HttpClient,
+  HttpError,
+} from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const wallRay = {
+  start: [79.99, -1.5, 32.0] as [number, number, number],
+  end: [73.99, -1.96, 32.0] as [number, number, number],
+  ignore_sensors: true,
+};
+
+test(
+  "raycast validates collision groups and keeps the level alias world-visible",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_RAYCAST_PORT ?? 8260),
+    });
+    // The first physics update populates Rapier's query broad phase.
+    await game.step({ frames: 1 });
+
+    // `level` was advertised by the API and used by its old default. Keep it
+    // as a compatibility alias, but resolve it to the real `world` group.
+    const aliasHit = await game.raycast({
+      ...wallRay,
+      collision_groups: ["level"],
+    });
+    assert.equal(aliasHit.hit, true, "level alias should see Hydro2 world geometry");
+    assert.ok(
+      aliasHit.distance !== null && Math.abs(aliasHit.distance - 1.5947) < 0.01,
+      `expected the Hydro2 wall about 1.595 units away, got ${JSON.stringify(aliasHit)}`,
+    );
+
+    const client = new HttpClient(game.baseUrl);
+    await assert.rejects(
+      client.post("/v1/physics/raycast", {
+        ...wallRay,
+        collision_groups: ["bogus"],
+      }),
+      (error: unknown) =>
+        error instanceof HttpError &&
+        error.status === 400 &&
+        /unknown collision group 'bogus'/i.test(error.body),
+      "unknown group should receive a clear 400 response",
+    );
+    await assert.rejects(
+      game.raycast({ ...wallRay, collision_groups: [] }),
+      (error: unknown) =>
+        error instanceof HttpError &&
+        error.status === 400 &&
+        /collision_groups must contain at least one group/i.test(error.body),
+      "an explicit empty mask should receive a clear 400 response",
+    );
+
+    // Omission remains the convenient common case and must include world
+    // geometry. Start just outside the Midwife capsule so the wall is first.
+    const defaultHit = await game.raycast({
+      start: [79.0, -1.6, 32.0],
+      end: wallRay.end,
+      ignore_sensors: true,
+    });
+    assert.equal(defaultHit.hit, true, "default raycast should see the Hydro2 wall");
+    assert.ok(
+      defaultHit.distance !== null && Math.abs(defaultHit.distance - 0.6015) < 0.01,
+      `expected the nearby Hydro2 wall, got ${JSON.stringify(defaultHit)}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #806

## Reproduction

On unmodified `origin/main` (`3ae2445`), I launched `hydro2.mis`, advanced one frame so Rapier's query broad phase was populated, and cast from `[79.99, -1.50, 32.0]` to `[73.99, -1.96, 32.0]`:

- `collision_groups: ["world"]` returned HTTP 200 with `hit: true` at distance `1.5946623`.
- `collision_groups: ["level"]` returned HTTP 200 with `hit: false`.
- `collision_groups: ["bogus"]` returned HTTP 200 with `hit: false`.
- `collision_groups: []` returned HTTP 200 with `hit: false`.

The handler default was `["entity", "level"]`, but the core string parser does not recognize `level` and silently drops every unknown name. The new Hydro2 SDK regression failed negative-first because the advertised `level` group could not see the wall.

## Fix

- Default raycasts to the canonical `["world", "entity"]` mask.
- Preserve API compatibility by normalizing the previously advertised `level` name to `world`.
- Validate masks before dispatch: unknown names and explicit empty masks now receive clear HTTP 400 responses instead of indistinguishable clear-ray results.
- Narrow the SDK request type to the supported group names plus the compatibility alias.
- Correct and document the SDK/debug-runtime examples and supported/default behavior.

## Verification

- Negative-first focused Hydro2 E2E: failed on main at `level alias should see Hydro2 world geometry`, then passed after the fix.
- Focused Hydro2 E2E: **1 passed**; confirms the alias hits the wall at ~1.595 units, unknown returns 400 with `unknown collision group 'bogus'`, empty returns 400 with `collision_groups must contain at least one group`, and the omitted default sees world geometry.
- `cargo test -p debug_runtime`: **4 passed**, 1 display-dependent test ignored.
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `cd tools/shock2-sdk && npm test`: **26 passed**, 191 expected E2E skips.
- Full serial SDK E2E: **212 passed, 3 expected skips, 2 failed** across 217 tests. The new raycast regression and all 23 mission loads passed. Both failures were isolated and reproduced identically on untouched `origin/main`:
  - `a loaded corpse does not replay its death` (pre-existing saved/live corpse collision-group mismatch)
  - `losing sight of the player triggers a search of the last-known position` (pre-existing spawned AI disappearance/null detail)

This is a non-visual debug API correctness change, so no visual capture is applicable.
