### PR TITLE
fix(rendering): load the master palette on a 25th Anniversary install

### DIFF
--- a/shock2vr/src/palette.rs
+++ b/shock2vr/src/palette.rs
@@ -6,12 +6,13 @@
 //! textures carry their own embedded palettes), so it isn't loaded elsewhere.
 //! Loaded once and cached.
 
+use std::io::Read;
 use std::sync::OnceLock;
 
 use cgmath::{Vector3, vec3};
 use tracing::warn;
 
-use crate::paths;
+use crate::data_files;
 
 /// Master palette PCX, relative to the data root.
 const PALETTE_FILE: &str = "res/pal/SHOCKPAL.PCX";
@@ -34,24 +35,24 @@ pub fn index_to_rgb(index: u8) -> Vector3<f32> {
 }
 
 fn load_master_palette() -> MasterPalette {
-    let path = paths::data_root().join(PALETTE_FILE);
-    match std::fs::read(&path) {
-        Ok(bytes) => parse_pcx_palette(&bytes).unwrap_or_else(|| {
-            warn!(
-                "[palette] {} has no 256-color palette trailer; using white",
-                path.display()
-            );
-            [[255; 3]; 256]
-        }),
-        Err(e) => {
-            warn!(
-                "[palette] could not read {}: {} - using white",
-                path.display(),
-                e
-            );
-            [[255; 3]; 256]
-        }
+    // Resolved through the data-file mounts, not the filesystem: a 25th
+    // Anniversary install has no loose files at all - the palette lives inside
+    // `sshock2.kpf` under `data/` - and reading the data root directly there
+    // silently fell back to white, which turns every palette-indexed particle
+    // color (explosion smoke, sparks, steam) white.
+    let Some(mut reader) = data_files::open_data_file(PALETTE_FILE) else {
+        warn!("[palette] {PALETTE_FILE} not found in the data root - using white");
+        return [[255; 3]; 256];
+    };
+    let mut bytes = Vec::new();
+    if let Err(e) = reader.read_to_end(&mut bytes) {
+        warn!("[palette] could not read {PALETTE_FILE}: {e} - using white");
+        return [[255; 3]; 256];
     }
+    parse_pcx_palette(&bytes).unwrap_or_else(|| {
+        warn!("[palette] {PALETTE_FILE} has no 256-color palette trailer; using white");
+        [[255; 3]; 256]
+    })
 }
 
 /// A 256-color PCX stores its palette in the trailing 769 bytes: a `0x0C` marker


### PR DESCRIPTION
Follow-up to #925, where the 25AE captures showed washed-out white puffs around a droid's death explosion. The cause turned out to have nothing to do with transparency or the smoke sprite.

`palette.rs` read the master palette with a plain filesystem read against the data root:

```rust
let path = paths::data_root().join("res/pal/SHOCKPAL.PCX");
match std::fs::read(&path) { ... }
```

A 25th Anniversary install has **no loose files at all** — `SHOCKPAL.PCX` lives inside `sshock2.kpf` under `data/res/pal/`. So the read always failed there and the documented fallback quietly returned an **all-white palette**.

Everything Dark stores as a palette index is therefore white on 25AE. In practice that is `PropParticleGroup`'s `cr/cg/cb` — explosion smoke, sparks, steam vents, every palette-colored emitter — rendering as white puffs instead of their authored color. The only symptom is one `WARN` at startup:

```
[palette] could not read <root>/res/pal/SHOCKPAL.PCX: No such file or directory - using white
```

## Fix

Resolve it through `data_files::open_data_file`, which already tries the 25AE archive mounts and then the loose data root. Both layouts now load the same palette, and the special case disappears rather than doubling — that helper exists precisely so callers stop `File::open`ing the data root.

## Before / after

`debug_particles` (its emitters are explicitly palette-indexed: red 20, orange 30, …) with `DARK_ASSET_PATH=<25AE install>`:

| Before (25AE) | After (25AE) | Classic install (reference) |
| --- | --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/palette-25ae-before.png) | ![after](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/palette-25ae-after.png) | ![classic](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/palette-classic.png) |

Measured over the lit pixels of those frames — strongly-colored (max−min channel > 60):

| | 25AE before | 25AE after | Classic |
| --- | --- | --- | --- |
| strongly-colored | **7%** | **82%** | 83% |

The `WARN` is gone on both layouts, and the classic path is unchanged (`open_data_file` falls through to the loose data root, retrying the exact-case name for case-sensitive filesystems).

## What it actually costs you

The washed-out puffs are not cosmetic dressing on the fireball — on a 25AE install they *are* the fireball. `Explosion Smoke` (template -1511) is `render_type: 4` with an empty `model_name`, so it never draws a sprite: it is the procedural glow disk tinted by `palette::index_to_rgb(28)`, and index 28 is **orange**. Forced to white, the explosion loses its entire warm glow and reads as a small bright core on dim grey discs.

A protocol droid detonating in `debug_protocol_droid`, same scene and same deterministic step sequence, `DARK_ASSET_PATH=<25AE install>` both times:

| Before (25AE) | After (25AE) |
| --- | --- |
| ![fireball before](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/fireball-25ae-before.png) | ![fireball after](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/fireball-25ae-after.png) |

![fireball after gif](https://gist.githubusercontent.com/tommy-xr/67a8f275e3efb1569ba0a6a83eac338a/raw/fireball-25ae-after.gif)

Fire-colored pixels in the peak blast frame go from **365** to **4311** — a ~12x difference. (The droid self-destruct that drives this capture is #925; the palette bug and this fix are independent of it — any explosion, grenade or barrel shows the same thing.)

`RUSTFLAGS="-D warnings" cargo check -p shock2vr` clean.
