### PR TITLE
fix(ui): blit inventory object icons at their authored size

### DIFF
--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -619,15 +619,23 @@ impl GuiComponentRenderInfo {
                         },
                     )
                     .clone();
-                // An object icon draws at its own authored pixels, anchored to
-                // the top-left of its slot; ordinary art fills the slot.
-                let size = &if self.is_object_icon() {
-                    vec2(
-                        texture.width() as f32 / panel_size_px.x,
-                        texture.height() as f32 / panel_size_px.y,
+                // An object icon draws at its own authored pixels, centered in
+                // its slot; ordinary art fills the slot. The panel's own
+                // coordinates are normalized, so the icon's authored pixels
+                // and the centering offset are converted through panel_size_px.
+                let (position, size) = &if self.is_object_icon() {
+                    let slot_px = vec2(size.x * panel_size_px.x, size.y * panel_size_px.y);
+                    let drawn_px = vec2(texture.width() as f32, texture.height() as f32);
+                    let offset_px = crate::ui::centered_offset(slot_px, drawn_px);
+                    (
+                        vec2(
+                            position.x + offset_px.x / panel_size_px.x,
+                            position.y + offset_px.y / panel_size_px.y,
+                        ),
+                        vec2(drawn_px.x / panel_size_px.x, drawn_px.y / panel_size_px.y),
                     )
                 } else {
-                    *size
+                    (*position, *size)
                 };
                 let texture = texture as Rc<dyn TextureTrait>;
                 let comp_mat = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -10,7 +10,7 @@ use engine::{
 use shipyard::EntityId;
 
 use crate::{
-    ui::{HAlign, UiElement, VAlign},
+    ui::{HAlign, ImageKind, UiElement, VAlign},
     vr_config::Handedness,
 };
 
@@ -30,14 +30,14 @@ where
                 size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
                 ..
             } => Self::Image {
                 position: new_position,
                 size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
             },
             Self::Bar {
                 size,
@@ -101,14 +101,14 @@ where
                 position,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
                 ..
             } => Self::Image {
                 position,
                 size: new_size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
             },
             Self::Bar {
                 position,
@@ -199,14 +199,14 @@ where
                 position,
                 size,
                 texture,
-                transparent_index_0,
+                kind,
                 ..
             } => Self::Image {
                 position,
                 size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
             },
             Self::Bar {
                 position,
@@ -297,14 +297,14 @@ where
                 alpha,
                 position,
                 size,
-                transparent_index_0,
+                kind,
                 ..
             } => Self::Image {
                 alpha,
                 position,
                 size,
                 texture: image.to_owned(),
-                transparent_index_0,
+                kind,
             },
             Self::Bar {
                 alpha,
@@ -414,13 +414,13 @@ where
                 size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
             } => GuiComponent::Image {
                 position,
                 size,
                 texture,
                 alpha,
-                transparent_index_0,
+                kind,
             },
             Self::Text {
                 position,
@@ -485,7 +485,7 @@ pub fn image<TMsg: Clone>(texture: &str) -> GuiComponent<TMsg> {
         size: vec2(30.0, 30.0),
         texture: texture.to_owned(),
         alpha: 0.5,
-        transparent_index_0: false,
+        kind: ImageKind::Ui,
     }
 }
 
@@ -556,6 +556,10 @@ pub enum GuiComponentRenderInfo {
         /// elevator floor name), if any. Purely informational - used by
         /// `GET /v1/ui`; takes precedence over entity/art-derived labels.
         label: Option<String>,
+        /// The source panel's pixel size. `position`/`size` are normalized by
+        /// it, so it is what converts an object icon's authored pixel
+        /// dimensions back into the same space (see [`Self::is_object_icon`]).
+        panel_size_px: Vector2<f32>,
     },
     Text {
         position: Vector2<f32>,
@@ -581,9 +585,11 @@ impl GuiComponentRenderInfo {
         }
     }
 
-    /// Entity-backed images are inventory/loot object icons. Dark keys their
-    /// paletted PCX art on palette index 0, independent of that entry's RGB.
-    pub(crate) fn transparent_index_0(&self) -> bool {
+    /// Entity-backed images are inventory/loot object icons: Dark keys their
+    /// paletted PCX art on palette index 0 (independent of that entry's RGB),
+    /// and blits it at its authored pixel size rather than stretching it to
+    /// the slot.
+    pub(crate) fn is_object_icon(&self) -> bool {
         matches!(
             self,
             Self::Image {
@@ -600,18 +606,30 @@ impl GuiComponentRenderInfo {
                 size,
                 texture,
                 alpha,
+                panel_size_px,
                 ..
             } => {
-                let texture: Rc<dyn TextureTrait> = asset_cache
+                let texture = asset_cache
                     .get_ext(
                         &TEXTURE_IMPORTER,
                         texture,
                         &TextureOptions {
-                            transparent_index_0: self.transparent_index_0(),
+                            transparent_index_0: self.is_object_icon(),
                             ..Default::default()
                         },
                     )
                     .clone();
+                // An object icon draws at its own authored pixels, anchored to
+                // the top-left of its slot; ordinary art fills the slot.
+                let size = &if self.is_object_icon() {
+                    vec2(
+                        texture.width() as f32 / panel_size_px.x,
+                        texture.height() as f32 / panel_size_px.y,
+                    )
+                } else {
+                    *size
+                };
+                let texture = texture as Rc<dyn TextureTrait>;
                 let comp_mat = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);
                 let mut comp_obj =
                     SceneObject::new(comp_mat, Box::new(engine::scene::quad::create()));
@@ -688,7 +706,7 @@ where
                 size,
                 texture,
                 alpha,
-                transparent_index_0: _,
+                kind: _,
             } => GuiComponentRenderInfo::Image {
                 position: vec2(position.x / screen_size.x, position.y / screen_size.y),
                 size: vec2(size.x / screen_size.x, size.y / screen_size.y),
@@ -697,6 +715,7 @@ where
                 interactive: false,
                 entity: None,
                 label: None,
+                panel_size_px: screen_size,
             },
             GuiComponent::Bar {
                 position,
@@ -712,6 +731,7 @@ where
                 interactive: false,
                 entity: None,
                 label: None,
+                panel_size_px: screen_size,
             },
             GuiComponent::Button {
                 position,
@@ -748,6 +768,7 @@ where
                     interactive: on_click.is_some() || on_grab.is_some(),
                     entity: *entity,
                     label: label.clone(),
+                    panel_size_px: screen_size,
                 }
             }
         }
@@ -813,10 +834,10 @@ mod tests {
 
         let render_info = component.to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
 
-        assert!(render_info.transparent_index_0());
+        assert!(render_info.is_object_icon());
 
         let backdrop =
             image::<()>("invback.pcx").to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
-        assert!(!backdrop.transparent_index_0());
+        assert!(!backdrop.is_object_icon());
     }
 }

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -61,6 +61,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 position: new_position,
@@ -72,6 +73,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
             },
             Self::Text {
                 size,
@@ -132,6 +134,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 position,
@@ -143,6 +146,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
             },
             Self::Text {
                 position,
@@ -177,8 +181,10 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
                 ..
             } => GuiComponent::Button {
+                kind,
                 alpha,
                 position,
                 size,
@@ -230,6 +236,7 @@ where
                 hover,
                 entity,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 position,
@@ -241,6 +248,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
             },
             Self::Text {
                 position,
@@ -275,6 +283,7 @@ where
                 on_grab,
                 entity,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 alpha,
@@ -286,6 +295,7 @@ where
                 hover,
                 entity,
                 label,
+                kind,
             },
             other => other,
         }
