### PR TITLE
fix(ai): honor authored creature collision widths

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -1082,12 +1082,11 @@ fn create_physics_representation_with_options(
         if v_creature.get(entity_id).is_ok() && v_creature_pose.get(entity_id).is_err() {
             let creature_type = v_creature.get(entity_id).unwrap();
             let creature_def = get_creature_definition(creature_type.0).unwrap();
-            let bbox = creature_def.bounding_size;
-            let radius = bbox.x.max(bbox.z) / 2.0;
-            let creature_shape = PhysicsShape::Capsule {
-                height: radius.max(bbox.y - radius * 2.0),
-                radius,
-            };
+            let creature_shape = live_creature_shape(
+                &creature_def,
+                v_phys_type.get(entity_id).ok(),
+                v_phys_dimensions.get(entity_id).ok(),
+            );
             rigid_body_handle = physics.add_dynamic(
                 entity_id,
                 pos.position + vec3(0.0, SCALE_FACTOR / 6.0, 0.0) /* bump up so that character is not stuck in geometry */,
@@ -1392,6 +1391,58 @@ fn create_physics_representation_with_options(
     }
 }
 
+fn live_creature_shape(
+    creature_def: &crate::creature::CreatureDefinition,
+    phys_type: Option<&PropPhysType>,
+    dimensions: Option<&PropPhysDimensions>,
+) -> PhysicsShape {
+    let bbox = creature_def.bounding_size;
+    let fallback_radius = bbox.x.max(bbox.z) / 2.0;
+    let fallback = || PhysicsShape::Capsule {
+        // Preserve the established fallback for creatures without a complete
+        // authored sphere model. Small animation bounds can otherwise leave a
+        // zero-length capsule segment, which Rapier does not accept here.
+        height: fallback_radius.max(bbox.y - fallback_radius * 2.0),
+        radius: fallback_radius,
+    };
+
+    let (Some(phys_type), Some(dimensions)) = (phys_type, dimensions) else {
+        return fallback();
+    };
+    if phys_type.phys_type != PhysicsModelType::SPHERE
+        || !(1..=2).contains(&phys_type.num_submodels)
+    {
+        return fallback();
+    }
+
+    // Dark drives a live creature's sphere submodels from animated joints and
+    // applies the creature descriptor's per-submodel radii (`SetPhysSubModScale`),
+    // rather than using the animation model's visual width as collision. The
+    // instantiated P$PhysDims mirrors those radii. This importer's historical
+    // representation stores each Dark radius at half its scaled value, so the
+    // conversion is deliberately scoped to live-creature SPHERE models; loose
+    // props keep their existing parser/physics semantics.
+    let imported_radii = [dimensions.radius0, dimensions.radius1];
+    let declared_radii = &imported_radii[..phys_type.num_submodels as usize];
+    if declared_radii
+        .iter()
+        .any(|radius| !radius.is_finite() || *radius <= 0.0)
+    {
+        return fallback();
+    }
+    let radius = declared_radii.iter().copied().fold(0.0, f32::max) * 2.0;
+    let segment_height = bbox.y - radius * 2.0;
+    if !radius.is_finite() || radius <= 0.0 || !segment_height.is_finite() || segment_height <= 0.0
+    {
+        return fallback();
+    }
+
+    PhysicsShape::Capsule {
+        height: segment_height,
+        radius,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct CreateEntityOptions {
     pub force_visible: bool,
@@ -1434,6 +1485,7 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::creature::{RUMBLER_HEIGHT, RUMBLER_WIDTH};
     use cgmath::{InnerSpace, point3};
     use collision::Aabb3;
     use dark::properties::{Links, ToLink};
@@ -1599,6 +1651,165 @@ mod tests {
             !needs_internal_ai(false, &threat_en_og_scripts),
             "ordinary scripted objects must not gain monster AI"
         );
+    }
+
+    /// A live Rumbler authors two 1.5 SS2-foot physics spheres. The property
+    /// importer's historical radius representation is half the scaled Dark
+    /// radius, so those values appear here as 0.3 world units. Its animated
+    /// model is five feet wide, but that is not its locomotion hull: Dark's
+    /// creature descriptor drives the two authored spheres independently.
+    ///
+    /// Negative-first: creature creation previously ignored both sphere
+    /// radii and built a 1.0-world-unit-radius capsule from animation bounds,
+    /// too broad for Rick1's shipped WALK|SMALL_CREATURE junction.
+    #[test]
+    fn live_creature_uses_authored_sphere_width_with_animation_height() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 4.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropCreature(3),
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::SPHERE,
+                num_submodels: 2,
+                remove_on_sleep: false,
+                is_special: true,
+            },
+            PropPhysDimensions {
+                radius0: 0.3,
+                radius1: 0.3,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: Vector3::zero(),
+                unk1: 0,
+                unk2: 0,
+            },
+        ));
+
+        let handle = create_physics_representation(&mut world, &mut physics, &None, entity_id)
+            .expect("a live creature should get a dynamic physics body");
+        let (radius, segment_height) = physics
+            .capsule_dimensions(handle)
+            .expect("the live creature body should remain a capsule");
+
+        assert!(
+            (radius - 0.6).abs() < 0.001,
+            "expected radius 0.6, got {radius}"
+        );
+        assert!(
+            (segment_height + radius * 2.0 - RUMBLER_HEIGHT).abs() < 0.001,
+            "authored width must not change the full animation-derived height"
+        );
+        let body = physics
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(entity_id.inner() as i32))
+            .expect("the creature body should remain introspectable");
+        assert_eq!(body.body_type, "dynamic");
+        assert!(body.blocks_player && body.blocks_actor);
+        assert!(body.collision_groups.iter().any(|group| group == "actor"));
+    }
+
+    fn capsule(shape: PhysicsShape) -> (f32, f32) {
+        match shape {
+            PhysicsShape::Capsule { height, radius } => (radius, height),
+            other => panic!("expected creature capsule, got {other:?}"),
+        }
+    }
+
+    fn sphere_type(num_submodels: u32) -> PropPhysType {
+        PropPhysType {
+            phys_type: PhysicsModelType::SPHERE,
+            num_submodels,
+            remove_on_sleep: false,
+            is_special: true,
+        }
+    }
+
+    fn sphere_dimensions(radius0: f32, radius1: f32) -> PropPhysDimensions {
+        PropPhysDimensions {
+            radius0,
+            radius1,
+            offset0: vec3(9.0, 8.0, 7.0),
+            offset1: vec3(-6.0, -5.0, -4.0),
+            size: Vector3::zero(),
+            unk1: 0,
+            unk2: 0,
+        }
+    }
+
+    #[test]
+    fn live_creature_shape_uses_largest_declared_sphere_radius() {
+        let rumbler = get_creature_definition(3).unwrap();
+        let two_spheres = sphere_type(2);
+        let dimensions = sphere_dimensions(0.25, 0.3);
+        let (radius, segment_height) = capsule(live_creature_shape(
+            &rumbler,
+            Some(&two_spheres),
+            Some(&dimensions),
+        ));
+
+        assert!((radius - 0.6).abs() < 0.001);
+        assert!((segment_height + 2.0 * radius - RUMBLER_HEIGHT).abs() < 0.001);
+    }
+
+    #[test]
+    fn invalid_or_incomplete_creature_spheres_keep_animation_fallback() {
+        let rumbler = get_creature_definition(3).unwrap();
+        let fallback = capsule(live_creature_shape(&rumbler, None, None));
+        assert_eq!(fallback, (RUMBLER_WIDTH / 2.0, RUMBLER_WIDTH / 2.0));
+
+        let mut obb = sphere_type(2);
+        obb.phys_type = PhysicsModelType::ORIENTED_BOUNDING_BOX;
+        let invalid_cases = [
+            (Some(sphere_type(0)), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(3)), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.3, 0.0))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.3, f32::NAN))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.7, 0.7))),
+            (Some(obb), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(2)), None),
+        ];
+        for (phys_type, dimensions) in invalid_cases {
+            assert_eq!(
+                capsule(live_creature_shape(
+                    &rumbler,
+                    phys_type.as_ref(),
+                    dimensions.as_ref(),
+                )),
+                fallback,
+            );
+        }
+    }
+
+    #[test]
+    fn shipped_creature_sphere_radii_match_original_descriptor_envelopes() {
+        for (creature_type, imported, expected_radius) in [
+            (0, [0.2, 0.24], 0.48),
+            (3, [0.3, 0.3], 0.6),
+            (4, [0.39, 0.0], 0.78),
+            (6, [0.16, 0.2], 0.4),
+        ] {
+            let creature = get_creature_definition(creature_type).unwrap();
+            let num_submodels = if imported[1] > 0.0 { 2 } else { 1 };
+            let dimensions = sphere_dimensions(imported[0], imported[1]);
+            let (radius, segment_height) = capsule(live_creature_shape(
+                &creature,
+                Some(&sphere_type(num_submodels)),
+                Some(&dimensions),
+            ));
+            assert!((radius - expected_radius).abs() < 0.001);
+            assert!((segment_height + radius * 2.0 - creature.bounding_size.y).abs() < 0.001);
+        }
     }
 
     /// A wall fixture the player can frob but never pick up or move - a

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2720,6 +2720,14 @@ impl PhysicsWorld {
         ))
     }
 
