### PR TITLE
fix(dark): register P$AI_AlertC under its truncated chunk name

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -2492,6 +2492,37 @@ mod tests {
         assert!(links.to_links.is_empty());
     }
 
+    /// Dark stores chunk names in a fixed 12-byte field (see
+    /// `ss2_chunk_file_reader::read_table_of_contents`), so an editor property
+    /// name longer than 11 characters is truncated on disk. Chunk lookup is an
+    /// exact match, so a longer registered name silently never parses - which
+    /// is exactly how `P$AI_AlertCap` went unparsed for every entity.
+    #[test]
+    fn registered_chunk_names_fit_the_11_char_chunk_field() {
+        // `P$AI_AwrDel2` is the same bug (the real chunk is `P$AI_AwrDel`), but
+        // the one shipped entry - Security Camera, template -367 - stores
+        // to_two = -1, a sentinel `AlertnessTimings::from_aware_delay` would
+        // turn into a ~50-day escalation delay, so simply renaming it would
+        // stop cameras alerting. Left broken deliberately until the sentinel is
+        // handled; see the tracking issue.
+        const KNOWN_TRUNCATED: [&str; 1] = ["P$AI_AwrDel2"];
+
+        let (props, _, _) = get::<io::Cursor<Vec<u8>>>();
+        let too_long: Vec<String> = props
+            .iter()
+            .map(|p| p.name())
+            // `__`-prefixed names are internal runtime-only properties with no
+            // chunk on disk, so the field width does not apply to them.
+            .filter(|name| !name.starts_with("__"))
+            .filter(|name| name.len() > 11 && !KNOWN_TRUNCATED.contains(&name.as_str()))
+            .collect();
+        assert!(
+            too_long.is_empty(),
+            "these registered property names exceed the 11-character chunk-name \
+             field and can never match a chunk: {too_long:?}"
+        );
+    }
+
     #[test]
     fn deserialize_skips_values_json_cannot_round_trip() {
         // A live world can still hold non-finite floats (e.g. physics NaNs);

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1175,7 +1175,9 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         ),
         define_prop("P$AI_Team", PropAITeam::read, identity, accumulator::latest),
         define_prop(
-            "P$AI_AlertCap",
+            // Dark truncates property chunk names to 11 characters, so the
+            // chunk in the game files is "P$AI_AlertC", not "P$AI_AlertCap".
+            "P$AI_AlertC",
             PropAIAlertCap::read,
             identity,
             accumulator::latest,

--- a/shock2vr/src/scripts/ai/alertness.rs
+++ b/shock2vr/src/scripts/ai/alertness.rs
@@ -239,7 +239,10 @@ pub fn clamp_level(level: AIAlertLevel, cap: &PropAIAlertCap) -> AIAlertLevel {
     let raw = level_to_u32(level);
     let min = level_to_u32(cap.min_level);
     let max = level_to_u32(cap.max_level);
-    let clamped = raw.clamp(min, max);
+    // `min.min(max)`, not `min`: `Ord::clamp` panics when min > max, and both
+    // bounds now come from mission bytes (an out-of-range level parses as
+    // `High` via `AIAlertLevel::from_raw`).
+    let clamped = raw.clamp(min.min(max), max);
     AIAlertLevel::from_u32(clamped).unwrap_or(cap.max_level)
 }
 
@@ -518,5 +521,20 @@ mod tests {
             clamp_level(AIAlertLevel::High, &cap),
             AIAlertLevel::Moderate
         );
+    }
+
+    /// Both bounds come from mission data now that `P$AI_AlertC` parses, and an
+    /// out-of-range level reads back as `High` - so an inverted cap must clamp
+    /// to `max_level` rather than panic inside `Ord::clamp`.
+    #[test]
+    fn test_clamp_level_with_inverted_cap_does_not_panic() {
+        let cap = PropAIAlertCap {
+            max_level: AIAlertLevel::Lowest,
+            min_level: AIAlertLevel::High,
+            min_relax: AIAlertLevel::Lowest,
+        };
+
+        assert_eq!(clamp_level(AIAlertLevel::High, &cap), AIAlertLevel::Lowest);
+        assert_eq!(clamp_level(AIAlertLevel::Lowest, &cap), AIAlertLevel::Lowest);
     }
 }

--- a/shock2vr/src/scripts/ai/alertness.rs
+++ b/shock2vr/src/scripts/ai/alertness.rs
@@ -535,6 +535,9 @@ mod tests {
         };
 
         assert_eq!(clamp_level(AIAlertLevel::High, &cap), AIAlertLevel::Lowest);
