### PR TITLE
test(sdk): cover crouched SHODAN log interaction

### DIFF
--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -159,6 +159,11 @@ impl DesktopInputMapper {
                 action: InputAction::DebugCalmAll,
             },
             Binding {
+                key: Key::U,
+                modifier: Modifier::None,
+                action: InputAction::ReadLastUnreadLog,
+            },
+            Binding {
                 key: Key::M,
                 modifier: Modifier::None,
                 action: InputAction::ToggleMap,

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -109,6 +109,12 @@ where
             // playing its clip) fire in both presentations. A gui can veto the
             // open (a content-less log disc) and/or ask for fresh per-open
             // state (the reader's scroll position).
+            // Opened without a frob (the audio-log reader): give the gui the
+            // same fresh per-open state a frob-open would have.
+            MessagePayload::PanelOpened => {
+                self.gui.prepare_state_on_frob(&mut self.state);
+                Effect::NoEffect
+            }
             MessagePayload::Frob => {
                 let frob_effect = self.gui.on_frob(entity_id, world);
                 if !self.gui.opens_on_frob(entity_id, world) {

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -120,7 +120,8 @@ where
                 if !self.gui.opens_on_frob(entity_id, world) {
                     return frob_effect;
                 }
-                self.gui.prepare_state_on_frob(&mut self.state);
+                // The per-open reset arrives via `PanelOpened`, dispatched by
+                // the `OpenPanel` handler, so both open paths share one hook.
                 Effect::combine(vec![Effect::OpenPanel { entity: entity_id }, frob_effect])
             }
             MessagePayload::GUIHover {

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -83,6 +83,15 @@ pub enum InputAction {
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key). No-op in VR. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
+
+    /// Play back the most recently collected audio log the player has not read
+    /// yet, opening the reader on it (the original's `play_unread_log`).
+    /// Collecting a disc only files it in the PDA, so this is how a log is
+    /// actually read.
+    ReadLastUnreadLog,
+
+    /// Dismiss the open MFD panel (the original closes its overlays on Tab).
+    CloseActivePanel,
 }
 
 impl InputAction {
@@ -120,6 +129,8 @@ impl InputAction {
             InputAction::DebugCalmAll,
             InputAction::DebugForceChase,
             InputAction::ToggleUseMode,
+            InputAction::ReadLastUnreadLog,
+            InputAction::CloseActivePanel,
             InputAction::ToggleMap,
         ]
     }
@@ -156,6 +167,8 @@ impl InputAction {
             InputAction::DebugCalmAll => "DebugCalmAll",
             InputAction::DebugForceChase => "DebugForceChase",
             InputAction::ToggleUseMode => "ToggleUseMode",
+            InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
+            InputAction::CloseActivePanel => "CloseActivePanel",
             InputAction::ToggleMap => "ToggleMap",
         }
     }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -89,9 +89,6 @@ pub enum InputAction {
     /// Collecting a disc only files it in the PDA, so this is how a log is
     /// actually read.
     ReadLastUnreadLog,
-
-    /// Dismiss the open MFD panel (the original closes its overlays on Tab).
-    CloseActivePanel,
 }
 
 impl InputAction {
@@ -130,7 +127,6 @@ impl InputAction {
             InputAction::DebugForceChase,
             InputAction::ToggleUseMode,
             InputAction::ReadLastUnreadLog,
-            InputAction::CloseActivePanel,
             InputAction::ToggleMap,
         ]
     }
@@ -168,7 +164,6 @@ impl InputAction {
             InputAction::DebugForceChase => "DebugForceChase",
             InputAction::ToggleUseMode => "ToggleUseMode",
             InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
-            InputAction::CloseActivePanel => "CloseActivePanel",
             InputAction::ToggleMap => "ToggleMap",
         }
     }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -144,9 +144,6 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
             effects.push(Effect::ReadLastUnreadLog);
         }
-        if state.just_triggered(InputAction::CloseActivePanel) {
-            effects.push(Effect::CloseActivePanel);
-        }
         effects
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -141,6 +141,12 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ToggleMap) {
             effects.push(Effect::ToggleMap);
         }
+        if state.just_triggered(InputAction::ReadLastUnreadLog) {
+            effects.push(Effect::ReadLastUnreadLog);
+        }
+        if state.just_triggered(InputAction::CloseActivePanel) {
+            effects.push(Effect::CloseActivePanel);
+        }
         effects
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2853,6 +2853,44 @@ impl MissionCore {
         self.make_un_physical(entity_id);
     }
 
