### PR TITLE
fix(rendering): apply switched lightmap layers

### DIFF
--- a/dark/src/mission/cell.rs
+++ b/dark/src/mission/cell.rs
@@ -332,10 +332,12 @@ fn read_lights<T: io::Read>(
     num_lightmaps: u8,
     light_size: u8,
 ) -> Vec<LightInfo> {
-    // Read lights
-    for _ in 0..num_lights {
-        let _ = reader.read_i16::<byteorder::LittleEndian>().unwrap();
-    }
+    // Cell-local order for the animated-light bits on each face. A set bit in
+    // `LightInfo::animation_flags` means the following layer belongs to the
+    // light number at the same index in this table.
+    let animated_light_numbers = (0..num_lights)
+        .map(|_| reader.read_i16::<byteorder::LittleEndian>().unwrap())
+        .collect::<Vec<_>>();
 
     let mut light_infos: Vec<LightInfo> = Vec::new();
     for _ in 0..num_lightmaps {
@@ -353,26 +355,25 @@ fn read_lights<T: io::Read>(
             let mut bytes = vec![0_u8; lm_size as usize];
             reader.read_exact(&mut bytes).unwrap();
 
+            let img = decode_lightmap(&bytes, li.lx, li.ly, light_size);
+
             if idx == 0 {
-                let img = image::ImageBuffer::from_fn(li.lx as u32, li.ly as u32, |x, y| {
-                    if x >= li.lx as u32 || y >= li.ly as u32 {
-                        image::Rgb([255, 255, 0])
-                    } else {
-                        let pos = ((y * (2 * li.lx as u32)) + x * 2) as usize;
-                        let b0 = bytes[pos] as u16;
-                        let b1 = bytes[pos + 1] as u16;
-
-                        // Two bits (u16) encoded to have R,G,B each taking 5 bits:
-                        let pix: u16 = (b1 << 8) + b0;
-                        let r = (pix & 0b0001_1111) << 3;
-                        let g = ((pix >> 5) & 0b0001_1111) << 3;
-                        let b = ((pix >> 10) & 0b0001_1111) << 3;
-
-                        image::Rgb([r as u8, g as u8, b as u8])
-                    }
-                });
-
                 li.texture_pack_result = packer.pack(&img);
+                if lm_count > 1 {
+                    li.base_pixels = Some(img.into_raw());
+                }
+            } else {
+                let layer_number = idx - 1;
+                let bit_index = set_bit_indices(li.animation_flags)
+                    .nth(layer_number as usize)
+                    .expect("animated lightmap layer must have a corresponding flag bit");
+                let light_number = *animated_light_numbers
+                    .get(bit_index)
+                    .expect("animated lightmap flag must index the cell light table");
+                li.switchable_layers.push(SwitchableLightmapLayer {
+                    light_number,
+                    pixels: img.into_raw(),
+                });
             }
         }
     }
@@ -383,6 +384,36 @@ fn read_lights<T: io::Read>(
     }
 
     light_infos
+}
+
+fn set_bit_indices(flags: u32) -> impl Iterator<Item = usize> {
+    (0..u32::BITS as usize).filter(move |bit| flags & (1 << bit) != 0)
+}
+
+fn decode_lightmap(bytes: &[u8], width: u16, height: u8, light_size: u8) -> image::RgbImage {
+    image::ImageBuffer::from_fn(width as u32, height as u32, |x, y| {
+        let pixel_index = (y * width as u32 + x) as usize;
+        match light_size {
+            1 => {
+                let value = bytes[pixel_index];
+                image::Rgb([value, value, value])
+            }
+            _ => {
+                let pos = pixel_index * light_size as usize;
+                let pix = u16::from_le_bytes([bytes[pos], bytes[pos + 1]]);
+                let r = (pix & 0b0001_1111) << 3;
+                let g = ((pix >> 5) & 0b0001_1111) << 3;
+                let b = ((pix >> 10) & 0b0001_1111) << 3;
+                image::Rgb([r as u8, g as u8, b as u8])
+            }
+        }
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct SwitchableLightmapLayer {
+    pub light_number: i16,
+    pub pixels: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -397,6 +428,9 @@ pub struct LightInfo {
     pub dynamic_lightmap_pointer: u32,
     pub animation_flags: u32,
     pub texture_pack_result: TexturePackResult,
+    /// Static pixels retained only for faces that have switchable layers.
+    pub base_pixels: Option<Vec<u8>>,
+    pub switchable_layers: Vec<SwitchableLightmapLayer>,
 }
 
 fn read_light_info<T: io::Read>(debug_idx: u32, reader: &mut T) -> LightInfo {
@@ -422,5 +456,30 @@ fn read_light_info<T: io::Read>(debug_idx: u32, reader: &mut T) -> LightInfo {
         dynamic_lightmap_pointer,
         animation_flags,
         texture_pack_result: TexturePackResult::DEFAULT,
+        base_pixels: None,
+        switchable_layers: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animation_flags_follow_cell_light_number_order() {
+        let flags = 0b1010;
+        assert_eq!(set_bit_indices(flags).collect::<Vec<_>>(), vec![1, 3]);
+        let cell_light_numbers = [12, 195, 27, 311];
+        let mapped = set_bit_indices(flags)
+            .map(|bit| cell_light_numbers[bit])
+            .collect::<Vec<_>>();
+        assert_eq!(mapped, vec![195, 311]);
+    }
+
+    #[test]
+    fn rgb16_lightmaps_decode_to_rgb888() {
+        let white = 0b0111_1111_1111_1111u16.to_le_bytes();
+        let image = decode_lightmap(&white, 1, 1, 2);
+        assert_eq!(image.get_pixel(0, 0).0, [248, 248, 248]);
     }
 }

--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -36,7 +36,7 @@ use cgmath::Vector4;
 use cgmath::vec4;
 use engine::assets::asset_paths::AbstractAssetPath;
 use engine::scene::VertexPositionTextureLightmapAtlasNormal;
-pub use scene_builder::to_scene;
+pub use scene_builder::{AnimatedLightmapController, MissionScene, to_scene};
 
 use crate::properties::PropertyDefinition;
 use crate::ss2_chunk_file_reader;

--- a/dark/src/mission/scene_builder.rs
+++ b/dark/src/mission/scene_builder.rs
@@ -10,10 +10,158 @@ use crate::{
     importers::TEXTURE_IMPORTER, properties::RenderType, util::load_multiple_textures_for_family,
 };
 
+/// GPU scene plus the sparse controller for authored switchable lightmaps.
+pub struct MissionScene {
+    pub objects: Vec<SceneObject>,
+    pub animated_lightmaps: AnimatedLightmapController,
+}
+
+struct AnimatedLightmapRegion {
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+    base_pixels: Vec<u8>,
+    layers: Vec<super::SwitchableLightmapLayer>,
+    dirty: bool,
+}
+
+/// Rare state changes update only the affected atlas rectangles. The ordinary
+/// frame shader remains the same single lightmap sample on desktop and Quest.
+pub struct AnimatedLightmapController {
+    texture: Rc<Texture>,
+    regions: Vec<AnimatedLightmapRegion>,
+    light_to_regions: HashMap<i16, Vec<usize>>,
+    intensities: HashMap<i16, f32>,
+    compose_scratch: Vec<u8>,
+}
+
+impl AnimatedLightmapController {
+    fn new(level: &crate::mission::SystemShock2Level, texture: Rc<Texture>) -> Self {
+        let mut regions = Vec::new();
+        let mut light_to_regions: HashMap<i16, Vec<usize>> = HashMap::new();
+
+        for light_info in level.cells.iter().flat_map(|cell| &cell.lights) {
+            let Some(base_pixels) = &light_info.base_pixels else {
+                continue;
+            };
+            if light_info.switchable_layers.is_empty() {
+                continue;
+            }
+
+            let placement = light_info.texture_pack_result;
+            let region_index = regions.len();
+            for layer in &light_info.switchable_layers {
+                light_to_regions
+                    .entry(layer.light_number)
+                    .or_default()
+                    .push(region_index);
+            }
+            regions.push(AnimatedLightmapRegion {
+                x: (placement.uv_offset_x * texture.width() as f32).round() as u32,
+                y: (placement.uv_offset_y * texture.height() as f32).round() as u32,
+                width: light_info.lx as u32,
+                height: light_info.ly as u32,
+                base_pixels: base_pixels.clone(),
+                layers: light_info.switchable_layers.clone(),
+                dirty: false,
+            });
+        }
+
+        tracing::debug!(
+            lights = light_to_regions.len(),
+            regions = regions.len(),
+            "prepared switchable lightmaps"
+        );
+        Self {
+            texture,
+            regions,
+            light_to_regions,
+            intensities: HashMap::new(),
+            compose_scratch: Vec::new(),
+        }
+    }
+
+    /// Queue one authored light value. Repeated effects in a script batch mark
+    /// rectangles only; [`flush`](Self::flush) recomposes each at most once.
+    pub fn set_light_intensity(&mut self, light_number: i16, intensity: f32) -> bool {
+        let Some(affected_regions) = self.light_to_regions.get(&light_number) else {
+            return false;
+        };
+        let intensity = intensity.clamp(0.0, 1.0);
+        if self.intensities.get(&light_number).copied() == Some(intensity) {
+            return true;
+        }
+
+        self.intensities.insert(light_number, intensity);
+        for &region_index in affected_regions {
+            self.regions[region_index].dirty = true;
+        }
+        true
+    }
+
+    /// Upload every dirty rectangle. Cost scales with the authored affected
+    /// pixels, not the 4096² atlas or the total entity count.
+    pub fn flush(&mut self) {
+        for region in &mut self.regions {
+            if !region.dirty {
+                continue;
+            }
+            compose_region(
+                &region.base_pixels,
+                &region.layers,
+                &self.intensities,
+                &mut self.compose_scratch,
+            );
+            self.texture.update_rgb_region(
+                region.x,
+                region.y,
+                region.width,
+                region.height,
+                &self.compose_scratch,
+            );
+            region.dirty = false;
+        }
+    }
+
+    pub fn light_count(&self) -> usize {
+        self.light_to_regions.len()
+    }
+
+    pub fn region_count(&self) -> usize {
+        self.regions.len()
+    }
+}
+
+fn compose_region(
+    base_pixels: &[u8],
+    layers: &[super::SwitchableLightmapLayer],
+    intensities: &HashMap<i16, f32>,
+    output: &mut Vec<u8>,
+) {
+    output.clear();
+    output.extend_from_slice(base_pixels);
+    for layer in layers {
+        let intensity = intensities
+            .get(&layer.light_number)
+            .copied()
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        if intensity <= 0.0 {
+            continue;
+        }
+        for (target, contribution) in output.iter_mut().zip(&layer.pixels) {
+            *target = (*target as f32 + *contribution as f32 * intensity)
+                .min(255.0)
+                .round() as u8;
+        }
+    }
+}
+
 pub fn to_scene(
     level: &crate::mission::SystemShock2Level,
     asset_cache: &mut AssetCache,
-) -> Vec<SceneObject> {
+) -> MissionScene {
     let lightmap_textures = level.lightmap_atlas.generate_textures();
     let tex = lightmap_textures.get(0).unwrap();
     let lightmap_texture = tex.clone();
@@ -116,5 +264,47 @@ pub fn to_scene(
         scene_objects.push(scene_object1)
     }
 
-    scene_objects
+    MissionScene {
+        objects: scene_objects,
+        animated_lightmaps: AnimatedLightmapController::new(level, lightmap_texture),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mission::SwitchableLightmapLayer;
+
+    #[test]
+    fn switchable_layers_add_to_static_light_and_saturate() {
+        let layers = vec![
+            SwitchableLightmapLayer {
+                light_number: 195,
+                pixels: vec![100, 20, 0],
+            },
+            SwitchableLightmapLayer {
+                light_number: 311,
+                pixels: vec![80, 80, 80],
+            },
+        ];
+        let intensities = HashMap::from([(195, 1.0), (311, 0.5)]);
+        let mut output = Vec::new();
+
+        compose_region(&[140, 200, 250], &layers, &intensities, &mut output);
+
+        assert_eq!(output, vec![255, 255, 255]);
+    }
+
+    #[test]
+    fn absent_light_intensity_leaves_static_pixels_unchanged() {
+        let layers = vec![SwitchableLightmapLayer {
+            light_number: 195,
+            pixels: vec![100, 100, 100],
+        }];
+        let mut output = Vec::new();
+
+        compose_region(&[10, 20, 30], &layers, &HashMap::new(), &mut output);
+
+        assert_eq!(output, vec![10, 20, 30]);
+    }
 }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -8,6 +8,7 @@ mod prop_ai_device;
 mod prop_ai_hearing;
 mod prop_ai_mode;
 mod prop_ambient_hacked;
+mod prop_anim_light;
 mod prop_anim_tex;
 mod prop_base_gun_desc;
 mod prop_bitmap_animation;
@@ -50,6 +51,7 @@ pub use prop_ai_device::*;
 pub use prop_ai_hearing::*;
 pub use prop_ai_mode::*;
 pub use prop_ambient_hacked::*;
+pub use prop_anim_light::*;
 pub use prop_anim_tex::*;
 pub use prop_base_gun_desc::*;
 pub use prop_bitmap_animation::*;
@@ -1228,6 +1230,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$AmbientHa",
             PropAmbientHacked::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$AnimLight",
+            PropAnimLight::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_anim_light.rs
+++ b/dark/src/properties/prop_anim_light.rs
@@ -1,0 +1,217 @@
+use std::io;
+
+use cgmath::Vector3;
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::{
+    read_bool, read_bytes, read_i16, read_i32, read_single, read_u16, read_vec3,
+};
+
+/// Dark's animated-light operating mode (`sAnimLight.mode`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnimLightMode {
+    Alternate,
+    AlternateSmoothly,
+    Random,
+    MinBrightness,
+    MaxBrightness,
+    ZeroBrightness,
+    BrightenSmoothly,
+    DimSmoothly,
+    SemiRandom,
+    Flicker,
+    Unknown(u16),
+}
+
+impl AnimLightMode {
+    fn from_raw(raw: u16) -> Self {
+        match raw {
+            0 => Self::Alternate,
+            1 => Self::AlternateSmoothly,
+            2 => Self::Random,
+            3 => Self::MinBrightness,
+            4 => Self::MaxBrightness,
+            5 => Self::ZeroBrightness,
+            6 => Self::BrightenSmoothly,
+            7 => Self::DimSmoothly,
+            8 => Self::SemiRandom,
+            9 => Self::Flicker,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+/// Authored `P$AnimLight` state. `light_number` indexes the switchable
+/// lightmap layers stored in the mission world-representation cells.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropAnimLight {
+    pub offset: Vector3<f32>,
+    pub cell_index: i16,
+    pub hit_cells: i16,
+    pub light_number: i16,
+    pub mode: AnimLightMode,
+    pub brighten_time_ms: i32,
+    pub dim_time_ms: i32,
+    pub min_brightness: f32,
+    pub max_brightness: f32,
+    pub rising: bool,
+    pub countdown_ms: i32,
+    pub inactive: bool,
+    pub radius: f32,
+}
+
+impl PropAnimLight {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> Self {
+        let _object_id = read_i32(reader);
+        let offset = read_vec3(reader);
+        let _quad_lit = read_i32(reader);
+        let cell_index = read_i16(reader);
+        let hit_cells = read_i16(reader);
+        let light_number = read_i16(reader);
+        let mode = AnimLightMode::from_raw(read_u16(reader));
+        let brighten_time_ms = read_i32(reader);
+        let dim_time_ms = read_i32(reader);
+        let min_brightness = read_single(reader);
+        let max_brightness = read_single(reader);
+        let _refresh = read_i32(reader);
+        let rising = read_bool(reader);
+        let countdown_ms = read_i32(reader);
+        let inactive = read_bool(reader);
+        let radius = read_single(reader);
+        let _runtime_light_handle = read_i32(reader);
+
+        const SS2_SIZE: u32 = 68;
+        if len > SS2_SIZE {
+            let _trailing = read_bytes(reader, (len - SS2_SIZE) as usize);
+        }
+
+        Self {
+            offset,
+            cell_index,
+            hit_cells,
+            light_number,
+            mode,
+            brighten_time_ms,
+            dim_time_ms,
+            min_brightness,
+            max_brightness,
+            rising,
+            countdown_ms,
+            inactive,
+            radius,
+        }
+    }
+
+    /// Intensity used by the switchable lightmap layer for steady modes.
+    pub fn steady_intensity(&self) -> Option<f32> {
+        match self.mode {
+            AnimLightMode::MaxBrightness => Some(1.0),
+            AnimLightMode::ZeroBrightness => Some(0.0),
+            AnimLightMode::MinBrightness => {
+                if self.max_brightness > 0.0 {
+                    Some((self.min_brightness / self.max_brightness).clamp(0.0, 1.0))
+                } else {
+                    Some(0.0)
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn minimum_intensity(&self) -> f32 {
+        if self.max_brightness > 0.0 {
+            (self.min_brightness / self.max_brightness).clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
+    }
+
+    /// Initial intensity represented by the persisted Dark property. Temporal
+    /// cycling modes start at their authored minimum; their later animation is
+    /// intentionally separate from the steady switched-light support.
+    pub fn initial_intensity(&self) -> f32 {
+        if self.inactive {
+            return 0.0;
+        }
+        self.steady_intensity()
+            .unwrap_or_else(|| self.minimum_intensity())
+    }
+
+    pub fn turn_off_intensity(&self) -> f32 {
+        match self.mode {
+            AnimLightMode::MinBrightness
+            | AnimLightMode::BrightenSmoothly
+            | AnimLightMode::DimSmoothly => self.minimum_intensity(),
+            _ => 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn reads_ss2_animated_light_layout() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&714i32.to_le_bytes());
+        for value in [1.0f32, 2.0, 3.0] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        bytes.extend_from_slice(&1i32.to_le_bytes());
+        bytes.extend_from_slice(&12i16.to_le_bytes());
+        bytes.extend_from_slice(&3i16.to_le_bytes());
+        bytes.extend_from_slice(&42i16.to_le_bytes());
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(&250i32.to_le_bytes());
+        bytes.extend_from_slice(&500i32.to_le_bytes());
+        bytes.extend_from_slice(&10.0f32.to_le_bytes());
+        bytes.extend_from_slice(&100.0f32.to_le_bytes());
+        bytes.extend_from_slice(&0i32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&125i32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&25.0f32.to_le_bytes());
+        bytes.extend_from_slice(&(-1i32).to_le_bytes());
+        assert_eq!(bytes.len(), 68);
+
+        let light = PropAnimLight::read(&mut Cursor::new(bytes), 68);
+
+        // read_vec3 applies the repository's Dark -> world axis conversion.
+        assert_eq!(light.offset, Vector3::new(-1.0, 3.0, 2.0));
+        assert_eq!(light.cell_index, 12);
+        assert_eq!(light.hit_cells, 3);
+        assert_eq!(light.light_number, 42);
+        assert_eq!(light.mode, AnimLightMode::MaxBrightness);
+        assert_eq!(light.brighten_time_ms, 250);
+        assert_eq!(light.dim_time_ms, 500);
+        assert_eq!(light.steady_intensity(), Some(1.0));
+        assert!(light.rising);
+        assert!(!light.inactive);
+        assert_eq!(light.radius, 25.0);
+    }
+
+    #[test]
+    fn minimum_brightness_is_relative_to_authored_maximum() {
+        let light = PropAnimLight {
+            offset: Vector3::new(0.0, 0.0, 0.0),
+            cell_index: -1,
+            hit_cells: 0,
+            light_number: 0,
+            mode: AnimLightMode::MinBrightness,
+            brighten_time_ms: 0,
+            dim_time_ms: 0,
+            min_brightness: 25.0,
+            max_brightness: 100.0,
+            rising: false,
+            countdown_ms: 0,
+            inactive: false,
+            radius: 0.0,
+        };
+
+        assert_eq!(light.steady_intensity(), Some(0.25));
+    }
+}

--- a/engine/src/texture.rs
+++ b/engine/src/texture.rs
@@ -66,6 +66,35 @@ impl Texture {
     pub fn height(&self) -> u32 {
         self.height
     }
+
+    /// Replace one RGB rectangle without reallocating the texture. Animated
+    /// Dark lightmaps use this for rare switch transitions; the ordinary
+    /// render path keeps sampling the same shared texture object.
+    pub fn update_rgb_region(&self, x: u32, y: u32, width: u32, height: u32, pixels: &[u8]) {
+        assert!(x + width <= self.width);
+        assert!(y + height <= self.height);
+        assert_eq!(pixels.len(), (width * height * 3) as usize);
+
+        unsafe {
+            gl::BindTexture(gl::TEXTURE_2D, self.gl_id);
+            // RGB rows are not necessarily four-byte aligned (many Dark
+            // lightmaps are odd widths), so override OpenGL's default while
+            // this tightly-packed slice is uploaded.
+            gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
+            gl::TexSubImage2D(
+                gl::TEXTURE_2D,
+                0,
+                x as i32,
+                y as i32,
+                width as i32,
+                height as i32,
+                gl::RGB,
+                gl::UNSIGNED_BYTE,
+                pixels.as_ptr() as *const c_void,
+            );
+            gl::PixelStorei(gl::UNPACK_ALIGNMENT, 4);
+        }
+    }
 }
 
 impl Drop for Texture {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -37,7 +37,7 @@ use dark::{
     },
     properties::{
         AmbientSoundFlags, Link, LinkDefinition, LinkDefinitionWithData, Links, PhysicsModelType,
-        PropAIAlertness, PropAIMode, PropAmbientHacked, PropClassTag, PropCreature,
+        PropAIAlertness, PropAIMode, PropAmbientHacked, PropAnimLight, PropClassTag, PropCreature,
         PropFrameAnimState, PropHasRefs, PropHitPoints, PropLimbModel, PropLocalPlayer,
         PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
@@ -473,6 +473,7 @@ pub struct MissionCore {
     pub physics: PhysicsWorld,
     pub script_world: ScriptWorld,
     pub scene_objects: Vec<SceneObject>,
+    pub animated_lightmaps: Option<dark::mission::AnimatedLightmapController>,
     pub id_to_animation_player: HashMap<EntityId, AnimationPlayer>,
     /// Failed-animation suppression state per entity: the failing key, a
     /// countdown (frames), and whether a suppressed request is owed a
@@ -584,6 +585,7 @@ fn restore_saved_script_namespaces(
 
 pub struct AbstractMission {
     pub scene_objects: Vec<SceneObject>,
+    pub animated_lightmaps: Option<dark::mission::AnimatedLightmapController>,
     pub song_params: SongParams,
     pub room_db: RoomDatabase,
     pub physics_geometry: Option<Collider>,
@@ -614,6 +616,7 @@ impl MissionCore {
         let start = SystemTime::now();
         info!("starting level load");
         let scene = abstract_mission.scene_objects;
+        let mut animated_lightmaps = abstract_mission.animated_lightmaps;
         let duration: Duration = start.elapsed().unwrap();
         info!("loading level took {}s", duration.as_secs_f32());
 
@@ -1201,6 +1204,18 @@ impl MissionCore {
         // Per-frame AI pathfind budget, refilled at the top of each update
         world.add_unique(crate::pathfinding::PathfindingFrameBudget::new());
 
+        // The atlas is initially packed with static lightmaps only. Restore
+        // every instantiated light's persisted value once at load, then later
+        // script effects update just the rectangles touched by a state change.
+        if let Some(controller) = &mut animated_lightmaps {
+            world.run(|lights: View<PropAnimLight>| {
+                for light in lights.iter() {
+                    controller.set_light_intensity(light.light_number, light.initial_intensity());
+                }
+            });
+            controller.flush();
+        }
+
         MissionCore {
             interaction,
             level_name: mission,
@@ -1215,6 +1230,7 @@ impl MissionCore {
             id_to_particle_system: HashMap::new(),
             template_name_to_template_id,
             scene_objects: scene,
+            animated_lightmaps,
             physics,
             world,
             id_to_physics,
@@ -4569,6 +4585,24 @@ impl MissionCore {
                         self.world.add_component(entity_id, PropObjState(state));
                     }
                 }
+                Effect::SetAnimatedLight {
+                    entity_id,
+                    intensity,
+                    inactive,
+                } => {
+                    let light_number =
+                        self.world
+                            .run(|mut lights: ViewMut<PropAnimLight>| -> Option<i16> {
+                                let light = (&mut lights).get(entity_id).ok()?;
+                                light.inactive = inactive;
+                                Some(light.light_number)
+                            });
+                    if let (Some(light_number), Some(controller)) =
+                        (light_number, &mut self.animated_lightmaps)
+                    {
+                        controller.set_light_intensity(light_number, intensity);
+                    }
+                }
                 Effect::SetReplicatorHackedContents {
                     entity_id,
                     contents,
@@ -5064,6 +5098,10 @@ impl MissionCore {
                     game_log!(WARN, "Unhandled effect: {effect:?}");
                 }
             }
+        }
+
+        if let Some(controller) = &mut self.animated_lightmaps {
+            controller.flush();
         }
 
         global_effects
@@ -6781,6 +6819,11 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     .or(v_ecology.get(id).ok().map(|_| 0))
             },
         );
+        let animated_light = self.world.run(|v: View<PropAnimLight>| {
+            v.get(id)
+                .ok()
+                .map(|light| (light.light_number, light.initial_intensity()))
+        });
 
         self.world.run(
             |v_pos: View<dark::properties::PropPosition>,
@@ -6874,6 +6917,16 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                             2 => "Alert".to_string(),
                             other => format!("Unknown({other})"),
                         },
+                    });
+                }
+                if let Some((light_number, intensity)) = animated_light {
+                    properties.push(DebugPropertyInfo {
+                        name: "AnimLightNumber".to_string(),
+                        value: light_number.to_string(),
+                    });
+                    properties.push(DebugPropertyInfo {
+                        name: "AnimLightIntensity".to_string(),
+                        value: format!("{intensity:.3}"),
                     });
                 }
 

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -86,7 +86,7 @@ impl Mission {
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
     ) -> Mission {
-        let scene_objects = dark::mission::to_scene(&level, asset_cache);
+        let mission_scene = dark::mission::to_scene(&level, asset_cache);
         let song_params = level.song_params.clone();
         let room_db = level.room_database.clone();
         let physics_geometry = create_physics_collider(&level);
@@ -94,7 +94,8 @@ impl Mission {
         let obj_map = level.obj_map.clone();
 
         let abstract_mission = AbstractMission {
-            scene_objects,
+            scene_objects: mission_scene.objects,
+            animated_lightmaps: Some(mission_scene.animated_lightmaps),
             song_params,
             room_db,
             physics_geometry,

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -129,6 +129,7 @@ impl DebugSceneBuilder {
 
         let abstract_mission = AbstractMission {
             scene_objects,
+            animated_lightmaps: None,
             song_params: SongParams {
                 song: String::new(),
             },

--- a/shock2vr/src/scripts/base_light.rs
+++ b/shock2vr/src/scripts/base_light.rs
@@ -1,0 +1,138 @@
+use dark::properties::PropAnimLight;
+use shipyard::{EntityId, Get, View, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script};
+
+/// Retail `BaseLight`: switch the object's authored animated-light contribution
+/// in response to the same TurnOn/TurnOff messages used by buttons and traps.
+pub struct BaseLight;
+
+impl BaseLight {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for BaseLight {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        let lights = world.borrow::<View<PropAnimLight>>().unwrap();
+        let Ok(light) = lights.get(entity_id) else {
+            return Effect::NoEffect;
+        };
+
+        match msg {
+            MessagePayload::TurnOn { .. } => Effect::SetAnimatedLight {
+                entity_id,
+                intensity: 1.0,
+                inactive: false,
+            },
+            MessagePayload::TurnOff { .. } => {
+                let intensity = light.turn_off_intensity();
+                Effect::SetAnimatedLight {
+                    entity_id,
+                    intensity,
+                    inactive: intensity <= f32::EPSILON,
+                }
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::Vector3;
+    use dark::properties::{AnimLightMode, PropAnimLight};
+    use shipyard::World;
+
+    use crate::physics::PhysicsWorld;
+
+    use super::*;
+
+    fn max_light() -> PropAnimLight {
+        PropAnimLight {
+            offset: Vector3::new(0.0, 0.0, 0.0),
+            cell_index: 287,
+            hit_cells: 11,
+            light_number: 195,
+            mode: AnimLightMode::MaxBrightness,
+            brighten_time_ms: 63,
+            dim_time_ms: 63,
+            min_brightness: 0.0,
+            max_brightness: 150.0,
+            rising: false,
+            countdown_ms: 0,
+            inactive: false,
+            radius: 50.0,
+        }
+    }
+
+    #[test]
+    fn switched_max_light_emits_persistent_render_effects() {
+        let mut world = World::new();
+        let entity = world.add_entity(max_light());
+        let physics = PhysicsWorld::new();
+        let mut script = BaseLight::new();
+
+        let off = script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::TurnOff { from: entity },
+        );
+        assert!(matches!(
+            off,
+            Effect::SetAnimatedLight {
+                entity_id,
+                intensity,
+                inactive: true,
+            } if entity_id == entity && intensity == 0.0
+        ));
+
+        let on = script.handle_message(
+            entity,
+            &world,
+            &physics,
+            &MessagePayload::TurnOn { from: entity },
+        );
+        assert!(matches!(
+            on,
+            Effect::SetAnimatedLight {
+                entity_id,
+                intensity,
+                inactive: false,
+            } if entity_id == entity && intensity == 1.0
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_messages_and_entities_without_anim_light() {
+        let mut world = World::new();
+        let light = world.add_entity(max_light());
+        let plain = world.add_entity(());
+        let physics = PhysicsWorld::new();
+        let mut script = BaseLight::new();
+
+        assert!(matches!(
+            script.handle_message(light, &world, &physics, &MessagePayload::Frob),
+            Effect::NoEffect
+        ));
+        assert!(matches!(
+            script.handle_message(
+                plain,
+                &world,
+                &physics,
+                &MessagePayload::TurnOn { from: light }
+            ),
+            Effect::NoEffect
+        ));
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -509,6 +509,16 @@ pub enum Effect {
         state: ObjectState,
     },
 
+    /// Persistently switch one authored animated light and update the matching
+    /// world-representation lightmap layers. `intensity` is normalized against
+    /// the light's authored maximum; `inactive` is stored in `P$AnimLight` so
+    /// the state survives mission save/load.
+    SetAnimatedLight {
+        entity_id: EntityId,
+        intensity: f32,
+        inactive: bool,
+    },
+
     /// Persistently replace a replicator's hacked catalog. Retail's
     /// `PutBombInReplicator` uses this to add the Command-deck objective item;
     /// the registered Dark property makes the change survive save/load.

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -7,6 +7,7 @@ mod apparition;
 mod auto_install_soft;
 mod base_button;
 mod base_elevator;
+mod base_light;
 mod base_monster;
 mod base_room;
 mod camera_alert;
@@ -128,6 +129,7 @@ use self::{
     auto_install_soft::AutoInstallSoft,
     base_button::BaseButton,
     base_elevator::BaseElevator,
+    base_light::BaseLight,
     base_monster::BaseMonster,
     camera_alert::CameraAlert,
     core_room::*,
@@ -1137,7 +1139,7 @@ impl ScriptWorld {
             // TODO: Handle keypad code
             "ammoscript" => Box::new(NoopScript::new()),
             //"BaseElevator" => Box::new(UnimplementedScript::new(&name)),
-            "baselight" => Box::new(NoopScript {}),
+            "baselight" => Box::new(BaseLight::new()),
             //"baseai" => Box::new(PanicOnLoadScript::new(&script_name)),
             "baseai" => Box::new(NoopScript::new()),
             "basemonster" => Box::new(BaseMonster::new()),

--- a/tools/shock2-sdk/test/rec-dynamic-lights.e2e.test.ts
+++ b/tools/shock2-sdk/test/rec-dynamic-lights.e2e.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const LIGHT_BUTTON_OBJECT = 77;
+const ANIM_OMNI_LIGHT_OBJECT = 714;
+const AUX_POWER_BREAKER_OBJECT = 807;
+const DEAD_POWER_CELL_OBJECT = 808;
+const RECHARGING_STATION_OBJECT = 809;
+const POWER_CELL_CORPSE_OBJECT = 107;
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function property(
+  detail: { properties: { name: string; value: string }[] },
+  name: string,
+): string | undefined {
+  return detail.properties.find((entry) => entry.name === name)?.value;
+}
+
+test(
+  "rec1: the auxiliary-power switch restores its authored animated lights",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8588),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids are deliberately not stable. The concrete mission object ids
+    // are: Light_button 77 -> 17 SwitchLinks, including Anim Omni Light 714.
+    const [button] = await game.entities.byTemplate(LIGHT_BUTTON_OBJECT);
+    const [omni] = await game.entities.byTemplate(ANIM_OMNI_LIGHT_OBJECT);
+    const [breaker] = await game.entities.byTemplate(AUX_POWER_BREAKER_OBJECT);
+    const [deadCell] = await game.entities.byTemplate(DEAD_POWER_CELL_OBJECT);
+    const [station] = await game.entities.byTemplate(RECHARGING_STATION_OBJECT);
+    const [corpse] = await game.entities.byTemplate(POWER_CELL_CORPSE_OBJECT);
+    assert.ok(button, `expected rec1 object ${LIGHT_BUTTON_OBJECT}`);
+    assert.ok(omni, `expected rec1 object ${ANIM_OMNI_LIGHT_OBJECT}`);
+    assert.ok(breaker, `expected rec1 object ${AUX_POWER_BREAKER_OBJECT}`);
+    assert.ok(deadCell, `expected rec1 object ${DEAD_POWER_CELL_OBJECT}`);
+    assert.ok(station, `expected rec1 object ${RECHARGING_STATION_OBJECT}`);
+    assert.ok(corpse, `expected rec1 object ${POWER_CELL_CORPSE_OBJECT}`);
+
+    // Exercise the authentic production setup: pick up rec1's authored dead
+    // cell from the REC Male Corpse's loot MFD, then frob its recharging
+    // station, leaving a charged Power Cell in the backpack for the Aux Power
+    // receptor to consume below.
+    await game.player.teleport({
+      x: corpse.position[0] + 1,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1,
+    });
+    await game.entities.sendMessage(corpse.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    const corpsePanel = (await game.ui.state()).active_panel;
+    assert.ok(corpsePanel, "frobbing the REC Male Corpse must open its loot MFD");
+    const cellElement = corpsePanel.elements.find(
+      (element) =>
+        element.kind === "button" && element.entity_id === deadCell.id,
+    );
+    assert.ok(cellElement, "the REC Male Corpse must contain dead power cell 808");
+    const [cellX, cellY, cellWidth, cellHeight] = cellElement.screen_rect;
+    await game.input.set("pointer.position", [
+      cellX + cellWidth / 2,
+      cellY + cellHeight / 2,
+    ]);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 2 });
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === deadCell.id,
+      ),
+      "clicking the corpse loot entry must take the dead power cell",
+    );
+    await game.entities.sendMessage(station.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (item) => item.name === "Power Cell",
+      ).length,
+      1,
+      "the production breaker chain requires rec1's recharged Power Cell",
+    );
+
+    // Stage the same fixed camera in the dark basketball-court corridor for
+    // both captures. This framing looks toward the authored light at z=-213.
+    await game.player.teleport({ x: -5.3, y: -0.5, z: -213.0 });
+    await game.input.set("head.look", [180, 0]);
+    await game.step({ frames: 2 });
+
+    await game.entities.sendMessage(button.id, { type: "TurnOff" });
+    await game.step({ frames: 2 });
+    const off = await game.screenshot("rec-dynamic-lights-off.png");
+    assert.equal(
+      property(await game.entities.detail(omni.id), "AnimLightIntensity"),
+      "0.000",
+      "TurnOff must remove the authored lightmap contribution",
+    );
+    assert.equal((await game.save("rec-dynamic-lights-off")).success, true);
+    const beforeOnSequence =
+      (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+
+    // Frob the real Aux Power receptor. ObjConsumeButton consumes the carried
+    // cell and sends TurnOn to Light_button 77, which fans out to the authored
+    // animated lights. This is the retail 807 -> 77 -> light chain.
+    await game.entities.sendMessage(breaker.id, { type: "Frob" });
+    await game.step({ frames: 2 });
+    const on = await game.screenshot("rec-dynamic-lights-on.png");
+
+    const recentMessages = (await game.messages.recent()).messages;
+    const breakerMessages = recentMessages.filter(
+      (message) =>
+        message.sequence > beforeOnSequence &&
+        message.payload === "TurnOn" &&
+        message.from?.template_id === AUX_POWER_BREAKER_OBJECT &&
+        message.to.template_id === LIGHT_BUTTON_OBJECT,
+    );
+    assert.equal(
+      breakerMessages.length,
+      1,
+      "the production Aux Power receptor must activate Light_button 77",
+    );
+    const onMessages = recentMessages.filter(
+      (message) =>
+        message.sequence > beforeOnSequence &&
+        message.payload === "TurnOn" &&
+        message.from?.template_id === LIGHT_BUTTON_OBJECT &&
+        message.to.template_id !== LIGHT_BUTTON_OBJECT,
+    );
+    assert.equal(
+      onMessages.length,
+      17,
+      "the production Simple Button must still reach every authored light target",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter(
+        (item) => item.name === "Power Cell",
+      ).length,
+      0,
+      "the production Aux Power receptor must consume the charged cell",
+    );
+
+    assert.notEqual(
+      sha256(on.full_path),
+      sha256(off.full_path),
+      "restoring auxiliary power must visibly change the fixed corridor render",
+    );
+    assert.equal(
+      property(await game.entities.detail(omni.id), "AnimLightIntensity"),
+      "1.000",
+      "BaseLight must retain the live full-brightness state on the authored property",
+    );
+
+    // `P$AnimLight` is a registered Dark property, so the non-default off
+    // state must restore through the normal mission save path. Entity ids are
+    // rediscovered because loading creates a new ECS world.
+    assert.equal((await game.load("rec-dynamic-lights-off")).success, true);
+    await game.step({ frames: 2 });
+    const [restoredOmni] = await game.entities.byTemplate(
+      ANIM_OMNI_LIGHT_OBJECT,
+    );
+    assert.ok(restoredOmni);
+    assert.equal(
+      property(
+        await game.entities.detail(restoredOmni.id),
+        "AnimLightIntensity",
+      ),
+      "0.000",
+      "the switched-off light state must survive save/load",
+    );
+    const restoredOff = await game.screenshot(
+      "rec-dynamic-lights-restored-off.png",
+    );
+    assert.notEqual(
+      sha256(restoredOff.full_path),
+      sha256(on.full_path),
+      "loading the off state must remove the visible light contribution again",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse and register Dark's persisted `P$AnimLight` property, including the authored WR light number and steady brightness mode
- retain the per-cell animated-light ID table and switchable lightmap layers that the WR loader previously discarded
- implement `BaseLight` as a pure script that emits a semantic effect; the mission applier persists the state and recomposes only affected atlas rectangles
- add an exact `rec1` SDK scenario covering corpse loot -> cell recharge -> Aux Power breaker -> `Light_button` -> 17 authored targets, rendered off/on state, and save/load

## Reproduction and root cause

On base `1f36f704`, stable mission object 77 delivered `TurnOn` to all 17 authored targets, including object 714, but the identical fixed camera produced the same PNG before and after:

- off: `6b0ff9702d4bda9fa9b5700616812261a2e0daafd410023ba1d54daa19e47728`
- on: `6b0ff9702d4bda9fa9b5700616812261a2e0daafd410023ba1d54daa19e47728`

Two pieces were missing. `BaseLight` was mapped to `NoopScript`, and the WR reader packed only each face's static base lightmap while discarding its animated-light ID table and every following contribution layer. Object 714's parsed `P$AnimLight` maps to WR light 195 (`MaxBrightness`, max 150), proving the object-to-render-data join.

With this change the authentic stable-object chain is exercised end to end: corpse 107 contains dead cell 808, station 809 recharges it, breaker 807 consumes it and sends `TurnOn` to button 77, and button 77 reaches all 17 targets. The same fixed view changes from off hash `6b0ff970...` to on hash `afc2a231...`; 376,417 / 480,000 pixels change and mean luminance rises from 21.961 to 45.724. The non-default off state also survives save/load.

## Rendering and performance

- No new dynamic fragment lights, shader branches, global brightness, mission coordinates, or object IDs are used by production code.
- Desktop and Quest retain the existing single lightmap texture sample and shader cost.
- State changes mark only lightmap faces referenced by the authored light number; one effect batch recomposes each dirty face at most once and uploads it with `glTexSubImage2D`.
- Ordinary frames do no light entity scans, allocations, composition, or uploads. The one entity scan happens at mission load to restore persisted state.
- `rec1` contains 24 switchable WR light IDs across 844 small face regions; the auxiliary-power transition remains bounded by those authored mappings.

## Scope

This implements the steady switched-light behavior authored by the Recreation auxiliary-power chain and establishes the general object -> WR lightmap path. Temporal `Alternate`/random/flicker/smooth cycling, `LightSoundOn` audio behavior, and the separately noted Med-Hall lightmap-coverage question are intentionally out of scope.

## Verification

- Negative-first SDK render test failed on base because off/on PNG hashes were identical; it is green after the implementation.
- `cargo test -p dark -p engine -p shock2vr --no-fail-fast`: 664 passed, 0 failed (plus 9 real-data Dark integration tests; doctests green/ignored as authored)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`: green
- `npm test --prefix tools/shock2-sdk`: 26 passed, 0 failed
- targeted post-rebase production-chain E2E: 1 passed, 0 failed
- full `npm run test:e2e`: 224 passed, 0 failed, 6 expected fixture-dependent skips; all 23 missions loaded
- `cargo fmt --all -- --check` and `git diff --check`: green
- Local Android check was unavailable because this host lacks its configured NDK path and `cargo-apk`; the shared shader is unchanged and Android CI is required below.

## Visual proof

![Recreation auxiliary-power lightmap toggle](https://gist.githubusercontent.com/tommy-xr/553f2412ecc83bca99de1bda421b89c7/raw/issue-588-aux-power-toggle-final.gif)

<sub>Recreation auxiliary-power switch now restores its authored corridor lightmaps. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before -> after

![Base leaves the powered corridor black; the fix restores its authored lightmaps](https://gist.githubusercontent.com/tommy-xr/553f2412ecc83bca99de1bda421b89c7/raw/issue-588-before-after.png)

<sub>Identical `rec1` camera, switch, `TurnOn`, and two-frame stepping sequence: base `1f36f704` remains black; the fixed build restores the authored lighting.</sub>

Fixes #588