-        assert_eq!(clamp_level(AIAlertLevel::Lowest, &cap), AIAlertLevel::Lowest);
+        assert_eq!(
+            clamp_level(AIAlertLevel::Lowest, &cap),
+            AIAlertLevel::Lowest
+        );
     }
 }

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -755,7 +755,9 @@ impl Script for AnimatedMonsterAI {
         // keeps that idle for the whole mission - including one flagged to
         // patrol, which then never takes a step of its authored route (#807).
         // (Selecting AFTER seeding alertness also keeps the two in step for a
-        // `P$AI_AlertC` whose `min_level` is above `Lowest`.)
+        // `P$AI_AlertC` whose `min_level` is above `Lowest`; every shipped
+        // entry has min_level = Lowest, so in practice every creature still
+        // starts on the calm arm.)
         //
         // This also holds a creature excluded from awareness entirely (an
         // apparition - see `build_config`) still, which the previous

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -755,9 +755,7 @@ impl Script for AnimatedMonsterAI {
         // keeps that idle for the whole mission - including one flagged to
         // patrol, which then never takes a step of its authored route (#807).
         // (Selecting AFTER seeding alertness also keeps the two in step for a
-        // hypothetical `P$AI_AlertCap` whose `min_level` is above `Lowest`;
-        // no shipped object authors that property, so in practice every
-        // creature starts on the calm arm.)
+        // `P$AI_AlertC` whose `min_level` is above `Lowest`.)
         //
         // This also holds a creature excluded from awareness entirely (an
         // apparition - see `build_config`) still, which the previous

--- a/tools/shock2-sdk/test/docile-alert-cap.e2e.test.ts
+++ b/tools/shock2-sdk/test/docile-alert-cap.e2e.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// earth.mis training protocol droids (mission objects 547/593, template
+// -4015 "Training Droid"), which inherit the `Docile` metaproperty (-1073)
+// authoring P$AI_AlertC = Lowest/Lowest/Lowest. Runtime entity ids are not
+// stable across launches, so they are discovered by name.
+const TRAINING_DROID_NAME = "Training Droid";
+
+function aiProp(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((p) => p.name === name)?.value;
+}
+
+function distanceXZ(a: [number, number, number], b: [number, number, number]): number {
+  const dx = a[0] - b[0];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+test(
+  "docile training droids stay pinned at Lowest alertness and hold their stand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8144),
+    });
+
+    await game.step({ frames: 10 });
+
+    const { entities } = await game.entities.list({ filter: TRAINING_DROID_NAME });
+    const droids = entities.filter((e) => e.name === TRAINING_DROID_NAME);
+    assert.ok(
+      droids.length > 0,
+      `expected at least one "${TRAINING_DROID_NAME}" in earth.mis`,
+    );
+
+    const start = new Map<number, [number, number, number]>();
+    for (const droid of droids) {
+      const detail = await game.entities.detail(droid.id);
+      assert.equal(
+        aiProp(detail, "AIAlertness"),
+        "Lowest",
+        `droid ${droid.id} should spawn calm`,
+      );
+      start.set(droid.id, detail.position);
+    }
+
+    // Force every AI to Moderate. The Docile alert cap (max_level = Lowest)
+    // must clamp that away for the training droids - before P$AI_AlertC was
+    // registered under its truncated chunk name the property never parsed,
+    // so they escalated to Chase and wandered off their stands.
+    await game.input.trigger("DebugAlertAll");
+    await game.step({ frames: 300 });
+
+    for (const droid of droids) {
+      const detail = await game.entities.detail(droid.id);
+      assert.equal(
+        aiProp(detail, "AIAlertness"),
+        "Lowest",
+        `droid ${droid.id} should be capped at Lowest by the Docile alert cap`,
+      );
+      const behavior = aiProp(detail, "AIBehavior");
+      assert.notEqual(behavior, "Chase", `droid ${droid.id} should not chase`);
+
+      const moved = distanceXZ(detail.position, start.get(droid.id)!);
+      assert.ok(
+        moved < 1.0,
+        `droid ${droid.id} should hold its stand (moved ${moved.toFixed(2)} units)`,
+      );
+    }
+  },
+);

--- a/tools/shock2-sdk/test/force-chase.e2e.test.ts
+++ b/tools/shock2-sdk/test/force-chase.e2e.test.ts
@@ -43,7 +43,6 @@ test(
       (e) => e.name.startsWith("OG-"),
     );
     assert.ok(hybrids.length >= 2, `expected hybrids in medsci1, got ${hybrids.length}`);
