### PR TITLE
feat(debug-runtime): boot the main menu when no mission is given

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,9 @@ For debugging visual/rendering changes without a full interactive session:
    # Pass `--visible` to watch the game in a real window.
    cargo dbgr --mission medsci1.mis --port 8080
 
+   # With no --mission it boots the main menu (same entry point as the flat
+   # desktop runtime), so always pass one when a scene/mission is what you want.
+
    # Control via HTTP
    curl http://127.0.0.1:8080/v1/step -X POST -d '{"frames": 10}'
    curl http://127.0.0.1:8080/v1/screenshot -X POST -d '{"filename": "test.png"}'

--- a/projects/vr-gloves.md
+++ b/projects/vr-gloves.md
@@ -100,7 +100,7 @@ Desktop `--vr` controls: hold **E** (right hand) or **Q** (left hand) to
 possess a hand — the mouse then drives it (move = aim, LMB = trigger,
 RMB = squeeze). Bare clicks do nothing to the hands in VR mode.
 
-Test headlessly with `cargo dbgr --vr`: the debug runtime's
+Test headlessly with `cargo dbgr --vr --mission earth.mis`: the debug runtime's
 `POST /v1/control/input` accepts `{left,right}_hand.position [x,y,z]`
 (pawn-local), `.rotation [x,y,z,w]`, `.trigger`, and `.squeeze` channels, so
 hand placement and finger state are fully scriptable for screenshots.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -77,8 +77,10 @@ where
 #[command(name = "debug_runtime")]
 #[command(about = "HTTP-controlled game runtime for LLM testing and automation")]
 struct Args {
-    /// Mission file to load (e.g., medsci1.mis)
-    #[arg(short, long, default_value = "earth.mis")]
+    /// Mission file to load (e.g., medsci1.mis), a debug scene name, or
+    /// "main_menu". Defaults to the main menu, the same entry point the flat
+    /// desktop runtime boots into - automation passes this explicitly anyway.
+    #[arg(short, long, default_value = "main_menu")]
     mission: String,
 
     /// Port to bind HTTP server to


### PR DESCRIPTION
**Stacked on #930.**

## What

`cargo dbgr` defaulted to `earth.mis`. The flat desktop runtime has booted the **main menu** with no `--mission` since #297:

```rust
let mission_arg = args.mission.clone().unwrap_or_else(|| {
    if args.vr { "earth.mis".to_owned() } else { "main_menu".to_owned() }
});
```

Match it, so "launch with no arguments" means the same thing in both runtimes.

## Why it's safe for automation

The SDK's `GameServer.launch` takes a **required** `mission: string` and always passes `--mission` explicitly, so no scenario test changes behavior. The only place in the repo that relied on the old default was `projects/vr-gloves.md`'s `cargo dbgr --vr`, which now passes a mission; AGENTS.md notes the new default.

## Not included

The **VR** defaults (`desktop_runtime --vr`, `oculus_runtime`) still boot a mission. That is deliberate and is not a one-line change: no VR runtime populates `InputContext::pointer`, so booting the menu there would strand the player on a screen they cannot click. The next PR in this stack gives VR a controller pointer first; flipping those defaults follows it.

