### PR TITLE
fix(rendering): lift decals off the surface they z-fight with

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -474,6 +474,19 @@ impl Model {
         }
     }
 
+    /// Set a model-space transform applied *inside* the entity transform. The
+    /// render path re-sets the entity (world) transform every frame; the local
+    /// one rides along with the model.
+    pub fn set_local_transform(&mut self, local_transform: Matrix4<f32>) {
+        let scene_objects = match &mut self.inner {
+            InnerModel::Static(static_model) => &mut static_model.scene_objects,
+            InnerModel::Animated(animated_model) => &mut animated_model.scene_objects,
+        };
+        for obj in scene_objects {
+            obj.set_local_transform(local_transform);
+        }
+    }
+
     pub fn transform(model: &Model, transform: Matrix4<f32>) -> Model {
         match &model.inner {
             InnerModel::Static(static_model) => Model {

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -465,6 +465,40 @@ fn initialize_sym_name_from_obj_map(
     }
 }
 
+/// How far a decal is pushed off the surface it is stuck to, in model-local
+/// units (1 world unit = `SCALE_FACTOR` Dark units). Small enough not to read
+/// as floating at grazing angles, large enough to clear depth-buffer precision
+/// at the ranges decals are legible from.
+const DECAL_SURFACE_OFFSET: f32 = 0.02;
+
+/// Decals (blood splatters, signs, bullet holes) are paper-thin models placed
+/// exactly coplanar with the surface they are stuck to, so they z-fight with
+/// the level geometry - they flicker, or vanish entirely, as the viewpoint
+/// moves. Lift such a model off its surface along its own outward normal.
+///
+/// A decal model has (near-)zero thickness along its local X axis (Dark's
+/// forward) and its visible face points along local -X, i.e. out of the wall.
+/// The offset is applied as the scene objects' *local* transform: the render
+/// path overwrites the model transform with the entity's
+/// `RuntimePropTransform` every frame, but composes it with the local one.
+fn apply_decal_offset(model: &mut Model) {
+    let Some(bbox) = model.bounding_box() else {
+        return;
+    };
+
+    let thickness = bbox.max.x - bbox.min.x;
+    let extent = (bbox.max.y - bbox.min.y).max(bbox.max.z - bbox.min.z);
+    if extent <= 0.0 || thickness > extent * 0.01 {
+        return;
+    }
+
+    model.set_local_transform(Matrix4::from_translation(vec3(
+        -DECAL_SURFACE_OFFSET,
+        0.0,
+        0.0,
+    )));
+}
+
 fn create_model(
     world: &mut World,
     asset_cache: &mut AssetCache,
@@ -529,7 +563,7 @@ fn create_model(
         // Runtime-generated terminal death poses are separate from authored
         // P$CretPose data, so mission-placed corpse decorations retain their
         // historical frame-1 bake and physics behavior.
-        let (model, animation_player) = {
+        let (mut model, animation_player) = {
             if let Ok(death_pose) = v_death_pose.get(entity_id) {
                 let animation_clip = asset_cache.get(
                     &ANIMATION_CLIP_IMPORTER,
@@ -581,6 +615,8 @@ fn create_model(
                 (transformed_model, None)
             }
         };
+
+        apply_decal_offset(&mut model);
 
         Some((model, animation_player))
     } else {


### PR DESCRIPTION
## Problem

Decals (blood splatters, signs, bullet holes) flicker and drop out as the viewpoint moves — reported in both desktop and VR, easiest to see on the medsci1 opening blood scene.

They are ordinary models, just paper-thin: `BLOOD02.BIN`'s bbox is `x ∈ ±2e-6`, `y,z ∈ ±3`. Zero thickness along local X, which is therefore the surface normal, and they are authored *exactly* coplanar with the wall/floor they sit on. Hence the z-fight.

`create_model` had a hack meant to prevent this:

```rust
// HACK: Move decals up slightly, to avoid z-fighting with level geometry...
let forward = qrotation.rotate_vector(vec3(0.0, 0.1, 0.0));
```

Two problems:

1. **Wrong axis.** Local Y lies *in* the decal plane — it slid the decal sideways and left it coplanar. (Checked against a real medsci1 floor splatter: its `localX` is `(0,-1,0)`, straight down, i.e. the floor normal; `localY` is horizontal.)
2. **Inert anyway.** The render loop overwrites the model transform with the entity's `RuntimePropTransform` every frame, so the baked offset never reached the screen — deleting the hack outright produced a byte-identical frame.


![decal z-fighting before/after](https://gist.githubusercontent.com/tommy-xr/a58d5cec2565561a7da239e539802743/raw/decal-zfight.gif)

<sub>medsci1 opening blood scene, same 10 camera positions on each side (4cm of camera creep, ping-ponged). Left: the splatter is eaten away and the holes churn as the camera moves. Right: solid and stable. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before/after still](https://gist.githubusercontent.com/tommy-xr/a58d5cec2565561a7da239e539802743/raw/decal-beforeafter.png)

## Fix

Offset along the decal's own outward normal (local **−X**), applied as the model's *local* transform so the per-frame world transform composes with it instead of clobbering it. Gated on the model actually being paper-thin (`thickness ≤ 1% of extent`), so ordinary props are untouched.

For reference, the original engine solved this with a constant depth bias on all object rendering (`g_obj_zbias = 4/65536`, plus a per-object `Z-Bias` property) rather than a positional offset. This engine has no depth-bias path (no `glPolygonOffset` anywhere in `engine/`), so the geometric fix stands in. If shimmer ever shows up on distant decals, a `depth_bias` flag on `SceneObject` is the durable follow-up.

## Verification

Creeping the camera 4cm across 10 frames at the medsci1 blood scene, mean per-pixel churn *inside* the splatter:

| | frame-to-frame churn |
|---|---|
| before | **10.22** (erratic: 6.2 – 13.7 — the fight flipping) |
| after | **4.69** (flat: 4.5 – 5.1 — parallax alone) |

Wall-mounted splatters render correctly too, so the normal's sign holds in both orientations.

`cargo fmt` + `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
