### PR TITLE
fix(ai): restore full patrol route semantics

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -443,6 +443,11 @@ pub struct PropHUDSelect(pub bool);
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropAIPatrol(pub bool);
 
+/// "AI_PtrlRnd": when true, the patrol ability may pick any other point in
+/// the connected patrol graph instead of following one outgoing branch.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropAIPatrolRandom(pub bool);
+
 //  This is a backlink to the template ID from the ss2 map file
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropTemplateId {
@@ -512,6 +517,10 @@ pub enum Link {
     /// with `PropAIPatrol(true)` walks this chain of points while idle. The
     /// link carries no data (a bare "go to the next point" edge).
     AIPatrol,
+    /// Runtime-only current patrol destination, from the AI to the marker it
+    /// must resume after an interruption or save/load. Dark names this local
+    /// relation `AICurrentPatrol`; it is not authored in mission data.
+    AICurrentPatrol,
     /// Names a destination object for scripted teleports (CS9 eggs/rumblers,
     /// TrapTeleport family, TrapDestroyTeleport's destroy target).
     Teleport,
@@ -1239,6 +1248,14 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$AI_Patrol",
             |reader, _len| read_bool(reader),
             PropAIPatrol,
+            accumulator::latest,
+        ),
+        // Dark chunk keys retain at most 11 characters, so the property
+        // `AI_PtrlRnd` is stored as `P$AI_PtrlRn` in retail missions.
+        define_prop(
+            "P$AI_PtrlRn",
+            |reader, _len| read_bool(reader),
+            PropAIPatrolRandom,
             accumulator::latest,
         ),
         define_prop(

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -85,6 +85,17 @@ fn count_patrolling_entities(info: &SystemShock2EntityInfo) -> usize {
         .count()
 }
 
+fn count_random_patrolling_entities(info: &SystemShock2EntityInfo) -> usize {
+    info.entity_to_properties
+        .values()
+        .filter(|props| {
+            props
+                .iter()
+                .any(|p| format!("{p:?}").contains("PropAIPatrolRandom(true)"))
+        })
+        .count()
+}
+
 /// Every `.mis` filename in `data`.
 fn all_missions(data: &Path) -> Vec<String> {
     std::fs::read_dir(data)
@@ -213,6 +224,19 @@ fn eng1_patrol_data_parses() {
     // ...and the AIs flagged to walk it (P$AI_Patrol = true).
     let patrollers = count_patrolling_entities(&info);
     assert_eq!(patrollers, 17, "eng1 PropAIPatrol(true) AI count changed");
+
+    // Dark's 12-character property name is truncated to the 11-character
+    // chunk key P$AI_PtrlRn in the mission file. Keep that real key registered
+    // so random-sequence patrols are not silently treated as ordinary routes.
+    assert!(
+        !info.unparsed_properties.contains_key("P$AI_PtrlRn"),
+        "P$AI_PtrlRn should parse as PropAIPatrolRandom"
+    );
+    assert_eq!(
+        count_random_patrolling_entities(&info),
+        14,
+        "eng1 PropAIPatrolRandom(true) AI count changed"
+    );
 }
 
 #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5245,7 +5245,60 @@ impl MissionCore {
                                     },
                                 );
                             }
+                            AIPropertyUpdate::PatrolEnabled { enabled } => {
+                                self.world.add_component(
+                                    entity_id,
+                                    dark::properties::PropAIPatrol(enabled),
+                                );
+                            }
                         }
