### PR TITLE
fix(save-load): holster displaced cross-mode weapon

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -583,6 +583,27 @@ fn restore_saved_script_namespaces(
         .unwrap_or_else(|error| panic!("unable to restore held-item script state: {error}"));
 }
 
+/// Reinstall the interaction controller's held-item state from a save.
+///
+/// Restoring both hands through a flat controller wields the second entity and
+/// produces effects that holster the displaced first entity. The caller must
+/// apply those effects after `PlayerInfo` has installed the backpack entity.
+fn restore_held_item_interaction(
+    interaction: &mut dyn PlayerInteraction,
+    world: &World,
+    left_hand_entity: Option<EntityId>,
+    right_hand_entity: Option<EntityId>,
+) -> Vec<VirtualHandEffect> {
+    let mut effects = Vec::new();
+    if let Some(entity_id) = left_hand_entity {
+        effects.extend(interaction.grab(world, entity_id, vr_config::Handedness::Left));
+    }
+    if let Some(entity_id) = right_hand_entity {
+        effects.extend(interaction.grab(world, entity_id, vr_config::Handedness::Right));
+    }
+    effects
+}
+
 pub struct AbstractMission {
     pub scene_objects: Vec<SceneObject>,
     pub animated_lightmaps: Option<dark::mission::AnimatedLightmapController>,
@@ -969,18 +990,21 @@ impl MissionCore {
             &held_script_entity_id_map,
         );
 
-        // If the player is holding anything, we should un-physical it.
-        // NB: these grabs discard their effects (there is no `self` yet to run
-        // them against), so a flat load of a VR two-handed save strands the
-        // displaced weapon - see #787.
+        // Restore the interaction controller now, but defer its effects until
+        // PlayerInfo below has installed the backpack they may store into.
+
+        let held_restore_effects = restore_held_item_interaction(
+            interaction.as_mut(),
+            &world,
+            left_hand_entity,
+            right_hand_entity,
+        );
 
         if let Some(entity_id) = left_hand_entity {
-            interaction.grab(&world, entity_id, vr_config::Handedness::Left);
             make_un_physical2(&mut id_to_physics, &mut physics, entity_id);
         };
 
         if let Some(entity_id) = right_hand_entity {
-            interaction.grab(&world, entity_id, vr_config::Handedness::Right);
             make_un_physical2(&mut id_to_physics, &mut physics, entity_id);
         };
 
@@ -1216,7 +1240,7 @@ impl MissionCore {
             controller.flush();
         }
 
-        MissionCore {
+        let mut mission_core = MissionCore {
             interaction,
             level_name: mission,
             entity_info: entity_info_rc.clone(),
@@ -1257,7 +1281,9 @@ impl MissionCore {
             player_controls_enabled: true,
             screen_fade_alpha: 0.0,
             screen_fade_texture,
-        }
+        };
+        mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
+        mission_core
     }
 
     fn player_is_alive(&self) -> bool {
@@ -7988,6 +8014,34 @@ mod saved_script_namespace_tests {
         let restored = loaded_scripts.save_states().unwrap();
         assert_eq!(saved_value(&restored, new_mission), 11);
         assert_eq!(saved_value(&restored, new_held), 22);
+    }
+}
+
+#[cfg(test)]
+mod held_item_restore_tests {
+    use super::*;
+
+    /// #787: flat mode only has one wield slot, so restoring a VR save with
+    /// two held items must retain the first grab's displacement effects. The
+    /// load path applies this batch after the backpack is available.
+    #[test]
+    fn flat_two_hand_restore_returns_effect_that_stores_displaced_item() {
+        let mut world = World::new();
+        let left = world.add_entity(());
+        let right = world.add_entity(());
+        let mut interaction = FlatInteraction::new();
+
+        let effects =
+            restore_held_item_interaction(&mut interaction, &world, Some(left), Some(right));
+
+        assert_eq!(interaction.held_entities(), (Some(right), None));
+        assert!(
+            effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::StoreItem { entity_id } if *entity_id == left
+            )),
+            "the displaced left-hand item must be returned to the backpack, got {effects:?}"
+        );
     }
 }
 

