### PR TITLE
fix(physics): support ladder bottom-out

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -7225,6 +7225,103 @@ mod tests {
         );
     }
 
+    /// Issue #880: Command's Generator shaft has a recessed lower floor behind
+    /// the ladder and one local terrain lip. A crouched east-face descent must
+    /// cross that bounded lip onto real support, then remain able to reverse
+    /// direction and climb out. The north/south closures make walking around
+    /// the ladder impossible, matching the authored shaft.
+    ///
+    /// Negative-first: the vertical climb pass consumed every horizontal
+    /// component and had no bottom-out transition. The player stayed east of
+    /// the lower floor and fell below it, unsupported.
+    #[test]
+    fn player_bottoms_out_onto_a_recessed_ladder_floor_and_can_reverse() {
+        let floor = |x0: f32, x1: f32, y: f32| {
+            let vertices = vec![
+                point![x0, y, -100.0],
+                point![x1, y, -100.0],
+                point![x1, y, 100.0],
+                point![x0, y, 100.0],
+            ];
+            ColliderBuilder::trimesh(vertices, vec![[0u32, 1, 2], [0, 2, 3]])
+                .expect("floor trimesh")
+        };
+
+        let mut world = PhysicsWorld::new();
+        // Lower support exists only west of the shaft lip at x=-5. Command's
+        // reachable descent is on the unsupported east side.
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            floor(-100.0, -5.0, 0.0).build(),
+        );
+        // The authored local lip and the shaft's north/south closures are
+        // immutable terrain, not ladder entities. The transition may cross
+        // the one ladder lip, but there is no tangent bypass.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            ColliderBuilder::cuboid(0.01, 4.0, 0.68)
+                .translation(vector![-5.0, 4.0, 0.0])
+                .build(),
+        );
+        for (id, z) in [(1002, -0.7), (1003, 0.7)] {
+            world.add_collider(
+                EntityId::from_inner(id).unwrap(),
+                ColliderBuilder::cuboid(2.5, 4.0, 0.02)
+                    .translation(vector![-2.5, 4.0, z])
+                    .build(),
+            );
+        }
+
+        // Command-shaped 0.8-unit rung stack, 0.2 units west of the terrain
+        // lip. Its bottom is one tenth above the recessed floor.
+        for rung in 0..10 {
+            world.add_kinematic(
+                EntityId::from_inner(2001 + rung).unwrap(),
+                vec3(-5.2, 0.5 + 0.8 * rung as f32, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.1, 0.8, 0.9),
+                CollisionGroup::climbable_entity(),
+                false,
+            );
+        }
+
+        let mut player =
+            world.create_player(vec3(-4.64, 5.6, 0.0), EntityId::from_inner(3000).unwrap());
+        assert!(world.set_player_crouch(true, &mut player));
+
+        // Look down while pushing west into the reachable east face.
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let descend = Vector3::new(-walk * 0.5, -walk * 0.866, 0.0);
+        for _ in 0..180 {
+            world.update(descend, &mut player);
+        }
+        for _ in 0..60 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let landed = world.get_player_translation(&player);
+        let crouched_center = PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR;
+        assert!(
+            landed.x < -5.4 && (landed.y - crouched_center).abs() < 0.1 && player.is_grounded,
+            "the descent must bottom out west of the lip on stable lower support, ended {landed:?}, grounded={} ",
+            player.is_grounded
+        );
+
+        // The same authored ladder is the only retreat. Facing east/up from
+        // the lower floor and pushing into its west face must climb again.
+        let before_ascent = landed;
+        let ascend = Vector3::new(walk * 0.5, walk * 0.866, 0.0);
+        for _ in 0..40 {
+            world.update(ascend, &mut player);
+        }
+        let climbed = world.get_player_translation(&player);
+        assert!(
+            climbed.y - before_ascent.y > 1.0,
+            "the bottom-out must preserve reverse ascent, went {before_ascent:?} -> {climbed:?}"
+        );
+    }
+
     /// A grip whose climb cannot move the player must not pin them in place.
     /// Standing at a ladder's foot while looking down redirects the push into a
     /// DESCENT, which is cast straight into the floor; since a grip also

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -294,6 +294,20 @@ const CLIMB_TOP_OUT_COLUMN_LOOKAHEAD: f32 =
 /// runtime advances at a fixed 60 Hz.
 const CLIMB_TOP_OUT_SUBSTEP: f32 = 10.0 / SCALE_FACTOR / 60.0;
 
