### PR TITLE
feat(ui): add the load-game screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,9 @@ For debugging visual/rendering changes without a full interactive session:
    # Pass `--visible` to watch the game in a real window.
    cargo dbgr --mission medsci1.mis --port 8080
 
+   # With no --mission it boots the main menu (same entry point as the flat
+   # desktop runtime), so always pass one when a scene/mission is what you want.
+
    # Control via HTTP
    curl http://127.0.0.1:8080/v1/step -X POST -d '{"frames": 10}'
    curl http://127.0.0.1:8080/v1/screenshot -X POST -d '{"filename": "test.png"}'

--- a/engine/src/font.rs
+++ b/engine/src/font.rs
@@ -33,6 +33,45 @@ pub fn measure_text_width(font: &dyn Font, text: &str, font_size: f32) -> f32 {
         .sum()
 }
 
+/// Shorten `text` until it fits `max_width`, marking the cut with a trailing
+/// ellipsis. Returns `text` unchanged when it already fits.
+///
+/// Used for text of unbounded length - save names, player-authored labels -
+/// which would otherwise spill out of its widget and over its neighbours.
+/// Measured with real glyph advances, so it is correct for the variable-width
+/// bitmap fonts Dark ships.
+pub fn ellipsize(font: &dyn Font, text: &str, font_size: f32, max_width: f32) -> String {
+    if measure_text_width(font, text, font_size) <= max_width {
+        return text.to_owned();
+    }
+
+    const ELLIPSIS: &str = "...";
+    let ellipsis_width = measure_text_width(font, ELLIPSIS, font_size);
+    // Too narrow to say anything meaningful - an empty string beats a stray
+    // fragment of an ellipsis drawn over the neighbouring widget.
+    if ellipsis_width > max_width {
+        return String::new();
+    }
+
+    let budget = max_width - ellipsis_width;
+    let multiplier = font_size / font.base_height();
+    let mut width = 0.0;
+    let mut end = 0;
+    for (index, c) in text.char_indices() {
+        let advance = font
+            .get_character_info(c)
+            .map(|info| info.advance * multiplier)
+            .unwrap_or(0.0);
+        if width + advance > budget {
+            break;
+        }
+        width += advance;
+        // `index` is the char's start, so the kept prefix ends after it.
+        end = index + c.len_utf8();
+    }
+    format!("{}{}", &text[..end], ELLIPSIS)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,5 +122,63 @@ mod tests {
         assert_eq!(measure_text_width(&f, "", 10.0), 0.0);
         // Doubling font_size doubles the advances (multiplier 2): 3*8 = 24.
         assert_eq!(measure_text_width(&f, "abc", 20.0), 24.0);
+    }
+
+    #[test]
+    fn ellipsize_leaves_text_that_already_fits() {
+        // 10px per glyph: "abc" is 30px in a 100px budget.
+        let font = StubFont {
+            advance: 10.0,
+            base_height: 10.0,
+        };
+        assert_eq!(ellipsize(&font, "abc", 10.0, 100.0), "abc");
+        // Exactly filling the width is still a fit.
+        assert_eq!(ellipsize(&font, "abc", 10.0, 30.0), "abc");
+    }
+
+    #[test]
+    fn ellipsize_shortens_text_that_overflows() {
+        let font = StubFont {
+            advance: 10.0,
+            base_height: 10.0,
+        };
+        // 60px budget - 30px of "..." leaves room for 3 glyphs.
+        let out = ellipsize(&font, "abcdefgh", 10.0, 60.0);
+        assert_eq!(out, "abc...");
+        // The result must actually fit, which is the whole point.
+        assert!(measure_text_width(&font, &out, 10.0) <= 60.0);
+    }
+
+    #[test]
+    fn ellipsize_gives_up_when_even_the_ellipsis_does_not_fit() {
+        let font = StubFont {
+            advance: 10.0,
+            base_height: 10.0,
+        };
+        // A stray fragment drawn over the neighbouring widget is worse than
+        // nothing.
+        assert_eq!(ellipsize(&font, "abcdef", 10.0, 20.0), "");
+    }
+
+    #[test]
+    fn ellipsize_cuts_on_character_boundaries() {
+        let font = StubFont {
+            advance: 10.0,
+            base_height: 10.0,
+        };
+        // Multi-byte characters must not be sliced mid-codepoint (that would
+        // panic on the string index).
+        let out = ellipsize(&font, "\u{e4}\u{f6}\u{fc}\u{df}\u{e4}\u{f6}", 10.0, 50.0);
+        assert_eq!(out, "\u{e4}\u{f6}...");
+    }
+
+    #[test]
+    fn ellipsize_scales_with_font_size() {
+        let font = StubFont {
+            advance: 10.0,
+            base_height: 10.0,
+        };
+        // At double size each glyph is 20px, so half as many survive.
+        assert_eq!(ellipsize(&font, "abcdefgh", 20.0, 120.0), "abc...");
     }
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -19,7 +19,7 @@ pub mod util;
 
 pub use crate::engine::Engine;
 pub use crate::engine::EngineRenderContext;
-pub use crate::font::{Font, FontCharacterInfo, measure_text_width};
+pub use crate::font::{Font, FontCharacterInfo, ellipsize, measure_text_width};
 
 pub fn opengl() -> Box<dyn Engine> {
     let engine = gl_engine::init_gl();

--- a/projects/vr-gloves.md
+++ b/projects/vr-gloves.md
@@ -100,7 +100,7 @@ Desktop `--vr` controls: hold **E** (right hand) or **Q** (left hand) to
 possess a hand — the mouse then drives it (move = aim, LMB = trigger,
 RMB = squeeze). Bare clicks do nothing to the hands in VR mode.
 
-Test headlessly with `cargo dbgr --vr`: the debug runtime's
+Test headlessly with `cargo dbgr --vr --mission earth.mis`: the debug runtime's
 `POST /v1/control/input` accepts `{left,right}_hand.position [x,y,z]`
 (pawn-local), `.rotation [x,y,z,w]`, `.trigger`, and `.squeeze` channels, so
 hand placement and finger state are fully scriptable for screenshots.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -77,8 +77,10 @@ where
 #[command(name = "debug_runtime")]
 #[command(about = "HTTP-controlled game runtime for LLM testing and automation")]
 struct Args {
-    /// Mission file to load (e.g., medsci1.mis)
-    #[arg(short, long, default_value = "earth.mis")]
+    /// Mission file to load (e.g., medsci1.mis), a debug scene name, or
+    /// "main_menu". Defaults to the main menu, the same entry point the flat
+    /// desktop runtime boots into - automation passes this explicitly anyway.
+    #[arg(short, long, default_value = "main_menu")]
     mission: String,
 
     /// Port to bind HTTP server to

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -83,6 +83,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect,
                 ..
             } => Self::Text {
                 position: new_position,
@@ -93,7 +94,7 @@ where
                 h,
                 v,
                 alpha,
-                fit_to_rect: false,
+                fit_to_rect,
             },
         }
     }
@@ -157,6 +158,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect,
                 ..
             } => Self::Text {
                 position,
@@ -167,7 +169,7 @@ where
                 h,
                 v,
                 alpha,
-                fit_to_rect: false,
+                fit_to_rect,
             },
         }
     }
@@ -260,6 +262,7 @@ where
                 font_size,
                 h,
                 v,
+                fit_to_rect,
                 ..
             } => Self::Text {
                 position,
@@ -270,7 +273,7 @@ where
                 h,
                 v,
                 alpha,
-                fit_to_rect: false,
+                fit_to_rect,
             },
         }
     }

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -93,6 +93,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect: false,
             },
         }
     }
@@ -166,6 +167,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect: false,
             },
         }
     }