+    /// Resolve an audio log's reader strings from `level<deck>.str` and cache
+    /// them on the disc for `MediaGui` to render.
+    ///
+    /// `RuntimePropLogData` is runtime-only and deliberately not serialized, so
+    /// this runs both when the log is collected and again each time the reader
+    /// is opened - otherwise a log collected before a save would open a blank
+    /// backdrop after loading.
+    fn attach_log_reader_strings(
+        &mut self,
+        entity_id: EntityId,
+        deck: u32,
+        log: u32,
+        asset_cache: &mut AssetCache,
+    ) {
+        let level_file = format!("level{deck:02}.str");
+        let Some(strings) = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
+        else {
+            return;
+        };
+        // The .str values carry literal backslash-n escapes ("AMANPOUR
+        // 07.JUL.14\nre: New code\n"); unescape them into real line breaks so
+        // the reader never draws "\n".
+        let get = |prefix: &str| {
+            strings
+                .get(&format!("{prefix}{log}"))
+                .map(|s| s.replace("\\n", "\n"))
+        };
+        self.world.add_component(
+            entity_id,
+            crate::runtime_props::RuntimePropLogData {
+                name: get("logname"),
+                text: get("logtext"),
+                portrait: get("logportrait"),
+                icon: get("logicon"),
+            },
+        );
+    }
+
     pub fn make_physical(&mut self, entity_id: EntityId) {
         let current_entity = self.id_to_physics.get(&entity_id);
         if current_entity.is_some() {
@@ -3623,6 +3661,12 @@ impl MissionCore {
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui.open(entity);
                     }
+                    // Give the gui its per-open state (the reader's scroll
+                    // reset) however the panel was reached.
+                    self.script_world.dispatch(Message {
+                        to: entity,
+                        payload: MessagePayload::PanelOpened,
+                    });
                 }
 
                 Effect::BeginResearch { entity_id } => {
@@ -3699,30 +3743,21 @@ impl MissionCore {
                         let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                         quests.collect_log(deck, log);
                     }
-                    // ...and resolve the reader strings from `level<deck>.str`,
-                    // caching them on the disc so the MediaGui panel can render
-                    // the portrait / deck icon / header / transcript.
-                    let level_file = format!("level{deck:02}.str");
-                    if let Some(strings) =
-                        asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
-                    {
-                        // The .str values carry literal backslash-n escapes
-                        // ("AMANPOUR 07.JUL.14\nre: New code\n"); unescape them
-                        // into real line breaks so the reader never draws "\n".
-                        let get = |prefix: &str| {
-                            strings
-                                .get(&format!("{prefix}{log}"))
-                                .map(|s| s.replace("\\n", "\n"))
-                        };
-                        self.world.add_component(
-                            entity_id,
-                            crate::runtime_props::RuntimePropLogData {
-                                name: get("logname"),
-                                text: get("logtext"),
-                                portrait: get("logportrait"),
-                                icon: get("logicon"),
-                            },
-                        );
+                    self.attach_log_reader_strings(entity_id, deck, log, asset_cache);
+
+                    // VR has no discrete-action mapper yet, so `ReadLastUnreadLog`
+                    // is unreachable there and the disc is retired from the world
+                    // on collection - without this, a Quest player could never
+                    // hear a log at all. Flat keeps the faithful split (collecting
+                    // files it; reading plays it). Remove once VR can trigger the
+                    // action (#916 tracks the surrounding player-feedback work).
+                    if game_options.presentation_mode != crate::PresentationMode::Flat {
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            source: Some(entity_id),
+                            name: format!("LOG{deck:02}{log:02}"),
+                            spatial: false,
+                        });
                     }
                     // Retail copies the entry into the PDA and destroys the
                     // pickup. Keep only the entity-bound reader state; retire
@@ -3730,68 +3765,86 @@ impl MissionCore {
                     self.consume_log_pickup(entity_id);
                 }
 
-                Effect::CloseActivePanel => {
-                    self.flat_ui.close();
-                }
-
                 Effect::ReadLastUnreadLog => {
                     // The reader is entity-bound, so playback needs the disc
-                    // entity carrying this log. Discs collected on an earlier
-                    // deck are gone with their mission - cross-mission replay
-                    // is tracked separately (#741).
-                    let target =
-                        self.world
-                            .borrow::<UniqueView<QuestInfo>>()
-                            .ok()
-                            .and_then(|quest_info| {
-                                quest_info.last_unread_log().map(|log| (log.deck, log.log))
-                            });
+                    // that carries this log. Logs collected on an earlier deck
+                    // left their disc behind with that mission (#741), so pick
+                    // the newest unread log that actually resolves here rather
+                    // than letting an unreachable one wedge the key forever.
+                    let unread: Vec<(u32, u32)> = self
+                        .world
+                        .borrow::<UniqueView<QuestInfo>>()
+                        .map(|quest_info| {
+                            quest_info
+                                .collected_logs()
+                                .iter()
+                                .rev()
+                                .filter(|entry| !entry.read)
+                                .map(|entry| (entry.deck, entry.log))
+                                .collect()
+                        })
+                        .unwrap_or_default();
 
-                    if let Some((deck, log)) = target {
-                        let disc = {
-                            let v_log = self
-                                .world
-                                .borrow::<View<dark::properties::PropLog>>()
-                                .unwrap();
-                            v_log
+                    let target = {
+                        let v_log = self
+                            .world
+                            .borrow::<View<dark::properties::PropLog>>()
+                            .unwrap();
+                        let v_data = self
+                            .world
+                            .borrow::<View<crate::runtime_props::RuntimePropLogData>>()
+                            .unwrap();
+                        unread.into_iter().find_map(|(deck, log)| {
+                            // A (deck, log) pair is not unique across the
+                            // campaign - command1 object 2382 and command2 2379
+                            // both author deck 6 / log 5 - so prefer the disc
+                            // that was actually collected (only it carries the
+                            // resolved reader strings) over an untouched twin
+                            // still lying in the current mission.
+                            let mut matches = v_log
                                 .iter()
                                 .with_id()
-                                .find(|(_, authored)| authored.deck == deck && authored.log == log)
-                                .map(|(entity_id, _)| entity_id)
-                        };
+                                .filter(|(_, authored)| {
+                                    authored.deck == deck && authored.log == log
+                                })
+                                .map(|(entity_id, _)| entity_id);
+                            let first = matches.next()?;
+                            let collected = std::iter::once(first)
+                                .chain(matches)
+                                .find(|entity_id| v_data.get(*entity_id).is_ok());
+                            Some((collected.unwrap_or(first), deck, log))
+                        })
+                    };
 
-                        match disc {
-                            Some(disc) => {
-                                if let Ok(mut quest_info) =
-                                    self.world.borrow::<UniqueViewMut<QuestInfo>>()
-                                {
-                                    quest_info.mark_log_read(deck, log);
-                                }
-                                // Reaching the reader without a frob still needs
-                                // the per-open reset a frob-open would have
-                                // given it (the transcript starts at the top).
-                                self.script_world.dispatch(Message {
-                                    to: disc,
-                                    payload: MessagePayload::PanelOpened,
-                                });
-                                if game_options.presentation_mode == crate::PresentationMode::Flat {
-                                    self.flat_ui.open_unbound(disc);
-                                }
-                                effects.push_front(Effect::PlaySound {
-                                    handle: AudioHandle::new(),
-                                    source: None,
-                                    name: format!("LOG{deck:02}{log:02}"),
-                                    spatial: false,
-                                });
+                    match target {
+                        Some((disc, deck, log)) => {
+                            // Re-resolve the strings: they are runtime-only, so
+                            // a log collected before a save has none after load.
+                            self.attach_log_reader_strings(disc, deck, log, asset_cache);
+                            // Reaching the reader without a frob still needs the
+                            // per-open reset a frob-open would have given it
+                            // (the transcript starts at the top).
+                            self.script_world.dispatch(Message {
+                                to: disc,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                            if let Ok(mut quest_info) =
+                                self.world.borrow::<UniqueViewMut<QuestInfo>>()
+                            {
+                                quest_info.mark_log_read(deck, log);
                             }
-                            None => {
-                                game_log!(
-                                    INFO,
-                                    "no backing disc for unread log {}/{}; cannot open the reader",
-                                    deck,
-                                    log
-                                );
+                            if game_options.presentation_mode == crate::PresentationMode::Flat {
+                                self.flat_ui.open_unbound(disc);
                             }
+                            effects.push_front(Effect::PlaySound {
+                                handle: AudioHandle::new(),
+                                source: None,
+                                name: format!("LOG{deck:02}{log:02}"),
+                                spatial: false,
+                            });
+                        }
+                        None => {
+                            game_log!(INFO, "no unread log is readable here");
                         }
                     }
                 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3582,29 +3582,37 @@ impl MissionCore {
                 Effect::ToggleUseMode => {
                     // Flat-presentation only: VR has no cursor mode to toggle.
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
-                        self.flat_use_mode = !self.flat_use_mode;
-                        // Use mode shows the player's backpack as the
-                        // top-docked inventory strip: bind the strip to the
-                        // `internal_inventory` entity (whose GuiScript
-                        // already emits SetUI every frame).
-                        // Leaving use mode drops any item on the cursor. It was
-                        // never removed from the backpack (the host only hid it
-                        // from the strip), so clearing the cursor is enough -
-                        // the item is already reachable there (projects/flat-ui.md
-                        // §1.5). This also means a save/transition mid-drag
-                        // serializes it correctly, with no orphan.
-                        if !self.flat_use_mode {
-                            self.flat_ui.take_cursor_item();
-                        }
-                        let strip_entity = if self.flat_use_mode {
-                            self.world
-                                .borrow::<UniqueView<PlayerInfo>>()
-                                .ok()
-                                .map(|player| player.inventory_entity_id)
+                        // Tab dismisses an open overlay first, as the original
+                        // does - reading a log (or looting a container) and
+                        // pressing Tab should put the panel away, not drop the
+                        // player into shooter mode with it still up.
+                        if self.flat_ui.active_panel().is_some() {
+                            self.flat_ui.close();
                         } else {
-                            None
-                        };
-                        self.flat_ui.set_strip(strip_entity);
+                            self.flat_use_mode = !self.flat_use_mode;
+                            // Use mode shows the player's backpack as the
+                            // top-docked inventory strip: bind the strip to the
+                            // `internal_inventory` entity (whose GuiScript
+                            // already emits SetUI every frame).
+                            // Leaving use mode drops any item on the cursor. It was
+                            // never removed from the backpack (the host only hid it
+                            // from the strip), so clearing the cursor is enough -
+                            // the item is already reachable there (projects/flat-ui.md
+                            // §1.5). This also means a save/transition mid-drag
+                            // serializes it correctly, with no orphan.
+                            if !self.flat_use_mode {
+                                self.flat_ui.take_cursor_item();
+                            }
+                            let strip_entity = if self.flat_use_mode {
+                                self.world
+                                    .borrow::<UniqueView<PlayerInfo>>()
+                                    .ok()
+                                    .map(|player| player.inventory_entity_id)
+                            } else {
+                                None
+                            };
+                            self.flat_ui.set_strip(strip_entity);
+                        }
                     }
                 }
 
@@ -3720,6 +3728,72 @@ impl MissionCore {
                     // pickup. Keep only the entity-bound reader state; retire
                     // the disc from the rendered, physical, frobbable world.
                     self.consume_log_pickup(entity_id);
+                }
+
+                Effect::CloseActivePanel => {
+                    self.flat_ui.close();
+                }
+
+                Effect::ReadLastUnreadLog => {
+                    // The reader is entity-bound, so playback needs the disc
+                    // entity carrying this log. Discs collected on an earlier
+                    // deck are gone with their mission - cross-mission replay
+                    // is tracked separately (#741).
+                    let target =
+                        self.world
+                            .borrow::<UniqueView<QuestInfo>>()
+                            .ok()
+                            .and_then(|quest_info| {
+                                quest_info.last_unread_log().map(|log| (log.deck, log.log))
+                            });
+
+                    if let Some((deck, log)) = target {
+                        let disc = {
+                            let v_log = self
+                                .world
+                                .borrow::<View<dark::properties::PropLog>>()
+                                .unwrap();
+                            v_log
+                                .iter()
+                                .with_id()
+                                .find(|(_, authored)| authored.deck == deck && authored.log == log)
+                                .map(|(entity_id, _)| entity_id)
+                        };
+
+                        match disc {
+                            Some(disc) => {
+                                if let Ok(mut quest_info) =
+                                    self.world.borrow::<UniqueViewMut<QuestInfo>>()
+                                {
+                                    quest_info.mark_log_read(deck, log);
+                                }
+                                // Reaching the reader without a frob still needs
+                                // the per-open reset a frob-open would have
+                                // given it (the transcript starts at the top).
+                                self.script_world.dispatch(Message {
+                                    to: disc,
+                                    payload: MessagePayload::PanelOpened,
+                                });
+                                if game_options.presentation_mode == crate::PresentationMode::Flat {
+                                    self.flat_ui.open_unbound(disc);
+                                }
+                                effects.push_front(Effect::PlaySound {
+                                    handle: AudioHandle::new(),
+                                    source: None,
+                                    name: format!("LOG{deck:02}{log:02}"),
+                                    spatial: false,
+                                });
+                            }
+                            None => {
+                                game_log!(
+                                    INFO,
+                                    "no backing disc for unread log {}/{}; cannot open the reader",
+                                    deck,
+                                    log
+                                );
+                            }
+                        }
+                    }
                 }
 
                 Effect::ToggleMap => {

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -21,6 +21,12 @@ use crate::research::ResearchState;
 pub struct CollectedLog {
     pub deck: u32,
     pub log: u32,
+    /// Whether the player has actually played this log back. Collecting a disc
+    /// only files it in the PDA; the reader is opened explicitly (the
+    /// `ReadLastUnreadLog` action). `#[serde(default)]` keeps saves written
+    /// before read tracking loadable - their logs restore as unread.
+    #[serde(default)]
+    pub read: bool,
 }
 
 #[derive(Deserialize, Serialize, Unique, Clone, Debug)]
@@ -93,7 +99,11 @@ impl QuestInfo {
         if self.has_collected_log(deck, log) {
             return false;
         }
-        self.collected_logs.push(CollectedLog { deck, log });
+        self.collected_logs.push(CollectedLog {
+            deck,
+            log,
+            read: false,
+        });
         true
     }
 
@@ -106,6 +116,31 @@ impl QuestInfo {
     /// The player's collected audio logs, in pickup order.
     pub fn collected_logs(&self) -> &[CollectedLog] {
         &self.collected_logs
+    }
+
+    /// The most recently collected log the player has not played back yet.
+    ///
+    /// The original gathers every unread log across all decks, sorts them by
+    /// acquisition time ascending and plays the *last* one - i.e. the newest
+    /// unread disc, not the oldest backlog entry. `collected_logs` is kept in
+    /// pickup order, so the newest unread is the last matching entry.
+    pub fn last_unread_log(&self) -> Option<&CollectedLog> {
+        self.collected_logs.iter().rev().find(|entry| !entry.read)
+    }
+
+    /// Mark a collected log as played back. Returns `true` when this flipped it
+    /// from unread (re-reading an already-read log is a no-op).
+    pub fn mark_log_read(&mut self, deck: u32, log: u32) -> bool {
+        let Some(entry) = self
+            .collected_logs
+            .iter_mut()
+            .find(|entry| entry.deck == deck && entry.log == log)
+        else {
+            return false;
+        };
+        let was_unread = !entry.read;
+        entry.read = true;
+        was_unread
     }
 
     /// The player's persistent character sheet.
@@ -165,5 +200,83 @@ impl QuestInfo {
 
     pub fn mark_email_as_played(&mut self, email: &str) {
         self.played_emails.insert(email.to_owned());
+    }
+}
+
+#[cfg(test)]
+mod log_tests {
+    use super::*;
+
+    fn quest_info_with(logs: &[(u32, u32)]) -> QuestInfo {
+        let mut quest_info = QuestInfo::new();
+        for (deck, log) in logs {
+            quest_info.collect_log(*deck, *log);
+        }
+        quest_info
+    }
+
+    #[test]
+    fn collected_logs_start_unread() {
+        let quest_info = quest_info_with(&[(2, 20)]);
+
+        assert_eq!(quest_info.collected_logs()[0].read, false);
+    }
+
+    /// The original sorts unread logs by acquisition time and plays the *last*
+    /// one - the newest unread disc, not the oldest outstanding backlog entry.
+    #[test]
+    fn the_newest_unread_log_is_the_one_played_back() {
+        let quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+
+        let unread = quest_info.last_unread_log().expect("nothing read yet");
+
+        assert_eq!((unread.deck, unread.log), (3, 3));
+    }
+
+    #[test]
+    fn reading_the_newest_falls_back_to_the_next_newest_unread() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+
+        assert!(quest_info.mark_log_read(3, 3));
+        let unread = quest_info.last_unread_log().expect("two still unread");
+
+        assert_eq!((unread.deck, unread.log), (2, 2));
+    }
+
+    #[test]
+    fn nothing_is_played_back_once_every_log_is_read() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2)]);
+
+        quest_info.mark_log_read(1, 1);
+        quest_info.mark_log_read(2, 2);
+
+        assert!(quest_info.last_unread_log().is_none());
+    }
+
+    /// Re-reading is a no-op, and an unknown log is not silently inserted.
+    #[test]
+    fn marking_read_reports_only_the_first_transition() {
+        let mut quest_info = quest_info_with(&[(2, 20)]);
+
+        assert!(quest_info.mark_log_read(2, 20));
+        assert!(!quest_info.mark_log_read(2, 20));
+        assert!(!quest_info.mark_log_read(9, 9));
+        assert_eq!(quest_info.collected_logs().len(), 1);
+    }
+
+    /// Saves written before read tracking restore their logs as unread.
+    #[test]
+    fn logs_from_older_saves_deserialize_as_unread() {
+        let restored: CollectedLog =
+            serde_json::from_str(r#"{"deck":2,"log":20}"#).expect("older save shape should load");
+
+        assert_eq!(
+            restored,
+            CollectedLog {
+                deck: 2,
+                log: 20,
+                read: false
+            }
+        );
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -180,6 +180,16 @@ pub enum Effect {
         log: u32,
     },
 
+    /// Play back the most recently collected audio log the player has not read
+    /// yet (the original's `play_unread_log`): open the reader bound to that
+    /// disc's backing entity, mark it read, and play its `LOG<dd><nn>` audio.
+    /// No-op when every collected log has been read. Emitted by
+    /// `InputAction::ReadLastUnreadLog`.
+    ReadLastUnreadLog,
+
+    /// Dismiss the open MFD panel, if any.
+    CloseActivePanel,
+
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the
     /// synthetic map-panel entity, or closes it if it is already open. No-op in

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -187,9 +187,6 @@ pub enum Effect {
     /// `InputAction::ReadLastUnreadLog`.
     ReadLastUnreadLog,
 
-    /// Dismiss the open MFD panel, if any.
-    CloseActivePanel,
-
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the
     /// synthetic map-panel entity, or closes it if it is already open. No-op in

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -27,7 +27,7 @@ use crate::runtime_props::RuntimePropLogData;
 /// posts; that beep is the only audio a log pickup produces. The port has no
 /// overlay-text facility yet, so the cue is fired here as a stand-in.
 ///
-/// When that facility lands (#N), this moves with it: `linebeep` belongs to
+/// When that facility lands (#916), this moves with it: `linebeep` belongs to
 /// posting a message, not to collecting a log. Note the original does *not*
 /// play its item-pickup cue (`pickup_item`) for discs - that fires only on the
 /// frob path that moves an object into the inventory, and `Audio Log` (-76)

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -18,6 +18,23 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::quest_info::QuestInfo;
 use crate::runtime_props::RuntimePropLogData;
+
+/// Acknowledgement cue played when a disc is collected.
+///
+/// This is the original's generic **HUD-message beep**, not a log or pickup
+/// sound. Retail posts an on-screen "Picked up log: <name>" line, and the
+/// overlay-text system plays `linebeep` unconditionally for every message it
+/// posts; that beep is the only audio a log pickup produces. The port has no
+/// overlay-text facility yet, so the cue is fired here as a stand-in.
+///
+/// When that facility lands (#N), this moves with it: `linebeep` belongs to
+/// posting a message, not to collecting a log. Note the original does *not*
+/// play its item-pickup cue (`pickup_item`) for discs - that fires only on the
+/// frob path that moves an object into the inventory, and `Audio Log` (-76)
+/// overrides `FrobInfo` to `world_action: SCRIPT`, dropping the `MOVE` bit it
+/// would inherit from `Goodies` (-49). Compare `cargo dq templates 76` with
+/// `cargo dq templates 49`.
+const LOG_PICKUP_SOUND: &str = "linebeep";
 use crate::scripts::{
     Effect, MessagePayload,
     script_util::{send_to_all_switch_links, set_quest_bit_effect},
@@ -254,10 +271,15 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         let Some((deck, log)) = readable_log(world, entity_id) else {
             return Effect::NoEffect;
         };
+        // Collecting a disc files it in the PDA; it does not play it. The
+        // transcript audio (`LOG{deck}{log}`) belongs to playback, which the
+        // player triggers explicitly via `InputAction::ReadLastUnreadLog` - in
+        // the original the call that would play it on pickup is commented out.
+        // See `LOG_PICKUP_SOUND` for why the cue here is a deviation.
         let audio = Effect::PlaySound {
             handle: AudioHandle::new(),
             source: Some(entity_id),
-            name: format!("LOG{deck:02}{log:02}"),
+            name: LOG_PICKUP_SOUND.to_owned(),
             spatial: false,
         };
         let collect = Effect::CollectLog {
@@ -287,11 +309,12 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         Effect::combine(vec![collect, audio, switchlinks, quest_bit])
     }
 
-    /// A disc with no readable log (unset `PropLog` sentinel) must not open an
-    /// empty backdrop with dead scroll buttons - its frob does nothing, just
-    /// like `on_frob` above.
-    fn opens_on_frob(&self, entity_id: EntityId, world: &World) -> bool {
-        readable_log(world, entity_id).is_some()
+    /// Collecting a log never opens the reader. The original files the entry
+    /// in the PDA and leaves reading to the player; popping a full-screen
+    /// transcript over the world on every pickup interrupts play and buries the
+    /// disc's own audio. Playback is the `ReadLastUnreadLog` action instead.
+    fn opens_on_frob(&self, _entity_id: EntityId, _world: &World) -> bool {
+        false
     }
 
     /// The original resets the reader on every open - a reopened transcript
@@ -388,10 +411,11 @@ mod tests {
         );
     }
 
-    /// A real log still opens, and reopening resets the scroll position to the
-    /// top (the original re-creates the overlay on every open).
+    /// Collecting a real log does not open the reader, and each open resets the
+    /// scroll position to the top (the original re-creates the overlay on every
+    /// open).
     #[test]
-    fn frob_opens_a_real_log_and_reopening_resets_scroll() {
+    fn collecting_a_real_log_does_not_open_it_and_opening_resets_scroll() {
         let mut world = World::new();
         let physics = PhysicsWorld::new();
         // 20 one-word lines: one PageDown scrolls to the clamped last page
@@ -419,7 +443,10 @@ mod tests {
         script.initialize(disc, &world);
 
         let effect = script.handle_message(disc, &world, &physics, &MessagePayload::Frob);
-        assert!(opens_panel(effect), "a readable log must open the panel");
+        assert!(
+            !opens_panel(effect),
+            "collecting a log files it in the PDA; it must not open the reader"
+        );
         assert_eq!(
             drawn_lines(&mut script, disc, &world, &physics)
                 .first()
@@ -440,9 +467,9 @@ mod tests {
             "PageDown should scroll to the clamped last page"
         );
 
-        // Re-frob: the reader reopens scrolled back to the top.
-        let effect = script.handle_message(disc, &world, &physics, &MessagePayload::Frob);
-        assert!(opens_panel(effect));
+        // Opening again (the reader is reached via `ReadLastUnreadLog`, which
+        // dispatches `PanelOpened`) starts scrolled back to the top.
+        script.handle_message(disc, &world, &physics, &MessagePayload::PanelOpened);
         assert_eq!(
             drawn_lines(&mut script, disc, &world, &physics)
                 .first()

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -210,6 +210,12 @@ pub struct DamageImpact {
 pub enum MessagePayload {
     Frob,
 
+    /// This entity's MFD panel was opened. Frobbing used to be the only way in,
+    /// so panels reset their per-open state on `Frob`; the audio-log reader is
+    /// opened by `ReadLastUnreadLog` instead, and any panel may later be opened
+    /// without a frob.
+    PanelOpened,
+
     // Physics events
     SensorBeginIntersect {
         with: EntityId,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -397,6 +397,8 @@ export interface PlayerSnapshot {
 export interface CollectedLog {
   deck: number;
   log: number;
+  /** Whether the player has played this log back. Collecting only files it. */
+  read: boolean;
 }
 
 /** Trainable skill levels (weapon proficiencies + tech skills). */

--- a/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
@@ -32,8 +32,8 @@ test(
 
     assert.deepEqual(
       (await game.info()).player.collected_logs,
-      [{ deck: 6, log: 1 }],
-      "frobbing the disc should download its log into the player's PDA state",
+      [{ deck: 6, log: 1, read: false }],
+      "frobbing the disc should download its log into the PDA, unread",
     );
     assert.equal(
       (await game.physics.bodies({ entityId: disc.id })).bodies.length,

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -187,12 +187,12 @@ test(
       "the Amanpour log should be recorded in the collection, now read",
     );
 
-    // --- Dismissing closes the reader (the original's Tab) ---
-    await game.input.trigger("CloseActivePanel");
+    // --- Tab dismisses the reader, as it does any open MFD panel ---
+    await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
     assert.ok(
       !(await game.ui.state()).active_panel,
-      "CloseActivePanel should dismiss the reader",
+      "Tab should dismiss the reader",
     );
 
     // Re-frobbing does not duplicate the collection entry.
@@ -225,6 +225,58 @@ test(
       (await game.info()).player.collected_logs,
       [{ deck: 2, log: 20, read: true }],
       "the collection and its read state should survive save/load",
+    );
+  },
+);
+
+// `RuntimePropLogData` (the resolved header/transcript/portrait/icon) is
+// runtime-only and deliberately not serialized. It used to be attached by the
+// same frob that opened the reader, so nothing noticed; now that reading is a
+// separate act, a log collected before a save must still render after loading.
+test(
+  "log reader MFD: a log collected before a save still reads back after loading",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
+    });
+    await game.step({ frames: 5 });
+
+    const amanpour = (
+      await game.entities.list({ filter: "Audio Log", limit: 80 })
+    ).entities.find((e) => e.template_id === 1608);
+    assert.ok(amanpour, "medsci1 should contain the Amanpour log (obj 1608)");
+
+    // Collect it, and deliberately do NOT read it.
+    await game.entities.sendMessage(amanpour.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: false }],
+      "the log should be collected and still unread",
+    );
+
+    await game.save("log-unread-roundtrip");
+    await game.load("log-unread-roundtrip");
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "the unread log should still open after a save/load");
+    const text = panel.elements
+      .filter((e) => e.kind === "text" && e.text)
+      .map((e) => e.text)
+      .join(" ");
+    assert.ok(
+      text.includes("45100"),
+      `the reloaded reader must render its transcript, not a blank backdrop (got: ${text.slice(0, 160)})`,
+    );
+    assert.ok(
+      text.toUpperCase().includes("AMANPOUR"),
+      "the reloaded reader should still name the sender",
     );
   },
 );

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -70,19 +70,41 @@ test(
     const [lx, ly, lz] = detail.position;
     await teleportVerified(game, { x: lx, y: ly + 0.5, z: lz });
 
-    // --- Frob: the reader panel opens, bound to the disc ---
+    // --- Frob: the disc is filed in the PDA, and nothing opens ---
+    // The original files the entry and leaves reading to the player: its
+    // pickup path never opens the overlay (the call that would is commented
+    // out in the reference engine).
     await game.entities.sendMessage(amanpour.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "collecting a log must not pop the reader over the world",
+    );
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: false }],
+      "the collected log should be filed unread",
+    );
+
+    // --- Read it: the original's `play_unread_log` opens the newest unread ---
+    await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
 
     const opened = await game.ui.state();
     assert.ok(
       opened.active_panel,
-      "frobbing the audio log should open the reader MFD panel",
+      "ReadLastUnreadLog should open the reader MFD panel",
     );
     assert.equal(
       opened.active_panel.template_id,
       1608,
       "the reader panel should be bound to the Amanpour log entity",
+    );
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: true }],
+      "playing a log back should mark it read",
     );
 
     // The transcript must surface the code 45100 in-fiction.
@@ -154,15 +176,23 @@ test(
     );
     assert.ok(
       sounds.includes("log0220"),
-      `frobbing the log should play LOG0220 (recent: ${sounds.join(", ")})`,
+      `playing the log back should play LOG0220 (recent: ${sounds.join(", ")})`,
     );
 
     // --- The log is recorded in the persistent collection ---
     const collected = (await game.info()).player.collected_logs;
     assert.deepEqual(
       collected,
-      [{ deck: 2, log: 20 }],
-      "the Amanpour log should be recorded in the collection",
+      [{ deck: 2, log: 20, read: true }],
+      "the Amanpour log should be recorded in the collection, now read",
+    );
+
+    // --- Dismissing closes the reader (the original's Tab) ---
+    await game.input.trigger("CloseActivePanel");
+    await game.step({ frames: 5 });
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "CloseActivePanel should dismiss the reader",
     );
 
     // Re-frobbing does not duplicate the collection entry.
@@ -193,8 +223,8 @@ test(
     await game.step({ frames: 5 });
     assert.deepEqual(
       (await game.info()).player.collected_logs,
-      [{ deck: 2, log: 20 }],
-      "the log collection should survive save/load",
+      [{ deck: 2, log: 20, read: true }],
+      "the collection and its read state should survive save/load",
     );
   },
 );

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -32,7 +32,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 test(
-  "log reader MFD: frob opens transcript with 45100, collects the log, persists",
+  "log reader MFD: collecting files the log, reading it opens the 45100 transcript, persists",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({

--- a/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "crouched flat interaction collects SHODAN Delacroix log 4",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    await using game = await GameServer.launch({
+      mission: "shodan.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8231),
+    });
+    await game.step({ frames: 5 });
+
+    const log = (await game.entities.list({ filter: "Audio Log", limit: 80 }))
+      .entities.find((entity) => entity.template_id === 290);
+    assert.ok(log, "shodan should contain Delacroix deck 9/log 4");
+
+    // Setup only: reproduce the campaign's stable crouched landing on the
+    // authored hidden platform. Runtime entity ids remain launch-local.
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+    await teleportVerified(game, {
+      x: 31.9264,
+      y: -27.315,
+      z: 28.5662,
+    });
+    await game.step({ frames: 30 });
+
+    const staged = await game.info();
+    assert.ok(
+      Math.abs(staged.player.camera_offset[1] - 0.48) < 1e-5,
+      `debug runtime should report the live crouched eye (got ${staged.player.camera_offset[1]})`,
+    );
+    const aim = await game.player.aimAt(log, {
+      hitbox: "surface",
+      visibility: "required",
+    });
+    assert.ok(
+      aim.target_confirmed,
+      `production camera ray should select log 4 (${JSON.stringify(aim)})`,
+    );
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+
+    const collected = (await game.info()).player.collected_logs;
+    assert.ok(
+      collected.some((entry) => entry.deck === 9 && entry.log === 4),
+      "production squeeze should collect Delacroix deck 9/log 4",
+    );
+    assert.equal(
+      (await game.ui.state()).active_panel?.template_id,
+      290,
+      "the normal log script should open Delacroix log 4 in the reader",
+    );
+
+    t.diagnostic(
+      `SHODAN log 4: camera ${JSON.stringify(staged.player.camera_offset)}, ` +
+        `aim target ${aim.interaction_target_id}, collected 9/4`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
@@ -7,7 +7,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 test(
-  "crouched flat interaction collects SHODAN Delacroix log 4",
+  "crouched flat interaction collects SHODAN Delacroix log 4, and reads it back",
   { skip: !e2eEnabled, timeout: 600_000 },
   async (t) => {
     await using game = await GameServer.launch({
@@ -52,13 +52,44 @@ test(
 
     const collected = (await game.info()).player.collected_logs;
     assert.ok(
-      collected.some((entry) => entry.deck === 9 && entry.log === 4),
-      "production squeeze should collect Delacroix deck 9/log 4",
+      collected.some((entry) => entry.deck === 9 && entry.log === 4 && !entry.read),
+      "production squeeze should collect Delacroix deck 9/log 4, unread",
     );
+    // Collecting files the log; it does not raise the reader over the world.
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "collecting a log must not open the reader",
+    );
+
+    // The disc is consumed by collection, so the world pickup is gone.
+    assert.equal(
+      (await game.physics.bodies({ entityId: log.id })).bodies.length,
+      0,
+      "the collected disc should lose its world presence",
+    );
+
+    // Reading it back is an explicit act: the newest unread log opens, and is
+    // marked read.
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
     assert.equal(
       (await game.ui.state()).active_panel?.template_id,
       290,
-      "the normal log script should open Delacroix log 4 in the reader",
+      "ReadLastUnreadLog should open Delacroix log 4 in the reader",
+    );
+    assert.ok(
+      (await game.info()).player.collected_logs.some(
+        (entry) => entry.deck === 9 && entry.log === 4 && entry.read,
+      ),
+      "playing the log back should mark it read",
+    );
+
+    // And it closes again, as any MFD panel does.
+    await game.input.trigger("CloseActivePanel");
+    await game.step({ frames: 5 });
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "CloseActivePanel should dismiss the reader",
     );
 
     t.diagnostic(

--- a/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
+++ b/tools/shock2-sdk/test/shodan-log4-interaction.e2e.test.ts
@@ -84,12 +84,12 @@ test(
       "playing the log back should mark it read",
     );
 
-    // And it closes again, as any MFD panel does.
-    await game.input.trigger("CloseActivePanel");
+    // And Tab closes it again, as it does any MFD panel.
+    await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
     assert.ok(
       !(await game.ui.state()).active_panel,
-      "CloseActivePanel should dismiss the reader",
+      "Tab should dismiss the reader",
     );
 
     t.diagnostic(


### PR DESCRIPTION
Fixes #721

## Summary

- restore the focused SHODAN regression that was left behind when #723 was superseded by #800
- discover Delacroix log 4 by stable `template_id === 290`, stage the authentic crouched hidden platform, and use normal flat `aimAt` + squeeze interaction
- assert the debug runtime reports the live 0.48-world-unit crouched camera, the production ray selects the disc, deck 9/log 4 enters `collected_logs`, and the reader opens

## Root cause and existing fix

The log, collider, `PropLog`, and `LogDiscScript` are healthy. The original reproduction aimed through debug automation from a stale 1.6-world-unit standing eye while the production crouched interaction ray originated at 0.48 world units. PR #800 merged the runtime/SDK alignment in `0e36fb11`: `/v1/info` reports `game.player_eye_height() / SCALE_FACTOR`, and the SDK aim helpers consume that live `camera_offset` by default.

PR #723 carried the unique SHODAN log-4 regression but was closed as superseded; its closure comment explicitly kept #721 open until the scenario was ported. This PR adds only that missing coverage against current `main`.

## Negative-first evidence

The same fresh-mission sequence was replayed against exact pre-fix parent `9acf17c1` and current `55c39cac`:

| | Pre-fix | Current |
|---|---:|---:|
| Reported camera offset Y | 1.6 | 0.48000002 |
| Actual production crouched eye | 0.48 | 0.48 |
| Collected 9/4 | no | yes |
| Reader panel | none | template 290 |

The new live-camera assertion fails on the pre-fix runtime, and its production squeeze leaves 9/4 uncollected. On current `main`, two fresh runs passed with different launch-local runtime IDs.

## Verification

- focused `shodan-log4-interaction.e2e.test.ts` — passed; live camera `[0, 0.48000002, 0]`, dynamic target selected, 9/4 collected, reader opened
- existing SHODAN Delacroix log-2 production jump/aim/squeeze E2E — passed
- existing MedSci log-reader collection/persistence E2E — passed
- SDK fast suite — 26 passed, 209 E2E-gated skips
- SDK world-aim unit suite — 12 passed
- focused media/camera/crosshair Rust tests — 3 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`; `git diff --check`

## Player-observable verification

![Crouched SHODAN log 4 interaction before and after](https://gist.githubusercontent.com/tommy-xr/6577220bbf4bc0796bcd327a7e68be71/raw/issue-721-crouched-log-frob.gif)

<sub>Matched fresh `shodan.mis` runs use dynamic template-290 discovery, the same crouched platform staging, SDK `aimAt(surface)` with no eye-height override, and the same one-frame production squeeze pulse. The pre-fix build aims into darkness and collects nothing; current `main` highlights the disc, records deck 9/log 4, and opens Delacroix's “Re: Stakes” reader. Captured headlessly through deterministic fixed-timestep stepping.</sub>

### Current result

![Current reader result](https://gist.githubusercontent.com/tommy-xr/6577220bbf4bc0796bcd327a7e68be71/raw/issue-721-current-reader.png)

### Before → after

![Stale standing aim versus live crouched aim](https://gist.githubusercontent.com/tommy-xr/6577220bbf4bc0796bcd327a7e68be71/raw/issue-721-before-after.png)

[Full-resolution matched captures](https://gist.github.com/tommy-xr/6577220bbf4bc0796bcd327a7e68be71).

## Adjacent tracked scope

Current `main` still leaves collected discs rendered and physical (`template 290` body count `1 → 1`), as the media intentionally shows. That global retail-consumption behavior is tracked by #797 and its existing open PR #838; it is not duplicated here.



---

## Rebased onto #917 and reworked

This PR originally asserted that the reader **opens on the frob that collects the disc**:

```js
assert.equal((await game.ui.state()).active_panel?.template_id, 290,
  "the normal log script should open Delacroix log 4 in the reader");
```

That pins behavior the original does not have — collecting a log files it in the PDA and reading it is an explicit act — so merging it as-is would have made the correction in #917 a test-breaking change, with the next person unable to tell a bug from a contract.

Rebased onto #917 and reworked to the new contract, which widens what the scenario proves:

- the log is collected **unread**
- **no panel is raised** by collecting
- the disc **loses its world presence** (it is consumed)
- `ReadLastUnreadLog` opens it and **marks it read**
- `CloseActivePanel` dismisses it

The setup this scenario exists for — the crouched landing on the authored hidden platform, the live crouched eye height, and the production camera ray selecting log 4 — is unchanged, which is why this stayed a separate PR rather than being folded into #917.

**Merge order:** #917 first; this rebases onto `main` behind it.


**Re-verified on the reworked scenario:** `SHOCK2_E2E=1 npx tsx --test test/shodan-log4-interaction.e2e.test.ts` — 1 passed, executed not skipped (12.7s), diagnostic `SHODAN log 4: camera [0,0.48,0], aim target 844, collected 9/4`.