+/// Begin a lower-end transfer only once the player's feet are within one
+/// scripted substep plus the controller gap of the ladder column's bottom.
+/// Unlike the broad top-out lookahead, this keeps the terrain-crossing
+/// exception pinned to the authored lower lip.
+const CLIMB_BOTTOM_OUT_BOTTOM_REACH: f32 =
+    CLIMB_TOP_OUT_SUBSTEP + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+/// A lower transfer may cross at most four authored feet. This covers one
+/// player footprint, the thin ladder body and its local terrain lip, but never
+/// searches across a room for unrelated support.
+const CLIMB_BOTTOM_OUT_MAX_FORWARD: f32 = 4.0 / SCALE_FACTOR;
+/// The destination floor must remain within two authored feet vertically of
+/// the player's lower-end approach.
+const CLIMB_BOTTOM_OUT_MAX_DROP: f32 = 2.0 / SCALE_FACTOR;
+
 /// Half-Life-style flat ladder movement: convert the into-ladder component of
 /// the desired movement into a vertical climb. `toward_ladder` is the
 /// horizontal unit normal from the player toward the climbable surface (from
@@ -608,6 +622,7 @@ fn try_step_up(
 struct ClimbPass<'a> {
     movement: Vector<Real>,
     top_out: Option<(Vector<Real>, Real)>,
+    bottom_out: Option<(Vector<Real>, Real, bool)>,
     validation_queries: QueryPipeline<'a>,
     probe_queries: QueryPipeline<'a>,
     scripted_queries: QueryPipeline<'a>,
@@ -1189,6 +1204,137 @@ fn plan_climb_top_out(
     })
 }
 
+/// Plan the supported transition at the bottom of a ladder column.
+///
+/// Dark's ladder release crosses the local ladder/lip before restoring the
+/// ordinary body on adjacent support. The continuous capsule cannot occupy
+/// that intermediate terrain, so use the same bounded scripted-transfer path
+/// as top-out: climbables and parentless terrain are omitted while crossing,
+/// parented blockers remain live, and the final crouched/standing pose is
+/// validated against every collider and must remain stably grounded.
+fn plan_climb_bottom_out(
+    controller: &KinematicCharacterController,
+    validation_queries: &QueryPipeline,
+    probe_queries: &QueryPipeline,
+    scripted_queries: &QueryPipeline,
+    shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    direction: Vector<Real>,
+    minimum_clear_forward: Real,
+    dt: Real,
+    is_crouched: bool,
+) -> Option<PlayerMovement> {
+    let capsule = shape.as_capsule()?;
+    let body_half_height = capsule.half_height() + capsule.radius;
+    let origin = pos.translation.vector;
+
+    // A normal ladder whose floor continues beneath the approached face needs
+    // no special transfer: let the vertical pass settle and the existing
+    // blocked-climb walking fallback take over.
+    let direct_support = probe_queries
+        .cast_ray_and_get_normal(
+            &Ray::new(Point::from(origin), -Vector::y()),
+            body_half_height + CLIMB_BOTTOM_OUT_BOTTOM_REACH,
+            true,
+        )
+        .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+    if direct_support {
+        return None;
+    }
+
+    let direction = vector![direction.x, 0.0, direction.z].try_normalize(1.0e-6)?;
+    let cross_distance = minimum_clear_forward + CLIMB_TOP_OUT_RECOVERY_RETREAT;
+    if cross_distance <= CLIMB_TOP_OUT_RECOVERY_RETREAT
+        || cross_distance > CLIMB_BOTTOM_OUT_MAX_FORWARD
+    {
+        return None;
+    }
+    let crossed = origin + direction * cross_distance;
+
+    // Find the nearest walkable floor on the far side, then restore the exact
+    // current body profile at its ordinary controller rest height.
+    let landing_probe = body_half_height + CLIMB_BOTTOM_OUT_MAX_DROP;
+    let (_, ground) = validation_queries.cast_ray_and_get_normal(
+        &Ray::new(Point::from(crossed), -Vector::y()),
+        landing_probe,
+        true,
+    )?;
+    if ground.normal.y <= CLIMB_TOP_OUT_MIN_GROUND_NORMAL {
+        return None;
+    }
+    let floor = crossed - Vector::y() * ground.time_of_impact;
+    let landing = floor
+        + Vector::y()
+            * (body_half_height
+                + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+                + PLAYER_REST_LIFT / SCALE_FACTOR);
+    if (landing.y - origin.y).abs() > CLIMB_BOTTOM_OUT_MAX_DROP
+        || shape_intersects(validation_queries, landing, shape)
+        || !shape_has_stable_support(controller, validation_queries, shape, landing, dt)
+    {
+        return None;
+    }
+
+    // Permit exactly one contiguous point-scale terrain obstruction inside the
+    // ladder-width bound. It must be exited before the landing, so this cannot
+    // tunnel through a second wall or end inside the local lip.
+    let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+    if !shape_route_exits_only_initial_obstruction(
+        probe_queries,
+        &[origin, crossed, landing],
+        &route_probe,
+        cross_distance + CLIMB_TOP_OUT_RECOVERY_RETREAT,
+    ) {
+        return None;
+    }
+
+    let waypoints = [origin, origin, origin, crossed, crossed, landing, landing];
+    let compressed_radius = if is_crouched {
+        PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+    } else {
+        CLIMB_TOP_OUT_RADIUS
+    };
+    let compressed = Ball::new(compressed_radius);
+    let mut simulated = origin;
+    let mut first_movement = None;
+    for waypoint in waypoints {
+        for _ in 0..512 {
+            if (waypoint - simulated).norm() <= PLAYER_MOVE_ARRIVAL_EPSILON {
+                break;
+            }
+            let movement = slide_toward(
+                controller,
+                scripted_queries,
+                &compressed,
+                simulated,
+                waypoint,
+                dt,
+            )?;
+            first_movement.get_or_insert(movement.translation);
+            simulated += movement.translation;
+        }
+        if (waypoint - simulated).norm() > PLAYER_MOVE_ARRIVAL_EPSILON {
+            return None;
+        }
+    }
+    let first_step = first_movement?;
+
+    // Reuse the existing live-validated scripted climb state. Its waypoints,
+    // reversal, final-shape restoration and moving-blocker checks are endpoint
+    // agnostic even though the historical type name says `TopOut`.
+    Some(PlayerMovement {
+        movement: scripted_character_movement(first_step),
+        top_out: Some(ClimbTopOut {
+            waypoints,
+            next_waypoint: 0,
+            save_pose: origin,
+            reversing: false,
+            is_crouched,
+        }),
+        slope_displacement: Vector::zeros(),
+    })
+}
+
 /// Plan Dark's ordinary jump-through/mantle for a grounded player pressing
 /// into a non-climbable low obstacle.
 ///