@@ -268,6 +270,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect: false,
             },
         }
     }
@@ -493,6 +496,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect,
             } => GuiComponent::Text {
                 position,
                 size,
@@ -502,6 +506,7 @@ where
                 h,
                 v,
                 alpha,
+                fit_to_rect,
             },
             Self::Bar {
                 position,
@@ -593,6 +598,7 @@ pub fn text<TMsg: Clone>(text: &str) -> GuiComponent<TMsg> {
         h: HAlign::Left,
         v: VAlign::Middle,
         alpha: 1.0,
+        fit_to_rect: false,
     }
 }
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -39,8 +39,8 @@ pub mod vr_crouch;
 pub mod zip_asset_path;
 
 use scenes::{
-    CutscenePlayerScene, GameOverScene, SceneInitResult, create_initial_scene,
-    load_mission_from_save_data, resolve_ending_cutscene,
+    CutscenePlayerScene, GameOverScene, LoadGameScene, MainMenuScene, SceneInitResult,
+    create_initial_scene, load_mission_from_save_data, resolve_ending_cutscene,
 };
 
 pub use mission::SpawnLocation;
@@ -1423,6 +1423,16 @@ impl Game {
                 // which replaces the ledger wholesale.
                 self.pending_transition = None;
                 self.active_game_scene = Box::new(GameOverScene::new());
+            }
+            GlobalEffect::ShowLoadGame => {
+                // A frontend screen swap, not a level transition: no ledger
+                // write-back, and any pending transition is abandoned.
+                self.pending_transition = None;
+                self.active_game_scene = Box::new(LoadGameScene::new());
+            }
+            GlobalEffect::ShowMainMenu => {
+                self.pending_transition = None;
+                self.active_game_scene = Box::new(MainMenuScene::new());
             }
             GlobalEffect::CompleteCampaign => {
                 // Preserve the destroyed head and the rest of the finale state

--- a/shock2vr/src/save_load/save_files.rs
+++ b/shock2vr/src/save_load/save_files.rs
@@ -1,9 +1,9 @@
 //! Discovery of saved games on disk.
 //!
 //! Named saves live in `<data_root>/saves/<name>.sav` (see
-//! [`crate::save_file_path`]). Screens that offer a reload - today the
-//! game-over screen after a terminal death - need to know what is actually
-//! available without hardcoding a file name, so they ask here.
+//! [`crate::save_file_path`]). Screens that offer a reload - the load-game
+//! screen, and the game-over screen after a terminal death - need to know what
+//! is actually available without hardcoding a file name, so they ask here.
 
 use std::{
     fs,
@@ -28,15 +28,23 @@ pub fn save_directory() -> PathBuf {
     paths::data_root().join("saves")
 }
 
+/// Every save on disk, most recent first. Empty when nothing has been saved
+/// yet (or the directory does not exist).
+pub fn all_saves() -> Vec<SaveFile> {
+    all_saves_in(&save_directory())
+}
+
 /// The most recently written save, or `None` when nothing has been saved yet.
 pub fn latest_save() -> Option<SaveFile> {
     latest_save_in(&save_directory())
 }
 
-/// [`latest_save`] against an explicit directory (missing directory -> `None`).
-fn latest_save_in(directory: &Path) -> Option<SaveFile> {
-    fs::read_dir(directory)
-        .ok()?
+/// [`all_saves`] against an explicit directory (missing directory -> empty).
+fn all_saves_in(directory: &Path) -> Vec<SaveFile> {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    let mut saves: Vec<SaveFile> = entries
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
@@ -50,13 +58,23 @@ fn latest_save_in(directory: &Path) -> Option<SaveFile> {
                 modified,
             })
         })
-        // Ties (same-second writes on coarse filesystems) resolve by name so
-        // the choice is deterministic rather than directory-order dependent.
-        .max_by(|a, b| {
-            a.modified
-                .cmp(&b.modified)
-                .then_with(|| a.name.cmp(&b.name))
-        })
+        .collect();
+    // Most recent first. Ties (same-second writes on coarse filesystems)
+    // resolve by name so the order is deterministic rather than
+    // directory-order dependent. Both keys descend, which keeps
+    // `latest_save` - now the head of this list - picking the same save it
+    // did when it was a `max_by` over the same ordering.
+    saves.sort_by(|a, b| {
+        b.modified
+            .cmp(&a.modified)
+            .then_with(|| b.name.cmp(&a.name))
+    });
+    saves
+}
+
+/// [`latest_save`] against an explicit directory (missing directory -> `None`).
+fn latest_save_in(directory: &Path) -> Option<SaveFile> {
+    all_saves_in(directory).into_iter().next()
 }
 
 #[cfg(test)]
@@ -94,6 +112,39 @@ mod tests {
         let dir = scratch_dir("filter");
         write_save(&dir, "notes.txt");
         assert_eq!(latest_save_in(&dir), None);
+    }
+
+    #[test]
+    fn all_saves_lists_every_save_most_recent_first() {
+        let dir = scratch_dir("listing");
+        write_save(&dir, "old.sav");
+        std::thread::sleep(Duration::from_millis(20));
+        write_save(&dir, "new.sav");
+        write_save(&dir, "notes.txt");
+
+        let names: Vec<String> = all_saves_in(&dir).into_iter().map(|s| s.name).collect();
+        assert_eq!(names, vec!["new".to_owned(), "old".to_owned()]);
+    }
+
+    #[test]
+    fn all_saves_is_empty_without_a_directory() {
+        assert!(all_saves_in(Path::new("/nonexistent/shock2vr/saves")).is_empty());
+    }
+
+    #[test]
+    fn same_timestamp_saves_order_by_name_descending() {
+        // Ties must resolve the same way they did when `latest_save` was a
+        // `max_by` over (modified, name): the greater name wins, so it heads
+        // the list and stays what `latest_save` returns.
+        let dir = scratch_dir("ties");
+        write_save(&dir, "alpha.sav");
+        write_save(&dir, "beta.sav");
+        let saves = all_saves_in(&dir);
+        // Only meaningful when the filesystem really gave them equal mtimes.
+        if saves[0].modified == saves[1].modified {
+            assert_eq!(saves[0].name, "beta");
+            assert_eq!(latest_save_in(&dir).unwrap().name, "beta");
+        }
     }
 
     #[test]

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -204,7 +204,12 @@ impl LoadGameScene {
             saves,
             selected,
             pointer: None,
-            last_pressed: false,
+            // A press held across a scene swap must not read as a click
+            // here: both screens sit on the same 640x480 canvas and their
+            // widgets overlap (the load screen's "Done" center falls inside
+            // the menu's "Quit" rect), so starting "already pressed" makes
+            // the next rising edge require a real release first.
+            last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
         }
     }

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -60,10 +60,37 @@ const FALLBACK_RECTS: [Rect; 4] = [
     Rect::new(527.0, 405.0, 95.0, 62.0),
 ];
 