--- a/tools/shock2-sdk/test/cross-mode-held-load.e2e.test.ts
+++ b/tools/shock2-sdk/test/cross-mode-held-load.e2e.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+/**
+ * Turn a flat save containing two backpack weapons into the exact ownership
+ * shape written by VR when it has one in each hand. This avoids simulating
+ * motion controllers while still exercising the production deserializer and
+ * MissionCore load path.
+ */
+function markWeaponsHeldByVr(
+  savePath: string,
+  leftEntity: number,
+  rightEntity: number,
+): void {
+  const save = JSON.parse(readFileSync(savePath, "utf8"));
+  const held = save.global_data.held_items;
+  const inventoryLinks = held.held_entities.links[String(held.inventory_entity)];
+  const heldIds = new Set([leftEntity, rightEntity]);
+
+  inventoryLinks.to_links = inventoryLinks.to_links.filter(
+    (link: { to_entity_id: number | null }) =>
+      link.to_entity_id === null || !heldIds.has(link.to_entity_id),
+  );
+  held.entity_in_left_hand = leftEntity;
+  held.entity_in_right_hand = rightEntity;
+  held.held_entities.properties["P$HasRefs"][String(leftEntity)] = true;
+  held.held_entities.properties["P$HasRefs"][String(rightEntity)] = true;
+
+  writeFileSync(savePath, JSON.stringify(save));
+}
+
+test(
+  "flat load holsters the displaced weapon from a VR two-hand save",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `cross_mode_held_${Date.now()}`;
+    let savePath: string | undefined;
+    t.after(() => {
+      if (savePath) rmSync(savePath, { force: true });
+    });
+
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8530),
+    });
+    await game.step({ frames: 10 });
+
+    const pistol = await game.player.spawnItem("Pistol");
+    const shotgun = await game.player.spawnItem("Shotgun");
+    await game.save(saveName);
+
+    savePath = findSavePath(saveName);
+    assert.ok(savePath, `save ${saveName} should exist on disk`);
+    markWeaponsHeldByVr(savePath, pistol.entity_id, shotgun.entity_id);
+
+    await game.load(saveName);
+    await game.step({ frames: 2 });
+
+    const inventory = await game.player.inventory();
+    assert.equal(
+      inventory.items.find((item) => item.name === "Shotgun")?.location,
+      "left_hand",
+      `the second restored hand should become the flat viewmodel: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      inventory.items.find((item) => item.name === "Pistol")?.location,
+      "inventory",
+      `the displaced first restored hand must return to the backpack: ${JSON.stringify(inventory.items)}`,
+    );
+    assert.equal(
+      inventory.items.filter((item) =>
+        ["Pistol", "Shotgun"].includes(item.name ?? ""),
+      ).length,
+      2,
+      "both VR-held weapons must remain reachable after the cross-mode load",
+    );
+
+    const loadedPistol = inventory.items.find((item) => item.name === "Pistol");
+    assert.ok(loadedPistol);
+    assert.equal(
+      (await game.physics.bodies({ entityId: loadedPistol.entity_id })).bodies
+        .length,
+      0,
+      "the holstered weapon must remain non-physical inside the backpack",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- retain the effects produced while reconstructing saved hand state
- apply the restoration batch after `PlayerInfo` makes the backpack available
- cover the complete VR-two-hand-save to flat-load path with an SDK scenario

## Reproduction

On `origin/main` at `97ef13696e58a7b267d53567ca08a7815c51538a`, restoring a left and right held entity through `FlatInteraction` returned a displacement batch from the second wield, but `MissionCore::load` discarded it. The focused negative test failed with:

```text
the displaced left-hand item must be returned to the backpack, got []
```

The displaced entity had already been removed from physics, was not the flat viewmodel, and had no backpack `Contains` link.

## Verification

- `cargo test -p shock2vr` — 548 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed
- `cargo fmt --all -- --check` — passed
- `cd tools/shock2-sdk && npm test` — 26 passed, 207 opt-in scenarios skipped
- `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked SHOCK2_E2E=1 node --test dist/test/cross-mode-held-load.e2e.test.js` — passed

The e2e scenario provisions two real weapons, serializes them, rewrites only their ownership into the exact shape of a VR two-hand save, then loads through the production flat-mode path. It verifies the second weapon becomes the viewmodel and the displaced first weapon remains reachable and non-physical in the backpack.

## Visual proof

![Flat loading a VR two-hand save demo](https://gist.githubusercontent.com/tommy-xr/d285b505d247e7f00d1e9b16f37130ce/raw/flat-vr-two-hand-save.gif)

<sub>Flat loading a VR two-hand save now holsters the displaced Pistol in the visible backpack strip while keeping the Shotgun wielded. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### After still

![Recovered Pistol in the flat backpack strip](https://gist.githubusercontent.com/tommy-xr/d285b505d247e7f00d1e9b16f37130ce/raw/flat-vr-two-hand-save-after.png)

### Before → after

![Before and after: displaced Pistol missing, then recovered](https://gist.githubusercontent.com/tommy-xr/d285b505d247e7f00d1e9b16f37130ce/raw/flat-vr-two-hand-save-before-after.png)

Fixes #787