@@ -1596,6 +1742,7 @@ fn step_player_movement(
     if let Some(ClimbPass {
         movement: climb,
         top_out,
+        bottom_out,
         validation_queries,
         probe_queries: climb_queries,
         scripted_queries,
@@ -1615,6 +1762,26 @@ fn step_player_movement(
                 )
             }) {
                 return top_out;
+            }
+        }
+        if climb.y < 0.0 {
+            if let Some(bottom_out) =
+                bottom_out.and_then(|(direction, minimum_clear_forward, is_crouched)| {
+                    plan_climb_bottom_out(
+                        controller,
+                        &validation_queries,
+                        &climb_queries,
+                        &scripted_queries,
+                        shape,
+                        pos,
+                        direction,
+                        minimum_clear_forward,
+                        dt,
+                        is_crouched,
+                    )
+                })
+            {
+                return bottom_out;
             }
         }
         let mvt = controller.move_shape(dt, &climb_queries, shape, pos, climb, |_c| ());
@@ -3896,12 +4063,23 @@ impl PhysicsWorld {
                     half_height + CLIMB_TOP_OUT_COLUMN_LOOKAHEAD,
                     capsule.radius + CLIMB_REACH
                 ]);
-                let column_top = queries
+                let column = queries
                     .intersect_shape(character_pos, &column_probe)
+                    .collect::<Vec<_>>();
+                let column_top = column
+                    .iter()
                     .map(|(_, collider)| collider.compute_aabb().maxs.y)
                     .fold(f32::NEG_INFINITY, f32::max);
+                let column_bottom = column
+                    .iter()
+                    .map(|(_, collider)| collider.compute_aabb().mins.y)
+                    .fold(f32::INFINITY, f32::min);
                 let character_top = character_pos.translation.vector.y + half_height;
+                let character_bottom = character_pos.translation.vector.y - half_height;
                 let near_column_top = column_top - character_top <= CLIMB_TOP_OUT_TOP_REACH;