-/// Height of one save row inside the list rect, in canvas pixels. Matches the
-/// 20px cell of `METAFONT.FON`, which is what the list was authored around -
-/// the vanilla 290px-tall list therefore holds 14 rows.
-const ROW_HEIGHT: f32 = 20.0;
+/// Row pitch inside the list rect, in canvas pixels. Rows are hit-tested at
+/// this pitch, so it also fixes the click targets.
+///
+/// The screen was authored around `METAFONT.FON`'s 20px cell, but save names
+/// draw in 11px [`LIST_FONT`], so a 20px pitch is mostly whitespace - and it
+/// costs a slot, because only 13 such rows clear [`FIELD_TOP_Y`]. 19px is the
+/// largest pitch that fits the shipped list's full 14, which matters while
+/// there is no scrolling: the last row is the last reachable save (#928).
+const ROW_HEIGHT: f32 = 19.0;
+
+/// Canvas y where `GAMELOD.PCX` starts painting a bordered field, decoded from
+/// the art (its border rows are 323, 325, 343 and 345). It is the save
+/// screen's name-entry box - `GAMESAVR.BIN` and `GAMELODR.BIN` are
+/// byte-identical and the two screens share this art - so on the load screen
+/// it is inert decoration that rows must still clear.
+///
+/// This is an absolute position in the backdrop, not an offset within the list
+/// rect: rows have to stop here no matter where the layout file puts the list.
+/// Naive `290 / 20` ignores it entirely, yielding 14 rows and drawing the last
+/// one straight through the field's border.
+const FIELD_TOP_Y: f32 = 323.0;
+
+/// Horizontal padding for a save name, applied to both edges of the row: the
+/// left so a left-aligned name clears the list panel's edge, the right so an
+/// ellipsized one stops short of it rather than running flush.
+const LIST_TEXT_INSET: f32 = 8.0;
+
+/// Save names are drawn in the small in-game font (11px) rather than the
+/// screen's 20px `METAFONT.FON`, so the list reads as data under the heavier
+/// header and buttons.
+const LIST_FONT: &str = "mainfont.fon";
 
 /// Opacity for a row or button that cannot be acted on.
 const DISABLED_OPACITY: f32 = 0.3;
@@ -120,9 +147,11 @@ fn label(strings: Option<&HashMap<String, String>>, key: &str, fallback: &str) -
         .unwrap_or_else(|| fallback.to_owned())
 }
 
-/// How many save rows fit in the list rect.
+/// How many save rows fit in the list rect, stopping at the backdrop's painted
+/// field (see [`FIELD_TOP_Y`]) when the rect runs past it.
 fn visible_row_count(list: Rect) -> usize {
-    (list.h / ROW_HEIGHT).floor().max(0.0) as usize
+    let usable = (list.y + list.h).min(FIELD_TOP_Y) - list.y;
+    (usable / ROW_HEIGHT).floor().max(0.0) as usize
 }
 
 /// The canvas rect of the `index`-th row of the list.
@@ -132,6 +161,19 @@ fn row_rect(list: Rect, index: usize) -> Rect {
         list.y + index as f32 * ROW_HEIGHT,
         list.w,
         ROW_HEIGHT,
+    )
+}
+
+/// The rect a row's save name is drawn in: the row, inset on both sides so the
+/// name clears the panel edges. Hit-testing still uses the full [`row_rect`],
+/// so the inset never costs a click.
+fn row_text_rect(list: Rect, index: usize) -> Rect {
+    let row = row_rect(list, index);
+    Rect::new(
+        row.x + LIST_TEXT_INSET,
+        row.y,
+        (row.w - 2.0 * LIST_TEXT_INSET).max(0.0),
+        row.h,
     )
 }
 
