### PR TITLE
fix(gameplay): require keycard reader activation

### DIFF
--- a/shock2vr/src/scripts/base_button.rs
+++ b/shock2vr/src/scripts/base_button.rs
@@ -1,5 +1,5 @@
 use engine::audio::AudioHandle;
-use shipyard::{EntityId, World};
+use shipyard::{EntityId, Get, View, World};
 
 use crate::physics::PhysicsWorld;
 
@@ -16,6 +16,19 @@ impl BaseButton {
 
     pub fn is_locked(&self, entity_id: EntityId, world: &World) -> bool {
         super::script_util::is_entity_locked(world, entity_id)
+    }
+
+    /// Whether Dark's authored lock is still set, independent of whether the
+    /// player currently carries a key that can clear it. Remote signals must
+    /// use this state: possessing a card is not the same as presenting it to
+    /// the reader.
+    fn lock_is_set(&self, entity_id: EntityId, world: &World) -> bool {
+        world
+            .borrow::<View<dark::properties::PropLocked>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|lock| lock.0)
+            .unwrap_or(false)
     }
 
     /// The refusal a locked button gives instead of activating, or `None` when
@@ -59,14 +72,25 @@ impl Script for BaseButton {
                         to: entity_id,
                     },
                 };
-                Effect::combine(vec![self.activate_effect(entity_id, world), notify_self])
+                let unlock = self
+                    .lock_is_set(entity_id, world)
+                    .then_some(Effect::SetLocked {
+                        entity_id,
+                        locked: false,
+                    });
+                Effect::combine(
+                    unlock
+                        .into_iter()
+                        .chain([self.activate_effect(entity_id, world), notify_self])
+                        .collect(),
+                )
             }),
 
             // In some places (like the computer for the engine room in eng1), invisible buttons are used as proxies -
             // there will be an actual button that sends a 'TurnOn' message to an invisible button. Not sure why
             // this pattern is used. A remote press still honors the proxy's lock;
             // otherwise tripwires can relay through authored locked card slots.
