### PR TITLE
fix(gameplay): spawn Corpse/Flinderize links when creatures die from damage

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -91,7 +91,9 @@ use crate::{
     scripts::{
         self, Effect, GlobalEffect, Message, MessagePayload,
         internal_fast_projectile::InternalFastProjectileScript,
-        script_util::{get_all_links_with_template, get_environmental_sound_query},
+        script_util::{
+            get_all_links_with_template, get_environmental_sound_query, has_death_links,
+        },
         speech_registry::SpeechVoiceRegistry,
     },
     systems::{
@@ -4399,31 +4401,28 @@ impl MissionCore {
                         // multibody rig is the default; `ragdoll_impulse` falls back
                         // to the legacy impulse-joint rig. Without the flag (or for
                         // non-ragdoll-able entities), fall back to the plain removal.
-                        let spawned_ragdoll =
-                            game_options.experimental_features.contains("ragdoll")
-                                && self
-                                    .spawn_ragdoll(
-                                        entity_id,
-                                        !game_options
-                                            .experimental_features
-                                            .contains("ragdoll_impulse"),
-                                        // Slain mid-animation, usually upright -
-                                        // not a crumpled pose.
-                                        false,
-                                    )
-                                    .is_some();
+                        // An entity replaced by its own Corpse/Flinderize links
+                        // (a droid's explosion and parts, an Overlord's gibs)
+                        // never ragdolls: the spawned links are the body, and a
+                        // ragdoll on top would leave a corpse the explosion was
+                        // supposed to consume.
+                        let spawned_ragdoll = !has_death_links(&self.world, entity_id)
+                            && game_options.experimental_features.contains("ragdoll")
+                            && self
+                                .spawn_ragdoll(
+                                    entity_id,
+                                    !game_options
+                                        .experimental_features
+                                        .contains("ragdoll_impulse"),
+                                    // Slain mid-animation, usually upright -
+                                    // not a crumpled pose.
+                                    false,
+                                )
+                                .is_some();
                         if !spawned_ragdoll {
                             self.remove_entity(entity_id);
                         }
                     }
-                }
-                Effect::SlayIntoLinks { entity_id } => {
-                    // The dying entity's Corpse/Flinderize links replace it:
-                    // spawn them at its position (same machinery as
-                    // Effect::SlayEntity) and remove it. No ragdoll - the
-                    // spawned explosion and parts are the death effect.
-                    self.slay_entity(entity_id, asset_cache);
-                    self.remove_entity(entity_id);
                 }
                 Effect::SpawnCorpseRagdoll { entity_id, impact } => {
                     // Death-crumple handoff (AI deaths): once the death

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -4417,6 +4417,14 @@ impl MissionCore {
                         }
                     }
                 }
