### PR TITLE
fix(gameplay): respawn ecology spawns named by a mission object

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -495,6 +495,10 @@ pub struct MissionCore {
     #[allow(dead_code)]
     pub template_to_entity_id: HashMap<i32, WrappedEntityId>,
     pub template_name_to_template_id: HashMap<String, EntityMetadata>,
+    /// This mission's own objects (positive ids) that author a unique
+    /// `P$SymName`, indexed by lowercased name - the fallback an ecology spawn
+    /// uses when the gamesys has no archetype under the authored name.
+    mission_object_name_to_id: HashMap<String, i32>,
     pub obj_map: HashMap<i32, String>,
     pub world: World,
     pub player_handle: PlayerHandle,
@@ -696,6 +700,7 @@ impl MissionCore {
         // This is important for creating entities based on template name
         let (template_name_to_template_id, unique_gamesys_template_names) =
             create_template_name_map(game_entity_info);
+        let mission_object_name_to_id = create_mission_object_name_map(&entity_info_rc);
 
         world.add_unique(GlobalEntityMetadata(template_name_to_template_id.clone()));
         world.add_unique(Time::default());
@@ -1253,6 +1258,7 @@ impl MissionCore {
             id_to_bitmap,
             id_to_particle_system: HashMap::new(),
             template_name_to_template_id,
+            mission_object_name_to_id,
             scene_objects: scene,
             animated_lightmaps,
             physics,
@@ -2681,15 +2687,36 @@ impl MissionCore {
                 .unwrap_or(false);
             (position.position, position.rotation, patrol)
         };
-        let Some(created) = self.create_entity_by_template_name(
-            asset_cache,
-            template_name,
-            Point3::new(position.x, position.y, position.z),
-            orientation,
-        ) else {
+        // Spawn markers name their archetype by object name, and that name
+        // often belongs to a concrete object placed in the mission and parked
+        // off-map (earth.mis's "DopeyDroid", the training-droid ecologies)
+        // rather than to a gamesys template - so fall back to this mission's
+        // own named objects. Gamesys archetypes still win, leaving every other
+        // by-name creation path untouched.
+        let name_lowercase = template_name.to_ascii_lowercase();
+        let archetype = self
+            .template_name_to_template_id
+            .get(&name_lowercase)
+            .map(|metadata| metadata.template_id)
+            .or_else(|| self.mission_object_name_to_id.get(&name_lowercase).copied());
+        let Some(archetype) = archetype else {
             warn!("TrapSpawn could not resolve archetype {template_name}");
             return;
         };
+        if archetype >= 0 {
+            // Cloning a concrete object also clones its authored links, which
+            // resolve to the *original's* live partners - log which object was
+            // picked so a bad resolution is diagnosable.
+            info!("TrapSpawn resolved archetype {template_name} to mission object {archetype}");
+        }
+        let created = self.create_entity_with_position(
+            asset_cache,
+            archetype,
+            Point3::new(position.x, position.y, position.z),
+            orientation,
+            Matrix4::identity(),
+            CreateEntityOptions::default(),
+        );
 
         if let Some(ecology_type) = ecology_type {
             self.world.add_component(
@@ -6129,6 +6156,48 @@ fn create_template_name_map(
     (name_to_template_id, unique_template_names)
 }
 
+/// Index this mission's own objects (the positive id space) that author their
+/// own `P$SymName`. Retail spawn markers name their archetype by object name,
+/// and that name often belongs to a concrete off-map object placed in the
+/// mission (earth.mis parks "DopeyDroid" as the training-droid archetype)
+/// rather than to a gamesys template. Only *own* `P$SymName`s are indexed - an
+/// object that merely inherits its archetype's name, or that is named only by
+/// the mission's `OBJ_MAP` (generic archetype names like "Marker", see
+/// `entity_creator::initialize_sym_name_from_obj_map`), is not a distinct
+/// archetype.
+fn create_mission_object_name_map(entity_info: &SystemShock2EntityInfo) -> HashMap<String, i32> {
+    let mut world = World::new();
+    for (id, props) in &entity_info.entity_to_properties {
+        if *id < 0 {
+            continue;
+        }
+        let entity = world.add_entity(dark::properties::PropTemplateId { template_id: *id });
+        for prop in props {
+            prop.initialize(&mut world, entity);
+        }
+    }
+
+    let mut ids_by_name: HashMap<String, Vec<i32>> = HashMap::new();
+    world.run(
+        |v_sym_name: View<dark::properties::PropSymName>,
+         v_template_id: View<dark::properties::PropTemplateId>| {
+            for (sym_name, template_id) in (&v_sym_name, &v_template_id).iter() {
+                ids_by_name
+                    .entry(sym_name.0.to_ascii_lowercase())
+                    .or_default()
+                    .push(template_id.template_id);
+            }
+        },
+    );
+    // Only unambiguous names resolve - picking one of several same-named
+    // objects would spawn an arbitrary one (same reasoning as the gamesys
+    // `unique_gamesys_template_names` map above).
+    ids_by_name
+        .into_iter()
+        .filter_map(|(name, ids)| (ids.len() == 1).then_some((name, ids[0])))
+        .collect()
+}
+
 /// Create a map of template IDs to their class tag data for script access
 fn create_template_class_tag_map(
     entity_info: &Arc<SystemShock2EntityInfo>,
@@ -8042,6 +8111,37 @@ mod held_item_restore_tests {
             )),
             "the displaced left-hand item must be returned to the backpack, got {effects:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod mission_object_name_map_tests {
+    use dark::properties::PropSymName;
+
+    use super::*;
+
+    fn named(entity_info: &mut SystemShock2EntityInfo, id: i32, name: &str) {
+        entity_info
+            .entity_to_properties
+            .insert(id, vec![Arc::new(Box::new(PropSymName(name.to_owned())))]);
+    }
+
+    #[test]
+    fn indexes_only_uniquely_named_mission_objects() {
+        let mut entity_info = SystemShock2EntityInfo::empty();
+        // The authored spawn archetype: a mission object with its own name.
+        named(&mut entity_info, 597, "DopeyDroid");
+        // Gamesys templates are resolved through the gamesys map instead.
+        named(&mut entity_info, -4015, "Training Droid");
+        // Two objects sharing a name cannot pick out an archetype.
+        named(&mut entity_info, 100, "Marker");
+        named(&mut entity_info, 101, "Marker");
+
+        let map = create_mission_object_name_map(&entity_info);
+
+        assert_eq!(map.get("dopeydroid"), Some(&597));
+        assert_eq!(map.get("training droid"), None);
+        assert_eq!(map.get("marker"), None);
     }
 }
 

--- a/shock2vr/src/scripts/trigger_ecology.rs
+++ b/shock2vr/src/scripts/trigger_ecology.rs
@@ -1,4 +1,4 @@
-use dark::properties::{PropEcoState, PropEcoType, PropEcology, PropHitPoints};
+use dark::properties::{PropEcoState, PropEcoType, PropEcology, PropHitPoints, PropTemplateId};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use shipyard::{EntityId, Get, IntoIter, IntoWithId, UniqueView, View, World};
@@ -38,6 +38,35 @@ impl TriggerEcology {
         }
     }
 
+    /// Whether this entity is a physical population member (a creature) rather
+    /// than one of the ecology's own non-physical markers, which carry the same
+    /// EcoType.
+    ///
+    /// The entity's *concrete* template is what answers that: the canonical
+    /// class id alone is the nearest negative ancestor, which for an object
+    /// whose metaprops sort ahead of its archetype is a **metaprop** (earth's
+    /// "DopeyDroid" and its third training droid both resolve to `Docile`,
+    /// which does not descend from `Physical`) - so those creatures were never
+    /// counted and their ecology spawned another every period, forever.
+    ///
+    /// The canonical id is the fallback for entities whose concrete template
+    /// this mission's hierarchy does not know - one carried in from another
+    /// mission, whose positive template id belongs to that mission's id space
+    /// and could alias an unrelated object here.
+    fn is_physical(
+        world: &World,
+        hierarchy: &GlobalTemplateHierarchy,
+        templates: Option<&View<PropTemplateId>>,
+        entity: EntityId,
+    ) -> bool {
+        let concrete = templates
+            .and_then(|templates| templates.get(entity).ok().map(|id| id.template_id))
+            .filter(|template| hierarchy.0.contains_key(template));
+        concrete
+            .or_else(|| entity_class_template_id(world, entity))
+            .is_some_and(|template| hierarchy.is_or_descends_from(template, PHYSICAL_TEMPLATE_ID))
+    }
+
     fn population(world: &World, ecology_type: i32) -> usize {
         let Ok(ecology_types) = world.borrow::<View<PropEcoType>>() else {
             return 0;
@@ -46,6 +75,7 @@ impl TriggerEcology {
             return 0;
         };
         let hit_points = world.borrow::<View<PropHitPoints>>().ok();
+        let templates = world.borrow::<View<PropTemplateId>>().ok();
         ecology_types
             .iter()
             .with_id()
@@ -55,9 +85,7 @@ impl TriggerEcology {
                         .as_ref()
                         .and_then(|hit_points| hit_points.get(*entity).ok())
                         .is_none_or(|hit_points| hit_points.hit_points > 0)
-                    && entity_class_template_id(world, *entity).is_some_and(|template| {
-                        hierarchy.is_or_descends_from(template, PHYSICAL_TEMPLATE_ID)
-                    })
+                    && Self::is_physical(world, &hierarchy, templates.as_ref(), *entity)
             })
             .count()
     }
@@ -345,6 +373,41 @@ mod tests {
         world.add_entity((PropEcoType(2501), RuntimePropCanonicalTemplateId(-196)));
         let effect = step(&mut script, ecology, &world, 15);
         assert!(!sends_to(effect, generator));
+    }
+
+    #[test]
+    fn counts_a_spawn_whose_canonical_class_is_a_metaprop() {
+        // earth's "DopeyDroid" archetype object: its nearest negative ancestor
+        // is the `Docile` metaprop (-1073, not under Physical), while its own
+        // template (597) does descend from Physical. Miscounting it as
+        // non-population makes the ecology respawn one droid every period.
+        let mut world = World::new();
+        world.add_unique(GlobalTemplateHierarchy(HashMap::from([
+            (597, vec![PHYSICAL_TEMPLATE_ID, -1073]),
+            (-1073, vec![-4]),
+        ])));
+        let generator = world.add_entity(());
+        let ecology = world.add_entity((
+            PropEcoType(41),
+            PropEcoState(ECOLOGY_STATE_NORMAL),
+            ecology_props([1, 0, 0], [1, 0, 0], [0.0; 3], [0, 0, 0]),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 598,
+                    to_entity_id: Some(WrappedEntityId(generator)),
+                    link: Link::SwitchLink,
+                }],
+            },
+        ));
+        world.add_entity((
+            PropEcoType(41),
+            PropTemplateId { template_id: 597 },
+            RuntimePropCanonicalTemplateId(-1073),
+        ));
+        let mut script = TriggerEcology::new();
+        script.initialize(ecology, &world);
+
+        assert!(!sends_to(step(&mut script, ecology, &world, 15), generator));
     }
 
     #[test]

--- a/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
@@ -73,5 +73,19 @@ test(
       "protonew",
       `the respawn should be a live protocol droid, got ${JSON.stringify(detail.properties)}`,
     );
+
+    // The respawn has to satisfy its ecology's population census, or every
+    // later period spawns another droid - on this stand and on the third
+    // training stand, whose authored droid is missed by the same census bug.
+    // Every stand clones "DopeyDroid", and the archetype object itself is
+    // parked off-map, so three more periods later the level must still hold
+    // exactly two: the parked archetype and this one respawn.
+    await game.step({ frames: 1500 });
+    const settled = await game.entities.byTemplate(DOPEY_DROID);
+    assert.equal(
+      settled.length,
+      2,
+      `the ecologies must stop at their authored population, got ${JSON.stringify(settled)}`,
+    );
   },
 );

