### PR TITLE
fix(physics): cross exact-height gravity apertures

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -121,6 +121,20 @@ fn crouched_player_shared_shape() -> SharedShape {
 /// and world geometry (`KinematicCharacterController::offset`).
 const PLAYER_CONTACT_OFFSET: f32 = 0.1;
 
+/// Numerical tolerance (world units) for recognizing a passage whose floor to
+/// ceiling clearance is exactly the player shape plus the controller offset
+/// on both faces. The authored Command gravshaft exit is exact to source-data
+/// precision; this tolerance covers only import/query float noise, not a
+/// visibly shorter or taller opening.
+const EXACT_APERTURE_CLEARANCE_EPSILON: f32 = 0.01;
+
+/// Number of horizontal samples used to find an exact-height passage around
+/// the moving capsule. The bounded interval starts one footprint behind the
+/// center (so gravity stays constrained until the trailing cap clears) and
+/// ends one footprint plus two ordinary walk substeps ahead (so the passage is
+/// discovered before gravity can carry the leading cap below its opening).
+const EXACT_APERTURE_SAMPLES: usize = 9;
+
 /// Extra height (SS2 ft) the player is lifted each grounded frame, keeping the
 /// resting gap a hair above `PLAYER_CONTACT_OFFSET`. Load-bearing: movement
 /// casts use `PLAYER_CONTACT_OFFSET` as their target distance, so a capsule
@@ -1542,6 +1556,94 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
     -0.5 / SCALE_FACTOR * character_body.gravity_scale()
 }
 
+/// Find the collision-derived center plane of an exact-height horizontal
+/// aperture the player is entering or leaving.
+///
+/// Dark's player is a sparse stack of spheres. It can begin crossing a slot
+/// while a gravity tick is pulling the stack toward the lower edge, then rest
+/// between the authored floor and ceiling. Our continuous capsule instead
+/// applies walk and gravity as separate full-shape casts: gravity can lower it
+/// before its footprint clears the edge, permanently wedging it outside. Keep
+/// the capsule centered only while nearby opposed, walkable floor/ceiling
+/// probes prove that exact authored passage exists. There are no mission ids,
+/// coordinates, or gravity-scale assumptions here.
+fn exact_aperture_center(
+    controller: &KinematicCharacterController,
+    queries: &QueryPipeline,
+    shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    desired: Vector<Real>,
+    gravity: Real,
+) -> Option<Real> {
+    if gravity >= 0.0 || desired.y.abs() > 1.0e-5 {
+        return None;
+    }
+    let horizontal = vector![desired.x, 0.0, desired.z];
+    let horizontal_len = horizontal.norm();
+    if horizontal_len <= 1.0e-5 {
+        return None;
+    }
+    let capsule = shape.as_capsule()?;
+    if (2.0 * (capsule.half_height() + capsule.radius) - PLAYER_CROUCH_HEIGHT / SCALE_FACTOR).abs()
+        > 1.0e-4
+    {
+        return None;
+    }
+    let CharacterLength::Absolute(contact_offset) = controller.offset else {
+        return None;
+    };
+    let shape_height = 2.0 * (capsule.half_height() + capsule.radius);
+    let required_clearance = shape_height + 2.0 * contact_offset;
+    let footprint = capsule.radius + contact_offset;
+    let direction = horizontal / horizontal_len;
+    let first_sample = -footprint;
+    let last_sample = 2.0 * footprint + 2.0 * horizontal_len;
+    let probe_distance = required_clearance + gravity.abs() + contact_offset;
+
+    for sample_index in 0..EXACT_APERTURE_SAMPLES {
+        let t = sample_index as Real / (EXACT_APERTURE_SAMPLES - 1) as Real;
+        let distance = first_sample + (last_sample - first_sample) * t;
+        let sample = pos.translation.vector + direction * distance;
+        let down_ray = Ray::new(Point::from(sample), -Vector::y());
+        let up_ray = Ray::new(Point::from(sample), Vector::y());
+        let Some((_, floor)) = queries
+            .cast_ray_and_get_normal(&down_ray, probe_distance, true)
+            .filter(|(_, hit)| hit.normal.y > PLAYER_MIN_WALKABLE_NORMAL)
+        else {
+            continue;
+        };
+        let Some((_, ceiling)) = queries
+            .cast_ray_and_get_normal(&up_ray, probe_distance, true)
+            .filter(|(_, hit)| hit.normal.y < -PLAYER_MIN_WALKABLE_NORMAL)
+        else {
+            continue;
+        };
+        let clearance = floor.time_of_impact + ceiling.time_of_impact;
+        if (clearance - required_clearance).abs() > EXACT_APERTURE_CLEARANCE_EPSILON {
+            continue;
+        }
+        let center = sample.y + (ceiling.time_of_impact - floor.time_of_impact) * 0.5;
+        // This is a one-gravity-step correction, not a mantle or teleport.
+        // Reject a remote parallel floor/ceiling pair even if its spacing
+        // happens to match the player's profile.
+        if (center - pos.translation.vector.y).abs() > gravity.abs() + contact_offset {
+            continue;
+        }
+        let centered_sample = vector![sample.x, center, sample.z];
+        if !shape_intersects(queries, centered_sample, shape)
+            && shape_sweep_is_clear(
+                queries,
+                pos.translation.vector,
+                vector![pos.translation.vector.x, center, pos.translation.vector.z],
+                shape,
+            )
+        {
+            return Some(center);
+        }
+    }
+    None
+}
+
 /// One frame of player locomotion: the character controller's walk pass, the
 /// gravity pass (with ground snapping and the resting lift), and the stair
 /// step-up probe. Shared by real player movement ([`PhysicsWorld::move_player`])
