### PR TITLE
feat(debug): report what the renderer drew via /v1/scene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,15 @@ For debugging visual/rendering changes without a full interactive session:
    curl "http://127.0.0.1:8080/v1/physics/bodies?entity_id=4"
    curl http://127.0.0.1:8080/v1/physics/bodies/12   # detail by body_id
 
+   # Inspect what the renderer actually drew on the last frame: per-object
+   # entity/model, effective transparency, depth-write and backface-culling
+   # winding. Answers "why does this prop look transparent/inside-out?" with
+   # data rather than screenshots. A translucent prop with depth_write=false
+   # came from PropRenderAlpha; with depth_write=true it is the material's own
+   # transparency.
+   curl "http://127.0.0.1:8080/v1/scene?transparent=true"
+   curl "http://127.0.0.1:8080/v1/scene?entity_id=246"
+
    # Inspect impulse joints (ragdoll constraint health): per-joint anchor
    # separation + applied impulse, labeled by skeleton bone. A healthy ball
    # joint at rest has separation ~0 and a small impulse; persistent values mean

--- a/engine/src/scene/basic_material.rs
+++ b/engine/src/scene/basic_material.rs
@@ -251,6 +251,10 @@ where
         };
     }
 
+    fn transparency(&self) -> Option<f32> {
+        Some(self.transparency)
+    }
+
     fn has_initialized(&self) -> bool {
         self.has_initialized
     }

--- a/engine/src/scene/material.rs
+++ b/engine/src/scene/material.rs
@@ -49,4 +49,10 @@ pub trait Material: Any {
     /// reset to its authored value with `None`. Default is a no-op for
     /// materials without transparency support.
     fn set_transparency_override(&mut self, _transparency: Option<f32>) {}
+
+    /// The transparency currently in effect (0.0 = opaque, 1.0 = invisible),
+    /// for debug inspection only. `None` for materials without transparency.
+    fn transparency(&self) -> Option<f32> {
+        None
+    }
 }

--- a/engine/src/scene/mod.rs
+++ b/engine/src/scene/mod.rs
@@ -24,7 +24,7 @@ mod billboard_material;
 pub use billboard_material::*;
 
 pub mod scene_object;
-pub use scene_object::{FrontFaceWinding, SceneObject};
+pub use scene_object::{FrontFaceWinding, SceneObject, SceneObjectDebugTag};
 
 pub mod renderable;
 pub use renderable::{

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -36,6 +36,20 @@ pub enum FrontFaceWinding {
     CounterClockwise,
 }
 
+/// Debug-only provenance for a scene object, so tooling can report *what* the
+/// renderer was handed. Never read by the renderer itself.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SceneObjectDebugTag {
+    /// Runtime entity this object was built for, when it came from one.
+    pub entity_id: Option<u64>,
+    /// The entity's authored name, when it has one.
+    pub name: Option<String>,
+    /// Model the geometry was loaded from (`PropModelName`).
+    pub model: Option<String>,
+    /// Which render path produced the object, e.g. "entity".
+    pub source: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct SceneObject {
     pub material: Rc<RefCell<Box<dyn Material>>>,
@@ -57,6 +71,8 @@ pub struct SceneObject {
     /// Front-face winding used to cull backfaces for this object. Most engine
     /// geometry remains double-sided; imported Dark models opt in explicitly.
     backface_culling: Option<FrontFaceWinding>,
+    /// Debug-only provenance; `Rc` so cloning an object per frame stays cheap.
+    debug_tag: Option<Rc<SceneObjectDebugTag>>,
 }
 
 impl SceneObject {
@@ -232,6 +248,7 @@ impl SceneObject {
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
+            debug_tag: None,
             backface_culling: None,
         }
     }
@@ -362,6 +379,7 @@ impl SceneObject {
             depth_write: true,
             clear_depth: false,
             transparency_override: None,
+            debug_tag: None,
             backface_culling: None,
         }
     }
@@ -376,6 +394,7 @@ impl SceneObject {
             depth_write: self.depth_write,
             clear_depth: self.clear_depth,
             transparency_override: self.transparency_override,
+            debug_tag: self.debug_tag.clone(),
             backface_culling: self.backface_culling,
         }
     }