@@ -328,6 +338,7 @@ where
                 hover,
                 entity,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 alpha,
@@ -339,10 +350,57 @@ where
                 hover,
                 entity,
                 label,
+                kind,
             },
             Self::Text { .. } => self,
         }
     }
+    /// Declare this element's art to be Dark object-icon art: keyed on
+    /// palette index 0 and blitted at its authored pixel size, centered in
+    /// the element's rect (see [`ImageKind`]). The rect still defines layout
+    /// and hit-testing.
+    pub fn with_object_icon(self) -> GuiComponent<TEvent> {
+        match self {
+            Self::Image {
+                position,
+                size,
+                texture,
+                alpha,
+                ..
+            } => Self::Image {
+                position,
+                size,
+                texture,
+                alpha,
+                kind: ImageKind::ObjectIcon,
+            },
+            Self::Button {
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                alpha,
+                entity,
+                label,
+                ..
+            } => Self::Button {
+                position,
+                size,
+                texture,
+                on_click,
+                on_grab,
+                hover,
+                alpha,
+                entity,
+                label,
+                kind: ImageKind::ObjectIcon,
+            },
+            other => other,
+        }
+    }
+
     /// Tag a `Button` with the world entity it stands for (no-op for other
     /// component kinds) - see `GuiComponent::Button::entity`.
     pub fn with_entity(self, new_entity: EntityId) -> GuiComponent<TEvent> {
@@ -356,6 +414,7 @@ where
                 on_grab,
                 hover,
                 label,
+                kind,
                 ..
             } => Self::Button {
                 alpha,
@@ -367,6 +426,7 @@ where
                 hover,
                 entity: Some(new_entity),
                 label,
+                kind,
             },
             other => other,
         }
@@ -387,6 +447,7 @@ where
                 on_grab,
                 hover,
                 entity,
+                kind,
                 ..
             } => Self::Button {
                 alpha,
@@ -398,6 +459,7 @@ where
                 hover,
                 entity,
                 label: Some(new_label.to_owned()),
+                kind,
             },
             other => other,
         }
@@ -464,6 +526,7 @@ where
                 alpha,
                 entity,
                 label,
+                kind,
             } => GuiComponent::Button {
                 position,
                 size,
@@ -472,6 +535,7 @@ where
                 on_grab: on_grab.map(|(left, right)| (f(left), f(right))),
                 hover,
                 alpha,
+                kind,
                 entity,
                 label,
             },
@@ -500,6 +564,7 @@ pub fn button<TMsg: Clone>(on_click: TMsg) -> GuiComponent<TMsg> {
         alpha: 0.5,
         entity: None,
         label: None,
+        kind: ImageKind::Ui,
     }
 }
 
@@ -514,6 +579,7 @@ pub fn grabbable<TMsg: Clone>(on_left_grab: TMsg, on_right_grab: TMsg) -> GuiCom
         alpha: 0.5,
         entity: None,
         label: None,
+        kind: ImageKind::Ui,
     }
 }
 
@@ -550,7 +616,8 @@ pub enum GuiComponentRenderInfo {
         interactive: bool,
         /// The world entity the source button stands for (a contained item in
         /// a loot panel), if any. Purely informational - used by `GET /v1/ui`
-        /// to label the element with the item's name and entity id.
+        /// to label the element with the item's name and entity id. How the
+        /// art draws is decided by `kind`, never by this.
         entity: Option<EntityId>,
         /// An explicit semantic label from the source `Button` (e.g. an
         /// elevator floor name), if any. Purely informational - used by
@@ -560,6 +627,9 @@ pub enum GuiComponentRenderInfo {
         /// it, so it is what converts an object icon's authored pixel
         /// dimensions back into the same space (see [`Self::is_object_icon`]).
         panel_size_px: Vector2<f32>,
+        /// How the art is keyed and sized, carried from the authoring
+        /// component (see [`ImageKind`]).
+        kind: ImageKind,
     },
     Text {
         position: Vector2<f32>,
@@ -585,15 +655,13 @@ impl GuiComponentRenderInfo {
         }
     }
 
-    /// Entity-backed images are inventory/loot object icons: Dark keys their
-    /// paletted PCX art on palette index 0 (independent of that entry's RGB),
-    /// and blits it at its authored pixel size rather than stretching it to
-    /// the slot.
+    /// Whether this is Dark object-icon art: keyed on palette index 0 and
+    /// blitted at its authored pixel size, centered in its slot.
     pub(crate) fn is_object_icon(&self) -> bool {
         matches!(
             self,
             Self::Image {
-                entity: Some(_),
+                kind: ImageKind::ObjectIcon,
                 ..
             }
         )
@@ -607,6 +675,7 @@ impl GuiComponentRenderInfo {
                 texture,
                 alpha,
                 panel_size_px,
+                kind,
                 ..
             } => {
                 let texture = asset_cache
@@ -619,24 +688,26 @@ impl GuiComponentRenderInfo {
                         },
                     )
                     .clone();
-                // An object icon draws at its own authored pixels, centered in
-                // its slot; ordinary art fills the slot. The panel's own
-                // coordinates are normalized, so the icon's authored pixels
-                // and the centering offset are converted through panel_size_px.
-                let (position, size) = &if self.is_object_icon() {
-                    let slot_px = vec2(size.x * panel_size_px.x, size.y * panel_size_px.y);
-                    let drawn_px = vec2(texture.width() as f32, texture.height() as f32);
-                    let offset_px = crate::ui::centered_offset(slot_px, drawn_px);
-                    (
-                        vec2(
-                            position.x + offset_px.x / panel_size_px.x,
-                            position.y + offset_px.y / panel_size_px.y,
-                        ),
-                        vec2(drawn_px.x / panel_size_px.x, drawn_px.y / panel_size_px.y),
-                    )
-                } else {
-                    (*position, *size)
-                };
+                // Placement is decided in panel pixels by the same helper the
+                // 2D presenters use, then renormalized - this panel's own
+                // coordinates are normalized by `panel_size_px`.
+                //
+                // NOTE: the quad below composes through a 180-degree z
+                // rotation, which negates both axes. `drawn_rect` breaks an
+                // odd pixel of centering slack toward the top-left, so here
+                // that lands toward the bottom-right - the two presentations
+                // can differ by one pixel on odd slack.
+                let (position_px, size_px) = crate::ui::drawn_rect(
+                    vec2(position.x * panel_size_px.x, position.y * panel_size_px.y),
+                    vec2(size.x * panel_size_px.x, size.y * panel_size_px.y),
+                    vec2(texture.width() as f32, texture.height() as f32),
+                    *kind,
+                );
+                let position = &vec2(
+                    position_px.x / panel_size_px.x,
+                    position_px.y / panel_size_px.y,
+                );
+                let size = &vec2(size_px.x / panel_size_px.x, size_px.y / panel_size_px.y);
                 let texture = texture as Rc<dyn TextureTrait>;
                 let comp_mat = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);
                 let mut comp_obj =
@@ -714,7 +785,7 @@ where
                 size,
                 texture,
                 alpha,
-                kind: _,
+                kind,
             } => GuiComponentRenderInfo::Image {
                 position: vec2(position.x / screen_size.x, position.y / screen_size.y),
                 size: vec2(size.x / screen_size.x, size.y / screen_size.y),
@@ -724,6 +795,7 @@ where
                 entity: None,
                 label: None,
                 panel_size_px: screen_size,
+                kind: *kind,
             },
             GuiComponent::Bar {
                 position,
@@ -740,6 +812,7 @@ where
                 entity: None,
                 label: None,
                 panel_size_px: screen_size,
+                kind: ImageKind::Ui,
             },
             GuiComponent::Button {
                 position,
@@ -751,6 +824,7 @@ where
                 on_grab,
                 entity,
                 label,
+                kind,
             } => {
                 let is_hovered = self
                     .rect()
@@ -777,6 +851,7 @@ where
                     entity: *entity,
                     label: label.clone(),
                     panel_size_px: screen_size,
+                    kind: *kind,
                 }
             }
         }