-    const probe = hybrids[0];
 
     // Baseline distances BEFORE pinning - convergence is measured from the
     // moment the pin lands, before anyone starts moving. (The pin phase runs
@@ -63,11 +62,21 @@ test(
     let detail: EntityDetailResult;
     await game.input.trigger("DebugForceChase");
     await game.step({ frames: 30 });
-    detail = await game.entities.detail(probe.id);
+    // Probe whichever hybrid actually took the pin, rather than the nearest:
+    // medsci1's scripted vent hybrid (mission object 613) authors an alert cap
+    // of Lowest (P$AI_AlertC), so it legitimately cannot be alerted at all.
+    const pinned = [];
+    for (const h of hybrids) {
+      const d = await game.entities.detail(h.id);
+      if (["Moderate", "High"].includes(aiProp(d, "AIAlertness") ?? "")) {
+        pinned.push(h);
+      }
+    }
     assert.ok(
-      ["Moderate", "High"].includes(aiProp(detail, "AIAlertness") ?? ""),
-      `expected pinned alertness, got ${aiProp(detail, "AIAlertness")}`,
+      pinned.length >= 2,
+      `expected at least 2 hybrids to take the pinned alertness, got ${pinned.length}`,
     );
+    const probe = pinned[0];
     await game.step({ frames: 600 });
     detail = await game.entities.detail(probe.id);
     assert.ok(


### PR DESCRIPTION
## The truncation trap

Dark stores every chunk name in a **fixed 12-byte field** (`ss2_chunk_file_reader::read_table_of_contents` → `read_string_with_size(reader, 12)`), so an editor property name longer than **11 characters** is truncated on disk. Chunk lookup is an exact `contains_key` match (`dark/src/ss2_entity_info.rs`), so a registration whose name exceeds 11 chars can never match anything: the property silently never parses, for any entity, in any mission.

`PropAIAlertCap` was registered as `"P$AI_AlertCap"` (13 chars). The real chunk in the game files is `"P$AI_AlertC"`.

## Symptom: the earth.mis training droids walk off their stands

The `Docile` metaproperty (template -1073) authors `P$AI_AlertC = [0, 0, 0]` (max / min / min_relax alert level = `Lowest`). The earth.mis training protocol droids (mission objects 547 / 593, template -4015 "Training Droid") inherit `Docile` and should be pinned at `Lowest` forever. Because the property never parsed, they got the permissive default cap, escalated on any stimulus, and walked off their stands.

`alertness::clamp_level` already implemented the cap correctly — it just never received the authored data.

Before / after with `dark_query`:

```
# before
$ cargo dq templates 1073
    ├─ Template -1073 (sym:Docile)
      Properties (1):
        1. PropSymName("Docile")
Unparsed Properties:
    1. P$AI_AlertC (12 bytes)     <-- never parsed

# after
    ├─ Template -1073 (sym:Docile)
      Properties (2):
        1. PropAIAlertCap { max_level: Lowest, min_level: Lowest, min_relax: Lowest }
        2. PropSymName("Docile")
```

## What this newly enables (full inventory)

Every object that authors `P$AI_AlertC` in the shipped data, decoded straight from the chunks:

| source | object(s) | what it is | cap (max/min/relax) |
| --- | --- | --- | --- |
| gamesys | -166 `Apparitions`, -551 `Crew`, -4010 `Posing`, -1073 `Docile`, -2477 `Deactivated` | metaproperties | 0/0/0 |
| gamesys | -2458 `CutScene Players` | metaproperty | 0/0/1 |
| earth | 150 | `Protocol Droid` | 0/0/0 |
| station | 71, 73, 105, 161, 474, 821 | `DROID-10` & co, protocol droids, crew | 0/0/0 |
| medsci1 | 613 | `OG-Shotgun` with `AIWatchObj -> crawlscene` — the scripted vent hybrid | 0/0/0 |
| ops1 | 191, 196, 197, 198 | `Rumbler1`–`Rumbler4`, scripts `CS9_HoloRumbler` + `TransluceInOutHolo`, alpha 0.65 — **holograms** | 0/0/0 |
| eng2 | 601 | `Rumbler` running `TransientCorpse` — a corpse | 0/0/0 |
| eng2 | 736, 763 | unnamed, unlinked `Overlord`s with `gravity_scale = 0` — placed but disabled | 0/0/0, 0/0/1 |
| command2 | 2315 | `Humbler` driven entirely by a scripted `AISignalResponse` (goto / face / play cutscene) | 0/0/1 |

Every one of them is a non-combatant: a hologram, a corpse, a scripted actor, a crew droid, or a designer-disabled placement. Honoring the cap makes them behave as authored (the ops1 holograms notably no longer charge the player).

**Known limitation, unchanged by this PR:** a capped AI cannot be woken. `alert_to_position` clamps its target and returns `Effect::NoEffect` when that doesn't raise the level, and nothing in the port mutates a cap or adds/removes a metaproperty — so if an object were ever meant to be activated by removing the `Deactivated` metaproperty, that path still isn't modeled. No shipped object links to `Deactivated`, so nothing regresses today.

## Audit: other registrations that can't match a chunk

Every registered `P$` name in `dark/src/properties/mod.rs` was checked against the chunk names actually present in `shock2.gam` and all 23 `.mis` files:

| Registered name | Real chunk | Status |
| --- | --- | --- |
| `P$AI_AlertCap` (13) | `P$AI_AlertC` | **Fixed here** — authored by 21 objects |
| `P$AI_AwrDel2` (12) | `P$AI_AwrDel` | Same bug, **not fixed here**: the one shipped entry (gamesys -367 `Security Camera`) stores `to_two = -1`, a sentinel that `AlertnessTimings::from_aware_delay` would turn into a ~50-day escalation delay — renaming it as-is would stop cameras alerting entirely. Tracked in #887. |
| `P$Automap` (9) | — | Short enough to match, but no such chunk exists in any shipped file (likely a Thief-era property). Dead registration, harmless. |

No other registered name exceeds 11 characters.

A new unit test, `registered_chunk_names_fit_the_11_char_chunk_field`, now fails the build if any registration exceeds the field width (with `P$AI_AwrDel2` on an explicit, documented allow-list pointing at #887), so this class of bug can't be reintroduced silently.

## Verification

- Negative test first: `cargo dq templates 1073` listed `P$AI_AlertC` under "Unparsed Properties" before the fix; parses as `PropAIAlertCap` after. The new guard unit test likewise fails when the old name is restored.
- New SDK e2e test `tools/shock2-sdk/test/docile-alert-cap.e2e.test.ts` (`SHOCK2_E2E=1`): loads earth.mis, discovers the training droids by name, fires `DebugAlertAll`, steps 300 frames and asserts they stay `Lowest`, never enter `Chase`, and hold position. It **fails on main** (`expected 'Lowest', actual 'Low'`) and passes with the fix.
- `clamp_level` hardened: both bounds now come from mission bytes and an out-of-range level parses as `High`, so an inverted cap would have panicked inside `Ord::clamp`. Guarded, with a regression test that panics without the guard.
- `force-chase.e2e.test.ts` updated: it probed the *nearest* medsci1 hybrid, which is the alert-capped scripted vent hybrid (613); it now probes hybrids that actually took the pin and requires at least two.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo test -p dark` (79 unit + 9 mission-loading) and `cargo test -p shock2vr alertness` (11) green.
- Full SDK e2e suite (`npm run test:e2e`, 220 tests): the only remaining failure is `monster-death`'s "a loaded corpse does not replay its death", which is pre-existing on main and unrelated (it reports zero position/pose error). `missions.e2e.test.ts` loads all 23 missions.

## Media

![Docile alert cap demo](https://gist.githubusercontent.com/tommy-xr/a57aca0af9d5a475d293ce3992b0ef2f/raw/docile-alert-cap.gif)

<sub>`earth.mis` training-protocol droid, same deterministic sequence on both sides: teleport the player in front of the droid, then fire the `DebugAlertAll` input action (forces every AI to Moderate) and step 640 sim frames. Left = `main`, right = this branch. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/a57aca0af9d5a475d293ce3992b0ef2f/raw/docile-alert-cap-beforeafter.png)

Entity state 640 sim frames after `DebugAlertAll` (`GET /v1/entities/<id>`, droid `template_id` 547, authored position `[88.03, 24.10, 187.04]`):

| | AIAlertness | AIBehavior | position |
| --- | --- | --- | --- |
| before (`main`) | `High` | `MeleeAttack` | `[85.74, 22.10, 184.12]` (off the stand, charging the player) |
| after (this branch) | `Lowest` | `Idle` | `[88.02, 24.10, 187.04]` (unmoved on its stand) |

