### PR TITLE
fix(oculus): pump Android events to prevent ANR

### DIFF
--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -470,6 +470,14 @@ fn main() {
     let mut ready_reported = false;
     let mut session_focused = false;
     'main_loop: loop {
+        // Drain Android's NativeActivity queues. OpenXR is the real input
+        // path - nothing here feeds gameplay - but NativeActivity hands the
+        // app a lifecycle event pipe and an input queue, and leaving them
+        // unconsumed is what makes Horizon OS raise "shock2quest isn't
+        // responding" while the OpenXR session renders happily at 90 Hz.
+        #[cfg(target_os = "android")]
+        android_pump_events();
+
         // println!(
         //     " - Before polling events: {}",
         //     render_time.elapsed().as_secs_f32()
@@ -1008,6 +1016,99 @@ fn create_projection_matrix(fov: &xr::Fovf, near_z: f32, far_z: f32) -> cgmath::
         c0r0, c1r0, c2r0, c3r0, c0r1, c1r1, c2r1, c3r1, c0r2, c1r2, c2r2, c3r2, c0r3, c1r3, c2r3,
         c3r3,
     )
+}
+
+/// Non-blockingly drain the Android lifecycle and input queues once per frame.
+///
+/// This must go through the thread's `ALooper`: `ndk_glue::poll_events()` is a
+/// raw read on the event pipe, and that pipe is left in blocking mode, so
+/// calling it speculatively would park the render thread forever the moment
+/// the queue ran dry. Polling the looper with a zero timeout first tells us
+/// which queue actually has something pending, so every read below is
+/// guaranteed not to block.
+///
+/// Teardown is deliberately *not* driven from here. The OpenXR session state
+/// machine already exits the main loop on EXITING/LOSS_PENDING after a clean
+/// `session.end()`; breaking out on ndk-glue's `Destroy` instead would tear
+/// down GL and XR objects after the activity is already gone, with the session
+/// possibly never ended - strictly worse ordering. `Destroy` is logged and the
+/// drain stops for the frame.
+///
+/// The input events are finished as *unhandled* on purpose: gameplay input
+/// arrives through OpenXR actions, and these only need to be consumed so the
+/// watchdog sees the app servicing its queues. Reporting them unhandled lets
+/// the platform apply its own default handling (e.g. BACK). `pre_dispatch`
+/// must be honored - when it takes the event (IME and friends) it owns it, and
+/// finishing it ourselves would be a double free.
+#[cfg(target_os = "android")]
+fn android_pump_events() {
+    use ndk::looper::{Poll, ThreadLooper};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Upper bound on Android queue events serviced per frame, so a burst can
+    /// never stall the 90 Hz render loop. Leftovers are handled next frame.
+    const MAX_ANDROID_EVENTS_PER_FRAME: u32 = 32;
+
+    static NO_LOOPER_REPORTED: AtomicBool = AtomicBool::new(false);
+
+    let Some(looper) = ThreadLooper::for_thread() else {
+        // No looper on this thread means the pump is inert and the ANR is
+        // back - say so once rather than failing silently.
+        if !NO_LOOPER_REPORTED.swap(true, Ordering::Relaxed) {
+            println!(
+                "android_pump_events: no ALooper for this thread - Android queues are NOT being serviced"
+            );
+        }
+        return;
+    };
+
+    // Bounded so a flooded queue can never starve rendering; anything left
+    // over is picked up on the next frame. A single budget covers both the
+    // outer poll and the inner input drain, so the cap is a real per-frame
+    // event budget rather than just a poll count.
+    let mut budget = MAX_ANDROID_EVENTS_PER_FRAME;
+    while budget > 0 {
+        budget -= 1;
+        match looper.poll_all_timeout(Duration::ZERO) {
+            Ok(Poll::Event { ident, .. }) => match ident {
+                ndk_glue::NDK_GLUE_LOOPER_EVENT_PIPE_IDENT => {
+                    if let Some(event) = ndk_glue::poll_events() {
+                        // Rendering is already governed by the OpenXR session
+                        // state, so the rest of the lifecycle is informational.
+                        if event == ndk_glue::Event::Destroy {
+                            println!("android_pump_events: activity destroyed");
+                            return;
+                        }
+                    }
+                }
+                ndk_glue::NDK_GLUE_LOOPER_INPUT_QUEUE_IDENT => {
+                    if let Some(input_queue) = ndk_glue::input_queue().as_ref() {
+                        while budget > 0 {
+                            let Some(event) = input_queue.get_event() else {
+                                break;
+                            };
+                            budget -= 1;
+                            if let Some(event) = input_queue.pre_dispatch(event) {
+                                input_queue.finish_event(event, false);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
+            // Both queues are empty (Timeout), we were only woken up (Wake),
+            // or the looper ran a callback itself (Callback, which
+            // `poll_all_timeout` never actually yields) - nothing more to
+            // service this frame.
+            Ok(Poll::Timeout) | Ok(Poll::Wake) | Ok(Poll::Callback) => break,
+            Err(e) => {
+                // A permanently failing looper would silently disable the
+                // pump; keep it visible.
+                println!("android_pump_events: looper poll failed: {e:?}");
+                break;
+            }
+        }
+    }
 }
 
 /// Convert a floor-origin STAGE-space position (meters) into the game's pawn


### PR DESCRIPTION
## Problem

Horizon OS periodically raised "shock2quest isn't responding" during normal play on Quest 3,
while the OpenXR session was rendering perfectly at 90 fps.

## Root cause

The Oculus runtime uses ndk-glue's `NativeActivity` entry point, but the main loop only ever
pumped **OpenXR** events. NativeActivity also hands the app two Android-side queues — a
lifecycle event pipe and an input queue — and neither was drained *anywhere* in the crate.
Android's watchdog judges liveness by whether the app services those queues, not by whether
it renders, so it fired while the render loop was entirely healthy.

The confirmed mechanism, from device logcat:

```
am_anr: ... Input dispatching timed out ... Waited 5000ms for KeyEvent
```

— a KeyEvent sitting in an input queue nobody read.

## Fix

Drain both queues once per frame, non-blockingly, at the top of the main loop.

**Why it is looper-gated.** The drain asks the thread's `ALooper` (zero timeout) which queue
has something pending, rather than calling `ndk_glue::poll_events()` speculatively.
`poll_events()` in ndk-glue 0.6.2 is a raw read on the lifecycle pipe, and that pipe is left
in **blocking** mode — calling it with an empty queue would park the render thread forever.
Polling the looper first guarantees every subsequent read has data waiting, so the pump can
never block rendering.

**Per-frame budget.** A single budget of 32 events is shared by the outer looper poll *and*
the inner input-queue drain, so the cap is a genuine bound on work per frame rather than a
poll count that an event burst could walk past. Anything left over is picked up next frame.

**Teardown stays with OpenXR.** The pump does not break the main loop on `Destroy`. The
OpenXR session state machine already exits on `EXITING`/`LOSS_PENDING` after a clean
`session.end()`; unwinding on ndk-glue's `Destroy` instead would tear down GL and XR objects
after the activity is already gone, with the session possibly never ended — strictly worse
ordering. `Destroy` is logged and ends that frame's drain, nothing more.

**Input events are finished as unhandled** — gameplay input comes from OpenXR actions, and
these only need consuming to satisfy the watchdog; reporting them unhandled leaves the
platform's default handling (e.g. BACK) intact. `pre_dispatch` is honored so events the
platform claims are not also finished by us.

A missing thread looper or a failing looper poll is logged instead of silently disabling the
whole pump.

## Verification

- `cargo apk build --release` from `runtimes/oculus_runtime` — clean, zero Rust warnings.
  (Android-only crate, so this is the compile gate.)
- On-device: steady 90 fps with the pump in place; the drain's cost per frame is
  unmeasurable against the frame budget.

Not a visual change, so no pr-visuals capture.

## Scope limitation

This covers **steady state only**. The startup window (`Game::init`, multi-second, runs
before the main loop exists) is still unserviced and can still ANR at launch.

Follow-up: #910