@@ -390,6 +409,22 @@ impl SceneObject {
 
     pub fn set_backface_culling(&mut self, front_face: Option<FrontFaceWinding>) {
         self.backface_culling = front_face;
+    }
+
+    /// Attach debug provenance (see [`SceneObjectDebugTag`]).
+    pub fn set_debug_tag(&mut self, tag: Option<Rc<SceneObjectDebugTag>>) {
+        self.debug_tag = tag;
+    }
+
+    pub fn debug_tag(&self) -> Option<&SceneObjectDebugTag> {
+        self.debug_tag.as_deref()
+    }
+
+    /// The transparency in effect for this draw: the per-object override when
+    /// set, otherwise the material's own value.
+    pub fn effective_transparency(&self) -> Option<f32> {
+        self.transparency_override
+            .or_else(|| self.material.borrow().transparency())
     }
 
     pub fn backface_culling(&self) -> Option<FrontFaceWinding> {
@@ -454,5 +489,42 @@ mod tests {
         );
 
         assert_eq!(object.backface_culling(), None);
+    }
+
+    #[test]
+    fn scene_objects_are_untagged_until_a_debug_tag_is_attached() {
+        let mut object = SceneObject::new(
+            super::super::color_material::create(vec3(1.0, 1.0, 1.0)),
+            Box::new(super::super::geometry::EmptyMesh),
+        );
+
+        assert_eq!(object.debug_tag(), None);
+
+        let tag = SceneObjectDebugTag {
+            entity_id: Some(246),
+            name: Some("Pistol".to_owned()),
+            model: Some("atek_w".to_owned()),
+            source: Some("entity".to_owned()),
+        };
+        object.set_debug_tag(Some(Rc::new(tag.clone())));
+
+        assert_eq!(object.debug_tag(), Some(&tag));
+        // The tag has to survive the per-frame clone the render path makes.
+        assert_eq!(object.clone().debug_tag(), Some(&tag));
+    }
+
+    #[test]
+    fn a_per_object_override_wins_over_the_shared_material_transparency() {
+        let mut object = SceneObject::new(
+            super::super::color_material::create(vec3(1.0, 1.0, 1.0)),
+            Box::new(super::super::geometry::EmptyMesh),
+        );
+
+        // color_material reports no transparency of its own.
+        assert_eq!(object.effective_transparency(), None);
+
+        object.set_transparency(Some(0.35));
+
+        assert_eq!(object.effective_transparency(), Some(0.35));
     }
 }

--- a/engine/src/scene/skinned_material.rs
+++ b/engine/src/scene/skinned_material.rs
@@ -314,6 +314,10 @@ impl Material for SkinnedMaterial {
         };
     }
 
+    fn transparency(&self) -> Option<f32> {
+        Some(self.transparency)
+    }
+
     fn has_initialized(&self) -> bool {
         self.has_initialized
     }

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -159,6 +159,18 @@ pub enum RuntimeCommand {
         reply: oneshot::Sender<PhysicsBodyListResult>,
     },
 