-            MessagePayload::TurnOn { from: _ } if !self.is_locked(entity_id, world) => {
+            MessagePayload::TurnOn { from: _ } if !self.lock_is_set(entity_id, world) => {
                 send_to_all_switch_links(
                     world,
                     entity_id,
@@ -81,7 +105,7 @@ impl Script for BaseButton {
 
 #[cfg(test)]
 mod tests {
-    use dark::properties::{Link, Links, PropLocked, ToLink, WrappedEntityId};
+    use dark::properties::{KeyCard, Link, Links, PropKeyDst, PropLocked, ToLink, WrappedEntityId};
 
     use crate::quest_info::QuestInfo;
 
@@ -91,6 +115,14 @@ mod tests {
         match effect {
             Effect::Send { msg } => vec![(msg.to, msg.payload.clone())],
             Effect::Combined { effects } => effects.iter().flat_map(sent_messages).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn lock_updates(effect: &Effect) -> Vec<(EntityId, bool)> {
+        match effect {
+            Effect::SetLocked { entity_id, locked } => vec![(*entity_id, *locked)],
+            Effect::Combined { effects } => effects.iter().flat_map(lock_updates).collect(),
             _ => Vec::new(),
         }
     }
@@ -141,6 +173,126 @@ mod tests {
                 .any(|(to, payload)| *to == target
                     && matches!(payload, MessagePayload::TurnOn { from } if *from == unlocked)),
             "an unlocked proxy button must keep relaying scripted TurnOn"
+        );
+    }
+
+    #[test]
+    fn card_reader_does_not_relay_turn_on_until_it_is_frobbed() {
+        let mut world = World::new();
+        let key = KeyCard {
+            is_master: false,
+            region_id: 256,
+            lock_id: 0,
+        };
+        let mut quest = QuestInfo::new();
+        quest.add_key_card(key.clone());
+        world.add_unique(quest);
+        let target = world.add_entity(());
+        let reader = world.add_entity((
+            PropLocked(true),
+            PropKeyDst(key),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = BaseButton::new();
+
+        let relayed = button.handle_message(
+            reader,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: reader },
+        );
+
+        assert!(
+            sent_messages(&relayed).is_empty(),
+            "possessing a matching card must not bypass a still-locked reader"
+        );
+    }
+
+    #[test]
+    fn frobbing_a_reader_without_its_card_keeps_it_locked_and_quiet() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let target = world.add_entity(());
+        let reader = world.add_entity((
+            PropLocked(true),
+            PropKeyDst(KeyCard {
+                is_master: false,
+                region_id: 128,
+                lock_id: 0,
+            }),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = BaseButton::new();
+
+        let effect = button.handle_message(reader, &world, &physics, &MessagePayload::Frob);
+
+        assert!(lock_updates(&effect).is_empty());
+        assert!(sent_messages(&effect).is_empty());
+        assert!(
+            matches!(effect, Effect::PlaySound { ref name, .. } if name == "hackfail"),
+            "an invalid reader frob must give the locked-button refusal"
+        );
+    }
+
+    #[test]
+    fn frobbing_a_reader_with_its_card_unlocks_and_activates_it() {
+        let mut world = World::new();
+        let key = KeyCard {
+            is_master: false,
+            region_id: 128,
+            lock_id: 0,
+        };
+        let mut quest = QuestInfo::new();
+        quest.add_key_card(key.clone());
+        world.add_unique(quest);
+        let target = world.add_entity(());
+        let reader = world.add_entity((
+            PropLocked(true),
+            PropKeyDst(key.clone()),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(target)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut button = BaseButton::new();
+
+        let effect = button.handle_message(reader, &world, &physics, &MessagePayload::Frob);
+
+        assert!(
+            lock_updates(&effect).contains(&(reader, false)),
+            "a legitimate card-reader frob must clear the authored lock"
+        );
+        assert!(
+            sent_messages(&effect)
+                .iter()
+                .any(|(to, payload)| *to == target
+                    && matches!(payload, MessagePayload::TurnOn { from } if *from == reader)),
+            "the legitimate frob must still activate the reader's switch links"
+        );
+        assert!(
+            world
+                .borrow::<shipyard::UniqueView<QuestInfo>>()
+                .unwrap()
+                .can_unlock(&key),
+            "unlocking a reader must retain the key card"
         );
     }
 }

--- a/tools/shock2-sdk/test/hydro2-keycard-gates.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-keycard-gates.e2e.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// Hydro 2 repeats one authored gate pattern on both sides of Sectors B and
+// C/D: a New Tripwire sends TurnOn to two locked TweqLockedButton card
+// readers, which in turn switch the translating door. The player may retain a
+// matching card, but the tripwire must not present it for them: only a Frob on
+// the reader legitimately clears PropLocked and enables later relays (#796).
+//
+// Negative-first on origin/main: after acquiring Hydro Card D without
+// frobbing either reader, entering tripwire 1178 raised door 1181 by 3.6 units.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const SECTOR_B_READER = 1120;
+const SECTOR_B_READER_OTHER_SIDE = 1122;
+const SECTOR_B_DOOR = 1127;
+const SECTOR_CD_TRIPWIRE = 1178;
+const SECTOR_CD_READER = 1152;
+const SECTOR_CD_DOOR = 1181;
+const HYDRO_CARD_B = -1495;
+const HYDRO_CARD_D = -1496;
+
+async function only(game: GameServer, objectId: number): Promise<EntitySummary> {
+  const found = await game.entities.byTemplate(objectId);
+  assert.equal(
+    found.length,
+    1,
+    `expected exactly one hydro2 object ${objectId}, got ${JSON.stringify(found)}`,
+  );
+  return found[0];
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+async function position(game: GameServer, objectId: number): Promise<Vec3> {
+  const entity = await only(game, objectId);
+  return (await game.entities.detail(entity.id)).position;
+}
+
+async function closeDoor(game: GameServer, objectId: number): Promise<Vec3> {
+  const door = await only(game, objectId);
+  await game.entities.sendMessage(door.id, { type: "TurnOff" });
+  await game.step({ frames: 240 });
+  return (await game.entities.detail(door.id)).position;
+}
+
+test(
+  "hydro2: keycard gates cannot activate before their locked readers are frobbed",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8196),
+    });
+    await game.step({ frames: 5 });
+
+    assert.equal((await game.player.inventory()).count, 0);
+
+    const sectorBDoor = await only(game, SECTOR_B_DOOR);
+    const sectorBBefore = sectorBDoor.position;
+    const sectorBReader = await only(game, SECTOR_B_READER);
+    await game.entities.sendMessage(sectorBReader.id, { type: "Frob" });
+    await game.step({ frames: 240 });
+    const sectorBAfter = (await game.entities.detail(sectorBDoor.id)).position;
+    assert.ok(
+      distance(sectorBBefore, sectorBAfter) < 0.01,
+      `an empty-card reader frob must leave Sector B closed: ${JSON.stringify({ sectorBBefore, sectorBAfter })}`,
+    );
+
+    // Presenting the matching card is the legitimate transition: the reader
+    // opens the door and clears its own authored lock.
+    const cardB = await game.player.spawnItem(HYDRO_CARD_B);
+    await game.entities.sendMessage(cardB.entity_id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.equal((await game.player.inventory()).count, 0);
+    await game.entities.sendMessage(sectorBReader.id, { type: "Frob" });
+    await game.step({ frames: 240 });
+    const sectorBOpened = await position(game, SECTOR_B_DOOR);
+    assert.ok(
+      distance(sectorBBefore, sectorBOpened) > 3.5,
+      `the matching Hydro B card must open Sector B: ${JSON.stringify({ sectorBBefore, sectorBOpened })}`,
+    );
+
+    // PropLocked is persisted game state. After save/load, a scripted TurnOn
+    // may pass through the reader the player already unlocked.
+    const sectorBClosed = await closeDoor(game, SECTOR_B_DOOR);
+    assert.ok(distance(sectorBBefore, sectorBClosed) < 0.01);
+    await game.save("hydro2-keycard-gates-e2e");
+    await game.load("hydro2-keycard-gates-e2e");
+    await game.step({ frames: 5 });
+    const loadedReader = await only(game, SECTOR_B_READER);
+    await game.entities.sendMessage(loadedReader.id, { type: "TurnOn" });
+    await game.step({ frames: 240 });
+    const sectorBRelayed = await position(game, SECTOR_B_DOOR);
+    assert.ok(
+      distance(sectorBBefore, sectorBRelayed) > 3.5,
+      "an explicitly unlocked reader must keep relaying after save/load",
+    );
+
+    // The key itself is retained too: the opposite still-locked reader can be
+    // legitimately unlocked without acquiring a second card entity.
+    await closeDoor(game, SECTOR_B_DOOR);
+    const otherReader = await only(game, SECTOR_B_READER_OTHER_SIDE);
+    await game.entities.sendMessage(otherReader.id, { type: "Frob" });
+    await game.step({ frames: 240 });
+    assert.ok(
+      distance(sectorBBefore, await position(game, SECTOR_B_DOOR)) > 3.5,
+      "the retained Hydro B card must unlock the opposite reader",
+    );
+
+    // Acquire the real Hydro D key state without pressing either reader. Key
+    // cards are retained in QuestInfo and the pickup entity is destroyed, so
+    // the ordinary inventory remains empty after this production script path.
+    const card = await game.player.spawnItem(HYDRO_CARD_D);
+    await game.entities.sendMessage(card.entity_id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.equal((await game.player.inventory()).count, 0);
+
+    const sectorCdDoor = await only(game, SECTOR_CD_DOOR);
+    const sectorCdBefore = sectorCdDoor.position;
+    const tripwire = await only(game, SECTOR_CD_TRIPWIRE);
+    const [x, y, z] = tripwire.position;
+    await game.player.teleport({ x, y: y + 0.5, z });
+    await game.step({ frames: 240 });
+    const sectorCdAfter = (await game.entities.detail(sectorCdDoor.id)).position;
+    assert.ok(
+      distance(sectorCdBefore, sectorCdAfter) < 0.01,
+      `possessing a card must not let a tripwire bypass still-locked readers: ${JSON.stringify({ sectorCdBefore, sectorCdAfter })}`,
+    );
+
+    // Once the player presents the card, normal reader activation and later
+    // tripwire relay behavior remain valid.
+    const sectorCdReader = await only(game, SECTOR_CD_READER);
+    await game.entities.sendMessage(sectorCdReader.id, { type: "Frob" });
+    await game.step({ frames: 240 });
+    assert.ok(
+      distance(sectorCdBefore, await position(game, SECTOR_CD_DOOR)) > 3.5,
+      "presenting Hydro D must open the C/D gate",
+    );
+    await closeDoor(game, SECTOR_CD_DOOR);
+    await game.player.teleport({ x: 30.4, y: 0.6, z: -7.2 });
+    await game.step({ frames: 10 });
+    await game.player.teleport({ x, y: y + 0.5, z });
+    await game.step({ frames: 240 });
+    assert.ok(
+      distance(sectorCdBefore, await position(game, SECTOR_CD_DOOR)) > 3.5,
+      "the tripwire must relay through a legitimately unlocked reader",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #796

## Summary

- require a card-gated `BaseButton` to be legitimately frobbed before scripted `TurnOn` may relay through it
- clear the reader's authored `PropLocked` through `Effect::SetLocked` on an accepted matching-card frob, so the unlock persists and later signals remain valid
- cover Hydro 2's Sector B and C/D readers, card retention, empty-card refusal, save/load, and pre-/post-unlock tripwire behavior end to end

## Reproduction

On exact base `1f36f704`, fresh `hydro2.mis` starts with an empty ordinary inventory. Directly frobbing Sector B reader 1120 without a card leaves door 1127 closed, so that literal path is already protected by merged #686.

The issue's extended C/D path remained live:

1. Acquire the real Hydro Card D (`-1496`) through its injected `internal_keycard` Frob; its entity is destroyed and ordinary inventory is empty again.
2. Do not frob either C/D reader 1152/1177.
3. Enter authored tripwire 1178.
4. Door 1181 moves from `[48.8, 2.5, 58.4]` to `[48.8, 6.1, 58.4]` in 240 frames.

The #795 prerequisite is resolved on current main by #800 / `0e36fb1`: the production crosshair scenario successfully opens corpse 754 and exposes Hydro Card B.

## Root cause and fix

`BaseButton` used `is_entity_locked` for both player interaction and relayed `TurnOn`. That helper deliberately treats possession of a matching card as player-accessible, even while the reader still carries `PropLocked(true)`. A tripwire therefore presented the player's retained card implicitly and bypassed the unfrobbed reader.

Remote signals now check the raw authored lock. An accepted player Frob on a card-gated reader emits `SetLocked(false)` before normal activation. This preserves card validation and retention, keeps keyless `TrapUnlock` buttons unchanged, persists through save/load, and lets legitimate later `TurnOn` signals relay.

## Negative-first evidence

On exact base:

- `card_reader_does_not_relay_turn_on_until_it_is_frobbed` failed because the card-owning locked reader sent `TurnOn` to its target.
- `frobbing_a_reader_with_its_card_unlocks_and_activates_it` failed because no `SetLocked(false)` effect was emitted.
- the Hydro E2E failed with door 1181 moving exactly 3.6 units after the real tripwire fired without a reader frob.

All three are green with this change.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 543 passed
- focused `BaseButton` tests — 4 passed
- `npm test` — 26 passed, E2E skipped as expected
- focused Hydro 2 keycard-gate E2E — passed; invalid B frob, valid B/D unlock, retained card, save/load, blocked pre-unlock relay, and valid post-unlock relay
- existing Command locked-card relay + Eng1 `TrapUnlock` E2Es — 2 passed
- #795 Hydro Card B corpse production-crosshair E2E — passed
- full SDK E2E — the new Hydro scenario and all affected button/door scenarios passed; overall 223 passed, 6 intentionally skipped, and one unrelated intermittent `search-behavior` debug-detail null failed once, then passed an exact focused rerun (and passed on exact base in the preceding full run)

## Visual verification

![Hydro C/D keycard gate comparison](https://gist.githubusercontent.com/tommy-xr/5f684fa157ebb54957c795c9536f72fe/raw/issue-796-hydro-gate-comparison.gif)

<sub>Matched deterministic `hydro2.mis` runs: acquire the real Hydro Card D through `internal_keycard`, enter authored tripwire 1178 without frobbing readers 1152/1177, then step 240 frames. On base, the locked readers relay the tripwire and lift door 1181; with the fix, the red locked reader remains locked and the gate stays closed. Captured headlessly via `/v1/step` and `/v1/screenshot`.</sub>

### Fixed behavior

![Locked reader keeps the gate closed](https://gist.githubusercontent.com/tommy-xr/5f684fa157ebb54957c795c9536f72fe/raw/issue-796-fixed-gate-still.png)

### Before → after

![Matched base and fix comparison after 240 frames](https://gist.githubusercontent.com/tommy-xr/5f684fa157ebb54957c795c9536f72fe/raw/issue-796-before-after.png)
