### PR TITLE
fix(ui): fit replicator catalog object icons

### DIFF
--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -655,15 +655,15 @@ impl GuiComponentRenderInfo {
         }
     }
 
-    /// Whether this is Dark object-icon art: keyed on palette index 0 and
-    /// blitted at its authored pixel size, centered in its slot.
+    /// Whether this is Dark object-icon art keyed on palette index 0. Its
+    /// sizing policy may be native-size or fitted to the slot.
     pub(crate) fn is_object_icon(&self) -> bool {
         matches!(
             self,
             Self::Image {
-                kind: ImageKind::ObjectIcon,
+                kind,
                 ..
-            }
+            } if kind.transparent_index_0()
         )
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -885,13 +885,17 @@ fn draw_components(
             // The original MFD art is opaque on screen; the render-info
             // alpha is a VR world-quad translucency, deliberately not
             // applied here.
-            GuiComponentRenderInfo::Image { texture, .. } => {
-                if component.is_object_icon() {
-                    canvas.object_icon(r, texture);
-                } else {
+            GuiComponentRenderInfo::Image { texture, kind, .. } => match kind {
+                crate::ui::ImageKind::Ui => {
                     canvas.image(r, texture);
                 }
-            }
+                crate::ui::ImageKind::ObjectIcon => {
+                    canvas.object_icon(r, texture);
+                }
+                crate::ui::ImageKind::ObjectIconFit => {
+                    canvas.fitted_object_icon(r, texture);
+                }
+            },
             GuiComponentRenderInfo::Text { text, font, .. } => {
                 // Render at the font's native pixel height (the Dark engine
                 // draws its bitmap fonts 1:1), not the component's box height -

--- a/shock2vr/src/scripts/gui/replicator.rs
+++ b/shock2vr/src/scripts/gui/replicator.rs
@@ -153,7 +153,11 @@ impl Gui<ReplicatorState, ReplicatorMsg> for ReplicatorGui {
             size: vec2(30.0, button_height - 10.0),
             texture: icon.to_owned(),
             alpha: 0.5,
-            kind: crate::ui::ImageKind::Ui,
+            // Replicator catalogs use the same PropObjIcon art as inventory,
+            // including palette-index-0 transparency. Unlike an inventory
+            // grid, this compact list has fixed 30x50 icon boxes, so uniformly
+            // fit oversized art rather than letting a tall icon overlap rows.
+            kind: crate::ui::ImageKind::ObjectIconFit,
         };
 
         let mut components: Vec<GuiComponent<ReplicatorMsg>> = vec![
@@ -450,10 +454,12 @@ fn effective_replicator_cost(world: &World, authored_cost: i32) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::super::keypad::{HackNode, HackPhase, base_hack_board, board_index};
     use super::*;
     use crate::gui::GuiScript;
-    use crate::mission::PlayerInfo;
+    use crate::mission::{EntityMetadata, PlayerInfo};
     use crate::physics::PhysicsWorld;
     use crate::runtime_props::RuntimePropTransform;
     use crate::scripts::{MessagePayload, Script};
@@ -469,6 +475,44 @@ mod tests {
             Effect::Combined { effects } => effects.iter().any(creates_template),
             _ => false,
         }
+    }
+
+    #[test]
+    fn catalog_item_art_is_declared_as_an_object_icon() {
+        let mut world = World::new();
+        world.add_unique(GlobalEntityMetadata(HashMap::from([(
+            "test item".to_owned(),
+            EntityMetadata {
+                template_id: -1,
+                obj_icon: Some("icn_pist.pcx".to_owned()),
+                obj_short_name: Some("Test item".to_owned()),
+                obj_name: None,
+            },
+        )])));
+        let replicator = world.add_entity(PropReplicatorContents {
+            costs: [10, 0, 0, 0, 0, 0],
+            object_names: [
+                "test item".to_owned(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ],
+        });
+
+        let components =
+            ReplicatorGui.get_components(&None, replicator, &world, &ReplicatorState::default());
+        let kind = components.iter().find_map(|component| match component {
+            GuiComponent::Image { texture, kind, .. } if texture == "icn_pist.pcx" => Some(*kind),
+            _ => None,
+        });
+
+        assert_eq!(
+            kind,
+            Some(crate::ui::ImageKind::ObjectIconFit),
+            "PropObjIcon art must key palette index 0 and preserve its aspect ratio"
+        );
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -161,9 +161,21 @@ pub enum ImageKind {
     #[default]
     Ui,
     /// Object-icon art: palette index 0 is transparent, and the icon draws at
-    /// its authored pixel size anchored to the element rect's top-left corner.
+    /// its authored pixel size centered inside the element rect.
     /// The rect still defines the element's slot for layout and hit-testing.
     ObjectIcon,
+    /// Object-icon art constrained to the element's rect. Palette index 0 is
+    /// transparent as above, but oversized art is scaled down uniformly and
+    /// centered so compact lists can show icons of every inventory footprint
+    /// without stretching or overlapping adjacent rows. Smaller art remains
+    /// at its authored size.
+    ObjectIconFit,
+}
+
+impl ImageKind {
+    pub(crate) fn transparent_index_0(self) -> bool {
+        matches!(self, Self::ObjectIcon | Self::ObjectIconFit)
+    }
 }
 
 /// One item in the shared 2D UI description language.
@@ -342,6 +354,18 @@ where
         self
     }
 
+    /// Add object-icon art centered and aspect-fitted inside `rect`.
+    pub fn fitted_object_icon(&mut self, rect: Rect, texture: &str) -> &mut Self {
+        self.elements.push(UiElement::Image {
+            position: vec2(rect.x, rect.y),
+            size: vec2(rect.w, rect.h),
+            texture: texture.to_owned(),
+            alpha: 1.0,
+            kind: ImageKind::ObjectIconFit,
+        });
+        self
+    }
+
     pub fn bar(&mut self, rect: Rect, texture: &str, fill: f32) -> &mut Self {
         self.elements.push(UiElement::Bar {
             position: vec2(rect.x, rect.y),
@@ -467,7 +491,7 @@ where
                         texture,
                         &TextureOptions {
                             wrap: false,
-                            transparent_index_0: *kind == ImageKind::ObjectIcon,
+                            transparent_index_0: kind.transparent_index_0(),
                         },
                     );
                     let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), *kind);
@@ -503,7 +527,7 @@ where
                         texture,
                         &TextureOptions {
                             wrap: false,
-                            transparent_index_0: kind == ImageKind::ObjectIcon,
+                            transparent_index_0: kind.transparent_index_0(),
                         },
                     );
                     let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), kind);
@@ -728,7 +752,7 @@ fn world_image(
             texture,
             &TextureOptions {
                 wrap: false,
-                transparent_index_0: kind == ImageKind::ObjectIcon,
+                transparent_index_0: kind.transparent_index_0(),
             },
         )
         .clone();
@@ -741,8 +765,8 @@ fn world_image(
 }
 
 /// The size an element's art actually draws at: its slot rect for ordinary UI
-/// art, or the icon's own authored pixels for [`ImageKind::ObjectIcon`], which
-/// the original blits 1:1 into the slot rather than stretching to fill it.
+/// art, the icon's own authored pixels for [`ImageKind::ObjectIcon`], or those
+/// authored pixels uniformly downscaled to fit for [`ImageKind::ObjectIconFit`].
 pub(crate) fn drawn_rect(
     position: Vector2<f32>,
     size: Vector2<f32>,
@@ -752,6 +776,11 @@ pub(crate) fn drawn_rect(
     match kind {
         ImageKind::Ui => (position, size),
         ImageKind::ObjectIcon => (position + centered_offset(size, texture_px), texture_px),
+        ImageKind::ObjectIconFit => {
+            let scale = (size.x / texture_px.x).min(size.y / texture_px.y).min(1.0);
+            let fitted = texture_px * scale;
+            (position + centered_offset(size, fitted), fitted)
+        }
     }
 }
 
@@ -893,6 +922,24 @@ mod tests {
             (at + centered_offset(slot, icon), icon)
         );
         assert_eq!(drawn_rect(at, slot, icon, ImageKind::Ui), (at, slot));
+    }
+
+    #[test]
+    fn fitted_object_icons_letterbox_without_distorting_or_upscaling() {
+        let slot = vec2(30.0, 50.0);
+        let at = vec2(10.0, 15.0);
+        assert!(ImageKind::ObjectIconFit.transparent_index_0());
+
+        let (tall_at, tall_size) = drawn_rect(at, slot, vec2(34.0, 99.0), ImageKind::ObjectIconFit);
+        assert_eq!(tall_at, at + vec2(6.0, 0.0));
+        assert!((tall_size.x - 34.0 * 50.0 / 99.0).abs() < 1e-5);
+        assert!((tall_size.y - 50.0).abs() < 1e-5);
+
+        assert_eq!(
+            drawn_rect(at, slot, vec2(16.0, 16.0), ImageKind::ObjectIconFit),
+            (at + vec2(7.0, 17.0), vec2(16.0, 16.0)),
+            "small icons should retain their authored pixels"
+        );
     }
 
     /// ...and centered in the slot, so narrow art (the 22px wrench in a 35px


### PR DESCRIPTION
## Reproduction

`ReplicatorGui` rendered each catalog item's real `PropObjIcon` as ordinary `ImageKind::Ui` art in a fixed 30x50 rect. That made palette index 0 opaque (black boxes behind the item art) and stretched every icon to 30x50, distorting its aspect ratio.

Negative-first regression evidence: `catalog_item_art_is_declared_as_an_object_icon` failed on `origin/main` because the catalog's `icn_pist.pcx` element was `Some(Ui)`.

## Fix

Add a fitted object-icon policy for compact panels:

- preserve Dark's palette-index-0 transparency;
- preserve authored aspect ratio;
- downscale only when the art exceeds the 30x50 catalog box;
- center/letterbox it so tall item art cannot overlap adjacent rows;
- carry the policy through screen-space, flat MFD, and VR panel rendering.

The inventory grid's existing native-size `ObjectIcon` behavior is unchanged.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' cargo test -p shock2vr` — 576 passed
- `npm test` — 26 passed, 212 opt-in skipped
- full `npm run test:e2e` — 238 total: 229 passed, 7 skipped, 2 known current-main failures:
  - `creature-loot` reader binding (#931)
  - `shodan-corpse-drift`
- both normal and hacked Earth replicator scenarios passed, including purchase and save/load; all 23 mission-load smoke tests passed.

## Visual verification

![Replicator catalog icon fitting demo](https://gist.githubusercontent.com/tommy-xr/11d8e7dc2a1a72e45e042e7aba81f69b/raw/replicator-icons-after.gif)

<sub>Replicator catalog icons now key out black backgrounds and preserve the authored item-art aspect ratio inside each row. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Matched fresh-launch capture: `origin/main` at `997383e` (before) and `ad8c175` (after).

### Fixed still

![Replicator catalog icons after](https://gist.githubusercontent.com/tommy-xr/11d8e7dc2a1a72e45e042e7aba81f69b/raw/replicator-icons-after.png)

### Before → after

![Replicator catalog icon fitting before and after](https://gist.githubusercontent.com/tommy-xr/11d8e7dc2a1a72e45e042e7aba81f69b/raw/replicator-icons-before-after.png)

Fixes #923
