### PR TITLE
fix(save): canonicalize mission snapshot keys

### DIFF
--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -596,8 +596,9 @@ impl Game {
             current_save_data.all_entities.len()
         );
 
-        self.mission_to_save_data.insert(
-            self.active_game_scene.scene_name().to_ascii_lowercase(),
+        save_load::insert_mission_snapshot(
+            &mut self.mission_to_save_data,
+            self.active_game_scene.scene_name(),
             current_save_data,
         );
 
@@ -617,9 +618,8 @@ impl Game {
         player_vitals: Option<PlayerVitals>,
     ) {
         let populator: Box<dyn EntityPopulator> = {
-            if let Some(save_data) = self
-                .mission_to_save_data
-                .get(&level_name.to_ascii_lowercase())
+            if let Some(save_data) =
+                save_load::mission_snapshot(&self.mission_to_save_data, &level_name)
             {
                 let save_data_cloned = save_data.clone();
                 let populator = SaveFileEntityPopulator::create(save_data_cloned);
@@ -714,9 +714,8 @@ impl Game {
             .expect("background level-parse thread panicked");
 
         let populator: Box<dyn EntityPopulator> = {
-            if let Some(save_data) = self
-                .mission_to_save_data
-                .get(&pending.level_name.to_ascii_lowercase())
+            if let Some(save_data) =
+                save_load::mission_snapshot(&self.mission_to_save_data, &pending.level_name)
             {
                 Box::new(SaveFileEntityPopulator::create(save_data.clone()))
             } else {
@@ -1282,14 +1281,18 @@ impl Game {
     }
 
     fn build_save_data(&self) -> Option<SaveData> {
-        let mut level_data = self.mission_to_save_data.clone();
+        let mut level_data = save_load::canonicalized_mission_snapshots(&self.mission_to_save_data);
 
         let (save_data, held_items) = save_load::to_save_data_with_scripts(
             self.active_game_scene.world(),
             self.active_game_scene.script_world(),
         );
 
-        level_data.insert(self.active_game_scene.scene_name().to_string(), save_data);
+        save_load::insert_mission_snapshot(
+            &mut level_data,
+            self.active_game_scene.scene_name(),
+            save_data,
+        );
 
         let is_crouched = self.active_game_scene.player_is_crouched();
         let (position, rotation) = self.player_standing_transform()?;

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -969,12 +969,11 @@ fn create_physics_representation_with_options(
         if v_creature.get(entity_id).is_ok() && v_creature_pose.get(entity_id).is_err() {
             let creature_type = v_creature.get(entity_id).unwrap();
             let creature_def = get_creature_definition(creature_type.0).unwrap();
-            let bbox = creature_def.bounding_size;
-            let radius = bbox.x.max(bbox.z) / 2.0;
-            let creature_shape = PhysicsShape::Capsule {
-                height: radius.max(bbox.y - radius * 2.0),
-                radius,
-            };
+            let creature_shape = live_creature_shape(
+                &creature_def,
+                v_phys_type.get(entity_id).ok(),
+                v_phys_dimensions.get(entity_id).ok(),
+            );
             rigid_body_handle = physics.add_dynamic(
                 entity_id,
                 pos.position + vec3(0.0, SCALE_FACTOR / 6.0, 0.0) /* bump up so that character is not stuck in geometry */,
@@ -1250,6 +1249,58 @@ fn create_physics_representation_with_options(
     }
 }
 
+fn live_creature_shape(
+    creature_def: &crate::creature::CreatureDefinition,
+    phys_type: Option<&PropPhysType>,
+    dimensions: Option<&PropPhysDimensions>,
+) -> PhysicsShape {
+    let bbox = creature_def.bounding_size;
+    let fallback_radius = bbox.x.max(bbox.z) / 2.0;
+    let fallback = || PhysicsShape::Capsule {
+        // Preserve the established fallback for creatures without a complete
+        // authored sphere model. Small animation bounds can otherwise leave a
+        // zero-length capsule segment, which Rapier does not accept here.
+        height: fallback_radius.max(bbox.y - fallback_radius * 2.0),
+        radius: fallback_radius,
+    };
+
+    let (Some(phys_type), Some(dimensions)) = (phys_type, dimensions) else {
+        return fallback();
+    };
+    if phys_type.phys_type != PhysicsModelType::SPHERE
+        || !(1..=2).contains(&phys_type.num_submodels)
+    {
+        return fallback();
+    }
+
+    // Dark drives a live creature's sphere submodels from animated joints and
+    // applies the creature descriptor's per-submodel radii (`SetPhysSubModScale`),
+    // rather than using the animation model's visual width as collision. The
+    // instantiated P$PhysDims mirrors those radii. This importer's historical
+    // representation stores each Dark radius at half its scaled value, so the
+    // conversion is deliberately scoped to live-creature SPHERE models; loose
+    // props keep their existing parser/physics semantics.
+    let imported_radii = [dimensions.radius0, dimensions.radius1];
+    let declared_radii = &imported_radii[..phys_type.num_submodels as usize];
+    if declared_radii
+        .iter()
+        .any(|radius| !radius.is_finite() || *radius <= 0.0)
+    {
+        return fallback();
+    }
+    let radius = declared_radii.iter().copied().fold(0.0, f32::max) * 2.0;
+    let segment_height = bbox.y - radius * 2.0;
+    if !radius.is_finite() || radius <= 0.0 || !segment_height.is_finite() || segment_height <= 0.0
+    {
+        return fallback();
+    }
+
+    PhysicsShape::Capsule {
+        height: segment_height,
+        radius,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct CreateEntityOptions {
     pub force_visible: bool,
@@ -1287,6 +1338,7 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::creature::{RUMBLER_HEIGHT, RUMBLER_WIDTH};
     use cgmath::InnerSpace;
     use collision::Aabb3;
     use dark::properties::{Links, ToLink};
@@ -1335,6 +1387,165 @@ mod tests {
     }
 
     const LADDER_SIZE: Vector3<f32> = Vector3::new(1.646, 6.4, 0.142);
+
+    /// A live Rumbler authors two 1.5 SS2-foot physics spheres. The property
+    /// importer's historical radius representation is half the scaled Dark
+    /// radius, so those values appear here as 0.3 world units. Its animated
+    /// model is five feet wide, but that is not its locomotion hull: Dark's
+    /// creature descriptor drives the two authored spheres independently.
+    ///
+    /// Negative-first: creature creation previously ignored both sphere
+    /// radii and built a 1.0-world-unit-radius capsule from animation bounds,
+    /// too broad for Rick1's shipped WALK|SMALL_CREATURE junction.
+    #[test]
+    fn live_creature_uses_authored_sphere_width_with_animation_height() {
+        let mut world = World::new();
+        let mut physics = PhysicsWorld::new();
+        let entity_id = world.add_entity((
+            PropPosition {
+                position: vec3(0.0, 4.0, 0.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            PropCreature(3),
+            PropFrobInfo {
+                world_action: FrobFlag::SCRIPT,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropPhysType {
+                phys_type: PhysicsModelType::SPHERE,
+                num_submodels: 2,
+                remove_on_sleep: false,
+                is_special: true,
+            },
+            PropPhysDimensions {
+                radius0: 0.3,
+                radius1: 0.3,
+                offset0: Vector3::zero(),
+                offset1: Vector3::zero(),
+                size: Vector3::zero(),
+                unk1: 0,
+                unk2: 0,
+            },
+        ));
+
+        let handle = create_physics_representation(&mut world, &mut physics, &None, entity_id)
+            .expect("a live creature should get a dynamic physics body");
+        let (radius, segment_height) = physics
+            .capsule_dimensions(handle)
+            .expect("the live creature body should remain a capsule");
+
+        assert!(
+            (radius - 0.6).abs() < 0.001,
+            "expected radius 0.6, got {radius}"
+        );
+        assert!(
+            (segment_height + radius * 2.0 - RUMBLER_HEIGHT).abs() < 0.001,
+            "authored width must not change the full animation-derived height"
+        );
+        let body = physics
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(entity_id.inner() as i32))
+            .expect("the creature body should remain introspectable");
+        assert_eq!(body.body_type, "dynamic");
+        assert!(body.blocks_player && body.blocks_actor);
+        assert!(body.collision_groups.iter().any(|group| group == "actor"));
+    }
+
+    fn capsule(shape: PhysicsShape) -> (f32, f32) {
+        match shape {
+            PhysicsShape::Capsule { height, radius } => (radius, height),
+            other => panic!("expected creature capsule, got {other:?}"),
+        }
+    }
+
+    fn sphere_type(num_submodels: u32) -> PropPhysType {
+        PropPhysType {
+            phys_type: PhysicsModelType::SPHERE,
+            num_submodels,
+            remove_on_sleep: false,
+            is_special: true,
+        }
+    }
+
+    fn sphere_dimensions(radius0: f32, radius1: f32) -> PropPhysDimensions {
+        PropPhysDimensions {
+            radius0,
+            radius1,
+            offset0: vec3(9.0, 8.0, 7.0),
+            offset1: vec3(-6.0, -5.0, -4.0),
+            size: Vector3::zero(),
+            unk1: 0,
+            unk2: 0,
+        }
+    }
+
+    #[test]
+    fn live_creature_shape_uses_largest_declared_sphere_radius() {
+        let rumbler = get_creature_definition(3).unwrap();
+        let two_spheres = sphere_type(2);
+        let dimensions = sphere_dimensions(0.25, 0.3);
+        let (radius, segment_height) = capsule(live_creature_shape(
+            &rumbler,
+            Some(&two_spheres),
+            Some(&dimensions),
+        ));
+
+        assert!((radius - 0.6).abs() < 0.001);
+        assert!((segment_height + 2.0 * radius - RUMBLER_HEIGHT).abs() < 0.001);
+    }
+
+    #[test]
+    fn invalid_or_incomplete_creature_spheres_keep_animation_fallback() {
+        let rumbler = get_creature_definition(3).unwrap();
+        let fallback = capsule(live_creature_shape(&rumbler, None, None));
+        assert_eq!(fallback, (RUMBLER_WIDTH / 2.0, RUMBLER_WIDTH / 2.0));
+
+        let mut obb = sphere_type(2);
+        obb.phys_type = PhysicsModelType::ORIENTED_BOUNDING_BOX;
+        let invalid_cases = [
+            (Some(sphere_type(0)), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(3)), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.3, 0.0))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.3, f32::NAN))),
+            (Some(sphere_type(2)), Some(sphere_dimensions(0.7, 0.7))),
+            (Some(obb), Some(sphere_dimensions(0.3, 0.3))),
+            (Some(sphere_type(2)), None),
+        ];
+        for (phys_type, dimensions) in invalid_cases {
+            assert_eq!(
+                capsule(live_creature_shape(
+                    &rumbler,
+                    phys_type.as_ref(),
+                    dimensions.as_ref(),
+                )),
+                fallback,
+            );
+        }
+    }
+
+    #[test]
+    fn shipped_creature_sphere_radii_match_original_descriptor_envelopes() {
+        for (creature_type, imported, expected_radius) in [
+            (0, [0.2, 0.24], 0.48),
+            (3, [0.3, 0.3], 0.6),
+            (4, [0.39, 0.0], 0.78),
+            (6, [0.16, 0.2], 0.4),
+        ] {
+            let creature = get_creature_definition(creature_type).unwrap();
+            let num_submodels = if imported[1] > 0.0 { 2 } else { 1 };
+            let dimensions = sphere_dimensions(imported[0], imported[1]);
+            let (radius, segment_height) = capsule(live_creature_shape(
+                &creature,
+                Some(&sphere_type(num_submodels)),
+                Some(&dimensions),
+            ));
+            assert!((radius - expected_radius).abs() < 0.001);
+            assert!((segment_height + radius * 2.0 - creature.bounding_size.y).abs() < 0.001);
+        }
+    }
 
     /// A wall fixture the player can frob but never pick up or move - a
     /// console, a card slot, the Resurrection Station casing. `phys_type` is

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1306,6 +1306,7 @@ fn mantle_lip_patch(
     mantle_feature: Option<(ColliderHandle, FeatureId)>,
     mantle_point: Vector<Real>,
     corridor: &[Vector<Real>],
+    allow_tall_direct_faces: bool,
 ) -> Option<MantleLipPatch> {
     let (handle, FeatureId::Face(sampled_mantle_face)) = mantle_feature? else {
         return None;
@@ -1319,6 +1320,19 @@ fn mantle_lip_patch(
     // Parry identifies a two-sided trimesh backface as `face + face_count`.
     // The topology and BVH use the canonical front-face index.
     let mantle_face = sampled_mantle_face % face_count as u32;
+    let mantle_triangle = mesh.triangle(mantle_face);
+    let coplanar_with_mantle = |face: u32| {
+        let triangle = mesh.triangle(face);
+        let (Some(mantle_normal), Some(normal)) = (mantle_triangle.normal(), triangle.normal())
+        else {
+            return false;
+        };
+        mantle_normal.dot(&normal).abs() >= 1.0 - 1.0e-4
+            && (triangle.a - mantle_triangle.a)
+                .dot(mantle_normal.as_ref())
+                .abs()
+                <= CLIMB_TOP_OUT_RECOVERY_RETREAT + 1.0e-5
+    };
 
     let local_mantle_point = collider
         .position()
@@ -1449,10 +1463,18 @@ fn mantle_lip_patch(
     let faces = corridor_faces
         .into_iter()
         .filter(|face| {
+            // Dark level meshes can represent one physical wall plane with
+            // overlapping fan triangles that do not share exact indexed
+            // edges. A ladder-attributed near/far boundary is independently
+            // ray-sampled; include only coplanar faces touching that same
+            // bounded corridor so the obstruction remains one local interval.
+            if allow_tall_direct_faces && coplanar_with_mantle(*face) {
+                return true;
+            }
             let Some(&hops) = connected.get(face) else {
                 return false;
             };
-            if hops > CLIMB_TOP_OUT_DIRECT_LIP_FACE_HOPS {
+            if allow_tall_direct_faces || hops > CLIMB_TOP_OUT_DIRECT_LIP_FACE_HOPS {
                 return true;
             }
             let triangle = mesh.triangle(*face);
@@ -1517,6 +1539,7 @@ fn trimesh_faces_connect_within_local_bounds(
         Some((first_handle, FeatureId::Face(first_face))),
         first_points[0],
         &corridor,
+        false,
     )
     .is_some_and(|patch| {
         patch.handle == second_handle && patch.faces.contains(&canonical_second_face)
@@ -1544,7 +1567,7 @@ fn standing_pose_matches_current_support(
     queries: &QueryPipeline,
     standing_pose: Vector<Real>,
 ) -> bool {
-    let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+    let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
         + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
         + PLAYER_REST_LIFT / SCALE_FACTOR;
     // The waypoint loop intentionally stops within arrival epsilon. Allow the
@@ -1678,10 +1701,15 @@ fn plan_climb_top_out(
     minimum_clear_forward: Real,
     dt: Real,
 ) -> Option<PlayerMovement> {
+    macro_rules! reject_top_out {
+        ($gate:literal) => {{
+            return None;
+        }};
+    }
     let direction_h = vector![direction.x, 0.0, direction.z];
     let direction_norm = direction_h.norm();
     if direction_norm <= 1.0e-6 {
-        return None;
+        reject_top_out!("direction");
     }
     let direction = direction_h / direction_norm;
     let head_offset = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
@@ -1701,11 +1729,56 @@ fn plan_climb_top_out(
     let up_hit = probe_queries.cast_ray_and_get_normal(&up_ray, CLIMB_TOP_OUT_UP, true);
     let up_obstruction = up_hit.map(|(_, hit)| (hit.time_of_impact, head.y + hit.time_of_impact));
     if up_obstruction.is_some_and(|(time_of_impact, _)| time_of_impact < CLIMB_TOP_OUT_RADIUS) {
-        return None;
+        reject_top_out!("low_ceiling");
     }
-    if !ray_segment_is_clear(probe_queries, raised, probe_ahead) {
-        return None;
+    let raised_probe_ray = Ray::new(Point::from(raised), direction);
+    let raised_probe_hit = probe_queries.cast_ray_and_get_normal(
+        &raised_probe_ray,
+        (probe_ahead - raised).norm(),
+        true,
+    );
+    let ladder_exit_hit = raised_probe_hit.filter(|(_, hit)| {
+        matches!(hit.feature, FeatureId::Face(_))
+            && hit.time_of_impact <= route_forward + CLIMB_TOP_OUT_RECOVERY_RETREAT
+            && vector![hit.normal.x, 0.0, hit.normal.z].dot(&direction) <= -MIN_CLIMB_GRIP_FRACTION
+    });
+    if raised_probe_hit.is_some() && ladder_exit_hit.is_none() {
+        reject_top_out!("raised_probe");
     }
+    let ladder_far_hit = ladder_exit_hit.and_then(|(near_handle, _)| {
+        let reverse_delta = raised - route_ahead;
+        let reverse_distance = reverse_delta.norm();
+        probe_queries
+            .cast_ray_and_get_normal(
+                &Ray::new(Point::from(route_ahead), reverse_delta / reverse_distance),
+                reverse_distance,
+                true,
+            )
+            .filter(|(handle, hit)| {
+                *handle == near_handle
+                    && matches!(hit.feature, FeatureId::Face(_))
+                    && vector![hit.normal.x, 0.0, hit.normal.z]
+                        .dot(&direction)
+                        .abs()
+                        >= MIN_CLIMB_GRIP_FRACTION
+            })
+    });
+    let ladder_exit_geometry = ladder_exit_hit.and_then(|(_, near_hit)| {
+        let (_, far_hit) = ladder_far_hit?;
+        let near_point = raised + direction * near_hit.time_of_impact;
+        let far_point = route_ahead - direction * far_hit.time_of_impact;
+        let thickness = (far_point - near_point).dot(&direction);
+        (thickness >= -1.0e-5 && thickness <= CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY).then_some((
+            near_point,
+            far_point,
+            thickness.max(0.0),
+        ))
+    });
+    if ladder_exit_hit.is_some() && ladder_exit_geometry.is_none() {
+        reject_top_out!("ladder_far_probe");
+    }
+    let lip_exit_allowance = CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE
+        + ladder_exit_geometry.map_or(0.0, |(_, _, thickness)| thickness);
     let down_ray = Ray::new(Point::from(probe_ahead), -Vector::y());
     let mantle_hit = probe_queries
         .cast_ray_and_get_normal(&down_ray, CLIMB_TOP_OUT_MAX_DROP, true)
@@ -1721,8 +1794,9 @@ fn plan_climb_top_out(
             floor.y + CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
                 < obstruction_y
         })
-    }) {
-        return None;
+    }) && ladder_exit_hit.is_none()
+    {
+        reject_top_out!("separate_ceiling");
     }
 
     // Dark's mantle target puts the physical head sphere just over the lip:
@@ -1742,13 +1816,21 @@ fn plan_climb_top_out(
     // simulated; the bounded recovery search below already selects its nearest
     // viable retreat and avoids multiplying hundreds of controller casts per
     // candidate.
-    let cross_y = minimum_cross_y.max(raised.y);
+    let cross_y = minimum_cross_y.max(raised.y)
+        + if ladder_exit_hit.is_some() {
+            CLIMB_TOP_OUT_RECOVERY_RETREAT
+        } else {
+            0.0
+        };
     // A full sphere can sit under an overhanging lip even when the head
     // point above it is clear. Dark's recovery searches backward/up within
     // four authored feet. Use the same bound and choose the first
     // contact-offset step whose full-radius vertical sweep is clear.
-    let rise_start =
-        climb_top_out_recovery_start(scripted_queries, head, direction, cross_y, &compressed)?;
+    let Some(rise_start) =
+        climb_top_out_recovery_start(scripted_queries, head, direction, cross_y, &compressed)
+    else {
+        reject_top_out!("recovery_start");
+    };
     let cross_start = vector![rise_start.x, cross_y, rise_start.z];
     let probe_cross_end = vector![probe_ahead.x, cross_y, probe_ahead.z];
     let cross_end = vector![route_ahead.x, cross_y, route_ahead.z];
@@ -1761,7 +1843,7 @@ fn plan_climb_top_out(
     // measured 0.7148-world-unit sample. Round that geometry extent up to the
     // next contact-offset sample: one compressed diameter plus two samples.
     if !shape_sweep_is_clear(probe_queries, head, rise_start, &compressed) {
-        return None;
+        reject_top_out!("head_to_recovery");
     }
     // The continuous capsule must compress before rising through the local
     // lip that Dark's sparse body can straddle. Validate the recovered
@@ -1778,22 +1860,55 @@ fn plan_climb_top_out(
                 > CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
         })
     }) {
-        return None;
+        reject_top_out!("recovery_ceiling");
     }
-    let lip_forward_end = cross_end + direction * CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE;
-    let mantle_feature = mantle_hit.map(|(handle, hit)| (handle, hit.feature));
-    let lip_patch = mantle_lip_patch(
+    let lip_forward_end = cross_end + direction * lip_exit_allowance;
+    let mantle_feature = ladder_exit_hit
+        .map(|(handle, hit)| (handle, hit.feature))
+        .or_else(|| mantle_hit.map(|(handle, hit)| (handle, hit.feature)));
+    let mantle_point = ladder_exit_hit
+        .map(|(_, hit)| raised + direction * hit.time_of_impact)
+        .unwrap_or_else(|| mantle_floor.unwrap_or(probe_ahead));
+    let lip_corridor = [
+        rise_start,
+        cross_start,
+        probe_cross_end,
+        cross_end,
+        lip_forward_end,
+    ];
+    let mut lip_patch = mantle_lip_patch(
         probe_queries,
         mantle_feature,
-        mantle_floor.unwrap_or(probe_ahead),
-        &[
-            rise_start,
-            cross_start,
-            probe_cross_end,
-            cross_end,
-            lip_forward_end,
-        ],
+        mantle_point,
+        &lip_corridor,
+        ladder_exit_hit.is_some(),
     );
+    if ladder_exit_hit.is_some() {
+        let up_feature = up_hit.map(|(handle, hit)| (handle, hit.feature));
+        let up_point = up_hit
+            .map(|(_, hit)| head + Vector::y() * hit.time_of_impact)
+            .unwrap_or(head);
+        if let (Some(lip_patch), Some(up_patch)) = (
+            lip_patch.as_mut(),
+            mantle_lip_patch(probe_queries, up_feature, up_point, &lip_corridor, true),
+        ) {
+            if lip_patch.handle == up_patch.handle {
+                lip_patch.faces.extend(up_patch.faces);
+            }
+        }
+        let far_feature = ladder_far_hit.map(|(handle, hit)| (handle, hit.feature));
+        let far_point = ladder_far_hit
+            .map(|(_, hit)| route_ahead - direction * hit.time_of_impact)
+            .unwrap_or(route_ahead);
+        if let (Some(lip_patch), Some(far_patch)) = (
+            lip_patch.as_mut(),
+            mantle_lip_patch(probe_queries, far_feature, far_point, &lip_corridor, true),
+        ) {
+            if lip_patch.handle == far_patch.handle {
+                lip_patch.faces.extend(far_patch.faces);
+            }
+        }
+    }
     if scan_initial_route_obstruction(
         probe_queries,
         &[rise_start, cross_start],
@@ -1804,16 +1919,17 @@ fn plan_climb_top_out(
     )
     .is_none()
     {
-        return None;
+        reject_top_out!("rise_obstruction_scan");
     }
     // Recovery may retreat the rise behind `raised`. Validate that entire
     // offset approach before permitting the one bounded lip overlap below;
     // otherwise the scripted parentless-terrain exception could cross an
     // unrelated wall between the recovered rise and Dark's probe endpoint.
-    if shape_intersects(probe_queries, cross_start, &route_probe)
-        || !shape_sweep_is_clear(probe_queries, cross_start, probe_cross_end, &route_probe)
+    if ladder_exit_hit.is_none()
+        && (shape_intersects(probe_queries, cross_start, &route_probe)
+            || !shape_sweep_is_clear(probe_queries, cross_start, probe_cross_end, &route_probe))
     {
-        return None;
+        reject_top_out!("point_approach");
     }
     // The point-scale centerline can remain clear while the full ball clips a
     // diagonal lip from the side. Find the ball's first actual terrain face on
@@ -1826,17 +1942,19 @@ fn plan_climb_top_out(
         &compressed,
         |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
     ) else {
-        return None;
+        reject_top_out!("first_lip_scan");
     };
     let (lip_approach, lip_clear) = if let Some(first_lip) = first_lip {
         if !shape_sweep_is_clear(probe_queries, cross_start, first_lip.position, &route_probe) {
-            return None;
+            reject_top_out!("point_to_lip");
         }
-        let exit_direction =
-            obstruction_exit_direction(probe_queries, &first_lip.obstructions, direction)?;
-        let lip_exit_end =
-            first_lip.position + exit_direction * CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE;
-        let exit_lip_patch = mantle_lip_patch(
+        let Some(exit_direction) =
+            obstruction_exit_direction(probe_queries, &first_lip.obstructions, direction)
+        else {
+            reject_top_out!("exit_direction");
+        };
+        let lip_exit_end = first_lip.position + exit_direction * lip_exit_allowance;
+        let mut exit_lip_patch = mantle_lip_patch(
             probe_queries,
             mantle_feature,
             mantle_floor.unwrap_or(probe_ahead),
@@ -1849,12 +1967,41 @@ fn plan_climb_top_out(
                 first_lip.position,
                 lip_exit_end,
             ],
+            ladder_exit_hit.is_some(),
         );
+        if ladder_exit_hit.is_some() {
+            let far_feature = ladder_far_hit.map(|(handle, hit)| (handle, hit.feature));
+            let far_point = ladder_far_hit
+                .map(|(_, hit)| route_ahead - direction * hit.time_of_impact)
+                .unwrap_or(route_ahead);
+            if let (Some(exit_lip_patch), Some(far_patch)) = (
+                exit_lip_patch.as_mut(),
+                mantle_lip_patch(
+                    probe_queries,
+                    far_feature,
+                    far_point,
+                    &[
+                        rise_start,
+                        cross_start,
+                        probe_cross_end,
+                        cross_end,
+                        lip_forward_end,
+                        first_lip.position,
+                        lip_exit_end,
+                    ],
+                    true,
+                ),
+            ) {
+                if exit_lip_patch.handle == far_patch.handle {
+                    exit_lip_patch.faces.extend(far_patch.faces);
+                }
+            }
+        }
         let Some(exit) = scan_initial_route_obstruction(
             probe_queries,
             &[first_lip.position, lip_exit_end],
             &compressed,
-            CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE,
+            lip_exit_allowance,
             CLIMB_TOP_OUT_RECOVERY_RETREAT,
             |hit| {
                 exit_lip_patch
@@ -1862,12 +2009,12 @@ fn plan_climb_top_out(
                     .is_some_and(|patch| patch.contains(hit))
             },
         ) else {
-            return None;
+            reject_top_out!("lip_exit_scan");
         };
         (first_lip.position, exit.first_clear)
     } else {
         if !shape_sweep_is_clear(probe_queries, cross_start, cross_end, &compressed) {
-            return None;
+            reject_top_out!("clear_cross");
         }
         (cross_end, cross_end)
     };
@@ -1944,7 +2091,7 @@ fn plan_climb_top_out(
         || !shape_sweep_is_clear(scripted_queries, lip_approach, lip_clear, &compressed)
         || !shape_obstructions(validation_queries, lip_clear, &compressed).is_empty()
     {
-        return None;
+        reject_top_out!("scripted_or_lip_clear");
     }
     let validated_landing = |landing: SupportedLanding| {
         (shape_sweep_is_clear(validation_queries, lip_clear, landing.sphere, &compressed)
@@ -2043,7 +2190,7 @@ fn plan_climb_top_out(
         .or(direct_fallback)
         .or(deep_fallback)
     else {
-        return None;
+        reject_top_out!("landing");
     };
     // Preserve Dark's ordered rise-then-cross states. Scripted casts keep
     // parented entity blockers live but deliberately permit passage through
@@ -2078,13 +2225,13 @@ fn plan_climb_top_out(
                 waypoint,
                 dt,
             ) else {
-                return None;
+                reject_top_out!("simulated_slide");
             };
             first_movement.get_or_insert(movement.translation);
             simulated += movement.translation;
         }
         if (waypoint - simulated).norm() > PLAYER_MOVE_ARRIVAL_EPSILON {
-            return None;
+            reject_top_out!("simulated_arrival");
         }
     }
     let first_step = first_movement?;
@@ -2581,11 +2728,13 @@ fn step_player_movement(
                 return PlayerMovement {
                     movement: reposition,
                     top_out: None,
+                    slope_displacement: Vector::zeros(),
                 };
             }
             return PlayerMovement {
                 movement: scripted_character_movement(Vector::zeros()),
                 top_out: None,
+                slope_displacement: Vector::zeros(),
             };
         }
     }
@@ -7428,6 +7577,8 @@ mod tests {
             Vector::zeros(),
             1.0 / 60.0,
             -0.2,
+            None,
+            None,
             Some(ClimbPass {
                 movement: Vector::y() * 0.25,
                 top_out: Some((Vector::x(), CLIMB_TOP_OUT_PROBE_FORWARD)),
@@ -7980,7 +8131,7 @@ mod tests {
                 )
             });
         let expected_standing_y = 0.5
-            + PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
             + PLAYER_REST_LIFT / SCALE_FACTOR;
         let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
@@ -8149,7 +8300,7 @@ mod tests {
         world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
 
         let queries = query_pipeline(&world, QueryFilter::default());
-        let head_y = (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR;
+        let head_y = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
         let cross_y = head_y + CLIMB_TOP_OUT_UP;
         let cross_end = vector![CLIMB_TOP_OUT_PROBE_FORWARD, cross_y, 0.0];
         let full_advance = cross_end + Vector::x() * CLIMB_TOP_OUT_ADVANCE;
@@ -8240,7 +8391,7 @@ mod tests {
         world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
         let queries = query_pipeline(&world, QueryFilter::default());
         let standing = standing_player_capsule();
-        let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+        let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
             + PLAYER_REST_LIFT / SCALE_FACTOR;
 
@@ -8276,7 +8427,7 @@ mod tests {
             .expect("an exact supported fallback should avoid re-freezing");
         let final_standing = movement.top_out.expect("planned top-out").waypoints[6];
         let expected_standing_y = 0.5
-            + PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
             + PLAYER_REST_LIFT / SCALE_FACTOR;
         assert!(
@@ -8427,7 +8578,7 @@ mod tests {
             world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
         world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
         let controller = KinematicCharacterController::default();
-        let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+        let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
             + PLAYER_REST_LIFT / SCALE_FACTOR;
         let final_pose = vector![4.0, standing_floor_offset, 0.0];

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1796,12 +1796,46 @@ fn plan_climb_top_out(
     }
     let lip_exit_allowance = CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE
         + ladder_exit_geometry.map_or(0.0, |(_, _, thickness)| thickness);
-    let down_ray = Ray::new(Point::from(probe_ahead), -Vector::y());
-    let mantle_hit = probe_queries
-        .cast_ray_and_get_normal(&down_ray, CLIMB_TOP_OUT_MAX_DROP, true)
-        .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+    // Prefer Dark's fixed two-radius mantle probe, but authored ladder wells
+    // can be deeper than that while the grip-derived exit distance already
+    // reaches the adjacent floor. Sample that bounded route endpoint as a
+    // fallback; the complete compressed route and final standing pose remain
+    // validated against all colliders below.
+    let mantle_probe = |origin| {
+        let down_ray = Ray::new(Point::from(origin), -Vector::y());
+        probe_queries
+            .cast_ray_and_get_normal(&down_ray, CLIMB_TOP_OUT_MAX_DROP, true)
+            .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+            .map(|(handle, landing)| (origin, handle, landing))
+    };
+    let fixed_mantle_hit = mantle_probe(probe_ahead);
+    let route_mantle_hit = fixed_mantle_hit
+        .is_none()
+        .then(|| mantle_probe(route_ahead))
+        .flatten();
+    let same_mantle_slab = match (up_hit, route_mantle_hit) {
+        (Some((up_handle, up)), Some((origin, floor_handle, floor)))
+            if up_handle == floor_handle
+                && (origin - probe_ahead).norm() > CLIMB_TOP_OUT_RECOVERY_RETREAT =>
+        {
+            let underside_y = head.y + up.time_of_impact;
+            let floor_y = origin.y - floor.time_of_impact;
+            up.normal.y < -CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+                && floor_y + 1.0e-4 >= underside_y
+                && floor_y - underside_y
+                    <= CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
+        }
+        _ => false,
+    };
+    let mantle_hit = fixed_mantle_hit.or_else(|| {
+        if same_mantle_slab {
+            route_mantle_hit
+        } else {
+            None
+        }
+    });
     let mantle_floor =
-        mantle_hit.map(|(_, landing)| probe_ahead - Vector::y() * landing.time_of_impact);
+        mantle_hit.map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
     if up_obstruction.is_some_and(|(_, obstruction_y)| {
         // A lip can have a thin underside above its adjacent landing. Treat
         // surfaces within one compressed radius plus the solver gap on both
@@ -1882,7 +1916,7 @@ fn plan_climb_top_out(
     let lip_forward_end = cross_end + direction * lip_exit_allowance;
     let mantle_feature = ladder_exit_hit
         .map(|(handle, hit)| (handle, hit.feature))
-        .or_else(|| mantle_hit.map(|(handle, hit)| (handle, hit.feature)));
+        .or_else(|| mantle_hit.map(|(_, handle, hit)| (handle, hit.feature)));
     let mantle_point = ladder_exit_hit
         .map(|(_, hit)| raised + direction * hit.time_of_impact)
         .unwrap_or_else(|| mantle_floor.unwrap_or(probe_ahead));
@@ -1900,7 +1934,7 @@ fn plan_climb_top_out(
         &lip_corridor,
         ladder_exit_hit.is_some(),
     );
-    if ladder_exit_hit.is_some() {
+    if ladder_exit_hit.is_some() || same_mantle_slab {
         let up_feature = up_hit.map(|(handle, hit)| (handle, hit.feature));
         let up_point = up_hit
             .map(|(_, hit)| head + Vector::y() * hit.time_of_impact)
@@ -1913,6 +1947,8 @@ fn plan_climb_top_out(
                 lip_patch.faces.extend(up_patch.faces);
             }
         }
+    }
+    if ladder_exit_hit.is_some() {
         let far_feature = ladder_far_hit.map(|(handle, hit)| (handle, hit.feature));
         let far_point = ladder_far_hit
             .map(|(_, hit)| route_ahead - direction * hit.time_of_impact)
@@ -2251,10 +2287,21 @@ fn plan_climb_top_out(
             .map(|(_, validated)| validated)
     })
     .flatten();
-    let forward_landing = direct_with_egress
-        .or(deep_with_egress.flatten())
-        .or(direct_fallback)
-        .or(deep_fallback);
+    let forward_landing = if same_mantle_slab {
+        // Once the upward and downward samples identify opposite faces of the
+        // same slab, a direct supported pose on its top is the authored exit.
+        // Do not carry the player across that landing and down a later opening
+        // merely because the lower floor offers a longer egress stride.
+        direct_with_egress
+            .or(direct_fallback)
+            .or(deep_with_egress.flatten())
+            .or(deep_fallback)
+    } else {
+        direct_with_egress
+            .or(deep_with_egress.flatten())
+            .or(direct_fallback)
+            .or(deep_fallback)
+    };
     // Prefer the held-direction result unless it needs more lateral steering
     // than the straight approach-side route. This preserves ordinary forward
     // top-outs and uses the recessed-floor alternative only when it avoids a

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -321,6 +321,12 @@ const CLIMB_TOP_OUT_MAX_APPROACH_RECOVERY: f32 = CLIMB_TOP_OUT_DEEP_DROP;
 /// landing. The three route bases, five forward offsets, and eleven signed
 /// lateral offsets cover the complete independently bounded recovery grid.
 const CLIMB_TOP_OUT_MAX_LANDING_CANDIDATES: usize = 3 * 5 * 11;
+/// A pre-lip side recovery is considered only after the ordinary forward grid
+/// fails. Retreat samples span at most one active-profile radius at the
+/// contact-offset interval; each may try both sides of the existing lateral
+/// distance bound. Crouching is the largest grid: sixteen retreat samples by
+/// eight lateral samples by two sides.
+const CLIMB_TOP_OUT_MAX_PRE_LIP_SIDE_CANDIDATES: usize = 16 * 8 * 2;
 /// Egress validation samples a full standing stride at contact-offset
 /// intervals. It is a landing preference, not a safety requirement, so limit
 /// it to the first few already-safe candidates in each support tier.
@@ -1866,6 +1872,86 @@ fn climb_top_out_recovery_start(
 /// matching Dark's jump-through transition. Parented entity colliders remain
 /// live blockers throughout, and the final standing pose is validated against
 /// every collider, including level terrain.
+#[derive(Clone, Copy)]
+struct SupportedLanding {
+    sphere: Vector<Real>,
+    standing: Vector<Real>,
+    direct: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn find_pre_lip_side_landing(
+    validation_queries: &QueryPipeline,
+    probe_queries: &QueryPipeline,
+    probe_cross_end: Vector<Real>,
+    direction: Vector<Real>,
+    lateral: Vector<Real>,
+    compressed: &Ball,
+    standing: &Capsule,
+    compressed_radius: Real,
+    lateral_steps: usize,
+    standing_floor_offset: Real,
+    mantle_floor: Vector<Real>,
+    lip_patch: Option<&MantleLipPatch>,
+) -> Option<(Vector<Real>, Vector<Real>, Vector<Real>)> {
+    let retreat_steps = (compressed_radius / (PROBE_SKIN / SCALE_FACTOR)).ceil() as usize;
+    let mut evaluated = 0;
+    for retreat_step in 1..=retreat_steps {
+        let retreat = -direction * (retreat_step as Real * PROBE_SKIN / SCALE_FACTOR);
+        for lateral_step in 1..=lateral_steps {
+            let lateral_offset = lateral_step as Real * compressed_radius;
+            for side in [1.0, -1.0] {
+                if evaluated == CLIMB_TOP_OUT_MAX_PRE_LIP_SIDE_CANDIDATES {
+                    return None;
+                }
+                evaluated += 1;
+                let candidate = probe_cross_end + retreat + lateral * (side * lateral_offset);
+                let Some((supported_standing, _)) = supported_standing_pose(
+                    validation_queries,
+                    candidate,
+                    CLIMB_TOP_OUT_DEEP_DROP,
+                    standing_floor_offset,
+                ) else {
+                    continue;
+                };
+                let floor_y = supported_standing.y - standing_floor_offset;
+                if (floor_y - mantle_floor.y).abs()
+                    > CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
+                    || shape_intersects(validation_queries, supported_standing, standing)
+                    || scan_initial_route_obstruction(
+                        probe_queries,
+                        &[probe_cross_end, candidate],
+                        compressed,
+                        compressed_radius,
+                        CLIMB_TOP_OUT_RECOVERY_RETREAT,
+                        true,
+                        None,
+                        |hit| lip_patch.is_some_and(|patch| patch.contains(hit)),
+                    )
+                    .is_none()
+                    || !shape_sweep_is_clear(
+                        validation_queries,
+                        candidate,
+                        supported_standing,
+                        compressed,
+                    )
+                    || !has_supported_standing_egress(
+                        validation_queries,
+                        supported_standing,
+                        lateral * side,
+                        standing,
+                        standing_floor_offset,
+                    )
+                {
+                    continue;
+                }
+                return Some((candidate, candidate, supported_standing));
+            }
+        }
+    }
+    None
+}
+
 fn plan_climb_top_out(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
@@ -2328,12 +2414,6 @@ fn plan_climb_top_out(
         (cross_end, cross_end)
     };
 
-    #[derive(Clone, Copy)]
-    struct SupportedLanding {
-        sphere: Vector<Real>,
-        standing: Vector<Real>,
-        direct: bool,
-    }
     let landing_pose = |candidate: Vector<Real>| {
         let (supported_standing, support_drop) = supported_standing_pose(
             validation_queries,
@@ -2553,15 +2633,45 @@ fn plan_climb_top_out(
             .or(direct_fallback)
             .or(deep_fallback)
     };
+    // A narrow landing can lie immediately behind the climbable itself but
+    // before the terrain lip's geometry-derived exit. In that layout the
+    // ordinary grid correctly clears the lip, then cannot come back through
+    // its wall to the landing. Only after that grid fails, search the mantle-
+    // probe side of the lip: clear the ladder laterally while compressed,
+    // retreat by at most one active-profile radius from the sampled wall, and
+    // require the authored mantle floor, full-profile fit, all-collider
+    // restoration, and supported egress away from the ladder. The initial
+    // wall graze must belong to the bounded mantle patch, clear exactly once,
+    // and stay clear through the candidate.
+    let pre_lip_side_landing = (recovery_landing.is_none() && forward_landing.is_none())
+        .then(|| {
+            mantle_floor.and_then(|mantle_floor| {
+                find_pre_lip_side_landing(
+                    validation_queries,
+                    probe_queries,
+                    probe_cross_end,
+                    direction,
+                    lateral,
+                    &compressed,
+                    &standing,
+                    compressed_radius,
+                    lateral_steps,
+                    standing_floor_offset,
+                    mantle_floor,
+                    lip_patch.as_ref(),
+                )
+            })
+        })
+        .flatten();
     // Prefer the held-direction result unless it needs more lateral steering
     // than the straight approach-side route. This preserves ordinary forward
     // top-outs and uses the recessed-floor alternative only when it avoids a
     // wider sideways recovery.
     let selected_landing = if let Some(recovery) = recovery_landing {
-        Some((recovery, false, true))
+        Some((recovery, false, true, false))
     } else {
-        match (forward_landing, approach_with_egress) {
-            (Some(forward), Some(approach)) => {
+        match (forward_landing, pre_lip_side_landing, approach_with_egress) {
+            (Some(forward), _, Some(approach)) => {
                 let lateral_distance = |landing: &(Vector<Real>, Vector<Real>, Vector<Real>)| {
                     (landing.1 - lip_clear).dot(&lateral).abs()
                 };
@@ -2569,18 +2679,23 @@ fn plan_climb_top_out(
                 if forward_lateral + 1.0e-5 >= CLIMB_TOP_OUT_LARGE_LATERAL_DOGLEG
                     && lateral_distance(&approach) + 1.0e-5 < forward_lateral
                 {
-                    Some((approach, true, false))
+                    Some((approach, true, false, false))
                 } else {
-                    Some((forward, false, false))
+                    Some((forward, false, false, false))
                 }
             }
-            (Some(forward), None) => Some((forward, false, false)),
-            (None, Some(approach)) => Some((approach, true, false)),
-            (None, None) => None,
+            (Some(forward), _, None) => Some((forward, false, false, false)),
+            (None, Some(pre_lip), _) => Some((pre_lip, false, false, true)),
+            (None, None, Some(approach)) => Some((approach, true, false, false)),
+            (None, None, None) => None,
         }
     };
-    let Some(((landing_route, final_sphere, final_standing), approach_side, recovery_side)) =
-        selected_landing
+    let Some((
+        (landing_route, final_sphere, final_standing),
+        approach_side,
+        recovery_side,
+        pre_lip_side,
+    )) = selected_landing
     else {
         reject_top_out!("landing");
     };
@@ -2606,6 +2721,17 @@ fn plan_climb_top_out(
             head,
             head,
             head,
+            landing_route,
+            final_sphere,
+            final_standing,
+        ]
+    } else if pre_lip_side {
+        [
+            head,
+            rise_start,
+            cross_start,
+            probe_cross_end,
+            landing_route,
             landing_route,
             final_sphere,
             final_standing,
@@ -8947,6 +9073,146 @@ mod tests {
         assert!(
             shape_sweep_is_clear(&validation_queries, cross_end, final_sphere, &compressed),
             "the full compressed sphere must have a clear lateral route"
+        );
+    }
+
+    fn pre_lip_side_test_world(block_side_routes: bool) -> PhysicsWorld {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(3.2, 0.05, 3.2)
+                .translation(vector![0.0, -0.05, 0.0])
+                .build(),
+        );
+        let (wall_vertices, wall_indices) = Cuboid::new(vector![0.01, 1.0, 3.2]).to_trimesh();
+        let wall_vertices = wall_vertices
+            .into_iter()
+            .map(|vertex| Point::from(vertex + vector![0.31, 1.0, 0.0]))
+            .collect();
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::trimesh(wall_vertices, wall_indices)
+                .expect("pre-lip WorldRep wall")
+                .build(),
+        );
+        // A live climbable centered on the route forces the compressed body
+        // to move laterally before its crouched profile can be restored.
+        world.add_kinematic(
+            EntityId::from_inner(3).unwrap(),
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.08, 4.0, 0.9),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        if block_side_routes {
+            // These parented blockers begin just outside the initial head
+            // sphere but span both possible side routes. They must remain
+            // solid even though the local WorldRep wall is an attributed lip.
+            for (index, z) in [-1.15, 1.15].into_iter().enumerate() {
+                world.add_kinematic(
+                    EntityId::from_inner(4 + index as u64).unwrap(),
+                    vec3(-0.1, 1.64, z),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.5, 1.0, 1.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            }
+        }
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(6).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        world
+    }
+
+    fn find_crouched_pre_lip_side_test(
+        world: &PhysicsWorld,
+        mantle_floor_y: Real,
+    ) -> Option<(Vector<Real>, Vector<Real>, Vector<Real>)> {
+        let validation_queries = query_pipeline(world, QueryFilter::default());
+        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            !collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        };
+        let probe_queries =
+            validation_queries.with_filter(QueryFilter::default().predicate(&not_climbable));
+        let (wall_handle, _) = probe_queries
+            .cast_ray_and_get_normal(&Ray::new(point![0.0, 1.64, 0.0], Vector::x()), 1.0, true)
+            .expect("local WorldRep wall");
+        let wall = validation_queries.colliders[wall_handle]
+            .shape()
+            .as_trimesh()
+            .expect("wall trimesh");
+        let lip_patch = MantleLipPatch {
+            handle: wall_handle,
+            faces: (0..wall.indices().len() as u32).collect(),
+        };
+        find_pre_lip_side_landing(
+            &validation_queries,
+            &probe_queries,
+            vector![0.0, 1.64, 0.0],
+            Vector::x(),
+            -Vector::z(),
+            &Ball::new(PLAYER_CROUCH_RADIUS / SCALE_FACTOR),
+            &crouched_player_capsule(),
+            PLAYER_CROUCH_RADIUS / SCALE_FACTOR,
+            (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / (PLAYER_CROUCH_RADIUS / SCALE_FACTOR)).ceil()
+                as usize,
+            PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+                + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+                + PLAYER_REST_LIFT / SCALE_FACTOR,
+            vector![0.0, mantle_floor_y, 0.0],
+            Some(&lip_patch),
+        )
+    }
+
+    #[test]
+    fn crouched_top_out_recovers_sideways_before_a_local_lip_wall() {
+        let world = pre_lip_side_test_world(false);
+        let (route, sphere, final_pose) = find_crouched_pre_lip_side_test(&world, 0.0)
+            .expect("the pre-lip deck should permit a supported side recovery");
+        let expected_y = PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+
+        assert!(
+            route.x < 0.0
+                && route.z.abs() >= 2.0 * PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+                && (route - sphere).norm() < 1.0e-5,
+            "the route must retreat before the lip and clear the climbable laterally: {route:?}"
+        );
+        assert!(
+            (final_pose.y - expected_y).abs() < 1.0e-4
+                && final_pose.x < 0.0
+                && final_pose.z.abs() >= 2.0 * PLAYER_CROUCH_RADIUS / SCALE_FACTOR,
+            "the active crouched profile must restore on the selected y=0 deck: {final_pose:?}"
+        );
+    }
+
+    #[test]
+    fn pre_lip_side_recovery_rejects_parented_route_blockers() {
+        let world = pre_lip_side_test_world(true);
+        let landing = find_crouched_pre_lip_side_test(&world, 0.0);
+
+        assert!(
+            landing.is_none(),
+            "parented blockers across both lateral routes must not inherit the WorldRep lip exception: {landing:?}"
+        );
+    }
+
+    #[test]
+    fn pre_lip_side_recovery_rejects_the_wrong_mantle_floor() {
+        let world = pre_lip_side_test_world(false);
+        let landing = find_crouched_pre_lip_side_test(&world, 1.0);
+
+        assert!(
+            landing.is_none(),
+            "a side support at a different height must not replace the sampled mantle floor: {landing:?}"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -7864,7 +7864,13 @@ mod tests {
             // A thin shelf above the player is a genuine upward lip: the
             // upward probe meets its underside after one full compressed
             // radius, while the forward/down probe sees its walkable top.
-            let shelf_vertices = append_cuboid(vector![0.36, 1.1, 0.0], vector![0.38, 0.01, 2.0]);
+            let head_y = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+            let shelf_y = head_y + CLIMB_TOP_OUT_RADIUS + 0.02;
+            let shelf_half_x = CLIMB_TOP_OUT_PROBE_FORWARD / 2.0 + 0.02;
+            let shelf_vertices = append_cuboid(
+                vector![CLIMB_TOP_OUT_PROBE_FORWARD / 2.0, shelf_y, 0.0],
+                vector![shelf_half_x, 0.01, 2.0],
+            );
             if include_wall {
                 // Add a wall whose lower edge exactly reuses the shelf's top
                 // outer edge in the SAME production-style parentless
@@ -8066,6 +8072,9 @@ mod tests {
     #[test]
     fn climb_top_out_finds_a_laterally_offset_supported_landing() {
         let mut world = PhysicsWorld::new();
+        let cross_y = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR
+            + CLIMB_TOP_OUT_UP;
+        let deck_top = cross_y - CLIMB_TOP_OUT_FINAL_DROP + 0.02;
         // Every forward-only candidate is unsupported. The only landing is a
         // narrow deck at the full four-radius lateral bound to the right of
         // the probe endpoint, forcing the candidate budget to reach the edge
@@ -8076,7 +8085,7 @@ mod tests {
             ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
                 .translation(vector![
                     CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
-                    0.45,
+                    deck_top - 0.05,
                     -CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY
                 ])
                 .build(),
@@ -8089,6 +8098,7 @@ mod tests {
         let parented_only = QueryFilter::default()
             .predicate(&|_handle: ColliderHandle, collider: &Collider| collider.parent().is_some());
         let scripted_queries = validation_queries.with_filter(parented_only);
+        let route_forward = 1.0;
         let movement = plan_climb_top_out(
             &KinematicCharacterController::default(),
             &validation_queries,
@@ -8096,7 +8106,7 @@ mod tests {
             &scripted_queries,
             &Isometry::translation(0.0, 0.0, 0.0),
             Vector::x(),
-            1.0,
+            route_forward,
             1.0 / 60.0,
         )
         .expect("the laterally offset deck should permit a top-out");
@@ -8112,20 +8122,20 @@ mod tests {
                     "the selected landing must be within the direct standing-drop bound; route {waypoints:?}"
                 )
             });
-        let expected_standing_y = 0.5
+        let expected_standing_y = deck_top
             + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
             + PLAYER_REST_LIFT / SCALE_FACTOR;
         let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
 
         assert!(
-            (final_sphere.x - CLIMB_TOP_OUT_PROBE_FORWARD).abs() < 1.0e-4
+            (final_sphere.x - route_forward).abs() < 1.0e-4
                 && (final_sphere.z + CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY).abs() < 1.0e-4,
             "the route must select the only laterally offset deck, got {final_sphere:?}"
         );
         assert!(
             support.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL
-                && (support.time_of_impact - (waypoints[5].y - 0.5)).abs() < 1.0e-4,
+                && (support.time_of_impact - (waypoints[5].y - deck_top)).abs() < 1.0e-4,
             "the selected deck support must be independently upward and nearby, got {support:?}"
         );
         assert!(
@@ -8218,8 +8228,8 @@ mod tests {
         // radius in +X clears the ledge before the exact descent.
         world.add_collider(
             EntityId::from_inner(2).unwrap(),
-            ColliderBuilder::cuboid(0.12, 0.05, 2.0)
-                .translation(vector![1.02, 1.65, 0.0])
+            ColliderBuilder::cuboid(0.48, 0.05, 2.0)
+                .translation(vector![1.32, 1.65, 0.0])
                 .build(),
         );
         let mut player =
@@ -8235,10 +8245,14 @@ mod tests {
         let full_advance = cross_end + Vector::x() * CLIMB_TOP_OUT_ADVANCE;
         let queries = query_pipeline(&world, QueryFilter::default());
         let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+        let expected_standing_y = -0.5
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
 
         assert!(
             final_sphere.x >= full_advance.x + CLIMB_TOP_OUT_RADIUS - 1.0e-4
-                && (final_standing.y - 0.504).abs() < 1.0e-4,
+                && (final_standing.y - expected_standing_y).abs() < 1.0e-4,
             "the route must stay high past the ledge before descending to the lower floor; got {waypoints:?}"
         );
         assert!(
@@ -8491,9 +8505,11 @@ mod tests {
     fn climb_top_out_reversal_returns_to_a_current_ladder_grip() {
         let mut world = PhysicsWorld::new();
         let save_pose = vector![0.0, 1.0, 0.0];
+        let ladder_x =
+            standing_player_capsule().radius + 0.04 + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
         world.add_kinematic(
             EntityId::from_inner(1).unwrap(),
-            vec3(0.48, save_pose.y, 0.0),
+            vec3(ladder_x, save_pose.y, 0.0),
             identity_quat(),
             Vector3::new(0.0, 0.0, 0.0),
             vec3(0.08, 2.0, 1.0),

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1050,7 +1050,7 @@ fn plan_climb_top_out(
     let cross_start = vector![rise_start.x, cross_y, rise_start.z];
     let probe_cross_end = vector![probe_ahead.x, cross_y, probe_ahead.z];
     let cross_end = vector![route_ahead.x, cross_y, route_ahead.z];
-    let final_sphere = cross_end + direction * CLIMB_TOP_OUT_ADVANCE;
+    let full_advance = cross_end + direction * CLIMB_TOP_OUT_ADVANCE;
     // Parry treats balls and boxes wholly inside a closed trimesh as
     // intersecting its volume. A tiny non-degenerate capsule uses the same
     // triangle-surface query as the player while remaining point-scale.
@@ -1098,45 +1098,65 @@ fn plan_climb_top_out(
     {
         return None;
     }
-    if mantle_floor.is_none() {
-        let support_ray = Ray::new(Point::from(final_sphere), -Vector::y());
+    let landing_pose = |candidate: Vector<Real>| {
+        let support_ray = Ray::new(Point::from(candidate), -Vector::y());
         let supported = validation_queries
             .cast_ray_and_get_normal(&support_ray, 2.0 * CLIMB_TOP_OUT_MAX_DROP, true)
             .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
         if !supported {
             return None;
         }
-    }
-    let final_down_ray = Ray::new(Point::from(final_sphere), -Vector::y());
-    let final_standing = validation_queries
-        .cast_ray_and_get_normal(&final_down_ray, CLIMB_TOP_OUT_FINAL_DROP, true)
-        .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-        .map(|(_, ground)| {
-            let floor = final_sphere - Vector::y() * ground.time_of_impact;
-            floor
-                + Vector::y()
-                    * (PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
-                        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
-                        + PLAYER_REST_LIFT / SCALE_FACTOR)
-        })
-        // Some ladder tops open over a drop. Expand at a pose validated
-        // against every collider, then let ordinary gravity find the lower
-        // deck.
-        .unwrap_or(final_sphere - Vector::y() * head_offset);
-    if shape_intersects(validation_queries, final_standing, &standing) {
-        return None;
-    }
+        let final_down_ray = Ray::new(Point::from(candidate), -Vector::y());
+        let final_standing = validation_queries
+            .cast_ray_and_get_normal(&final_down_ray, CLIMB_TOP_OUT_FINAL_DROP, true)
+            .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+            .map(|(_, ground)| {
+                let floor = candidate - Vector::y() * ground.time_of_impact;
+                floor
+                    + Vector::y()
+                        * (PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+                            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+                            + PLAYER_REST_LIFT / SCALE_FACTOR)
+            })
+            // The bounded support can be below Dark's short final-drop probe.
+            // Expand at a pose validated against every collider, then let
+            // ordinary gravity settle onto that known landing.
+            .unwrap_or(candidate - Vector::y() * head_offset);
+        (!shape_intersects(validation_queries, final_standing, &standing)).then_some(final_standing)
+    };
+    // Dark advances a body diameter after probing the mantle floor. On a
+    // narrow landing that full advance can put the capsule over an open shaft
+    // even though the probe itself found the deck. Search the full advance,
+    // geometry-derived exit, and probe endpoint for the nearest standing-safe
+    // landing, widening sideways in one-radius increments within Dark's
+    // four-foot recovery bound. The compressed route still reaches
+    // `cross_end` before moving to the selected landing.
+    let lateral = vector![direction.z, 0.0, -direction.x];
+    let lateral_steps = (CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
     let initial_obstruction_limit =
         (cross_end - probe_cross_end).norm() + CLIMB_TOP_OUT_RECOVERY_RETREAT;
-    if !shape_route_exits_only_initial_obstruction(
-        probe_queries,
-        &[probe_cross_end, cross_end, final_sphere, final_standing],
-        &route_probe,
-        initial_obstruction_limit,
-    ) {
-        return None;
+    let mut selected_landing = None;
+    'search: for step in 0..=lateral_steps {
+        let offset = (step as Real * CLIMB_TOP_OUT_RADIUS).min(CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT);
+        let sides: &[Real] = if step == 0 { &[0.0] } else { &[1.0, -1.0] };
+        for base in [full_advance, cross_end, probe_cross_end] {
+            for side in sides {
+                let candidate = base + lateral * (offset * side);
+                if let Some(final_standing) = landing_pose(candidate)
+                    && shape_route_exits_only_initial_obstruction(
+                        probe_queries,
+                        &[probe_cross_end, cross_end, candidate, final_standing],
+                        &route_probe,
+                        initial_obstruction_limit,
+                    )
+                {
+                    selected_landing = Some((candidate, final_standing));
+                    break 'search;
+                }
+            }
+        }
     }
-
+    let (final_sphere, final_standing) = selected_landing?;
     // Preserve Dark's ordered rise-then-cross states. Scripted casts keep
     // parented entity blockers live but deliberately permit passage through
     // parentless immutable level terrain, the narrow Dark jump-through
@@ -6607,24 +6627,37 @@ mod tests {
     #[test]
     fn climb_top_out_stays_over_the_nearest_supported_landing() {
         let mut world = PhysicsWorld::new();
-        // The mantle probe at x=0.64 sees this narrow deck, but the full
-        // body-diameter advance ends at x=1.28 over an open drop.
+        // The mantle probe at x=0.64 sees this narrow deck, but both the
+        // geometry-derived crossing endpoint at x=1.0 and the full
+        // body-diameter advance at x=1.64 are over an open drop.
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::cuboid(0.5, 0.05, 2.0)
-                .translation(vector![0.6, -0.05, 0.0])
+            ColliderBuilder::cuboid(0.4, 0.05, 2.0)
+                .translation(vector![0.5, -0.05, 0.0])
                 .build(),
         );
         let mut player =
             world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
         world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
 
-        let movement =
-            plan_top_out_from_origin(&world).expect("the nearby deck should permit a top-out");
+        let validation_queries = query_pipeline(&world, QueryFilter::default());
+        let parented_only = QueryFilter::default()
+            .predicate(&|_handle: ColliderHandle, collider: &Collider| collider.parent().is_some());
+        let scripted_queries = validation_queries.with_filter(parented_only);
+        let movement = plan_climb_top_out(
+            &KinematicCharacterController::default(),
+            &validation_queries,
+            &validation_queries,
+            &scripted_queries,
+            &Isometry::translation(0.0, 0.0, 0.0),
+            Vector::x(),
+            1.0,
+            1.0 / 60.0,
+        )
+        .expect("the nearby probe-supported deck should permit a top-out");
         let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
-        let queries = query_pipeline(&world, QueryFilter::default());
         let support_ray = Ray::new(Point::from(final_sphere), -Vector::y());
-        let supported = queries
+        let supported = validation_queries
             .cast_ray_and_get_normal(&support_ray, 2.0 * CLIMB_TOP_OUT_MAX_DROP, true)
             .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -6605,6 +6605,36 @@ mod tests {
     }
 
     #[test]
+    fn climb_top_out_stays_over_the_nearest_supported_landing() {
+        let mut world = PhysicsWorld::new();
+        // The mantle probe at x=0.64 sees this narrow deck, but the full
+        // body-diameter advance ends at x=1.28 over an open drop.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.5, 0.05, 2.0)
+                .translation(vector![0.6, -0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement =
+            plan_top_out_from_origin(&world).expect("the nearby deck should permit a top-out");
+        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let support_ray = Ray::new(Point::from(final_sphere), -Vector::y());
+        let supported = queries
+            .cast_ray_and_get_normal(&support_ray, 2.0 * CLIMB_TOP_OUT_MAX_DROP, true)
+            .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+
+        assert!(
+            supported,
+            "the planned final sphere must stay over the probed deck, got {final_sphere:?}"
+        );
+    }
+
+    #[test]
     fn climb_top_out_reverses_when_a_parented_blocker_appears() {
         let mut world = PhysicsWorld::new();
         let mut player =

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -8246,6 +8246,48 @@ mod tests {
     }
 
     #[test]
+    fn climb_top_out_keeps_a_small_forward_sidestep_over_a_recessed_landing() {
+        let mut world = PhysicsWorld::new();
+        let head_y = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+        let cross_y = head_y + CLIMB_TOP_OUT_UP;
+        let deck_top = cross_y - CLIMB_TOP_OUT_FINAL_DROP + 0.02;
+        // A normal forward landing needs only one compressed-radius sidestep
+        // and has ordinary +X egress.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
+                .translation(vector![
+                    CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
+                    deck_top - 0.05,
+                    -CLIMB_TOP_OUT_RADIUS,
+                ])
+                .build(),
+        );
+        // A lower approach-side floor is also safe, but it should not redirect
+        // an otherwise ordinary small forward sidestep back down the ladder.
+        let recessed_floor_top = -1.0;
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(2.0, 0.05, 0.6)
+                .translation(vector![-2.4, recessed_floor_top - 0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement = plan_top_out_from_origin(&world)
+            .expect("the small-offset forward deck should permit a top-out");
+        let waypoints = movement.top_out.expect("planned top-out").waypoints;
+        let final_sphere = waypoints[6];
+
+        assert!(
+            final_sphere.x > 0.0 && (final_sphere.z + CLIMB_TOP_OUT_RADIUS).abs() < 1.0e-5,
+            "the one-radius forward sidestep must outrank the recessed approach floor: {waypoints:?}"
+        );
+    }
+
+    #[test]
     fn climb_top_out_reaches_the_full_forward_recovery_bound() {
         let mut world = PhysicsWorld::new();
         let route_forward = 1.0;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -272,11 +272,23 @@ const CLIMB_TOP_OUT_ADVANCE: f32 = 2.0 * PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 /// Dark's mantle probe goes 3.5 units up, then seven down.
 const CLIMB_TOP_OUT_UP: f32 = 3.5 / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MAX_DROP: f32 = 7.0 / SCALE_FACTOR;
+const CLIMB_TOP_OUT_DEEP_DROP: f32 = 2.0 * CLIMB_TOP_OUT_MAX_DROP;
 const CLIMB_TOP_OUT_RADIUS: f32 = PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 const CLIMB_TOP_OUT_FINAL_DROP: f32 = 4.0 / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MIN_GROUND_NORMAL: f32 = 0.72;
 const CLIMB_TOP_OUT_RECOVERY_RETREAT: f32 = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT: f32 = 4.0 / SCALE_FACTOR;
+/// Search at most four compressed-player radii farther in the held heading
+/// when an otherwise-supported landing still clips the upper ledge on descent.
+const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
+/// A narrow landing can require clearing the side of a rail after the forward
+/// lip crossing. Keep that safety recovery separate from Dark's backward rise
+/// retreat and bound it to four compressed-player radii.
+const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
+/// Require enough clear, similarly supported standing room after the landing
+/// to take one ordinary stride in the player's held heading. This rejects a
+/// rail-top perch that geometrically fits one stationary capsule.
+const CLIMB_TOP_OUT_EGRESS_DISTANCE: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 
 /// Begin probing only when the highest climbable in the current ladder column
 /// is within Dark's authored 3.5-foot mantle probe. The expanded column query
@@ -939,6 +951,62 @@ fn shape_route_exits_only_initial_obstruction(
     !obstruction_seen || cleared_after_obstruction
 }
 
+fn supported_standing_pose(
+    queries: &QueryPipeline,
+    probe: Vector<Real>,
+    max_drop: Real,
+    standing_floor_offset: Real,
+) -> Option<(Vector<Real>, Real)> {
+    let support_ray = Ray::new(Point::from(probe), -Vector::y());
+    let (_, ground) = queries
+        .cast_ray_and_get_normal(&support_ray, max_drop, true)
+        .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)?;
+    let floor = probe - Vector::y() * ground.time_of_impact;
+    Some((
+        floor + Vector::y() * standing_floor_offset,
+        ground.time_of_impact,
+    ))
+}
+
+fn has_supported_standing_egress(
+    queries: &QueryPipeline,
+    start: Vector<Real>,
+    direction: Vector<Real>,
+    standing: &Capsule,
+    standing_floor_offset: Real,
+) -> bool {
+    let step_height = PLAYER_STEP_HEIGHT / SCALE_FACTOR;
+    let narrowed = Capsule::new(
+        standing.segment.a,
+        standing.segment.b,
+        standing.radius - PROBE_SKIN / SCALE_FACTOR,
+    );
+    let steps = (CLIMB_TOP_OUT_EGRESS_DISTANCE / CLIMB_TOP_OUT_RECOVERY_RETREAT)
+        .ceil()
+        .max(1.0) as usize;
+    let mut previous = start;
+    for step in 1..=steps {
+        let distance = CLIMB_TOP_OUT_EGRESS_DISTANCE * step as Real / steps as Real;
+        let support_probe = start + direction * distance;
+        let Some((sample_standing, _)) = supported_standing_pose(
+            queries,
+            support_probe,
+            standing_floor_offset + step_height,
+            standing_floor_offset,
+        ) else {
+            return false;
+        };
+        if (sample_standing.y - start.y).abs() > step_height
+            || shape_intersects(queries, sample_standing, &narrowed)
+            || !shape_sweep_is_clear(queries, previous, sample_standing, &narrowed)
+        {
+            return false;
+        }
+        previous = sample_standing;
+    }
+    !shape_intersects(queries, previous, standing)
+}
+
 fn climb_top_out_recovery_start(
     queries: &QueryPipeline,
     head: Vector<Real>,
@@ -1098,65 +1166,154 @@ fn plan_climb_top_out(
     {
         return None;
     }
+    let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + PLAYER_REST_LIFT / SCALE_FACTOR;
+    #[derive(Clone, Copy)]
+    struct SupportedLanding {
+        sphere: Vector<Real>,
+        standing: Vector<Real>,
+        direct: bool,
+    }
     let landing_pose = |candidate: Vector<Real>| {
-        let support_ray = Ray::new(Point::from(candidate), -Vector::y());
-        let supported = validation_queries
-            .cast_ray_and_get_normal(&support_ray, 2.0 * CLIMB_TOP_OUT_MAX_DROP, true)
-            .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
-        if !supported {
-            return None;
-        }
-        let final_down_ray = Ray::new(Point::from(candidate), -Vector::y());
-        let final_standing = validation_queries
-            .cast_ray_and_get_normal(&final_down_ray, CLIMB_TOP_OUT_FINAL_DROP, true)
-            .filter(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-            .map(|(_, ground)| {
-                let floor = candidate - Vector::y() * ground.time_of_impact;
-                floor
-                    + Vector::y()
-                        * (PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
-                            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
-                            + PLAYER_REST_LIFT / SCALE_FACTOR)
-            })
-            // The bounded support can be below Dark's short final-drop probe.
-            // Expand at a pose validated against every collider, then let
-            // ordinary gravity settle onto that known landing.
-            .unwrap_or(candidate - Vector::y() * head_offset);
-        (!shape_intersects(validation_queries, final_standing, &standing)).then_some(final_standing)
+        let (supported_standing, support_drop) = supported_standing_pose(
+            validation_queries,
+            candidate,
+            CLIMB_TOP_OUT_DEEP_DROP,
+            standing_floor_offset,
+        )?;
+        (!shape_intersects(validation_queries, supported_standing, &standing)).then_some(
+            SupportedLanding {
+                sphere: candidate,
+                standing: supported_standing,
+                direct: support_drop <= CLIMB_TOP_OUT_FINAL_DROP,
+            },
+        )
     };
     // Dark advances a body diameter after probing the mantle floor. On a
     // narrow landing that full advance can put the capsule over an open shaft
     // even though the probe itself found the deck. Search the full advance,
     // geometry-derived exit, and probe endpoint for the nearest standing-safe
-    // landing, widening sideways in one-radius increments within Dark's
-    // four-foot recovery bound. The compressed route still reaches
-    // `cross_end` before moving to the selected landing.
+    // landing. Each ordered base can recover forward past an overhang, while a
+    // separate one-radius-step lateral search can clear a narrow rail. Both
+    // searches have four-radius safety bounds. The compressed route still
+    // reaches `cross_end` before moving to the selected landing.
     let lateral = vector![direction.z, 0.0, -direction.x];
-    let lateral_steps = (CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
-    let initial_obstruction_limit =
-        (cross_end - probe_cross_end).norm() + CLIMB_TOP_OUT_RECOVERY_RETREAT;
-    let mut selected_landing = None;
-    'search: for step in 0..=lateral_steps {
-        let offset = (step as Real * CLIMB_TOP_OUT_RADIUS).min(CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT);
+    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    let point_high_obstruction_limit =
+        (cross_end - probe_cross_end).norm() + CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY;
+    let mut candidate_bases = Vec::new();
+    for step in 0..=lateral_steps {
+        let offset = step as Real * CLIMB_TOP_OUT_RADIUS;
         let sides: &[Real] = if step == 0 { &[0.0] } else { &[1.0, -1.0] };
         for base in [full_advance, cross_end, probe_cross_end] {
             for side in sides {
-                let candidate = base + lateral * (offset * side);
-                if let Some(final_standing) = landing_pose(candidate)
-                    && shape_route_exits_only_initial_obstruction(
-                        probe_queries,
-                        &[probe_cross_end, cross_end, candidate, final_standing],
-                        &route_probe,
-                        initial_obstruction_limit,
-                    )
-                {
-                    selected_landing = Some((candidate, final_standing));
-                    break 'search;
-                }
+                candidate_bases.push(base + lateral * (offset * side));
             }
         }
     }
-    let (final_sphere, final_standing) = selected_landing?;
+    let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    let compressed_lip_allowance = if shape_intersects(probe_queries, cross_end, &compressed) {
+        CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY
+    } else {
+        0.0
+    };
+    let validated_landing = |landing: SupportedLanding| {
+        // Keep parented blockers live throughout the scripted route. For
+        // immutable terrain, sample both the point-scale Dark corridor and the
+        // full ball only along the high horizontal leg. Each may leave the one
+        // bounded merged lip but must be clear by the shifted candidate and
+        // may never re-enter a later rail or wall. Validate both descents as
+        // separate zero-exception casts: Parry reports stationary balls wholly
+        // inside a closed level trimesh as intersecting its volume even in
+        // empty rooms, while shape casts still correctly test triangle
+        // crossings along the descent.
+        (shape_sweep_is_clear(scripted_queries, cross_end, landing.sphere, &compressed)
+            && shape_sweep_is_clear(
+                scripted_queries,
+                landing.sphere,
+                landing.standing,
+                &compressed,
+            )
+            && !shape_intersects(scripted_queries, landing.sphere, &compressed)
+            && !shape_intersects(scripted_queries, landing.standing, &compressed)
+            && shape_route_exits_only_initial_obstruction(
+                probe_queries,
+                &[probe_cross_end, cross_end, landing.sphere],
+                &route_probe,
+                point_high_obstruction_limit,
+            )
+            && shape_sweep_is_clear(
+                probe_queries,
+                landing.sphere,
+                landing.standing,
+                &route_probe,
+            )
+            && shape_route_exits_only_initial_obstruction(
+                probe_queries,
+                &[cross_end, landing.sphere],
+                &compressed,
+                compressed_lip_allowance,
+            )
+            && shape_sweep_is_clear(probe_queries, landing.sphere, landing.standing, &compressed))
+        .then_some((landing.sphere, landing.standing))
+    };
+    // Preserve cheap forward-first candidate order and validate each route at
+    // most once. A supported egress is a preference: direct then bounded-deep.
+    // If neither tier has room for the ordinary stride, retain the first exact
+    // supported standing pose as a controlled fallback instead of re-freezing
+    // the ladder. No tier ever restores a midair pose.
+    let mut direct_fallback = None;
+    let mut direct_with_egress = None;
+    let mut deep_candidates = Vec::new();
+    'candidate_search: for base in candidate_bases {
+        for forward_step in 0..=forward_steps {
+            let candidate = base + direction * (forward_step as Real * CLIMB_TOP_OUT_RADIUS);
+            let Some(landing) = landing_pose(candidate) else {
+                continue;
+            };
+            if landing.direct {
+                let Some(validated) = validated_landing(landing) else {
+                    continue;
+                };
+                direct_fallback.get_or_insert(validated);
+                let has_egress = has_supported_standing_egress(
+                    validation_queries,
+                    validated.1,
+                    direction,
+                    &standing,
+                    standing_floor_offset,
+                );
+                if has_egress {
+                    direct_with_egress = Some(validated);
+                    break 'candidate_search;
+                }
+            } else {
+                // Cache the one support cast and defer the expensive terrain
+                // route until the deep-priority pass below.
+                deep_candidates.push(landing);
+            }
+        }
+    }
+    let mut deep_fallback = None;
+    let deep_with_egress = direct_with_egress.is_none().then(|| {
+        deep_candidates.into_iter().find_map(|landing| {
+            let validated = validated_landing(landing)?;
+            deep_fallback.get_or_insert(validated);
+            let has_egress = has_supported_standing_egress(
+                validation_queries,
+                validated.1,
+                direction,
+                &standing,
+                standing_floor_offset,
+            );
+            has_egress.then_some(validated)
+        })
+    });
+    let (final_sphere, final_standing) = direct_with_egress
+        .or(deep_with_egress.flatten())
+        .or(direct_fallback)
+        .or(deep_fallback)?;
     // Preserve Dark's ordered rise-then-cross states. Scripted casts keep
     // parented entity blockers live but deliberately permit passage through
     // parentless immutable level terrain, the narrow Dark jump-through
@@ -6500,6 +6657,52 @@ mod tests {
     }
 
     #[test]
+    fn climb_top_out_point_route_allows_bounded_lip_but_rejects_reentry() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.2, 0.2, 2.0)
+                .translation(vector![0.5, 0.0, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let route = [vector![0.0, 0.0, 0.0], vector![2.0, 0.0, 0.0]];
+        let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+        {
+            let queries = query_pipeline(&world, QueryFilter::default());
+            assert!(
+                shape_route_exits_only_initial_obstruction(
+                    &queries,
+                    &route,
+                    &route_probe,
+                    CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+                ),
+                "the point core may leave one merged lip within the bounded high recovery"
+            );
+        }
+
+        world.add_collider(
+            EntityId::from_inner(3).unwrap(),
+            ColliderBuilder::cuboid(0.05, 0.2, 2.0)
+                .translation(vector![1.4, 0.0, 0.0])
+                .build(),
+        );
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        assert!(
+            !shape_route_exits_only_initial_obstruction(
+                &queries,
+                &route,
+                &route_probe,
+                CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+            ),
+            "a later point obstruction after clearing the merged lip must reject the route"
+        );
+    }
+
+    #[test]
     fn climb_top_out_rejects_an_initial_obstruction_that_outlasts_its_bound() {
         let mut world = PhysicsWorld::new();
         world.add_collider(
@@ -6595,7 +6798,7 @@ mod tests {
     }
 
     #[test]
-    fn climb_top_out_rejects_parentless_terrain_beyond_the_lip_probe() {
+    fn climb_top_out_rejects_parentless_terrain_reentry_beyond_the_lip_probe() {
         let mut world = PhysicsWorld::new();
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
@@ -6603,37 +6806,45 @@ mod tests {
                 .translation(vector![0.0, -0.55, 0.0])
                 .build(),
         );
-        // The Dark point probe ends at x=0.64. This wall sits beyond that
-        // bounded lip region but before the otherwise-clear final standing
-        // pose. A blanket parentless-terrain exemption phases through it.
-        world.add_collider(
-            EntityId::from_inner(2).unwrap(),
-            ColliderBuilder::cuboid(0.05, 2.0, 2.0)
-                .translation(vector![1.0, 1.0, 0.0])
-                .build(),
-        );
+        // The Dark point probe ends at x=0.64. Two separated walls sit beyond
+        // it before the otherwise-clear final standing pose. The bounded high
+        // route may leave the first merged lip, but entering the second wall
+        // after that clearance is a forbidden re-entry.
+        for (index, x) in [1.0, 1.5].into_iter().enumerate() {
+            world.add_collider(
+                EntityId::from_inner(index as u64 + 2).unwrap(),
+                ColliderBuilder::cuboid(0.05, 2.0, 2.0)
+                    .translation(vector![x, 1.0, 0.0])
+                    .build(),
+            );
+        }
         let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(4).unwrap());
         world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
 
         let movement = plan_top_out_from_origin(&world);
 
         assert!(
             movement.is_none(),
-            "the lip exception must not permit crossing unrelated parentless terrain"
+            "the lip exception must not permit re-entry into later parentless terrain"
         );
     }
 
     #[test]
-    fn climb_top_out_stays_over_the_nearest_supported_landing() {
+    fn climb_top_out_finds_a_laterally_offset_supported_landing() {
         let mut world = PhysicsWorld::new();
-        // The mantle probe at x=0.64 sees this narrow deck, but both the
-        // geometry-derived crossing endpoint at x=1.0 and the full
-        // body-diameter advance at x=1.64 are over an open drop.
+        // Every forward-only candidate is unsupported. The only landing is a
+        // narrow deck two compressed-player radii to the right of the probe
+        // endpoint, forcing the lateral recovery branch. It extends far enough
+        // in +X to provide the required supported standing egress.
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::cuboid(0.4, 0.05, 2.0)
-                .translation(vector![0.5, -0.05, 0.0])
+            ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
+                .translation(vector![
+                    CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
+                    0.45,
+                    -0.64
+                ])
                 .build(),
         );
         let mut player =
@@ -6654,16 +6865,225 @@ mod tests {
             1.0,
             1.0 / 60.0,
         )
-        .expect("the nearby probe-supported deck should permit a top-out");
-        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+        .expect("the laterally offset deck should permit a top-out");
+        let waypoints = movement.top_out.expect("planned top-out").waypoints;
+        let cross_end = waypoints[4];
+        let final_sphere = waypoints[5];
+        let final_standing = waypoints[6];
         let support_ray = Ray::new(Point::from(final_sphere), -Vector::y());
-        let supported = validation_queries
-            .cast_ray_and_get_normal(&support_ray, 2.0 * CLIMB_TOP_OUT_MAX_DROP, true)
-            .is_some_and(|(_, ground)| ground.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+        let (_, support) = validation_queries
+            .cast_ray_and_get_normal(&support_ray, CLIMB_TOP_OUT_FINAL_DROP, true)
+            .unwrap_or_else(|| {
+                panic!(
+                    "the selected landing must be within the direct standing-drop bound; route {waypoints:?}"
+                )
+            });
+        let expected_standing_y = 0.5
+            + PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+        let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
 
         assert!(
-            supported,
-            "the planned final sphere must stay over the probed deck, got {final_sphere:?}"
+            (final_sphere.x - CLIMB_TOP_OUT_PROBE_FORWARD).abs() < 1.0e-4
+                && (final_sphere.z + 0.64).abs() < 1.0e-4,
+            "the route must select the only laterally offset deck, got {final_sphere:?}"
+        );
+        assert!(
+            support.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+                && (support.time_of_impact - (waypoints[5].y - 0.5)).abs() < 1.0e-4,
+            "the selected deck support must be independently upward and nearby, got {support:?}"
+        );
+        assert!(
+            (final_standing.y - expected_standing_y).abs() < 1.0e-4,
+            "the planned standing pose must put the capsule feet on the deck, got {final_standing:?}"
+        );
+        assert!(
+            shape_sweep_is_clear(&validation_queries, cross_end, final_sphere, &compressed),
+            "the full compressed sphere must have a clear lateral route"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_prefers_full_advance_on_a_wide_deck() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
+                .translation(vector![0.0, -0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement =
+            plan_top_out_from_origin(&world).expect("the wide deck should permit egress");
+        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+        assert!(
+            (final_sphere.x - (CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_ADVANCE)).abs() < 1.0e-4
+                && final_sphere.z.abs() < 1.0e-4,
+            "the first full-advance candidate should win without lateral recovery, got {final_sphere:?}"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_moves_forward_past_an_upper_ledge_before_descending() {
+        let mut world = PhysicsWorld::new();
+        // A broad lower floor is reachable only after descending from the
+        // mantle height.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
+                .translation(vector![0.0, -0.55, 0.0])
+                .build(),
+        );
+        // The ordinary full-advance center ray is beyond this upper ledge, but
+        // its compressed sphere clips the edge if it descends there. One more
+        // radius in +X clears the ledge before the exact descent.
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(0.12, 0.05, 2.0)
+                .translation(vector![1.02, 1.65, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement = plan_top_out_from_origin(&world)
+            .expect("the lower floor should be reachable past the upper ledge");
+        let waypoints = movement.top_out.expect("planned top-out").waypoints;
+        let cross_end = waypoints[4];
+        let final_sphere = waypoints[5];
+        let final_standing = waypoints[6];
+        let full_advance = cross_end + Vector::x() * CLIMB_TOP_OUT_ADVANCE;
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+
+        assert!(
+            final_sphere.x >= full_advance.x + CLIMB_TOP_OUT_RADIUS - 1.0e-4
+                && (final_standing.y - 0.504).abs() < 1.0e-4,
+            "the route must stay high past the ledge before descending to the lower floor; got {waypoints:?}"
+        );
+        assert!(
+            shape_route_exits_only_initial_obstruction(
+                &queries,
+                &[cross_end, final_sphere],
+                &compressed,
+                0.0,
+            ) && shape_sweep_is_clear(&queries, final_sphere, final_standing, &compressed,),
+            "the full-radius high-horizontal route must remain clear through its descent"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_rejects_a_side_rail_clipped_only_by_the_full_sphere() {
+        let mut world = PhysicsWorld::new();
+        // Only the forward-most candidate has support and egress.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
+                .translation(vector![
+                    CLIMB_TOP_OUT_PROBE_FORWARD
+                        + CLIMB_TOP_OUT_ADVANCE
+                        + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
+                    0.45,
+                    0.0
+                ])
+                .build(),
+        );
+        // Its face stays outside the point-scale centerline probe at z=0, but
+        // clips the 0.32-world-unit compressed player between cross and land.
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(0.05, 0.2, 0.04)
+                .translation(vector![0.95, 2.04, 0.34])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let head_y = (PLAYER_HEIGHT / 2.0 - PLAYER_RADIUS) / SCALE_FACTOR;
+        let cross_y = head_y + CLIMB_TOP_OUT_UP;
+        let cross_end = vector![CLIMB_TOP_OUT_PROBE_FORWARD, cross_y, 0.0];
+        let full_advance = cross_end + Vector::x() * CLIMB_TOP_OUT_ADVANCE;
+        assert!(
+            !shape_sweep_is_clear(
+                &queries,
+                cross_end,
+                full_advance,
+                &Ball::new(CLIMB_TOP_OUT_RADIUS),
+            ),
+            "the production full-ball sweep must hit the side rail"
+        );
+        let movement = plan_top_out_from_origin(&world);
+        assert!(
+            movement.is_none(),
+            "a side rail clipped by the full compressed radius must reject the route"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_supported_egress_rejects_two_caps_separated_by_a_floor_gap() {
+        let mut world = PhysicsWorld::new();
+        for (index, x) in [0.0, CLIMB_TOP_OUT_EGRESS_DISTANCE].into_iter().enumerate() {
+            world.add_collider(
+                EntityId::from_inner(index as u64 + 1).unwrap(),
+                ColliderBuilder::cuboid(0.12, 0.05, 0.4)
+                    .translation(vector![x, -0.05, 0.0])
+                    .build(),
+            );
+        }
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let standing = standing_player_capsule();
+        let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+
+        assert!(
+            !has_supported_standing_egress(
+                &queries,
+                Vector::y() * standing_floor_offset,
+                Vector::x(),
+                &standing,
+                standing_floor_offset,
+            ),
+            "supported endpoints must not hide an unsupported gap along the egress"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_keeps_an_exact_supported_rail_as_last_resort() {
+        let mut world = PhysicsWorld::new();
+        // The first short-drop candidate fits exactly on this rail cap, but a
+        // stride in the held +X heading has no similarly supported standing
+        // pose. It remains a controlled exact-standing fallback.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.12, 0.05, 0.12)
+                .translation(vector![CLIMB_TOP_OUT_PROBE_FORWARD, 0.45, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement = plan_top_out_from_origin(&world)
+            .expect("an exact supported fallback should avoid re-freezing");
+        let final_standing = movement.top_out.expect("planned top-out").waypoints[6];
+        let expected_standing_y = 0.5
+            + PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+        assert!(
+            (final_standing.y - expected_standing_y).abs() < 1.0e-4,
+            "the fallback must restore the exact support-derived standing pose, got {final_standing:?}"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -918,23 +918,6 @@ fn shape_sweep_is_clear(
         .is_none()
 }
 
-fn ray_segment_is_clear(queries: &QueryPipeline, from: Vector<Real>, to: Vector<Real>) -> bool {
-    // The compressed sphere intentionally models Dark's sparse body and may
-    // overlap immutable terrain around the ladder lip. Its centerline still
-    // has to pass every authored point probe unobstructed: this prevents the
-    // exception from becoming permission to cross an unrelated wall.
-    let delta = to - from;
-    let distance = delta.norm();
-    distance <= 1.0e-6
-        || queries
-            .cast_ray(
-                &Ray::new(Point::from(from), delta / distance),
-                distance,
-                true,
-            )
-            .is_none()
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum ShapeObstruction {
     Collider(ColliderHandle),
@@ -7577,7 +7560,6 @@ mod tests {
             Vector::zeros(),
             1.0 / 60.0,
             -0.2,
-            None,
             None,
             Some(ClimbPass {
                 movement: Vector::y() * 0.25,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -120,21 +120,34 @@ fn crouched_player_shared_shape() -> SharedShape {
 /// Gap (SS2 ft) the character controller keeps between the player collider
 /// and world geometry (`KinematicCharacterController::offset`).
 const PLAYER_CONTACT_OFFSET: f32 = 0.1;
+/// Crouching is the authored small-creature profile, including its tighter
+/// clearance through low utility passages. Keep a nonzero target distance for
+/// robust contact resolution, but do not charge the standing margin against
+/// both sides of an opening only the crouched body is intended to cross.
+const PLAYER_CROUCH_CONTACT_OFFSET: f32 = 0.05;
 
 /// Extra height (SS2 ft) the player is lifted each grounded frame, keeping the
-/// resting gap a hair above `PLAYER_CONTACT_OFFSET`. Load-bearing: movement
-/// casts use `PLAYER_CONTACT_OFFSET` as their target distance, so a capsule
-/// resting at exactly that gap starts every cast already "in contact" with
-/// its own floor. On a yaw-ROTATED support (e.g. the earth.mis tram floor
-/// slab) the rotated top-face normal carries ~1e-6 float error, which makes
-/// even purely tangential walking read as "approaching" - every solver
-/// iteration then re-hits the same contact at toi=0, applies zero
-/// translation, and the player freezes in place. (Axis-aligned floors yield
-/// an exact (0,1,0) normal, where tangential motion reports no hit - which is
-/// why flat test floors work without this.) The next frame's gravity pass
-/// consumes the lift again, so the rest height is stable. Regression-tested
-/// by `player_walks_on_rotated_platform`.
+/// resting gap a hair above the active posture-specific contact offset.
+/// Load-bearing: movement casts use that target distance, so a capsule resting
+/// at exactly that gap starts every cast already "in contact" with its own
+/// floor. On a yaw-ROTATED support (e.g. the earth.mis tram floor slab) the
+/// rotated top-face normal carries ~1e-6 float error, which makes even purely
+/// tangential walking read as "approaching" - every solver iteration then
+/// re-hits the same contact at toi=0, applies zero translation, and the player
+/// freezes in place. (Axis-aligned floors yield an exact (0,1,0) normal, where
+/// tangential motion reports no hit - which is why flat test floors work
+/// without this.) The next frame's gravity pass consumes the lift again, so
+/// the rest height is stable. Regression-tested by
+/// `player_walks_on_rotated_platform`.
 const PLAYER_REST_LIFT: f32 = 0.01;
+
+fn player_contact_offset(is_crouched: bool) -> f32 {
+    if is_crouched {
+        PLAYER_CROUCH_CONTACT_OFFSET
+    } else {
+        PLAYER_CONTACT_OFFSET
+    }
+}
 
 /// Half-life for gravity-induced horizontal displacement after a slope hands
 /// the player onto walkable flat ground. Dark's dynamic player coasts through
@@ -1802,7 +1815,7 @@ fn player_pose_matches_current_support(
         PLAYER_STANDING_HEIGHT
     };
     let floor_offset = body_height / 2.0 / SCALE_FACTOR
-        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + player_contact_offset(is_crouched) / SCALE_FACTOR
         + PLAYER_REST_LIFT / SCALE_FACTOR;
     // The waypoint loop intentionally stops within arrival epsilon. Allow the
     // same residual plus one probe skin for floating-point/contact seams while
@@ -5165,6 +5178,8 @@ impl PhysicsWorld {
 
         if want_crouch {
             self.collider_set[collider_handle].set_shape(crouched_player_shared_shape());
+            player_handle.controller.offset =
+                CharacterLength::Absolute(PLAYER_CROUCH_CONTACT_OFFSET / SCALE_FACTOR);
             let body = &mut self.rigid_body_set[character_handle];
             let mut translation = *body.translation();
             translation.y -= center_shift;
@@ -5249,6 +5264,8 @@ impl PhysicsWorld {
 
             if !blocked {
                 self.collider_set[collider_handle].set_shape(standing_player_shared_shape());
+                player_handle.controller.offset =
+                    CharacterLength::Absolute(PLAYER_CONTACT_OFFSET / SCALE_FACTOR);
                 let body = &mut self.rigid_body_set[character_handle];
                 let mut translation = *body.translation();
                 translation.y += center_shift;
@@ -7518,6 +7535,17 @@ mod tests {
         );
     }
 
+    fn assert_player_contact_offset(player: &PlayerHandle, expected_ss2_feet: f32) {
+        let CharacterLength::Absolute(offset) = player.controller.offset else {
+            panic!("player controller offset must remain absolute");
+        };
+        assert!(
+            (offset * SCALE_FACTOR - expected_ss2_feet).abs() < 1.0e-6,
+            "expected a {expected_ss2_feet}-foot controller offset, got {}",
+            offset * SCALE_FACTOR
+        );
+    }
+
     /// Standing restores Dark's original 6 x 2.4-foot body, while crouch and
     /// direct relocation retain the 2.8 x 1.6-foot profile added in #513.
     #[test]
@@ -7526,6 +7554,7 @@ mod tests {
         let mut player = world.create_player(vec3(0.0, 0.0, 0.0), EntityId::from_inner(1).unwrap());
 
         assert_player_capsule_dimensions(&world, &player, 6.0, 2.4);
+        assert_player_contact_offset(&player, PLAYER_CONTACT_OFFSET);
         assert!(
             (player_crouch_center_shift() - 0.64).abs() < 1.0e-6,
             "save/load normalization must use the new feet-planted center shift"
@@ -7533,6 +7562,7 @@ mod tests {
 
         assert!(world.set_player_crouch(true, &mut player));
         assert_player_capsule_dimensions(&world, &player, 2.8, 1.6);
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
         world.set_player_translation(vec3(1.0, 2.0, 3.0), &mut player);
         assert_player_capsule_dimensions(&world, &player, 2.8, 1.6);
 
@@ -7541,6 +7571,7 @@ mod tests {
         step(&mut world, &mut player, 1);
         assert!(!world.set_player_crouch(false, &mut player));
         assert_player_capsule_dimensions(&world, &player, 6.0, 2.4);
+        assert_player_contact_offset(&player, PLAYER_CONTACT_OFFSET);
     }
 
     /// The scene-wide query pipeline the climb/top-out helpers take.
@@ -11647,6 +11678,129 @@ mod tests {
         );
     }
 
+    fn world_with_parentless_wall_and_parented_gap(gap: f32) -> PhysicsWorld {
+        let mut world = PhysicsWorld::new();
+        let half_gap = gap / 2.0;
+        world.add_collider(
+            EntityId::from_inner(1000).unwrap(),
+            ColliderBuilder::cuboid(4.0, 2.0, 0.1)
+                .translation(vector![-2.0, 2.0, half_gap + 0.1])
+                .build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(-2.0, 2.0, -half_gap - 0.1),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 4.0, 0.2),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.add_collider(
+            EntityId::from_inner(1002).unwrap(),
+            ColliderBuilder::cuboid(5.0, 0.1, 5.0)
+                .translation(vector![0.0, -0.1, 0.0])
+                .build(),
+        );
+        world
+    }
+
+    fn walk_west_through_gap(gap: f32, crouched: bool) -> (Vector3<f32>, Vector3<f32>) {
+        let mut world = world_with_parentless_wall_and_parented_gap(gap);
+
+        let mut player = world.create_player(
+            vec3(0.15, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        if crouched {
+            assert!(world.set_player_crouch(true, &mut player));
+        }
+        step(&mut world, &mut player, 30);
+        let start = world.get_player_translation(&player);
+        for _ in 0..90 {
+            world.update(vec3(-0.05, 0.0, 0.0), &mut player);
+        }
+        let end = world.get_player_translation(&player);
+        (start, end)
+    }
+
+    /// Rick1's upper-deck portal leaves an authored 1.72-SS2-foot passage
+    /// between a WorldRep wall and the square end of a live pipe. The
+    /// 1.6-foot crouched body fits, but charging the standing 0.1-foot
+    /// controller margin on both sides makes its effective width 1.8 feet and
+    /// pins it at the pipe corner. Crouched locomotion must retain both solid
+    /// colliders while fitting through the real opening.
+    #[test]
+    fn crouched_player_crosses_a_tight_world_and_parented_collider_gap() {
+        let gap = 1.72 / SCALE_FACTOR;
+        let (start, end) = walk_west_through_gap(gap, true);
+        assert!(
+            end.x < -1.0,
+            "the 1.6-foot crouched body should cross the 1.72-foot opening without ignoring either collider, moved {start:?} -> {end:?}"
+        );
+        assert!(
+            end.z.abs() + PLAYER_CROUCH_RADIUS / SCALE_FACTOR < gap / 2.0 + 1.0e-3,
+            "the player must stay inside the authored gap, not escape around a collider: {end:?}"
+        );
+    }
+
+    #[test]
+    fn tight_gap_still_rejects_standing_and_subdiameter_profiles() {
+        let (_, standing) = walk_west_through_gap(1.72 / SCALE_FACTOR, false);
+        assert!(
+            standing.x > -0.2,
+            "the 2.4-foot standing body must remain blocked by the 1.72-foot gap: {standing:?}"
+        );
+
+        let (_, too_narrow) = walk_west_through_gap(1.55 / SCALE_FACTOR, true);
+        assert!(
+            too_narrow.x > -0.2,
+            "a gap narrower than the 1.6-foot crouched body must remain blocked: {too_narrow:?}"
+        );
+    }
+
+    #[test]
+    fn crouch_offset_does_not_cross_real_world_or_parented_walls() {
+        for parented in [false, true] {
+            let mut world = world_with_parentless_wall_and_parented_gap(1.72 / SCALE_FACTOR);
+            let wall = ColliderBuilder::cuboid(0.1, 2.0, 1.0)
+                .translation(vector![-0.4, 2.0, 0.0])
+                .build();
+            if parented {
+                world.add_kinematic(
+                    EntityId::from_inner(1003).unwrap(),
+                    vec3(-0.4, 2.0, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.2, 4.0, 2.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            } else {
+                world.add_collider(EntityId::from_inner(1003).unwrap(), wall);
+            }
+            let mut player = world.create_player(
+                vec3(0.15, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+                EntityId::from_inner(2000).unwrap(),
+            );
+            assert!(world.set_player_crouch(true, &mut player));
+            step(&mut world, &mut player, 30);
+            for _ in 0..90 {
+                world.update(vec3(-0.05, 0.0, 0.0), &mut player);
+            }
+            let end = world.get_player_translation(&player);
+            assert!(
+                end.x > -0.25,
+                "the crouched margin must not cross a {} wall: {end:?}",
+                if parented {
+                    "parented"
+                } else {
+                    "parentless world"
+                }
+            );
+        }
+    }
+
     /// Build a floor whose top face is flush with the bottom of a walk-in
     /// fixture's model-bounds box - hydro2's Resurrection Station casing sits
     /// on the alcove floor exactly like this - and return the world plus the
@@ -12602,6 +12756,8 @@ mod tests {
             crouched_world.set_player_crouch(false, &mut crouched_player),
             "standing must be refused under the five-foot ceiling"
         );
+        assert_player_capsule_dimensions(&crouched_world, &crouched_player, 2.8, 1.6);
+        assert_player_contact_offset(&crouched_player, PLAYER_CROUCH_CONTACT_OFFSET);
     }
 
     /// A crawlspace whose 3.875 ft clearance admits the 2.8 ft crouched body
@@ -12609,7 +12765,10 @@ mod tests {
     /// collider centre a save file stores (`GlobalData::position`).
     fn world_with_low_ceiling_crawlspace() -> (PhysicsWorld, PlayerHandle) {
         let mut world = PhysicsWorld::new();
-        for (entity, y) in [(1000u64, 0.0), (1001, 1.55)] {
+        for (entity, y, triangles) in [
+            (1000u64, 0.0, vec![[0u32, 2, 1], [0, 3, 2]]),
+            (1001, 1.55, vec![[0u32, 1, 2], [0, 2, 3]]),
+        ] {
             world.add_collider(
                 EntityId::from_inner(entity).unwrap(),
                 ColliderBuilder::trimesh(
@@ -12619,7 +12778,7 @@ mod tests {
                         point![50.0, y, 50.0],
                         point![-50.0, y, 50.0],
                     ],
-                    vec![[0u32, 1, 2], [0, 2, 3]],
+                    triangles,
                 )
                 .expect("crawlspace trimesh")
                 .build(),
@@ -12659,6 +12818,7 @@ mod tests {
             world.set_player_crouch(false, &mut player),
             "standing must stay refused before the world can answer a query"
         );
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
 
         // ...and the player is still free to crawl back out.
         step(&mut world, &mut player, 10);
@@ -12675,6 +12835,7 @@ mod tests {
             player.is_crouched(),
             "the ceiling must still refuse standing once the world is queryable"
         );
+        assert_player_contact_offset(&player, PLAYER_CROUCH_CONTACT_OFFSET);
     }
 
     /// The same first-frame load against the real hydro2 geometry and the exact

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -278,15 +278,15 @@ const CLIMB_TOP_OUT_MIN_GROUND_NORMAL: f32 = 0.72;
 const CLIMB_TOP_OUT_RECOVERY_RETREAT: f32 = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT: f32 = 4.0 / SCALE_FACTOR;
 
-/// Begin probing only near the highest climbable in the current ladder column.
-/// The expanded column query sees the next segment in stacked ladders, avoiding
-/// a false "top" at every rung seam. Include one scripted substep and the
-/// controller gap: rick1's vertical cast stops with the capsule crown just over
-/// one half-height below the authored top, before the nominal crown-only
-/// threshold can ever become true.
-const CLIMB_TOP_OUT_TOP_REACH: f32 = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
-    + CLIMB_TOP_OUT_SUBSTEP
-    + PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
+/// Begin probing only when the highest climbable in the current ladder column
+/// is within Dark's authored 3.5-foot mantle probe. The expanded column query
+/// sees the next segment in stacked ladders, avoiding a false "top" at every
+/// rung seam. Use the full probe reach here: nearby level geometry can stop the
+/// standing capsule before its crown gets within one body half-height of the
+/// authored ladder top (rick1's diagonal approach stops 3.1 feet below it).
+/// Gating at the shorter body-derived distance leaves the climb redirect active
+/// but permanently blocked before top-out planning is ever attempted.
+const CLIMB_TOP_OUT_TOP_REACH: f32 = CLIMB_TOP_OUT_UP;
 const CLIMB_TOP_OUT_COLUMN_LOOKAHEAD: f32 =
     CLIMB_TOP_OUT_UP + PLAYER_STANDING_HEIGHT / SCALE_FACTOR;
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -190,6 +190,12 @@ const PLAYER_STEP_HEIGHT: f32 = 2.0;
 const PLAYER_JUMP_SPEED: f32 = 28.0;
 const PLAYER_JUMP_GRAVITY: f32 = 40.0;
 const PLAYER_MAX_FALL_SPEED: f32 = 30.0;
+/// Dark's `BreakClimb` adds a short facing impulse to the ordinary jump that
+/// released the climb. Keep these in authored SS2 feet/second like the jump
+/// constants above; player velocity is converted to world units at launch.
+const CLIMB_JUMP_FORWARD_SPEED: f32 = 10.0;
+const CLIMB_JUMP_VERTICAL_BONUS: f32 = 0.5;
+const CLIMB_JUMP_REBOUND_SPEED: f32 = 5.0;
 /// Maximum forward search for a jump-through landing. This is deliberately a
 /// short body-scale transition, not a general wall bypass.
 const PLAYER_JUMP_MANTLE_FORWARD: f32 = 8.0;
@@ -307,12 +313,6 @@ const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 /// needed when the compressed route fits beside a wall but the standing
 /// capsule must clear that wall before expanding.
 const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 5.0 * CLIMB_TOP_OUT_RADIUS;
-/// A fixed mantle sample may land on a lower pipe or shelf while the player's
-/// head is already touching the underside of the actual deck. Only in that
-/// separate-ceiling case, sample the same bounded lateral offsets used by the
-/// landing search for a floor face locally connected to that exact underside.
-/// Crouching is the largest grid: eight radius steps on either side.
-const CLIMB_TOP_OUT_MAX_LATERAL_MANTLE_CANDIDATES: usize = 8 * 2;
 /// Only redirect a valid forward landing onto a recessed approach-side floor
 /// when the forward route needs at least a full compressed-body-width dogleg.
 /// A one-radius sidestep is ordinary ledge recovery and must keep the player's
@@ -417,6 +417,14 @@ fn climb_top_out_direction(desired: Vector<Real>, facing: Vector<Real>) -> Optio
     let desired = vector![desired.x, 0.0, desired.z].try_normalize(1.0e-6)?;
     let facing = vector![facing.x, 0.0, facing.z].try_normalize(1.0e-6)?;
     (desired.dot(&facing) >= MIN_CLIMB_GRIP_FRACTION).then_some(facing)
+}
+
+/// Dark's object-ladder BreakClimb gate compares the player's projected body
+/// center with the gripped OBB's own top, using a strict one-foot radius. This
+/// is intentionally separate from the mantle planner's much broader head
+/// lookahead across a stacked ladder column.
+fn break_climb_near_top(climbable_top: Real, player_center: Real) -> bool {
+    (climbable_top - player_center).abs() < 1.0 / SCALE_FACTOR
 }
 
 /// How much (SS2 ft) the step probe's clearance sweeps shrink the player
@@ -675,11 +683,48 @@ fn try_step_up(
 struct ClimbPass<'a> {
     movement: Vector<Real>,
     top_out: Option<(Vector<Real>, Real)>,
+    retained: RetainedClimb,
     allow_top_out_attempt: bool,
     is_crouched: bool,
     validation_queries: QueryPipeline<'a>,
     probe_queries: QueryPipeline<'a>,
     scripted_queries: QueryPipeline<'a>,
+}
+
+/// Climb contact sampled by the preceding movement frame. Dark evaluates a
+/// jump against the climb it was already holding before the newly turned
+/// player-facing is used for another grip query; that ordering is what lets a
+/// player turn away and jump off a ladder atomically.
+#[derive(Clone, Copy, Debug)]
+struct RetainedClimb {
+    toward_ladder: Vector<Real>,
+    climbable_top: Real,
+}
+
+/// Source-compatible facing impulse for an explicit jump from a retained
+/// climb, in authored SS2 feet/second. The caller adds the ordinary vertical
+/// jump shared with grounded movement and converts both components to world
+/// units.
+fn climb_jump_release(
+    retained: RetainedClimb,
+    facing: Vector<Real>,
+    player_center: Real,
+) -> Option<(Vector<Real>, Real)> {
+    let facing = vector![facing.x, 0.0, facing.z].try_normalize(1.0e-6)?;
+    if break_climb_near_top(retained.climbable_top, player_center) {
+        return Some((facing * CLIMB_JUMP_FORWARD_SPEED, CLIMB_JUMP_VERTICAL_BONUS));
+    }
+
+    // Away from the top, BreakClimb rebounds from the contacted face. Facing
+    // away keeps the full five-foot impulse; facing into it reflects and
+    // halves that direction before applying the same scale.
+    let away = -retained.toward_ladder;
+    let jump_direction = if facing.dot(&away) > 0.0 {
+        facing
+    } else {
+        (facing - away * (2.0 * facing.dot(&away))) * 0.5
+    };
+    Some((jump_direction * CLIMB_JUMP_REBOUND_SPEED, 0.0))
 }
 
 #[derive(Clone, Copy)]
@@ -697,6 +742,9 @@ struct ClimbTopOut {
 struct PlayerMovement {
     movement: EffectiveCharacterMovement,
     top_out: Option<ClimbTopOut>,
+    /// A grip this exact movement frame proved by vertical progress, or by an
+    /// intentional near-top cap stall that kept compatible ladder contact.
+    retained_climb: Option<RetainedClimb>,
     /// Horizontal part of a gravity-induced slope slide, carried into the
     /// next gravity pass so a seam does not erase the player's momentum.
     slope_displacement: Vector<Real>,
@@ -1534,80 +1582,6 @@ fn mantle_lip_patch(
     Some(MantleLipPatch { handle, faces })
 }
 
-/// Find a laterally offset mantle floor belonging to the exact local terrain
-/// slab currently obstructing the player's rise.
-///
-/// WorldRep is one mission-wide trimesh, so a shared collider handle and equal
-/// height are not proof of one surface. The downward floor sample must be
-/// connected to the canonical upward-hit face inside the same bounded probe
-/// corridor. This permits a ladder to exit beside a lower pipe without
-/// authorizing a disconnected ceiling or another island in WorldRep.
-fn lateral_same_slab_mantle_hit(
-    queries: &QueryPipeline,
-    up_hit: Option<(ColliderHandle, RayIntersection)>,
-    head: Vector<Real>,
-    probe_ahead: Vector<Real>,
-    lateral: Vector<Real>,
-    compressed_radius: Real,
-    lateral_steps: usize,
-) -> Option<(Vector<Real>, ColliderHandle, RayIntersection)> {
-    let (up_handle, up) = up_hit?;
-    let FeatureId::Face(up_face) = up.feature else {
-        return None;
-    };
-    if up.normal.y >= -CLIMB_TOP_OUT_MIN_GROUND_NORMAL {
-        return None;
-    }
-    let collider = queries.colliders.get(up_handle)?;
-    let mesh = collider.shape().as_trimesh()?;
-    let face_count = mesh.indices().len() as u32;
-    if face_count == 0 {
-        return None;
-    }
-    let canonical_up_face = up_face % face_count;
-    let underside = head + Vector::y() * up.time_of_impact;
-    let mut evaluated = 0;
-    for lateral_step in 1..=lateral_steps {
-        for side in [1.0, -1.0] {
-            if evaluated == CLIMB_TOP_OUT_MAX_LATERAL_MANTLE_CANDIDATES {
-                return None;
-            }
-            evaluated += 1;
-            let origin = probe_ahead + lateral * (side * lateral_step as Real * compressed_radius);
-            let Some((floor_handle, floor)) = queries
-                .cast_ray_and_get_normal(
-                    &Ray::new(Point::from(origin), -Vector::y()),
-                    CLIMB_TOP_OUT_MAX_DROP,
-                    true,
-                )
-                .filter(|(_, floor)| floor.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-            else {
-                continue;
-            };
-            let floor_point = origin - Vector::y() * floor.time_of_impact;
-            if floor_handle != up_handle
-                || floor_point.y + 1.0e-4 < underside.y
-                || floor_point.y - underside.y > CLIMB_TOP_OUT_MAX_LOCAL_SLAB_THICKNESS + 1.0e-4
-            {
-                continue;
-            }
-            let floor_patch = mantle_lip_patch(
-                queries,
-                Some((floor_handle, floor.feature)),
-                floor_point,
-                &[underside, floor_point],
-                false,
-            );
-            if floor_patch.is_some_and(|patch| {
-                patch.handle == up_handle && patch.faces.contains(&canonical_up_face)
-            }) {
-                return Some((origin, floor_handle, floor));
-            }
-        }
-    }
-    None
-}
-
 /// Extend a floor-seeded mantle patch with only the underside faces crossed by
 /// the actual recovered rise.
 ///
@@ -2068,8 +2042,6 @@ fn plan_climb_top_out(
         )
     };
     let compressed_radius = body_radius / SCALE_FACTOR;
-    let lateral = vector![direction.z, 0.0, -direction.x];
-    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / compressed_radius).ceil() as usize;
     let head_offset = (body_height / 2.0 - body_radius) / SCALE_FACTOR;
     let head = pos.translation.vector + Vector::y() * head_offset;
     let raised = head + Vector::y() * CLIMB_TOP_OUT_UP;
@@ -2154,7 +2126,7 @@ fn plan_climb_top_out(
         .is_none()
         .then(|| mantle_probe(route_ahead))
         .flatten();
-    let route_same_mantle_slab = match (up_hit, route_mantle_hit) {
+    let same_mantle_slab = match (up_hit, route_mantle_hit) {
         (Some((up_handle, up)), Some((origin, floor_handle, floor)))
             if up_handle == floor_handle
                 && (origin - probe_ahead).norm() > CLIMB_TOP_OUT_RECOVERY_RETREAT =>
@@ -2168,44 +2140,26 @@ fn plan_climb_top_out(
         }
         _ => false,
     };
-    let initial_mantle_hit = fixed_mantle_hit.or_else(|| {
-        if route_same_mantle_slab {
+    let mantle_hit = fixed_mantle_hit.or_else(|| {
+        if same_mantle_slab {
             route_mantle_hit
         } else {
             None
         }
     });
-    let initial_mantle_floor = initial_mantle_hit
-        .map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
-    let separate_ceiling = up_obstruction.is_some_and(|(_, obstruction_y)| {
+    let mantle_floor =
+        mantle_hit.map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
+    if up_obstruction.is_some_and(|(_, obstruction_y)| {
         // A lip can have a thin underside above its adjacent landing. Treat
         // surfaces within one compressed radius plus the solver gap on both
         // faces as the same landing edge; a genuinely separate low ceiling
         // remains farther above the probed floor.
-        initial_mantle_floor.is_none_or(|floor| {
+        mantle_floor.is_none_or(|floor| {
             floor.y + compressed_radius + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
                 < obstruction_y
         })
-    });
-    let lateral_mantle_hit = (separate_ceiling && ladder_exit_hit.is_none())
-        .then(|| {
-            lateral_same_slab_mantle_hit(
-                probe_queries,
-                up_hit,
-                head,
-                probe_ahead,
-                lateral,
-                compressed_radius,
-                lateral_steps,
-            )
-        })
-        .flatten();
-    let lateral_mantle_slab = lateral_mantle_hit.is_some();
-    let mantle_hit = lateral_mantle_hit.or(initial_mantle_hit);
-    let same_mantle_slab = route_same_mantle_slab || lateral_mantle_slab;
-    let mantle_floor =
-        mantle_hit.map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
-    if separate_ceiling && lateral_mantle_hit.is_none() && ladder_exit_hit.is_none() {
+    }) && ladder_exit_hit.is_none()
+    {
         reject_top_out!("separate_ceiling");
     }
 
@@ -2538,6 +2492,8 @@ fn plan_climb_top_out(
     // recovery stays within four radii and lateral recovery within five. The
     // compressed route first reaches the geometry-derived `lip_clear` before
     // moving to the selected landing.
+    let lateral = vector![direction.z, 0.0, -direction.x];
+    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / compressed_radius).ceil() as usize;
     let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / compressed_radius).ceil() as usize;
     // Breadth-first by total recovery distance. Within an equal distance,
     // consider lateral recovery first so the fixed candidate budget reaches
@@ -2628,14 +2584,6 @@ fn plan_climb_top_out(
         let Some(landing) = landing_pose(candidate) else {
             continue;
         };
-        if lateral_mantle_slab
-            && mantle_floor.is_some_and(|floor| {
-                (landing.standing.y - standing_floor_offset - floor.y).abs()
-                    > CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
-            })
-        {
-            continue;
-        }
         let Some(validated) = validated_landing(landing) else {
             continue;
         };
@@ -2895,6 +2843,7 @@ fn plan_climb_top_out(
             is_crouched,
             requires_final_support: true,
         }),
+        retained_climb: None,
         slope_displacement: Vector::zeros(),
     })
 }
@@ -3162,6 +3111,7 @@ fn plan_jump_mantle(
             is_crouched,
             requires_final_support: false,
         }),
+        retained_climb: None,
         slope_displacement: Vector::zeros(),
     })
 }
@@ -3342,6 +3292,7 @@ fn step_player_movement(
     if let Some(ClimbPass {
         movement: climb,
         top_out,
+        retained,
         allow_top_out_attempt,
         is_crouched,
         validation_queries,
@@ -3373,6 +3324,7 @@ fn step_player_movement(
             return PlayerMovement {
                 movement: mvt,
                 top_out: None,
+                retained_climb: Some(retained),
                 slope_displacement: Vector::zeros(),
             };
         }
@@ -3393,12 +3345,14 @@ fn step_player_movement(
                 return PlayerMovement {
                     movement: reposition,
                     top_out: None,
+                    retained_climb: Some(retained),
                     slope_displacement: Vector::zeros(),
                 };
             }
             return PlayerMovement {
                 movement: scripted_character_movement(Vector::zeros()),
                 top_out: None,
+                retained_climb: Some(retained),
                 slope_displacement: Vector::zeros(),
             };
         }
@@ -3571,6 +3525,7 @@ fn step_player_movement(
     PlayerMovement {
         movement: mvt,
         top_out: None,
+        retained_climb: None,
         slope_displacement: next_slope_displacement,
     }
 }
@@ -3906,6 +3861,13 @@ pub struct PlayerHandle {
     // A live ordinary jump's vertical velocity (world units / second).
     // `None` means the legacy constant-gravity walk/fall path is active.
     jump_velocity: Option<Real>,
+    // Prior-frame ladder contact, retained just long enough for an atomic
+    // turn+jump to release it before the new facing recomputes grip.
+    retained_climb: Option<RetainedClimb>,
+    // Horizontal part of a live BreakClimb jump (world units / second).
+    // Ordinary input cannot steer it; collision and gravity own the arc until
+    // the controller reports a supported landing.
+    climb_jump_velocity: Option<Vector<Real>>,
     // Held-button edge state: one press launches at most one jump.
     jump_was_pressed: bool,
 }
@@ -4346,6 +4308,8 @@ impl PhysicsWorld {
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
         player_handle.jump_velocity = None;
+        player_handle.retained_climb = None;
+        player_handle.climb_jump_velocity = None;
         player_handle.top_out_retry_cooldown = 0;
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         let shape = if player_handle.is_crouched {
@@ -5166,6 +5130,8 @@ impl PhysicsWorld {
             slope_displacement: Vector::zeros(),
             is_grounded: false,
             jump_velocity: None,
+            retained_climb: None,
+            climb_jump_velocity: None,
             jump_was_pressed: false,
         }
     }
@@ -5190,6 +5156,7 @@ impl PhysicsWorld {
             return player_handle.is_crouched;
         }
         player_handle.top_out_retry_cooldown = 0;
+        player_handle.retained_climb = None;
 
         let character_handle = player_handle.character_handle;
         let collider_handle = self.rigid_body_set[character_handle].colliders()[0];
@@ -5492,11 +5459,12 @@ impl PhysicsWorld {
 
     /// Update player movement with facing and a held ordinary-jump button.
     ///
-    /// The button is edge-triggered inside [`PlayerHandle`], starts only from
-    /// controller-confirmed ground, and then follows a collision-cast ballistic
-    /// arc until landing. Keeping the request here (rather than as a debug
-    /// relocation/effect) means desktop, VR, and automated playtests all drive
-    /// the same production character controller.
+    /// The button is edge-triggered inside [`PlayerHandle`]. It starts from
+    /// controller-confirmed ground, or releases a climb retained by the prior
+    /// frame, then follows a collision-cast ballistic arc until landing.
+    /// Keeping the request here (rather than as a debug relocation/effect)
+    /// means desktop, VR, and automated playtests all drive the same production
+    /// character controller.
     pub fn update_with_facing_and_jump(
         &mut self,
         desired_movement: Vector3<f32>,
@@ -5615,9 +5583,34 @@ impl PhysicsWorld {
     ) -> (Vec<CollisionEvent>, &RigidBody) {
         let jump_edge = jump_pressed && !player_handle.jump_was_pressed;
         player_handle.jump_was_pressed = jump_pressed;
-        let launch_jump = jump_edge && player_handle.is_grounded && player_handle.top_out.is_none();
+        // Consume the prior frame's grip before the freshly turned facing can
+        // fail the into-ladder query below. It is deliberately one-frame
+        // state: separation without a simultaneous edge cannot launch later.
+        let retained_climb = player_handle.retained_climb.take();
+        let player_center = self.rigid_body_set[player_handle.character_handle]
+            .translation()
+            .y;
+        let climb_jump = (jump_edge
+            && player_handle.top_out.is_none()
+            && player_handle.jump_velocity.is_none())
+        .then(|| {
+            retained_climb.and_then(|retained| climb_jump_release(retained, facing, player_center))
+        })
+        .flatten();
+        if let Some((horizontal_velocity, vertical_bonus)) = climb_jump {
+            player_handle.jump_velocity = Some((PLAYER_JUMP_SPEED + vertical_bonus) / SCALE_FACTOR);
+            player_handle.climb_jump_velocity = Some(horizontal_velocity / SCALE_FACTOR);
+            player_handle.slope_displacement = Vector::zeros();
+            player_handle.is_grounded = false;
+            player_handle.support = None;
+        }
+        let launch_jump = jump_edge
+            && climb_jump.is_none()
+            && player_handle.is_grounded
+            && player_handle.top_out.is_none();
         if launch_jump {
             player_handle.jump_velocity = Some(PLAYER_JUMP_SPEED / SCALE_FACTOR);
+            player_handle.climb_jump_velocity = None;
             player_handle.is_grounded = false;
             // A jumping player has left their moving support. Its carry is
             // already represented by the first frame's body pose; do not keep
@@ -5693,7 +5686,7 @@ impl PhysicsWorld {
                 // (The collider-center direction is wrong when the player is
                 // off-center: it tilts away from the face, which under-reads
                 // the into-ladder push the grip test and climb speed use.)
-                let mut nearest: Option<(f32, Vector<Real>)> = None;
+                let mut nearest: Option<(f32, Vector<Real>, Real)> = None;
                 for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
                     let contact = rapier3d::parry::query::contact(
                         &character_pos,
@@ -5708,13 +5701,13 @@ impl PhysicsWorld {
                         let toward_norm = toward_h.norm();
                         // A mostly-vertical normal means the player is on top of
                         // (or under) the surface - that's standing, not climbing.
-                        if toward_norm > 0.5 && nearest.is_none_or(|(d, _)| contact.dist < d) {
+                        if toward_norm > 0.5 && nearest.is_none_or(|(d, _, _)| contact.dist < d) {
                             let toward = toward_h / toward_norm;
-                            nearest = Some((contact.dist, toward));
+                            nearest = Some((contact.dist, toward, collider.compute_aabb().maxs.y));
                         }
                     }
                 }
-                nearest.and_then(|(_, toward)| {
+                nearest.and_then(|(_, toward, climbable_top)| {
                     climb_redirect(desired_movement, toward).map(|movement| {
                         let top_out = if near_column_top {
                             climb_top_out_direction(desired_movement, facing).map(|direction| {
@@ -5739,15 +5732,21 @@ impl PhysicsWorld {
                         } else {
                             None
                         };
-                        (movement, top_out)
+                        (
+                            movement,
+                            top_out,
+                            RetainedClimb {
+                                toward_ladder: toward,
+                                climbable_top,
+                            },
+                        )
                     })
                 })
             })
         };
         let attempted_top_out = climb_movement
             .as_ref()
-            .is_some_and(|(_, top_out)| allow_top_out_attempt && top_out.is_some());
-
+            .is_some_and(|(_, top_out, _)| allow_top_out_attempt && top_out.is_some());
         // The climb cast collides with everything the walk does EXCEPT the
         // climbable surfaces themselves - see `ClimbPass`. Membership is checked
         // by predicate rather than by group filter because a ladder is also an
@@ -5797,6 +5796,7 @@ impl PhysicsWorld {
                 PlayerMovement {
                     movement,
                     top_out,
+                    retained_climb: None,
                     slope_displacement: Vector::zeros(),
                 }
             } else {
@@ -5820,6 +5820,11 @@ impl PhysicsWorld {
                 if let Some(jump_mantle) = jump_mantle {
                     jump_mantle
                 } else {
+                    let horizontal_movement = player_handle
+                        .climb_jump_velocity
+                        .map_or(desired_movement, |velocity| {
+                            velocity * self.integration_parameters.dt
+                        });
                     let airborne_vertical = player_handle
                         .jump_velocity
                         .map(|velocity| velocity * self.integration_parameters.dt);
@@ -5828,15 +5833,16 @@ impl PhysicsWorld {
                         &queries,
                         character_shape.as_ref(),
                         &character_pos,
-                        desired_movement,
+                        horizontal_movement,
                         carry,
                         self.integration_parameters.dt,
                         gravity,
                         Some(player_handle.slope_displacement),
                         airborne_vertical,
-                        climb_movement.map(|(movement, top_out)| ClimbPass {
+                        climb_movement.map(|(movement, top_out, retained)| ClimbPass {
                             movement,
                             top_out,
+                            retained,
                             allow_top_out_attempt,
                             is_crouched: player_handle.is_crouched,
                             validation_queries: queries,
@@ -5855,6 +5861,7 @@ impl PhysicsWorld {
             };
         }
         let was_top_out = player_handle.top_out.is_some();
+        let next_retained_climb = player_movement.retained_climb;
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
         let is_top_out = player_handle.top_out.is_some();
@@ -5880,15 +5887,31 @@ impl PhysicsWorld {
         self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
+        // Rapier's broad `grounded` flag can be set while a falling capsule is
+        // sliding against a wall/pipe. That is sufficient for ordinary jumps,
+        // which start from a floor, but a BreakClimb release may first collide
+        // with a side face on its way to the arrival-side deck. Preserve its
+        // horizontal impulse until the resolved full-profile pose has genuine
+        // upward support underfoot.
+        let resolved_pose = character_pos.translation.vector + mvt.translation;
+        let climb_jump_has_support = player_handle.climb_jump_velocity.is_some() && {
+            let queries = self.player_movement_queries(dispatcher, movement_filter);
+            player_pose_matches_current_support(&queries, resolved_pose, player_handle.is_crouched)
+        };
 
         if is_top_out {
             player_handle.jump_velocity = None;
+            player_handle.climb_jump_velocity = None;
             player_handle.is_grounded = false;
         } else if let Some(mut velocity) = player_handle.jump_velocity {
             let requested_vertical = velocity * self.integration_parameters.dt;
             let applied_vertical = mvt.translation.y - carry.y;
-            if mvt.grounded && requested_vertical <= 0.0 {
+            if mvt.grounded
+                && requested_vertical <= 0.0
+                && (player_handle.climb_jump_velocity.is_none() || climb_jump_has_support)
+            {
                 player_handle.jump_velocity = None;
+                player_handle.climb_jump_velocity = None;
                 player_handle.is_grounded = true;
             } else {
                 // A ceiling (or other overhead collision) consumes the upward
@@ -5903,8 +5926,14 @@ impl PhysicsWorld {
                 player_handle.is_grounded = false;
             }
         } else {
+            player_handle.climb_jump_velocity = None;
             player_handle.is_grounded = mvt.grounded;
         }
+        player_handle.retained_climb = if is_top_out || player_handle.jump_velocity.is_some() {
+            None
+        } else {
+            next_retained_climb
+        };
 
         // Edges already observed along a swept `move_player_validated` hop come
         // first: they happened before this frame's pose. They also leave
@@ -8261,6 +8290,10 @@ mod tests {
             Some(ClimbPass {
                 movement: Vector::y() * 0.25,
                 top_out: Some((Vector::x(), CLIMB_TOP_OUT_PROBE_FORWARD)),
+                retained: RetainedClimb {
+                    toward_ladder: Vector::x(),
+                    climbable_top: 0.0,
+                },
                 allow_top_out_attempt: true,
                 is_crouched: false,
                 validation_queries: query_pipeline(&world, QueryFilter::default()),
@@ -8466,222 +8499,6 @@ mod tests {
             final_pose,
             &crouched_player_capsule(),
         ));
-    }
-
-    fn merged_cuboid_worldrep(parts: &[(Vector<Real>, Vector<Real>)]) -> PhysicsWorld {
-        let mut vertices = Vec::new();
-        let mut indices = Vec::new();
-        for (center, half_extents) in parts {
-            let (part_vertices, part_indices) = Cuboid::new(*half_extents).to_trimesh();
-            let base = vertices.len() as u32;
-            vertices.extend(
-                part_vertices
-                    .into_iter()
-                    .map(|vertex| Point::from(vertex + *center)),
-            );
-            indices.extend(
-                part_indices
-                    .into_iter()
-                    .map(|triangle| triangle.map(|index| index + base)),
-            );
-        }
-        let mut world = PhysicsWorld::new();
-        world.add_collider(
-            EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::trimesh(vertices, indices)
-                .expect("merged WorldRep")
-                .build(),
-        );
-        let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
-        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-        world
-    }
-
-    fn diagonal_slab_worldrep() -> PhysicsWorld {
-        let (vertices, indices) = Cuboid::new(vector![1.0, 0.05, 0.2]).to_trimesh();
-        let angle = -std::f32::consts::FRAC_PI_4;
-        let (sin, cos) = angle.sin_cos();
-        let vertices = vertices
-            .into_iter()
-            .map(|vertex| {
-                Point::new(
-                    0.48 + cos * vertex.x + sin * vertex.z,
-                    1.55 + vertex.y,
-                    0.48 - sin * vertex.x + cos * vertex.z,
-                )
-            })
-            .collect();
-        let mut world = PhysicsWorld::new();
-        world.add_collider(
-            EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::trimesh(vertices, indices)
-                .expect("diagonal WorldRep slab")
-                .build(),
-        );
-        let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
-        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-        world
-    }
-
-    fn diagonal_ribbon_worldrep(stations: &[(Real, Real)]) -> PhysicsWorld {
-        let along = vector![
-            std::f32::consts::FRAC_1_SQRT_2,
-            0.0,
-            std::f32::consts::FRAC_1_SQRT_2
-        ];
-        let across = vector![
-            std::f32::consts::FRAC_1_SQRT_2,
-            0.0,
-            -std::f32::consts::FRAC_1_SQRT_2
-        ];
-        let half_width = 0.3;
-        let mut vertices = Vec::new();
-        for &(distance, y) in stations {
-            let center = along * distance + Vector::y() * y;
-            vertices.push(Point::from(center - across * half_width));
-            vertices.push(Point::from(center + across * half_width));
-        }
-        let mut indices = Vec::new();
-        for segment in 0..stations.len() - 1 {
-            let left = (2 * segment) as u32;
-            let right = left + 1;
-            let next_left = left + 2;
-            let next_right = left + 3;
-            indices.push([left, next_left, next_right]);
-            indices.push([left, next_right, right]);
-        }
-        let mut world = PhysicsWorld::new();
-        world.add_collider(
-            EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::trimesh(vertices, indices)
-                .expect("diagonal WorldRep ribbon")
-                .build(),
-        );
-        let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
-        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-        world
-    }
-
-    fn lateral_slab_test_hit(world: &PhysicsWorld) -> Option<(Vector<Real>, Real)> {
-        let queries = query_pipeline(world, QueryFilter::default());
-        let head = vector![0.0, 0.72, 0.0];
-        let probe_ahead = vector![2.0 * CLIMB_TOP_OUT_RADIUS, 2.12, 0.0];
-        let up_hit = queries.cast_ray_and_get_normal(
-            &Ray::new(Point::from(head), Vector::y()),
-            CLIMB_TOP_OUT_UP,
-            true,
-        );
-        lateral_same_slab_mantle_hit(
-            &queries,
-            up_hit,
-            head,
-            probe_ahead,
-            Vector::z(),
-            CLIMB_TOP_OUT_RADIUS,
-            (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize,
-        )
-        .map(|(origin, _, hit)| (origin, origin.y - hit.time_of_impact))
-    }
-
-    #[test]
-    fn lateral_mantle_finds_an_edge_connected_same_slab_floor() {
-        // A thin closed slab runs diagonally through U and T. Dark's fixed
-        // forward probe lies outside its near edge, while the second lateral
-        // sample reaches the top through that edge inside the local corridor.
-        let world = diagonal_slab_worldrep();
-        let (origin, floor_y) = lateral_slab_test_hit(&world)
-            .expect("the edge-connected lateral top should identify the rise's local slab");
-
-        assert!((origin.z - 2.0 * CLIMB_TOP_OUT_RADIUS).abs() < 1.0e-4);
-        assert!((floor_y - 1.6).abs() < 1.0e-4);
-    }
-
-    #[test]
-    fn lateral_mantle_rejects_a_disconnected_island_in_one_worldrep() {
-        // The same collider and same top height are insufficient: these two
-        // closed boxes are separated in x/z and have no local edge path.
-        let world = merged_cuboid_worldrep(&[
-            (vector![0.0, 1.55, 0.0], vector![0.2, 0.05, 0.2]),
-            (vector![0.96, 1.55, 0.96], vector![0.2, 0.05, 0.2]),
-        ]);
-
-        assert!(
-            lateral_slab_test_hit(&world).is_none(),
-            "mission-wide WorldRep identity must not connect a lateral island to the sampled underside"
-        );
-    }
-
-    #[test]
-    fn lateral_mantle_rejects_a_broad_ceiling_without_a_local_edge() {
-        // U and T are opposite sides of one same-height closed slab, but its
-        // nearest edge lies far outside the bounded probe corridor. Treating
-        // collider identity or thickness as sufficient would turn an ordinary
-        // room ceiling into a through-ceiling mantle.
-        let world = merged_cuboid_worldrep(&[(vector![0.0, 1.55, 0.0], vector![4.0, 0.05, 4.0])]);
-
-        assert!(
-            lateral_slab_test_hit(&world).is_none(),
-            "a broad solid ceiling must remain an obstruction when no slab edge is locally reachable"
-        );
-    }
-
-    #[test]
-    fn lateral_mantle_rejects_a_parented_floor_before_the_worldrep_top() {
-        let mut world = diagonal_slab_worldrep();
-        // Model the authored Pipe8x3 failure mode: a live parented OBB is the
-        // first downward floor hit at the otherwise-valid lateral sample.
-        world.add_kinematic(
-            EntityId::from_inner(3).unwrap(),
-            vec3(0.96, 1.86, 0.96),
-            identity_quat(),
-            vec3(0.0, 0.0, 0.0),
-            vec3(0.35, 0.1, 0.35),
-            CollisionGroup::entity(),
-            false,
-        );
-        let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(4).unwrap());
-        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-
-        assert!(
-            lateral_slab_test_hit(&world).is_none(),
-            "a parented pipe floor must not inherit the WorldRep underside exception"
-        );
-    }
-
-    #[test]
-    fn lateral_mantle_rejects_a_floor_below_the_sampled_underside() {
-        // One connected ribbon starts horizontal above the upward sample,
-        // slopes down, and becomes horizontal again under lateral T. Deleting
-        // the explicit T >= U gate would therefore make this negative pass.
-        let world = diagonal_ribbon_worldrep(&[(-0.3, 1.5), (0.3, 1.5), (1.0, 1.0), (1.7, 1.0)]);
-
-        assert!(
-            lateral_slab_test_hit(&world).is_none(),
-            "a lower shelf must not be paired with an unrelated overhead underside"
-        );
-    }
-
-    #[test]
-    fn lateral_mantle_rejects_an_edge_connected_floor_above_the_thin_slab_bound() {
-        // The same local ribbon stays connected but rises by 1.1 wu from U to
-        // T, just beyond the standing-profile slab bound of 1.04 wu. Its ramp
-        // is split into short faces so topology alone still reaches both ends.
-        let world = diagonal_ribbon_worldrep(&[
-            (-0.3, 1.0),
-            (0.2, 1.0),
-            (0.7, 1.55),
-            (1.1, 2.1),
-            (1.7, 2.1),
-        ]);
-
-        assert!(
-            lateral_slab_test_hit(&world).is_none(),
-            "a thick local shell must remain a ceiling rather than becoming a mantle slab"
-        );
     }
 
     #[test]
@@ -11000,6 +10817,400 @@ mod tests {
             max_y - start.y > 0.25,
             "the player should step onto the threshold under the ceiling, rose {}",
             max_y - start.y
+        );
+    }
+
+    #[test]
+    fn climb_jump_release_matches_dark_top_and_rebound_impulses() {
+        let toward_ladder = vector![1.0, 0.0, 0.0];
+        let (top_horizontal, top_bonus) = climb_jump_release(
+            RetainedClimb {
+                toward_ladder,
+                climbable_top: 0.0,
+            },
+            vector![0.6, 1.0, -0.8],
+            0.0,
+        )
+        .expect("a finite horizontal facing should release a climb");
+        assert!((top_horizontal - vector![6.0, 0.0, -8.0]).norm() < 1.0e-5);
+        assert_eq!(top_bonus, CLIMB_JUMP_VERTICAL_BONUS);
+
+        let below_top = RetainedClimb {
+            toward_ladder,
+            climbable_top: 10.0,
+        };
+        let (away, away_bonus) =
+            climb_jump_release(below_top, -Vector::x(), 0.0).expect("away-facing rebound");
+        assert!((away + Vector::x() * CLIMB_JUMP_REBOUND_SPEED).norm() < 1.0e-5);
+        assert_eq!(away_bonus, 0.0);
+        let (reflected, reflected_bonus) =
+            climb_jump_release(below_top, Vector::x(), 0.0).expect("into-face rebound");
+        assert!((reflected + Vector::x() * (0.5 * CLIMB_JUMP_REBOUND_SPEED)).norm() < 1.0e-5);
+        assert_eq!(reflected_bonus, 0.0);
+
+        let one_foot = 1.0 / SCALE_FACTOR;
+        assert!(break_climb_near_top(10.0, 10.0 - one_foot + 1.0e-4));
+        assert!(!break_climb_near_top(10.0, 10.0 - one_foot - 1.0e-4));
+        let top_boundary = RetainedClimb {
+            toward_ladder,
+            climbable_top: 10.0,
+        };
+        let (entered_band, entered_bonus) =
+            climb_jump_release(top_boundary, -Vector::x(), 10.0 - one_foot + 1.0e-4)
+                .expect("current pose just inside the band");
+        assert!((entered_band.x + CLIMB_JUMP_FORWARD_SPEED).abs() < 1.0e-4);
+        assert_eq!(entered_bonus, CLIMB_JUMP_VERTICAL_BONUS);
+        for current_center in [10.0 - one_foot - 1.0e-4, 10.0 + one_foot + 1.0e-4] {
+            let (left_band, left_bonus) =
+                climb_jump_release(top_boundary, -Vector::x(), current_center)
+                    .expect("current pose just outside the band");
+            assert!((left_band.x + CLIMB_JUMP_REBOUND_SPEED).abs() < 1.0e-4);
+            assert_eq!(left_bonus, 0.0);
+        }
+    }
+
+    fn flat_jump_world() -> (PhysicsWorld, PlayerHandle) {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(1000).unwrap(),
+            vec3(0.0, -0.5, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(20.0, 1.0, 20.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player = world.create_player(
+            vec3(0.0, PLAYER_HALF_HEIGHT + 0.1, 0.0),
+            EntityId::from_inner(2000).unwrap(),
+        );
+        step(&mut world, &mut player, 30);
+        (world, player)
+    }
+
+    #[test]
+    fn near_top_climb_jump_keeps_its_impulse_after_input_is_neutral() {
+        let (mut world, mut player) = flat_jump_world();
+        let start = world.get_player_translation(&player);
+        player.retained_climb = Some(RetainedClimb {
+            toward_ladder: Vector::x(),
+            climbable_top: start.y,
+        });
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        let edge = world.get_player_translation(&player);
+        let first_velocity = player
+            .climb_jump_velocity
+            .expect("the BreakClimb horizontal impulse should remain live");
+        assert!((first_velocity.x - CLIMB_JUMP_FORWARD_SPEED / SCALE_FACTOR).abs() < 1.0e-5);
+        assert_eq!(
+            edge, start,
+            "kinematic next-position applies on the following physics step"
+        );
+
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_z(),
+            false,
+            &mut player,
+        );
+        let in_flight = world.get_player_translation(&player);
+        assert!(
+            in_flight.x > start.x + 0.05 && in_flight.y > start.y + 0.1,
+            "the retained +X impulse, not fresh neutral input/facing, must own the arc: start={start:?}, edge={edge:?}, in_flight={in_flight:?}"
+        );
+
+        let horizontal_before_crouch = player.climb_jump_velocity;
+        let vertical_before_crouch = player.jump_velocity;
+        assert!(world.set_player_crouch(true, &mut player));
+        assert_eq!(
+            player.climb_jump_velocity, horizontal_before_crouch,
+            "changing posture during the arc must preserve horizontal momentum"
+        );
+        assert_eq!(
+            player.jump_velocity, vertical_before_crouch,
+            "changing posture during the arc must preserve vertical momentum"
+        );
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            -Vector3::unit_z(),
+            false,
+            &mut player,
+        );
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            -Vector3::unit_z(),
+            false,
+            &mut player,
+        );
+        let after_crouch = world.get_player_translation(&player);
+        assert!(
+            after_crouch.x > in_flight.x + 0.05,
+            "posture must not steer or cancel the retained release: in_flight={in_flight:?}, after={after_crouch:?}"
+        );
+    }
+
+    #[test]
+    fn climb_jump_requires_a_fresh_grip_and_is_one_edge() {
+        let (mut world, mut player) = flat_jump_world();
+        let center = world.get_player_translation(&player).y;
+        player.retained_climb = Some(RetainedClimb {
+            toward_ladder: Vector::x(),
+            climbable_top: center,
+        });
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            false,
+            &mut player,
+        );
+        assert!(
+            player.retained_climb.is_none(),
+            "one separated frame must expire a prior grip"
+        );
+
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        assert!(
+            player.climb_jump_velocity.is_none(),
+            "a stale grip must not become a BreakClimb launch"
+        );
+        let ordinary = player
+            .jump_velocity
+            .expect("the supported press should remain an ordinary jump");
+        assert!(ordinary < PLAYER_JUMP_SPEED / SCALE_FACTOR);
+
+        let before_held = ordinary;
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        assert!(
+            player.jump_velocity.expect("jump remains airborne") < before_held,
+            "holding jump must not relaunch either ordinary or climb motion"
+        );
+    }
+
+    #[test]
+    fn a_blocked_below_top_redirect_does_not_arm_break_climb() {
+        let (mut world, mut player) = flat_jump_world();
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(1.0, 5.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.2, 10.0, 4.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        world.update_with_facing_and_jump(
+            Vector3::new(walk, -walk, 0.0),
+            Vector3::unit_x(),
+            false,
+            &mut player,
+        );
+        assert!(
+            player.retained_climb.is_none(),
+            "a descent redirect blocked by the floor must fall through to ordinary movement without arming a release"
+        );
+        world.update_with_facing_and_jump(
+            Vector3::new(-walk, 0.0, 0.0),
+            -Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        assert!(
+            player.climb_jump_velocity.is_none(),
+            "the next away-facing edge must remain an ordinary grounded jump"
+        );
+    }
+
+    #[test]
+    fn climb_jump_retains_the_gripped_objects_top_not_an_adjacent_segment() {
+        let (mut world, mut player) = flat_jump_world();
+        let center_y = world.get_player_translation(&player).y;
+        // The nearer/taller collider is the object actually gripped. A second
+        // climbable is also inside the broad column/reach query and has a top
+        // inside Dark's one-foot band, but it is not the selected contact.
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.75, 3.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.1, 6.0, 4.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1002).unwrap(),
+            vec3(0.92, center_y, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.1, 0.2, 4.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let walk = 25.0 / SCALE_FACTOR / 60.0;
+        world.update_with_facing_and_jump(
+            Vector3::new(walk, 0.0, 0.0),
+            Vector3::unit_x(),
+            false,
+            &mut player,
+        );
+        let retained = player
+            .retained_climb
+            .expect("a real upward climb frame must retain its selected contact");
+        assert!(
+            (retained.climbable_top - 6.0).abs() < 1.0e-4,
+            "the nearest tall object, not the adjacent short segment/column, must supply the BreakClimb top: {retained:?}"
+        );
+
+        world.update_with_facing_and_jump(
+            Vector3::new(-walk, 0.0, 0.0),
+            -Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        let rebound = player
+            .climb_jump_velocity
+            .expect("the retained below-top grip should detach");
+        assert!(
+            (rebound.x + CLIMB_JUMP_REBOUND_SPEED / SCALE_FACTOR).abs() < 1.0e-4,
+            "an unrelated segment inside the top band must not upgrade the rebound to a ten-foot top release: {rebound:?}"
+        );
+    }
+
+    #[test]
+    fn climb_jump_keeps_new_world_and_parented_walls_solid() {
+        let run = |parented: bool| {
+            let (mut world, mut player) = flat_jump_world();
+            if parented {
+                world.add_kinematic(
+                    EntityId::from_inner(1001).unwrap(),
+                    vec3(0.7, 5.0, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.2, 10.0, 4.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            } else {
+                world.add_collider(
+                    EntityId::from_inner(1001).unwrap(),
+                    ColliderBuilder::cuboid(0.1, 5.0, 2.0)
+                        .translation(vector![0.7, 5.0, 0.0])
+                        .build(),
+                );
+            }
+            player.retained_climb = Some(RetainedClimb {
+                toward_ladder: Vector::x(),
+                climbable_top: world.get_player_translation(&player).y,
+            });
+            for frame in 0..120 {
+                world.update_with_facing_and_jump(
+                    Vector3::new(0.0, 0.0, 0.0),
+                    Vector3::unit_x(),
+                    frame == 0,
+                    &mut player,
+                );
+            }
+            world.get_player_translation(&player)
+        };
+
+        for (kind, end) in [("world", run(false)), ("parented", run(true))] {
+            assert!(
+                end.x < 0.2,
+                "a BreakClimb impulse must not suppress a newly met {kind} wall, ended {end:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn climb_jump_survives_side_contact_and_clears_on_real_floor_support() {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(1000).unwrap(),
+            vec3(0.0, -0.5, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(20.0, 1.0, 20.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.add_kinematic(
+            EntityId::from_inner(1001).unwrap(),
+            vec3(0.7, 10.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.2, 20.0, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(0.0, 3.0, 0.0), EntityId::from_inner(2000).unwrap());
+        player.retained_climb = Some(RetainedClimb {
+            toward_ladder: Vector::x(),
+            climbable_top: 3.0,
+        });
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+
+        let mut side_contact_frames = 0;
+        for _ in 0..360 {
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                -Vector3::unit_z(),
+                false,
+                &mut player,
+            );
+            let position = world.get_player_translation(&player);
+            if position.x > 0.04 && position.x < 0.2 && position.y > 2.0 {
+                side_contact_frames += 1;
+                assert!(
+                    player.climb_jump_velocity.is_some(),
+                    "side contact without underfoot support must not consume the horizontal release at {position:?}"
+                );
+            }
+            if player.jump_velocity.is_none() {
+                break;
+            }
+        }
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            -Vector3::unit_z(),
+            false,
+            &mut player,
+        );
+        let landed = world.get_player_translation(&player);
+        assert!(
+            side_contact_frames >= 3,
+            "the fixture must exercise a sustained airborne side contact"
+        );
+        let movement_filter = player_movement_filter(player.character_handle);
+        let queries =
+            world.player_movement_queries(world.narrow_phase.query_dispatcher(), movement_filter);
+        assert!(
+            player_pose_matches_current_support(&queries, vec_to_nvec(landed), false),
+            "the release should finish only on real floor support, ended {landed:?}"
+        );
+        assert!(
+            player.jump_velocity.is_none() && player.climb_jump_velocity.is_none(),
+            "both ballistic components must clear together on the supported landing"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod util;
 
 use collision::Aabb3;
 use engine::profile;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use util::*;
 
 use bitflags::bitflags;
@@ -278,6 +278,19 @@ const CLIMB_TOP_OUT_FINAL_DROP: f32 = 4.0 / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MIN_GROUND_NORMAL: f32 = 0.72;
 const CLIMB_TOP_OUT_RECOVERY_RETREAT: f32 = PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
 const CLIMB_TOP_OUT_MAX_RECOVERY_RETREAT: f32 = 4.0 / SCALE_FACTOR;
+/// Keep a mantle exception on the small connected surface patch around the
+/// probed floor. Rick1's authored floor-to-lip route is five triangle edges;
+/// eight leaves room for the neighboring triangles touched by the full ball
+/// without allowing connectivity through the rest of the level cell.
+const CLIMB_TOP_OUT_MAX_LIP_FACE_HOPS: usize = 8;
+/// Faces welded directly to the sampled floor must fit the bounded lip height.
+/// Rick1's authored transition genuinely touches tall vertical faces from hop
+/// three onward (including face 19461 on the staged route), so farther faces
+/// are instead constrained by the fixed corridor, overall hop cap, and the
+/// single bounded obstruction interval enforced by the route scan.
+const CLIMB_TOP_OUT_DIRECT_LIP_FACE_HOPS: usize = 2;
+const CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE: f32 =
+    2.0 * CLIMB_TOP_OUT_RADIUS + 2.0 * CLIMB_TOP_OUT_RECOVERY_RETREAT;
 /// Search at most four compressed-player radii farther in the held heading
 /// when an otherwise-supported landing still clips the upper ledge on descent.
 const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
@@ -285,6 +298,18 @@ const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 /// lip crossing. Keep that safety recovery separate from Dark's backward rise
 /// retreat and bound it to four compressed-player radii.
 const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
+/// Bound synchronous support/route evaluation when a ladder top has no valid
+/// landing. Candidates are ordered by total recovery distance; 75 covers every
+/// three-base/two-side candidate through the complete four-radius Manhattan
+/// shell, including both zero-forward lateral and zero-lateral forward bounds.
+const CLIMB_TOP_OUT_MAX_LANDING_CANDIDATES: usize = 75;
+/// Egress validation samples a full standing stride at contact-offset
+/// intervals. It is a landing preference, not a safety requirement, so limit
+/// it to the first few already-safe candidates in each support tier.
+const CLIMB_TOP_OUT_MAX_EGRESS_CANDIDATES: usize = 8;
+/// After an unchanged approach fails to plan, keep ordinary climbing responsive
+/// and retry at 10 Hz instead of repeating the bounded search every 60 Hz frame.
+const CLIMB_TOP_OUT_RETRY_COOLDOWN_FRAMES: u8 = 5;
 /// Require enough clear, similarly supported standing room after the landing
 /// to take one ordinary stride in the player's held heading. This rejects a
 /// rail-top perch that geometrically fits one stationary capsule.
@@ -620,6 +645,7 @@ fn try_step_up(
 struct ClimbPass<'a> {
     movement: Vector<Real>,
     top_out: Option<(Vector<Real>, Real)>,
+    allow_top_out_attempt: bool,
     validation_queries: QueryPipeline<'a>,
     probe_queries: QueryPipeline<'a>,
     scripted_queries: QueryPipeline<'a>,
@@ -909,46 +935,592 @@ fn ray_segment_is_clear(queries: &QueryPipeline, from: Vector<Real>, to: Vector<
             .is_none()
 }
 
-fn shape_route_exits_only_initial_obstruction(
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum ShapeObstruction {
+    Collider(ColliderHandle),
+    TrimeshFace(ColliderHandle, u32),
+}
+
+/// Actual surface features touched by `shape`.
+///
+/// A whole closed level trimesh reports a solid-volume intersection even when
+/// the shape is in empty room space. Enumerating its triangle BVH and testing
+/// the candidate triangles distinguishes those volume false positives from
+/// real surface contact and, crucially, identifies every face involved.
+fn shape_obstructions(
+    queries: &QueryPipeline,
+    position: Vector<Real>,
+    shape: &dyn Shape,
+) -> HashSet<ShapeObstruction> {
+    let shape_position = Isometry::translation(position.x, position.y, position.z);
+    let shape_aabb = shape.compute_aabb(&shape_position);
+    let mut obstructions = HashSet::new();
+    for (handle, collider) in queries.intersect_aabb_conservative(shape_aabb) {
+        if let Some(mesh) = collider.shape().as_trimesh() {
+            let shape_in_collider = collider.position().inv_mul(&shape_position);
+            let local_aabb = shape.compute_aabb(&shape_in_collider);
+            for face in mesh.bvh().intersect_aabb(&local_aabb) {
+                let triangle = mesh.triangle(face);
+                if queries
+                    .dispatcher
+                    .intersection_test(&shape_in_collider, &triangle, shape)
+                    == Ok(true)
+                {
+                    obstructions.insert(ShapeObstruction::TrimeshFace(handle, face));
+                }
+            }
+        } else {
+            let shape_to_collider = shape_position.inv_mul(collider.position());
+            if queries
+                .dispatcher
+                .intersection_test(&shape_to_collider, shape, collider.shape())
+                == Ok(true)
+            {
+                obstructions.insert(ShapeObstruction::Collider(handle));
+            }
+        }
+    }
+    obstructions
+}
+
+#[derive(Clone, Copy)]
+struct ShapeCastObstruction {
+    distance: Real,
+    obstruction: ShapeObstruction,
+}
+
+/// Every actual surface feature touched by a continuous shape cast.
+///
+/// QueryPipeline's composite cast reports only the first collider and does not
+/// expose a trimesh face. Cast against the broad-phase candidates' local
+/// triangles instead, using each mesh BVH to keep the work proportional to the
+/// short route corridor rather than the whole mission mesh.
+fn shape_cast_obstructions(
+    queries: &QueryPipeline,
+    from: Vector<Real>,
+    to: Vector<Real>,
+    shape: &dyn Shape,
+) -> Vec<ShapeCastObstruction> {
+    let delta = to - from;
+    let distance = delta.norm();
+    if distance <= 1.0e-6 {
+        return shape_obstructions(queries, from, shape)
+            .into_iter()
+            .map(|obstruction| ShapeCastObstruction {
+                distance: 0.0,
+                obstruction,
+            })
+            .collect();
+    }
+
+    let start = Isometry::translation(from.x, from.y, from.z);
+    let end = Isometry::translation(to.x, to.y, to.z);
+    let swept_aabb = shape.compute_swept_aabb(&start, &end);
+    let options = rapier3d::parry::query::ShapeCastOptions {
+        max_time_of_impact: distance,
+        target_distance: 0.0,
+        stop_at_penetration: true,
+        compute_impact_geometry_on_penetration: true,
+    };
+    let mut hits = Vec::new();
+    for (handle, collider) in queries.intersect_aabb_conservative(swept_aabb) {
+        let local_start = collider.position().inv_mul(&start);
+        let local_end = collider.position().inv_mul(&end);
+        let local_delta = local_end.translation.vector - local_start.translation.vector;
+        let local_direction = local_delta / distance;
+        if let Some(mesh) = collider.shape().as_trimesh() {
+            let local_swept_aabb = shape.compute_swept_aabb(&local_start, &local_end);
+            for face in mesh.bvh().intersect_aabb(&local_swept_aabb) {
+                let triangle = mesh.triangle(face);
+                if let Ok(Some(hit)) = queries.dispatcher.cast_shapes(
+                    &local_start,
+                    &local_direction,
+                    &triangle,
+                    shape,
+                    options,
+                ) {
+                    hits.push(ShapeCastObstruction {
+                        distance: hit.time_of_impact,
+                        obstruction: ShapeObstruction::TrimeshFace(handle, face),
+                    });
+                }
+            }
+        } else if let Ok(Some(hit)) = queries.dispatcher.cast_shapes(
+            &local_start,
+            &local_direction,
+            collider.shape(),
+            shape,
+            options,
+        ) {
+            hits.push(ShapeCastObstruction {
+                distance: hit.time_of_impact,
+                obstruction: ShapeObstruction::Collider(handle),
+            });
+        }
+    }
+    hits
+}
+
+struct RouteObstructionScan {
+    first_clear: Vector<Real>,
+}
+
+/// Follow a sampled route and permit exactly one bounded obstruction interval.
+///
+/// The route may begin obstructed, or enter within `entry_limit`, but has to
+/// clear by `initial_obstruction_limit` and may never re-enter. Every actual
+/// collider/triangle touched must also satisfy `allowed`.
+fn scan_initial_route_obstruction(
     queries: &QueryPipeline,
     waypoints: &[Vector<Real>],
     shape: &dyn Shape,
     initial_obstruction_limit: Real,
-) -> bool {
-    // Dark's sparse body may meet the local lip before reaching the ladder
-    // column's geometry-derived exit. Permit one continuous overlap in that
-    // bounded interval, but require the route to exit it and reject any later
-    // re-entry/new solid. Contact-offset sampling is finer than shipped wall
-    // thicknesses and keeps the exception spatially bound even when level
-    // terrain is one monolithic parentless collider.
-    let Some(first) = waypoints.first().copied() else {
-        return false;
-    };
-    let mut obstruction_seen = shape_intersects(queries, first, shape);
+    entry_limit: Real,
+    allowed: impl Fn(ShapeObstruction) -> bool,
+) -> Option<RouteObstructionScan> {
+    // Dark's sparse body may start inside the local lip before reaching the
+    // ladder column's geometry-derived exit. Permit only that continuous
+    // initial overlap in the bounded interval. A route that starts clear may
+    // enter only within its caller's explicit entry bound, and a route that
+    // exits may not re-enter. An entry bound of zero permits start-overlap
+    // only.
+    // Contact-offset sampling is finer than shipped wall thicknesses and keeps
+    // the exception spatially bound even when level terrain is one monolithic
+    // parentless collider.
+    let first = waypoints.first().copied()?;
+    let mut obstruction_seen = false;
     let mut cleared_after_obstruction = false;
+    let mut first_clear = first;
     let mut route_distance = 0.0;
+    let inspect = |sample: Vector<Real>,
+                   sample_distance: Real,
+                   obstruction_seen: &mut bool,
+                   cleared_after_obstruction: &mut bool,
+                   first_clear: &mut Vector<Real>| {
+        let sample_obstructions = shape_obstructions(queries, sample, shape);
+        let blocked = !sample_obstructions.is_empty();
+        if blocked {
+            if sample_obstructions.iter().copied().any(|hit| !allowed(hit))
+                || (!*obstruction_seen && sample_distance > entry_limit)
+                || *cleared_after_obstruction
+                || sample_distance > initial_obstruction_limit
+            {
+                return false;
+            }
+            *obstruction_seen = true;
+        } else if *obstruction_seen && !*cleared_after_obstruction {
+            *cleared_after_obstruction = true;
+            *first_clear = sample;
+        }
+        true
+    };
+    if !inspect(
+        first,
+        0.0,
+        &mut obstruction_seen,
+        &mut cleared_after_obstruction,
+        &mut first_clear,
+    ) {
+        return None;
+    }
     for segment in waypoints.windows(2) {
         let from = segment[0];
         let to = segment[1];
         let delta = to - from;
         let distance = delta.norm();
         let steps = (distance / CLIMB_TOP_OUT_RECOVERY_RETREAT).ceil().max(1.0) as usize;
+        let mut previous = from;
+        let mut previous_distance = route_distance;
         for step in 1..=steps {
             let sample = from + delta * (step as Real / steps as Real);
-            let blocked = shape_intersects(queries, sample, shape);
             let sample_distance = route_distance + distance * step as Real / steps as Real;
-            if blocked {
-                if cleared_after_obstruction || sample_distance > initial_obstruction_limit {
-                    return false;
+            for hit in shape_cast_obstructions(queries, previous, sample, shape) {
+                let hit_distance = previous_distance + hit.distance;
+                if !allowed(hit.obstruction)
+                    || cleared_after_obstruction
+                    || (!obstruction_seen && hit_distance > entry_limit)
+                    || hit_distance > initial_obstruction_limit
+                {
+                    return None;
                 }
                 obstruction_seen = true;
-            } else if obstruction_seen {
-                cleared_after_obstruction = true;
             }
+            if !inspect(
+                sample,
+                sample_distance,
+                &mut obstruction_seen,
+                &mut cleared_after_obstruction,
+                &mut first_clear,
+            ) {
+                return None;
+            }
+            previous = sample;
+            previous_distance = sample_distance;
         }
         route_distance += distance;
     }
-    !obstruction_seen || cleared_after_obstruction
+    if obstruction_seen && !cleared_after_obstruction {
+        return None;
+    }
+    Some(RouteObstructionScan { first_clear })
+}
+
+struct FirstRouteObstruction {
+    position: Vector<Real>,
+    obstructions: HashSet<ShapeObstruction>,
+}
+
+/// Find the first actual surface touched along a route. `None` in the outer
+/// option rejects a feature outside the allowed mantle patch; `Some(None)`
+/// means the route stayed clear.
+fn first_allowed_route_obstruction(
+    queries: &QueryPipeline,
+    waypoints: &[Vector<Real>],
+    shape: &dyn Shape,
+    allowed: impl Fn(ShapeObstruction) -> bool,
+) -> Option<Option<FirstRouteObstruction>> {
+    let first = waypoints.first().copied()?;
+    let inspect = |position| {
+        let obstructions = shape_obstructions(queries, position, shape);
+        if obstructions.iter().copied().any(|hit| !allowed(hit)) {
+            return None;
+        }
+        Some((!obstructions.is_empty()).then_some(FirstRouteObstruction {
+            position,
+            obstructions,
+        }))
+    };
+    if let Some(hit) = inspect(first)? {
+        return Some(Some(hit));
+    }
+    for segment in waypoints.windows(2) {
+        let from = segment[0];
+        let delta = segment[1] - from;
+        let distance = delta.norm();
+        if distance <= 1.0e-6 {
+            continue;
+        }
+        let cast_hits = shape_cast_obstructions(queries, from, segment[1], shape);
+        let first_distance = cast_hits
+            .iter()
+            .map(|hit| hit.distance)
+            .min_by(Real::total_cmp);
+        let Some(first_distance) = first_distance else {
+            continue;
+        };
+        let obstructions = cast_hits
+            .into_iter()
+            .filter(|hit| {
+                (hit.distance - first_distance).abs() <= CLIMB_TOP_OUT_RECOVERY_RETREAT * 0.25
+            })
+            .map(|hit| hit.obstruction)
+            .collect::<HashSet<_>>();
+        if obstructions.iter().copied().any(|hit| !allowed(hit)) {
+            return None;
+        }
+        return Some(Some(FirstRouteObstruction {
+            position: from + delta / distance * first_distance,
+            obstructions,
+        }));
+    }
+    Some(None)
+}
+
+fn obstruction_exit_direction(
+    queries: &QueryPipeline,
+    obstructions: &HashSet<ShapeObstruction>,
+    route_direction: Vector<Real>,
+) -> Option<Vector<Real>> {
+    obstructions
+        .iter()
+        .filter_map(|obstruction| {
+            let ShapeObstruction::TrimeshFace(handle, face) = *obstruction else {
+                return None;
+            };
+            let collider = queries.colliders.get(handle)?;
+            let mesh = collider.shape().as_trimesh()?;
+            let local_normal = mesh.triangle(face).normal()?;
+            let world_normal = collider.position().rotation * local_normal;
+            let mut horizontal = vector![world_normal.x, 0.0, world_normal.z];
+            let length = horizontal.norm();
+            if length <= 1.0e-6 {
+                return None;
+            }
+            horizontal /= length;
+            if horizontal.dot(&route_direction) < 0.0 {
+                horizontal = -horizontal;
+            }
+            let alignment = horizontal.dot(&route_direction);
+            (alignment > 1.0e-4).then_some((alignment, horizontal))
+        })
+        .max_by(
+            |(first_alignment, first_direction), (second_alignment, second_direction)| {
+                first_alignment
+                    .total_cmp(second_alignment)
+                    .then_with(|| first_direction.x.total_cmp(&second_direction.x))
+                    .then_with(|| first_direction.z.total_cmp(&second_direction.z))
+            },
+        )
+        .map(|(_, direction)| direction)
+}
+
+#[cfg(test)]
+fn shape_route_exits_only_initial_obstruction(
+    queries: &QueryPipeline,
+    waypoints: &[Vector<Real>],
+    shape: &dyn Shape,
+    initial_obstruction_limit: Real,
+    entry_limit: Real,
+) -> bool {
+    scan_initial_route_obstruction(
+        queries,
+        waypoints,
+        shape,
+        initial_obstruction_limit,
+        entry_limit,
+        |_| true,
+    )
+    .is_some()
+}
+
+struct MantleLipPatch {
+    handle: ColliderHandle,
+    faces: HashSet<u32>,
+}
+
+impl MantleLipPatch {
+    fn contains(&self, obstruction: ShapeObstruction) -> bool {
+        matches!(
+            obstruction,
+            ShapeObstruction::TrimeshFace(handle, face)
+                if handle == self.handle && self.faces.contains(&face)
+        )
+    }
+}
+
+/// Reconstruct the small, edge-connected terrain patch around the sampled
+/// mantle floor. The fixed corridor bounds and hop cap do not grow with Dark's
+/// room-sized fan triangles, and the mesh BVH avoids a whole-level scan.
+fn mantle_lip_patch(
+    queries: &QueryPipeline,
+    mantle_feature: Option<(ColliderHandle, FeatureId)>,
+    mantle_point: Vector<Real>,
+    corridor: &[Vector<Real>],
+) -> Option<MantleLipPatch> {
+    let (handle, FeatureId::Face(sampled_mantle_face)) = mantle_feature? else {
+        return None;
+    };
+    let collider = queries.colliders.get(handle)?;
+    let mesh = collider.shape().as_trimesh()?;
+    let face_count = mesh.indices().len();
+    if face_count == 0 {
+        return None;
+    }
+    // Parry identifies a two-sided trimesh backface as `face + face_count`.
+    // The topology and BVH use the canonical front-face index.
+    let mantle_face = sampled_mantle_face % face_count as u32;
+
+    let local_mantle_point = collider
+        .position()
+        .inverse_transform_point(&Point::from(mantle_point));
+    let local_corridor = corridor
+        .iter()
+        .copied()
+        .map(|point| {
+            collider
+                .position()
+                .inverse_transform_point(&Point::from(point))
+        })
+        .collect::<Vec<_>>();
+    let mut corridor_points =
+        std::iter::once(local_mantle_point).chain(local_corridor.iter().copied());
+    let first_point = corridor_points.next()?;
+    let mut bounds_min = first_point;
+    let mut bounds_max = first_point;
+    for point in corridor_points {
+        bounds_min.x = bounds_min.x.min(point.x);
+        bounds_min.y = bounds_min.y.min(point.y);
+        bounds_min.z = bounds_min.z.min(point.z);
+        bounds_max.x = bounds_max.x.max(point.x);
+        bounds_max.y = bounds_max.y.max(point.y);
+        bounds_max.z = bounds_max.z.max(point.z);
+    }
+    bounds_min -= Vector::repeat(CLIMB_TOP_OUT_RADIUS);
+    bounds_max += Vector::repeat(CLIMB_TOP_OUT_RADIUS);
+    let bounds = rapier3d::parry::bounding_volume::Aabb::new(bounds_min, bounds_max);
+
+    let vertex_key = |point: Point<Real>| {
+        [point.x, point.y, point.z].map(|value| {
+            if value == 0.0 {
+                0.0f32.to_bits()
+            } else {
+                value.to_bits()
+            }
+        })
+    };
+    type VertexKey = [u32; 3];
+    type EdgeKey = (VertexKey, VertexKey);
+    let edge_key = |first: VertexKey, second: VertexKey| {
+        if first <= second {
+            (first, second)
+        } else {
+            (second, first)
+        }
+    };
+    let corridor_probe = Ball::new(CLIMB_TOP_OUT_RADIUS + CLIMB_TOP_OUT_RECOVERY_RETREAT);
+    let face_touches_probe_corridor = |triangle: &Triangle| {
+        let touches_point = |point: Point<Real>| {
+            queries.dispatcher.intersection_test(
+                &Isometry::translation(point.x, point.y, point.z),
+                triangle,
+                &corridor_probe,
+            ) == Ok(true)
+        };
+        touches_point(local_mantle_point)
+            || local_corridor.iter().copied().any(touches_point)
+            || local_corridor.windows(2).any(|segment| {
+                let delta = segment[1] - segment[0];
+                let distance = delta.norm();
+                distance > 1.0e-6
+                    && queries
+                        .dispatcher
+                        .cast_shapes(
+                            &Isometry::translation(segment[0].x, segment[0].y, segment[0].z),
+                            &(delta / distance),
+                            triangle,
+                            &corridor_probe,
+                            rapier3d::parry::query::ShapeCastOptions {
+                                max_time_of_impact: distance,
+                                target_distance: 0.0,
+                                stop_at_penetration: true,
+                                compute_impact_geometry_on_penetration: true,
+                            },
+                        )
+                        .is_ok_and(|hit| hit.is_some())
+            })
+    };
+    let mut local_faces = HashSet::new();
+    let mut corridor_faces = HashSet::new();
+    let mut faces_by_edge: HashMap<EdgeKey, Vec<u32>> = HashMap::new();
+    for face in mesh.bvh().intersect_aabb(&bounds) {
+        let triangle = mesh.triangle(face);
+        if face == mantle_face || face_touches_probe_corridor(&triangle) {
+            corridor_faces.insert(face);
+        }
+        let vertices = mesh.indices()[face as usize];
+        let points = vertices.map(|vertex| vertex_key(mesh.vertices()[vertex as usize]));
+        local_faces.insert(face);
+        for edge in [
+            edge_key(points[0], points[1]),
+            edge_key(points[1], points[2]),
+            edge_key(points[2], points[0]),
+        ] {
+            faces_by_edge.entry(edge).or_default().push(face);
+        }
+    }
+    if !local_faces.contains(&mantle_face) {
+        return None;
+    }
+
+    let mut neighbors: HashMap<u32, HashSet<u32>> = HashMap::new();
+    for edge_faces in faces_by_edge.values() {
+        for &face in edge_faces {
+            neighbors.entry(face).or_default().extend(
+                edge_faces
+                    .iter()
+                    .copied()
+                    .filter(|neighbor| *neighbor != face),
+            );
+        }
+    }
+    let mut connected = HashMap::from([(mantle_face, 0usize)]);
+    let mut pending = VecDeque::from([(mantle_face, 0usize)]);
+    while let Some((face, hops)) = pending.pop_front() {
+        if hops == CLIMB_TOP_OUT_MAX_LIP_FACE_HOPS {
+            continue;
+        }
+        for &neighbor in neighbors.get(&face).into_iter().flatten() {
+            if let std::collections::hash_map::Entry::Vacant(entry) = connected.entry(neighbor) {
+                entry.insert(hops + 1);
+                pending.push_back((neighbor, hops + 1));
+            }
+        }
+    }
+    let faces = corridor_faces
+        .into_iter()
+        .filter(|face| {
+            let Some(&hops) = connected.get(face) else {
+                return false;
+            };
+            if hops > CLIMB_TOP_OUT_DIRECT_LIP_FACE_HOPS {
+                return true;
+            }
+            let triangle = mesh.triangle(*face);
+            let world_y =
+                [triangle.a, triangle.b, triangle.c].map(|point| (collider.position() * point).y);
+            let min_y = world_y.into_iter().fold(Real::INFINITY, Real::min);
+            let max_y = world_y.into_iter().fold(Real::NEG_INFINITY, Real::max);
+            max_y - min_y <= CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE + 1.0e-5
+        })
+        .collect::<HashSet<_>>();
+    Some(MantleLipPatch { handle, faces })
+}
+
+#[cfg(test)]
+fn trimesh_faces_connect_within_local_bounds(
+    queries: &QueryPipeline,
+    first: (ColliderHandle, FeatureId),
+    second: (ColliderHandle, FeatureId),
+) -> bool {
+    let (
+        (first_handle, FeatureId::Face(first_face)),
+        (second_handle, FeatureId::Face(second_face)),
+    ) = (first, second)
+    else {
+        return false;
+    };
+    if first_handle != second_handle {
+        return false;
+    }
+    let collider = match queries.colliders.get(first_handle) {
+        Some(collider) => collider,
+        None => return false,
+    };
+    let mesh = match collider.shape().as_trimesh() {
+        Some(mesh) => mesh,
+        None => return false,
+    };
+    let face_count = mesh.indices().len() as u32;
+    if face_count == 0 {
+        return false;
+    }
+    let canonical_first_face = first_face % face_count;
+    let canonical_second_face = second_face % face_count;
+    let (Some(first_vertices), Some(second_vertices)) = (
+        mesh.indices().get(canonical_first_face as usize),
+        mesh.indices().get(canonical_second_face as usize),
+    ) else {
+        return false;
+    };
+    let world_vertex = |vertex: u32| {
+        let point = collider.position() * mesh.vertices()[vertex as usize];
+        vector![point.x, point.y, point.z]
+    };
+    let first_points = first_vertices.map(world_vertex);
+    let second_points = second_vertices.map(world_vertex);
+    let corridor = first_points
+        .into_iter()
+        .chain(second_points)
+        .collect::<Vec<_>>();
+    mantle_lip_patch(
+        queries,
+        Some((first_handle, FeatureId::Face(first_face))),
+        first_points[0],
+        &corridor,
+    )
+    .is_some_and(|patch| {
+        patch.handle == second_handle && patch.faces.contains(&canonical_second_face)
+    })
 }
 
 fn supported_standing_pose(
@@ -966,6 +1538,68 @@ fn supported_standing_pose(
         floor + Vector::y() * standing_floor_offset,
         ground.time_of_impact,
     ))
+}
+
+fn standing_pose_matches_current_support(
+    queries: &QueryPipeline,
+    standing_pose: Vector<Real>,
+) -> bool {
+    let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + PLAYER_REST_LIFT / SCALE_FACTOR;
+    // The waypoint loop intentionally stops within arrival epsilon. Allow the
+    // same residual plus one probe skin for floating-point/contact seams while
+    // still requiring the support to resolve to the planned standing height.
+    let release_tolerance = PLAYER_MOVE_ARRIVAL_EPSILON + PROBE_SKIN / SCALE_FACTOR;
+    supported_standing_pose(
+        queries,
+        standing_pose,
+        standing_floor_offset + release_tolerance,
+        standing_floor_offset,
+    )
+    .is_some_and(|(supported_pose, _)| {
+        (supported_pose - standing_pose).norm() <= release_tolerance + 1.0e-5
+    })
+}
+
+/// Direction toward a climbable that a standing player at `pose` can
+/// immediately grip through ordinary ladder detection.
+fn standing_pose_climb_direction(
+    queries: &QueryPipeline,
+    pose: Vector<Real>,
+    standing: &Capsule,
+) -> Option<Vector<Real>> {
+    let half_height = standing.half_height() + standing.radius;
+    let probe = Cuboid::new(vector![
+        standing.radius + CLIMB_REACH,
+        half_height,
+        standing.radius + CLIMB_REACH,
+    ]);
+    let position = Isometry::translation(pose.x, pose.y, pose.z);
+    queries
+        .intersect_shape(position, &probe)
+        .filter(|(_, collider)| {
+            collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        })
+        .find_map(|(_, collider)| {
+            rapier3d::parry::query::contact(
+                &position,
+                standing,
+                collider.position(),
+                collider.shape(),
+                CLIMB_REACH,
+            )
+            .ok()
+            .flatten()
+            .and_then(|contact| {
+                let toward = vector![contact.normal1.x, 0.0, contact.normal1.z];
+                let length = toward.norm();
+                (length > 0.5).then_some(toward / length)
+            })
+        })
 }
 
 fn has_supported_standing_egress(
@@ -1064,9 +1698,8 @@ fn plan_climb_top_out(
     // authored fallback with a low ceiling: it must clear at least one full
     // head radius before the first upward obstruction. Rick1's merged lip is
     // hit after 0.559 wu; a ceiling close enough to pin the sphere is rejected.
-    let up_obstruction = probe_queries
-        .cast_ray(&up_ray, CLIMB_TOP_OUT_UP, true)
-        .map(|(_, time_of_impact)| (time_of_impact, head.y + time_of_impact));
+    let up_hit = probe_queries.cast_ray_and_get_normal(&up_ray, CLIMB_TOP_OUT_UP, true);
+    let up_obstruction = up_hit.map(|(_, hit)| (hit.time_of_impact, head.y + hit.time_of_impact));
     if up_obstruction.is_some_and(|(time_of_impact, _)| time_of_impact < CLIMB_TOP_OUT_RADIUS) {
         return None;
     }
@@ -1074,10 +1707,11 @@ fn plan_climb_top_out(
         return None;
     }
     let down_ray = Ray::new(Point::from(probe_ahead), -Vector::y());
-    let mantle_floor = probe_queries
+    let mantle_hit = probe_queries
         .cast_ray_and_get_normal(&down_ray, CLIMB_TOP_OUT_MAX_DROP, true)
-        .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
-        .map(|(_, landing)| probe_ahead - Vector::y() * landing.time_of_impact);
+        .filter(|(_, landing)| landing.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+    let mantle_floor =
+        mantle_hit.map(|(_, landing)| probe_ahead - Vector::y() * landing.time_of_impact);
     if up_obstruction.is_some_and(|(_, obstruction_y)| {
         // A lip can have a thin underside above its adjacent landing. Treat
         // surfaces within one compressed radius plus the solver gap on both
@@ -1123,6 +1757,9 @@ fn plan_climb_top_out(
     // intersecting its volume. A tiny non-degenerate capsule uses the same
     // triangle-surface query as the player while remaining point-scale.
     let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+    // Rick1's merged lip keeps the compressed sphere intersecting through a
+    // measured 0.7148-world-unit sample. Round that geometry extent up to the
+    // next contact-offset sample: one compressed diameter plus two samples.
     if !shape_sweep_is_clear(probe_queries, head, rise_start, &compressed) {
         return None;
     }
@@ -1143,20 +1780,32 @@ fn plan_climb_top_out(
     }) {
         return None;
     }
-    let recovery_obstruction_limit = recovery_up_obstruction
-        .map(|(time_of_impact, _)| time_of_impact + CLIMB_TOP_OUT_RECOVERY_RETREAT)
-        .unwrap_or(0.0);
-    if !shape_route_exits_only_initial_obstruction(
+    let lip_forward_end = cross_end + direction * CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE;
+    let mantle_feature = mantle_hit.map(|(handle, hit)| (handle, hit.feature));
+    let lip_patch = mantle_lip_patch(
+        probe_queries,
+        mantle_feature,
+        mantle_floor.unwrap_or(probe_ahead),
+        &[
+            rise_start,
+            cross_start,
+            probe_cross_end,
+            cross_end,
+            lip_forward_end,
+        ],
+    );
+    if scan_initial_route_obstruction(
         probe_queries,
         &[rise_start, cross_start],
-        &route_probe,
-        recovery_obstruction_limit,
-    ) {
+        &compressed,
+        (cross_start - rise_start).norm(),
+        (cross_start - rise_start).norm(),
+        |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
+    )
+    .is_none()
+    {
         return None;
     }
-    // Validate Dark's sparse-body corridor with a point-scale probe: it may
-    // remain inside the one local lip component while crossing, but must
-    // exit by the end and may never enter a second obstruction.
     // Recovery may retreat the rise behind `raised`. Validate that entire
     // offset approach before permitting the one bounded lip overlap below;
     // otherwise the scripted parentless-terrain exception could cross an
@@ -1166,6 +1815,63 @@ fn plan_climb_top_out(
     {
         return None;
     }
+    // The point-scale centerline can remain clear while the full ball clips a
+    // diagonal lip from the side. Find the ball's first actual terrain face on
+    // the held approach, require it to belong to the local mantle patch, then
+    // clear it along that face's outward horizontal normal. The exception ends
+    // after this one geometry-derived leg; candidate recovery is ordinary.
+    let Some(first_lip) = first_allowed_route_obstruction(
+        probe_queries,
+        &[cross_start, lip_forward_end],
+        &compressed,
+        |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
+    ) else {
+        return None;
+    };
+    let (lip_approach, lip_clear) = if let Some(first_lip) = first_lip {
+        if !shape_sweep_is_clear(probe_queries, cross_start, first_lip.position, &route_probe) {
+            return None;
+        }
+        let exit_direction =
+            obstruction_exit_direction(probe_queries, &first_lip.obstructions, direction)?;
+        let lip_exit_end =
+            first_lip.position + exit_direction * CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE;
+        let exit_lip_patch = mantle_lip_patch(
+            probe_queries,
+            mantle_feature,
+            mantle_floor.unwrap_or(probe_ahead),
+            &[
+                rise_start,
+                cross_start,
+                probe_cross_end,
+                cross_end,
+                lip_forward_end,
+                first_lip.position,
+                lip_exit_end,
+            ],
+        );
+        let Some(exit) = scan_initial_route_obstruction(
+            probe_queries,
+            &[first_lip.position, lip_exit_end],
+            &compressed,
+            CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE,
+            CLIMB_TOP_OUT_RECOVERY_RETREAT,
+            |hit| {
+                exit_lip_patch
+                    .as_ref()
+                    .is_some_and(|patch| patch.contains(hit))
+            },
+        ) else {
+            return None;
+        };
+        (first_lip.position, exit.first_clear)
+    } else {
+        if !shape_sweep_is_clear(probe_queries, cross_start, cross_end, &compressed) {
+            return None;
+        }
+        (cross_end, cross_end)
+    };
+
     let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
         + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
         + PLAYER_REST_LIFT / SCALE_FACTOR;
@@ -1196,124 +1902,149 @@ fn plan_climb_top_out(
     // geometry-derived exit, and probe endpoint for the nearest standing-safe
     // landing. Each ordered base can recover forward past an overhang, while a
     // separate one-radius-step lateral search can clear a narrow rail. Both
-    // searches have four-radius safety bounds. The compressed route still
-    // reaches `cross_end` before moving to the selected landing.
+    // searches have four-radius safety bounds. The compressed route first
+    // reaches the geometry-derived `lip_clear` before moving to the selected
+    // landing.
     let lateral = vector![direction.z, 0.0, -direction.x];
     let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
-    let point_high_obstruction_limit =
-        (cross_end - probe_cross_end).norm() + CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY;
-    let mut candidate_bases = Vec::new();
-    for step in 0..=lateral_steps {
-        let offset = step as Real * CLIMB_TOP_OUT_RADIUS;
-        let sides: &[Real] = if step == 0 { &[0.0] } else { &[1.0, -1.0] };
-        for base in [full_advance, cross_end, probe_cross_end] {
+    let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    // Breadth-first by total recovery distance. Within an equal distance,
+    // consider lateral recovery first so the fixed candidate budget always
+    // reaches the promised four-radius side clearance at zero forward offset.
+    let mut landing_candidates = Vec::new();
+    for total_step in 0..=lateral_steps + forward_steps {
+        for lateral_step in (0..=lateral_steps).rev() {
+            let Some(forward_step) = total_step.checked_sub(lateral_step) else {
+                continue;
+            };
+            if forward_step > forward_steps {
+                continue;
+            }
+            let lateral_offset = lateral_step as Real * CLIMB_TOP_OUT_RADIUS;
+            let sides: &[Real] = if lateral_step == 0 {
+                &[0.0]
+            } else {
+                &[1.0, -1.0]
+            };
             for side in sides {
-                candidate_bases.push(base + lateral * (offset * side));
+                for base in [full_advance, cross_end, probe_cross_end] {
+                    landing_candidates.push(
+                        base + lateral * (lateral_offset * side)
+                            + direction * (forward_step as Real * CLIMB_TOP_OUT_RADIUS),
+                    );
+                }
             }
         }
     }
-    let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
-    let compressed_lip_allowance = if shape_intersects(probe_queries, cross_end, &compressed) {
-        CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY
-    } else {
-        0.0
-    };
+    // The only immutable-terrain exception is the geometry-attributed path to
+    // `lip_clear`. Validate its parented blockers once, before considering any
+    // landing. Every leg after `lip_clear` uses the ordinary all-collider
+    // pipeline, including climbables.
+    if !shape_sweep_is_clear(scripted_queries, cross_start, lip_approach, &compressed)
+        || !shape_sweep_is_clear(scripted_queries, lip_approach, lip_clear, &compressed)
+        || !shape_obstructions(validation_queries, lip_clear, &compressed).is_empty()
+    {
+        return None;
+    }
     let validated_landing = |landing: SupportedLanding| {
-        // Keep parented blockers live throughout the scripted route. For
-        // immutable terrain, sample both the point-scale Dark corridor and the
-        // full ball only along the high horizontal leg. Each may leave the one
-        // bounded merged lip but must be clear by the shifted candidate and
-        // may never re-enter a later rail or wall. Validate both descents as
-        // separate zero-exception casts: Parry reports stationary balls wholly
-        // inside a closed level trimesh as intersecting its volume even in
-        // empty rooms, while shape casts still correctly test triangle
-        // crossings along the descent.
-        (shape_sweep_is_clear(scripted_queries, cross_end, landing.sphere, &compressed)
+        (shape_sweep_is_clear(validation_queries, lip_clear, landing.sphere, &compressed)
             && shape_sweep_is_clear(
-                scripted_queries,
+                validation_queries,
                 landing.sphere,
                 landing.standing,
                 &compressed,
-            )
-            && !shape_intersects(scripted_queries, landing.sphere, &compressed)
-            && !shape_intersects(scripted_queries, landing.standing, &compressed)
-            && shape_route_exits_only_initial_obstruction(
-                probe_queries,
-                &[probe_cross_end, cross_end, landing.sphere],
-                &route_probe,
-                point_high_obstruction_limit,
-            )
-            && shape_sweep_is_clear(
-                probe_queries,
-                landing.sphere,
-                landing.standing,
-                &route_probe,
-            )
-            && shape_route_exits_only_initial_obstruction(
-                probe_queries,
-                &[cross_end, landing.sphere],
-                &compressed,
-                compressed_lip_allowance,
-            )
-            && shape_sweep_is_clear(probe_queries, landing.sphere, landing.standing, &compressed))
+            ))
         .then_some((landing.sphere, landing.standing))
     };
-    // Preserve cheap forward-first candidate order and validate each route at
-    // most once. A supported egress is a preference: direct then bounded-deep.
+    // Preserve cheap forward-first candidate order, generating bases lazily
+    // and deduplicating identical coordinates before their support and route
+    // queries. A supported egress is a preference: direct then bounded-deep.
     // If neither tier has room for the ordinary stride, retain the first exact
     // supported standing pose as a controlled fallback instead of re-freezing
     // the ladder. No tier ever restores a midair pose.
-    let mut direct_fallback = None;
     let mut direct_with_egress = None;
+    let mut direct_candidates = Vec::new();
     let mut deep_candidates = Vec::new();
-    'candidate_search: for base in candidate_bases {
-        for forward_step in 0..=forward_steps {
-            let candidate = base + direction * (forward_step as Real * CLIMB_TOP_OUT_RADIUS);
-            let Some(landing) = landing_pose(candidate) else {
-                continue;
-            };
-            if landing.direct {
-                let Some(validated) = validated_landing(landing) else {
-                    continue;
-                };
-                direct_fallback.get_or_insert(validated);
+    let mut seen_candidates = HashSet::new();
+    let mut evaluated_candidates = 0;
+    let mut direct_egress_candidates = 0;
+    for candidate in landing_candidates {
+        if !seen_candidates.insert([
+            candidate.x.to_bits(),
+            candidate.y.to_bits(),
+            candidate.z.to_bits(),
+        ]) {
+            continue;
+        }
+        if evaluated_candidates == CLIMB_TOP_OUT_MAX_LANDING_CANDIDATES {
+            break;
+        }
+        evaluated_candidates += 1;
+        let Some(landing) = landing_pose(candidate) else {
+            continue;
+        };
+        let Some(validated) = validated_landing(landing) else {
+            continue;
+        };
+        if landing.direct {
+            direct_candidates.push(validated);
+            if direct_egress_candidates < CLIMB_TOP_OUT_MAX_EGRESS_CANDIDATES {
+                direct_egress_candidates += 1;
                 let has_egress = has_supported_standing_egress(
                     validation_queries,
-                    validated.1,
+                    landing.standing,
                     direction,
                     &standing,
                     standing_floor_offset,
                 );
                 if has_egress {
                     direct_with_egress = Some(validated);
-                    break 'candidate_search;
+                    break;
                 }
-            } else {
-                // Cache the one support cast and defer the expensive terrain
-                // route until the deep-priority pass below.
-                deep_candidates.push(landing);
             }
+        } else {
+            // Cache the support and route casts and defer only the
+            // lower-priority egress probe.
+            deep_candidates.push((landing, validated));
         }
     }
-    let mut deep_fallback = None;
     let deep_with_egress = direct_with_egress.is_none().then(|| {
-        deep_candidates.into_iter().find_map(|landing| {
-            let validated = validated_landing(landing)?;
-            deep_fallback.get_or_insert(validated);
-            let has_egress = has_supported_standing_egress(
-                validation_queries,
-                validated.1,
-                direction,
-                &standing,
-                standing_floor_offset,
-            );
-            has_egress.then_some(validated)
-        })
+        deep_candidates
+            .iter()
+            .copied()
+            .take(CLIMB_TOP_OUT_MAX_EGRESS_CANDIDATES)
+            .find_map(|(landing, validated)| {
+                let has_egress = has_supported_standing_egress(
+                    validation_queries,
+                    landing.standing,
+                    direction,
+                    &standing,
+                    standing_floor_offset,
+                );
+                has_egress.then_some(validated)
+            })
     });
-    let (final_sphere, final_standing) = direct_with_egress
+    let direct_fallback = direct_with_egress
+        .is_none()
+        .then(|| direct_candidates.into_iter().next())
+        .flatten();
+    let deep_fallback = (direct_with_egress.is_none()
+        && deep_with_egress.as_ref().is_none_or(Option::is_none)
+        && direct_fallback.is_none())
+    .then(|| {
+        deep_candidates
+            .into_iter()
+            .next()
+            .map(|(_, validated)| validated)
+    })
+    .flatten();
+    let Some((final_sphere, final_standing)) = direct_with_egress
         .or(deep_with_egress.flatten())
         .or(direct_fallback)
-        .or(deep_fallback)?;
+        .or(deep_fallback)
+    else {
+        return None;
+    };
     // Preserve Dark's ordered rise-then-cross states. Scripted casts keep
     // parented entity blockers live but deliberately permit passage through
     // parentless immutable level terrain, the narrow Dark jump-through
@@ -1322,21 +2053,26 @@ fn plan_climb_top_out(
         head,
         rise_start,
         cross_start,
-        probe_cross_end,
-        cross_end,
+        lip_approach,
+        lip_clear,
         final_sphere,
         final_standing,
     ];
     let mut simulated = pos.translation.vector;
     let mut first_movement = None;
-    for waypoint in waypoints {
+    for (waypoint_index, waypoint) in waypoints.into_iter().enumerate() {
+        let movement_queries = if waypoint_index >= 5 {
+            validation_queries
+        } else {
+            scripted_queries
+        };
         for _ in 0..512 {
             if (waypoint - simulated).norm() <= PLAYER_MOVE_ARRIVAL_EPSILON {
                 break;
             }
             let Some(movement) = slide_toward(
                 controller,
-                scripted_queries,
+                movement_queries,
                 &compressed,
                 simulated,
                 waypoint,
@@ -1632,17 +2368,19 @@ fn plan_jump_mantle(
 }
 
 /// Advance a compressed ladder or ordinary-jump top-out by one fixed-timestep
-/// step, checking every substep against current parented entity geometry.
-/// Parentless immutable level terrain is the narrow Dark jump-through
-/// exception. A newly-blocked route returns to its last valid standing pose
-/// before the capsule is expanded, and final standing fit is checked against
-/// every collider.
+/// step, checking
+/// every substep against current parented entity geometry. Parentless immutable
+/// level terrain is the narrow Dark jump-through exception. A newly-blocked
+/// route returns to its last valid standing pose before the capsule is expanded.
+/// Final body fit and its current upward support are revalidated against
+/// every collider immediately before release.
 fn advance_climb_top_out(
     controller: &KinematicCharacterController,
     validation_queries: &QueryPipeline,
     scripted_queries: &QueryPipeline,
     pos: &Isometry<Real>,
     mut top_out: ClimbTopOut,
+    desired_movement: Vector<Real>,
     dt: Real,
 ) -> (EffectiveCharacterMovement, Option<ClimbTopOut>) {
     let final_shape = if top_out.is_crouched {
@@ -1658,7 +2396,9 @@ fn advance_climb_top_out(
             }
         } else if let Some(target) = top_out.waypoints.get(top_out.next_waypoint) {
             *target
-        } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape) {
+        } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape)
+            || !standing_pose_matches_current_support(validation_queries, pos.translation.vector)
+        {
             top_out.reversing = true;
             continue;
         } else {
@@ -1670,7 +2410,18 @@ fn advance_climb_top_out(
         }
         if top_out.reversing {
             if top_out.next_waypoint == 0 {
-                if shape_intersects(validation_queries, top_out.save_pose, &final_shape) {
+                let save_pose_is_supported =
+                    standing_pose_matches_current_support(validation_queries, top_out.save_pose);
+                let save_pose_can_resume_climb =
+                    standing_pose_climb_direction(
+                        validation_queries,
+                        top_out.save_pose,
+                        &final_shape,
+                    )
+                    .is_some_and(|toward| climb_redirect(desired_movement, toward).is_some());
+                if shape_intersects(validation_queries, top_out.save_pose, &final_shape)
+                    || (!save_pose_is_supported && !save_pose_can_resume_climb)
+                {
                     return (scripted_character_movement(Vector::zeros()), Some(top_out));
                 }
                 return (scripted_character_movement(Vector::zeros()), None);
@@ -1686,17 +2437,25 @@ fn advance_climb_top_out(
         CLIMB_TOP_OUT_RADIUS
     };
     let compressed = Ball::new(compressed_radius);
+    let movement_queries = if top_out.next_waypoint >= 5 {
+        // Waypoint 4 is `lip_clear`; every segment leaving or returning to it
+        // uses ordinary all-collider validation, including climbables.
+        validation_queries
+    } else {
+        scripted_queries
+    };
     // A live entity can move into the compressed sphere between frames. The
     // forward route must stop, but refusing every cast from an overlapping
     // pose would pin the recovery forever. During reversal only, let Rapier's
     // character controller compute a collision-checked depenetrating step
     // toward the preceding validated waypoint.
-    let movement = (!shape_intersects(scripted_queries, pos.translation.vector, &compressed)
-        || top_out.reversing)
+    let current_obstructed =
+        !shape_obstructions(movement_queries, pos.translation.vector, &compressed).is_empty();
+    let movement = (!current_obstructed || top_out.reversing)
         .then(|| {
             slide_toward(
                 controller,
-                scripted_queries,
+                movement_queries,
                 &compressed,
                 pos.translation.vector,
                 target,
@@ -1773,12 +2532,14 @@ fn step_player_movement(
     if let Some(ClimbPass {
         movement: climb,
         top_out,
+        allow_top_out_attempt,
         validation_queries,
         probe_queries: climb_queries,
         scripted_queries,
     }) = climb
     {
-        if climb.y > 0.0 {
+        let top_out_requested = climb.y > 0.0 && top_out.is_some();
+        if top_out_requested && allow_top_out_attempt {
             if let Some(top_out) = top_out.and_then(|(direction, minimum_clear_forward)| {
                 plan_climb_top_out(
                     controller,
@@ -1801,6 +2562,30 @@ fn step_player_movement(
                 movement: mvt,
                 top_out: None,
                 slope_displacement: Vector::zeros(),
+            };
+        }
+        if top_out_requested {
+            // An unsafe or throttled top-out remains an active climb frame.
+            // A horizontal contact slide may adjust the approach, but only
+            // while the resulting standing pose keeps a compatible grip on a
+            // climbable. Gravity stays suppressed, so this cannot reinterpret
+            // the diagonal input as unsupported ordinary movement.
+            let horizontal = vector![desired.x, 0.0, desired.z];
+            let reposition = controller.move_shape(dt, queries, shape, pos, horizontal, |_c| ());
+            let repositioned = pos.translation.vector + reposition.translation;
+            let keeps_grip = shape.as_capsule().is_some_and(|capsule| {
+                standing_pose_climb_direction(&validation_queries, repositioned, capsule)
+                    .is_some_and(|toward| climb_redirect(desired, toward).is_some())
+            });
+            if keeps_grip {
+                return PlayerMovement {
+                    movement: reposition,
+                    top_out: None,
+                };
+            }
+            return PlayerMovement {
+                movement: scripted_character_movement(Vector::zeros()),
+                top_out: None,
             };
         }
     }
@@ -2290,6 +3075,9 @@ pub struct PlayerHandle {
     // transient locomotion state: direct relocation and crouching cancel it,
     // while save/load uses the last valid standing pose stored with it.
     top_out: Option<ClimbTopOut>,
+    // Short throttle after an unchanged top-out approach fails its bounded
+    // landing search. Ordinary ladder climbing continues during the cooldown.
+    top_out_retry_cooldown: u8,
     // Moving terrain the player was last seen standing on, and where it was
     // then. Purely derived per-frame state (re-probed every move), so nothing
     // needs to save or restore it.
@@ -2744,6 +3532,7 @@ impl PhysicsWorld {
         player_handle.slope_displacement = Vector::zeros();
         player_handle.is_grounded = false;
         player_handle.jump_velocity = None;
+        player_handle.top_out_retry_cooldown = 0;
         let collider_handle = self.rigid_body_set[player_handle.character_handle].colliders()[0];
         let shape = if player_handle.is_crouched {
             crouched_player_shared_shape()
@@ -3558,6 +4347,7 @@ impl PhysicsWorld {
             character_handle,
             is_crouched: false,
             top_out: None,
+            top_out_retry_cooldown: 0,
             support: None,
             slope_displacement: Vector::zeros(),
             is_grounded: false,
@@ -3585,6 +4375,7 @@ impl PhysicsWorld {
         if want_crouch == player_handle.is_crouched {
             return player_handle.is_crouched;
         }
+        player_handle.top_out_retry_cooldown = 0;
 
         let character_handle = player_handle.character_handle;
         let collider_handle = self.rigid_body_set[character_handle].colliders()[0];
@@ -4036,6 +4827,10 @@ impl PhysicsWorld {
 
         let movement_filter = player_movement_filter(player_handle.character_handle);
         let dispatcher = self.narrow_phase.query_dispatcher();
+        if player_handle.top_out.is_none() && player_handle.top_out_retry_cooldown > 0 {
+            player_handle.top_out_retry_cooldown -= 1;
+        }
+        let allow_top_out_attempt = player_handle.top_out_retry_cooldown == 0;
 
         // Flat climbing: when the player overlaps a climbable surface (ladder)
         // and pushes toward it, redirect that input to vertical movement and
@@ -4135,6 +4930,9 @@ impl PhysicsWorld {
                 })
             })
         };
+        let attempted_top_out = climb_movement
+            .as_ref()
+            .is_some_and(|(_, top_out)| allow_top_out_attempt && top_out.is_some());
 
         // The climb cast collides with everything the walk does EXCEPT the
         // climbable surfaces themselves - see `ClimbPass`. Membership is checked
@@ -4179,6 +4977,7 @@ impl PhysicsWorld {
                     &queries.with_filter(scripted_top_out_filter),
                     &character_pos,
                     top_out,
+                    desired_movement,
                     self.integration_parameters.dt,
                 );
                 PlayerMovement {
@@ -4224,6 +5023,7 @@ impl PhysicsWorld {
                         climb_movement.map(|(movement, top_out)| ClimbPass {
                             movement,
                             top_out,
+                            allow_top_out_attempt,
                             validation_queries: queries,
                             probe_queries: queries.with_filter(climb_pass_filter),
                             scripted_queries: queries.with_filter(scripted_top_out_filter),
@@ -4232,6 +5032,13 @@ impl PhysicsWorld {
                 }
             }
         });
+        if attempted_top_out {
+            player_handle.top_out_retry_cooldown = if player_movement.top_out.is_some() {
+                0
+            } else {
+                CLIMB_TOP_OUT_RETRY_COOLDOWN_FRAMES
+            };
+        }
         let was_top_out = player_handle.top_out.is_some();
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
@@ -6597,6 +7404,50 @@ mod tests {
     }
 
     #[test]
+    fn rejected_climb_top_out_does_not_fall_through_to_walk_or_gravity() {
+        let mut world = PhysicsWorld::new();
+        let standing = standing_player_capsule();
+        let standing_half_height = standing.half_height() + standing.radius;
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
+                .translation(vector![0.0, standing_half_height + 0.06, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let movement = step_player_movement(
+            &controller,
+            &queries,
+            &standing,
+            &Isometry::identity(),
+            Vector::x() * 0.25,
+            Vector::zeros(),
+            1.0 / 60.0,
+            -0.2,
+            Some(ClimbPass {
+                movement: Vector::y() * 0.25,
+                top_out: Some((Vector::x(), CLIMB_TOP_OUT_PROBE_FORWARD)),
+                allow_top_out_attempt: true,
+                validation_queries: query_pipeline(&world, QueryFilter::default()),
+                probe_queries: query_pipeline(&world, QueryFilter::default()),
+                scripted_queries: query_pipeline(&world, QueryFilter::default()),
+            }),
+        );
+
+        assert!(
+            movement.movement.translation.x.abs() < 1.0e-5
+                && movement.movement.translation.y >= -1.0e-5,
+            "a rejected top-out must hold the climb instead of walking/falling: {:?}",
+            movement.movement.translation
+        );
+        assert!(movement.top_out.is_none());
+    }
+
+    #[test]
     fn climb_top_out_recovery_uses_minimum_bounded_clearance() {
         let mut world = PhysicsWorld::new();
         let mut player =
@@ -6662,7 +7513,7 @@ mod tests {
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
             ColliderBuilder::cuboid(0.2, 0.2, 2.0)
-                .translation(vector![0.5, 0.0, 0.0])
+                .translation(vector![0.0, 0.0, 0.0])
                 .build(),
         );
         let mut player =
@@ -6678,8 +7529,9 @@ mod tests {
                     &route,
                     &route_probe,
                     CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+                    0.0,
                 ),
-                "the point core may leave one merged lip within the bounded high recovery"
+                "the point core may leave a merged lip it genuinely starts inside"
             );
         }
 
@@ -6697,8 +7549,63 @@ mod tests {
                 &route,
                 &route_probe,
                 CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+                0.0,
             ),
             "a later point obstruction after clearing the merged lip must reject the route"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_point_route_limits_known_lip_entry_and_rejects_a_later_wall() {
+        let mut world = PhysicsWorld::new();
+        // The point probe starts clear and first touches this thin lip in the
+        // first 0.04-world-unit contact sample. Supplying Rick1's measured
+        // known-lip entry bound makes the exception active rather than
+        // vacuously relying on a start overlap.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.02, 0.2, 2.0)
+                .translation(vector![0.08, 0.0, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let route = [vector![0.0, 0.0, 0.0], vector![2.0, 0.0, 0.0]];
+        let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+        let known_lip_entry_limit = 3.0 * CLIMB_TOP_OUT_RECOVERY_RETREAT;
+        {
+            let queries = query_pipeline(&world, QueryFilter::default());
+            assert!(!shape_intersects(&queries, route[0], &route_probe));
+            assert!(
+                shape_route_exits_only_initial_obstruction(
+                    &queries,
+                    &route,
+                    &route_probe,
+                    CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+                    known_lip_entry_limit,
+                ),
+                "the clear point route may enter the known lip within its bounded first interval"
+            );
+        }
+
+        world.add_collider(
+            EntityId::from_inner(3).unwrap(),
+            ColliderBuilder::cuboid(0.05, 0.2, 2.0)
+                .translation(vector![0.8, 0.0, 0.0])
+                .build(),
+        );
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        assert!(
+            !shape_route_exits_only_initial_obstruction(
+                &queries,
+                &route,
+                &route_probe,
+                CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY,
+                known_lip_entry_limit,
+            ),
+            "the active known-lip exception must still reject a later unrelated wall"
         );
     }
 
@@ -6722,6 +7629,7 @@ mod tests {
                 &queries,
                 &[vector![0.0, 0.0, 0.0], vector![2.0, 0.0, 0.0]],
                 &route_probe,
+                0.4,
                 0.4,
             ),
             "an obstruction entered inside the allowance must still clear before the bound ends"
@@ -6798,35 +7706,227 @@ mod tests {
     }
 
     #[test]
-    fn climb_top_out_rejects_parentless_terrain_reentry_beyond_the_lip_probe() {
-        let mut world = PhysicsWorld::new();
-        world.add_collider(
-            EntityId::from_inner(1).unwrap(),
-            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
-                .translation(vector![0.0, -0.55, 0.0])
-                .build(),
-        );
-        // The Dark point probe ends at x=0.64. Two separated walls sit beyond
-        // it before the otherwise-clear final standing pose. The bounded high
-        // route may leave the first merged lip, but entering the second wall
-        // after that clearance is a forbidden re-entry.
-        for (index, x) in [1.0, 1.5].into_iter().enumerate() {
+    fn climb_top_out_rejects_a_single_parentless_wall_beyond_the_lip_probe() {
+        let plan = |include_wall: bool| {
+            let mut vertices = Vec::new();
+            let mut indices = Vec::new();
+            let mut append_cuboid = |center: Vector<Real>, half_extents: Vector<Real>| {
+                let start = vertices.len();
+                let base = start as u32;
+                let (box_vertices, box_indices) = Cuboid::new(half_extents).to_trimesh();
+                vertices.extend(
+                    box_vertices
+                        .into_iter()
+                        .map(|vertex| Point::from(vertex + center)),
+                );
+                indices.extend(
+                    box_indices
+                        .into_iter()
+                        .map(|face| face.map(|vertex| vertex + base)),
+                );
+                start..vertices.len()
+            };
+            let _floor_vertices =
+                append_cuboid(vector![0.0, -0.55, 0.0], vector![10.0, 0.05, 10.0]);
+            // A thin shelf above the player is a genuine upward lip: the
+            // upward probe meets its underside after one full compressed
+            // radius, while the forward/down probe sees its walkable top.
+            let shelf_vertices = append_cuboid(vector![0.36, 1.1, 0.0], vector![0.38, 0.01, 2.0]);
+            if include_wall {
+                // Add a wall whose lower edge exactly reuses the shelf's top
+                // outer edge in the SAME production-style parentless
+                // trimesh. Local topology alone must not authorize crossing
+                // its center-blocking faces.
+                let edge_x = vertices[shelf_vertices.clone()]
+                    .iter()
+                    .map(|point| point.x)
+                    .fold(Real::NEG_INFINITY, Real::max);
+                let edge_y = vertices[shelf_vertices.clone()]
+                    .iter()
+                    .filter(|point| point.x == edge_x)
+                    .map(|point| point.y)
+                    .fold(Real::NEG_INFINITY, Real::max);
+                let mut edge = vertices[shelf_vertices]
+                    .iter()
+                    .copied()
+                    .filter(|point| point.x == edge_x && point.y == edge_y)
+                    .collect::<Vec<_>>();
+                edge.sort_by(|first, second| first.z.total_cmp(&second.z));
+                edge.dedup();
+                assert_eq!(edge.len(), 2);
+                let base = vertices.len() as u32;
+                vertices.extend([
+                    edge[0],
+                    edge[1],
+                    point![edge_x, 3.0, edge[1].z],
+                    point![edge_x, 3.0, edge[0].z],
+                ]);
+                indices.extend([[base, base + 1, base + 2], [base, base + 2, base + 3]]);
+            }
+
+            let mut world = PhysicsWorld::new();
             world.add_collider(
-                EntityId::from_inner(index as u64 + 2).unwrap(),
-                ColliderBuilder::cuboid(0.05, 2.0, 2.0)
-                    .translation(vector![x, 1.0, 0.0])
+                EntityId::from_inner(1).unwrap(),
+                ColliderBuilder::trimesh(vertices, indices)
+                    .expect("valid combined terrain")
                     .build(),
             );
-        }
-        let mut player =
-            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(4).unwrap());
-        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
-
-        let movement = plan_top_out_from_origin(&world);
+            let mut player =
+                world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+            world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+            plan_top_out_from_origin(&world)
+        };
 
         assert!(
-            movement.is_none(),
-            "the lip exception must not permit re-entry into later parentless terrain"
+            plan(false).is_some(),
+            "the authored upward-lip branch must be active before testing the unrelated wall"
+        );
+        assert!(
+            plan(true).is_none(),
+            "the lip exception must reject an unrelated face in the same parentless trimesh"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_matches_only_edge_connected_local_trimesh_faces() {
+        let mut world = PhysicsWorld::new();
+        // Dark duplicates vertices per triangle, so these first three faces
+        // use distinct indices while sharing exact geometric edges. The final
+        // face is spatially nearby but shares no edge with the mantle patch.
+        let vertices = vec![
+            point![0.0, 0.0, 0.0],
+            point![1.0, 0.0, 0.0],
+            point![0.0, 0.0, 1.0],
+            point![1.0, 0.0, 0.0],
+            point![0.0, 0.0, 1.0],
+            point![1.0, 0.2, 0.0],
+            point![0.0, 0.0, 1.0],
+            point![1.0, 0.2, 0.0],
+            point![1.0, 0.2, 1.0],
+            point![0.9, 0.1, 0.1],
+            point![0.9, 1.0, 0.1],
+            point![0.9, 1.0, 0.9],
+        ];
+        let indices = vec![[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]];
+        let collider = ColliderBuilder::trimesh(vertices, indices)
+            .expect("valid local topology")
+            .build();
+        let handle = world.collider_set.insert(collider);
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        assert!(trimesh_faces_connect_within_local_bounds(
+            &queries,
+            (handle, FeatureId::Face(0)),
+            (handle, FeatureId::Face(2)),
+        ));
+        assert!(
+            trimesh_faces_connect_within_local_bounds(
+                &queries,
+                (handle, FeatureId::Face(4)),
+                (handle, FeatureId::Face(2)),
+            ),
+            "a two-sided backface id must resolve to the same sampled mantle face"
+        );
+        assert!(!trimesh_faces_connect_within_local_bounds(
+            &queries,
+            (handle, FeatureId::Face(0)),
+            (handle, FeatureId::Face(3)),
+        ));
+    }
+
+    #[test]
+    fn climb_top_out_bounds_the_lip_patch_by_edge_hops() {
+        let mut world = PhysicsWorld::new();
+        // A triangle strip gives every face exactly one edge-connected next
+        // hop. All faces sit inside the same small corridor, so only the
+        // explicit topology-hop bound can exclude the farther face.
+        let vertices = (0..13)
+            .map(|index| {
+                point![
+                    index as Real * 0.05,
+                    if index % 2 == 0 { 0.0 } else { 0.1 },
+                    0.0
+                ]
+            })
+            .collect::<Vec<_>>();
+        let indices = (0..11)
+            .map(|index| [index, index + 1, index + 2])
+            .collect::<Vec<_>>();
+        let collider = ColliderBuilder::trimesh(vertices, indices)
+            .expect("valid triangle strip")
+            .build();
+        let handle = world.collider_set.insert(collider);
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        assert!(trimesh_faces_connect_within_local_bounds(
+            &queries,
+            (handle, FeatureId::Face(0)),
+            (
+                handle,
+                FeatureId::Face(CLIMB_TOP_OUT_MAX_LIP_FACE_HOPS as u32),
+            ),
+        ));
+        assert!(!trimesh_faces_connect_within_local_bounds(
+            &queries,
+            (handle, FeatureId::Face(0)),
+            (
+                handle,
+                FeatureId::Face(CLIMB_TOP_OUT_MAX_LIP_FACE_HOPS as u32 + 1),
+            ),
+        ));
+    }
+
+    #[test]
+    fn climb_top_out_finds_offset_full_sphere_contact_on_a_trimesh_face() {
+        let mut world = PhysicsWorld::new();
+        let (vertices, indices) = Cuboid::new(vector![0.05, 0.2, 0.04]).to_trimesh();
+        let vertices = vertices
+            .into_iter()
+            // The near face is only 0.001 inside the ball radius, making the
+            // contact interval shorter than one old fixed sampling step.
+            .map(|vertex| Point::from(vertex + vector![1.0, 0.0, 0.359]))
+            .collect();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("valid offset terrain rail")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let route = [vector![0.0, 0.0, 0.0], vector![2.0, 0.0, 0.0]];
+        let route_probe = Capsule::new_y(PROBE_SKIN / SCALE_FACTOR, PROBE_SKIN / SCALE_FACTOR);
+
+        assert!(
+            shape_sweep_is_clear(&queries, route[0], route[1], &route_probe),
+            "the point-scale centerline must miss the offset rail"
+        );
+        let full_sphere_contact = first_allowed_route_obstruction(
+            &queries,
+            &route,
+            &Ball::new(CLIMB_TOP_OUT_RADIUS),
+            |_| true,
+        )
+        .expect("every terrain face is allowed for this contact probe")
+        .expect("the full compressed sphere must touch the offset rail");
+        assert!(
+            full_sphere_contact
+                .obstructions
+                .iter()
+                .all(|hit| matches!(hit, ShapeObstruction::TrimeshFace(_, _))),
+            "the contact must be attributed to actual trimesh faces"
+        );
+        assert!(
+            first_allowed_route_obstruction(
+                &queries,
+                &route,
+                &Ball::new(CLIMB_TOP_OUT_RADIUS),
+                |_| false,
+            )
+            .is_none(),
+            "a full-sphere face outside the mantle patch must reject the route"
         );
     }
 
@@ -6834,16 +7934,17 @@ mod tests {
     fn climb_top_out_finds_a_laterally_offset_supported_landing() {
         let mut world = PhysicsWorld::new();
         // Every forward-only candidate is unsupported. The only landing is a
-        // narrow deck two compressed-player radii to the right of the probe
-        // endpoint, forcing the lateral recovery branch. It extends far enough
-        // in +X to provide the required supported standing egress.
+        // narrow deck at the full four-radius lateral bound to the right of
+        // the probe endpoint, forcing the candidate budget to reach the edge
+        // of the promised recovery search. It extends far enough in +X to
+        // provide the required supported standing egress.
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
             ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
                 .translation(vector![
                     CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
                     0.45,
-                    -0.64
+                    -CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY
                 ])
                 .build(),
         );
@@ -6886,7 +7987,7 @@ mod tests {
 
         assert!(
             (final_sphere.x - CLIMB_TOP_OUT_PROBE_FORWARD).abs() < 1.0e-4
-                && (final_sphere.z + 0.64).abs() < 1.0e-4,
+                && (final_sphere.z + CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY).abs() < 1.0e-4,
             "the route must select the only laterally offset deck, got {final_sphere:?}"
         );
         assert!(
@@ -6901,6 +8002,47 @@ mod tests {
         assert!(
             shape_sweep_is_clear(&validation_queries, cross_end, final_sphere, &compressed),
             "the full compressed sphere must have a clear lateral route"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_reaches_the_full_forward_recovery_bound() {
+        let mut world = PhysicsWorld::new();
+        let route_forward = 1.0;
+        let expected_x = route_forward + CLIMB_TOP_OUT_ADVANCE + CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY;
+        // A narrow cap supports only the full-advance base at the last forward
+        // recovery step. It intentionally has no standing egress, exercising
+        // the exact-supported fallback after the complete four-radius shell.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.12, 0.05, 0.12)
+                .translation(vector![expected_x, 0.45, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let validation_queries = query_pipeline(&world, QueryFilter::default());
+        let parented_only = QueryFilter::default()
+            .predicate(&|_handle: ColliderHandle, collider: &Collider| collider.parent().is_some());
+        let scripted_queries = validation_queries.with_filter(parented_only);
+        let movement = plan_climb_top_out(
+            &KinematicCharacterController::default(),
+            &validation_queries,
+            &validation_queries,
+            &scripted_queries,
+            &Isometry::identity(),
+            Vector::x(),
+            route_forward,
+            1.0 / 60.0,
+        )
+        .expect("the candidate budget must reach the full forward recovery bound");
+        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+
+        assert!(
+            (final_sphere.x - expected_x).abs() < 1.0e-4 && final_sphere.z.abs() < 1.0e-4,
+            "the route must select the only four-radius forward landing, got {final_sphere:?}"
         );
     }
 
@@ -6972,6 +8114,7 @@ mod tests {
                 &[cross_end, final_sphere],
                 &compressed,
                 0.0,
+                0.0,
             ) && shape_sweep_is_clear(&queries, final_sphere, final_standing, &compressed,),
             "the full-radius high-horizontal route must remain clear through its descent"
         );
@@ -7023,6 +8166,61 @@ mod tests {
         assert!(
             movement.is_none(),
             "a side rail clipped by the full compressed radius must reject the route"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_post_lip_route_includes_unrelated_climbables() {
+        let mut world = PhysicsWorld::new();
+        // Support exists only beyond the barrier, so no pre-barrier exact
+        // standing fallback can make the test pass for the wrong reason.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(1.0, 0.05, 2.0)
+                .translation(vector![1.7, -0.05, 0.0])
+                .build(),
+        );
+        world.add_kinematic(
+            EntityId::from_inner(2).unwrap(),
+            vec3(0.85, 2.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.08, 4.0, 4.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let validation_queries = query_pipeline(&world, QueryFilter::default());
+        let not_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            !collider
+                .collision_groups()
+                .memberships
+                .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        };
+        let parented_non_climbable = |handle: ColliderHandle, collider: &Collider| {
+            collider.parent().is_some() && not_climbable(handle, collider)
+        };
+        let probe_queries =
+            validation_queries.with_filter(QueryFilter::default().predicate(&not_climbable));
+        let scripted_queries = validation_queries
+            .with_filter(QueryFilter::default().predicate(&parented_non_climbable));
+        let movement = plan_climb_top_out(
+            &KinematicCharacterController::default(),
+            &validation_queries,
+            &probe_queries,
+            &scripted_queries,
+            &Isometry::translation(0.0, 0.0, 0.0),
+            Vector::x(),
+            CLIMB_TOP_OUT_PROBE_FORWARD,
+            1.0 / 60.0,
+        );
+
+        assert!(
+            movement.is_none(),
+            "once the lip exception ends, an unrelated climbable must block the only supported landing route"
         );
     }
 
@@ -7088,6 +8286,178 @@ mod tests {
     }
 
     #[test]
+    fn climb_top_out_final_release_reverses_without_current_support() {
+        let mut world = PhysicsWorld::new();
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(1).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let final_pose = vector![4.0, 1.0, 0.0];
+        let pos = Isometry::translation(final_pose.x, final_pose.y, final_pose.z);
+        let mut waypoints = [final_pose; 7];
+        waypoints[5] = final_pose + Vector::y();
+        let top_out = ClimbTopOut {
+            waypoints,
+            next_waypoint: 6,
+            save_pose: vector![-1.0, 1.0, 0.0],
+            reversing: false,
+        };
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            top_out,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
+
+        assert!(
+            movement.translation.y > 0.0 && active.is_some_and(|top_out| top_out.reversing),
+            "a final pose whose planned support disappeared must reverse before restoring standing"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_reversal_does_not_release_without_support_or_a_ladder_grip() {
+        let mut world = PhysicsWorld::new();
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(1).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let save_pose = vector![0.0, 1.0, 0.0];
+        let pos = Isometry::translation(save_pose.x, save_pose.y, save_pose.z);
+        let top_out = ClimbTopOut {
+            waypoints: [save_pose; 7],
+            next_waypoint: 0,
+            save_pose,
+            reversing: true,
+        };
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            top_out,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
+
+        assert_eq!(movement.translation, Vector::zeros());
+        assert!(
+            active.is_some_and(|top_out| top_out.reversing),
+            "reversal completion must remain compressed when neither support nor a ladder grip is current"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_reversal_returns_to_a_current_ladder_grip() {
+        let mut world = PhysicsWorld::new();
+        let save_pose = vector![0.0, 1.0, 0.0];
+        world.add_kinematic(
+            EntityId::from_inner(1).unwrap(),
+            vec3(0.48, save_pose.y, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.08, 2.0, 1.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let pos = Isometry::translation(save_pose.x, save_pose.y, save_pose.z);
+        let top_out = ClimbTopOut {
+            waypoints: [save_pose; 7],
+            next_waypoint: 0,
+            save_pose,
+            reversing: true,
+        };
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        assert!(
+            standing_pose_climb_direction(&queries, save_pose, &standing_player_capsule(),)
+                .is_some()
+        );
+        let (_, inactive_input) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            top_out,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
+        assert!(
+            inactive_input.is_some_and(|top_out| top_out.reversing),
+            "nearby ladder geometry alone must not release an unsupported reversal"
+        );
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            top_out,
+            Vector::x(),
+            1.0 / 60.0,
+        );
+
+        assert_eq!(movement.translation, Vector::zeros());
+        assert!(
+            active.is_none(),
+            "reversal may return to ordinary climb handling when the original ladder is still grippable"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_final_release_accepts_current_upward_support() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(10.0, 0.05, 10.0)
+                .translation(vector![0.0, -0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let standing_floor_offset = PLAYER_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+        let final_pose = vector![4.0, standing_floor_offset, 0.0];
+        let pos = Isometry::translation(final_pose.x, final_pose.y, final_pose.z);
+        let top_out = ClimbTopOut {
+            waypoints: [final_pose; 7],
+            next_waypoint: 6,
+            save_pose: vector![-1.0, standing_floor_offset, 0.0],
+            reversing: false,
+        };
+        let queries = query_pipeline(&world, QueryFilter::default());
+
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            top_out,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
+
+        assert_eq!(movement.translation, Vector::zeros());
+        assert!(
+            active.is_none(),
+            "an unblocked final pose on unchanged upward support should restore standing"
+        );
+    }
+
+    #[test]
     fn climb_top_out_reverses_when_a_parented_blocker_appears() {
         let mut world = PhysicsWorld::new();
         let mut player =
@@ -7104,7 +8474,15 @@ mod tests {
         };
         let first = {
             let queries = query_pipeline(&world, QueryFilter::default());
-            advance_climb_top_out(&controller, &queries, &queries, &pos, top_out, 1.0 / 60.0)
+            advance_climb_top_out(
+                &controller,
+                &queries,
+                &queries,
+                &pos,
+                top_out,
+                Vector::zeros(),
+                1.0 / 60.0,
+            )
         };
         assert!(first.0.translation.x > 0.0);
         pos.translation.vector += first.0.translation;
@@ -7124,8 +8502,15 @@ mod tests {
         let mut active = first.1.expect("route remains active");
         let mut reversing = None;
         for _ in 0..32 {
-            let (movement, next) =
-                advance_climb_top_out(&controller, &queries, &queries, &pos, active, 1.0 / 60.0);
+            let (movement, next) = advance_climb_top_out(
+                &controller,
+                &queries,
+                &queries,
+                &pos,
+                active,
+                Vector::zeros(),
+                1.0 / 60.0,
+            );
             pos.translation.vector += movement.translation;
             active = next.expect("blocked route should remain recoverable");
             if active.reversing {
@@ -7140,6 +8525,59 @@ mod tests {
             world.get_player_save_translation(&player),
             Some(vec3(-1.0, 0.0, 0.0)),
             "an in-flight save must serialize the last standing pose"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_execution_includes_climbables_after_lip_clear() {
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(1).unwrap(),
+            vec3(0.3, 0.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.04, 2.0, 2.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let controller = KinematicCharacterController::default();
+        let pos = Isometry::translation(0.0, 0.0, 0.0);
+        let mut waypoints = test_waypoints();
+        waypoints[4] = pos.translation.vector;
+        let top_out = ClimbTopOut {
+            waypoints,
+            next_waypoint: 5,
+            save_pose: vector![-1.0, 0.0, 0.0],
+            reversing: false,
+        };
+        let validation_queries = query_pipeline(&world, QueryFilter::default());
+        let parented_non_climbable = |_handle: ColliderHandle, collider: &Collider| {
+            collider.parent().is_some()
+                && !collider
+                    .collision_groups()
+                    .memberships
+                    .intersects(InternalCollisionGroups::CLIMBABLE.bits.into())
+        };
+        let scripted_queries = validation_queries
+            .with_filter(QueryFilter::default().predicate(&parented_non_climbable));
+
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &validation_queries,
+            &scripted_queries,
+            &pos,
+            top_out,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
+
+        assert_eq!(movement.translation, Vector::zeros());
+        assert!(
+            active.is_some_and(|top_out| top_out.reversing),
+            "a climbable that moves into a post-lip waypoint must reverse the live route"
         );
     }
 
@@ -7171,8 +8609,15 @@ mod tests {
 
         for _ in 0..32 {
             let queries = query_pipeline(&world, QueryFilter::default());
-            let (movement, next) =
-                advance_climb_top_out(&controller, &queries, &queries, &pos, active, 1.0 / 60.0);
+            let (movement, next) = advance_climb_top_out(
+                &controller,
+                &queries,
+                &queries,
+                &pos,
+                active,
+                Vector::zeros(),
+                1.0 / 60.0,
+            );
             pos.translation.vector += movement.translation;
             let Some(next) = next else {
                 break;

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -300,6 +300,16 @@ const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 /// needed when the compressed route fits beside a wall but the standing
 /// capsule must clear that wall before expanding.
 const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 5.0 * CLIMB_TOP_OUT_RADIUS;
+/// Only redirect a valid forward landing onto a recessed approach-side floor
+/// when the forward route needs at least a full compressed-body-width dogleg.
+/// A one-radius sidestep is ordinary ledge recovery and must keep the player's
+/// held-direction intent.
+const CLIMB_TOP_OUT_LARGE_LATERAL_DOGLEG: f32 = 2.0 * CLIMB_TOP_OUT_RADIUS;
+/// When every ordinary forward landing needs a wider sideways detour, also
+/// consider stepping back onto the ladder's approach side. Dark ladders can
+/// terminate above a recessed same-side floor; bounding this search by the
+/// already-validated deep-drop reach keeps the compressed route local.
+const CLIMB_TOP_OUT_MAX_APPROACH_RECOVERY: f32 = CLIMB_TOP_OUT_DEEP_DROP;
 /// Bound synchronous support/route evaluation when a ladder top has no valid
 /// landing. The three route bases, five forward offsets, and eleven signed
 /// lateral offsets cover the complete independently bounded recovery grid.
@@ -2193,6 +2203,40 @@ fn plan_climb_top_out(
                 has_egress.then_some(validated)
             })
     });
+    // A ladder may project above a recessed floor on the same side from which
+    // it is climbed. The normal held-direction search cannot see that floor:
+    // every candidate advances beyond the ladder, potentially finding a
+    // collision-safe but disconnected roof only after a large lateral dogleg.
+    // Probe a bounded straight retreat from `lip_clear` and validate both the
+    // complete all-collider route and an ordinary stride away from the shaft.
+    // This is deliberately not a general second 2-D grid: straight approach-
+    // side recovery is the least-steering alternative to a sideways detour.
+    let approach_steps =
+        (CLIMB_TOP_OUT_MAX_APPROACH_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    let approach_with_egress = (1..=approach_steps).find_map(|step| {
+        let offset = lip_clear - direction * (step as Real * CLIMB_TOP_OUT_RADIUS);
+        let candidate = vector![offset.x, head.y, offset.z];
+        let landing = landing_pose(candidate)?;
+        if !shape_obstructions(validation_queries, candidate, &compressed).is_empty()
+            || !shape_sweep_is_clear(validation_queries, head, candidate, &compressed)
+            || !shape_sweep_is_clear(
+                validation_queries,
+                landing.sphere,
+                landing.standing,
+                &compressed,
+            )
+            || !has_supported_standing_egress(
+                validation_queries,
+                landing.standing,
+                -direction,
+                &standing,
+                standing_floor_offset,
+            )
+        {
+            return None;
+        }
+        Some((head, landing.sphere, landing.standing))
+    });
     let direct_fallback = direct_with_egress
         .is_none()
         .then(|| direct_candidates.into_iter().next())
@@ -2207,10 +2251,33 @@ fn plan_climb_top_out(
             .map(|(_, validated)| validated)
     })
     .flatten();
-    let Some((landing_route, final_sphere, final_standing)) = direct_with_egress
+    let forward_landing = direct_with_egress
         .or(deep_with_egress.flatten())
         .or(direct_fallback)
-        .or(deep_fallback)
+        .or(deep_fallback);
+    // Prefer the held-direction result unless it needs more lateral steering
+    // than the straight approach-side route. This preserves ordinary forward
+    // top-outs and uses the recessed-floor alternative only when it avoids a
+    // wider sideways recovery.
+    let selected_landing = match (forward_landing, approach_with_egress) {
+        (Some(forward), Some(approach)) => {
+            let lateral_distance = |landing: &(Vector<Real>, Vector<Real>, Vector<Real>)| {
+                (landing.1 - lip_clear).dot(&lateral).abs()
+            };
+            let forward_lateral = lateral_distance(&forward);
+            if forward_lateral + 1.0e-5 >= CLIMB_TOP_OUT_LARGE_LATERAL_DOGLEG
+                && lateral_distance(&approach) + 1.0e-5 < forward_lateral
+            {
+                Some((approach, true))
+            } else {
+                Some((forward, false))
+            }
+        }
+        (Some(forward), None) => Some((forward, false)),
+        (None, Some(approach)) => Some((approach, true)),
+        (None, None) => None,
+    };
+    let Some(((landing_route, final_sphere, final_standing), approach_side)) = selected_landing
     else {
         reject_top_out!("landing");
     };
@@ -2218,16 +2285,29 @@ fn plan_climb_top_out(
     // parented entity blockers live but deliberately permit passage through
     // parentless immutable level terrain, the narrow Dark jump-through
     // exception. Final standing fit still uses `validation_queries`.
-    let waypoints = [
-        head,
-        rise_start,
-        cross_start,
-        lip_approach,
-        lip_clear,
-        landing_route,
-        final_sphere,
-        final_standing,
-    ];
+    let waypoints = if approach_side {
+        [
+            head,
+            head,
+            head,
+            head,
+            head,
+            landing_route,
+            final_sphere,
+            final_standing,
+        ]
+    } else {
+        [
+            head,
+            rise_start,
+            cross_start,
+            lip_approach,
+            lip_clear,
+            landing_route,
+            final_sphere,
+            final_standing,
+        ]
+    };
     let mut simulated = pos.translation.vector;
     let mut first_movement = None;
     for (waypoint_index, waypoint) in waypoints.into_iter().enumerate() {
@@ -8284,6 +8364,63 @@ mod tests {
         assert!(
             final_sphere.x > 0.0 && (final_sphere.z + CLIMB_TOP_OUT_RADIUS).abs() < 1.0e-5,
             "the one-radius forward sidestep must outrank the recessed approach floor: {waypoints:?}"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_prefers_a_straight_recessed_approach_side_landing() {
+        let mut world = PhysicsWorld::new();
+        let head_y = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+        let cross_y = head_y + CLIMB_TOP_OUT_UP;
+        let roof_top = cross_y - CLIMB_TOP_OUT_FINAL_DROP + 0.02;
+        // A collision-safe roof exists only after the maximum lateral dogleg,
+        // matching the misleading Hydro2 landing. It has ordinary +X egress.
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0 + 0.12, 0.05, 0.12)
+                .translation(vector![
+                    CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_EGRESS_DISTANCE / 2.0,
+                    roof_top - 0.05,
+                    -CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY,
+                ])
+                .build(),
+        );
+        // The approach side instead has a lower, straight, fully supported
+        // floor. Reaching it never crosses the upper slab: the compressed body
+        // backs away at head height and then descends through clear space.
+        let recessed_floor_top = -1.0;
+        world.add_collider(
+            EntityId::from_inner(2).unwrap(),
+            ColliderBuilder::cuboid(2.0, 0.05, 0.6)
+                .translation(vector![-2.4, recessed_floor_top - 0.05, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let movement = plan_top_out_from_origin(&world)
+            .expect("the recessed approach-side floor should permit a top-out");
+        let waypoints = movement.top_out.expect("planned top-out").waypoints;
+        let final_sphere = waypoints[6];
+        let final_standing = waypoints[7];
+        let expected_standing_y = recessed_floor_top
+            + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+
+        assert!(
+            waypoints[0..=5]
+                .iter()
+                .all(|waypoint| (*waypoint - waypoints[0]).norm() < 1.0e-5),
+            "same-side recovery must remain below the upper slab instead of running the rise/cross route: {waypoints:?}"
+        );
+        assert!(
+            final_sphere.x < 0.0
+                && final_sphere.z.abs() < 1.0e-5
+                && (final_sphere.y - head_y).abs() < 1.0e-5
+                && (final_standing.y - expected_standing_y).abs() < 1.0e-5,
+            "the straight recessed floor must outrank the maximum-lateral roof: {waypoints:?}"
         );
     }
 

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -296,13 +296,14 @@ const CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE: f32 =
 const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 /// A narrow landing can require clearing the side of a rail after the forward
 /// lip crossing. Keep that safety recovery separate from Dark's backward rise
-/// retreat and bound it to four compressed-player radii.
-const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
+/// retreat and bound it to five compressed-player radii. The fifth sample is
+/// needed when the compressed route fits beside a wall but the standing
+/// capsule must clear that wall before expanding.
+const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 5.0 * CLIMB_TOP_OUT_RADIUS;
 /// Bound synchronous support/route evaluation when a ladder top has no valid
-/// landing. Candidates are ordered by total recovery distance; 75 covers every
-/// three-base/two-side candidate through the complete four-radius Manhattan
-/// shell, including both zero-forward lateral and zero-lateral forward bounds.
-const CLIMB_TOP_OUT_MAX_LANDING_CANDIDATES: usize = 75;
+/// landing. The three route bases, five forward offsets, and eleven signed
+/// lateral offsets cover the complete independently bounded recovery grid.
+const CLIMB_TOP_OUT_MAX_LANDING_CANDIDATES: usize = 3 * 5 * 11;
 /// Egress validation samples a full standing stride at contact-offset
 /// intervals. It is a landing preference, not a safety requirement, so limit
 /// it to the first few already-safe candidates in each support tier.
@@ -653,7 +654,7 @@ struct ClimbPass<'a> {
 
 #[derive(Clone, Copy)]
 struct ClimbTopOut {
-    waypoints: [Vector<Real>; 7],
+    waypoints: [Vector<Real>; 8],
     next_waypoint: usize,
     save_pose: Vector<Real>,
     reversing: bool,
@@ -1051,14 +1052,16 @@ struct RouteObstructionScan {
 /// Follow a sampled route and permit exactly one bounded obstruction interval.
 ///
 /// The route may begin obstructed, or enter within `entry_limit`, but has to
-/// clear by `initial_obstruction_limit` and may never re-enter. Every actual
-/// collider/triangle touched must also satisfy `allowed`.
+/// stay within `initial_obstruction_limit` and may never re-enter. When
+/// `require_clear` is true it must also clear before the route ends. Every
+/// actual collider/triangle touched must satisfy `allowed`.
 fn scan_initial_route_obstruction(
     queries: &QueryPipeline,
     waypoints: &[Vector<Real>],
     shape: &dyn Shape,
     initial_obstruction_limit: Real,
     entry_limit: Real,
+    require_clear: bool,
     allowed: impl Fn(ShapeObstruction) -> bool,
 ) -> Option<RouteObstructionScan> {
     // Dark's sparse body may start inside the local lip before reaching the
@@ -1142,7 +1145,7 @@ fn scan_initial_route_obstruction(
         }
         route_distance += distance;
     }
-    if obstruction_seen && !cleared_after_obstruction {
+    if require_clear && obstruction_seen && !cleared_after_obstruction {
         return None;
     }
     Some(RouteObstructionScan { first_clear })
@@ -1261,6 +1264,7 @@ fn shape_route_exits_only_initial_obstruction(
         shape,
         initial_obstruction_limit,
         entry_limit,
+        true,
         |_| true,
     )
     .is_some()
@@ -1898,6 +1902,7 @@ fn plan_climb_top_out(
         &compressed,
         (cross_start - rise_start).norm(),
         (cross_start - rise_start).norm(),
+        false,
         |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
     )
     .is_none()
@@ -1986,6 +1991,7 @@ fn plan_climb_top_out(
             &compressed,
             lip_exit_allowance,
             CLIMB_TOP_OUT_RECOVERY_RETREAT,
+            true,
             |hit| {
                 exit_lip_patch
                     .as_ref()
@@ -2031,16 +2037,16 @@ fn plan_climb_top_out(
     // even though the probe itself found the deck. Search the full advance,
     // geometry-derived exit, and probe endpoint for the nearest standing-safe
     // landing. Each ordered base can recover forward past an overhang, while a
-    // separate one-radius-step lateral search can clear a narrow rail. Both
-    // searches have four-radius safety bounds. The compressed route first
-    // reaches the geometry-derived `lip_clear` before moving to the selected
-    // landing.
+    // separate one-radius-step lateral search can clear a narrow rail. Forward
+    // recovery stays within four radii and lateral recovery within five. The
+    // compressed route first reaches the geometry-derived `lip_clear` before
+    // moving to the selected landing.
     let lateral = vector![direction.z, 0.0, -direction.x];
     let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
     let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
     // Breadth-first by total recovery distance. Within an equal distance,
-    // consider lateral recovery first so the fixed candidate budget always
-    // reaches the promised four-radius side clearance at zero forward offset.
+    // consider lateral recovery first so the fixed candidate budget reaches
+    // the complete independently bounded forward/lateral grid.
     let mut landing_candidates = Vec::new();
     for total_step in 0..=lateral_steps + forward_steps {
         for lateral_step in (0..=lateral_steps).rev() {
@@ -2077,14 +2083,27 @@ fn plan_climb_top_out(
         reject_top_out!("scripted_or_lip_clear");
     }
     let validated_landing = |landing: SupportedLanding| {
-        (shape_sweep_is_clear(validation_queries, lip_clear, landing.sphere, &compressed)
-            && shape_sweep_is_clear(
-                validation_queries,
-                landing.sphere,
-                landing.standing,
-                &compressed,
-            ))
-        .then_some((landing.sphere, landing.standing))
+        if !shape_sweep_is_clear(
+            validation_queries,
+            landing.sphere,
+            landing.standing,
+            &compressed,
+        ) {
+            return None;
+        }
+        let landing_delta = landing.sphere - lip_clear;
+        let lateral_turn = lip_clear + lateral * landing_delta.dot(&lateral);
+        let forward_turn = lip_clear + direction * landing_delta.dot(&direction);
+        // A diagonal can cut through the corner of an otherwise-clear shaft
+        // cap. Prefer the direct route, then try the two geometry-derived
+        // orthogonal doglegs; every leg uses ordinary all-collider sweeps.
+        [lip_clear, lateral_turn, forward_turn]
+            .into_iter()
+            .find(|turn| {
+                shape_sweep_is_clear(validation_queries, lip_clear, *turn, &compressed)
+                    && shape_sweep_is_clear(validation_queries, *turn, landing.sphere, &compressed)
+            })
+            .map(|turn| (turn, landing.sphere, landing.standing))
     };
     // Preserve cheap forward-first candidate order, generating bases lazily
     // and deduplicating identical coordinates before their support and route
@@ -2168,7 +2187,7 @@ fn plan_climb_top_out(
             .map(|(_, validated)| validated)
     })
     .flatten();
-    let Some((final_sphere, final_standing)) = direct_with_egress
+    let Some((landing_route, final_sphere, final_standing)) = direct_with_egress
         .or(deep_with_egress.flatten())
         .or(direct_fallback)
         .or(deep_fallback)
@@ -2185,6 +2204,7 @@ fn plan_climb_top_out(
         cross_start,
         lip_approach,
         lip_clear,
+        landing_route,
         final_sphere,
         final_standing,
     ];
@@ -7297,14 +7317,15 @@ mod tests {
         );
     }
 
-    /// The seven-waypoint route the reversal tests drive by hand.
-    fn test_waypoints() -> [Vector<Real>; 7] {
+    /// The eight-waypoint route the reversal tests drive by hand.
+    fn test_waypoints() -> [Vector<Real>; 8] {
         [
             vector![0.0, 0.0, 0.0],
             vector![0.0, 0.0, 0.0],
             vector![2.0, 0.0, 0.0],
             vector![2.5, 0.0, 0.0],
             vector![3.0, 0.0, 0.0],
+            vector![3.5, 0.0, 0.0],
             vector![4.0, 0.0, 0.0],
             vector![4.0, -0.64, 0.0],
         ]
@@ -7770,6 +7791,51 @@ mod tests {
     }
 
     #[test]
+    fn climb_top_out_rise_can_hand_off_one_attributed_overlap() {
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::cuboid(0.6, 0.6, 0.6)
+                .translation(vector![1.0, 0.0, 0.0])
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let compressed = Ball::new(0.2);
+        let route = [vector![0.0, 0.0, 0.0], vector![1.0, 0.0, 0.0]];
+
+        assert!(
+            scan_initial_route_obstruction(&queries, &route, &compressed, 1.0, 1.0, false, |_| {
+                true
+            },)
+            .is_some(),
+            "an attributed initial interval may remain contiguous for the next route leg to clear"
+        );
+        assert!(
+            scan_initial_route_obstruction(
+                &queries,
+                &route,
+                &compressed,
+                1.0,
+                1.0,
+                true,
+                |_| true,
+            )
+            .is_none(),
+            "a caller that owns the complete route must still require the interval to clear"
+        );
+        assert!(
+            scan_initial_route_obstruction(&queries, &route, &compressed, 1.0, 1.0, false, |_| {
+                false
+            },)
+            .is_none(),
+            "an unfinished interval never permits an unattributed obstruction"
+        );
+    }
+
+    #[test]
     fn climb_top_out_rejects_parentless_terrain_on_recovered_approach() {
         let mut world = PhysicsWorld::new();
         world.add_collider(
@@ -8076,7 +8142,7 @@ mod tests {
             + CLIMB_TOP_OUT_UP;
         let deck_top = cross_y - CLIMB_TOP_OUT_FINAL_DROP + 0.02;
         // Every forward-only candidate is unsupported. The only landing is a
-        // narrow deck at the full four-radius lateral bound to the right of
+        // narrow deck at the full five-radius lateral bound to the right of
         // the probe endpoint, forcing the candidate budget to reach the edge
         // of the promised recovery search. It extends far enough in +X to
         // provide the required supported standing egress.
@@ -8112,8 +8178,8 @@ mod tests {
         .expect("the laterally offset deck should permit a top-out");
         let waypoints = movement.top_out.expect("planned top-out").waypoints;
         let cross_end = waypoints[4];
-        let final_sphere = waypoints[5];
-        let final_standing = waypoints[6];
+        let final_sphere = waypoints[6];
+        let final_standing = waypoints[7];
         let support_ray = Ray::new(Point::from(final_sphere), -Vector::y());
         let (_, support) = validation_queries
             .cast_ray_and_get_normal(&support_ray, CLIMB_TOP_OUT_FINAL_DROP, true)
@@ -8135,7 +8201,7 @@ mod tests {
         );
         assert!(
             support.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL
-                && (support.time_of_impact - (waypoints[5].y - deck_top)).abs() < 1.0e-4,
+                && (support.time_of_impact - (waypoints[6].y - deck_top)).abs() < 1.0e-4,
             "the selected deck support must be independently upward and nearby, got {support:?}"
         );
         assert!(
@@ -8155,7 +8221,7 @@ mod tests {
         let expected_x = route_forward + CLIMB_TOP_OUT_ADVANCE + CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY;
         // A narrow cap supports only the full-advance base at the last forward
         // recovery step. It intentionally has no standing egress, exercising
-        // the exact-supported fallback after the complete four-radius shell.
+        // the exact-supported fallback after the complete forward bound.
         world.add_collider(
             EntityId::from_inner(1).unwrap(),
             ColliderBuilder::cuboid(0.12, 0.05, 0.12)
@@ -8181,7 +8247,7 @@ mod tests {
             1.0 / 60.0,
         )
         .expect("the candidate budget must reach the full forward recovery bound");
-        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+        let final_sphere = movement.top_out.expect("planned top-out").waypoints[6];
 
         assert!(
             (final_sphere.x - expected_x).abs() < 1.0e-4 && final_sphere.z.abs() < 1.0e-4,
@@ -8204,7 +8270,7 @@ mod tests {
 
         let movement =
             plan_top_out_from_origin(&world).expect("the wide deck should permit egress");
-        let final_sphere = movement.top_out.expect("planned top-out").waypoints[5];
+        let final_sphere = movement.top_out.expect("planned top-out").waypoints[6];
         assert!(
             (final_sphere.x - (CLIMB_TOP_OUT_PROBE_FORWARD + CLIMB_TOP_OUT_ADVANCE)).abs() < 1.0e-4
                 && final_sphere.z.abs() < 1.0e-4,
@@ -8240,8 +8306,8 @@ mod tests {
             .expect("the lower floor should be reachable past the upper ledge");
         let waypoints = movement.top_out.expect("planned top-out").waypoints;
         let cross_end = waypoints[4];
-        let final_sphere = waypoints[5];
-        let final_standing = waypoints[6];
+        let final_sphere = waypoints[6];
+        let final_standing = waypoints[7];
         let full_advance = cross_end + Vector::x() * CLIMB_TOP_OUT_ADVANCE;
         let queries = query_pipeline(&world, QueryFilter::default());
         let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
@@ -8421,7 +8487,7 @@ mod tests {
 
         let movement = plan_top_out_from_origin(&world)
             .expect("an exact supported fallback should avoid re-freezing");
-        let final_standing = movement.top_out.expect("planned top-out").waypoints[6];
+        let final_standing = movement.top_out.expect("planned top-out").waypoints[7];
         let expected_standing_y = 0.5
             + PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
             + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
@@ -8441,11 +8507,11 @@ mod tests {
         let controller = KinematicCharacterController::default();
         let final_pose = vector![4.0, 1.0, 0.0];
         let pos = Isometry::translation(final_pose.x, final_pose.y, final_pose.z);
-        let mut waypoints = [final_pose; 7];
-        waypoints[5] = final_pose + Vector::y();
+        let mut waypoints = [final_pose; 8];
+        waypoints[6] = final_pose + Vector::y();
         let top_out = ClimbTopOut {
             waypoints,
-            next_waypoint: 6,
+            next_waypoint: 7,
             save_pose: vector![-1.0, 1.0, 0.0],
             reversing: false,
         };
@@ -8477,7 +8543,7 @@ mod tests {
         let save_pose = vector![0.0, 1.0, 0.0];
         let pos = Isometry::translation(save_pose.x, save_pose.y, save_pose.z);
         let top_out = ClimbTopOut {
-            waypoints: [save_pose; 7],
+            waypoints: [save_pose; 8],
             next_waypoint: 0,
             save_pose,
             reversing: true,
@@ -8522,7 +8588,7 @@ mod tests {
         let controller = KinematicCharacterController::default();
         let pos = Isometry::translation(save_pose.x, save_pose.y, save_pose.z);
         let top_out = ClimbTopOut {
-            waypoints: [save_pose; 7],
+            waypoints: [save_pose; 8],
             next_waypoint: 0,
             save_pose,
             reversing: true,
@@ -8582,8 +8648,8 @@ mod tests {
         let final_pose = vector![4.0, standing_floor_offset, 0.0];
         let pos = Isometry::translation(final_pose.x, final_pose.y, final_pose.z);
         let top_out = ClimbTopOut {
-            waypoints: [final_pose; 7],
-            next_waypoint: 6,
+            waypoints: [final_pose; 8],
+            next_waypoint: 7,
             save_pose: vector![-1.0, standing_floor_offset, 0.0],
             reversing: false,
         };
@@ -8834,7 +8900,7 @@ mod tests {
         world.collider_set[collider_handle].set_shape(SharedShape::ball(CLIMB_TOP_OUT_RADIUS));
         world.rigid_body_set[player.character_handle].enable_ccd(false);
         player.top_out = Some(ClimbTopOut {
-            waypoints: [compressed_pose; 7],
+            waypoints: [compressed_pose; 8],
             next_waypoint: 3,
             save_pose,
             reversing: true,
@@ -10556,7 +10622,7 @@ mod tests {
         world.collider_set[collider_handle].set_shape(SharedShape::ball(CLIMB_TOP_OUT_RADIUS));
         world.rigid_body_set[player.character_handle].enable_ccd(false);
         player.top_out = Some(ClimbTopOut {
-            waypoints: [compressed_pose; 7],
+            waypoints: [compressed_pose; 8],
             next_waypoint: 3,
             save_pose,
             reversing: false,

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4265,6 +4265,14 @@ impl PhysicsWorld {
         ))
     }
 
+    #[cfg(test)]
+    pub(crate) fn capsule_dimensions(&self, handle: RigidBodyHandle) -> Option<(f32, f32)> {
+        let body = self.rigid_body_set.get(handle)?;
+        let collider = self.collider_set.get(*body.colliders().first()?)?;
+        let capsule = collider.shape().as_capsule()?;
+        Some((capsule.radius, capsule.half_height() * 2.0))
+    }
+
     /// Whether any collider on a body is solid to the given character
     /// membership. Mirrors the player/actor movement queries: disabled bodies,
     /// disabled colliders, sensors, and non-collidable memberships never stop a

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -307,6 +307,12 @@ const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
 /// needed when the compressed route fits beside a wall but the standing
 /// capsule must clear that wall before expanding.
 const CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY: f32 = 5.0 * CLIMB_TOP_OUT_RADIUS;
+/// A fixed mantle sample may land on a lower pipe or shelf while the player's
+/// head is already touching the underside of the actual deck. Only in that
+/// separate-ceiling case, sample the same bounded lateral offsets used by the
+/// landing search for a floor face locally connected to that exact underside.
+/// Crouching is the largest grid: eight radius steps on either side.
+const CLIMB_TOP_OUT_MAX_LATERAL_MANTLE_CANDIDATES: usize = 8 * 2;
 /// Only redirect a valid forward landing onto a recessed approach-side floor
 /// when the forward route needs at least a full compressed-body-width dogleg.
 /// A one-radius sidestep is ordinary ledge recovery and must keep the player's
@@ -1528,6 +1534,80 @@ fn mantle_lip_patch(
     Some(MantleLipPatch { handle, faces })
 }
 
+/// Find a laterally offset mantle floor belonging to the exact local terrain
+/// slab currently obstructing the player's rise.
+///
+/// WorldRep is one mission-wide trimesh, so a shared collider handle and equal
+/// height are not proof of one surface. The downward floor sample must be
+/// connected to the canonical upward-hit face inside the same bounded probe
+/// corridor. This permits a ladder to exit beside a lower pipe without
+/// authorizing a disconnected ceiling or another island in WorldRep.
+fn lateral_same_slab_mantle_hit(
+    queries: &QueryPipeline,
+    up_hit: Option<(ColliderHandle, RayIntersection)>,
+    head: Vector<Real>,
+    probe_ahead: Vector<Real>,
+    lateral: Vector<Real>,
+    compressed_radius: Real,
+    lateral_steps: usize,
+) -> Option<(Vector<Real>, ColliderHandle, RayIntersection)> {
+    let (up_handle, up) = up_hit?;
+    let FeatureId::Face(up_face) = up.feature else {
+        return None;
+    };
+    if up.normal.y >= -CLIMB_TOP_OUT_MIN_GROUND_NORMAL {
+        return None;
+    }
+    let collider = queries.colliders.get(up_handle)?;
+    let mesh = collider.shape().as_trimesh()?;
+    let face_count = mesh.indices().len() as u32;
+    if face_count == 0 {
+        return None;
+    }
+    let canonical_up_face = up_face % face_count;
+    let underside = head + Vector::y() * up.time_of_impact;
+    let mut evaluated = 0;
+    for lateral_step in 1..=lateral_steps {
+        for side in [1.0, -1.0] {
+            if evaluated == CLIMB_TOP_OUT_MAX_LATERAL_MANTLE_CANDIDATES {
+                return None;
+            }
+            evaluated += 1;
+            let origin = probe_ahead + lateral * (side * lateral_step as Real * compressed_radius);
+            let Some((floor_handle, floor)) = queries
+                .cast_ray_and_get_normal(
+                    &Ray::new(Point::from(origin), -Vector::y()),
+                    CLIMB_TOP_OUT_MAX_DROP,
+                    true,
+                )
+                .filter(|(_, floor)| floor.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL)
+            else {
+                continue;
+            };
+            let floor_point = origin - Vector::y() * floor.time_of_impact;
+            if floor_handle != up_handle
+                || floor_point.y + 1.0e-4 < underside.y
+                || floor_point.y - underside.y > CLIMB_TOP_OUT_MAX_LOCAL_SLAB_THICKNESS + 1.0e-4
+            {
+                continue;
+            }
+            let floor_patch = mantle_lip_patch(
+                queries,
+                Some((floor_handle, floor.feature)),
+                floor_point,
+                &[underside, floor_point],
+                false,
+            );
+            if floor_patch.is_some_and(|patch| {
+                patch.handle == up_handle && patch.faces.contains(&canonical_up_face)
+            }) {
+                return Some((origin, floor_handle, floor));
+            }
+        }
+    }
+    None
+}
+
 /// Extend a floor-seeded mantle patch with only the underside faces crossed by
 /// the actual recovered rise.
 ///
@@ -1988,6 +2068,8 @@ fn plan_climb_top_out(
         )
     };
     let compressed_radius = body_radius / SCALE_FACTOR;
+    let lateral = vector![direction.z, 0.0, -direction.x];
+    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / compressed_radius).ceil() as usize;
     let head_offset = (body_height / 2.0 - body_radius) / SCALE_FACTOR;
     let head = pos.translation.vector + Vector::y() * head_offset;
     let raised = head + Vector::y() * CLIMB_TOP_OUT_UP;
@@ -2072,7 +2154,7 @@ fn plan_climb_top_out(
         .is_none()
         .then(|| mantle_probe(route_ahead))
         .flatten();
-    let same_mantle_slab = match (up_hit, route_mantle_hit) {
+    let route_same_mantle_slab = match (up_hit, route_mantle_hit) {
         (Some((up_handle, up)), Some((origin, floor_handle, floor)))
             if up_handle == floor_handle
                 && (origin - probe_ahead).norm() > CLIMB_TOP_OUT_RECOVERY_RETREAT =>
@@ -2086,26 +2168,44 @@ fn plan_climb_top_out(
         }
         _ => false,
     };
-    let mantle_hit = fixed_mantle_hit.or_else(|| {
-        if same_mantle_slab {
+    let initial_mantle_hit = fixed_mantle_hit.or_else(|| {
+        if route_same_mantle_slab {
             route_mantle_hit
         } else {
             None
         }
     });
-    let mantle_floor =
-        mantle_hit.map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
-    if up_obstruction.is_some_and(|(_, obstruction_y)| {
+    let initial_mantle_floor = initial_mantle_hit
+        .map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
+    let separate_ceiling = up_obstruction.is_some_and(|(_, obstruction_y)| {
         // A lip can have a thin underside above its adjacent landing. Treat
         // surfaces within one compressed radius plus the solver gap on both
         // faces as the same landing edge; a genuinely separate low ceiling
         // remains farther above the probed floor.
-        mantle_floor.is_none_or(|floor| {
+        initial_mantle_floor.is_none_or(|floor| {
             floor.y + compressed_radius + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
                 < obstruction_y
         })
-    }) && ladder_exit_hit.is_none()
-    {
+    });
+    let lateral_mantle_hit = (separate_ceiling && ladder_exit_hit.is_none())
+        .then(|| {
+            lateral_same_slab_mantle_hit(
+                probe_queries,
+                up_hit,
+                head,
+                probe_ahead,
+                lateral,
+                compressed_radius,
+                lateral_steps,
+            )
+        })
+        .flatten();
+    let lateral_mantle_slab = lateral_mantle_hit.is_some();
+    let mantle_hit = lateral_mantle_hit.or(initial_mantle_hit);
+    let same_mantle_slab = route_same_mantle_slab || lateral_mantle_slab;
+    let mantle_floor =
+        mantle_hit.map(|(origin, _, landing)| origin - Vector::y() * landing.time_of_impact);
+    if separate_ceiling && lateral_mantle_hit.is_none() && ladder_exit_hit.is_none() {
         reject_top_out!("separate_ceiling");
     }
 
@@ -2438,8 +2538,6 @@ fn plan_climb_top_out(
     // recovery stays within four radii and lateral recovery within five. The
     // compressed route first reaches the geometry-derived `lip_clear` before
     // moving to the selected landing.
-    let lateral = vector![direction.z, 0.0, -direction.x];
-    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / compressed_radius).ceil() as usize;
     let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / compressed_radius).ceil() as usize;
     // Breadth-first by total recovery distance. Within an equal distance,
     // consider lateral recovery first so the fixed candidate budget reaches
@@ -2530,6 +2628,14 @@ fn plan_climb_top_out(
         let Some(landing) = landing_pose(candidate) else {
             continue;
         };
+        if lateral_mantle_slab
+            && mantle_floor.is_some_and(|floor| {
+                (landing.standing.y - standing_floor_offset - floor.y).abs()
+                    > CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
+            })
+        {
+            continue;
+        }
         let Some(validated) = validated_landing(landing) else {
             continue;
         };
@@ -8360,6 +8466,222 @@ mod tests {
             final_pose,
             &crouched_player_capsule(),
         ));
+    }
+
+    fn merged_cuboid_worldrep(parts: &[(Vector<Real>, Vector<Real>)]) -> PhysicsWorld {
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        for (center, half_extents) in parts {
+            let (part_vertices, part_indices) = Cuboid::new(*half_extents).to_trimesh();
+            let base = vertices.len() as u32;
+            vertices.extend(
+                part_vertices
+                    .into_iter()
+                    .map(|vertex| Point::from(vertex + *center)),
+            );
+            indices.extend(
+                part_indices
+                    .into_iter()
+                    .map(|triangle| triangle.map(|index| index + base)),
+            );
+        }
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("merged WorldRep")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        world
+    }
+
+    fn diagonal_slab_worldrep() -> PhysicsWorld {
+        let (vertices, indices) = Cuboid::new(vector![1.0, 0.05, 0.2]).to_trimesh();
+        let angle = -std::f32::consts::FRAC_PI_4;
+        let (sin, cos) = angle.sin_cos();
+        let vertices = vertices
+            .into_iter()
+            .map(|vertex| {
+                Point::new(
+                    0.48 + cos * vertex.x + sin * vertex.z,
+                    1.55 + vertex.y,
+                    0.48 - sin * vertex.x + cos * vertex.z,
+                )
+            })
+            .collect();
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("diagonal WorldRep slab")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        world
+    }
+
+    fn diagonal_ribbon_worldrep(stations: &[(Real, Real)]) -> PhysicsWorld {
+        let along = vector![
+            std::f32::consts::FRAC_1_SQRT_2,
+            0.0,
+            std::f32::consts::FRAC_1_SQRT_2
+        ];
+        let across = vector![
+            std::f32::consts::FRAC_1_SQRT_2,
+            0.0,
+            -std::f32::consts::FRAC_1_SQRT_2
+        ];
+        let half_width = 0.3;
+        let mut vertices = Vec::new();
+        for &(distance, y) in stations {
+            let center = along * distance + Vector::y() * y;
+            vertices.push(Point::from(center - across * half_width));
+            vertices.push(Point::from(center + across * half_width));
+        }
+        let mut indices = Vec::new();
+        for segment in 0..stations.len() - 1 {
+            let left = (2 * segment) as u32;
+            let right = left + 1;
+            let next_left = left + 2;
+            let next_right = left + 3;
+            indices.push([left, next_left, next_right]);
+            indices.push([left, next_right, right]);
+        }
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("diagonal WorldRep ribbon")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        world
+    }
+
+    fn lateral_slab_test_hit(world: &PhysicsWorld) -> Option<(Vector<Real>, Real)> {
+        let queries = query_pipeline(world, QueryFilter::default());
+        let head = vector![0.0, 0.72, 0.0];
+        let probe_ahead = vector![2.0 * CLIMB_TOP_OUT_RADIUS, 2.12, 0.0];
+        let up_hit = queries.cast_ray_and_get_normal(
+            &Ray::new(Point::from(head), Vector::y()),
+            CLIMB_TOP_OUT_UP,
+            true,
+        );
+        lateral_same_slab_mantle_hit(
+            &queries,
+            up_hit,
+            head,
+            probe_ahead,
+            Vector::z(),
+            CLIMB_TOP_OUT_RADIUS,
+            (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize,
+        )
+        .map(|(origin, _, hit)| (origin, origin.y - hit.time_of_impact))
+    }
+
+    #[test]
+    fn lateral_mantle_finds_an_edge_connected_same_slab_floor() {
+        // A thin closed slab runs diagonally through U and T. Dark's fixed
+        // forward probe lies outside its near edge, while the second lateral
+        // sample reaches the top through that edge inside the local corridor.
+        let world = diagonal_slab_worldrep();
+        let (origin, floor_y) = lateral_slab_test_hit(&world)
+            .expect("the edge-connected lateral top should identify the rise's local slab");
+
+        assert!((origin.z - 2.0 * CLIMB_TOP_OUT_RADIUS).abs() < 1.0e-4);
+        assert!((floor_y - 1.6).abs() < 1.0e-4);
+    }
+
+    #[test]
+    fn lateral_mantle_rejects_a_disconnected_island_in_one_worldrep() {
+        // The same collider and same top height are insufficient: these two
+        // closed boxes are separated in x/z and have no local edge path.
+        let world = merged_cuboid_worldrep(&[
+            (vector![0.0, 1.55, 0.0], vector![0.2, 0.05, 0.2]),
+            (vector![0.96, 1.55, 0.96], vector![0.2, 0.05, 0.2]),
+        ]);
+
+        assert!(
+            lateral_slab_test_hit(&world).is_none(),
+            "mission-wide WorldRep identity must not connect a lateral island to the sampled underside"
+        );
+    }
+
+    #[test]
+    fn lateral_mantle_rejects_a_broad_ceiling_without_a_local_edge() {
+        // U and T are opposite sides of one same-height closed slab, but its
+        // nearest edge lies far outside the bounded probe corridor. Treating
+        // collider identity or thickness as sufficient would turn an ordinary
+        // room ceiling into a through-ceiling mantle.
+        let world = merged_cuboid_worldrep(&[(vector![0.0, 1.55, 0.0], vector![4.0, 0.05, 4.0])]);
+
+        assert!(
+            lateral_slab_test_hit(&world).is_none(),
+            "a broad solid ceiling must remain an obstruction when no slab edge is locally reachable"
+        );
+    }
+
+    #[test]
+    fn lateral_mantle_rejects_a_parented_floor_before_the_worldrep_top() {
+        let mut world = diagonal_slab_worldrep();
+        // Model the authored Pipe8x3 failure mode: a live parented OBB is the
+        // first downward floor hit at the otherwise-valid lateral sample.
+        world.add_kinematic(
+            EntityId::from_inner(3).unwrap(),
+            vec3(0.96, 1.86, 0.96),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.35, 0.1, 0.35),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(4).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        assert!(
+            lateral_slab_test_hit(&world).is_none(),
+            "a parented pipe floor must not inherit the WorldRep underside exception"
+        );
+    }
+
+    #[test]
+    fn lateral_mantle_rejects_a_floor_below_the_sampled_underside() {
+        // One connected ribbon starts horizontal above the upward sample,
+        // slopes down, and becomes horizontal again under lateral T. Deleting
+        // the explicit T >= U gate would therefore make this negative pass.
+        let world = diagonal_ribbon_worldrep(&[(-0.3, 1.5), (0.3, 1.5), (1.0, 1.0), (1.7, 1.0)]);
+
+        assert!(
+            lateral_slab_test_hit(&world).is_none(),
+            "a lower shelf must not be paired with an unrelated overhead underside"
+        );
+    }
+
+    #[test]
+    fn lateral_mantle_rejects_an_edge_connected_floor_above_the_thin_slab_bound() {
+        // The same local ribbon stays connected but rises by 1.1 wu from U to
+        // T, just beyond the standing-profile slab bound of 1.04 wu. Its ramp
+        // is split into short faces so topology alone still reaches both ends.
+        let world = diagonal_ribbon_worldrep(&[
+            (-0.3, 1.0),
+            (0.2, 1.0),
+            (0.7, 1.55),
+            (1.1, 2.1),
+            (1.7, 2.1),
+        ]);
+
+        assert!(
+            lateral_slab_test_hit(&world).is_none(),
+            "a thick local shell must remain a ceiling rather than becoming a mantle slab"
+        );
     }
 
     #[test]

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -659,6 +659,9 @@ struct ClimbTopOut {
     save_pose: Vector<Real>,
     reversing: bool,
     is_crouched: bool,
+    /// Ladder recovery must restore onto proven upward support. An ordinary
+    /// jump mantle may instead release into its authored ballistic fall.
+    requires_final_support: bool,
 }
 
 struct PlayerMovement {
@@ -917,6 +920,23 @@ fn shape_sweep_is_clear(
             },
         )
         .is_none()
+}
+
+fn ray_segment_is_clear(queries: &QueryPipeline, from: Vector<Real>, to: Vector<Real>) -> bool {
+    // The compressed body intentionally models Dark's sparse player and may
+    // overlap immutable terrain during a scripted transition. Its centerline
+    // still has to pass every authored point probe unobstructed, preventing
+    // that exception from becoming permission to cross an unrelated wall.
+    let delta = to - from;
+    let distance = delta.norm();
+    distance <= 1.0e-6
+        || queries
+            .cast_ray(
+                &Ray::new(Point::from(from), delta / distance),
+                distance,
+                true,
+            )
+            .is_none()
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -2247,6 +2267,7 @@ fn plan_climb_top_out(
             save_pose: pos.translation.vector,
             reversing: false,
             is_crouched: false,
+            requires_final_support: true,
         }),
         slope_displacement: Vector::zeros(),
     })
@@ -2475,6 +2496,7 @@ fn plan_jump_mantle(
         final_head,
         final_head,
         final_standing,
+        final_standing,
     ];
 
     // Preflight the exact fixed-timestep route against every parented entity
@@ -2512,6 +2534,7 @@ fn plan_jump_mantle(
             save_pose: pos.translation.vector,
             reversing: false,
             is_crouched,
+            requires_final_support: false,
         }),
         slope_displacement: Vector::zeros(),
     })
@@ -2547,7 +2570,11 @@ fn advance_climb_top_out(
         } else if let Some(target) = top_out.waypoints.get(top_out.next_waypoint) {
             *target
         } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape)
-            || !standing_pose_matches_current_support(validation_queries, pos.translation.vector)
+            || (top_out.requires_final_support
+                && !standing_pose_matches_current_support(
+                    validation_queries,
+                    pos.translation.vector,
+                ))
         {
             top_out.reversing = true;
             continue;
@@ -2562,15 +2589,16 @@ fn advance_climb_top_out(
             if top_out.next_waypoint == 0 {
                 let save_pose_is_supported =
                     standing_pose_matches_current_support(validation_queries, top_out.save_pose);
-                let save_pose_can_resume_climb =
-                    standing_pose_climb_direction(
-                        validation_queries,
-                        top_out.save_pose,
-                        &final_shape,
-                    )
-                    .is_some_and(|toward| climb_redirect(desired_movement, toward).is_some());
+                let save_pose_can_resume_climb = standing_pose_climb_direction(
+                    validation_queries,
+                    top_out.save_pose,
+                    &final_shape,
+                )
+                .is_some_and(|toward| climb_redirect(desired_movement, toward).is_some());
                 if shape_intersects(validation_queries, top_out.save_pose, &final_shape)
-                    || (!save_pose_is_supported && !save_pose_can_resume_climb)
+                    || (top_out.requires_final_support
+                        && !save_pose_is_supported
+                        && !save_pose_can_resume_climb)
                 {
                     return (scripted_character_movement(Vector::zeros()), Some(top_out));
                 }
@@ -2587,9 +2615,11 @@ fn advance_climb_top_out(
         CLIMB_TOP_OUT_RADIUS
     };
     let compressed = Ball::new(compressed_radius);
-    let movement_queries = if top_out.next_waypoint >= 5 {
+    let movement_queries = if top_out.requires_final_support && top_out.next_waypoint >= 5 {
         // Waypoint 4 is `lip_clear`; every segment leaving or returning to it
-        // uses ordinary all-collider validation, including climbables.
+        // in a ladder recovery uses ordinary all-collider validation,
+        // including climbables. Jump mantles keep Dark's parentless-terrain
+        // exception through their whole scripted transition.
         validation_queries
     } else {
         scripted_queries
@@ -7582,6 +7612,7 @@ mod tests {
             1.0 / 60.0,
             -0.2,
             None,
+            None,
             Some(ClimbPass {
                 movement: Vector::y() * 0.25,
                 top_out: Some((Vector::x(), CLIMB_TOP_OUT_PROBE_FORWARD)),
@@ -8514,6 +8545,8 @@ mod tests {
             next_waypoint: 7,
             save_pose: vector![-1.0, 1.0, 0.0],
             reversing: false,
+            is_crouched: false,
+            requires_final_support: true,
         };
         let queries = query_pipeline(&world, QueryFilter::default());
 
@@ -8547,6 +8580,8 @@ mod tests {
             next_waypoint: 0,
             save_pose,
             reversing: true,
+            is_crouched: false,
+            requires_final_support: true,
         };
         let queries = query_pipeline(&world, QueryFilter::default());
 
@@ -8592,6 +8627,8 @@ mod tests {
             next_waypoint: 0,
             save_pose,
             reversing: true,
+            is_crouched: false,
+            requires_final_support: true,
         };
         let queries = query_pipeline(&world, QueryFilter::default());
 
@@ -8652,6 +8689,8 @@ mod tests {
             next_waypoint: 7,
             save_pose: vector![-1.0, standing_floor_offset, 0.0],
             reversing: false,
+            is_crouched: false,
+            requires_final_support: true,
         };
         let queries = query_pipeline(&world, QueryFilter::default());
 
@@ -8686,6 +8725,7 @@ mod tests {
             save_pose: vector![-1.0, 0.0, 0.0],
             reversing: false,
             is_crouched: false,
+            requires_final_support: true,
         };
         let first = {
             let queries = query_pipeline(&world, QueryFilter::default());
@@ -8767,6 +8807,8 @@ mod tests {
             next_waypoint: 5,
             save_pose: vector![-1.0, 0.0, 0.0],
             reversing: false,
+            is_crouched: false,
+            requires_final_support: true,
         };
         let validation_queries = query_pipeline(&world, QueryFilter::default());
         let parented_non_climbable = |_handle: ColliderHandle, collider: &Collider| {
@@ -8807,6 +8849,7 @@ mod tests {
             save_pose: vector![-1.0, 0.0, 0.0],
             reversing: false,
             is_crouched: false,
+            requires_final_support: true,
         };
         world.add_kinematic(
             EntityId::from_inner(2).unwrap(),
@@ -8867,10 +8910,18 @@ mod tests {
             save_pose: Vector::zeros(),
             reversing: false,
             is_crouched: true,
+            requires_final_support: false,
         };
 
-        let (movement, active) =
-            advance_climb_top_out(&controller, &queries, &queries, &pos, completed, 1.0 / 60.0);
+        let (movement, active) = advance_climb_top_out(
+            &controller,
+            &queries,
+            &queries,
+            &pos,
+            completed,
+            Vector::zeros(),
+            1.0 / 60.0,
+        );
 
         assert_eq!(movement.translation, Vector::zeros());
         assert!(
@@ -8905,6 +8956,7 @@ mod tests {
             save_pose,
             reversing: true,
             is_crouched: false,
+            requires_final_support: true,
         });
         assert_eq!(
             world.get_player_save_translation(&player),
@@ -10627,6 +10679,7 @@ mod tests {
             save_pose,
             reversing: false,
             is_crouched: false,
+            requires_final_support: true,
         });
 
         let result = world.move_player_validated(vec3(f32::NAN, 0.5, 0.0), &mut player);

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -266,7 +266,9 @@ const CLIMB_MIN_PROGRESS_FRACTION: f32 = 0.1;
 
 /// Dark probes one head diameter beyond the cleared lip, then advances the
 /// compressed player another body diameter.
+#[cfg(test)]
 const CLIMB_TOP_OUT_PROBE_FORWARD: f32 = 2.0 * CLIMB_TOP_OUT_RADIUS;
+#[cfg(test)]
 const CLIMB_TOP_OUT_ADVANCE: f32 = 2.0 * PLAYER_STANDING_RADIUS / SCALE_FACTOR;
 
 /// Dark's mantle probe goes 3.5 units up, then seven down.
@@ -291,6 +293,11 @@ const CLIMB_TOP_OUT_MAX_LIP_FACE_HOPS: usize = 8;
 const CLIMB_TOP_OUT_DIRECT_LIP_FACE_HOPS: usize = 2;
 const CLIMB_TOP_OUT_LOCAL_LIP_EXIT_ALLOWANCE: f32 =
     2.0 * CLIMB_TOP_OUT_RADIUS + 2.0 * CLIMB_TOP_OUT_RECOVERY_RETREAT;
+/// A recovery rise may pass through opposite faces of one local deck slab.
+/// Bound that exception to one compressed body diameter plus the solver gap;
+/// thicker room geometry remains a ceiling rather than a mantle surface.
+const CLIMB_TOP_OUT_MAX_LOCAL_SLAB_THICKNESS: f32 =
+    2.0 * CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR;
 /// Search at most four compressed-player radii farther in the held heading
 /// when an otherwise-supported landing still clips the upper ledge on descent.
 const CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY: f32 = 4.0 * CLIMB_TOP_OUT_RADIUS;
@@ -657,6 +664,7 @@ struct ClimbPass<'a> {
     movement: Vector<Real>,
     top_out: Option<(Vector<Real>, Real)>,
     allow_top_out_attempt: bool,
+    is_crouched: bool,
     validation_queries: QueryPipeline<'a>,
     probe_queries: QueryPipeline<'a>,
     scripted_queries: QueryPipeline<'a>,
@@ -1092,6 +1100,7 @@ fn scan_initial_route_obstruction(
     initial_obstruction_limit: Real,
     entry_limit: Real,
     require_clear: bool,
+    bridged_interval: Option<(Real, Real)>,
     allowed: impl Fn(ShapeObstruction) -> bool,
 ) -> Option<RouteObstructionScan> {
     // Dark's sparse body may start inside the local lip before reaching the
@@ -1114,7 +1123,14 @@ fn scan_initial_route_obstruction(
                    cleared_after_obstruction: &mut bool,
                    first_clear: &mut Vector<Real>| {
         let sample_obstructions = shape_obstructions(queries, sample, shape);
-        let blocked = !sample_obstructions.is_empty();
+        // A proven closed slab may have more space between its opposite
+        // triangle surfaces than the probe's diameter. Treat that enclosed
+        // underside-to-top span as part of the same physical obstruction,
+        // instead of a false clear followed by a re-entry at the top face.
+        let bridged = bridged_interval.is_some_and(|(start, end)| {
+            sample_distance + 1.0e-5 >= start && sample_distance <= end + 1.0e-5
+        });
+        let blocked = !sample_obstructions.is_empty() || bridged;
         if blocked {
             if sample_obstructions.iter().copied().any(|hit| !allowed(hit))
                 || (!*obstruction_seen && sample_distance > entry_limit)
@@ -1295,6 +1311,7 @@ fn shape_route_exits_only_initial_obstruction(
         initial_obstruction_limit,
         entry_limit,
         true,
+        None,
         |_| true,
     )
     .is_some()
@@ -1505,6 +1522,140 @@ fn mantle_lip_patch(
     Some(MantleLipPatch { handle, faces })
 }
 
+/// Extend a floor-seeded mantle patch with only the underside faces crossed by
+/// the actual recovered rise.
+///
+/// WorldRep is one mission-wide trimesh, so collider identity alone cannot
+/// prove that an overhead face belongs to the selected landing. Sample the
+/// underside and top at the recovered rise's exact x/z, require a bounded
+/// opposite-face slab whose top is already in the floor patch and matches the
+/// selected mantle height, then add a separately bounded underside patch.
+fn extend_lip_patch_with_recovery_slab(
+    queries: &QueryPipeline,
+    lip_patch: &mut Option<MantleLipPatch>,
+    mantle_handle: Option<ColliderHandle>,
+    mantle_floor: Option<Vector<Real>>,
+    rise_start: Vector<Real>,
+    cross_start: Vector<Real>,
+) -> Option<(Real, Real)> {
+    let (Some(floor_patch), Some(mantle_handle), Some(mantle_floor)) =
+        (lip_patch.as_ref(), mantle_handle, mantle_floor)
+    else {
+        return None;
+    };
+    if floor_patch.handle != mantle_handle {
+        return None;
+    }
+    let rise_distance = cross_start.y - rise_start.y;
+    if rise_distance <= 1.0e-6 {
+        return None;
+    }
+    let Some((underside_handle, underside)) = queries.cast_ray_and_get_normal(
+        &Ray::new(Point::from(rise_start), Vector::y()),
+        rise_distance,
+        true,
+    ) else {
+        return None;
+    };
+    let Some((top_handle, top)) = queries.cast_ray_and_get_normal(
+        &Ray::new(Point::from(cross_start), -Vector::y()),
+        rise_distance,
+        true,
+    ) else {
+        return None;
+    };
+    let (FeatureId::Face(underside_face), FeatureId::Face(top_face)) =
+        (underside.feature, top.feature)
+    else {
+        return None;
+    };
+    if underside_handle != mantle_handle
+        || top_handle != mantle_handle
+        || underside.normal.y >= -CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+        || top.normal.y <= CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+    {
+        return None;
+    }
+    let underside_y = rise_start.y + underside.time_of_impact;
+    let top_y = cross_start.y - top.time_of_impact;
+    let thickness = top_y - underside_y;
+    if thickness <= 1.0e-4
+        || thickness > CLIMB_TOP_OUT_MAX_LOCAL_SLAB_THICKNESS + 1.0e-4
+        || (top_y - mantle_floor.y).abs()
+            > CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
+    {
+        return None;
+    }
+    let Some(collider) = queries.colliders.get(top_handle) else {
+        return None;
+    };
+    let Some(mesh) = collider.shape().as_trimesh() else {
+        return None;
+    };
+    let face_count = mesh.indices().len() as u32;
+    if face_count == 0
+        || !floor_patch.contains(ShapeObstruction::TrimeshFace(
+            top_handle,
+            top_face % face_count,
+        ))
+    {
+        return None;
+    }
+
+    // Prove these opposite-facing samples are the two sides of one closed
+    // local slab, rather than two disconnected surfaces that merely share the
+    // mission-wide WorldRep handle. Start just inside U and require the very
+    // next surface along the exact recovered rise to be T. A stacked slab,
+    // ceiling, or other intermediate shell is therefore a hard rejection
+    // before the geometric interior is authorized below.
+    let surface_epsilon = (thickness * 0.25).min(1.0e-4);
+    let inside_underside = rise_start + Vector::y() * (underside.time_of_impact + surface_epsilon);
+    let next_surface_distance = top_y - inside_underside.y + surface_epsilon;
+    let Some(next_surface) = collider.shape().cast_ray_and_get_normal(
+        collider.position(),
+        &Ray::new(Point::from(inside_underside), Vector::y()),
+        next_surface_distance,
+        false,
+    ) else {
+        return None;
+    };
+    let FeatureId::Face(next_face) = next_surface.feature else {
+        return None;
+    };
+    let next_y = inside_underside.y + next_surface.time_of_impact;
+    // Rapier orients a two-sided trimesh hit normal against the ray, so this
+    // upward crossing reports -Y even though it is the slab's authored top.
+    if next_surface.normal.y >= -CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+        || (next_y - top_y).abs() > 2.0 * surface_epsilon
+        || !floor_patch.contains(ShapeObstruction::TrimeshFace(
+            top_handle,
+            next_face % face_count,
+        ))
+    {
+        return None;
+    }
+
+    let underside_point = rise_start + Vector::y() * underside.time_of_impact;
+    let Some(underside_patch) = mantle_lip_patch(
+        queries,
+        Some((underside_handle, FeatureId::Face(underside_face))),
+        underside_point,
+        &[rise_start, cross_start],
+        false,
+    ) else {
+        return None;
+    };
+    if underside_patch.handle != floor_patch.handle {
+        return None;
+    }
+    lip_patch
+        .as_mut()
+        .expect("floor patch was checked above")
+        .faces
+        .extend(underside_patch.faces);
+    Some((underside_y, top_y))
+}
+
 #[cfg(test)]
 fn trimesh_faces_connect_within_local_bounds(
     queries: &QueryPipeline,
@@ -1580,11 +1731,17 @@ fn supported_standing_pose(
     ))
 }
 
-fn standing_pose_matches_current_support(
+fn player_pose_matches_current_support(
     queries: &QueryPipeline,
-    standing_pose: Vector<Real>,
+    pose: Vector<Real>,
+    is_crouched: bool,
 ) -> bool {
-    let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
+    let body_height = if is_crouched {
+        PLAYER_CROUCH_HEIGHT
+    } else {
+        PLAYER_STANDING_HEIGHT
+    };
+    let floor_offset = body_height / 2.0 / SCALE_FACTOR
         + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
         + PLAYER_REST_LIFT / SCALE_FACTOR;
     // The waypoint loop intentionally stops within arrival epsilon. Allow the
@@ -1593,17 +1750,15 @@ fn standing_pose_matches_current_support(
     let release_tolerance = PLAYER_MOVE_ARRIVAL_EPSILON + PROBE_SKIN / SCALE_FACTOR;
     supported_standing_pose(
         queries,
-        standing_pose,
-        standing_floor_offset + release_tolerance,
-        standing_floor_offset,
+        pose,
+        floor_offset + release_tolerance,
+        floor_offset,
     )
-    .is_some_and(|(supported_pose, _)| {
-        (supported_pose - standing_pose).norm() <= release_tolerance + 1.0e-5
-    })
+    .is_some_and(|(supported_pose, _)| (supported_pose - pose).norm() <= release_tolerance + 1.0e-5)
 }
 
-/// Direction toward a climbable that a standing player at `pose` can
-/// immediately grip through ordinary ladder detection.
+/// Direction toward a climbable that the supplied player profile at `pose`
+/// can immediately grip through ordinary ladder detection.
 fn standing_pose_climb_direction(
     queries: &QueryPipeline,
     pose: Vector<Real>,
@@ -1682,7 +1837,8 @@ fn has_supported_standing_egress(
 }
 
 fn climb_top_out_recovery_start(
-    queries: &QueryPipeline,
+    rise_queries: &QueryPipeline,
+    approach_queries: &QueryPipeline,
     head: Vector<Real>,
     direction: Vector<Real>,
     cross_y: Real,
@@ -1693,7 +1849,9 @@ fn climb_top_out_recovery_start(
     (0..=recovery_steps).find_map(|step| {
         let candidate = head - direction * (step as Real * CLIMB_TOP_OUT_RECOVERY_RETREAT);
         let raised_candidate = vector![candidate.x, cross_y, candidate.z];
-        shape_sweep_is_clear(queries, candidate, raised_candidate, compressed).then_some(candidate)
+        (shape_sweep_is_clear(approach_queries, head, candidate, compressed)
+            && shape_sweep_is_clear(rise_queries, candidate, raised_candidate, compressed))
+        .then_some(candidate)
     })
 }
 
@@ -1717,6 +1875,7 @@ fn plan_climb_top_out(
     direction: Vector<Real>,
     minimum_clear_forward: Real,
     dt: Real,
+    is_crouched: bool,
 ) -> Option<PlayerMovement> {
     macro_rules! reject_top_out {
         ($gate:literal) => {{
@@ -1729,14 +1888,28 @@ fn plan_climb_top_out(
         reject_top_out!("direction");
     }
     let direction = direction_h / direction_norm;
-    let head_offset = (PLAYER_STANDING_HEIGHT / 2.0 - PLAYER_STANDING_RADIUS) / SCALE_FACTOR;
+    let (body_height, body_radius, standing) = if is_crouched {
+        (
+            PLAYER_CROUCH_HEIGHT,
+            PLAYER_CROUCH_RADIUS,
+            crouched_player_capsule(),
+        )
+    } else {
+        (
+            PLAYER_STANDING_HEIGHT,
+            PLAYER_STANDING_RADIUS,
+            standing_player_capsule(),
+        )
+    };
+    let compressed_radius = body_radius / SCALE_FACTOR;
+    let head_offset = (body_height / 2.0 - body_radius) / SCALE_FACTOR;
     let head = pos.translation.vector + Vector::y() * head_offset;
     let raised = head + Vector::y() * CLIMB_TOP_OUT_UP;
-    let probe_ahead = raised + direction * CLIMB_TOP_OUT_PROBE_FORWARD;
-    let route_forward = minimum_clear_forward.max(CLIMB_TOP_OUT_PROBE_FORWARD);
+    let probe_forward = 2.0 * compressed_radius;
+    let probe_ahead = raised + direction * probe_forward;
+    let route_forward = minimum_clear_forward.max(probe_forward);
     let route_ahead = raised + direction * route_forward;
-    let standing = standing_player_capsule();
-    let compressed = Ball::new(CLIMB_TOP_OUT_RADIUS);
+    let compressed = Ball::new(compressed_radius);
     let up_ray = Ray::new(Point::from(head), Vector::y());
     // BreakClimb's jump-through remains valid when the mantle search meets a
     // lip after the compressed head has room to rise. Do not conflate that
@@ -1745,7 +1918,7 @@ fn plan_climb_top_out(
     // hit after 0.559 wu; a ceiling close enough to pin the sphere is rejected.
     let up_hit = probe_queries.cast_ray_and_get_normal(&up_ray, CLIMB_TOP_OUT_UP, true);
     let up_obstruction = up_hit.map(|(_, hit)| (hit.time_of_impact, head.y + hit.time_of_impact));
-    if up_obstruction.is_some_and(|(time_of_impact, _)| time_of_impact < CLIMB_TOP_OUT_RADIUS) {
+    if up_obstruction.is_some_and(|(time_of_impact, _)| time_of_impact < compressed_radius) {
         reject_top_out!("low_ceiling");
     }
     let raised_probe_ray = Ray::new(Point::from(raised), direction);
@@ -1823,7 +1996,7 @@ fn plan_climb_top_out(
             up.normal.y < -CLIMB_TOP_OUT_MIN_GROUND_NORMAL
                 && floor_y + 1.0e-4 >= underside_y
                 && floor_y - underside_y
-                    <= CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
+                    <= compressed_radius + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
         }
         _ => false,
     };
@@ -1842,7 +2015,7 @@ fn plan_climb_top_out(
         // faces as the same landing edge; a genuinely separate low ceiling
         // remains farther above the probed floor.
         mantle_floor.is_none_or(|floor| {
-            floor.y + CLIMB_TOP_OUT_RADIUS + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
+            floor.y + compressed_radius + 2.0 * PLAYER_CONTACT_OFFSET / SCALE_FACTOR + 1.0e-4
                 < obstruction_y
         })
     }) && ladder_exit_hit.is_none()
@@ -1859,7 +2032,7 @@ fn plan_climb_top_out(
     let minimum_cross_y = mantle_floor
         .map(|floor| {
             head.y
-                .max(floor.y + (1.02 * PLAYER_STANDING_RADIUS + 1.0) / SCALE_FACTOR)
+                .max(floor.y + (1.02 * body_radius + 1.0) / SCALE_FACTOR)
         })
         .unwrap_or(head.y);
     // Dark's rise target is the authored 3.5-foot probe endpoint (or the
@@ -1877,15 +2050,20 @@ fn plan_climb_top_out(
     // point above it is clear. Dark's recovery searches backward/up within
     // four authored feet. Use the same bound and choose the first
     // contact-offset step whose full-radius vertical sweep is clear.
-    let Some(rise_start) =
-        climb_top_out_recovery_start(scripted_queries, head, direction, cross_y, &compressed)
-    else {
+    let Some(rise_start) = climb_top_out_recovery_start(
+        scripted_queries,
+        probe_queries,
+        head,
+        direction,
+        cross_y,
+        &compressed,
+    ) else {
         reject_top_out!("recovery_start");
     };
     let cross_start = vector![rise_start.x, cross_y, rise_start.z];
     let probe_cross_end = vector![probe_ahead.x, cross_y, probe_ahead.z];
     let cross_end = vector![route_ahead.x, cross_y, route_ahead.z];
-    let full_advance = cross_end + direction * CLIMB_TOP_OUT_ADVANCE;
+    let full_advance = cross_end + direction * (2.0 * compressed_radius);
     // Parry treats balls and boxes wholly inside a closed trimesh as
     // intersecting its volume. A tiny non-degenerate capsule uses the same
     // triangle-surface query as the player while remaining point-scale.
@@ -1917,6 +2095,7 @@ fn plan_climb_top_out(
     let mantle_feature = ladder_exit_hit
         .map(|(handle, hit)| (handle, hit.feature))
         .or_else(|| mantle_hit.map(|(_, handle, hit)| (handle, hit.feature)));
+    let mantle_handle = mantle_hit.map(|(_, handle, _)| handle);
     let mantle_point = ladder_exit_hit
         .map(|(_, hit)| raised + direction * hit.time_of_impact)
         .unwrap_or_else(|| mantle_floor.unwrap_or(probe_ahead));
@@ -1962,24 +2141,83 @@ fn plan_climb_top_out(
             }
         }
     }
-    if scan_initial_route_obstruction(
+    let recovery_slab = extend_lip_patch_with_recovery_slab(
+        probe_queries,
+        &mut lip_patch,
+        mantle_handle,
+        mantle_floor,
+        rise_start,
+        cross_start,
+    );
+    let recovery_slab_proven = recovery_slab.is_some();
+    let same_mantle_slab = same_mantle_slab || recovery_slab_proven;
+    let bridged_rise_interval = recovery_slab.map(|(underside_y, top_y)| {
+        (
+            (underside_y - compressed_radius - rise_start.y).max(0.0),
+            (top_y + compressed_radius - rise_start.y).min((cross_start - rise_start).norm()),
+        )
+    });
+    let rise_scan = scan_initial_route_obstruction(
         probe_queries,
         &[rise_start, cross_start],
         &compressed,
         (cross_start - rise_start).norm(),
         (cross_start - rise_start).norm(),
-        false,
+        recovery_slab_proven,
+        bridged_rise_interval,
         |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
-    )
-    .is_none()
-    {
+    );
+    if rise_scan.is_none() {
         reject_top_out!("rise_obstruction_scan");
     }
+    let standing_floor_offset = body_height / 2.0 / SCALE_FACTOR
+        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+        + PLAYER_REST_LIFT / SCALE_FACTOR;
+    // A recovered rise can finish directly above the approach-side surface
+    // of a thin deck. Forcing the generic forward lip exit in that case steps
+    // off narrow authored decks before the active capsule is restored. The
+    // endpoint-local U/T proof and one-interval rise scan above authorize only
+    // that vertical transition; the restored pose and an ordinary one-stride
+    // egress still use every collider.
+    let recovery_landing = recovery_slab_proven
+        .then(|| {
+            let mantle_handle = mantle_handle?;
+            let mantle_floor = mantle_floor?;
+            let (support_handle, support) = validation_queries.cast_ray_and_get_normal(
+                &Ray::new(Point::from(cross_start), -Vector::y()),
+                CLIMB_TOP_OUT_FINAL_DROP,
+                true,
+            )?;
+            let floor = cross_start - Vector::y() * support.time_of_impact;
+            let standing_pose = floor + Vector::y() * standing_floor_offset;
+            (support_handle == mantle_handle
+                && support.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL
+                && (floor.y - mantle_floor.y).abs()
+                    <= CLIMB_TOP_OUT_RECOVERY_RETREAT + PROBE_SKIN / SCALE_FACTOR
+                && shape_obstructions(validation_queries, cross_start, &compressed).is_empty()
+                && !shape_intersects(validation_queries, standing_pose, &standing)
+                && shape_sweep_is_clear(
+                    validation_queries,
+                    cross_start,
+                    standing_pose,
+                    &compressed,
+                )
+                && has_supported_standing_egress(
+                    validation_queries,
+                    standing_pose,
+                    -direction,
+                    &standing,
+                    standing_floor_offset,
+                ))
+            .then_some((cross_start, cross_start, standing_pose))
+        })
+        .flatten();
     // Recovery may retreat the rise behind `raised`. Validate that entire
     // offset approach before permitting the one bounded lip overlap below;
     // otherwise the scripted parentless-terrain exception could cross an
     // unrelated wall between the recovered rise and Dark's probe endpoint.
-    if ladder_exit_hit.is_none()
+    if recovery_landing.is_none()
+        && ladder_exit_hit.is_none()
         && (shape_intersects(probe_queries, cross_start, &route_probe)
             || !shape_sweep_is_clear(probe_queries, cross_start, probe_cross_end, &route_probe))
     {
@@ -1990,15 +2228,22 @@ fn plan_climb_top_out(
     // the held approach, require it to belong to the local mantle patch, then
     // clear it along that face's outward horizontal normal. The exception ends
     // after this one geometry-derived leg; candidate recovery is ordinary.
-    let Some(first_lip) = first_allowed_route_obstruction(
-        probe_queries,
-        &[cross_start, lip_forward_end],
-        &compressed,
-        |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
-    ) else {
-        reject_top_out!("first_lip_scan");
+    let first_lip = if recovery_landing.is_some() {
+        None
+    } else {
+        let Some(first_lip) = first_allowed_route_obstruction(
+            probe_queries,
+            &[cross_start, lip_forward_end],
+            &compressed,
+            |hit| lip_patch.as_ref().is_some_and(|patch| patch.contains(hit)),
+        ) else {
+            reject_top_out!("first_lip_scan");
+        };
+        first_lip
     };
-    let (lip_approach, lip_clear) = if let Some(first_lip) = first_lip {
+    let (lip_approach, lip_clear) = if recovery_landing.is_some() {
+        (cross_start, cross_start)
+    } else if let Some(first_lip) = first_lip {
         if !shape_sweep_is_clear(probe_queries, cross_start, first_lip.position, &route_probe) {
             reject_top_out!("point_to_lip");
         }
@@ -2022,6 +2267,14 @@ fn plan_climb_top_out(
                 lip_exit_end,
             ],
             ladder_exit_hit.is_some(),
+        );
+        extend_lip_patch_with_recovery_slab(
+            probe_queries,
+            &mut exit_lip_patch,
+            mantle_handle,
+            mantle_floor,
+            rise_start,
+            cross_start,
         );
         if ladder_exit_hit.is_some() {
             let far_feature = ladder_far_hit.map(|(handle, hit)| (handle, hit.feature));
@@ -2058,6 +2311,7 @@ fn plan_climb_top_out(
             lip_exit_allowance,
             CLIMB_TOP_OUT_RECOVERY_RETREAT,
             true,
+            None,
             |hit| {
                 exit_lip_patch
                     .as_ref()
@@ -2074,9 +2328,6 @@ fn plan_climb_top_out(
         (cross_end, cross_end)
     };
 
-    let standing_floor_offset = PLAYER_STANDING_HEIGHT / 2.0 / SCALE_FACTOR
-        + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
-        + PLAYER_REST_LIFT / SCALE_FACTOR;
     #[derive(Clone, Copy)]
     struct SupportedLanding {
         sphere: Vector<Real>,
@@ -2108,8 +2359,8 @@ fn plan_climb_top_out(
     // compressed route first reaches the geometry-derived `lip_clear` before
     // moving to the selected landing.
     let lateral = vector![direction.z, 0.0, -direction.x];
-    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
-    let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    let lateral_steps = (CLIMB_TOP_OUT_MAX_LATERAL_RECOVERY / compressed_radius).ceil() as usize;
+    let forward_steps = (CLIMB_TOP_OUT_MAX_FORWARD_RECOVERY / compressed_radius).ceil() as usize;
     // Breadth-first by total recovery distance. Within an equal distance,
     // consider lateral recovery first so the fixed candidate budget reaches
     // the complete independently bounded forward/lateral grid.
@@ -2122,7 +2373,7 @@ fn plan_climb_top_out(
             if forward_step > forward_steps {
                 continue;
             }
-            let lateral_offset = lateral_step as Real * CLIMB_TOP_OUT_RADIUS;
+            let lateral_offset = lateral_step as Real * compressed_radius;
             let sides: &[Real] = if lateral_step == 0 {
                 &[0.0]
             } else {
@@ -2132,7 +2383,7 @@ fn plan_climb_top_out(
                 for base in [full_advance, cross_end, probe_cross_end] {
                     landing_candidates.push(
                         base + lateral * (lateral_offset * side)
-                            + direction * (forward_step as Real * CLIMB_TOP_OUT_RADIUS),
+                            + direction * (forward_step as Real * compressed_radius),
                     );
                 }
             }
@@ -2142,9 +2393,10 @@ fn plan_climb_top_out(
     // `lip_clear`. Validate its parented blockers once, before considering any
     // landing. Every leg after `lip_clear` uses the ordinary all-collider
     // pipeline, including climbables.
-    if !shape_sweep_is_clear(scripted_queries, cross_start, lip_approach, &compressed)
-        || !shape_sweep_is_clear(scripted_queries, lip_approach, lip_clear, &compressed)
-        || !shape_obstructions(validation_queries, lip_clear, &compressed).is_empty()
+    if recovery_landing.is_none()
+        && (!shape_sweep_is_clear(scripted_queries, cross_start, lip_approach, &compressed)
+            || !shape_sweep_is_clear(scripted_queries, lip_approach, lip_clear, &compressed)
+            || !shape_obstructions(validation_queries, lip_clear, &compressed).is_empty())
     {
         reject_top_out!("scripted_or_lip_clear");
     }
@@ -2247,10 +2499,9 @@ fn plan_climb_top_out(
     // complete all-collider route and an ordinary stride away from the shaft.
     // This is deliberately not a general second 2-D grid: straight approach-
     // side recovery is the least-steering alternative to a sideways detour.
-    let approach_steps =
-        (CLIMB_TOP_OUT_MAX_APPROACH_RECOVERY / CLIMB_TOP_OUT_RADIUS).ceil() as usize;
+    let approach_steps = (CLIMB_TOP_OUT_MAX_APPROACH_RECOVERY / compressed_radius).ceil() as usize;
     let approach_with_egress = (1..=approach_steps).find_map(|step| {
-        let offset = lip_clear - direction * (step as Real * CLIMB_TOP_OUT_RADIUS);
+        let offset = lip_clear - direction * (step as Real * compressed_radius);
         let candidate = vector![offset.x, head.y, offset.z];
         let landing = landing_pose(candidate)?;
         if !shape_obstructions(validation_queries, candidate, &compressed).is_empty()
@@ -2306,25 +2557,30 @@ fn plan_climb_top_out(
     // than the straight approach-side route. This preserves ordinary forward
     // top-outs and uses the recessed-floor alternative only when it avoids a
     // wider sideways recovery.
-    let selected_landing = match (forward_landing, approach_with_egress) {
-        (Some(forward), Some(approach)) => {
-            let lateral_distance = |landing: &(Vector<Real>, Vector<Real>, Vector<Real>)| {
-                (landing.1 - lip_clear).dot(&lateral).abs()
-            };
-            let forward_lateral = lateral_distance(&forward);
-            if forward_lateral + 1.0e-5 >= CLIMB_TOP_OUT_LARGE_LATERAL_DOGLEG
-                && lateral_distance(&approach) + 1.0e-5 < forward_lateral
-            {
-                Some((approach, true))
-            } else {
-                Some((forward, false))
+    let selected_landing = if let Some(recovery) = recovery_landing {
+        Some((recovery, false, true))
+    } else {
+        match (forward_landing, approach_with_egress) {
+            (Some(forward), Some(approach)) => {
+                let lateral_distance = |landing: &(Vector<Real>, Vector<Real>, Vector<Real>)| {
+                    (landing.1 - lip_clear).dot(&lateral).abs()
+                };
+                let forward_lateral = lateral_distance(&forward);
+                if forward_lateral + 1.0e-5 >= CLIMB_TOP_OUT_LARGE_LATERAL_DOGLEG
+                    && lateral_distance(&approach) + 1.0e-5 < forward_lateral
+                {
+                    Some((approach, true, false))
+                } else {
+                    Some((forward, false, false))
+                }
             }
+            (Some(forward), None) => Some((forward, false, false)),
+            (None, Some(approach)) => Some((approach, true, false)),
+            (None, None) => None,
         }
-        (Some(forward), None) => Some((forward, false)),
-        (None, Some(approach)) => Some((approach, true)),
-        (None, None) => None,
     };
-    let Some(((landing_route, final_sphere, final_standing), approach_side)) = selected_landing
+    let Some(((landing_route, final_sphere, final_standing), approach_side, recovery_side)) =
+        selected_landing
     else {
         reject_top_out!("landing");
     };
@@ -2332,7 +2588,18 @@ fn plan_climb_top_out(
     // parented entity blockers live but deliberately permit passage through
     // parentless immutable level terrain, the narrow Dark jump-through
     // exception. Final standing fit still uses `validation_queries`.
-    let waypoints = if approach_side {
+    let waypoints = if recovery_side {
+        [
+            head,
+            rise_start,
+            cross_start,
+            cross_start,
+            cross_start,
+            landing_route,
+            final_sphere,
+            final_standing,
+        ]
+    } else if approach_side {
         [
             head,
             head,
@@ -2393,7 +2660,7 @@ fn plan_climb_top_out(
             next_waypoint: 0,
             save_pose: pos.translation.vector,
             reversing: false,
-            is_crouched: false,
+            is_crouched,
             requires_final_support: true,
         }),
         slope_displacement: Vector::zeros(),
@@ -2671,7 +2938,7 @@ fn plan_jump_mantle(
 /// step, checking
 /// every substep against current parented entity geometry. Parentless immutable
 /// level terrain is the narrow Dark jump-through exception. A newly-blocked
-/// route returns to its last valid standing pose before the capsule is expanded.
+/// route returns to its last valid full-profile pose before the capsule is restored.
 /// Final body fit and its current upward support are revalidated against
 /// every collider immediately before release.
 fn advance_climb_top_out(
@@ -2698,9 +2965,10 @@ fn advance_climb_top_out(
             *target
         } else if shape_intersects(validation_queries, pos.translation.vector, &final_shape)
             || (top_out.requires_final_support
-                && !standing_pose_matches_current_support(
+                && !player_pose_matches_current_support(
                     validation_queries,
                     pos.translation.vector,
+                    top_out.is_crouched,
                 ))
         {
             top_out.reversing = true;
@@ -2714,8 +2982,11 @@ fn advance_climb_top_out(
         }
         if top_out.reversing {
             if top_out.next_waypoint == 0 {
-                let save_pose_is_supported =
-                    standing_pose_matches_current_support(validation_queries, top_out.save_pose);
+                let save_pose_is_supported = player_pose_matches_current_support(
+                    validation_queries,
+                    top_out.save_pose,
+                    top_out.is_crouched,
+                );
                 let save_pose_can_resume_climb = standing_pose_climb_direction(
                     validation_queries,
                     top_out.save_pose,
@@ -2840,6 +3111,7 @@ fn step_player_movement(
         movement: climb,
         top_out,
         allow_top_out_attempt,
+        is_crouched,
         validation_queries,
         probe_queries: climb_queries,
         scripted_queries,
@@ -2857,6 +3129,7 @@ fn step_player_movement(
                     direction,
                     minimum_clear_forward,
                     dt,
+                    is_crouched,
                 )
             }) {
                 return top_out;
@@ -5211,7 +5484,7 @@ impl PhysicsWorld {
                 }
                 nearest.and_then(|(_, toward)| {
                     climb_redirect(desired_movement, toward).map(|movement| {
-                        let top_out = if near_column_top && !player_handle.is_crouched {
+                        let top_out = if near_column_top {
                             climb_top_out_direction(desired_movement, facing).map(|direction| {
                                 // Stay compressed until projected facing has
                                 // exited every horizontally-expanded climbable
@@ -5333,6 +5606,7 @@ impl PhysicsWorld {
                             movement,
                             top_out,
                             allow_top_out_attempt,
+                            is_crouched: player_handle.is_crouched,
                             validation_queries: queries,
                             probe_queries: queries.with_filter(climb_pass_filter),
                             scripted_queries: queries.with_filter(scripted_top_out_filter),
@@ -7117,6 +7391,13 @@ mod tests {
     /// Plan the standard rejection-test mantle: from the origin, facing +X,
     /// with the scripted casts seeing only parented (entity) colliders.
     fn plan_top_out_from_origin(world: &PhysicsWorld) -> Option<PlayerMovement> {
+        plan_top_out_from_origin_with_profile(world, false)
+    }
+
+    fn plan_top_out_from_origin_with_profile(
+        world: &PhysicsWorld,
+        is_crouched: bool,
+    ) -> Option<PlayerMovement> {
         let validation_queries = query_pipeline(world, QueryFilter::default());
         let parented_only = QueryFilter::default()
             .predicate(&|_handle: ColliderHandle, collider: &Collider| collider.parent().is_some());
@@ -7128,8 +7409,13 @@ mod tests {
             &scripted_queries,
             &Isometry::translation(0.0, 0.0, 0.0),
             Vector::x(),
-            CLIMB_TOP_OUT_PROBE_FORWARD,
+            if is_crouched {
+                2.0 * PLAYER_CROUCH_RADIUS / SCALE_FACTOR
+            } else {
+                CLIMB_TOP_OUT_PROBE_FORWARD
+            },
             1.0 / 60.0,
+            is_crouched,
         )
     }
 
@@ -7744,6 +8030,7 @@ mod tests {
                 movement: Vector::y() * 0.25,
                 top_out: Some((Vector::x(), CLIMB_TOP_OUT_PROBE_FORWARD)),
                 allow_top_out_attempt: true,
+                is_crouched: false,
                 validation_queries: query_pipeline(&world, QueryFilter::default()),
                 probe_queries: query_pipeline(&world, QueryFilter::default()),
                 scripted_queries: query_pipeline(&world, QueryFilter::default()),
@@ -7796,7 +8083,7 @@ mod tests {
         );
 
         let recovered =
-            climb_top_out_recovery_start(&queries, head, direction, cross_y, &compressed)
+            climb_top_out_recovery_start(&queries, &queries, head, direction, cross_y, &compressed)
                 .expect("the authored recovery bound should reach a clear vertical sweep");
         let retreat = (head - recovered).norm();
         assert!(retreat > CLIMB_TOP_OUT_RECOVERY_RETREAT);
@@ -7816,6 +8103,281 @@ mod tests {
                 &compressed,
             ),
             "the recovery search must return the first clear contact-offset step"
+        );
+    }
+
+    #[test]
+    fn climb_top_out_bridges_only_one_proven_closed_slab_interval() {
+        let mut world = PhysicsWorld::new();
+        let (vertices, indices) = Cuboid::new(vector![2.0, 0.4, 2.0]).to_trimesh();
+        let vertices = vertices
+            .into_iter()
+            .map(|vertex| Point::from(vertex + Vector::y() * 1.2))
+            .collect();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("closed slab trimesh")
+                .build(),
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        let route = [vector![0.0, 0.0, 0.0], vector![0.0, 2.4, 0.0]];
+        let crouched_head = Ball::new(PLAYER_CROUCH_RADIUS / SCALE_FACTOR);
+        let terrain_only = |hit| matches!(hit, ShapeObstruction::TrimeshFace(_, _));
+        assert!(
+            scan_initial_route_obstruction(
+                &query_pipeline(&world, QueryFilter::default()),
+                &route,
+                &crouched_head,
+                2.4,
+                2.4,
+                true,
+                None,
+                terrain_only,
+            )
+            .is_none(),
+            "a 0.64-wide surface probe sees a false clear inside this 0.8-thick closed slab"
+        );
+        assert!(
+            scan_initial_route_obstruction(
+                &query_pipeline(&world, QueryFilter::default()),
+                &route,
+                &crouched_head,
+                2.4,
+                2.4,
+                true,
+                Some((0.8 - crouched_head.radius, 1.6 + crouched_head.radius)),
+                terrain_only,
+            )
+            .is_some(),
+            "the proven underside-to-top span must remain one obstruction interval and clear above the slab"
+        );
+
+        world.add_kinematic(
+            EntityId::from_inner(3).unwrap(),
+            vec3(0.0, 2.2, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 0.1, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        assert!(
+            scan_initial_route_obstruction(
+                &query_pipeline(&world, QueryFilter::default()),
+                &route,
+                &crouched_head,
+                2.4,
+                2.4,
+                true,
+                Some((0.8 - crouched_head.radius, 1.6 + crouched_head.radius)),
+                terrain_only,
+            )
+            .is_none(),
+            "a parented blocker after the slab remains a forbidden second obstruction"
+        );
+    }
+
+    #[test]
+    fn crouched_top_out_plans_below_headroom_that_rejects_standing() {
+        let mut world = PhysicsWorld::new();
+        let deck_top = 1.634;
+        let deck_thickness = 0.8;
+        let (vertices, indices) = Cuboid::new(vector![4.0, deck_thickness / 2.0, 4.0]).to_trimesh();
+        let vertices = vertices
+            .into_iter()
+            .map(|vertex| Point::from(vertex + Vector::y() * (deck_top - deck_thickness / 2.0)))
+            .collect();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("closed deck trimesh")
+                .build(),
+        );
+        // 1.4 world units of headroom matches the authored Rick1 pipe: the
+        // crouched 1.12-world-unit body fits, while the 2.4-world-unit
+        // standing body cannot. This is a real parented blocker and remains in
+        // every scripted and final-fit query.
+        world.add_kinematic(
+            EntityId::from_inner(2).unwrap(),
+            vec3(0.0, deck_top + 1.45, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(8.0, 0.1, 8.0),
+            CollisionGroup::entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(3).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+
+        assert!(
+            plan_top_out_from_origin_with_profile(&world, false).is_none(),
+            "the planner must not ignore the parented ceiling or auto-crouch a standing player"
+        );
+        let crouched = plan_top_out_from_origin_with_profile(&world, true)
+            .expect("an explicitly crouched player should fit the proven deck landing");
+        let top_out = crouched.top_out.expect("planned crouched top-out");
+        let final_pose = top_out.waypoints[7];
+        let expected_y = deck_top
+            + PLAYER_CROUCH_HEIGHT / 2.0 / SCALE_FACTOR
+            + PLAYER_CONTACT_OFFSET / SCALE_FACTOR
+            + PLAYER_REST_LIFT / SCALE_FACTOR;
+        assert!(top_out.is_crouched);
+        assert!((final_pose.y - expected_y).abs() < 1.0e-4);
+        assert!(!shape_intersects(
+            &query_pipeline(&world, QueryFilter::default()),
+            final_pose,
+            &crouched_player_capsule(),
+        ));
+    }
+
+    #[test]
+    fn recovery_slab_rejects_a_disconnected_surface_in_one_worldrep() {
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        for center_x in [-1.0, 1.0] {
+            let (island_vertices, island_indices) =
+                Cuboid::new(vector![0.4, 0.4, 0.4]).to_trimesh();
+            let base = vertices.len() as u32;
+            vertices.extend(
+                island_vertices
+                    .into_iter()
+                    .map(|vertex| Point::from(vertex + Vector::x() * center_x)),
+            );
+            indices.extend(
+                island_indices
+                    .into_iter()
+                    .map(|triangle| triangle.map(|index| index + base)),
+            );
+        }
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("two-island WorldRep")
+                .build(),
+        );
+        let handle = world.collider_set.iter().next().expect("WorldRep").0;
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let floor_origin = vector![1.0, 1.0, 0.0];
+        let (_, floor_hit) = queries
+            .cast_ray_and_get_normal(
+                &Ray::new(Point::from(floor_origin), -Vector::y()),
+                2.0,
+                true,
+            )
+            .expect("right-island top");
+        assert!(floor_hit.normal.y > CLIMB_TOP_OUT_MIN_GROUND_NORMAL);
+        let floor = floor_origin - Vector::y() * floor_hit.time_of_impact;
+        let floor_patch = || {
+            mantle_lip_patch(
+                &queries,
+                Some((handle, floor_hit.feature)),
+                floor,
+                &[floor],
+                false,
+            )
+            .map(Some)
+            .expect("right-island floor patch")
+        };
+
+        let mut same_island_patch = floor_patch();
+        assert!(
+            extend_lip_patch_with_recovery_slab(
+                &queries,
+                &mut same_island_patch,
+                Some(handle),
+                Some(floor),
+                vector![1.0, -1.0, 0.0],
+                vector![1.0, 1.0, 0.0],
+            )
+            .is_some(),
+            "the paired underside and top of the selected island should prove one closed slab"
+        );
+
+        let mut disjoint_patch = floor_patch();
+        assert!(
+            extend_lip_patch_with_recovery_slab(
+                &queries,
+                &mut disjoint_patch,
+                Some(handle),
+                Some(floor),
+                vector![-1.0, -1.0, 0.0],
+                vector![-1.0, 1.0, 0.0],
+            )
+            .is_none(),
+            "collider identity and equal slab height must not connect disjoint islands in one WorldRep"
+        );
+    }
+
+    #[test]
+    fn recovery_slab_rejects_stacked_disconnected_surfaces_in_one_worldrep() {
+        let mut vertices = Vec::new();
+        let mut indices = Vec::new();
+        for center_y in [0.0, 0.3] {
+            let (slab_vertices, slab_indices) = Cuboid::new(vector![0.4, 0.1, 0.4]).to_trimesh();
+            let base = vertices.len() as u32;
+            vertices.extend(
+                slab_vertices
+                    .into_iter()
+                    .map(|vertex| Point::from(vertex + Vector::y() * center_y)),
+            );
+            indices.extend(
+                slab_indices
+                    .into_iter()
+                    .map(|triangle| triangle.map(|index| index + base)),
+            );
+        }
+        let mut world = PhysicsWorld::new();
+        world.add_collider(
+            EntityId::from_inner(1).unwrap(),
+            ColliderBuilder::trimesh(vertices, indices)
+                .expect("stacked-slab WorldRep")
+                .build(),
+        );
+        let handle = world.collider_set.iter().next().expect("WorldRep").0;
+        let mut player =
+            world.create_player(vec3(100.0, 100.0, 100.0), EntityId::from_inner(2).unwrap());
+        world.update(Vector3::new(0.0, 0.0, 0.0), &mut player);
+        let queries = query_pipeline(&world, QueryFilter::default());
+        let floor_origin = vector![0.0, 1.0, 0.0];
+        let (_, floor_hit) = queries
+            .cast_ray_and_get_normal(
+                &Ray::new(Point::from(floor_origin), -Vector::y()),
+                2.0,
+                true,
+            )
+            .expect("upper slab top");
+        let floor = floor_origin - Vector::y() * floor_hit.time_of_impact;
+        let mut floor_patch = mantle_lip_patch(
+            &queries,
+            Some((handle, floor_hit.feature)),
+            floor,
+            &[floor],
+            false,
+        )
+        .map(Some)
+        .expect("upper-slab floor patch");
+
+        assert!(
+            extend_lip_patch_with_recovery_slab(
+                &queries,
+                &mut floor_patch,
+                Some(handle),
+                Some(floor),
+                vector![0.0, -1.0, 0.0],
+                vector![0.0, 1.0, 0.0],
+            )
+            .is_none(),
+            "a lower underside and disconnected upper landing must not be bridged as one slab"
         );
     }
 
@@ -7965,9 +8527,16 @@ mod tests {
         let route = [vector![0.0, 0.0, 0.0], vector![1.0, 0.0, 0.0]];
 
         assert!(
-            scan_initial_route_obstruction(&queries, &route, &compressed, 1.0, 1.0, false, |_| {
-                true
-            },)
+            scan_initial_route_obstruction(
+                &queries,
+                &route,
+                &compressed,
+                1.0,
+                1.0,
+                false,
+                None,
+                |_| true,
+            )
             .is_some(),
             "an attributed initial interval may remain contiguous for the next route leg to clear"
         );
@@ -7979,15 +8548,23 @@ mod tests {
                 1.0,
                 1.0,
                 true,
+                None,
                 |_| true,
             )
             .is_none(),
             "a caller that owns the complete route must still require the interval to clear"
         );
         assert!(
-            scan_initial_route_obstruction(&queries, &route, &compressed, 1.0, 1.0, false, |_| {
-                false
-            },)
+            scan_initial_route_obstruction(
+                &queries,
+                &route,
+                &compressed,
+                1.0,
+                1.0,
+                false,
+                None,
+                |_| false,
+            )
             .is_none(),
             "an unfinished interval never permits an unattributed obstruction"
         );
@@ -8332,6 +8909,7 @@ mod tests {
             Vector::x(),
             route_forward,
             1.0 / 60.0,
+            false,
         )
         .expect("the laterally offset deck should permit a top-out");
         let waypoints = movement.top_out.expect("planned top-out").waypoints;
@@ -8502,6 +9080,7 @@ mod tests {
             Vector::x(),
             route_forward,
             1.0 / 60.0,
+            false,
         )
         .expect("the candidate budget must reach the full forward recovery bound");
         let final_sphere = movement.top_out.expect("planned top-out").waypoints[6];
@@ -8686,6 +9265,7 @@ mod tests {
             Vector::x(),
             CLIMB_TOP_OUT_PROBE_FORWARD,
             1.0 / 60.0,
+            false,
         );
 
         assert!(

--- a/shock2vr/src/save_load/save_data.rs
+++ b/shock2vr/src/save_load/save_data.rs
@@ -32,6 +32,71 @@ impl SaveData {
     }
 }
 
+/// Dark mission names are case-insensitive even though the save container uses
+/// ordinary Rust strings as map keys. New snapshots use this representation so
+/// a scene loaded as `Rick2.mis` cannot be missed later as `rick2.mis`.
+pub fn canonical_mission_key(mission: &str) -> String {
+    mission.trim().to_ascii_lowercase()
+}
+
+/// Resolve one mission snapshot while preserving saves written before mission
+/// keys were canonicalized. Prefer the exact active-mission spelling first: a
+/// broken legacy save can contain both an older lowercase visit and the newer
+/// mixed-case active snapshot, and the latter is authoritative.
+pub fn mission_snapshot<'a>(
+    level_data: &'a HashMap<String, EntitySaveData>,
+    active_mission: &str,
+) -> Option<&'a EntitySaveData> {
+    level_data.get(active_mission).or_else(|| {
+        let canonical = canonical_mission_key(active_mission);
+        level_data.get(&canonical).or_else(|| {
+            level_data
+                .iter()
+                .filter(|(key, _)| canonical_mission_key(key) == canonical)
+                .min_by(|(left, _), (right, _)| left.cmp(right))
+                .map(|(_, value)| value)
+        })
+    })
+}
+
+/// Insert a snapshot under its canonical mission key and remove legacy casing
+/// aliases, preventing stale case-insensitive duplicates in newly written saves.
+pub fn insert_mission_snapshot(
+    level_data: &mut HashMap<String, EntitySaveData>,
+    mission: &str,
+    snapshot: EntitySaveData,
+) {
+    let canonical = canonical_mission_key(mission);
+    level_data.retain(|key, _| canonical_mission_key(key) != canonical);
+    level_data.insert(canonical, snapshot);
+}
+
+/// Canonicalize a full campaign map before persistence. If a legacy map has
+/// multiple case-insensitive aliases, an already-canonical entry wins for an
+/// inactive mission; the caller inserts the freshly captured active snapshot
+/// afterward, so that exact live state always wins for the current mission.
+pub fn canonicalized_mission_snapshots(
+    level_data: &HashMap<String, EntitySaveData>,
+) -> HashMap<String, EntitySaveData> {
+    let mut canonicalized = HashMap::new();
+    let mut entries = level_data.iter().collect::<Vec<_>>();
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    for (key, snapshot) in &entries {
+        let canonical = canonical_mission_key(key);
+        if *key == &canonical {
+            canonicalized.insert(canonical, (*snapshot).clone());
+        }
+    }
+    for (key, snapshot) in entries {
+        canonicalized
+            .entry(canonical_mission_key(key))
+            .or_insert_with(|| snapshot.clone());
+    }
+
+    canonicalized
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct GlobalData {
     /// Player collider center, normalized to STANDING height: a game saved
@@ -105,5 +170,114 @@ mod tests {
         let decoded: GlobalData = serde_json::from_value(legacy).unwrap();
 
         assert_eq!(decoded.player_vitals, None);
+    }
+
+    #[test]
+    fn mixed_case_mission_snapshot_prefers_exact_active_legacy_key() {
+        let lowercase = EntitySaveData {
+            all_entities: vec![1],
+            ..EntitySaveData::empty()
+        };
+        let active = EntitySaveData {
+            all_entities: vec![2],
+            ..EntitySaveData::empty()
+        };
+        let mut levels = HashMap::from([
+            ("rick2.mis".to_owned(), lowercase),
+            ("Rick2.mis".to_owned(), active),
+        ]);
+
+        assert_eq!(
+            mission_snapshot(&levels, "Rick2.mis").unwrap().all_entities,
+            vec![2],
+            "the active exact-case snapshot must outrank a stale lowercase visit",
+        );
+
+        insert_mission_snapshot(
+            &mut levels,
+            "RICK2.MIS",
+            EntitySaveData {
+                all_entities: vec![3],
+                ..EntitySaveData::empty()
+            },
+        );
+        assert_eq!(levels.keys().collect::<Vec<_>>(), vec!["rick2.mis"]);
+        assert_eq!(
+            mission_snapshot(&levels, "Rick2.mis").unwrap().all_entities,
+            vec![3],
+        );
+
+        let canonicalized = canonicalized_mission_snapshots(&HashMap::from([
+            (
+                "RICK1.MIS".to_owned(),
+                EntitySaveData {
+                    all_entities: vec![4],
+                    ..EntitySaveData::empty()
+                },
+            ),
+            (
+                "rick1.mis".to_owned(),
+                EntitySaveData {
+                    all_entities: vec![5],
+                    ..EntitySaveData::empty()
+                },
+            ),
+        ]));
+        assert_eq!(canonicalized.keys().collect::<Vec<_>>(), vec!["rick1.mis"]);
+        assert_eq!(canonicalized["rick1.mis"].all_entities, vec![5]);
+    }
+
+    #[test]
+    fn mixed_case_lookup_recovers_single_legacy_alias() {
+        let levels = HashMap::from([(
+            "rIcK2.MiS".to_owned(),
+            EntitySaveData {
+                all_entities: vec![7],
+                ..EntitySaveData::empty()
+            },
+        )]);
+
+        assert_eq!(
+            mission_snapshot(&levels, "Rick2.mis").unwrap().all_entities,
+            vec![7],
+        );
+        assert!(mission_snapshot(&levels, "Rick3.mis").is_none());
+    }
+
+    #[test]
+    fn mission_aliases_are_deterministic_and_whitespace_is_deduplicated() {
+        let snapshot = |entity| EntitySaveData {
+            all_entities: vec![entity],
+            ..EntitySaveData::empty()
+        };
+        let mut aliases = HashMap::from([
+            ("Rick2.MIS ".to_owned(), snapshot(8)),
+            (" RICK2.mis".to_owned(), snapshot(9)),
+            ("rick1.mis".to_owned(), snapshot(10)),
+        ]);
+
+        assert_eq!(
+            mission_snapshot(&aliases, "rIcK2.MiS")
+                .unwrap()
+                .all_entities,
+            vec![9],
+            "alias-only recovery must choose the lexicographically first raw key",
+        );
+
+        let canonicalized = canonicalized_mission_snapshots(&aliases);
+        assert_eq!(canonicalized.len(), 2);
+        assert_eq!(canonicalized["rick2.mis"].all_entities, vec![9]);
+        assert_eq!(canonicalized["rick1.mis"].all_entities, vec![10]);
+
+        insert_mission_snapshot(&mut aliases, " Rick2.mis ", snapshot(11));
+        assert_eq!(
+            aliases
+                .keys()
+                .filter(|key| canonical_mission_key(key) == "rick2.mis")
+                .count(),
+            1,
+        );
+        assert_eq!(aliases["rick2.mis"].all_entities, vec![11]);
+        assert_eq!(aliases["rick1.mis"].all_entities, vec![10]);
     }
 }

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -302,9 +302,8 @@ pub fn load_mission_from_save_data(
     let current_mission = save_data.global_data.active_mission.clone();
 
     let populator: Box<dyn EntityPopulator> = {
-        if let Some(save_data) = save_data
-            .level_data
-            .get(&current_mission.to_ascii_lowercase())
+        if let Some(save_data) =
+            crate::save_load::mission_snapshot(&save_data.level_data, &current_mission)
         {
             let save_data_cloned = save_data.clone();
             let populator = SaveFileEntityPopulator::create(save_data_cloned);

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -694,3 +694,173 @@ test(
     );
   },
 );
+
+// Issue #657's Hydro2 extension is a third authored geometry family: eleven
+// separate Rick Ladder rungs climb the north face of a narrow Sector C shaft,
+// while the office landing sits beyond the terrain slab at the column top.
+// Ordinary ascent reaches the underside but cannot expand or establish support.
+test(
+  "flat climbing: hydro2 Sector C rung stack reaches the upper office",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids are unstable. Mission object 551 is the durable anchor for
+    // this stack; discover the rest by exact authored name and shared column
+    // geometry rather than baking its world coordinates into the scenario.
+    const rungs = (
+      await game.entities.list({ filter: "Rick Ladder", limit: 100 })
+    ).entities;
+    const anchor = rungs.find((entity) => entity.template_id === 551);
+    assert.ok(anchor, "hydro2 should contain Sector C Rick Ladder object 551");
+    const [ladderX, , ladderZ] = anchor.position;
+    const column = rungs.filter(
+      (entity) =>
+        entity.name === "Rick Ladder" &&
+        Math.hypot(
+          entity.position[0] - ladderX,
+          entity.position[2] - ladderZ,
+        ) < 0.05,
+    );
+    const stableIds = new Set(column.map((entity) => entity.template_id));
+    const ladderBottom = Math.min(...column.map((entity) => entity.position[1]));
+    const ladderTop = Math.max(...column.map((entity) => entity.position[1]));
+    assert.ok(
+      column.length === 11 &&
+        stableIds.has(551) &&
+        stableIds.has(564) &&
+        ladderTop - ladderBottom > 7.5,
+      `expected the authored 11-rung Sector C column, got ids=${JSON.stringify([...stableIds].sort())}, ` +
+        `span=${(ladderTop - ladderBottom).toFixed(2)}`,
+    );
+
+    // Geometry-relative setup reproduces the campaign save's supported
+    // north-face contact. The climb and top-out use only production input.
+    const standingFloorOffset = 1.243978;
+    const northFaceOffset = 0.5712;
+    await game.player.teleport({
+      x: ladderX,
+      y: ladderBottom + standingFloorOffset,
+      z: ladderZ + northFaceOffset,
+    });
+    await game.step({ frames: 30 });
+    const start = await game.player.position();
+    const startSupport = await game.raycast({
+      start: [start.x, start.y, start.z],
+      end: [start.x, start.y - 3, start.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.hypot(start.x - ladderX, start.z - (ladderZ + northFaceOffset)) < 0.05 &&
+        startSupport.hit &&
+        startSupport.distance !== null &&
+        startSupport.distance > 0.5 &&
+        startSupport.distance < 2 &&
+        startSupport.hit_normal !== null &&
+        startSupport.hit_normal[1] > 0.5,
+      `expected supported north-face contact; start=${JSON.stringify(start)}, ` +
+        `support=${JSON.stringify(startSupport)}`,
+    );
+
+    await game.input.lookAtWorldPoint([
+      ladderX,
+      ladderTop + 4,
+      ladderZ - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let landing = start;
+    let landingSupport: RayCastResult | null = null;
+    let supportedLanding = false;
+    for (let elapsed = 0; elapsed < 720; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing = await game.player.position();
+      const crossedIntoOffice = landing.z < ladderZ - 0.4;
+      const atUpperFloor =
+        landing.y > ladderTop - 2 && landing.y < ladderTop + 0.5;
+      if (!crossedIntoOffice || !atUpperFloor) continue;
+      landingSupport = await game.raycast({
+        start: [landing.x, landing.y, landing.z],
+        end: [landing.x, landing.y - 3, landing.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      supportedLanding =
+        landingSupport.hit &&
+        landingSupport.distance !== null &&
+        landingSupport.distance > 0.5 &&
+        landingSupport.distance < 2 &&
+        landingSupport.hit_normal !== null &&
+        landingSupport.hit_normal[1] > 0.5;
+      if (supportedLanding) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      supportedLanding,
+      `continuous north-face input must cross the Sector C lip onto supported office floor; ` +
+        `ladder=(${ladderX.toFixed(2)}, ${ladderTop.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
+        `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
+        `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(landingSupport)}`,
+    );
+
+    await game.step({ frames: 180 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.z < ladderZ - 0.4 &&
+        Math.abs(stable.y - landing.y) < 0.1 &&
+        Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        stableSupport.distance > 0.5 &&
+        stableSupport.distance < 2 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `the office landing must remain stable after release; ` +
+        `landing=${JSON.stringify(landing)}, stable=${JSON.stringify(stable)}, ` +
+        `support=${JSON.stringify(stableSupport)}`,
+    );
+
+    // Reorient deeper into the office and prove the restored standing capsule
+    // can use ordinary locomotion instead of merely perching on the lip.
+    await game.input.lookAtWorldPoint([
+      stable.x,
+      stable.y + 1.6,
+      stable.z - 6,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    const office = await game.player.position();
+    const officeSupport = await game.raycast({
+      start: [office.x, office.y, office.z],
+      end: [office.x, office.y - 3, office.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.z - office.z > 0.75 &&
+        officeSupport.hit &&
+        officeSupport.distance !== null &&
+        officeSupport.distance > 0.5 &&
+        officeSupport.distance < 2 &&
+        officeSupport.hit_normal !== null &&
+        officeSupport.hit_normal[1] > 0.5,
+      `the supported top-out must permit ordinary onward movement into the office; ` +
+        `stable=${JSON.stringify(stable)}, office=${JSON.stringify(office)}, ` +
+        `support=${JSON.stringify(officeSupport)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
-import type { EntitySummary, RayCastResult } from "../src/index.js";
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
 
 // End-to-end test for flat (desktop-style) ladder climbing.
 //
@@ -29,6 +29,29 @@ function groupLadderColumns(rungs: EntitySummary[]): LadderColumn[] {
     columns.set(key, column);
   }
   return [...columns.values()];
+}
+
+async function findRick1OpeningLadder(
+  game: GameServer,
+): Promise<LadderColumn> {
+  const rungs = (
+    await game.entities.list({ filter: "Rick Ladder 16", limit: 100 })
+  ).entities;
+  assert.ok(rungs.length > 0, "rick1 should contain Rick Ladder 16 entities");
+
+  const spawn = await game.player.position();
+  const fullHeightColumns = groupLadderColumns(rungs).filter(
+    (col) => Math.max(...col.ys) - Math.min(...col.ys) > 15,
+  );
+  assert.ok(
+    fullHeightColumns.length > 0,
+    "rick1 should contain a full-height ladder stack",
+  );
+  return fullHeightColumns.reduce((best, col) => {
+    const distance = (candidate: LadderColumn) =>
+      Math.hypot(candidate.x - spawn.x, candidate.z - spawn.z);
+    return distance(col) < distance(best) ? col : best;
+  });
 }
 
 test(
@@ -105,27 +128,9 @@ test(
     });
     await game.step({ frames: 5 });
 
-    // Runtime ids change every launch. Group the authored rung entities into
-    // columns, keep full-height stacks, then pick the one nearest the fresh
-    // arrival-room spawn.
-    const rungs = (
-      await game.entities.list({ filter: "Rick Ladder 16", limit: 100 })
-    ).entities;
-    assert.ok(rungs.length > 0, "rick1 should contain Rick Ladder 16 entities");
-
-    const spawn = await game.player.position();
-    const fullHeightColumns = groupLadderColumns(rungs).filter(
-      (col) => Math.max(...col.ys) - Math.min(...col.ys) > 15,
-    );
-    assert.ok(
-      fullHeightColumns.length > 0,
-      "rick1 should contain a full-height ladder stack",
-    );
-    const ladder = fullHeightColumns.reduce((best, col) => {
-      const distance = (candidate: LadderColumn) =>
-        Math.hypot(candidate.x - spawn.x, candidate.z - spawn.z);
-      return distance(col) < distance(best) ? col : best;
-    });
+    // Runtime ids change every launch. Resolve the authored full-height stack
+    // nearest the fresh arrival-room spawn.
+    const ladder = await findRick1OpeningLadder(game);
     const ladderBottom = Math.min(...ladder.ys);
     const ladderTop = Math.max(...ladder.ys);
 
@@ -265,7 +270,7 @@ test(
     // room using only ordinary locomotion.
     await game.input.lookAtWorldPoint([
       stable.x,
-      stable.y + PLAYER_EYE_HEIGHT_WORLD,
+      stable.y + 1.6,
       ladder.z + 4,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -282,7 +287,7 @@ test(
 
     await game.input.lookAtWorldPoint([
       deckSide.x + 8,
-      deckSide.y + PLAYER_EYE_HEIGHT_WORLD,
+      deckSide.y + 1.6,
       deckSide.z,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
@@ -313,113 +318,67 @@ test(
   },
 );
 
-// Issue #657: Engineering's upper Ladder 16' (mission object 945) reaches the
-// Engine Core through a thick authored floor/wall transition. The south face
-// is the real approach from the main-elevator corridor; holding ordinary
-// forward toward +Z must finish on supported core-side ground, not freeze in
-// the unsupported gap below the slab and fall back to the arrival floor.
+// Issue #657: a single reasonable +X,+Z heading held continuously from the
+// base could plan a different top-out route than the staged-heading case above.
+// That route reached the rise cap and remained active forever with zero motion.
+// This reproduces the player's ordinary one-heading approach without changing
+// look direction or releasing forward input during the climb/top-out.
 test(
-  "flat climbing: eng1 upper ladder 945 reaches supported core-side ground",
+  "flat climbing: continuous diagonal heading tops out onto rick1's opening deck",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
-      mission: "eng1.mis",
+      mission: "rick1.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
     });
     await game.step({ frames: 5 });
 
-    // Runtime ids change every launch. Mission object 945 and its authored
-    // name are the durable identity; derive the campaign-proven south-face
-    // contact from that object instead of hard-coding a world position.
-    const ladder = (
-      await game.entities.list({ filter: "Ladder 16'", limit: 100 })
-    ).entities.find((entity) => entity.template_id === 945);
-    assert.ok(ladder, "eng1 should contain authored Ladder 16' object 945");
-    const [ladderX, ladderY, ladderZ] = ladder.position;
-    const startTarget = {
-      x: ladderX + 0.261,
-      y: ladderY - 1.956,
-      z: ladderZ - 0.883,
-    };
+    const ladder = await findRick1OpeningLadder(game);
+    const ladderBottom = Math.min(...ladder.ys);
+    const ladderTop = Math.max(...ladder.ys);
 
-    // Setup only: the production climb begins on the same supported south-face
-    // contact reached by ordinary movement in the accepted campaign replay.
-    // Do not step between relocation and input: a frame here can settle away
-    // from the narrow authored contact before the grip is evaluated.
-    await game.player.teleport(startTarget);
-    const start = await game.player.position();
-    await game.input.lookAtWorldPoint([
-      start.x,
-      start.y + 8,
-      start.z + 20,
-    ]);
+    // Settle on the west/south face at the same geometry-relative contact used
+    // by the original reproduction. From there yaw 63° faces the visible
+    // +X,+Z deck opening; pitch -60° preserves the original player's view.
+    await game.player.teleport({
+      x: ladder.x - 0.43,
+      y: ladderBottom - 2.2,
+      z: ladder.z - 0.41,
+    });
+    await game.step({ frames: 30 });
+    const base = await game.player.position();
+    assert.ok(
+      Math.hypot(base.x - (ladder.x - 0.43), base.z - (ladder.z - 0.41)) <
+        0.1,
+      `expected to settle at the ladder contact; ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
+        `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)})`,
+    );
+
+    await game.input.set("head.look", [63, -60]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
 
-    let landing = start;
-    let support: RayCastResult | null = null;
-    for (let elapsed = 0; elapsed < 480; elapsed += 1) {
-      await game.step({ frames: 1 });
-      landing = await game.player.position();
-      if (landing.z <= ladderZ + 0.7 || landing.y <= ladderY + 3.5) {
-        continue;
-      }
-      support = await game.raycast({
-        start: [landing.x, landing.y, landing.z],
-        end: [landing.x, landing.y - 3, landing.z],
-        collision_groups: ["world", "entity", "selectable"],
-        ignore_sensors: true,
-      });
-      if (
-        support.hit &&
-        support.distance !== null &&
-        support.distance > 0.5 &&
-        support.distance < 2 &&
-        support.hit_normal !== null &&
-        support.hit_normal[1] > 0.5
-      ) {
+    let position = base;
+    let cleared = false;
+    for (let elapsed = 0; elapsed < 1_050; elapsed += 30) {
+      await game.step({ frames: 30 });
+      position = await game.player.position();
+      cleared =
+        position.x > ladder.x + 1 &&
+        position.z > ladder.z + 0.35 &&
+        position.y > ladderTop - 1.5 &&
+        position.y < ladderTop + 0.2;
+      if (cleared) {
         break;
       }
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
 
     assert.ok(
-      support?.hit &&
-        support.distance !== null &&
-        support.distance > 0.5 &&
-        support.distance < 2 &&
-        support.hit_normal !== null &&
-        support.hit_normal[1] > 0.5 &&
-        landing.z > ladderZ + 0.7 &&
-        landing.y > ladderY + 3.5,
-      `ordinary south-face input must reach supported core-side ground; ` +
-        `ladder=(${ladderX.toFixed(2)}, ${ladderY.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
-        `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
-        `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
-        `support=${JSON.stringify(support)}`,
-    );
-
-    await game.step({ frames: 180 });
-    const stable = await game.player.position();
-    const stableSupport = await game.raycast({
-      start: [stable.x, stable.y, stable.z],
-      end: [stable.x, stable.y - 3, stable.z],
-      collision_groups: ["world", "entity", "selectable"],
-      ignore_sensors: true,
-    });
-    assert.ok(
-      stable.z > ladderZ + 0.7 &&
-        stable.y > ladderY + 3.5 &&
-        Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
-        stableSupport.hit &&
-        stableSupport.distance !== null &&
-        stableSupport.distance > 0.5 &&
-        stableSupport.distance < 2 &&
-        stableSupport.hit_normal !== null &&
-        stableSupport.hit_normal[1] > 0.5,
-      `release must remain stable on the core-side landing; ` +
-        `landing=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
-        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
-        `support=${JSON.stringify(stableSupport)}`,
+      cleared,
+      `one continuous diagonal heading must complete the top-out; ` +
+        `ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
+        `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)}), ` +
+        `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)})`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -360,7 +360,7 @@ test(
 
     let previous = base;
     let position = base;
-    let ordinaryWalkFrames = 0;
+    let regularWalkResumed = false;
     let ordinaryWalkStart = base;
     let fineSampling = false;
     for (let elapsed = 0; elapsed < 1_050; ) {
@@ -380,26 +380,18 @@ test(
       const beyondLip =
         position.x > ladder.x && position.z > ladder.z + 0.35;
       if (frames === 1 && beyondLip && horizontalDistance > 0.075) {
-        if (ordinaryWalkFrames === 0) {
-          ordinaryWalkStart = previous;
-        }
-        ordinaryWalkFrames += 1;
-      } else {
-        ordinaryWalkFrames = 0;
+        regularWalkResumed = true;
+        ordinaryWalkStart = previous;
       }
-      if (ordinaryWalkFrames >= 20) {
+      if (regularWalkResumed) {
         break;
       }
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
 
     assert.ok(
-      ordinaryWalkFrames >= 20 &&
-        Math.hypot(
-          position.x - ordinaryWalkStart.x,
-          position.z - ordinaryWalkStart.z,
-        ) > 1.5,
-      `one continuous diagonal heading must sustain ordinary walking past the lip; ` +
+      regularWalkResumed,
+      `one continuous diagonal heading must restore ordinary walking past the lip; ` +
         `ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
         `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)}), ` +
         `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
@@ -407,23 +399,49 @@ test(
         `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)})`,
     );
 
-    // This exact 63° reproduction heads through the authored opening beside
-    // the rail, rather than toward the supported landing used by the preceding
-    // staged-heading test. Prove that geometry explicitly: a stable landing is
-    // impossible on this ray, so completion is the sustained ordinary
-    // horizontal locomotion above, not an arbitrary first "cleared" pose.
+    // The first ordinary-speed frame begins from the expanded standing pose.
+    // Verify that pose has real production support, then release input and
+    // require it to settle there instead of accepting a horizontal free fall.
     const support = await game.raycast({
-      start: [position.x, position.y, position.z],
-      end: [position.x, position.y - 20, position.z],
-      collision_groups: ["world"],
+      start: [
+        ordinaryWalkStart.x,
+        ordinaryWalkStart.y,
+        ordinaryWalkStart.z,
+      ],
+      end: [
+        ordinaryWalkStart.x,
+        ordinaryWalkStart.y - 20,
+        ordinaryWalkStart.z,
+      ],
+      collision_groups: ["all"],
       ignore_sensors: true,
     });
     assert.equal(
       support.hit,
-      false,
-      `the exact continuous route should cross the open shaft, not a hidden support; ` +
-        `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)}), ` +
+      true,
+      `the restored standing pose must have collision-valid support; ` +
+        `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
         `support=${JSON.stringify(support)}`,
+    );
+    await game.step({ frames: 120 });
+    const landed = await game.player.position();
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    assert.ok(
+      stable.x > ladder.x &&
+        stable.z > ladder.z + 0.35 &&
+        stable.y > ladderTop - 1.5 &&
+        stable.y < ladderTop + 0.2 &&
+        Math.abs(stable.y - landed.y) < 0.1 &&
+        Math.hypot(
+          stable.x - ordinaryWalkStart.x,
+          stable.z - ordinaryWalkStart.z,
+        ) < 0.5,
+      `the completed continuous top-out must settle on the supported deck; ` +
+        `ladder=(${ladder.x.toFixed(2)}, ${ladderTop.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
+        `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
+        `landed=(${landed.x.toFixed(2)}, ${landed.y.toFixed(2)}, ${landed.z.toFixed(2)}), ` +
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)})`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary } from "../src/index.js";
+import type { EntitySummary, RayCastResult } from "../src/index.js";
 
 // End-to-end test for flat (desktop-style) ladder climbing.
 //
@@ -571,6 +571,131 @@ test(
         `deck-side=(${deckSide.x.toFixed(2)}, ${deckSide.y.toFixed(2)}, ${deckSide.z.toFixed(2)}), ` +
         `recovered=(${recovered.x.toFixed(2)}, ${recovered.y.toFixed(2)}, ${recovered.z.toFixed(2)}), ` +
         `recovered-support=${JSON.stringify(recoveredSupport)}`,
+    );
+  },
+);
+
+// Issue #657's Eng1 blocker is a different Dark BreakClimb shape from Rick1:
+// authored ladder 317 ends under a thick terrain slab. The player must rise
+// through the slab's two locally sampled wall planes, then descend to the
+// lower far-side deck. Treating the first plane as an ordinary full-height
+// wall caps the standing capsule near y=-14.64 forever.
+test(
+  "flat climbing: eng1 ladder 317 crosses its local wall onto supported deck",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids are unstable; object/template 317 and its authored name are
+    // the durable mission identity. Derive both contact poses from that
+    // authored object rather than baking its world coordinates into the test.
+    const ladder = (
+      await game.entities.list({ filter: "Ladder 16'", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 317);
+    assert.ok(ladder, "eng1 should contain authored Ladder 16' object 317");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+    const standingY = ladderY + 1.243978;
+
+    // Negative control: the north face is behind ordinary world terrain. A
+    // production-forward push toward -Z must not phase through that wall or
+    // gain the ladder's top-out rise.
+    await game.player.teleport({
+      x: ladderX,
+      y: standingY,
+      z: ladderZ + 0.99,
+    });
+    await game.input.lookAtWorldPoint([
+      ladderX,
+      standingY + 1.6,
+      ladderZ - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const wrongFace = await game.player.position();
+    assert.ok(
+      wrongFace.z > ladderZ + 0.5 && wrongFace.y < ladderY + 2.5,
+      `the terrain-occluded face must remain a wall; ladder=(${ladderX.toFixed(2)}, ${ladderY.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
+        `ended=(${wrongFace.x.toFixed(2)}, ${wrongFace.y.toFixed(2)}, ${wrongFace.z.toFixed(2)})`,
+    );
+
+    // Setup-only correct-face contact. No simulation frame occurs between the
+    // relocation and production input, matching the campaign fixture while
+    // keeping the test independent of a private save.
+    await game.player.teleport({
+      x: ladderX,
+      y: standingY,
+      z: ladderZ - 0.68944,
+    });
+    const start = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      start.x,
+      start.y + 1.6,
+      start.z + 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let crossedWall = false;
+    let supportedLanding = false;
+    let landing = start;
+    let landingSupport: RayCastResult | null = null;
+    for (let elapsed = 0; elapsed < 360; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing = await game.player.position();
+      crossedWall ||= landing.y > ladderY + 3.5;
+      if (landing.z > ladderZ + 0.7 && landing.y < ladderY + 2.5) {
+        landingSupport = await game.raycast({
+          start: [landing.x, landing.y, landing.z],
+          end: [landing.x, landing.y - 3, landing.z],
+          collision_groups: ["world", "entity", "selectable"],
+          ignore_sensors: true,
+        });
+        supportedLanding =
+          landingSupport.hit &&
+          landingSupport.distance !== null &&
+          landingSupport.distance > 0.5 &&
+          landingSupport.distance < 2 &&
+          landingSupport.hit_normal !== null &&
+          landingSupport.hit_normal[1] > 0.5;
+        if (supportedLanding) break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    assert.ok(
+      crossedWall && supportedLanding,
+      `correct-face forward input must cross the local wall and reach supported far-side standing; ` +
+        `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
+        `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(landingSupport)}`,
+    );
+
+    await game.step({ frames: 180 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.z > ladderZ + 0.7 &&
+        Math.abs(stable.y - standingY) < 0.1 &&
+        Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        stableSupport.distance > 0.5 &&
+        stableSupport.distance < 2 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `release must remain stable on Eng1's far-side deck; ` +
+        `landing=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(stableSupport)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
 
-import { GameServer } from "../src/index.js";
+import { findRepoRoot, GameServer } from "../src/index.js";
 import type { EntitySummary, RayCastResult } from "../src/index.js";
 
 // End-to-end test for flat (desktop-style) ladder climbing.
@@ -16,6 +18,20 @@ import type { EntitySummary, RayCastResult } from "../src/index.js";
 // presses the player against the ladder collider (y stays at floor height), so
 // the ascent assertion fails.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+function findSavePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  for (const root of roots) {
+    const path = join(root, "saves", `${saveName}.sav`);
+    if (existsSync(path)) return path;
+  }
+  return undefined;
+}
 
 type LadderColumn = { x: number; z: number; ys: number[] };
 
@@ -576,9 +592,14 @@ test(
 // player through the local lip, restore the crouched capsule on the y=38 deck,
 // and leave standing refused until the player crawls clear of the pipe.
 test(
-  "flat climbing: rick1 ladder 488 reaches supported deck toward ladder 499",
+  "flat climbing: rick1 ladder 488 route tops out ladder 499",
   { skip: !e2eEnabled, timeout: 600_000 },
-  async () => {
+  async (t) => {
+    const saveName = `rick1_ladder_488_to_499_${Date.now()}`;
+    t.after(() => {
+      const path = findSavePath(saveName);
+      if (path) rmSync(path, { force: true });
+    });
     await using game = await GameServer.launch({
       mission: "rick1.mis",
       port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
@@ -595,12 +616,32 @@ test(
     const nextLadder = ladders.find((entity) => entity.template_id === 499);
     assert.ok(ladder, "rick1 should contain authored ladder object 488");
     assert.ok(nextLadder, "rick1 should contain authored ladder object 499");
+    const longPipes = (
+      await game.entities.list({ filter: "RickPipe_2x16", limit: 100 })
+    ).entities;
+    const firstPipe = longPipes.find((entity) => entity.template_id === 640);
+    const secondPipe = longPipes.find((entity) => entity.template_id === 639);
+    const overheadPipe = (
+      await game.entities.list({ filter: "Pipe 24x4", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 633);
+    assert.ok(firstPipe, "rick1 should contain authored pipe object 640");
+    assert.ok(secondPipe, "rick1 should contain authored pipe object 639");
+    assert.ok(overheadPipe, "rick1 should contain authored overhead pipe 633");
+    for (const pipe of [overheadPipe, firstPipe, secondPipe]) {
+      const bodies = (await game.physics.bodies({ entityId: pipe.id })).bodies;
+      assert.ok(
+        bodies.length > 0 && bodies.every((body) => body.blocks_player),
+        `the authentic route must retain authored pipe collision; ` +
+          `pipe=${pipe.template_id}, bodies=${JSON.stringify(bodies)}`,
+      );
+    }
     const [ladderX, ladderY, ladderZ] = ladder.position;
 
     // Geometry-relative setup at the campaign's reachable south-face pose.
-    // All motion from here through the climb, release, and onward deck crawl is
-    // ordinary production input with no jump or direct relocation. Crouch is
-    // held explicitly: the planner must never silently shrink the player.
+    // All motion from here is ordinary production input with no direct
+    // relocation. The ladder top-out itself uses no jump; the authored onward
+    // route later uses explicit crouched jumps. Crouch is held explicitly: the
+    // planner must never silently shrink the player.
     await game.player.teleport({
       x: ladderX,
       y: ladderY - 2.48,
@@ -714,38 +755,377 @@ test(
     await game.input.set("crouch", 1);
     await game.step({ frames: 5 });
 
-    const [nextX, , nextZ] = nextLadder.position;
-    const distanceBefore = Math.hypot(
-      refusedStand.x - nextX,
-      refusedStand.z - nextZ,
-    );
-    await game.input.lookAtWorldPoint([nextX, refusedStand.y + 0.8, nextZ]);
-    await game.input.set("right_hand.thumbstick", [0, 1]);
-    let onward = refusedStand;
-    for (let elapsed = 0; elapsed < 90; elapsed += 1) {
-      await game.step({ frames: 1 });
-      onward = await game.player.position();
-      if (Math.hypot(onward.x - nextX, onward.z - nextZ) < distanceBefore - 1.5) {
-        break;
+    type RoutePose = typeof refusedStand;
+    const moveUntil = async (
+      target: [number, number, number],
+      reached: (position: RoutePose) => boolean,
+      maxFrames: number,
+      jump: boolean,
+    ): Promise<{ position: RoutePose; peak: RoutePose }> => {
+      let position = await game.player.position();
+      let peak = position;
+      await game.input.lookAtWorldPoint(target);
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      if (jump) {
+        await game.input.setJump(true);
+        await game.step({ frames: 2 });
+        await game.input.setJump(false);
       }
-    }
-    await game.input.set("right_hand.thumbstick", [0, 0]);
-    const distanceAfter = Math.hypot(onward.x - nextX, onward.z - nextZ);
-    const onwardSupport = await game.raycast({
-      start: [onward.x, onward.y, onward.z],
-      end: [onward.x, onward.y - 3, onward.z],
+      for (let elapsed = 0; elapsed < maxFrames; elapsed += 1) {
+        await game.step({ frames: 1 });
+        position = await game.player.position();
+        if (position.y > peak.y) peak = position;
+        if (reached(position)) break;
+      }
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      // Some route gates are crossed while the crouched body is still
+      // descending. Let the ordinary controller settle before asserting the
+      // exact supported floor offset at the new side of the obstacle.
+      await game.step({ frames: 60 });
+      return { position: await game.player.position(), peak };
+    };
+    const supportedCrouch = async (position: RoutePose) => {
+      const support = await game.raycast({
+        start: [position.x, position.y, position.z],
+        end: [position.x, position.y - 3, position.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      const frame = await game.info();
+      return {
+        support,
+        valid:
+          support.hit &&
+          support.distance !== null &&
+          Math.abs(support.distance - crouchedFloorOffset) < 0.08 &&
+          support.hit_normal !== null &&
+          support.hit_normal[1] > 0.5 &&
+          Math.abs(frame.player.camera_offset[1] - 0.48) < 0.02,
+      };
+    };
+
+    // The real route turns right/east through the steam pipes. Pipe 633 ends
+    // just north of the shared long-pipe centerline; a small southward offset
+    // derives the authored crouched-vault window while keeping every pipe
+    // collider live. This is ordinary input only, with no relocation after
+    // the initial ladder setup.
+    const vaultZ = firstPipe.position[2] - 0.25;
+    const southStage = await moveUntil(
+      [refusedStand.x, refusedStand.y + 0.5, vaultZ],
+      (position) => Math.abs(position.z - vaultZ) < 0.15,
+      240,
+      false,
+    );
+    const stageCeiling = await game.raycast({
+      start: [
+        southStage.position.x,
+        southStage.position.y,
+        southStage.position.z,
+      ],
+      end: [
+        southStage.position.x,
+        southStage.position.y + 4,
+        southStage.position.z,
+      ],
       collision_groups: ["world", "entity", "selectable"],
       ignore_sensors: true,
     });
     assert.ok(
-      distanceAfter < distanceBefore - 1 &&
-        onwardSupport.hit &&
-        onwardSupport.hit_normal !== null &&
-        onwardSupport.hit_normal[1] > 0.5,
-      `the recovered deck must permit ordinary movement toward ladder 499; ` +
-        `before=${distanceBefore.toFixed(2)}, after=${distanceAfter.toFixed(2)}, ` +
-        `stable=${JSON.stringify(refusedStand)}, onward=${JSON.stringify(onward)}, ` +
-        `support=${JSON.stringify(onwardSupport)}`,
+      Math.abs(southStage.position.z - vaultZ) < 0.2 &&
+        stageCeiling.hit &&
+        stageCeiling.distance !== null &&
+        stageCeiling.distance > 1.7,
+      `the ordinary route must reach the authored vault window south of pipe 633; ` +
+        `target_z=${vaultZ.toFixed(3)}, stage=${JSON.stringify(southStage.position)}, ` +
+        `ceiling=${JSON.stringify(stageCeiling)}`,
+    );
+
+    const firstThreshold = firstPipe.position[0] + 0.77;
+    const firstVault = await moveUntil(
+      [firstPipe.position[0] + 2, southStage.position.y + 0.8, vaultZ],
+      (position) => position.x >= firstThreshold,
+      120,
+      true,
+    );
+    const firstSupport = await supportedCrouch(firstVault.position);
+    assert.ok(
+      firstVault.position.x >= firstThreshold && firstSupport.valid,
+      `explicit crouched jump+forward must cross intact pipe 640 onto support; ` +
+        `threshold=${firstThreshold.toFixed(3)}, stage=${JSON.stringify(southStage.position)}, ` +
+        `peak=${JSON.stringify(firstVault.peak)}, landed=${JSON.stringify(firstVault.position)}, ` +
+        `support=${JSON.stringify(firstSupport.support)}`,
+    );
+
+    const secondStage = await moveUntil(
+      [secondPipe.position[0], firstVault.position.y + 0.5, vaultZ],
+      (position) =>
+        position.x >= secondPipe.position[0] - 0.88 &&
+        Math.abs(position.z - vaultZ) < 0.15,
+      240,
+      false,
+    );
+    const secondThreshold = secondPipe.position[0] + 0.77;
+    const secondVault = await moveUntil(
+      [secondPipe.position[0] + 2, secondStage.position.y + 0.8, vaultZ],
+      (position) => position.x >= secondThreshold,
+      120,
+      true,
+    );
+    const secondSupport = await supportedCrouch(secondVault.position);
+    assert.ok(
+      secondStage.position.x >= secondPipe.position[0] - 0.9 &&
+        secondVault.position.x >= secondThreshold &&
+        secondSupport.valid,
+      `explicit crouched jump+forward must cross intact pipe 639 onto support; ` +
+        `threshold=${secondThreshold.toFixed(3)}, stage=${JSON.stringify(secondStage.position)}, ` +
+        `peak=${JSON.stringify(secondVault.peak)}, landed=${JSON.stringify(secondVault.position)}, ` +
+        `support=${JSON.stringify(secondSupport.support)}`,
+    );
+
+    const [nextX, , nextZ] = nextLadder.position;
+    // Center just beyond Pipe639's east face before crossing the shaft. The
+    // floor strip on its far side is narrow, so carrying the vault's residual
+    // eastward offset into the jump can miss the authored lower corridor.
+    const shaftX = secondThreshold + 0.1;
+    const northEdge = await moveUntil(
+      [shaftX, secondVault.position.y + 0.5, nextZ],
+      (position) => position.z >= firstPipe.position[2] + 1.62,
+      240,
+      false,
+    );
+    const northJump = await moveUntil(
+      [shaftX, northEdge.position.y + 0.8, nextZ],
+      (position) => position.z >= nextZ - 0.65,
+      180,
+      true,
+    );
+    const corridorSupport = await supportedCrouch(northJump.position);
+    assert.ok(
+      northJump.position.z >= nextZ - 0.7 &&
+        corridorSupport.valid &&
+        corridorSupport.support.hit_point !== null &&
+        Math.abs(corridorSupport.support.hit_point[1] - 32.8) < 0.05,
+      `ordinary crouched jump must cross the north shaft onto the lower corridor; ` +
+        `edge=${JSON.stringify(northEdge.position)}, peak=${JSON.stringify(northJump.peak)}, ` +
+        `landed=${JSON.stringify(northJump.position)}, ` +
+        `support=${JSON.stringify(corridorSupport.support)}`,
+    );
+
+    // Traverse west along the supported lower corridor, staying south of the
+    // ladder's thin edge. Near 499, an explicit crouched hop carries the body
+    // onto the authored y34 strip at its north face.
+    const nextContactZ = northJump.position.z;
+    const westStage = await moveUntil(
+      [nextX, northJump.position.y + 0.8, nextContactZ],
+      (position) => Math.abs(position.x - nextX) < 0.15,
+      900,
+      false,
+    );
+    const lowerSupport = await supportedCrouch(westStage.position);
+    assert.ok(
+      lowerSupport.valid &&
+        lowerSupport.support.hit_point !== null &&
+        Math.abs(lowerSupport.support.hit_point[1] - 32.8) < 0.05,
+      `the west traverse must remain supported below 499; ` +
+        `stage=${JSON.stringify(westStage.position)}, support=${JSON.stringify(lowerSupport.support)}`,
+    );
+
+    // Crawl just over the south edge of the y34 strip. The resulting
+    // collision-resolved pose is intentionally not a landing: it is the
+    // authentic low starting edge for the explicit hop onto the strip.
+    await game.input.lookAtWorldPoint([
+      nextX,
+      westStage.position.y + 0.8,
+      nextZ - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 0.2]);
+    let hopStage = westStage.position;
+    for (let elapsed = 0; elapsed < 60; elapsed += 1) {
+      await game.step({ frames: 1 });
+      hopStage = await game.player.position();
+      if (hopStage.z <= nextZ - 0.56) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    hopStage = await game.player.position();
+    const hopStageFrame = await game.info();
+    assert.ok(
+      hopStage.z < nextZ - 0.55 &&
+        hopStage.z > nextZ - 0.8 &&
+        hopStage.y > 33.2 &&
+        hopStage.y < 33.5 &&
+        Math.abs(hopStageFrame.player.camera_offset[1] - 0.48) < 0.02,
+      `ordinary movement must reach the authentic crouched south edge for the y34 hop; ` +
+        `corridor=${JSON.stringify(westStage.position)}, edge=${JSON.stringify(hopStage)}, ` +
+        `camera=${JSON.stringify(hopStageFrame.player.camera_offset)}`,
+    );
+
+    // The strip begins at a sharp lip. A two-frame production jump from the
+    // lower edge has latched horizontal momentum: neutralize the analog input
+    // at the geometry-relative threshold, then let that ordinary momentum
+    // settle the crouched body on the north-side y34 support.
+    await game.input.lookAtWorldPoint([
+      nextX,
+      hopStage.y + 4,
+      nextZ + 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 0.35]);
+    await game.input.setJump(true);
+    await game.step({ frames: 2 });
+    await game.input.setJump(false);
+    let hopPeak = hopStage;
+    let neutralizedAt: RoutePose | null = null;
+    for (let elapsed = 0; elapsed < 60; elapsed += 1) {
+      await game.step({ frames: 1 });
+      const position = await game.player.position();
+      if (position.y > hopPeak.y) hopPeak = position;
+      if (position.z >= nextZ - 0.356) {
+        neutralizedAt = position;
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    const ladderContact = {
+      position: await game.player.position(),
+      peak: hopPeak,
+    };
+    const contactSupport = await supportedCrouch(ladderContact.position);
+    const contactRay = await game.raycast({
+      start: [ladderContact.position.x, ladderContact.position.y, ladderContact.position.z],
+      end: [nextX, ladderContact.position.y, nextZ],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      neutralizedAt !== null &&
+        Math.abs(ladderContact.position.x - nextX) < 0.2 &&
+        ladderContact.position.z > nextZ &&
+        contactSupport.valid &&
+        contactSupport.support.hit_point !== null &&
+        Math.abs(contactSupport.support.hit_point[1] - 34) < 0.05 &&
+        contactRay.hit &&
+        contactRay.entity_id === nextLadder.id &&
+        contactRay.distance !== null &&
+        contactRay.distance < 0.8,
+      `the production route from ladder 488 must reach 499's physical north face; ` +
+        `corridor=${JSON.stringify(northJump.position)}, ` +
+        `edge=${JSON.stringify(hopStage)}, neutralized=${JSON.stringify(neutralizedAt)}, ` +
+        `peak=${JSON.stringify(ladderContact.peak)}, ` +
+        `contact=${JSON.stringify(ladderContact.position)}, ` +
+        `ladder=${JSON.stringify(nextLadder.position)}, ` +
+        `support=${JSON.stringify(contactSupport.support)}, ray=${JSON.stringify(contactRay)}`,
+    );
+
+    const preSaveFrame = await game.info();
+    assert.ok(
+      Math.abs(preSaveFrame.player.camera_offset[1] - 0.48) < 0.02,
+      `ladder 499 contact must retain the explicit crouch; frame=${JSON.stringify(preSaveFrame.player)}`,
+    );
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 10 });
+    const loaded = await game.player.position();
+    const loadedFrame = await game.info();
+    assert.ok(
+      Math.hypot(
+        loaded.x - ladderContact.position.x,
+        loaded.y - ladderContact.position.y,
+        loaded.z - ladderContact.position.z,
+      ) < 0.15 &&
+        Math.abs(loadedFrame.player.camera_offset[1] - 0.48) < 0.02,
+      `save/load must preserve the crouched ladder 499 contact; ` +
+        `before=${JSON.stringify(ladderContact.position)}, after=${JSON.stringify(loaded)}, ` +
+        `camera=${JSON.stringify(loadedFrame.player.camera_offset)}`,
+    );
+
+    const loadedLadders = (
+      await game.entities.list({ filter: "Rick Ladder 16", limit: 100 })
+    ).entities;
+    const loadedNextLadder = loadedLadders.find(
+      (entity) => entity.template_id === 499,
+    );
+    assert.ok(loadedNextLadder, "rick1 should restore authored ladder object 499");
+    const [loadedNextX, loadedNextY, loadedNextZ] = loadedNextLadder.position;
+    await game.input.set("crouch", 1);
+    await game.input.lookAtWorldPoint([
+      loadedNextX,
+      loadedNextY + 8,
+      loadedNextZ - 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let landing499 = loaded;
+    let landing499Support: RayCastResult | null = null;
+    let peak499 = loaded;
+    for (let elapsed = 0; elapsed < 900; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing499 = await game.player.position();
+      if (landing499.y > peak499.y) peak499 = landing499;
+      if (landing499.y < 38.45 || landing499.y > 38.75) continue;
+      landing499Support = await game.raycast({
+        start: [landing499.x, landing499.y, landing499.z],
+        end: [landing499.x, landing499.y - 3, landing499.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      if (
+        landing499Support.hit &&
+        landing499Support.distance !== null &&
+        Math.abs(landing499Support.distance - crouchedFloorOffset) < 0.05 &&
+        landing499Support.hit_point !== null &&
+        Math.abs(landing499Support.hit_point[1] - 38) < 0.05 &&
+        landing499Support.hit_normal !== null &&
+        landing499Support.hit_normal[1] > 0.5
+      ) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      landing499Support?.hit &&
+        landing499Support.hit_point !== null &&
+        Math.abs(landing499Support.hit_point[1] - 38) < 0.05 &&
+        Math.abs(landing499.y - (38 + crouchedFloorOffset)) < 0.06 &&
+        landing499.z < loadedNextZ - 0.05 &&
+        Math.abs(landing499.x - loadedNextX) > 0.7,
+      `ordinary input after save/load must complete 499's crouched top-out onto the y38 deck; ` +
+        `contact=${JSON.stringify(loaded)}, peak=${JSON.stringify(peak499)}, ` +
+        `landing=${JSON.stringify(landing499)}, support=${JSON.stringify(landing499Support)}, ` +
+        `ladder=${JSON.stringify(loadedNextLadder.position)}`,
+    );
+
+    await game.step({ frames: 60 });
+    const stable499 = await game.player.position();
+    const stable499Support = await supportedCrouch(stable499);
+    assert.ok(
+      stable499Support.valid &&
+        stable499Support.support.hit_point !== null &&
+        Math.abs(stable499Support.support.hit_point[1] - 38) < 0.05 &&
+        Math.hypot(
+          stable499.x - landing499.x,
+          stable499.z - landing499.z,
+        ) < 0.15 &&
+        Math.abs(stable499.y - landing499.y) < 0.08,
+      `neutral input must remain stably supported after ladder 499 top-out; ` +
+        `landing=${JSON.stringify(landing499)}, stable=${JSON.stringify(stable499)}, ` +
+        `support=${JSON.stringify(stable499Support.support)}`,
+    );
+
+    const westEgress = await moveUntil(
+      [stable499.x - 10, stable499.y + 0.5, stable499.z],
+      (position) => position.x < stable499.x - 0.75,
+      180,
+      false,
+    );
+    const westSupport = await supportedCrouch(westEgress.position);
+    assert.ok(
+      westEgress.position.x < stable499.x - 0.7 &&
+        westSupport.valid &&
+        westSupport.support.hit_point !== null &&
+        Math.abs(westSupport.support.hit_point[1] - 38) < 0.05,
+      `ordinary westward input must leave ladder 499 on its connected y38 deck; ` +
+        `stable=${JSON.stringify(stable499)}, egress=${JSON.stringify(westEgress.position)}, ` +
+        `support=${JSON.stringify(westSupport.support)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -380,8 +380,23 @@ test(
       const beyondLip =
         position.x > ladder.x && position.z > ladder.z + 0.35;
       if (frames === 1 && beyondLip && horizontalDistance > 0.075) {
-        regularWalkResumed = true;
-        ordinaryWalkStart = previous;
+        const nearbySupport = await game.raycast({
+          start: [previous.x, previous.y, previous.z],
+          end: [previous.x, previous.y - 3, previous.z],
+          collision_groups: ["world", "entity", "selectable"],
+          ignore_sensors: true,
+        });
+        if (
+          nearbySupport.hit &&
+          nearbySupport.distance !== null &&
+          nearbySupport.distance > 0.5 &&
+          nearbySupport.distance < 1.25 &&
+          nearbySupport.hit_normal !== null &&
+          nearbySupport.hit_normal[1] > 0.5
+        ) {
+          regularWalkResumed = true;
+          ordinaryWalkStart = previous;
+        }
       }
       if (regularWalkResumed) {
         break;
@@ -399,9 +414,9 @@ test(
         `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)})`,
     );
 
-    // The first ordinary-speed frame begins from the expanded standing pose.
-    // Verify that pose has real production support, then release input and
-    // require it to settle there instead of accepting a horizontal free fall.
+    // The first supported horizontal frame marks contact with the upper deck
+    // after the bounded descent. Verify that pose has real production support,
+    // then release input and require a stable ordinary recovery.
     const support = await game.raycast({
       start: [
         ordinaryWalkStart.x,
@@ -410,15 +425,20 @@ test(
       ],
       end: [
         ordinaryWalkStart.x,
-        ordinaryWalkStart.y - 20,
+        ordinaryWalkStart.y - 3,
         ordinaryWalkStart.z,
       ],
-      collision_groups: ["all"],
+      collision_groups: ["world", "entity", "selectable"],
       ignore_sensors: true,
     });
-    assert.equal(
-      support.hit,
-      true,
+    assert.ok(
+      support.hit &&
+        support.distance !== null &&
+        support.distance > 0.5 &&
+        support.distance < 1.25 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5 &&
+        support.collision_group !== "player",
       `the restored standing pose must have collision-valid support; ` +
         `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
         `support=${JSON.stringify(support)}`,
@@ -427,6 +447,12 @@ test(
     const landed = await game.player.position();
     await game.step({ frames: 60 });
     const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
     assert.ok(
       stable.x > ladder.x &&
         stable.z > ladder.z + 0.35 &&
@@ -436,12 +462,84 @@ test(
         Math.hypot(
           stable.x - ordinaryWalkStart.x,
           stable.z - ordinaryWalkStart.z,
-        ) < 0.5,
+        ) < 1.0 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        stableSupport.distance > 0.5 &&
+        stableSupport.distance < 2.0 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5 &&
+        stableSupport.collision_group !== "player",
       `the completed continuous top-out must settle on the supported deck; ` +
         `ladder=(${ladder.x.toFixed(2)}, ${ladderTop.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
         `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
         `landed=(${landed.x.toFixed(2)}, ${landed.y.toFixed(2)}, ${landed.z.toFixed(2)}), ` +
-        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)})`,
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
+        `stable-support=${JSON.stringify(stableSupport)}`,
+    );
+
+    // Prove the supported pose is the usable upper room. Reorient and walk
+    // first along +Z past the ladder opening, then +X into the room using only
+    // ordinary production locomotion.
+    await game.input.lookAtWorldPoint([
+      stable.x,
+      stable.y + 1.6,
+      ladder.z + 4,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let deckSide = stable;
+    for (let elapsed = 0; elapsed < 60; elapsed += 2) {
+      await game.step({ frames: 2 });
+      deckSide = await game.player.position();
+      if (deckSide.z > stable.z + 0.75) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+
+    await game.input.lookAtWorldPoint([
+      deckSide.x + 8,
+      deckSide.y + 1.6,
+      deckSide.z,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let advanced = deckSide;
+    for (let elapsed = 0; elapsed < 120; elapsed += 5) {
+      await game.step({ frames: 5 });
+      advanced = await game.player.position();
+      if (advanced.x > deckSide.x + 1.5) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    const recovered = await game.player.position();
+    const recoveredSupport = await game.raycast({
+      start: [recovered.x, recovered.y, recovered.z],
+      end: [recovered.x, recovered.y - 3, recovered.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      deckSide.z > stable.z + 0.5 &&
+        recovered.x > ladder.x + 3 &&
+        recovered.z > ladder.z + 1 &&
+        recovered.x > deckSide.x + 1 &&
+        recovered.y > ladderTop - 1.5 &&
+        recovered.y < ladderTop + 0.2 &&
+        recoveredSupport.hit &&
+        recoveredSupport.distance !== null &&
+        recoveredSupport.distance > 0.5 &&
+        recoveredSupport.distance < 2.0 &&
+        recoveredSupport.hit_normal !== null &&
+        recoveredSupport.hit_normal[1] > 0.5 &&
+        recoveredSupport.collision_group !== "player",
+      `the continuous top-out must permit ordinary recovery into the upper room; ` +
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
+        `deck-side=(${deckSide.x.toFixed(2)}, ${deckSide.y.toFixed(2)}, ${deckSide.z.toFixed(2)}), ` +
+        `recovered=(${recovered.x.toFixed(2)}, ${recovered.y.toFixed(2)}, ${recovered.z.toFixed(2)}), ` +
+        `recovered-support=${JSON.stringify(recoveredSupport)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -697,8 +697,10 @@ test(
 
 // Issue #657's Hydro2 extension is a third authored geometry family: eleven
 // separate Rick Ladder rungs climb the north face of a narrow Sector C shaft,
-// while the office landing sits beyond the terrain slab at the column top.
-// Ordinary ascent reaches the underside but cannot expand or establish support.
+// while the authored office sits below and behind the terrain slab at the
+// column top. A collision-supported exterior roof is not a successful landing:
+// the real route must descend through tripwire 1194, open doors 1195/1196, and
+// permit ordinary movement into the furnished office toward ACR3.
 test(
   "flat climbing: hydro2 Sector C rung stack reaches the upper office",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -737,6 +739,24 @@ test(
       `expected the authored 11-rung Sector C column, got ids=${JSON.stringify([...stableIds].sort())}, ` +
         `span=${(ladderTop - ladderBottom).toFixed(2)}`,
     );
+
+    // Discover the authored progression gate by stable mission identities.
+    // Their runtime ids vary between launches. Door positions are live, so the
+    // paired z deltas prove the tripwire actually fired rather than inferring
+    // success from a nearby player coordinate.
+    const tripwire = (
+      await game.entities.list({ filter: "New Tripwire", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 1194);
+    const hydroDoors = (
+      await game.entities.list({ filter: "Double_Hydro", limit: 100 })
+    ).entities;
+    const nearDoor = hydroDoors.find((entity) => entity.template_id === 1196);
+    const farDoor = hydroDoors.find((entity) => entity.template_id === 1195);
+    assert.ok(tripwire, "hydro2 should contain authored office tripwire 1194");
+    assert.ok(nearDoor, "hydro2 should contain authored office door 1196");
+    assert.ok(farDoor, "hydro2 should contain authored office door 1195");
+    const nearDoorClosedZ = nearDoor.position[2];
+    const farDoorClosedZ = farDoor.position[2];
 
     // Geometry-relative setup reproduces the campaign save's supported
     // north-face contact. The climb and top-out use only production input.
@@ -780,7 +800,8 @@ test(
     for (let elapsed = 0; elapsed < 720; elapsed += 1) {
       await game.step({ frames: 1 });
       landing = await game.player.position();
-      const crossedIntoOffice = landing.z < ladderZ - 0.4;
+      const crossedIntoOffice =
+        landing.z > ladderZ + 1 && landing.y < ladderTop - 1;
       if (!crossedIntoOffice) continue;
       landingSupport = await game.raycast({
         start: [landing.x, landing.y, landing.z],
@@ -795,7 +816,10 @@ test(
         landingSupport.distance < 2 &&
         Math.abs(landingSupport.distance - standingFloorOffset) < 0.05 &&
         landingSupport.hit_point !== null &&
-        landingSupport.hit_point[1] >= ladderTop - 0.1 &&
+        Math.abs(
+          landingSupport.hit_point[1] -
+            (tripwire.position[1] - 1.6),
+        ) < 0.05 &&
         landingSupport.hit_normal !== null &&
         landingSupport.hit_normal[1] > 0.5;
       if (supportedLanding) break;
@@ -803,7 +827,7 @@ test(
     await game.input.set("right_hand.thumbstick", [0, 0]);
     assert.ok(
       supportedLanding,
-      `continuous north-face input must cross the Sector C lip onto supported office floor; ` +
+      `continuous north-face input must recover onto the supported lower office floor; ` +
         `ladder=(${ladderX.toFixed(2)}, ${ladderTop.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
         `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
         `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
@@ -819,7 +843,8 @@ test(
       ignore_sensors: true,
     });
     assert.ok(
-      stable.z < ladderZ - 0.4 &&
+      stable.z > ladderZ + 1 &&
+        stable.y < ladderTop - 1 &&
         Math.abs(stable.y - landing.y) < 0.1 &&
         Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
         stableSupport.hit &&
@@ -827,7 +852,10 @@ test(
         stableSupport.distance > 0.5 &&
         stableSupport.distance < 2 &&
         stableSupport.hit_point !== null &&
-        stableSupport.hit_point[1] >= ladderTop - 0.1 &&
+        Math.abs(
+          stableSupport.hit_point[1] -
+            (tripwire.position[1] - 1.6),
+        ) < 0.05 &&
         stableSupport.hit_normal !== null &&
         stableSupport.hit_normal[1] > 0.5,
       `the office landing must remain stable after release; ` +
@@ -835,15 +863,61 @@ test(
         `support=${JSON.stringify(stableSupport)}`,
     );
 
-    // Reorient deeper into the office and prove the restored standing capsule
-    // can use ordinary locomotion instead of merely perching on the lip.
+    // Reorient toward the authored office threshold using only ordinary
+    // locomotion. The old oracle walked farther across the same exterior roof;
+    // this one requires the real sensor and its paired door movement.
     await game.input.lookAtWorldPoint([
-      stable.x,
+      tripwire.position[0],
       stable.y + 1.6,
-      stable.z - 6,
+      tripwire.position[2],
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
+    let threshold = stable;
+    for (let elapsed = 0; elapsed < 180; elapsed += 1) {
+      await game.step({ frames: 1 });
+      threshold = await game.player.position();
+      if (
+        Math.hypot(
+          threshold.x - tripwire.position[0],
+          threshold.z - tripwire.position[2],
+        ) < 0.25
+      ) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
     await game.step({ frames: 60 });
+    threshold = await game.player.position();
+    const openedNearDoor = await game.entities.detail(nearDoor.id);
+    const openedFarDoor = await game.entities.detail(farDoor.id);
+    const nearDoorTravel = Math.abs(
+      openedNearDoor.position[2] - nearDoorClosedZ,
+    );
+    const farDoorTravel = Math.abs(
+      openedFarDoor.position[2] - farDoorClosedZ,
+    );
+
+    assert.ok(
+      threshold.y < ladderTop - 1 &&
+        Math.abs(threshold.y - (tripwire.position[1] - 0.356022)) < 0.2 &&
+        nearDoorTravel > 1 &&
+        farDoorTravel > 1,
+      `the production top-out and ordinary approach must reach the lower office sensor and open both doors; ` +
+        `ladder-top=${ladderTop.toFixed(2)}, stable=${JSON.stringify(stable)}, ` +
+        `tripwire=${JSON.stringify(tripwire.position)}, threshold=${JSON.stringify(threshold)}, ` +
+        `door1196-z=${nearDoorClosedZ.toFixed(2)}->${openedNearDoor.position[2].toFixed(2)}, ` +
+        `door1195-z=${farDoorClosedZ.toFixed(2)}->${openedFarDoor.position[2].toFixed(2)}`,
+    );
+
+    // With the gate open, walk east through the real office instead of merely
+    // proving a sensor overlap. This remains ordinary production input.
+    await game.input.lookAtWorldPoint([
+      tripwire.position[0] + 8,
+      threshold.y + 1.6,
+      tripwire.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 120 });
     await game.input.set("right_hand.thumbstick", [0, 0]);
     await game.step({ frames: 60 });
     const office = await game.player.position();
@@ -854,17 +928,18 @@ test(
       ignore_sensors: true,
     });
     assert.ok(
-      stable.z - office.z > 0.75 &&
+      office.x > tripwire.position[0] + 2 &&
+        office.y < ladderTop - 1 &&
         officeSupport.hit &&
         officeSupport.distance !== null &&
         officeSupport.distance > 0.5 &&
         officeSupport.distance < 2 &&
         officeSupport.hit_point !== null &&
-        officeSupport.hit_point[1] >= ladderTop - 0.1 &&
+        officeSupport.hit_point[1] < ladderTop - 1 &&
         officeSupport.hit_normal !== null &&
         officeSupport.hit_normal[1] > 0.5,
       `the supported top-out must permit ordinary onward movement into the office; ` +
-        `stable=${JSON.stringify(stable)}, office=${JSON.stringify(office)}, ` +
+        `threshold=${JSON.stringify(threshold)}, office=${JSON.stringify(office)}, ` +
         `support=${JSON.stringify(officeSupport)}`,
     );
   },

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -320,10 +320,10 @@ test(
 
 // Issue #657: a single reasonable +X,+Z heading held continuously from the
 // base approached the ladder on a path whose climb was blocked 3.1 feet below
-// the authored column top. The shorter top-out gate never opened, so no mantle
-// was planned and the gripped climb remained frozen forever. This reproduces
-// the player's ordinary one-heading approach without changing look direction
-// or releasing forward input during the climb/top-out.
+// the authored column top. The original shorter top-out gate never planned a
+// mantle; after moving-terrain support landed, the same route could instead
+// leave scripted climbing through unsupported ordinary movement. Reproduce the
+// player's one-heading approach and require a controlled, supported release.
 test(
   "flat climbing: continuous diagonal heading tops out onto rick1's opening deck",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -363,6 +363,14 @@ test(
     let regularWalkResumed = false;
     let ordinaryWalkStart = base;
     let fineSampling = false;
+    let maxDownwardDelta = 0;
+    let maxDropStart = base;
+    let maxDropEnd = base;
+    let unsupportedOrdinaryFrame = false;
+    let unsupportedOrdinaryStart = base;
+    let unsupportedOrdinaryEnd = base;
+    let unsupportedOrdinaryDistance = 0;
+    let unsupportedOrdinarySupport = "";
     for (let elapsed = 0; elapsed < 1_050; ) {
       // Climb quickly to the approach, then sample each frame so the test can
       // distinguish the scripted mantle's <=0.067-unit substeps from ordinary
@@ -373,6 +381,12 @@ test(
       elapsed += frames;
       previous = position;
       position = await game.player.position();
+      const downwardDelta = previous.y - position.y;
+      if (frames === 1 && downwardDelta > maxDownwardDelta) {
+        maxDownwardDelta = downwardDelta;
+        maxDropStart = previous;
+        maxDropEnd = position;
+      }
       const horizontalDistance = Math.hypot(
         position.x - previous.x,
         position.z - previous.z,
@@ -386,16 +400,22 @@ test(
           collision_groups: ["world", "entity", "selectable"],
           ignore_sensors: true,
         });
-        if (
+        const hasNearbySupport =
           nearbySupport.hit &&
           nearbySupport.distance !== null &&
           nearbySupport.distance > 0.5 &&
           nearbySupport.distance < 1.25 &&
           nearbySupport.hit_normal !== null &&
-          nearbySupport.hit_normal[1] > 0.5
-        ) {
+          nearbySupport.hit_normal[1] > 0.5;
+        if (hasNearbySupport) {
           regularWalkResumed = true;
           ordinaryWalkStart = previous;
+        } else if (!unsupportedOrdinaryFrame) {
+          unsupportedOrdinaryFrame = true;
+          unsupportedOrdinaryStart = previous;
+          unsupportedOrdinaryEnd = position;
+          unsupportedOrdinaryDistance = horizontalDistance;
+          unsupportedOrdinarySupport = JSON.stringify(nearbySupport);
         }
       }
       if (regularWalkResumed) {
@@ -404,6 +424,17 @@ test(
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
 
+    assert.ok(
+      !unsupportedOrdinaryFrame,
+      `ordinary-speed movement beyond the lip must begin only from a supported standing pose; ` +
+        `horizontal=${unsupportedOrdinaryDistance.toFixed(4)}, ` +
+        `from=(${unsupportedOrdinaryStart.x.toFixed(2)}, ${unsupportedOrdinaryStart.y.toFixed(2)}, ${unsupportedOrdinaryStart.z.toFixed(2)}), ` +
+        `to=(${unsupportedOrdinaryEnd.x.toFixed(2)}, ${unsupportedOrdinaryEnd.y.toFixed(2)}, ${unsupportedOrdinaryEnd.z.toFixed(2)}), ` +
+        `support=${unsupportedOrdinarySupport}, ` +
+        `max-downward-delta=${maxDownwardDelta.toFixed(4)} ` +
+        `from=(${maxDropStart.x.toFixed(2)}, ${maxDropStart.y.toFixed(2)}, ${maxDropStart.z.toFixed(2)}) ` +
+        `to=(${maxDropEnd.x.toFixed(2)}, ${maxDropEnd.y.toFixed(2)}, ${maxDropEnd.z.toFixed(2)})`,
+    );
     assert.ok(
       regularWalkResumed,
       `one continuous diagonal heading must restore ordinary walking past the lip; ` +

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -781,9 +781,7 @@ test(
       await game.step({ frames: 1 });
       landing = await game.player.position();
       const crossedIntoOffice = landing.z < ladderZ - 0.4;
-      const atUpperFloor =
-        landing.y > ladderTop - 2 && landing.y < ladderTop + 0.5;
-      if (!crossedIntoOffice || !atUpperFloor) continue;
+      if (!crossedIntoOffice) continue;
       landingSupport = await game.raycast({
         start: [landing.x, landing.y, landing.z],
         end: [landing.x, landing.y - 3, landing.z],
@@ -795,6 +793,9 @@ test(
         landingSupport.distance !== null &&
         landingSupport.distance > 0.5 &&
         landingSupport.distance < 2 &&
+        Math.abs(landingSupport.distance - standingFloorOffset) < 0.05 &&
+        landingSupport.hit_point !== null &&
+        landingSupport.hit_point[1] >= ladderTop - 0.1 &&
         landingSupport.hit_normal !== null &&
         landingSupport.hit_normal[1] > 0.5;
       if (supportedLanding) break;
@@ -825,6 +826,8 @@ test(
         stableSupport.distance !== null &&
         stableSupport.distance > 0.5 &&
         stableSupport.distance < 2 &&
+        stableSupport.hit_point !== null &&
+        stableSupport.hit_point[1] >= ladderTop - 0.1 &&
         stableSupport.hit_normal !== null &&
         stableSupport.hit_normal[1] > 0.5,
       `the office landing must remain stable after release; ` +
@@ -856,6 +859,8 @@ test(
         officeSupport.distance !== null &&
         officeSupport.distance > 0.5 &&
         officeSupport.distance < 2 &&
+        officeSupport.hit_point !== null &&
+        officeSupport.hit_point[1] >= ladderTop - 0.1 &&
         officeSupport.hit_normal !== null &&
         officeSupport.hit_normal[1] > 0.5,
       `the supported top-out must permit ordinary onward movement into the office; ` +

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1130,12 +1130,14 @@ test(
   },
 );
 
-// Rick1 object532 is a tall south-face ladder whose authored exit is the y42
-// deck west of the column. A lower y38.8 floor also fits a standing capsule,
-// but it is a sealed pocket beneath that deck and cannot be accepted merely
-// because it is locally supported.
+// Rick1 object532 is a tall south-face ladder whose real progression exit uses
+// Dark's explicit BreakClimb jump back onto the y38.8 arrival-side corridor.
+// From there the authored U-route steps down to y38.4, physically opens the
+// Security door, and reaches the Control Station. The north pocket and y42
+// roof are disconnected traps; a locally supported landing alone is not
+// campaign progress.
 test(
-  "flat climbing: rick1 ladder 532 reaches the connected y42 deck",
+  "flat climbing: rick1 ladder 532 reaches Security Control Station",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -1149,6 +1151,35 @@ test(
     ).entities.find((entity) => entity.template_id === 532);
     assert.ok(ladder, "rick1 should contain authored ladder object 532");
     const [ladderX, ladderY, ladderZ] = ladder.position;
+
+    // Runtime ids vary every launch. Resolve the authored Security route gate
+    // and terminal by stable mission identities, then observe their live
+    // transforms so the test proves physical ENTER effects rather than
+    // coordinate proximity.
+    const tripwires = (
+      await game.entities.list({ filter: "Tripwire", limit: 200 })
+    ).entities;
+    const doors = (
+      await game.entities.list({ filter: "RD_Door_1", limit: 200 })
+    ).entities;
+    const securityTripwire = tripwires.find(
+      (entity) => entity.template_id === 842,
+    );
+    const securityDoor = doors.find((entity) => entity.template_id === 841);
+    const securityTerminal = (
+      await game.entities.list({ filter: "Security", limit: 200 })
+    ).entities.find((entity) => entity.template_id === 2110);
+    assert.ok(securityTripwire, "rick1 should contain authored tripwire 842");
+    assert.ok(securityDoor, "rick1 should contain authored door 841");
+    assert.ok(
+      securityTerminal,
+      "rick1 should contain Security Control Station terminal 2110",
+    );
+    const securityDoorClosedY = securityDoor.position[1];
+    const arrivalFloorY = securityTripwire.position[1] - 0.8;
+    const arrivalBodyY = arrivalFloorY + 1.244;
+    const lowerFloorY = securityTripwire.position[1] - 1.2;
+    const lowerBodyY = lowerFloorY + 1.244;
 
     // Geometry-relative setup reproduces the reachable supported south-face
     // stage. The climb and all post-setup movement use production controls.
@@ -1169,21 +1200,64 @@ test(
         `start=${JSON.stringify(start)}, camera=${JSON.stringify(startFrame.player.camera_offset)}`,
     );
 
+    // The walkthrough route climbs straight back up from the only reachable
+    // south face. Keep the held heading due north; the former NW aim was an
+    // invented oracle for the now-rejected west/roof landings.
     const horizontal = 10;
     await game.input.lookAtWorldPoint([
-      start.x - 0.35 * horizontal,
+      start.x,
       start.y + Math.tan(Math.PI / 3) * horizontal,
-      start.z + 0.94 * horizontal,
+      start.z + horizontal,
     ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
     let peak = start;
-    let reachedUpperDeck = false;
+    let cap = start;
+    let previous = start;
+    let stalledFrames = 0;
+    for (let frame = 0; frame < 240; frame += 1) {
+      await game.step({ frames: 1 });
+      cap = await game.player.position();
+      if (cap.y > peak.y) peak = cap;
+      stalledFrames =
+        cap.y > start.y + 7 && Math.abs(cap.y - previous.y) < 1e-4
+          ? stalledFrames + 1
+          : 0;
+      previous = cap;
+      if (stalledFrames >= 3) break;
+    }
+    assert.ok(
+      stalledFrames >= 3,
+      `pure-north grip must reach a stable high cap before BreakClimb; start=${JSON.stringify(start)}, cap=${JSON.stringify(cap)}`,
+    );
+
+    // Dark exits an object ladder only through PhysPlayerJump/BreakClimb. At
+    // the stable cap, atomically turn back toward the arrival-side corridor
+    // and emit one jump edge. The launch impulse must persist independently of
+    // thumbstick input; neutralize immediately so ordinary collision, gravity,
+    // and the inherited release velocity alone choose the landing.
+    await game.input.lookAtWorldPoint([
+      cap.x + 0.342 * horizontal,
+      cap.y + Math.tan(Math.PI / 3) * horizontal,
+      cap.z - 0.94 * horizontal,
+    ]);
+    await game.input.setJump(true);
+    await game.step({ frames: 1 });
+    const jumpAt = await game.player.position();
+    await game.input.setJump(false);
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    let reachedArrivalSide = false;
     let landing = start;
     for (let frame = 0; frame < 360; frame += 1) {
       await game.step({ frames: 1 });
       const position = await game.player.position();
       if (position.y > peak.y) peak = position;
-      if (position.y > 43.1) {
+      if (
+        Math.abs(position.y - arrivalBodyY) < 0.12 &&
+        position.x > 35.5 &&
+        position.x < 38.5 &&
+        position.z > -12 &&
+        position.z < -9.7
+      ) {
         const support = await game.raycast({
           start: [position.x, position.y + 0.1, position.z],
           end: [position.x, position.y - 3, position.z],
@@ -1193,16 +1267,17 @@ test(
         if (
           support.hit_point !== null &&
           support.hit_normal !== null &&
-          Math.abs(support.hit_point[1] - 42) < 0.05 &&
+          Math.abs(
+            support.hit_point[1] - arrivalFloorY,
+          ) < 0.05 &&
           support.hit_normal[1] > 0.5
         ) {
-          reachedUpperDeck = true;
+          reachedArrivalSide = true;
           landing = position;
           break;
         }
       }
     }
-    await game.input.set("right_hand.thumbstick", [0, 0]);
     await game.step({ frames: 60 });
     const stable = await game.player.position();
     const stableSupport = await game.raycast({
@@ -1212,50 +1287,185 @@ test(
       ignore_sensors: true,
     });
     assert.ok(
-      reachedUpperDeck &&
-        Math.abs(stable.y - 43.244) < 0.08 &&
-        stable.x < ladderX - 0.5 &&
+      reachedArrivalSide &&
+        Math.abs(stable.y - arrivalBodyY) < 0.08 &&
+        stable.x > 35.5 &&
+        stable.x < 38.5 &&
+        stable.z > -12 &&
+        stable.z < -9.7 &&
         stableSupport.hit &&
         stableSupport.hit_point !== null &&
-        Math.abs(stableSupport.hit_point[1] - 42) < 0.05 &&
+        Math.abs(
+          stableSupport.hit_point[1] - arrivalFloorY,
+        ) < 0.05 &&
         stableSupport.hit_normal !== null &&
         stableSupport.hit_normal[1] > 0.5,
-      `ordinary standing input must reject the lower pocket and settle on the connected y42 deck; ` +
-        `start=${JSON.stringify(start)}, peak=${JSON.stringify(peak)}, landing=${JSON.stringify(landing)}, ` +
+      `the explicit BreakClimb impulse must settle on the supported y38.8 arrival-side corridor; ` +
+        `start=${JSON.stringify(start)}, cap=${JSON.stringify(cap)}, jumpAt=${JSON.stringify(jumpAt)}, peak=${JSON.stringify(peak)}, landing=${JSON.stringify(landing)}, ` +
         `stable=${JSON.stringify(stable)}, support=${JSON.stringify(stableSupport)}`,
     );
 
-    await game.input.lookAtWorldPoint([
-      stable.x + 10,
-      stable.y + 1.6,
-      stable.z,
-    ]);
-    await game.input.set("right_hand.thumbstick", [0, 1]);
-    let egress = stable;
-    for (let frame = 0; frame < 180; frame += 1) {
-      await game.step({ frames: 1 });
-      egress = await game.player.position();
-      if (egress.x > stable.x + 0.75) break;
+    const walkTo = async (
+      target: [number, number],
+      label: string,
+      maxFrames = 240,
+      tolerance = 0.65,
+    ) => {
+      let position = await game.player.position();
+      const initialDistance = Math.hypot(
+        position.x - target[0],
+        position.z - target[1],
+      );
+      let bestDistance = initialDistance;
+      let stalledFrames = 0;
+      await game.input.lookAtWorldPoint([
+        target[0],
+        position.y + 1.04,
+        target[1],
+      ]);
+      await game.input.set("right_hand.thumbstick", [0, 1]);
+      for (let frame = 0; frame < maxFrames; frame += 1) {
+        if (frame > 0 && frame % 12 === 0) {
+          await game.input.lookAtWorldPoint([
+            target[0],
+            position.y + 1.04,
+            target[1],
+          ]);
+        }
+        await game.step({ frames: 1 });
+        position = await game.player.position();
+        const distance = Math.hypot(
+          position.x - target[0],
+          position.z - target[1],
+        );
+        if (distance < tolerance) {
+          break;
+        }
+        if (distance < bestDistance - 0.05) {
+          bestDistance = distance;
+          stalledFrames = 0;
+        } else {
+          stalledFrames += 1;
+        }
+        if (stalledFrames >= 90 || distance > initialDistance + 3) {
+          break;
+        }
+      }
+      await game.input.set("right_hand.thumbstick", [0, 0]);
+      assert.ok(
+        Math.hypot(position.x - target[0], position.z - target[1]) < tolerance,
+        `${label} must be reachable with ordinary input; target=${JSON.stringify(target)}, ` +
+          `ended=${JSON.stringify(position)}`,
+      );
+      return position;
+    };
+
+    // Follow the collision-supported arrival-side U-route from the y38.8
+    // landing. Crossing x=42 takes the authored small step down to y38.4;
+    // this is ordinary movement, not another top-out or relocation.
+    const arrivalSideRoute: [number, number][] = [
+      [36.4, -10.8],
+      [35.1, -14],
+      [34, -15.6],
+      [34.95, -16.4],
+    ];
+    for (const [index, waypoint] of arrivalSideRoute.entries()) {
+      await walkTo(waypoint, `arrival-side U-route waypoint ${index + 1}`);
     }
-    await game.input.set("right_hand.thumbstick", [0, 0]);
-    await game.step({ frames: 60 });
-    egress = await game.player.position();
-    const egressSupport = await game.raycast({
-      start: [egress.x, egress.y + 0.1, egress.z],
-      end: [egress.x, egress.y - 3, egress.z],
+    const lowerStep = await walkTo([37, -18], "arrival-side lower-route step");
+    const lowerStepSupport = await game.raycast({
+      start: [lowerStep.x, lowerStep.y + 0.1, lowerStep.z],
+      end: [lowerStep.x, lowerStep.y - 3, lowerStep.z],
       collision_groups: ["world", "entity", "selectable"],
       ignore_sensors: true,
     });
     assert.ok(
-      egress.x > stable.x + 0.7 &&
-        Math.abs(egress.y - stable.y) < 0.08 &&
-        egressSupport.hit_point !== null &&
-        Math.abs(egressSupport.hit_point[1] - 42) < 0.05 &&
-        egressSupport.hit_normal !== null &&
-        egressSupport.hit_normal[1] > 0.5,
-      `the selected top-out must permit ordinary eastward egress on y42; ` +
-        `stable=${JSON.stringify(stable)}, egress=${JSON.stringify(egress)}, ` +
-        `support=${JSON.stringify(egressSupport)}`,
+      Math.abs(lowerStep.y - lowerBodyY) < 0.08 &&
+        lowerStepSupport.hit_point !== null &&
+        Math.abs(
+          lowerStepSupport.hit_point[1] - lowerFloorY,
+        ) < 0.05 &&
+        lowerStepSupport.hit_normal !== null &&
+        lowerStepSupport.hit_normal[1] > 0.5,
+      `ordinary movement must turn around the authored wall and step from y38.8 onto the connected y38.4 lower route; ` +
+        `position=${JSON.stringify(lowerStep)}, support=${JSON.stringify(lowerStepSupport)}`,
+    );
+    const lowerStepRoute: [number, number][] = [
+      [41.6, -18],
+      [42.2, -16.8],
+      [42.2, -15.1],
+    ];
+    for (const [index, waypoint] of lowerStepRoute.entries()) {
+      await walkTo(waypoint, `lower-route step waypoint ${index + 1}`);
+    }
+    const routeToSecurityGate: [number, number][] = [
+      [42.4, -14],
+      [44, -11.2],
+      [48, -11.2],
+      [51.2, -11.2],
+      [57.6, -11.2],
+      [61.2, -11.2],
+      [65.6, -12.8],
+      [65.6, -15.8],
+      [66.8, -17.2],
+    ];
+    for (const [index, waypoint] of routeToSecurityGate.entries()) {
+      await walkTo(waypoint, `Security route waypoint ${index + 1}`);
+    }
+
+    // Enter the real Security tripwire. The door's vertical travel is durable
+    // evidence that its sibling script received the physical ENTER event, and
+    // reaching the terminal beyond it matches the original game's route.
+    await walkTo(
+      [securityTripwire.position[0], securityTripwire.position[2]],
+      "tripwire842",
+    );
+    await game.step({ frames: 120 });
+    const openedSecurityDoor = await game.entities.detail(securityDoor.id);
+    assert.ok(
+      openedSecurityDoor.position[1] > securityDoorClosedY + 1,
+      `physical tripwire842 ENTER must open door841; ` +
+        `door-y=${securityDoorClosedY}->${openedSecurityDoor.position[1]}`,
+    );
+
+    const routeToSecurity: [number, number][] = [
+      [67.75, -18],
+      [68, -18],
+      [71, -15.6],
+      [72.6, -15.2],
+    ];
+    for (const [index, waypoint] of routeToSecurity.entries()) {
+      await walkTo(waypoint, `post-door Security waypoint ${index + 1}`);
+    }
+    const terminalApproach = await walkTo(
+      [securityTerminal.position[0], securityTerminal.position[2]],
+      "Security Control Station",
+      480,
+      1.2,
+    );
+    await game.step({ frames: 60 });
+    const terminalStable = await game.player.position();
+    const terminalSupport = await game.raycast({
+      start: [terminalStable.x, terminalStable.y + 0.1, terminalStable.z],
+      end: [terminalStable.x, terminalStable.y - 3, terminalStable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.hypot(
+        terminalApproach.x - securityTerminal.position[0],
+        terminalApproach.z - securityTerminal.position[2],
+      ) < 1.2 &&
+        Math.hypot(
+          terminalStable.x - securityTerminal.position[0],
+          terminalStable.z - securityTerminal.position[2],
+        ) < 1.5 &&
+        terminalSupport.hit &&
+        terminalSupport.hit_normal !== null &&
+        terminalSupport.hit_normal[1] > 0.5,
+      `ordinary input must cross open door841 and settle at Security Control Station; ` +
+        `approach=${JSON.stringify(terminalApproach)}, stable=${JSON.stringify(terminalStable)}, ` +
+        `support=${JSON.stringify(terminalSupport)}, terminal=${JSON.stringify(securityTerminal.position)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -944,3 +944,121 @@ test(
     );
   },
 );
+
+// Issue #657: Engineering's upper Ladder 16' (mission object 945) reaches the
+// Engine Core through a thick authored floor/wall transition. The south face
+// is the real approach from the main-elevator corridor; holding ordinary
+// forward toward +Z must finish on supported core-side ground, not freeze in
+// the unsupported gap below the slab and fall back to the arrival floor.
+test(
+  "flat climbing: eng1 upper ladder 945 reaches supported core-side ground",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids change every launch. Mission object 945 and its authored
+    // name are the durable identity; derive the campaign-proven south-face
+    // contact from that object instead of hard-coding a world position.
+    const ladder = (
+      await game.entities.list({ filter: "Ladder 16'", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 945);
+    assert.ok(ladder, "eng1 should contain authored Ladder 16' object 945");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+    const startTarget = {
+      x: ladderX + 0.261,
+      y: ladderY - 1.956,
+      z: ladderZ - 0.883,
+    };
+
+    // Setup only: the production climb begins on the same supported south-face
+    // contact reached by ordinary movement in the accepted campaign replay.
+    // Do not step between relocation and input: a frame here can settle away
+    // from the narrow authored contact before the grip is evaluated.
+    await game.player.teleport(startTarget);
+    const start = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      start.x,
+      start.y + 8,
+      start.z + 20,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let landing = start;
+    let support: RayCastResult | null = null;
+    for (let elapsed = 0; elapsed < 480; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing = await game.player.position();
+      if (landing.z <= ladderZ + 0.7 || landing.y <= ladderY + 3.5) {
+        continue;
+      }
+      support = await game.raycast({
+        start: [landing.x, landing.y, landing.z],
+        end: [landing.x, landing.y - 3, landing.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      if (
+        support.hit &&
+        support.distance !== null &&
+        support.distance > 0.5 &&
+        support.distance < 2 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5
+      ) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    assert.ok(
+      support?.hit &&
+        support.distance !== null &&
+        support.distance > 0.5 &&
+        support.distance < 2 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5 &&
+        landing.z > ladderZ + 0.7 &&
+        landing.y > ladderY + 3.5,
+      `ordinary south-face input must reach supported core-side ground; ` +
+        `ladder=(${ladderX.toFixed(2)}, ${ladderY.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
+        `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
+        `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(support)}`,
+    );
+
+    // Releasing input does not cancel an in-flight top-out; let its bounded
+    // scripted waypoints finish, then prove the resulting pose itself remains
+    // still rather than mistaking an intermediate supported crossing for the
+    // landing.
+    await game.step({ frames: 180 });
+    const settled = await game.player.position();
+    await game.step({ frames: 180 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.z > ladderZ + 0.7 &&
+        stable.y > ladderY + 3.5 &&
+        Math.hypot(stable.x - settled.x, stable.z - settled.z) < 0.05 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        stableSupport.distance > 0.5 &&
+        stableSupport.distance < 2 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `release must remain stable on the core-side landing; ` +
+        `landing=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `settled=(${settled.x.toFixed(2)}, ${settled.y.toFixed(2)}, ${settled.z.toFixed(2)}), ` +
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(stableSupport)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -570,6 +570,186 @@ test(
   },
 );
 
+// Issue #657's later Rick1 manifestation is a full-height ladder below a thin
+// upper-deck slab and an authored pipe with only 3.5 feet of headroom. Ordinary
+// +Z input from its reachable south face must carry an explicitly crouched
+// player through the local lip, restore the crouched capsule on the y=38 deck,
+// and leave standing refused until the player crawls clear of the pipe.
+test(
+  "flat climbing: rick1 ladder 488 reaches supported deck toward ladder 499",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids vary on every launch. Resolve both authored ladders by their
+    // stable mission identities, then derive the contact and onward heading
+    // from their live positions.
+    const ladders = (
+      await game.entities.list({ filter: "Rick Ladder 16", limit: 100 })
+    ).entities;
+    const ladder = ladders.find((entity) => entity.template_id === 488);
+    const nextLadder = ladders.find((entity) => entity.template_id === 499);
+    assert.ok(ladder, "rick1 should contain authored ladder object 488");
+    assert.ok(nextLadder, "rick1 should contain authored ladder object 499");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+
+    // Geometry-relative setup at the campaign's reachable south-face pose.
+    // All motion from here through the climb, release, and onward deck crawl is
+    // ordinary production input with no jump or direct relocation. Crouch is
+    // held explicitly: the planner must never silently shrink the player.
+    await game.player.teleport({
+      x: ladderX,
+      y: ladderY - 2.48,
+      z: ladderZ - 0.6884,
+    });
+    await game.step({ frames: 30 });
+    const start = await game.player.position();
+    const startSupport = await game.raycast({
+      start: [start.x, start.y, start.z],
+      end: [start.x, start.y - 3, start.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.hypot(start.x - ladderX, start.z - (ladderZ - 0.6884)) < 0.05 &&
+        startSupport.hit &&
+        startSupport.distance !== null &&
+        startSupport.distance > 0.5 &&
+        startSupport.distance < 2 &&
+        startSupport.hit_normal !== null &&
+        startSupport.hit_normal[1] > 0.5,
+      `expected supported south-face contact; ladder=${JSON.stringify(ladder.position)}, ` +
+        `start=${JSON.stringify(start)}, support=${JSON.stringify(startSupport)}`,
+    );
+
+    await game.input.setJump(false);
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 10 });
+    const crouchedStart = await game.player.position();
+    assert.ok(
+      start.y - crouchedStart.y > 0.5 && start.y - crouchedStart.y < 0.75,
+      `the fixture must enter the explicit crouched profile before climbing; ` +
+        `standing=${JSON.stringify(start)}, crouched=${JSON.stringify(crouchedStart)}`,
+    );
+
+    await game.input.lookAtWorldPoint([
+      ladderX,
+      ladderY + 8,
+      ladderZ + 10,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    const crouchedFloorOffset = 0.604;
+    let landing = crouchedStart;
+    let landingSupport: RayCastResult | null = null;
+    let supportedDeckReached = false;
+    for (let elapsed = 0; elapsed < 720; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing = await game.player.position();
+      if (landing.y < ladderY + 5.5) continue;
+      landingSupport = await game.raycast({
+        start: [landing.x, landing.y, landing.z],
+        end: [landing.x, landing.y - 3, landing.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      supportedDeckReached =
+        landingSupport.hit &&
+        landingSupport.distance !== null &&
+        Math.abs(landingSupport.distance - crouchedFloorOffset) < 0.05 &&
+        landingSupport.hit_point !== null &&
+        Math.abs(landingSupport.hit_point[1] - 38) < 0.05 &&
+        landingSupport.hit_normal !== null &&
+        landingSupport.hit_normal[1] > 0.5;
+      if (supportedDeckReached) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    assert.ok(
+      supportedDeckReached,
+      `ordinary south-face input while crouched must reach supported crouch on the upper deck; ` +
+        `ladder=${JSON.stringify(ladder.position)}, start=${JSON.stringify(start)}, ` +
+        `ended=${JSON.stringify(landing)}, support=${JSON.stringify(landingSupport)}`,
+    );
+
+    await game.step({ frames: 180 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.abs(stable.y - landing.y) < 0.1 &&
+        Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        Math.abs(stableSupport.distance - crouchedFloorOffset) < 0.05 &&
+        stableSupport.hit_point !== null &&
+        Math.abs(stableSupport.hit_point[1] - 38) < 0.05 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `release must remain stable on ladder 488's upper deck; ` +
+        `landing=${JSON.stringify(landing)}, stable=${JSON.stringify(stable)}, ` +
+        `support=${JSON.stringify(stableSupport)}`,
+    );
+
+    // The pipe above this exact landing is authored collision, not a planner
+    // exception. Releasing crouch must therefore keep the feet-planted center
+    // unchanged (standing would raise it by 0.64 world units).
+    await game.input.set("crouch", 0);
+    await game.step({ frames: 20 });
+    const refusedStand = await game.player.position();
+    assert.ok(
+      Math.abs(refusedStand.y - stable.y) < 0.1 &&
+        Math.hypot(refusedStand.x - stable.x, refusedStand.z - stable.z) < 0.1,
+      `standing under the authored pipe must be refused; ` +
+        `crouched=${JSON.stringify(stable)}, released=${JSON.stringify(refusedStand)}`,
+    );
+    await game.input.set("crouch", 1);
+    await game.step({ frames: 5 });
+
+    const [nextX, , nextZ] = nextLadder.position;
+    const distanceBefore = Math.hypot(
+      refusedStand.x - nextX,
+      refusedStand.z - nextZ,
+    );
+    await game.input.lookAtWorldPoint([nextX, refusedStand.y + 0.8, nextZ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let onward = refusedStand;
+    for (let elapsed = 0; elapsed < 90; elapsed += 1) {
+      await game.step({ frames: 1 });
+      onward = await game.player.position();
+      if (Math.hypot(onward.x - nextX, onward.z - nextZ) < distanceBefore - 1.5) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const distanceAfter = Math.hypot(onward.x - nextX, onward.z - nextZ);
+    const onwardSupport = await game.raycast({
+      start: [onward.x, onward.y, onward.z],
+      end: [onward.x, onward.y - 3, onward.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      distanceAfter < distanceBefore - 1 &&
+        onwardSupport.hit &&
+        onwardSupport.hit_normal !== null &&
+        onwardSupport.hit_normal[1] > 0.5,
+      `the recovered deck must permit ordinary movement toward ladder 499; ` +
+        `before=${distanceBefore.toFixed(2)}, after=${distanceAfter.toFixed(2)}, ` +
+        `stable=${JSON.stringify(refusedStand)}, onward=${JSON.stringify(onward)}, ` +
+        `support=${JSON.stringify(onwardSupport)}`,
+    );
+  },
+);
+
 // Issue #657's Eng1 blocker is a different Dark BreakClimb shape from Rick1:
 // authored ladder 317 ends under a thick terrain slab. The player must rise
 // through the slab's two locally sampled wall planes, then descend to the

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -319,10 +319,11 @@ test(
 );
 
 // Issue #657: a single reasonable +X,+Z heading held continuously from the
-// base could plan a different top-out route than the staged-heading case above.
-// That route reached the rise cap and remained active forever with zero motion.
-// This reproduces the player's ordinary one-heading approach without changing
-// look direction or releasing forward input during the climb/top-out.
+// base approached the ladder on a path whose climb was blocked 3.1 feet below
+// the authored column top. The shorter top-out gate never opened, so no mantle
+// was planned and the gripped climb remained frozen forever. This reproduces
+// the player's ordinary one-heading approach without changing look direction
+// or releasing forward input during the climb/top-out.
 test(
   "flat climbing: continuous diagonal heading tops out onto rick1's opening deck",
   { skip: !e2eEnabled, timeout: 600_000 },
@@ -357,28 +358,72 @@ test(
     await game.input.set("head.look", [63, -60]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
 
+    let previous = base;
     let position = base;
-    let cleared = false;
-    for (let elapsed = 0; elapsed < 1_050; elapsed += 30) {
-      await game.step({ frames: 30 });
+    let ordinaryWalkFrames = 0;
+    let ordinaryWalkStart = base;
+    let fineSampling = false;
+    for (let elapsed = 0; elapsed < 1_050; ) {
+      // Climb quickly to the approach, then sample each frame so the test can
+      // distinguish the scripted mantle's <=0.067-unit substeps from ordinary
+      // locomotion after the standing capsule has been restored.
+      fineSampling ||= position.y >= ladderTop - 3;
+      const frames = fineSampling ? 1 : 30;
+      await game.step({ frames });
+      elapsed += frames;
+      previous = position;
       position = await game.player.position();
-      cleared =
-        position.x > ladder.x + 1 &&
-        position.z > ladder.z + 0.35 &&
-        position.y > ladderTop - 1.5 &&
-        position.y < ladderTop + 0.2;
-      if (cleared) {
+      const horizontalDistance = Math.hypot(
+        position.x - previous.x,
+        position.z - previous.z,
+      );
+      const beyondLip =
+        position.x > ladder.x && position.z > ladder.z + 0.35;
+      if (frames === 1 && beyondLip && horizontalDistance > 0.075) {
+        if (ordinaryWalkFrames === 0) {
+          ordinaryWalkStart = previous;
+        }
+        ordinaryWalkFrames += 1;
+      } else {
+        ordinaryWalkFrames = 0;
+      }
+      if (ordinaryWalkFrames >= 20) {
         break;
       }
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
 
     assert.ok(
-      cleared,
-      `one continuous diagonal heading must complete the top-out; ` +
+      ordinaryWalkFrames >= 20 &&
+        Math.hypot(
+          position.x - ordinaryWalkStart.x,
+          position.z - ordinaryWalkStart.z,
+        ) > 1.5,
+      `one continuous diagonal heading must sustain ordinary walking past the lip; ` +
         `ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
         `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)}), ` +
+        `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
+        `previous=(${previous.x.toFixed(2)}, ${previous.y.toFixed(2)}, ${previous.z.toFixed(2)}), ` +
         `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)})`,
+    );
+
+    // This exact 63° reproduction heads through the authored opening beside
+    // the rail, rather than toward the supported landing used by the preceding
+    // staged-heading test. Prove that geometry explicitly: a stable landing is
+    // impossible on this ray, so completion is the sustained ordinary
+    // horizontal locomotion above, not an arbitrary first "cleared" pose.
+    const support = await game.raycast({
+      start: [position.x, position.y, position.z],
+      end: [position.x, position.y - 20, position.z],
+      collision_groups: ["world"],
+      ignore_sensors: true,
+    });
+    assert.equal(
+      support.hit,
+      false,
+      `the exact continuous route should cross the open shaft, not a hidden support; ` +
+        `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(support)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -338,65 +338,75 @@ test(
     const ladderBottom = Math.min(...ladder.ys);
     const ladderTop = Math.max(...ladder.ys);
 
-    // Settle on the west/south face at the same geometry-relative contact used
-    // by the original reproduction. From there yaw 63° faces the visible
-    // +X,+Z deck opening; pitch -60° preserves the original player's view.
-    await game.player.teleport({
-      x: ladder.x - 0.43,
+    // Start in clear floor space on the west/south side. The old direct-contact
+    // teleport was valid for the temporary narrow player but overlaps this
+    // rung stack after #712 restores Dark's 2.4-foot standing footprint. From
+    // this reachable pose, one continuous production heading performs the
+    // approach, grip, climb, and top-out. Aim in world space because the
+    // low-level `head.look` channel is pawn-local and rick1's restored player
+    // rotation otherwise turns the nominal +X,+Z heading toward -Z.
+    const clearTarget = {
+      x: ladder.x - 1,
       y: ladderBottom - 2.2,
-      z: ladder.z - 0.41,
-    });
+      z: ladder.z - 0.4,
+    };
+    await game.player.teleport(clearTarget);
     await game.step({ frames: 30 });
     const base = await game.player.position();
+    const baseSupport = await game.raycast({
+      start: [base.x, base.y, base.z],
+      end: [base.x, base.y - 3, base.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
     assert.ok(
-      Math.hypot(base.x - (ladder.x - 0.43), base.z - (ladder.z - 0.41)) <
-        0.1,
-      `expected to settle at the ladder contact; ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
-        `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)})`,
+      Math.hypot(
+        base.x - clearTarget.x,
+        base.z - clearTarget.z,
+      ) < 0.05 &&
+        baseSupport.hit &&
+        baseSupport.distance !== null &&
+        baseSupport.distance > 0.5 &&
+        baseSupport.distance < 1.5 &&
+        baseSupport.hit_normal !== null &&
+        baseSupport.hit_normal[1] > 0.5,
+      `expected to settle in clear floor space before the one-heading approach; ` +
+        `ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
+        `target=(${clearTarget.x.toFixed(2)}, ${clearTarget.y.toFixed(2)}, ${clearTarget.z.toFixed(2)}), ` +
+        `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(baseSupport)}`,
     );
 
-    await game.input.set("head.look", [63, -60]);
+    await game.input.lookAtWorldPoint([
+      ladder.x + 8,
+      ladderTop + 2,
+      ladder.z + 2,
+    ]);
     await game.input.set("right_hand.thumbstick", [0, 1]);
 
     let previous = base;
     let position = base;
-    let regularWalkResumed = false;
+    let supportedFarSideReached = false;
     let ordinaryWalkStart = base;
-    let fineSampling = false;
-    let maxDownwardDelta = 0;
-    let maxDropStart = base;
-    let maxDropEnd = base;
-    let unsupportedOrdinaryFrame = false;
-    let unsupportedOrdinaryStart = base;
-    let unsupportedOrdinaryEnd = base;
-    let unsupportedOrdinaryDistance = 0;
-    let unsupportedOrdinarySupport = "";
+    let ordinaryWalkSupport = "";
     for (let elapsed = 0; elapsed < 1_050; ) {
-      // Climb quickly to the approach, then sample each frame so the test can
-      // distinguish the scripted mantle's <=0.067-unit substeps from ordinary
-      // locomotion after the standing capsule has been restored.
-      fineSampling ||= position.y >= ladderTop - 3;
-      const frames = fineSampling ? 1 : 30;
+      // Sample every frame from input onset. With the restored full footprint,
+      // the bounded mantle can begin several feet below the authored rung top;
+      // a coarse ascent batch can therefore hide the first supported far-side
+      // landing pose that this safety regression must inspect.
+      const frames = 1;
       await game.step({ frames });
       elapsed += frames;
       previous = position;
       position = await game.player.position();
-      const downwardDelta = previous.y - position.y;
-      if (frames === 1 && downwardDelta > maxDownwardDelta) {
-        maxDownwardDelta = downwardDelta;
-        maxDropStart = previous;
-        maxDropEnd = position;
-      }
-      const horizontalDistance = Math.hypot(
-        position.x - previous.x,
-        position.z - previous.z,
-      );
       const beyondLip =
         position.x > ladder.x && position.z > ladder.z + 0.35;
-      if (frames === 1 && beyondLip && horizontalDistance > 0.075) {
+      const atDeckHeight =
+        position.y > ladderTop - 1.5 && position.y < ladderTop + 0.2;
+      if (beyondLip && atDeckHeight) {
         const nearbySupport = await game.raycast({
-          start: [previous.x, previous.y, previous.z],
-          end: [previous.x, previous.y - 3, previous.z],
+          start: [position.x, position.y, position.z],
+          end: [position.x, position.y - 3, position.z],
           collision_groups: ["world", "entity", "selectable"],
           ignore_sensors: true,
         });
@@ -408,46 +418,31 @@ test(
           nearbySupport.hit_normal !== null &&
           nearbySupport.hit_normal[1] > 0.5;
         if (hasNearbySupport) {
-          regularWalkResumed = true;
-          ordinaryWalkStart = previous;
-        } else if (!unsupportedOrdinaryFrame) {
-          unsupportedOrdinaryFrame = true;
-          unsupportedOrdinaryStart = previous;
-          unsupportedOrdinaryEnd = position;
-          unsupportedOrdinaryDistance = horizontalDistance;
-          unsupportedOrdinarySupport = JSON.stringify(nearbySupport);
+          supportedFarSideReached = true;
+          ordinaryWalkStart = position;
+          ordinaryWalkSupport = JSON.stringify(nearbySupport);
         }
       }
-      if (regularWalkResumed) {
+      if (supportedFarSideReached) {
         break;
       }
     }
     await game.input.set("right_hand.thumbstick", [0, 0]);
 
     assert.ok(
-      !unsupportedOrdinaryFrame,
-      `ordinary-speed movement beyond the lip must begin only from a supported standing pose; ` +
-        `horizontal=${unsupportedOrdinaryDistance.toFixed(4)}, ` +
-        `from=(${unsupportedOrdinaryStart.x.toFixed(2)}, ${unsupportedOrdinaryStart.y.toFixed(2)}, ${unsupportedOrdinaryStart.z.toFixed(2)}), ` +
-        `to=(${unsupportedOrdinaryEnd.x.toFixed(2)}, ${unsupportedOrdinaryEnd.y.toFixed(2)}, ${unsupportedOrdinaryEnd.z.toFixed(2)}), ` +
-        `support=${unsupportedOrdinarySupport}, ` +
-        `max-downward-delta=${maxDownwardDelta.toFixed(4)} ` +
-        `from=(${maxDropStart.x.toFixed(2)}, ${maxDropStart.y.toFixed(2)}, ${maxDropStart.z.toFixed(2)}) ` +
-        `to=(${maxDropEnd.x.toFixed(2)}, ${maxDropEnd.y.toFixed(2)}, ${maxDropEnd.z.toFixed(2)})`,
-    );
-    assert.ok(
-      regularWalkResumed,
-      `one continuous diagonal heading must restore ordinary walking past the lip; ` +
+      supportedFarSideReached,
+      `one continuous diagonal heading must reach supported standing height past the lip; ` +
         `ladder=(${ladder.x.toFixed(2)}, ${ladder.z.toFixed(2)}), ` +
         `base=(${base.x.toFixed(2)}, ${base.y.toFixed(2)}, ${base.z.toFixed(2)}), ` +
         `ordinary-start=(${ordinaryWalkStart.x.toFixed(2)}, ${ordinaryWalkStart.y.toFixed(2)}, ${ordinaryWalkStart.z.toFixed(2)}), ` +
         `previous=(${previous.x.toFixed(2)}, ${previous.y.toFixed(2)}, ${previous.z.toFixed(2)}), ` +
-        `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)})`,
+        `ended=(${position.x.toFixed(2)}, ${position.y.toFixed(2)}, ${position.z.toFixed(2)}), ` +
+        `support=${ordinaryWalkSupport}`,
     );
 
-    // The first supported horizontal frame marks contact with the upper deck
-    // after the bounded descent. Verify that pose has real production support,
-    // then release input and require a stable ordinary recovery.
+    // The first supported standing-height frame marks contact with the upper
+    // deck after the bounded descent. Verify that pose has real production
+    // support, then release input and require a stable ordinary recovery.
     const support = await game.raycast({
       start: [
         ordinaryWalkStart.x,

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
-import type { EntitySummary } from "../src/index.js";
+import type { EntitySummary, RayCastResult } from "../src/index.js";
 
 // End-to-end test for flat (desktop-style) ladder climbing.
 //
@@ -309,6 +309,117 @@ test(
         `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
         `deckSide=(${deckSide.x.toFixed(2)}, ${deckSide.y.toFixed(2)}, ${deckSide.z.toFixed(2)}), ` +
         `ended=(${final.x.toFixed(2)}, ${final.y.toFixed(2)}, ${final.z.toFixed(2)})`,
+    );
+  },
+);
+
+// Issue #657: Engineering's upper Ladder 16' (mission object 945) reaches the
+// Engine Core through a thick authored floor/wall transition. The south face
+// is the real approach from the main-elevator corridor; holding ordinary
+// forward toward +Z must finish on supported core-side ground, not freeze in
+// the unsupported gap below the slab and fall back to the arrival floor.
+test(
+  "flat climbing: eng1 upper ladder 945 reaches supported core-side ground",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "eng1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    // Runtime ids change every launch. Mission object 945 and its authored
+    // name are the durable identity; derive the campaign-proven south-face
+    // contact from that object instead of hard-coding a world position.
+    const ladder = (
+      await game.entities.list({ filter: "Ladder 16'", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 945);
+    assert.ok(ladder, "eng1 should contain authored Ladder 16' object 945");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+    const startTarget = {
+      x: ladderX + 0.261,
+      y: ladderY - 1.956,
+      z: ladderZ - 0.883,
+    };
+
+    // Setup only: the production climb begins on the same supported south-face
+    // contact reached by ordinary movement in the accepted campaign replay.
+    // Do not step between relocation and input: a frame here can settle away
+    // from the narrow authored contact before the grip is evaluated.
+    await game.player.teleport(startTarget);
+    const start = await game.player.position();
+    await game.input.lookAtWorldPoint([
+      start.x,
+      start.y + 8,
+      start.z + 20,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+
+    let landing = start;
+    let support: RayCastResult | null = null;
+    for (let elapsed = 0; elapsed < 480; elapsed += 1) {
+      await game.step({ frames: 1 });
+      landing = await game.player.position();
+      if (landing.z <= ladderZ + 0.7 || landing.y <= ladderY + 3.5) {
+        continue;
+      }
+      support = await game.raycast({
+        start: [landing.x, landing.y, landing.z],
+        end: [landing.x, landing.y - 3, landing.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      if (
+        support.hit &&
+        support.distance !== null &&
+        support.distance > 0.5 &&
+        support.distance < 2 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5
+      ) {
+        break;
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+
+    assert.ok(
+      support?.hit &&
+        support.distance !== null &&
+        support.distance > 0.5 &&
+        support.distance < 2 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5 &&
+        landing.z > ladderZ + 0.7 &&
+        landing.y > ladderY + 3.5,
+      `ordinary south-face input must reach supported core-side ground; ` +
+        `ladder=(${ladderX.toFixed(2)}, ${ladderY.toFixed(2)}, ${ladderZ.toFixed(2)}), ` +
+        `start=(${start.x.toFixed(2)}, ${start.y.toFixed(2)}, ${start.z.toFixed(2)}), ` +
+        `ended=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(support)}`,
+    );
+
+    await game.step({ frames: 180 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.z > ladderZ + 0.7 &&
+        stable.y > ladderY + 3.5 &&
+        Math.hypot(stable.x - landing.x, stable.z - landing.z) < 0.25 &&
+        stableSupport.hit &&
+        stableSupport.distance !== null &&
+        stableSupport.distance > 0.5 &&
+        stableSupport.distance < 2 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `release must remain stable on the core-side landing; ` +
+        `landing=(${landing.x.toFixed(2)}, ${landing.y.toFixed(2)}, ${landing.z.toFixed(2)}), ` +
+        `stable=(${stable.x.toFixed(2)}, ${stable.y.toFixed(2)}, ${stable.z.toFixed(2)}), ` +
+        `support=${JSON.stringify(stableSupport)}`,
     );
   },
 );

--- a/tools/shock2-sdk/test/climbing.e2e.test.ts
+++ b/tools/shock2-sdk/test/climbing.e2e.test.ts
@@ -1130,6 +1130,136 @@ test(
   },
 );
 
+// Rick1 object532 is a tall south-face ladder whose authored exit is the y42
+// deck west of the column. A lower y38.8 floor also fits a standing capsule,
+// but it is a sealed pocket beneath that deck and cannot be accepted merely
+// because it is locally supported.
+test(
+  "flat climbing: rick1 ladder 532 reaches the connected y42 deck",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8109),
+    });
+    await game.step({ frames: 5 });
+
+    const ladder = (
+      await game.entities.list({ filter: "Rick Ladder 16", limit: 100 })
+    ).entities.find((entity) => entity.template_id === 532);
+    assert.ok(ladder, "rick1 should contain authored ladder object 532");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+
+    // Geometry-relative setup reproduces the reachable supported south-face
+    // stage. The climb and all post-setup movement use production controls.
+    await game.player.teleport({
+      x: ladderX,
+      y: ladderY - 7.15797,
+      z: ladderZ - 0.62918,
+    });
+    await game.input.set("crouch", 0);
+    await game.input.setJump(false);
+    await game.step({ frames: 30 });
+    const start = await game.player.position();
+    const startFrame = await game.info();
+    assert.ok(
+      Math.hypot(start.x - ladderX, start.z - (ladderZ - 0.62918)) < 0.05 &&
+        Math.abs(startFrame.player.camera_offset[1] - 1.04) < 0.02,
+      `expected standing south-face stage; ladder=${JSON.stringify(ladder.position)}, ` +
+        `start=${JSON.stringify(start)}, camera=${JSON.stringify(startFrame.player.camera_offset)}`,
+    );
+
+    const horizontal = 10;
+    await game.input.lookAtWorldPoint([
+      start.x - 0.35 * horizontal,
+      start.y + Math.tan(Math.PI / 3) * horizontal,
+      start.z + 0.94 * horizontal,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let peak = start;
+    let reachedUpperDeck = false;
+    let landing = start;
+    for (let frame = 0; frame < 360; frame += 1) {
+      await game.step({ frames: 1 });
+      const position = await game.player.position();
+      if (position.y > peak.y) peak = position;
+      if (position.y > 43.1) {
+        const support = await game.raycast({
+          start: [position.x, position.y + 0.1, position.z],
+          end: [position.x, position.y - 3, position.z],
+          collision_groups: ["world", "entity", "selectable"],
+          ignore_sensors: true,
+        });
+        if (
+          support.hit_point !== null &&
+          support.hit_normal !== null &&
+          Math.abs(support.hit_point[1] - 42) < 0.05 &&
+          support.hit_normal[1] > 0.5
+        ) {
+          reachedUpperDeck = true;
+          landing = position;
+          break;
+        }
+      }
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    const stableSupport = await game.raycast({
+      start: [stable.x, stable.y + 0.1, stable.z],
+      end: [stable.x, stable.y - 3, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      reachedUpperDeck &&
+        Math.abs(stable.y - 43.244) < 0.08 &&
+        stable.x < ladderX - 0.5 &&
+        stableSupport.hit &&
+        stableSupport.hit_point !== null &&
+        Math.abs(stableSupport.hit_point[1] - 42) < 0.05 &&
+        stableSupport.hit_normal !== null &&
+        stableSupport.hit_normal[1] > 0.5,
+      `ordinary standing input must reject the lower pocket and settle on the connected y42 deck; ` +
+        `start=${JSON.stringify(start)}, peak=${JSON.stringify(peak)}, landing=${JSON.stringify(landing)}, ` +
+        `stable=${JSON.stringify(stable)}, support=${JSON.stringify(stableSupport)}`,
+    );
+
+    await game.input.lookAtWorldPoint([
+      stable.x + 10,
+      stable.y + 1.6,
+      stable.z,
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let egress = stable;
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      egress = await game.player.position();
+      if (egress.x > stable.x + 0.75) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 60 });
+    egress = await game.player.position();
+    const egressSupport = await game.raycast({
+      start: [egress.x, egress.y + 0.1, egress.z],
+      end: [egress.x, egress.y - 3, egress.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      egress.x > stable.x + 0.7 &&
+        Math.abs(egress.y - stable.y) < 0.08 &&
+        egressSupport.hit_point !== null &&
+        Math.abs(egressSupport.hit_point[1] - 42) < 0.05 &&
+        egressSupport.hit_normal !== null &&
+        egressSupport.hit_normal[1] > 0.5,
+      `the selected top-out must permit ordinary eastward egress on y42; ` +
+        `stable=${JSON.stringify(stable)}, egress=${JSON.stringify(egress)}, ` +
+        `support=${JSON.stringify(egressSupport)}`,
+    );
+  },
+);
+
 // Issue #657's Eng1 blocker is a different Dark BreakClimb shape from Rick1:
 // authored ladder 317 ends under a thick terrain slab. The player must rise
 // through the slab's two locally sampled wall planes, then descend to the

--- a/tools/shock2-sdk/test/portal-seam.e2e.test.ts
+++ b/tools/shock2-sdk/test/portal-seam.e2e.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const reproSave = process.env.SHOCK2_PORTAL_SEAM_SAVE;
+
+async function walkTo(
+  game: GameServer,
+  target: [number, number],
+  label: string,
+  tolerance = 0.45,
+): Promise<Position> {
+  let position = await game.player.position();
+  let best = Math.hypot(position.x - target[0], position.z - target[1]);
+  let stalledFrames = 0;
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  for (let frame = 0; frame < 240; frame += 1) {
+    if (frame % 8 === 0) {
+      await game.input.lookAtWorldPoint([
+        target[0],
+        position.y + 0.48,
+        target[1],
+      ]);
+    }
+    await game.step({ frames: 1 });
+    position = await game.player.position();
+    const distance = Math.hypot(
+      position.x - target[0],
+      position.z - target[1],
+    );
+    if (distance <= tolerance) break;
+    if (distance < best - 0.03) {
+      best = distance;
+      stalledFrames = 0;
+    } else {
+      stalledFrames += 1;
+    }
+    assert.ok(
+      stalledFrames < 45,
+      `${label} stalled at ${JSON.stringify(position)} (${distance.toFixed(3)} from target)`,
+    );
+  }
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  assert.ok(
+    Math.hypot(position.x - target[0], position.z - target[1]) <= tolerance,
+    `${label} did not reach ${JSON.stringify(target)}: ${JSON.stringify(position)}`,
+  );
+  return position;
+}
+
+// Rick1's high-deck return route is a shipped SMALL_CREATURE AIPATH passage
+// between a WorldRep wall and the end of a live Pipe 24x3. The 1.6-foot
+// crouched body fits the 1.72-foot opening, but the old 0.1-foot controller
+// margin was charged on both sides and pinned the capsule at x=44.88 forever.
+//
+// The save is private campaign state and is supplied only to local/opt-in
+// runs; it is never checked in or uploaded. From that authentic pose the test
+// uses ordinary input only: cross cells 270 -> 269 -> 271, physically enter
+// tripwire1259, and walk through its opened door1257.
+test(
+  "rick1: crouched player crosses the high-deck portal and opens door 1257",
+  {
+    skip: !e2eEnabled || !reproSave || !existsSync(reproSave),
+    timeout: 600_000,
+  },
+  async () => {
+    assert.ok(reproSave, "SHOCK2_PORTAL_SEAM_SAVE must name the private repro save");
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8270),
+      debugFlags: ["--save-file", reproSave],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 10 });
+
+    const [tripwire] = await game.entities.byTemplate(1259);
+    const [door] = await game.entities.byTemplate(1257);
+    assert.ok(tripwire, "rick1 should contain authored tripwire1259");
+    assert.ok(door, "rick1 should contain authored door1257");
+    const closedDoor = await game.entities.detail(door.id);
+
+    await game.input.set("crouch", 1);
+    await game.input.set("jump", 0);
+    await game.step({ frames: 20 });
+    const start = await game.player.position();
+    assert.ok(
+      start.x > 44.7 && start.x < 45.1 && start.z > -15.8 && start.z < -15.3,
+      `the repro must start at the blocked portal: ${JSON.stringify(start)}`,
+    );
+
+    const crossed = await walkTo(game, [42.4, -16.0], "portal crossing");
+    assert.ok(
+      crossed.x < 44.4,
+      `ordinary crouched input must cross west of the portal, ended ${JSON.stringify(crossed)}`,
+    );
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    const stablePlayer = (await game.info()).player;
+    const support = await game.raycast({
+      start: [stable.x, stable.y + 0.1, stable.z],
+      end: [stable.x, stable.y - 2, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      Math.abs(stable.y - 62.184) < 0.08 &&
+        Math.abs(stablePlayer.camera_offset[1] - 0.48) < 0.02 &&
+        support.hit &&
+        support.hit_point !== null &&
+        Math.abs(support.hit_point[1] - 61.6) < 0.05 &&
+        support.hit_normal !== null &&
+        support.hit_normal[1] > 0.5,
+      `the crossed player must remain crouched and supported on y61.6: ` +
+        `stable=${JSON.stringify(stable)}, camera=${JSON.stringify(stablePlayer.camera_offset)}, ` +
+        `support=${JSON.stringify(support)}`,
+    );
+
+    await walkTo(game, [37.6, -16.0], "cell269 corridor");
+    await walkTo(
+      game,
+      [tripwire.position[0], tripwire.position[2]],
+      "physical tripwire1259 entry",
+      0.35,
+    );
+    await game.step({ frames: 120 });
+    const openedDoor = await game.entities.detail(door.id);
+    const doorTravel = Math.hypot(
+      openedDoor.position[0] - closedDoor.position[0],
+      openedDoor.position[1] - closedDoor.position[1],
+      openedDoor.position[2] - closedDoor.position[2],
+    );
+    assert.ok(
+      doorTravel > 2,
+      `physical tripwire1259 entry must open door1257: ` +
+        `${JSON.stringify(closedDoor.position)} -> ${JSON.stringify(openedDoor.position)}`,
+    );
+
+    const beyondDoor = await walkTo(
+      game,
+      [tripwire.position[0], door.position[2] - 1.5],
+      "opened door1257 crossing",
+      0.55,
+    );
+    assert.ok(
+      beyondDoor.z < door.position[2] - 0.8,
+      `ordinary movement must continue through opened door1257: ${JSON.stringify(beyondDoor)}`,
+    );
+  },
+);

--- a/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick1-rumbler-junction.e2e.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Position } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const reproSave = process.env.SHOCK2_RUMBLER_JUNCTION_SAVE;
+
+function property(
+  detail: { properties: Array<{ name: string; value: unknown }> },
+  name: string,
+): unknown {
+  return detail.properties.find((item) => item.name === name)?.value;
+}
+
+async function walkTo(
+  game: GameServer,
+  target: [number, number],
+  label: string,
+  tolerance = 0.4,
+): Promise<Position> {
+  let position = await game.player.position();
+  let best = Math.hypot(position.x - target[0], position.z - target[1]);
+  let stalledFrames = 0;
+  await game.input.set("right_hand.thumbstick", [0, 1]);
+  for (let frame = 0; frame < 360; frame += 1) {
+    if (frame % 6 === 0) {
+      await game.input.lookAtWorldPoint([
+        target[0],
+        position.y + 0.8,
+        target[1],
+      ]);
+    }
+    await game.step({ frames: 1 });
+    position = await game.player.position();
+    const distance = Math.hypot(
+      position.x - target[0],
+      position.z - target[1],
+    );
+    if (distance <= tolerance) break;
+    if (distance < best - 0.02) {
+      best = distance;
+      stalledFrames = 0;
+    } else {
+      stalledFrames += 1;
+    }
+    assert.ok(
+      stalledFrames < 60,
+      `${label} stalled at ${JSON.stringify(position)} (${distance.toFixed(3)} from target)`,
+    );
+  }
+  await game.input.set("right_hand.thumbstick", [0, 0]);
+  assert.ok(
+    Math.hypot(position.x - target[0], position.z - target[1]) <= tolerance,
+    `${label} did not reach ${JSON.stringify(target)}: ${JSON.stringify(position)}`,
+  );
+  return position;
+}
+
+// Rick1's final-Rumbler lure uses the shipped WALK|SMALL_CREATURE link from
+// AIPATH cell1408 to cell1400. The live Rumbler authored two 1.5-foot physics
+// spheres, but the old runtime replaced that envelope with the five-foot-wide
+// animation bounds. Its 2wu-wide capsule therefore oscillated forever at the
+// junction instead of following its complete route back to Ladder951.
+//
+// The save is private campaign state and is supplied only to local/opt-in
+// runs; it is never checked in or uploaded. This scenario uses ordinary player
+// control throughout: acquire the Rumbler, reverse the intact route, require
+// its real body to pass the former waypoint and reach the ladder lip, descend
+// Ladder951, and land a real Crystal Shard edge without losing any of 24HP.
+test(
+  "rick1: authored Rumbler body follows the lure through the narrow junction",
+  {
+    skip: !e2eEnabled || !reproSave || !existsSync(reproSave),
+    timeout: 900_000,
+  },
+  async () => {
+    assert.ok(
+      reproSave,
+      "SHOCK2_RUMBLER_JUNCTION_SAVE must name the private repro save",
+    );
+    await using game = await GameServer.launch({
+      mission: "rick1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8290),
+      debugFlags: ["--save-file", reproSave],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+      repoRoot: process.env.SHOCK2_REPO_ROOT,
+    });
+    await game.step({ frames: 10 });
+
+    const [rumbler] = await game.entities.byTemplate(2188);
+    assert.ok(rumbler, "rick1 should contain authored Rumbler2188");
+    const initial = await game.entities.detail(rumbler.id);
+    assert.equal(property(initial, "HitPoints"), "220");
+    assert.equal((await game.info()).player.hit_points, 24);
+    const body = (await game.physics.bodies({ entityId: rumbler.id })).bodies[0];
+    assert.ok(body, "Rumbler2188 must retain a live physics body");
+    assert.equal(body.body_type, "dynamic");
+    assert.equal(body.blocks_player, true);
+    assert.equal(body.blocks_actor, true);
+    assert.ok(
+      body.collision_groups.includes("actor"),
+      `Rumbler must remain in the actor collision group: ${JSON.stringify(body)}`,
+    );
+
+    const route: Array<[number, number]> = [
+      [113.6, -1.6],
+      [113.6, -2.4],
+      [112.4, -4.4],
+      [111.7, -9.2],
+      [111.43, -10.02],
+    ];
+    for (let index = 0; index < route.length; index += 1) {
+      await walkTo(game, route[index], `outbound lure leg ${index}`);
+    }
+
+    let acquired = false;
+    for (let frame = 0; frame < 600; frame += 10) {
+      await game.step({ frames: 10 });
+      const player = await game.player.position();
+      const detail = await game.entities.detail(rumbler.id);
+      const distance = Math.hypot(
+        detail.position[0] - player.x,
+        detail.position[2] - player.z,
+      );
+      if (
+        ["Moderate", "High"].includes(
+          String(property(detail, "AIAlertness") ?? ""),
+        ) && distance < 2.5
+      ) {
+        acquired = true;
+        break;
+      }
+    }
+    assert.ok(acquired, "the intact lure must acquire Rumbler2188");
+
+    for (let index = route.length - 2; index >= 0; index -= 1) {
+      await walkTo(game, route[index], `return lure leg ${index}`);
+    }
+    await walkTo(game, [111.91, -0.812], "Ladder951 midpoint", 0.4);
+
+    let passedJunction = false;
+    let reachedLip = false;
+    let lastRumbler = initial;
+    for (let frame = 0; frame < 720; frame += 5) {
+      await game.step({ frames: 5 });
+      lastRumbler = await game.entities.detail(rumbler.id);
+      if (lastRumbler.position[2] > -9.5) passedJunction = true;
+      const player = await game.player.position();
+      const distance = Math.hypot(
+        lastRumbler.position[0] - player.x,
+        lastRumbler.position[2] - player.z,
+      );
+      if (lastRumbler.position[2] > -3.2 && distance < 3.0) {
+        reachedLip = true;
+        break;
+      }
+    }
+    const livePath = (await game.pathfinding.aiPaths()).find(
+      (path) => path.entity_id === rumbler.id,
+    );
+    assert.ok(
+      passedJunction,
+      `Rumbler must advance past the former cell1408->1400 stall: ` +
+        `${JSON.stringify(lastRumbler.position)}, path=${JSON.stringify(livePath)}`,
+    );
+    assert.ok(
+      reachedLip,
+      `Rumbler must follow the lure to Ladder951, not merely pass one waypoint: ` +
+        `${JSON.stringify(lastRumbler.position)}, path=${JSON.stringify(livePath)}`,
+    );
+
+    let player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y - 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 300; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y < 77.4) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      player.y < 77.4 && player.x < 111.2,
+      `ordinary WEST/down input must acquire and descend Ladder951: ${JSON.stringify(player)}`,
+    );
+    assert.equal((await game.info()).player.hit_points, 24);
+
+    // One real attack edge is enough to prove the post-fix lure is tactically
+    // usable without turning this controller regression into a brittle 37-hit
+    // combat-animation test. The campaign replay owns the complete 220HP kill.
+    await game.input.trigger("EquipCrystalShard");
+    await game.step({ frames: 5 });
+    player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y + 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y > 80.1) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.player.aimAt(rumbler.id);
+    const beforeHit = Number(property(await game.entities.detail(rumbler.id), "HitPoints"));
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    const afterHit = Number(property(await game.entities.detail(rumbler.id), "HitPoints"));
+    assert.equal(
+      beforeHit,
+      220,
+      "the controller fix must not alter the Rumbler's authored health",
+    );
+    assert.equal(
+      afterHit,
+      214,
+      `one real Crystal Shard edge must deal exactly 6HP: ${beforeHit} -> ${afterHit}`,
+    );
+
+    player = await game.player.position();
+    await game.input.lookAtWorldPoint([player.x - 10, player.y - 17.32, player.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    for (let frame = 0; frame < 180; frame += 1) {
+      await game.step({ frames: 1 });
+      player = await game.player.position();
+      if (player.y <= 75.8) break;
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    assert.ok(
+      player.y <= 75.8,
+      `the player must retreat down Ladder951 after the strike: ${JSON.stringify(player)}`,
+    );
+    await game.step({ frames: 30 });
+    assert.equal(
+      (await game.info()).player.hit_points,
+      24,
+      "the player must remain safely separated after executing the ladder lure",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/rick2-mixed-case-save.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick2-mixed-case-save.e2e.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, GameServer } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const reproSave = process.env.SHOCK2_RICK2_MIXED_CASE_SAVE;
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8295);
+
+function savePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+async function turret709(game: GameServer) {
+  return (await game.entities.list({ limit: 10_000 })).entities.find(
+    (entity) => entity.template_id === 709,
+  );
+}
+
+// Negative-first: on the old runtime this creates level_data["Rick2.mis"],
+// then the fresh process looks up only "rick2.mis" and reconstructs turret709
+// from the pristine mission. The test owns its save and needs no campaign data.
+test(
+  "Rick2.mis: a destroyed mission entity stays absent across a fresh process",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    const saveName = `rick2_mixed_case_${Date.now()}`;
+    try {
+      {
+        await using game = await GameServer.launch({
+          mission: "earth.mis",
+          port: basePort,
+          echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+          repoRoot: process.env.SHOCK2_REPO_ROOT,
+        });
+        assert.equal((await game.transitionLevel("Rick2.mis")).success, true);
+        await game.step({ frames: 5 });
+        assert.equal((await game.info()).mission, "Rick2.mis");
+
+        const turret = await turret709(game);
+        assert.ok(turret, "Rick2 must contain mission turret709 before damage");
+        await game.entities.sendMessage(turret.id, {
+          type: "Damage",
+          amount: 1_000,
+        });
+        await game.step({ frames: 5 });
+        assert.equal(
+          await turret709(game),
+          undefined,
+          "ordinary lethal Damage must remove mission turret709 before save",
+        );
+        assert.equal((await game.save(saveName)).success, true);
+      }
+
+      {
+        await using game = await GameServer.launch({
+          mission: "earth.mis",
+          port: basePort + 1,
+          echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+          repoRoot: process.env.SHOCK2_REPO_ROOT,
+        });
+        const loaded = await game.load(saveName);
+        assert.equal(loaded.success, true);
+        assert.equal(loaded.mission, "Rick2.mis");
+        await game.step({ frames: 5 });
+        assert.equal(
+          await turret709(game),
+          undefined,
+          "the fresh process must use the saved Rick2 entity snapshot",
+        );
+      }
+    } finally {
+      const path = savePath(saveName);
+      if (path) rmSync(path);
+    }
+  },
+);
+
+// The private checkpoint was written immediately after mission turret709 was
+// destroyed with ordinary Crystal Shard edges. Its active mission and current
+// entity snapshot are both keyed `Rick2.mis`. Before #905, cold load lowercased
+// only the lookup, missed that exact snapshot, and silently rebuilt pristine
+// mission entities even though global player state restored correctly.
+test(
+  "Rick2.mis: cold load restores a mixed-case mission entity snapshot",
+  {
+    skip: !e2eEnabled || !reproSave || !existsSync(reproSave),
+    timeout: 600_000,
+  },
+  async () => {
+    assert.ok(
+      reproSave,
+      "SHOCK2_RICK2_MIXED_CASE_SAVE must name the private repro save",
+    );
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: basePort + 2,
+      debugFlags: ["--save-file", reproSave],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+      repoRoot: process.env.SHOCK2_REPO_ROOT,
+    });
+    await game.step({ frames: 10 });
+
+    const info = await game.info();
+    const position = await game.player.position();
+    assert.equal(info.mission, "Rick2.mis");
+    assert.equal(info.player.hit_points, 24);
+    assert.equal(info.player.stats?.cyber_modules, 175);
+    assert.ok(
+      Math.hypot(
+        position.x - 156.13382,
+        position.y - 92.82399,
+        position.z + 10.840119,
+      ) < 0.2,
+      `global player pose must still restore exactly: ${JSON.stringify(position)}`,
+    );
+
+    const restoredTurret709 = await turret709(game);
+    assert.equal(
+      restoredTurret709,
+      undefined,
+      `destroyed mission turret709 must remain absent after cold load; got ${JSON.stringify(restoredTurret709)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- canonicalize newly written mission snapshot keys so `Rick2.mis` and `rick2.mis` cannot diverge
- recover legacy mixed-case saves with exact-active, canonical, then deterministic case-insensitive lookup precedence
- remove case/whitespace duplicate keys without merging or dropping unrelated mission snapshots
- cover the regression with a self-contained two-process Rick2 save/load scenario and the original legacy checkpoint

## Root cause

`Game::build_save_data` stored the current entity snapshot under the scene's exact spelling (`Rick2.mis`), while cold load looked up only a lowercased key (`rick2.mis`). The lookup missed the valid 299-entity snapshot and silently rebuilt pristine mission entities, resurrecting destroyed turret709 even though global player state loaded correctly.

## Compatibility policy

- new writes use trimmed lowercase mission keys and remove canonical-equivalent aliases
- legacy reads prefer the exact active-mission spelling, then the canonical key, then the lexicographically first canonical-equivalent alias
- whole-campaign canonicalization prefers an existing canonical inactive snapshot and preserves distinct missions
- the freshly captured active scene is inserted last, so current live state remains authoritative

## Negative-first proof

- **Base `ba89d098`: RED** — exact `Rick2.mis` transition, lethal ordinary `Damage` to mission turret709, save, and fresh-process load respawned template709 at `(157.038, 92.355, -10.866)`
- **Fixed `408b3470`: GREEN** — the identical self-contained two-process flow keeps turret709 absent
- **Legacy checkpoint: GREEN** — the pre-fix mixed-case save restores `Rick2.mis`, HP24, 175 modules, exact pose, and the uppercase 299-entity snapshot with turret709 absent

The private campaign save remained local and was never uploaded.

## Visual evidence

![Rick2 mixed-case save persistence](https://gist.githubusercontent.com/tommy-xr/531add3393d0d198e05a8eb539bbc9e5/raw/rick2-save-persistence.gif)

<sub>The exact base respawns Rick Turret template 709 into the saved player view; the fixed build restores the mixed-case mission snapshot and keeps the destroyed turret absent. Both panels cold-load the same checkpoint, restore `Rick2.mis`, HP 24/30, 175 cyber modules, and the same pose, then use identical fixed-timestep steps and camera aim.</sub>

### Before → after

![Base respawn versus fixed absence](https://gist.githubusercontent.com/tommy-xr/531add3393d0d198e05a8eb539bbc9e5/raw/rick2-save-before-after.png)

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/fix/903-rumbler-authored-width..HEAD`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 554 passed
- `cargo test -p shock2vr save_load::save_data::tests` — 5 passed
- `npm test` — 26 passed / 224 total (198 opt-in scenarios skipped)
- `rick2-mixed-case-save.e2e.test.ts` — 2/2 passed on the final PR stack (fresh self-contained save plus legacy compatibility)
- `save-load.e2e.test.ts` — 3/3 passed
- `missions.e2e.test.ts` — 23/23 missions loaded

## Stack

This PR is stacked on #904 and contains one focused save/load commit.

Fixes #905