### PR TITLE
fix(physics): pass spring head under thin railings

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -29,6 +29,25 @@ use self::debug_render_pipeline::DebugRenderer;
 const PLAYER_STANDING_HEIGHT: f32 = 6.0;
 const PLAYER_STANDING_RADIUS: f32 = 1.2;
 
+/// Collision envelope of Dark's rigid standing-player submodels, in SS2 ft.
+/// The original profile's body sphere is centered 0.6 ft below the object
+/// origin with radius 1.2 ft, and its foot collision point is at -3 ft. A
+/// conservative capsule enclosing both is 3.6 ft tall and centered 1.2 ft
+/// below our body origin. The separate head sphere is spring-driven rather
+/// than rigidly welded to that envelope (see `PhysCreateDefaultPlayer`).
+const PLAYER_RIGID_BODY_HEIGHT: f32 = 3.6;
+const PLAYER_RIGID_BODY_CENTER_DROP: f32 = 1.2;
+
+/// A spring-head compatibility pass is only valid for an entity band this
+/// thin vertically and along the direction of travel. Hydro2's authored
+/// Railing Terminator OBB is 0.3 ft in both dimensions; half a foot leaves a
+/// small data tolerance without treating ceiling slabs or walls as head rails.
+const PLAYER_SPRING_HEAD_MAX_BAND_THICKNESS: f32 = 0.5 / SCALE_FACTOR;
+/// Dark's head can yield under a short obstruction, but it cannot remain
+/// displaced under a corridor-length low ceiling. Require a clear standing
+/// endpoint within 3.5 ft (the Hydro2 band exits in about 2.9 ft from contact).
+const PLAYER_SPRING_HEAD_MAX_EXIT_DISTANCE: f32 = 3.5 / SCALE_FACTOR;
+
 /// The standing collider's radius in world units, for callers that must place
 /// something outside the player's own body (the camera sits on the capsule
 /// axis, so "in front of the eye" is only outside the collider beyond this).
@@ -1555,6 +1574,150 @@ fn player_gravity_step(character_body: &RigidBody) -> Real {
     -0.5 / SCALE_FACTOR * character_body.gravity_scale()
 }
 