@@ -1769,6 +1871,41 @@ fn step_player_movement(
             Vector::zeros(),
         )
     };
+    // A zero-slack authored aperture cannot tolerate a separate gravity tick
+    // while the capsule's leading/trailing edge still spans its boundary.
+    // Probe only when the ordinary gravity result remains airborne; supported
+    // crouch-walking therefore stays on the established cheap path. When
+    // opposed probes prove the passage, combine the collision-valid center
+    // correction with this frame's horizontal input and suppress only this
+    // gravity pass. As soon as the bounded probes no longer see it, ordinary
+    // gravity resumes.
+    let leaving_support =
+        !fall.grounded || fall.translation.y < -PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    if airborne_vertical.is_none() && leaving_support {
+        if let Some(center) =
+            exact_aperture_center(controller, queries, shape, pos, desired, gravity)
+        {
+            let correction = center - pos.translation.vector.y;
+            let requested = desired + Vector::y() * correction;
+            let aperture = controller.move_shape(dt, queries, shape, pos, requested, |_c| ());
+            let desired_h = vector![desired.x, 0.0, desired.z];
+            let moved_h = vector![aperture.translation.x, 0.0, aperture.translation.z];
+            if moved_h.dot(&desired_h) >= 0.5 * desired_h.norm_squared()
+                && (pos.translation.vector.y + aperture.translation.y - center).abs()
+                    <= PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            {
+                return PlayerMovement {
+                    movement: EffectiveCharacterMovement {
+                        grounded: false,
+                        is_sliding_down_slope: false,
+                        translation: aperture.translation + carried,
+                    },
+                    top_out: None,
+                    slope_displacement: Vector::zeros(),
+                };
+            }
+        }
+    }
     mvt.translation += fall.translation;
     mvt.grounded = fall.grounded;
     if mvt.grounded {

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -7847,6 +7847,143 @@ mod tests {
         );
     }
 
