### PR TITLE
feat(vr): use the 25AE authored hands as a VR hand pose library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,7 @@ For debugging visual/rendering changes without a full interactive session:
    | `debug_ragdoll`          | Test ragdoll physics                         |
    | `debug_hitbox`           | View fitted hitbox shapes vs ragdoll colliders across poses |
    | `debug_gloves`           | Test VR hand/glove rendering                 |
+   | `debug_hand_poses`       | 25AE authored hand poses, anchored at a common hand origin |
    | `debug_teleport`         | Test VR teleport locomotion                  |
    | `debug_joint_constraint` | Test physics joint constraints               |
    | `debug_hud`              | Test HUD rendering                           |

--- a/dark/examples/dump_weapon_animations.rs
+++ b/dark/examples/dump_weapon_animations.rs
@@ -1,0 +1,38 @@
+//! Dumps the 25AE first-person weapon animations from the remaster's
+//! `sq_scripts/animations_weapons.nut`, to check the parser against the real
+//! shipped file rather than only a fixture.
+//!
+//! ```bash
+//! cargo run -p dark --example dump_weapon_animations -- <path>/animations_weapons.nut
+//! ```
+
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let text = std::fs::read_to_string(&path).unwrap();
+    let animations = dark::weapon_animation::parse(&text);
+    let mut categories: Vec<&String> = animations.by_category.keys().collect();
+    categories.sort();
+    let mut total = 0;
+    for category in categories {
+        let clips = &animations.by_category[category];
+        let mut names: Vec<&String> = clips.keys().collect();
+        names.sort();
+        for name in names {
+            let a = &clips[name];
+            total += 1;
+            let tracks: Vec<String> = a
+                .tracks
+                .iter()
+                .map(|t| format!("{}:{}", t.joint, t.keys.len()))
+                .collect();
+            println!(
+                "{category:24} {name:8} {}fps {:>3}f {:.2}s  [{}]",
+                a.fps as i32,
+                a.length as i32,
+                a.duration_seconds(),
+                tracks.join(" ")
+            );
+        }
+    }
+    println!("\n{total} animations parsed");
+}

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -84,3 +84,65 @@ fn process_model(
 
 pub static MODELS_IMPORTER: Lazy<AssetImporter<SystemShockContentModel, Model, ()>> =
     Lazy::new(|| AssetImporter::define(load_model, process_model));
+
+/// Whether `name` is a material the 25th Anniversary Edition draws the player's
+/// hand and forearm with on a first-person weapon model (`obj/*_h.bin`).
+///
+/// The remaster gives the arm its own material - `ND-arm.psd` on most models,
+/// `ND-arm_atek.psd` on the pistol and shotgun - which is the only selector
+/// that isolates it everywhere. A sub-object filter works on `ar15_h`/`atek_h`,
+/// where the hand is its own `@s01_han`/`@s02_han`, but not on `sg_h` or
+/// `empgun_h`, where the hand rides a moving gun sub-object.
+pub fn is_first_person_arm_material(name: &str) -> bool {
+    name.to_ascii_lowercase().starts_with("nd-arm")
+}
+
+/// Newtype so this importer gets its own [`AssetCache`] bucket.
+///
+/// The cache keys by `importer.type_id()`, which is the *type* of the importer,
+/// so two importers that share `AssetImporter<_, Model, _>` would share one
+/// bucket and silently serve whichever view of the model was requested first.
+/// Any further view of an already-imported type needs its own newtype.
+/// One authored hand, as its own model plus the frame it sits in.
+pub struct FirstPersonHand {
+    pub frame: ss2_bin_obj_loader::HandFrame,
+    pub model: Model,
+}
+
+/// Every hand a first-person model draws, split apart. Newtype for cache
+/// separation, as [`FirstPersonArm`].
+pub struct FirstPersonHands(pub Vec<FirstPersonHand>);
+
+fn process_first_person_hands(
+    mesh: SystemShockContentModel,
+    asset_cache: &mut AssetCache,
+    _config: &(),
+) -> FirstPersonHands {
+    let SystemShockContentModel::Obj(obj) = mesh else {
+        return FirstPersonHands(Vec::new());
+    };
+
+    FirstPersonHands(
+        ss2_bin_obj_loader::split_connected(&obj, is_first_person_arm_material)
+            .into_iter()
+            .filter_map(|mut island| {
+                let frame = ss2_bin_obj_loader::hand_frame(&island, is_first_person_arm_material)?;
+                // Vhots belong to the weapon, and render as debug cubes.
+                island.vhots.clear();
+
+                Some(FirstPersonHand {
+                    frame,
+                    model: Model::from_obj_bin(island, asset_cache),
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Each hand a first-person weapon model draws, as a separate model - the pose
+/// library we snap between. Ordered largest-island first, so index 0 is the
+/// main hand.
+pub static FIRST_PERSON_HANDS_IMPORTER: Lazy<
+    AssetImporter<SystemShockContentModel, FirstPersonHands, ()>,
+> = Lazy::new(|| AssetImporter::define(load_model, process_first_person_hands));
+

--- a/dark/src/importers/model_importer.rs
+++ b/dark/src/importers/model_importer.rs
@@ -145,4 +145,3 @@ fn process_first_person_hands(
 pub static FIRST_PERSON_HANDS_IMPORTER: Lazy<
     AssetImporter<SystemShockContentModel, FirstPersonHands, ()>,
 > = Lazy::new(|| AssetImporter::define(load_model, process_first_person_hands));
-

--- a/dark/src/lib.rs
+++ b/dark/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ss2_entity_info;
 pub mod ss2_skeleton;
 pub mod tag_database;
 pub mod util;
+pub mod weapon_animation;
 
 pub mod properties;
 

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     io::{SeekFrom, prelude::*},
     rc::Rc,
@@ -72,6 +72,7 @@ impl Vhot {
     }
 }
 
+#[derive(Clone)]
 pub struct SystemShock2ObjectMesh {
     pub header: ObjBinHeader,
     pub version: u32,
@@ -375,6 +376,320 @@ fn build_vertex(
         bone_weights: [1.0, 0.0, 0.0, 0.0], // Single bone weighting for obj files
         normal,
     }
+}
+
+/// Drops every polygon whose material name `keep` rejects, leaving the part of
+/// the model that the accepted materials draw.
+///
+/// Filtering *polygons* is enough to isolate a part, and is why this is cheap:
+/// `to_vertices` walks the polygon list and only emits the vertices those
+/// polygons reference, so the shared vertex/uv/normal arrays stay valid as-is
+/// and the entries nothing references are simply never read. Sub-objects are
+/// left intact so the skeleton - and hence the per-vertex bone index that
+/// places each sub-object at its rest transform - still resolves.
+pub fn retain_materials(
+    mesh: SystemShock2ObjectMesh,
+    keep: impl Fn(&str) -> bool,
+) -> SystemShock2ObjectMesh {
+    let kept_slots = material_slots(&mesh, keep);
+    retain_polygons(mesh, |polygon| {
+        kept_slots.contains(&polygon.slot_index)
+    })
+}
+
+/// The material slots whose name `keep` accepts.
+fn material_slots(mesh: &SystemShock2ObjectMesh, keep: impl Fn(&str) -> bool) -> HashSet<u16> {
+    mesh.materials
+        .iter()
+        .filter(|material| keep(&material.name))
+        .map(|material| material.slot_num as u16)
+        .collect()
+}
+
+/// Drops every polygon `keep` rejects. See [`retain_materials`] for why
+/// filtering polygons alone is sufficient.
+fn retain_polygons(
+    mut mesh: SystemShock2ObjectMesh,
+    keep: impl Fn(&SystemShock2ObjectPolygon) -> bool,
+) -> SystemShock2ObjectMesh {
+    mesh.polygons.retain(&keep);
+    mesh
+}
+
+/// Wrist-to-fingertip length of an adult hand, in world units (~19 cm).
+/// Anthropometric, not asset-specific - the yardstick for placing and trimming
+/// any hand mesh.
+pub const HAND_LENGTH_WORLD: f32 = 0.2493;
+
+/// Splits the geometry `keep` selects into connected pieces - one per hand.
+///
+/// A model can draw more than one hand with the same material (the pistol has a
+/// trigger hand and a support hand), and they are separate islands of geometry,
+/// so connectivity is what tells them apart. Returns one mesh per island,
+/// largest first, each still carrying the full material table.
+pub fn split_connected(
+    mesh: &SystemShock2ObjectMesh,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<SystemShock2ObjectMesh> {
+    let kept_slots = material_slots(mesh, keep);
+
+    // Union-find over vertex indices, joined along every kept polygon's edges.
+    let mut parent: HashMap<u16, u16> = HashMap::new();
+    fn find(parent: &mut HashMap<u16, u16>, mut node: u16) -> u16 {
+        while let Some(&next) = parent.get(&node) {
+            if next == node {
+                break;
+            }
+            let grand = *parent.get(&next).unwrap_or(&next);
+            parent.insert(node, grand);
+            node = grand;
+        }
+        parent.entry(node).or_insert(node);
+        node
+    }
+
+    for polygon in &mesh.polygons {
+        if !kept_slots.contains(&polygon.slot_index) {
+            continue;
+        }
+        let Some(&first) = polygon.vertex_indices.first() else {
+            continue;
+        };
+        for index in &polygon.vertex_indices {
+            let (a, b) = (find(&mut parent, first), find(&mut parent, *index));
+            if a != b {
+                parent.insert(a, b);
+            }
+        }
+    }
+
+    let mut islands: HashMap<u16, Vec<usize>> = HashMap::new();
+    for (index, polygon) in mesh.polygons.iter().enumerate() {
+        if !kept_slots.contains(&polygon.slot_index) {
+            continue;
+        }
+        let Some(&first) = polygon.vertex_indices.first() else {
+            continue;
+        };
+        let root = find(&mut parent, first);
+        islands.entry(root).or_default().push(index);
+    }
+
+    // Largest first, then by earliest polygon: `HashMap::into_values` is
+    // randomized, so equal-sized islands would otherwise swap between runs -
+    // and callers select a hand by ordinal.
+    let mut islands = islands.into_values().collect::<Vec<_>>();
+    islands.sort_by_key(|polygons| {
+        (
+            std::cmp::Reverse(polygons.len()),
+            polygons.iter().copied().min().unwrap_or(usize::MAX),
+        )
+    });
+
+    islands
+        .into_iter()
+        .map(|polygons| {
+            let wanted = polygons.into_iter().collect::<HashSet<usize>>();
+            let mut island = mesh.clone();
+            island.polygons = mesh
+                .polygons
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| wanted.contains(index))
+                .map(|(_, polygon)| polygon.clone())
+                .collect();
+            island
+        })
+        .collect()
+}
+
+/// Where one hand sits on a first-person weapon, in model space.
+///
+/// Derived from the hand's *geometry* rather than its bone transform. A
+/// sub-object's vertices are bone-local and are placed by the bone's global
+/// transform at skinning time, so the bone's own translation is a joint pivot
+/// (zero on `ar15_h`) and says nothing about where the hand ended up - only the
+/// transformed geometry does.
+#[derive(Debug, Clone)]
+pub struct HandFrame {
+    pub name: String,
+    /// The wrist end of the hand, where a controller would be held.
+    pub origin: Point3<f32>,
+    /// Unit vector from wrist toward the fingertips.
+    pub forward: Vector3<f32>,
+    /// Wrist-to-fingertip distance, for sanity checks and scaling.
+    pub length: f32,
+}
+
+/// The authored placement of every hand on a first-person weapon.
+///
+/// `keep` selects the hand material (see `is_first_person_arm_material`); each
+/// sub-object drawing it yields one frame, so a two-handed model reports both.
+pub fn hand_frames(
+    mesh: &SystemShock2ObjectMesh,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<HandFrame> {
+    let kept_slots = mesh
+        .materials
+        .iter()
+        .filter(|material| keep(&material.name))
+        .map(|material| material.slot_num as u16)
+        .collect::<HashSet<u16>>();
+
+    let transforms = sub_object_transforms(mesh);
+
+    // Group the hand's vertices by the sub-object that owns them, and put each
+    // group where skinning would put it.
+    let mut by_sub_object: HashMap<usize, Vec<Point3<f32>>> = HashMap::new();
+    for polygon in &mesh.polygons {
+        if !kept_slots.contains(&polygon.slot_index) {
+            continue;
+        }
+        for index in &polygon.vertex_indices {
+            let sub_object = get_bone_index_for_point(mesh, *index) as usize;
+            let Some((_, transform)) = transforms.get(sub_object) else {
+                continue;
+            };
+            let local = mesh.vertices[*index as usize];
+            let placed = transform.transform_point(point3(local.x, local.y, local.z));
+            by_sub_object.entry(sub_object).or_default().push(placed);
+        }
+    }
+
+    let mut frames = by_sub_object
+        .into_iter()
+        .filter_map(|(sub_object, points)| {
+            let (wrist, tip) = wrist_and_fingertip(&points)?;
+            let axis = tip - wrist;
+            let length = axis.magnitude();
+            if length <= f32::EPSILON {
+                return None;
+            }
+            Some(HandFrame {
+                name: transforms
+                    .get(sub_object)
+                    .map(|(name, _)| name.clone())
+                    .unwrap_or_default(),
+                origin: wrist,
+                forward: axis / length,
+                length,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    // Stable order so callers (and screenshots) don't shuffle between runs -
+    // `by_sub_object` is a HashMap.
+    frames.sort_by(|a, b| a.name.cmp(&b.name));
+    frames
+}
+
+/// One frame over all the geometry `keep` selects, for a mesh already known to
+/// hold a single hand (an island out of [`split_connected`]).
+pub fn hand_frame(
+    mesh: &SystemShock2ObjectMesh,
+    keep: impl Fn(&str) -> bool,
+) -> Option<HandFrame> {
+    let kept_slots = material_slots(mesh, keep);
+    let transforms = sub_object_transforms(mesh);
+
+    // Deduplicate by vertex index first. Walking polygon corners would push a
+    // shared vertex once per incident face, so the endpoint scoring below would
+    // measure triangulation density rather than geometry - a fan-triangulated
+    // palm can then outweigh the fingertips and reverse the axis.
+    let mut seen = HashSet::new();
+    let mut points = Vec::new();
+    for polygon in &mesh.polygons {
+        if !kept_slots.contains(&polygon.slot_index) {
+            continue;
+        }
+        for index in &polygon.vertex_indices {
+            if !seen.insert(*index) {
+                continue;
+            }
+            let sub_object = get_bone_index_for_point(mesh, *index) as usize;
+            let Some((_, transform)) = transforms.get(sub_object) else {
+                continue;
+            };
+            let local = mesh.vertices[*index as usize];
+            points.push(transform.transform_point(point3(local.x, local.y, local.z)));
+        }
+    }
+
+    let (wrist, tip) = wrist_and_fingertip(&points)?;
+    let axis = tip - wrist;
+    let length = axis.magnitude();
+    if length <= f32::EPSILON {
+        return None;
+    }
+
+    Some(HandFrame {
+        name: String::new(),
+        origin: wrist,
+        forward: axis / length,
+        length,
+    })
+}
+
+/// The hand's long axis, as the farthest-apart pair of points, oriented so the
+/// wrist comes first.
+///
+/// The *fingertip* end is the denser one: five separate digits pack far more
+/// geometry into the end of the hand than the smooth tube of a forearm (or the
+/// stump of a bare hand) does at the other. Verified against all six authored
+/// hands - picking the denser end as the wrist instead points every one of them
+/// backwards.
+fn wrist_and_fingertip(points: &[Point3<f32>]) -> Option<(Point3<f32>, Point3<f32>)> {
+    if points.len() < 2 {
+        return None;
+    }
+
+    let mut best = (0usize, 1usize, 0.0_f32);
+    for (i, a) in points.iter().enumerate() {
+        for (j, b) in points.iter().enumerate().skip(i + 1) {
+            let distance = (b - a).magnitude2();
+            if distance > best.2 {
+                best = (i, j, distance);
+            }
+        }
+    }
+
+    let (a, b) = (points[best.0], points[best.1]);
+    let near_end = |end: Point3<f32>, other: Point3<f32>| {
+        let cutoff = (other - end).magnitude() * 0.25;
+        points
+            .iter()
+            .filter(|point| (*point - end).magnitude() < cutoff)
+            .count()
+    };
+
+    if near_end(a, b) >= near_end(b, a) {
+        Some((b, a))
+    } else {
+        Some((a, b))
+    }
+}
+
+/// The model-space transform of every sub-object, paired with its name - the
+/// placement the artist authored for that part.
+///
+/// For a 25AE first-person weapon this is what carries the *grip*: the hand
+/// sub-objects (`@s01_han`, `@s02_han`) are posed onto the weapon by hand, so
+/// their transforms say exactly where a hand belongs on that gun.
+pub fn sub_object_transforms(mesh: &SystemShock2ObjectMesh) -> Vec<(String, Matrix4<f32>)> {
+    let mut bones = Vec::new();
+    build_skeleton_for_obj_mesh(mesh, 0, None, &mut bones);
+    let skeleton = Skeleton::create_from_bones(bones);
+
+    mesh.sub_objects
+        .iter()
+        .enumerate()
+        .map(|(index, sub_object)| {
+            (
+                sub_object.name.clone(),
+                skeleton.global_transform(&(index as u32)),
+            )
+        })
+        .collect()
 }
 
 pub fn to_vertices(
@@ -705,7 +1020,7 @@ fn read_vertices<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Vec<V
     vertices
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SubObjectHeader {
     #[allow(dead_code)]
     idx: u32,
@@ -771,6 +1086,7 @@ fn read_sub_objects<T: Read + Seek>(header: &ObjBinHeader, reader: &mut T) -> Ve
     objs
 }
 
+#[derive(Clone)]
 pub struct ObjBinHeader {
     bbox_min: Point3<f32>,
     bbox_max: Point3<f32>,
@@ -940,6 +1256,87 @@ mod tests {
         let object = create_dark_object_scene_object(material, geometry);
 
         assert_eq!(object.backface_culling(), Some(FrontFaceWinding::Clockwise));
+    }
+
+    fn material_in_slot(name: &str, slot_num: u8) -> SystemShock2MeshMaterial {
+        SystemShock2MeshMaterial {
+            slot_num,
+            ..material(name)
+        }
+    }
+
+    fn polygon_in_slot(slot_index: u16) -> SystemShock2ObjectPolygon {
+        SystemShock2ObjectPolygon {
+            vertex_indices: vec![0, 1, 2],
+            normal_indices: vec![0, 1, 2],
+            uv_indices: vec![0, 1, 2],
+            slot_index,
+        }
+    }
+
+    /// A 25AE first-person model draws the hand with its own `ND-arm*` material,
+    /// so selecting on the material name is what isolates the arm from the
+    /// weapon - including on `sg_h`/`empgun_h`, where the hand shares a
+    /// sub-object with moving gun parts and a sub-object filter would take the
+    /// gun with it.
+    fn mesh_with(
+        materials: Vec<SystemShock2MeshMaterial>,
+        polygons: Vec<SystemShock2ObjectPolygon>,
+    ) -> SystemShock2ObjectMesh {
+        SystemShock2ObjectMesh {
+            header: header_with_mat_extra(0),
+            version: 4,
+            bounding_box: Aabb3::new(point3(0.0, 0.0, 0.0), point3(1.0, 1.0, 1.0)),
+            materials,
+            uvs: vec![Vector2::new(0.0, 0.0); 3],
+            vertices: vec![vec3(0.0, 0.0, 0.0); 3],
+            normals: vec![vec3(0.0, 1.0, 0.0); 3],
+            vhots: Vec::new(),
+            polygons,
+            sub_objects: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn retain_materials_keeps_only_the_selected_slots() {
+        let mesh = mesh_with(
+            vec![
+                material_in_slot("ND-ar15.psd", 0),
+                material_in_slot("ND-arm.psd", 1),
+            ],
+            vec![
+                polygon_in_slot(0),
+                polygon_in_slot(1),
+                polygon_in_slot(0),
+                polygon_in_slot(1),
+            ],
+        );
+
+        let arm = retain_materials(mesh, |name| name.starts_with("ND-arm"));
+
+        assert_eq!(arm.polygons.len(), 2);
+        assert!(arm.polygons.iter().all(|polygon| polygon.slot_index == 1));
+        // The material table is left whole, so the kept slot still resolves to
+        // its texture when the mesh is turned into scene objects.
+        assert_eq!(arm.materials.len(), 2);
+    }
+
+    /// The weapon half is the complement, which is what lets the same call site
+    /// draw the gun without the hand.
+    #[test]
+    fn retain_materials_can_select_the_complement() {
+        let mesh = mesh_with(
+            vec![
+                material_in_slot("ND-ar15.psd", 0),
+                material_in_slot("ND-arm.psd", 1),
+            ],
+            vec![polygon_in_slot(0), polygon_in_slot(1)],
+        );
+
+        let weapon = retain_materials(mesh, |name| !name.starts_with("ND-arm"));
+
+        assert_eq!(weapon.polygons.len(), 1);
+        assert_eq!(weapon.polygons[0].slot_index, 0);
     }
 
     fn material(name: &str) -> SystemShock2MeshMaterial {

--- a/dark/src/ss2_bin_obj_loader.rs
+++ b/dark/src/ss2_bin_obj_loader.rs
@@ -392,9 +392,7 @@ pub fn retain_materials(
     keep: impl Fn(&str) -> bool,
 ) -> SystemShock2ObjectMesh {
     let kept_slots = material_slots(&mesh, keep);
-    retain_polygons(mesh, |polygon| {
-        kept_slots.contains(&polygon.slot_index)
-    })
+    retain_polygons(mesh, |polygon| kept_slots.contains(&polygon.slot_index))
 }
 
 /// The material slots whose name `keep` accepts.
@@ -521,74 +519,9 @@ pub struct HandFrame {
     pub length: f32,
 }
 
-/// The authored placement of every hand on a first-person weapon.
-///
-/// `keep` selects the hand material (see `is_first_person_arm_material`); each
-/// sub-object drawing it yields one frame, so a two-handed model reports both.
-pub fn hand_frames(
-    mesh: &SystemShock2ObjectMesh,
-    keep: impl Fn(&str) -> bool,
-) -> Vec<HandFrame> {
-    let kept_slots = mesh
-        .materials
-        .iter()
-        .filter(|material| keep(&material.name))
-        .map(|material| material.slot_num as u16)
-        .collect::<HashSet<u16>>();
-
-    let transforms = sub_object_transforms(mesh);
-
-    // Group the hand's vertices by the sub-object that owns them, and put each
-    // group where skinning would put it.
-    let mut by_sub_object: HashMap<usize, Vec<Point3<f32>>> = HashMap::new();
-    for polygon in &mesh.polygons {
-        if !kept_slots.contains(&polygon.slot_index) {
-            continue;
-        }
-        for index in &polygon.vertex_indices {
-            let sub_object = get_bone_index_for_point(mesh, *index) as usize;
-            let Some((_, transform)) = transforms.get(sub_object) else {
-                continue;
-            };
-            let local = mesh.vertices[*index as usize];
-            let placed = transform.transform_point(point3(local.x, local.y, local.z));
-            by_sub_object.entry(sub_object).or_default().push(placed);
-        }
-    }
-
-    let mut frames = by_sub_object
-        .into_iter()
-        .filter_map(|(sub_object, points)| {
-            let (wrist, tip) = wrist_and_fingertip(&points)?;
-            let axis = tip - wrist;
-            let length = axis.magnitude();
-            if length <= f32::EPSILON {
-                return None;
-            }
-            Some(HandFrame {
-                name: transforms
-                    .get(sub_object)
-                    .map(|(name, _)| name.clone())
-                    .unwrap_or_default(),
-                origin: wrist,
-                forward: axis / length,
-                length,
-            })
-        })
-        .collect::<Vec<_>>();
-
-    // Stable order so callers (and screenshots) don't shuffle between runs -
-    // `by_sub_object` is a HashMap.
-    frames.sort_by(|a, b| a.name.cmp(&b.name));
-    frames
-}
-
 /// One frame over all the geometry `keep` selects, for a mesh already known to
 /// hold a single hand (an island out of [`split_connected`]).
-pub fn hand_frame(
-    mesh: &SystemShock2ObjectMesh,
-    keep: impl Fn(&str) -> bool,
-) -> Option<HandFrame> {
+pub fn hand_frame(mesh: &SystemShock2ObjectMesh, keep: impl Fn(&str) -> bool) -> Option<HandFrame> {
     let kept_slots = material_slots(mesh, keep);
     let transforms = sub_object_transforms(mesh);
 

--- a/dark/src/weapon_animation.rs
+++ b/dark/src/weapon_animation.rs
@@ -1,0 +1,593 @@
+//! First-person weapon animations, as the 25th Anniversary Edition ships them.
+//!
+//! The remaster animates its viewmodels from **plain-text keyframe data**, not
+//! from `.mc` motion files - which is why nothing in `res/motions` targets a
+//! first-person arm. The data lives in the KEX layer's Squirrel scripts
+//! (`sq_scripts/animations_weapons.nut`) as literal tables:
+//!
+//! ```text
+//! ND.g_weaponAnimations["Pistol"]["raise"] <- ND.PointRigAnimation("raise", 30, 60,
+//! {
+//!     "gunPoint" : [
+//!         { "frame":0,  "pos":[0.0, 0.0,-1.5], "rot":[45.0, 45.0, -45.0] },
+//!         { "frame":15, "pos":[0.1, 0.2, 0.1], "rot":[15.0, -15.0, -60.0] },
+//!     ],
+//!     "joint1" : [ ... ],   // the pistol's slide
+//! });
+//! ```
+//!
+//! A track name is either `gunPoint` - the viewmodel as a whole - or `jointN`,
+//! addressing the model's Nth sub-object. Those sub-objects are the moving parts
+//! *and the hands* (`@s01_han`, `@s02_han`), so these clips animate the hand
+//! rigidly, as translation and rotation. That is exactly what a leaf bone can
+//! do, and is why draw/fire/reload need no finger rig.
+//!
+//! Positions are in SS2 units (divide by [`crate::SCALE_FACTOR`]); rotations are
+//! Euler degrees. `events` fire at a frame - `muzzleFlash`, `eject`, `sound`.
+//!
+//! Only the subset of Squirrel these tables use is parsed, tolerantly: comments,
+//! and the missing commas between keyframes that the shipped file contains.
+
+use std::collections::HashMap;
+
+use cgmath::{Vector3, vec3};
+
+/// One authored key. `pos` is in SS2 units, `rot` Euler degrees.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Keyframe {
+    pub frame: f32,
+    pub pos: Vector3<f32>,
+    pub rot: Vector3<f32>,
+    pub events: Vec<String>,
+}
+
+/// The keys for one track - `gunPoint`, or `jointN` for the Nth sub-object.
+#[derive(Debug, Clone)]
+pub struct Track {
+    pub joint: String,
+    pub keys: Vec<Keyframe>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WeaponAnimation {
+    pub name: String,
+    pub fps: f32,
+    /// Authored length in frames.
+    pub length: f32,
+    pub tracks: Vec<Track>,
+}
+
+impl WeaponAnimation {
+    pub fn duration_seconds(&self) -> f32 {
+        if self.fps > 0.0 {
+            self.length / self.fps
+        } else {
+            0.0
+        }
+    }
+
+    pub fn track(&self, joint: &str) -> Option<&Track> {
+        self.tracks.iter().find(|track| track.joint == joint)
+    }
+
+    /// The track's `(pos, rot)` at `frame`, linearly interpolated and clamped to
+    /// the authored range.
+    pub fn sample(&self, joint: &str, frame: f32) -> Option<(Vector3<f32>, Vector3<f32>)> {
+        let keys = &self.track(joint)?.keys;
+        let first = keys.first()?;
+        let last = keys.last()?;
+
+        if frame <= first.frame {
+            return Some((first.pos, first.rot));
+        }
+        if frame >= last.frame {
+            return Some((last.pos, last.rot));
+        }
+
+        // `<` not `<=`, so an exact hit on a repeated frame selects the *last*
+        // key at that frame - authored data uses a duplicated frame to make a
+        // value jump, and taking the first key would render the pre-jump value.
+        let span = keys.windows(2).find(|pair| frame < pair[1].frame)?;
+        let (a, b) = (&span[0], &span[1]);
+        let width = b.frame - a.frame;
+        // Coincident keys would divide by zero; the later key wins.
+        let t = if width.abs() <= f32::EPSILON {
+            1.0
+        } else {
+            (frame - a.frame) / width
+        };
+
+        Some((a.pos + (b.pos - a.pos) * t, a.rot + (b.rot - a.rot) * t))
+    }
+
+    /// Events firing in `(previous, current]`, so stepping the clip reports each
+    /// event exactly once.
+    ///
+    /// The window is half-open at the start, so a caller must seed `previous`
+    /// *below* the first frame - start a clip at `-1.0`, not `0.0`, or a
+    /// frame-0 event (every `shoot` clip's `muzzleFlash`) never fires. Looping
+    /// likewise needs two calls: to the end, then from below zero again.
+    pub fn events_between(&self, previous: f32, current: f32) -> Vec<&str> {
+        self.tracks
+            .iter()
+            .flat_map(|track| track.keys.iter())
+            .filter(|key| key.frame > previous && key.frame <= current)
+            .flat_map(|key| key.events.iter().map(String::as_str))
+            .collect()
+    }
+}
+
+/// Every animation, by weapon category then clip name (`shoot`, `reload`,
+/// `raise`, `drop`, `idle1`). Categories match the weapon's name; `default`
+/// is the fallback.
+#[derive(Debug, Clone, Default)]
+pub struct WeaponAnimations {
+    pub by_category: HashMap<String, HashMap<String, WeaponAnimation>>,
+}
+
+impl WeaponAnimations {
+    /// `category`'s clip, falling back to `default` - which is how the shipped
+    /// data covers weapons with no bespoke animation.
+    pub fn get(&self, category: &str, clip: &str) -> Option<&WeaponAnimation> {
+        self.by_category
+            .get(category)
+            .and_then(|clips| clips.get(clip))
+            .or_else(|| self.by_category.get("default")?.get(clip))
+    }
+}
+
+/// Parses the subset of Squirrel `animations_weapons.nut` uses.
+///
+/// Anything unrecognized is skipped rather than fatal: this is third-party data
+/// we do not control, and a future remaster patch adding syntax we do not model
+/// should cost us one animation, not the whole file.
+pub fn parse(source: &str) -> WeaponAnimations {
+    let text = strip_comments(source);
+    let bytes = text.as_bytes();
+    let mut animations = WeaponAnimations::default();
+
+    let mut at = 0usize;
+    while let Some(found) = text[at..].find("g_weaponAnimations[") {
+        let start = at + found + "g_weaponAnimations[".len();
+        at = start;
+
+        let Some((category, after_category)) = quoted(bytes, start) else {
+            continue;
+        };
+        // A category declaration (`... <- {}`) has no second subscript.
+        let Some(open) = next_non_space(bytes, after_category) else {
+            continue;
+        };
+        if bytes.get(open) != Some(&b']') {
+            continue;
+        }
+        let Some(second) = next_non_space(bytes, open + 1) else {
+            continue;
+        };
+        if bytes.get(second) != Some(&b'[') {
+            continue;
+        }
+        let Some((clip, after_clip)) = quoted(bytes, second + 1) else {
+            continue;
+        };
+
+        // Bound every search below to this statement. Scanning to end-of-file
+        // lets an entry we cannot parse latch onto the *next* clip's call and
+        // table, filing it under the wrong key and then skipping the real
+        // definition - one unsupported entry costing two animations plus a
+        // corrupt one. The next declaration starts the next statement.
+        let statement = text[after_clip..]
+            .find("g_weaponAnimations[")
+            .map(|found| after_clip + found)
+            .unwrap_or(text.len());
+
+        let Some(call) = text[after_clip..statement].find("PointRigAnimation") else {
+            continue;
+        };
+        let call = after_clip + call + "PointRigAnimation".len();
+
+        let Some(paren) = next_non_space(bytes, call) else {
+            continue;
+        };
+        if bytes.get(paren) != Some(&b'(') {
+            continue;
+        }
+        let Some((name, after_name)) = quoted(bytes, paren + 1) else {
+            continue;
+        };
+        let Some((fps, after_fps)) = number_after_comma(bytes, after_name) else {
+            continue;
+        };
+        let Some((length, after_length)) = number_after_comma(bytes, after_fps) else {
+            continue;
+        };
+
+        let Some(table) = text[after_length..statement].find('{') else {
+            continue;
+        };
+        let table = after_length + table;
+        let Some(end) = matching_brace(bytes, table) else {
+            continue;
+        };
+
+        let tracks = parse_tracks(&text[table + 1..end]);
+        at = end;
+
+        animations.by_category.entry(category).or_default().insert(
+            clip,
+            WeaponAnimation {
+                name,
+                fps,
+                length,
+                tracks,
+            },
+        );
+    }
+
+    animations
+}
+
+fn parse_tracks(body: &str) -> Vec<Track> {
+    let bytes = body.as_bytes();
+    let mut tracks = Vec::new();
+    let mut at = 0usize;
+
+    while let Some((joint, after_joint)) = next_quoted(bytes, at) {
+        let Some(colon) = next_non_space(bytes, after_joint) else {
+            break;
+        };
+        if bytes.get(colon) != Some(&b':') {
+            at = after_joint;
+            continue;
+        }
+        let Some(open) = next_non_space(bytes, colon + 1) else {
+            break;
+        };
+        if bytes.get(open) != Some(&b'[') {
+            at = colon + 1;
+            continue;
+        }
+        let Some(close) = matching_bracket(bytes, open) else {
+            break;
+        };
+
+        tracks.push(Track {
+            joint: joint.to_owned(),
+            keys: parse_keys(&body[open + 1..close]),
+        });
+        at = close + 1;
+    }
+
+    tracks
+}
+
+fn parse_keys(body: &str) -> Vec<Keyframe> {
+    let bytes = body.as_bytes();
+    let mut keys = Vec::new();
+    let mut at = 0usize;
+
+    // Keyframes are `{...}` records; the shipped file omits some separating
+    // commas, so scan brace to brace rather than splitting on commas.
+    while let Some(open) = body[at..].find('{').map(|found| at + found) {
+        let Some(close) = matching_brace(bytes, open) else {
+            break;
+        };
+        let record = &body[open + 1..close];
+        at = close + 1;
+
+        let Some(frame) = field_number(record, "frame") else {
+            continue;
+        };
+        keys.push(Keyframe {
+            frame,
+            pos: field_vec3(record, "pos").unwrap_or_else(|| vec3(0.0, 0.0, 0.0)),
+            rot: field_vec3(record, "rot").unwrap_or_else(|| vec3(0.0, 0.0, 0.0)),
+            events: field_strings(record, "events"),
+        });
+    }
+
+    keys.sort_by(|a, b| a.frame.total_cmp(&b.frame));
+    keys
+}
+
+fn strip_comments(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(at) => &line[..at],
+            None => line,
+        })
+        .collect::<Vec<&str>>()
+        .join("\n")
+}
+
+fn next_non_space(bytes: &[u8], from: usize) -> Option<usize> {
+    (from..bytes.len()).find(|at| !bytes[*at].is_ascii_whitespace())
+}
+
+/// The string literal starting at the quote at or after `from`.
+fn quoted(bytes: &[u8], from: usize) -> Option<(String, usize)> {
+    let open = next_non_space(bytes, from)?;
+    if bytes.get(open) != Some(&b'"') {
+        return None;
+    }
+    let close = (open + 1..bytes.len()).find(|at| bytes[*at] == b'"')?;
+    Some((
+        String::from_utf8_lossy(&bytes[open + 1..close]).into_owned(),
+        close + 1,
+    ))
+}
+
+/// The next string literal anywhere at or after `from`.
+fn next_quoted(bytes: &[u8], from: usize) -> Option<(String, usize)> {
+    let open = (from..bytes.len()).find(|at| bytes[*at] == b'"')?;
+    let close = (open + 1..bytes.len()).find(|at| bytes[*at] == b'"')?;
+    Some((
+        String::from_utf8_lossy(&bytes[open + 1..close]).into_owned(),
+        close + 1,
+    ))
+}
+
+fn number_after_comma(bytes: &[u8], from: usize) -> Option<(f32, usize)> {
+    let comma = next_non_space(bytes, from)?;
+    if bytes.get(comma) != Some(&b',') {
+        return None;
+    }
+    let start = next_non_space(bytes, comma + 1)?;
+    let end = (start..bytes.len())
+        .find(|at| !matches!(bytes[*at], b'0'..=b'9' | b'.' | b'-' | b'+'))
+        .unwrap_or(bytes.len());
+    let text = std::str::from_utf8(&bytes[start..end]).ok()?;
+    Some((text.parse().ok()?, end))
+}
+
+/// The value of `"field" : ...` inside one record.
+fn field_body(record: &str, field: &str) -> Option<usize> {
+    let needle = format!("\"{field}\"");
+    let at = record.find(&needle)? + needle.len();
+    let colon = next_non_space(record.as_bytes(), at)?;
+    if record.as_bytes().get(colon) != Some(&b':') {
+        return None;
+    }
+    next_non_space(record.as_bytes(), colon + 1)
+}
+
+fn field_number(record: &str, field: &str) -> Option<f32> {
+    let start = field_body(record, field)?;
+    let bytes = record.as_bytes();
+    let end = (start..bytes.len())
+        .find(|at| !matches!(bytes[*at], b'0'..=b'9' | b'.' | b'-' | b'+'))
+        .unwrap_or(bytes.len());
+    record[start..end].parse().ok()
+}
+
+fn field_vec3(record: &str, field: &str) -> Option<Vector3<f32>> {
+    let start = field_body(record, field)?;
+    if record.as_bytes().get(start) != Some(&b'[') {
+        return None;
+    }
+    let close = matching_bracket(record.as_bytes(), start)?;
+    let parts = record[start + 1..close]
+        .split(',')
+        .filter_map(|part| part.trim().parse::<f32>().ok())
+        .collect::<Vec<f32>>();
+    match parts.len() {
+        3 => Some(vec3(parts[0], parts[1], parts[2])),
+        _ => None,
+    }
+}
+
+fn field_strings(record: &str, field: &str) -> Vec<String> {
+    let Some(start) = field_body(record, field) else {
+        return Vec::new();
+    };
+    if record.as_bytes().get(start) != Some(&b'[') {
+        return Vec::new();
+    }
+    let Some(close) = matching_bracket(record.as_bytes(), start) else {
+        return Vec::new();
+    };
+    record[start + 1..close]
+        .split(',')
+        .filter_map(|part| {
+            let trimmed = part.trim().trim_matches('"').trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_owned())
+        })
+        .collect()
+}
+
+fn matching(bytes: &[u8], from: usize, open: u8, close: u8) -> Option<usize> {
+    if bytes.get(from) != Some(&open) {
+        return None;
+    }
+    let mut depth = 0usize;
+    for at in from..bytes.len() {
+        if bytes[at] == open {
+            depth += 1;
+        } else if bytes[at] == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(at);
+            }
+        }
+    }
+    None
+}
+
+fn matching_brace(bytes: &[u8], from: usize) -> Option<usize> {
+    matching(bytes, from, b'{', b'}')
+}
+
+fn matching_bracket(bytes: &[u8], from: usize) -> Option<usize> {
+    matching(bytes, from, b'[', b']')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim from the shipped `animations_weapons.nut`, including the two
+    /// things that break a naive parser: a `//` comment, and the **missing
+    /// commas** between the frame-26 and frame-28 keys.
+    const PISTOL_RAISE: &str = r#"
+ND.g_weaponAnimations["Pistol"] <- {};
+ND.g_weaponAnimations["Pistol"]["raise"] <- ND.PointRigAnimation("raise", 30, 60,
+{
+	// Weapon
+	"gunPoint" : [
+		{ "frame":0, "pos":[0.0, 0.0,-1.5], "rot":[45.0, 45.0, -45.0]},
+		{ "frame":15, "pos":[0.1, 0.2, 0.1], "rot":[15.0, -15.0, -60.0] },
+		{ "frame":26, "pos":[0.1, 0.2, 0.1], "rot":[15.0, -15.0, -60.0] }
+
+		{ "frame":28, "pos":[0.15, 0.2, 0.1], "rot":[0.0, 0.0, -45.0] }
+		{ "frame":52, "pos":[0.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+	],
+
+	// Slide
+	"joint1" : [
+		{ "frame":0, "pos":[0.0, 0.0,0.0], "rot":[0.0, 0.0, 0.0] },
+		{ "frame":16, "pos":[-0.20, 0.0,0.0], "rot":[0.0, 0.0, 0.0] },
+		{ "frame":26, "pos":[0.0, 0.0,0.0], "rot":[0.0, 0.0, 0.0] },
+	],
+});
+"#;
+
+    fn pistol_raise() -> WeaponAnimation {
+        parse(PISTOL_RAISE)
+            .by_category
+            .remove("Pistol")
+            .expect("Pistol category")
+            .remove("raise")
+            .expect("raise clip")
+    }
+
+    #[test]
+    fn parses_the_clip_header() {
+        let raise = pistol_raise();
+        assert_eq!(raise.name, "raise");
+        assert_eq!(raise.fps, 30.0);
+        assert_eq!(raise.length, 60.0);
+        assert_eq!(raise.duration_seconds(), 2.0);
+    }
+
+    /// The comma between frames 26 and 28 is missing in the shipped file, so a
+    /// comma-splitting parser silently loses keys.
+    #[test]
+    fn keyframes_survive_missing_commas() {
+        let raise = pistol_raise();
+        let gun = raise.track("gunPoint").expect("gunPoint track");
+        assert_eq!(gun.keys.len(), 5);
+        assert_eq!(
+            gun.keys.iter().map(|key| key.frame).collect::<Vec<f32>>(),
+            vec![0.0, 15.0, 26.0, 28.0, 52.0]
+        );
+    }
+
+    /// The slide pull: back by frame 16, returned by 26.
+    #[test]
+    fn samples_the_slide_pull() {
+        let raise = pistol_raise();
+
+        let (back, _) = raise.sample("joint1", 16.0).expect("slide at 16");
+        assert!(
+            (back.x - -0.20).abs() < 1e-5,
+            "slide should be back: {back:?}"
+        );
+
+        let (mid, _) = raise.sample("joint1", 8.0).expect("slide at 8");
+        assert!(
+            mid.x < 0.0 && mid.x > -0.20,
+            "slide should be part way back: {mid:?}"
+        );
+
+        let (home, _) = raise.sample("joint1", 26.0).expect("slide at 26");
+        assert!((home.x).abs() < 1e-5, "slide should be home: {home:?}");
+    }
+
+    #[test]
+    fn sampling_clamps_outside_the_authored_range() {
+        let raise = pistol_raise();
+        let (before, _) = raise.sample("gunPoint", -5.0).expect("before start");
+        let (after, _) = raise.sample("gunPoint", 999.0).expect("after end");
+        assert_eq!(before.z, -1.5);
+        assert_eq!(after, vec3(0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn events_fire_once_per_frame_window() {
+        let source = r#"
+ND.g_weaponAnimations["default"]["shoot"] <- ND.PointRigAnimation("shoot", 30, 60,
+{
+	"gunPoint" : [
+		{ "frame":0, "pos":[0.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0], "events": ["muzzleFlash", "eject"]},
+		{ "frame":12, "pos":[0.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+	],
+});
+"#;
+        let shoot = parse(source)
+            .get("default", "shoot")
+            .cloned()
+            .expect("shoot");
+        assert_eq!(
+            shoot.events_between(-1.0, 0.0),
+            vec!["muzzleFlash", "eject"]
+        );
+        // Already consumed - stepping past must not repeat it.
+        assert!(shoot.events_between(0.0, 12.0).is_empty());
+    }
+
+    /// An entry we cannot parse must cost only itself. Before this was bounded,
+    /// the unparsable entry swallowed the *next* clip's call and table.
+    #[test]
+    fn an_unparsable_entry_does_not_consume_the_next() {
+        let source = r#"
+ND.g_weaponAnimations["Pistol"]["broken"] <- ND.SomethingElse();
+ND.g_weaponAnimations["Pistol"]["shoot"] <- ND.PointRigAnimation("shoot", 30, 42,
+{
+	"gunPoint" : [ { "frame":0, "pos":[7.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] } ],
+});
+"#;
+        let animations = parse(source);
+        let shoot = animations.get("Pistol", "shoot").expect("shoot survives");
+        assert_eq!(shoot.length, 42.0);
+        assert_eq!(shoot.sample("gunPoint", 0.0).expect("sample").0.x, 7.0);
+        assert!(animations.get("Pistol", "broken").is_none());
+    }
+
+    /// Authored data repeats a frame to make a value jump; the later key wins.
+    #[test]
+    fn a_repeated_frame_takes_the_later_key() {
+        let source = r#"
+ND.g_weaponAnimations["default"]["shoot"] <- ND.PointRigAnimation("shoot", 30, 10,
+{
+	"gunPoint" : [
+		{ "frame":0, "pos":[0.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+		{ "frame":5, "pos":[1.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+		{ "frame":5, "pos":[9.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+		{ "frame":10, "pos":[9.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] },
+	],
+});
+"#;
+        let shoot = parse(source)
+            .get("default", "shoot")
+            .cloned()
+            .expect("shoot");
+        let (at_five, _) = shoot.sample("gunPoint", 5.0).expect("sample at 5");
+        assert_eq!(at_five.x, 9.0, "the later key at frame 5 should win");
+    }
+
+    /// A weapon with no bespoke clip falls back to `default`, which is how the
+    /// shipped data covers most of the roster.
+    #[test]
+    fn unknown_category_falls_back_to_default() {
+        let source = r#"
+ND.g_weaponAnimations["default"]["reload"] <- ND.PointRigAnimation("reload", 30, 60,
+{
+	"gunPoint" : [ { "frame":0, "pos":[1.0, 0.0, 0.0], "rot":[0.0, 0.0, 0.0] } ],
+});
+"#;
+        let animations = parse(source);
+        assert!(animations.get("Fusion Cannon", "reload").is_some());
+        assert!(animations.get("Fusion Cannon", "shoot").is_none());
+    }
+}

--- a/shock2vr/src/hand_glove.rs
+++ b/shock2vr/src/hand_glove.rs
@@ -24,6 +24,30 @@ use crate::{
 const GLOVE_MODEL: &str = "vr_glove_model.glb";
 const GLOVE_TEXTURE: &str = "vr_glove_color.jpg";
 
+/// Wrist-to-fingertip length the glove model is authored at, in world units -
+/// the +Z span of its bind-pose bounding box (fingers point along +Z).
+pub const AUTHORED_HAND_LENGTH_WORLD: f32 = 0.2049;
+
+/// Wrist-to-fingertip length of an adult hand. Anthropometric mean is ~19 cm.
+const REAL_HAND_LENGTH_METERS: f32 = 0.19;
+
+/// Corrects the glove to life size.
+///
+/// VR renders the world at true scale - tracked poses are divided by
+/// [`crate::METERS_PER_WORLD_UNIT`], so a world unit really is 0.762 m - which
+/// means the hand has to be a real hand's size in world units or it reads as
+/// too small against everything around it. The model is authored at ~15.6 cm
+/// where a hand is ~19 cm, so it renders about a fifth undersized.
+///
+/// Measured, not guessed: rendering the glove beside a cube of known edge
+/// length in `debug_hands` put its bind pose at its authored bounding box, so
+/// the shortfall is in the asset, not in the skinning path.
+///
+/// This is the one number to adjust if life size turns out to read wrong in an
+/// actual headset - VR hands are often tuned slightly large.
+pub const GLOVE_SCALE: f32 =
+    (REAL_HAND_LENGTH_METERS / crate::METERS_PER_WORLD_UNIT) / AUTHORED_HAND_LENGTH_WORLD;
+
 /// Everything constant about the glove, resolved once: the model (a private
 /// clone whose skeleton is re-posed each frame), the pose retargeting, the
 /// blend endpoints, and one textured material per mesh (fresh cells so the
@@ -127,7 +151,11 @@ impl GloveRenderer {
             Handedness::Right => Matrix4::from_scale(1.0),
             Handedness::Left => Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0),
         };
-        let world = Matrix4::from_translation(position) * Matrix4::from(rotation) * mirror * grip;
+        let world = Matrix4::from_translation(position)
+            * Matrix4::from(rotation)
+            * mirror
+            * grip
+            * Matrix4::from_scale(GLOVE_SCALE);
 
         let mut objects = self.model.to_scene_objects_with_skinning();
         for (object, material) in objects.iter_mut().zip(&self.materials) {
@@ -135,5 +163,34 @@ impl GloveRenderer {
             object.set_transform(world);
         }
         objects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the two constants against drifting apart: the scale exists to put
+    /// the authored glove at a real hand's length once the world's true scale
+    /// (`METERS_PER_WORLD_UNIT`) is applied.
+    #[test]
+    fn glove_scale_renders_a_life_size_hand() {
+        let rendered_meters =
+            AUTHORED_HAND_LENGTH_WORLD * GLOVE_SCALE * crate::METERS_PER_WORLD_UNIT;
+
+        assert!(
+            (rendered_meters - REAL_HAND_LENGTH_METERS).abs() < 1e-4,
+            "glove renders {rendered_meters} m, expected {REAL_HAND_LENGTH_METERS} m"
+        );
+    }
+
+    /// The uncorrected glove is undersized, not oversized - a scale below 1.0
+    /// would mean a unit slip somewhere rather than a real correction.
+    #[test]
+    fn glove_scale_is_a_modest_enlargement() {
+        assert!(
+            (1.0..2.0).contains(&GLOVE_SCALE),
+            "unexpected glove scale {GLOVE_SCALE}"
+        );
     }
 }

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -1,0 +1,237 @@
+//! The free-hand pose library: 25AE authored hands, snapped between.
+//!
+//! The remaster's first-person weapon models each carry a hand posed onto that
+//! weapon. Those hands have no finger joints (see
+//! `~/notes/projects/shock2quest/vr-hand-rigging.md`), so we cannot blend
+//! between poses - but the poses themselves are good, and there are enough of
+//! them to cover the states a free hand needs. We pick one per state and snap.
+//!
+//! Held weapons do not come through here: for those the whole `_h` model is
+//! drawn, hand included, which is already the artist's grip.
+//!
+//! # Aligning a pose
+//!
+//! Each hand is anchored by its geometric frame ([`dark`'s `HandFrame`]): the
+//! wrist goes to the hand origin and the fingers point along the hand's forward
+//! axis. That fixes position and two of three rotational degrees of freedom
+//! from the geometry itself, so the only thing left to author per pose is the
+//! **roll** about the finger axis - one number, tuned visually in
+//! `debug_hand_poses`.
+//!
+//! # Known limitation: the wrist is estimated, not authored
+//!
+//! `HandFrame` derives the wrist by stepping back a hand's length from the
+//! far end of the point cloud. That endpoint is an extended fingertip on one
+//! hand and a knuckle on a curled one, so the estimate lands a few centimetres
+//! differently per pose - visibly, the axis marker sits mid-palm on `ar15_h`
+//! rather than at the wrist. It also means the authored `forward` is the
+//! *forearm* axis on the models that include a forearm, not the finger axis.
+//!
+//! Consequences: the poses do not present the same amount of sleeve, and a
+//! common-cuff trim built on this landmark cut into the wrist on the worst
+//! case. A per-pose wrist offset alongside `roll`, tuned in the harness, is
+//! the intended fix.
+
+use cgmath::{Deg, InnerSpace, Matrix4, Rad, Vector3, vec3};
+use dark::{importers::FIRST_PERSON_HANDS_IMPORTER, ss2_bin_obj_loader::HAND_LENGTH_WORLD};
+use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+
+/// A free-hand state we can show. Ordered open to closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandPose {
+    /// Idle/empty hand, fingers extended.
+    Rest,
+    /// Reaching or about to grab - fingers curled partway.
+    SemiClosed,
+    /// Closed around something, or a trigger pull.
+    Grip,
+}
+
+impl HandPose {
+    pub const ALL: [HandPose; 3] = [HandPose::Rest, HandPose::SemiClosed, HandPose::Grip];
+
+    /// Which authored hand supplies this pose, and how it is rolled into place.
+    ///
+    /// The sources are the 25AE first-person weapon models; the index selects
+    /// among the hands that model draws (largest island first), so the pistol's
+    /// support hand is `atek_h.bin` index 2.
+    fn source(self) -> PoseSource {
+        match self {
+            // The only authored hand with extended fingers.
+            HandPose::Rest => PoseSource {
+                model: "ar15_h.bin",
+                index: 0,
+                roll: Deg(0.0),
+            },
+            // The pistol's trigger hand: fingers curled partway, as if closing.
+            HandPose::SemiClosed => PoseSource {
+                model: "atek_h.bin",
+                index: 0,
+                roll: Deg(0.0),
+            },
+            // The pistol's support hand, the most closed of the three: fingers
+            // curled under into a cup.
+            HandPose::Grip => PoseSource {
+                model: "atek_h.bin",
+                index: 2,
+                roll: Deg(0.0),
+            },
+        }
+    }
+}
+
+struct PoseSource {
+    model: &'static str,
+    index: usize,
+    roll: Deg<f32>,
+}
+
+/// One pose's geometry, already anchored so the wrist sits at the origin with
+/// the fingers pointing along -Z (the hand frame's forward, matching
+/// `VirtualHand`).
+pub struct LoadedPose {
+    pub pose: HandPose,
+    objects: Vec<SceneObject>,
+}
+
+impl LoadedPose {
+    /// The pose's scene objects at a hand's world transform.
+    pub fn at(&self, world: Matrix4<f32>) -> Vec<SceneObject> {
+        self.objects
+            .iter()
+            .map(|object| {
+                let mut clone = object.clone();
+                clone.set_transform(world * object.get_transform());
+                clone
+            })
+            .collect()
+    }
+}
+
+/// Every pose we could load. Missing poses are skipped rather than fatal - a
+/// non-25AE install has none of these models.
+pub fn load(asset_cache: &mut AssetCache) -> Vec<LoadedPose> {
+    HandPose::ALL
+        .into_iter()
+        .filter_map(|pose| load_pose(asset_cache, pose))
+        .collect()
+}
+
+fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose> {
+    let source = pose.source();
+    let hands = asset_cache.get_opt(&FIRST_PERSON_HANDS_IMPORTER, source.model)?;
+    let hand = hands.0.get(source.index)?;
+
+    // Take the hand out of model space and into hand space: wrist to the
+    // origin, fingers down the frame's forward axis, then the authored roll.
+    let anchor = anchor_of(&hand.frame, source.roll);
+
+    let objects = hand
+        .model
+        .clone_scene_objects()
+        .into_iter()
+        .map(|mut object| {
+            object.set_transform(anchor * object.get_transform());
+            object
+        })
+        .collect();
+
+    Some(LoadedPose { pose, objects })
+}
+
+/// Maps a hand's authored frame onto the hand origin.
+///
+/// `VirtualHand`'s forward is -Z (the aim/raycast direction), so the fingers are
+/// pointed down -Z here and the whole hand is rolled about that axis by the
+/// pose's authored roll.
+fn anchor_of(frame: &dark::ss2_bin_obj_loader::HandFrame, roll: Deg<f32>) -> Matrix4<f32> {
+    let forward = frame.forward;
+    let reference = if forward.y.abs() > 0.9 {
+        vec3(1.0, 0.0, 0.0)
+    } else {
+        vec3(0.0, 1.0, 0.0)
+    };
+    let right = reference.cross(forward).normalize();
+    let up = forward.cross(right);
+
+    // Rows are the target basis, so this maps the frame into hand space.
+    //
+    // `right` is negated to keep the basis right-handed. Mapping `forward` to
+    // -Z while sending `right` to +X and `up` to +Y is geometrically impossible
+    // without a flip: with `up = forward x right`, the rows (right, up,
+    // -forward) have determinant -1. That reflection renders the authored right
+    // hand as a left hand and reverses triangle winding, so backface culling
+    // shows the inside of the mesh - see `anchor_is_a_rotation_not_a_reflection`.
+    let to_hand = Matrix4::from_cols(
+        vec3(-right.x, up.x, -forward.x).extend(0.0),
+        vec3(-right.y, up.y, -forward.y).extend(0.0),
+        vec3(-right.z, up.z, -forward.z).extend(0.0),
+        cgmath::Vector4::new(0.0, 0.0, 0.0, 1.0),
+    );
+
+    Matrix4::from_angle_z(Rad::from(roll))
+        * to_hand
+        * Matrix4::from_translation(-wrist_vector(frame))
+}
+
+/// The wrist, set back from the fingertips by a hand's length.
+///
+/// `HandFrame::origin` is the far end of the geometry, which on the models whose
+/// hand includes a forearm is the *elbow* - anchoring there would hang the hand
+/// off the controller by an arm's length.
+fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame) -> Vector3<f32> {
+    let fingertip = frame.origin + frame.forward * frame.length;
+    let wrist = fingertip - frame.forward * HAND_LENGTH_WORLD;
+    vec3(wrist.x, wrist.y, wrist.z)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{SquareMatrix, Vector4, assert_relative_eq};
+    use dark::ss2_bin_obj_loader::HandFrame;
+    use cgmath::point3;
+
+    fn frame(forward: Vector3<f32>) -> HandFrame {
+        HandFrame {
+            name: String::new(),
+            origin: point3(0.0, 0.0, 0.0),
+            forward: forward.normalize(),
+            length: 1.0,
+        }
+    }
+
+    /// The anchor must be a *rotation*. A negative determinant is a reflection:
+    /// it renders the right hand as a left hand and reverses triangle winding,
+    /// so backface culling shows the inside of the mesh.
+    #[test]
+    fn anchor_is_a_rotation_not_a_reflection() {
+        for forward in [
+            vec3(0.0, 0.0, 1.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.3, -0.5, 0.8),
+            vec3(0.0, 1.0, 0.0),
+        ] {
+            let anchor = anchor_of(&frame(forward), Deg(0.0));
+            let determinant = anchor.determinant();
+            assert!(
+                determinant > 0.0,
+                "anchor for {forward:?} has determinant {determinant} - it mirrors the hand"
+            );
+        }
+    }
+
+    /// The fingers must end up pointing down -Z, which is `VirtualHand`'s forward.
+    #[test]
+    fn anchor_points_the_fingers_down_negative_z() {
+        for forward in [vec3(0.0, 0.0, 1.0), vec3(1.0, 0.0, 0.0), vec3(0.3, -0.5, 0.8)] {
+            let f = frame(forward);
+            let anchor = anchor_of(&f, Deg(0.0));
+            let pointed = anchor * Vector4::new(f.forward.x, f.forward.y, f.forward.z, 0.0);
+            assert_relative_eq!(pointed.x, 0.0, epsilon = 1e-4);
+            assert_relative_eq!(pointed.y, 0.0, epsilon = 1e-4);
+            assert_relative_eq!(pointed.z, -1.0, epsilon = 1e-4);
+        }
+    }
+}

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -185,13 +185,12 @@ fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame) -> Vector3<f32> {
     vec3(wrist.x, wrist.y, wrist.z)
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::point3;
     use cgmath::{SquareMatrix, Vector4, assert_relative_eq};
     use dark::ss2_bin_obj_loader::HandFrame;
-    use cgmath::point3;
 
     fn frame(forward: Vector3<f32>) -> HandFrame {
         HandFrame {
@@ -225,7 +224,11 @@ mod tests {
     /// The fingers must end up pointing down -Z, which is `VirtualHand`'s forward.
     #[test]
     fn anchor_points_the_fingers_down_negative_z() {
-        for forward in [vec3(0.0, 0.0, 1.0), vec3(1.0, 0.0, 0.0), vec3(0.3, -0.5, 0.8)] {
+        for forward in [
+            vec3(0.0, 0.0, 1.0),
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.3, -0.5, 0.8),
+        ] {
             let f = frame(forward);
             let anchor = anchor_of(&f, Deg(0.0));
             let pointed = anchor * Vector4::new(f.forward.x, f.forward.y, f.forward.z, 0.0);

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod audio_log;
 pub mod game_scene;
 pub mod hand_pose;
+pub mod hand_pose_library;
 pub mod input;
 pub mod input_context;
 pub mod inventory;

--- a/shock2vr/src/scenes/debug_hand_poses.rs
+++ b/shock2vr/src/scenes/debug_hand_poses.rs
@@ -1,0 +1,128 @@
+//! Tuning harness for the free-hand pose library (`hand_pose_library`).
+//!
+//! Each authored pose is drawn at its own hand origin, with a marker showing
+//! that origin's axes. Because the poses are anchored by their geometry, a
+//! correctly aligned pose puts its wrist on the marker with the fingers down the
+//! blue (-Z, "where the hand points") axis. Whatever roll is left over is the
+//! number to author in `HandPose::source`.
+//!
+//! ```bash
+//! cargo dbgr --mission debug_hand_poses --port 8080
+//! curl -X POST http://127.0.0.1:8080/v1/step -d '{"frames": 30}'
+//! curl -X POST http://127.0.0.1:8080/v1/screenshot -d '{"filename": "poses.png"}'
+//! ```
+
+use cgmath::{Deg, Matrix4, Quaternion, Rotation3, Vector3, vec3};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, color_material, cube},
+};
+use shipyard::EntityId;
+use tracing::info;
+
+use crate::{
+    GameOptions,
+    game_scene::GameScene,
+    hand_pose_library::{self, LoadedPose},
+    mission::{GlobalContext, SpawnLocation, mission_core::MissionCore},
+    scenes::debug_common::{
+        DebugSceneBuildOptions, DebugSceneBuilder, DebugSceneHooks, HookedDebugScene,
+    },
+};
+
+const ROW_HEIGHT: f32 = 3.0;
+const SPACING: f32 = 0.7;
+
+/// A stubby axis marker at the hand origin: red +X, green +Y, blue -Z (forward).
+fn axis_marker() -> Vec<SceneObject> {
+    let axes = [
+        (vec3(1.0, 0.0, 0.0), vec3(0.09, 0.006, 0.006), vec3(0.05, 0.0, 0.0)),
+        (vec3(0.0, 1.0, 0.0), vec3(0.006, 0.09, 0.006), vec3(0.0, 0.05, 0.0)),
+        (vec3(0.2, 0.4, 1.0), vec3(0.006, 0.006, 0.14), vec3(0.0, 0.0, -0.07)),
+    ];
+
+    axes.into_iter()
+        .map(|(color, scale, offset)| {
+            let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+            object.set_transform(
+                Matrix4::from_translation(offset)
+                    * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),
+            );
+            object
+        })
+        .collect()
+}
+
+struct PoseHooks {
+    poses: Vec<LoadedPose>,
+    markers: Vec<SceneObject>,
+}
+
+impl DebugSceneHooks for PoseHooks {
+    fn after_render(
+        &mut self,
+        _core: &mut MissionCore,
+        scene_objects: &mut Vec<SceneObject>,
+        _camera_position: &mut Vector3<f32>,
+        _camera_rotation: &mut Quaternion<f32>,
+        _asset_cache: &mut AssetCache,
+        _options: &GameOptions,
+    ) {
+        let count = self.poses.len() as f32;
+        for (index, pose) in self.poses.iter().enumerate() {
+            // Negated so the row reads left to right (the camera looks along -X).
+            let offset = ((count - 1.0) / 2.0 - index as f32) * SPACING;
+            let world = Matrix4::from_translation(vec3(offset, ROW_HEIGHT, 1.0))
+                * Matrix4::from_angle_y(Deg(90.0));
+
+            scene_objects.extend(pose.at(world));
+            scene_objects.extend(self.markers.iter().map(|marker| {
+                let mut clone = marker.clone();
+                clone.set_transform(world * marker.get_transform());
+                clone
+            }));
+        }
+    }
+}
+
+pub struct DebugHandPosesScene;
+
+impl DebugHandPosesScene {
+    pub fn new(
+        global_context: &GlobalContext,
+        game_options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Box<dyn GameScene> {
+        let builder = DebugSceneBuilder::new("debug_hand_poses")
+            .with_default_floor()
+            .with_spawn_location(SpawnLocation::PositionRotation(
+                vec3(0.0, 3.0, -1.4),
+                Quaternion::from_angle_y(Deg(90.0)),
+            ));
+
+        let build_options = DebugSceneBuildOptions {
+            global_context,
+            game_options,
+            asset_cache,
+            audio_context,
+        };
+
+        let core = builder.build_core(build_options);
+        let poses = hand_pose_library::load(asset_cache);
+
+        info!(
+            "Created debug hand poses scene: {:?}",
+            poses.iter().map(|pose| pose.pose).collect::<Vec<_>>()
+        );
+
+        Box::new(HookedDebugScene::new(
+            core,
+            PoseHooks {
+                poses,
+                markers: axis_marker(),
+            },
+        ))
+    }
+}

--- a/shock2vr/src/scenes/debug_hand_poses.rs
+++ b/shock2vr/src/scenes/debug_hand_poses.rs
@@ -37,14 +37,27 @@ const SPACING: f32 = 0.7;
 /// A stubby axis marker at the hand origin: red +X, green +Y, blue -Z (forward).
 fn axis_marker() -> Vec<SceneObject> {
     let axes = [
-        (vec3(1.0, 0.0, 0.0), vec3(0.09, 0.006, 0.006), vec3(0.05, 0.0, 0.0)),
-        (vec3(0.0, 1.0, 0.0), vec3(0.006, 0.09, 0.006), vec3(0.0, 0.05, 0.0)),
-        (vec3(0.2, 0.4, 1.0), vec3(0.006, 0.006, 0.14), vec3(0.0, 0.0, -0.07)),
+        (
+            vec3(1.0, 0.0, 0.0),
+            vec3(0.09, 0.006, 0.006),
+            vec3(0.05, 0.0, 0.0),
+        ),
+        (
+            vec3(0.0, 1.0, 0.0),
+            vec3(0.006, 0.09, 0.006),
+            vec3(0.0, 0.05, 0.0),
+        ),
+        (
+            vec3(0.2, 0.4, 1.0),
+            vec3(0.006, 0.006, 0.14),
+            vec3(0.0, 0.0, -0.07),
+        ),
     ];
 
     axes.into_iter()
         .map(|(color, scale, offset)| {
-            let mut object = SceneObject::new(color_material::create(color), Box::new(cube::create()));
+            let mut object =
+                SceneObject::new(color_material::create(color), Box::new(cube::create()));
             object.set_transform(
                 Matrix4::from_translation(offset)
                     * Matrix4::from_nonuniform_scale(scale.x, scale.y, scale.z),

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -22,6 +22,7 @@ pub mod cutscene_player;
 pub mod debug_camera;
 pub mod debug_common;
 pub mod debug_gloves;
+pub mod debug_hand_poses;
 pub mod debug_hitbox;
 pub mod debug_hud;
 pub mod debug_joint_constraint;
@@ -41,6 +42,7 @@ pub mod main_menu;
 pub use cutscene_player::CutscenePlayerScene;
 pub use debug_camera::DebugCameraScene;
 pub use debug_gloves::DebugGlovesScene;
+pub use debug_hand_poses::DebugHandPosesScene;
 pub use debug_hitbox::DebugHitboxScene;
 pub use debug_hud::DebugHudScene;
 pub use debug_joint_constraint::DebugJointConstraintScene;
@@ -224,6 +226,13 @@ pub fn create_initial_scene(
     if options.mission.eq_ignore_ascii_case("debug_gloves") {
         return SceneInitResult {
             scene: DebugGlovesScene::new(global_context, options, asset_cache, audio_context),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    if options.mission.eq_ignore_ascii_case("debug_hand_poses") {
+        return SceneInitResult {
+            scene: DebugHandPosesScene::new(global_context, options, asset_cache, audio_context),
             mission_save_data: HashMap::new(),
         };
     }


### PR DESCRIPTION
Replaces the SteamVR glove with the hands the 25th Anniversary Edition already poses onto its first-person weapon models. They look far better, and every user now has the 25AE assets.

## The pose library

`cargo dbgr --mission debug_hand_poses` — three authored poses anchored at a common hand origin (markers: red +X, green +Y, blue −Z forward):

![hand poses](https://gist.githubusercontent.com/tommy-xr/0ddf335c268187074105b269a1e16e69/raw/hand-poses.png)

| pose | source | reads as |
| --- | --- | --- |
| `Rest` | `ar15_h` island 0 | fingers extended |
| `SemiClosed` | `atek_h` island 0 | curled partway |
| `Grip` | `atek_h` island 2 | curled under |

Six authored hands exist across the ranged viewmodels; these three cover the range:

![authored hands](https://gist.githubusercontent.com/tommy-xr/0ddf335c268187074105b269a1e16e69/raw/authored-hands.png)

## How the extraction works

The hand is selected by **material** (`ND-arm*`), not by sub-object name. A sub-object filter works on `ar15_h`/`atek_h`, where the hand is its own `@s01_han`, but not on `sg_h`/`empgun_h`, where the hand rides a moving gun sub-object and would drag the weapon with it.

A sub-object's **bone transform is a joint pivot, not a placement** — it is `[0,0,0]` on `ar15_h` — so the grip only exists in where the geometry actually lands. Hence `hand_frame`, which derives a wrist/forward frame from the placed vertices.

## Bug found by review: the anchor was a reflection

`anchor_of` built rows `(right, up, −forward)`. With `up = forward × right` that determinant is exactly **−1** — a reflection, not a rotation. Every authored right hand rendered as a mirrored left hand with reversed winding, so backface culling showed the mesh interior.

Before — the blue axis bar draws straight *through* the palms:

![before](https://gist.githubusercontent.com/tommy-xr/0ddf335c268187074105b269a1e16e69/raw/mirror-before.png)

After — the hands occlude it and render solid:

![after](https://gist.githubusercontent.com/tommy-xr/0ddf335c268187074105b269a1e16e69/raw/mirror-after.png)

Pinned by `anchor_is_a_rotation_not_a_reflection` (determinant > 0) and `anchor_points_the_fingers_down_negative_z`.

## Also here

- **Glove scaled to life size.** It is authored ~15.6 cm where a hand is ~19 cm. VR renders the world at true scale (`METERS_PER_WORLD_UNIT`), so it read as undersized in a headset. Measured against a known-edge reference cube in-engine, not eyeballed; two tests pin the constants together.

## Known limitations

- **The hands have no finger joints** — every hand is a leaf bone, so poses **snap** rather than blend. Plan for rigging one is in `~/notes/projects/shock2quest/vr-hand-rigging.md`.
- **The wrist is estimated, not authored.** `HandFrame` steps back a hand's length from the far end of the point cloud; that endpoint is an extended fingertip on one hand and a knuckle on a curled one, so it lands a few cm differently per pose (visibly, the marker sits mid-palm on `ar15_h`). Consequently the poses do not present the same amount of sleeve. A per-pose wrist offset alongside `roll` is the intended fix — an automatic common-cuff trim built on this landmark cut into the wrist and was dropped rather than shipped.
- **Not yet wired into `VirtualHand`** — production still renders `GloveRenderer`. This lands the library and the harness; selection from hand state is the next PR.

## Gotcha worth knowing

`AssetCache` keys by `importer.type_id()` — the importer's *type*. Two importers sharing `AssetImporter<_, Model, _>` silently share one cache bucket and serve whichever view loaded first. Hence the `FirstPersonHands` newtype; any further view of an already-imported type needs its own.

## Verification

- 98 `dark` + 562 `shock2vr` tests pass; clean under `RUSTFLAGS="-D warnings"`
- Reviewed with `/xreview` (Claude + Codex + a dedicated de-dup pass); the Critical above and five other findings fixed in-branch
