### PR TITLE
fix(ui): land inventory grids on their authored cells

### DIFF
--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -62,14 +62,30 @@ fn creature_is_lootable(world: &World, entity_id: EntityId) -> bool {
     })
 }
 
+/// One inventory cell, in panel pixels. Both the backpack strip and the loot
+/// panel step their item grids by this pitch - it is the spacing of the cell
+/// separators drawn into `invback.pcx` and `contain.pcx`, whose grid lines sit
+/// 35px apart horizontally and 34px apart vertically.
+const SLOT_PITCH: (f32, f32) = (35.0, 34.0);
+
+/// Top-left of the loot panel's 4x4 item grid, in `contain.pcx` pixels: its
+/// cell separators run at x = 13 + 35n and y = 150 + 34n, and items are
+/// authored just inside that first line.
+const LOOT_GRID_ORIGIN: (f32, f32) = (15.0, 153.0);
+
+/// Top-left of the backpack strip's 15x3 item grid, in `invback.pcx` pixels
+/// (separators at x = 2 + 35n, y = 15 + 34n; the EQUIP paperdoll owns
+/// everything right of x = 527).
+const BACKPACK_GRID_ORIGIN: (f32, f32) = (4.0, 17.0);
+
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
         ContainerGui {
             background_image: "contain.pcx".to_owned(),
             width: 188.0,
             height: 296.0,
-            inv_offset_x: 15.0,
-            inv_offset_y: 160.0,
+            inv_offset_x: LOOT_GRID_ORIGIN.0,
+            inv_offset_y: LOOT_GRID_ORIGIN.1,
             num_slots_x: 4,
             num_slots_y: 4,
             take_on_click: true,
@@ -93,8 +109,8 @@ impl ContainerGui {
             background_image: "invback.pcx".to_owned(),
             width: 635.0,
             height: 120.0,
-            inv_offset_x: 4.0,
-            inv_offset_y: 18.0,
+            inv_offset_x: BACKPACK_GRID_ORIGIN.0,
+            inv_offset_y: BACKPACK_GRID_ORIGIN.1,
             num_slots_x: 15,
             num_slots_y: 3,
             take_on_click: false,
@@ -148,8 +164,8 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             inventory.insert_first_available(entity.0, inv_dims.0 as usize, inv_dims.1 as usize);
         }
 
-        let slot_pixel_width = 35.0;
-        let slot_pixel_height = 32.0;
+        let slot_pixel_width = SLOT_PITCH.0;
+        let slot_pixel_height = SLOT_PITCH.1;
         let initial_offset_y = self.inv_offset_y;
         let initial_offset_x = self.inv_offset_x;
 
@@ -434,6 +450,37 @@ mod tests {
                 assert_eq!(dropped_entity_id, item);
             }
             other => panic!("Take should transfer via DropEntityInfo, got {:?}", other),
+        }
+    }
+
+    /// Both panels' item grids must land on the cell separators authored into
+    /// their backdrops - `contain.pcx` (loot) and `invback.pcx` (backpack) -
+    /// stepping by the shared 35x34 cell pitch. A 1x1 item therefore occupies
+    /// exactly one cell at the grid origin.
+    #[test]
+    fn item_grids_sit_on_the_authored_backdrop_cells() {
+        let (world, container, item, _inventory) = loot_world();
+
+        for (gui, expected_origin) in [
+            (ContainerGui::loot_container(), vec2(15.0, 153.0)),
+            (ContainerGui::inv_container(), vec2(4.0, 17.0)),
+        ] {
+            let components = gui.get_components(&None, container, &world, &ContainerGuiState {});
+            let (position, size) = components
+                .iter()
+                .find_map(|c| match c {
+                    GuiComponent::Button {
+                        entity: Some(e),
+                        position,
+                        size,
+                        ..
+                    } if *e == item => Some((*position, *size)),
+                    _ => None,
+                })
+                .expect("the panel should expose a button bound to the contained item");
+
+            assert_eq!(position, expected_origin, "grid origin");
+            assert_eq!(size, vec2(35.0, 34.0), "one cell of the shared pitch");
         }
     }
 


### PR DESCRIPTION
Stacked on #840 (base: `fix/issue-357-unify-ui`).

## Reproduction

Open the corpse at the start of `medsci1` (it holds the Wrench) and read the panel back
over HTTP:

```
$ curl -s :8080/v1/ui | jq '.active_panel.elements[1]'
{ "texture": "icon_wrench.pcx", "label": "Wrench", "rect": [17, 284, 35, 96] }
```

The item sits at panel-local `(15, 160)` and steps by a 35x32 cell. Neither matches the
art it is drawn on. Decoding the cell separators straight out of the shipped backdrops:

| Backdrop | Separator lines | Cell pitch | First item cell |
| --- | --- | --- | --- |
| `contain.pcx` (loot panel) | `x = 13 + 35n`, `y = 150 + 34n` | 35 x 34 | (15, 153) |
| `invback.pcx` (backpack strip) | `x = 2 + 35n`, `y = 15 + 34n` | 35 x 34 | (4, 17) |

So rows are 34px apart, not 32. The 2px-per-row error accumulates down the grid, and the
loot panel's items additionally float 7px below their cells - visible as items drifting
off their separators toward the bottom of the panel.

(The backpack strip's grid is 15 columns wide; everything right of `x = 527` belongs to
the EQUIP paperdoll.)

## Fix

Name the three values - `SLOT_PITCH`, `LOOT_GRID_ORIGIN`, `BACKPACK_GRID_ORIGIN` - and
derive both panels' offsets from them. No behavior beyond the geometry changes.

After: `"rect": [17, 277, 35, 102]` - the item now lands exactly on the backdrop's first
cell.

## Verification

- negative-first: `item_grids_sit_on_the_authored_backdrop_cells` fails on the old
  constants (`left: Vector2 [15.0, 160.0]`, `right: Vector2 [15.0, 153.0]`), passes after
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` - 556 passed
- full `npm run test:e2e` - 235 tests, 226 pass, 7 skipped; the 2 failures are baseline
  (`shodan-corpse-drift` reproduces on detached `main`; `ally-line-of-fire` passes in
  isolation and only fails when the suite shares the machine)


## Visual verification

Loot MFD panel (bottom-left, 4x4 grid) + top inventory strip, same frame, same deterministic
capture sequence on both revisions (medsci1.mis, headless debug runtime: teleport -> frob corpse
-> spawn 3 backpack items -> `ToggleUseMode` -> `/v1/step` -> `/v1/screenshot`).

![before/after: inventory grid geometry](https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/pr919_beforeafter.png)

Before, every item floats ~7px below its cell and the rows walk out of register with the
backdrop's painted separators (the wrench's head hangs into the row above its cell line). After,
the grid origin lands on the authored cells and rows step by the backdrop's 34px pitch, so items
sit inside the cells they occupy — visible in both the loot grid and the top strip.

![grid geometry loop](https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/pr919_demo.gif)

<sub>Loop cycles the same panel between before and after. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). Full uncropped frames: <a href="https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/base.png">before</a>, <a href="https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/mid.png">after</a>.</sub>