@@ -833,19 +908,45 @@ mod tests {
         assert_eq!(canvas.click_at(vec2(5.0, 5.0)), None);
     }
 
+    /// The declared `ImageKind` survives the trip into render info - the
+    /// renderers must not have to re-guess it (they used to infer it from
+    /// `entity`, which silently disagreed with the flat path for the icon
+    /// riding the cursor: a plain image with no entity).
     #[test]
-    fn entity_backed_object_icons_use_palette_index_zero_transparency() {
+    fn the_declared_object_icon_kind_reaches_render_info() {
         let entity = EntityId::from_inner(1).unwrap();
-        let component = grabbable((), ())
+        let button = grabbable((), ())
             .with_entity(entity)
-            .with_image("passkey.pcx");
+            .with_image("passkey.pcx")
+            .with_object_icon();
+        assert!(
+            button
+                .to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5))
+                .is_object_icon()
+        );
 
-        let render_info = component.to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
+        // An entity-less plain image is object-icon art too, when it says so.
+        let cursor_item = image::<()>("passkey.pcx").with_object_icon();
+        assert!(
+            cursor_item
+                .to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5))
+                .is_object_icon()
+        );
 
-        assert!(render_info.is_object_icon());
+        // ...and an entity-tagged button is NOT, unless it says so.
+        let plain = button_from_entity(entity);
+        assert!(
+            !plain
+                .to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5))
+                .is_object_icon()
+        );
 
         let backdrop =
             image::<()>("invback.pcx").to_render_info(vec2(640.0, 480.0), Point2::new(0.5, 0.5));
         assert!(!backdrop.is_object_icon());
+    }
+
+    fn button_from_entity(entity: EntityId) -> GuiComponent<()> {
+        grabbable((), ()).with_entity(entity).with_image("key0.pcx")
     }
 }

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -71,7 +71,7 @@ where
             position: vec2(self.cursor.x, self.cursor.y),
             size,
             texture: "cursor.pcx".to_owned(),
-            transparent_index_0: false,
+            kind: crate::ui::ImageKind::Ui,
         });
         let render_components = canvas
             .into_elements()

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -891,7 +891,7 @@ fn draw_components(
             // alpha is a VR world-quad translucency, deliberately not
             // applied here.
             GuiComponentRenderInfo::Image { texture, .. } => {
-                if component.transparent_index_0() {
+                if component.is_object_icon() {
                     canvas.object_icon(r, texture);
                 } else {
                     canvas.image(r, texture);
@@ -1023,6 +1023,7 @@ mod tests {
             interactive: true,
             entity: None,
             label: None,
+            panel_size_px: vec2(188.0, 296.0),
         };
         let r = component_canvas_rect(&info, panel);
         assert!((r.x - 17.0).abs() < 1e-3);
@@ -1128,6 +1129,7 @@ mod tests {
             interactive: false,
             entity: None,
             label: None,
+            panel_size_px: vec2(188.0, 296.0),
         };
         assert!(is_gui_cursor(&cursor));
         let backdrop = GuiComponentRenderInfo::Image {
@@ -1138,6 +1140,7 @@ mod tests {
             interactive: false,
             entity: None,
             label: None,
+            panel_size_px: vec2(188.0, 296.0),
         };
         assert!(!is_gui_cursor(&backdrop));
     }
@@ -1203,6 +1206,7 @@ mod tests {
                 interactive: true,
                 entity: Some(item),
                 label: None,
+                panel_size_px: vec2(188.0, 296.0),
             }],
         );
         let elements = host.debug_elements(&world);
@@ -1357,6 +1361,7 @@ mod tests {
                     interactive: false,
                     entity: None,
                     label: None,
+                    panel_size_px: vec2(188.0, 296.0),
                 },
                 GuiComponentRenderInfo::Image {
                     position: vec2(4.0 / 635.0, 18.0 / 120.0),
@@ -1366,6 +1371,7 @@ mod tests {
                     interactive: true,
                     entity: Some(wrench),
                     label: None,
+                    panel_size_px: vec2(188.0, 296.0),
                 },
             ],
         );
@@ -1411,6 +1417,7 @@ mod tests {
             interactive: true,
             entity: Some(entity),
             label: None,
+            panel_size_px: vec2(188.0, 296.0),
         }
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -61,11 +61,6 @@ const CLOSE_BUTTON_MARGIN: Vector2<f32> = Vector2::new(25.0, 8.0);
 /// `CURSOR.PCX` native size.
 const CURSOR_SIZE: Vector2<f32> = Vector2::new(12.0, 16.0);
 
-/// Size of the item icon drawn when the cursor "is" a lifted item (the
-/// original replaces the arrow with the object's `objicon` art). One
-/// inventory slot (35x32, matching `ContainerGui`'s slot pixels).
-const CURSOR_ITEM_SIZE: Vector2<f32> = Vector2::new(35.0, 32.0);
-
 /// A host-side action produced by the cursor-is-the-item drag (§1.5/§2.4),
 /// applied by `mission_core` because it touches physics/effects.
 ///
@@ -673,10 +668,10 @@ impl FlatUiHost {
             // arrow (the original's `SCM_DRAGOBJ`, §2.4). Fall back to the
             // arrow when the held item has no icon or nothing is held.
             match self.cursor_item.as_ref().and_then(|c| c.icon.as_deref()) {
-                Some(icon) => canvas.object_icon(
-                    Rect::new(cursor.x, cursor.y, CURSOR_ITEM_SIZE.x, CURSOR_ITEM_SIZE.y),
-                    icon,
-                ),
+                // No slot rect: object icons draw at their authored size, and
+                // any rect bigger than the art would only center the icon
+                // inside it - i.e. slide it off the pointer.
+                Some(icon) => canvas.object_icon(Rect::new(cursor.x, cursor.y, 0.0, 0.0), icon),
                 None => canvas.image(
                     Rect::new(cursor.x, cursor.y, CURSOR_SIZE.x, CURSOR_SIZE.y),
                     "cursor.pcx",
@@ -1024,6 +1019,7 @@ mod tests {
             entity: None,
             label: None,
             panel_size_px: vec2(188.0, 296.0),
+            kind: crate::ui::ImageKind::Ui,
         };
         let r = component_canvas_rect(&info, panel);
         assert!((r.x - 17.0).abs() < 1e-3);
@@ -1130,6 +1126,7 @@ mod tests {
             entity: None,
             label: None,
             panel_size_px: vec2(188.0, 296.0),
+            kind: crate::ui::ImageKind::Ui,
         };
         assert!(is_gui_cursor(&cursor));
         let backdrop = GuiComponentRenderInfo::Image {
@@ -1141,6 +1138,7 @@ mod tests {
             entity: None,
             label: None,
             panel_size_px: vec2(188.0, 296.0),
+            kind: crate::ui::ImageKind::Ui,
         };
         assert!(!is_gui_cursor(&backdrop));
     }
@@ -1207,6 +1205,7 @@ mod tests {
                 entity: Some(item),
                 label: None,
                 panel_size_px: vec2(188.0, 296.0),
+                kind: crate::ui::ImageKind::Ui,
             }],
         );
         let elements = host.debug_elements(&world);
@@ -1362,16 +1361,18 @@ mod tests {
                     entity: None,
                     label: None,
                     panel_size_px: vec2(188.0, 296.0),
+                    kind: crate::ui::ImageKind::Ui,
                 },
                 GuiComponentRenderInfo::Image {
-                    position: vec2(4.0 / 635.0, 18.0 / 120.0),
-                    size: vec2(35.0 / 635.0, 32.0 / 120.0),
+                    position: vec2(4.0 / 635.0, 17.0 / 120.0),
+                    size: vec2(35.0 / 635.0, 34.0 / 120.0),
                     texture: "icn_wrench.pcx".to_owned(),
                     alpha: 0.5,
                     interactive: true,
                     entity: Some(wrench),
                     label: None,
                     panel_size_px: vec2(188.0, 296.0),
+                    kind: crate::ui::ImageKind::Ui,
                 },
             ],
         );