+                    }
+                }
+                Effect::SetAICurrentPatrol { entity_id, target } => {
+                    let is_alive = self
+                        .world
+                        .borrow::<shipyard::EntitiesView>()
+                        .map(|entities| entities.is_alive(entity_id))
+                        .unwrap_or(false);
+                    if !is_alive {
+                        continue;
+                    }
+                    let target_template_id = target.and_then(|target| {
+                        self.world
+                            .borrow::<View<dark::properties::PropTemplateId>>()
+                            .ok()
+                            .and_then(|templates| {
+                                templates.get(target).ok().map(|value| value.template_id)
+                            })
+                    });
+                    let mut needs_links = false;
+                    self.world.run(|mut v_links: ViewMut<Links>| {
+                        if let Ok(links) = (&mut v_links).get(entity_id) {
+                            links
+                                .to_links
+                                .retain(|link| link.link != Link::AICurrentPatrol);
+                            if let Some(target) = target {
+                                links.to_links.push(ToLink {
+                                    to_template_id: target_template_id.unwrap_or(0),
+                                    to_entity_id: Some(WrappedEntityId(target)),
+                                    link: Link::AICurrentPatrol,
+                                });
+                            }
+                        } else {
+                            needs_links = target.is_some();
+                        }
+                    });
+                    if let Some(target) = target.filter(|_| needs_links) {
+                        self.world.add_component(
+                            entity_id,
+                            Links {
+                                to_links: vec![ToLink {
+                                    to_template_id: target_template_id.unwrap_or(0),
+                                    to_entity_id: Some(WrappedEntityId(target)),
+                                    link: Link::AICurrentPatrol,
+                                }],
+                            },
+                        );
                     }
                 }
                 Effect::SetAllAIAlertness { level, pin } => {

--- a/shock2vr/src/save_load/entity_save_data.rs
+++ b/shock2vr/src/save_load/entity_save_data.rs
@@ -136,6 +136,7 @@ impl EntitySaveData {
 mod tests {
     use super::*;
     use crate::scripts::{SavedScriptState, ScriptState, ScriptStateIdentity};
+    use dark::properties::{Link, ToLink};
     use shipyard::{Get, View};
 
     #[test]
@@ -227,6 +228,42 @@ mod tests {
         assert!(data.canonical_template_ids.is_empty());
         assert!(data.launched_projectiles.is_empty());
         assert!(data.script_states.is_empty());
+    }
+
+    #[test]
+    fn current_patrol_link_round_trip_remaps_its_target() {
+        let old_ai = EntityId::new_from_index_and_gen(7, 3);
+        let old_target = EntityId::new_from_index_and_gen(8, 4);
+        let mut data = EntitySaveData::empty();
+        data.all_entities
+            .extend([old_ai.inner(), old_target.inner()]);
+        data.links.insert(
+            old_ai.inner(),
+            serde_json::to_value(Links {
+                to_links: vec![ToLink {
+                    to_template_id: 42,
+                    to_entity_id: Some(WrappedEntityId(old_target)),
+                    link: Link::AICurrentPatrol,
+                }],
+            })
+            .unwrap(),
+        );
+        let mut world = World::new();
+
+        let (_, entity_map) = data.instantiate(&mut world);
+
+        let new_ai = entity_map[&old_ai];
+        let new_target = entity_map[&old_target];
+        let links = world.borrow::<View<Links>>().unwrap();
+        let current = links
+            .get(new_ai)
+            .unwrap()
+            .to_links
+            .iter()
+            .find(|link| link.link == Link::AICurrentPatrol)
+            .unwrap();
+        assert_eq!(current.to_entity_id.unwrap().0, new_target);
+        assert_eq!(current.to_template_id, 42);
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, f32::consts::PI};
+use std::{
+    collections::{HashMap, HashSet},
+    f32::consts::PI,
+};
 
 use cgmath::{
     Deg, EuclideanSpace, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation, Rotation3,
@@ -14,7 +17,12 @@ use crate::{
     mission::{PlayerInfo, entity_creator::CreateEntityOptions},
     physics::{InternalCollisionGroups, PhysicsWorld},
     runtime_props::{RuntimePropJointTransforms, RuntimePropProxyEntity, RuntimePropTransform},
-    scripts::{Effect, script_util::get_first_link_with_template_and_data},
+    scripts::{
+        Effect,
+        script_util::{
+            get_all_links_of_type, get_first_link_of_type, get_first_link_with_template_and_data,
+        },
+    },
 };
 
 ///
@@ -59,16 +67,31 @@ pub fn current_patrol_point(
     world: &World,
     patroller: EntityId,
 ) -> Option<(EntityId, Vector3<f32>)> {
-    let links = world.borrow::<View<Links>>().ok()?;
-    let target = links
-        .get(patroller)
-        .ok()?
-        .to_links
-        .iter()
-        .find(|link| link.link == Link::AICurrentPatrol)?
-        .to_entity_id?
-        .0;
+    let target = get_first_link_of_type(world, patroller, Link::AICurrentPatrol)?;
     entity_origin(world, target).map(|position| (target, position))
+}
+
+/// Whether `point` is a genuine end of chain - it authors no outgoing
+/// `AIPatrol` link at all. Distinct from `next_patrol_point` returning None,
+/// which also covers a link whose target was never instantiated or has no
+/// transform. Only a true dead end may clear the authored `AI_Patrol` flag;
+/// an unresolved route is a broken mission, not the end of a patrol.
+pub fn is_patrol_dead_end(world: &World, point: EntityId) -> bool {
+    // Deliberately inspects the authored links rather than going through
+    // `get_first_link_of_type`, which drops links whose target was never
+    // instantiated - exactly the case this must NOT report as an end of chain.
+    world
+        .borrow::<View<Links>>()
+        .ok()
+        .and_then(|links| {
+            links.get(point).ok().map(|links| {
+                !links
+                    .to_links
+                    .iter()
+                    .any(|link| link.link == Link::AIPatrol)
+            })
+        })
+        .unwrap_or(true)
 }
 
 /// The transform origin of an entity, if it has a runtime transform.
@@ -119,6 +142,23 @@ fn connected_patrol_points(world: &World, start: EntityId) -> Vec<EntityId> {
     let Ok(v_links) = world.borrow::<View<Links>>() else {
         return Vec::new();
     };
+
+    // One pass over the link storage builds both directions of the patrol
+    // graph, so the walk below is O(nodes + edges) rather than rescanning
+    // every entity's links once per node reached.
+    let mut adjacency: HashMap<EntityId, Vec<EntityId>> = HashMap::new();
+    for (source, links) in (&v_links).iter().with_id() {
+        for target in links
+            .to_links
+            .iter()
+            .filter(|link| link.link == Link::AIPatrol)
+            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+        {
+            adjacency.entry(source).or_default().push(target);
+            adjacency.entry(target).or_default().push(source);
+        }
+    }
+
     let mut points = vec![start];
     let mut seen = HashSet::from([start]);
     let mut index = 0;
@@ -126,26 +166,9 @@ fn connected_patrol_points(world: &World, start: EntityId) -> Vec<EntityId> {
         let current = points[index];
         index += 1;
 
-        if let Ok(links) = v_links.get(current) {
-            for next in links
-                .to_links
-                .iter()
-                .filter(|link| link.link == Link::AIPatrol)
-                .filter_map(|link| link.to_entity_id.map(|id| id.0))
-            {
-                if seen.insert(next) {
-                    points.push(next);
-                }
-            }
-        }
-
-        for (source, links) in (&v_links).iter().with_id() {
-            let reaches_current = links.to_links.iter().any(|link| {
-                link.link == Link::AIPatrol
-                    && link.to_entity_id.is_some_and(|target| target.0 == current)
-            });
-            if reaches_current && seen.insert(source) {
-                points.push(source);
+        for neighbor in adjacency.get(&current).into_iter().flatten() {
+            if seen.insert(*neighbor) {
+                points.push(*neighbor);
             }
         }
     }
@@ -182,14 +205,8 @@ fn next_patrol_point_with_rng<R: Rng + ?Sized>(
             .filter_map(|candidate| entity_origin(world, candidate).map(|pos| (candidate, pos)))
             .collect::<Vec<_>>()
     } else {
-        let links = world.borrow::<View<Links>>().ok()?;
-        links
-            .get(point)
-            .ok()?
-            .to_links
-            .iter()
-            .filter(|link| link.link == Link::AIPatrol)
-            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+        get_all_links_of_type(world, point, Link::AIPatrol)
+            .into_iter()
             .filter_map(|candidate| entity_origin(world, candidate).map(|pos| (candidate, pos)))
             .collect::<Vec<_>>()
     };

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::PI;
+use std::{collections::HashSet, f32::consts::PI};
 
 use cgmath::{
     Deg, EuclideanSpace, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation, Rotation3,
@@ -14,10 +14,7 @@ use crate::{
     mission::{PlayerInfo, entity_creator::CreateEntityOptions},
     physics::{InternalCollisionGroups, PhysicsWorld},
     runtime_props::{RuntimePropJointTransforms, RuntimePropProxyEntity, RuntimePropTransform},
-    scripts::{
-        Effect,
-        script_util::{get_first_link_of_type, get_first_link_with_template_and_data},
-    },
+    scripts::{Effect, script_util::get_first_link_with_template_and_data},
 };
 
 ///
@@ -55,6 +52,25 @@ pub fn is_patroller(world: &World, entity_id: EntityId) -> bool {
         .unwrap_or(false)
 }
 
+/// Current patrol destination stored in Dark's runtime-only relation. The
+/// Links component is serialized and entity-remapped by the normal save path,
+/// so this is also the alertness and save/load resume point.
+pub fn current_patrol_point(
+    world: &World,
+    patroller: EntityId,
+) -> Option<(EntityId, Vector3<f32>)> {
+    let links = world.borrow::<View<Links>>().ok()?;
+    let target = links
+        .get(patroller)
+        .ok()?
+        .to_links
+        .iter()
+        .find(|link| link.link == Link::AICurrentPatrol)?
+        .to_entity_id?
+        .0;
+    entity_origin(world, target).map(|position| (target, position))
+}
+
 /// The transform origin of an entity, if it has a runtime transform.
 fn entity_origin(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
     let v_transform = world.borrow::<View<RuntimePropTransform>>().ok()?;
@@ -62,48 +78,220 @@ fn entity_origin(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
     Some(xform.transform_point(point3(0.0, 0.0, 0.0)).to_vec())
 }
 
-/// The nearest patrol-point object to `from` - a node with an outgoing
-/// `AIPatrol` link (so the chain can actually be walked from it) - with its
-/// position. None if the mission has no patrol network. Scans all links, so
-/// call it on a behavior change (entering idle), not every frame.
+/// Initial patrol destination chosen the way Dark's `TargetNextPatrolObj`
+/// does: find the `AIPatrol` link whose source is nearest to `from`, but head
+/// directly to that link's destination. None if the mission has no usable
+/// patrol edge. Scans all links, so call it only when beginning a route.
 pub fn nearest_patrol_point(world: &World, from: Vector3<f32>) -> Option<(EntityId, Vector3<f32>)> {
     let v_links = world.borrow::<View<Links>>().ok()?;
     let v_transform = world.borrow::<View<RuntimePropTransform>>().ok()?;
 
     let mut best: Option<(EntityId, Vector3<f32>, f32)> = None;
-    for (id, links) in (&v_links).iter().with_id() {
-        let has_outgoing = links.to_links.iter().any(|l| l.link == Link::AIPatrol);
-        if !has_outgoing {
-            continue;
-        }
-        let Ok(xform) = v_transform.get(id) else {
+    for (source, links) in (&v_links).iter().with_id() {
+        let Ok(xform) = v_transform.get(source) else {
             continue;
         };
-        let pos = xform.0.transform_point(point3(0.0, 0.0, 0.0)).to_vec();
-        let dist_sq = (pos - from).magnitude2();
-        if best
-            .map(|(_, _, best_sq)| dist_sq < best_sq)
-            .unwrap_or(true)
+        let source_pos = xform.0.transform_point(point3(0.0, 0.0, 0.0)).to_vec();
+        let dist_sq = (source_pos - from).magnitude2();
+        for link in links
+            .to_links
+            .iter()
+            .filter(|link| link.link == Link::AIPatrol)
         {
-            best = Some((id, pos, dist_sq));
+            let Some(target) = link.to_entity_id.map(|id| id.0) else {
+                continue;
+            };
+            let Some(target_pos) = entity_origin(world, target) else {
+                continue;
+            };
+            if best
+                .map(|(_, _, best_sq)| dist_sq < best_sq)
+                .unwrap_or(true)
+            {
+                best = Some((target, target_pos, dist_sq));
+            }
         }
     }
     best.map(|(id, pos, _)| (id, pos))
 }
 
-/// The next patrol point after `point`, following its first outgoing `AIPatrol`
-/// link, with position. None at a dead-end. A route is usually a closed loop,
-/// so following the chain repeats forever.
-pub fn next_patrol_point(world: &World, point: EntityId) -> Option<(EntityId, Vector3<f32>)> {
-    let next = get_first_link_of_type(world, point, Link::AIPatrol)?;
-    let pos = entity_origin(world, next)?;
-    Some((next, pos))
+fn connected_patrol_points(world: &World, start: EntityId) -> Vec<EntityId> {
+    let Ok(v_links) = world.borrow::<View<Links>>() else {
+        return Vec::new();
+    };
+    let mut points = vec![start];
+    let mut seen = HashSet::from([start]);
+    let mut index = 0;
+    while index < points.len() {
+        let current = points[index];
+        index += 1;
+
+        if let Ok(links) = v_links.get(current) {
+            for next in links
+                .to_links
+                .iter()
+                .filter(|link| link.link == Link::AIPatrol)
+                .filter_map(|link| link.to_entity_id.map(|id| id.0))
+            {
+                if seen.insert(next) {
+                    points.push(next);
+                }
+            }
+        }
+
+        for (source, links) in (&v_links).iter().with_id() {
+            let reaches_current = links.to_links.iter().any(|link| {
+                link.link == Link::AIPatrol
+                    && link.to_entity_id.is_some_and(|target| target.0 == current)
+            });
+            if reaches_current && seen.insert(source) {
+                points.push(source);
+            }
+        }
+    }
+    points
+}
+
+/// Pick the next patrol target. Ordinary routes choose uniformly among the
+/// current point's outgoing branches. `AI_PtrlRnd` routes may jump to any
+/// other node in the bidirectionally connected graph, matching Dark's random
+/// sequence mode.
+pub fn next_patrol_point(
+    world: &World,
+    patroller: EntityId,
+    point: EntityId,
+) -> Option<(EntityId, Vector3<f32>)> {
+    next_patrol_point_with_rng(world, patroller, point, &mut thread_rng())
+}
+
+fn next_patrol_point_with_rng<R: Rng + ?Sized>(
+    world: &World,
+    patroller: EntityId,
+    point: EntityId,
+    rng: &mut R,
+) -> Option<(EntityId, Vector3<f32>)> {
+    let random_sequence = world
+        .borrow::<View<PropAIPatrolRandom>>()
+        .ok()
+        .and_then(|random| random.get(patroller).ok().map(|value| value.0))
+        .unwrap_or(false);
+    let candidates = if random_sequence {
+        connected_patrol_points(world, point)
+            .into_iter()
+            .filter(|candidate| *candidate != point)
+            .filter_map(|candidate| entity_origin(world, candidate).map(|pos| (candidate, pos)))
+            .collect::<Vec<_>>()
+    } else {
+        let links = world.borrow::<View<Links>>().ok()?;
+        links
+            .get(point)
+            .ok()?
+            .to_links
+            .iter()
+            .filter(|link| link.link == Link::AIPatrol)
+            .filter_map(|link| link.to_entity_id.map(|id| id.0))
+            .filter_map(|candidate| entity_origin(world, candidate).map(|pos| (candidate, pos)))
+            .collect::<Vec<_>>()
+    };
+    (!candidates.is_empty()).then(|| {
+        let index = rng.gen_range(0..candidates.len());
+        candidates[index]
+    })
 }
 
 pub fn current_yaw(entity_id: shipyard::EntityId, world: &shipyard::World) -> Deg<f32> {
     let (point, forward) = get_position_and_forward(world, entity_id);
     let position = point.to_vec();
     yaw_between_vectors(position, position + forward)
+}
+
+#[cfg(test)]
+mod patrol_tests {
+    use std::collections::HashSet;
+
+    use super::*;
+    use cgmath::Matrix4;
+    use rand::{SeedableRng, rngs::StdRng};
+    use shipyard::{Get, ViewMut};
+
+    fn point(world: &mut World, position: Vector3<f32>) -> EntityId {
+        world.add_entity((
+            RuntimePropTransform(Matrix4::from_translation(position)),
+            Links::empty(),
+        ))
+    }
+
+    fn link(world: &World, source: EntityId, dest: EntityId) {
+        let mut links = world.borrow::<ViewMut<Links>>().unwrap();
+        (&mut links).get(source).unwrap().to_links.push(ToLink {
+            to_template_id: 0,
+            to_entity_id: Some(WrappedEntityId(dest)),
+            link: Link::AIPatrol,
+        });
+    }
+
+    #[test]
+    fn initial_patrol_target_is_destination_of_nearest_source() {
+        let mut world = World::new();
+        let near_source = point(&mut world, vec3(1.0, 0.0, 0.0));
+        let near_dest = point(&mut world, vec3(20.0, 0.0, 0.0));
+        let far_source = point(&mut world, vec3(5.0, 0.0, 0.0));
+        let far_dest = point(&mut world, vec3(6.0, 0.0, 0.0));
+        link(&world, near_source, near_dest);
+        link(&world, far_source, far_dest);
+
+        let (target, goal) = nearest_patrol_point(&world, vec3(0.0, 0.0, 0.0)).unwrap();
+
+        assert_eq!(target, near_dest, "distance is measured to the link source");
+        assert_eq!(
+            goal,
+            vec3(20.0, 0.0, 0.0),
+            "the link destination is targeted"
+        );
+    }
+
+    #[test]
+    fn ordinary_patrol_can_take_every_outgoing_branch() {
+        let mut world = World::new();
+        let patroller = world.add_entity(PropAIPatrolRandom(false));
+        let source = point(&mut world, vec3(0.0, 0.0, 0.0));
+        let left = point(&mut world, vec3(-5.0, 0.0, 0.0));
+        let right = point(&mut world, vec3(5.0, 0.0, 0.0));
+        link(&world, source, left);
+        link(&world, source, right);
+
+        let mut rng = StdRng::seed_from_u64(410);
+        let selected: HashSet<_> = (0..256)
+            .filter_map(|_| {
+                next_patrol_point_with_rng(&world, patroller, source, &mut rng).map(|(id, _)| id)
+            })
+            .collect();
+
+        assert_eq!(selected, HashSet::from([left, right]));
+    }
+
+    #[test]
+    fn random_sequence_can_target_any_other_node_in_connected_graph() {
+        let mut world = World::new();
+        let patroller = world.add_entity(PropAIPatrolRandom(true));
+        let current = point(&mut world, vec3(0.0, 0.0, 0.0));
+        let outgoing = point(&mut world, vec3(1.0, 0.0, 0.0));
+        let descendant = point(&mut world, vec3(2.0, 0.0, 0.0));
+        let upstream = point(&mut world, vec3(-1.0, 0.0, 0.0));
+        link(&world, current, outgoing);
+        link(&world, outgoing, descendant);
+        link(&world, upstream, current);
+
+        let mut rng = StdRng::seed_from_u64(410);
+        let selected: HashSet<_> = (0..512)
+            .filter_map(|_| {
+                next_patrol_point_with_rng(&world, patroller, current, &mut rng).map(|(id, _)| id)
+            })
+            .collect();
+
+        assert_eq!(selected, HashSet::from([outgoing, descendant, upstream]));
+        assert!(!selected.contains(&current));
+    }
 }
 
 pub fn clamp_to_minimal_delta_angle(ang: Deg<f32>) -> Deg<f32> {

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -298,7 +298,9 @@ impl AnimatedMonsterAI {
         }
         if is_patroller(world, entity_id) {
             let (position, _) = get_position_and_forward(world, entity_id);
-            if let Some((point, goal)) = nearest_patrol_point(world, position.to_vec()) {
+            if let Some((point, goal)) = current_patrol_point(world, entity_id)
+                .or_else(|| nearest_patrol_point(world, position.to_vec()))
+            {
                 return Box::new(RefCell::new(PatrolBehavior::new(point, goal)));
             }
         }
@@ -1475,6 +1477,8 @@ fn is_attack_animation(motion_query_items: &[MotionQueryItem]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::Transform;
+    use shipyard::{IntoIter, IntoWithId};
 
     /// A live monster at the origin, turned `heading` degrees off +Z, with the
     /// player standing 10 units down +Z. The physics world is empty, so
@@ -1646,6 +1650,73 @@ mod tests {
             monster.current_behavior.borrow().name(),
             "Patrol",
             "a flagged patroller with a reachable route patrols from spawn",
+        );
+    }
+
+    #[test]
+    fn patroller_resumes_current_target_after_alertness_interrupts_it() {
+        let (mut world, entity_id) = world_with_monster_and_player(Deg(180.0));
+        make_patroller(&mut world, entity_id, true);
+
+        // The fresh nearest-source rule would target the x=20 destination.
+        // Persist x=10 instead, as Dark's AICurrentPatrol relation does after
+        // a route has already advanced, so the two cases are distinguishable.
+        let resume_target = {
+            let transforms = world
+                .borrow::<shipyard::View<crate::runtime_props::RuntimePropTransform>>()
+                .unwrap();
+            let links = world
+                .borrow::<shipyard::View<dark::properties::Links>>()
+                .unwrap();
+            (&links)
+                .iter()
+                .with_id()
+                .filter(|(id, links)| {
+                    *id != entity_id
+                        && links
+                            .to_links
+                            .iter()
+                            .any(|link| link.link == Link::AIPatrol)
+                })
+                .find_map(|(id, _)| {
+                    let x = transforms
+                        .get(id)
+                        .ok()?
+                        .0
+                        .transform_point(cgmath::point3(0.0, 0.0, 0.0))
+                        .x;
+                    ((x - 10.0).abs() < 0.01).then_some(id)
+                })
+                .unwrap()
+        };
+        world.add_component(
+            entity_id,
+            dark::properties::Links {
+                to_links: vec![dark::properties::ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(dark::properties::WrappedEntityId(resume_target)),
+                    link: Link::AICurrentPatrol,
+                }],
+            },
+        );
+
+        let physics = PhysicsWorld::new();
+        let mut monster = AnimatedMonsterAI::new();
+        monster.initialize(entity_id, &world);
+        assert_eq!(
+            monster.current_behavior.borrow().patrol_target(),
+            Some(resume_target),
+            "fresh script initialization must hydrate the saved route target"
+        );
+
+        monster.force_alertness(AIAlertLevel::Moderate, &world, &physics, entity_id);
+        assert_eq!(monster.current_behavior.borrow().name(), "Chase");
+        monster.force_alertness(AIAlertLevel::Lowest, &world, &physics, entity_id);
+        assert_eq!(monster.current_behavior.borrow().name(), "Patrol");
+        assert_eq!(
+            monster.current_behavior.borrow().patrol_target(),
+            Some(resume_target),
+            "calming down must resume the interrupted destination"
         );
     }
 

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -103,6 +103,13 @@ pub trait Behavior {
     fn preempted_by_alertness(&self) -> bool {
         true
     }
+
+    /// Live patrol destination, exposed to focused behavior tests without
+    /// downcasting trait objects.
+    #[cfg(test)]
+    fn patrol_target(&self) -> Option<EntityId> {
+        None
+    }
 }
 
 #[allow(dead_code)]

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -68,6 +68,13 @@ pub struct PatrolBehavior {
     /// The runtime AICurrentPatrol link must be published once for a fresh
     /// behavior and whenever the target changes.
     target_dirty: bool,
+    /// Whether the route has actually advanced at least one edge. Dark clears
+    /// the authored AI_Patrol flag at a real end of chain, but the start rule
+    /// targets the *destination* of the nearest link, which in shipped data
+    /// can itself be a sink (eng2, hydro1, station all have some). Clearing on
+    /// that first arrival would disable the creature's patrol permanently -
+    /// the flag is a saved property - so a route that never moved on keeps it.
+    walked_an_edge: bool,
 }
 
 impl PatrolBehavior {
@@ -81,6 +88,7 @@ impl PatrolBehavior {
             stall_seconds: 0.0,
             skipped_points: 0,
             target_dirty: true,
+            walked_an_edge: false,
         }
     }
 
@@ -100,14 +108,10 @@ impl PatrolBehavior {
             && (position.y - self.goal.y).abs() < PATROL_ARRIVE_HEIGHT
     }
 
-    /// Advance to the next point on the route; a closed loop repeats. A
-    /// dead-end (no next link) ends the patrol.
-    fn advance(
-        &mut self,
-        world: &World,
-        entity_id: EntityId,
-        clear_flag_on_dead_end: bool,
-    ) -> Effect {
+    /// Advance to the next point on the route; a closed loop repeats. Running
+    /// out of route ends the patrol, and - when this arrival is a genuine end
+    /// of chain the AI actually walked to - also clears the authored flag.
+    fn advance(&mut self, world: &World, entity_id: EntityId, may_clear_flag: bool) -> Effect {
         match ai_util::next_patrol_point(world, entity_id, self.target_point) {
             Some((next, goal)) => {
                 self.target_point = next;
@@ -115,7 +119,7 @@ impl PatrolBehavior {
                 self.steering_strategy = Self::steering_to(goal);
                 self.stall_anchor = None;
                 self.stall_seconds = 0.0;
-                self.target_dirty = false;
+                self.walked_an_edge = true;
                 Effect::SetAICurrentPatrol {
                     entity_id,
                     target: Some(next),
@@ -127,7 +131,13 @@ impl PatrolBehavior {
                     entity_id,
                     target: None,
                 }];
-                if clear_flag_on_dead_end {
+                // Only an authored end of chain retires the route. A link the
+                // mission never resolved (no instantiated target, or one with
+                // no transform) also lands here, and that is a broken route,
+                // not a finished one - leave the flag alone so the AI can pick
+                // the route up again the next time it calms down.
+                let true_dead_end = ai_util::is_patrol_dead_end(world, self.target_point);
+                if may_clear_flag && true_dead_end && self.walked_an_edge {
                     effects.push(Effect::SetAIProperty {
                         entity_id,
                         update: crate::scripts::AIPropertyUpdate::PatrolEnabled { enabled: false },
@@ -397,21 +407,115 @@ mod tests {
         )));
     }
 
-    #[test]
-    fn patrol_dead_end_clears_flag_and_current_target() {
+    /// A two-point route `first -> final_point`, with the creature and both
+    /// markers stacked at the origin so every `arrived()` is immediate: the
+    /// AI walks one real edge and then hits the end of the chain.
+    fn world_with_route_ending_in_a_sink() -> (World, EntityId, EntityId, EntityId) {
         let mut world = World::new();
         let creature = world.add_entity(RuntimePropTransform(Matrix4::from_scale(1.0)));
         let final_point = world.add_entity((
             RuntimePropTransform(Matrix4::from_scale(1.0)),
             Links::empty(),
         ));
-        let physics = PhysicsWorld::new();
-        let mut patrol = PatrolBehavior::new(final_point, vec3(0.0, 0.0, 0.0));
-        let time = Time {
+        let first = world.add_entity((
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(final_point)),
+                    link: Link::AIPatrol,
+                }],
+            },
+        ));
+        (world, creature, first, final_point)
+    }
+
+    fn tick() -> Time {
+        Time {
             elapsed: std::time::Duration::from_millis(100),
             total: std::time::Duration::from_millis(0),
-        };
+        }
+    }
 
+    fn cleared_patrol_flag(effects: &[Effect], creature: EntityId) -> bool {
+        effects.iter().any(|effect| {
+            matches!(
+                effect,
+                Effect::SetAIProperty {
+                    entity_id,
+                    update: crate::scripts::AIPropertyUpdate::PatrolEnabled { enabled: false },
+                } if *entity_id == creature
+            )
+        })
+    }
+
+    /// The start rule targets the *destination* of the nearest link, and in
+    /// shipped data (eng2, hydro1, station) that destination can itself be a
+    /// sink. Retiring the route on that very first arrival would write
+    /// `PropAIPatrol(false)`, which is saved - the creature would never patrol
+    /// again for the rest of the playthrough.
+    #[test]
+    fn patrol_does_not_retire_a_route_it_never_walked() {
+        let (world, creature, _, sink) = world_with_route_ending_in_a_sink();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(sink, vec3(0.0, 0.0, 0.0));
+
+        let (_, effect) = patrol
+            .steer(Deg(0.0), &world, &physics, creature, &tick())
+            .expect("the terminal transition must still emit its effects");
+
+        let effects = Effect::flatten(vec![effect]);
+        assert!(patrol.finished, "the behavior still ends");
+        assert!(
+            !cleared_patrol_flag(&effects, creature),
+            "a route that never advanced must keep its authored patrol flag"
+        );
+    }
+
+    /// A link the mission never resolved is a broken route, not a finished
+    /// one - it must not retire the authored flag either.
+    #[test]
+    fn patrol_does_not_retire_a_route_with_an_unresolved_link() {
+        let mut world = World::new();
+        let creature = world.add_entity(RuntimePropTransform(Matrix4::from_scale(1.0)));
+        let dangling = world.add_entity((
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 77,
+                    to_entity_id: None,
+                    link: Link::AIPatrol,
+                }],
+            },
+        ));
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(dangling, vec3(0.0, 0.0, 0.0));
+        patrol.walked_an_edge = true;
+
+        let (_, effect) = patrol
+            .steer(Deg(0.0), &world, &physics, creature, &tick())
+            .expect("the terminal transition must still emit its effects");
+
+        assert!(
+            !cleared_patrol_flag(&Effect::flatten(vec![effect]), creature),
+            "an unresolved patrol link is not an authored end of chain"
+        );
+    }
+
+    #[test]
+    fn patrol_dead_end_clears_flag_and_current_target() {
+        let (world, creature, first, _) = world_with_route_ending_in_a_sink();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(first, vec3(0.0, 0.0, 0.0));
+        let time = tick();
+
+        // First arrival walks the real edge first -> final_point...
+        patrol
+            .steer(Deg(0.0), &world, &physics, creature, &time)
+            .expect("an active patrol steers");
+        assert!(!patrol.finished, "one edge still remains");
+
+        // ...and the second arrival is the genuine end of the chain.
         let (_, effect) = patrol
             .steer(Deg(0.0), &world, &physics, creature, &time)
             .expect("the terminal transition must still emit its effects");

--- a/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/patrol_behavior.rs
@@ -9,8 +9,8 @@ use crate::{
         Effect,
         ai::ai_util,
         ai::steering::{
-            self, CollisionAvoidanceSteeringStrategy, PathFollowSteeringStrategy, SteeringOutput,
-            SteeringStrategy,
+            self, CollisionAvoidanceSteeringStrategy, PathFollowSteeringStrategy, Steering,
+            SteeringOutput, SteeringStrategy,
         },
     },
     time::Time,
@@ -65,6 +65,9 @@ pub struct PatrolBehavior {
     stall_seconds: f32,
     /// Points given up on since the last one actually reached.
     skipped_points: u32,
+    /// The runtime AICurrentPatrol link must be published once for a fresh
+    /// behavior and whenever the target changes.
+    target_dirty: bool,
 }
 
 impl PatrolBehavior {
@@ -77,6 +80,7 @@ impl PatrolBehavior {
             stall_anchor: None,
             stall_seconds: 0.0,
             skipped_points: 0,
+            target_dirty: true,
         }
     }
 
@@ -98,16 +102,39 @@ impl PatrolBehavior {
 
     /// Advance to the next point on the route; a closed loop repeats. A
     /// dead-end (no next link) ends the patrol.
-    fn advance(&mut self, world: &World) {
-        match ai_util::next_patrol_point(world, self.target_point) {
+    fn advance(
+        &mut self,
+        world: &World,
+        entity_id: EntityId,
+        clear_flag_on_dead_end: bool,
+    ) -> Effect {
+        match ai_util::next_patrol_point(world, entity_id, self.target_point) {
             Some((next, goal)) => {
                 self.target_point = next;
                 self.goal = goal;
                 self.steering_strategy = Self::steering_to(goal);
                 self.stall_anchor = None;
                 self.stall_seconds = 0.0;
+                self.target_dirty = false;
+                Effect::SetAICurrentPatrol {
+                    entity_id,
+                    target: Some(next),
+                }
             }
-            None => self.finished = true,
+            None => {
+                self.finished = true;
+                let mut effects = vec![Effect::SetAICurrentPatrol {
+                    entity_id,
+                    target: None,
+                }];
+                if clear_flag_on_dead_end {
+                    effects.push(Effect::SetAIProperty {
+                        entity_id,
+                        update: crate::scripts::AIPropertyUpdate::PatrolEnabled { enabled: false },
+                    });
+                }
+                Effect::combine(effects)
+            }
         }
     }
 
@@ -143,12 +170,20 @@ impl Behavior for PatrolBehavior {
         entity_id: EntityId,
         time: &Time,
     ) -> Option<(SteeringOutput, Effect)> {
+        let mut patrol_effects = Vec::new();
+        if self.target_dirty {
+            self.target_dirty = false;
+            patrol_effects.push(Effect::SetAICurrentPatrol {
+                entity_id,
+                target: Some(self.target_point),
+            });
+        }
         if !self.finished {
             let (position, _) = ai_util::get_position_and_forward(world, entity_id);
             let position = position.to_vec();
             if self.arrived(position) {
                 self.skipped_points = 0;
-                self.advance(world);
+                patrol_effects.push(self.advance(world, entity_id, true));
             } else if self.stalled(position, time) {
                 // Going nowhere: give up on this point and try the next one.
                 // Enough of those in a row and the whole route is out of
@@ -157,18 +192,29 @@ impl Behavior for PatrolBehavior {
                 self.skipped_points += 1;
                 if self.skipped_points >= PATROL_MAX_SKIPPED_POINTS {
                     self.finished = true;
+                    patrol_effects.push(Effect::SetAICurrentPatrol {
+                        entity_id,
+                        target: None,
+                    });
                 } else {
-                    self.advance(world);
+                    patrol_effects.push(self.advance(world, entity_id, false));
                 }
             }
         }
 
         if self.finished {
-            return None;
+            return Some((
+                Steering::from_current(current_heading),
+                Effect::combine(patrol_effects),
+            ));
         }
 
-        self.steering_strategy
+        let (steering, steering_effect) = self
+            .steering_strategy
             .steer(current_heading, world, physics, entity_id, time)
+            .unwrap_or((Steering::from_current(current_heading), Effect::NoEffect));
+        patrol_effects.push(steering_effect);
+        Some((steering, Effect::combine(patrol_effects)))
     }
 
     fn next_behavior(
@@ -196,6 +242,11 @@ impl Behavior for PatrolBehavior {
 
     fn is_locomotion(&self) -> bool {
         !self.finished
+    }
+
+    #[cfg(test)]
+    fn patrol_target(&self) -> Option<EntityId> {
+        (!self.finished).then_some(self.target_point)
     }
 }
 
@@ -251,12 +302,15 @@ mod tests {
         // 20 simulated seconds without the body ever moving - four times the
         // stall window, so every point on the loop gets its turn.
         let mut elapsed = 0.0;
+        let mut emitted = Vec::new();
         for _ in 0..200 {
             let time = Time {
                 elapsed: std::time::Duration::from_millis(100),
                 total: std::time::Duration::from_millis(0),
             };
-            patrol.steer(Deg(0.0), &world, &physics, creature, &time);
+            if let Some((_, effect)) = patrol.steer(Deg(0.0), &world, &physics, creature, &time) {
+                emitted.extend(Effect::flatten(vec![effect]));
+            }
             elapsed += 0.1;
             if patrol.finished {
                 break;
@@ -273,6 +327,23 @@ mod tests {
                 NextBehavior::Next(_)
             ),
             "giving up should hand back to idle",
+        );
+        assert!(emitted.iter().any(|effect| matches!(
+            effect,
+            Effect::SetAICurrentPatrol {
+                entity_id,
+                target: None,
+            } if *entity_id == creature
+        )));
+        assert!(
+            !emitted.iter().any(|effect| matches!(
+                effect,
+                Effect::SetAIProperty {
+                    update: crate::scripts::AIPropertyUpdate::PatrolEnabled { enabled: false },
+                    ..
+                }
+            )),
+            "movement failure stops this attempt but leaves the authored patrol flag enabled"
         );
     }
 
@@ -302,5 +373,62 @@ mod tests {
             "a moving patroller must stay on its route"
         );
         assert_eq!(patrol.target_point, first, "and keep the same point");
+    }
+
+    #[test]
+    fn patrol_publishes_its_live_target_relation() {
+        let (world, creature, first, goal) = world_with_unreachable_route();
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(first, goal);
+        let time = Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_millis(0),
+        };
+
+        let (_, effect) = patrol
+            .steer(Deg(0.0), &world, &physics, creature, &time)
+            .expect("an active patrol steers");
+        assert!(Effect::flatten(vec![effect]).iter().any(|effect| matches!(
+            effect,
+            Effect::SetAICurrentPatrol {
+                entity_id,
+                target: Some(target),
+            } if *entity_id == creature && *target == first
+        )));
+    }
+
+    #[test]
+    fn patrol_dead_end_clears_flag_and_current_target() {
+        let mut world = World::new();
+        let creature = world.add_entity(RuntimePropTransform(Matrix4::from_scale(1.0)));
+        let final_point = world.add_entity((
+            RuntimePropTransform(Matrix4::from_scale(1.0)),
+            Links::empty(),
+        ));
+        let physics = PhysicsWorld::new();
+        let mut patrol = PatrolBehavior::new(final_point, vec3(0.0, 0.0, 0.0));
+        let time = Time {
+            elapsed: std::time::Duration::from_millis(100),
+            total: std::time::Duration::from_millis(0),
+        };
+
+        let (_, effect) = patrol
+            .steer(Deg(0.0), &world, &physics, creature, &time)
+            .expect("the terminal transition must still emit its effects");
+        let effects = Effect::flatten(vec![effect]);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetAIProperty {
+                entity_id,
+                update: crate::scripts::AIPropertyUpdate::PatrolEnabled { enabled: false },
+            } if *entity_id == creature
+        )));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SetAICurrentPatrol {
+                entity_id,
+                target: None,
+            } if *entity_id == creature
+        )));
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -91,6 +91,11 @@ pub enum AIPropertyUpdate {
     /// The AI forgot its target (fully calmed / position consumed by a
     /// search) - chase falls back to the true player position again
     ClearTargetAwareness,
+    /// Enable or disable the authored Dark `AI_Patrol` property. A true
+    /// patrol-chain dead end disables it, matching the original ability.
+    PatrolEnabled {
+        enabled: bool,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -619,6 +624,13 @@ pub enum Effect {
     SetAIProperty {
         entity_id: EntityId,
         update: AIPropertyUpdate,
+    },
+
+    /// Replace Dark's runtime-only `AICurrentPatrol` relation for one AI.
+    /// `None` removes the relation when patrol stops or gives up.
+    SetAICurrentPatrol {
+        entity_id: EntityId,
+        target: Option<EntityId>,
     },
 
     /// Debug: force the alertness level of every AI in the mission (broadcast

--- a/tools/dark_query/src/entity_analyzer.rs
+++ b/tools/dark_query/src/entity_analyzer.rs
@@ -394,6 +394,7 @@ fn get_link_types(entity_id: i32, entity_info: &SystemShock2EntityInfo) -> Vec<S
                 Link::TPath(_) => "TPath".to_string(),
                 Link::ScriptParams => "ScriptParams".to_string(),
                 Link::AIPatrol => "AIPatrol".to_string(),
+                Link::AICurrentPatrol => "AICurrentPatrol".to_string(),
                 Link::Teleport => "Teleport".to_string(),
                 Link::StimSource(_) => "StimSource".to_string(),
                 Link::Receptron(_) => "Receptron".to_string(),

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -603,6 +603,7 @@ fn format_link_type(link: &dark::properties::Link) -> String {
         dark::properties::Link::TPath(_) => "TPath".to_string(),
         dark::properties::Link::ScriptParams => "ScriptParams".to_string(),
         dark::properties::Link::AIPatrol => "AIPatrol".to_string(),
+        dark::properties::Link::AICurrentPatrol => "AICurrentPatrol".to_string(),
         dark::properties::Link::Teleport => "Teleport".to_string(),
         // Include the payload: blast tuning (intensity/radius) is exactly what
         // one inspects these links for.

--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { GameServer, findRepoRoot } from "../src/index.js";
 import type { EntityDetailResult } from "../src/index.js";
 
 // End-to-end: a calm AI flagged to patrol (P$AI_Patrol) walks its authored
@@ -10,6 +12,18 @@ import type { EntityDetailResult } from "../src/index.js";
 //
 // Opt-in (needs Data/ assets + compiles the runtime): npm run test:e2e
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((directory): directory is string => Boolean(directory));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
 
 function aiProp(detail: EntityDetailResult, name: string): string | undefined {
   return detail.properties.find((p) => p.name === name)?.value;
@@ -117,6 +131,96 @@ test(
   },
 );
 
+test(
+  "a patroller resumes its live target across alertness and save/load (#410)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `patrol_target_resume_${Date.now()}`;
+    t.after(() => {
+      const path = findSavePath(saveName);
+      if (path) rmSync(path, { force: true });
+    });
+
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8163),
+    });
+    await game.player.teleport({ x: 300, y: 0, z: 300 });
+    await game.step({ frames: 2 });
+
+    const findPatroller = async () => {
+      const pipes = await game.entities.list({ filter: "OG-Pipe", limit: 100 });
+      const patroller = pipes.entities.find(
+        (entity) => entity.template_id === MEDSCI1_PATROLLER_OBJ,
+      );
+      assert.ok(patroller, "medsci1 native patroller should exist");
+      return patroller;
+    };
+    let patroller = await findPatroller();
+    let detail = await game.entities.detail(patroller.id);
+    const current = detail.outgoing_links.find(
+      (link) => link.link_type === "AICurrentPatrol",
+    );
+    assert.ok(current, "active patrol should publish its live destination");
+    const targetTemplate = (await game.entities.detail(current.target_id)).template_id;
+
+    await game.entities.sendMessage(patroller.id, {
+      type: "SetAlertness",
+      level: "Moderate",
+    });
+    await game.step({ frames: 5 });
+    detail = await game.entities.detail(patroller.id);
+    assert.equal(aiProp(detail, "AIBehavior"), "Chase");
+    assert.equal(
+      detail.outgoing_links.find(
+        (link) => link.link_type === "AICurrentPatrol",
+      )?.target_id,
+      current.target_id,
+      "an alertness interruption must not discard the patrol destination",
+    );
+
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 1 });
+
+    patroller = await findPatroller();
+    detail = await game.entities.detail(patroller.id);
+    const restoredCurrent = detail.outgoing_links.find(
+      (link) => link.link_type === "AICurrentPatrol",
+    );
+    assert.ok(restoredCurrent, "save/load should retain the current patrol link");
+    assert.equal(
+      (await game.entities.detail(restoredCurrent.target_id)).template_id,
+      targetTemplate,
+      "the restored relation must point to the same authored patrol marker",
+    );
+    assert.equal(aiProp(detail, "AIBehavior"), "Patrol");
+
+    // A second live interruption after hydration proves the restored relation
+    // is also the handback target, not merely inert serialized metadata.
+    await game.entities.sendMessage(patroller.id, {
+      type: "SetAlertness",
+      level: "Moderate",
+    });
+    await game.step({ frames: 5 });
+    await game.entities.sendMessage(patroller.id, {
+      type: "SetAlertness",
+      level: "Lowest",
+    });
+    await game.step({ frames: 1 });
+    detail = await game.entities.detail(patroller.id);
+    const resumed = detail.outgoing_links.find(
+      (link) => link.link_type === "AICurrentPatrol",
+    );
+    assert.ok(resumed);
+    assert.equal(
+      (await game.entities.detail(resumed.target_id)).template_id,
+      targetTemplate,
+    );
+    assert.equal(aiProp(detail, "AIBehavior"), "Patrol");
+  },
+);
+
 // #807: the test above starts its patroller with a SetAlertness, and that
 // forced transition is the ONLY reason patrol used to engage - behavior was
 // picked exclusively on an alertness LEVEL CHANGE, so a creature that spawns
@@ -155,11 +259,9 @@ test(
       `medsci1 should have its native patroller (object ${MEDSCI1_PATROLLER_OBJ})`,
     );
 
-    // Its authored route, resolved the way ai_util::nearest_patrol_point
-    // does: the 3D-nearest marker that actually has an outgoing AIPatrol link
-    // (so the chain can be walked from it), then whatever that link chains to.
-    // Following the link matters - medsci1 has unrelated markers on the
-    // walkway above that a proximity guess would pick up.
+    // Resolve the two-point authored loop around it. Dark measures the initial
+    // distance to an AIPatrol link's source but targets that link's destination;
+    // following the edge also avoids unrelated markers on the walkway above.
     const candidates = await Promise.all(
       (await game.entities.list({ limit: 5000 })).entities
         .filter((e) => e.name === "Patrol Path")

--- a/tools/shock2-sdk/test/patrol.e2e.test.ts
+++ b/tools/shock2-sdk/test/patrol.e2e.test.ts
@@ -326,3 +326,86 @@ test(
     );
   },
 );
+
+// Random-sequence patrol (P$AI_PtrlRnd) is the mode most shipped patrollers
+// use - eng1 flags 14 of its 17, medsci1 13 of its 14 - yet every other test
+// here targets an ordinary patroller (medsci1 object 163 is that mission's
+// only one). Random mode does not step to the adjacent marker: it may pick
+// ANY node in the connected patrol graph, so this is the only coverage that
+// the graph-wide selection actually drives a creature in a real mission.
+//
+// eng1 object 1672 is a live random patroller on a healthy stretch of the
+// network. (Not every patroller in the shipped data can walk its route - some
+// sit on nav islands the engine cannot path across, with or without random
+// mode - so this deliberately picks one that can.)
+const ENG1_RANDOM_PATROLLER_OBJ = 1672;
+
+test(
+  "a random-sequence patroller walks its graph (P$AI_PtrlRnd)",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8164),
+    });
+
+    // Keep the player far away: this is about an AI nobody ever alerted.
+    await game.player.teleport({ x: 300, y: 0, z: 300 });
+    await game.step({ frames: 60 });
+
+    const all = await game.entities.list({ limit: 5000 });
+    const patroller = all.entities.find(
+      (e) => e.template_id === ENG1_RANDOM_PATROLLER_OBJ,
+    );
+    assert.ok(
+      patroller,
+      `eng1 should have its random patroller (object ${ENG1_RANDOM_PATROLLER_OBJ})`,
+    );
+
+    let detail = await game.entities.detail(patroller.id);
+    assert.equal(
+      aiProp(detail, "AIBehavior"),
+      "Patrol",
+      "a random-sequence patroller patrols straight out of the load",
+    );
+
+    // Random mode picks a fresh target from the whole connected graph on every
+    // arrival, so the route it walks differs run to run - assert on what must
+    // hold for ANY selection: it keeps patrolling, keeps covering ground, and
+    // its live AICurrentPatrol target moves through more than one node.
+    let prev = detail.position;
+    let traveled = 0;
+    const targets: number[] = [];
+    for (let tick = 0; tick < 40; tick++) {
+      await game.step({ frames: 120 });
+      detail = await game.entities.detail(patroller.id);
+      traveled += distXZ(detail.position, prev);
+      prev = detail.position;
+      const current = detail.outgoing_links.find(
+        (l) => l.link_type === "AICurrentPatrol",
+      );
+      if (current && !targets.includes(current.target_id)) {
+        targets.push(current.target_id);
+      }
+      assert.equal(
+        aiProp(detail, "AIAlertness"),
+        "Lowest",
+        "nothing should have alerted the random patroller",
+      );
+    }
+
+    assert.equal(
+      aiProp(detail, "AIBehavior"),
+      "Patrol",
+      "a random-sequence patroller should stay on its route, not fall to Idle",
+    );
+    assert.ok(
+      traveled > WAYPOINT_REACHED * 4,
+      `random patroller should cover ground; traveled ${traveled.toFixed(1)}`,
+    );
+    assert.ok(
+      targets.length > 1,
+      `random patroller should retarget as it goes; saw ${JSON.stringify(targets)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- parse the authentic truncated `P$AI_PtrlRn` property and implement both ordinary random outgoing branches and random-sequence connected-graph selection
- restore Dark startup semantics (nearest link source, target its destination) and publish `AICurrentPatrol` as a runtime relation
- retain/remap the live destination across alertness changes and save/load, clear `AI_Patrol` only at a true dead end, and keep the existing faithful stall give-up behavior

## Reproduction and design evidence

Current main always selected the first outgoing patrol link, targeted the nearest source object itself, silently left `P$AI_PtrlRn` unparsed, and discarded the live patrol destination on interruption/load. Negative-first tests reproduced each behavior. Authentic eng1 data contains 81 route edges, 17 patrollers, and 14 random-sequence patrollers.

The pinned Dark patrol implementation in [`aipatrol.cpp`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/ai/aipatrol.cpp) chooses a random outgoing edge for ordinary routes, any other bidirectionally connected graph node for `AI_PtrlRnd`, measures initial distance to each source while targeting its destination, stores the current target in `AICurrentPatrol`, clears `AI_Patrol` only at a real end of chain, and stops without clearing the authored flag on movement failure.

## Verification

- `cargo test -p shock2vr -p dark` — `shock2vr` 556, `dark` 88, authentic mission loading 9 passed
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query`
- `cargo fmt --all -- --check`; `git diff --check`
- SDK patrol scenarios — 3 passed: authentic eng1 motion, #410 alertness/save-load resume, and #807 fresh-load startup
- full SDK e2e — 227 passed, 1 unrelated stochastic SHODAN corpse-settling failure, 7 intentional skips; the failed case passed immediately in isolation

## Visual evidence

### Authentic MedSci resume — exact base → fix

![Exact base/fix MedSci patrol resume](https://gist.githubusercontent.com/tommy-xr/da5852d007e11ca28c95a208aad58d41/raw/issue410-authentic-resume.gif)

<sub>Authentic `medsci1.mis` object 163 under the same fixed-step requests. Base `55c39cac` resumes without a current destination; fix `d733438` retains patrol target #235 through Patrol → Chase → save/load → Patrol.</sub>

### Branching, true dead end, and unreachable-route give-up

![Patrol branch, dead-end, and give-up sequence](https://gist.githubusercontent.com/tommy-xr/da5852d007e11ca28c95a208aad58d41/raw/issue410-branch-deadend-giveup.gif)

<sub>Uncommitted capture-only fixture at exact fix `d733438`, exercising production patrol behavior: choose one of two outgoing links at the cyan junction; clear the live link and idle at the yellow true dead end; at the red blocking wall advance A → B → C after 5 seconds without progress at each target, then clear the link and idle after the third skip. Captured headlessly at a fixed 60 Hz via `/v1/step` + `/v1/screenshot`.</sub>

### Labeled current still

![Patrol fidelity labeled comparison](https://gist.githubusercontent.com/tommy-xr/da5852d007e11ca28c95a208aad58d41/raw/issue410-patrol-fidelity.png)

Fixes #410
