### PR TITLE
fix(audio): track spatial emitters with head rotation

### DIFF
--- a/engine/src/audio/mod.rs
+++ b/engine/src/audio/mod.rs
@@ -55,46 +55,92 @@ pub trait BackgroundMusic<TCue> {
     fn next_clip(&mut self, cue: Option<TCue>) -> Option<Rc<AudioClip>>;
 }
 
-pub enum SinkAdapter {
-    StaticSink(SpatialSink),
-    PositionalSink(SpatialSink),
+#[derive(Clone, Copy, Debug)]
+struct TrackedEmitter<TSourceKey> {
+    position: Vector3<f32>,
+    source: Option<TSourceKey>,
 }
 
-impl SinkAdapter {
-    pub fn inner(&self) -> &SpatialSink {
-        match self {
-            SinkAdapter::StaticSink(sink) => sink,
-            SinkAdapter::PositionalSink(sink) => sink,
+impl<TSourceKey> TrackedEmitter<TSourceKey>
+where
+    TSourceKey: Copy,
+{
+    fn new(position: Vector3<f32>, source: Option<TSourceKey>) -> Self {
+        Self { position, source }
+    }
+
+    fn refresh<F>(&mut self, mut source_position: F)
+    where
+        F: FnMut(TSourceKey) -> Option<Vector3<f32>>,
+    {
+        if let Some(position) = self.source.and_then(&mut source_position) {
+            self.position = position;
         }
     }
 
-    pub fn fixed(sink: SpatialSink) -> SinkAdapter {
+    fn position(&self) -> Vector3<f32> {
+        self.position
+    }
+}
+
+enum SinkAdapter<TSourceKey> {
+    StaticSink(SpatialSink),
+    PositionalSink {
+        sink: SpatialSink,
+        emitter: TrackedEmitter<TSourceKey>,
+    },
+}
+
+impl<TSourceKey> SinkAdapter<TSourceKey>
+where
+    TSourceKey: Copy,
+{
+    fn inner(&self) -> &SpatialSink {
+        match self {
+            SinkAdapter::StaticSink(sink) => sink,
+            SinkAdapter::PositionalSink { sink, .. } => sink,
+        }
+    }
+
+    fn fixed(sink: SpatialSink) -> SinkAdapter<TSourceKey> {
         SinkAdapter::StaticSink(sink)
     }
 
-    pub fn positional(sink: SpatialSink) -> SinkAdapter {
-        SinkAdapter::PositionalSink(sink)
+    fn positional(
+        sink: SpatialSink,
+        position: Vector3<f32>,
+        source: Option<TSourceKey>,
+    ) -> SinkAdapter<TSourceKey> {
+        SinkAdapter::PositionalSink {
+            sink,
+            emitter: TrackedEmitter::new(position, source),
+        }
     }
 
-    pub fn update_listener_position(
+    fn update_spatial_position<F>(
         &mut self,
         left_ear_position: [f32; 3],
         right_ear_position: [f32; 3],
-    ) {
+        source_position: &mut F,
+    ) where
+        F: FnMut(TSourceKey) -> Option<Vector3<f32>>,
+    {
         match self {
             SinkAdapter::StaticSink(_) => (),
-            SinkAdapter::PositionalSink(sink) => {
+            SinkAdapter::PositionalSink { sink, emitter } => {
+                emitter.refresh(source_position);
+                sink.set_emitter_position(to_audio_position(emitter.position()));
                 sink.set_left_ear_position(left_ear_position);
                 sink.set_right_ear_position(right_ear_position);
             }
         }
     }
 
-    pub fn empty(&self) -> bool {
+    fn empty(&self) -> bool {
         self.inner().empty()
     }
 
-    pub fn stop(&self) {
+    fn stop(&self) {
         self.inner().stop();
     }
 }
@@ -110,7 +156,7 @@ where
     #[allow(dead_code)]
     sinks: Vec<Sink>,
     channel_to_last_handle: HashMap<String, u64>,
-    handle_to_sink: HashMap<u64, SinkAdapter>,
+    handle_to_sink: HashMap<u64, SinkAdapter<TAmbientKey>>,
     // Background music
     background_music: Option<Sink>,
     background_music_player: Option<Box<dyn BackgroundMusic<TCue>>>,
@@ -189,11 +235,15 @@ where
         self.environmental_sink = Some((sink, clip.clone()));
     }
 
-    pub fn update(
+    pub fn update<F>(
         &mut self,
-        position: Vector3<f32>,
+        left_ear_position: Vector3<f32>,
+        right_ear_position: Vector3<f32>,
         current_ambient_sounds: Vec<(TAmbientKey, Vector3<f32>, Rc<AudioClip>)>,
-    ) {
+        mut source_position: F,
+    ) where
+        F: FnMut(TAmbientKey) -> Option<Vector3<f32>>,
+    {
         audio_log!(DEBUG, "Audio system update started");
         self.update_background_music();
         self.update_environmental_sounds();
@@ -203,16 +253,8 @@ where
             current_ambient_sounds.len()
         );
 
-        let left_ear_position = [
-            (position.x - 1.0) / SOUND_SCALE_FACTOR,
-            position.y / SOUND_SCALE_FACTOR,
-            position.z / SOUND_SCALE_FACTOR,
-        ];
-        let right_ear_position = [
-            (position.x + 1.0) / SOUND_SCALE_FACTOR,
-            position.y / SOUND_SCALE_FACTOR,
-            position.z / SOUND_SCALE_FACTOR,
-        ];
+        let left_ear_position = to_audio_position(left_ear_position);
+        let right_ear_position = to_audio_position(right_ear_position);
 
         self.last_left_ear_position = vec3(
             left_ear_position[0],
@@ -228,7 +270,11 @@ where
         self.handle_to_sink.retain(|_, sink| !sink.empty());
         // Update positional sounds
         for sink in self.handle_to_sink.values_mut() {
-            sink.update_listener_position(left_ear_position, right_ear_position);
+            sink.update_spatial_position(
+                left_ear_position,
+                right_ear_position,
+                &mut source_position,
+            );
         }
 
         // Build hash map for new ambient sounds
@@ -245,11 +291,7 @@ where
                     clip.add_to_spatial_sink(sink);
                 }
 
-                sink.set_emitter_position([
-                    current_sound.0.x / SOUND_SCALE_FACTOR,
-                    current_sound.0.y / SOUND_SCALE_FACTOR,
-                    current_sound.0.z / SOUND_SCALE_FACTOR,
-                ]);
+                sink.set_emitter_position(to_audio_position(*current_sound.0));
 
                 // TODO
                 sink.set_left_ear_position(left_ear_position);
@@ -272,11 +314,7 @@ where
             if !self.ambient_sounds.contains_key(key) {
                 let sink = rodio::SpatialSink::try_new(
                     &self.handle,
-                    [
-                        pos.x / SOUND_SCALE_FACTOR,
-                        pos.y / SOUND_SCALE_FACTOR,
-                        pos.z / SOUND_SCALE_FACTOR,
-                    ],
+                    to_audio_position(*pos),
                     left_ear_position,
                     right_ear_position,
                 )
@@ -452,6 +490,7 @@ pub fn play_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
 pub fn play_spatial_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     context: &mut AudioContext<TAmbientKey, TCue>,
     position: Vector3<f32>,
+    source: Option<TAmbientKey>,
     handle: AudioHandle,
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
@@ -463,8 +502,16 @@ pub fn play_spatial_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
 
     context
         .handle_to_sink
-        .insert(id, SinkAdapter::positional(sink));
+        .insert(id, SinkAdapter::positional(sink, position, source));
     preempted
+}
+
+fn to_audio_position(position: Vector3<f32>) -> [f32; 3] {
+    [
+        position.x / SOUND_SCALE_FACTOR,
+        position.y / SOUND_SCALE_FACTOR,
+        position.z / SOUND_SCALE_FACTOR,
+    ]
 }
 
 pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
@@ -531,7 +578,8 @@ pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
 
 #[cfg(test)]
 mod tests {
-    use super::wav_duration;
+    use super::{TrackedEmitter, wav_duration};
+    use cgmath::vec3;
 
     fn riff(avg_bytes_per_sec: u32, data_len: usize) -> Vec<u8> {
         let mut fmt = Vec::new();
@@ -568,5 +616,17 @@ mod tests {
     fn wav_duration_rejects_non_riff_buffers() {
         assert!(wav_duration(b"not a wave file at all").is_none());
         assert!(wav_duration(&[]).is_none());
+    }
+
+    #[test]
+    fn positional_emitter_refreshes_from_its_live_source() {
+        let mut emitter = TrackedEmitter::new(vec3(1.0, 2.0, 3.0), Some(7_u32));
+
+        emitter.refresh(|source| {
+            assert_eq!(source, 7);
+            Some(vec3(4.0, 5.0, 6.0))
+        });
+
+        assert_eq!(emitter.position(), vec3(4.0, 5.0, 6.0));
     }
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -133,6 +133,17 @@ use crate::{
 };
 use zip_asset_path::ZipAssetPath;
 
+const AUDIO_EAR_OFFSET: f32 = 1.0;
+
+fn listener_ear_positions(
+    position: Vector3<f32>,
+    player_rotation: Quaternion<f32>,
+    head_rotation: Quaternion<f32>,
+) -> (Vector3<f32>, Vector3<f32>) {
+    let right = (player_rotation * head_rotation) * vec3(AUDIO_EAR_OFFSET, 0.0, 0.0);
+    (position - right, position + right)
+}
+
 fn read_save_file(path: &Path) -> io::Result<SaveData> {
     let mut file = File::open(path)?;
     Ok(SaveData::read(&mut file))
@@ -1152,19 +1163,27 @@ impl Game {
 
         // Handle ambient audio
         let ambient_state = self.active_game_scene.ambient_audio_state();
+        let player_pose = self
+            .active_game_scene
+            .world()
+            .borrow::<UniqueView<PlayerInfo>>()
+            .ok()
+            .map(|player_info| (player_info.pos, player_info.rotation));
         let listener_position = ambient_state
             .as_ref()
             .map(|state| state.player_position)
-            .or_else(|| {
-                self.active_game_scene
-                    .world()
-                    .borrow::<UniqueView<PlayerInfo>>()
-                    .ok()
-                    .map(|player_info| player_info.pos)
-            })
+            .or_else(|| player_pose.map(|pose| pose.0))
             .unwrap_or(vec3(0.0, 0.0, 0.0));
+        let player_rotation = player_pose
+            .map(|pose| pose.1)
+            .unwrap_or_else(|| Quaternion::new(1.0, 0.0, 0.0, 0.0));
+        let (left_ear_position, right_ear_position) = listener_ear_positions(
+            listener_position,
+            player_rotation,
+            input_context.head.rotation,
+        );
 
-        if let Some(state) = ambient_state {
+        let ambient_sounds = if let Some(state) = ambient_state {
             if let Some(cue) = state.music_cue {
                 self.update_music_cue_if_necessary(cue);
             }
@@ -1174,7 +1193,7 @@ impl Game {
                 self.update_env_sound_if_necessary(resolved);
             }
 
-            let ambient_sounds = state
+            state
                 .ambient_emitters
                 .into_iter()
                 .filter_map(|(id, position, schema_name)| {
@@ -1184,12 +1203,18 @@ impl Game {
                         .get_opt(&AUDIO_IMPORTER, &format!("{asset_name}.wav"));
                     maybe_audio_clip.map(|clip| (id, position, clip.clone()))
                 })
-                .collect::<Vec<(EntityId, Vector3<f32>, Rc<AudioClip>)>>();
-
-            self.audio_context.update(listener_position, ambient_sounds);
+                .collect::<Vec<(EntityId, Vector3<f32>, Rc<AudioClip>)>>()
         } else {
-            self.audio_context.update(listener_position, Vec::new());
-        }
+            Vec::new()
+        };
+
+        let world = self.active_game_scene.world();
+        self.audio_context.update(
+            left_ear_position,
+            right_ear_position,
+            ambient_sounds,
+            |entity_id| util::get_entity_position(world, entity_id),
+        );
 
         // Handle global effects
         let global_effects = self.active_game_scene.handle_effects(
@@ -1578,6 +1603,7 @@ impl Game {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::{Deg, InnerSpace, Rotation3};
     use std::path::PathBuf;
 
     fn features(list: &[&str]) -> HashSet<String> {
@@ -1626,5 +1652,17 @@ mod tests {
         let result = read_save_file(&missing);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn listener_ears_follow_head_rotation() {
+        let position = vec3(10.0, 20.0, 30.0);
+        let player_rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        let head_rotation = Quaternion::from_angle_y(Deg(90.0));
+
+        let (left, right) = listener_ear_positions(position, player_rotation, head_rotation);
+
+        assert!((left - vec3(10.0, 20.0, 31.0)).magnitude() < 0.0001);
+        assert!((right - vec3(10.0, 20.0, 29.0)).magnitude() < 0.0001);
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -102,7 +102,7 @@ use crate::{
     },
     teleport::{TeleportSystem, TeleportUI, TeleportVisualStyle},
     time::Time,
-    util::{debug_entity, get_email_sound_file, has_refs, vec3_to_point3},
+    util::{debug_entity, get_email_sound_file, get_entity_position, has_refs, vec3_to_point3},
     virtual_hand::VirtualHandEffect,
     vr_config,
 };
@@ -4504,6 +4504,7 @@ impl MissionCore {
                             engine::audio::play_spatial_audio(
                                 audio_context,
                                 position,
+                                source,
                                 handle,
                                 None,
                                 audio_clip,
@@ -4551,6 +4552,7 @@ impl MissionCore {
                                 engine::audio::play_spatial_audio(
                                     audio_context,
                                     position,
+                                    Some(entity_id),
                                     handle,
                                     None,
                                     audio_clip,
@@ -6594,24 +6596,6 @@ pub fn make_un_physical2(
     id_to_physics.remove(&entity_id);
 }
 
-fn get_entity_position(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
-    // Prefer the live transform; PropPosition can lag for entities moved by
-    // animation/physics, and is frozen for held/contained entities.
-    if let Ok(transforms) = world.borrow::<View<RuntimePropTransform>>() {
-        if let Ok(xform) = transforms.get(entity_id) {
-            use cgmath::Transform;
-            let p = xform.0.transform_point(cgmath::point3(0.0, 0.0, 0.0));
-            return Some(vec3(p.x, p.y, p.z));
-        }
-    }
-    if let Ok(positions) = world.borrow::<View<PropPosition>>() {
-        if let Ok(prop) = positions.get(entity_id) {
-            return Some(prop.position);
-        }
-    }
-    None
-}
-
 fn resolve_schema(global_context: &GlobalContext, name: &str) -> String {
     let sound_schema = &global_context.gamesys.sound_schema;
     let ret = sound_schema
@@ -6720,6 +6704,7 @@ fn play_environmental_sound(
         let preempted = engine::audio::play_spatial_audio(
             audio_context,
             position,
+            None,
             audio_handle,
             None,
             audio_clip,

--- a/shock2vr/src/util.rs
+++ b/shock2vr/src/util.rs
@@ -100,6 +100,22 @@ pub fn get_position_from_transform(
     }
 }
 
+/// The entity's current world position, preferring the runtime transform that
+/// follows animation and physics over the authored position property.
+pub fn get_entity_position(world: &World, entity_id: EntityId) -> Option<Vector3<f32>> {
+    if let Ok(transforms) = world.borrow::<View<RuntimePropTransform>>() {
+        if let Ok(xform) = transforms.get(entity_id) {
+            return Some(point3_to_vec3(
+                xform.0.transform_point(point3(0.0, 0.0, 0.0)),
+            ));
+        }
+    }
+    world
+        .borrow::<View<PropPosition>>()
+        .ok()
+        .and_then(|positions| positions.get(entity_id).ok().map(|prop| prop.position))
+}
+
 pub fn has_refs(world: &World, entity_id: EntityId) -> bool {
     let v_has_refs = world.borrow::<View<PropHasRefs>>().unwrap();
 
@@ -173,6 +189,7 @@ pub fn get_rotation_from_forward_vector(forward: Vector3<f32>) -> Quaternion<f32
 mod tests {
     use super::*;
     use cgmath::{Deg, Matrix4, Point3, Quaternion, Rotation3, Vector3};
+    use shipyard::ViewMut;
 
     #[test]
     fn test_get_position_from_matrix() {
@@ -205,6 +222,33 @@ mod tests {
             close_enough,
             "Rotations are not close enough: {:?} vs {:?}",
             extracted_rotation, known_rotation
+        );
+    }
+
+    #[test]
+    fn entity_position_follows_the_live_runtime_transform() {
+        let mut world = World::new();
+        let entity = world.add_entity((
+            PropPosition {
+                position: vec3(1.0, 2.0, 3.0),
+                cell: 0,
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            },
+            RuntimePropTransform(Matrix4::from_translation(vec3(4.0, 5.0, 6.0))),
+        ));
+
+        assert_eq!(
+            get_entity_position(&world, entity),
+            Some(vec3(4.0, 5.0, 6.0))
+        );
+
+        let mut transforms = world.borrow::<ViewMut<RuntimePropTransform>>().unwrap();
+        (&mut transforms).get(entity).unwrap().0 = Matrix4::from_translation(vec3(7.0, 8.0, 9.0));
+        drop(transforms);
+
+        assert_eq!(
+            get_entity_position(&world, entity),
+            Some(vec3(7.0, 8.0, 9.0))
         );
     }
 }


### PR DESCRIPTION
Fixes #872

## Reproduction

On `origin/main` (`997383e`):

- `SinkAdapter::PositionalSink` stored only the rodio sink. `AudioContext::update` refreshed its ears but never called `set_emitter_position`, so a one-shot remained at its play-time coordinates when its source entity moved.
- Listener ears were derived as `position ± (1, 0, 0)` in world space. Turning the player or headset did not rotate that ear axis, so panning stayed pinned to world X.
- Added the coordinate regressions first. On the unmodified base they failed to compile because there was no source-tracked emitter state and no head-relative ear geometry function, directly confirming both missing behaviors before implementation.

## Fix

- Carry an optional source entity key and last-known world position with each positional one-shot.
- Resolve active source entities from their live `RuntimePropTransform` on every audio update (`PropPosition` remains the fallback) and refresh rodio's emitter position. Sources with no entity, such as contact sounds, remain fixed.
- Derive the listener's right axis from `player_rotation * head_rotation`; pass the resulting left and right ear positions into the audio context for one-shots and ambient emitters.

## Verification

- `RUSTFLAGS='-D warnings' cargo test -p engine positional_emitter_refreshes_from_its_live_source` — 1 passed
- `RUSTFLAGS='-D warnings' cargo test -p shock2vr listener_ears_follow_head_rotation` — 1 passed; a 90° yaw rotates ears from world ±X to ±Z
- `RUSTFLAGS='-D warnings' cargo test -p shock2vr entity_position_follows_the_live_runtime_transform` — 1 passed; a changed runtime transform changes the coordinate returned for the same entity
- `cargo test -p engine` — 37 passed
- `cargo test -p shock2vr` — 576 passed
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed
- `cargo fmt --all -- --check` — passed
- `npm test` in `tools/shock2-sdk` — 26 passed, 212 e2e-only skips
- Full `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked npm run test:e2e` — 229 passed, 2 failed, 7 skipped. The two failures are unrelated existing scenario assertions: creature-loot did not open reader MFD entity 251; a SHODAN assassin corpse drifted 1.604 units. No audio code participates in either assertion.

## Visual proof assessment

Approved non-renderable rationale: this fix changes only the binaural coordinates supplied to rodio—live emitter coordinates and left/right ear positions. The renderer, scene transforms, and visible simulation are unaffected; identical deterministic `/v1/step` + `/v1/screenshot` sequences cannot encode channel gain/panning or distinguish pinned from moving sound. GIF/PNG before/after evidence would therefore be misleading. Objective substitutes are the negative-first coordinate tests above, the full Rust suites, and the runtime E2E suite.