+                Effect::SlayIntoLinks { entity_id } => {
+                    // The dying entity's Corpse/Flinderize links replace it:
+                    // spawn them at its position (same machinery as
+                    // Effect::SlayEntity) and remove it. No ragdoll - the
+                    // spawned explosion and parts are the death effect.
+                    self.slay_entity(entity_id, asset_cache);
+                    self.remove_entity(entity_id);
+                }
                 Effect::SpawnCorpseRagdoll { entity_id, impact } => {
                     // Death-crumple handoff (AI deaths): once the death
                     // animation has finished, replace the animated corpse with

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -553,6 +553,18 @@ impl AnimatedMonsterAI {
         // later than they were dealt).
         self.death_elapsed = 0.0;
 
+        // Robot-style death: a creature that authors Corpse/Flinderize links
+        // (droids link a `Corpse` explosion, plus `Flinderize` parts) is
+        // replaced by those links rather than leaving a body - the explosion
+        // is the death effect, so there is no crumple animation, no death
+        // speech (the explosion template carries its own `CreateSound`) and no
+        // ragdoll. Pre-mark the handoff so the removed entity is never offered
+        // to physics if it survives a frame.
+        if crate::scripts::script_util::has_death_links(world, entity_id) {
+            self.handoff_emitted = true;
+            return Effect::SlayIntoLinks { entity_id };
+        }
+
         let death_sound_effect = if let Some(voice_index) =
             crate::scripts::speech_util::resolve_entity_voice_index(world, entity_id)
         {
@@ -1737,6 +1749,90 @@ mod tests {
             true,
             NotScripted
         ));
+    }
+
+    /// A lethal blow on a creature that authors death links (droids link a
+    /// `Corpse` explosion and `Flinderize` parts) must spawn those links and
+    /// remove the creature - no crumple animation, death speech or ragdoll
+    /// handoff for a body that no longer exists.
+    #[test]
+    fn creature_with_death_links_slays_into_its_links() {
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(0.0));
+        world.add_component(
+            entity_id,
+            dark::properties::Links {
+                to_links: vec![dark::properties::ToLink {
+                    to_template_id: -1425,
+                    to_entity_id: None,
+                    link: dark::properties::Link::Flinderize(dark::properties::FlinderizeOptions {
+                        count: 1,
+                        impulse: 0.0,
+                        scatter: false,
+                        offset: vec3(0.0, 0.0, 0.0),
+                    }),
+                }],
+            },
+        );
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        let physics = PhysicsWorld::new();
+        let effects = Effect::flatten(vec![monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::Damage {
+                amount: 100.0,
+                impact: None,
+            },
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::SlayIntoLinks { .. })),
+            "expected a link death, got {effects:?}"
+        );
+        assert!(
+            effects.iter().all(|effect| !matches!(
+                effect,
+                Effect::PlayAnimationBySchema { .. } | Effect::PlaySpeech { .. }
+            )),
+            "a link death has no crumple or death speech, got {effects:?}"
+        );
+        assert!(monster.handoff_emitted, "a removed body must not ragdoll");
+    }
+
+    /// Organics author no death links: they keep the crumple + death speech.
+    #[test]
+    fn creature_without_death_links_crumples() {
+        let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+
+        let physics = PhysicsWorld::new();
+        let effects = Effect::flatten(vec![monster.handle_message(
+            entity_id,
+            &world,
+            &physics,
+            &MessagePayload::Damage {
+                amount: 100.0,
+                impact: None,
+            },
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .all(|effect| !matches!(effect, Effect::SlayIntoLinks { .. })),
+            "an organic must not slay into links, got {effects:?}"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::PlayAnimationBySchema { .. })),
+            "expected the crumple animation, got {effects:?}"
+        );
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -553,16 +553,18 @@ impl AnimatedMonsterAI {
         // later than they were dealt).
         self.death_elapsed = 0.0;
 
-        // Robot-style death: a creature that authors Corpse/Flinderize links
-        // (droids link a `Corpse` explosion, plus `Flinderize` parts) is
-        // replaced by those links rather than leaving a body - the explosion
-        // is the death effect, so there is no crumple animation, no death
-        // speech (the explosion template carries its own `CreateSound`) and no
-        // ragdoll. Pre-mark the handoff so the removed entity is never offered
-        // to physics if it survives a frame.
+        // A creature that authors Corpse/Flinderize links bursts instead of
+        // leaving a body: droids link a `Corpse` explosion (plus `Flinderize`
+        // parts), and organics that gib - the Overlord's viral explosion and
+        // its limb/organ flinders - do the same. `Effect::SlayEntity` spawns
+        // those links, plays the death environmental sound and removes the
+        // entity (its handler skips the ragdoll for link deaths), so there is
+        // no crumple animation and no death speech either. Pre-mark the
+        // handoff so the removed entity is never offered to physics if it
+        // survives a frame.
         if crate::scripts::script_util::has_death_links(world, entity_id) {
             self.handoff_emitted = true;
-            return Effect::SlayIntoLinks { entity_id };
+            return Effect::SlayEntity { entity_id };
         }
 
         let death_sound_effect = if let Some(voice_index) =
@@ -1751,10 +1753,28 @@ mod tests {
         ));
     }
 
+    /// Deal a killing blow to a fresh monster and return it with the effects
+    /// its death produced.
+    fn kill(world: &World, entity_id: EntityId) -> (AnimatedMonsterAI, Vec<Effect>) {
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, world);
+        let physics = PhysicsWorld::new();
+        let effects = Effect::flatten(vec![monster.handle_message(
+            entity_id,
+            world,
+            &physics,
+            &MessagePayload::Damage {
+                amount: 100.0,
+                impact: None,
+            },
+        )]);
+        (monster, effects)
+    }
+
     /// A lethal blow on a creature that authors death links (droids link a
-    /// `Corpse` explosion and `Flinderize` parts) must spawn those links and
-    /// remove the creature - no crumple animation, death speech or ragdoll
-    /// handoff for a body that no longer exists.
+    /// `Corpse` explosion and `Flinderize` parts) must slay it into those
+    /// links - no crumple animation, death speech or ragdoll handoff for a
+    /// body that no longer exists.
     #[test]
     fn creature_with_death_links_slays_into_its_links() {
         let (mut world, entity_id) = world_with_monster_and_player(Deg(0.0));
@@ -1773,24 +1793,13 @@ mod tests {
                 }],
             },
         );