--- a/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8534);
+
+// earth.mis's basic-training stand:
+//
+//   Ecology 599 (EcoType 41, period 8s, min/max 1)
+//        --SwitchLink--> Spawn 598 (EcoType 41, SELF_MARKER, "DopeyDroid")
+//   Droid 547 (EcoType 41) stands on the marker.
+//
+// "DopeyDroid" is mission object 597 - a concrete archetype parked off-map,
+// NOT a gamesys template - so resolving the spawn archetype by name has to
+// look at the mission's own objects. These are stable mission object ids;
+// runtime entity ids are discovered afresh on every launch.
+const TRAINING_DROID = 547;
+const DOPEY_DROID = 597;
+
+function distance(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  return Math.hypot(left[0] - right[0], left[1] - right[1], left[2] - right[2]);
+}
+
+test(
+  "a killed training droid is respawned on its stand by the ecology",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 10 });
+
+    const droids = await game.entities.byTemplate(TRAINING_DROID);
+    assert.equal(
+      droids.length,
+      1,
+      `expected the basic-training droid, got ${JSON.stringify(droids)}`,
+    );
+    const droid = droids[0]!;
+    const stand = droid.position;
+
+    await game.entities.sendMessage(droid.id, { type: "Damage", amount: 100 });
+    await game.step({ frames: 5 });
+    const afterDeath = await game.entities.byTemplate(TRAINING_DROID);
+    assert.equal(afterDeath.length, 0, "the killed droid should be gone");
+
+    // The ecology polls every 8s; give it two periods of headroom.
+    await game.step({ frames: 900 });
+
+    const respawned = (await game.entities.byTemplate(DOPEY_DROID)).filter(
+      (entity) => distance(entity.position, stand) < 2.0,
+    );
+    assert.equal(
+      respawned.length,
+      1,
+      `expected one droid respawned on the stand at ${JSON.stringify(stand)}, got ${JSON.stringify(
+        await game.entities.byTemplate(DOPEY_DROID),
+      )}`,
+    );
+
+    const detail = await game.entities.detail(respawned[0]!.id);
+    const model = detail.properties.find(
+      (property) => property.name === "Model",
+    )?.value;
+    assert.equal(
+      model,
+      "protonew",
+      `the respawn should be a live protocol droid, got ${JSON.stringify(detail.properties)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Problem

In the original game a killed training droid on Earth is put back on its stand by an
ecology a few seconds later. In our port it never came back: every ecology tick logged

```
WARN TrapSpawn could not resolve archetype DopeyDroid
```

(now observable since #888 made the droids actually die).

Two bugs, both on the path from "the ecology wants a droid" to "one droid stands there".

## Bug 1 - the spawn archetype never resolved

`MissionCore::spawn_ecology_entity` resolved `PropSpawn`'s authored archetype name
through `create_entity_by_template_name` → `template_name_to_template_id`, and
`create_template_name_map` (`shock2vr/src/mission/mission_core.rs:6027`) builds that map
from the **gamesys only**.

earth.mis's spawn markers name `"DopeyDroid"`, which is not a gamesys template — it is a
concrete **mission object** (earth.mis object 597, a `Training Droid` + `Docile` + `Silent`
archetype parked off-map) that retail's `TrapSpawn` looks up by object name:

```
Ecology 599 (P$EcoType 41, period 8s, min/max 1)
    --SwitchLink--> Spawn 598 (P$EcoType 41, SELF_MARKER, object_names ["DopeyDroid", ...])
Droid 547 (P$EcoType 41) stands on that marker.
```

**Fix**: index this mission's own objects that author a **unique** `P$SymName`
(`create_mission_object_name_map`) and use it as a fallback **after** the gamesys lookup,
**only in the ecology spawn path**:

- Scoped to `spawn_ecology_entity`, not to the shared `create_entity_by_template_name`, so
  no other by-name creation path (SpawnSFX, tweq emitters, the replicator) changes
  behavior.
- Own `P$SymName` only — an object that merely inherits its archetype's name, or is named
  only by the mission's `OBJ_MAP`, is not a distinct archetype.
- Ambiguous names are dropped, not resolved arbitrarily, mirroring the existing
  `unique_gamesys_template_names`.
- Resolving to a mission object is logged, since cloning a concrete object also clones its
  authored links.

## Bug 2 - the ecology never counted the droid it spawned

With bug 1 fixed the droid came back, and then kept coming back: **one more droid per
stand every 8 s, forever**, past the authored `max_count` of 1.

`TriggerEcology::population` (`shock2vr/src/scripts/trigger_ecology.rs:41`) decided
"is this a physical population member (a creature) or one of my own markers?" from
`entity_class_template_id`, i.e. `RuntimePropCanonicalTemplateId` — the **nearest negative
ancestor**. For an object whose metaprops sort ahead of its archetype that ancestor is a
**metaprop**: both earth's `DopeyDroid` (597) and the third stand's authored droid (567)
resolve to `Docile` (-1073), which does not descend from `Physical` (-11). So those
creatures were invisible to the census and their ecology respawned one every period.
Runtime instrumentation of the census:

```
ECODBG entity EId(49.0)  eco 41 class Some(-4015) physical true    <- authored droid 547
ECODBG entity EId(750.0) eco 42 class Some(-1073) physical false   <- a spawned droid
```

**Fix**: judge membership from the entity's **concrete** `PropTemplateId` ancestry, which
does descend from `Physical`, falling back to the canonical class id only when this
mission's hierarchy does not know the concrete template (an entity carried in from another
mission, whose positive id belongs to that mission's id space). Markers stay excluded:
`Spawn` (-976) and `Ecology` (-975) descend from `Traps` → `Object`, never `Physical`.

## Verification

Headless, deterministic (`/v1/step` at fixed 60 Hz), killing the basic-training droid at
t=0 and stepping five 8 s periods — before, one droid accumulated per stand per period
(4 → 13 droids); now:

```
t=8s   669 DopeyDroid 597 [88.0, 24.2, 187.0]   <- respawned on the stand
t=40s  669 DopeyDroid 597 [87.8, 24.1, 187.1]   <- still exactly one, three periods later
```

Before/after capture of the same sequence — the boxed stand stays empty on `main`, and
holds a fresh protocol droid with the fix:

![before/after](https://gist.githubusercontent.com/tommy-xr/a957e89a5ea430bfd9a7c893b57668e1/raw/3dd882de9c9d87d9f47770b224ba436c99695392/beforeafter.png)

| before (main) | after (fix) |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/a957e89a5ea430bfd9a7c893b57668e1/raw/3dd882de9c9d87d9f47770b224ba436c99695392/before.gif) | ![after](https://gist.githubusercontent.com/tommy-xr/a957e89a5ea430bfd9a7c893b57668e1/raw/3dd882de9c9d87d9f47770b224ba436c99695392/after.gif) |

(The droid in the foreground is present in both runs and is unrelated to the change.)

## Tests

Both fixes are **negative-tested first** — each test fails without its fix:

- `tools/shock2-sdk/test/earth-training-droid-respawn.e2e.test.ts` — kill the droid, step
  past two periods, assert exactly one live protocol droid on the stand (fails on `main`:
  `0 !== 1`), then step three more periods and assert the level still holds exactly two
  template-597 droids: the parked archetype and the one respawn (fails without the census
  fix: 11 droids).
- `counts_a_spawn_whose_canonical_class_is_a_metaprop` — the census unit regression.
- `mission_object_name_map_tests` — positive-ids-only, own-name-only, unique-name-only.

Validation:

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 544 passed.
- `SHOCK2_E2E=1`: all 23 missions load, plus `death-links`, `security-ecology`,
  `shodan-avatar-ecology`, `monster-death`, `spawn-drop-to-floor`,
  `earth-training-narration`, `earth-psionic-training` and the new test — 30 passed /
  0 failed.
- Full e2e suite (on the first fix): 229 tests, 221 pass, 2 fail, 6 skipped — the two
  failures are in the known pre-existing/flaky set; every test covering the systems this
  touches passes.
