### PR TITLE
fix(physics): top out onto narrow ladder decks

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -996,20 +996,72 @@ fn plan_climb_top_out(
     // authored fallback with a low ceiling: it must clear at least one full
     // head radius before the first upward obstruction. Rick1's merged lip is
     // hit after 0.559 wu; a ceiling close enough to pin the sphere is rejected.
-    let up_obstruction = probe_queries
-        .cast_ray(&up_ray, CLIMB_TOP_OUT_UP, true)
-        .map(|(_, time_of_impact)| (time_of_impact, head.y + time_of_impact));
+    let up_hit = probe_queries.cast_ray_and_get_normal(&up_ray, CLIMB_TOP_OUT_UP, true);
+    let up_obstruction = up_hit.map(|(_, hit)| (hit.time_of_impact, head.y + hit.time_of_impact));
     if up_obstruction.is_some_and(|(time_of_impact, _)| time_of_impact < CLIMB_TOP_OUT_RADIUS) {
         return None;
     }
     if !ray_segment_is_clear(probe_queries, raised, probe_ahead) {
         return None;
     }
-    let down_ray = Ray::new(Point::from(probe_ahead), -Vector::y());
-    let mantle_floor = probe_queries
-        .cast_ray_and_get_normal(&down_ray, CLIMB_TOP_OUT_MAX_DROP, true)
-        .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-        .map(|(_, landing)| probe_ahead - Vector::y() * landing.time_of_impact);
+    let mantle_probe = |origin| {
+        probe_queries
+            .cast_ray_and_get_normal(
+                &Ray::new(Point::from(origin), -Vector::y()),
+                CLIMB_TOP_OUT_MAX_DROP,
+                true,
+            )
+            .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+            .map(|(handle, landing)| (origin, handle, landing))
+    };
+    let fixed_mantle_hit = mantle_probe(probe_ahead);
+
+    // A narrow deck can end between the player's approach-side center and
+    // Dark's fixed two-radius sample. When the upward probe sees its underside
+    // but the fixed downward sample overshoots, sample one contact-offset back
+    // along that same probe. Accept only the opposite face of the exact
+    // collider hit from below, thin enough to be the same local slab, and only
+    // at a complete standing pose with stable support. Farther landings remain
+    // the existing recovery planner's responsibility.
+    let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + PLAYER_REST_LIFT / SCALE_FACTOR;
+    let near_mantle_landing = fixed_mantle_hit
+        .is_none()
+        .then(|| {
+            let (up_handle, up) = up_hit?;
+            if up.normal.y >= -CLIMB_TOP_OUT_MIN_GROUND_NORMAL {
+                return None;
+            }
+            let sample_forward = CLIMB_TOP_OUT_PROBE_FORWARD - CLIMB_TOP_OUT_RECOVERY_RETREAT;
+            let origin = raised + direction * sample_forward;
+            let (origin, floor_handle, floor_hit) = mantle_probe(origin)?;
+            if floor_handle != up_handle {
+                return None;
+            }
+            let floor = origin - Vector::y() * floor_hit.time_of_impact;
+            let underside_y = head.y + up.time_of_impact;
+            if floor.y + 1.0e-4 < underside_y
+                || floor.y - underside_y
+                    > CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
+            {
+                return None;
+            }
+            let standing_pose = floor + Vector::y() * standing_floor_offset;
+            (!shape_intersects(validation_queries, standing_pose, &standing)
+                && shape_has_stable_support(
+                    controller,
+                    validation_queries,
+                    &standing,
+                    standing_pose,
+                    dt,
+                ))
+            .then_some((floor, standing_pose))
+        })
+        .flatten();
+    let mantle_floor = fixed_mantle_hit
+        .map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact)
+        .or_else(|| near_mantle_landing.map(|(floor, _)| floor));
     if up_obstruction.is_some_and(|(_, obstruction_y)| {
         // A lip can have a thin underside above its adjacent landing. Treat
         // surfaces within one compressed radius plus the solver gap on both
@@ -1021,6 +1073,55 @@ fn plan_climb_top_out(
         })
     }) {
         return None;
+    }
+
+    if let Some((_, final_standing)) = near_mantle_landing {
+        // Dark's sparse body can rise through this one locally identified slab.
+        // The point-scale route may encounter only one bounded obstruction and
+        // must clear it before the fully validated standing endpoint.
+        let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+        if !shape_route_exits_only_initial_obstruction(
+            probe_queries,
+            &[head, final_standing],
+            &route_probe,
+            CLIMB_TOP_OUT_UP + CLIMB_TOP_OUT_RECOVERY_RETREAT,
+        ) {
+            return None;
+        }
+        let waypoints = [head, head, head, head, head, final_standing, final_standing];
+        let mut simulated = pos.translation.vector;
+        let mut first_movement = None;
+        for waypoint in waypoints {
+            for _ in 0..512 {
+                if (waypoint - simulated).norm() <= PLAYER_MOVE_ARRIVAL_EPSILON {
+                    break;
+                }
+                let movement = slide_toward(
+                    controller,
+                    scripted_queries,
+                    &compressed,
+                    simulated,
+                    waypoint,
+                    dt,
+                )?;
+                first_movement.get_or_insert(movement.translation);
+                simulated += movement.translation;
+            }
+            if (waypoint - simulated).norm() > PLAYER_MOVE_ARRIVAL_EPSILON {
+                return None;
+            }
+        }
+        return Some(PlayerMovement {
+            movement: scripted_character_movement(first_movement?),
+            top_out: Some(ClimbTopOut {
+                waypoints,
+                next_waypoint: 0,
+                save_pose: pos.translation.vector,
+                reversing: false,
+                is_crouched: false,
+            }),
+            slope_displacement: Vector::zeros(),
+        });
     }
 
     // Dark's mantle target puts the physical head sphere just over the lip:
@@ -7068,12 +7169,12 @@ mod tests {
             EntityId::from_inner(1000).unwrap(),
             quad(-100.0, 100.0, 0.0).build(),
         );
-        // The upper deck ends 0.25 world units past the player's natural
-        // ladder-face center. It is broad enough for a complete standing
-        // capsule, but the fixed 0.96-unit sample lands beyond its edge.
+        // The upper deck ends 0.94 world units past the player's natural
+        // ladder-face center. The fixed 0.96-unit sample lands beyond its edge,
+        // while the immediately preceding contact-offset sample reaches it.
         world.add_collider(
             EntityId::from_inner(1001).unwrap(),
-            quad(-100.0, -5.2, 6.4).build(),
+            quad(-100.0, -4.56, 6.4).build(),
         );
         world.add_kinematic(
             EntityId::from_inner(2001).unwrap(),
@@ -7091,25 +7192,29 @@ mod tests {
             world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
         }
         let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let expected_center = 6.4
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR;
         let mut highest = f32::NEG_INFINITY;
         for _ in 0..180 {
             world.update(Vector3::new(walk, 0.0, 0.0), &mut player);
-            highest = highest.max(world.get_player_translation(&player).y);
+            let position = world.get_player_translation(&player);
+            highest = highest.max(position.y);
+            if (position.y - expected_center).abs() < 0.1 {
+                break;
+            }
         }
         for _ in 0..60 {
             world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
         }
         let end = world.get_player_translation(&player);
-        let expected_center = 6.4
-            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
-            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR;
 
         assert!(
             highest > 5.0,
             "the setup must climb to the upper deck underside, highest={highest}, ended {end:?}"
         );
         assert!(
-            end.x < -5.2 && (end.y - expected_center).abs() < 0.1 && player.is_grounded,
+            end.x < -4.56 && (end.y - expected_center).abs() < 0.1 && player.is_grounded,
             "the top-out must release stably on the narrow approach-side deck, ended {end:?}, grounded={}",
             player.is_grounded
         );

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -7041,6 +7041,80 @@ mod tests {
         );
     }
 