+    /// Command's GravDown exit is exactly one crouched capsule plus the
+    /// controller's contact offsets tall. A horizontal-only cast fits, but a
+    /// separate downward-gravity pass lowers the capsule while its footprint
+    /// still crosses the wall plane, wedges it against the sill, and drops it
+    /// down the unsupported shaft instead of through the authored aperture.
+    ///
+    /// This fixture keeps the same essential topology without mission ids or
+    /// coordinates: solid chute sides, an exact-height south aperture,
+    /// unsupported space below the north approach, and a lower floor only on
+    /// the far side. Negative-first: ordinary crouched input never reaches the
+    /// lower floor on the baseline implementation.
+    #[test]
+    fn crouched_gravity_crosses_an_exact_height_aperture_to_lower_support() {
+        let mut world = PhysicsWorld::new();
+        let add_box = |world: &mut PhysicsWorld,
+                       entity: u64,
+                       center: Vector<Real>,
+                       half_extents: Vector<Real>| {
+            world.add_collider(
+                EntityId::from_inner(entity).unwrap(),
+                ColliderBuilder::cuboid(half_extents.x, half_extents.y, half_extents.z)
+                    .translation(center)
+                    .build(),
+            );
+        };
+
+        // Put every wall/tunnel polygon in one parentless trimesh, matching
+        // the monolithic WorldRep collider rather than giving Rapier one
+        // independently resolvable collider per face.
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        let mut add_quad = |points: [Point<Real>; 4], reverse: bool| {
+            let base = vertices.len() as u32;
+            vertices.extend(points);
+            if reverse {
+                indices.extend([[base, base + 2, base + 1], [base, base + 3, base + 2]]);
+            } else {
+                indices.extend([[base, base + 1, base + 2], [base, base + 2, base + 3]]);
+            }
+        };
+        // Level-style wall plane at z=0. Its opening is y=-0.6..0.6: exactly
+        // the 1.12 wu crouched body plus 0.04 wu contact offset at each end.
+        for (y0, y1) in [(-4.0, -0.6), (0.6, 4.0)] {
+            add_quad(
+                [
+                    point![-0.8, y0, 0.0],
+                    point![0.8, y0, 0.0],
+                    point![0.8, y1, 0.0],
+                    point![-0.8, y1, 0.0],
+                ],
+                false,
+            );
+        }
+        // The aperture opens into a two-unit low tunnel bounded by opposed
+        // level polygons at the same exact 1.20 wu separation. Gravity can
+        // settle the capsule onto the lower face, but the normal rest lift
+        // then consumes the upper contact offset and wedges the next frame.
+        for (y, reverse) in [(-0.6, false), (0.6, true)] {
+            add_quad(
+                [
+                    point![-0.8, y, 0.0],
+                    point![0.8, y, 0.0],
+                    point![0.8, y, -2.0],
+                    point![-0.8, y, -2.0],
+                ],
+                reverse,
+            );
+        }
+        world.add_collider(
+            EntityId::from_inner(2200).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("valid monolithic aperture world")
+                .build(),
+        );
+        // Solid east/west chute faces leave a 1.6 wu-wide center channel.
+        add_box(
+            &mut world,
+            2204,
+            vector![-1.0, 0.0, -0.5],
+            vector![0.2, 4.0, 3.0],
+        );
+        add_box(
+            &mut world,
+            2205,
+            vector![1.0, 0.0, -0.5],
+            vector![0.2, 4.0, 3.0],
+        );
+        // Only the south side is supported; its top is y=-4.
+        add_box(
+            &mut world,
+            2206,
+            vector![0.0, -4.1, -11.1],
+            vector![10.0, 0.1, 8.9],
+        );
+
+        let mut player =
+            world.create_player(vec3(0.0, 0.64, 0.8), EntityId::from_inner(2300).unwrap());
+        // Build Rapier's broad phase without letting the unsupported setup
+        // fall, then plant the authentic crouched profile at the aperture
+        // center and enable the ordinary downward gravity restored at the
+        // lower room-sensor boundary.
+        world.rigid_body_set[player.character_handle].set_gravity_scale(0.0, true);
+        step(&mut world, &mut player, 1);
+        assert!(world.set_player_crouch(true, &mut player));
+        // The Command route approaches 0.10353 wu above the opening's exact
+        // midpoint. The rounded capsule initially fits from that offset, but
+        // gravity changes the cross-section presented to the edge while the
+        // body is still spanning the wall plane. The lower slot begins just
+        // beyond the GravDown room sensor, so its exit event has restored
+        // ordinary world gravity by this point.
+        world.set_player_translation(vec3(0.0, 0.10353, 0.8), &mut player);
+        step(&mut world, &mut player, 1);
+        world.rigid_body_set[player.character_handle].set_gravity_scale(1.0, true);
+
+        // Production per-frame walk displacement. Stop driving once the body
+        // has fully cleared the wall, then let ordinary gravity find the far
+        // floor instead of masking a failure with continued movement.
+        for _ in 0..30 {
+            if world.get_player_translation(&player).z < -2.5 {
+                break;
+            }
+            world.update(vec3(0.0, 0.0, -25.0 / 60.0 / SCALE_FACTOR), &mut player);
+        }
+        let crossed = world.get_player_translation(&player);
+        assert!(
+            crossed.z < -2.5,
+            "ordinary crouched movement should clear the exact-height aperture route, got {crossed:?}"
+        );
+
+        step(&mut world, &mut player, 120);
+        let landed = world.get_player_translation(&player);
+        assert!(
+            landed.z < -2.5 && (-3.5..-3.2).contains(&landed.y),
+            "the crossing should land on the lower south support, got {landed:?}"
+        );
+    }
+
     /// Build a floor whose top face is flush with the bottom of a walk-in
     /// fixture's model-bounds box - hydro2's Resurrection Station casing sits
     /// on the alcove floor exactly like this - and return the world plus the