@@ -241,6 +283,11 @@ impl GameScene for LoadGameScene {
             .len()
             .min(visible_row_count(rects[LIST_RECT_INDEX]));
 
+        // Only a save the player can actually see is loadable. The constructor
+        // preselects row 0 from `saves` alone, which a layout too short to show
+        // a single row would otherwise turn into a "Load" for an invisible one.
+        let selected = self.selected.filter(|index| *index < visible);
+
         self.pointer = input_context.pointer;
         let (action, last_pressed) = resolve_click(
             input_context.pointer,
@@ -248,7 +295,7 @@ impl GameScene for LoadGameScene {
             self.last_screen_size,
             &rects,
             visible,
-            self.selected.is_some(),
+            selected.is_some(),
         );
         self.last_pressed = last_pressed;
 
@@ -257,8 +304,7 @@ impl GameScene for LoadGameScene {
                 self.selected = Some(index);
                 Vec::new()
             }
-            Some(LoadGameAction::Load) => self
-                .selected
+            Some(LoadGameAction::Load) => selected
                 .and_then(|index| self.saves.get(index))
                 .map(|save| {
                     vec![Effect::GlobalEffect(GlobalEffect::Load {
@@ -322,6 +368,9 @@ impl GameScene for LoadGameScene {
 
         let list = rects[LIST_RECT_INDEX];
         if self.saves.is_empty() {
+            // Deliberately header-styled rather than row-styled: this is a
+            // message about the list, not an entry in it, so it stays centered
+            // in MENU_FONT while real saves read as left-aligned data.
             canvas
                 .text_native(
                     row_rect(list, 0),
@@ -339,10 +388,10 @@ impl GameScene for LoadGameScene {
                     // are ellipsized to the list width rather than spilling
                     // over the Load button.
                     .text_native_fit(
-                        row_rect(list, index),
+                        row_text_rect(list, index),
                         &save.name,
-                        MENU_FONT,
-                        HAlign::Center,
+                        LIST_FONT,
+                        HAlign::Left,
                         VAlign::Middle,
                     )
                     .opacity(if self.selected == Some(index) {
@@ -510,15 +559,59 @@ mod tests {
     }
 
     #[test]
-    fn the_vanilla_list_holds_fourteen_rows() {
-        // 290px of list at a 20px row pitch. Guards the row geometry that the
-        // hit-testing and the render loop share.
-        assert_eq!(visible_row_count(FALLBACK_RECTS[LIST_RECT_INDEX]), 14);
+    fn the_vanilla_list_holds_fourteen_rows_clear_of_the_field() {
+        // Guards the row geometry that the hit-testing and the render loop
+        // share: all 14 of the shipped list's rows are reachable, and none of
+        // them touches the backdrop's painted field.
         let list = FALLBACK_RECTS[LIST_RECT_INDEX];
-        assert_eq!(row_rect(list, 0), Rect::new(261.0, 54.0, 202.0, 20.0));
-        assert_eq!(row_rect(list, 13), Rect::new(261.0, 314.0, 202.0, 20.0));
-        // Every row stays inside the authored list rect.
+        assert_eq!(visible_row_count(list), 14);
+        assert_eq!(row_rect(list, 0), Rect::new(261.0, 54.0, 202.0, 19.0));
+        assert_eq!(row_rect(list, 13), Rect::new(261.0, 301.0, 202.0, 19.0));
+        // Every row stays inside the authored list rect...
         assert!(row_rect(list, 13).y + ROW_HEIGHT <= list.y + list.h);
+        // ...and clears the painted field.
+        assert!(row_rect(list, 13).y + ROW_HEIGHT <= FIELD_TOP_Y);
+        // A 15th would not, so the count stops where the art does.
+        assert!(row_rect(list, 14).y + ROW_HEIGHT > FIELD_TOP_Y);
+        // The pitch is the largest that fits all 14 - one more pixel loses a
+        // row, which is what a naive 20px pitch did.
+        assert!(list.y + 14.0 * (ROW_HEIGHT + 1.0) > FIELD_TOP_Y);
+    }
+
+    #[test]
+    fn the_row_count_tracks_the_field_position_not_the_rect_height() {
+        // The field is at a fixed place in the backdrop, so the row count has
+        // to follow the list's position, not just its height. Reserving a
+        // fixed slice of `h` would get both of these wrong.
+        //
+        // A list clear of the field uses its full height...
+        let above = Rect::new(261.0, 20.0, 202.0, 290.0);
+        assert!(above.y + above.h <= FIELD_TOP_Y);
+        assert_eq!(visible_row_count(above), 15);
+        // ...while one running past it stops at the field, however tall it is.
+        let over = Rect::new(261.0, 54.0, 202.0, 350.0);
+        assert_eq!(visible_row_count(over), 14);
+        assert!(row_rect(over, 13).y + ROW_HEIGHT <= FIELD_TOP_Y);
+        // A list starting below the field shows nothing rather than underflowing.
+        assert_eq!(visible_row_count(Rect::new(261.0, 400.0, 202.0, 60.0)), 0);
+    }
+
+    #[test]
+    fn row_text_is_inset_from_the_left_but_the_whole_row_stays_clickable() {
+        let list = FALLBACK_RECTS[LIST_RECT_INDEX];
+        let row = row_rect(list, 0);
+        let text = row_text_rect(list, 0);
+        assert_eq!(text, Rect::new(269.0, 54.0, 186.0, ROW_HEIGHT));
+        // Inset on both edges, so an ellipsized name stops short of the panel.
+        assert_eq!(text.x - row.x, LIST_TEXT_INSET);
+        assert_eq!((row.x + row.w) - (text.x + text.w), LIST_TEXT_INSET);
+        // A click in either inset gap still selects the row.
+        for x in [list.x + 2.0, list.x + list.w - 2.0] {
+            assert_eq!(
+                click(at_canvas(vec2(x, list.y + 10.0)), 3, false),
+                Some(LoadGameAction::Select(0))
+            );
+        }
     }
 
     #[test]

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -1,0 +1,570 @@
+//! Load-game screen ("the Tri-Optimum archive database").
+//!
+//! The original `GAMELOD.PCX` backdrop with its `GAMELODR.BIN` widget rects: a
+//! header line, a scrolling list of saves, and "Load" / "Done" buttons. Labels
+//! come from `GAMELOD.STR`, so nothing about the screen's text or geometry is
+//! hardcoded (see the sibling [`crate::scenes::MainMenuScene`]).
+//!
+//! Reached from the main menu's "Load Game" entry; "Done" returns there.
+//! [`crate::scenes::GameOverScene`] is a degenerate cousin of this screen -
+//! same backdrop and layout, but offering only the single most recent save.
+
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use dark::{
+    importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
+    map::MapRect,
+};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, light::SpotLight},
+};
+use shipyard::{EntityId, UniqueViewMut, World};
+use std::collections::HashMap;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    input_context::{InputContext, Pointer2D},
+    mission::GlobalContext,
+    save_load::{SaveFile, all_saves},
+    scripts::{Effect, GlobalEffect},
+    time::Time,
+    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+};
+
+/// The screen is authored on the original 640x480 `GAMELOD.PCX` canvas.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
+/// The original load screen's widget layout - LTRB rects (`UI_LAYOUT_IMPORTER`).
+const LAYOUT_FILE: &str = "GAMELODR.BIN";
+/// The original label strings for this screen.
+const LABELS_FILE: &str = "GAMELOD.STR";
+/// Same display font the rest of the frontend uses (`res/intrface/METAFONT.FON`).
+const MENU_FONT: &str = "metafont.fon";
+/// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+/// Indices into the `GAMELODR.BIN` rect list, in the screen's authored order.
+const HEADER_RECT_INDEX: usize = 0;
+const LIST_RECT_INDEX: usize = 1;
+const LOAD_RECT_INDEX: usize = 2;
+const DONE_RECT_INDEX: usize = 3;
+
+/// Decoded `GAMELODR.BIN` values, used when the layout file is absent.
+const FALLBACK_RECTS: [Rect; 4] = [
+    Rect::new(261.0, 31.0, 202.0, 20.0),
+    Rect::new(261.0, 54.0, 202.0, 290.0),
+    Rect::new(527.0, 161.0, 96.0, 62.0),
+    Rect::new(527.0, 405.0, 95.0, 62.0),
+];
+
+/// Height of one save row inside the list rect, in canvas pixels. Matches the
+/// 20px cell of `METAFONT.FON`, which is what the list was authored around -
+/// the vanilla 290px-tall list therefore holds 14 rows.
+const ROW_HEIGHT: f32 = 20.0;
+
+/// Opacity for a row or button that cannot be acted on.
+const DISABLED_OPACITY: f32 = 0.3;
+/// Opacity for an actionable, unhighlighted element.
+const IDLE_OPACITY: f32 = 0.65;
+/// Opacity for the selected row / the hovered button.
+const ACTIVE_OPACITY: f32 = 1.0;
+
+/// `GAMELOD.STR` keys, with the shipped English text as a fallback.
+const HEADER_KEY: &str = "initial";
+const HEADER_FALLBACK: &str = "Select a file to load.";
+const EMPTY_KEY: &str = "unused";
+const EMPTY_FALLBACK: &str = "< EMPTY >";
+const LOAD_KEY: &str = "load";
+const LOAD_FALLBACK: &str = "Load";
+const DONE_KEY: &str = "done";
+const DONE_FALLBACK: &str = "Done";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LoadGameAction {
+    /// Highlight the save at this index in the visible list.
+    Select(usize),
+    /// Load the highlighted save.
+    Load,
+    /// Return to the main menu.
+    Done,
+}
+
+/// Resolve the screen's widget rects from `GAMELODR.BIN`, falling back to the
+/// decoded values when it is absent.
+fn screen_rects(layout: Option<&[MapRect]>) -> [Rect; 4] {
+    let mut rects = FALLBACK_RECTS;
+    for (index, rect) in rects.iter_mut().enumerate() {
+        if let Some(r) = layout.and_then(|rects| rects.get(index)) {
+            *rect = Rect::new(
+                r.ul_x as f32,
+                r.ul_y as f32,
+                r.width() as f32,
+                r.height() as f32,
+            );
+        }
+    }
+    rects
+}
+
+/// Look a label up in `GAMELOD.STR`, falling back to the shipped English text
+/// when the table (or the key) is missing, or the value is empty.
+fn label(strings: Option<&HashMap<String, String>>, key: &str, fallback: &str) -> String {
+    strings
+        // The strings importer lowercases its keys.
+        .and_then(|s| s.get(key))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+/// How many save rows fit in the list rect.
+fn visible_row_count(list: Rect) -> usize {
+    (list.h / ROW_HEIGHT).floor().max(0.0) as usize
+}
+
+/// The canvas rect of the `index`-th row of the list.
+fn row_rect(list: Rect, index: usize) -> Rect {
+    Rect::new(
+        list.x,
+        list.y + index as f32 * ROW_HEIGHT,
+        list.w,
+        ROW_HEIGHT,
+    )
+}
+
+/// Pure click resolution: on a rising press edge, map the pointer to whatever
+/// it is over - a save row, "Load" (only when a save is selected), or "Done".
+/// Also returns the new `last_pressed` to track for the next frame.
+fn resolve_click(
+    pointer: Option<Pointer2D>,
+    last_pressed: bool,
+    screen_size: Vector2<f32>,
+    rects: &[Rect; 4],
+    visible_saves: usize,
+    has_selection: bool,
+) -> (Option<LoadGameAction>, bool) {
+    let Some(p) = pointer else {
+        return (None, false);
+    };
+    if !p.pressed || last_pressed {
+        return (None, p.pressed);
+    }
+
+    let action = pointer_to_canvas(
+        vec2(CANVAS_W, CANVAS_H),
+        p.position,
+        screen_size,
+        SCALE_MODE,
+    )
+    .and_then(|c| {
+        if has_selection && rects[LOAD_RECT_INDEX].contains(c) {
+            return Some(LoadGameAction::Load);
+        }
+        if rects[DONE_RECT_INDEX].contains(c) {
+            return Some(LoadGameAction::Done);
+        }
+        // Rows past the end of the save list are empty backdrop, not buttons.
+        (0..visible_saves)
+            .find(|index| row_rect(rects[LIST_RECT_INDEX], *index).contains(c))
+            .map(LoadGameAction::Select)
+    });
+    (action, p.pressed)
+}
+
+pub struct LoadGameScene {
+    world: World,
+    scene_name: String,
+    /// Saves offered by the list, resolved once when the screen opens so the
+    /// rows and the click agree. Most recent first.
+    saves: Vec<SaveFile>,
+    /// Index into [`Self::saves`] of the highlighted row, if any.
+    selected: Option<usize>,
+    /// Pointer from the latest update, used for hover highlighting in render.
+    pointer: Option<Pointer2D>,
+    /// Whether the pointer was pressed last frame (for rising-edge clicks).
+    last_pressed: bool,
+    /// Screen size from the latest render, so `update` can map the pointer into
+    /// canvas space consistently with how the canvas is drawn.
+    last_screen_size: Vector2<f32>,
+}
+
+impl LoadGameScene {
+    pub fn new() -> Self {
+        let saves = all_saves();
+        // Preselect the most recent save so "Load" is immediately meaningful,
+        // matching the recovery the game-over screen offers.
+        let selected = (!saves.is_empty()).then_some(0);
+
+        Self {
+            world: super::ui_scene_world(),
+            scene_name: "load_game".to_owned(),
+            saves,
+            selected,
+            pointer: None,
+            last_pressed: false,
+            last_screen_size: vec2(CANVAS_W, CANVAS_H),
+        }
+    }
+}
+
+impl Default for LoadGameScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameScene for LoadGameScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+        _command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let visible = self
+            .saves
+            .len()
+            .min(visible_row_count(rects[LIST_RECT_INDEX]));
+
+        self.pointer = input_context.pointer;
+        let (action, last_pressed) = resolve_click(
+            input_context.pointer,
+            self.last_pressed,
+            self.last_screen_size,
+            &rects,
+            visible,
+            self.selected.is_some(),
+        );
+        self.last_pressed = last_pressed;
+
+        match action {
+            Some(LoadGameAction::Select(index)) => {
+                self.selected = Some(index);
+                Vec::new()
+            }
+            Some(LoadGameAction::Load) => self
+                .selected
+                .and_then(|index| self.saves.get(index))
+                .map(|save| {
+                    vec![Effect::GlobalEffect(GlobalEffect::Load {
+                        file_name: save.path.to_string_lossy().into_owned(),
+                    })]
+                })
+                .unwrap_or_default(),
+            Some(LoadGameAction::Done) => {
+                vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)]
+            }
+            None => Vec::new(),
+        }
+    }
+
+    fn render(
+        &mut self,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        // The screen is drawn in screen space in `render_per_eye` (which has
+        // the screen size); the 3D scene is empty.
+        (
+            Vec::new(),
+            vec3(0.0, 0.0, 0.0),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        )
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        _options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        self.last_screen_size = screen_size;
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
+        let strings = strings.as_deref();
+        let pointer_canvas = self.pointer.and_then(|p| {
+            pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            )
+        });
+
+        canvas.text_native(
+            rects[HEADER_RECT_INDEX],
+            &label(strings, HEADER_KEY, HEADER_FALLBACK),
+            MENU_FONT,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+
+        let list = rects[LIST_RECT_INDEX];
+        if self.saves.is_empty() {
+            canvas
+                .text_native(
+                    row_rect(list, 0),
+                    &label(strings, EMPTY_KEY, EMPTY_FALLBACK),
+                    MENU_FONT,
+                    HAlign::Center,
+                    VAlign::Middle,
+                )
+                .opacity(DISABLED_OPACITY);
+        } else {
+            let visible = self.saves.len().min(visible_row_count(list));
+            for (index, save) in self.saves.iter().take(visible).enumerate() {
+                canvas
+                    // Save names are player-authored and unbounded, so they
+                    // are ellipsized to the list width rather than spilling
+                    // over the Load button.
+                    .text_native_fit(
+                        row_rect(list, index),
+                        &save.name,
+                        MENU_FONT,
+                        HAlign::Center,
+                        VAlign::Middle,
+                    )
+                    .opacity(if self.selected == Some(index) {
+                        ACTIVE_OPACITY
+                    } else {
+                        IDLE_OPACITY
+                    });
+            }
+        }
+
+        // "Load" is inert with nothing selected, so it reads as disabled.
+        for (index, text, enabled) in [
+            (
+                LOAD_RECT_INDEX,
+                label(strings, LOAD_KEY, LOAD_FALLBACK),
+                self.selected.is_some(),
+            ),
+            (
+                DONE_RECT_INDEX,
+                label(strings, DONE_KEY, DONE_FALLBACK),
+                true,
+            ),
+        ] {
+            let rect = rects[index];
+            let opacity = if !enabled {
+                DISABLED_OPACITY
+            } else if pointer_canvas.is_some_and(|p| rect.contains(p)) {
+                ACTIVE_OPACITY
+            } else {
+                IDLE_OPACITY
+            };
+            canvas
+                .text_native(rect, &text, MENU_FONT, HAlign::Center, VAlign::Middle)
+                .opacity(opacity);
+        }
+
+        canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
+    }
+
+    fn handle_effects(
+        &mut self,
+        effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        _asset_cache: &mut AssetCache,
+        _audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        effects
+            .into_iter()
+            .filter_map(|e| match e {
+                Effect::GlobalEffect(g) => Some(g),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn wants_pointer(&self) -> bool {
+        true
+    }
+
+    fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
+        Vec::new()
+    }
+
+    fn world(&self) -> &World {
+        &self.world
+    }
+
+    fn scene_name(&self) -> &str {
+        &self.scene_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The runtimes render at a 4:3 resolution, so PreserveAspect == stretch and
+    // normalized coords map straight onto the 640x480 canvas.
+    const SCREEN: Vector2<f32> = Vector2 { x: 800.0, y: 600.0 };
+
+    fn pointer_at(x: f32, y: f32, pressed: bool) -> Option<Pointer2D> {
+        Some(Pointer2D {
+            position: vec2(x, y),
+            pressed,
+        })
+    }
+
+    /// Canvas point -> normalized screen point, so tests can name the widget
+    /// they mean instead of a magic normalized pair.
+    fn at_canvas(p: Vector2<f32>) -> Option<Pointer2D> {
+        pointer_at(p.x / CANVAS_W, p.y / CANVAS_H, true)
+    }
+
+    fn click(
+        pointer: Option<Pointer2D>,
+        visible: usize,
+        has_selection: bool,
+    ) -> Option<LoadGameAction> {
+        resolve_click(
+            pointer,
+            false,
+            SCREEN,
+            &FALLBACK_RECTS,
+            visible,
+            has_selection,
+        )
+        .0
+    }
+
+    #[test]
+    fn clicking_a_row_selects_that_save() {
+        let list = FALLBACK_RECTS[LIST_RECT_INDEX];
+        for index in 0..3 {
+            assert_eq!(
+                click(at_canvas(row_rect(list, index).center()), 3, false),
+                Some(LoadGameAction::Select(index)),
+                "row {index}"
+            );
+        }
+    }
+
+    #[test]
+    fn clicking_past_the_last_save_does_nothing() {
+        // Only two saves exist, so the third row is bare backdrop.
+        let list = FALLBACK_RECTS[LIST_RECT_INDEX];
+        assert_eq!(click(at_canvas(row_rect(list, 2).center()), 2, false), None);
+    }
+
+    #[test]
+    fn load_requires_a_selection() {
+        let load = FALLBACK_RECTS[LOAD_RECT_INDEX].center();
+        assert_eq!(click(at_canvas(load), 3, true), Some(LoadGameAction::Load));
+        // With nothing selected the button is inert rather than loading
+        // whatever happens to be first.
+        assert_eq!(click(at_canvas(load), 3, false), None);
+    }
+
+    #[test]
+    fn done_returns_to_the_menu_even_with_no_saves() {
+        let done = FALLBACK_RECTS[DONE_RECT_INDEX].center();
+        assert_eq!(click(at_canvas(done), 0, false), Some(LoadGameAction::Done));
+    }
+
+    #[test]
+    fn held_press_does_not_re_activate() {
+        let done = FALLBACK_RECTS[DONE_RECT_INDEX].center();
+        let (action, last) = resolve_click(
+            pointer_at(done.x / CANVAS_W, done.y / CANVAS_H, true),
+            true,
+            SCREEN,
+            &FALLBACK_RECTS,
+            0,
+            false,
+        );
+        assert_eq!(action, None);
+        assert!(last);
+    }
+
+    #[test]
+    fn no_pointer_means_no_action() {
+        let (action, last) = resolve_click(None, true, SCREEN, &FALLBACK_RECTS, 3, true);
+        assert_eq!(action, None);
+        assert!(!last);
+    }
+
+    #[test]
+    fn the_vanilla_list_holds_fourteen_rows() {
+        // 290px of list at a 20px row pitch. Guards the row geometry that the
+        // hit-testing and the render loop share.
+        assert_eq!(visible_row_count(FALLBACK_RECTS[LIST_RECT_INDEX]), 14);
+        let list = FALLBACK_RECTS[LIST_RECT_INDEX];
+        assert_eq!(row_rect(list, 0), Rect::new(261.0, 54.0, 202.0, 20.0));
+        assert_eq!(row_rect(list, 13), Rect::new(261.0, 314.0, 202.0, 20.0));
+        // Every row stays inside the authored list rect.
+        assert!(row_rect(list, 13).y + ROW_HEIGHT <= list.y + list.h);
+    }
+
+    #[test]
+    fn screen_rects_prefer_layout_and_fall_back() {
+        let layout: Vec<MapRect> = (0..4)
+            .map(|i| MapRect::new(10, i * 70, 110, i * 70 + 50))
+            .collect();
+        let rects = screen_rects(Some(&layout));
+        assert_eq!(rects[HEADER_RECT_INDEX], Rect::new(10.0, 0.0, 100.0, 50.0));
+        assert_eq!(rects[DONE_RECT_INDEX], Rect::new(10.0, 210.0, 100.0, 50.0));
+        // Without a layout: the decoded vanilla GAMELODR.BIN geometry.
+        assert_eq!(screen_rects(None), FALLBACK_RECTS);
+    }
+
+    /// The body of the shipped `res/intrface/GAMELOD.STR`, verbatim. Kept here
+    /// so a key rename - ours or the data's - fails a test rather than silently
+    /// falling back to the English constants, which is invisible at runtime on
+    /// an English install because the two agree.
+    const SHIPPED_GAMELOD_STR: &str = concat!(
+        "delete:\"Delete\"\n",
+        "failed:\"Load Failed\"\n",
+        "loading:\"Loading...\"\n",
+        "initial:\"Select a file to load.\"\n",
+        "unused:\"< EMPTY >\"\n",
+        "done:\"Done\"\n",
+        "load:\"Load\"\n",
+    );
+
+    #[test]
+    fn every_label_key_resolves_against_the_shipped_string_table() {
+        let lines: Vec<String> = SHIPPED_GAMELOD_STR.lines().map(|l| l.to_owned()).collect();
+        let strings = dark::importers::parse_strings(&lines);
+
+        for (key, fallback) in [
+            (HEADER_KEY, HEADER_FALLBACK),
+            (EMPTY_KEY, EMPTY_FALLBACK),
+            (LOAD_KEY, LOAD_FALLBACK),
+            (DONE_KEY, DONE_FALLBACK),
+        ] {
+            assert!(strings.contains_key(key), "GAMELOD.STR has no key '{key}'");
+            // The shipped text is what we fall back to, so a drift in either
+            // direction shows up here.
+            assert_eq!(label(Some(&strings), key, "!unused!"), fallback);
+        }
+    }
+
+    #[test]
+    fn labels_fall_back_without_a_string_table() {
+        assert_eq!(label(None, LOAD_KEY, LOAD_FALLBACK), "Load");
+        // An empty shipped value must not blank the widget.
+        let strings = HashMap::from([(DONE_KEY.to_owned(), String::new())]);
+        assert_eq!(label(Some(&strings), DONE_KEY, DONE_FALLBACK), "Done");
+    }
+}

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -74,6 +74,7 @@ const FALLBACK_BUTTON_PITCH: f32 = 76.0;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MenuAction {
     NewGame,
+    LoadGame,
     Quit,
 }
 
@@ -103,7 +104,7 @@ const MENU_ITEMS: &[MenuItem] = &[
     MenuItem {
         string_key: "load_game",
         fallback_label: "Load Game",
-        action: None,
+        action: Some(MenuAction::LoadGame),
     },
     MenuItem {
         string_key: "options",
@@ -272,6 +273,9 @@ impl GameScene for MainMenuScene {
                     vitals_transition:
                         crate::scripts::PlayerVitalsTransition::InitializeFromDestination,
                 })]
+            }
+            Some(MenuAction::LoadGame) => {
+                vec![Effect::GlobalEffect(GlobalEffect::ShowLoadGame)]
             }
             Some(MenuAction::Quit) => vec![Effect::GlobalEffect(GlobalEffect::Quit)],
             None => Vec::new(),
@@ -442,12 +446,20 @@ mod tests {
     }
 
     #[test]
-    fn click_over_an_unimplemented_item_does_nothing() {
-        // Rect 1 is "Load Game", which has no action yet: canvas y 96..156, so
-        // normalized y ~0.26 sits inside it.
+    fn rising_edge_over_load_game_activates_it() {
+        // Rect 1 is "Load Game": canvas y 96..156, so y ~0.26 sits inside it.
         let rects = menu_rects(None);
         assert!(rects[1].contains(vec2(512.0, 126.0)));
         let (action, _) = resolve_click(pointer_at(0.8, 0.2625, true), false, SCREEN, &rects);
+        assert_eq!(action, Some(MenuAction::LoadGame));
+    }
+
+    #[test]
+    fn click_over_an_unimplemented_item_does_nothing() {
+        // Rect 2 is "Options", still unimplemented: canvas y 172..232.
+        let rects = menu_rects(None);
+        assert!(rects[2].contains(vec2(512.0, 202.0)));
+        let (action, _) = resolve_click(pointer_at(0.8, 0.4208, true), false, SCREEN, &rects);
         assert_eq!(action, None);
     }
 

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -227,7 +227,12 @@ impl MainMenuScene {
             world,
             scene_name: "main_menu".to_owned(),
             pointer: None,
-            last_pressed: false,
+            // A press held across a scene swap must not read as a click
+            // here: both screens sit on the same 640x480 canvas and their
+            // widgets overlap (the load screen's "Done" center falls inside
+            // the menu's "Quit" rect), so starting "already pressed" makes
+            // the next rising edge require a real release first.
+            last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
         }
     }
@@ -436,6 +441,36 @@ mod tests {
             &menu_rects(None),
         );
         assert_eq!(action, None);
+    }
+
+    #[test]
+    fn a_press_held_from_the_previous_scene_does_not_click() {
+        // The load screen's "Done" button center (canvas 574.5, 436) falls
+        // inside this menu's "Quit" rect, so a press still held when that
+        // screen swaps to the menu would otherwise quit the game outright.
+        let rects = menu_rects(None);
+        assert!(
+            rects[5].contains(vec2(574.5, 436.0)),
+            "this test is only meaningful while the rects overlap"
+        );
+
+        let mut scene = MainMenuScene::new();
+        let held = pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, true);
+
+        // First frame after the swap: the press is held, not new.
+        let (action, last) = resolve_click(held, scene.last_pressed, SCREEN, &rects);
+        assert_eq!(action, None, "a carried-over press must not activate Quit");
+        scene.last_pressed = last;
+
+        // Releasing and pressing again is a real click.
+        let (_, last) = resolve_click(
+            pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, false),
+            scene.last_pressed,
+            SCREEN,
+            &rects,
+        );
+        let (action, _) = resolve_click(held, last, SCREEN, &rects);
+        assert_eq!(action, Some(MenuAction::Quit));
     }
 
     #[test]

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -36,6 +36,7 @@ pub mod debug_teleport;
 pub mod debug_turret;
 pub mod debug_weapons;
 pub mod game_over;
+pub mod load_game;
 pub mod loading;
 pub mod main_menu;
 
@@ -56,6 +57,7 @@ pub use debug_teleport::DebugTeleportScene;
 pub use debug_turret::DebugTurretScene;
 pub use debug_weapons::create_debug_weapons_scene;
 pub use game_over::GameOverScene;
+pub use load_game::LoadGameScene;
 pub use loading::LoadingScene;
 pub use main_menu::MainMenuScene;
 

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -56,6 +56,13 @@ pub enum GlobalEffect {
     /// with the game-over screen, which offers the load/quit recovery path.
     GameOver,
 
+    /// Open the load-game screen (the Tri-Optimum archive database), replacing
+    /// whatever scene is active.
+    ShowLoadGame,
+
+    /// Return to the main menu, replacing whatever scene is active.
+    ShowMainMenu,
+
     /// Play the retail ending and enter the campaign's terminal state.
     CompleteCampaign,
 

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -22,7 +22,7 @@ use cgmath::{Deg, Matrix4, Vector2, vec2, vec3};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
 use engine::{
     assets::asset_cache::AssetCache,
-    measure_text_width,
+    ellipsize, measure_text_width,
     scene::SceneObject,
     texture::{Texture, TextureOptions, TextureTrait},
 };
@@ -230,6 +230,10 @@ where
         h: HAlign,
         v: VAlign,
         alpha: f32,
+        /// When set, text wider than its rect is shortened with a trailing
+        /// ellipsis instead of spilling over neighbouring widgets. Only the
+        /// screen-space path honours this (see [`UiCanvas::text_native_fit`]).
+        fit_to_rect: bool,
     },
 }
 
@@ -420,17 +424,7 @@ where
         h: HAlign,
         v: VAlign,
     ) -> &mut Self {
-        self.elements.push(UiElement::Text {
-            position: vec2(rect.x, rect.y),
-            size: vec2(rect.w, rect.h),
-            text: text.to_owned(),
-            font: font.to_owned(),
-            font_size: size,
-            h,
-            v,
-            alpha: 1.0,
-        });
-        self
+        self.push_text(rect, text, font, size, h, v, false)
     }
 
     /// Add text rendered at the font's **native pixel height** on the 640x480
@@ -448,6 +442,46 @@ where
         v: VAlign,
     ) -> &mut Self {
         self.text(rect, text, font, 0.0, h, v)
+    }
+
+    /// [`text_native`](Self::text_native) for text of unbounded length - a save
+    /// name, a player-authored label - that must stay inside its rect. Anything
+    /// too wide is shortened with a trailing ellipsis at render time, where the
+    /// font (and so the real glyph widths) is available.
+    pub fn text_native_fit(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        font: &str,
+        h: HAlign,
+        v: VAlign,
+    ) -> &mut Self {
+        self.push_text(rect, text, font, 0.0, h, v, true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn push_text(
+        &mut self,
+        rect: Rect,
+        text: &str,
+        font: &str,
+        size: f32,
+        h: HAlign,
+        v: VAlign,
+        fit_to_rect: bool,
+    ) -> &mut Self {
+        self.elements.push(UiElement::Text {
+            position: vec2(rect.x, rect.y),
+            size: vec2(rect.w, rect.h),
+            text: text.to_owned(),
+            font: font.to_owned(),
+            font_size: size,
+            h,
+            v,
+            alpha: 1.0,
+            fit_to_rect,
+        });
+        self
     }
 
     /// Render the canvas as a screen-space overlay on `screen_size`, mapped via
@@ -573,6 +607,7 @@ where
                     h,
                     v,
                     alpha,
+                    fit_to_rect,
                 } => {
                     let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
                     // `size <= 0` renders at the font's native pixel height, so
@@ -584,12 +619,20 @@ where
                         font_obj.base_height()
                     };
                     let font_size = canvas_size * scale.y;
-                    let width = measure_text_width(&**font_obj, text, font_size);
 
                     let rx = position.x * scale.x + offset.x;
                     let ry = position.y * scale.y + offset.y;
                     let rw = size.x * scale.x;
                     let rh = size.y * scale.y;
+
+                    let fitted;
+                    let text: &str = if *fit_to_rect {
+                        fitted = ellipsize(&**font_obj, text, font_size, rw);
+                        &fitted
+                    } else {
+                        text
+                    };
+                    let width = measure_text_width(&**font_obj, text, font_size);
                     let x = match h {
                         HAlign::Left => rx,
                         HAlign::Center => rx + (rw - width) / 2.0,

--- a/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
+++ b/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
@@ -18,7 +18,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 // Canvas-space widget centers on the 640x480 UI canvas, normalized to the
 // [0,1] pointer channel. From the shipped layouts: MAINR.BIN button 1 is
 // "Load Game" at (400,96,179x60); GAMELODR.BIN gives Load at (527,161,96x62),
-// Done at (527,405,95x62), and a list starting at (261,54) with a 20px pitch.
+// Done at (527,405,95x62), and a list starting at (261,54) with a 19px pitch.
 const CANVAS_W = 640;
 const CANVAS_H = 480;
 const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
@@ -26,7 +26,7 @@ const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANV
 const LOAD_GAME_ENTRY = norm(400 + 179 / 2, 96 + 60 / 2);
 const LOAD_BUTTON = norm(527 + 96 / 2, 161 + 62 / 2);
 const DONE_BUTTON = norm(527 + 95 / 2, 405 + 62 / 2);
-const FIRST_ROW = norm(261 + 202 / 2, 54 + 20 / 2);
+const FIRST_ROW = norm(261 + 202 / 2, 54 + 19 / 2);
 
 async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
   await game.input.set("pointer.position", [x, y]);

--- a/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
+++ b/tools/shock2-sdk/test/load-game-screen.e2e.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// End-to-end test for the main menu -> load-game screen -> back round trip,
+// and for actually restoring a save from the list.
+//
+// These are frontend scenes, so there is nothing in the world to assert on
+// while a menu is up: entity count is the observable that separates "a menu is
+// showing" (0 entities) from "a mission is live" (thousands).
+//
+// Negative-first: before the load screen existed, clicking "Load Game" did
+// nothing at all, so the entity count stayed 0 through the whole sequence and
+// `loading a save from the list restores a mission` failed.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+// Canvas-space widget centers on the 640x480 UI canvas, normalized to the
+// [0,1] pointer channel. From the shipped layouts: MAINR.BIN button 1 is
+// "Load Game" at (400,96,179x60); GAMELODR.BIN gives Load at (527,161,96x62),
+// Done at (527,405,95x62), and a list starting at (261,54) with a 20px pitch.
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
+
+const LOAD_GAME_ENTRY = norm(400 + 179 / 2, 96 + 60 / 2);
+const LOAD_BUTTON = norm(527 + 96 / 2, 161 + 62 / 2);
+const DONE_BUTTON = norm(527 + 95 / 2, 405 + 62 / 2);
+const FIRST_ROW = norm(261 + 202 / 2, 54 + 20 / 2);
+
+async function click(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", [x, y]);
+  await game.step({ frames: 2 });
+  // The screens act on a rising press edge, so the click must be a pulse.
+  await game.input.set("pointer.pressed", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("pointer.pressed", 0);
+  await game.step({ frames: 6 });
+}
+
+async function entityCount(game: GameServer): Promise<number> {
+  const result = await game.entities.list();
+  return result.entities.length;
+}
+
+/**
+ * Guarantee the load screen has something to list. The screen reads the real
+ * save directory, so a machine that has never saved would otherwise show
+ * "< EMPTY >" and the load assertions would be vacuous.
+ */
+async function seedSave(port: number): Promise<void> {
+  await using game = await GameServer.launch({ mission: "medsci1.mis", port });
+  await game.step({ frames: 30 });
+  await game.input.trigger("QuickSave");
+  await game.step({ frames: 30 });
+}
+
+test(
+  "the load screen opens from the menu and Done returns to it",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await seedSave(8120);
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8121 });
+    await game.step({ frames: 5 });
+
+    // A frontend scene has no world entities.
+    assert.equal(await entityCount(game), 0, "the menu should have no world");
+
+    await click(game, LOAD_GAME_ENTRY);
+    // Still a frontend scene - but a different one. Clicking "Done" only gets
+    // back to a menu if we actually left it, which the load assertion below
+    // pins down properly.
+    assert.equal(await entityCount(game), 0);
+
+    await click(game, DONE_BUTTON);
+    assert.equal(await entityCount(game), 0, "Done should land on the menu");
+
+    // Proof we are on the main menu and not still on the load screen: the
+    // load screen has no widget at the "Load Game" entry's position, whereas
+    // the menu does - so clicking there opens the load screen again, and from
+    // there a save can be loaded.
+    await click(game, LOAD_GAME_ENTRY);
+    await click(game, FIRST_ROW);
+    await click(game, LOAD_BUTTON);
+    await game.step({ frames: 30 });
+    assert.ok(
+      (await entityCount(game)) > 0,
+      "the menu -> load screen path should still work after a round trip",
+    );
+  },
+);
+
+test(
+  "loading a save from the list restores a mission",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await seedSave(8123);
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8122 });
+    await game.step({ frames: 5 });
+    assert.equal(await entityCount(game), 0);
+
+    await click(game, LOAD_GAME_ENTRY);
+    // Row 0 is the most recent save; the screen preselects it, but click it
+    // anyway so the test covers row selection rather than the default.
+    await click(game, FIRST_ROW);
+    await click(game, LOAD_BUTTON);
+    await game.step({ frames: 30 });
+
+    assert.ok(
+      (await entityCount(game)) > 100,
+      "loading a save should bring up a populated mission",
+    );
+  },
+);


### PR DESCRIPTION
#927 has landed, so this now diffs against `main`. #934 (debug runtime boots the
main menu with no `--mission`) was merged into this branch and rides along here.

