### PR TITLE
feat(gameplay): protocol droids self-destruct on the player

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2539,6 +2539,19 @@ impl MissionCore {
             }
         }
 
+        // The player's pawn is physics-driven: its position lives in
+        // PlayerInfo and it never gets a RuntimePropTransform, so the sweep
+        // above cannot see it - without this, no blast has ever reached the
+        // player. Its receptrons (from `The Player` archetype) resolve the
+        // stim exactly like any other victim's.
+        {
+            let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+            let distance = (player.pos - center).magnitude();
+            if distance < radius && !in_range.iter().any(|(id, _)| *id == player.entity_id) {
+                in_range.push((player.entity_id, intensity * (1.0 - distance / radius)));
+            }
+        }
+
         for (entity_id, felt_intensity) in in_range {
             let receptrons =
                 get_all_links_with_template(&self.world, entity_id, |link| match link {

--- a/shock2vr/src/scenes/debug_protocol_droid.rs
+++ b/shock2vr/src/scenes/debug_protocol_droid.rs
@@ -1,0 +1,59 @@
+use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, SquareMatrix, point3};
+use engine::{assets::asset_cache::AssetCache, audio::AudioContext};
+use shipyard::EntityId;
+use tracing::info;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    mission::{GlobalContext, entity_creator::CreateEntityOptions},
+    scenes::debug_common::{DebugSceneBuildOptions, DebugSceneBuilder},
+};
+
+/// Far enough that the droid has to walk in (so the approach is observable),
+/// close enough to spot the player from where it stands. `DebugSceneBuilder`
+/// spawns the player above the origin, so this is a straight 10-unit walk
+/// down +Z - world units, matching the identity root transform below.
+const DROID_START_POS: Point3<f32> = point3(0.0, 1.8, 10.0);
+const PROTOCOL_DROID_TEMPLATE_ID: i32 = -174;
+
+/// Isolates the protocol droid's self-destruct: it spots the player, closes,
+/// and detonates its `Corpse` Incendiary Explosion at melee range, which
+/// damages the player standing there.
+pub struct DebugProtocolDroidScene;
+
+impl DebugProtocolDroidScene {
+    pub fn new(
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Box<dyn GameScene> {
+        let builder = DebugSceneBuilder::new("debug_protocol_droid").with_default_floor();
+
+        let build_options = DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        };
+
+        let mut scene = builder.build(build_options);
+
+        let droid_entity = scene
+            .core_mut()
+            .create_entity_with_position(
+                asset_cache,
+                PROTOCOL_DROID_TEMPLATE_ID,
+                DROID_START_POS,
+                Quaternion::from_angle_y(Deg(180.0)),
+                Matrix4::identity(),
+                CreateEntityOptions::default(),
+            )
+            .entity_id;
+
+        info!("Spawned debug protocol droid entity {droid_entity:?}");
+
+        Box::new(scene)
+    }
+}

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -28,6 +28,7 @@ pub mod debug_joint_constraint;
 pub mod debug_map;
 pub mod debug_minimal;
 pub mod debug_particles;
+pub mod debug_protocol_droid;
 pub mod debug_psi;
 pub mod debug_ragdoll;
 pub mod debug_teleport;
@@ -46,6 +47,7 @@ pub use debug_joint_constraint::DebugJointConstraintScene;
 pub use debug_map::DebugMapScene;
 pub use debug_minimal::DebugMinimalScene;
 pub use debug_particles::DebugParticlesScene;
+pub use debug_protocol_droid::DebugProtocolDroidScene;
 pub use debug_psi::create_debug_psi_scene;
 pub use debug_ragdoll::DebugRagdollScene;
 pub use debug_teleport::DebugTeleportScene;
@@ -189,6 +191,18 @@ pub fn create_initial_scene(
     if options.mission.eq_ignore_ascii_case("debug_camera") {
         return SceneInitResult {
             scene: DebugCameraScene::new(global_context, options, asset_cache, audio_context),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("debug_protocol_droid") {
+        return SceneInitResult {
+            scene: DebugProtocolDroidScene::new(
+                global_context,
+                options,
+                asset_cache,
+                audio_context,
+            ),
             mission_save_data: HashMap::new(),
         };
     }

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -540,6 +540,16 @@ pub fn is_killed(entity_id: EntityId, world: &World) -> bool {
     maybe_prop_hit_points.unwrap().hit_points <= 0
 }
 
+/// Whether this AI attacks by destroying itself: the `protocol` AI type (the
+/// protocol droid), whose gamesys template carries no `L$Weapon` archetype to
+/// resolve a blow with, but does link a `Corpse` explosion.
+pub fn is_self_destructing(world: &World, entity_id: EntityId) -> bool {
+    let v_ai = world.borrow::<View<PropAI>>().unwrap();
+    v_ai.get(entity_id)
+        .map(|prop_ai| prop_ai.0.eq_ignore_ascii_case("protocol"))
+        .unwrap_or(false)
+}
+
 /// Check if an entity has a ranged weapon capability
 ///
 /// Returns true if the entity has either an AIRangedWeapon link (used by turrets)

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -908,8 +908,14 @@ impl Script for AnimatedMonsterAI {
                 // replaced - by alertness swings; the alertness state still
                 // updates and takes effect once the sequence finishes. (The
                 // original engine gates this via the response priority; we
-                // protect all sequences.)
-                if self.current_behavior.borrow().scripted_state() == ScriptedState::Running {
+                // protect all sequences.) A behavior mid-commitment (a
+                // protocol droid's lit fuse) declines preemption for the same
+                // reason: re-selecting it would restart the timer it is
+                // counting down.
+                let holds_against_alertness = self.current_behavior.borrow().scripted_state()
+                    == ScriptedState::Running
+                    || !self.current_behavior.borrow().preempted_by_alertness();
+                if holds_against_alertness {
                     (sync_effect, Effect::NoEffect)
                 } else {
                     // AIAlertLevel is repr(u32) in escalation order

--- a/shock2vr/src/scripts/ai/behavior/behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/behavior.rs
@@ -96,6 +96,13 @@ pub trait Behavior {
     fn is_locomotion(&self) -> bool {
         false
     }
+
+    /// Whether an alertness level change may replace this behavior. False for
+    /// a behavior counting down a commitment it must not restart (see
+    /// `SelfDestructBehavior`).
+    fn preempted_by_alertness(&self) -> bool {
+        true
+    }
 }
 
 #[allow(dead_code)]

--- a/shock2vr/src/scripts/ai/behavior/mod.rs
+++ b/shock2vr/src/scripts/ai/behavior/mod.rs
@@ -8,6 +8,7 @@ mod patrol_behavior;
 mod ranged_attack_behavior;
 mod scripted_sequence_behavior;
 mod search_behavior;
+mod self_destruct_behavior;
 mod wander_behavior;
 
 pub use behavior::*;
@@ -19,6 +20,7 @@ pub use patrol_behavior::*;
 pub use ranged_attack_behavior::*;
 pub use scripted_sequence_behavior::*;
 pub use search_behavior::*;
+pub use self_destruct_behavior::*;
 pub use wander_behavior::*;
 
 use std::cell::RefCell;
@@ -30,8 +32,15 @@ use crate::{
     physics::PhysicsWorld,
     scripts::ai::ai_util::{
         chase_target, chase_target_distance, has_line_of_fire, has_ranged_weapon,
+        is_self_destructing,
     },
 };
+
+/// How close a protocol droid gets before lighting its fuse. Same reach as a
+/// melee swing - the detonation IS its melee attack (see
+/// `SelfDestructBehavior`) - but named separately so tuning the blast's
+/// trigger doesn't move every creature's melee range.
+pub const PROTOCOL_DETONATION_RANGE: f32 = crate::scripts::ai::ai_util::MELEE_ATTACK_RANGE;
 
 /// The attack behavior for the current distance to the player, or None when
 /// out of attack range (the caller should chase to close the distance).
@@ -53,6 +62,12 @@ pub fn attack_behavior_for_distance(
     let melee_attack_distance = 8.0 / SCALE_FACTOR;
     let ranged_max_attack_distance = 40.0 / SCALE_FACTOR;
     let ranged_min_attack_distance = 15.0 / SCALE_FACTOR;
+
+    // A protocol droid has no weapon to swing: closing the distance starts
+    // its self-destruct instead of a melee attack.
+    if distance < PROTOCOL_DETONATION_RANGE && is_self_destructing(world, entity_id) {
+        return Some(Box::new(RefCell::new(SelfDestructBehavior::new())));
+    }
 
     // Only ranged-armed AIs stop to shoot; melee AIs must keep chasing or
     // they stall at mid-range bouncing between chase and ranged-attack.

--- a/shock2vr/src/scripts/ai/behavior/self_destruct_behavior.rs
+++ b/shock2vr/src/scripts/ai/behavior/self_destruct_behavior.rs
@@ -1,0 +1,103 @@
+use cgmath::Deg;
+use dark::motion::MotionQueryItem;
+
+use shipyard::*;
+
+use crate::{
+    physics::PhysicsWorld,
+    scripts::{
+        Effect,
+        ai::steering::{ChasePlayerSteeringStrategy, Steering, SteeringOutput, SteeringStrategy},
+    },
+    time::Time,
+};
+
+use super::{Behavior, NextBehavior};
+
+/// How long the droid holds on the player before it goes off. Long enough for
+/// the attack bark to register, and for a reacting player to shoot it - a
+/// droid killed mid-fuse still detonates (its `Corpse` link is the blast
+/// either way), so the reward for reacting is putting it down before it
+/// closes, not after. Like every other behavior's state, the fuse doesn't
+/// survive save/load: a restored droid re-acquires and lights a fresh one.
+const FUSE_SECONDS: f32 = 1.0;
+
+/// A protocol droid's attack is its own destruction: the template carries no
+/// `L$Weapon` archetype to resolve a melee blow, but does link a `Corpse`
+/// Incendiary Explosion. Reaching the player starts a short fuse; when it
+/// expires the droid slays itself and that authored explosion - stimming
+/// everything in its radius - is the damage.
+pub struct SelfDestructBehavior {
+    fuse_remaining: f32,
+}
+
+impl SelfDestructBehavior {
+    pub fn new() -> SelfDestructBehavior {
+        SelfDestructBehavior {
+            fuse_remaining: FUSE_SECONDS,
+        }
+    }
+}
+
+impl Behavior for SelfDestructBehavior {
+    fn name(&self) -> &'static str {
+        "SelfDestruct"
+    }
+
+    /// The melee schema: this IS the droid's melee attack, and querying it
+    /// under those tags is also what makes the AI play the `comattack` bark
+    /// on the way in (see `is_attack_animation`).
+    fn animation(self: &SelfDestructBehavior) -> Vec<MotionQueryItem> {
+        vec![
+            MotionQueryItem::new("meleecombat"),
+            MotionQueryItem::new("attack").optional(),
+            MotionQueryItem::new("direction").optional(),
+        ]
+    }
+
+    fn steer(
+        &mut self,
+        current_heading: Deg<f32>,
+        world: &World,
+        physics: &PhysicsWorld,
+        entity_id: EntityId,
+        time: &Time,
+    ) -> Option<(SteeringOutput, Effect)> {
+        // Burning past zero is the detonation. The slay removes the entity
+        // (and this script with it), so it can only happen once.
+        let was_burning = self.fuse_remaining > 0.0;
+        self.fuse_remaining -= time.elapsed.as_secs_f32();
+        let detonation_effect = if was_burning && self.fuse_remaining <= 0.0 {
+            Effect::SlayEntity { entity_id }
+        } else {
+            Effect::NoEffect
+        };
+
+        // Keep closing on the player while the fuse burns, like a melee swing
+        let (steering_output, steering_effect) = ChasePlayerSteeringStrategy
+            .steer(current_heading, world, physics, entity_id, time)
+            .unwrap_or((Steering::from_current(current_heading), Effect::NoEffect));
+
+        Some((
+            steering_output,
+            Effect::combine(vec![detonation_effect, steering_effect]),
+        ))
+    }
+
+    fn preempted_by_alertness(&self) -> bool {
+        // Escalating from Moderate to High mid-windup would otherwise build a
+        // fresh behavior and restart the fuse (and re-play the bark).
+        false
+    }
+
+    fn next_behavior(
+        &mut self,
+        _world: &World,
+        _physics: &PhysicsWorld,
+        _entity_id: EntityId,
+    ) -> NextBehavior {
+        // Once lit, the fuse burns: a droid that has committed doesn't
+        // disengage to chase a player backing out of range.
+        NextBehavior::Stay
+    }
+}

--- a/tools/shock2-sdk/test/docile-training-droid.e2e.test.ts
+++ b/tools/shock2-sdk/test/docile-training-droid.e2e.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// earth.mis's shooting-range "Training Droid" (template -4015) shares the
+// protocol droid's PropAI("Protocol"), so it takes the same self-destruct
+// branch - but it wears the `Docile` metaproperty
+// (PropAIAlertCap { max_level: Lowest }), which pins it below the alertness
+// levels that reach any attack behavior. It must therefore stand still to be
+// shot at, however close the player gets: the training range depends on it.
+const DROID_NAME = "Training Droid";
+
+async function listTrainingDroids(game: GameServer): Promise<EntitySummary[]> {
+  const { entities } = await game.entities.list({ filter: DROID_NAME, limit: 20 });
+  return entities.filter((e) => e.name === DROID_NAME);
+}
+
+test(
+  "Docile training droids never self-destruct, however close the player stands",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
+    });
+
+    await game.step({ frames: 10 });
+
+    const droids = await listTrainingDroids(game);
+    assert.ok(droids.length >= 1, `expected a ${DROID_NAME} in earth.mis`);
+    const droid = droids[0];
+
+    const before = await game.info();
+    assert.ok(before.player.hit_points !== null, "player should have a health pool");
+
+    // Stand right on top of it - well inside the detonation range a hostile
+    // protocol droid would trigger at.
+    const [dx, dy, dz] = droid.position;
+    await game.player.teleport({ x: dx, y: dy, z: dz - 3.0 });
+
+    // Give it far longer than the ~1s fuse plus the time to escalate.
+    for (let i = 0; i < 10; i++) {
+      await game.step({ frames: 60 });
+    }
+
+    const detail = await game.entities.detail(droid.id);
+    const prop = (name: string) => detail.properties.find((p) => p.name === name)?.value;
+    assert.equal(prop("AIAlertness"), "Lowest", "Docile caps alertness at Lowest");
+    assert.notEqual(prop("AIBehavior"), "SelfDestruct", "a docile droid must not light a fuse");
+
+    const after = await listTrainingDroids(game);
+    assert.ok(
+      after.some((e) => e.id === droid.id),
+      "the training droid must still be standing (it did not blow itself up)",
+    );
+
+    const afterInfo = await game.info();
+    assert.equal(
+      afterInfo.player.hit_points,
+      before.player.hit_points,
+      "the player must take no damage standing beside a docile training droid",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/protocol-droid-self-destruct.e2e.test.ts
+++ b/tools/shock2-sdk/test/protocol-droid-self-destruct.e2e.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/index.js";
+
+// End-to-end test against a real debug runtime. Requires game assets in
+// Data/ and compiles the runtime on first run, so it is opt-in:
+//
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// The protocol droid (template -174) carries no L$Weapon to swing with, but
+// does link a Corpse "Incendiary Explosion" (intensity 15 over a 4-unit
+// radius). Its attack IS that detonation: it spots the player, closes, lights
+// a ~1s fuse at melee range and blows up - and the blast damages the player
+// standing there. `debug_protocol_droid` puts one 10 units down +Z with
+// nothing else in the scene, so the whole sequence runs on plain sight and
+// steering (no DebugForceChase).
+const DROID_NAME = "Protocol Droid";
+
+async function findDroid(game: GameServer): Promise<EntitySummary | undefined> {
+  const { entities } = await game.entities.list({ filter: DROID_NAME, limit: 10 });
+  return entities.find((e) => e.name === DROID_NAME);
+}
+
+test(
+  "Protocol droid: closes on the player, self-destructs, and the blast hurts them",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_protocol_droid",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8137),
+    });
+
+    await game.step({ frames: 10 });
+
+    const droid = await findDroid(game);
+    assert.ok(droid, `expected a ${DROID_NAME} in the debug scene`);
+    const startDistance = droid.distance;
+    assert.ok(startDistance > 5, `droid should start away from the player`);
+
+    const before = await game.info();
+    assert.ok(before.player.hit_points !== null, "player should have a health pool");
+
+    // It spots the player, walks in, and lights the fuse at melee range. (The
+    // sim only advances on step, so poll by stepping.)
+    let atRange: EntitySummary | undefined;
+    for (let i = 0; i < 80 && !atRange; i++) {
+      await game.step({ frames: 15 });
+      const detail = await game.entities.detail(droid.id);
+      const behavior = detail.properties.find((p) => p.name === "AIBehavior")?.value;
+      if (behavior === "SelfDestruct") {
+        atRange = await findDroid(game);
+      }
+    }
+    assert.ok(atRange, "expected the droid to close and enter SelfDestruct");
+    assert.ok(
+      atRange.distance < startDistance,
+      `expected the droid to approach (${startDistance.toFixed(1)} -> ${atRange.distance.toFixed(1)})`,
+    );
+
+    // ...and goes off: the droid is consumed by its own Corpse explosion.
+    let detonated = false;
+    for (let i = 0; i < 30 && !detonated; i++) {
+      await game.step({ frames: 6 });
+      detonated = (await findDroid(game)) === undefined;
+    }
+    assert.ok(detonated, "expected the lit fuse to detonate the droid");
+
+    // The blast is the damage: the player it walked up to must feel it.
+    await game.step({ frames: 5 });
+    const after = await game.info();
+    assert.ok(
+      after.player.hit_points! < before.player.hit_points!,
+      `expected the detonation to damage the player (${before.player.hit_points} -> ${after.player.hit_points})`,
+    );
+  },
+);


### PR DESCRIPTION
In retail, a protocol droid runs at you and blows up. Ours closed to melee range and then stood there, forever.

The gamesys already says what it should do: template **-174** carries **no `L$Weapon`** archetype for `melee_contact_attack` to resolve a blow with, but it *does* link a `Corpse` **Incendiary Explosion** (intensity 15 over a 4-unit radius). `PropAI("protocol")` fell through to the generic `AnimatedMonsterAI`, which picked `MeleeAttackBehavior` and swung at nothing.

![protocol droid self-destruct](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/protocol-droid-selfdestruct.gif)

<sub>The droid spots the player, closes, lights a ~1s fuse, and detonates its authored Corpse explosion — player HP 30 → 26 (the HUD reads 100 → 87). Captured headlessly in the new `debug_protocol_droid` scene via `/v1/step` + `/v1/screenshot`, deterministic fixed-timestep.</sub>

| Approach (t≈1s) | Fuse at melee range (t≈9.4s) | Detonation (t≈9.5s) |
| --- | --- | --- |
| ![far](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/still-far.png) | ![close](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/still-close.png) | ![fireball](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/still-fireball.png) |

## What's here

**1. `SelfDestructBehavior`** — selected in `attack_behavior_for_distance` for `PropAI("protocol")` inside `PROTOCOL_DETONATION_RANGE`. It keeps closing while a 1s fuse burns, then `SlayEntity` — and the authored `Corpse` explosion is the damage. Nothing invents a damage number.

- **The fuse is interruptible.** Killing the droid mid-windup runs the normal death path, which spawns the same explosion. The reward for reacting is putting it down *before* it closes, not after.
- **The bark rides the existing path.** Querying the melee schema is what makes the AI play `comattack` on the way in (`is_attack_animation`), so the behavior emits no speech of its own.
- **`Behavior::preempted_by_alertness`** lets a lit fuse decline the alertness-driven behavior rebuild. Without it a Moderate→High escalation built a *fresh* behavior and the fuse measured **2.0s instead of 1.0s** (plus a double bark).

**2. Explosions can now damage the player at all** (separate commit). The player pawn has `PropHitPoints` but never gets a `RuntimePropTransform` — its position lives in `PlayerInfo` — so `radius_blast`'s `(hit_points, transform)` sweep could not see it. **No** explosion had ever taken a point off the player: not a grenade, not a barrel, not a droid's death blast. It is now enrolled from `PlayerInfo.pos` with the same falloff, resolved through its own receptrons.

**3. `debug_protocol_droid`** — one droid, 10 units down +Z, flat floor. The whole sequence runs on plain sight and steering; no `DebugForceChase` needed.

## Verification

- New e2e `protocol-droid-self-destruct.e2e.test.ts`: asserts approach → `SelfDestruct` → detonation → **player HP drops**. A rec1-based variant of it **fails on `main`** at the `SelfDestruct` assertion (true negative).
- New e2e `docile-training-droid.e2e.test.ts`: earth.mis's shooting-range **Training Droids** share `PropAI("Protocol")` but wear the **Docile** metaproperty (alert cap `Lowest`), pinning them below the alertness levels that reach any attack behavior. Verified live: `Idle`/`Lowest`, player HP untouched with the player standing on top of them for 10s. The test locks that in.
- Explosion-adjacent suite green: `explosion`, `player-death`, `monster-death`, `death-links`, `flinderize`, `damage-alert`, `earth-training-narration`.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p debug_runtime` clean.

Reviewed with two independent engines plus a de-dup pass; findings applied (dropped a duplicate `comattack` bark that the AI already emits, dropped two now-dead fields).

## 25th Anniversary assets

Also verified against a 25AE install (`DARK_ASSET_PATH=~/ss2-25th`) — the SHTUP/SCP mod stack mounts and the sequence is identical (player 30 → 27). SHTUP's `droid.dds` (87KB) vs the classic `DROID.PCX` (3.4KB), and a much better fireball:

![25ae](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/still-25ae-fireball.png)

## Known gaps (follow-ups, not in this PR)

- **#924** — blasts have no occlusion check, so an explosion damages through a thin wall or floor. Pre-existing for NPCs; player-visible now that the player is in the sweep.
- Large dark discs bloom around the blast under 25AE. `/v1/scene` shows `Explosion Smoke` is not in the mesh path at all (it is `fx_particle`), so it is a **particle** blending issue, not material transparency or `PropRenderAlpha`. Investigating separately.
