### PR TITLE
fix(debug-runtime): report live controls in info snapshot

### DIFF
--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -756,7 +756,7 @@ pub struct PlayerInfo {
 /// Input state snapshot
 #[derive(Debug, Serialize, Clone)]
 pub struct InputSnapshot {
-    pub head_rotation: [f32; 4], // quaternion
+    pub head_rotation: [f32; 4], // Quaternion [x, y, z, w]
     pub hands: HandsSnapshot,
 }
 
@@ -771,7 +771,7 @@ pub struct HandsSnapshot {
 #[derive(Debug, Serialize, Clone)]
 pub struct HandSnapshot {
     pub position: [f32; 3],
-    pub rotation: [f32; 4], // quaternion
+    pub rotation: [f32; 4], // Quaternion [x, y, z, w]
     pub thumbstick: [f32; 2],
     pub trigger: f32,
     pub squeeze: f32,

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -908,7 +908,7 @@ fn process_command(
 ) {
     match command {
         RuntimeCommand::GetInfo(reply) => {
-            let snapshot = capture_frame_snapshot(game, time, frame_counter);
+            let snapshot = capture_frame_snapshot(game, time, frame_counter, current_input);
             if let Err(_) = reply.send(snapshot) {
                 tracing::warn!("Failed to send frame snapshot - receiver dropped");
             }
@@ -2008,8 +2008,35 @@ fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> 
     }
 }
 
+fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
+    fn hand_snapshot(hand: commands::InputHand) -> HandSnapshot {
+        HandSnapshot {
+            position: hand.position,
+            rotation: hand.rotation,
+            thumbstick: hand.thumbstick,
+            trigger: hand.trigger_value,
+            squeeze: hand.squeeze_value,
+            a: hand.a_value,
+        }
+    }
+
+    let input = input_state_from_context(input);
+    InputSnapshot {
+        head_rotation: input.head.rotation,
+        hands: HandsSnapshot {
+            left: hand_snapshot(input.left_hand),
+            right: hand_snapshot(input.right_hand),
+        },
+    }
+}
+
 /// Capture current game state as a frame snapshot
-fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> FrameSnapshot {
+fn capture_frame_snapshot(
+    game: &Game,
+    time: &Time,
+    frame_counter: u64,
+    current_input: &InputContext,
+) -> FrameSnapshot {
     let world = game.world();
 
     // Query entity count by getting all entities with template IDs
@@ -2137,27 +2164,7 @@ fn capture_frame_snapshot(game: &Game, time: &Time, frame_counter: u64) -> Frame
         },
         entity_count,
         debug_features: vec![], // TODO: List active debug features
-        inputs: InputSnapshot {
-            head_rotation: [1.0, 0.0, 0.0, 0.0],
-            hands: HandsSnapshot {
-                left: HandSnapshot {
-                    position: [0.0, 0.0, 0.0],
-                    rotation: [1.0, 0.0, 0.0, 0.0],
-                    thumbstick: [0.0, 0.0],
-                    trigger: 0.0,
-                    squeeze: 0.0,
-                    a: 0.0,
-                },
-                right: HandSnapshot {
-                    position: [0.0, 0.0, 0.0],
-                    rotation: [1.0, 0.0, 0.0, 0.0],
-                    thumbstick: [0.0, 0.0],
-                    trigger: 0.0,
-                    squeeze: 0.0,
-                    a: 0.0,
-                },
-            },
-        },
+        inputs: input_snapshot_from_context(current_input),
     }
 }
 
@@ -3775,5 +3782,43 @@ mod shutdown_tests {
                 .1
                 .contains("collision_groups must contain at least one group")
         );
+    }
+
+    #[test]
+    fn info_input_snapshot_reports_patched_live_controls() {
+        let mut input = InputContext::default();
+        for (channel, value) in [
+            ("head.rotation", json!([0.0, 1.0, 0.0, 0.0])),
+            ("left_hand.position", json!([1.25, -2.5, 3.75])),
+            ("left_hand.rotation", json!([1.0, 0.0, 0.0, 0.0])),
+            ("left_hand.thumbstick", json!([0.25, -0.75])),
+            ("left_hand.trigger", json!(0.2)),
+            ("left_hand.squeeze", json!(0.4)),
+            ("left_hand.a", json!(0.6)),
+            ("right_hand.position", json!([-1.5, 2.25, -3.0])),
+            ("right_hand.rotation", json!([0.0, 0.0, 1.0, 0.0])),
+            ("right_hand.thumbstick", json!([-0.5, 0.75])),
+            ("right_hand.trigger", json!(0.3)),
+            ("right_hand.squeeze", json!(0.5)),
+            ("right_hand.a", json!(0.7)),
+        ] {
+            apply_input_patch(&mut input, channel, &value).unwrap();
+        }
+
+        let snapshot = input_snapshot_from_context(&input);
+
+        assert_eq!(snapshot.head_rotation, [0.0, 1.0, 0.0, 0.0]);
+        assert_eq!(snapshot.hands.left.position, [1.25, -2.5, 3.75]);
+        assert_eq!(snapshot.hands.left.rotation, [1.0, 0.0, 0.0, 0.0]);
+        assert_eq!(snapshot.hands.left.thumbstick, [0.25, -0.75]);
+        assert_eq!(snapshot.hands.left.trigger, 0.2);
+        assert_eq!(snapshot.hands.left.squeeze, 0.4);
+        assert_eq!(snapshot.hands.left.a, 0.6);
+        assert_eq!(snapshot.hands.right.position, [-1.5, 2.25, -3.0]);
+        assert_eq!(snapshot.hands.right.rotation, [0.0, 0.0, 1.0, 0.0]);
+        assert_eq!(snapshot.hands.right.thumbstick, [-0.5, 0.75]);
+        assert_eq!(snapshot.hands.right.trigger, 0.3);
+        assert_eq!(snapshot.hands.right.squeeze, 0.5);
+        assert_eq!(snapshot.hands.right.a, 0.7);
     }
 }