@@ -1406,18 +1407,20 @@ mod tests {
     }
 
     fn strip_item(entity: EntityId, slot_x: usize) -> GuiComponentRenderInfo {
-        // ContainerGui strip slots: 4px inset, 35px slot pitch, 32px tall
-        // (container.rs inv_container), emitted normalized by 635x120.
+        // ContainerGui strip slots: BACKPACK_GRID_ORIGIN (4,17) stepping by
+        // SLOT_PITCH 35x34 (container.rs inv_container), emitted normalized
+        // by the 635x120 strip.
         let x = 4.0 + 35.0 * slot_x as f32;
         GuiComponentRenderInfo::Image {
-            position: vec2(x / 635.0, 18.0 / 120.0),
-            size: vec2(35.0 / 635.0, 32.0 / 120.0),
+            position: vec2(x / 635.0, 17.0 / 120.0),
+            size: vec2(35.0 / 635.0, 34.0 / 120.0),
             texture: "icn_x.pcx".to_owned(),
             alpha: 0.5,
             interactive: true,
             entity: Some(entity),
             label: None,
             panel_size_px: vec2(188.0, 296.0),
+            kind: crate::ui::ImageKind::Ui,
         }
     }
 

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -66,17 +66,20 @@ fn creature_is_lootable(world: &World, entity_id: EntityId) -> bool {
 /// panel step their item grids by this pitch - it is the spacing of the cell
 /// separators drawn into `invback.pcx` and `contain.pcx`, whose grid lines sit
 /// 35px apart horizontally and 34px apart vertically.
-const SLOT_PITCH: (f32, f32) = (35.0, 34.0);
+const SLOT_PITCH: Vector2<f32> = Vector2::new(35.0, 34.0);
 
-/// Top-left of the loot panel's 4x4 item grid, in `contain.pcx` pixels: its
-/// cell separators run at x = 13 + 35n and y = 150 + 34n, and items are
-/// authored just inside that first line.
-const LOOT_GRID_ORIGIN: (f32, f32) = (15.0, 153.0);
+/// Top-left of the loot panel's 4x4 item grid, in `contain.pcx` pixels. Its
+/// cell separators run at x = 13 + 35n and y = 150 + 34n; both are 2px wide,
+/// so this is flush with the first cell's interior horizontally and one row
+/// below it vertically. The two panels' insets differ - that asymmetry is the
+/// original's, not a rounding of ours.
+const LOOT_GRID_ORIGIN: Vector2<f32> = Vector2::new(15.0, 153.0);
 
-/// Top-left of the backpack strip's 15x3 item grid, in `invback.pcx` pixels
-/// (separators at x = 2 + 35n, y = 15 + 34n; the EQUIP paperdoll owns
-/// everything right of x = 527).
-const BACKPACK_GRID_ORIGIN: (f32, f32) = (4.0, 17.0);
+/// Top-left of the backpack strip's 15x3 item grid, in `invback.pcx` pixels:
+/// separators at x = 2 + 35n and y = 15 + 34n, so this sits 2px inside the
+/// first cell horizontally and flush with its interior vertically. The EQUIP
+/// paperdoll owns everything right of x = 527.
+const BACKPACK_GRID_ORIGIN: Vector2<f32> = Vector2::new(4.0, 17.0);
 
 impl ContainerGui {
     pub fn loot_container() -> ContainerGui {
@@ -84,8 +87,8 @@ impl ContainerGui {
             background_image: "contain.pcx".to_owned(),
             width: 188.0,
             height: 296.0,
-            inv_offset_x: LOOT_GRID_ORIGIN.0,
-            inv_offset_y: LOOT_GRID_ORIGIN.1,
+            inv_offset_x: LOOT_GRID_ORIGIN.x,
+            inv_offset_y: LOOT_GRID_ORIGIN.y,
             num_slots_x: 4,
             num_slots_y: 4,
             take_on_click: true,
@@ -109,8 +112,8 @@ impl ContainerGui {
             background_image: "invback.pcx".to_owned(),
             width: 635.0,
             height: 120.0,
-            inv_offset_x: BACKPACK_GRID_ORIGIN.0,
-            inv_offset_y: BACKPACK_GRID_ORIGIN.1,
+            inv_offset_x: BACKPACK_GRID_ORIGIN.x,
+            inv_offset_y: BACKPACK_GRID_ORIGIN.y,
             num_slots_x: 15,
             num_slots_y: 3,
             take_on_click: false,
@@ -164,8 +167,8 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
             inventory.insert_first_available(entity.0, inv_dims.0 as usize, inv_dims.1 as usize);
         }
 
-        let slot_pixel_width = SLOT_PITCH.0;
-        let slot_pixel_height = SLOT_PITCH.1;
+        let slot_pixel_width = SLOT_PITCH.x;
+        let slot_pixel_height = SLOT_PITCH.y;
         let initial_offset_y = self.inv_offset_y;
         let initial_offset_x = self.inv_offset_x;
 
@@ -203,6 +206,7 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                 .with_onclick(on_click)
                 .with_entity(ent)
                 .with_image(&format!("{}.pcx", obj_icon))
+                .with_object_icon()
                 .with_position(vec2(
                     initial_offset_x + position_x,
                     initial_offset_y + position_y,
@@ -225,6 +229,7 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                         .unwrap_or((1, 1));
                     components.push(
                         gui::image(&format!("{}.pcx", obj_icon.0))
+                            .with_object_icon()
                             .with_position(vec2(cursor.position.x, cursor.position.y))
                             .with_size(vec2(
                                 slot_pixel_width * inv_dims.0 as f32,
@@ -481,6 +486,53 @@ mod tests {
 
             assert_eq!(position, expected_origin, "grid origin");
             assert_eq!(size, vec2(35.0, 34.0), "one cell of the shared pitch");
+        }
+    }
+
+    /// Every icon a panel draws for a contained item - the grid buttons and
+    /// the one riding the cursor - must be declared object-icon art, or it
+    /// renders stretched to the slot with palette index 0 opaque (a black box
+    /// behind the icon). The cursor image is the easy one to forget: it is a
+    /// plain `image`, not a button, so nothing about it says "item".
+    #[test]
+    fn contained_item_art_is_declared_as_object_icons() {
+        use crate::gui::GuiCursor;
+        use crate::ui::ImageKind;
+
+        let (world, container, item, _inventory) = loot_world();
+        let cursor = Some(GuiCursor {
+            position: point2(10.0, 10.0),
+            held_entity_id: Some(item),
+        });
+
+        for gui in [
+            ContainerGui::loot_container(),
+            ContainerGui::inv_container(),
+        ] {
+            let backdrop = gui.background_image.clone();
+            let components = gui.get_components(&cursor, container, &world, &ContainerGuiState {});
+            let kinds: Vec<ImageKind> = components
+                .iter()
+                .filter_map(|c| match c {
+                    GuiComponent::Button { kind, .. } => Some(*kind),
+                    // The panel's own backdrop is the only art that is not
+                    // an item icon.
+                    GuiComponent::Image { kind, texture, .. } if *texture != backdrop => {
+                        Some(*kind)
+                    }
+                    _ => None,
+                })
+                .collect();
+
+            assert!(
+                !kinds.is_empty(),
+                "expected the panel to draw the item and the cursor icon"
+            );
+            assert!(
+                kinds.iter().all(|k| *k == ImageKind::ObjectIcon),
+                "every item icon should be object-icon art, got {:?}",
+                kinds
+            );
         }
     }
 

--- a/shock2vr/src/scripts/gui/keypad.rs
+++ b/shock2vr/src/scripts/gui/keypad.rs
@@ -260,7 +260,7 @@ fn draw_number(num: u32) -> Vec<GuiComponent<KeyPadMsg>> {
             size: vec2(numeral_width, numeral_height),
             texture: get_texture_for_char(ch),
             alpha: 0.5,
-            transparent_index_0: false,
+            kind: crate::ui::ImageKind::Ui,
         });
         x += numeral_width + padding;
     }

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -153,7 +153,7 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
             size: vec2(30.0, button_height - 10.0),
             texture: icon.to_owned(),
             alpha: 0.5,
-            transparent_index_0: false,
+            kind: crate::ui::ImageKind::Ui,
         };
 
         let mut components: Vec<GuiComponent<ReplicatorMsg>> = vec![

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -24,7 +24,7 @@ use engine::{
     assets::asset_cache::AssetCache,
     measure_text_width,
     scene::SceneObject,
-    texture::{TextureOptions, TextureTrait},
+    texture::{Texture, TextureOptions, TextureTrait},
 };
 use shipyard::EntityId;
 
@@ -148,6 +148,24 @@ pub enum ButtonHoverBehavior {
     Texture(String),
 }
 
+/// How an image's art is keyed and sized.
+///
+/// Dark's inventory object icons are authored at their own pixel size - a 1x1
+/// item ships a 32x32 icon, a 1x3 weapon a ~34x99 one, and some are narrower
+/// than their cell (the wrench is 22 wide) - and are blitted 1:1 into the
+/// slot, not stretched to it. They also key transparency on palette index 0,
+/// independent of that entry's RGB.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ImageKind {
+    /// Ordinary UI art: opaque, stretched to the element's rect.
+    #[default]
+    Ui,
+    /// Object-icon art: palette index 0 is transparent, and the icon draws at
+    /// its authored pixel size anchored to the element rect's top-left corner.
+    /// The rect still defines the element's slot for layout and hit-testing.
+    ObjectIcon,
+}
+
 /// One item in the shared 2D UI description language.
 ///
 /// `TEvent` is presentation-agnostic: interactive panels attach their
@@ -164,9 +182,8 @@ where
         size: Vector2<f32>,
         texture: String,
         alpha: f32,
-        /// Dark's paletted object-icon art keys transparency on palette index
-        /// 0, independent of that entry's RGB (see [`UiCanvas::object_icon`]).
-        transparent_index_0: bool,
+        /// How the art is keyed and sized (see [`ImageKind`]).
+        kind: ImageKind,
     },
     /// Horizontally-filling bar; `fill` (0..1) clips the texture from the left.
     Bar {
@@ -305,7 +322,7 @@ where
             size: vec2(rect.w, rect.h),
             texture: texture.to_owned(),
             alpha: 1.0,
-            transparent_index_0: false,
+            kind: ImageKind::Ui,
         });
         self
     }
@@ -318,7 +335,7 @@ where
             size: vec2(rect.w, rect.h),
             texture: texture.to_owned(),
             alpha: 1.0,
-            transparent_index_0: true,
+            kind: ImageKind::ObjectIcon,
         });
         self
     }
