### PR TITLE
feat(playtest): exercise anniversary assets in VR

### DIFF
--- a/.claude/skills/play-through/SKILL.md
+++ b/.claude/skills/play-through/SKILL.md
@@ -12,7 +12,8 @@ description: >-
   a self-contained HTML timeline report. Invoke with a mission (default medsci1)
   and a goal (default: reach the level's exit). Use `--auto` to keep iterating to
   campaign completion, `--auto-once` for one iteration, or `--restart` to forget
-  the previous ledger and roll a fresh campaign.
+  the previous ledger and roll a fresh campaign. Use `--vr` to override the
+  presentation roll and force the debug runtime's VR mode.
 ---
 
 # play-through — the playtest → review → fix → replay loop
@@ -73,7 +74,9 @@ intent, not at random.
 
 Classify each validated finding two ways:
 - **Domain:** `[gameplay]` (broken interaction/objective) · `[visual]` (rendering)
-  · `[functionality]` (crash / won't load).
+  · `[physics]` (collision/rigid-body behavior) · `[functionality]` (crash /
+  won't load) · `[tool]` (debug runtime/SDK access) · `[test]` (playtest harness
+  or coverage).
 - **Kind — this matters as much as the domain, because this is a *partial* port:**
   - **bug** — broken logic in something that's implemented (an off-by-one, a wrong
     comparator, a crash). Targeted fix.
@@ -82,16 +85,31 @@ Classify each validated finding two ways:
     unparsed property). **Most blockers here are this kind.** The "fix" is a real
     feature, and it must be **faithful**, not a shim.
 
-**Blockers first** (they gate progress). File a GitHub issue (domain + kind,
-mission, repro: exact levers + step count, expected vs actual, the screenshot,
-and — in a rolled campaign — the campaign configuration: scenario, tweak,
-asset set, seed; same on the fix PR).
+**Apply GitHub labels when filing, not just bracketed title prefixes.** Select
+only the labels that describe the finding:
+
+- Kind: `bug` for broken implemented behavior; `enhancement` for a feature gap.
+- Area: `gameplay`, `visual`, or `physics`; add `vr` when VR-specific or found
+  through a missing/inaccessible VR interaction.
+- Test surface: `tool` for debug runtime/SDK/tooling gaps; `test` for playtest
+  harness, automation, or coverage gaps.
+- Severity: add `blocker` only when the finding halts campaign progress.
+
+Pass them to `gh issue create --label <label> --label <label> ...`; every label
+must exist in the repository. Do not attach every label mechanically.
+
+**Blockers first** (they gate progress). File a GitHub issue with those labels,
+domain + kind, mission, repro: exact levers + step count, expected vs actual,
+the screenshot, and — in a rolled campaign — the campaign configuration:
+scenario, tweak, 25th Anniversary asset set, presentation mode, and seed; include
+the same configuration on the fix PR.
 
 **Attach stateful reproduction evidence locally.** When a finding depends on
 deep campaign state, create a dedicated game save immediately before the
 smallest reproducing action (for example `pt-shodan-issue-725-repro`), then
-record its logical save name, SHA-256, mission, position, asset set, and load
-steps in `data.json`, the local report, and the fix-agent handoff. Never
+record its logical save name, SHA-256, mission, position, asset set,
+presentation mode, and load steps in `data.json`, the local report, and the
+fix-agent handoff. Never
 overwrite or repurpose the campaign frontier or a user-owned save; the fix agent
 copies the reproduction save into its task-owned asset directory before using
 it. Skip this artifact when a fresh mission plus concise steps reproduces the
