### PR TITLE
chore(sdk): fail loudly when SDK deps are missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,7 @@ For debugging visual/rendering changes without a full interactive session:
 
    ```bash
    cd tools/shock2-sdk
-   npm install         # first time only
+   npm install         # first time only (per worktree - node_modules is not shared)
    npm test            # fast unit tests
    npm run test:e2e    # launches real debug runtimes (pathfinding scenario, mission load smoke tests)
    ```

--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -13,10 +13,15 @@
     }
   },
   "scripts": {
+    "prebuild": "node scripts/check-deps.mjs",
     "build": "tsc",
+    "pretest": "node scripts/check-deps.mjs",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
+    "pretest:e2e": "node scripts/check-deps.mjs",
     "test:e2e": "tsc && SHOCK2_E2E=1 node --test --test-concurrency=1 \"dist/test/*.test.js\"",
+    "pretest:e2e:reliability": "node scripts/check-deps.mjs",
     "test:e2e:reliability": "tsc && node scripts/reliability.mjs",
+    "preanim-smoothness": "node scripts/check-deps.mjs",
     "anim-smoothness": "tsc && node dist/scripts/anim-smoothness.js"
   },
   "engines": {

--- a/tools/shock2-sdk/scripts/check-deps.mjs
+++ b/tools/shock2-sdk/scripts/check-deps.mjs
@@ -1,0 +1,30 @@
+// Fail loudly when this package's dev dependencies are not installed.
+//
+// npm puts `node_modules/.bin` first on PATH, so with deps installed `tsc`
+// resolves to the pinned local TypeScript. Without them it silently falls
+// through to whatever `tsc` happens to be on the global PATH - often one many
+// major versions old - and `npm test` / `npm run test:e2e` die in a wall of
+// TS6046/TS1005 errors that read like source problems but are just the wrong
+// compiler. That is easy to hit in a fresh git worktree, where `node_modules`
+// does not carry over.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+try {
+  require.resolve("typescript");
+} catch {
+  console.error(
+    [
+      "",
+      "@shock2vr/sdk: dependencies are not installed in this worktree.",
+      "",
+      "  cd tools/shock2-sdk && npm install",
+      "",
+      "(Without them `tsc` resolves to the global TypeScript, if any, and the",
+      " build fails with confusing TS6046/TS1005 errors.)",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Reproduction

In a fresh git worktree, `cd tools/shock2-sdk && npm run test:e2e` dies like this:

```
test/world-aim.test.ts(146,5): error TS1005: ',' expected.
tsconfig.json(3,15): error TS6046: Argument for '--target' option must be: 'es3', 'es5', ...
```

Nothing is wrong with the source. `node_modules` does not carry over into a new
worktree, and npm - having no local `node_modules/.bin/tsc` to put on PATH - silently
fell through to a global TypeScript (4.2.4 on the machine this was hit on), which cannot
parse the project's `tsconfig.json` or its modern syntax. The failure reads like a broken
checkout and costs a while to see through.

## Fix

Add a preflight to every SDK script that shells out to `tsc`. Missing deps now say so:

```
@shock2vr/sdk: dependencies are not installed in this worktree.

  cd tools/shock2-sdk && npm install

(Without them `tsc` resolves to the global TypeScript, if any, and the
 build fails with confusing TS6046/TS1005 errors.)
```

Also note in AGENTS.md that the install is per-worktree.

This guards rather than pins the global toolchain, so it holds regardless of what (if
anything) is installed globally on a given machine.

## Verification

- negative-first: moved `node_modules` aside, ran `npm run build`, got the wall of
  TS6046/TS1005 errors; with the preflight it exits 1 with the message above
- restored `node_modules`; `npm test` - 26 passed
