### PR TITLE
feat(gameplay): read audio logs on demand instead of on pickup

### DIFF
--- a/runtimes/desktop_runtime/src/input_mapper.rs
+++ b/runtimes/desktop_runtime/src/input_mapper.rs
@@ -159,6 +159,11 @@ impl DesktopInputMapper {
                 action: InputAction::DebugCalmAll,
             },
             Binding {
+                key: Key::U,
+                modifier: Modifier::None,
+                action: InputAction::ReadLastUnreadLog,
+            },
+            Binding {
                 key: Key::M,
                 modifier: Modifier::None,
                 action: InputAction::ToggleMap,

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -109,6 +109,12 @@ where
             // playing its clip) fire in both presentations. A gui can veto the
             // open (a content-less log disc) and/or ask for fresh per-open
             // state (the reader's scroll position).
+            // Opened without a frob (the audio-log reader): give the gui the
+            // same fresh per-open state a frob-open would have.
+            MessagePayload::PanelOpened => {
+                self.gui.prepare_state_on_frob(&mut self.state);
+                Effect::NoEffect
+            }
             MessagePayload::Frob => {
                 let frob_effect = self.gui.on_frob(entity_id, world);
                 if !self.gui.opens_on_frob(entity_id, world) {

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -120,7 +120,8 @@ where
                 if !self.gui.opens_on_frob(entity_id, world) {
                     return frob_effect;
                 }
-                self.gui.prepare_state_on_frob(&mut self.state);
+                // The per-open reset arrives via `PanelOpened`, dispatched by
+                // the `OpenPanel` handler, so both open paths share one hook.
                 Effect::combine(vec![Effect::OpenPanel { entity: entity_id }, frob_effect])
             }
             MessagePayload::GUIHover {

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -83,6 +83,15 @@ pub enum InputAction {
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key). No-op in VR. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
+
+    /// Play back the most recently collected audio log the player has not read
+    /// yet, opening the reader on it (the original's `play_unread_log`).
+    /// Collecting a disc only files it in the PDA, so this is how a log is
+    /// actually read.
+    ReadLastUnreadLog,
+
+    /// Dismiss the open MFD panel (the original closes its overlays on Tab).
+    CloseActivePanel,
 }
 
 impl InputAction {
@@ -120,6 +129,8 @@ impl InputAction {
             InputAction::DebugCalmAll,
             InputAction::DebugForceChase,
             InputAction::ToggleUseMode,
+            InputAction::ReadLastUnreadLog,
+            InputAction::CloseActivePanel,
             InputAction::ToggleMap,
         ]
     }
@@ -156,6 +167,8 @@ impl InputAction {
             InputAction::DebugCalmAll => "DebugCalmAll",
             InputAction::DebugForceChase => "DebugForceChase",
             InputAction::ToggleUseMode => "ToggleUseMode",
+            InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
+            InputAction::CloseActivePanel => "CloseActivePanel",
             InputAction::ToggleMap => "ToggleMap",
         }
     }

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -89,9 +89,6 @@ pub enum InputAction {
     /// Collecting a disc only files it in the PDA, so this is how a log is
     /// actually read.
     ReadLastUnreadLog,
-
-    /// Dismiss the open MFD panel (the original closes its overlays on Tab).
-    CloseActivePanel,
 }
 
 impl InputAction {
@@ -130,7 +127,6 @@ impl InputAction {
             InputAction::DebugForceChase,
             InputAction::ToggleUseMode,
             InputAction::ReadLastUnreadLog,
-            InputAction::CloseActivePanel,
             InputAction::ToggleMap,
         ]
     }
@@ -168,7 +164,6 @@ impl InputAction {
             InputAction::DebugForceChase => "DebugForceChase",
             InputAction::ToggleUseMode => "ToggleUseMode",
             InputAction::ReadLastUnreadLog => "ReadLastUnreadLog",
-            InputAction::CloseActivePanel => "CloseActivePanel",
             InputAction::ToggleMap => "ToggleMap",
         }
     }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -144,9 +144,6 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
             effects.push(Effect::ReadLastUnreadLog);
         }
