### PR TITLE
fix(rendering): keep the decal lift correct under scale and thickness

### DIFF
--- a/dark/src/model.rs
+++ b/dark/src/model.rs
@@ -474,16 +474,18 @@ impl Model {
         }
     }
 
-    /// Set a model-space transform applied *inside* the entity transform. The
-    /// render path re-sets the entity (world) transform every frame; the local
-    /// one rides along with the model.
-    pub fn set_local_transform(&mut self, local_transform: Matrix4<f32>) {
+    /// Compose a model-space transform *inside* the entity transform, on top of
+    /// whatever local transform each scene object already carries (the obj
+    /// loader gives vhot debug cubes theirs). The render path re-sets the
+    /// entity (world) transform every frame; the local one rides along with
+    /// the model.
+    pub fn apply_local_transform(&mut self, local_transform: Matrix4<f32>) {
         let scene_objects = match &mut self.inner {
             InnerModel::Static(static_model) => &mut static_model.scene_objects,
             InnerModel::Animated(animated_model) => &mut animated_model.scene_objects,
         };
         for obj in scene_objects {
-            obj.set_local_transform(local_transform);
+            obj.set_local_transform(local_transform * obj.local_transform);
         }
     }
 

--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -10,9 +10,10 @@ use crate::{
 use engine::physics_log;
 
 use cgmath::{
-    EuclideanSpace, Matrix4, Point3, Quaternion, Rotation, SquareMatrix, Transform, Vector3, Zero,
+    EuclideanSpace, Matrix4, Point3, Quaternion, SquareMatrix, Transform, Vector3, Zero,
     num_traits::abs, vec3,
 };
+use collision::Aabb3;
 use dark::{
     BitmapAnimation, SCALE_FACTOR,
     importers::{ANIMATION_CLIP_IMPORTER, BITMAP_ANIMATION_IMPORTER, MODELS_IMPORTER},
@@ -465,38 +466,60 @@ fn initialize_sym_name_from_obj_map(
     }
 }
 
-/// How far a decal is pushed off the surface it is stuck to, in model-local
+/// How far a decal is pushed off the surface it is stuck to, in **world**
 /// units (1 world unit = `SCALE_FACTOR` Dark units). Small enough not to read
 /// as floating at grazing angles, large enough to clear depth-buffer precision
 /// at the ranges decals are legible from.
 const DECAL_SURFACE_OFFSET: f32 = 0.02;
+
+/// The local-space X translation that lifts a paper-thin decal off its
+/// surface, or `None` when the model is not a decal.
+///
+/// A decal model has (near-)zero thickness along its local X axis (Dark's
+/// forward) and its visible face points along local -X, i.e. out of the wall,
+/// so the nudge is along -X.
+///
+/// `scale_x` is the X component of the entity's `PropScale` **as the renderer
+/// applies it** - `RuntimePropTransform` uses the raw, signed value, and the
+/// shipped data stores it negative (the property reader mirrors X). Since the
+/// offset rides inside that transform, it is divided out here so the world
+/// displacement is always `DECAL_SURFACE_OFFSET` along local -X, whatever the
+/// entity is scaled by.
+fn decal_local_x_offset(bbox: Aabb3<f32>, scale_x: f32) -> Option<f32> {
+    let thickness = bbox.max.x - bbox.min.x;
+    let extent = (bbox.max.y - bbox.min.y).max(bbox.max.z - bbox.min.z);
+
+    // Paper-thin in absolute terms, not merely relative: a long pipe is 1%
+    // as thick as it is long and is not a decal.
+    if thickness > DECAL_SURFACE_OFFSET || extent <= DECAL_SURFACE_OFFSET {
+        return None;
+    }
+
+    if scale_x.abs() < f32::EPSILON {
+        return None;
+    }
+
+    Some(-DECAL_SURFACE_OFFSET / scale_x)
+}
 
 /// Decals (blood splatters, signs, bullet holes) are paper-thin models placed
 /// exactly coplanar with the surface they are stuck to, so they z-fight with
 /// the level geometry - they flicker, or vanish entirely, as the viewpoint
 /// moves. Lift such a model off its surface along its own outward normal.
 ///
-/// A decal model has (near-)zero thickness along its local X axis (Dark's
-/// forward) and its visible face points along local -X, i.e. out of the wall.
 /// The offset is applied as the scene objects' *local* transform: the render
 /// path overwrites the model transform with the entity's
 /// `RuntimePropTransform` every frame, but composes it with the local one.
-fn apply_decal_offset(model: &mut Model) {
+fn apply_decal_offset(model: &mut Model, scale_x: f32) {
     let Some(bbox) = model.bounding_box() else {
         return;
     };
 
-    let thickness = bbox.max.x - bbox.min.x;
-    let extent = (bbox.max.y - bbox.min.y).max(bbox.max.z - bbox.min.z);
-    if extent <= 0.0 || thickness > extent * 0.01 {
+    let Some(offset) = decal_local_x_offset(bbox, scale_x) else {
         return;
-    }
+    };
 
-    model.set_local_transform(Matrix4::from_translation(vec3(
-        -DECAL_SURFACE_OFFSET,
-        0.0,
-        0.0,
-    )));
+    model.apply_local_transform(Matrix4::from_translation(vec3(offset, 0.0, 0.0)));
 }
 
 fn create_model(
@@ -544,10 +567,7 @@ fn create_model(
         let rotation = Matrix4::<f32>::from(qrotation);
         let mut scale = Matrix4::<f32>::from_nonuniform_scale(1.0, 1.0, 1.0);
 
-        // HACK:
-        // Move decals up slightly, to avoid z-fighting with level geometry...
-        let forward = qrotation.rotate_vector(vec3(0.0, 0.1, 0.0));
-        let translation = Matrix4::from_translation(pos.position + forward);
+        let translation = Matrix4::from_translation(pos.position);
 
         if v_scale.contains(entity_id) {
             let scale_vec = v_scale.get(entity_id).unwrap().0;
@@ -616,7 +636,11 @@ fn create_model(
             }
         };
 
-        apply_decal_offset(&mut model);
+        // The raw, signed scale - matching `RuntimePropTransform`, which is what
+        // the renderer composes the local offset with (note the model bake
+        // above deliberately uses the absolute value instead).
+        let render_scale_x = v_scale.get(entity_id).map(|s| s.0.x).unwrap_or(1.0);
+        apply_decal_offset(&mut model, render_scale_x);
 
         Some((model, animation_player))
     } else {
@@ -1377,9 +1401,71 @@ impl Default for CreateEntityOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::InnerSpace;
+    use cgmath::{InnerSpace, point3};
     use collision::Aabb3;
     use dark::properties::{Links, ToLink};
+
+    /// `BLOOD02.BIN`-shaped: zero thickness in X, 6x6 Dark units across
+    /// (bounds are stored already divided by `SCALE_FACTOR`).
+    fn decal_bbox() -> Aabb3<f32> {
+        Aabb3::new(
+            point3(-2.0e-6, -3.0 / SCALE_FACTOR, -3.0 / SCALE_FACTOR),
+            point3(2.0e-6, 3.0 / SCALE_FACTOR, 3.0 / SCALE_FACTOR),
+        )
+    }
+
+    /// The world displacement the renderer ends up applying: the local offset
+    /// rides inside `RuntimePropTransform`, which scales by the raw signed X.
+    fn world_offset(bbox: Aabb3<f32>, scale_x: f32) -> Option<f32> {
+        decal_local_x_offset(bbox, scale_x).map(|local| local * scale_x)
+    }
+
+    #[test]
+    fn decal_is_lifted_off_its_surface() {
+        let offset = decal_local_x_offset(decal_bbox(), 1.0).unwrap();
+        assert!(offset < 0.0, "decal must move along local -X, got {offset}");
+    }
+
+    /// medsci1's entity 772 (`Blood Splatter Small`) carries
+    /// `PropScale([-1.013279, 0.667, 1.0])`, and the renderer applies that sign,
+    /// so an uncompensated local offset is mirrored *into* the floor.
+    #[test]
+    fn decal_lift_survives_a_mirrored_scale() {
+        for scale_x in [1.0, -1.013_279, 0.5, -3.0] {
+            let world = world_offset(decal_bbox(), scale_x).unwrap();
+            assert!(
+                (world + DECAL_SURFACE_OFFSET).abs() < 1.0e-6,
+                "scale {scale_x} displaced the decal by {world}, want {}",
+                -DECAL_SURFACE_OFFSET
+            );
+        }
+    }
+
+    #[test]
+    fn a_degenerate_scale_is_left_alone() {
+        assert_eq!(decal_local_x_offset(decal_bbox(), 0.0), None);
+    }
+
+    /// `pipe312.BIN` is 1% as thick as it is long, but it is a 312-unit pipe,
+    /// not a decal - the flatness test must be absolute, not a ratio.
+    #[test]
+    fn a_long_thin_pipe_is_not_a_decal() {
+        let pipe = Aabb3::new(
+            point3(0.0, 0.0, 0.0),
+            point3(
+                3.0 / SCALE_FACTOR,
+                3.005 / SCALE_FACTOR,
+                312.0 / SCALE_FACTOR,
+            ),
+        );
+        assert_eq!(decal_local_x_offset(pipe, 1.0), None);
+    }
+
+    #[test]
+    fn an_ordinary_prop_is_not_a_decal() {
+        let crate_bbox = Aabb3::new(point3(-1.0, -1.0, -1.0), point3(1.0, 1.0, 1.0));
+        assert_eq!(decal_local_x_offset(crate_bbox, 1.0), None);
+    }
 
     /// A ladder-shaped entity: climbable terrain with a physics type but - like
     /// most shipped ladders - no `P$PhysDims` at all.

--- a/shock2vr/src/scripts/internal_fast_projectile.rs
+++ b/shock2vr/src/scripts/internal_fast_projectile.rs
@@ -22,6 +22,14 @@ use crate::{
 
 use super::{Effect, MessagePayload, Script};
 
+/// How far an impact spang is backed off the surface it struck - just enough
+/// to keep it out of the world, matching the original engine's hair-width
+/// backup (0.01 Dark units). Clearance for the decal riding the spang (the
+/// bullet hole) is the decal surface offset's job, applied when its model is
+/// created; spawning the spang a visible distance out stacked the two and
+/// left the hole hanging off the wall.
+const SPANG_SURFACE_BACKUP: f32 = 0.01 / SCALE_FACTOR;
+
 pub struct InternalFastProjectileScript {
     velocity: Vector3<f32>,
 }
@@ -129,7 +137,7 @@ impl Script for InternalFastProjectileScript {
             if let Some(template_id) = choose_impact_spang(world, entity_id, hit_entity_id) {
                 effects.push(Effect::CreateEntity {
                     template_id,
-                    position: hit_point + hit_normal * SCALE_FACTOR / 25.0,
+                    position: hit_point + hit_normal * SPANG_SURFACE_BACKUP,
                     orientation: get_rotation_from_forward_vector(hit_normal)
                         * Quaternion::from_axis_angle(vec3(0.0, 1.0, 0.0), Deg(90.0)),
                     root_transform: Matrix4::identity(),


### PR DESCRIPTION
Follow-up to #915, from its cross-engine review. Two real defects in the decal surface offset, both raised independently by both review engines, both now covered by unit tests confirmed to fail without their fix.

## 1. `PropScale` flipped the lift *into* the surface (the bug #915 was fixing)

The offset rides in the model's local transform, so the renderer applies it as `RuntimePropTransform * local` — and `RuntimePropTransform` uses the **raw, signed** scale (`entity_creator.rs`), unlike the model-bake path right above it, which deliberately `abs()`es it. The property reader mirrors X, so the shipped data stores `PropScale.x` negative on **every** scaled entity — all 131 of them in medsci1.

Concretely, medsci1 entity 772 (`Blood Splatter Small`, `PropScale([-1.013279, 0.6666667, 1.0])`, a `blood01` floor decal):

| | world displacement |
|---|---|
| intended | `-0.02` along local X (out of the floor) |
| actual | `+0.0203` along local X (**into** the floor) |

So exactly the decals that carry a scale kept z-fighting. Fixed by dividing the scale out, so the world displacement is always `DECAL_SURFACE_OFFSET` regardless of what the entity is scaled by; a degenerate (zero) scale is skipped.

## 2. The flatness test was a ratio, so a long pipe qualified

`thickness <= extent * 0.01` is satisfied by `pipe312.bin` — 1.2 world units thick, 125 long. It got nudged 1.5cm. Harmless in practice, but only accidentally so. Now the test is absolute: a decal must be thinner than the offset itself, which every real decal is (they are all exactly 0.0 thick).


## 3. Bullet-hole decals were double-offset

The generic decal lift also applies to the `Bullet Hit` sprite riding an impact spang — but `internal_fast_projectile.rs` already spawned the spang at `hit_normal * SCALE_FACTOR / 25.0`, i.e. **0.1 world units** (~7.6cm) off the surface. Stacked with the decal's own 0.02, the hole sat 0.12 out from the wall — more than its entire 0.1-unit width, so it read as hanging in front of the surface at any oblique angle.

The original engine backs a spang off its collision point by **0.01 Dark units**, purely to keep it out of the world; clearance from the surface was the renderer's depth bias, not the spawn position. This uses that same hair-width backup and lets the decal offset do the clearance, which is what it's for.

Measured in medsci1 (pistol shot into the corridor wall), the spang's spawn position moves from 0.1 to 0.004 off the wall:

| | spang spawn | + decal lift | total standoff |
|---|---|---|---|
| before | 0.100 | 0.02 | **0.120** (~9cm) |
| after | 0.004 | 0.02 | **0.024** (~1.8cm) |

`bullet-hole.e2e.test.ts` (spang/decal lifetimes) still passes.


![bullet hole before/after](https://gist.githubusercontent.com/tommy-xr/a58d5cec2565561a7da239e539802743/raw/35b7a6558f67cfee1a53a8b42d2a53229f4dec63/bullethole-beforeafter.png)

<sub>`debug_weapons`, same shot and same camera on both builds: the wall is viewed at 63° off its normal, and the crosshair marks the point the bullet actually struck. Before, the hole parallaxes away from that point because it hangs 9cm off the wall; after, it sits on it. Measured hole centroid: 54px from the crosshair before, 36px after (the residual is the aim-point-to-decal-centre offset plus the remaining 1.8cm standoff).</sub>


## Also folded in

Two findings that landed after #915 was cut:

- **Compose, don't overwrite, the local transform.** The obj loader gives vhot debug cubes their own `local_transform` (`ss2_bin_obj_loader.rs:260`); a blanket set would have clobbered them. No live bug today (no flat model has vhots) but the API was a trap.
- **Deleted the superseded `// HACK: Move decals up slightly` line.** It offset along an in-plane axis and was inert anyway (the render loop overwrites that transform), but left in place it read as a second, conflicting offset.

## Known remaining case

`SIGNSEC.BIN` and its family are paper-thin along local **Z**, not X, so they aren't recognised as decals and still z-fight. Fixing that needs the outward direction for that orientation family, which this change does not guess at. The durable fix for all of it remains a depth bias (`glPolygonOffset`), as the original engine did with `g_obj_zbias` — that would moot the axis, the sign, and the scale interaction all at once.

## Verification

- 5 new unit tests over the extracted pure function `decal_local_x_offset`. Each was confirmed to **fail without its fix** — the mirrored-scale test reports `scale -1.013279 displaced the decal by 0.02026558, want -0.02`, and the pipe test misclassifies `pipe312`.
- `cargo test -p shock2vr`: 558 passed, 0 failed.
- The medsci1 in-decal churn metric from #915 is unchanged at **4.65** (baseline 10.22), so the original fix hasn't regressed.
- `cargo fmt` + `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

No new visuals: the on-screen effect is the #915 before/after already merged there, and the one scaled decal in medsci1 sits in an unlit corner where a screenshot shows nothing either way — hence the unit test as the durable evidence instead.