--- a/tools/shock2-sdk/test/info-inputs.e2e.test.ts
+++ b/tools/shock2-sdk/test/info-inputs.e2e.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+
+// Negative-first: /v1/control/input accepted and used these controls while
+// /v1/info.inputs returned only hard-coded defaults.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+test(
+  "/v1/info reports the live controls used for the current frame",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "debug_minimal",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 9370),
+    });
+
+    for (const [channel, value] of [
+      ["head.rotation", [0, 1, 0, 0]],
+      ["left_hand.position", [1.25, -2.5, 3.75]],
+      ["left_hand.rotation", [1, 0, 0, 0]],
+      ["left_hand.thumbstick", [0.25, -0.75]],
+      ["left_hand.trigger", 0.2],
+      ["left_hand.squeeze", 0.4],
+      ["left_hand.a", 0.6],
+      ["right_hand.position", [-1.5, 2.25, -3]],
+      ["right_hand.rotation", [0, 0, 1, 0]],
+      ["right_hand.thumbstick", [-0.5, 0.75]],
+      ["right_hand.trigger", 0.3],
+      ["right_hand.squeeze", 0.5],
+      ["right_hand.a", 0.7],
+    ] as const) {
+      await game.input.set(channel, value);
+    }
+
+    await game.step({ frames: 1 });
+
+    const info = (await game.info()) as {
+      inputs: {
+        head_rotation: number[];
+        hands: {
+          left: {
+            position: number[];
+            rotation: number[];
+            thumbstick: number[];
+            trigger: number;
+            squeeze: number;
+            a: number;
+          };
+          right: {
+            position: number[];
+            rotation: number[];
+            thumbstick: number[];
+            trigger: number;
+            squeeze: number;
+            a: number;
+          };
+        };
+      };
+    };
+
+    assert.deepEqual(info.inputs, {
+      head_rotation: [0, 1, 0, 0],
+      hands: {
+        left: {
+          position: [1.25, -2.5, 3.75],
+          rotation: [1, 0, 0, 0],
+          thumbstick: [0.25, -0.75],
+          trigger: 0.2,
+          squeeze: 0.4,
+          a: 0.6,
+        },
+        right: {
+          position: [-1.5, 2.25, -3],
+          rotation: [0, 0, 1, 0],
+          thumbstick: [-0.5, 0.75],
+          trigger: 0.3,
+          squeeze: 0.5,
+          a: 0.7,
+        },
+      },
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- pass the debug runtime owned `InputContext` into `/v1/info` frame capture
- serialize `inputs` through the same live state conversion used by `/v1/control/input`
- cover every existing head and hand snapshot field with negative-first unit and runtime tests

## Reproduction

1. Launch the debug runtime and patch non-default hand pose, rotation, thumbstick, trigger, squeeze, and A-button channels through `POST /v1/control/input`.
2. Step one frame.
3. Read `GET /v1/info`.

Before this change, `inputs` remained hard-coded identity/zero values even though the patched controls drove the current frame and `GET /v1/control/input` echoed them. After this change, `/v1/info.inputs` reports the runtime-owned live values in the existing response shape.

Campaign: command · none · 25th Anniversary assets · VR · seed 2110635141.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p debug_runtime` — 5 passed, 1 display-dependent integration test ignored
- `cargo test -p shock2vr` — 574 passed
- `npm test` in `tools/shock2-sdk` — 26 passed, opt-in E2E scenarios skipped
- focused `info-inputs.e2e.test.ts` on 25th Anniversary assets — 1 passed
- `cargo fmt --all -- --check`

## PR visuals assessment

Not applicable. This changes only debug-runtime JSON observability; it does not alter rendering, HUD, world visuals, animation, or any player-visible behavior.

Fixes #937