### PR TITLE
fix(rendering): only take a .mtl redirect from a base pass

### DIFF
--- a/dark/src/util/mod.rs
+++ b/dark/src/util/mod.rs
@@ -103,13 +103,12 @@ fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) ->
 /// and reach their real diffuse through an `include` (not yet followed - see
 /// #912); treating such an overlay as the diffuse renders the object with its
 /// spec map and can make it disappear. Passes that cannot be a base pass are
-/// skipped, and `$TEXTURE` means the model keeps its authored texture.
+/// skipped, and `$TEXTURE` in a base pass means the model keeps its authored
+/// texture.
 fn primary_render_pass_texture(script: &str) -> Option<String> {
-    let mut in_render_pass = false;
+    let mut pass: Option<RenderPassFields> = None;
     let mut brace_depth = 0_i32;
     let mut saw_open_brace = false;
-    let mut pass_texture: Option<String> = None;
-    let mut pass_is_base = true;
 
     for raw_line in script.lines() {
         let line = raw_line
@@ -120,39 +119,36 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
             continue;
         }
 
-        if !in_render_pass {
-            if !line
-                .split_whitespace()
-                .next()
-                .is_some_and(|directive| directive.eq_ignore_ascii_case("render_pass"))
-            {
-                continue;
-            }
-            in_render_pass = true;
-            saw_open_brace = false;
+        let mut fields = line.split_whitespace();
+        let directive = fields.next().unwrap_or_default();
+
+        // Reset on every `render_pass`, so an unterminated block cannot bleed
+        // its fields into the next pass.
+        if directive.eq_ignore_ascii_case("render_pass") {
+            pass = Some(RenderPassFields::default());
             brace_depth = 0;
-            pass_texture = None;
-            pass_is_base = true;
+            saw_open_brace = false;
         }
 
-        let mut fields = line.split_whitespace();
-        match fields.next() {
-            Some(field) if field.eq_ignore_ascii_case("texture") => {
-                let texture = fields.next()?.trim_matches('"');
-                if texture.eq_ignore_ascii_case("$texture") {
-                    // The material asks for the model's own texture, so there
-                    // is nothing to redirect - and no later pass overrides that.
-                    return None;
+        if let Some(fields_so_far) = pass.as_mut() {
+            if directive.eq_ignore_ascii_case("texture") {
+                match fields.next().map(|texture| texture.trim_matches('"')) {
+                    // `$TEXTURE` is the model's own texture, i.e. no redirect.
+                    Some(texture) if texture.eq_ignore_ascii_case("$texture") => {
+                        fields_so_far.keeps_authored_texture = true;
+                    }
+                    // The first `texture` is the diffuse; later ones are
+                    // additional stages of the same pass.
+                    Some(texture) if fields_so_far.texture.is_none() => {
+                        fields_so_far.texture = Some(texture.to_owned());
+                    }
+                    _ => {}
                 }
-                pass_texture = Some(texture.to_owned());
+            } else if directive.eq_ignore_ascii_case("blend") {
+                let source = fields.next();
+                let destination = fields.next();
+                fields_so_far.blend_is_base = Some(blend_is_base(source, destination));
             }
-            Some(field) if field.eq_ignore_ascii_case("blend") => {
-                // `blend <source> <destination>`; the destination factor is
-                // what distinguishes a base pass from an overlay.
-                let _source_factor = fields.next();
-                pass_is_base = is_base_pass_blend(fields.next());
-            }
-            _ => {}
         }
 
         brace_depth += line.chars().filter(|character| *character == '{').count() as i32;
@@ -162,26 +158,56 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
         brace_depth -= line.chars().filter(|character| *character == '}').count() as i32;
 
         if saw_open_brace && brace_depth <= 0 {
-            if pass_is_base {
-                if let Some(texture) = pass_texture.take() {
-                    return normalize_material_texture_reference(&texture);
+            if let Some(fields_so_far) = pass.take() {
+                // A pass with no `blend` directive draws normally.
+                if fields_so_far.blend_is_base.unwrap_or(true) {
+                    if fields_so_far.keeps_authored_texture {
+                        return None;
+                    }
+                    if let Some(texture) = fields_so_far.texture.as_deref() {
+                        return normalize_material_texture_reference(texture);
+                    }
                 }
+                // An overlay, or a base pass naming no texture: keep looking.
             }
-            // Not a base pass (or carried no texture): keep looking.
-            in_render_pass = false;
+            saw_open_brace = false;
         }
     }
 
     None
 }
 
-/// Whether a `blend <src> <dst>` destination factor describes a base pass.
+/// The fields of one `render_pass` block that texture selection depends on.
+#[derive(Default)]
+struct RenderPassFields {
+    /// The first `texture` directive in the pass.
+    texture: Option<String>,
+    /// The pass names `$TEXTURE` - the model's own texture.
+    keeps_authored_texture: bool,
+    /// `None` when the pass carries no `blend` directive at all.
+    blend_is_base: Option<bool>,
+}
+
+/// Whether a `blend <source> <destination>` pair describes a base pass - one
+/// that can carry the diffuse - rather than an overlay composited onto an
+/// earlier pass.
 ///
-/// Ordinary alpha blending (`INV_SRC_ALPHA`) replaces what is underneath and so
-/// can carry the diffuse. Additive (`ONE`) and modulate (`ZERO`) destinations
-/// composite *onto* an earlier pass, which makes them overlays.
-fn is_base_pass_blend(destination_factor: Option<&str>) -> bool {
-    destination_factor.is_none_or(|factor| factor.eq_ignore_ascii_case("INV_SRC_ALPHA"))
+/// Ordinary alpha blending (`SRC_ALPHA INV_SRC_ALPHA`) and plain opaque replace
+/// (`ONE ZERO`) are base passes. Additive destinations (`ONE`) accumulate onto
+/// what is already drawn, and any factor reading the destination colour
+/// modulates it, so both are overlays.
+fn blend_is_base(source: Option<&str>, destination: Option<&str>) -> bool {
+    // A `blend` directive we cannot read is assumed to composite: guessing
+    // "base" here would reinstate exactly the bug this selection prevents.
+    let (Some(source), Some(destination)) = (source, destination) else {
+        return false;
+    };
+
+    if source.eq_ignore_ascii_case("DST_COLOR") || source.eq_ignore_ascii_case("INV_DST_COLOR") {
+        return false;
+    }
+
+    destination.eq_ignore_ascii_case("INV_SRC_ALPHA") || destination.eq_ignore_ascii_case("ZERO")
 }
 
 fn normalize_material_texture_reference(reference: &str) -> Option<String> {
@@ -463,6 +489,102 @@ render_pass
         assert_eq!(
             resolve_object_material_texture_name(&asset_cache, "SCREEN"),
             Some("txt16/screen_2.dds".to_owned())
+        );
+    }
+
+    /// `ONE ZERO` is plain opaque replace - the most base-like blend there is.
+    /// Rejecting it as a "modulate" overlay confuses the destination factor
+    /// with `DST_COLOR ZERO`.
+    #[test]
+    fn object_material_accepts_an_opaque_replace_pass() {
+        let asset_cache = cache(&[
+            (
+                "txt16/panel.mtl",
+                b"render_pass\n{\n blend ONE ZERO\n texture OBJ\\TXT16\\panel_2\n}\n",
+            ),
+            ("txt16/panel.dds", b"placeholder"),
+            ("txt16/panel_2.dds", b"real panel"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/panel_2.dds".to_owned())
+        );
+    }
+
+    /// Within one pass the first `texture` is the diffuse; later ones are
+    /// additional stages and must not override it.
+    #[test]
+    fn object_material_takes_the_first_texture_stage_of_a_pass() {
+        let asset_cache = cache(&[
+            (
+                "txt16/panel.mtl",
+                b"render_pass\n{\n texture OBJ\\TXT16\\diffuse\n texture OBJ\\TXT16\\lightmap\n}\n",
+            ),
+            ("txt16/panel.dds", b"placeholder"),
+            ("txt16/diffuse.dds", b"diffuse"),
+            ("txt16/lightmap.dds", b"lightmap"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/diffuse.dds".to_owned())
+        );
+    }
+
+    /// A `blend` we cannot read must not be optimistically treated as a base
+    /// pass - that would reinstate the overlay-as-diffuse bug.
+    #[test]
+    fn object_material_treats_an_unreadable_blend_as_an_overlay() {
+        let asset_cache = cache(&[
+            (
+                "txt16/panel.mtl",
+                b"render_pass\n{\n blend add\n texture OBJ\\TXT16\\glow\n}\n",
+            ),
+            ("txt16/panel.dds", b"diffuse"),
+            ("txt16/glow.dds", b"glow"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/panel.dds".to_owned())
+        );
+    }
+
+    /// One truncated directive must not discard every later pass.
+    #[test]
+    fn object_material_survives_a_malformed_texture_directive() {
+        let asset_cache = cache(&[
+            (
+                "txt16/screen.mtl",
+                b"render_pass\n{\n texture\n}\nrender_pass\n{\n texture OBJ\\TXT16\\screen_2\n}\n",
+            ),
+            ("txt16/screen.dds", b"placeholder"),
+            ("txt16/screen_2.dds", b"real screen"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "SCREEN"),
+            Some("txt16/screen_2.dds".to_owned())
+        );
+    }
+
+    /// An unterminated block must not bleed its fields into the next pass.
+    #[test]
+    fn object_material_does_not_merge_an_unterminated_pass_into_the_next() {
+        let asset_cache = cache(&[
+            (
+                "txt16/screen.mtl",
+                b"render_pass\n texture OBJ\\TXT16\\orphan\nrender_pass\n{\n blend SRC_ALPHA ONE\n texture OBJ\\TXT16\\glow\n}\n",
+            ),
+            ("txt16/screen.dds", b"authored"),
+            ("txt16/orphan.dds", b"orphan"),
+            ("txt16/glow.dds", b"glow"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "SCREEN"),
+            Some("txt16/screen.dds".to_owned())
         );
     }
 

--- a/dark/src/util/mod.rs
+++ b/dark/src/util/mod.rs
@@ -95,10 +95,21 @@ fn object_material_primary_texture(asset_cache: &AssetCache, requested: &str) ->
     Some(texture)
 }
 
+/// Find the texture a render-material script substitutes for the model's own
+/// diffuse, if any.
+///
+/// Only a *base* pass can supply the diffuse. 25AE materials routinely open
+/// with an additive shine or modulate overlay whose texture is a specular map,
+/// and reach their real diffuse through an `include` (not yet followed - see
+/// #912); treating such an overlay as the diffuse renders the object with its
+/// spec map and can make it disappear. Passes that cannot be a base pass are
+/// skipped, and `$TEXTURE` means the model keeps its authored texture.
 fn primary_render_pass_texture(script: &str) -> Option<String> {
     let mut in_render_pass = false;
-    let mut saw_open_brace = false;
     let mut brace_depth = 0_i32;
+    let mut saw_open_brace = false;
+    let mut pass_texture: Option<String> = None;
+    let mut pass_is_base = true;
 
     for raw_line in script.lines() {
         let line = raw_line
@@ -110,23 +121,38 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
         }
 
         if !in_render_pass {
-            let directive = line.split_whitespace().next()?;
-            if !directive.eq_ignore_ascii_case("render_pass") {
+            if !line
+                .split_whitespace()
+                .next()
+                .is_some_and(|directive| directive.eq_ignore_ascii_case("render_pass"))
+            {
                 continue;
             }
             in_render_pass = true;
+            saw_open_brace = false;
+            brace_depth = 0;
+            pass_texture = None;
+            pass_is_base = true;
         }
 
         let mut fields = line.split_whitespace();
-        if fields
-            .next()
-            .is_some_and(|field| field.eq_ignore_ascii_case("texture"))
-        {
-            let texture = fields.next()?.trim_matches('"');
-            if texture.eq_ignore_ascii_case("$texture") {
-                return None;
+        match fields.next() {
+            Some(field) if field.eq_ignore_ascii_case("texture") => {
+                let texture = fields.next()?.trim_matches('"');
+                if texture.eq_ignore_ascii_case("$texture") {
+                    // The material asks for the model's own texture, so there
+                    // is nothing to redirect - and no later pass overrides that.
+                    return None;
+                }
+                pass_texture = Some(texture.to_owned());
             }
-            return normalize_material_texture_reference(texture);
+            Some(field) if field.eq_ignore_ascii_case("blend") => {
+                // `blend <source> <destination>`; the destination factor is
+                // what distinguishes a base pass from an overlay.
+                let _source_factor = fields.next();
+                pass_is_base = is_base_pass_blend(fields.next());
+            }
+            _ => {}
         }
 
         brace_depth += line.chars().filter(|character| *character == '{').count() as i32;
@@ -134,12 +160,28 @@ fn primary_render_pass_texture(script: &str) -> Option<String> {
             saw_open_brace = true;
         }
         brace_depth -= line.chars().filter(|character| *character == '}').count() as i32;
+
         if saw_open_brace && brace_depth <= 0 {
-            return None;
+            if pass_is_base {
+                if let Some(texture) = pass_texture.take() {
+                    return normalize_material_texture_reference(&texture);
+                }
+            }
+            // Not a base pass (or carried no texture): keep looking.
+            in_render_pass = false;
         }
     }
 
     None
+}
+
+/// Whether a `blend <src> <dst>` destination factor describes a base pass.
+///
+/// Ordinary alpha blending (`INV_SRC_ALPHA`) replaces what is underneath and so
+/// can carry the diffuse. Additive (`ONE`) and modulate (`ZERO`) destinations
+/// composite *onto* an earlier pass, which makes them overlays.
+fn is_base_pass_blend(destination_factor: Option<&str>) -> bool {
+    destination_factor.is_none_or(|factor| factor.eq_ignore_ascii_case("INV_SRC_ALPHA"))
 }
 
 fn normalize_material_texture_reference(reference: &str) -> Option<String> {
@@ -339,6 +381,88 @@ mod tests {
         assert_eq!(
             resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
             Some("txt16/panel.dds".to_owned())
+        );
+    }
+
+    /// 25AE viewmodel materials open with an *additive* shine overlay whose
+    /// texture is the specular map (`ND-atek.mtl` is the pistol); the diffuse
+    /// pass arrives through an `include`. Taking that overlay as the diffuse
+    /// swapped the pistol's base texture for its spec map and rendered it
+    /// see-through.
+    #[test]
+    fn object_material_ignores_an_additive_overlay_pass() {
+        let asset_cache = cache(&[
+            (
+                "txt16/nd-atek.mtl",
+                b"include ../../materials/ND-viewmodel.inc
+render_pass
+{
+ blend SRC_ALPHA ONE
+ texture obj/txt16/nd-atek_S
+ shaded 1
+}
+",
+            ),
+            ("txt16/nd-atek.dds", b"diffuse"),
+            ("txt16/nd-atek_s.dds", b"specular map"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "ND-atek"),
+            Some("txt16/nd-atek.dds".to_owned())
+        );
+    }
+
+    /// `blend DST_COLOR ZERO` modulates what is already in the framebuffer, so
+    /// it is an overlay too.
+    #[test]
+    fn object_material_ignores_a_modulate_overlay_pass() {
+        let asset_cache = cache(&[
+            (
+                "txt16/panel.mtl",
+                b"render_pass
+{
+ blend DST_COLOR ZERO
+ texture OBJ\\TXT16\\shine
+}
+",
+            ),
+            ("txt16/panel.dds", b"diffuse"),
+            ("txt16/shine.dds", b"shine"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "PANEL.PCX"),
+            Some("txt16/panel.dds".to_owned())
+        );
+    }
+
+    /// An overlay first, then a real base pass: the base pass wins.
+    #[test]
+    fn object_material_takes_the_first_base_pass_after_an_overlay() {
+        let asset_cache = cache(&[
+            (
+                "txt16/screen.mtl",
+                b"render_pass
+{
+ blend SRC_ALPHA ONE
+ texture OBJ\\TXT16\\glow
+}
+render_pass
+{
+ blend SRC_ALPHA INV_SRC_ALPHA
+ texture OBJ\\TXT16\\screen_2
+}
+",
+            ),
+            ("txt16/screen.dds", b"placeholder"),
+            ("txt16/glow.dds", b"glow"),
+            ("txt16/screen_2.dds", b"real screen"),
+        ]);
+
+        assert_eq!(
+            resolve_object_material_texture_name(&asset_cache, "SCREEN"),
+            Some("txt16/screen_2.dds".to_owned())
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the "the gun went transparent" regression with 25th Anniversary assets. Bisected to `6a2af26` (#841).

#841 taught the object loader to honor a `.mtl` render-material script by using the texture named in its **first `render_pass`** as the model's diffuse. That heuristic misreads the Nightdive/25AE material system, where the first *literal* pass in a material file is frequently an overlay and the real diffuse arrives through an `include`.

## Root cause

`obj/txt16/ND-atek.mtl` — the pistol — is the clearest case. Its only active pass is an additive fresnel shine:

```
include ../../materials/ND-viewmodel.inc

render_pass
{
	blend SRC_ALPHA ONE          // additive overlay
	texture obj/txt16/nd-atek_S  // the SPECULAR map
	alpha func INCIDENCE 1.0 1.0 MATERIALS/ND-IR_SHINE
}
```

So we adopted `nd-atek_S` — the specular map — as the diffuse. The EE `atek_w.bin` has exactly **one** material slot (`ND-atek.psd`), so the *entire* gun was textured with its spec map, and read as transparent: either through that map's mask alpha (it is BC7, with alpha), or through the `dropping mesh slot {slot}` path when the DX10/BC7 decode fails, which drops the geometry outright. `atek_h.bin` slot 4 is the same material, so the viewmodel was affected too.

The real diffuse is reached via the include chain, `materials/ND-viewmodel.inc` → `materials/pass/ND-pass_dif.inc`:

```
// Diffuse
render_pass
{
	blend SRC_ALPHA INV_SRC_ALPHA
	texture $TEXTURE
	shaded 1
}
```

Note `$TEXTURE`: the diffuse pass uses **the model's own texture**, i.e. for this material there is no redirect at all.

## The fix

Scan passes in order and only take a redirect from a pass that can actually carry the diffuse: blend absent, or a destination factor of `INV_SRC_ALPHA`. Additive (`ONE`) and modulate (`ZERO`) destinations composite *onto* an earlier pass, so they are overlays and can never be the base texture. `$TEXTURE` still means "keep the authored texture" and stops the search.

This is the tactical fix. Following `include` and modelling passes as real render state is **#912**.

## Blast radius

Measured by running the patched selection logic over **all 2,274 `.mtl` files** in a 25AE install (`sshock2ee` / `400` / `shtup` / `scp` / `patch_ext`):

| | before | after |
|---|---|---|
| materials redirected to a `*_S` specular map | **21** | **0** |
| legitimate base-pass redirects preserved | 9 | 9 |

The 21 include the pistol, the grub, the player model, the protocol droid, apes and bots — consistent with the stray transparent props reported alongside the gun. The 9 legitimate redirects still resolve (`nd-airlock_scr` → `ND-airlock_2`, `nd-hyd_gls` → `ND-hydroD`, `nd-phone_gl` → `ND-phone`, …), which is exactly what #841 was built for and is covered by its existing test.

## Verification

- **Negative-first**: the three new tests fail on the parent commit — `object_material_ignores_an_additive_overlay_pass` reproduces the pistol directly — and pass here.
- `object_material_takes_the_first_base_pass_after_an_overlay` caught a real bug in the first cut of this fix, which read the blend **source** factor instead of the destination.
- `cargo test -p dark --lib` (91)
- `cd tools/shock2-sdk && SHOCK2_E2E=1 npx tsx --test test/missions.e2e.test.ts` — **23/23 missions load** (the safety net that matters here, since this changes texture resolution)
- `cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`

## Visuals — owed

Per AGENTS.md this is a visual change and should carry a before/after. I could not stage the shot headlessly: the `earth.mis` training pistol (mission object 246) is never submitted to the renderer from a cold load even when standing beside it — it appears to be spawned by the tutorial sequence — and `debug_weapons` starts with no weapon equipped. The static evidence above is conclusive on the mechanism, but a before/after capture on a 25AE data root is still wanted before merge.



## Cross-engine review (`/xreview`)

Reviewed by a Claude subagent and Codex independently, plus a dedicated de-duplication pass. **No Critical or High findings.** Six robustness defects were found and fixed in `49dfa3e`; two were raised by *both* engines:

| Finding | Engines |
|---|---|
| `blend ONE ZERO` (opaque replace) rejected as an overlay — confused with modulate (`DST_COLOR ZERO`) | Claude (Med) |
| Within one pass the *last* `texture` won; the first stage is the diffuse | Claude (Med) |
| An unreadable `blend` was optimistically treated as a base pass, reinstating this bug | **both** (Med) |
| One truncated `texture` line aborted the whole scan via `?` | **both** (Low) |
| An unterminated block bled its fields into the next pass | Claude (Low) |
| `$TEXTURE` in an *overlay* pass aborted the scan | Claude (Low) |

Pass fields are now gathered into a small `RenderPassFields` struct and judged when the block closes, which is what made the ordering and reset bugs visible.

**A reviewer hypothesis I checked and rejected:** both the original PR text and the review noted 3 redirects disappeared (12 → 9), and `ONE ZERO` was the suspected cause. Verified against the corpus — it explains none of it, and changes nothing on shipped data. The dropped redirects resolve to `def_cubemap`, `med_cubemap` and `ND-TRAMCAR` on windows and bottles: environment reflection maps on glass, i.e. overlays, correctly dropped. `ONE ZERO` was fixed regardless, because rejecting an opaque pass is wrong on its own terms.

De-duplication pass: **no actionable duplication** — this is the repo's only `.mtl` parser, and there is no existing blend-mode type to reuse (the engine has a single hardcoded `gl::BlendFunc`).

Re-validated after the fixes: **5 new regression tests** (dark unit tests 91 → 96), the corpus re-run is byte-identical to before the fixes (9 redirects, 0 specular), and **23/23 missions still load**.