@@ -440,23 +457,24 @@ where
                     size,
                     texture,
                     alpha,
-                    transparent_index_0,
+                    kind,
                 } => {
                     let tex = asset_cache.get_ext(
                         &TEXTURE_IMPORTER,
                         texture,
                         &TextureOptions {
                             wrap: false,
-                            transparent_index_0: *transparent_index_0,
+                            transparent_index_0: *kind == ImageKind::ObjectIcon,
                         },
                     );
+                    let drawn = drawn_size(*size, texture_px(&tex), *kind);
                     objs.push(SceneObject::screen_space_quad2(
                         tex.clone() as Rc<dyn TextureTrait>,
                         vec2(
                             position.x * scale.x + offset.x,
                             position.y * scale.y + offset.y,
                         ),
-                        vec2(size.x * scale.x, size.y * scale.y),
+                        vec2(drawn.x * scale.x, drawn.y * scale.y),
                         *alpha,
                     ));
                 }
@@ -466,6 +484,7 @@ where
                     texture,
                     hover,
                     alpha,
+                    entity,
                     ..
                 } => {
                     let hovered = pointer.is_some_and(|point| {
@@ -475,7 +494,16 @@ where
                         (true, ButtonHoverBehavior::Texture(hover_texture)) => hover_texture,
                         _ => texture,
                     };
-                    let tex = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options);
+                    let kind = button_image_kind(entity);
+                    let tex = asset_cache.get_ext(
+                        &TEXTURE_IMPORTER,
+                        texture,
+                        &TextureOptions {
+                            wrap: false,
+                            transparent_index_0: kind == ImageKind::ObjectIcon,
+                        },
+                    );
+                    let size = &drawn_size(*size, texture_px(&tex), kind);
                     objs.push(SceneObject::screen_space_quad2(
                         tex.clone() as Rc<dyn TextureTrait>,
                         vec2(
@@ -580,7 +608,7 @@ where
                     size,
                     texture,
                     alpha,
-                    transparent_index_0,
+                    kind,
                 } => world_image(
                     asset_cache,
                     texture,
@@ -588,7 +616,7 @@ where
                     *size,
                     self.size,
                     force_alpha.unwrap_or(*alpha),
-                    *transparent_index_0,
+                    *kind,
                 ),
                 UiElement::Button {
                     position,
@@ -613,9 +641,7 @@ where
                         *size,
                         self.size,
                         force_alpha.unwrap_or(*alpha),
-                        // Entity-backed buttons are inventory/loot object
-                        // icons: Dark keys their paletted art on index 0.
-                        entity.is_some(),
+                        button_image_kind(entity),
                     )
                 }
                 UiElement::Bar {
@@ -691,22 +717,48 @@ fn world_image(
     size: Vector2<f32>,
     canvas_size: Vector2<f32>,
     alpha: f32,
-    transparent_index_0: bool,
+    kind: ImageKind,
 ) -> SceneObject {
-    let texture: Rc<dyn TextureTrait> = asset_cache
+    let texture = asset_cache
         .get_ext(
             &TEXTURE_IMPORTER,
             texture,
             &TextureOptions {
                 wrap: false,
-                transparent_index_0,
+                transparent_index_0: kind == ImageKind::ObjectIcon,
             },
         )
         .clone();
-    let material = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);
+    let size = drawn_size(size, texture_px(&texture), kind);
+    let material =
+        engine::scene::basic_material::create(texture as Rc<dyn TextureTrait>, 1.0, 1.0 - alpha);
     let mut object = SceneObject::new(material, Box::new(engine::scene::quad::create()));
     object.set_local_transform(world_element_transform(position, size, canvas_size, 0.0));
     object
+}
+
+/// A button's art kind. Entity-backed buttons are the inventory/loot object
+/// icons; every other button is ordinary UI art.
+fn button_image_kind(entity: &Option<EntityId>) -> ImageKind {
+    match entity {
+        Some(_) => ImageKind::ObjectIcon,
+        None => ImageKind::Ui,
+    }
+}
+
+/// The size an element's art actually draws at: its slot rect for ordinary UI
+/// art, or the icon's own authored pixels for [`ImageKind::ObjectIcon`], which
+/// the original blits 1:1 into the slot rather than stretching to fill it.
+fn drawn_size(size: Vector2<f32>, texture_px: Vector2<f32>, kind: ImageKind) -> Vector2<f32> {
+    match kind {
+        ImageKind::Ui => size,
+        ImageKind::ObjectIcon => texture_px,
+    }
+}
+
+/// A loaded texture's authored pixel dimensions.
+fn texture_px(texture: &Texture) -> Vector2<f32> {
+    vec2(texture.width() as f32, texture.height() as f32)
 }
 
 fn world_element_transform(
@@ -814,6 +866,18 @@ mod tests {
         assert_eq!(p, Some(vec2(320.0, 120.0)));
     }
 
+    /// Object icons are blitted 1:1 at their authored size, not stretched to
+    /// the slot: the wrench ships a 22x99 icon for a 1x3 (35x102) slot, so
+    /// stretching it would make it ~60% too wide next to every other item.
+    #[test]
+    fn object_icons_draw_at_their_authored_pixel_size() {
+        let slot = vec2(35.0, 102.0);
+        let icon = vec2(22.0, 99.0);
+
+        assert_eq!(drawn_size(slot, icon, ImageKind::ObjectIcon), icon);
+        assert_eq!(drawn_size(slot, icon, ImageKind::Ui), slot);
+    }
+
     #[test]
     fn object_icon_marks_palette_index_zero_as_transparent() {
         let mut canvas = UiCanvas::new(vec2(640.0, 480.0));
@@ -824,11 +888,11 @@ mod tests {
             canvas.elements.as_slice(),
             [
                 UiElement::Image {
-                    transparent_index_0: false,
+                    kind: ImageKind::Ui,
                     ..
                 },
                 UiElement::Image {
-                    transparent_index_0: true,
+                    kind: ImageKind::ObjectIcon,
                     ..
                 }
             ]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -467,12 +467,12 @@ where
                             transparent_index_0: *kind == ImageKind::ObjectIcon,
                         },
                     );
-                    let drawn = drawn_size(*size, texture_px(&tex), *kind);
+                    let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), *kind);
                     objs.push(SceneObject::screen_space_quad2(
                         tex.clone() as Rc<dyn TextureTrait>,
                         vec2(
-                            position.x * scale.x + offset.x,
-                            position.y * scale.y + offset.y,
+                            drawn_at.x * scale.x + offset.x,
+                            drawn_at.y * scale.y + offset.y,
                         ),
                         vec2(drawn.x * scale.x, drawn.y * scale.y),
                         *alpha,
@@ -503,14 +503,14 @@ where
                             transparent_index_0: kind == ImageKind::ObjectIcon,
                         },
                     );
-                    let size = &drawn_size(*size, texture_px(&tex), kind);
+                    let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), kind);
                     objs.push(SceneObject::screen_space_quad2(
                         tex.clone() as Rc<dyn TextureTrait>,
                         vec2(
-                            position.x * scale.x + offset.x,
-                            position.y * scale.y + offset.y,
+                            drawn_at.x * scale.x + offset.x,
+                            drawn_at.y * scale.y + offset.y,
                         ),
-                        vec2(size.x * scale.x, size.y * scale.y),
+                        vec2(drawn.x * scale.x, drawn.y * scale.y),
                         *alpha,
                     ));
                 }
