### PR TITLE
fix(physics): simulate flinderized debris

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -294,6 +294,7 @@ pub fn create_entity_core(
             &maybe_just_model.as_ref(),
             entity_id,
             additional_options.launch_projectile,
+            additional_options.flinderize_debris,
         )
     } else {
         None
@@ -782,7 +783,7 @@ pub fn create_physics_representation(
     maybe_model: &Option<&Model>,
     entity_id: EntityId,
 ) -> Option<RigidBodyHandle> {
-    create_physics_representation_with_options(world, physics, maybe_model, entity_id, false)
+    create_physics_representation_with_options(world, physics, maybe_model, entity_id, false, false)
 }
 
 fn create_physics_representation_with_options(
@@ -791,6 +792,7 @@ fn create_physics_representation_with_options(
     maybe_model: &Option<&Model>,
     entity_id: EntityId,
     launch_projectile: bool,
+    flinderize_debris: bool,
 ) -> Option<RigidBodyHandle> {
     // A door the authors left permanently open (no travel between its open and
     // closed endpoints, authored open) has nowhere to retract to: a collider
@@ -1213,11 +1215,11 @@ fn create_physics_representation_with_options(
             // level fixtures solid, and climbable is excluded outright: the
             // climb probe queries as `PLAYER` too, so a non-solid ladder would
             // also be an unclimbable one.
-            let is_unsimulated_debris = phys_type.phys_type == PhysicsModelType::SPHERE
+            let is_movable_dimensionless_sphere = phys_type.phys_type == PhysicsModelType::SPHERE
                 && maybe_dimensions.is_none()
                 && !immobile
                 && !is_climbable;
-            let group = if is_unsimulated_debris {
+            let group = if is_movable_dimensionless_sphere {
                 group.non_solid_to_characters()
             } else {
                 group
@@ -1229,15 +1231,20 @@ fn create_physics_representation_with_options(
                 (None, None) => Vector3::zero(),
             };
 
-            // Only an object with authored dimensions takes the dynamic path.
-            // A dimension-less SPHERE has no authored radius, so a dynamic
-            // body would be a model-box-shaped prop falling under gravity -
-            // the fallback exists to make static geometry solid, not to
-            // animate it.
-            let rigid_body_handle = if !immobile
+            // Ordinary model-bounds fallbacks remain conservative kinematic
+            // stand-ins: their box is not an authored collision volume. A
+            // Flinderize target is different because the creation itself
+            // carries an impulse and means the debris must be simulated. Use
+            // its bounded model box for mass/inertia only in that explicit
+            // mode; authored-dimension spheres keep their existing dynamic
+            // path. Sensors stay kinematic so their trigger volume cannot
+            // drift away from its authored location.
+            let is_authored_dynamic_sphere = !immobile
                 && maybe_dimensions.is_some()
-                && phys_type.phys_type == PhysicsModelType::SPHERE
-            {
+                && phys_type.phys_type == PhysicsModelType::SPHERE;
+            let is_dynamic_flinder =
+                flinderize_debris && is_movable_dimensionless_sphere && !is_sensor;
+            let rigid_body_handle = if is_authored_dynamic_sphere || is_dynamic_flinder {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
                 physics.add_dynamic(
                     entity_id,
@@ -1288,6 +1295,10 @@ pub struct CreateEntityOptions {
     /// Tweq emitter calls `launchProjectile`; this keeps frobbable emitted
     /// archetypes from being reduced to kinematic selection colliders.
     pub launch_projectile: bool,
+    /// This entity was created as a Flinderize target. Keeping this separate
+    /// from the general model-bounds fallback lets only launched debris turn a
+    /// dimension-less moving sphere into a simulated body.
+    pub flinderize_debris: bool,
 }
 
 impl Default for CreateEntityOptions {
@@ -1298,6 +1309,7 @@ impl Default for CreateEntityOptions {
             transient_fx: false,
             projectile_raycast_origin: None,
             launch_projectile: false,
+            flinderize_debris: false,
         }
     }
 }
@@ -1536,6 +1548,7 @@ mod tests {
             &None,
             entity_id,
             true,
+            false,
         )
         .expect("an authored launched sphere should get a body");
         physics.set_velocity(entity_id, vec3(-10.0, 0.0, 0.0));
@@ -1637,6 +1650,43 @@ mod tests {
             );
             assert_eq!(bodies[0].blocks_player, should_block);
             assert_eq!(bodies[0].blocks_actor, should_block);
+        }
+    }
+
+    /// A dimension-less moving sphere only becomes simulated when it was
+    /// explicitly spawned by Flinderize. Ordinary model-bounds fallbacks keep
+    /// the conservative kinematic policy established by #597/#767.
+    ///
+    /// Negative-first: before #815, both cases were kinematic and ignored the
+    /// Flinderize impulse and gravity.
+    #[test]
+    fn only_flinderized_dimensionless_debris_becomes_dynamic() {
+        for (flinderize_debris, expected_body_type) in [(false, "kinematic"), (true, "dynamic")] {
+            let mut world = World::new();
+            let mut physics = PhysicsWorld::new();
+            let entity_id = add_dimensionless_object(&mut world, PhysicsModelType::SPHERE, false);
+            let model = gib_model();
+
+            create_physics_representation_with_options(
+                &mut world,
+                &mut physics,
+                &Some(&model),
+                entity_id,
+                false,
+                flinderize_debris,
+            )
+            .expect("dimension-less debris should retain a model-bounds collider");
+
+            let bodies = physics.debug_list_bodies();
+            assert_eq!(bodies.len(), 1);
+            assert_eq!(bodies[0].body_type, expected_body_type);
+            assert!(
+                bodies[0].mass.is_finite() && bodies[0].mass > 0.0 && bodies[0].mass < 1.0,
+                "small gib bounds should yield a finite, bounded mass, got {}",
+                bodies[0].mass
+            );
+            assert!(!bodies[0].blocks_player);
+            assert!(!bodies[0].blocks_actor);
         }
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2437,7 +2437,10 @@ impl MissionCore {
                         spawn_position,
                         spawn_rotation,
                         Matrix4::identity(),
-                        CreateEntityOptions::default(),
+                        CreateEntityOptions {
+                            flinderize_debris: true,
+                            ..CreateEntityOptions::default()
+                        },
                     );
 
                     if created.rigid_body.is_some() {

--- a/tools/shock2-sdk/test/debris-wedge.e2e.test.ts
+++ b/tools/shock2-sdk/test/debris-wedge.e2e.test.ts
@@ -4,19 +4,16 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { PhysicsBodySummary } from "../src/types.js";
 
-// Regression coverage for #803. Smashing an annelid Floor Pod flinderizes it
-// into `Eggbit` gibs. `Eggbit` inherits `P$PhysType { SPHERE }` from
-// `Monster Parts` (-2182) but no `P$PhysDims`, so each gib gets the #597
-// model-bounds fallback: an immovable kinematic box, hanging wherever the
-// flinder spawned. Dark's SPHERE model is its *simulated, movable* one - the
-// player shoves debris aside - so an immovable stand-in is the opposite of
-// faithful, and because the character controller has no depenetration pass, a
-// gib resting against the capsule resolves every direction to a zero-length
-// move. In hydro2's cold storage, where the pods block aisles the player MUST
-// smash through, that is a softlock.
+// Regression coverage for #803 and #815. Smashing an annelid Floor Pod
+// flinderizes it into `Eggbit` gibs. `Eggbit` inherits `P$PhysType { SPHERE }`
+// and a 30-second TweqDelete from `Monster Parts` (-2182), but no `P$PhysDims`.
+// The #597 model-bounds fallback supplies a bounded box, while the explicit
+// Flinderize creation mode makes that box dynamic so its authored impulse and
+// gravity launch, bounce, settle, and sleep it. The #810 character filter stays
+// intact so debris cannot wedge the player or a pursuing creature.
 //
-// Negative-first: on #810 every spawned gib still reports blocks_actor: true,
-// because living creatures and ordinary props share the `entity` membership.
+// Negative-first for #815: on current main every Eggbit body was kinematic;
+// its position was identical after 300 frames and it never slept.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 // Stable mission-object id (`template_id`), not a runtime entity id: the Floor
@@ -27,8 +24,20 @@ function gibBodies(bodies: PhysicsBodySummary[]): PhysicsBodySummary[] {
   return bodies.filter((b) => b.entity_name === "Eggbit");
 }
 
+function distance(a: PhysicsBodySummary, b: PhysicsBodySummary): number {
+  return Math.hypot(
+    a.position[0] - b.position[0],
+    a.position[1] - b.position[1],
+    a.position[2] - b.position[2],
+  );
+}
+
+function speed(body: PhysicsBodySummary): number {
+  return Math.hypot(...body.velocity);
+}
+
 test(
-  "hydro2: gibs from a smashed Floor Pod are never solid to characters",
+  "hydro2: Floor Pod gibs launch, settle, expire, and stay non-solid to characters",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -45,15 +54,14 @@ test(
 
     // An egg has 10 HP; one hit slays it and fires its Flinderize link.
     await game.entities.sendMessage(pod.id, { type: "Damage", amount: 50 });
-    await game.step({ frames: 30 });
 
-    const gibs = gibBodies((await game.physics.bodies()).bodies);
+    const launched = gibBodies((await game.physics.bodies()).bodies);
     assert.ok(
-      gibs.length > 0,
+      launched.length > 0,
       "smashing the pod should flinderize it into Eggbit gibs",
     );
 
-    for (const gib of gibs) {
+    for (const gib of launched) {
       assert.equal(
         gib.blocks_player,
         false,
@@ -67,12 +75,48 @@ test(
       // Characters are taken out of the collider's filter, but the gib keeps
       // its body and `entity` membership: it remains raycastable, shootable,
       // and solid to physical projectiles and ordinary movable props.
-      assert.equal(gib.body_type, "kinematic");
+      assert.equal(gib.body_type, "dynamic");
       assert.equal(gib.is_sensor, false);
+      assert.equal(gib.is_sleeping, false);
+      assert.ok(
+        gib.mass !== null && gib.mass > 0.001 && gib.mass < 1,
+        `gib ${gib.body_id} should have bounded model-box mass, got ${gib.mass}`,
+      );
       assert.ok(
         gib.collision_groups.includes("entity"),
         `gib ${gib.body_id} must stay raycastable, got ${JSON.stringify(gib.collision_groups)}`,
       );
+    }
+    assert.ok(
+      Math.max(...launched.map(speed)) > 1,
+      "Flinderize should immediately apply its authored impulse",
+    );
+
+    await game.step({ frames: 30 });
+    const moving = gibBodies((await game.physics.bodies()).bodies);
+    assert.equal(moving.length, launched.length);
+    const launchedByEntity = new Map(launched.map((gib) => [gib.entity_id, gib]));
+    const farthestTravel = Math.max(
+      ...moving.map((gib) => {
+        const start = launchedByEntity.get(gib.entity_id);
+        assert.ok(start, `gib ${gib.entity_id} should retain its dynamic body`);
+        return distance(start, gib);
+      }),
+    );
+    assert.ok(
+      farthestTravel > 0.5,
+      `the launched gibs should fly away from their spawn points, max travel ${farthestTravel.toFixed(3)}`,
+    );
+
+    // The small bodies must stop consuming solver time once they have bounced
+    // and come to rest. Rapier wakes them again normally on a later contact.
+    await game.step({ frames: 270 });
+    const settled = gibBodies((await game.physics.bodies()).bodies);
+    assert.equal(settled.length, launched.length);
+    for (const gib of settled) {
+      assert.equal(gib.body_type, "dynamic");
+      assert.equal(gib.is_sleeping, true, `gib ${gib.body_id} should settle and sleep`);
+      assert.ok(speed(gib) < 0.001, `gib ${gib.body_id} should be still after settling`);
     }
 
     // Nothing else about the smash changed: the pod itself is gone and the
@@ -90,6 +134,21 @@ test(
     assert.ok(
       end[0] > x,
       `the player must walk past the smashed pod at x ${x}: ${start[0]} -> ${end[0]}`,
+    );
+
+    // Monster Parts authors a 30-second TweqDelete. Dynamic bodies must still
+    // receive normal entity teardown rather than accumulating permanently.
+    await game.step({ frames: 1501 });
+    const deleted = gibBodies((await game.physics.bodies()).bodies);
+    assert.equal(deleted.length, 0, "TweqDelete should remove every gib body");
+    const remainingEntities = await game.entities.list({
+      filter: "Eggbit",
+      limit: 5000,
+    });
+    assert.equal(
+      remainingEntities.entities.filter((entity) => entity.name === "Eggbit").length,
+      0,
+      "TweqDelete should remove every gib entity",
     );
   },
 );


### PR DESCRIPTION
Fixes #815

## Summary

- mark entities created specifically by `Flinderize` so dimension-less moving
  spheres can use their bounded model box as a dynamic body
- keep every ordinary #597/#767 model-bounds fallback kinematic, and preserve
  #810's player/actor-passable debris collision filter
- extend the Hydro2 Floor Pod scenario through impulse, gravity-driven motion,
  settling/sleep, aisle traversal, and the authored 30-second `TweqDelete`

## Reproduction and root cause

On exact base `1f36f704a3edbace8723ab013a9fa24dccefa932`, I damaged Hydro2's
stable Floor Pod mission object `1354` and discovered its spawned bodies by the
name `Eggbit`. All three were `kinematic`, stayed at byte-identical positions
through 300 fixed-timestep frames, ignored gravity and the Flinderize impulse,
and never slept. Example positions were:

```
[40.30695, -8.049036, -30.041574]
[40.898827, -8.527187, -30.157024]
[39.255344, -7.451844, -29.925077]
```

`Eggbit` (`-4647`) inherits `SPHERE`, a 30-second delete tweq, and no
`P$PhysDims` from `Monster Parts` (`-2182`). The general model-bounds fallback
therefore supplied a position-based kinematic box. `slay_entity` did set the
authored launch velocity, but Rapier kinematic bodies do not integrate that
velocity or gravity.

## Fix and scope

`CreateEntityOptions::flinderize_debris` is explicit and defaults off.
`slay_entity` turns it on only while realizing a Flinderize target. The physics
creator permits a dynamic model-box body only when that mode is set and the
entity is a non-immobile, non-climbable, non-sensor `SPHERE` with no authored
dimensions.

This is deliberately not a broad dynamic conversion of model-bounds fallback
objects. Ordinary dimension-less props, structural OBBs, ladders, immobile
fixtures, and sensors retain their prior body policy. Authored-dimension
Flinderize targets such as `Glass1..4` retain their existing sphere path.

The Eggbit model box yields a finite mass of `0.013430523`. Live, the three
fragments launched near 4 units/s, fell and bounced, reached near-zero residual
motion by frame 120, and all reported zero velocity plus `is_sleeping: true` by
frame 300. They keep `entity` membership while remaining non-solid to the
player and living actors, preserving #810's anti-wedge behavior. The delete
tweq removes both entities and bodies after 30 seconds, so debris neither stays
active nor accumulates permanently on Quest.

## Verification

- negative-first unit: `only_flinderized_dimensionless_debris_becomes_dynamic`
  failed on the old behavior with `kinematic != dynamic`, then passed
- `cargo test -p shock2vr` — 541 passed, 0 failed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `git diff --check`
- SDK fast suite — 26 passed, 0 failed, 203 opt-in skipped
- focused Hydro2 debris lifecycle E2E — passed, including dynamic body, bounded
  mass, impulse travel, settle/sleep, character filtering, aisle traversal,
  body/entity deletion
- existing authored-dimension glass Flinderize E2E — passed
- full SDK E2E — 223 passed, 0 failed, 6 expected skips; all 23 missions loaded

## Visual verification

![Flinder debris physics comparison](https://gist.githubusercontent.com/tommy-xr/233ebae867ba7c9c695202a57644f680/raw/flinder-debris-demo.gif)

<sub>Smashing Hydroponics 2 Floor Pod `template_id: 1354`: base leaves kinematic Eggbit fragments suspended at their scatter positions; the fix applies the authored launch impulses, allowing them to fall, bounce, settle, and sleep. Captured with matched deterministic 60 Hz debug-runtime sequences.</sub>

### Launch still

![Dynamic Eggbit fragments launching](https://gist.githubusercontent.com/tommy-xr/233ebae867ba7c9c695202a57644f680/raw/flinder-debris-fix-launch-t0.5s.png)

### Before → after

![Kinematic suspended debris versus dynamic settled debris](https://gist.githubusercontent.com/tommy-xr/233ebae867ba7c9c695202a57644f680/raw/flinder-debris-before-after-t5s.png)

### Fixed motion timeline

![Flinder debris launch, bounce, and settle timeline](https://gist.githubusercontent.com/tommy-xr/233ebae867ba7c9c695202a57644f680/raw/flinder-debris-fix-contact-sheet.png)

Matched pre-smash captures were byte-identical. Inspection confirmed that all
three base fragments held identical positions from 0.05s through 5s, while the
fixed fragments launched at up to about 4.35 units/s and all slept at 5s.