## What

Implements **Load Game**, one of the four main-menu entries #927 lights up but leaves inert. It maps to a real original screen: the Tri-Optimum archive database.

- `LoadGameScene` draws `GAMELOD.PCX` with the `GAMELODR.BIN` widget rects (header, list, Load, Done) and `GAMELOD.STR` labels — same data-driven idiom as the main menu, nothing about its text or geometry hardcoded.
- Clicking a row selects it, **Load** emits `GlobalEffect::Load` for that save, **Done** returns to the menu.
- `save_load::all_saves` lists every save most recent first; `latest_save` is now its head.
- Two frontend scene swaps — `GlobalEffect::ShowLoadGame` / `ShowMainMenu` — handled beside `GameOver` in the game loop.

## Two things worth a reviewer's attention

**`latest_save`'s tie-break was easy to break.** It was a `max_by` over (modified, name), which returns the *greatest* name when timestamps tie. Refactoring it to "head of the sorted list" silently flipped that to the smallest until both sort keys were made to descend. `same_timestamp_saves_order_by_name_descending` pins it.

**Long save names overflowed the list panel** — clean out of the 202px rect and over the Load button (very visible with e2e-generated names). Fixed at the UI layer rather than in the scene: `engine::ellipsize` beside `measure_text_width`, using real glyph advances (correct for Dark's variable-width bitmap fonts) and cutting on character boundaries — a byte-offset cut would panic on a multi-byte name. Exposed as `UiCanvas::text_native_fit`; `fit_to_rect` defaults to false, so no existing text changes.

## Known gaps (filed, not hidden)

- The list holds **14 rows** and there is no scrolling, so older saves are unreachable — #928.
- A failed load is silent; `GAMELOD.STR`'s `failed` string is unused — #929.

## Verification

- Full round trip driven headlessly: menu → load screen → select row → **Load** → live mission (0 → 2212 entities, HUD and vitals restored), and **Done** → back to the menu.
- New SDK scenario test `test/load-game-screen.e2e.test.ts`, self-seeding (quicksaves in `medsci1` first so the list is never vacuously empty).
- 585 `shock2vr` + 41 `engine` unit tests; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

### A real bug the review caught

The load screen's **Done** center (canvas 574.5, 436) falls **inside the main menu's Quit rect** (400,400 179×60) — same 640×480 canvas. Both scenes started with `last_pressed: false`, so the press still held when Done swapped the scene read as a *fresh* rising edge on the menu and **quit the game**. The debug runtime masked it (it ignores `should_quit`); desktop would have closed the window.

Frontend scenes now start "already pressed", so the first click needs a real release first. `a_press_held_from_the_previous_scene_does_not_click` fails without the fix.


## Visual evidence

![load game screen demo](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/load-game.gif)

<sub>Main menu → <b>Load Game</b> → the Tri-Optimum archive database → select a row → <b>Load</b> → the restored mission (camera panned at the end to show the level came back). Captured headlessly through the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

**The list** — row 0 is preselected on open; clicking row 5 moves the highlight. Save names are left-aligned in the small 11px `mainfont.fon` so the list reads as data under the heavier header and buttons, and long e2e-generated names are ellipsized with real glyph advances rather than overflowing the 202px panel:

![row selection](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/selection.png)

![load result](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/load-result.png)

**The list stops at the backdrop's painted field — without losing a row.** `GAMELOD.PCX` paints a bordered box from canvas y 323 (the save screen's name-entry field — `GAMESAVR.BIN` and `GAMELODR.BIN` are byte-identical and the two screens share the art). At the authored 20px pitch the 14th row ran straight through it:

![row count before and after](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/rowfix-beforeafter.png)

![row count zoom](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/rowfix-zoom.png)

<sub>Two parts. The field sits at a fixed spot in the backdrop, so <code>visible_row_count</code> clamps the list's bottom to it rather than reserving a slice of the rect's height — a layout that moves or resizes the list then still stops in the right place instead of dropping rows it could show, or running over the field anyway. And the pitch drops to 19px so all 14 rows still fit: 20px came from <code>METAFONT.FON</code>'s cell, but names now draw at 11px, and while there is no scrolling the last row is the last reachable save (#928). <code>the_vanilla_list_holds_fourteen_rows_clear_of_the_field</code> and <code>the_row_count_tracks_the_field_position_not_the_rect_height</code> pin both.</sub>

**Done returns to the menu** — and this is the pointer-carryover fix in the frame: Done's center lands inside the menu's Quit rect, so the pointer is sitting on a highlighted **Quit** the instant the menu appears, and the game is still running. Before the fix that held press read as a fresh click and quit:

![done round trip](https://gist.githubusercontent.com/tommy-xr/e895b3fd4221d0a26b5831effab33413/raw/done-roundtrip.png)