@@ -729,7 +729,7 @@ fn world_image(
             },
         )
         .clone();
-    let size = drawn_size(size, texture_px(&texture), kind);
+    let (position, size) = drawn_rect(position, size, texture_px(&texture), kind);
     let material =
         engine::scene::basic_material::create(texture as Rc<dyn TextureTrait>, 1.0, 1.0 - alpha);
     let mut object = SceneObject::new(material, Box::new(engine::scene::quad::create()));
@@ -749,11 +749,29 @@ fn button_image_kind(entity: &Option<EntityId>) -> ImageKind {
 /// The size an element's art actually draws at: its slot rect for ordinary UI
 /// art, or the icon's own authored pixels for [`ImageKind::ObjectIcon`], which
 /// the original blits 1:1 into the slot rather than stretching to fill it.
-fn drawn_size(size: Vector2<f32>, texture_px: Vector2<f32>, kind: ImageKind) -> Vector2<f32> {
+fn drawn_rect(
+    position: Vector2<f32>,
+    size: Vector2<f32>,
+    texture_px: Vector2<f32>,
+    kind: ImageKind,
+) -> (Vector2<f32>, Vector2<f32>) {
     match kind {
-        ImageKind::Ui => size,
-        ImageKind::ObjectIcon => texture_px,
+        ImageKind::Ui => (position, size),
+        ImageKind::ObjectIcon => (position + centered_offset(size, texture_px), texture_px),
     }
+}
+
+/// Where to place art of `drawn` size inside a `slot`, so it sits centered
+/// rather than flush against the slot's top-left corner.
+///
+/// Whole pixels only - a half-pixel origin would resample the icon's pixel art
+/// - and never negative: art bigger than its slot stays anchored at the
+/// top-left and overhangs to the right/bottom, which keeps it inside the panel.
+pub(crate) fn centered_offset(slot: Vector2<f32>, drawn: Vector2<f32>) -> Vector2<f32> {
+    vec2(
+        (((slot.x - drawn.x) / 2.0).floor()).max(0.0),
+        (((slot.y - drawn.y) / 2.0).floor()).max(0.0),
+    )
 }
 
 /// A loaded texture's authored pixel dimensions.
@@ -874,8 +892,39 @@ mod tests {
         let slot = vec2(35.0, 102.0);
         let icon = vec2(22.0, 99.0);
 
-        assert_eq!(drawn_size(slot, icon, ImageKind::ObjectIcon), icon);
-        assert_eq!(drawn_size(slot, icon, ImageKind::Ui), slot);
+        let at = vec2(15.0, 153.0);
+        // Size is the icon's own; position is its centered placement in the slot.
+        assert_eq!(
+            drawn_rect(at, slot, icon, ImageKind::ObjectIcon),
+            (at + centered_offset(slot, icon), icon)
+        );
+        assert_eq!(drawn_rect(at, slot, icon, ImageKind::Ui), (at, slot));
+    }
+
+    /// ...and centered in the slot, so narrow art (the 22px wrench in a 35px
+    /// cell) is not shoved against one separator with all its slack on the
+    /// other side. Whole pixels only, and art wider than its slot keeps the
+    /// top-left anchor instead of overhanging into the panel's chrome.
+    #[test]
+    fn object_icons_center_in_their_slot() {
+        assert_eq!(
+            centered_offset(vec2(35.0, 102.0), vec2(22.0, 99.0)),
+            vec2(6.0, 1.0)
+        );
+        assert_eq!(
+            centered_offset(vec2(35.0, 34.0), vec2(32.0, 32.0)),
+            vec2(1.0, 1.0)
+        );
+        // No half-pixel origins: 35 - 34 = 1 floors to 0 rather than 0.5.
+        assert_eq!(
+            centered_offset(vec2(35.0, 102.0), vec2(34.0, 99.0)),
+            vec2(0.0, 1.0)
+        );
+        // Art larger than its slot stays anchored top-left.
+        assert_eq!(
+            centered_offset(vec2(35.0, 34.0), vec2(66.0, 68.0)),
+            vec2(0.0, 0.0)
+        );
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -201,6 +201,8 @@ where
         on_grab: Option<(TEvent, TEvent)>,
         hover: ButtonHoverBehavior,
         alpha: f32,
+        /// How the art is keyed and sized (see [`ImageKind`]).
+        kind: ImageKind,
         /// The world entity this button represents, for UI introspection.
         entity: Option<EntityId>,
         /// Optional semantic label, for UI introspection and automation.
@@ -364,6 +366,7 @@ where
             alpha: 1.0,
             entity: None,
             label: None,
+            kind: ImageKind::Ui,
         });
         self
     }
