### PR TITLE
fix(physics): grab ladders during descending jumps

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -5663,11 +5663,22 @@ impl PhysicsWorld {
             player_handle.top_out_retry_cooldown -= 1;
         }
         let allow_top_out_attempt = player_handle.top_out_retry_cooldown == 0;
+        let validation_queries = self.player_movement_queries(dispatcher, movement_filter);
 
         // Flat climbing: when the player overlaps a climbable surface (ladder)
         // and pushes toward it, redirect that input to vertical movement and
         // suppress the gravity pass for this frame (see `climb_redirect`).
-        let climb_movement = if player_handle.jump_velocity.is_some() {
+        // A rising jump remains an ordinary ballistic arc. Once it is falling,
+        // however, a real into-face ladder contact may take ownership of the
+        // frame: Dark permits players to jump onto ladders, and suppressing the
+        // grip query for the entire lifetime of `jump_velocity` made that
+        // handoff impossible. `step_player_movement` still has to produce
+        // signed vertical climb progress before the arc is cancelled below.
+        let can_acquire_airborne_climb = player_handle
+            .jump_velocity
+            .is_some_and(|velocity| velocity <= 0.0);
+        let climb_movement = if player_handle.jump_velocity.is_some() && !can_acquire_airborne_climb
+        {
             None
         } else {
             let climb_filter = QueryFilter::new()
@@ -5712,7 +5723,7 @@ impl PhysicsWorld {
                 // off-center: it tilts away from the face, which under-reads
                 // the into-ladder push the grip test and climb speed use.)
                 let mut nearest: Option<(f32, Vector<Real>, Real)> = None;
-                for (_handle, collider) in queries.intersect_shape(character_pos, &inflated) {
+                for (handle, collider) in queries.intersect_shape(character_pos, &inflated) {
                     let contact = rapier3d::parry::query::contact(
                         &character_pos,
                         character_shape.as_ref(),
@@ -5728,7 +5739,23 @@ impl PhysicsWorld {
                         // (or under) the surface - that's standing, not climbing.
                         if toward_norm > 0.5 && nearest.is_none_or(|(d, _, _)| contact.dist < d) {
                             let toward = toward_h / toward_norm;
-                            nearest = Some((contact.dist, toward, collider.compute_aabb().maxs.y));
+                            // The inflated overlap is only a reach query. On an
+                            // airborne first contact, a solid wall between the
+                            // capsule and the ladder must not grant a grip
+                            // through geometry. Grounded climbing retains its
+                            // established contact semantics.
+                            let unobstructed = !can_acquire_airborne_climb || {
+                                let max_toi = capsule.radius + contact.dist.max(0.0) + 1.0e-3;
+                                let ray =
+                                    Ray::new(Point::from(character_pos.translation.vector), toward);
+                                validation_queries
+                                    .cast_ray(&ray, max_toi, true)
+                                    .is_some_and(|(first, _)| first == handle)
+                            };
+                            if unobstructed {
+                                nearest =
+                                    Some((contact.dist, toward, collider.compute_aabb().maxs.y));
+                            }
                         }
                     }
                 }
@@ -5769,9 +5796,10 @@ impl PhysicsWorld {
                 })
             })
         };
-        let attempted_top_out = climb_movement
-            .as_ref()
-            .is_some_and(|(_, top_out, _)| allow_top_out_attempt && top_out.is_some());
+        let attempted_top_out = !can_acquire_airborne_climb
+            && climb_movement
+                .as_ref()
+                .is_some_and(|(_, top_out, _)| allow_top_out_attempt && top_out.is_some());
         // The climb cast collides with everything the walk does EXCEPT the
         // climbable surfaces themselves - see `ClimbPass`. Membership is checked
         // by predicate rather than by group filter because a ladder is also an
@@ -5866,7 +5894,17 @@ impl PhysicsWorld {
                         airborne_vertical,
                         climb_movement.map(|(movement, top_out, retained)| ClimbPass {
                             movement,
-                            top_out,
+                            // An airborne first contact has not acquired the
+                            // ladder until this pass makes signed vertical
+                            // progress. Suppress the zero-progress near-top
+                            // cap/stall path for this one handoff frame; after
+                            // real acquisition cancels the arc, the next frame
+                            // may plan a normal top-out.
+                            top_out: if can_acquire_airborne_climb {
+                                None
+                            } else {
+                                top_out
+                            },
                             retained,
                             allow_top_out_attempt,
                             is_crouched: player_handle.is_crouched,
@@ -5887,6 +5925,7 @@ impl PhysicsWorld {
         }
         let was_top_out = player_handle.top_out.is_some();
         let next_retained_climb = player_movement.retained_climb;
+        let acquired_airborne_climb = can_acquire_airborne_climb && next_retained_climb.is_some();
         player_handle.top_out = player_movement.top_out;
         player_handle.slope_displacement = player_movement.slope_displacement;
         let is_top_out = player_handle.top_out.is_some();
@@ -5925,6 +5964,10 @@ impl PhysicsWorld {
         };
 
         if is_top_out {
+            player_handle.jump_velocity = None;
+            player_handle.climb_jump_velocity = None;
+            player_handle.is_grounded = false;
+        } else if acquired_airborne_climb {
             player_handle.jump_velocity = None;
             player_handle.climb_jump_velocity = None;
             player_handle.is_grounded = false;
@@ -10240,6 +10283,307 @@ mod tests {
     /// direction the residual lateral term steers the player sideways along
     /// the wall while climbing; the contact face normal keeps the climb
     /// straight (with center-delta the ascent itself also collapses here).
+    #[test]
+    fn descending_jump_acquires_a_climbable_with_matching_input() {
+        let mut world = PhysicsWorld::new();
+        let floor = ColliderBuilder::trimesh(
+            vec![
+                point![-10.0, 0.0, -10.0],
+                point![10.0, 0.0, -10.0],
+                point![10.0, 0.0, 10.0],
+                point![-10.0, 0.0, 10.0],
+            ],
+            vec![[0u32, 1, 2], [0, 2, 3]],
+        )
+        .expect("floor trimesh")
+        .build();
+        world.add_collider(EntityId::from_inner(2200).unwrap(), floor);
+        // The player's center is x=-1.0 and the ladder's west face is x=-0.35:
+        // after subtracting the standing radius, the 0.33wu surface gap is
+        // inside the ordinary 0.4wu climb reach without overlapping it.
+        world.add_kinematic(
+            EntityId::from_inner(2201).unwrap(),
+            vec3(-0.3, 10.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.1, 20.0, 2.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(-1.0, 1.5, 0.0), EntityId::from_inner(2202).unwrap());
+        step(&mut world, &mut player, 30);
+
+        // Launch straight up without an into-ladder input, then wait until the
+        // ordinary ballistic arc is descending while still within reach.
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            true,
+            &mut player,
+        );
+        for _ in 0..90 {
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                false,
+                &mut player,
+            );
+            if player.jump_velocity.is_some_and(|velocity| velocity < -0.1) {
+                break;
+            }
+        }
+        assert!(
+            player.jump_velocity.is_some_and(|velocity| velocity < -0.1),
+            "fixture must reach a genuine descending ordinary jump"
+        );
+
+        let before = world.get_player_translation(&player);
+        world.update_with_facing_and_jump(
+            Vector3::new(0.1, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            false,
+            &mut player,
+        );
+
+        assert!(
+            player.jump_velocity.is_none(),
+            "a qualifying airborne grip must cancel the ballistic arc"
+        );
+        assert!(
+            player.retained_climb.is_some(),
+            "the successful frame must retain the real climb contact"
+        );
+        world.update_with_facing_and_jump(
+            Vector3::new(0.1, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            false,
+            &mut player,
+        );
+        let after = world.get_player_translation(&player);
+        assert!(
+            after.y > before.y,
+            "matching into-face input must begin controlled ascent instead of continuing the fall: {before:?} -> {after:?}"
+        );
+    }
+
+    /// Airborne acquisition keeps the same authored grip boundaries as an
+    /// ordinary floor approach: the surface must be climbable, the input must
+    /// point substantially into its face, and no solid may stand between the
+    /// capsule and the ladder. Rising jumps remain ballistic so merely taking
+    /// off beside a ladder cannot erase an ordinary jump arc.
+    #[test]
+    fn airborne_ladder_acquisition_rejects_invalid_surfaces_and_input() {
+        let run = |group: CollisionGroup, desired: Vector3<f32>, blocker: bool| {
+            let mut world = PhysicsWorld::new();
+            let floor = ColliderBuilder::trimesh(
+                vec![
+                    point![-10.0, 0.0, -10.0],
+                    point![10.0, 0.0, -10.0],
+                    point![10.0, 0.0, 10.0],
+                    point![-10.0, 0.0, 10.0],
+                ],
+                vec![[0u32, 1, 2], [0, 2, 3]],
+            )
+            .expect("floor trimesh")
+            .build();
+            world.add_collider(EntityId::from_inner(2210).unwrap(), floor);
+            world.add_kinematic(
+                EntityId::from_inner(2211).unwrap(),
+                vec3(-0.3, 10.0, 0.0),
+                identity_quat(),
+                Vector3::new(0.0, 0.0, 0.0),
+                vec3(0.1, 20.0, 2.0),
+                group,
+                false,
+            );
+            if blocker {
+                world.add_kinematic(
+                    EntityId::from_inner(2212).unwrap(),
+                    vec3(-0.55, 10.0, 0.0),
+                    identity_quat(),
+                    Vector3::new(0.0, 0.0, 0.0),
+                    vec3(0.04, 20.0, 2.0),
+                    CollisionGroup::entity(),
+                    false,
+                );
+            }
+            let mut player =
+                world.create_player(vec3(-1.05, 1.5, 0.0), EntityId::from_inner(2213).unwrap());
+            step(&mut world, &mut player, 30);
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+                true,
+                &mut player,
+            );
+            for _ in 0..90 {
+                world.update_with_facing_and_jump(
+                    Vector3::new(0.0, 0.0, 0.0),
+                    Vector3::new(1.0, 0.0, 0.0),
+                    false,
+                    &mut player,
+                );
+                if player.jump_velocity.is_some_and(|velocity| velocity < -0.1) {
+                    break;
+                }
+            }
+            assert!(player.jump_velocity.is_some_and(|velocity| velocity < 0.0));
+            world.update_with_facing_and_jump(
+                desired,
+                Vector3::new(1.0, 0.0, 0.0),
+                false,
+                &mut player,
+            );
+            (player.jump_velocity, player.retained_climb)
+        };
+
+        for (label, group, desired, blocker) in [
+            (
+                "plain wall",
+                CollisionGroup::entity(),
+                Vector3::new(0.1, 0.0, 0.0),
+                false,
+            ),
+            (
+                "away input",
+                CollisionGroup::climbable_entity(),
+                Vector3::new(-0.1, 0.0, 0.0),
+                false,
+            ),
+            (
+                "grazing input",
+                CollisionGroup::climbable_entity(),
+                Vector3::new(0.02, 0.0, 0.1),
+                false,
+            ),
+            (
+                "intervening blocker",
+                CollisionGroup::climbable_entity(),
+                Vector3::new(0.1, 0.0, 0.0),
+                true,
+            ),
+        ] {
+            let (jump_velocity, retained) = run(group, desired, blocker);
+            assert!(
+                jump_velocity.is_some(),
+                "{label} must leave the ordinary fall active"
+            );
+            assert!(
+                retained.is_none(),
+                "{label} must not manufacture a ladder grip"
+            );
+        }
+
+        // Rising beside the same valid ladder remains an ordinary jump until
+        // the apex; acquisition is specifically the descending handoff.
+        let mut world = PhysicsWorld::new();
+        world.add_kinematic(
+            EntityId::from_inner(2220).unwrap(),
+            vec3(-0.3, 10.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.1, 20.0, 2.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        let mut player =
+            world.create_player(vec3(-1.0, 1.5, 0.0), EntityId::from_inner(2221).unwrap());
+        player.is_grounded = true;
+        world.update_with_facing_and_jump(
+            Vector3::new(0.1, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            true,
+            &mut player,
+        );
+        assert!(player.jump_velocity.is_some_and(|velocity| velocity > 0.0));
+        assert!(player.retained_climb.is_none());
+    }
+
+    /// Reaching the top of a ladder is not itself proof that a falling player
+    /// acquired it. The ordinary climb pass also retains contact when a
+    /// near-top attempt is intentionally stalled, so the first airborne frame
+    /// must require real signed ascent before cancelling the ballistic arc.
+    #[test]
+    fn blocked_near_top_airborne_contact_remains_a_fall() {
+        let (mut world, mut player) = flat_jump_world();
+
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            true,
+            &mut player,
+        );
+        for _ in 0..90 {
+            world.update_with_facing_and_jump(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::unit_x(),
+                false,
+                &mut player,
+            );
+            if player.jump_velocity.is_some_and(|velocity| velocity < -0.1) {
+                break;
+            }
+        }
+        assert!(player.jump_velocity.is_some_and(|velocity| velocity < -0.1));
+        let descending = world.get_player_translation(&player);
+
+        // The short climbable is genuinely in horizontal reach and ends beside
+        // the current pose, which would authorize the ordinary near-top stall.
+        // A separate live entity ceiling clears the current capsule but blocks
+        // the first upward climb step.
+        world.add_kinematic(
+            EntityId::from_inner(2222).unwrap(),
+            vec3(0.7, descending.y - 1.0, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(0.1, 2.1, 2.0),
+            CollisionGroup::climbable_entity(),
+            false,
+        );
+        world.add_kinematic(
+            EntityId::from_inner(2223).unwrap(),
+            vec3(0.0, descending.y + PLAYER_HALF_HEIGHT + 0.06, 0.0),
+            identity_quat(),
+            Vector3::new(0.0, 0.0, 0.0),
+            vec3(4.0, 0.08, 4.0),
+            CollisionGroup::entity(),
+            false,
+        );
+
+        let velocity_before = player.jump_velocity.expect("descending arc");
+        world.update_with_facing_and_jump(
+            Vector3::new(0.1, 0.0, 0.0),
+            Vector3::unit_x(),
+            false,
+            &mut player,
+        );
+        let after = world.get_player_translation(&player);
+        assert!(
+            player
+                .jump_velocity
+                .is_some_and(|velocity| velocity < velocity_before),
+            "a blocked first climb step must preserve and advance the fall"
+        );
+        assert!(
+            player.retained_climb.is_none(),
+            "zero signed climb progress must not retain an airborne grip"
+        );
+        world.update_with_facing_and_jump(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::unit_x(),
+            false,
+            &mut player,
+        );
+        let after_applied = world.get_player_translation(&player);
+        assert!(
+            after_applied.y < descending.y,
+            "the overhead blocker must not convert a fall into a cap stall: {descending:?} -> {after:?} -> {after_applied:?}"
+        );
+        assert!(player.jump_velocity.is_some());
+        assert!(player.retained_climb.is_none());
+    }
+
     #[test]
     fn player_climbs_climbable_wall_but_not_plain_wall() {
         let run = |group: CollisionGroup| -> (f32, f32) {

--- a/tools/shock2-sdk/test/rick2-airborne-ladder.e2e.test.ts
+++ b/tools/shock2-sdk/test/rick2-airborne-ladder.e2e.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { findRepoRoot, GameServer } from "../src/index.js";
+import type { Position, RayCastResult, Vec3 } from "../src/index.js";
+
+// Private 25th Anniversary campaign frontier immediately before the authored
+// Pipe 46 -> Ladder 210 jump. The save remains local and is never committed.
+const FIXTURE_SAVE = process.env.SHOCK2_RICK2_PIPE46_SAVE ?? "frontier";
+const FIXTURE_SHA256 =
+  "803238ed47de5b266da609f986c83d84f67dd63e04de751397f58f999a7441e6";
+const LADDER = 210;
+
+function savePath(saveName: string): string | undefined {
+  const root = findRepoRoot(process.cwd()) ?? process.cwd();
+  return [process.env.DARK_ASSET_PATH, join(root, "Data"), join(root, "..", "Data")]
+    .filter((path): path is string => Boolean(path))
+    .map((path) => join(path, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+function distance(a: Position, b: Position): number {
+  return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+const fixturePath = savePath(FIXTURE_SAVE);
+const enabled = process.env.SHOCK2_E2E === "1" && Boolean(fixturePath);
+
+test(
+  "Rick2 Pipe 46 jump acquires Ladder 210 while descending and reaches the main tunnel",
+  { skip: !enabled, timeout: 600_000 },
+  async (t) => {
+    assert.ok(fixturePath);
+    assert.equal(
+      createHash("sha256").update(readFileSync(fixturePath)).digest("hex"),
+      FIXTURE_SHA256,
+      "the regression must use the accepted Pipe 46 campaign frontier",
+    );
+
+    await using game = await GameServer.launch({
+      mission: "rick2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8301),
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    const loaded = await game.load(FIXTURE_SAVE);
+    assert.equal(loaded.success, true);
+    assert.equal(loaded.mission.toLowerCase(), "rick2.mis");
+
+    await game.input.set("crouch", 1);
+    await game.input.setJump(false);
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 2 });
+    const start = await game.player.position();
+    assert.equal((await game.info()).player.hit_points, 24);
+
+    const ladder = (await game.entities.byTemplate(LADDER))[0];
+    assert.ok(ladder, "Rick2 must contain mission Ladder 210");
+    const [ladderX, ladderY, ladderZ] = ladder.position;
+
+    // Ordinary east movement reaches the campaign-proven takeoff point on
+    // Pipe 46. No relocation or collider filtering is used.
+    await game.input.lookAtWorldPoint([start.x + 10, start.y, start.z]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let stage = start;
+    for (let frame = 0; frame < 12 && stage.x < 166.4; frame += 1) {
+      await game.step({ frames: 1 });
+      stage = await game.player.position();
+    }
+    assert.ok(
+      stage.x >= 166.35 && stage.x <= 166.55 && Math.abs(stage.z - start.z) < 0.08,
+      `ordinary Pipe 46 stage must match the accepted takeoff: ${JSON.stringify({ start, stage })}`,
+    );
+
+    // Jump toward the pipe opening (horizontal dx/dz ratio 2.204), then at
+    // the authored clearance frame turn due north and keep the original
+    // forward input. The descending capsule remains within Ladder 210's real
+    // south-face reach for many frames; it must hand off to controlled climb.
+    const initialDx = 0.9107;
+    const initialDz = 0.4132;
+    const horizontal = 10;
+    const rise = Math.tan((20 * Math.PI) / 180) * horizontal;
+    await game.input.lookAtWorldPoint([
+      stage.x + initialDx * horizontal,
+      stage.y + rise,
+      stage.z + initialDz * horizontal,
+    ]);
+    await game.input.setJump(true);
+    await game.step({ frames: 1 });
+    await game.input.setJump(false);
+    await game.step({ frames: 7 });
+    await game.input.lookAtWorldPoint([stage.x, stage.y + rise, stage.z + horizontal]);
+
+    let previous = await game.player.position();
+    let grip: Position | null = null;
+    let risingFrames = 0;
+    const trace: Position[] = [previous];
+    for (let frame = 0; frame < 90; frame += 1) {
+      await game.step({ frames: 1 });
+      const position = await game.player.position();
+      trace.push(position);
+      const dy = position.y - previous.y;
+      const nearSouthFace =
+        Math.abs(position.x - ladderX) < 0.8 &&
+        position.z < ladderZ &&
+        ladderZ - position.z < 0.9;
+      risingFrames = nearSouthFace && dy > 0.01 ? risingFrames + 1 : 0;
+      if (risingFrames >= 2) {
+        grip = position;
+        break;
+      }
+      previous = position;
+    }
+    assert.ok(
+      grip && grip.y >= 92.5,
+      `the descending jump must acquire Ladder 210 before falling below y=92.5; ` +
+        `ladder=${JSON.stringify(ladder.position)}, tail=${JSON.stringify(trace.slice(-12))}`,
+    );
+
+    // Keep the same ordinary north input through the ladder's normal climb and
+    // top-out. Require a real upward-support hit and a short ordinary transfer
+    // toward the connected main tunnel, never an unsupported intermediate.
+    let supported: { position: Position; support: RayCastResult } | null = null;
+    for (let frame = 0; frame < 420; frame += 1) {
+      await game.step({ frames: 1 });
+      const position = await game.player.position();
+      if (position.y < ladderY + 2) continue;
+      const support = await game.raycast({
+        start: [position.x, position.y + 0.1, position.z],
+        end: [position.x, position.y - 3, position.z],
+        collision_groups: ["world", "entity", "selectable"],
+        ignore_sensors: true,
+      });
+      if (
+        support.hit_normal?.[1] !== undefined &&
+        support.hit_normal[1] > 0.5 &&
+        support.distance !== null &&
+        support.distance > 0.4 &&
+        support.distance < 2
+      ) {
+        supported = { position, support };
+        break;
+      }
+    }
+    assert.ok(
+      supported,
+      `controlled climb must reach authored support above Ladder 210; grip=${JSON.stringify(grip)}`,
+    );
+
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const landed = await game.player.position();
+    const eastTarget = [Math.max(169.6, landed.x + 2), landed.y, landed.z] as Vec3;
+    await game.input.lookAtWorldPoint(eastTarget);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    let tunnel = landed;
+    for (let frame = 0; frame < 120 && tunnel.x < 169.4; frame += 1) {
+      await game.step({ frames: 1 });
+      tunnel = await game.player.position();
+    }
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    await game.step({ frames: 30 });
+    const settled = await game.player.position();
+    await game.step({ frames: 60 });
+    const stable = await game.player.position();
+    // The crouched capsule's center is just east of the WorldRep floor edge;
+    // sample beneath its west footprint where the same resolved capsule is
+    // supported, rather than point-testing the unsupported center projection.
+    const tunnelSupport = await game.raycast({
+      start: [stable.x - 0.4, stable.y + 2, stable.z],
+      end: [stable.x - 0.4, stable.y - 5, stable.z],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.ok(
+      stable.x >= 169.4 &&
+        tunnelSupport.hit_point !== null &&
+        Math.abs(tunnelSupport.hit_point[1] - 94.8) < 0.05 &&
+        tunnelSupport.hit_normal !== null &&
+        tunnelSupport.hit_normal[1] > 0.5 &&
+        distance(stable, settled) < 0.05,
+      `ordinary transfer must end stable on the main tunnel: ${JSON.stringify({ landed, tunnel, settled, stable, tunnelSupport })}`,
+    );
+    assert.equal((await game.info()).player.hit_points, 24);
+    t.diagnostic(
+      `Pipe46 ${JSON.stringify(start)} -> stage ${JSON.stringify(stage)} -> grip ${JSON.stringify(grip)} -> ` +
+        `support ${JSON.stringify(supported)} -> tunnel ${JSON.stringify(stable)}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- let a descending ordinary jump acquire a climbable when matching into-face input produces real signed climb progress
- keep rising jumps ballistic, require the ladder to be the first airborne contact, and leave blockers/non-climbables/grazing input solid
- suppress only the first-contact top-out so a blocked near-top attempt cannot erase the fall without acquiring the ladder

## Root cause

Player movement skipped the climb-contact query whenever `jump_velocity` existed. The exact Pipe 46 jump therefore stayed an ordinary fall even while the capsule remained inside Ladder 210's authored south-face reach. Simply querying ladders during a fall was not enough: the established near-top branch can retain a zero-progress cap stall, so the handoff now withholds top-out for its first frame and cancels the arc only after signed vertical climb progress.

## Negative-first campaign replay

25th Anniversary campaign, Rickenbacker · OSA tier 2, accepted local frontier SHA-256 `803238ed47de5b266da609f986c83d84f67dd63e04de751397f58f999a7441e6` (private save not committed or uploaded):

- exact base `113ee9c1315e92b62bad316b2a5107c0fff89805` — **RED** in 9.216 s: after the Pipe 46 jump, the player stayed around x=167.28/z=10.52 while falling through y=90.96→89.58 and never acquired Ladder 210
- fixed campaign stack — **GREEN** in 10.346 s: real grip at `(167.87056, 94.35324, 10.33932)`, normal climb/top-out to +Y WORLD y=94.8, then ordinary transfer to stable main-tunnel `(169.61351, 95.38378, 10.935257)`, HP 24
- final rebased commit `5cd0f563d28548cf0d4cc8b1278882c8d6db2f1a` repeated the same GREEN scenario in 10.671 s

The committed SDK scenario is opt-in and skips when the reviewed private save is unavailable.

## Regression coverage

- descending jump + valid climbable + matching input acquires and ascends
- non-climbable, away/grazing input, rising arc, and a parented blocker preserve the ordinary jump
- a near-top ladder under a live overhead blocker cannot retain a zero-progress grip or freeze the fall
- existing ladder/top-out campaign scenarios remain green

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 557 passed
- `npm test` (`tools/shock2-sdk`) — 26 passed, 216 skipped E2E scenarios
- `SHOCK2_E2E=1 node --test dist/test/climbing.e2e.test.js` — 8/8 passed in 374111.615917 ms
- `SHOCK2_E2E=1 node --test dist/test/missions.e2e.test.js` — 23/23 passed in 236997.122625 ms
- exact private-fixture SDK scenario — base RED / fixed GREEN as above

## Visual evidence

![Matched before and after Pipe 46 jump](https://gist.githubusercontent.com/tommy-xr/286d8019d24cf4b33e0ef88cfd648e4f/raw/airborne-ladder-before-after.gif)

<sub>Matched headless capture from the same private frontier and fixed-step request sequence: crouched Pipe 46 stage → ordinary +20° jump → north input into authored Ladder 210. Base falls to y=90.34; fixed grips at y=94.35 and climbs to y=95.86. Debug collision outlines expose the geometry in this intentionally dark shaft. The private save was not uploaded.</sub>

### Before → after

![Before and after airborne ladder acquisition with measured trajectory](https://gist.githubusercontent.com/tommy-xr/286d8019d24cf4b33e0ef88cfd648e4f/raw/airborne-ladder-before-after.png)

### Fixed route completion

![Fixed ladder top-out and main tunnel transfer](https://gist.githubusercontent.com/tommy-xr/286d8019d24cf4b33e0ef88cfd648e4f/raw/airborne-ladder-fixed-outcome.png)

<sub>The fixed run reaches real upward WORLD support at y=94.8, then transfers by ordinary movement to the main tunnel at x=169.62 with HP unchanged at 24.</sub>

Fixes #907

<sub>Stacked on #906; #902, #904, and #906 remain unchanged.</sub>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