+/// Reproduce the useful part of Dark's spring-mounted head collision without
+/// weakening the standing player's real six-foot endpoint footprint.
+///
+/// Dark's rigid body sphere clears a short band whose underside is above 3.6
+/// ft; only the independently sprung head meets it, so forward motion can carry
+/// the body through and the head catches back up on the other side. Our single
+/// continuous capsule otherwise turns that head-only contact into a full-body
+/// wall. When an ordinary grounded walk is stopped by one thin parented OBB,
+/// prove that the source-derived rigid-body envelope has a short clear route to
+/// a same-height, supported, full-standing endpoint. Only then return the lower
+/// envelope's horizontal movement for this frame. The visible/collidable body
+/// remains standing throughout and ordinary walls and WorldRep ceilings stay
+/// on the normal capsule path.
+fn spring_head_walk_translation(
+    controller: &KinematicCharacterController,
+    queries: &QueryPipeline,
+    standing_shape: &dyn Shape,
+    pos: &Isometry<Real>,
+    desired: Vector<Real>,
+    regular: &EffectiveCharacterMovement,
+    dt: Real,
+) -> Option<Vector<Real>> {
+    let standing = standing_shape.as_capsule()?;
+    let standing_half_height = standing.half_height() + standing.radius;
+    if (standing.radius - PLAYER_STANDING_RADIUS / SCALE_FACTOR).abs() > 1.0e-4
+        || (standing_half_height - PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR).abs() > 1.0e-4
+        || !regular.grounded
+        || desired.y.abs() > 1.0e-5
+    {
+        return None;
+    }
+
+    let desired_h = vector![desired.x, 0.0, desired.z];
+    let requested = desired_h.norm();
+    if requested <= 1.0e-5 {
+        return None;
+    }
+    let direction = desired_h / requested;
+    let regular_h = vector![regular.translation.x, 0.0, regular.translation.z];
+    if regular_h.dot(&direction) >= requested * 0.5 {
+        return None;
+    }
+
+    let center = pos.translation.vector;
+    let rigid_top =
+        center.y + (PLAYER_RIGID_BODY_HEIGHT / 2.0 - PLAYER_RIGID_BODY_CENTER_DROP) / SCALE_FACTOR;
+    let standing_top = center.y + standing_half_height;
+    let candidate = |_handle: ColliderHandle, collider: &Collider| {
+        let groups = collider.collision_groups().memberships;
+        let aabb = collider.compute_aabb();
+        let extents = aabb.extents();
+        let travel_thickness = direction.x.abs() * extents.x + direction.z.abs() * extents.z;
+        collider.parent().is_some()
+            && collider.shape().as_cuboid().is_some()
+            && groups.intersects(InternalCollisionGroups::ENTITY.bits.into())
+            && !groups.intersects(
+                (InternalCollisionGroups::ACTOR | InternalCollisionGroups::CLIMBABLE)
+                    .bits
+                    .into(),
+            )
+            && extents.y <= PLAYER_SPRING_HEAD_MAX_BAND_THICKNESS
+            && travel_thickness <= PLAYER_SPRING_HEAD_MAX_BAND_THICKNESS
+            && aabb.mins.y >= rigid_top
+            && aabb.maxs.y <= standing_top
+    };
+    let candidate_queries = queries.with_filter(queries.filter.predicate(&candidate));
+    let obstruction = candidate_queries
+        .intersect_shape(*pos, standing_shape)
+        .next()
+        .map(|(handle, _)| handle)
+        .or_else(|| {
+            candidate_queries
+                .cast_shape(
+                    pos,
+                    &direction,
+                    standing_shape,
+                    rapier3d::parry::query::ShapeCastOptions {
+                        max_time_of_impact: requested + PLAYER_CONTACT_OFFSET / SCALE_FACTOR,
+                        target_distance: 0.0,
+                        stop_at_penetration: false,
+                        compute_impact_geometry_on_penetration: true,
+                    },
+                )
+                .map(|(handle, _)| handle)
+        })?;
+    let obstruction_aabb = queries.colliders.get(obstruction)?.compute_aabb();
+    let clearance = standing.radius + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    let exit_distance =
+        climbable_aabb_exit_distance(center, direction, &obstruction_aabb, clearance)?
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+    if exit_distance > PLAYER_SPRING_HEAD_MAX_EXIT_DISTANCE {
+        return None;
+    }
+
+    let standing_exit = center + direction * exit_distance;
+    if shape_intersects(queries, standing_exit, standing_shape) {
+        return None;
+    }
+
+    // Keep both endpoints on the same walkable floor. This rules out a thin
+    // beam at the lip of a shaft: the lower envelope may sweep through it, but
+    // the standing player is never advanced toward an unsupported exit.
+    let support_distance = |at: Vector<Real>| {
+        let ray = Ray::new(Point::from(at), -Vector::y());
+        queries
+            .cast_ray_and_get_normal(&ray, standing_half_height + SUPPORT_PROBE_DISTANCE, true)
+            .and_then(|(_, hit)| {
+                (hit.normal.y >= SUPPORT_MIN_GROUND_NORMAL).then_some(hit.time_of_impact)
+            })
+    };
+    let start_support = support_distance(center)?;
+    let exit_support = support_distance(standing_exit)?;
+    if (start_support - exit_support).abs() > PLAYER_CONTACT_OFFSET / SCALE_FACTOR {
+        return None;
+    }
+
+    let rigid_shape = Capsule::new_y(
+        (PLAYER_RIGID_BODY_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR,
+        PLAYER_STANDING_RADIUS / SCALE_FACTOR,
+    );
+    let center_drop = Vector::y() * (PLAYER_RIGID_BODY_CENTER_DROP / SCALE_FACTOR);
+    let rigid_start = center - center_drop;
+    let rigid_exit = standing_exit - center_drop;
+    if !shape_sweep_is_clear(queries, rigid_start, rigid_exit, &rigid_shape) {
+        return None;
+    }
+
+    let rigid_pos = Isometry::translation(rigid_start.x, rigid_start.y, rigid_start.z);
+    let rigid_movement = controller.move_shape(
+        dt,
+        queries,
+        &rigid_shape,
+        &rigid_pos,
+        desired_h,
+        |_collision| (),
+    );
+    let rigid_h = vector![
+        rigid_movement.translation.x,
+        0.0,
+        rigid_movement.translation.z
+    ];
+    (rigid_h.dot(&direction) >= requested * 0.5).then_some(rigid_h)
+}
+
 /// One frame of player locomotion: the character controller's walk pass, the
 /// gravity pass (with ground snapping and the resting lift), and the stair
 /// step-up probe. Shared by real player movement ([`PhysicsWorld::move_player`])
@@ -1595,6 +1758,10 @@ fn step_player_movement(
     airborne_vertical: Option<Real>,
     climb: Option<ClimbPass<'_>>,
 ) -> PlayerMovement {
+    let allow_spring_head_walk = climb.is_none()
+        && airborne_vertical.is_none()
+        && carry == Vector::zeros()
+        && desired.y.abs() <= 1.0e-5;
     // Ladder: the climb vector replaces both the walk and the gravity pass.
     // Only if it actually moves the player, though - a climb consumes the
     // horizontal input, so a grip whose redirect is cast into solid geometry
@@ -1800,6 +1967,13 @@ fn step_player_movement(
         ) {
             mvt.translation += step;
         }
+    }
+    if allow_spring_head_walk
+        && let Some(horizontal) =
+            spring_head_walk_translation(controller, queries, shape, pos, desired, &mvt, dt)
+    {
+        mvt.translation.x = horizontal.x;
+        mvt.translation.z = horizontal.z;
     }
     // The caller applies one translation from the ORIGINAL pose, so fold the
     // platform's contribution back in only now that every pass above (which
@@ -8913,6 +9087,55 @@ mod tests {
         assert!(
             crouched_world.set_player_crouch(false, &mut crouched_player),
             "standing must be refused under the five-foot ceiling"
+        );
+    }
+
+    /// Hydro2's two `Railing Terminator` OBBs form a 0.3 ft-thick horizontal
+    /// band 4.43 ft above the corridor floor. Dark's rigid body sphere ends at
+    /// 3.6 ft and its independently-sprung head can yield under the short band,
+    /// so both standing and crouched locomotion traverse the authored AIPATH
+    /// route. A single continuous six-foot capsule instead stops standing at
+    /// the band while crouching passes (issue #808).
+    #[test]
+    fn standing_player_passes_under_a_thin_head_height_entity_band() {
+        fn world_with_railing_band() -> (PhysicsWorld, PlayerHandle) {
+            let (mut world, player) = world_with_floor();
+            world.add_kinematic(
+                EntityId::from_inner(2300).unwrap(),
+                vec3(0.0, 1.83, 0.0),
+                identity_quat(),
+                vec3(0.0, 0.0, 0.0),
+                // The railterm OBB after its authored Hydro2 rotation: short
+                // across the corridor and vertically, long along the railing.
+                vec3(0.12, 0.12, 4.2),
+                CollisionGroup::entity(),
+                false,
+            );
+            (world, player)
+        }
+
+        let start = vec3(-1.5, PLAYER_HALF_HEIGHT + 0.1, 0.0);
+        let target = vec3(1.5, 0.0, 0.0);
+
+        let (mut crouched_world, mut crouched_player) = world_with_railing_band();
+        crouched_world.set_player_translation(start, &mut crouched_player);
+        step(&mut crouched_world, &mut crouched_player, 30);
+        assert!(crouched_world.set_player_crouch(true, &mut crouched_player));
+        walk_player_toward(&mut crouched_world, &mut crouched_player, target, 60);
+        let crouched_end = crouched_world.get_player_translation(&crouched_player);
+        assert!(
+            crouched_end.x > 1.0,
+            "fixture precondition: crouched player should cross the band; ended {crouched_end:?}"
+        );
+
+        let (mut standing_world, mut standing_player) = world_with_railing_band();
+        standing_world.set_player_translation(start, &mut standing_player);
+        step(&mut standing_world, &mut standing_player, 30);
+        walk_player_toward(&mut standing_world, &mut standing_player, target, 60);
+        let standing_end = standing_world.get_player_translation(&standing_player);
+        assert!(
+            standing_end.x > 1.0,
+            "standing player should cross the short head-height band; ended {standing_end:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/hydro2-railing-clearance.e2e.test.ts
+++ b/tools/shock2-sdk/test/hydro2-railing-clearance.e2e.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// End-to-end regression for #808 against the two authentic Hydro2 Railing
+// Terminators and ordinary production thumbstick locomotion. Opt in with:
+//
+//   npm run test:e2e
+//
+// Negative-first: on e616231, crouching reaches x=59.2 but the standing
+// capsule stops at x=56.12 because the two rendered rail ends form a thin
+// collider band across the continuous floor and authored AIPATH route.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "standing locomotion crosses Hydro2's spring-head railing band",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8288),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 2 });
+
+    // Stable mission object IDs, never launch-local runtime entity IDs.
+    const [southRail] = await game.entities.byTemplate(228);
+    const [northRail] = await game.entities.byTemplate(1701);
+    assert.ok(southRail && northRail, "both Railing Terminators must be instantiated");
+    for (const rail of [southRail, northRail]) {
+      assert.equal(rail.name, "Railing Terminator");
+      const bodies = await game.physics.bodies({ entityId: rail.id });
+      assert.equal(bodies.total_count, 1, `rail ${rail.template_id} must have its authored OBB`);
+      assert.equal(bodies.bodies[0]?.blocks_player, true);
+      assert.equal(bodies.bodies[0]?.is_sensor, false);
+    }
+
+    const stage = { x: 54.8, y: -0.796, z: 24.1 };
+    const crossStanding = async () => {
+      await teleportVerified(game, stage);
+      await game.step({ frames: 30 });
+      const start = await game.player.position();
+      await game.input.lookAtWorldPoint([
+        start.x + 10,
+        start.y + PLAYER_EYE_HEIGHT_WORLD,
+        start.z,
+      ]);
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      await game.step({ frames: 90 });
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      return { start, end: await game.player.position() };
+    };
+
+    const standing = await crossStanding();
+    assert.ok(
+      standing.end.x > 58.4,
+      `standing player must cross the band (${JSON.stringify(standing)})`,
+    );
+    assert.ok(
+      Math.abs(standing.end.z - standing.start.z) < 0.25,
+      `standing route must remain in the corridor (${JSON.stringify(standing)})`,
+    );
+
+    // Fixture control: the pre-fix workaround remains a legal route too.
+    await teleportVerified(game, stage);
+    await game.step({ frames: 30 });
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 10 });
+    const crouchedStart = await game.player.position();
+    const crouchedEyeHeight = (await game.info()).player.camera_offset?.[1];
+    await game.input.lookAtWorldPoint([
+      crouchedStart.x + 10,
+      crouchedStart.y + (crouchedEyeHeight ?? PLAYER_EYE_HEIGHT_WORLD),
+      crouchedStart.z,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 90 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const crouchedEnd = await game.player.position();
+    assert.ok(
+      crouchedEnd.x > 58.4,
+      `crouched player must still cross the band (${JSON.stringify({ crouchedStart, crouchedEnd })})`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- preserve Hydro2's authored `Railing Terminator` OBBs and reproduce the useful part of Dark's spring-mounted player head when a short, head-only entity band stops ordinary standing locomotion
- require a clear source-derived lower-body sweep, a nearby unobstructed full-standing endpoint, and same-height walkable support before allowing each horizontal step
- add a negative-first physics regression plus an authentic `hydro2.mis` SDK scenario that discovers stable mission objects 228/1701 and exercises ordinary standing and crouched thumbstick traversal

## Root cause

The issue's 686/986 values were launch-local runtime IDs. The stable mission objects are 228 and 1701, both `Railing Terminator` instances inheriting gamesys template -602. They explicitly author a nonsensor blocking OBB (`2.048896 × 0.12 × 0.12` before mission rotation), so neither the model-bounds fallback nor the related #765/#768 dogleg work is responsible. Together the two OBBs form a thin band about 4.43 SS2 ft above the continuous corridor floor, directly across an authored WALK AIPATH route.

The current continuous six-foot capsule welds that head-height contact to the whole player and stops standing at x=56.12. Dark's original player instead has a rigid body sphere whose top is 3.6 ft above the floor plus an independently sprung head sphere. The original definitions are visible in [`physapi.h`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/physapi.h#L38-L51) and [`PhysCreateDefaultPlayer`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/physics/physapi.cpp#L2678-L2731). That profile can yield its head under a short upper band while the rigid body continues through.

The compatibility pass is deliberately narrow: grounded horizontal standing walks only; a parented cuboid entity band at most 0.5 SS2 ft thick vertically and along travel; entirely above the rigid envelope and below the standing crown; no actors, climbables, WorldRep, jumps, or platform carry. It also proves a clear conservative lower-body sweep, a same-height supported route, and a clear full-standing endpoint within 3.5 ft. The real player shape remains the full standing capsule throughout.

## Verification

- negative-first unit regression: exact railterm-style band passes crouched but stopped standing at x=-0.58 on `e616231`; it crosses after this change
- `cargo test -p shock2vr`: 549 passed before rebasing over unrelated save/load PR #895
- post-rebase focused physics matrix: thin spring-head band, authentic MedSci five-foot ceiling rejection, and crouch-only five-foot clearance all pass
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`; `git diff --check`
- SDK unit suite: 26 passed, 209 opt-in scenarios skipped
- authentic Hydro2 scenario: passed after current-main rebase; standing and crouched routes both cross on fresh runtimes
- focused railing reliability: 3/3 fresh runtimes passed
- full SDK E2E: 226 passed, 7 existing exact-save fixture skips, 1 intermittent unrelated AI-search null-detail failure; that identical teleport-only scenario passed 3/3 in isolation on this branch and 1/1 on exact base

## Player-observable verification

![Hydro2 railing traversal before and after](https://gist.githubusercontent.com/tommy-xr/f23591f95ab9576effe244c006803cc6/raw/hydro2-railing-before-after.gif)

<sub>Matched fresh `hydro2.mis` runs with the standing player at `(54.8, -0.796, 24.1)`, 30 fixed settle frames, pawn-aware aim along world +X, and ordinary forward thumbstick input. Exact base `e616231` stops at x=56.12; the fix crosses to x=59.13 in the same 27 input frames. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed timestep).</sub>

### Representative still

![Standing player beyond the railing, looking back](https://gist.githubusercontent.com/tommy-xr/f23591f95ab9576effe244c006803cc6/raw/hydro2-railing-after.png)

<sub>After 24 fixed input frames the standing player is at x=58.63, beyond the authored railing band, and looks back at it.</sub>

### Before → after

![Labeled before and after comparison](https://gist.githubusercontent.com/tommy-xr/f23591f95ab9576effe244c006803cc6/raw/hydro2-railing-before-after.png)

Visual source and matched raw captures: https://gist.github.com/f23591f95ab9576effe244c006803cc6

Fixes #808
