### PR TITLE
feat(vr): open object panels on frob

### DIFF
--- a/projects/flat-ui.md
+++ b/projects/flat-ui.md
@@ -446,10 +446,9 @@ a **flat presentation + a mouse-cursor input source**, and an **open/close model
   codebase**), which the proxy converts from a world-space hit point into normalized
   panel coordinates. A flat presentation replaces exactly this pair — nothing above
   it.
-- **Gating:** `Effect::SetUI` is only processed under `--experimental gui`
-  (`mission/mission_core.rs:2250-2270`, gate at `:2257`). In a default flat session
-  the panels neither render nor interact — part of why #435 sessions saw *nothing*
-  on frob.
+- **Gating (current):** flat `SetUI` snapshots feed the default MFD host. Default
+  VR feeds only the object-bound world panel opened through `OpenPanel`; the
+  explicit `--experimental gui` mode retains the historical all-panels world.
 
 ### 4.2 Panels already implemented against that trait (`shock2vr/src/scripts/gui/`)
 
@@ -569,7 +568,9 @@ drive frob → panel → take (§6 PR 3's e2e shows how).
    entity — the same message `ProxyGuiScript` synthesizes from the VR hand ray
    (`proxy_gui_script.rs:69-85`). One message type in, all panels work.
 3. **Panels are *opened*, not floating.** Original flat behavior: frob → MFD
-   overlay + cursor; close → cursor released. VR keeps its always-on world quads.
+   overlay + cursor; close → cursor released. Default VR now binds that same
+   `OpenPanel` event to one world quad and closes it on walk-away; only the
+   explicit GUI experiment keeps the old always-on presentation.
 4. **Every increment headlessly verifiable** (repo core principle): pointer
    channels + a UI-introspection endpoint land *with* the first panel, so e2e
    tests click real digits instead of teleporting state.
@@ -653,7 +654,7 @@ save/restore semantics) until taken (transfer link → player backpack, reusing
 | Shared with VR (untouched) | Flat-only (new) |
 | --- | --- |
 | `Gui` trait, all `scripts/gui/*` panels, `GuiScript` state machine, `GUIHover` contract, `Effect` vocabulary (`TurnOn` to SwitchLinks, sounds, grabs) | `FlatUiHost` (mode, active panel, anchor layout), `UiCanvas` panel rendering, cursor draw + `pointer_to_canvas` mapping, Tab action, `wants_pointer` wiring, pointer debug channels, `/v1/ui` |
-| Containment-at-creation fix (VR loot panels also stop double-placing items) | BIOFULL/AMMOFULL expanded readouts, inventory strip docking |
+| Containment-at-creation fix and the frob-bound default-VR world-panel slot | BIOFULL/AMMOFULL expanded readouts, inventory strip docking |
 
 ---
 
@@ -730,8 +731,9 @@ visible.
   path but couples flat rendering to the effect stream; a `FlatUiHost` that *calls*
   `Gui::get_components` directly (skipping `GuiScript`) would duplicate state.
   Current lean: intercept, keep `GuiScript` the single state owner.
-- **`--experimental gui` gate:** flat panels should work by default (they resolve
-  #435); does the VR world-quad path stay gated? Lean: yes, ungate only flat.
+- **`--experimental gui` gate (resolved by #940):** flat panels and the single
+  frob-bound VR world panel work by default. The flag is reserved for the legacy
+  all-panels world presentation.
 - **Keypad check timing fidelity:** the original defers the code check until
   **exactly 5 digits** are typed (`KeypadButton`, §2.3); shock2quest's
   `KeyPadGui` checks after *every* press (`keypad.rs:216-238`) — functionally

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, Matrix4, Vector2, Vector3, vec3};
+use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Vector2, Vector3, vec3};
 
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use rapier3d::prelude::RigidBodyHandle;
-use shipyard::{Component, EntityId, Get, View, World};
+use shipyard::{Component, EntitiesView, EntityId, Get, UniqueView, View, World};
 
 use crate::{
+    mission::PlayerInfo,
     physics::{CollisionGroup, PhysicsWorld},
     runtime_props::{RuntimePropDoNotSerialize, RuntimePropTransform},
     scripts::ScriptWorld,
@@ -16,7 +17,6 @@ use crate::{
 use crate::gui::*;
 
 pub struct GuiInstanceInfo {
-    #[allow(dead_code)]
     pub parent_entity: EntityId,
     pub proxy_entity: EntityId,
     #[allow(dead_code)]
@@ -29,7 +29,16 @@ pub struct GuiInstanceInfo {
 pub struct GuiManager {
     handle_to_instance: HashMap<GuiHandle, GuiInstanceInfo>,
     entity_id_to_proxy_entity_id: HashMap<EntityId, EntityId>,
+    /// The single object-bound world panel opened through `Effect::OpenPanel`
+    /// in default VR. The old `--experimental gui` mode still materializes
+    /// every panel and does not consult this slot.
+    active_panel: Option<EntityId>,
 }
+
+/// Match the original container overlay's distance-close behavior. Four world
+/// units is beyond normal frob reach, so small looting movements keep the
+/// panel open while walking away removes its transient collider and art.
+const PANEL_AUTO_CLOSE_DISTANCE: f32 = 4.0;
 
 #[derive(Component)]
 pub struct GuiPropProxyEntity {
@@ -45,6 +54,139 @@ impl GuiManager {
         GuiManager {
             handle_to_instance: HashMap::new(),
             entity_id_to_proxy_entity_id: HashMap::new(),
+            active_panel: None,
+        }
+    }
+
+    pub fn active_panel(&self) -> Option<EntityId> {
+        self.active_panel
+    }
+
+    /// Bind the default-VR world-panel slot to one gameplay entity. Opening a
+    /// second object removes the first panel's transient proxy, just as the
+    /// original left MFD slot replaces the previous object-bound overlay.
+    ///
+    /// `retain_existing` preserves the legacy `--experimental gui` behavior,
+    /// where all authored panels are materialized at once.
+    pub fn open_panel(
+        &mut self,
+        entity: EntityId,
+        retain_existing: bool,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        if self.active_panel != Some(entity) && !retain_existing {
+            if let Some(previous) = self.active_panel {
+                self.remove_parent_instances(previous, world, physics, scripts, id_to_physics);
+            }
+        }
+        self.active_panel = Some(entity);
+    }
+
+    /// Close the active default-VR panel and remove its non-serialized proxy.
+    pub fn close_panel(
+        &mut self,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        if let Some(parent) = self.active_panel.take() {
+            self.remove_parent_instances(parent, world, physics, scripts, id_to_physics);
+        }
+    }
+
+    /// Preserve the original overlay's close conditions in world space: a
+    /// destroyed host or a player walking away dismisses the panel. Carried
+    /// panel hosts are exempt because their authored world position is stale.
+    pub fn maintain_active_panel(
+        &mut self,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        let Some(parent) = self.active_panel else {
+            return;
+        };
+        let alive = world
+            .borrow::<EntitiesView>()
+            .map(|entities| entities.is_alive(parent))
+            .unwrap_or(false);
+        let carried =
+            alive && crate::scripts::script_util::player_carried_items(world).contains(&parent);
+        let too_far = alive
+            && !carried
+            && world
+                .borrow::<UniqueView<PlayerInfo>>()
+                .map(|player| {
+                    let position = get_position_from_transform(world, parent, vec3(0.0, 0.0, 0.0));
+                    (position.to_vec() - player.pos).magnitude() > PANEL_AUTO_CLOSE_DISTANCE
+                })
+                .unwrap_or(false);
+        if !alive || too_far {
+            self.close_panel(world, physics, scripts, id_to_physics);
+        }
+    }
+
+    /// Remove GUI state owned by a gameplay entity before that entity is
+    /// deleted. This also handles a proxy being removed independently, so no
+    /// recycled `EntityId` can inherit stale panel state.
+    pub fn on_entity_destroyed(
+        &mut self,
+        entity: EntityId,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        if self.active_panel == Some(entity) {
+            self.active_panel = None;
+        }
+        self.remove_parent_instances(entity, world, physics, scripts, id_to_physics);
+
+        let handles: Vec<_> = self
+            .handle_to_instance
+            .iter()
+            .filter_map(|(handle, info)| (info.proxy_entity == entity).then_some(*handle))
+            .collect();
+        for handle in handles {
+            self.handle_to_instance.remove(&handle);
+        }
+        self.entity_id_to_proxy_entity_id
+            .retain(|_, proxy| *proxy != entity);
+    }
+
+    fn remove_parent_instances(
+        &mut self,
+        parent: EntityId,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        let handles: Vec<_> = self
+            .handle_to_instance
+            .iter()
+            .filter_map(|(handle, info)| (info.parent_entity == parent).then_some(*handle))
+            .collect();
+        for handle in handles {
+            if let Some(instance) = self.handle_to_instance.remove(&handle) {
+                let proxy = instance.proxy_entity;
+                self.entity_id_to_proxy_entity_id.remove(&parent);
+                id_to_physics.remove(&proxy);
+                physics.remove(proxy);
+                scripts.remove_entity(proxy);
+                let alive = world
+                    .borrow::<EntitiesView>()
+                    .map(|entities| entities.is_alive(proxy))
+                    .unwrap_or(false);
+                if alive {
+                    world.delete_entity(proxy);
+                }
+            }
         }
     }
 
@@ -119,9 +261,31 @@ impl GuiManager {
     pub fn update(&mut self) {}
 
     pub fn render(&mut self, asset_cache: &mut AssetCache, world: &World) -> Vec<SceneObject> {
+        self.render_filtered(asset_cache, world, false)
+    }
+
+    /// Render only the object-bound default-VR slot. Experimental GUI keeps
+    /// using [`render`](Self::render) to show every authored panel.
+    pub fn render_active(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+    ) -> Vec<SceneObject> {
+        self.render_filtered(asset_cache, world, true)
+    }
+
+    fn render_filtered(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        world: &World,
+        active_only: bool,
+    ) -> Vec<SceneObject> {
         let mut ret = Vec::new();
         let v_transform = world.borrow::<View<RuntimePropTransform>>().unwrap();
         for (_handle, info) in &self.handle_to_instance {
+            if active_only && Some(info.parent_entity) != self.active_panel {
+                continue;
+            }
             let player_mat = engine::scene::color_material::create(Vector3::new(0.0, 0.0, 1.0));
             let mut gui_obj = SceneObject::new(player_mat, Box::new(engine::scene::quad::create()));
             let maybe_transform = v_transform.get(info.proxy_entity);
@@ -157,8 +321,8 @@ impl GuiManager {
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{Matrix4, vec2, vec3};
-    use shipyard::Get;
+    use cgmath::{Matrix4, Quaternion, vec2, vec3};
+    use shipyard::{EntitiesView, Get};
 
     use super::*;
 
@@ -210,5 +374,108 @@ mod tests {
             physics.cuboid_full_size(instance.physics_handle),
             Some(vec3(188.0, 296.0, 0.01))
         );
+    }
+
+    #[test]
+    fn opening_a_second_default_panel_removes_the_first_transient_proxy() {
+        let mut world = World::new();
+        let first = world.add_entity((RuntimePropTransform(Matrix4::from_scale(1.0)),));
+        let second = world.add_entity((RuntimePropTransform(Matrix4::from_scale(1.0)),));
+        let mut physics = PhysicsWorld::new();
+        let mut scripts = ScriptWorld::new();
+        let mut id_to_physics = HashMap::new();
+        let mut manager = GuiManager::new();
+
+        manager.open_panel(
+            first,
+            false,
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+        );
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            GuiHandle::new(),
+            first,
+            vec2(0.75, 1.18),
+            vec3(0.0, 1.0, 0.0),
+            Vec::new(),
+        );
+        let first_instance = manager.handle_to_instance.values().next().unwrap();
+        let first_proxy = first_instance.proxy_entity;
+        let first_physics = first_instance.physics_handle;
+
+        manager.open_panel(
+            second,
+            false,
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+        );
+
+        assert_eq!(manager.active_panel(), Some(second));
+        assert!(manager.handle_to_instance.is_empty());
+        assert!(!id_to_physics.contains_key(&first_proxy));
+        assert!(physics.get_position(first_physics).is_none());
+        assert!(
+            !world
+                .borrow::<EntitiesView>()
+                .unwrap()
+                .is_alive(first_proxy)
+        );
+    }
+
+    #[test]
+    fn walking_beyond_the_overlay_distance_closes_the_default_panel() {
+        let mut world = World::new();
+        let inventory = world.add_entity(());
+        let player_entity = world.add_entity(());
+        let parent = world.add_entity((RuntimePropTransform(Matrix4::from_translation(vec3(
+            PANEL_AUTO_CLOSE_DISTANCE + 1.0,
+            0.0,
+            0.0,
+        ))),));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player_entity,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        let mut physics = PhysicsWorld::new();
+        let mut scripts = ScriptWorld::new();
+        let mut id_to_physics = HashMap::new();
+        let mut manager = GuiManager::new();
+        manager.open_panel(
+            parent,
+            false,
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+        );
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            GuiHandle::new(),
+            parent,
+            vec2(0.75, 1.18),
+            vec3(0.0, 1.0, 0.0),
+            Vec::new(),
+        );
+
+        manager.maintain_active_panel(&mut world, &mut physics, &mut scripts, &mut id_to_physics);
+
+        assert_eq!(manager.active_panel(), None);
+        assert!(manager.handle_to_instance.is_empty());
+        assert!(id_to_physics.is_empty());
     }
 }

--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -106,11 +106,11 @@ where
                     parent_entity_id: entity_id,
                     dropped_entity_id: *entity,
                 }),
-            // Frobbing a GUI-bearing entity opens its panel as a flat-mode MFD
-            // (the original's frob-script -> overlay flow). VR ignores the
-            // OpenPanel effect - its panels are world quads driven by `Hover` -
-            // but the `on_frob` side effects (e.g. an audio log recording +
-            // playing its clip) fire in both presentations. A gui can veto the
+            // Frobbing a GUI-bearing entity opens its presentation's panel
+            // slot (flat MFD or VR world quad), preserving the original's
+            // frob-script -> overlay flow. The `on_frob` side effects (e.g. an
+            // audio log recording + playing its clip) fire in both
+            // presentations. A gui can veto the
             // open (a content-less log disc) and/or ask for fresh per-open
             // state (the reader's scroll position).
             // Opened without a frob (the audio-log reader): give the gui the

--- a/shock2vr/src/hud/item_outline.rs
+++ b/shock2vr/src/hud/item_outline.rs
@@ -35,8 +35,6 @@ pub fn draw_item_name(
 
     let v_prop_obj_short_name = world.borrow::<View<PropObjName>>().unwrap();
     let maybe_prop_obj_short_name = v_prop_obj_short_name.get(entity_id);
-    let v_prop_template_id = world.borrow::<View<PropTemplateId>>().unwrap();
-    let prop_template_id = v_prop_template_id.get(entity_id).unwrap();
 
     if maybe_prop_obj_short_name.is_err() {
         return vec![];
@@ -67,11 +65,17 @@ pub fn draw_item_name(
         .unwrap_or("?".to_string());
 
     let text_content = if debug_show_ids {
+        let template_id = world
+            .borrow::<View<PropTemplateId>>()
+            .unwrap()
+            .get(entity_id)
+            .map(|prop| prop.template_id.to_string())
+            .unwrap_or_else(|_| "runtime".to_owned());
         format!(
             "{} | {} (Tem {}| Ent {})",
             item_name,
             &maybe_hitpoints,
-            prop_template_id.template_id,
+            template_id,
             entity_id.inner(),
         )
     } else {

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -1,9 +1,9 @@
 //! Flat-mode MFD panel host (projects/flat-ui.md §5.2, PR 2).
 //!
-//! The flat presentation of the shared `Gui` layer: where VR shows every
-//! panel as an always-on world quad (`GuiManager` + `ProxyGuiScript`), the
-//! original flat game *opens* an object-bound MFD overlay on frob and drives
-//! it with the mouse cursor. This host holds that flat-only state:
+//! The flat presentation of the shared `Gui` layer: default VR opens the same
+//! object-bound panel as a world quad (`GuiManager` + `ProxyGuiScript`), while
+//! the original flat game docks it in an MFD and drives it with the mouse
+//! cursor. This host holds that flat-only state:
 //!
 //! - **Open**: `Effect::OpenPanel { entity }` (emitted by `GuiScript` on
 //!   Frob) binds the panel to one world object - the original's single
@@ -575,8 +575,8 @@ impl FlatUiHost {
             return (Vec::new(), Vec::new());
         };
 
-        // Host-drawn close button (the shared guis have no close component -
-        // VR panels never close).
+        // Host-drawn close button (the shared guis have no close component;
+        // VR uses its world-space distance close instead).
         let close_rect = close_button_canvas_rect(rect);
         self.hover_close = close_rect.contains(canvas_pos);
         if pressed_edge && self.hover_close {

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -532,8 +532,9 @@ pub struct MissionCore {
     pub flat_use_mode: bool,
 
     /// Flat-mode MFD panel host: the object-bound panel opened on frob, its
-    /// canvas rendering, and the pointer -> GUIHover input mapping. Inert in
-    /// VR (nothing opens a panel there). See `projects/flat-ui.md` §5.2.
+    /// canvas rendering, and the pointer -> GUIHover input mapping. VR uses
+    /// `GuiManager` for the corresponding object-bound world panel.
+    /// See `projects/flat-ui.md` §5.2.
     pub flat_ui: crate::mission::flat_ui_host::FlatUiHost,
 
     /// Whether ordinary movement/hand/pointer input reaches the active player.
@@ -1805,6 +1806,21 @@ impl MissionCore {
             &self.id_to_model,
             &mut self.id_to_physics,
         );
+
+        // Default VR has one object-bound world-panel slot. Keep its
+        // transient proxy faithful to the original overlay lifecycle before
+        // either hand raycasts: destroyed hosts and walk-away panels close,
+        // while `--experimental gui` retains its legacy all-panels behavior.
+        if game_options.presentation_mode == crate::PresentationMode::Vr
+            && !game_options.experimental_features.contains("gui")
+        {
+            self.gui.maintain_active_panel(
+                &mut self.world,
+                &mut self.physics,
+                &mut self.script_world,
+                &mut self.id_to_physics,
+            );
+        }
 
         // VR drives two hands; flat drives a single first-person weapon
         // controller. Both feed the same effect-processing path.
@@ -3374,7 +3390,13 @@ impl MissionCore {
         // must not outlive the entity (a recycled id would inherit it).
         self.id_to_animation_player.remove(&entity_id);
         self.failed_animation_queries.remove(&entity_id);
-        // TODO: gui - remove entity
+        self.gui.on_entity_destroyed(
+            entity_id,
+            &mut self.world,
+            &mut self.physics,
+            &mut self.script_world,
+            &mut self.id_to_physics,
+        );
         self.hit_boxes.remove_entity(
             entity_id,
             &mut self.world,
@@ -3668,11 +3690,21 @@ impl MissionCore {
                 }
 
                 Effect::OpenPanel { entity } => {
-                    // Flat-presentation only: bind the MFD panel to the
-                    // frobbed object (the original's frob-script -> overlay
-                    // flow). VR ignores it - panels are world quads there.
-                    if game_options.presentation_mode == crate::PresentationMode::Flat {
-                        self.flat_ui.open(entity);
+                    // Bind the presentation's single object-panel slot to the
+                    // frobbed entity (the original's frob-script -> overlay
+                    // flow). Flat docks it in the MFD; default VR creates a
+                    // world quad beside the object. The explicit experimental
+                    // mode retains its historical all-panels presentation.
+                    match game_options.presentation_mode {
+                        crate::PresentationMode::Flat => self.flat_ui.open(entity),
+                        crate::PresentationMode::Vr => self.gui.open_panel(
+                            entity,
+                            game_options.experimental_features.contains("gui"),
+                            &mut self.world,
+                            &mut self.physics,
+                            &mut self.script_world,
+                            &mut self.id_to_physics,
+                        ),
                     }
                     // Give the gui its per-open state (the reader's scroll
                     // reset) however the panel was reached.
@@ -4320,13 +4352,17 @@ impl MissionCore {
                     // Flat presentation: the active panel's components are
                     // drawn by the FlatUiHost onto the screen-space canvas.
                     // Deliberately NOT behind `--experimental gui` - the flat
-                    // MFD is the #435 fix; only the VR world-quad path below
-                    // keeps its gating (projects/flat-ui.md §7).
+                    // MFD is the #435 fix. Default VR accepts only the panel
+                    // explicitly opened through `OpenPanel`; the experimental
+                    // mode retains its legacy all-panels behavior.
                     if game_options.presentation_mode == crate::PresentationMode::Flat {
                         self.flat_ui
                             .on_set_ui(&self.world, parent_entity, world_size, &components);
                     }
-                    if game_options.experimental_features.contains("gui") {
+                    let update_world_panel = game_options.experimental_features.contains("gui")
+                        || (game_options.presentation_mode == crate::PresentationMode::Vr
+                            && self.gui.active_panel() == Some(parent_entity));
+                    if update_world_panel {
                         self.gui.update_ui(
                             &mut self.world,
                             &mut self.physics,
@@ -6060,11 +6096,13 @@ impl MissionCore {
             scene.push(debug);
         }
 
-        // Render gui
+        // Render world-space GUI. The explicit experiment preserves the old
+        // all-panels mode; default VR renders only the gameplay panel opened
+        // by frobbing its object.
         if options.experimental_features.contains("gui") {
-            let guis = self.gui.render(asset_cache, &self.world);
-
-            scene.extend(guis);
+            scene.extend(self.gui.render(asset_cache, &self.world));
+        } else if options.presentation_mode == crate::PresentationMode::Vr {
+            scene.extend(self.gui.render_active(asset_cache, &self.world));
         }
 
         // Note: Hand spotlights for enhanced lighting are now handled in the runtime

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -149,10 +149,10 @@ pub enum Effect {
     /// See `projects/flat-ui.md`.
     ToggleUseMode,
 
-    /// Open the flat-mode MFD panel bound to `entity` - emitted by `GuiScript`
-    /// when its entity is frobbed, mirroring the original engine where the
-    /// frob script opens the overlay (`cShockGameSrv::Keypad`). Ignored in VR,
-    /// where panels are always-on world quads. See `projects/flat-ui.md` §5.2.
+    /// Open the presentation's object-bound panel slot - a flat MFD or a VR
+    /// world quad - emitted by `GuiScript` when its entity is frobbed. This
+    /// mirrors the original engine's frob-script overlay flow
+    /// (`cShockGameSrv::Keypad`). See `projects/flat-ui.md` §5.2.
     OpenPanel {
         entity: EntityId,
     },

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -1,0 +1,96 @@
+import type { GameServer } from "../../src/index.js";
+import type { Vec3 } from "../../src/types.js";
+
+export type Quat = [number, number, number, number];
+
+export const add = (a: Vec3, b: Vec3): Vec3 => [
+  a[0] + b[0],
+  a[1] + b[1],
+  a[2] + b[2],
+];
+const sub = (a: Vec3, b: Vec3): Vec3 => [
+  a[0] - b[0],
+  a[1] - b[1],
+  a[2] - b[2],
+];
+const scale = (v: Vec3, amount: number): Vec3 => [
+  v[0] * amount,
+  v[1] * amount,
+  v[2] * amount,
+];
+const dot = (a: Vec3, b: Vec3): number =>
+  a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const normalize = (v: Vec3): Vec3 => scale(v, 1 / Math.sqrt(dot(v, v)));
+
+const quatConjugate = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
+const quatMultiply = (
+  [ax, ay, az, aw]: Quat,
+  [bx, by, bz, bw]: Quat,
+): Quat => [
+  aw * bx + ax * bw + ay * bz - az * by,
+  aw * by - ax * bz + ay * bw + az * bx,
+  aw * bz + ax * by - ay * bx + az * bw,
+  aw * bw - ax * bx - ay * by - az * bz,
+];
+const quatNormalize = (q: Quat): Quat => {
+  const length = Math.sqrt(q.reduce((sum, value) => sum + value * value, 0));
+  return q.map((value) => value / length) as Quat;
+};
+
+export const quatRotate = (q: Quat, v: Vec3): Vec3 =>
+  quatMultiply(quatMultiply(q, [...v, 0]), quatConjugate(q)).slice(
+    0,
+    3,
+  ) as Vec3;
+
+function quatFromTo(from: Vec3, to: Vec3): Quat {
+  const a = normalize(from);
+  const b = normalize(to);
+  const d = dot(a, b);
+  if (d < -0.999999) {
+    const axis =
+      Math.abs(a[0]) < 0.9
+        ? normalize(cross(a, [1, 0, 0]))
+        : normalize(cross(a, [0, 1, 0]));
+    return [axis[0], axis[1], axis[2], 0];
+  }
+  return quatNormalize([...cross(a, b), 1 + d]);
+}
+
+/** Aim the production VR hand ray at a world point without direct entity messages. */
+export async function aimVrHandAt(
+  game: GameServer,
+  target: Vec3,
+  standOff = 0.45,
+): Promise<{ start: Vec3; target: Vec3 }> {
+  const snapshot = await game.info();
+  const pawn = snapshot.player.position;
+  const pawnRotation = snapshot.player.rotation;
+  const eye = add(pawn, [0, snapshot.player.camera_offset[1], 0]);
+  const toward = normalize(sub(target, eye));
+  const worldHand = sub(target, scale(toward, standOff));
+  const worldHandRotation = quatFromTo(
+    [0, 0, -1],
+    normalize(sub(target, worldHand)),
+  );
+  const inversePawn = quatConjugate(pawnRotation);
+  const localHand = quatRotate(inversePawn, sub(worldHand, pawn));
+  const localHandRotation = quatNormalize(
+    quatMultiply(inversePawn, worldHandRotation),
+  );
+
+  await game.input.lookAtWorldPoint(target, {
+    eyeHeight: snapshot.player.camera_offset[1],
+  });
+  await game.input.set("right_hand.position", localHand);
+  await game.input.set("right_hand.rotation", localHandRotation);
+  await game.input.set("right_hand.trigger", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 3 });
+  return { start: worldHand, target };
+}

--- a/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { GameServer } from "../src/index.js";
 import type { Vec3 } from "../src/types.js";
 import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
 
 // Default-VR regression for #940. The mission data and gameplay path are the
 // real ones:
@@ -21,81 +22,6 @@ const CORPSE_PSI_AMP = 219;
 const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
 const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 const LOOT_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
-
-const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
-const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
-const scale = (v: Vec3, amount: number): Vec3 => [
-  v[0] * amount,
-  v[1] * amount,
-  v[2] * amount,
-];
-const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-const cross = (a: Vec3, b: Vec3): Vec3 => [
-  a[1] * b[2] - a[2] * b[1],
-  a[2] * b[0] - a[0] * b[2],
-  a[0] * b[1] - a[1] * b[0],
-];
-const normalize = (v: Vec3): Vec3 => scale(v, 1 / Math.sqrt(dot(v, v)));
-
-type Quat = [number, number, number, number];
-
-const quatConjugate = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
-const quatMultiply = (
-  [ax, ay, az, aw]: Quat,
-  [bx, by, bz, bw]: Quat,
-): Quat => [
-  aw * bx + ax * bw + ay * bz - az * by,
-  aw * by - ax * bz + ay * bw + az * bx,
-  aw * bz + ax * by - ay * bx + az * bw,
-  aw * bw - ax * bx - ay * by - az * bz,
-];
-const quatNormalize = (q: Quat): Quat => {
-  const length = Math.sqrt(q.reduce((sum, value) => sum + value * value, 0));
-  return q.map((value) => value / length) as Quat;
-};
-const quatRotate = (q: Quat, v: Vec3): Vec3 =>
-  quatMultiply(quatMultiply(q, [...v, 0]), quatConjugate(q)).slice(0, 3) as Vec3;
-
-function quatFromTo(from: Vec3, to: Vec3): Quat {
-  const a = normalize(from);
-  const b = normalize(to);
-  const d = dot(a, b);
-  if (d < -0.999999) {
-    const axis =
-      Math.abs(a[0]) < 0.9
-        ? normalize(cross(a, [1, 0, 0]))
-        : normalize(cross(a, [0, 1, 0]));
-    return [axis[0], axis[1], axis[2], 0];
-  }
-  return quatNormalize([...cross(a, b), 1 + d]);
-}
-
-async function aimVrHandAt(
-  game: GameServer,
-  target: Vec3,
-  standOff = 0.45,
-): Promise<{ start: Vec3; target: Vec3 }> {
-  const snapshot = await game.info();
-  const pawn = snapshot.player.position;
-  const pawnRotation = snapshot.player.rotation;
-  const eye = add(pawn, [0, snapshot.player.camera_offset[1], 0]);
-  const toward = normalize(sub(target, eye));
-  const worldHand = sub(target, scale(toward, standOff));
-  const worldHandRotation = quatFromTo([0, 0, -1], normalize(sub(target, worldHand)));
-  const inversePawn = quatConjugate(pawnRotation);
-  const localHand = quatRotate(inversePawn, sub(worldHand, pawn));
-  const localHandRotation = quatNormalize(quatMultiply(inversePawn, worldHandRotation));
-
-  await game.input.lookAtWorldPoint(target, {
-    eyeHeight: snapshot.player.camera_offset[1],
-  });
-  await game.input.set("right_hand.position", localHand);
-  await game.input.set("right_hand.rotation", localHandRotation);
-  await game.input.set("right_hand.trigger", 0);
-  await game.input.set("right_hand.squeeze", 0);
-  await game.step({ frames: 3 });
-  return { start: worldHand, target };
-}
 
 test(
   "default VR opens a container world panel and grabs contained loot through the hand ray",

--- a/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-container-world-panel.e2e.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+
+// Default-VR regression for #940. The mission data and gameplay path are the
+// real ones:
+//
+//   medsci1 corpse 219 --Contains--> Psi Amp 1407
+//   production hand trigger -> ContainerScript/GuiScript::OpenPanel
+//   production hand ray + squeeze -> ProxyGuiScript::GUIHover -> GrabEntity
+//
+// No direct Frob, Give, or experimental `gui` flag is used. Before the fix the
+// trigger reaches the corpse but no UI collider is created, so the first
+// post-frob UI-body assertion is the negative key.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const CORPSE_PSI_AMP = 219;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const LOOT_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+
+const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const scale = (v: Vec3, amount: number): Vec3 => [
+  v[0] * amount,
+  v[1] * amount,
+  v[2] * amount,
+];
+const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const normalize = (v: Vec3): Vec3 => scale(v, 1 / Math.sqrt(dot(v, v)));
+
+type Quat = [number, number, number, number];
+
+const quatConjugate = ([x, y, z, w]: Quat): Quat => [-x, -y, -z, w];
+const quatMultiply = (
+  [ax, ay, az, aw]: Quat,
+  [bx, by, bz, bw]: Quat,
+): Quat => [
+  aw * bx + ax * bw + ay * bz - az * by,
+  aw * by - ax * bz + ay * bw + az * bx,
+  aw * bz + ax * by - ay * bx + az * bw,
+  aw * bw - ax * bx - ay * by - az * bz,
+];
+const quatNormalize = (q: Quat): Quat => {
+  const length = Math.sqrt(q.reduce((sum, value) => sum + value * value, 0));
+  return q.map((value) => value / length) as Quat;
+};
+const quatRotate = (q: Quat, v: Vec3): Vec3 =>
+  quatMultiply(quatMultiply(q, [...v, 0]), quatConjugate(q)).slice(0, 3) as Vec3;
+
+function quatFromTo(from: Vec3, to: Vec3): Quat {
+  const a = normalize(from);
+  const b = normalize(to);
+  const d = dot(a, b);
+  if (d < -0.999999) {
+    const axis =
+      Math.abs(a[0]) < 0.9
+        ? normalize(cross(a, [1, 0, 0]))
+        : normalize(cross(a, [0, 1, 0]));
+    return [axis[0], axis[1], axis[2], 0];
+  }
+  return quatNormalize([...cross(a, b), 1 + d]);
+}
+
+async function aimVrHandAt(
+  game: GameServer,
+  target: Vec3,
+  standOff = 0.45,
+): Promise<{ start: Vec3; target: Vec3 }> {
+  const snapshot = await game.info();
+  const pawn = snapshot.player.position;
+  const pawnRotation = snapshot.player.rotation;
+  const eye = add(pawn, [0, snapshot.player.camera_offset[1], 0]);
+  const toward = normalize(sub(target, eye));
+  const worldHand = sub(target, scale(toward, standOff));
+  const worldHandRotation = quatFromTo([0, 0, -1], normalize(sub(target, worldHand)));
+  const inversePawn = quatConjugate(pawnRotation);
+  const localHand = quatRotate(inversePawn, sub(worldHand, pawn));
+  const localHandRotation = quatNormalize(quatMultiply(inversePawn, worldHandRotation));
+
+  await game.input.lookAtWorldPoint(target, {
+    eyeHeight: snapshot.player.camera_offset[1],
+  });
+  await game.input.set("right_hand.position", localHand);
+  await game.input.set("right_hand.rotation", localHandRotation);
+  await game.input.set("right_hand.trigger", 0);
+  await game.input.set("right_hand.squeeze", 0);
+  await game.step({ frames: 3 });
+  return { start: worldHand, target };
+}
+
+test(
+  "default VR opens a container world panel and grabs contained loot through the hand ray",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8540),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [corpse] = await game.entities.byTemplate(CORPSE_PSI_AMP);
+    assert.ok(corpse, "expected medsci1 corpse 219");
+    const corpseDetail = await game.entities.detail(corpse.id);
+    const contained = corpseDetail.outgoing_links.filter((link) =>
+      link.link_type.startsWith("Contains"),
+    );
+    assert.equal(contained.length, 1, "corpse 219 should contain exactly the Psi Amp");
+    const ampId = contained[0].target_id;
+    assert.match(contained[0].target_name, /Psi Amp/i);
+    assert.equal(
+      (await game.physics.bodies({ entityId: ampId })).bodies.length,
+      0,
+      "contained loot must begin with HasRefs(false) and no world body",
+    );
+
+    await teleportVerified(game, {
+      x: corpse.position[0] + 1.2,
+      y: corpse.position[1] + 0.5,
+      z: corpse.position[2] + 1.2,
+    });
+    await game.step({ frames: 5 });
+    const aim = await game.player.aimAt(corpse, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(
+      aim.target_confirmed,
+      true,
+      `corpse must be reachable by the production ray: ${JSON.stringify(aim)}`,
+    );
+    await aimVrHandAt(game, aim.world_point);
+
+    const uiBodiesBefore = (await game.physics.bodies()).bodies.filter((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.equal(uiBodiesBefore.length, 0, "no VR panel should exist before the frob");
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    const uiBodiesAfter = (await game.physics.bodies()).bodies.filter((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.equal(
+      uiBodiesAfter.length,
+      1,
+      "a production VR frob must create one interactable world-panel collider",
+    );
+    const panel = uiBodiesAfter[0];
+    assert.equal(panel.body_type, "kinematic");
+
+    // ProxyGuiScript maps a panel hit back with:
+    //   u = 1 - (local.x + width/2) / width
+    //   v = 1 - (local.y + height/2) / height
+    // Invert that mapping for the center of the first 35x34 loot slot. The
+    // corpse has exactly one item, so the real ContainerGui places the amp
+    // there through its normal Inventory packing path.
+    const panelSize: Vec3 = [
+      PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+      PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+      0,
+    ];
+    const u = LOOT_SLOT_CENTER_PX[0] / PANEL_SIZE_PX[0];
+    const v = LOOT_SLOT_CENTER_PX[1] / PANEL_SIZE_PX[1];
+    const localSlot: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+    const slotWorld = add(panel.position, quatRotate(panel.rotation, localSlot));
+
+    const panelAim = await aimVrHandAt(game, slotWorld, 0.35);
+    const panelHit = await game.raycast({
+      start: panelAim.start,
+      end: panelAim.target,
+      collision_groups: ["ui"],
+      max_distance: 1,
+    });
+    assert.equal(panelHit.entity_id, panel.entity_id, "the production hand ray must hit the panel");
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      ampId,
+      "squeezing the rendered loot icon must grab the contained Psi Amp",
+    );
+    assert.equal(
+      (await game.entities.detail(corpse.id)).outgoing_links.filter((link) =>
+        link.link_type.startsWith("Contains"),
+      ).length,
+      0,
+      "grabbing the amp must sever the corpse Contains link",
+    );
+
+    const saveName = `vr_container_panel_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+
+    const loaded = await game.info();
+    assert.ok(loaded.player.right_hand_entity_id, "save/load must preserve the held loot");
+    const held = await game.entities.detail(loaded.player.right_hand_entity_id);
+    assert.match(held.name ?? "", /Psi Amp/i);
+    assert.equal(
+      (await game.physics.bodies()).bodies.filter((body) =>
+        body.collision_groups.includes("ui"),
+      ).length,
+      0,
+      "the transient panel closes on load instead of leaking a serialized proxy",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
@@ -28,6 +28,30 @@ const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
     body.collision_groups.includes("ui"),
   );
 
+async function assertPanelIsRendered(
+  game: GameServer,
+  panel: PhysicsBodySummary,
+): Promise<void> {
+  const response = await fetch(`${game.baseUrl}/v1/scene`);
+  assert.equal(response.ok, true, "scene inspection should succeed");
+  const scene = (await response.json()) as {
+    objects: Array<{ position: Vec3; transparency: number | null }>;
+  };
+  const visiblePanelDraws = scene.objects.filter(
+    (object) =>
+      object.transparency !== 1 &&
+      Math.hypot(
+        object.position[0] - panel.position[0],
+        object.position[1] - panel.position[1],
+        object.position[2] - panel.position[2],
+      ) < 0.01,
+  );
+  assert.ok(
+    visiblePanelDraws.length > 0,
+    "the sole UI collider must have visible ElevatorGui draws at its world transform",
+  );
+}
+
 async function openElevatorThroughVrHand(
   game: GameServer,
 ): Promise<PhysicsBodySummary> {
@@ -69,6 +93,7 @@ async function openElevatorThroughVrHand(
     "production VR frob of button 74 must create exactly one visible/collidable panel",
   );
   assert.equal(panels[0].body_type, "kinematic");
+  await assertPanelIsRendered(game, panels[0]);
   return panels[0];
 }
 

--- a/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-elevator-world-panel.e2e.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Command campaign blocker regression for #940. rec1 mission object 74 is the
+// main-tram ElevatorButton. This deliberately uses default `--vr`, the real
+// trigger ray for both frob and GUI input, and no direct Frob or experimental
+// `gui` flag. Before #941, OpenPanel had no default-VR host, so no UI collider
+// existed after the first trigger pull.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const REC1_ELEVATOR_BUTTON = 74;
+// Authored ops2 Level Start Marker whose PropStartLoc and PropDestLoc are 22.
+const OPS2_START_LOC_22 = 560;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+
+// ElevatorGui draws deck 5 at row 0 and deck 1 at row 4. Operations is deck 4,
+// therefore row 1. Aim at its 142x54 button center.
+const OPERATIONS_CENTER_PX: Vec3 = [14 + 142 / 2, 6 + (54 + 4) + 54 / 2, 0];
+
+const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
+  (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+
+async function openElevatorThroughVrHand(
+  game: GameServer,
+): Promise<PhysicsBodySummary> {
+  const [button] = await game.entities.byTemplate(REC1_ELEVATOR_BUTTON);
+  assert.ok(button, "expected rec1 main elevator button mission object 74");
+
+  await teleportVerified(game, {
+    x: button.position[0] - 1.2,
+    y: button.position[1] + 0.5,
+    z: button.position[2],
+  });
+  await game.step({ frames: 5 });
+
+  const aim = await game.player.aimAt(button, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(
+    aim.target_confirmed,
+    true,
+    `button 74 must be reachable by the production ray: ${JSON.stringify(aim)}`,
+  );
+  await aimVrHandAt(game, aim.world_point);
+
+  assert.equal(
+    (await uiBodies(game)).length,
+    0,
+    "no VR panel should exist before frob",
+  );
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 5 });
+
+  const panels = await uiBodies(game);
+  assert.equal(
+    panels.length,
+    1,
+    "production VR frob of button 74 must create exactly one visible/collidable panel",
+  );
+  assert.equal(panels[0].body_type, "kinematic");
+  return panels[0];
+}
+
+test(
+  "default VR rec1 elevator world panel survives save/load cleanup and reaches ops2 loc 22",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "rec1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8541),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    // Complete power makes Operations (deck 4) a real enabled ElevatorGui
+    // button; the test still opens and selects it only through production VR
+    // input below.
+    await game.quests.set("ElevState", "complete");
+    const panelBeforeSave = await openElevatorThroughVrHand(game);
+
+    const saveName = `vr_elevator_panel_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await uiBodies(game)).length,
+      0,
+      "loading must close the transient world-panel proxy",
+    );
+    assert.equal(await game.quests.get("ElevState"), "complete");
+
+    // Loading rebuilds runtime entity IDs. Reopen by stable mission object 74,
+    // then invert ProxyGuiScript's pixel-to-world mapping for Operations row.
+    const panel = await openElevatorThroughVrHand(game);
+    assert.notEqual(
+      panel.body_id,
+      panelBeforeSave.body_id,
+      "the reopened panel should be a newly created transient body",
+    );
+    const panelSize: Vec3 = [
+      PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+      PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+      0,
+    ];
+    const u = OPERATIONS_CENTER_PX[0] / PANEL_SIZE_PX[0];
+    const v = OPERATIONS_CENTER_PX[1] / PANEL_SIZE_PX[1];
+    const localOperations: Vec3 = [
+      panelSize[0] * (0.5 - u),
+      panelSize[1] * (0.5 - v),
+      0,
+    ];
+    const operationsWorld = add(
+      panel.position,
+      quatRotate(panel.rotation, localOperations),
+    );
+
+    const panelAim = await aimVrHandAt(game, operationsWorld, 0.35);
+    const panelHit = await game.raycast({
+      start: panelAim.start,
+      end: panelAim.target,
+      collision_groups: ["ui"],
+      max_distance: 1,
+    });
+    assert.equal(
+      panelHit.entity_id,
+      panel.entity_id,
+      "the production hand ray must hit the Operations row",
+    );
+
+    assert.equal((await game.info()).mission, "rec1.mis");
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 20 });
+
+    const arrived = await game.info();
+    assert.equal(
+      arrived.mission,
+      "ops2.mis",
+      "triggering the enabled Operations row must perform the normal elevator transition",
+    );
+    assert.equal(
+      await game.quests.get("ElevState"),
+      "complete",
+      "the elevator transition must preserve global campaign state",
+    );
+
+    // ElevatorGui requests loc 22. The mission loader places the player at the
+    // matching StartLoc; resolve that stable object and verify the landing.
+    const [startLoc22] = await game.entities.byTemplate(OPS2_START_LOC_22);
+    assert.ok(startLoc22, "ops2 should contain the authored StartLoc 22 marker");
+    const distance = Math.hypot(
+      arrived.player.position[0] - startLoc22.position[0],
+      arrived.player.position[1] - startLoc22.position[1],
+      arrived.player.position[2] - startLoc22.position[2],
+    );
+    assert.ok(
+      distance < 2,
+      `expected ops2 loc 22 landing, got distance ${distance}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- make the existing `GuiScript::OpenPanel` flow bind one object-backed world panel in default VR instead of requiring `--experimental gui`
- reuse the existing `GuiManager`, `ProxyGuiScript`, production hand ray, GUI implementations, `Contains` links, and ordinary level-transition/save wiring
- replace/close the transient panel when another object opens, its host disappears, the player walks beyond the original overlay distance, or a save is loaded; retain the legacy all-panels experiment unchanged
- ignore runtime-only UI proxy entities in the item-name HUD lookup so aiming a hand at a panel cannot panic

Fixes #940

## Campaign reproduction

The original play-through finding was **Command · no tweak · 25th Anniversary assets · VR · seed `2110635141`**: Command2 Locker1489 contained Log2387 with `HasRefs(false)`; the production hand could frob the locker but received no presentation or loot path.

The same gap later became a real campaign blocker at the rec1 main elevator. Baseline default `--vr` save `pt-command-iter7-rec1-elevator-approach.sav` (SHA-256 `64fe77954cd691c68babe07ba9ba20e5ad9ed0539da69062582986d1e2d5b690`) put the player at stable mission object 74 (`Master Elevator Button`). The production hand ray and trigger reached Button74, but no `ElevatorGui` quad, proxy, UI body, or transition appeared.

The durable fresh-mission regression uses that exact authored elevator path without relying on the campaign save or unstable runtime IDs:

1. Launch `rec1.mis` with default `--vr` and no experimental GUI; set the ordinary `ElevState` quest bit to complete so Operations is enabled.
2. Resolve stable mission object 74, aim the production right-hand ray, and pulse trigger.
3. Assert exactly one kinematic UI collider and live `/v1/scene` ElevatorGui draws at its world transform.
4. Save/load and assert the transient proxy closes while campaign quest state persists.
5. Resolve object 74 again, reopen it, invert the real panel mapping to Operations (4), and use the production hand ray + trigger.
6. Assert normal transition to `ops2.mis`, arrival within two world units of authored `StartLoc 22` marker 560, and preserved `ElevState`.

Negative-first against pre-fix main reached Button74 and failed at the exact post-trigger assertion (`UI bodies 0 !== 1`). The same scenario passes on this branch.

The original container regression remains: fresh `medsci1.mis` corpse 219 (`Contains` → `Psi Amp`) opens with the production VR trigger, renders one panel, and lets production hand-ray squeeze grab the `HasRefs(false)` item. Save/load preserves held loot and closes the transient proxy.

## Faithful design

Original SS2 object overlays are opened by gameplay scripts and occupy one object-bound overlay slot. This change keeps that existing `GuiScript` → `OpenPanel` → `SetUI` flow and gives default VR a world-space presentation of the same slot. `ContainerGui`, `ElevatorGui`, and every other GUI continue to own their normal components and effects; the VR hand reaches them through the existing `ProxyGuiScript::GUIHover` mapping.

There are no debug interaction shims, hardcoded mission coordinates, direct `Frob`/`Give`, or wholesale experimental-system enablement. `--experimental gui` retains its historical all-panels behavior. Flat mode remains on its existing MFD host. Runtime panel proxies remain `RuntimePropDoNotSerialize`; switching hosts, destroying a host, walking away, and loading all remove the active proxy.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` — 576 passed
- `npm test` — 26 passed, 214 E2E skipped as designed
- focused exact-feature-binary E2Es — 4/4 passed sequentially: default-VR rec1 elevator, default-VR container, flat elevator, flat container
- exact feature binary SHA-256: `ffed22f99dd1f7290e301e773027fd0173cc176e801a59f9e8504510b9507afb`
- full sequential SDK E2E before the elevator follow-up: 230 passed, 7 skipped, 2 unrelated failures out of 239; all 23 mission loads, the VR container regression, and flat container regression passed. `search-behavior` passed in isolation; `creature-loot` reproducibly reaches its final historical flat-reader check only after teleporting to the contained disc's stale authored position, where existing flat distance-close behavior dismisses it. Its preceding slain-creature and Watts assertions pass; this branch does not change that test or flat host behavior.
- final-head CI: format plus Android, Ubuntu, macOS, and Windows warning-denied build/test jobs all green

## Visuals

![Default VR container panel and grab](https://gist.githubusercontent.com/tommy-xr/ef78d1f2cbaaa3a5cf9b1c804a66980e/raw/vr-container-panel.gif)

<sub>Default-VR production trigger opens the existing `contain.pcx` panel; the hand ray moves to the Psi Amp and squeeze removes it from the real container. Captured headlessly with fixed-timestep `/v1/step` + `/v1/screenshot`.</sub>

### Before → after

![Before: no panel; after: world panel and contained loot](https://gist.githubusercontent.com/tommy-xr/ef78d1f2cbaaa3a5cf9b1c804a66980e/raw/vr-container-panel-before-after.png)

<sub>Same fresh mission, position, hand frob, timestep, and camera sequence against pre-fix and post-fix binaries. Media gist: https://gist.github.com/tommy-xr/ef78d1f2cbaaa3a5cf9b1c804a66980e</sub>