+    /// Issue #882: Command's Generator ladder ends beneath a narrow upper
+    /// deck on the side the player climbs from. The fixed two-radius mantle
+    /// sample overshoots that deck, but a nearer sample along the same bounded
+    /// probe reaches its top. Ordinary forward climbing must release onto that
+    /// real support instead of treating the deck underside as a separate
+    /// ceiling and stalling forever.
+    ///
+    /// Negative-first: the climb reaches the underside and remains below the
+    /// deck because `plan_climb_top_out` only samples the fixed forward point.
+    #[test]
+    fn player_tops_out_onto_a_narrow_approach_side_deck() {
+        let quad = |x0: f32, x1: f32, y: f32| {
+            let vertices = vec![
+                point![x0, y, -100.0],
+                point![x1, y, -100.0],
+                point![x1, y, 100.0],
+                point![x0, y, 100.0],
+            ];
+            ColliderBuilder::trimesh(vertices, vec![[0u32, 1, 2], [0, 2, 3]])
+                .expect("floor trimesh")
+        };
+
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            quad(-100.0, 100.0, 0.0).build(),
+        );
+        // The upper deck ends 0.25 world units past the player's natural
+        // ladder-face center. It is broad enough for a complete standing
+        // capsule, but the fixed 0.96-unit sample lands beyond its edge.
+        world.add_collider(
+            EntityId::from_inner(1001).unwrap(),
+            quad(-100.0, -5.2, 6.4).build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(2001).unwrap(),
+            vec3(-5.0, 3.2, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.2, 6.4, 2.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+
+        let mut player =
+            world.create_player(vec3(-5.5, 1.0, 0.0), EntityId::from_inner(3000).unwrap());
+        for _ in 0..30 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        let mut highest = f32::NEG_INFINITY;
+        for _ in 0..180 {
+            world.update(Vector3::new(walk, 0.0, 0.0), &mut player);
+            highest = highest.max(world.get_player_translation(&player).y);
+        }
+        for _ in 0..60 {
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        let expected_center = 6.4
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+            + (PLAYER_CONTACT_OFFSET + PLAYER_REST_LIFT) / SCALE_FACTOR;
+
+        assert!(
+            highest > 5.0,
+            "the setup must climb to the upper deck underside, highest={highest}, ended {end:?}"
+        );
+        assert!(
+            end.x < -5.2 && (end.y - expected_center).abs() < 0.1 && player.is_grounded,
+            "the top-out must release stably on the narrow approach-side deck, ended {end:?}, grounded={}",
+            player.is_grounded
+        );
+    }
+
     /// Issue #603: a gripped ladder must be climbable DOWN, not just up. The
     /// player stands against the rung stack (at the resting gap a real approach
     /// leaves - `PLAYER_CONTACT_OFFSET`) and looks down: a downward-pitched

--- a/tools/shock2-sdk/test/command-ladder-top-out.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-ladder-top-out.e2e.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const GENERATOR_LADDER = 2354;
+const SHIELD_GENERATOR = 285;
+
+test(
+  "command1: the Generator ladder tops out onto durable upper support",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9477),
+    });
+    await game.step({ frames: 5 });
+
+    const [ladder] = await game.entities.byTemplate(GENERATOR_LADDER);
+    const [generator] = await game.entities.byTemplate(SHIELD_GENERATOR);
+    assert.ok(ladder, "command1 must instantiate Generator ladder2354");
+    assert.ok(generator, "command1 must instantiate Shield Generator285");
+    assert.ok(
+      Math.abs(ladder.position[0] - -334.1879) < 0.05,
+      `test must resolve the authored Generator ladder: ${JSON.stringify(ladder)}`,
+    );
+
+    // Teleport is setup only: begin standing on the real lower Generator-room
+    // floor, then use ordinary look and held forward input for the complete
+    // west-face climb and release. No Generator interaction is performed.
+    await game.input.set("crouch", 0);
+    await game.player.teleport({ x: -334.94, y: -7.156, z: 85.34618 });
+    await game.step({ frames: 5 });
+    const hpBefore = (await game.info()).player.hit_points;
+    await game.input.lookAtWorldPoint([-324.94, -7.156, 85.34618]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let highestY = Number.NEGATIVE_INFINITY;
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      highestY = Math.max(highestY, (await game.player.position()).y);
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+    const landed = await game.player.position();
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    const support = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 2, stable.z],
+      collision_groups: ["entity", "world"],
+      ignore_sensors: true,
+    });
+    const hpAfter = (await game.info()).player.hit_points;
+
+    assert.ok(
+      highestY > -0.2,
+      `ordinary ascent must reach the authored upper-deck underside: ${JSON.stringify({ highestY, landed, stable })}`,
+    );
+    assert.ok(
+      stable.x < -334 &&
+        Math.abs(stable.y - 2.444) < 0.08 &&
+        Math.abs(stable.y - landed.y) < 0.02 &&
+        support.hit &&
+        support.hit_point !== null &&
+        Math.abs(support.hit_point[1] - 1.2) < 0.05 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.9,
+      `ordinary west-face ascent must release durably on upper world support: ${JSON.stringify({ highestY, landed, stable, support })}`,
+    );
+    assert.equal(hpAfter, hpBefore, "the ladder route must not damage the player");
+  },
+);