-        if state.just_triggered(InputAction::CloseActivePanel) {
-            effects.push(Effect::CloseActivePanel);
-        }
         effects
     }
 }

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -141,6 +141,12 @@ impl ActionDispatcher {
         if state.just_triggered(InputAction::ToggleMap) {
             effects.push(Effect::ToggleMap);
         }
+        if state.just_triggered(InputAction::ReadLastUnreadLog) {
+            effects.push(Effect::ReadLastUnreadLog);
+        }
+        if state.just_triggered(InputAction::CloseActivePanel) {
+            effects.push(Effect::CloseActivePanel);
+        }
         effects
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3749,8 +3749,8 @@ impl MissionCore {
                     // is unreachable there and the disc is retired from the world
                     // on collection - without this, a Quest player could never
                     // hear a log at all. Flat keeps the faithful split (collecting
-                    // files it; reading plays it). Remove once VR can trigger the
-                    // action (#916 tracks the surrounding player-feedback work).
+                    // files it; reading plays it). Stopgap: remove once VR can
+                    // trigger the action (#921).
                     if game_options.presentation_mode != crate::PresentationMode::Flat {
                         effects.push_front(Effect::PlaySound {
                             handle: AudioHandle::new(),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2853,6 +2853,44 @@ impl MissionCore {
         self.make_un_physical(entity_id);
     }
 
+    /// Resolve an audio log's reader strings from `level<deck>.str` and cache
+    /// them on the disc for `MediaGui` to render.
+    ///
+    /// `RuntimePropLogData` is runtime-only and deliberately not serialized, so
+    /// this runs both when the log is collected and again each time the reader
+    /// is opened - otherwise a log collected before a save would open a blank
+    /// backdrop after loading.
+    fn attach_log_reader_strings(
+        &mut self,
+        entity_id: EntityId,
+        deck: u32,
+        log: u32,
+        asset_cache: &mut AssetCache,
+    ) {
+        let level_file = format!("level{deck:02}.str");
+        let Some(strings) = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
+        else {
+            return;
+        };
+        // The .str values carry literal backslash-n escapes ("AMANPOUR
+        // 07.JUL.14\nre: New code\n"); unescape them into real line breaks so
+        // the reader never draws "\n".
+        let get = |prefix: &str| {
+            strings
+                .get(&format!("{prefix}{log}"))
+                .map(|s| s.replace("\\n", "\n"))
+        };
+        self.world.add_component(
+            entity_id,
+            crate::runtime_props::RuntimePropLogData {
+                name: get("logname"),
+                text: get("logtext"),
+                portrait: get("logportrait"),
+                icon: get("logicon"),
+            },
+        );
+    }
+
     pub fn make_physical(&mut self, entity_id: EntityId) {
         let current_entity = self.id_to_physics.get(&entity_id);
         if current_entity.is_some() {
@@ -3623,6 +3661,12 @@ impl MissionCore {
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui.open(entity);
                     }
+                    // Give the gui its per-open state (the reader's scroll
+                    // reset) however the panel was reached.
+                    self.script_world.dispatch(Message {
+                        to: entity,
+                        payload: MessagePayload::PanelOpened,
+                    });
                 }
 
                 Effect::BeginResearch { entity_id } => {
@@ -3699,30 +3743,21 @@ impl MissionCore {
                         let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                         quests.collect_log(deck, log);
                     }
-                    // ...and resolve the reader strings from `level<deck>.str`,
-                    // caching them on the disc so the MediaGui panel can render
-                    // the portrait / deck icon / header / transcript.
-                    let level_file = format!("level{deck:02}.str");
-                    if let Some(strings) =
-                        asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
-                    {
-                        // The .str values carry literal backslash-n escapes
-                        // ("AMANPOUR 07.JUL.14\nre: New code\n"); unescape them
-                        // into real line breaks so the reader never draws "\n".
-                        let get = |prefix: &str| {
-                            strings
-                                .get(&format!("{prefix}{log}"))
-                                .map(|s| s.replace("\\n", "\n"))
-                        };
-                        self.world.add_component(
-                            entity_id,
-                            crate::runtime_props::RuntimePropLogData {
-                                name: get("logname"),
-                                text: get("logtext"),
-                                portrait: get("logportrait"),
-                                icon: get("logicon"),
-                            },
-                        );
+                    self.attach_log_reader_strings(entity_id, deck, log, asset_cache);
+
+                    // VR has no discrete-action mapper yet, so `ReadLastUnreadLog`
+                    // is unreachable there and the disc is retired from the world
+                    // on collection - without this, a Quest player could never
+                    // hear a log at all. Flat keeps the faithful split (collecting
+                    // files it; reading plays it). Remove once VR can trigger the
+                    // action (#916 tracks the surrounding player-feedback work).
+                    if game_options.presentation_mode != crate::PresentationMode::Flat {
+                        effects.push_front(Effect::PlaySound {
+                            handle: AudioHandle::new(),
+                            source: Some(entity_id),
+                            name: format!("LOG{deck:02}{log:02}"),
+                            spatial: false,
+                        });
                     }
                     // Retail copies the entry into the PDA and destroys the
                     // pickup. Keep only the entity-bound reader state; retire
@@ -3730,68 +3765,86 @@ impl MissionCore {
                     self.consume_log_pickup(entity_id);
                 }
 
-                Effect::CloseActivePanel => {
-                    self.flat_ui.close();
-                }
-
                 Effect::ReadLastUnreadLog => {
                     // The reader is entity-bound, so playback needs the disc
-                    // entity carrying this log. Discs collected on an earlier
-                    // deck are gone with their mission - cross-mission replay
-                    // is tracked separately (#741).
-                    let target =
-                        self.world
-                            .borrow::<UniqueView<QuestInfo>>()
-                            .ok()
-                            .and_then(|quest_info| {
-                                quest_info.last_unread_log().map(|log| (log.deck, log.log))
-                            });
+                    // that carries this log. Logs collected on an earlier deck
+                    // left their disc behind with that mission (#741), so pick
+                    // the newest unread log that actually resolves here rather
+                    // than letting an unreachable one wedge the key forever.
+                    let unread: Vec<(u32, u32)> = self
+                        .world
+                        .borrow::<UniqueView<QuestInfo>>()
+                        .map(|quest_info| {
+                            quest_info
+                                .collected_logs()
+                                .iter()
+                                .rev()
+                                .filter(|entry| !entry.read)
+                                .map(|entry| (entry.deck, entry.log))
+                                .collect()
+                        })
+                        .unwrap_or_default();
 
-                    if let Some((deck, log)) = target {
-                        let disc = {
-                            let v_log = self
-                                .world
-                                .borrow::<View<dark::properties::PropLog>>()
-                                .unwrap();
-                            v_log
+                    let target = {
+                        let v_log = self
+                            .world
+                            .borrow::<View<dark::properties::PropLog>>()
+                            .unwrap();
+                        let v_data = self
+                            .world
+                            .borrow::<View<crate::runtime_props::RuntimePropLogData>>()
+                            .unwrap();
+                        unread.into_iter().find_map(|(deck, log)| {
+                            // A (deck, log) pair is not unique across the
+                            // campaign - command1 object 2382 and command2 2379
+                            // both author deck 6 / log 5 - so prefer the disc
+                            // that was actually collected (only it carries the
+                            // resolved reader strings) over an untouched twin
+                            // still lying in the current mission.
+                            let mut matches = v_log
                                 .iter()
                                 .with_id()
-                                .find(|(_, authored)| authored.deck == deck && authored.log == log)
-                                .map(|(entity_id, _)| entity_id)
-                        };
+                                .filter(|(_, authored)| {
+                                    authored.deck == deck && authored.log == log
+                                })
+                                .map(|(entity_id, _)| entity_id);
+                            let first = matches.next()?;
+                            let collected = std::iter::once(first)
+                                .chain(matches)
+                                .find(|entity_id| v_data.get(*entity_id).is_ok());
+                            Some((collected.unwrap_or(first), deck, log))
+                        })
+                    };
 
-                        match disc {
-                            Some(disc) => {
-                                if let Ok(mut quest_info) =
-                                    self.world.borrow::<UniqueViewMut<QuestInfo>>()
-                                {
-                                    quest_info.mark_log_read(deck, log);
-                                }
-                                // Reaching the reader without a frob still needs
-                                // the per-open reset a frob-open would have
-                                // given it (the transcript starts at the top).
-                                self.script_world.dispatch(Message {
-                                    to: disc,
-                                    payload: MessagePayload::PanelOpened,
-                                });
-                                if game_options.presentation_mode == crate::PresentationMode::Flat {
-                                    self.flat_ui.open_unbound(disc);
-                                }
-                                effects.push_front(Effect::PlaySound {
-                                    handle: AudioHandle::new(),
-                                    source: None,
-                                    name: format!("LOG{deck:02}{log:02}"),
-                                    spatial: false,
-                                });
+                    match target {
+                        Some((disc, deck, log)) => {
+                            // Re-resolve the strings: they are runtime-only, so
+                            // a log collected before a save has none after load.
+                            self.attach_log_reader_strings(disc, deck, log, asset_cache);
+                            // Reaching the reader without a frob still needs the
+                            // per-open reset a frob-open would have given it
+                            // (the transcript starts at the top).
+                            self.script_world.dispatch(Message {
+                                to: disc,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                            if let Ok(mut quest_info) =
+                                self.world.borrow::<UniqueViewMut<QuestInfo>>()
+                            {
+                                quest_info.mark_log_read(deck, log);
                             }
-                            None => {
-                                game_log!(
-                                    INFO,
-                                    "no backing disc for unread log {}/{}; cannot open the reader",
-                                    deck,
-                                    log
-                                );
+                            if game_options.presentation_mode == crate::PresentationMode::Flat {
+                                self.flat_ui.open_unbound(disc);
                             }
+                            effects.push_front(Effect::PlaySound {
+                                handle: AudioHandle::new(),
+                                source: None,
+                                name: format!("LOG{deck:02}{log:02}"),
+                                spatial: false,
+                            });
+                        }
+                        None => {
+                            game_log!(INFO, "no unread log is readable here");
                         }
                     }
                 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -3582,29 +3582,37 @@ impl MissionCore {
                 Effect::ToggleUseMode => {
                     // Flat-presentation only: VR has no cursor mode to toggle.
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
-                        self.flat_use_mode = !self.flat_use_mode;
-                        // Use mode shows the player's backpack as the
-                        // top-docked inventory strip: bind the strip to the
-                        // `internal_inventory` entity (whose GuiScript
-                        // already emits SetUI every frame).
-                        // Leaving use mode drops any item on the cursor. It was
-                        // never removed from the backpack (the host only hid it
-                        // from the strip), so clearing the cursor is enough -
-                        // the item is already reachable there (projects/flat-ui.md
-                        // §1.5). This also means a save/transition mid-drag
-                        // serializes it correctly, with no orphan.
-                        if !self.flat_use_mode {
-                            self.flat_ui.take_cursor_item();
-                        }
-                        let strip_entity = if self.flat_use_mode {
-                            self.world
-                                .borrow::<UniqueView<PlayerInfo>>()
-                                .ok()
-                                .map(|player| player.inventory_entity_id)
+                        // Tab dismisses an open overlay first, as the original
+                        // does - reading a log (or looting a container) and
+                        // pressing Tab should put the panel away, not drop the
+                        // player into shooter mode with it still up.
+                        if self.flat_ui.active_panel().is_some() {
+                            self.flat_ui.close();
                         } else {
-                            None
-                        };
-                        self.flat_ui.set_strip(strip_entity);
+                            self.flat_use_mode = !self.flat_use_mode;
+                            // Use mode shows the player's backpack as the
+                            // top-docked inventory strip: bind the strip to the
+                            // `internal_inventory` entity (whose GuiScript
+                            // already emits SetUI every frame).
+                            // Leaving use mode drops any item on the cursor. It was
+                            // never removed from the backpack (the host only hid it
+                            // from the strip), so clearing the cursor is enough -
+                            // the item is already reachable there (projects/flat-ui.md
+                            // §1.5). This also means a save/transition mid-drag
+                            // serializes it correctly, with no orphan.
+                            if !self.flat_use_mode {
+                                self.flat_ui.take_cursor_item();
+                            }
+                            let strip_entity = if self.flat_use_mode {
+                                self.world
+                                    .borrow::<UniqueView<PlayerInfo>>()
+                                    .ok()
+                                    .map(|player| player.inventory_entity_id)
+                            } else {
+                                None
+                            };
+                            self.flat_ui.set_strip(strip_entity);
+                        }
                     }
                 }
 
@@ -3720,6 +3728,72 @@ impl MissionCore {
                     // pickup. Keep only the entity-bound reader state; retire
                     // the disc from the rendered, physical, frobbable world.
                     self.consume_log_pickup(entity_id);
+                }
+
+                Effect::CloseActivePanel => {
+                    self.flat_ui.close();
+                }
+
+                Effect::ReadLastUnreadLog => {
+                    // The reader is entity-bound, so playback needs the disc
+                    // entity carrying this log. Discs collected on an earlier
+                    // deck are gone with their mission - cross-mission replay
+                    // is tracked separately (#741).
+                    let target =
+                        self.world
+                            .borrow::<UniqueView<QuestInfo>>()
+                            .ok()
+                            .and_then(|quest_info| {
+                                quest_info.last_unread_log().map(|log| (log.deck, log.log))
+                            });
+
+                    if let Some((deck, log)) = target {
+                        let disc = {
+                            let v_log = self
+                                .world
+                                .borrow::<View<dark::properties::PropLog>>()
+                                .unwrap();
+                            v_log
+                                .iter()
+                                .with_id()
+                                .find(|(_, authored)| authored.deck == deck && authored.log == log)
+                                .map(|(entity_id, _)| entity_id)
+                        };
+
+                        match disc {
+                            Some(disc) => {
+                                if let Ok(mut quest_info) =
+                                    self.world.borrow::<UniqueViewMut<QuestInfo>>()
+                                {
+                                    quest_info.mark_log_read(deck, log);
+                                }
+                                // Reaching the reader without a frob still needs
+                                // the per-open reset a frob-open would have
+                                // given it (the transcript starts at the top).
+                                self.script_world.dispatch(Message {
+                                    to: disc,
+                                    payload: MessagePayload::PanelOpened,
+                                });
+                                if game_options.presentation_mode == crate::PresentationMode::Flat {
+                                    self.flat_ui.open_unbound(disc);
+                                }
+                                effects.push_front(Effect::PlaySound {
+                                    handle: AudioHandle::new(),
+                                    source: None,
+                                    name: format!("LOG{deck:02}{log:02}"),
+                                    spatial: false,
+                                });
+                            }
+                            None => {
+                                game_log!(
+                                    INFO,
+                                    "no backing disc for unread log {}/{}; cannot open the reader",
+                                    deck,
+                                    log
+                                );
+                            }
+                        }
+                    }
                 }
 
                 Effect::ToggleMap => {

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -21,6 +21,12 @@ use crate::research::ResearchState;
 pub struct CollectedLog {
     pub deck: u32,
     pub log: u32,
+    /// Whether the player has actually played this log back. Collecting a disc
+    /// only files it in the PDA; the reader is opened explicitly (the
+    /// `ReadLastUnreadLog` action). `#[serde(default)]` keeps saves written
+    /// before read tracking loadable - their logs restore as unread.
+    #[serde(default)]
+    pub read: bool,
 }
 
 #[derive(Deserialize, Serialize, Unique, Clone, Debug)]
@@ -93,7 +99,11 @@ impl QuestInfo {
         if self.has_collected_log(deck, log) {
             return false;
         }
-        self.collected_logs.push(CollectedLog { deck, log });
+        self.collected_logs.push(CollectedLog {
+            deck,
+            log,
+            read: false,
+        });
         true
     }
 
@@ -106,6 +116,31 @@ impl QuestInfo {
     /// The player's collected audio logs, in pickup order.
     pub fn collected_logs(&self) -> &[CollectedLog] {
         &self.collected_logs
+    }
+
+    /// The most recently collected log the player has not played back yet.
+    ///
+    /// The original gathers every unread log across all decks, sorts them by
+    /// acquisition time ascending and plays the *last* one - i.e. the newest
+    /// unread disc, not the oldest backlog entry. `collected_logs` is kept in
+    /// pickup order, so the newest unread is the last matching entry.
+    pub fn last_unread_log(&self) -> Option<&CollectedLog> {
+        self.collected_logs.iter().rev().find(|entry| !entry.read)
+    }
+
+    /// Mark a collected log as played back. Returns `true` when this flipped it
+    /// from unread (re-reading an already-read log is a no-op).
+    pub fn mark_log_read(&mut self, deck: u32, log: u32) -> bool {
+        let Some(entry) = self
+            .collected_logs
+            .iter_mut()
+            .find(|entry| entry.deck == deck && entry.log == log)
+        else {
+            return false;
+        };
+        let was_unread = !entry.read;
+        entry.read = true;
+        was_unread
     }
 
     /// The player's persistent character sheet.
@@ -165,5 +200,83 @@ impl QuestInfo {
 
     pub fn mark_email_as_played(&mut self, email: &str) {
         self.played_emails.insert(email.to_owned());
+    }
+}
+
+#[cfg(test)]
+mod log_tests {
+    use super::*;
+
+    fn quest_info_with(logs: &[(u32, u32)]) -> QuestInfo {
+        let mut quest_info = QuestInfo::new();
+        for (deck, log) in logs {
+            quest_info.collect_log(*deck, *log);
+        }
+        quest_info
+    }
+
+    #[test]
+    fn collected_logs_start_unread() {
+        let quest_info = quest_info_with(&[(2, 20)]);
+
+        assert_eq!(quest_info.collected_logs()[0].read, false);
+    }
+
+    /// The original sorts unread logs by acquisition time and plays the *last*
+    /// one - the newest unread disc, not the oldest outstanding backlog entry.
+    #[test]
+    fn the_newest_unread_log_is_the_one_played_back() {
+        let quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+
+        let unread = quest_info.last_unread_log().expect("nothing read yet");
+
+        assert_eq!((unread.deck, unread.log), (3, 3));
+    }
+
+    #[test]
+    fn reading_the_newest_falls_back_to_the_next_newest_unread() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+
+        assert!(quest_info.mark_log_read(3, 3));
+        let unread = quest_info.last_unread_log().expect("two still unread");
+
+        assert_eq!((unread.deck, unread.log), (2, 2));
+    }
+
+    #[test]
+    fn nothing_is_played_back_once_every_log_is_read() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2)]);
+
+        quest_info.mark_log_read(1, 1);
+        quest_info.mark_log_read(2, 2);
+
+        assert!(quest_info.last_unread_log().is_none());
+    }
+
+    /// Re-reading is a no-op, and an unknown log is not silently inserted.
+    #[test]
+    fn marking_read_reports_only_the_first_transition() {
+        let mut quest_info = quest_info_with(&[(2, 20)]);
+
+        assert!(quest_info.mark_log_read(2, 20));
+        assert!(!quest_info.mark_log_read(2, 20));
+        assert!(!quest_info.mark_log_read(9, 9));
+        assert_eq!(quest_info.collected_logs().len(), 1);
+    }
+
+    /// Saves written before read tracking restore their logs as unread.
+    #[test]
+    fn logs_from_older_saves_deserialize_as_unread() {
+        let restored: CollectedLog =
+            serde_json::from_str(r#"{"deck":2,"log":20}"#).expect("older save shape should load");
+
+        assert_eq!(
+            restored,
+            CollectedLog {
+                deck: 2,
+                log: 20,
+                read: false
+            }
+        );
     }
 }

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -180,6 +180,16 @@ pub enum Effect {
         log: u32,
     },
 
+    /// Play back the most recently collected audio log the player has not read
+    /// yet (the original's `play_unread_log`): open the reader bound to that
+    /// disc's backing entity, mark it read, and play its `LOG<dd><nn>` audio.
+    /// No-op when every collected log has been read. Emitted by
+    /// `InputAction::ReadLastUnreadLog`.
+    ReadLastUnreadLog,
+
+    /// Dismiss the open MFD panel, if any.
+    CloseActivePanel,
+
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the
     /// synthetic map-panel entity, or closes it if it is already open. No-op in

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -187,9 +187,6 @@ pub enum Effect {
     /// `InputAction::ReadLastUnreadLog`.
     ReadLastUnreadLog,
 
-    /// Dismiss the open MFD panel, if any.
-    CloseActivePanel,
-
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the
     /// synthetic map-panel entity, or closes it if it is already open. No-op in

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -27,7 +27,7 @@ use crate::runtime_props::RuntimePropLogData;
 /// posts; that beep is the only audio a log pickup produces. The port has no
 /// overlay-text facility yet, so the cue is fired here as a stand-in.
 ///
-/// When that facility lands (#N), this moves with it: `linebeep` belongs to
+/// When that facility lands (#916), this moves with it: `linebeep` belongs to
 /// posting a message, not to collecting a log. Note the original does *not*
 /// play its item-pickup cue (`pickup_item`) for discs - that fires only on the
 /// frob path that moves an object into the inventory, and `Audio Log` (-76)

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -18,6 +18,23 @@ use shipyard::{EntityId, Get, UniqueView, View, World};
 use crate::gui::{self, Gui, GuiComponent, GuiConfig, GuiCursor};
 use crate::quest_info::QuestInfo;
 use crate::runtime_props::RuntimePropLogData;
+
+/// Acknowledgement cue played when a disc is collected.
+///
+/// This is the original's generic **HUD-message beep**, not a log or pickup
+/// sound. Retail posts an on-screen "Picked up log: <name>" line, and the
+/// overlay-text system plays `linebeep` unconditionally for every message it
+/// posts; that beep is the only audio a log pickup produces. The port has no
+/// overlay-text facility yet, so the cue is fired here as a stand-in.
+///
+/// When that facility lands (#N), this moves with it: `linebeep` belongs to
+/// posting a message, not to collecting a log. Note the original does *not*
+/// play its item-pickup cue (`pickup_item`) for discs - that fires only on the
+/// frob path that moves an object into the inventory, and `Audio Log` (-76)
+/// overrides `FrobInfo` to `world_action: SCRIPT`, dropping the `MOVE` bit it
+/// would inherit from `Goodies` (-49). Compare `cargo dq templates 76` with
+/// `cargo dq templates 49`.
+const LOG_PICKUP_SOUND: &str = "linebeep";
 use crate::scripts::{
     Effect, MessagePayload,
     script_util::{send_to_all_switch_links, set_quest_bit_effect},
@@ -254,10 +271,15 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         let Some((deck, log)) = readable_log(world, entity_id) else {
             return Effect::NoEffect;
         };
+        // Collecting a disc files it in the PDA; it does not play it. The
+        // transcript audio (`LOG{deck}{log}`) belongs to playback, which the
+        // player triggers explicitly via `InputAction::ReadLastUnreadLog` - in
+        // the original the call that would play it on pickup is commented out.
+        // See `LOG_PICKUP_SOUND` for why the cue here is a deviation.
         let audio = Effect::PlaySound {
             handle: AudioHandle::new(),
             source: Some(entity_id),
-            name: format!("LOG{deck:02}{log:02}"),
+            name: LOG_PICKUP_SOUND.to_owned(),
             spatial: false,
         };
         let collect = Effect::CollectLog {
@@ -287,11 +309,12 @@ impl Gui<MediaGuiState, MediaGuiMsg> for MediaGui {
         Effect::combine(vec![collect, audio, switchlinks, quest_bit])
     }
 
-    /// A disc with no readable log (unset `PropLog` sentinel) must not open an
-    /// empty backdrop with dead scroll buttons - its frob does nothing, just
-    /// like `on_frob` above.
-    fn opens_on_frob(&self, entity_id: EntityId, world: &World) -> bool {
-        readable_log(world, entity_id).is_some()
+    /// Collecting a log never opens the reader. The original files the entry
+    /// in the PDA and leaves reading to the player; popping a full-screen
+    /// transcript over the world on every pickup interrupts play and buries the
+    /// disc's own audio. Playback is the `ReadLastUnreadLog` action instead.
+    fn opens_on_frob(&self, _entity_id: EntityId, _world: &World) -> bool {
+        false
     }
 
     /// The original resets the reader on every open - a reopened transcript
@@ -388,10 +411,11 @@ mod tests {
         );
     }
 
-    /// A real log still opens, and reopening resets the scroll position to the
-    /// top (the original re-creates the overlay on every open).
+    /// Collecting a real log does not open the reader, and each open resets the
+    /// scroll position to the top (the original re-creates the overlay on every
+    /// open).
     #[test]
-    fn frob_opens_a_real_log_and_reopening_resets_scroll() {
+    fn collecting_a_real_log_does_not_open_it_and_opening_resets_scroll() {
         let mut world = World::new();
         let physics = PhysicsWorld::new();
         // 20 one-word lines: one PageDown scrolls to the clamped last page
@@ -419,7 +443,10 @@ mod tests {
         script.initialize(disc, &world);
 
         let effect = script.handle_message(disc, &world, &physics, &MessagePayload::Frob);
-        assert!(opens_panel(effect), "a readable log must open the panel");
+        assert!(
+            !opens_panel(effect),
+            "collecting a log files it in the PDA; it must not open the reader"
+        );
         assert_eq!(
             drawn_lines(&mut script, disc, &world, &physics)
                 .first()
@@ -440,9 +467,9 @@ mod tests {
             "PageDown should scroll to the clamped last page"
         );
 
-        // Re-frob: the reader reopens scrolled back to the top.
-        let effect = script.handle_message(disc, &world, &physics, &MessagePayload::Frob);
-        assert!(opens_panel(effect));
+        // Opening again (the reader is reached via `ReadLastUnreadLog`, which
+        // dispatches `PanelOpened`) starts scrolled back to the top.
+        script.handle_message(disc, &world, &physics, &MessagePayload::PanelOpened);
         assert_eq!(
             drawn_lines(&mut script, disc, &world, &physics)
                 .first()

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -210,6 +210,12 @@ pub struct DamageImpact {
 pub enum MessagePayload {
     Frob,
 
+    /// This entity's MFD panel was opened. Frobbing used to be the only way in,
+    /// so panels reset their per-open state on `Frob`; the audio-log reader is
+    /// opened by `ReadLastUnreadLog` instead, and any panel may later be opened
+    /// without a frob.
+    PanelOpened,
+
     // Physics events
     SensorBeginIntersect {
         with: EntityId,

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -397,6 +397,8 @@ export interface PlayerSnapshot {
 export interface CollectedLog {
   deck: number;
   log: number;
+  /** Whether the player has played this log back. Collecting only files it. */
+  read: boolean;
 }
 
 /** Trainable skill levels (weapon proficiencies + tech skills). */

--- a/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-pickup-consumption.e2e.test.ts
@@ -32,8 +32,8 @@ test(
 
     assert.deepEqual(
       (await game.info()).player.collected_logs,
-      [{ deck: 6, log: 1 }],
-      "frobbing the disc should download its log into the player's PDA state",
+      [{ deck: 6, log: 1, read: false }],
+      "frobbing the disc should download its log into the PDA, unread",
     );
     assert.equal(
       (await game.physics.bodies({ entityId: disc.id })).bodies.length,

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -187,12 +187,12 @@ test(
       "the Amanpour log should be recorded in the collection, now read",
     );
 
-    // --- Dismissing closes the reader (the original's Tab) ---
-    await game.input.trigger("CloseActivePanel");
+    // --- Tab dismisses the reader, as it does any open MFD panel ---
+    await game.input.trigger("ToggleUseMode");
     await game.step({ frames: 5 });
     assert.ok(
       !(await game.ui.state()).active_panel,
-      "CloseActivePanel should dismiss the reader",
+      "Tab should dismiss the reader",
     );
 
     // Re-frobbing does not duplicate the collection entry.
@@ -225,6 +225,58 @@ test(
       (await game.info()).player.collected_logs,
       [{ deck: 2, log: 20, read: true }],
       "the collection and its read state should survive save/load",
+    );
+  },
+);
+
+// `RuntimePropLogData` (the resolved header/transcript/portrait/icon) is
+// runtime-only and deliberately not serialized. It used to be attached by the
+// same frob that opened the reader, so nothing noticed; now that reading is a
+// separate act, a log collected before a save must still render after loading.
+test(
+  "log reader MFD: a log collected before a save still reads back after loading",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8233),
+    });
+    await game.step({ frames: 5 });
+
+    const amanpour = (
+      await game.entities.list({ filter: "Audio Log", limit: 80 })
+    ).entities.find((e) => e.template_id === 1608);
+    assert.ok(amanpour, "medsci1 should contain the Amanpour log (obj 1608)");
+
+    // Collect it, and deliberately do NOT read it.
+    await game.entities.sendMessage(amanpour.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: false }],
+      "the log should be collected and still unread",
+    );
+
+    await game.save("log-unread-roundtrip");
+    await game.load("log-unread-roundtrip");
+    await game.step({ frames: 5 });
+
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+
+    const panel = (await game.ui.state()).active_panel;
+    assert.ok(panel, "the unread log should still open after a save/load");
+    const text = panel.elements
+      .filter((e) => e.kind === "text" && e.text)
+      .map((e) => e.text)
+      .join(" ");
+    assert.ok(
+      text.includes("45100"),
+      `the reloaded reader must render its transcript, not a blank backdrop (got: ${text.slice(0, 160)})`,
+    );
+    assert.ok(
+      text.toUpperCase().includes("AMANPOUR"),
+      "the reloaded reader should still name the sender",
     );
   },
 );

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -70,19 +70,41 @@ test(
     const [lx, ly, lz] = detail.position;
     await teleportVerified(game, { x: lx, y: ly + 0.5, z: lz });
 
-    // --- Frob: the reader panel opens, bound to the disc ---
+    // --- Frob: the disc is filed in the PDA, and nothing opens ---
+    // The original files the entry and leaves reading to the player: its
+    // pickup path never opens the overlay (the call that would is commented
+    // out in the reference engine).
     await game.entities.sendMessage(amanpour.id, { type: "Frob" });
+    await game.step({ frames: 5 });
+
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "collecting a log must not pop the reader over the world",
+    );
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: false }],
+      "the collected log should be filed unread",
+    );
+
+    // --- Read it: the original's `play_unread_log` opens the newest unread ---
+    await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
 
     const opened = await game.ui.state();
     assert.ok(
       opened.active_panel,
-      "frobbing the audio log should open the reader MFD panel",
+      "ReadLastUnreadLog should open the reader MFD panel",
     );
     assert.equal(
       opened.active_panel.template_id,
       1608,
       "the reader panel should be bound to the Amanpour log entity",
+    );
+    assert.deepEqual(
+      (await game.info()).player.collected_logs,
+      [{ deck: 2, log: 20, read: true }],
+      "playing a log back should mark it read",
     );
 
     // The transcript must surface the code 45100 in-fiction.
@@ -154,15 +176,23 @@ test(
     );
     assert.ok(
       sounds.includes("log0220"),
-      `frobbing the log should play LOG0220 (recent: ${sounds.join(", ")})`,
+      `playing the log back should play LOG0220 (recent: ${sounds.join(", ")})`,
     );
 
     // --- The log is recorded in the persistent collection ---
     const collected = (await game.info()).player.collected_logs;
     assert.deepEqual(
       collected,
-      [{ deck: 2, log: 20 }],
-      "the Amanpour log should be recorded in the collection",
+      [{ deck: 2, log: 20, read: true }],
+      "the Amanpour log should be recorded in the collection, now read",
+    );
+
+    // --- Dismissing closes the reader (the original's Tab) ---
+    await game.input.trigger("CloseActivePanel");
+    await game.step({ frames: 5 });
+    assert.ok(
+      !(await game.ui.state()).active_panel,
+      "CloseActivePanel should dismiss the reader",
     );
 
     // Re-frobbing does not duplicate the collection entry.
@@ -193,8 +223,8 @@ test(
     await game.step({ frames: 5 });
     assert.deepEqual(
       (await game.info()).player.collected_logs,
-      [{ deck: 2, log: 20 }],
-      "the log collection should survive save/load",
+      [{ deck: 2, log: 20, read: true }],
+      "the collection and its read state should survive save/load",
     );
   },
 );

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -32,7 +32,7 @@ import { teleportVerified } from "./helpers/teleport.js";
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 test(
-  "log reader MFD: frob opens transcript with 45100, collects the log, persists",
+  "log reader MFD: collecting files the log, reading it opens the 45100 transcript, persists",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({


### PR DESCRIPTION
## Summary

Collecting an audio log popped the reader over the world and played the log's own audio. The original does neither: its pickup path files the entry in the PDA and leaves reading to the player.

- Collecting no longer opens the reader (`opens_on_frob` → `false`), in both flat and VR.
- The transcript audio (`LOG<dd><nn>`) moves off pickup and onto playback.
- New **`ReadLastUnreadLog`** action (desktop `U`) plays back the most recently collected unread log.
- New **`CloseActivePanel`** action; `Tab` now dismisses an open MFD before toggling use mode.
- `CollectedLog` gains `read`, tracked in `QuestInfo`.

Builds on #838 (now merged), which retires the disc from the world on collection.

## Fidelity

Checked against the original rather than assumed — three details came out contrary to expectation:

1. **No auto-play, no auto-open on pickup.** In the reference engine the call that would play the content and raise the MFD is commented out in the log pickup path. Pickup only sets the ownership bit, timestamps it, and posts a message line.
2. **"Last unread" means newest, not oldest.** The original gathers every unread log, sorts by acquisition time, and plays the *last* one. An earlier draft of this change played the oldest outstanding entry; `last_unread_log()` now walks from the newest and there is a unit test pinning it.
3. **Read/unread is campaign-scoped**, surviving save/load and level transitions — hence `QuestInfo` rather than per-mission state.

### The pickup cue is a deliberate, documented deviation

Retail's only audio when frobbing a disc is the generic **HUD-message beep** (`linebeep`), played unconditionally by the overlay-text system when the "Picked up log" line is posted. This port has no overlay-text facility yet (**#916**), so the disc fires that schema directly until it does, with the reasoning recorded at `LOG_PICKUP_SOUND`.

Retail notably does *not* play its **item** pickup cue for discs: that fires only on the frob path that moves an object into the inventory, and `Audio Log` overrides `FrobInfo` to `world_action: SCRIPT`, dropping the `MOVE` bit it would inherit from `Goodies`. Public-safe check:

```
cargo dq templates 76   # Audio Log: world_action: SCRIPT
cargo dq templates 49   # Goodies:   world_action: MOVE
```

So an ordinary auto-pickup item makes two sounds (beep, then pickup cue) and a log makes exactly one.

## Notable implementation detail

Per-open panel state (the reader's scroll reset) was coupled to *the frob that opened the panel*. Decoupling collection from opening silently broke "a reopened transcript starts at the top" — caught by the existing unit test. Rather than special-casing the reader, this adds `MessagePayload::PanelOpened`, dispatched when a panel is opened without a frob, so per-open state works however the panel was reached.

`Tab` closing an open panel applies to **any** MFD — loot containers, keypads and computers, not just the reader.

## Scope

The reader is entity-bound, so playback needs the disc entity, which exists only within the mission that collected it. Cross-mission replay is **#741**.

## Backwards compatibility

`read` is `#[serde(default)]`, so saves written before read tracking load with their logs restored as unread.

## Tests

- **6 new quest-info unit tests**: newest-unread selection, falling back to the next-newest, exhaustion, first-transition-only marking, and older-save deserialization.
- The media reader unit test now proves collecting does **not** open the panel.
- `log-reader.e2e.test.ts` rewritten: frobbing files the log unread and opens nothing; the action opens it, plays `LOG0220` and marks it read; closing dismisses it; read state survives save/load. **This test was previously asserting the old frob-opens-panel behavior in `main`.**
- `cargo test -p shock2vr --lib` (559 passed)
- `SHOCK2_E2E=1` log-reader + log-pickup-consumption scenarios (2 passed, executed not skipped)
- `cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`

No visual change to capture — the change is that a panel *stops* appearing on pickup; the reader itself is unchanged and covered by the e2e screenshot already in that scenario.


## Visual evidence

![Log reader before and after](https://gist.githubusercontent.com/tommy-xr/6f6af2fe6b898a6ffaa21dafd73f1a92/raw/log-reader-before-after.png)

<sub>Identical deterministic sequence on both refs: load `medsci1.mis`, discover the Amanpour disc by stable template id 1608, teleport to it, frob it, then trigger `ReadLastUnreadLog`. Captured headlessly via `/v1/step` + `/v1/screenshot` at the fixed 60 Hz timestep — no window interaction. Base `12aa696`, head `feat/log-reader-controls`.</sub>

The change is that a panel **stops** appearing, so the evidence is the same action producing different results:

| ref | after frobbing the disc | `/v1/ui` reports | `/v1/info` collected_logs |
|---|---|---|---|
| base `12aa696` | reader pops open over the world | `active_panel=1608` | `[{deck: 2, log: 20}]` |
| this PR | nothing opens | `active_panel=None` | `[{deck: 2, log: 20, read: false}]` |
| this PR, after `ReadLastUnreadLog` | reader opens | `active_panel=1608` | `[{deck: 2, log: 20, read: true}]` |

The middle frame is byte-identical in size to the pre-frob frame on this branch, i.e. collecting the log is visually a no-op — which is the point.

Full-size individual frames: [after frob](https://gist.githubusercontent.com/tommy-xr/6f6af2fe6b898a6ffaa21dafd73f1a92/raw/after-2-after-frob.png) · [after pressing U](https://gist.githubusercontent.com/tommy-xr/6f6af2fe6b898a6ffaa21dafd73f1a92/raw/after-3-after-read-action.png)


## Cross-engine review (`/xreview`)

Reviewed independently by a Claude subagent and Codex, plus a dedicated de-duplication pass. **Two High findings, both raised by both engines** — both real regressions, both fixed in `4237a1a`.

| Finding | Engines |
|---|---|
| **Save/load opened a blank reader and burned the log.** `RuntimePropLogData` is runtime-only and not in the save allowlist. It used to be attached by the same frob that opened the reader, so nothing noticed; once reading became a separate act, collect → save → load → read rendered an empty backdrop, marked the log read, and left no replay path | **both** (High) |
| **VR lost audio logs entirely.** `opens_on_frob` is false in both presentations and playback moved onto an action the Oculus runtime has no mapper for, while the disc is retired on pickup — so a Quest player could never hear a log | **both** (High) |
| A `(deck, log)` pair is not unique across the campaign, so playback could bind an uncollected twin | Codex (Med) |
| Two divergent panel-opened paths | Claude (Med) |
| `CloseActivePanel` was unbound scope creep | Claude (Med) |

**Fixes:** reader strings now resolve at *open* time via a shared helper; VR keeps pickup-path playback until it can trigger the action (stopgap, tracked as **#921** — the Oculus runtime maps no discrete actions at all); playback picks the newest unread that actually resolves (so an unreachable cross-deck log cannot wedge the key) and prefers the collected disc among twins; `PanelOpened` is dispatched from the `OpenPanel` handler so both open paths share one hook; `CloseActivePanel` is removed and the e2e exercises the real `Tab` path instead.

**Verified rather than assumed:** Codex claimed command1 object 2382 and command2 object 2379 both author deck 6 / log 5 — confirmed with `cargo dq entities command1.mis 2382` / `command2.mis 2379`. The Claude reviewer had cleared duplicates by checking *within* each mission (148 discs across all 23, none duplicated); the collision is cross-mission. Both were right about their own scope.

**Negative-first on the headline fix:** with the open-time string resolution disabled, the new save/load test fails with an empty transcript (`got: `) — the exact blank backdrop predicted; it passes with the fix restored.

De-duplication pass: no actionable duplication in the added API.

Re-validated: `cargo test -p shock2vr --lib` (559), log e2e **3/3** including the new save/load regression, `cargo fmt --all -- --check`, `RUSTFLAGS="-D warnings"` clean.

The visual evidence above was captured before these fixes; they change no player-visible behavior in flat mode (the captured sequence is unaffected), so it still represents the shipped change.