@@ -484,7 +487,7 @@ where
                     texture,
                     hover,
                     alpha,
-                    entity,
+                    kind,
                     ..
                 } => {
                     let hovered = pointer.is_some_and(|point| {
@@ -494,7 +497,7 @@ where
                         (true, ButtonHoverBehavior::Texture(hover_texture)) => hover_texture,
                         _ => texture,
                     };
-                    let kind = button_image_kind(entity);
+                    let kind = *kind;
                     let tex = asset_cache.get_ext(
                         &TEXTURE_IMPORTER,
                         texture,
@@ -624,7 +627,7 @@ where
                     texture,
                     hover,
                     alpha,
-                    entity,
+                    kind,
                     ..
                 } => {
                     let hovered = pointer.is_some_and(|point| {
@@ -641,7 +644,7 @@ where
                         *size,
                         self.size,
                         force_alpha.unwrap_or(*alpha),
-                        button_image_kind(entity),
+                        *kind,
                     )
                 }
                 UiElement::Bar {
@@ -737,19 +740,10 @@ fn world_image(
     object
 }
 
-/// A button's art kind. Entity-backed buttons are the inventory/loot object
-/// icons; every other button is ordinary UI art.
-fn button_image_kind(entity: &Option<EntityId>) -> ImageKind {
-    match entity {
-        Some(_) => ImageKind::ObjectIcon,
-        None => ImageKind::Ui,
-    }
-}
-
 /// The size an element's art actually draws at: its slot rect for ordinary UI
 /// art, or the icon's own authored pixels for [`ImageKind::ObjectIcon`], which
 /// the original blits 1:1 into the slot rather than stretching to fill it.
-fn drawn_rect(
+pub(crate) fn drawn_rect(
     position: Vector2<f32>,
     size: Vector2<f32>,
     texture_px: Vector2<f32>,
@@ -767,7 +761,7 @@ fn drawn_rect(
 /// Whole pixels only - a half-pixel origin would resample the icon's pixel art
 /// - and never negative: art bigger than its slot stays anchored at the
 /// top-left and overhangs to the right/bottom, which keeps it inside the panel.
-pub(crate) fn centered_offset(slot: Vector2<f32>, drawn: Vector2<f32>) -> Vector2<f32> {
+fn centered_offset(slot: Vector2<f32>, drawn: Vector2<f32>) -> Vector2<f32> {
     vec2(
         (((slot.x - drawn.x) / 2.0).floor()).max(0.0),
         (((slot.y - drawn.y) / 2.0).floor()).max(0.0),


### PR DESCRIPTION
Follows #919 (now merged); rebased onto `main`.

## Reproduction

Every inventory/loot icon is stretched to fill its slot (`slot_pitch * InvDims`). Dark
authors these icons at their own pixel size and blits them 1:1 into the cell, so
stretching is wrong for every item whose art is not exactly cell-sized - and several are
deliberately not:

| Item | `objicon` art | Slot (1x1 = 35x34) | Drawn before |
| --- | --- | --- | --- |
| Nanites | 32 x 32 | 35 x 34 | stretched wider |
| Pistol | 34 x 99 | 35 x 102 | ~ok |
| **Wrench** | **22 x 99** | 35 x 102 | **35 x 102 - ~60% too wide** |
| Armor | 66 x 68 | 70 x 68 | stretched wider |

The wrench is the obvious one: its icon is deliberately narrow, so stretching it to the
full cell makes it visibly fatter than every other item in the same panel. It is also
why items paint over the cell separators baked into the backdrops.

`InvDims` is a *footprint in cells* - it decides occupancy and hit-testing, never draw
size.

### Anchoring

Blitting at the authored size exposes a second question: where in the slot? The
original top-left anchors, but its icons are effectively cell-sized (a 1x1 item's art
is 32x32 in a 33x32 interior), so the anchor never showed. Ours must place
deliberately narrow art too - flush-left put all 13px of the wrench's slack on one
side and read as misaligned - so icons are **centered** in the slot instead. That is a
small deliberate deviation from the original for looks.

Centering is on whole pixels only (a half-pixel origin would resample the icon's pixel
art), and art larger than its slot keeps the top-left anchor so it overhangs
right/bottom into the grid rather than up/left into the panel's chrome.

## Fix

Describe an image's art with an `ImageKind` (`Ui` | `ObjectIcon`) instead of a
`transparent_index_0: bool`. Both behaviors describe the same thing - Dark object-icon
art keys transparency on palette index 0 *and* draws at its authored pixels, anchored to
the top-left of its slot.

The element rect still defines the slot, so layout, hit-testing and `/v1/ui` are
unchanged; only the drawn quad differs. All three render paths honor it: the
screen-space canvas, the world-space canvas, and the VR panel quads (which carry the
panel's pixel size in their render info to convert authored pixels into normalized
space).

## Verification

- negative-first: `object_icons_draw_at_their_authored_pixel_size` (a 22x99 icon in a
  35x102 slot draws 22x99 at a centered origin, not 35x102 flush-left) and
  `object_icons_center_in_their_slot`. Both were checked by reverting the behavior and
  confirming they fail - the first test initially did *not* fail, because it asserted the
  drawn size but never that the offset was applied; it was strengthened until it did.
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` - 563 passed
- full `npm run test:e2e` - 235 tests, 226 pass, 7 skipped; the 2 failures are baseline
  (`shodan-corpse-drift` reproduces on detached `main`; `ally-line-of-fire` passes in
  isolation)


## Visual verification

Same deterministic capture as #919 (medsci1.mis, headless debug runtime: teleport -> frob corpse
-> spawn 3 backpack items -> `ToggleUseMode` -> `/v1/step` -> `/v1/screenshot`), taken on this
branch's parent (#919) and on this branch.

![before/after: authored size, centered](https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/pr920_beforeafter.png)

Before, the wrench icon is stretched across the full 35px cell width; its head bleeds over the
cell's vertical separator so the backdrop's grid lines are painted out. After, it blits at its
authored 22px width — correct aspect, and the separators stay visible on both sides.

![native icon size loop](https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/pr920_demo.gif)

<sub>Loop cycles the same panel between before and after. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep). Full uncropped frames: <a href="https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/mid.png">before</a>, <a href="https://gist.githubusercontent.com/tommy-xr/ce4b5a2cc21da28894c4e20439e0d0e0/raw/after.png">after</a>.</sub>



Measured from the captures: the wrench shaft moves right exactly 6px (`floor((35-22)/2)`) and down 1px (`floor((102-99)/2)`).



## From review

Cross-engine review (two independent adversarial reviewers plus a duplication pass) found
one real bug and several loose ends, all fixed in `3d7e950`:

- **The enum was thrown away at the VR boundary.** `to_render_info` discarded the authored
  `ImageKind` (`kind: _`) and `is_object_icon()` re-guessed it from `entity: Some(_)`, so
  the explicit description and the old heuristic disagreed on the same element. The icon
  riding the cursor is a plain image with no entity: flat drew it keyed and native-size,
  VR drew it stretched with palette index 0 opaque (a black box behind the icon). The kind
  is now carried through - `UiElement::Button` gained one too - and the heuristic is
  deleted, so `entity` is introspection-only as its doc always claimed.
- **`CURSOR_ITEM_SIZE` is gone.** Once object icons draw at their authored size, its 35x32
  sized nothing, but it still supplied centering slack - sliding the dragged icon up to 6px
  off the pointer.
- **The VR path called `centered_offset` by hand**, re-deriving `drawn_rect`'s branch. It
  now converts to panel pixels, calls `drawn_rect`, and renormalizes, so placement lives in
  one place. Documented there: the quad composes through a 180-degree z rotation, so an odd
  pixel of centering slack breaks top-left in the 2D presenters and bottom-right in VR -
  the two can differ by 1px on odd slack.
- Test fixtures encoded the pre-change grid (`y=18`, 32 tall) and passed a loot-panel
  `panel_size_px` for strip elements; they now model what the game emits.

Known and deliberately **not** fixed here: the replicator draws real `PropObjIcon` art as
`ImageKind::Ui` (same bug class), but its icons sit in a 30x50 box and a 34x99 weapon icon
drawn native would overflow the row. That needs a layout decision of its own - #923.

## Verification (final, post-rebase)

- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` - 570 passed
- full `npm run test:e2e` - 236 tests, 227 pass, 7 skipped. Both failures are pre-existing
  on `main`, each bisected rather than assumed:
  - `shodan-corpse-drift` - reproduces on detached `main`
  - `creature-loot` - passes at `9033073`, fails from `c9626f5` (#917) onward; filed as
    #931
- rendered output is pixel-identical before and after the review fixes, which is the
  expected result: the flat grid items were already object-icon art via the heuristic and
  are now merely declared. The paths that changed - VR panels and the dragged cursor icon -
  are covered by unit tests rather than that screenshot.