@@ -213,9 +231,12 @@ play and stitch with the **`video-capture`** skill (60Hz sim / 4 = real-time
 
 ## Campaign randomization (`roll`)
 
-**Every new campaign starts with a roll.** Instead of always marching
-earth→shodan, the campaign randomizer picks three independent axes and persists
-them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
+**Every new campaign starts with a roll.** Every runtime uses the stock 25th
+Anniversary install at `$HOME/ss2-25th`; this is fixed, not a random axis or an
+override. Verify that it contains `sshock2.kpf` (or another data-root sentinel)
+and launch with `DARK_ASSET_PATH=$HOME/ss2-25th`; never fall back to legacy
+assets. The campaign randomizer picks three independent axes and persists them
+in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
 
 1. **Mission-sequence scenario** — one of eight slices of the game, each with
    its own mission order and goal: `earth-to-medsci` (training → station →
@@ -229,31 +250,32 @@ them in the ledger (tables + per-pick instructions live in `scenarios.mjs`):
    verify OS upgraders, cutscene/research/regen/camera-alarm verification, Navy
    (hack/repair/modify), Marine (standard/electronic/organic/heavy weapons), OSA
    (psi tiers 1–5), AI/pathfinding stress, or a detailed test run.
-3. **Asset set** — legacy assets or the 25th Anniversary assets (loaded
-   directly from the stock `.kpf` install since #557); the pick is the
-   `DARK_ASSET_PATH` every runtime in the campaign must be launched with. Only
-   sets where a data-root sentinel exists (`shock2.gam` / `sshock2.kpf` / ...,
-   same list as `paths::data_root()`) enter the random draw; a missing install
-   can still be forced with `assets=<id>` and the roll prints a warning.
+3. **Presentation mode** — a uniform two-entry draw, `flat` or `vr`, gives each
+   campaign a 50/50 chance of running the debug runtime with `--vr`. Persist the
+   pick so fixes replay under the same interaction model. An explicit `--vr` in
+   the skill invocation forces VR for both new and resumed campaigns without
+   resetting their frontier.
 
 ```
 node .agents/skills/play-through/playthrough-state.mjs roll              # random campaign (idempotent)
 node .agents/skills/play-through/playthrough-state.mjs roll seed=42      # reproducible roll
+node .agents/skills/play-through/playthrough-state.mjs roll --vr         # force VR; preserve an existing frontier
 node .agents/skills/play-through/playthrough-state.mjs roll --restart    # forget ledger, roll fresh
-node .agents/skills/play-through/playthrough-state.mjs roll --force scenario=hydroponics tweak=melee-only assets=legacy
+node .agents/skills/play-through/playthrough-state.mjs roll --force scenario=hydroponics tweak=melee-only presentation=flat
 node .agents/skills/play-through/scenarios.mjs list                      # browse all ids
 ```
 
 **The roll happens once per campaign and then sticks**: like `init`, `roll` is
 idempotent — re-invoking the skill mid-campaign keeps the existing roll, so the
-frontier, scenario, tweak, and assets stay consistent across iterations
-(`--force` starts a fresh campaign with a new roll). `--restart` is different:
+frontier, scenario, tweak, and presentation stay consistent across iterations.
+The one exception is an explicit `--vr`, which changes only the persisted
+presentation. `--force` starts a fresh campaign with a new roll. `--restart` is different:
 it is the autonomous-mode spelling for forgetting the previous ledger and
 starting a newly rolled campaign; it does not retain the old seed, scenario,
-tweak, assets, mission order, fix branch, frontier, blockers, or history. `show`
-re-surfaces the goal, the tweak instructions, and the
-`DARK_ASSET_PATH` in its NEXT line every iteration — **feed the tweak
-instructions and campaign goal into every `playtest` prompt**, and treat a
+tweak, presentation, mission order, fix branch, frontier, blockers, or history.
+`show` re-surfaces the goal, tweak instructions, `DARK_ASSET_PATH`, and any
+required `--vr` in its NEXT line every iteration — **feed the presentation,
+tweak instructions, and campaign goal into every `playtest` prompt**, and treat a
 tweak's verifications as first-class findings (a broken psi power under an OSA
 tweak is a real finding even if the mission could be finished without it).
 Every roll prints its `seed`, so any campaign can be reproduced exactly (the
@@ -292,9 +314,10 @@ resources the character was never given.
 
 **Record the roll everywhere it matters:** every issue filed and every fix PR
 opened during a campaign must state the rolled configuration — scenario, tweak,
-asset set, and seed (e.g. `campaign: hydroponics · melee-only · legacy · seed
-42`) — so a reader can tell whether a finding is specific to a playstyle or
-asset set, and can reproduce the campaign that surfaced it.
+25th Anniversary asset set, presentation, and seed (e.g. `campaign:
+hydroponics · melee-only · 25th · vr · seed 42`) — so a reader can tell whether
+a finding is specific to a playstyle or presentation and can reproduce the
+campaign that surfaced it.
 
 ## Autonomous modes (`--auto`, `--auto-once`)
 
@@ -306,6 +329,10 @@ Choose the mode from the user's invocation:
   three times, or progress genuinely requires human input.
 - **`--auto-once` — bounded:** run exactly one complete iteration, persist its
   result, report, and return. A later invocation resumes from the ledger.
+- **`--vr` — presentation override:** combine it with either mode (or a manual
+  invocation) to force VR. Pass it to `playthrough-state.mjs roll --vr` on every
+  iteration so it also upgrades an existing flatscreen ledger without resetting
+  progress.
 
 Both modes **auto-create the campaign ledger on first run** — no setup step.
 State persists in that ledger so work survives restarts and context compaction,
@@ -320,8 +347,8 @@ node .agents/skills/play-through/playthrough-state.mjs show      # ledger + the 
 #   complete <finalLevel> [note...]                             (marks the campaign finished)
 ```
 
-The ledger holds: the campaign **roll** (`scenario` + `tweak` + `assets`, with
-its `seed`), `frontier` (the game **save** to `/v1/load` from), the
+The ledger holds: the campaign **roll** (`scenario` + `tweak` + `presentation`,
+the fixed `assets`, and its `seed`), `frontier` (the game **save** to `/v1/load` from), the
 `blockers` ledger (issue → PR → status + failed-fix count), terminal campaign
 completion, and `fix_branch` — the running branch that **stacks each fix** so
 the campaign plays *past* an already-fixed-but-unmerged blocker.
@@ -334,22 +361,25 @@ randomized campaign. Consume `--restart` once; every later iteration in the same
 normally.
 
 **Clear & start a new campaign:** `playthrough-state.mjs roll --force` (wipes
-the ledger back to iteration 0 with a fresh scenario/tweak/assets roll; plain
-`init --force` still exists for a fixed, non-randomized order). For a *truly*
+the ledger back to iteration 0 with a fresh scenario/tweak/presentation roll;
+plain `init --force` still exists for a fixed, non-randomized order). For a *truly*
 clean slate also recreate the `fix_branch` off current `main` and delete stale
 frontier saves (`<data_root>/saves/frontier*.sav`) — otherwise the fresh
 campaign just launches mission 0 with no frontier to load, which is harmless.
 
 **Each autonomous iteration:**
 
-1. `playthrough-state.mjs roll` (idempotent — rolls scenario + tweak + assets
+1. `playthrough-state.mjs roll` (idempotent — rolls scenario + tweak + presentation
    and creates the ledger on the first iteration, keeps the roll after), then
-   `show` → read the frontier + NEXT action (goal, tweak, `DARK_ASSET_PATH`).
+   `show` → read the frontier + NEXT action (goal, tweak, `DARK_ASSET_PATH`, and
+   presentation). When the skill was invoked with `--vr`, use `roll --vr` here.
 2. **Resume:** build the runtime from the **`fix_branch`** (so accrued fixes are
-   in), launch it **with the campaign's `DARK_ASSET_PATH`**, and `POST /v1/load
-   {file: frontier.save}` — or launch the first mission fresh at iteration 0.
+   in), launch it **with the campaign's `DARK_ASSET_PATH`** and append `--vr`
+   when the presentation is VR, then `POST /v1/load {file: frontier.save}` — or
+   launch the first mission fresh at iteration 0.
 3. **Playtest** from here toward the goal (the `playtest` primitive), passing the
-   campaign goal + the tweak instructions into the playtest prompt → `data.json`.
+   campaign goal + tweak instructions + presentation into the playtest prompt →
+   `data.json`.
 4. **Review** the session (§2). Shallow/invalid → re-playtest with guidance.
 5. **Triage** every validated finding (bug vs **feature-gap** — §3-4;
    feature-gaps get a *faithful*, non-shim fix). While play continues, file and

--- a/.claude/skills/play-through/playthrough-state.mjs
+++ b/.claude/skills/play-through/playthrough-state.mjs
@@ -6,11 +6,12 @@
 //
 //   node playthrough-state.mjs <cmd> [args]
 //     init [order=earth,station,medsci1,eng1,...] [fixBranch=playthrough-fixes]
-//     roll [seed=N] [scenario=<id>] [tweak=<id>] [assets=<id>] [fixBranch=...] [--force|--restart]
+//     roll [seed=N] [scenario=<id>] [tweak=<id>] [presentation=<flat|vr>|--vr] [fixBranch=...] [--force|--restart]
 //                                       init a RANDOMIZED campaign: pick a mission-
-//                                       sequence scenario, a special tweak, and an
-//                                       asset set (see scenarios.mjs) and persist
-//                                       them in the ledger. Idempotent like init —
+//                                       sequence scenario, a special tweak, and a
+//                                       50/50 presentation mode (see scenarios.mjs)
+//                                       and persist them in the ledger. Assets are
+//                                       always 25th Anniversary. Idempotent like init —
 //                                       an existing campaign keeps its roll;
 //                                       --force re-rolls from scratch; --restart
 //                                       forgets the previous ledger and rolls a
@@ -25,11 +26,37 @@
 // State file: $PT_STATE, else /tmp/claude/playthrough/state.json.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { roll } from "./scenarios.mjs";
+import { ANNIVERSARY_ASSETS, PRESENTATION_MODES, roll } from "./scenarios.mjs";
 
 const FILE = process.env.PT_STATE || "/tmp/claude/playthrough/state.json";
-const load = () => (existsSync(FILE) ? JSON.parse(readFileSync(FILE, "utf8")) : null);
-const save = (s) => { mkdirSync(dirname(FILE), { recursive: true }); writeFileSync(FILE, JSON.stringify(s, null, 2) + "\n"); };
+const save = (s) => {
+  mkdirSync(dirname(FILE), { recursive: true });
+  writeFileSync(FILE, JSON.stringify(s, null, 2) + "\n");
+};
+const presentationById = (id) => PRESENTATION_MODES.find((mode) => mode.id === id);
+const load = () => {
+  if (!existsSync(FILE)) return null;
+  const state = JSON.parse(readFileSync(FILE, "utf8"));
+  if (!state.scenario) return state;
+
+  // Migrate rolled ledgers created before 25th-only / presentation-mode
+  // campaigns. Preserve their frontier, blockers, scenario, tweak, and seed.
+  let changed = false;
+  if (state.assets?.id !== ANNIVERSARY_ASSETS.id || state.assets?.path !== ANNIVERSARY_ASSETS.path) {
+    state.assets = ANNIVERSARY_ASSETS;
+    changed = true;
+  }
+  if (!state.presentation) {
+    state.presentation = roll({
+      seed: state.seed,
+      scenarioId: state.scenario.id,
+      tweakId: state.tweak?.id,
+    }).presentation;
+    changed = true;
+  }
+  if (changed) save(state);
+  return state;
+};
 const baseState = (order, fixBranch) => ({
   iteration: 0,
   mission_order: order,
@@ -49,7 +76,9 @@ function nextAction(s) {
   const failed = s.blockers.find((b) =>
     (b.fix_failures ?? (b.status === "failed" ? 3 : 0)) >= 3
   );
-  const campaign = (s.assets ? ` Launch every runtime with DARK_ASSET_PATH=${s.assets.path} (${s.assets.name}).` : "")
+  const campaign = (s.assets
+    ? ` Launch every runtime with DARK_ASSET_PATH=${s.assets.path} (${s.assets.name}) in ${s.presentation?.name ?? "the recorded presentation"}${s.presentation?.id === "vr" ? " with --vr" : ""}.`
+    : "")
     + (s.scenario ? ` Campaign goal: ${s.scenario.goal}` : "")
     + (s.tweak && s.tweak.id !== "none" ? ` TWEAK [${s.tweak.name}]: ${s.tweak.instructions}` : "");
   if (s.completed) {
@@ -80,29 +109,47 @@ switch (cmd) {
     break;
   }
   case "roll": {
-    // Randomized init: pick scenario + tweak + asset set and persist them so
+    // Randomized init: pick scenario + tweak + presentation and persist them so
     // every later iteration of the campaign plays under the same roll.
     // Idempotent like init — only rolls when no ledger exists. `--force`
     // replaces the roll; `--restart` forgets the old ledger and starts fresh.
     const force = args.includes("--force");
     const restart = args.includes("--restart");
+    const forceVr = args.includes("--vr");
+    const kv = (k) => rest.find((a) => a.startsWith(`${k}=`))?.slice(k.length + 1);
     if (force && restart) {
       console.error("--force and --restart are mutually exclusive: choose one way to replace the current campaign");
+      process.exit(1);
+    }
+    if (forceVr && kv("presentation") && kv("presentation") !== "vr") {
+      console.error("--vr conflicts with a non-VR presentation= override");
+      process.exit(1);
+    }
+    if (kv("assets") !== undefined) {
+      console.error("assets= is no longer configurable — every playtest uses the 25th Anniversary assets");
       process.exit(1);
     }
     const hadLedger = existsSync(FILE);
     if (hadLedger && !force && !restart) {
       const s = load();
       if (s.scenario) {
+        if (forceVr && s.presentation?.id !== "vr") {
+          s.presentation = presentationById("vr");
+          save(s);
+          console.log(
+            `overrode presentation to VR for existing campaign at ${FILE}; frontier and iteration kept.`,
+          );
+        }
         console.log(`ledger already exists at ${FILE} (iteration ${s.iteration}) — kept its roll. Use --restart or --force to replace it with a fresh roll.`);
-        console.log(`scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name}`);
+        console.log(
+          `scenario: ${s.scenario.name} · tweak: ${s.tweak?.name} · assets: ${s.assets?.name} · presentation: ${s.presentation?.name ?? "not recorded"}`,
+        );
       } else {
-        console.log(`WARNING: ledger at ${FILE} (iteration ${s.iteration}) predates campaign randomization — it has NO scenario/tweak/assets roll.`);
+        console.log(`WARNING: ledger at ${FILE} (iteration ${s.iteration}) predates campaign randomization — it has NO scenario/tweak/presentation roll.`);
         console.log(`Kept as-is (a mid-campaign re-roll would strand its frontier). Finish or abandon it, then 'roll --force' to start a rolled campaign.`);
       }
       break;
     }
-    const kv = (k) => rest.find((a) => a.startsWith(`${k}=`))?.slice(k.length + 1);
     const rawSeed = kv("seed");
     if (rawSeed !== undefined && !Number.isFinite(Number(rawSeed))) {
       console.error(`invalid seed '${rawSeed}' — must be a number`);
@@ -114,7 +161,7 @@ switch (cmd) {
         seed: rawSeed !== undefined ? Number(rawSeed) : undefined,
         scenarioId: kv("scenario"),
         tweakId: kv("tweak"),
-        assetsId: kv("assets"),
+        presentationId: forceVr ? "vr" : kv("presentation"),
       });
     } catch (e) {
       console.error(e.message);
@@ -127,6 +174,7 @@ switch (cmd) {
       scenario: { id: picked.scenario.id, name: picked.scenario.name, goal: picked.scenario.goal },
       tweak: picked.tweak,
       assets: picked.assets,
+      presentation: picked.presentation,
     });
     if (restart && hadLedger) {
       console.log(`forgot previous ledger and rolled fresh campaign (seed ${picked.seed}) -> ${FILE}`);
@@ -138,6 +186,9 @@ switch (cmd) {
     console.log(`  goal:     ${picked.scenario.goal}`);
     console.log(`  tweak:    ${picked.tweak.name} [${picked.tweak.id}] — ${picked.tweak.instructions}`);
     console.log(`  assets:   ${picked.assets.name} [${picked.assets.id}] — DARK_ASSET_PATH=${picked.assets.path}`);
+    console.log(
+      `  mode:     ${picked.presentation.name} [${picked.presentation.id}]${picked.presentation.runtimeArgs.length ? ` — ${picked.presentation.runtimeArgs.join(" ")}` : ""}`,
+    );
     break;
   }
   case "show": {
@@ -223,6 +274,6 @@ switch (cmd) {
     break;
   }
   default:
-    console.error("usage: init | roll [--force|--restart] | show | advance | complete | blocker add|set|fail (see file header)");
+    console.error("usage: init | roll [--vr] [--force|--restart] | show | advance | complete | blocker add|set|fail (see file header)");
     process.exit(1);
 }

--- a/.claude/skills/play-through/playthrough-state.test.mjs
+++ b/.claude/skills/play-through/playthrough-state.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
+
+import { ANNIVERSARY_ASSETS, PRESENTATION_MODES, roll } from "./scenarios.mjs";
 
 const SCRIPT = fileURLToPath(new URL("./playthrough-state.mjs", import.meta.url));
 
@@ -17,9 +19,10 @@ function withLedger(runTest) {
       env: { ...process.env, PT_STATE: stateFile },
     });
   const state = () => JSON.parse(readFileSync(stateFile, "utf8"));
+  const writeState = (value) => writeFileSync(stateFile, `${JSON.stringify(value, null, 2)}\n`);
 
   try {
-    runTest({ run, state });
+    runTest({ run, state, writeState });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -77,7 +80,7 @@ test("--restart forgets the previous ledger and creates a fresh roll", () => {
       "seed=111",
       "scenario=engineering",
       "tweak=none",
-      "assets=legacy",
+      "presentation=flat",
       "fixBranch=old-campaign-stack",
     );
     assert.equal(first.status, 0, first.stderr);
@@ -90,7 +93,7 @@ test("--restart forgets the previous ledger and creates a fresh roll", () => {
       "seed=222",
       "scenario=shodan",
       "tweak=detailed",
-      "assets=legacy",
+      "presentation=vr",
       "fixBranch=fresh-campaign-stack",
     );
     assert.equal(restarted.status, 0, restarted.stderr);
@@ -100,6 +103,8 @@ test("--restart forgets the previous ledger and creates a fresh roll", () => {
     assert.equal(fresh.seed, 222);
     assert.equal(fresh.scenario.id, "shodan");
     assert.equal(fresh.tweak.id, "detailed");
+    assert.equal(fresh.assets.id, "25th");
+    assert.equal(fresh.presentation.id, "vr");
     assert.equal(fresh.fix_branch, "fresh-campaign-stack");
     assert.equal(fresh.iteration, 0);
     assert.equal(fresh.frontier, null);
@@ -107,5 +112,104 @@ test("--restart forgets the previous ledger and creates a fresh roll", () => {
     assert.deepEqual(fresh.history, []);
     assert.equal(fresh.completed, false);
     assert.equal(fresh.completion, null);
+  });
+});
+
+test("campaign rolls always use 25th Anniversary assets and persist presentation", () => {
+  withLedger(({ run, state }) => {
+    const rolled = run(
+      "roll",
+      "seed=42",
+      "scenario=hydroponics",
+      "tweak=none",
+      "presentation=vr",
+    );
+    assert.equal(rolled.status, 0, rolled.stderr);
+    assert.equal(state().assets.id, "25th");
+    assert.equal(state().presentation.id, "vr");
+
+    const shown = run("show");
+    assert.equal(shown.status, 0, shown.stderr);
+    assert.match(shown.stdout, /DARK_ASSET_PATH=.*ss2-25th.*in VR with --vr/s);
+
+    const legacyOverride = run("roll", "--force", "assets=legacy");
+    assert.notEqual(legacyOverride.status, 0);
+    assert.match(legacyOverride.stderr, /every playtest uses the 25th Anniversary/i);
+  });
+});
+
+test("the presentation roll is a uniform flat/VR choice with fixed assets", () => {
+  assert.deepEqual(
+    PRESENTATION_MODES.map((mode) => mode.id),
+    ["flat", "vr"],
+  );
+
+  const seenModes = new Set();
+  for (let seed = 0; seed < 20; seed += 1) {
+    const campaign = roll({ seed });
+    assert.equal(campaign.assets, ANNIVERSARY_ASSETS);
+    assert.ok(PRESENTATION_MODES.includes(campaign.presentation));
+    seenModes.add(campaign.presentation.id);
+  }
+  assert.deepEqual([...seenModes].sort(), ["flat", "vr"]);
+});
+
+test("--vr forces new and resumed campaigns without resetting progress", () => {
+  withLedger(({ run, state }) => {
+    const created = run(
+      "roll",
+      "seed=7",
+      "scenario=engineering",
+      "tweak=none",
+      "presentation=flat",
+    );
+    assert.equal(created.status, 0, created.stderr);
+    assert.equal(run("advance", "eng1", "frontier-007", "4,5,6").status, 0);
+
+    const overridden = run("roll", "--vr");
+    assert.equal(overridden.status, 0, overridden.stderr);
+    assert.match(overridden.stdout, /overrode presentation to VR/i);
+    assert.equal(state().presentation.id, "vr");
+    assert.equal(state().iteration, 1);
+    assert.equal(state().frontier.save, "frontier-007");
+
+    const restarted = run(
+      "roll",
+      "--restart",
+      "--vr",
+      "seed=8",
+      "scenario=shodan",
+      "tweak=none",
+    );
+    assert.equal(restarted.status, 0, restarted.stderr);
+    assert.equal(state().presentation.id, "vr");
+    assert.equal(state().iteration, 0);
+    assert.equal(state().frontier, null);
+  });
+});
+
+test("show migrates an existing legacy-assets campaign without losing its frontier", () => {
+  withLedger(({ run, state, writeState }) => {
+    writeState({
+      iteration: 3,
+      mission_order: ["eng1", "eng2"],
+      fix_branch: "playthrough-fixes",
+      frontier: { level: "eng1", save: "frontier-old", position: [1, 2, 3] },
+      blockers: [],
+      history: [],
+      completed: false,
+      completion: null,
+      seed: 99,
+      scenario: { id: "engineering", name: "Engineering", goal: "Enable power" },
+      tweak: { id: "none", name: "None", instructions: "No special constraint" },
+      assets: { id: "legacy", name: "Legacy assets", path: "/old/assets" },
+    });
+
+    const shown = run("show");
+    assert.equal(shown.status, 0, shown.stderr);
+    assert.equal(state().assets.id, "25th");
+    assert.ok(["flat", "vr"].includes(state().presentation.id));
+    assert.equal(state().iteration, 3);
+    assert.equal(state().frontier.save, "frontier-old");
   });
 });

--- a/.claude/skills/play-through/scenarios.mjs
+++ b/.claude/skills/play-through/scenarios.mjs
@@ -1,7 +1,7 @@
 // Campaign randomization tables for the play-through skill: the mission-sequence
-// scenarios and the bonus-objective / special-tweak playstyles a campaign can
-// roll. Consumed by `playthrough-state.mjs roll` (which persists the pick in the
-// ledger) — run directly only to browse the tables:
+// scenarios, bonus-objective / special-tweak playstyles, and presentation modes
+// a campaign can roll. Consumed by `playthrough-state.mjs roll` (which persists
+// the picks in the ledger) — run directly only to browse the tables:
 //
 //   node scenarios.mjs list          print all scenarios and tweaks with ids
 
@@ -177,24 +177,20 @@ export const TWEAKS = [
   },
 ];
 
-// Asset set to launch with: exported as DARK_ASSET_PATH for every runtime the
-// campaign starts. Paths are the two install locations used on our machines.
-// A set is only eligible for the random draw when a data-root sentinel exists
-// there — the same sentinel list as `shock2vr::paths::data_root()`: loose
-// classic data (`shock2.gam`, ...) or a 25th Anniversary install
-// (`sshock2.kpf`, supported since #557). A set with no sentinel (missing or
-// broken install) can still be forced (assets=<id>), never rolled.
-export const ASSET_SETS = [
-  {
-    id: "legacy",
-    name: "Legacy assets",
-    path: `${process.env.HOME}/ss2-data-unpacked`,
-  },
-  {
-    id: "25th",
-    name: "25th Anniversary assets",
-    path: `${process.env.HOME}/ss2-25th`,
-  },
+// Every playtest uses the 25th Anniversary install. Keep this as structured
+// campaign data so session reports and issues can identify the exact asset set,
+// but never put it back in the random draw.
+export const ANNIVERSARY_ASSETS = {
+  id: "25th",
+  name: "25th Anniversary assets",
+  path: `${process.env.HOME}/ss2-25th`,
+};
+
+// A two-entry uniform draw makes VR selection exactly 50/50. Persist the pick
+// for the campaign so every rebuild/replay uses the same interaction model.
+export const PRESENTATION_MODES = [
+  { id: "flat", name: "Flatscreen", runtimeArgs: [] },
+  { id: "vr", name: "VR", runtimeArgs: ["--vr"] },
 ];
 
 const DATA_ROOT_SENTINELS = ["shock2.gam", "res/obj.crf", "res/mesh.crf", "motiondb.bin", "sshock2.kpf"];
@@ -211,11 +207,12 @@ function mulberry32(seed) {
   };
 }
 
-// Roll a campaign: random scenario + tweak + asset set, seeded. Any of the
-// three can be forced by id. The RNG stream is drawn identically whether or
-// not picks are forced, so `seed=N` alone always reproduces the same random
-// draws regardless of which overrides were combined with it.
-export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
+// Roll a campaign: random scenario + tweak + presentation, seeded. Any of the
+// three can be forced by id. Assets remain fixed to the 25th Anniversary set.
+// The RNG stream is drawn identically whether or not picks are forced, so
+// `seed=N` alone always reproduces the same random draws regardless of which
+// overrides were combined with it.
+export function roll({ seed, scenarioId, tweakId, presentationId } = {}) {
   const s = seed ?? Math.floor(Math.random() * 2 ** 31);
   const rng = mulberry32(s);
   const byId = (table, id, label) => {
@@ -226,15 +223,25 @@ export function roll({ seed, scenarioId, tweakId, assetsId } = {}) {
   const draw = (table) => table[Math.floor(rng() * table.length)];
   const rolledScenario = draw(SCENARIOS);
   const rolledTweak = draw(TWEAKS);
-  const usableSets = ASSET_SETS.filter(assetSetUsable);
-  const rolledAssets = draw(usableSets.length ? usableSets : ASSET_SETS);
+  const rolledPresentation = draw(PRESENTATION_MODES);
   const scenario = scenarioId ? byId(SCENARIOS, scenarioId, "scenario") : rolledScenario;
   const tweak = tweakId ? byId(TWEAKS, tweakId, "tweak") : rolledTweak;
-  const assets = assetsId ? byId(ASSET_SETS, assetsId, "assets") : rolledAssets;
+  const presentation = presentationId
+    ? byId(PRESENTATION_MODES, presentationId, "presentation")
+    : rolledPresentation;
   const warnings = [];
-  if (!assetSetUsable(assets))
-    warnings.push(`asset set '${assets.id}' has no data-root sentinel (shock2.gam / sshock2.kpf / ...) at ${assets.path} — the engine cannot load it (missing install?)`);
-  return { seed: s, scenario, tweak, assets, warnings };
+  if (!assetSetUsable(ANNIVERSARY_ASSETS))
+    warnings.push(
+      `25th Anniversary assets have no data-root sentinel (sshock2.kpf / ...) at ${ANNIVERSARY_ASSETS.path} — the engine cannot load them (missing install?)`,
+    );
+  return {
+    seed: s,
+    scenario,
+    tweak,
+    assets: ANNIVERSARY_ASSETS,
+    presentation,
+    warnings,
+  };
 }
 
 if (process.argv[1]?.endsWith("scenarios.mjs")) {
@@ -244,8 +251,13 @@ if (process.argv[1]?.endsWith("scenarios.mjs")) {
     for (const s of SCENARIOS) console.log(`  ${s.id.padEnd(18)} ${s.missions.join(",").padEnd(28)} ${s.goal}`);
     console.log("Bonus objectives / tweaks:");
     for (const t of TWEAKS) console.log(`  ${t.id.padEnd(22)} ${t.instructions}`);
-    console.log("Asset sets:");
-    for (const a of ASSET_SETS) console.log(`  ${a.id.padEnd(22)} ${a.name} (DARK_ASSET_PATH=${a.path})${assetSetUsable(a) ? "" : " [NOT USABLE: no data-root sentinel — force-only, excluded from random draw]"}`);
+    console.log("Assets (fixed):");
+    console.log(
+      `  ${ANNIVERSARY_ASSETS.id.padEnd(22)} ${ANNIVERSARY_ASSETS.name} (DARK_ASSET_PATH=${ANNIVERSARY_ASSETS.path})${assetSetUsable(ANNIVERSARY_ASSETS) ? "" : " [NOT USABLE: no data-root sentinel]"}`,
+    );
+    console.log("Presentation modes (50/50):");
+    for (const mode of PRESENTATION_MODES)
+      console.log(`  ${mode.id.padEnd(22)} ${mode.name}${mode.runtimeArgs.length ? ` (${mode.runtimeArgs.join(" ")})` : ""}`);
   } else if (cmd) {
     console.error("usage: node scenarios.mjs list");
     process.exit(1);

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -26,9 +26,36 @@ bypassable, then keep playing. Do not wait until `data.json` is complete: the
 manager validates, files, and delegates its fix in parallel. Continue to record
 the finding in the final `data.json`.
 
+## Choose the launch configuration
+
+**Always use the 25th Anniversary assets.** Set
+`DARK_ASSET_PATH="$HOME/ss2-25th"` on every debug-runtime launch and verify that
+the directory contains a data-root sentinel such as `sshock2.kpf` before
+starting. If it is missing, report a setup blocker; never fall back to legacy
+assets or the repository's `Data/` directory.
+
+Choose the presentation once per session:
+
+- Use the manager's persisted `presentation` when it supplied one.
+- An explicit `--vr` in the skill invocation overrides the manager choice or
+  standalone coin flip and forces VR.
+- Otherwise, for a standalone session, make a fair 50/50 `flat`/`vr` random
+  choice by running `node -e 'console.log(Math.random()<.5?"flat":"vr")'`
+  exactly once. Record the result before launch so it cannot be re-rolled after
+  a failure.
+
+Launch flatscreen with no presentation flag; launch VR by appending `--vr`.
+With the SDK, pass `debugFlags: presentation === "vr" ? ["--vr"] : []` to
+`GameServer.launch` (the process inherits `DARK_ASSET_PATH`). With raw Cargo:
+
+```bash
+DARK_ASSET_PATH="$HOME/ss2-25th" cargo dbgr --mission <m>.mis --port <p>
+DARK_ASSET_PATH="$HOME/ss2-25th" cargo dbgr --mission <m>.mis --port <p> --vr
+```
+
 ## Reach the start state
 - **Fresh:** launch the runtime on the mission (SDK `GameServer.launch`, or
-  `cargo dbgr --mission <m>.mis --port <p>`), `step 5` to settle.
+  the matching command above), `step 5` to settle.
 - **Resume at a frontier** (the manager passes one): warp with
   `POST /v1/control/transition-level {level, loc}` and/or `teleport {x,y,z}` to
   where the last session stalled, so you don't replay solved parts. (`QuickLoad`
@@ -50,11 +77,13 @@ the finding in the final `data.json`.
 `/v1/step {frames:N}` after each action so it takes effect (deterministic; no
 sleeps). Tripwires fire on entry; bulkhead buttons fire on Frob.
 
-### Frobbing *in world* (flat mode) — squeeze, not trigger
+### Player-authentic interaction differs by presentation
 
 `POST /v1/entities/:id/message {type:"Frob"}` is a **debug injection**: it drives
 the script directly and is fine for diagnosis, but it does **not** prove a player
-could do it. To frob the way a player does, in flat mode (the default):
+could do it.
+
+In **flat mode**, frob under the crosshair with squeeze, not trigger:
 
 1. **Aim** — the target must be under the crosshair. With the preferred SDK,
    call `game.player.aimAt(entity, {hitbox:"torso", visibility:"required"})`
@@ -88,6 +117,21 @@ curl -X POST .../v1/step -d '{"frames": 2}'
 
 A session that reports "frob does nothing" **without** having driven the squeeze
 edge has not tested frobbing — that finding will be rejected at review.
+
+In **VR mode**, exercise the production two-hand path. Place and rotate a hand
+with `{left|right}_hand.position` and `{left|right}_hand.rotation`, aim its ray at
+the object, drive that hand's `squeeze_value` across the 0.5 edge, then step and
+verify the result. Nearby movable items should attach to a hand (check
+`left_hand_entity_id` / `right_hand_entity_id` in `/v1/info`) and release when
+squeeze returns below 0.5. Do not use the flat crosshair/`aimAt` result as proof
+that a VR hand can reach or operate something.
+
+Use the actual VR forearm/two-hand UI and interaction whenever it is available.
+If `/v1/ui`, pointer input, inventory access, combat, or another debug-runtime
+lever only exposes the flat path, try the closest production VR input first and
+record the missing VR access as a `vr` + `tool` finding. Mark it as a blocker
+when it prevents the session goal. A debug-injected Frob may diagnose what lies
+beyond the gap, but does not clear the finding.
 
 **Tab opens the inventory UI in flat mode.** `POST /v1/input/action
 {action:"ToggleUseMode"}` enters the original's metagame "use" mode: `/v1/ui`
@@ -157,15 +201,18 @@ frontier/issues to drive the loop:
   "mission": "medsci1",
   "goal": "reach the eng1 exit",
   "generated": "iteration N",
+  "asset_set": "25th",
+  "presentation": "flat|vr",
   "frontier": "medsci1 @ (x,y,z) — reached the locked Sci door",
   "verdict": "one-line summary of how it went",
   "steps": [
     { "index": 1, "title": "Wake in cryo bay", "screenshot": "pt-01.png",
       "observation": "what you saw", "action": "what you did",
-      "bug": { "severity": "High|Med|Low", "class": "[gameplay|visual|functionality]", "detail": "..." } }
+      "bug": { "severity": "High|Med|Low", "class": "[gameplay|visual|physics|functionality|tool|test]", "detail": "..." } }
   ],
   "bugs": [
-    { "title": "short", "severity": "High", "class": "[gameplay]", "screenshot": "pt-07.png",
+    { "title": "short", "severity": "High", "class": "[gameplay]", "kind": "bug|feature-gap",
+      "labels": ["bug", "gameplay", "blocker"], "screenshot": "pt-07.png",
       "detail": "what's wrong + how you triggered it", "blocker": true }
   ]
 }
@@ -173,6 +220,9 @@ frontier/issues to drive the loop:
 
 - `steps[].bug` is optional (null when the step was clean).
 - Mark the progress **blocker** (`"blocker": true`) — the manager fixes it first.
+- Suggest only applicable issue `labels` from `bug`, `enhancement`, `gameplay`,
+  `visual`, `physics`, `vr`, `test`, `tool`, and `blocker`; never attach every
+  label mechanically.
 - Set `frontier` to the furthest reachable state so the next session resumes there.
 - Optional **session video**: also capture `frame-NNNN.png` every 4 sim-frames
   during play, stitch with the `video-capture` skill, and set `"video":


### PR DESCRIPTION
## Summary

- pin playtest and play-through launches to the 25th Anniversary install and migrate existing rolled legacy-asset ledgers without losing their frontier
- replace the asset-set roll with a reproducible 50/50 flatscreen/VR presentation roll, and support `--vr` as a first-class override for new or resumed campaigns
- teach playtest sessions to exercise the production VR hand path, record assets/presentation in `data.json`, and file issues with applicable GitHub labels (`gameplay`, `blocker`, `vr`, `test`, `tool`, etc.)

The debug runtime already supports `--vr`, so this change deliberately puts that path into regular playtest coverage; missing VR UI/input accessibility should now surface as actionable `vr` + `tool` findings.

Repository setup performed alongside this PR: added the `test` and `tool` issue labels because those labels did not previously exist.

## Validation

- `node --test .claude/skills/play-through/playthrough-state.test.mjs` (7 passing)
- skill-creator `quick_validate.py` for both `playtest` and `play-through`
- verified `$HOME/ss2-25th/sshock2.kpf` exists
- `git diff --check`

## Visual evidence

Not applicable: this changes playtest orchestration and QA reporting only; it does not alter player-visible rendering.