+                let near_column_bottom = column_bottom.is_finite()
+                    && character_bottom <= column_bottom + CLIMB_BOTTOM_OUT_BOTTOM_REACH
+                    && character_bottom >= column_bottom - CLIMB_BOTTOM_OUT_MAX_DROP;
                 // Grip the closest climbable within reach, by contact distance,
                 // and take the contact's *face normal* as the climb direction.
                 // (The collider-center direction is wrong when the player is
@@ -3930,15 +4108,15 @@ impl PhysicsWorld {
                 }
                 nearest.and_then(|(_, toward)| {
                     climb_redirect(desired_movement, toward).map(|movement| {
+                        let capsule_clearance =
+                            capsule.radius + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
                         let top_out = if near_column_top && !player_handle.is_crouched {
                             climb_top_out_direction(desired_movement, facing).map(|direction| {
                                 // Stay compressed until projected facing has
                                 // exited every horizontally-expanded climbable
                                 // AABB in this ladder column.
-                                let capsule_clearance =
-                                    capsule.radius + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
-                                let minimum_clear_forward = queries
-                                    .intersect_shape(character_pos, &column_probe)
+                                let minimum_clear_forward = column
+                                    .iter()
                                     .filter_map(|(_, collider)| {
                                         climbable_aabb_exit_distance(
                                             character_pos.translation.vector,
@@ -3953,7 +4131,24 @@ impl PhysicsWorld {
                         } else {
                             None
                         };
-                        (movement, top_out)
+                        let bottom_out = (near_column_bottom && movement.y < 0.0).then(|| {
+                            // Exit the same ladder face the player is gripping.
+                            // The destination floor and complete route are
+                            // validated later before a transition may start.
+                            let minimum_clear_forward = column
+                                .iter()
+                                .filter_map(|(_, collider)| {
+                                    climbable_aabb_exit_distance(
+                                        character_pos.translation.vector,
+                                        toward,
+                                        &collider.compute_aabb(),
+                                        capsule_clearance,
+                                    )
+                                })
+                                .fold(0.0, f32::max);
+                            (toward, minimum_clear_forward, player_handle.is_crouched)
+                        });
+                        (movement, top_out, bottom_out)
                     })
                 })
             })
@@ -4044,9 +4239,10 @@ impl PhysicsWorld {
                         gravity,
                         Some(player_handle.slope_displacement),
                         airborne_vertical,
-                        climb_movement.map(|(movement, top_out)| ClimbPass {
+                        climb_movement.map(|(movement, top_out, bottom_out)| ClimbPass {
                             movement,
                             top_out,
+                            bottom_out,
                             validation_queries: queries,
                             probe_queries: queries.with_filter(climb_pass_filter),
                             scripted_queries: queries.with_filter(scripted_top_out_filter),
@@ -7295,8 +7491,14 @@ mod tests {
         let descend = Vector3::new(-walk * 0.5, -walk * 0.866, 0.0);
         for _ in 0..180 {
             world.update(descend, &mut player);
+            if player.top_out.is_none()
+                && player.is_grounded
+                && world.get_player_translation(&player).x < -5.4
+            {
+                break;
+            }
         }
-        for _ in 0..60 {
+        for _ in 0..10 {
             world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
         }
         let landed = world.get_player_translation(&player);

--- a/tools/shock2-sdk/test/command-ladder-bottom-out.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-ladder-bottom-out.e2e.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const GENERATOR_LADDER = 2354;
+const GENERATOR_BOTTOM_RUNG = 2307;
+const SHIELD_GENERATOR = 285;
+
+test(
+  "command1: the Generator ladder bottoms out onto supported lower terrain",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9472),
+    });
+    await game.step({ frames: 5 });
+
+    const [ladder] = await game.entities.byTemplate(GENERATOR_LADDER);
+    const [bottomRung] = await game.entities.byTemplate(GENERATOR_BOTTOM_RUNG);
+    const [generator] = await game.entities.byTemplate(SHIELD_GENERATOR);
+    assert.ok(ladder, "command1 must instantiate Generator ladder2354");
+    assert.ok(bottomRung, "command1 must instantiate bottom rung2307");
+    assert.ok(generator, "command1 must instantiate Shield Generator285");
+    assert.ok(
+      Math.abs(ladder.position[0] - -334.1879) < 0.05 &&
+        Math.abs(bottomRung.position[1] - -7.9) < 0.05,
+      `test must resolve the authored Generator column: ${JSON.stringify({ ladder, bottomRung })}`,
+    );
+
+    // Teleport is setup only: begin already touching the proven reachable east
+    // face, then use ordinary crouch, look, and forward locomotion for the
+    // entire descent and reverse ascent.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 2 });
+    await game.player.teleport({ x: -333.6399, y: -3.9, z: 85.40596 });
+    await game.input.lookAtWorldPoint([-344, -15, 85.40596]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let crossedLip = false;
+    let descent = await game.player.position();
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      descent = await game.player.position();
+      if (descent.x < -334.2 && descent.y < -7.0) {
+        crossedLip = true;
+        break;
+      }
+      if (descent.y < -9.0) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+
+    const landed = await game.player.position();
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    const support = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 1.0, stable.z],
+      collision_groups: ["entity", "world"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      crossedLip &&
+        stable.x < -334.2 &&
+        Math.abs(stable.y - -7.796) < 0.08 &&
+        Math.abs(stable.y - landed.y) < 0.02 &&
+        support.hit &&
+        support.hit_point !== null &&
+        Math.abs(support.hit_point[1] - -8.4) < 0.05 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.9,
+      `ordinary east-face descent must settle on lower world support before Generator285: ${JSON.stringify({ crossedLip, descent, landed, stable, support })}`,
+    );
+
+    // The retail route requires climbing the same column back out after using
+    // the Generator. Exercise the retreat without frobbing Generator285.
+    await game.input.lookAtWorldPoint([-324, stable.y + 10, 85.40596]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 40 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const reversed = await game.player.position();
+    assert.ok(
+      reversed.y - stable.y > 1,
+      `supported bottom-out must preserve reverse ascent: ${JSON.stringify({ stable, reversed })}`,
+    );
+  },
+);


### PR DESCRIPTION
Fixes #880

## Summary

- detect the authored lower end of a gripped ladder column
- plan a geometry-bounded transfer across only the local ladder/lip onto nearby walkable support
- keep every parented entity blocker live, validate the complete landing shape and stable support, and preserve crouched/standing state
- cover Command ladder2354 with a fresh production locomotion regression and a Command-shaped stacked-rung/unit fixture

## Negative-first evidence

On unchanged `origin/main` (`3ae2445d`):

- the unit fixture fell to `(-10.553857, -36.737724, ~0)`, unsupported
- fresh `command1.mis` ordinary east-face descent never crossed onto cell3753 and fell from `(-333.751, -9.224922, 85.40596)` to `(-333.86212, -45.34924, 85.40596)` with no floor ray hit

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 519 passed
- focused climbing tests — 23 passed, including ordinary descent/top-lip descent/top-out
- `npm test` — 26 passed, 191 E2E skipped as expected
- fresh `command1.mis` production E2E — ordinary crouch/look/thumbstick descent settles near y=-7.796 on floor y=-8.4, then reverses up the same ladder
- local integration against the active campaign ladder stack — 44 focused ladder tests, warning-clean runtimes, and the same fresh Command E2E passed
- exhaustive exact-head SDK E2E — 212 passed, 3 intentionally skipped; the known clean-main loaded-corpse failure reproduced, and one unrelated SHODAN assassin-support run failed nondeterministically then passed an immediate exact-head focused rerun
- GitHub CI — format plus Ubuntu, macOS, Windows, and unit/build jobs passed

## Visuals

![Command Generator ladder bottom-out before and after](https://gist.githubusercontent.com/tommy-xr/7496d688bc2bcec2b614edbee8009d10/raw/command-ladder-bottom-out-before-after.gif)

<sub>Identical fresh `command1.mis` crouch, east-face setup, look, and ordinary thumbstick sequence. Baseline falls unsupported below the authored floor; the fix crosses the local lip, settles on the lower support, and reverses upward. Captured headlessly from exact base `3ae2445d` and fix `d4a7ab57` via deterministic fixed-timestep `/v1/step` + `/v1/screenshot`.</sub>

### Supported landing

![Command Generator ladder supported landing before and after](https://gist.githubusercontent.com/tommy-xr/7496d688bc2bcec2b614edbee8009d10/raw/command-ladder-bottom-out-still.png)

<sub>Same released/settle sample: baseline y=-10.501 in unsupported space; fix x=-334.638, y=-7.796 on the authored lower floor.</sub>