### PR TITLE
fix(gameplay): preserve FrobQB container hosts

### DIFF
--- a/shock2vr/src/scripts/frob_qb.rs
+++ b/shock2vr/src/scripts/frob_qb.rs
@@ -22,14 +22,16 @@ impl Script for FrobQB {
             MessagePayload::Frob => match set_quest_bit_effect(world, entity_id) {
                 Some(quest_bit_effect) => {
                     // What happens to the object after the quest bit is awarded
-                    // is decided by its `PropFrobInfo`, not by this script: a
+                    // is decided by its `PropFrobInfo`, not by this script. A
                     // pickup item (`world_action` with MOVE/USE_AMMO - the
                     // Engineering circuit board, the access key cards, the Big
                     // Bomb) is *taken*, so it goes into the player's backpack
                     // through the same `DropEntityInfo` transfer the grab and
-                    // loot-container paths use. Everything else (buttons,
-                    // corpses, computers) is used in place and consumed, as
-                    // before. `can_grab_item` is the shared eligibility rule -
+                    // loot-container paths use. A use-in-place host (buttons,
+                    // corpses, computers) remains alive: its sibling scripts
+                    // own the host lifetime and may need it after this effect
+                    // batch, notably `ContainerScript`'s open loot panel.
+                    // `can_grab_item` is the shared eligibility rule -
                     // reparenting anything else would corrupt it.
                     //
                     // A take-able object only goes to the backpack if there is
@@ -38,27 +40,22 @@ impl Script for FrobQB {
                     // and leaving the object frobbable would let a second frob
                     // re-fire the other scripts attached to it - `BaseButton`
                     // resends every SwitchLink - after the bit is already set.
-                    let backpack = if crate::virtual_hand::can_grab_item(world, entity_id) {
-                        world
-                            .borrow::<UniqueView<PlayerInfo>>()
-                            .map(|player| player.inventory_entity_id)
-                            .ok()
+                    if crate::virtual_hand::can_grab_item(world, entity_id) {
+                        match world.borrow::<UniqueView<PlayerInfo>>() {
+                            Ok(player) => Effect::combine(vec![
+                                quest_bit_effect,
+                                Effect::DropEntityInfo {
+                                    parent_entity_id: player.inventory_entity_id,
+                                    dropped_entity_id: entity_id,
+                                },
+                            ]),
+                            Err(_) => Effect::combine(vec![
+                                quest_bit_effect,
+                                Effect::DestroyEntity { entity_id },
+                            ]),
+                        }
                     } else {
-                        None
-                    };
-
-                    match backpack {
-                        Some(parent_entity_id) => Effect::combine(vec![
-                            quest_bit_effect,
-                            Effect::DropEntityInfo {
-                                parent_entity_id,
-                                dropped_entity_id: entity_id,
-                            },
-                        ]),
-                        None => Effect::combine(vec![
-                            quest_bit_effect,
-                            Effect::DestroyEntity { entity_id },
-                        ]),
+                        quest_bit_effect
                     }
                 }
                 None => Effect::NoEffect,
@@ -74,12 +71,13 @@ mod tests {
     use dark::properties::{
         FrobFlag, Links, PropFrobInfo, PropQuestBitName, PropQuestBitValue, QuestBitValue,
     };
-    use shipyard::World;
+    use shipyard::{EntitiesView, World};
 
     use crate::{
+        gui::gui_script,
         mission::PlayerInfo,
         physics::PhysicsWorld,
-        scripts::{Effect, MessagePayload, Script},
+        scripts::{CompositeScript, ContainerGui, Effect, MessagePayload, Script, script_util},
     };
 
     use super::FrobQB;
@@ -190,9 +188,10 @@ mod tests {
     }
 
     /// Use-in-place objects (corpses, the Shield Computer, plot buttons) have no
-    /// MOVE in their world action and keep the consume-on-frob behavior.
+    /// MOVE in their world action. `FrobQB` contributes the quest transition but
+    /// leaves their lifetime to their sibling scripts.
     #[test]
-    fn frobbing_a_use_only_object_still_consumes_it() {
+    fn frobbing_a_use_only_object_leaves_its_lifetime_to_sibling_scripts() {
         let (world, object, _inventory) = quest_object_world(FrobFlag::SCRIPT);
 
         let effects = Effect::flatten(vec![FrobQB::new().handle_message(
@@ -210,11 +209,122 @@ mod tests {
             "the quest bit must be awarded, got {effects:?}"
         );
         assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == object)),
+            "FrobQB must not consume a sibling-owned use-only host, got {effects:?}"
+        );
+    }
+
+    /// Rickenbacker 1 corpse 1636 is an authored composite host: its
+    /// `ContainerScript` owns the loot panel while `FrobQB` awards Note_7_8.
+    /// One Frob must not tear down that shared host (and its Contains links)
+    /// after opening the panel.
+    #[test]
+    fn frobbing_a_quest_container_opens_it_without_destroying_its_contents() {
+        let mut world = World::new();
+        let card = world.add_entity(());
+        let corpse = world.add_entity((
+            PropQuestBitName("Note_7_8".to_owned()),
+            PropQuestBitValue(QuestBitValue::COMPLETE),
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            Links {
+                to_links: vec![dark::properties::ToLink {
+                    to_template_id: 1779,
+                    to_entity_id: Some(dark::properties::WrappedEntityId(card)),
+                    link: dark::properties::Link::Contains(0),
+                }],
+            },
+        ));
+        let mut scripts = CompositeScript::new(vec![
+            gui_script(Box::new(ContainerGui::loot_container())),
+            Box::new(FrobQB::new()),
+        ]);
+
+        let effects = Effect::flatten(vec![scripts.handle_message(
+            corpse,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::OpenPanel { entity } if *entity == corpse)),
+            "the container sibling must open its panel, got {effects:?}"
+        );
+        assert!(
             effects.iter().any(|effect| matches!(
                 effect,
-                Effect::DestroyEntity { entity_id } if *entity_id == object
+                Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_7_8"
             )),
-            "a use-only object must still be consumed, got {effects:?}"
+            "FrobQB must still award the corpse's quest bit, got {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == corpse)),
+            "FrobQB must not destroy a use-in-place host owned by sibling scripts, got {effects:?}"
+        );
+
+        // Apply the only lifetime-changing effect relevant to this regression.
+        // Production handles OpenPanel/SetQuestBit without modifying the host;
+        // DestroyEntity is what removed the corpse and orphaned its children.
+        for effect in &effects {
+            if matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == corpse) {
+                world.delete_entity(corpse);
+            }
+        }
+
+        assert!(
+            world.borrow::<EntitiesView>().unwrap().is_alive(corpse),
+            "the shared quest/container host must survive the effect batch"
+        );
+        let contains = script_util::get_all_links_with_data(&world, corpse, |link| match link {
+            dark::properties::Link::Contains(_) => Some(()),
+            _ => None,
+        })
+        .into_iter()
+        .map(|(entity, ())| entity)
+        .collect::<Vec<_>>();
+        assert_eq!(
+            contains,
+            vec![card],
+            "the corpse must retain its authored Contains link"
+        );
+
+        // Setting the same Dark quest value is idempotent. A later Frob may
+        // reopen a sibling-owned panel, but FrobQB must never start owning the
+        // persistent host's lifetime on a repeat interaction.
+        let repeat = Effect::flatten(vec![scripts.handle_message(
+            corpse,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        )]);
+        assert!(repeat.iter().any(|effect| matches!(
+            effect,
+            Effect::SetQuestBit { quest_bit_name, .. } if quest_bit_name == "Note_7_8"
+        )));
+        assert!(
+            !repeat
+                .iter()
+                .any(|effect| matches!(effect, Effect::DestroyEntity { entity_id } if *entity_id == corpse)),
+            "repeat Frob must remain an idempotent quest transition, got {repeat:?}"
+        );
+        assert_eq!(
+            script_util::get_all_links_with_data(&world, corpse, |link| match link {
+                dark::properties::Link::Contains(_) => Some(()),
+                _ => None,
+            })
+            .len(),
+            1,
+            "repeat Frob must leave the quest container's contents intact"
         );
     }
 }

--- a/shock2vr/src/scripts/level_change_button.rs
+++ b/shock2vr/src/scripts/level_change_button.rs
@@ -18,9 +18,8 @@ use super::{BaseButton, Effect, MessagePayload, Script};
 /// `TurnOn`.
 ///
 /// A frob changes level immediately rather than by way of a self-addressed
-/// `TurnOn`: sibling scripts on the same entity can consume the frob too (the
-/// rick3 shuttle button also runs `FrobQB`, which destroys the entity), and a
-/// deferred message would never reach it.
+/// `TurnOn`: the transition should be part of the player's direct action, not
+/// depend on a self-addressed message surviving until the next script update.
 pub struct LevelChangeButton {
     base_button: BaseButton,
 }
@@ -145,8 +144,7 @@ mod tests {
             "frob must relay TurnOn over switch links, got {sent:?}"
         );
         // The transition is in the frob's own effect, not deferred behind a
-        // self-addressed message - a sibling script (rick3's FrobQB) can
-        // destroy the entity on the same frob.
+        // self-addressed message that would not run until the next update.
         assert_eq!(
             transition_target(&effect),
             Some("ops3.mis".to_owned()),

--- a/tools/shock2-sdk/test/rick1-quest-container.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick1-quest-container.e2e.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { UiElement } from "../src/types.js";
+
+// This regression depends on a deep campaign save, which contains player state
+// and retail-derived mission data and therefore cannot live in the repository.
+// Opt in by naming the locally preserved save (without `.sav`):
+//
+//   SHOCK2_RICK1_CARD_CORPSE_SAVE=repro-rick1-card-corpse-before-frob \
+//     SHOCK2_E2E=1 node --test dist/test/rick1-quest-container.e2e.test.js
+const saveName = process.env.SHOCK2_RICK1_CARD_CORPSE_SAVE;
+const e2eEnabled = process.env.SHOCK2_E2E === "1" && saveName !== undefined;
+
+// Stable rick1 mission-object ids. Runtime entity ids are rediscovered after
+// every launch/load and are never hardcoded.
+const QUEST_CORPSE = 1636;
+const RICKENBACKER_CARD = 1779;
+
+const containsLinks = async (game: GameServer, entityId: number) =>
+  (await game.entities.detail(entityId)).outgoing_links.filter((link) =>
+    link.link_type.startsWith("Contains"),
+  );
+
+const clickElement = async (game: GameServer, element: UiElement) => {
+  const [x, y, width, height] = element.screen_rect;
+  await game.input.set("pointer.position", [x + width / 2, y + height / 2]);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 5 });
+};
+
+test(
+  "rick1 exact save: FrobQB quest corpse keeps its Container MFD and loot",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8523),
+    });
+
+    const loaded = await game.load(saveName!);
+    assert.equal(loaded.success, true);
+    assert.equal(loaded.mission, "rick1.mis");
+    await game.step({ frames: 5 });
+
+    const [corpse] = await game.entities.byTemplate(QUEST_CORPSE);
+    const [card] = await game.entities.byTemplate(RICKENBACKER_CARD);
+    assert.ok(corpse, "expected rick1 RIC Male Corpse object 1636");
+    assert.ok(card, "expected the corpse's Rickenbacker Card object 1779");
+    const beforeLinks = await containsLinks(game, corpse.id);
+    assert.equal(beforeLinks.length, 4, "the intact corpse should begin with all four loot links");
+    assert.ok(
+      beforeLinks.some((link) => link.target_id === card.id),
+      `corpse 1636 should contain card 1779; got ${JSON.stringify(beforeLinks)}`,
+    );
+    assert.equal(await game.quests.get("note_7_8"), "unknown");
+
+    const aim = await game.player.aimAt(corpse, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `the corpse should be production-targeted before frob: ${JSON.stringify(aim)}`,
+    );
+    await game.step({ frames: 2 });
+    await game.screenshot("rick1-quest-container-before.png");
+
+    // Production interaction: one real squeeze edge dispatches both authored
+    // siblings (`ContainerScript` + `FrobQB`) in the same update.
+    await game.input.set("right_hand.squeeze_value", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze_value", 0);
+    await game.step({ frames: 5 });
+
+    const opened = await game.ui.state();
+    assert.ok(
+      opened.active_panel,
+      `the corpse's Container MFD must survive the FrobQB effect batch: ${JSON.stringify(opened)}`,
+    );
+    assert.equal(opened.active_panel.entity_id, corpse.id);
+    assert.equal(await game.quests.get("note_7_8"), "complete");
+
+    const [stillCorpse] = await game.entities.byTemplate(QUEST_CORPSE);
+    assert.ok(stillCorpse, "FrobQB must not destroy the sibling-owned corpse host");
+    assert.equal(stillCorpse.id, corpse.id);
+    const afterFrobLinks = await containsLinks(game, stillCorpse.id);
+    assert.equal(
+      afterFrobLinks.length,
+      4,
+      "opening the quest container must preserve all four Contains links",
+    );
+    assert.ok(afterFrobLinks.some((link) => link.target_id === card.id));
+
+    const cardElement = opened.active_panel.elements.find(
+      (element) => element.kind === "button" && element.entity_id === card.id,
+    );
+    assert.ok(
+      cardElement,
+      `the intact Container MFD should expose card 1779; got ${JSON.stringify(opened.active_panel.elements)}`,
+    );
+    await game.screenshot("rick1-quest-container-open.png");
+
+    // Taking the card is deliberately the existing ordinary Container MFD
+    // path. Logical key-access acquisition is tracked separately by #583 / PR
+    // #743; this regression owns host lifetime, panel stability, and physical
+    // loot transfer only.
+    await clickElement(game, cardElement);
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.entity_id === card.id)?.location,
+      "inventory",
+      `the physical card should transfer normally: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      (await containsLinks(game, corpse.id)).length,
+      3,
+      "taking only the card should leave the corpse and its other three loot links intact",
+    );
+    await game.screenshot("rick1-quest-container-card-taken.png");
+
+    const roundTripSave = `rick1_quest_container_${Date.now()}`;
+    assert.equal((await game.save(roundTripSave)).success, true);
+    assert.equal((await game.load(roundTripSave)).success, true);
+    await game.step({ frames: 5 });
+
+    const [loadedCorpse] = await game.entities.byTemplate(QUEST_CORPSE);
+    assert.ok(loadedCorpse, "save/load must retain the corpse container host");
+    assert.equal((await containsLinks(game, loadedCorpse.id)).length, 3);
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.name === "Rickenbacker Card" && item.location === "inventory",
+      ),
+      "save/load must retain the physically taken Rickenbacker Card",
+    );
+    assert.equal(await game.quests.get("note_7_8"), "complete");
+  },
+);


### PR DESCRIPTION
Fixes #890

## Problem

Rickenbacker 1 corpse 1636 has sibling `ContainerScript` and `FrobQB` scripts. One production frob emitted:

1. `OpenPanel { corpse }`
2. `SetQuestBit { Note_7_8 = COMPLETE }`
3. `DestroyEntity { corpse }`

The destroy invalidated the just-opened Container MFD and released all four `Contains` children. The unique Rickenbacker Card then existed as an unselectable orphan, blocking the Nacelle B route.

The same lifetime rule affected the other non-grabbable `FrobQB` hosts: they are use-in-place corpses, logs, computers, or buttons whose sibling scripts own their behavior and lifetime.

## Fix

- Keep the existing `MOVE`/`USE_AMMO` path: takeable `FrobQB` quest objects still transfer to the backpack, or retain the no-backpack consume fallback.
- For non-takeable/use-in-place hosts, emit only the authored quest-bit transition. Do not destroy a host owned by sibling scripts.
- Add a negative-first composite regression proving one frob yields `OpenPanel + SetQuestBit`, no `DestroyEntity`, and preserves the host plus its `Contains` link. Repeat frob remains idempotent.
- Add an exact-save rick1 SDK scenario using production aim, squeeze, Container MFD click, and save/load.

`#583` / PR #743 remains complementary: it grants logical key access when a scripted keycard is taken from a valid container. This PR fixes the earlier host-destruction failure and intentionally does not duplicate that keycard work. On current `main`, the exact scenario proves the panel remains open, all four links persist before the click, the physical card transfers normally, and that physical state survives save/load.

## Exact campaign proof

- Campaign: `rickenbacker · osa-tier2 · 25th · seed 1065943174`
- Save: `repro-rick1-card-corpse-before-frob` (retained locally; not uploaded)
- SHA-256: `ae1c0c3f1daf90586843cdbb8d343f1a6f8ff366451ce3f615b523b14238e77f`
- Runtime identities dynamically rediscovered from stable mission objects 1636/1779; no runtime entity IDs are hardcoded.
- Production result: target-confirmed corpse → squeeze → Container MFD stays open → `Note_7_8=complete` → corpse retains all four loot links → real pointer click takes only the card → save/load retains corpse, three remaining links, quest state, and physical card.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 541 passed
- `tools/shock2-sdk`: `npm test` — 26 passed, 204 E2E-gated
- Focused SDK gameplay matrix — 6 passed:
  - exact rick1 quest container/save-load
  - ordinary container loot
  - repeated log quest-bit behavior
  - rec1 and rick3 level-change buttons
  - scripted takeable circuit-board pickup

## Visual evidence

![Rickenbacker quest-container frob demo](https://gist.githubusercontent.com/tommy-xr/eb81f6ae61818589429512d8ad63d67b/raw/rick1-quest-container-frob.gif)

<sub>Rickenbacker corpse 1636 survives its quest-bit frob, allowing the Container MFD to open with all four authored loot items. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![Before: corpse destroyed with no panel; after: persistent corpse with four-item Container MFD](https://gist.githubusercontent.com/tommy-xr/eb81f6ae61818589429512d8ad63d67b/raw/rick1-quest-container-before-after.png)

The base/fixed targeted frames are byte-identical before the squeeze. The comparison uses `origin/main` `1f36f704` and this branch with the same fresh-process load, aim, input, and fixed-step sequence.