-        let mut monster = AnimatedMonsterAI::new();
-        monster.initialize(entity_id, &world);
 
-        let physics = PhysicsWorld::new();
-        let effects = Effect::flatten(vec![monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::Damage {
-                amount: 100.0,
-                impact: None,
-            },
-        )]);
+        let (monster, effects) = kill(&world, entity_id);
 
         assert!(
             effects
                 .iter()
-                .any(|effect| matches!(effect, Effect::SlayIntoLinks { .. })),
+                .any(|effect| matches!(effect, Effect::SlayEntity { .. })),
             "expected a link death, got {effects:?}"
         );
         assert!(
@@ -1807,24 +1816,13 @@ mod tests {
     #[test]
     fn creature_without_death_links_crumples() {
         let (world, entity_id) = world_with_monster_and_player(Deg(0.0));
-        let mut monster = AnimatedMonsterAI::new();
-        monster.initialize(entity_id, &world);
 
-        let physics = PhysicsWorld::new();
-        let effects = Effect::flatten(vec![monster.handle_message(
-            entity_id,
-            &world,
-            &physics,
-            &MessagePayload::Damage {
-                amount: 100.0,
-                impact: None,
-            },
-        )]);
+        let (_monster, effects) = kill(&world, entity_id);
 
         assert!(
             effects
                 .iter()
-                .all(|effect| !matches!(effect, Effect::SlayIntoLinks { .. })),
+                .all(|effect| !matches!(effect, Effect::SlayEntity { .. })),
             "an organic must not slay into links, got {effects:?}"
         );
         assert!(

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -360,6 +360,14 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
+    /// Death by `Corpse`/`Flinderize` links: spawn the linked explosion and
+    /// parts at the dying entity's position and remove it. Emitted by the AI
+    /// death path for creatures that author those links (droids), where the
+    /// spawned explosion replaces the body - no corpse, crumple or ragdoll.
+    SlayIntoLinks {
+        entity_id: EntityId,
+    },
+
     /// The death (crumple) animation finished: hand the corpse over to physics
     /// as a ragdoll, optionally seeded with the killing blow (so the corpse
     /// reacts at the struck limb, in the shot's direction). Emitted

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -360,14 +360,6 @@ pub enum Effect {
         entity_id: EntityId,
     },
 
-    /// Death by `Corpse`/`Flinderize` links: spawn the linked explosion and
-    /// parts at the dying entity's position and remove it. Emitted by the AI
-    /// death path for creatures that author those links (droids), where the
-    /// spawned explosion replaces the body - no corpse, crumple or ragdoll.
-    SlayIntoLinks {
-        entity_id: EntityId,
-    },
-
     /// The death (crumple) animation finished: hand the corpse over to physics
     /// as a ragdoll, optionally seeded with the killing blow (so the corpse
     /// reacts at the struck limb, in the shot's direction). Emitted

--- a/shock2vr/src/scripts/script_util.rs
+++ b/shock2vr/src/scripts/script_util.rs
@@ -152,6 +152,19 @@ pub fn get_all_links_with_template<TData>(
     linked_entities
 }
 
+/// True when the entity authors any `Corpse` or `Flinderize` link
+/// (inheritance-aware, like every other link lookup: the links are merged down
+/// the template hierarchy at instantiation). Objects that do - droids link a
+/// `Corpse` explosion, and often `Flinderize` parts - are replaced by those
+/// links when they die instead of leaving a body behind.
+pub fn has_death_links(world: &World, entity_id: EntityId) -> bool {
+    !get_all_links_with_template(world, entity_id, |link| match link {
+        Link::Corpse(_) | Link::Flinderize(_) => Some(()),
+        _ => None,
+    })
+    .is_empty()
+}
+
 /// A weapon's selectable `Projectile` links (its ammo types), filtered to the
 /// current gun setting and ordered by `ProjectileOptions.order`. This is the
 /// canonical ammo-type list - firing, ammo-type cycling, and the HUD all derive

--- a/tools/shock2-sdk/test/death-links.e2e.test.ts
+++ b/tools/shock2-sdk/test/death-links.e2e.test.ts
@@ -36,7 +36,9 @@ test(
     const knownIds = new Set(before.entities.map((entity) => entity.id));
 
     await game.entities.sendMessage(droid.id, { type: "Damage", amount: 100 });
-    await game.step({ frames: 30 });
+    // HE_Harmless is a bitmap animation with kill_on_completion (~0.9s), so
+    // sample right after the kill rather than near its self-destruct.
+    await game.step({ frames: 2 });
 
     const after = await game.entities.list({ limit: 2000 });
     const spawned = after.entities.filter(
@@ -53,41 +55,7 @@ test(
   },
 );
 
-test(
-  "a killed organic still leaves a corpse",
-  { skip: !e2eEnabled, timeout: 600_000 },
-  async () => {
-    await using game = await GameServer.launch({
-      mission: "medsci1.mis",
-      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
-    });
-
-    await game.step({ frames: 10 });
-
-    // Spawn a hybrid (OG-Pipe): organics author no Corpse/Flinderize links,
-    // so they must keep crumpling into a persistent body. Diff the list -
-    // medsci1 has native OG-Pipes too.
-    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
-    const known = new Set(preSpawn.entities.map((entity) => entity.id));
-    await game.input.trigger("SpawnDebugMonster");
-    await game.step({ frames: 30 });
-    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
-    const monster = postSpawn.entities.find(
-      (entity) => entity.name === "OG-Pipe" && !known.has(entity.id),
-    );
-    assert.ok(monster, "expected a newly spawned OG-Pipe");
-
-    await game.entities.sendMessage(monster.id, {
-      type: "Damage",
-      amount: 1000,
-    });
-    await game.step({ frames: 120 });
-
-    const detail = await game.entities.detail(monster.id);
-    assert.equal(
-      detail.properties.find((p) => p.name === "AIBehavior")?.value,
-      "Dead",
-      "an organic should crumple into a persistent corpse",
-    );
-  },
-);
+// The organic regression (no death links -> crumple into a persistent corpse)
+// is covered by monster-death.e2e.test.ts's "a killed monster dies and stays
+// dead" and by the `creature_without_death_links_crumples` unit test, so it
+// does not warrant a second runtime launch here.

--- a/tools/shock2-sdk/test/death-links.e2e.test.ts
+++ b/tools/shock2-sdk/test/death-links.e2e.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "a killed droid explodes into its Corpse link and leaves no body",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
+    });
+
+    await game.step({ frames: 10 });
+
+    // earth.mis's training droids inherit template -4015 "Training Droid",
+    // which links Corpse -> -2912 "HE_Harmless". Runtime entity IDs are
+    // assigned afresh every launch, so discover the droid by name.
+    const droids = await game.entities.list({
+      filter: "Training Droid",
+      limit: 50,
+    });
+    const droid = droids.entities.find(
+      (entity) => entity.name === "Training Droid",
+    );
+    assert.ok(droid, "earth.mis should contain a Training Droid");
+
+    const before = await game.entities.list({ limit: 2000 });
+    const knownIds = new Set(before.entities.map((entity) => entity.id));
+
+    await game.entities.sendMessage(droid.id, { type: "Damage", amount: 100 });
+    await game.step({ frames: 30 });
+
+    const after = await game.entities.list({ limit: 2000 });
+    const spawned = after.entities.filter(
+      (entity) => !knownIds.has(entity.id),
+    );
+    assert.ok(
+      spawned.some((entity) => entity.template_id === -2912),
+      `expected the linked HE_Harmless explosion, got ${JSON.stringify(spawned)}`,
+    );
+    assert.ok(
+      !after.entities.some((entity) => entity.id === droid.id),
+      "the exploded droid must be removed, not left as a corpse",
+    );
+  },
+);
+
+test(
+  "a killed organic still leaves a corpse",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8131),
+    });
+
+    await game.step({ frames: 10 });
+
+    // Spawn a hybrid (OG-Pipe): organics author no Corpse/Flinderize links,
+    // so they must keep crumpling into a persistent body. Diff the list -
+    // medsci1 has native OG-Pipes too.
+    const preSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const known = new Set(preSpawn.entities.map((entity) => entity.id));
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 30 });
+    const postSpawn = await game.entities.list({ filter: "OG-Pipe", limit: 50 });
+    const monster = postSpawn.entities.find(
+      (entity) => entity.name === "OG-Pipe" && !known.has(entity.id),
+    );
+    assert.ok(monster, "expected a newly spawned OG-Pipe");
+
+    await game.entities.sendMessage(monster.id, {
+      type: "Damage",
+      amount: 1000,
+    });
+    await game.step({ frames: 120 });
+
+    const detail = await game.entities.detail(monster.id);
+    assert.equal(
+      detail.properties.find((p) => p.name === "AIBehavior")?.value,
+      "Dead",
+      "an organic should crumple into a persistent corpse",
+    );
+  },
+);