+    #[cfg(test)]
+    pub(crate) fn capsule_dimensions(&self, handle: RigidBodyHandle) -> Option<(f32, f32)> {
+        let body = self.rigid_body_set.get(handle)?;
+        let collider = self.collider_set.get(*body.colliders().first()?)?;
+        let capsule = collider.shape().as_capsule()?;
+        Some((capsule.radius, capsule.half_height() * 2.0))
+    }
+
     /// Whether any collider on a body is solid to the given character
     /// membership. Mirrors the player/actor movement queries: disabled bodies,
     /// disabled colliders, sensors, and non-collidable memberships never stop a

--- a/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const reproSave = process.env.SHOCK2_RUMBLER_JUNCTION_SAVE;
+
+function property(
+  detail: { properties: Array<{ name: string; value: unknown }> },
+  name: string,
+): unknown {
+  return detail.properties.find((item) => item.name === name)?.value;
+}
+
+async function walkTo(
+  game: GameServer,
+  target: [number, number],
+  label: string,
+  tolerance = 0.4,
+): Promise<Position> {
+  let position = await game.player.position();
+  let best = Math.hypot(position.x - target[0], position.z - target[1]);
+  let stalledFrames = 0;
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  for (let frame = 0; frame < 360; frame += 1) {
+    if (frame % 6 === 0) {
+      await game.input.lookAtWorldPoint([
+        target[0],
+        position.y + 0.8,
+        target[1],
+      ]);
+    }
+    await game.step({ frames: 1 });
+    position = await game.player.position();
+    const distance = Math.hypot(
+      position.x - target[0],
+      position.z - target[1],
+    );
+    if (distance <= tolerance) break;
+    if (distance < best - 0.02) {
+      best = distance;
+      stalledFrames = 0;
+    } else {
+      stalledFrames += 1;
+    }
+    assert.ok(
+      stalledFrames < 60,
+      `${label} stalled at ${JSON.stringify(position)} (${distance.toFixed(3)} from target)`,
+    );
+  }
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  assert.ok(
+    Math.hypot(position.x - target[0], position.z - target[1]) <= tolerance,
+    `${label} did not reach ${JSON.stringify(target)}: ${JSON.stringify(position)}`,
+  );
+  return position;
+}
+
+// Rick1's final-Rumbler lure uses the shipped WALK|SMALL_CREATURE link from
+// AIPATH cell1408 to cell1400. The live Rumbler authored two 1.5-foot physics
+// spheres, but the old runtime replaced that envelope with the five-foot-wide
+// animation bounds. Its 2wu-wide capsule therefore oscillated forever at the
+// junction instead of following its complete route back to Ladder951.
+//
+// The save is private campaign state and is supplied only to local/opt-in
+// runs; it is never checked in or uploaded. This scenario uses ordinary player
+// control throughout: acquire the Rumbler, reverse the intact route, require
+// its real body to pass the former waypoint and reach the ladder lip, descend
+// Ladder951, and land a real Crystal Shard edge without losing any of 24HP.
+test(
+  "rick1: authored Rumbler body follows the lure through the narrow junction",
+  {
+    skip: !e2eEnabled || !reproSave || !existsSync(reproSave),
+    timeout: 900_000,
+  },
+  async () => {
+    assert.ok(
+      reproSave,
+      "SHOCK2_RUMBLER_JUNCTION_SAVE must name the private repro save",
+    );
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8290),
+      debugFlags: ["--save-file", reproSave],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+      repoRoot: process.env.SHOCK2_REPO_ROOT,
+    });
+    await game.step({ frames: 10 });
+
+    const [rumbler] = await game.entities.byTemplate(2188);
+    assert.ok(rumbler, "rick1 should contain authored Rumbler2188");
+    const initial = await game.entities.detail(rumbler.id);
+    assert.equal(property(initial, "HitPoints"), "220");
+    assert.equal((await game.info()).player.hit_points, 24);
+    const body = (await game.physics.bodies({ entityId: rumbler.id })).bodies[0];
+    assert.ok(body, "Rumbler2188 must retain a live physics body");
+    assert.equal(body.body_type, "dynamic");
+    assert.equal(body.blocks_player, true);
+    assert.equal(body.blocks_actor, true);
+    assert.ok(
+      body.collision_groups.includes("actor"),
+      `Rumbler must remain in the actor collision group: ${JSON.stringify(body)}`,
+    );
+
+    const route: Array<[number, number]> = [
+      [113.6, -1.6],
+      [113.6, -2.4],
+      [112.4, -4.4],
+      [111.7, -9.2],
+      [111.43, -10.02],
+    ];
+    for (let index = 0; index < route.length; index += 1) {
+      await walkTo(game, route[index], `outbound lure leg ${index}`);
+    }
+
+    let acquired = false;
+    for (let frame = 0; frame < 600; frame += 10) {
+      await game.step({ frames: 10 });
+      const player = await game.player.position();
+      const detail = await game.entities.detail(rumbler.id);
+      const distance = Math.hypot(
+        detail.position[0] - player.x,
+        detail.position[2] - player.z,
+      );
+      if (
+        ["Moderate", "High"].includes(
+          String(property(detail, "AIAlertness") ?? ""),
+        ) && distance < 2.5
+      ) {
+        acquired = true;
+        break;
+      }
+    }
+    assert.ok(acquired, "the intact lure must acquire Rumbler2188");
+
+    for (let index = route.length - 2; index >= 0; index -= 1) {
+      await walkTo(game, route[index], `return lure leg ${index}`);
+    }
+    await walkTo(game, [111.91, -0.812], "Ladder951 midpoint", 0.4);
+
+    let passedJunction = false;
+    let reachedLip = false;
+    let lastRumbler = initial;
+    for (let frame = 0; frame < 720; frame += 5) {
+      await game.step({ frames: 5 });
+      lastRumbler = await game.entities.detail(rumbler.id);
+      if (lastRumbler.position[2] > -9.5) passedJunction = true;
+      const player = await game.player.position();
+      const distance = Math.hypot(
+        lastRumbler.position[0] - player.x,
+        lastRumbler.position[2] - player.z,
+      );
+      if (lastRumbler.position[2] > -3.2 && distance < 3.0) {
+        reachedLip = true;
+        break;
+      }
+    }
+    const livePath = (await game.pathfinding.aiPaths()).find(
+      (path) => path.entity_id === rumbler.id,
+    );
+    assert.ok(
+      passedJunction,
+      `Rumbler must advance past the former cell1408->1400 stall: ` +
+        `${JSON.stringify(lastRumbler.position)}, path=${JSON.stringify(livePath)}`,
+    );
+    assert.ok(
+      reachedLip,
+      `Rumbler must follow the lure to Ladder951, not merely pass one waypoint: ` +
+        `${JSON.stringify(lastRumbler.position)}, path=${JSON.stringify(livePath)}`,
+    );
+
+    let player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y - 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 300; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y < 77.4) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      player.y < 77.4 && player.x < 111.2,
+      `ordinary WEST/down input must acquire and descend Ladder951: ${JSON.stringify(player)}`,
+    );
+    assert.equal((await game.info()).player.hit_points, 24);
+
+    // One real attack edge is enough to prove the post-fix lure is tactically
+    // usable without turning this controller regression into a brittle 37-hit
+    // combat-animation test. The campaign replay owns the complete 220HP kill.
+    await game.input.trigger("EquipCrystalShard");
+    await game.step({ frames: 5 });
+    player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y + 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y > 80.1) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.player.aimAt(rumbler.id);
+    const beforeHit = Number(property(await game.entities.detail(rumbler.id), "HitPoints"));
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    const afterHit = Number(property(await game.entities.detail(rumbler.id), "HitPoints"));
+    assert.equal(
+      beforeHit,
+      220,
+      "the controller fix must not alter the Rumbler's authored health",
+    );
+    assert.equal(
+      afterHit,
+      214,
+      `one real Crystal Shard edge must deal exactly 6HP: ${beforeHit} -> ${afterHit}`,
+    );
+
+    player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y - 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y <= 75.8) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      player.y <= 75.8,
+      `the player must retreat down Ladder951 after the strike: ${JSON.stringify(player)}`,
+    );
+    await game.step({ frames: 30 });
+    assert.equal(
+      (await game.info()).player.hit_points,
+      24,
+      "the player must remain safely separated after executing the ladder lure",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- size live creature capsules from their authored SPHERE submodel radii instead of the animation model's visual width
- keep the established animation-bounds fallback for missing, malformed, non-sphere, or height-incompatible creature physics data
- preserve the animation-derived full height, dynamic actor collision group, corpse behavior, and loose-prop physics semantics
- add an exact Rick1 regression that proves the Rumbler crosses the shipped narrow junction, reaches Ladder951, and remains vulnerable to a real, safe Crystal Shard edge

## Root cause

Dark's creature physics drives one or two controlled sphere submodels and applies the creature descriptor's per-submodel radii. The port instead built every living creature's locomotion capsule from its animation bounding box.

For Rick1 Rumbler2188 that produced a radius of `1.0wu` from its five-foot visual width. Its two authored 1.5-foot spheres correspond to `0.6wu` at runtime. The oversized body could receive a complete authored AIPATH route but oscillated forever at the ordinary `WALK|SMALL_CREATURE` cell1408→1400 junction.

The conversion is deliberately scoped to live creatures with a valid one- or two-submodel `SPHERE` model. It does not reinterpret the shared physics-dimensions importer for doors, props, or other entities.

## Negative-first proof

Private campaign checkpoint SHA-256 (not committed or uploaded):

`21cae43962803e28a3d09cbd1762480f74bad8b6abf23f48bb81ee0ff450af1b`

The same durable E2E was run against both refs:

- exact base `6735cfa5`: **RED** in `110.75s`; Rumbler ended at `(111.0802, 81.8989, -11.7507)`, retained a `Full` path at `live_next_waypoint=2` toward `(111.40973, 80, -9.742441)`, and never crossed the junction
- exact stacked PR head `99934d6d`: **GREEN** in `95.49s`; Rumbler advances past that waypoint and physically reaches Ladder951, the player descends with ordinary input, a real Crystal Shard edge changes authored HP `220→214`, and the player retreats below `y75.8` with HP still `24` after 30 further frames

No test or production code teleports the Rumbler, filters AIPATH, ignores colliders, freezes AI, or injects damage. Runtime entity IDs are dynamically discovered from stable template IDs.

## Visual evidence

The matched authentic capture dynamically discovers Rumbler template2188 on each launch and replays the same ordinary lure on exact stacked base `248e97ec` and fixed `99934d6d`. The private checkpoint was used locally only; no save, runtime entity ID, or telemetry trajectory was uploaded.

![Rick1 Rumbler junction before/after](https://gist.githubusercontent.com/tommy-xr/66ed8654ec6ea0555b484f54aa4ff4ad/raw/rick1-rumbler-junction-before-after.gif)

<sub>Identical deterministic production sequence on both refs: after the initial 10 settle frames, ordinary outbound lure legs run for `10/5/14/29/56` frames toward `(113.6,-1.6)`, `(113.6,-2.4)`, `(112.4,-4.4)`, `(111.7,-9.2)`, and `(111.43,-10.02)`; remain neutral for 100 acquisition frames; ordinary return legs run for `4/29/14/5/11` frames toward the reverse route and Ladder951 midpoint; then remain neutral for 720 matched observation frames. Base oscillates behind the junction over z `-11.387..-10.574`, never crosses waypoint z `-9.742`, retains a full path at live waypoint2, and decays to `Lowest/Search`. Fixed crosses z `-9.742` after 70 observation frames, reaches the Ladder951 lip after 395 (`z=-3.160`), advances as far as z `-2.297`, and remains engaged near the player. For player-visible framing only, after each five-frame simulation step the camera aims at dynamically discovered Rumbler2188, captures without stepping, then restores the common static junction look before the next step; the simulated gameplay inputs remain identical. Captured headlessly through `/v1/step` + `/v1/screenshot` at fixed 60 Hz; no teleport, AI freeze, damage injection, or debug move is used.</sub>

![Fixed Rumbler at the Ladder951 lip](https://gist.githubusercontent.com/tommy-xr/66ed8654ec6ea0555b484f54aa4ff4ad/raw/rick1-rumbler-fixed-ladder951-lip.png)

### Before → after

![Rick1 Rumbler junction matched final before/after](https://gist.githubusercontent.com/tommy-xr/66ed8654ec6ea0555b484f54aa4ff4ad/raw/rick1-rumbler-junction-before-after.png)

[Issue #903 matched capture artifacts](https://gist.github.com/tommy-xr/66ed8654ec6ea0555b484f54aa4ff4ad)

<sub>Capture executables: stacked base `248e97ec3b444646f017091bbe110241cb0d7976`, SHA-256 `69a105722590164bef1f826b79374bcaa74d821034b382fc422d2bd7932f145b`; fixed `99934d6d3a763b7e7dab017d6a5b0596c54f9125`, SHA-256 `9055193a319a59ed5998d2dc0f0bc0999abd4fc002700854560217b1f6506e58`.</sub>

## Validation

- `cargo fmt --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 551/551 on the exact stacked PR head
- `cargo test -p shock2vr mission::entity_creator` — 20/20 on the exact stacked PR head
- `npm test` — 26/26 SDK unit tests
- exact Rick1 Rumbler E2E — 1/1
- climbing E2E matrix — 8/8
- crouch/save-load E2Es — 2/2
- mission load smoke matrix — 23/23

Fixes #903

<sub>Stacked on #902 via `gh stack`; this PR contains only the authored creature-width change and its tests.</sub>
