### PR TITLE
fix(vr): gate authored melee contact damage

### DIFF
--- a/shock2vr/src/mission/entity_creator.rs
+++ b/shock2vr/src/mission/entity_creator.rs
@@ -22,8 +22,8 @@ use dark::{
     properties::{
         FrobFlag, InternalPropOriginalModelName, Link, Links, PhysicsModelType, PoseType,
         PropClassTag, PropCollisionType, PropCreature, PropCreaturePose, PropFrobInfo,
-        PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropModelName,
-        PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
+        PropHUDSelect, PropHasRefs, PropHitPoints, PropImmobile, PropKeySrc, PropLimbModel,
+        PropModelName, PropPhysAttr, PropPhysDimensions, PropPhysState, PropPhysType, PropPosition,
         PropRenderType, PropScale, PropSymName, PropTemplateId, PropTranslatingDoor, PropTripFlags,
         RenderType, StimPropagator, StimSourceOptions, TemplateLinks, WrappedEntityId,
     },
@@ -60,6 +60,10 @@ fn needs_internal_simple_health(
             || authored_scripts
                 .iter()
                 .any(|script| script.eq_ignore_ascii_case("TriggerDestroy")))
+}
+
+fn needs_internal_triggered_melee(has_limb_model: bool) -> bool {
+    has_limb_model
 }
 
 pub fn create_entity_with_position(
@@ -350,6 +354,15 @@ pub fn create_entity_core(
         processed_scripts.push("internal_keycard".to_owned());
     }
 
+    // Player melee weapons are authored by their first-person limb model, not
+    // by a literal `wrench` script (that name belongs to Maintenance Tool
+    // -2949). Give every such weapon the trigger-gated VR contact behavior;
+    // ordinary dropped weapons remain harmless because the script is inactive.
+    let v_limb_model = world.borrow::<View<PropLimbModel>>().unwrap();
+    if needs_internal_triggered_melee(v_limb_model.get(entity_id).is_ok()) {
+        processed_scripts.push("internal_triggered_melee_weapon".to_owned());
+    }
+
     // `MOVE` is an engine frob action, not an object script. Ordinary goodies
     // such as Med Patches and armor only inherit that flag, so give them the
     // internal handler that moves them into the backpack on Frob. Objects that
@@ -398,6 +411,7 @@ pub fn create_entity_core(
     drop(v_creature);
     drop(v_hp);
     drop(v_keysrc);
+    drop(v_limb_model);
 
     if is_explosion {
         processed_scripts.push("internal_explosion".to_owned());
@@ -1531,6 +1545,18 @@ mod tests {
         assert!(
             !needs_internal_simple_health(true, true, &trigger_destroy),
             "creatures retain ownership of their hitbox damage path"
+        );
+    }
+
+    #[test]
+    fn authored_limb_model_is_the_generic_player_melee_marker() {
+        assert!(
+            needs_internal_triggered_melee(true),
+            "player Wrench -928 and the other authored melee weapons carry PropLimbModel"
+        );
+        assert!(
+            !needs_internal_triggered_melee(false),
+            "Maintenance Tool -2949's literal Wrench script and guns must not gain player melee"
         );
     }
 

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -1001,11 +1001,11 @@ impl MissionCore {
         );
 
         if let Some(entity_id) = left_hand_entity {
-            make_un_physical2(&mut id_to_physics, &mut physics, entity_id);
+            restore_held_item_physics(&world, &mut id_to_physics, &mut physics, entity_id);
         };
 
         if let Some(entity_id) = right_hand_entity {
-            make_un_physical2(&mut id_to_physics, &mut physics, entity_id);
+            restore_held_item_physics(&world, &mut id_to_physics, &mut physics, entity_id);
         };
 
         let (start_pos, start_rotation) = spawn_loc.calculate_start_position(
@@ -4188,6 +4188,15 @@ impl MissionCore {
                     self.process_virtual_hand_effects(asset_cache, grab_effects);
 
                     if self.interaction.is_holding(entity_id) {
+                        // A grab routed through this effect (equip a carried
+                        // weapon, a backpack double-click) never emits
+                        // `HoldItem`, so establish the melee contact body here
+                        // too - otherwise a weapon equipped this way is held
+                        // without a collider and never reports contacts.
+                        if self.is_vr_melee_weapon(entity_id) {
+                            self.attach_held_melee_physics(entity_id);
+                        }
+
                         // Let the scripts know we are now holding the item..
                         self.script_world.dispatch(Message {
                             payload: MessagePayload::Hold,
@@ -6178,8 +6187,7 @@ impl MissionCore {
                         // weapon needs its authored collider to report genuine
                         // controller-driven contacts. Kinematic motion keeps it
                         // seated in the hand without gravity or solver drift.
-                        self.make_physical(entity_id);
-                        self.physics.set_held_melee(entity_id);
+                        self.attach_held_melee_physics(entity_id);
                     } else {
                         self.make_un_physical(entity_id);
                     }
@@ -6216,13 +6224,15 @@ impl MissionCore {
     }
 
     fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
-        self.world
-            .borrow::<UniqueView<GlobalPresentationMode>>()
-            .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr)
-            && self
-                .world
-                .borrow::<View<PropLimbModel>>()
-                .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
+        is_vr_melee_weapon(&self.world, entity_id)
+    }
+
+    /// Give a held melee weapon the contact body the VR damage window needs.
+    /// Idempotent: `make_physical` no-ops when the body already exists, so this
+    /// is safe on both a fresh grab and a restore.
+    fn attach_held_melee_physics(&mut self, entity_id: EntityId) {
+        self.make_physical(entity_id);
+        self.physics.set_held_melee(entity_id);
     }
 
     /// Queue an entity to be triggered after scripts are initialized
@@ -6602,6 +6612,39 @@ fn drop_contains_links_to(links: &mut Links, target: EntityId) {
     links.to_links.retain(|link| {
         !(matches!(link.link, Link::Contains(_)) && link.to_entity_id.map(|e| e.0) == Some(target))
     });
+}
+
+/// Is this a melee weapon whose VR contact damage needs a live collider while
+/// held? Authored player melee weapons are marked by `PropLimbModel`
+/// (gamesys-wide: Wrench -928, PsiSword -2291, Crystal Shard -28, Electro
+/// Shock -24); the flat presentation swings by raycast and needs none of this.
+pub fn is_vr_melee_weapon(world: &World, entity_id: EntityId) -> bool {
+    world
+        .borrow::<UniqueView<GlobalPresentationMode>>()
+        .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr)
+        && world
+            .borrow::<View<PropLimbModel>>()
+            .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
+}
+
+/// Physics for an item restored into a hand by save/load or a level change.
+///
+/// The restore path cannot reuse `VirtualHandEffect::HoldItem` - only a fresh
+/// world grab emits that, and `VrInteraction::grab` returns no effects - so
+/// without this branch a carried melee weapon came back with its collider
+/// stripped and silently stopped reporting contacts for the rest of the
+/// session. Every other held item still goes unphysical, as before.
+fn restore_held_item_physics(
+    world: &World,
+    id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    physics: &mut PhysicsWorld,
+    entity_id: EntityId,
+) {
+    if is_vr_melee_weapon(world, entity_id) {
+        physics.set_held_melee(entity_id);
+    } else {
+        make_un_physical2(id_to_physics, physics, entity_id);
+    }
 }
 
 pub fn make_un_physical2(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -6173,7 +6173,16 @@ impl MissionCore {
                     );
                 }
                 VirtualHandEffect::HoldItem { entity_id } => {
-                    self.make_un_physical(entity_id);
+                    if self.is_vr_melee_weapon(entity_id) {
+                        // Held guns/items stay unphysical, but a VR melee
+                        // weapon needs its authored collider to report genuine
+                        // controller-driven contacts. Kinematic motion keeps it
+                        // seated in the hand without gravity or solver drift.
+                        self.make_physical(entity_id);
+                        self.physics.set_held_melee(entity_id);
+                    } else {
+                        self.make_un_physical(entity_id);
+                    }
                     self.script_world.dispatch(Message {
                         payload: MessagePayload::Hold,
                         to: entity_id,
@@ -6190,6 +6199,11 @@ impl MissionCore {
                     }
                 }
                 VirtualHandEffect::DropItem { entity_id } => {
+                    if self.is_vr_melee_weapon(entity_id) {
+                        // Recreate from authored physics so the released item
+                        // is an ordinary dynamic, harmless loose prop again.
+                        self.make_un_physical(entity_id);
+                    }
                     self.make_physical(entity_id);
 
                     self.script_world.dispatch(Message {
@@ -6199,6 +6213,16 @@ impl MissionCore {
                 }
             }
         }
+    }
+
+    fn is_vr_melee_weapon(&self, entity_id: EntityId) -> bool {
+        self.world
+            .borrow::<UniqueView<GlobalPresentationMode>>()
+            .is_ok_and(|mode| mode.0 == crate::PresentationMode::Vr)
+            && self
+                .world
+                .borrow::<View<PropLimbModel>>()
+                .is_ok_and(|limb_models| limb_models.get(entity_id).is_ok())
     }
 
     /// Queue an entity to be triggered after scripts are initialized

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1948,6 +1948,21 @@ impl CollisionGroup {
         })
     }
 
+    /// A player-held VR melee weapon remains a kinematic contact shape so an
+    /// actual controller swing can meet authored world/actor collision, while
+    /// ignoring the player's own capsule. Damage is still owned by the
+    /// weapon's trigger-gated script; this group only preserves contact events.
+    pub fn held_melee() -> CollisionGroup {
+        CollisionGroup(InteractionGroups {
+            memberships: InternalCollisionGroups::ENTITY.bits.into(),
+            filter: (InternalCollisionGroups::WORLD.bits
+                | InternalCollisionGroups::ENTITIES.bits
+                | InternalCollisionGroups::SELECTABLE.bits)
+                .into(),
+            test_mode: Default::default(),
+        })
+    }
+
     /// Collision behavior for a living creature capsule. It collides exactly
     /// like an ordinary physical entity, but its distinct membership lets
     /// interaction-only fixtures and unsimulated movable debris opt out of
@@ -2538,6 +2553,21 @@ impl PhysicsWorld {
                 collider.set_collision_groups(group.0);
             }
         }
+    }
+
+    /// Turn an existing loose-prop body into the controller-driven contact
+    /// shape used while a melee weapon is held in VR.
+    pub fn set_held_melee(&mut self, entity_id: EntityId) {
+        let Some(handle) = self.entity_id_to_body.get(&entity_id).copied() else {
+            return;
+        };
+        let Some(body) = self.rigid_body_set.get_mut(handle) else {
+            return;
+        };
+        body.set_body_type(RigidBodyType::KinematicPositionBased, true);
+        body.set_linvel(Vector::zeros(), true);
+        body.set_angvel(Vector::zeros(), true);
+        self.set_collision_group(entity_id, CollisionGroup::held_melee());
     }
 
     /// Resize every cuboid collider attached to a kinematic body. GUI panels
@@ -5332,6 +5362,38 @@ mod tests {
 
     fn identity_quat() -> Quaternion<f32> {
         Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    #[test]
+    fn held_melee_is_controller_driven_contact_without_blocking_player() {
+        let mut world = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(1).unwrap();
+        world.add_dynamic(
+            weapon,
+            vec3(0.0, 0.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.1, 0.5, 0.1)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+
+        world.set_held_melee(weapon);
+
+        let body = world
+            .debug_list_bodies()
+            .into_iter()
+            .find(|body| body.entity_id == Some(weapon.inner() as i32))
+            .unwrap();
+        assert_eq!(body.body_type, "kinematic");
+        assert!(!body.blocks_player, "the weapon must ignore its owner");
+        assert!(
+            body.blocks_actor,
+            "the controller-driven weapon must retain physical actor contact"
+        );
+        assert_eq!(body.linear_velocity, [0.0; 3]);
+        assert_eq!(body.angular_velocity, [0.0; 3]);
     }
 
     /// A collider deliberately made non-solid to characters must not remain an

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -2567,6 +2567,16 @@ impl PhysicsWorld {
         body.set_body_type(RigidBodyType::KinematicPositionBased, true);
         body.set_linvel(Vector::zeros(), true);
         body.set_angvel(Vector::zeros(), true);
+        let collider_handles = body.colliders().to_vec();
+        for collider_handle in collider_handles {
+            if let Some(collider) = self.collider_set.get_mut(collider_handle) {
+                collider.set_active_collision_types(
+                    ActiveCollisionTypes::default()
+                        | ActiveCollisionTypes::KINEMATIC_KINEMATIC
+                        | ActiveCollisionTypes::KINEMATIC_FIXED,
+                );
+            }
+        }
         self.set_collision_group(entity_id, CollisionGroup::held_melee());
     }
 
@@ -5394,6 +5404,12 @@ mod tests {
         );
         assert_eq!(body.linear_velocity, [0.0; 3]);
         assert_eq!(body.angular_velocity, [0.0; 3]);
+
+        let body_handle = world.entity_id_to_body[&weapon];
+        let collider_handle = world.rigid_body_set[body_handle].colliders()[0];
+        let active_types = world.collider_set[collider_handle].active_collision_types();
+        assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_KINEMATIC));
+        assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_FIXED));
     }
 
     /// A collider deliberately made non-solid to characters must not remain an

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -26,6 +26,11 @@ impl MeleeWeapon {
 /// edge is that production attack gesture: contacts before it, after release,
 /// and after dropping the weapon are harmless. A target can be damaged only
 /// once per pull even if the physical swing chatters across several contacts.
+///
+/// Physical contact is *never* the damage trigger outside VR - a flat swing is
+/// `WeaponScript`'s aimed short-range raycast, so bumping a wielded wrench into
+/// scenery must do nothing. The whole script is therefore inert in flat mode
+/// rather than guarding individual messages.
 pub struct TriggeredMeleeWeapon {
     attack_active: bool,
     hit_entities: HashSet<EntityId>,
@@ -48,8 +53,12 @@ impl Script for TriggeredMeleeWeapon {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
+        if !is_vr(world) {
+            return Effect::NoEffect;
+        }
+
         match msg {
-            MessagePayload::TriggerPull if is_vr(world) => {
+            MessagePayload::TriggerPull => {
                 self.attack_active = true;
                 self.hit_entities.clear();
                 Effect::NoEffect

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -1,8 +1,13 @@
+use std::collections::HashSet;
+
 use cgmath::{EuclideanSpace, vec3};
 use dark::properties::{CollisionType, PropCollisionType};
-use shipyard::{EntityId, Get, View, World};
+use shipyard::{EntityId, Get, UniqueView, View, World};
 
-use crate::{physics::PhysicsWorld, util::get_position_from_transform};
+use crate::{
+    PresentationMode, mission::GlobalPresentationMode, physics::PhysicsWorld,
+    util::get_position_from_transform,
+};
 
 use super::{Effect, Message, MessagePayload, Script, script_util::play_impact_sound};
 
@@ -15,6 +20,89 @@ impl MeleeWeapon {
     }
 }
 
+/// Contact damage for the player's authored melee weapons (`PropLimbModel`).
+///
+/// Dark opens melee collision only during an attack window. In VR the trigger
+/// edge is that production attack gesture: contacts before it, after release,
+/// and after dropping the weapon are harmless. A target can be damaged only
+/// once per pull even if the physical swing chatters across several contacts.
+pub struct TriggeredMeleeWeapon {
+    attack_active: bool,
+    hit_entities: HashSet<EntityId>,
+}
+
+impl TriggeredMeleeWeapon {
+    pub fn new() -> Self {
+        Self {
+            attack_active: false,
+            hit_entities: HashSet::new(),
+        }
+    }
+}
+
+impl Script for TriggeredMeleeWeapon {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        match msg {
+            MessagePayload::TriggerPull if is_vr(world) => {
+                self.attack_active = true;
+                self.hit_entities.clear();
+                Effect::NoEffect
+            }
+            MessagePayload::TriggerRelease | MessagePayload::Drop => {
+                self.attack_active = false;
+                self.hit_entities.clear();
+                Effect::NoEffect
+            }
+            MessagePayload::Collided { with }
+                if self.attack_active && self.hit_entities.insert(*with) =>
+            {
+                melee_impact(entity_id, *with, world)
+            }
+            _ => Effect::NoEffect,
+        }
+    }
+}
+
+fn is_vr(world: &World) -> bool {
+    world
+        .borrow::<UniqueView<GlobalPresentationMode>>()
+        .map(|mode| mode.0 == PresentationMode::Vr)
+        .unwrap_or(false)
+}
+
+fn melee_impact(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
+    let damage_effect = Effect::Send {
+        msg: Message {
+            to: with,
+            payload: MessagePayload::Damage {
+                amount: 1.0,
+                impact: None,
+            },
+        },
+    };
+    // Impact sound: the weapon's collision schema (weapontype class tag + hit
+    // material - wrench on metal clangs, on a creature thuds), unless its
+    // collision type opts out.
+    let no_sound = world
+        .borrow::<View<PropCollisionType>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
+        .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
+    let sound_effect = if no_sound {
+        Effect::NoEffect
+    } else {
+        let position = get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
+        play_impact_sound(world, entity_id, with, position.to_vec())
+    };
+    Effect::Multiple(vec![damage_effect, sound_effect])
+}
+
 impl Script for MeleeWeapon {
     fn handle_message(
         &mut self,
@@ -24,34 +112,128 @@ impl Script for MeleeWeapon {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => {
-                let damage_effect = Effect::Send {
-                    msg: Message {
-                        to: *with,
-                        payload: MessagePayload::Damage {
-                            amount: 1.0,
-                            impact: None,
-                        },
-                    },
-                };
-                // Impact sound: the weapon's collision schema (weapontype
-                // class tag + hit material - wrench on metal clangs, on a
-                // creature thuds), unless its collision type opts out.
-                let no_sound = world
-                    .borrow::<View<PropCollisionType>>()
-                    .ok()
-                    .and_then(|v| v.get(entity_id).ok().map(|c| c.collision_type))
-                    .is_some_and(|flags| flags.contains(CollisionType::NO_COLLISION_SOUND));
-                let sound_effect = if no_sound {
-                    Effect::NoEffect
-                } else {
-                    let position =
-                        get_position_from_transform(world, entity_id, vec3(0.0, 0.0, 0.0));
-                    play_impact_sound(world, entity_id, *with, position.to_vec())
-                };
-                Effect::Multiple(vec![damage_effect, sound_effect])
-            }
+            MessagePayload::Collided { with } => melee_impact(entity_id, *with, world),
             _ => Effect::NoEffect,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_world(mode: PresentationMode) -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        world.add_unique(GlobalPresentationMode(mode));
+        let weapon = world.add_entity(PropCollisionType {
+            collision_type: CollisionType::NO_COLLISION_SOUND,
+        });
+        let target = world.add_entity(());
+        (world, weapon, target)
+    }
+
+    fn assert_damage(effect: Effect, target: EntityId) {
+        let Effect::Multiple(effects) = effect else {
+            panic!("expected melee impact effects, got {effect:?}");
+        };
+        assert!(effects.iter().any(|effect| {
+            matches!(
+                effect,
+                Effect::Send { msg }
+                    if msg.to == target
+                        && matches!(
+                            msg.payload,
+                            MessagePayload::Damage { amount, impact: None }
+                                if (amount - 1.0).abs() < f32::EPSILON
+                        )
+            )
+        }));
+    }
+
+    fn collide(
+        script: &mut TriggeredMeleeWeapon,
+        world: &World,
+        weapon: EntityId,
+        target: EntityId,
+    ) -> Effect {
+        script.handle_message(
+            weapon,
+            world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Collided { with: target },
+        )
+    }
+
+    #[test]
+    fn authored_melee_contact_is_harmless_until_vr_trigger_pull() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+        assert_damage(collide(&mut script, &world, weapon, target), target);
+    }
+
+    #[test]
+    fn one_vr_trigger_pull_can_damage_each_contact_only_once() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        assert_damage(collide(&mut script, &world, weapon, target), target);
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
+    }
+
+    #[test]
+    fn release_and_drop_close_the_vr_melee_damage_window() {
+        for close in [MessagePayload::TriggerRelease, MessagePayload::Drop] {
+            let (world, weapon, target) = test_world(PresentationMode::Vr);
+            let mut script = TriggeredMeleeWeapon::new();
+            script.handle_message(
+                weapon,
+                &world,
+                &PhysicsWorld::new(),
+                &MessagePayload::TriggerPull,
+            );
+            script.handle_message(weapon, &world, &PhysicsWorld::new(), &close);
+
+            assert!(matches!(
+                collide(&mut script, &world, weapon, target),
+                Effect::NoEffect
+            ));
+        }
+    }
+
+    #[test]
+    fn flat_trigger_does_not_arm_physical_melee_damage() {
+        let (world, weapon, target) = test_world(PresentationMode::Flat);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
     }
 }

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -1,11 +1,13 @@
 use std::collections::HashSet;
 
 use cgmath::{EuclideanSpace, vec3};
-use dark::properties::{CollisionType, PropCollisionType};
+use dark::properties::{CollisionType, PropCollisionType, PropTemplateId};
 use shipyard::{EntityId, Get, UniqueView, View, World};
 
 use crate::{
-    PresentationMode, mission::GlobalPresentationMode, physics::PhysicsWorld,
+    PresentationMode,
+    mission::{GlobalPresentationMode, stim_response::contact_stim_damage},
+    physics::PhysicsWorld,
     util::get_position_from_transform,
 };
 
@@ -71,7 +73,10 @@ impl Script for TriggeredMeleeWeapon {
             MessagePayload::Collided { with }
                 if self.attack_active && self.hit_entities.insert(*with) =>
             {
-                melee_impact(entity_id, *with, world)
+                let Some(amount) = authored_contact_damage(world, entity_id, *with) else {
+                    return Effect::NoEffect;
+                };
+                melee_impact(entity_id, *with, world, amount)
             }
             _ => Effect::NoEffect,
         }
@@ -85,12 +90,30 @@ fn is_vr(world: &World) -> bool {
         .unwrap_or(false)
 }
 
-fn melee_impact(entity_id: EntityId, with: EntityId, world: &World) -> Effect {
+/// Damage the weapon's own authored `Contact` stims deal to this victim,
+/// resolved through the victim's receptrons (armor, immunities, Amplify) -
+/// the same data path AI melee uses (`ai_util::melee_attack`). The player
+/// Wrench (-928) authors WeaponBash at 6/9, so a VR swing now costs what the
+/// gamesys says it costs instead of a flat placeholder.
+///
+/// `None` means "this contact does no authored damage" (a wall, a victim with
+/// no receptron for the stim): the caller emits nothing at all, so a swing at
+/// scenery is silent rather than a free 1-point tap.
+fn authored_contact_damage(world: &World, weapon: EntityId, victim: EntityId) -> Option<f32> {
+    let template_id = world
+        .borrow::<View<PropTemplateId>>()
+        .ok()
+        .and_then(|v| v.get(weapon).ok().map(|t| t.template_id))?;
+    let damage = contact_stim_damage(world, template_id, victim);
+    (damage > 0.0).then_some(damage)
+}
+
+fn melee_impact(entity_id: EntityId, with: EntityId, world: &World, amount: f32) -> Effect {
     let damage_effect = Effect::Send {
         msg: Message {
             to: with,
             payload: MessagePayload::Damage {
-                amount: 1.0,
+                amount,
                 impact: None,
             },
         },
@@ -121,7 +144,10 @@ impl Script for MeleeWeapon {
         msg: &MessagePayload,
     ) -> Effect {
         match msg {
-            MessagePayload::Collided { with } => melee_impact(entity_id, *with, world),
+            // Legacy literal `wrench` script (Maintenance Tool -2949): keep its
+            // historical flat contact damage rather than re-tuning a shipped
+            // path from a VR bugfix. Tracked with its flat gating in #951.
+            MessagePayload::Collided { with } => melee_impact(entity_id, *with, world, 1.0),
             _ => Effect::NoEffect,
         }
     }
@@ -129,16 +155,66 @@ impl Script for MeleeWeapon {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use dark::properties::{Link, Links, ReceptronEffect, ReceptronOptions, ToLink};
+
+    use crate::mission::stim_response::GlobalContactStims;
+
     use super::*;
 
+    /// Stand-ins for the shipped chain the runtime resolves: the player Wrench
+    /// (-928) emits WeaponBash on contact, and a vulnerable victim carries a
+    /// x1 WeaponBash damage receptron.
+    const WRENCH: i32 = -928;
+    const WEAPON_BASH: i32 = -3058;
+    const WEAPON_BASH_INTENSITY: f32 = 6.0;
+
+    /// A world where the weapon's authored contact stim resolves against the
+    /// target's receptron - so a landed swing costs WEAPON_BASH_INTENSITY.
     fn test_world(mode: PresentationMode) -> (World, EntityId, EntityId) {
+        test_world_with_victim_receptrons(mode, vec![(WEAPON_BASH, damage_receptron(16, 1.0))])
+    }
+
+    fn test_world_with_victim_receptrons(
+        mode: PresentationMode,
+        receptrons: Vec<(i32, ReceptronOptions)>,
+    ) -> (World, EntityId, EntityId) {
         let mut world = World::new();
         world.add_unique(GlobalPresentationMode(mode));
-        let weapon = world.add_entity(PropCollisionType {
-            collision_type: CollisionType::NO_COLLISION_SOUND,
+        world.add_unique(GlobalContactStims(HashMap::from([(
+            WRENCH,
+            vec![(WEAPON_BASH, WEAPON_BASH_INTENSITY)],
+        )])));
+        let weapon = world.add_entity((
+            PropCollisionType {
+                collision_type: CollisionType::NO_COLLISION_SOUND,
+            },
+            PropTemplateId {
+                template_id: WRENCH,
+            },
+        ));
+        let target = world.add_entity(Links {
+            to_links: receptrons
+                .into_iter()
+                .map(|(to_template_id, options)| ToLink {
+                    to_template_id,
+                    to_entity_id: None,
+                    link: Link::Receptron(options),
+                })
+                .collect(),
         });
-        let target = world.add_entity(());
         (world, weapon, target)
+    }
+
+    fn damage_receptron(order: i32, multiplier: f32) -> ReceptronOptions {
+        ReceptronOptions {
+            order,
+            effect: ReceptronEffect::Damage {
+                multiplier,
+                use_intensity: true,
+            },
+        }
     }
 
     fn assert_damage(effect: Effect, target: EntityId) {
@@ -153,10 +229,59 @@ mod tests {
                         && matches!(
                             msg.payload,
                             MessagePayload::Damage { amount, impact: None }
-                                if (amount - 1.0).abs() < f32::EPSILON
+                                if (amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON
                         )
             )
         }));
+    }
+
+    /// The regression behind the damage fix: a landed VR swing must cost the
+    /// weapon's *authored* WeaponBash intensity, not a flat placeholder.
+    #[test]
+    fn a_landed_vr_swing_deals_the_weapons_authored_contact_damage() {
+        let (world, weapon, target) = test_world(PresentationMode::Vr);
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        let Effect::Multiple(effects) = collide(&mut script, &world, weapon, target) else {
+            panic!("expected melee impact effects");
+        };
+        let amount = effects
+            .iter()
+            .find_map(|effect| match effect {
+                Effect::Send { msg } => match msg.payload {
+                    MessagePayload::Damage { amount, .. } => Some(amount),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .expect("a landed swing should send Damage");
+        assert!((amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON, "got {amount}");
+    }
+
+    /// Type effectiveness still applies: a target with no WeaponBash receptron
+    /// (a robot) takes nothing, and the swing emits no Damage at all.
+    #[test]
+    fn a_target_with_no_matching_receptron_takes_no_vr_melee_damage() {
+        let (world, weapon, target) =
+            test_world_with_victim_receptrons(PresentationMode::Vr, Vec::new());
+        let mut script = TriggeredMeleeWeapon::new();
+        script.handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TriggerPull,
+        );
+
+        assert!(matches!(
+            collide(&mut script, &world, weapon, target),
+            Effect::NoEffect
+        ));
     }
 
     fn collide(

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -261,7 +261,10 @@ mod tests {
                 _ => None,
             })
             .expect("a landed swing should send Damage");
-        assert!((amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON, "got {amount}");
+        assert!(
+            (amount - WEAPON_BASH_INTENSITY).abs() < f32::EPSILON,
+            "got {amount}"
+        );
     }
 
     /// Type effectiveness still applies: a target with no WeaponBash receptron

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -151,7 +151,7 @@ use self::{
     internal_simple_health::InternalSimpleHealth,
     level_change_button::LevelChangeButton,
     many_ride::{ParalyzePlayers, SitDownRightNow, StandUpAgain, WhiteOut},
-    melee_weapon::MeleeWeapon,
+    melee_weapon::{MeleeWeapon, TriggeredMeleeWeapon},
     obj_consume_button::ObjConsumeButton,
     once_room::OnceRoom,
     once_router::OnceRouter,
@@ -869,6 +869,7 @@ impl ScriptWorld {
                 Box::new(WeaponScript::new()),
                 Box::new(InternalSwitchHeldModelScript::new()),
             ])),
+            "internal_triggered_melee_weapon" => Box::new(TriggeredMeleeWeapon::new()),
             "pistolmodify" => Box::new(NoopScript::new()),
 
             // TODO: Necessary

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -106,8 +106,8 @@ impl Script for WeaponScript {
                 // A weapon with no Projectile link is melee. In flat mode a swing
                 // is a short forward raycast along the crosshair ray
                 // (RuntimePropFlatAim); a hit deals melee damage. (VR melee
-                // damages via physical collision - MeleeWeapon's Collided handler
-                // - and has no flat aim, so it just no-ops here.)
+                // damages through its trigger-gated physical contact handler
+                // and has no flat aim, so it just no-ops here.)
                 if maybe_projectile.is_none() {
                     if let Ok(aim) = world
                         .borrow::<View<RuntimePropFlatAim>>()

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -190,3 +190,82 @@ test(
     );
   },
 );
+
+// Regression for the #943 review: `set_held_melee` was reachable only from
+// `VirtualHandEffect::HoldItem`, which only a fresh VR world grab emits.
+// `restore_held_item_interaction` goes through `VrInteraction::grab` (which
+// returns no effects) and then unconditionally strips held-item physics, so a
+// wrench carried through a save/load came back with NO collider and silently
+// never reported contacts again - the feature was dead on the path a player
+// actually uses to carry a weapon.
+test(
+  "a melee weapon carried through a save/load keeps its contact body and still damages",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT_SAVE ?? 8139),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.lookAtWorldPoint(wrench.position);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+
+    await game.save("melee-holdthrough");
+    await game.load("melee-holdthrough");
+    await game.step({ frames: 5 });
+
+    // Runtime ids are reassigned by the load, so rediscover everything.
+    const restoredWrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      restoredWrench.id,
+      "the Wrench should still be held after the load",
+    );
+
+    // The actual regression: the restored weapon must still have a live,
+    // controller-driven contact body.
+    const bodies = (await game.physics.bodies({ entityId: restoredWrench.id })).bodies;
+    assert.equal(
+      bodies[0]?.body_type,
+      "kinematic",
+      `a restored held melee weapon must keep its kinematic contact body: ${JSON.stringify(bodies)}`,
+    );
+
+    // ...and it must still actually damage an authored one-HP pane.
+    const pane = await byMissionId(game, "Window 2", BREAKABLE_PANE_MISSION_ID);
+    await game.player.teleport({
+      x: pane.position[0],
+      y: pane.position[1] - 1.04,
+      z: pane.position[2] - 2.6,
+    });
+    await game.step({ frames: 2 });
+    await game.input.lookAtWorldPoint(pane.position);
+    await game.input.set("right_hand.position", HAND_REST);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await sweepHeldWrench(game);
+
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      false,
+      "a wrench carried through a save/load should still break the pane",
+    );
+  },
+);

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntitySummary } from "../src/types.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
 
 // Production regression for #942. This deliberately uses a shipped Wrench and
 // shipped one-HP panes in command2: no debug spawn, damage message, or mission
@@ -29,9 +29,24 @@ async function byMissionId(
   return entity;
 }
 
-async function moveHeldWrenchX(game: GameServer, offsets: number[]): Promise<void> {
-  for (const x of offsets) {
-    await game.input.set("right_hand.position", [x, 1.6, 0]);
+// `right_hand.position` is pawn-local and the held grip sits 0.4 behind the
+// hand, so the wrench's world z is `player.z + local_z - 0.4`. Staging is
+// expressed relative to the pane rather than as bare magic coordinates.
+const HAND_Y = 1.03;
+const HAND_REST: Vec3 = [0.55, HAND_Y, 1.1];
+const HAND_SWEEP: Vec3[] = [
+  [0.5, HAND_Y, 1.4],
+  [0.42, HAND_Y, 1.7],
+  [0.34, HAND_Y, 2.0],
+  [0.26, HAND_Y, 2.3],
+  [0.18, HAND_Y, 2.6],
+  [0.1, HAND_Y, 2.8],
+  [0.05, HAND_Y, 3.0],
+];
+
+async function sweepHeldWrench(game: GameServer): Promise<void> {
+  for (const hand of HAND_SWEEP) {
+    await game.input.set("right_hand.position", hand);
     await game.step({ frames: 1 });
   }
 }
@@ -67,7 +82,11 @@ test(
       y: wrench.position[1] - 1.4,
       z: wrench.position[2] + 1.2,
     });
-    await game.input.set("head.look", [0, 0]);
+    // Aim with the SDK look-at helper, not raw `head.look`: it composes pawn
+    // rotation with the real eye height from `/v1/info`, so the subject is
+    // genuinely in frame. Hand-tuned yaw/pitch is how this scenario previously
+    // produced screenshots that framed neither the wrench nor the pane.
+    await game.input.lookAtWorldPoint(wrench.position);
     await game.input.set("right_hand.position", [0, 1.4, 0]);
     await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
     await game.input.set("right_hand.squeeze", 0);
@@ -81,11 +100,16 @@ test(
       "the real authored Wrench should be grabbed",
     );
 
-    // Stage at the issue's real one-HP pane. The held wrench has a -0.4 Z
-    // grip offset, hence the player is placed 0.4 units in front of the pane.
-    await game.player.teleport({ x: -32, y: 18, z: pane.position[2] + 0.4 });
-    await game.input.set("head.look", [90, 0]);
-    await game.input.set("right_hand.position", [-1.5, 1.6, 0]);
+    // Stage square in front of the issue's real one-HP pane, far enough back
+    // that the pane, the swing and the alcove behind it are all in frame.
+    await game.player.teleport({
+      x: pane.position[0],
+      y: pane.position[1] - 1.04,
+      z: pane.position[2] - 2.6,
+    });
+    await game.step({ frames: 2 });
+    await game.input.lookAtWorldPoint(pane.position);
+    await game.input.set("right_hand.position", HAND_REST);
     await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
     await game.input.set("right_hand.squeeze", 1);
     await game.input.set("right_hand.trigger", 0);
@@ -94,7 +118,7 @@ test(
     // Negative first: physically sweep through the pane without pulling the
     // trigger. Before the fix the authored Wrench had no collision damage at
     // all; an always-hot workaround would incorrectly destroy it here.
-    await moveHeldWrenchX(game, [-1.7, -1.9, -2.1, -2.3, -2.5, -2.7, -2.9, -3.1]);
+    await sweepHeldWrench(game);
     assert.equal(
       await paneStillExists(game, pane.id),
       true,
@@ -103,13 +127,13 @@ test(
 
     // Leave contact, open the attack window with the production VR trigger,
     // then make a fresh controller-driven physics contact.
-    await game.input.set("right_hand.position", [-1.5, 1.6, 0]);
+    await game.input.set("right_hand.position", HAND_REST);
     await game.step({ frames: 5 });
     const beforeAttack =
       (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
     await game.input.set("right_hand.trigger", 1);
     await game.step({ frames: 2 });
-    await moveHeldWrenchX(game, [-1.7, -1.9, -2.1, -2.3, -2.5, -2.7, -2.9, -3.1]);
+    await sweepHeldWrench(game);
 
     const attackMessages = (await game.messages.recent()).messages.filter(
       (message) => message.sequence > beforeAttack && message.to.entity_id === pane.id,

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary } from "../src/types.js";
+
+// Production regression for #942. This deliberately uses a shipped Wrench and
+// shipped one-HP panes in command2: no debug spawn, damage message, or mission
+// runtime id is involved. Runtime ids shuffle, so every object is discovered
+// by its stable mission template id.
+//
+// Opt-in (compiles the runtime + needs Data/ assets):
+//   npm run test:e2e        (or SHOCK2_E2E=1 node --test dist/test/)
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const WRENCH_MISSION_ID = 786;
+const BREAKABLE_PANE_MISSION_ID = 82;
+const DROP_PANE_MISSION_ID = 1477;
+
+async function byMissionId(
+  game: GameServer,
+  name: string,
+  missionId: number,
+): Promise<EntitySummary> {
+  const entity = (
+    await game.entities.list({ filter: name, limit: 20 })
+  ).entities.find((candidate) => candidate.template_id === missionId);
+  assert.ok(entity, `expected ${name} mission object ${missionId}`);
+  return entity;
+}
+
+async function moveHeldWrenchX(game: GameServer, offsets: number[]): Promise<void> {
+  for (const x of offsets) {
+    await game.input.set("right_hand.position", [x, 1.6, 0]);
+    await game.step({ frames: 1 });
+  }
+}
+
+async function paneStillExists(game: GameServer, runtimeId: number): Promise<boolean> {
+  return (
+    await game.entities.list({ filter: "Window 2", limit: 20 })
+  ).entities.some((entity) => entity.id === runtimeId);
+}
+
+test(
+  "VR authored melee damages only during a trigger-gated physical contact window",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8138),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    const pane = await byMissionId(
+      game,
+      "Window 2",
+      BREAKABLE_PANE_MISSION_ID,
+    );
+
+    // Pick up the authored world Wrench through VirtualHand's production
+    // selection ray. Its authored contact body must remain live while held.
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.set("head.look", [0, 0]);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      wrench.id,
+      "the real authored Wrench should be grabbed",
+    );
+
+    // Stage at the issue's real one-HP pane. The held wrench has a -0.4 Z
+    // grip offset, hence the player is placed 0.4 units in front of the pane.
+    await game.player.teleport({ x: -32, y: 18, z: pane.position[2] + 0.4 });
+    await game.input.set("head.look", [90, 0]);
+    await game.input.set("right_hand.position", [-1.5, 1.6, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 3 });
+
+    // Negative first: physically sweep through the pane without pulling the
+    // trigger. Before the fix the authored Wrench had no collision damage at
+    // all; an always-hot workaround would incorrectly destroy it here.
+    await moveHeldWrenchX(game, [-1.7, -1.9, -2.1, -2.3, -2.5, -2.7, -2.9, -3.1]);
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      true,
+      "idle held-Wrench contact must remain harmless",
+    );
+
+    // Leave contact, open the attack window with the production VR trigger,
+    // then make a fresh controller-driven physics contact.
+    await game.input.set("right_hand.position", [-1.5, 1.6, 0]);
+    await game.step({ frames: 5 });
+    const beforeAttack =
+      (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await moveHeldWrenchX(game, [-1.7, -1.9, -2.1, -2.3, -2.5, -2.7, -2.9, -3.1]);
+
+    const attackMessages = (await game.messages.recent()).messages.filter(
+      (message) => message.sequence > beforeAttack && message.to.entity_id === pane.id,
+    );
+    assert.ok(
+      attackMessages.some((message) => message.payload === "Damage"),
+      `trigger + physical contact should damage the pane: ${JSON.stringify(attackMessages)}`,
+    );
+    assert.ok(
+      attackMessages.some((message) => message.payload === "Slay"),
+      `the one-HP pane should break: ${JSON.stringify(attackMessages)}`,
+    );
+    assert.equal(
+      await paneStillExists(game, pane.id),
+      false,
+      "the armed wrench contact should remove the pane",
+    );
+
+    // A drop closes the window and restores the Wrench's ordinary dynamic
+    // loose-prop body. Drop it while overlapping a second authored pane: the
+    // physical contact remains real, but it must not deal melee damage.
+    const dropPane = await byMissionId(
+      game,
+      "Window 2",
+      DROP_PANE_MISSION_ID,
+    );
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+    await game.player.teleport({
+      x: dropPane.position[0] + 2,
+      y: dropPane.position[1] - 1.6,
+      z: dropPane.position[2] + 0.4,
+    });
+    await game.input.set("right_hand.position", [-2, 1.6, 0]);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 10 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "the Wrench should leave the hand",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: wrench.id })).bodies[0]?.body_type,
+      "dynamic",
+      "a dropped Wrench should regain ordinary loose-prop physics",
+    );
+    assert.equal(
+      await paneStillExists(game, dropPane.id),
+      true,
+      "drop contact must remain harmless",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #942

## Summary

- recognize authored melee weapons generically from `PropLimbModel` and add an internal VR-only, trigger-gated contact-damage script
- keep the real world collider while a melee weapon is held, with controller-driven kinematic physics that ignores the player but contacts world props, actors, and kinematic/fixed breakables
- close the damage window on trigger release or drop, restore ordinary dynamic loose-prop physics on drop, and limit each target to one hit per pull
- deal the weapon's **authored** contact-stim damage (the Wrench's `StimSource(WeaponBash, 6.0/9.0, Contact)`) through `stim_response::contact_stim_damage`, the same data path AI melee uses, so a VR swing respects receptrons/armor instead of a flat placeholder
- keep the contact body across a save/load, level transition, and `Effect::GrabEntity`, not only on a fresh world grab
- preserve the legacy literal `wrench` script for the Maintenance Tool template (`-2949`); the player Wrench is template `-928` and continues through `WeaponScript`

## VR result

![VR Wrench trigger/contact demo](https://gist.githubusercontent.com/tommy-xr/6ab6a7d1a9341ed2b170f9125a555e5c/raw/vr-melee-contact.gif)

<sub>The gloved VR hand, the real authored Wrench and the shipped one-HP `Window 2` pane in `command2` are all in frame for the whole swing. With the trigger <b>idle</b> the wrench sweeps physically through the pane and the pane survives; with the production VR trigger <b>held</b> the same contact emits `Damage` → `Slay`, the pane is removed and the keycard behind it is exposed. Captured headlessly in default VR via `/v1/step` + `/v1/screenshot` at a deterministic fixed timestep.</sub>

### Before → after

![origin/main versus fixed VR Wrench contact](https://gist.githubusercontent.com/tommy-xr/6ab6a7d1a9341ed2b170f9125a555e5c/raw/vr-melee-before-after.png)

Both halves are the *same* fresh-launch request sequence against separately-built runtimes. On `origin/main` the armed contact produces no messages at all and the pane survives; on this branch the runtime trace records `Damage` then `Slay` for the pane and the alcove opens.

The camera is aimed with the SDK's `input.lookAtWorldPoint`, which composes pawn rotation with the real eye height from `/v1/info`, rather than hand-tuned `head.look` yaw/pitch — the earlier revision of these visuals framed empty scenery because the raw channel is pawn-local.

## Campaign evidence

Reviewed play-through configuration: **Command · no tweak · 25th Anniversary assets · VR · seed 2110635141**.

The deterministic regression (`tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts`) uses the same authored interaction chain from `command2.mis`:

1. discover and physically grab the real player Wrench (mission object/template id `786`, inheriting Wrench `-928`) through `VirtualHand`
2. sweep it through the authored one-HP `Window 2` pane (mission object/template id `82`) with the trigger idle and verify the pane remains
3. leave contact, pull the production VR trigger, swing back into the pane, and verify runtime `Damage` + `Slay`
4. release and drop against a second authored one-HP pane, verify the Wrench is dynamic again and the pane remains

A second scenario, `a melee weapon carried through a save/load keeps its contact body and still damages`, grabs the Wrench, saves, loads, and asserts the restored weapon is still a kinematic contact body and still breaks a pane. It fails on the parent commit with `bodies: []`.

No mission ids exist in production code; stable mission ids are used only by the E2E to discover shipped fixtures because runtime entity ids shuffle every launch.

## Validation

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p shock2vr` — 580 passed
- `npm test` (SDK TypeScript + unit suite) — 26 passed, 213 opt-in E2E skipped
- `SHOCK2_E2E=1 npm run test:e2e` — 240 tests, 230 passed, 7 skipped, 3 failed. All three are unrelated to this change: `security-ecology` and `trap-unlock` failed with `fetch failed` under suite load and **pass in isolation**; `creature-loot` fails **identically on `origin/main`** (verified by rebuilding the runtime at `origin/main` and re-running) and is tracked as #931.
- targeted real-runtime SDK E2E — 1 passed: `VR authored melee damages only during a trigger-gated physical contact window`
- deterministic `origin/main` vs feature capture against fresh private VR runtimes: baseline pane survives with no pane `Damage`/`Slay`; feature emits `Damage` + `Slay` and removes it

## Compatibility

- flatscreen `WeaponScript` firing/wield behavior is unchanged; the internal contact script is inert outside VR — physical contact is never the damage trigger in flat mode
- authored grab/drop transforms and collision sounds remain in their existing paths
- guns keep their current VR trigger behavior; the melee physics path is selected only for entities with an authored limb model
- attack-window state is intentionally transient across save/load; restored sessions begin harmless until a new trigger pull (the *collider* now survives the load — only the armed window resets)

## Review follow-ups

Found while reviewing this change, filed rather than folded in:

- #951 — flat melee's own timing problem: damage applied on the `TriggerPull` edge rather than on a swing animation event, plus the legacy `wrench` script's unconditional contact damage. Pre-existing on `main`.
- #954 — the held weapon keeps `ENTITY` membership, so the VR hands' selection ray can now hit the weapon the hand is holding.
- #955 — the attack window stays open for as long as the trigger is held, and each target can be hit only once per pull.
- #956 — the VR contact path sends `impact: None`, losing the death-ragdoll directionality the flat swing provides.
