### PR TITLE
fix(physics): attach zero-volume lift walls

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1194,6 +1194,28 @@ fn create_physics_representation_with_options(
                 }
             };
 
+            // `Lift 1 Walls` is authored as a zero-radius SPHERE with an
+            // outgoing PhysAttach link. Treat that zero-volume marker as the
+            // transform anchor for the visible wall shell, not a simulated
+            // ball: its authored dimensions contribute no collision geometry.
+            // Keep a collider-less kinematic body so the attachment machinery
+            // can drive its render transform without inventing a model-bounds
+            // OBB that would fill the lift's hollow interior.
+            let is_zero_radius_phys_attach_anchor = phys_type.phys_type == PhysicsModelType::SPHERE
+                && maybe_dimensions.is_some_and(|dimensions| {
+                    dimensions.radius0 == 0.0 && dimensions.radius1 == 0.0
+                })
+                && world
+                    .borrow::<View<Links>>()
+                    .unwrap()
+                    .get(entity_id)
+                    .is_ok_and(|links| {
+                        links
+                            .to_links
+                            .iter()
+                            .any(|link| matches!(link.link, Link::PhysAttach(_)))
+                    });
+
             let group = if is_climbable {
                 CollisionGroup::climbable_entity()
             } else {
@@ -1244,7 +1266,9 @@ fn create_physics_representation_with_options(
                 && phys_type.phys_type == PhysicsModelType::SPHERE;
             let is_dynamic_flinder =
                 flinderize_debris && is_movable_dimensionless_sphere && !is_sensor;
-            let rigid_body_handle = if is_authored_dynamic_sphere || is_dynamic_flinder {
+            let rigid_body_handle = if is_zero_radius_phys_attach_anchor {
+                physics.add_kinematic_anchor(entity_id, pos.position, qrotation)
+            } else if is_authored_dynamic_sphere || is_dynamic_flinder {
                 physics_log!(DEBUG, "Creating dynamic hitbox entity");
                 physics.add_dynamic(
                     entity_id,
@@ -1830,6 +1854,87 @@ mod tests {
             physics.collider_blocks_player(handle),
             "a climbable must stay solid to the player"
         );
+    }
+
+    /// The shipped `Lift 1 Walls` uses a zero-radius SPHERE as its physical
+    /// attachment anchor. The anchor must be kinematic so the PhysAttach link
+    /// can drive it with the lift; simulating the zero-volume marker as a
+    /// dynamic ball makes attachment registration fail and lets the visible
+    /// walls separate from the moving platform.
+    #[test]
+    fn zero_radius_phys_attach_sphere_is_a_kinematic_anchor() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let parent = world.add_entity((
+            PropPosition {
+                position: vec3(2.0, 3.0, 4.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::ORIENTED_BOUNDING_BOX,
+                num_submodels: 6,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysDimensions {
+                radius0: 0.0,
+                radius1: 0.0,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: vec3(2.4, 0.4, 2.4),
+                unk1: 0,
+                unk2: 0,
+            },
+        ));
+        let child = world.add_entity((
+            PropPosition {
+                position: vec3(2.0, 4.0, 4.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::SPHERE,
+                num_submodels: 1,
+                remove_on_sleep: false,
+                is_special: false,
+            },
+            PropPhysDimensions {
+                radius0: 0.0,
+                radius1: 0.0,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: Vector3::zero(),
+                unk1: 0,
+                unk2: 0,
+            },
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(parent)),
+                    link: Link::PhysAttach(dark::properties::PhysAttachOptions {
+                        offset: vec3(0.0, 1.0, 0.0),
+                    }),
+                }],
+            },
+        ));
+
+        let _parent_handle = create_physics_representation(&mut world, &mut physics, &None, parent)
+            .expect("the lift floor should get its authored OBB");
+        let _child_handle = create_physics_representation(&mut world, &mut physics, &None, child)
+            .expect("the attached wall shell should retain a transform anchor");
+
+        let child_body = physics
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(child.inner() as i32))
+            .expect("the attached shell should have a body");
+        assert_eq!(child_body.body_type, "kinematic");
+        assert!(
+            physics.get_aabb2(child).is_none(),
+            "a zero-radius authored anchor must not invent collision geometry"
+        );
+        assert!(physics.attach_kinematic(child, parent, vec3(0.0, 1.0, 0.0)));
     }
 
     /// `PhysType::NONE` means the archetype deliberately disables physical

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -3077,13 +3077,14 @@ impl PhysicsWorld {
     pub fn get_aabb2(&self, entity_id: EntityId) -> Option<Aabb3<f32>> {
         if let Some(handle) = self.entity_id_to_body.get(&entity_id) {
             let maybe_rigid_body = self.rigid_body_set.get(*handle);
-            maybe_rigid_body.map(|rigid_body| {
-                let character_collider = &self.collider_set[rigid_body.colliders()[0]];
+            maybe_rigid_body.and_then(|rigid_body| {
+                let collider_handle = rigid_body.colliders().first()?;
+                let character_collider = self.collider_set.get(*collider_handle)?;
                 let aabb = character_collider.compute_aabb();
-                Aabb3 {
+                Some(Aabb3 {
                     min: point3(aabb.mins.x, aabb.mins.y, aabb.mins.z),
                     max: point3(aabb.maxs.x, aabb.maxs.y, aabb.maxs.z),
-                }
+                })
             })
         } else {
             None
@@ -3224,6 +3225,38 @@ impl PhysicsWorld {
         is_sensor: bool,
     ) -> RigidBodyHandle {
         //for (pos, size, facing, id, is_sensor) in &phys_objs {
+        let handle = self.add_kinematic_anchor(entity_id, pos, facing);
+        let size = sanitize_collider_size(entity_id, "add_kinematic", size);
+        let mut collider = ColliderBuilder::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0)
+            //.rotation(vector!(angles.0, angles.1, angles.2))
+            //.rotation(vector!(facing.z, facing.x, facing.y))
+            .translation(vec_to_nvec(offset))
+            //.position(test)
+            .restitution(0.7)
+            .build();
+
+        collider.set_enabled(true);
+        collider.set_sensor(is_sensor);
+        collider.user_data = entity_id.inner() as u128;
+        collider.set_collision_groups(collision_groups.0);
+
+        self.collider_set
+            .insert_with_parent(collider, handle, &mut self.rigid_body_set);
+        handle
+    }
+
+    /// Create a kinematic transform anchor without collision geometry.
+    ///
+    /// Zero-volume PhysAttach objects (notably `Lift 1 Walls`) still own a
+    /// render transform that follows moving terrain, but contribute no shape
+    /// to collision queries. A bare body preserves that transform flow without
+    /// turning the marker into a tiny solid collider.
+    pub fn add_kinematic_anchor(
+        &mut self,
+        entity_id: EntityId,
+        pos: Vector3<f32>,
+        facing: Quaternion<f32>,
+    ) -> RigidBodyHandle {
         let nquat =
             nalgebra::geometry::Quaternion::new(facing.s, facing.v.x, facing.v.y, facing.v.z);
         let nquat_unit = UnitQuaternion::from_quaternion(nquat);
@@ -3247,26 +3280,9 @@ impl PhysicsWorld {
             .pose(test)
             .build();
         rigid_body.user_data = entity_id.inner() as u128;
-        let handle = &self.rigid_body_set.insert(rigid_body);
-        let size = sanitize_collider_size(entity_id, "add_kinematic", size);
-        let mut collider = ColliderBuilder::cuboid(size.x / 2.0, size.y / 2.0, size.z / 2.0)
-            //.rotation(vector!(angles.0, angles.1, angles.2))
-            //.rotation(vector!(facing.z, facing.x, facing.y))
-            .translation(vec_to_nvec(offset))
-            //.position(test)
-            .restitution(0.7)
-            .build();
-
-        self.entity_id_to_body.insert(entity_id, *handle);
-
-        collider.set_enabled(true);
-        collider.set_sensor(is_sensor);
-        collider.user_data = entity_id.inner() as u128;
-        collider.set_collision_groups(collision_groups.0);
-
-        self.collider_set
-            .insert_with_parent(collider, *handle, &mut self.rigid_body_set);
-        *handle
+        let handle = self.rigid_body_set.insert(rigid_body);
+        self.entity_id_to_body.insert(entity_id, handle);
+        handle
     }
 
     /// Attach one kinematic entity to another using Dark's PhysAttach

--- a/tools/shock2-sdk/test/lift-wall-attachment.e2e.test.ts
+++ b/tools/shock2-sdk/test/lift-wall-attachment.e2e.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+
+// MedSci's visible lift-wall shell is a zero-volume physical attachment, not a
+// dynamic prop or a solid model-bounds box. Runtime ids are rediscovered from
+// the stable mission object ids every launch.
+//
+// Negative-first: before #479, the shell became a clamped 0.005-radius dynamic
+// ball. PhysAttach rejected it because only kinematic bodies can be driven;
+// when Lift 1 moved, contact launched the tiny body upward and rotated the
+// visible shell away from the platform.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const LIFT_WALLS_OBJECT = 1852;
+const LIFT_OBJECT = 1853;
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+const delta = (after: Vec3, before: Vec3): Vec3 => [
+  after[0] - before[0],
+  after[1] - before[1],
+  after[2] - before[2],
+];
+
+test(
+  "medsci1.mis: zero-volume Lift 1 Walls anchor tracks the moving lift",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8216),
+    });
+    await game.step({ frames: 5 });
+
+    const walls = only(
+      await game.entities.byTemplate(LIFT_WALLS_OBJECT),
+      "Lift 1 Walls mission object",
+    );
+    const lift = only(
+      await game.entities.byTemplate(LIFT_OBJECT),
+      "Lift 1 mission object",
+    );
+    const wallBodies = (await game.physics.bodies({ entityId: walls.id })).bodies;
+    assert.equal(wallBodies.length, 1, "wall shell should retain one transform body");
+    assert.equal(wallBodies[0].body_type, "kinematic");
+    assert.deepEqual(
+      wallBodies[0].collision_groups,
+      [],
+      "the authored zero-volume anchor must not invent collision geometry",
+    );
+
+    const liftBefore = (await game.entities.detail(lift.id)).position;
+    const wallsBefore = (await game.entities.detail(walls.id)).position;
+    await game.entities.sendMessage(lift.id, { type: "TurnOn" });
+    await game.step({ frames: 120 });
+    const liftAfter = (await game.entities.detail(lift.id)).position;
+    const wallsAfter = (await game.entities.detail(walls.id)).position;
+    const liftTravel = delta(liftAfter, liftBefore);
+    const wallsTravel = delta(wallsAfter, wallsBefore);
+
+    assert.ok(liftTravel[1] > 4, `Lift 1 should move upward, travel=${liftTravel}`);
+    assert.ok(
+      Math.hypot(
+        wallsTravel[0] - liftTravel[0],
+        wallsTravel[1] - liftTravel[1],
+        wallsTravel[2] - liftTravel[2],
+      ) < 0.05,
+      `wall shell must match lift travel: walls=${wallsTravel}, lift=${liftTravel}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- represent zero-radius PhysAttach spheres as colliderless kinematic transform anchors
- let the authored Lift 1 Walls shell track its moving lift without inventing a solid full-model OBB
- make AABB lookup tolerate transform-only bodies and cover the real MedSci lift flow end to end

## Reproduction and root cause

On current main, medsci1 mission object 1852 overrides its inherited OBB with an exact SPHERE whose two radii and dimensions are zero. It also authors a PhysAttach link to Lift 1. The radius clamp from #480 makes its collider numerically safe, so the collider audit is clean, but entity creation still turns the marker into a dynamic 0.005-radius ball.

The later PhysAttach implementation accepts only kinematic child/parent bodies. At load it therefore warns that the Lift 1 Walls attachment is ignored. In a deterministic live reproduction, TurnOn moved the lift floor upward 4.74 world units while contact launched and rotated the tiny wall body away from it.

The lift01_w model bounds enclose the hollow cabin, so substituting one model-bounds OBB would make its interior solid. This change instead preserves the authored zero collision volume while retaining a kinematic body solely for physics-to-render transform synchronization and PhysAttach propagation.

## Negative-first proof

Before the production change, the focused Rust regression failed because the wall anchor was dynamic rather than kinematic. It now verifies that the body is kinematic, has no AABB/collider, and can register its PhysAttach relationship.

The SDK scenario launches medsci1, discovers mission objects 1852 and 1853 by stable template id, verifies the wall anchor has no collision groups, dispatches the real BaseElevator through TurnOn, and confirms the wall shell matches the lift's travel over 120 fixed frames.

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo test -p shock2vr — 548 passed
- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- npm test in tools/shock2-sdk — 26 passed, 207 opt-in scenarios skipped
- focused lift-wall-attachment.e2e.test.ts — passed
- full SDK e2e suite — 224 passed, 7 fixture-dependent skips, 2 unrelated failures; the SHODAN corpse test passed on isolated rerun, while the AI search failure reproduced identically on exact base 97ef136

## Visual proof

![Matched base and fix lift-wall ride](https://gist.githubusercontent.com/tommy-xr/6fe07b3ffbf1e3956c0e5b2710588562/raw/lift-wall-attachment.gif)

<sub>MedSci Lift 1 wall shell now remains attached to the moving lift instead of collision-launching and rotating away. Matched rider-view captures use the exact base (`97ef136`) and fix (`7955a25`), stable mission objects 1852/1853, `TurnOn`, and 120 fixed 60 Hz frames via the headless debug runtime.</sub>

### Corrected result

![Lift wall attached after the fix](https://gist.githubusercontent.com/tommy-xr/6fe07b3ffbf1e3956c0e5b2710588562/raw/after.png)

### Before → after at 1.5 seconds

![Before and after comparison of the Lift 1 wall shell](https://gist.githubusercontent.com/tommy-xr/6fe07b3ffbf1e3956c0e5b2710588562/raw/before-after.png)

Fixes #479
