### PR TITLE
fix(physics): fit crouched players through tight passages

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -120,21 +120,34 @@ fn crouched_player_shared_shape() -> SharedShape {
 /// Gap (SS2 ft) the character controller keeps between the player collider
 /// and world geometry (`KinematicCharacterController::offset`).
 const PLAYER_CONTACT_OFFSET: f32 = 0.1;
+/// Crouching is the authored small-creature profile, including its tighter
+/// clearance through low utility passages. Keep a nonzero target distance for
+/// robust contact resolution, but do not charge the standing margin against
+/// both sides of an opening only the crouched body is intended to cross.
+const PLAYER_CROUCH_CONTACT_OFFSET: f32 = 0.05;
 
 /// Extra height (SS2 ft) the player is lifted each grounded frame, keeping the
-/// resting gap a hair above `PLAYER_CONTACT_OFFSET`. Load-bearing: movement
-/// casts use `PLAYER_CONTACT_OFFSET` as their target distance, so a capsule
-/// resting at exactly that gap starts every cast already "in contact" with
-/// its own floor. On a yaw-ROTATED support (e.g. the earth.mis tram floor
-/// slab) the rotated top-face normal carries ~1e-6 float error, which makes
-/// even purely tangential walking read as "approaching" - every solver
-/// iteration then re-hits the same contact at toi=0, applies zero
-/// translation, and the player freezes in place. (Axis-aligned floors yield
-/// an exact (0,1,0) normal, where tangential motion reports no hit - which is
-/// why flat test floors work without this.) The next frame's gravity pass
-/// consumes the lift again, so the rest height is stable. Regression-tested
-/// by `player_walks_on_rotated_platform`.
+/// resting gap a hair above the active posture-specific contact offset.
+/// Load-bearing: movement casts use that target distance, so a capsule resting
+/// at exactly that gap starts every cast already "in contact" with its own
+/// floor. On a yaw-ROTATED support (e.g. the earth.mis tram floor slab) the
+/// rotated top-face normal carries ~1e-6 float error, which makes even purely
+/// tangential walking read as "approaching" - every solver iteration then
+/// re-hits the same contact at toi=0, applies zero translation, and the player
+/// freezes in place. (Axis-aligned floors yield an exact (0,1,0) normal, where
+/// tangential motion reports no hit - which is why flat test floors work
+/// without this.) The next frame's gravity pass consumes the lift again, so
+/// the rest height is stable. Regression-tested by
+/// `player_walks_on_rotated_platform`.
 const PLAYER_REST_LIFT: f32 = 0.01;
+
+fn player_contact_offset(is_crouched: bool) -> f32 {
+    if is_crouched {
+        PLAYER_CROUCH_CONTACT_OFFSET
+    } else {
+        PLAYER_CONTACT_OFFSET
+    }
+}
 
 /// Half-life for gravity-induced horizontal displacement after a slope hands
 /// the player onto walkable flat ground. Dark's dynamic player coasts through
@@ -1802,7 +1815,7 @@ fn player_pose_matches_current_support(
         PLAYER_STANDING_HEIGHT
     };
     let floor_offset = body_height / 2.0 / SCALE_FACTOR
-        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + player_contact_offset(is_crouched) / SCALE_FACTOR
         + PLAYER_REST_LIFT / SCALE_FACTOR;
     // The waypoint loop intentionally stops within arrival epsilon. Allow the
     // same residual plus one probe skin for floating-point/contact seams while
@@ -5165,6 +5178,8 @@ impl PhysicsWorld {
 
         if want_crouch {
             self.collider_set[collider_handle].set_shape(crouched_player_shared_shape());
+            player_handle.controller.offset =
+                CharacterLength::Absolute(PLAYER_CROUCH_CONTACT_OFFSET / SCALE_FACTOR);
             let body = &mut self.rigid_body_set[character_handle];
             let mut translation = *body.translation();
             translation.y -= center_shift;
@@ -5249,6 +5264,8 @@ impl PhysicsWorld {
 
             if !blocked {
                 self.collider_set[collider_handle].set_shape(standing_player_shared_shape());
+                player_handle.controller.offset =
+                    CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
                 let body = &mut self.rigid_body_set[character_handle];
                 let mut translation = *body.translation();
                 translation.y += center_shift;
@@ -7518,6 +7535,17 @@ mod tests {
         );
     }
 
+    fn assert_player_contact_offset(player: &PlayerHandle, expected_ss2_feet: f32) {
+        let CharacterLength::Absolute(offset) = player.controller.offset else {
+            panic!("player controller offset must remain absolute");
+        };
+        assert!(
+            (offset * SCALE_FACTOR - expected_ss2_feet).abs() < 1.0e-6,
+            "expected a {expected_ss2_feet}-foot controller offset, got {}",
+            offset * SCALE_FACTOR
+        );
+    }
+
     /// Standing restores Dark's original 6 x 2.4-foot body, while crouch and
     /// direct relocation retain the 2.8 x 1.6-foot profile added in #513.
     #[test]
@@ -7526,6 +7554,7 @@ mod tests {
         let mut player = world.create_player(vec3(0.0, 0.0, 0.0), EntityId::from_inner(1).unwrap());
 
         assert_player_capsule_dimensions(&world, &player, 6.0, 2.4);
+        assert_player_contact_offset(&player, PLAYER_CONTACT_OFFSET);
         assert!(
             (player_crouch_center_shift() - 0.64).abs() < 1.0e-6,
             "save/load normalization must use the new feet-planted center shift"
@@ -7533,6 +7562,7 @@ mod tests {
 
         assert!(world.set_player_crouch(true, &mut player));
         assert_player_capsule_dimensions(&world, &player, 2.8, 1.6);
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
         world.set_player_translation(vec3(1.0, 2.0, 3.0), &mut player);
         assert_player_capsule_dimensions(&world, &player, 2.8, 1.6);
 
@@ -7541,6 +7571,7 @@ mod tests {
         step(&mut world, &mut player, 1);
         assert!(!world.set_player_crouch(false, &mut player));
         assert_player_capsule_dimensions(&world, &player, 6.0, 2.4);
+        assert_player_contact_offset(&player, PLAYER_CONTACT_OFFSET);
     }
 
     /// The scene-wide query pipeline the climb/top-out helpers take.
@@ -11647,6 +11678,129 @@ mod tests {
         );
     }
 
+    fn world_with_parentless_wall_and_parented_gap(gap: f32) -> PhysicsWorld {
+        let mut world = PhysicsWorld::new();
+        let half_gap = gap / 2.0;
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(4.0, 2.0, 0.1)
+                .translation(vector![-2.0, 2.0, half_gap + 0.1])
+                .build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(-2.0, 2.0, -half_gap - 0.1),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 4.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.add_collider(
+            EntityId::from_inner(1002).unwrap(),
+            ColliderBuilder::cuboid(5.0, 0.1, 5.0)
+                .translation(vector![0.0, -0.1, 0.0])
+                .build(),
+        );
+        world
+    }
+
+    fn walk_west_through_gap(gap: f32, crouched: bool) -> (Vector3<f32>, Vector3<f32>) {
+        let mut world = world_with_parentless_wall_and_parented_gap(gap);
+
+        let mut player = world.create_player(
+            vec3(0.15, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        if crouched {
+            assert!(world.set_player_crouch(true, &mut player));
+        }
+        step(&mut world, &mut player, 30);
+        let start = world.get_player_translation(&player);
+        for _ in 0..90 {
+            world.update(vec3(-0.05, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        (start, end)
+    }
+
+    /// Rick1's upper-deck portal leaves an authored 1.72-SS2-foot passage
+    /// between a WorldRep wall and the square end of a live pipe. The
+    /// 1.6-foot crouched body fits, but charging the standing 0.1-foot
+    /// controller margin on both sides makes its effective width 1.8 feet and
+    /// pins it at the pipe corner. Crouched locomotion must retain both solid
+    /// colliders while fitting through the real opening.
+    #[test]
+    fn crouched_player_crosses_a_tight_world_and_parented_collider_gap() {
+        let gap = 1.72 / SCALE_FACTOR;
+        let (start, end) = walk_west_through_gap(gap, true);
+        assert!(
+            end.x < -1.0,
+            "the 1.6-foot crouched body should cross the 1.72-foot opening without ignoring either collider, moved {start:?} -> {end:?}"
+        );
+        assert!(
+            end.z.abs() + PLAYER_CROUCH_RADIUS / SCALE_FACTOR < gap / 2.0 + 1.0e-3,
+            "the player must stay inside the authored gap, not escape around a collider: {end:?}"
+        );
+    }
+
+    #[test]
+    fn tight_gap_still_rejects_standing_and_subdiameter_profiles() {
+        let (_, standing) = walk_west_through_gap(1.72 / SCALE_FACTOR, false);
+        assert!(
+            standing.x > -0.2,
+            "the 2.4-foot standing body must remain blocked by the 1.72-foot gap: {standing:?}"
+        );
+
+        let (_, too_narrow) = walk_west_through_gap(1.55 / SCALE_FACTOR, true);
+        assert!(
+            too_narrow.x > -0.2,
+            "a gap narrower than the 1.6-foot crouched body must remain blocked: {too_narrow:?}"
+        );
+    }
+
+    #[test]
+    fn crouch_offset_does_not_cross_real_world_or_parented_walls() {
+        for parented in [false, true] {
+            let mut world = world_with_parentless_wall_and_parented_gap(1.72 / SCALE_FACTOR);
+            let wall = ColliderBuilder::cuboid(0.1, 2.0, 1.0)
+                .translation(vector![-0.4, 2.0, 0.0])
+                .build();
+            if parented {
+                world.add_kinematic(
+                    EntityId::from_inner(1003).unwrap(),
+                    vec3(-0.4, 2.0, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.2, 4.0, 2.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            } else {
+                world.add_collider(EntityId::from_inner(1003).unwrap(), wall);
+            }
+            let mut player = world.create_player(
+                vec3(0.15, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+                EntityId::from_inner(2000).unwrap(),
+            );
+            assert!(world.set_player_crouch(true, &mut player));
+            step(&mut world, &mut player, 30);
+            for _ in 0..90 {
+                world.update(vec3(-0.05, 0.0, 0.0), &mut player);
+            }
+            let end = world.get_player_translation(&player);
+            assert!(
+                end.x > -0.25,
+                "the crouched margin must not cross a {} wall: {end:?}",
+                if parented {
+                    "parented"
+                } else {
+                    "parentless world"
+                }
+            );
+        }
+    }
+
     /// Build a floor whose top face is flush with the bottom of a walk-in
     /// fixture's model-bounds box - hydro2's Resurrection Station casing sits
     /// on the alcove floor exactly like this - and return the world plus the
@@ -12602,6 +12756,8 @@ mod tests {
             crouched_world.set_player_crouch(false, &mut crouched_player),
             "standing must be refused under the five-foot ceiling"
         );
+        assert_player_capsule_dimensions(&crouched_world, &crouched_player, 2.8, 1.6);
+        assert_player_contact_offset(&crouched_player, PLAYER_CROUCH_CONTACT_OFFSET);
     }
 
     /// A crawlspace whose 3.875 ft clearance admits the 2.8 ft crouched body
@@ -12609,7 +12765,10 @@ mod tests {
     /// collider centre a save file stores (`GlobalData::position`).
     fn world_with_low_ceiling_crawlspace() -> (PhysicsWorld, PlayerHandle) {
         let mut world = PhysicsWorld::new();
-        for (entity, y) in [(1000u64, 0.0), (1001, 1.55)] {
+        for (entity, y, triangles) in [
+            (1000u64, 0.0, vec![[0u32, 2, 1], [0, 3, 2]]),
+            (1001, 1.55, vec![[0u32, 1, 2], [0, 2, 3]]),
+        ] {
             world.add_collider(
                 EntityId::from_inner(entity).unwrap(),
                 ColliderBuilder::trimesh(
@@ -12619,7 +12778,7 @@ mod tests {
                         point![50.0, y, 50.0],
                         point![-50.0, y, 50.0],
                     ],
-                    vec![[0u32, 1, 2], [0, 2, 3]],
+                    triangles,
                 )
                 .expect("crawlspace trimesh")
                 .build(),
@@ -12659,6 +12818,7 @@ mod tests {
             world.set_player_crouch(false, &mut player),
             "standing must stay refused before the world can answer a query"
         );
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
 
         // ...and the player is still free to crawl back out.
         step(&mut world, &mut player, 10);
@@ -12675,6 +12835,7 @@ mod tests {
             player.is_crouched(),
             "the ceiling must still refuse standing once the world is queryable"
         );
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
     }
 
     /// The same first-frame load against the real hydro2 geometry and the exact

--- a/tools/shock2-sdk/test/portal-seam.e2e.test.ts
+++ b/tools/shock2-sdk/test/portal-seam.e2e.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const reproSave = process.env.SHOCK2_PORTAL_SEAM_SAVE;
+
+async function walkTo(
+  game: GameServer,
+  target: [number, number],
+  label: string,
+  tolerance = 0.45,
+): Promise<Position> {
+  let position = await game.player.position();
+  let best = Math.hypot(position.x - target[0], position.z - target[1]);
+  let stalledFrames = 0;
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  for (let frame = 0; frame < 240; frame += 1) {
+    if (frame % 8 === 0) {
+      await game.input.lookAtWorldPoint([
+        target[0],
+        position.y + 0.48,
+        target[1],
+      ]);
+    }
+    await game.step({ frames: 1 });
+    position = await game.player.position();
+    const distance = Math.hypot(
+      position.x - target[0],
+      position.z - target[1],
+    );
+    if (distance <= tolerance) break;
+    if (distance < best - 0.03) {
+      best = distance;
+      stalledFrames = 0;
+    } else {
+      stalledFrames += 1;
+    }
+    assert.ok(
+      stalledFrames < 45,
+      `${label} stalled at ${JSON.stringify(position)} (${distance.toFixed(3)} from target)`,
+    );
+  }
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  assert.ok(
+    Math.hypot(position.x - target[0], position.z - target[1]) <= tolerance,
+    `${label} did not reach ${JSON.stringify(target)}: ${JSON.stringify(position)}`,
+  );
+  return position;
+}
+
+// Rick1's high-deck return route is a shipped SMALL_CREATURE AIPATH passage
+// between a WorldRep wall and the end of a live Pipe 24x3. The 1.6-foot
+// crouched body fits the 1.72-foot opening, but the old 0.1-foot controller
+// margin was charged on both sides and pinned the capsule at x=44.88 forever.
+//
+// The save is private campaign state and is supplied only to local/opt-in
+// runs; it is never checked in or uploaded. From that authentic pose the test
+// uses ordinary input only: cross cells 270 -> 269 -> 271, physically enter
+// tripwire1259, and walk through its opened door1257.
+test(
+  "rick1: crouched player crosses the high-deck portal and opens door 1257",
+  {
+    skip: !e2eEnabled || !reproSave || !existsSync(reproSave),
+    timeout: 600_000,
+  },
+  async () => {
+    assert.ok(reproSave, "SHOCK2_PORTAL_SEAM_SAVE must name the private repro save");
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8270),
+      debugFlags: ["--save-file", reproSave],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    const [tripwire] = await game.entities.byTemplate(1259);
+    const [door] = await game.entities.byTemplate(1257);
+    assert.ok(tripwire, "rick1 should contain authored tripwire1259");
+    assert.ok(door, "rick1 should contain authored door1257");
+    const closedDoor = await game.entities.detail(door.id);
+
+    await game.input.set("crouch", 1);
+    await game.input.set("jump", 0);
+    await game.step({ frames: 20 });
+    const start = await game.player.position();
+    assert.ok(
+      start.x > 44.7 && start.x < 45.1 && start.z > -15.8 && start.z < -15.3,
+      `the repro must start at the blocked portal: ${JSON.stringify(start)}`,
+    );
+
+    const crossed = await walkTo(game, [42.4, -16.0], "portal crossing");
+    assert.ok(
+      crossed.x < 44.4,
+      `ordinary crouched input must cross west of the portal, ended ${JSON.stringify(crossed)}`,
+    );
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    const stablePlayer = (await game.info()).player;
+    const support = await game.raycast({
+      start: [stable.x, stable.y + 0.1, stable.z],
+      end: [stable.x, stable.y - 2, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.abs(stable.y - 62.184) < 0.08 &&
+        Math.abs(stablePlayer.camera_offset[1] - 0.48) < 0.02 &&
+        support.hit &&
+        support.hit_point !== null &&
+        Math.abs(support.hit_point[1] - 61.6) < 0.05 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5,
+      `the crossed player must remain crouched and supported on y61.6: ` +
+        `stable=${JSON.stringify(stable)}, camera=${JSON.stringify(stablePlayer.camera_offset)}, ` +
+        `support=${JSON.stringify(support)}`,
+    );
+
+    await walkTo(game, [37.6, -16.0], "cell269 corridor");
+    await walkTo(
+      game,
+      [tripwire.position[0], tripwire.position[2]],
+      "physical tripwire1259 entry",
+      0.35,
+    );
+    await game.step({ frames: 120 });
+    const openedDoor = await game.entities.detail(door.id);
+    const doorTravel = Math.hypot(
+      openedDoor.position[0] - closedDoor.position[0],
+      openedDoor.position[1] - closedDoor.position[1],
+      openedDoor.position[2] - closedDoor.position[2],
+    );
+    assert.ok(
+      doorTravel > 2,
+      `physical tripwire1259 entry must open door1257: ` +
+        `${JSON.stringify(closedDoor.position)} -> ${JSON.stringify(openedDoor.position)}`,
+    );
+
+    const beyondDoor = await walkTo(
+      game,
+      [tripwire.position[0], door.position[2] - 1.5],
+      "opened door1257 crossing",
+      0.55,
+    );
+    assert.ok(
+      beyondDoor.z < door.position[2] - 0.8,
+      `ordinary movement must continue through opened door1257: ${JSON.stringify(beyondDoor)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- give the authored crouched player profile a 0.05-SS2-foot controller target distance while preserving the standing profile's existing 0.1-foot margin
- switch the margin atomically with the real collision capsule, including refused stand-up and save/load paths
- keep WorldRep and parented entity colliders fully live; standing bodies, sub-body-width openings, and direct walls remain blocked
- cover the authentic Rick1 high-deck route from the private campaign save through cells 270/269/271, physical tripwire1259 entry, and opened door1257

## Root cause

Rick1's shipped `WALK | SMALL_CREATURE` high-deck passage is about 0.688 world units (1.72 SS2 feet) wide between a WorldRep wall and the end of a live parented `Pipe 24x3`. The authored crouched capsule is 0.64 world units (1.6 feet) wide, but the former 0.04-world-unit (0.1-foot) controller target distance was charged on both sides, making its effective width 0.72 world units and pinning it at x≈44.88.

The corrected crouched margin is 0.02 world units per side, leaving a small collision-safe clearance without shrinking the body or suppressing either collider. Successful stand-up restores the standing margin; refused stand-up retains both the crouched profile and margin.

## Reproduction and validation

Private reproduction save SHA-256: `bad20425dd1df902ba28b2a615d43bf5aeb4cf9c447cf1952f4eb6b730a97439`. The save remained local and was not committed, uploaded, or included in visual hosting.

Negative-first synthetic: an authored-equivalent 1.72-foot parentless-wall/parented-OBB opening moved the crouched player only x `0.150 → 0.109` in 90 frames before the fix. It crosses after the posture-specific margin change.

Authentic focused E2E (ordinary controls, no teleport after load, runtime entity discovery):

- exact saved crouched start near `(44.881, 62.204, -15.560)`
- crosses west of x=44.4 and neutral-settles at body y≈62.184 on +Y WorldRep floor y=61.6
- remains crouched (camera offset y=0.48)
- follows the shipped route through cells 269/271
- physically enters dynamically discovered tripwire1259
- observes dynamically discovered door1257 travel >2 world units and crosses it normally

## Visual evidence

The matched authentic capture uses exact base `90c5830d` and fixed `248e97ec` with the same private saved pose and deterministic production controls. It dynamically discovers tripwire1259 and door1257 on every launch; no save, runtime IDs, or diagnostic trajectory was uploaded.

![Rick1 crouched portal seam before/after](https://gist.githubusercontent.com/tommy-xr/270b95a0d33bdc4f6d715c06108b7f4a/raw/rick1-portal-seam-before-after.gif)

<sub>Identical matched sequence on both refs: before frame 1 explicitly hold crouch, clear jump, face horizontal west, and apply ordinary forward input; step exactly 4 frames—the first frame at which fixed crosses x&lt;44.4—then neutralize locomotion for 60 frames. Base remains pinned at `(44.880, 62.204, -15.560)`; fixed first crosses on frame 4 at `(44.390, 62.184, -15.541)` and neutral-settles at `(44.223, 62.184, -15.541)`. Both remain crouched (camera offset y `0.48`) and ray-confirmed on WorldRep floor y `61.6`, normal +Y. The labeled fixed-only tail then uses ordinary forward movement through `(42.4, -16.0)` and `(37.6, -16.0)`, physically enters dynamically discovered tripwire1259 at `(36.661, 62.184, -16.085)`, waits 120 fixed frames for door1257 to travel `2.700` world units, walks through it, and neutral-settles at `(36.376, 62.184, -18.428)` with the same y61.6 +Y support. The base panel is frozen only during this clearly marked fixed-only continuation. Captured headlessly through `/v1/step` + `/v1/screenshot` at fixed 60 Hz; there is no teleport or debug move.</sub>

![Rick1 fixed supported at opened door1257](https://gist.githubusercontent.com/tommy-xr/270b95a0d33bdc4f6d715c06108b7f4a/raw/rick1-portal-seam-fixed-door-supported.png)

### Before → after

![Rick1 portal seam matched final before/after](https://gist.githubusercontent.com/tommy-xr/270b95a0d33bdc4f6d715c06108b7f4a/raw/rick1-portal-seam-before-after.png)

[Issue #901 matched capture artifacts](https://gist.github.com/tommy-xr/270b95a0d33bdc4f6d715c06108b7f4a)

<sub>Capture executables: base `90c5830d8efda0921a3af1d75670053d0fdbc2ed`, SHA-256 `12c994092ee9acf24a58f324769401af25803887de7af6ea248ba352ce9d7b3f`; fixed `248e97ec3b444646f017091bbe110241cb0d7976`, SHA-256 `de8ec8e58e4c92afb7337beb74c05d83c07c4d486a2637b6c7c3170245735125`.</sub>

## Tests

- `cargo fmt`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 547 passed
- `npm test` — 26 passed, 195 opt-in skipped (221 total)
- focused portal E2E — 1/1 passed, 23,720.101208 ms
- complete climbing E2E — 8/8 passed, 382,785.263542 ms
- crouch/load E2E — 2/2 passed, 29,010.944834 ms
- all-mission load E2E — 23/23 passed, 220,267.53525 ms
- independent adversarial review: approved after exact collision attribution, gap math, boundary tests, and physical tripwire/door acceptance

Stacked on #679 because the campaign save and preserved Rick1 ladder regressions depend on that branch. This PR does not modify #679's branch/head.

Fixes #901