+    /// Describe the scene objects handed to the renderer on the last drawn
+    /// frame - what is actually being rendered, and with what transparency,
+    /// depth-write and backface-culling state.
+    ListSceneObjects {
+        /// Only objects belonging to this entity id.
+        entity_id: Option<i32>,
+        /// Only objects that are not fully opaque.
+        transparent_only: bool,
+        limit: Option<usize>,
+        reply: oneshot::Sender<SceneListResult>,
+    },
+
     /// Get detailed information about a physics body
     PhysicsBodyDetail {
         id: u32,
@@ -255,6 +267,36 @@ pub struct RayCastResult {
     pub body_id: Option<u32>,
     pub collision_group: Option<String>,
     pub is_sensor: bool,
+}
+
+/// Scene objects submitted on the last rendered frame
+#[derive(Debug, Serialize)]
+pub struct SceneListResult {
+    pub objects: Vec<SceneObjectSummary>,
+    /// Objects in the frame before any filtering.
+    pub total_count: usize,
+    /// Objects matching the filters, before `limit`.
+    pub matched_count: usize,
+    /// Frame index the snapshot came from.
+    pub frame_index: u64,
+}
+
+/// One scene object as submitted to the renderer
+#[derive(Debug, Serialize)]
+pub struct SceneObjectSummary {
+    pub entity_id: Option<u64>,
+    pub name: Option<String>,
+    pub model: Option<String>,
+    /// Render path that produced it, e.g. "entity". Absent for engine-built
+    /// geometry (world, HUD, debug overlays).
+    pub source: Option<String>,
+    pub position: [f32; 3],
+    /// Transparency in effect for this draw (0.0 = opaque, 1.0 = invisible).
+    pub transparency: Option<f32>,
+    pub depth_write: bool,
+    pub clear_depth: bool,
+    /// Front-face winding used for culling, or absent when double-sided.
+    pub backface_culling: Option<String>,
 }
 
 /// List of physics rigid bodies

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -305,6 +305,7 @@ async fn start_http_server(
         .route("/v1/player/spawn-item", axum::routing::post(spawn_item))
         .route("/v1/player/stats", axum::routing::post(set_player_stats))
         .route("/v1/physics/raycast", axum::routing::post(perform_raycast))
+        .route("/v1/scene", get(list_scene_objects))
         .route("/v1/physics/bodies", get(list_physics_bodies))
         .route("/v1/physics/bodies/:id", get(get_physics_body_detail))
         .route("/v1/physics/joints", get(list_physics_joints))
@@ -502,6 +503,10 @@ fn run_game_blocking(
     let mut accumulated_time = 0.0f32;
     let mut shutdown_requested = false;
     let mut frame_counter = 0u64;
+    // Snapshot of the objects submitted to the renderer on the last drawn
+    // frame, served by `/v1/scene`.
+    let mut last_scene: Vec<commands::SceneObjectSummary> = Vec::new();
+    let mut last_scene_frame = 0u64;
     let mut frames_to_step = 0u32;
     let mut target_step_time: Option<f32> = None;
     let mut action_state = InputActionState::new();
@@ -645,6 +650,8 @@ fn run_game_blocking(
                         frame_counter,
                         &mut action_state,
                         &mut current_input,
+                        &last_scene,
+                        last_scene_frame,
                     );
                 }
             }
@@ -820,6 +827,10 @@ fn run_game_blocking(
         // Combine scene objects
         scene.extend(per_eye_scene);
 
+        // Snapshot what the renderer is about to be handed, for `/v1/scene`.
+        last_scene = summarize_scene(&scene);
+        last_scene_frame = frame_counter;
+
         // Create the final scene for rendering
         let mut scene_for_render = Scene::from_objects(scene);
 
@@ -863,6 +874,28 @@ fn run_game_blocking(
 }
 
 /// Process a command from the HTTP server
+/// Describe the scene objects submitted to the renderer, for `/v1/scene`.
+fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneObjectSummary> {
+    scene
+        .iter()
+        .map(|obj| {
+            let tag = obj.debug_tag();
+            let translation = obj.get_transform().w;
+            commands::SceneObjectSummary {
+                entity_id: tag.and_then(|t| t.entity_id),
+                name: tag.and_then(|t| t.name.clone()),
+                model: tag.and_then(|t| t.model.clone()),
+                source: tag.and_then(|t| t.source.clone()),
+                position: [translation.x, translation.y, translation.z],
+                transparency: obj.effective_transparency(),
+                depth_write: obj.depth_write,
+                clear_depth: obj.clear_depth,
+                backface_culling: obj.backface_culling().map(|w| format!("{w:?}")),
+            }
+        })
+        .collect()
+}
+
 fn process_command(
     command: RuntimeCommand,
     game: &mut Game,
@@ -870,6 +903,8 @@ fn process_command(
     frame_counter: u64,
     action_state: &mut InputActionState,
     current_input: &mut InputContext,
+    last_scene: &[commands::SceneObjectSummary],
+    last_scene_frame: u64,
 ) {
     match command {
         RuntimeCommand::GetInfo(reply) => {
@@ -1523,6 +1558,47 @@ fn process_command(
                 if let Err(_) = reply.send(result) {
                     tracing::warn!("No debug scene available for physics body listing");
                 }
+            }
+        }
+        RuntimeCommand::ListSceneObjects {
+            entity_id,
+            transparent_only,
+            limit,
+            reply,
+        } => {
+            let total_count = last_scene.len();
+            let matched: Vec<&commands::SceneObjectSummary> = last_scene
+                .iter()
+                .filter(|o| match entity_id {
+                    Some(id) => o.entity_id == Some(id as u64),
+                    None => true,
+                })
+                .filter(|o| !transparent_only || o.transparency.is_some_and(|t| t > 0.0))
+                .collect();
+            let matched_count = matched.len();
+            let objects = matched
+                .into_iter()
+                .take(limit.unwrap_or(usize::MAX))
+                .map(|o| commands::SceneObjectSummary {
+                    entity_id: o.entity_id,
+                    name: o.name.clone(),
+                    model: o.model.clone(),
+                    source: o.source.clone(),
+                    position: o.position,
+                    transparency: o.transparency,
+                    depth_write: o.depth_write,
+                    clear_depth: o.clear_depth,
+                    backface_culling: o.backface_culling.clone(),
+                })
+                .collect();
+            let result = commands::SceneListResult {
+                objects,
+                total_count,
+                matched_count,
+                frame_index: last_scene_frame,
+            };
+            if let Err(_) = reply.send(result) {
+                tracing::warn!("Failed to send scene list - receiver dropped");
             }
         }
         RuntimeCommand::PhysicsBodyDetail { id, reply } => {
@@ -3016,6 +3092,51 @@ async fn perform_raycast(
 }
 
 /// Query parameters for physics body listing
+#[derive(Deserialize)]
+struct SceneQueryParams {
+    limit: Option<usize>,
+    /// Only objects belonging to this entity id.
+    entity_id: Option<i32>,
+    /// Only objects that are not fully opaque.
+    transparent: Option<bool>,
+}
+
+/// HTTP handler describing what the renderer drew on the last frame
+async fn list_scene_objects(
+    State(command_tx): State<mpsc::UnboundedSender<RuntimeCommand>>,
+    Query(params): Query<SceneQueryParams>,
+) -> Json<commands::SceneListResult> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    let empty = || commands::SceneListResult {
+        objects: vec![],
+        total_count: 0,
+        matched_count: 0,
+        frame_index: 0,
+    };
+
+    if command_tx
+        .send(RuntimeCommand::ListSceneObjects {
+            entity_id: params.entity_id,
+            transparent_only: params.transparent.unwrap_or(false),
+            limit: params.limit,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        tracing::error!("Failed to send ListSceneObjects command - game loop receiver dropped");
+        return Json(empty());
+    }
+
+    match reply_rx.await {
+        Ok(result) => Json(result),
+        Err(_) => {
+            tracing::error!("Failed to receive scene list - sender dropped");
+            Json(empty())
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct PhysicsBodyQueryParams {
     limit: Option<usize>,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5641,6 +5641,13 @@ impl MissionCore {
             .world
             .borrow::<View<dark::properties::PropRenderAlpha>>()
             .unwrap();
+        // Debug-only provenance, so tooling can report which entity/model each
+        // rendered object came from.
+        let v_model_name = self.world.borrow::<View<PropModelName>>().unwrap();
+        let v_sym_name = self
+            .world
+            .borrow::<View<dark::properties::PropSymName>>()
+            .unwrap();
         let v_joint_transforms = self
             .world
             .borrow::<View<RuntimePropJointTransforms>>()
@@ -5720,10 +5727,18 @@ impl MissionCore {
                 .map(|a| a.0.clamp(0.0, 1.0))
                 .filter(|a| *a < 1.0);
 
+            let debug_tag = Rc::new(engine::scene::SceneObjectDebugTag {
+                entity_id: Some(entity_id.inner()),
+                name: v_sym_name.get(*entity_id).ok().map(|n| n.0.clone()),
+                model: v_model_name.get(*entity_id).ok().map(|m| m.0.clone()),
+                source: Some("entity".to_owned()),
+            });
+
             if let Ok(xform) = v_transform.get(*entity_id).map(|p| p.0) {
                 for obj in scene_objs {
                     let mut xformed_obj = obj.clone();
                     xformed_obj.set_transform(xform);
+                    xformed_obj.set_debug_tag(Some(debug_tag.clone()));
                     if options.debug_skeletons && is_animated_model {
                         xformed_obj.set_depth_write(false);
                         xformed_obj.set_skinned_transparency(Some(0.35));


### PR DESCRIPTION
## Summary

Adds a scene-inspection endpoint to the debug runtime, so rendering questions ("why does this prop look transparent?") can be answered with **data** instead of by reading screenshots — which also makes them scriptable, e.g. as a `git bisect run` predicate.

`GET /v1/scene` describes every `SceneObject` submitted on the last drawn frame — the world pass **and** the per-eye/viewmodel pass, so the flat viewmodel is covered:

```
GET /v1/scene?transparent=true
{"objects":[
  {"entity_id":56,"name":"UBWin_4x8_thin","model":"wnd_48u",
   "source":"entity","position":[10.2,2.1,-10.4],
   "transparency":0.55,"depth_write":false,"clear_depth":false,
   "backface_culling":"Clockwise"}],
 "total_count":291,"matched_count":3,"frame_index":30}
```

Filters: `?entity_id=`, `?transparent=true`, `?limit=`.

The output **discriminates the two ways a prop can go translucent**, which is the diagnostically useful part:

- `depth_write: false` ⇒ `PropRenderAlpha` (the render path also disables depth-write for it)
- `depth_write: true` ⇒ the material's own transparency

## Design

To carry identity into the renderer, `SceneObject` gains an optional debug-only `SceneObjectDebugTag` (entity id, name, model, source), set in `mission_core`'s render loop where the entity is in scope. It is held behind an `Rc` so the per-frame `clone()` in that loop stays cheap, and **nothing in the render path reads it**.

`Material` also gains a defaulted `transparency()` getter so the endpoint can report the material's own value, and `SceneObject::effective_transparency()` resolves the per-object override against it.

Geometry has no triangle count to report — `Geometry` is a one-method `draw()` trait, and widening it would touch every implementation for no diagnostic gain here.

## Verification

- `cargo test -p engine --lib` (36, including 3 new), `-p dark --lib` (88), `-p shock2vr --lib` (553)
- `cd tools/shock2-sdk && SHOCK2_E2E=1 npx tsx --test test/missions.e2e.test.ts` — **23/23 missions load**
- `cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- On `earth.mis`: 291 objects, 168 tagged entities culled `Clockwise`, 3 translucent — two windows (α 0.55, depth-write off ⇒ `RenderAlpha`) and a tramcar (α 0.3, depth-write on ⇒ material). All legitimate.

No visual change — this is inspection-only, so there is nothing for pr-visuals to capture.

Used in anger immediately: it is how the `.mtl` regression in the sibling PR was scoped and confirmed.