--- a/tools/shock2-sdk/test/command-gravdown-aperture.e2e.test.ts
+++ b/tools/shock2-sdk/test/command-gravdown-aperture.e2e.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Fresh-mission production regression for command1's GravDown103 south exit.
+// Stable mission coordinates identify authored world geometry only; runtime
+// entity ids remain launch-specific and are never hardcoded.
+test(
+  "command1: crouched GravDown movement exits the exact-height south aperture",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8524),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    const hpBefore = (await game.info()).player.hit_points;
+    const overlordBefore = await game.quests.get("overlord");
+
+    // Enter crouch in open space first, then enter the authored GravDown room
+    // sensor so this setup exercises the real ROOM_DB -> CoreRoom gravity
+    // chain. The lower slot lies just past that sensor: staging the exact
+    // reviewed pose also reproduces its ordinary SensorEndIntersect reset to
+    // downward world gravity before the crossing begins.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 2 });
+    assert.ok(
+      (await game.player.teleport({ x: -310.4, y: 1.4, z: 87.59998 }))
+        .success,
+      "the player must enter the authored GravDown room sensor",
+    );
+    await game.step({ frames: 2 });
+    assert.ok(
+      (await game.player.teleport({ x: -311.8, y: -2.49647, z: 87.59998 }))
+        .success,
+      "the crouched capsule must fit in the GravDown chute",
+    );
+    await game.step({ frames: 2 });
+    assert.ok(
+      (await game.player.teleport({ x: -311.8, y: -2.49647, z: 87.59998 }))
+        .success,
+      "the exact reviewed pre-crossing pose must remain collision-valid",
+    );
+    const start = await game.player.position();
+
+    // Aim the production camera horizontally toward world -Z/south while
+    // accounting for command1's authored pawn rotation. This is ordinary flat
+    // locomotion with the real crouch held throughout: no validated-move
+    // helper, jump, teleport, entity mutation, or direct gravity/quest message
+    // performs the crossing.
+    const cameraOffset = (await game.info()).player.camera_offset?.[1] ?? 0.48;
+    await game.input.lookAtWorldPoint([
+      start.x,
+      start.y + cameraOffset,
+      start.z - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 18 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 120 });
+
+    const landed = await game.player.position();
+    assert.ok(
+      landed.z < 86.4 && Math.abs(landed.y - -2.596) < 0.15,
+      `ordinary crouched movement must clear the aperture and settle on the ` +
+        `authored low-corridor floor (start=${JSON.stringify(start)}, landed=${JSON.stringify(landed)})`,
+    );
+    const support = await game.raycast({
+      start: [landed.x, landed.y, landed.z],
+      end: [landed.x, landed.y - 2.0, landed.z],
+      collision_groups: ["world"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      support.hit_point !== null &&
+        support.hit_normal !== null &&
+        Math.abs(support.hit_point[1] - -3.2) < 0.05 &&
+        support.hit_normal[1] > 0.9,
+      `the endpoint must have durable authored world support at y=-3.2: ${JSON.stringify(support)}`,
+    );
+    assert.equal((await game.info()).player.hit_points, hpBefore, "the exit must not damage the player");
+    assert.equal(
+      await game.quests.get("overlord"),
+      overlordBefore,
+      "the focused crossing must not enter the later tram/umbilical tripwire",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- detect an exact crouch-height floor/ceiling passage from nearby collision geometry
- keep a falling crouched capsule on that collision-validated center plane only while its footprint crosses the zero-slack boundary
- resume ordinary gravity immediately outside the bounded aperture, with no Command ids or coordinates
- add a generic monolithic-world fixture and a fresh `command1.mis` production regression through GravDown103

The fresh runtime also corrected two review measurements now recorded on the issue: the room sensor has reset gravity to 1.0 by the lower aperture, and the first south support is the authored low-corridor floor at y=-3.2. Baseline still reproduces the reviewed z=87.60→87.16 wedge; this change reaches z=84.94 and remains supported at crouched center y=-2.596.

Fixes #884

## Validation

- [x] negative-first generic exact-height aperture unit test (baseline stalls/falls)
- [x] negative-first fresh Command production E2E with real crouch + thumbstick (baseline z=87.1601 and unsupported)
- [x] `cargo test -p shock2vr` (537 passed)
- [x] focused Command production E2E (fixed z=84.935, center y=-2.596, world floor y=-3.2, HP/objective unchanged)
- [x] `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- [x] `npm test` in `tools/shock2-sdk` (26 passed, E2Es skipped by default)
- [x] 15/15 production movement E2Es: aperture, gravshaft, crouch/headroom save, ladders/top-out, jumps/ceilings, trams/lifts, moving support
- [x] all-mission SDK smoke: 23/23 shipped missions load
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] GitHub CI: format + Ubuntu/macOS/Windows builds

## Visuals

![Command GravDown exact-height aperture before/after](https://gist.githubusercontent.com/tommy-xr/e6a01c188cb3174054aff2d5f4ece5e4/raw/gravdown-aperture-before-after.gif)

<sub>Matched fresh `command1.mis` runs from the reviewed pose: base `ff09cde1` wedges at z=87.160 and falls unsupported; fix `61936ca1` crosses to z=84.643 and remains at crouched center y=-2.596 on the authored floor at y=-3.20. Captured headlessly via `/v1/step` + `/v1/screenshot` with deterministic fixed-timestep stepping.</sub>

### Before → after

![Command GravDown aperture final before/after](https://gist.githubusercontent.com/tommy-xr/e6a01c188cb3174054aff2d5f4ece5e4/raw/gravdown-aperture-before-after.png)