### PR DESCRIPTION
## Problem

Creatures killed by damage never ran their authored `Corpse`/`Flinderize` links, so robots did not explode on death — a shot Training Droid just stood there as an intact corpse.

The link-spawning machinery (`MissionCore::slay_entity`) was correct but unreachable from the creature death path: it only runs for `Effect::SlayEntity`, which is emitted by traps, collisions and `MessagePayload::Slay` — never by `AnimatedMonsterAI`'s lethal-damage branch, which plays a crumple animation instead.

Reproduced on `earth.mis` before the fix: damage a Training Droid (template `-4015`, `Corpse -> -2912 HE_Harmless`) to death and no explosion entity appears; the droid remains with `AIBehavior: Dead`.

## Fix

Death is now data-driven, matching the original engine. On lethal damage, `enter_death` checks whether the creature authors any `Corpse`/`Flinderize` link (inheritance-aware — links are merged down the template hierarchy at instantiation) and, if so, returns `Effect::SlayEntity`, whose handler already spawns the links at the body's position and removes it.

The handler additionally gates the ragdoll spawn on `has_death_links`, so *every* death route agrees: an entity replaced by its own links never leaves a ragdoll behind (previously a droid slain by a trap or a tweq got explosion **plus** an articulated corpse under `--experimental ragdoll`).