--- a/tools/shock2-sdk/test/command-ladder-top-out.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-ladder-top-out.e2e.test.ts
@@ -40,7 +40,9 @@ test(
     let highestY = Number.NEGATIVE_INFINITY;
     for (let frame = 0; frame < 180; frame += 1) {
       await game.step({ frames: 1 });
-      highestY = Math.max(highestY, (await game.player.position()).y);
+      const position = await game.player.position();
+      highestY = Math.max(highestY, position.y);
+      if (position.y > 2.3) break;
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
     await game.step({ frames: 120 });


### PR DESCRIPTION
Fixes #882

## Summary

- sample the authored landing one contact-offset behind Dark fixed mantle point when that point narrowly overshoots a deck
- require opposite faces of the exact collider, a thin local slab, a collision-free fully supported standing pose, and a bounded point-scale route that exits its only obstruction
- preserve the existing mantle path for fixed-point and farther recovery landings

## Validation

- negative-first Command-shaped unit: fixed probe misses and the player stalls below the upper deck
- fresh command1 production E2E: ordinary east-face ascent on Ladder2354 settles at the authored upper floor with HP unchanged and Generator285 untouched
- cargo test -p shock2vr: 519 passed
- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- SDK unit suite: 26 passed, 191 E2E-gated skips
- campaign-stack integration: 34 top-out safety tests, ordinary/wide/narrow top-out units, earlier bottom-out/reverse unit, Eng317 and Eng945 production scenarios
- exhaustive SDK E2E: 217 total — 212 passed, 3 intentionally skipped, 1 known origin/main corpse baseline failure, and 1 asynchronous AI-search failure that passed its focused rerun (1/1)

## Visuals

![Command Generator narrow-deck top-out before and after](https://gist.githubusercontent.com/tommy-xr/14516f64b4a8d6232f3243b563a7f9b7/raw/command-ladder-narrow-deck-before-after.gif)

<sub>Identical fresh `command1.mis` standing setup, +X look, and 113-frame ordinary forward ascent from Ladder2354's supported lower floor. Baseline repeatedly rejects the narrow deck and falls; the fix tops out and remains supported above. Captured headlessly from exact base `3ae2445d` and fix `30d46ca0` via deterministic fixed-timestep `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Command Generator narrow-deck supported landing](https://gist.githubusercontent.com/tommy-xr/14516f64b4a8d6232f3243b563a7f9b7/raw/command-ladder-narrow-deck-still.png)

<sub>Same post-release sample: baseline y=-3.277 with no walkable support; fix x=-334.024, y=2.444 on the authored upper floor at y=1.200.</sub>