Creatures that author no such links — every organic hybrid, arachnid, monkey, assassin — are unchanged: crumple, and the optional ragdoll handoff.

### Design decisions

- **Entity removal**: link deaths remove the dying entity. The spawned explosion + flinders *are* the body, and the original engine does the same. Save/load is unaffected (the save is rebuilt from the live entity list, so a removed droid stays removed).
- **No crumple, no death speech**: the explosion template carries its own `CreateSound`, and the entity is gone the same frame, so the crumple animation and `comdieloud`/`comdiesoft` speech are skipped. The `"death"` *environmental* sound `SlayEntity` already plays is retained.
- **No new effect variant**: an earlier revision added `Effect::SlayIntoLinks`; review (both engines agreed) showed it was a strict subset of `SlayEntity` and that forking the path is exactly what let trap/tweq droid deaths diverge. Routing through `SlayEntity` is a smaller diff and unifies all death sources.
- **Not just robots**: the rule is the data, not a robot check. Organic Overlords also author `Corpse -> AH Viral Explosion` + `Flinderize -> Overlord Tail/Limb/Chunk/Organ`, and they gib in the original game too — so they take this path by design.

## Testing

- `shock2vr/src/scripts/ai/animated_monster_ai.rs`: unit tests for both arms — a creature with a `Flinderize` link slays into its links with no crumple/speech; one without keeps the crumple.
- `tools/shock2-sdk/test/death-links.e2e.test.ts` (new, `SHOCK2_E2E=1`): kills an `earth.mis` Training Droid (discovered by name — runtime IDs are not stable) and asserts an `HE_Harmless` (`-2912`) entity appears and the droid is gone. **Verified as a negative test**: it fails on `main` with `expected the linked HE_Harmless explosion, got []`.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — clean.
- `cargo test -p shock2vr` — 526 passed.
- Full SDK e2e suite (`SHOCK2_E2E=1 npm run test:e2e`): **220 tests, 215 pass, 3 skipped, 2 fail** — both failures investigated and unrelated:
  - `monster-death`: "a loaded corpse does not replay its death" — fails identically on `main` (pre-existing).
  - `search-behavior`: "losing sight of the player triggers a search of the last-known position" — flaky; passes on two consecutive re-runs with this branch built, and it exercises an OG-Pipe, which authors no `Corpse`/`Flinderize` links (verified with `cargo dq`), so the changed branch never fires for it.


## Media

![Training Droid explosion demo](https://gist.githubusercontent.com/tommy-xr/839f9a892a8068997b3a52e97269cfe2/raw/demo.gif)

<sub>Damaging a Training Droid to death on `earth.mis` — it explodes into its authored `HE_Harmless` link and disappears. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/839f9a892a8068997b3a52e97269cfe2/raw/beforeafter.png)

<sub>Same kill sequence at the same simulated time on `main` (BEFORE) vs. this branch (AFTER): the droid stays standing intact on `main`; on this branch it has exploded and vanished.</sub>

