### PR TITLE
fix(audio): honor schema volume and pan

### DIFF
--- a/dark/src/gamesys/gamesys.rs
+++ b/dark/src/gamesys/gamesys.rs
@@ -1,9 +1,7 @@
 use std::io;
 
-use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
-
 use crate::{
-    EnvMap, EnvSoundQuery, SoundSchema, SpeechDB, TagDatabase,
+    EnvMap, EnvSoundQuery, ResolvedSoundSchema, SoundSchema, SpeechDB, TagDatabase,
     gamesys::params::{HrmParams, SkillParams, TrainerCostTables},
     properties::{LinkDefinition, LinkDefinitionWithData, PropertyDefinition},
     ss2_chunk_file_reader::{self},
@@ -25,26 +23,17 @@ pub struct Gamesys {
 }
 
 impl Gamesys {
-    pub fn get_random_environmental_sound(&self, query: &EnvSoundQuery) -> Option<String> {
+    pub fn get_random_environmental_sound(
+        &self,
+        query: &EnvSoundQuery,
+    ) -> Option<ResolvedSoundSchema> {
         let tag_query = query.to_tag_query(&self.speech_db.tag_map, &self.speech_db.value_map);
         let result = self.env_tag_map.query_match_all(&tag_query);
         if result.is_empty() {
             return None;
         }
 
-        let sample = result[0];
-        let maybe_samples = self.sound_schema.id_to_samples.get(&sample);
-
-        maybe_samples?;
-
-        let samples = maybe_samples.unwrap();
-
-        let mut rng = thread_rng();
-        let weights = samples.iter().map(|s| s.frequency).collect::<Vec<u8>>();
-        let weight_index = WeightedIndex::new(weights).unwrap();
-        let idx = weight_index.sample(&mut rng);
-
-        Some(samples[idx].sample_name.to_owned())
+        self.sound_schema.resolve_id(result[0])
     }
 
     pub fn speech_db(&self) -> &SpeechDB {

--- a/dark/src/gamesys/sound_schema.rs
+++ b/dark/src/gamesys/sound_schema.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, io};
 
-use rand::{distributions::WeightedIndex, prelude::Distribution, thread_rng};
+use rand::{Rng, distributions::WeightedIndex, prelude::Distribution, thread_rng};
 use shipyard::{Get, View, World};
 use tracing::trace;
 
 use crate::{
-    properties::{PropSymName, PropTemplateId},
+    properties::{PropSchemaPlayParams, PropSymName},
     ss2_chunk_file_reader::ChunkFileTableOfContents,
     ss2_common::{read_i32, read_string_with_size, read_u8, read_u32},
     ss2_entity_info::SystemShock2EntityInfo,
@@ -17,26 +17,96 @@ pub struct SchemaSample {
     pub frequency: u8,
 }
 
+/// A concrete sample plus the authored playback values resolved from its
+/// schema inheritance chain.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedSoundSchema {
+    pub sample_name: String,
+    pub volume_millibels: i32,
+    pub pan_millibels: i32,
+}
+
+impl ResolvedSoundSchema {
+    /// Convert Dark's millibel gain to the linear amplitude used by rodio.
+    pub fn linear_gain(&self) -> f32 {
+        10.0_f32.powf(self.volume_millibels.clamp(-10_000, 0) as f32 / 2000.0)
+    }
+
+    /// Convert Dark's fixed pan into per-channel amplitude multipliers.
+    pub fn channel_gains(&self) -> [f32; 2] {
+        let pan = self.pan_millibels.clamp(-10_000, 10_000);
+        if pan < 0 {
+            [1.0, 10.0_f32.powf(pan as f32 / 2000.0)]
+        } else if pan > 0 {
+            [10.0_f32.powf(-(pan as f32) / 2000.0), 1.0]
+        } else {
+            [1.0, 1.0]
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SoundSchema {
-    name_to_samples: HashMap<String, Vec<SchemaSample>>,
+    name_to_schema_id: HashMap<String, i32>,
     pub id_to_samples: HashMap<i32, Vec<SchemaSample>>,
+    id_to_play_params: HashMap<i32, PropSchemaPlayParams>,
 }
 
 impl SoundSchema {
     pub fn get_random_sample(&self, schema: &str) -> Option<String> {
-        let maybe_samples = self.name_to_samples.get(&schema.to_ascii_lowercase());
+        let id = *self.name_to_schema_id.get(&schema.to_ascii_lowercase())?;
+        let samples = self.id_to_samples.get(&id)?;
+        let mut rng = thread_rng();
+        let weights = samples.iter().map(|s| s.frequency).collect::<Vec<u8>>();
+        let weight_index = WeightedIndex::new(weights).unwrap();
+        Some(samples[weight_index.sample(&mut rng)].sample_name.clone())
+    }
 
-        if let Some(samples) = maybe_samples {
-            let mut rng = thread_rng();
-            let weights = samples.iter().map(|s| s.frequency).collect::<Vec<u8>>();
-            let weight_index = WeightedIndex::new(weights).unwrap();
-            let idx = weight_index.sample(&mut rng);
+    pub fn resolve(&self, schema: &str) -> Option<ResolvedSoundSchema> {
+        let id = *self.name_to_schema_id.get(&schema.to_ascii_lowercase())?;
+        self.resolve_id(id)
+    }
 
-            Some(samples[idx].sample_name.to_owned())
+    pub fn resolve_id(&self, schema_id: i32) -> Option<ResolvedSoundSchema> {
+        let samples = self.id_to_samples.get(&schema_id)?;
+        let mut rng = thread_rng();
+        let weights = samples.iter().map(|s| s.frequency).collect::<Vec<u8>>();
+        let weight_index = WeightedIndex::new(weights).unwrap();
+        let sample = &samples[weight_index.sample(&mut rng)];
+
+        self.resolve_sample(schema_id, sample.sample_name.clone())
+    }
+
+    /// Attach a schema's play parameters to a sample already selected by a
+    /// caller. Speech uses this to retain its established candidate/sample
+    /// selection rules without losing volume and pan.
+    pub fn resolve_sample(
+        &self,
+        schema_id: i32,
+        sample_name: String,
+    ) -> Option<ResolvedSoundSchema> {
+        self.id_to_samples.get(&schema_id)?;
+        let params = self
+            .id_to_play_params
+            .get(&schema_id)
+            .cloned()
+            .unwrap_or_default();
+        let mut rng = thread_rng();
+
+        let pan_millibels = if params.flags & PropSchemaPlayParams::PAN_POSITION != 0 {
+            params.pan
+        } else if params.flags & PropSchemaPlayParams::PAN_RANGE != 0 {
+            let range = params.pan.clamp(-10_000, 10_000).abs();
+            rng.gen_range(-range..=range)
         } else {
-            None
-        }
+            0
+        };
+
+        Some(ResolvedSoundSchema {
+            sample_name,
+            volume_millibels: params.volume,
+            pan_millibels,
+        })
     }
 
     pub fn read<T: io::Read + io::Seek>(
@@ -77,36 +147,88 @@ impl SoundSchema {
         // 2) Create database of entities - initializing the props, so we can read the sym name.
         // This will let us get the symname <-> EntityId relationship
         let mut world = World::new();
-        let mut template_id_to_entity = HashMap::new();
-        for (id, props) in &gamesys_entity_info.entity_to_properties {
-            // Create the entity
-            let entity = world.add_entity(());
-            world.add_component(entity, PropTemplateId { template_id: *id });
+        let template_id_to_entity =
+            gamesys_entity_info
+                .initialize_world_with_entities(&mut world, HashMap::new(), |_| true);
 
-            template_id_to_entity.insert(*id, entity);
-
-            for prop in props {
-                prop.initialize(&mut world, entity);
-            }
-        }
-
-        // 3) Finally, we can use 1) and 2) above to create a map of string to schema samples
-        let mut name_to_samples = HashMap::new();
-        for (k, v) in &id_to_samples {
+        // 3) Finally, use the hydrated world to associate schema ids with names
+        // and inherited playback values.
+        let mut name_to_schema_id = HashMap::new();
+        let mut id_to_play_params = HashMap::new();
+        let v_sym_name = world.borrow::<View<PropSymName>>().unwrap();
+        let v_play_params = world.borrow::<View<PropSchemaPlayParams>>().unwrap();
+        for k in id_to_samples.keys() {
             let entity = template_id_to_entity.get(k).unwrap();
-
-            let v_sym_name = world.borrow::<View<PropSymName>>().unwrap();
-            let maybe_name = v_sym_name.get(*entity);
-
-            if let Ok(name) = maybe_name {
-                name_to_samples.insert(name.0.to_ascii_lowercase(), v.clone());
+            if let Ok(name) = v_sym_name.get(*entity) {
+                name_to_schema_id.insert(name.0.to_ascii_lowercase(), *k);
+            }
+            if let Ok(params) = v_play_params.get(*entity) {
+                id_to_play_params.insert(*k, params.clone());
             }
         }
 
-        trace!("{:?}", name_to_samples);
+        trace!("{:?}", name_to_schema_id);
         SoundSchema {
-            name_to_samples,
+            name_to_schema_id,
             id_to_samples,
+            id_to_play_params,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_with_params(params: PropSchemaPlayParams) -> SoundSchema {
+        SoundSchema {
+            name_to_schema_id: HashMap::from([("test".to_owned(), -1)]),
+            id_to_samples: HashMap::from([(
+                -1,
+                vec![SchemaSample {
+                    sample_name: "sample".to_owned(),
+                    frequency: 1,
+                }],
+            )]),
+            id_to_play_params: HashMap::from([(-1, params)]),
+        }
+    }
+
+    #[test]
+    fn millibels_convert_to_linear_gain_and_channel_pan() {
+        let resolved = ResolvedSoundSchema {
+            sample_name: "sample".to_owned(),
+            volume_millibels: -2500,
+            pan_millibels: -1000,
+        };
+        assert!((resolved.linear_gain() - 0.056_234_132).abs() < 0.000_001);
+        let [left, right] = resolved.channel_gains();
+        assert_eq!(left, 1.0);
+        assert!((right - 0.316_227_76).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn schema_pan_flags_control_fixed_and_randomized_pan() {
+        let fixed = schema_with_params(PropSchemaPlayParams {
+            flags: PropSchemaPlayParams::PAN_POSITION,
+            pan: -700,
+            ..Default::default()
+        });
+        assert_eq!(fixed.resolve("test").unwrap().pan_millibels, -700);
+
+        let ranged = schema_with_params(PropSchemaPlayParams {
+            flags: PropSchemaPlayParams::PAN_RANGE,
+            pan: 1200,
+            ..Default::default()
+        });
+        for _ in 0..32 {
+            assert!((-1200..=1200).contains(&ranged.resolve("test").unwrap().pan_millibels));
+        }
+
+        let unpanned = schema_with_params(PropSchemaPlayParams {
+            pan: 9000,
+            ..Default::default()
+        });
+        assert_eq!(unpanned.resolve("test").unwrap().pan_millibels, 0);
     }
 }

--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -35,6 +35,7 @@ mod prop_render_type;
 mod prop_replicator;
 mod prop_research;
 mod prop_room_gravity;
+mod prop_schema_play_params;
 mod prop_service;
 mod prop_spawn;
 mod prop_trip_flags;
@@ -78,6 +79,7 @@ pub use prop_render_type::*;
 pub use prop_replicator::*;
 pub use prop_research::*;
 pub use prop_room_gravity::*;
+pub use prop_schema_play_params::*;
 pub use prop_service::*;
 pub use prop_spawn::*;
 pub use prop_trip_flags::*;
@@ -1747,6 +1749,12 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
         define_prop(
             "P$RoomGrav",
             PropRoomGravity::read,
+            identity,
+            accumulator::latest,
+        ),
+        define_prop(
+            "P$SchPlayPa",
+            PropSchemaPlayParams::read,
             identity,
             accumulator::latest,
         ),

--- a/dark/src/properties/prop_schema_play_params.rs
+++ b/dark/src/properties/prop_schema_play_params.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use shipyard::Component;
+
+use crate::ss2_common::{read_i32, read_u32};
+
+/// Dark's `sSchemaPlayParams` (`P$SchPlayPa`) record.
+///
+/// Volumes and pans use the sound library's millibel scale. Volume runs from
+/// -10_000 (silent) to -1 (nominal); pan runs from -10_000 (left) through 0
+/// (center) to 10_000 (right).
+#[derive(Clone, Debug, Component, Deserialize, PartialEq, Serialize)]
+pub struct PropSchemaPlayParams {
+    pub flags: u32,
+    pub volume: i32,
+    pub pan: i32,
+    pub initial_delay: i32,
+    pub fade: i32,
+}
+
+impl Default for PropSchemaPlayParams {
+    fn default() -> Self {
+        Self {
+            flags: 0,
+            volume: -1,
+            pan: 0,
+            initial_delay: 0,
+            fade: 0,
+        }
+    }
+}
+
+impl PropSchemaPlayParams {
+    pub const PAN_POSITION: u32 = 1 << 1;
+    pub const PAN_RANGE: u32 = 1 << 2;
+
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> Self {
+        Self {
+            flags: read_u32(reader),
+            volume: read_i32(reader),
+            pan: read_i32(reader),
+            initial_delay: read_i32(reader),
+            fade: read_i32(reader),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn reads_all_five_little_endian_words() {
+        let bytes = [
+            0x02, 0x00, 0x01, 0x00, // flags = 0x00010002
+            0x18, 0xfc, 0xff, 0xff, // volume = -1000
+            0x44, 0xfd, 0xff, 0xff, // pan = -700
+            0xc8, 0x00, 0x00, 0x00, // delay = 200
+            0x2c, 0x01, 0x00, 0x00, // fade = 300
+        ];
+        let parsed = PropSchemaPlayParams::read(&mut Cursor::new(bytes), bytes.len() as u32);
+        assert_eq!(
+            parsed,
+            PropSchemaPlayParams {
+                flags: 0x0001_0002,
+                volume: -1000,
+                pan: -700,
+                initial_delay: 200,
+                fade: 300,
+            }
+        );
+    }
+}

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -490,3 +490,32 @@ fn gamesys_hrm_params_match_retail_hacking_tuning() {
     assert_eq!(params.success_chance(50, 0, 1), 55);
     assert_eq!(params.mine_count(2, 0, 1), 1);
 }
+
+#[test]
+fn gamesys_sound_schema_resolves_authored_and_inherited_play_params() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let (props, links, links_with_data) = properties::get();
+    let file = File::open(data.join("shock2.gam")).expect("shock2.gam should open");
+    let mut reader = BufReader::new(file);
+    let gamesys = dark::gamesys::read(&mut reader, &links, &links_with_data, &props);
+
+    // linebeep authors its own -25 dB attenuation in P$SchPlayPa.
+    let linebeep = gamesys
+        .sound_schema()
+        .resolve("linebeep")
+        .expect("linebeep schema should resolve");
+    assert_eq!(linebeep.volume_millibels, -2500);
+    assert_eq!(linebeep.pan_millibels, 0);
+
+    // log0219 has samples but no local play-params property. It inherits the
+    // SPEECH_LOGS fixed-pan values, so direct-only property loading loses both.
+    let log = gamesys
+        .sound_schema()
+        .resolve("log0219")
+        .expect("log0219 schema should resolve");
+    assert_eq!(log.volume_millibels, -300);
+    assert_eq!(log.pan_millibels, -1000);
+}

--- a/engine/src/audio/mod.rs
+++ b/engine/src/audio/mod.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use cgmath::{Vector3, vec3};
 use rodio::buffer::SamplesBuffer;
-use rodio::source::{Buffered, Source};
+use rodio::source::{Buffered, ChannelVolume, Source};
 use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink, SpatialSink};
 
 use crate::audio_log;
@@ -16,6 +16,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static NEXT_HANDLE_ID: AtomicU64 = AtomicU64::new(0);
 
 const SOUND_SCALE_FACTOR: f32 = 5.0;
+// `play_audio` historically used a SpatialSink placed midway between the ears;
+// rodio's centered spatial mix applies 0.75 to both channels. Retain that
+// listener-relative baseline when using a regular Sink for authored pan.
+const STATIC_CENTER_GAIN: f32 = 0.75;
 
 #[derive(Clone, Debug)]
 pub struct AudioHandle {
@@ -43,6 +47,39 @@ impl AudioHandle {
 
 pub struct AudioChannel {
     name: String,
+}
+
+/// Gain, stereo channel attenuation and repeat behavior for
+/// listener-relative playback.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AudioPlaybackSettings {
+    pub gain: f32,
+    pub channel_gains: [f32; 2],
+    /// Repeat forever instead of playing once. `stop_audio` ends it.
+    pub looping: bool,
+}
+
+impl Default for AudioPlaybackSettings {
+    fn default() -> Self {
+        Self {
+            gain: 1.0,
+            channel_gains: [STATIC_CENTER_GAIN, STATIC_CENTER_GAIN],
+            looping: false,
+        }
+    }
+}
+
+impl AudioPlaybackSettings {
+    pub fn listener_relative(gain: f32, pan_gains: [f32; 2]) -> Self {
+        Self {
+            gain,
+            channel_gains: [
+                pan_gains[0] * STATIC_CENTER_GAIN,
+                pan_gains[1] * STATIC_CENTER_GAIN,
+            ],
+            ..Default::default()
+        }
+    }
 }
 
 impl AudioChannel {
@@ -84,7 +121,7 @@ where
 }
 
 enum SinkAdapter<TSourceKey> {
-    StaticSink(SpatialSink),
+    StaticSink(Sink),
     PositionalSink {
         sink: SpatialSink,
         emitter: TrackedEmitter<TSourceKey>,
@@ -95,14 +132,7 @@ impl<TSourceKey> SinkAdapter<TSourceKey>
 where
     TSourceKey: Copy,
 {
-    fn inner(&self) -> &SpatialSink {
-        match self {
-            SinkAdapter::StaticSink(sink) => sink,
-            SinkAdapter::PositionalSink { sink, .. } => sink,
-        }
-    }
-
-    fn fixed(sink: SpatialSink) -> SinkAdapter<TSourceKey> {
+    fn fixed(sink: Sink) -> SinkAdapter<TSourceKey> {
         SinkAdapter::StaticSink(sink)
     }
 
@@ -137,11 +167,17 @@ where
     }
 
     fn empty(&self) -> bool {
-        self.inner().empty()
+        match self {
+            SinkAdapter::StaticSink(sink) => sink.empty(),
+            SinkAdapter::PositionalSink { sink, .. } => sink.empty(),
+        }
     }
 
     fn stop(&self) {
-        self.inner().stop();
+        match self {
+            SinkAdapter::StaticSink(sink) => sink.stop(),
+            SinkAdapter::PositionalSink { sink, .. } => sink.stop(),
+        }
     }
 }
 
@@ -387,20 +423,35 @@ impl AudioClip {
             SourceType::Raw(source) => sink.append(source.clone()),
         }
     }
-
-    /// Append the clip so it repeats forever - a seamless bed (a menu hum, a
-    /// machine loop) rather than the re-append-when-empty pattern, which leaves
-    /// an audible gap of however long the caller takes to notice.
-    pub fn add_to_spatial_sink_looping(&self, sink: &SpatialSink) {
-        match &self.source {
-            SourceType::Bytes(source) => sink.append(source.clone().repeat_infinite()),
-            SourceType::Raw(source) => sink.append(source.clone().repeat_infinite()),
-        }
-    }
     pub fn add_to_sink(&self, sink: &Sink) {
         match &self.source {
             SourceType::Bytes(source) => sink.append(source.clone()),
             SourceType::Raw(source) => sink.append(source.clone()),
+        }
+    }
+
+    fn add_to_sink_with_settings(&self, sink: &Sink, settings: AudioPlaybackSettings) {
+        sink.set_volume(settings.gain);
+        let channel_volumes = settings.channel_gains.to_vec();
+        // A looping clip repeats inside the source - a seamless bed (a menu
+        // hum, a machine loop) rather than the re-append-when-empty pattern,
+        // which leaves an audible gap of however long the caller takes to
+        // notice.
+        match (&self.source, settings.looping) {
+            (SourceType::Bytes(source), false) => {
+                sink.append(ChannelVolume::new(source.clone(), channel_volumes))
+            }
+            (SourceType::Raw(source), false) => {
+                sink.append(ChannelVolume::new(source.clone(), channel_volumes))
+            }
+            (SourceType::Bytes(source), true) => sink.append(ChannelVolume::new(
+                source.clone().repeat_infinite(),
+                channel_volumes,
+            )),
+            (SourceType::Raw(source), true) => sink.append(ChannelVolume::new(
+                source.clone().repeat_infinite(),
+                channel_volumes,
+            )),
         }
     }
     pub fn from_bytes(bytes: Vec<u8>) -> AudioClip {
@@ -481,24 +532,6 @@ pub fn stop_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     }
 }
 
-/// How a clip is played, beyond where it is played.
-#[derive(Clone, Copy, Debug)]
-pub struct PlayOptions {
-    /// Sink volume, 1.0 being the clip's own level.
-    pub volume: f32,
-    /// Repeat forever instead of playing once. `stop_audio` ends it.
-    pub looping: bool,
-}
-
-impl Default for PlayOptions {
-    fn default() -> Self {
-        PlayOptions {
-            volume: 1.0,
-            looping: false,
-        }
-    }
-}
-
 /// Plays audio at the listener origin (non-spatial).
 pub fn play_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     context: &mut AudioContext<TAmbientKey, TCue>,
@@ -506,35 +539,26 @@ pub fn play_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
 ) -> Vec<u64> {
-    play_audio_with(
+    play_audio_with_settings(
         context,
         handle,
         maybe_channel,
         audio_clip,
-        PlayOptions::default(),
+        AudioPlaybackSettings::default(),
     )
 }
 
-/// [`play_audio`] with explicit volume/looping - for non-diegetic audio that
-/// is not simply "play this once at full volume" (a looping menu bed).
-pub fn play_audio_with<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
+pub fn play_audio_with_settings<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     context: &mut AudioContext<TAmbientKey, TCue>,
     handle: AudioHandle,
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
-    options: PlayOptions,
+    settings: AudioPlaybackSettings,
 ) -> Vec<u64> {
-    let position = (context.last_left_ear_position + context.last_right_ear_position) / 2.0;
-
     let id = handle.id;
-    let (sink, preempted) = play_audio_core(
-        context,
-        position,
-        handle,
-        maybe_channel,
-        audio_clip,
-        options,
-    );
+    let preempted = prepare_audio_play(context, &handle, maybe_channel);
+    let sink = rodio::Sink::try_new(&context.handle).unwrap();
+    audio_clip.add_to_sink_with_settings(&sink, settings);
 
     context.handle_to_sink.insert(id, SinkAdapter::fixed(sink));
     preempted
@@ -548,16 +572,31 @@ pub fn play_spatial_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
 ) -> Vec<u64> {
-    let id = handle.id;
-    let scaled_position = position / SOUND_SCALE_FACTOR;
-    let (sink, preempted) = play_audio_core(
+    play_spatial_audio_with_gain(
         context,
-        scaled_position,
+        position,
+        source,
         handle,
         maybe_channel,
         audio_clip,
-        PlayOptions::default(),
-    );
+        1.0,
+    )
+}
+
+pub fn play_spatial_audio_with_gain<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
+    context: &mut AudioContext<TAmbientKey, TCue>,
+    position: Vector3<f32>,
+    source: Option<TAmbientKey>,
+    handle: AudioHandle,
+    maybe_channel: Option<AudioChannel>,
+    audio_clip: Rc<AudioClip>,
+    gain: f32,
+) -> Vec<u64> {
+    let id = handle.id;
+    let scaled_position = position / SOUND_SCALE_FACTOR;
+    let (sink, preempted) =
+        play_audio_core(context, scaled_position, handle, maybe_channel, audio_clip);
+    sink.set_volume(gain);
 
     context
         .handle_to_sink
@@ -579,11 +618,41 @@ pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     handle: AudioHandle,
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
-    options: PlayOptions,
 ) -> (SpatialSink, Vec<u64>) {
     // Handles whose playback this play cuts short. Reported back so callers
     // (the audio log) can mark them stopped - these preemptions never go
     // through `stop_audio`.
+    let preempted = prepare_audio_play(context, &handle, maybe_channel);
+
+    //let reverb = source.buffered().reverb(Duration::from_millis(40), 0.7);
+    // let x = rand::thread_rng().gen_range(-1.0..1.0);
+    // let y = rand::thread_rng().gen_range(-1.0..1.0);
+    // let z = rand::thread_rng().gen_range(-1.0..1.0);
+    let scaled_x = position.x;
+    let scaled_y = position.y;
+    let scaled_z = position.z;
+    let left_ear = context.last_left_ear_position;
+    let right_ear = context.last_right_ear_position;
+    let positions = (
+        [scaled_x, scaled_y, scaled_z],
+        [left_ear.x, left_ear.y, left_ear.z],
+        [right_ear.x, right_ear.y, right_ear.z],
+    );
+    let sink = rodio::SpatialSink::try_new(&context.handle, positions.0, positions.1, positions.2)
+        .unwrap();
+    audio_clip.add_to_spatial_sink(&sink);
+
+    //context.handle_to_sink.insert(handle.id, sink);
+    (sink, preempted)
+
+    //context.spatial_sinks.push(sink);
+}
+
+fn prepare_audio_play<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
+    context: &mut AudioContext<TAmbientKey, TCue>,
+    handle: &AudioHandle,
+    maybe_channel: Option<AudioChannel>,
+) -> Vec<u64> {
     let mut preempted = Vec::new();
 
     if let Some(channel) = maybe_channel {
@@ -612,38 +681,12 @@ pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
         }
     }
 
-    //let reverb = source.buffered().reverb(Duration::from_millis(40), 0.7);
-    // let x = rand::thread_rng().gen_range(-1.0..1.0);
-    // let y = rand::thread_rng().gen_range(-1.0..1.0);
-    // let z = rand::thread_rng().gen_range(-1.0..1.0);
-    let scaled_x = position.x;
-    let scaled_y = position.y;
-    let scaled_z = position.z;
-    let left_ear = context.last_left_ear_position;
-    let right_ear = context.last_right_ear_position;
-    let positions = (
-        [scaled_x, scaled_y, scaled_z],
-        [left_ear.x, left_ear.y, left_ear.z],
-        [right_ear.x, right_ear.y, right_ear.z],
-    );
-    let sink = rodio::SpatialSink::try_new(&context.handle, positions.0, positions.1, positions.2)
-        .unwrap();
-    sink.set_volume(options.volume);
-    if options.looping {
-        audio_clip.add_to_spatial_sink_looping(&sink);
-    } else {
-        audio_clip.add_to_spatial_sink(&sink);
-    }
-
-    //context.handle_to_sink.insert(handle.id, sink);
-    (sink, preempted)
-
-    //context.spatial_sinks.push(sink);
+    preempted
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{TrackedEmitter, wav_duration};
+    use super::{AudioClip, AudioPlaybackSettings, TrackedEmitter, wav_duration};
     use cgmath::vec3;
 
     fn riff(avg_bytes_per_sec: u32, data_len: usize) -> Vec<u8> {
@@ -693,5 +736,23 @@ mod tests {
         });
 
         assert_eq!(emitter.position(), vec3(4.0, 5.0, 6.0));
+    }
+
+    #[test]
+    fn static_sink_receives_schema_gain_and_pan() {
+        let clip = AudioClip::from_raw(1, 1, vec![i16::MAX / 2]);
+        let (sink, mut output) = rodio::Sink::new_idle();
+        clip.add_to_sink_with_settings(
+            &sink,
+            AudioPlaybackSettings {
+                gain: 0.5,
+                channel_gains: [1.0, 0.25],
+                looping: false,
+            },
+        );
+
+        assert_eq!(sink.volume(), 0.5);
+        assert!((output.next().unwrap() - 0.25).abs() < 0.001);
+        assert!((output.next().unwrap() - 0.0625).abs() < 0.001);
     }
 }

--- a/shock2vr/src/audio_log.rs
+++ b/shock2vr/src/audio_log.rs
@@ -51,6 +51,14 @@ pub struct PlayedSound {
     pub frame: u64,
     /// Resolved sample name (e.g. "bulmet2"), without extension.
     pub sample: String,
+    /// Authored Dark-schema volume, in millibels; absent for direct samples.
+    pub volume_millibels: Option<i32>,
+    /// Linear gain actually assigned to the rodio sink.
+    pub gain: f32,
+    /// Resolved authored pan, in millibels; absent for direct samples.
+    pub pan_millibels: Option<i32>,
+    /// False when positional 3D panning superseded the schema pan.
+    pub pan_applied: bool,
     /// The schema query's (tag, value) pairs (e.g. event=collision, material=metal).
     pub tags: Vec<(String, String)>,
     pub position: [f32; 3],
@@ -69,6 +77,10 @@ pub struct PlayedSound {
 /// Arguments for [`record`], grouped so call sites stay readable.
 pub struct SoundRecord<'a> {
     pub sample: &'a str,
+    pub volume_millibels: Option<i32>,
+    pub gain: f32,
+    pub pan_millibels: Option<i32>,
+    pub pan_applied: bool,
     pub tags: Vec<(String, String)>,
     pub position: [f32; 3],
     pub duration: Option<Duration>,
@@ -109,6 +121,10 @@ pub fn record(record: SoundRecord) {
         sim_time,
         frame: frame_of(sim_time),
         sample: record.sample.to_owned(),
+        volume_millibels: record.volume_millibels,
+        gain: record.gain,
+        pan_millibels: record.pan_millibels,
+        pan_applied: record.pan_applied,
         tags: record.tags,
         position: record.position,
         duration_secs: record.duration.map(|d| d.as_secs_f64()),
@@ -182,6 +198,10 @@ mod tests {
             sim_time,
             frame: frame_of(sim_time),
             sample: "test".to_owned(),
+            volume_millibels: None,
+            gain: 1.0,
+            pan_millibels: None,
+            pan_applied: false,
             tags: vec![],
             position: [0.0, 0.0, 0.0],
             duration_secs,
@@ -222,6 +242,10 @@ mod tests {
         for _ in 0..2 {
             record(SoundRecord {
                 sample: "test",
+                volume_millibels: None,
+                gain: 1.0,
+                pan_millibels: None,
+                pan_applied: false,
                 tags: vec![],
                 position: [0.0, 0.0, 0.0],
                 duration: Some(Duration::from_secs(5)),

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -51,7 +51,7 @@ use dark::{
 };
 use engine::{
     assets::asset_cache::AssetCache,
-    audio::{AudioChannel, AudioContext, AudioHandle},
+    audio::{AudioChannel, AudioContext, AudioHandle, AudioPlaybackSettings},
     game_log, profile,
     scene::{
         BillboardMaterial, ParticleSystem, SceneObject, VertexPosition, light::SpotLight, quad,
@@ -5081,6 +5081,10 @@ impl MissionCore {
                         crate::audio_log::record_stops(&preempted);
                         crate::audio_log::record(crate::audio_log::SoundRecord {
                             sample: &email_file,
+                            volume_millibels: None,
+                            gain: 1.0,
+                            pan_millibels: None,
+                            pan_applied: false,
                             tags: vec![("kind".to_string(), "email".to_string())],
                             position: [0.0, 0.0, 0.0],
                             duration,
@@ -5097,14 +5101,15 @@ impl MissionCore {
                     spatial,
                 } => {
                     println!("Trying to play sound: {}", &name);
-                    let audio_file = resolve_schema(global_context, &name.to_string());
-                    let maybe_audio_clip =
-                        asset_cache.get_opt(&AUDIO_IMPORTER, &format!("{audio_file}.wav"));
+                    let (resolved, has_schema) = resolve_schema(global_context, &name);
+                    let maybe_audio_clip = asset_cache
+                        .get_opt(&AUDIO_IMPORTER, &format!("{}.wav", resolved.sample_name));
 
                     if let Some(audio_clip) = maybe_audio_clip {
                         info!("Playing clip: {} handle: {:?}", name, &handle);
                         let duration = audio_clip.total_duration();
                         let handle_id = handle.id();
+                        let gain = resolved.linear_gain();
                         // Spatial emitters (TrapSound narrations anchored at
                         // their authored station) play at the source entity,
                         // like the original engine's object sounds. Everything
@@ -5117,16 +5122,26 @@ impl MissionCore {
                             None
                         };
                         let preempted = if let Some(position) = maybe_position {
-                            engine::audio::play_spatial_audio(
+                            engine::audio::play_spatial_audio_with_gain(
                                 audio_context,
                                 position,
                                 source,
                                 handle,
                                 None,
                                 audio_clip,
+                                gain,
                             )
                         } else {
-                            engine::audio::play_audio(audio_context, handle, None, audio_clip)
+                            engine::audio::play_audio_with_settings(
+                                audio_context,
+                                handle,
+                                None,
+                                audio_clip,
+                                AudioPlaybackSettings::listener_relative(
+                                    gain,
+                                    resolved.channel_gains(),
+                                ),
+                            )
                         };
                         // Observability: record scripted one-shot sounds (audio
                         // logs, keypad beeps, ...) so headless tooling can assert
@@ -5134,7 +5149,11 @@ impl MissionCore {
                         let position = maybe_position.unwrap_or_else(|| vec3(0.0, 0.0, 0.0));
                         crate::audio_log::record_stops(&preempted);
                         crate::audio_log::record(crate::audio_log::SoundRecord {
-                            sample: &audio_file,
+                            sample: &resolved.sample_name,
+                            volume_millibels: has_schema.then_some(resolved.volume_millibels),
+                            gain,
+                            pan_millibels: has_schema.then_some(resolved.pan_millibels),
+                            pan_applied: has_schema && maybe_position.is_none(),
                             tags: vec![("kind".to_string(), "sound".to_string())],
                             position: [position.x, position.y, position.z],
                             duration,
@@ -5151,30 +5170,41 @@ impl MissionCore {
                     concept,
                     tags,
                 } => {
-                    if let Some(sample_name) = resolve_speech_sample(
+                    if let Some(resolved) = resolve_speech_sample(
                         &global_context.gamesys,
                         voice_index,
                         concept.as_str(),
                         &tags,
                     ) {
-                        let audio_path = format!("{sample_name}.wav");
+                        let audio_path = format!("{}.wav", resolved.sample_name);
                         if let Some(audio_clip) = asset_cache.get_opt(&AUDIO_IMPORTER, &audio_path)
                         {
                             let handle = AudioHandle::new();
                             let duration = audio_clip.total_duration();
                             let handle_id = handle.id();
+                            let gain = resolved.linear_gain();
                             let maybe_position = get_entity_position(&self.world, entity_id);
                             let preempted = if let Some(position) = maybe_position {
-                                engine::audio::play_spatial_audio(
+                                engine::audio::play_spatial_audio_with_gain(
                                     audio_context,
                                     position,
                                     Some(entity_id),
                                     handle,
                                     None,
                                     audio_clip,
+                                    gain,
                                 )
                             } else {
-                                engine::audio::play_audio(audio_context, handle, None, audio_clip)
+                                engine::audio::play_audio_with_settings(
+                                    audio_context,
+                                    handle,
+                                    None,
+                                    audio_clip,
+                                    AudioPlaybackSettings::listener_relative(
+                                        gain,
+                                        resolved.channel_gains(),
+                                    ),
+                                )
                             };
                             crate::audio_log::record_stops(&preempted);
                             // Observability: speech is the loudest source of
@@ -5186,7 +5216,11 @@ impl MissionCore {
                             ];
                             sound_tags.extend(tags.iter().cloned());
                             crate::audio_log::record(crate::audio_log::SoundRecord {
-                                sample: &sample_name,
+                                sample: &resolved.sample_name,
+                                volume_millibels: Some(resolved.volume_millibels),
+                                gain,
+                                pan_millibels: Some(resolved.pan_millibels),
+                                pan_applied: maybe_position.is_none(),
                                 tags: sound_tags,
                                 position: [position.x, position.y, position.z],
                                 duration,
@@ -7487,13 +7521,25 @@ pub fn make_un_physical2(
     id_to_physics.remove(&entity_id);
 }
 
-fn resolve_schema(global_context: &GlobalContext, name: &str) -> String {
+fn resolve_schema(global_context: &GlobalContext, name: &str) -> (dark::ResolvedSoundSchema, bool) {
     let sound_schema = &global_context.gamesys.sound_schema;
-    let ret = sound_schema
-        .get_random_sample(name)
-        .unwrap_or_else(|| name.to_owned());
-    trace!("resolved sound schema {} to {}", name, ret);
-    ret
+    if let Some(resolved) = sound_schema.resolve(name) {
+        trace!(
+            "resolved sound schema {} to {} at {} millibels, pan {}",
+            name, resolved.sample_name, resolved.volume_millibels, resolved.pan_millibels
+        );
+        (resolved, true)
+    } else {
+        trace!("sound {} is a direct sample, not a schema", name);
+        (
+            dark::ResolvedSoundSchema {
+                sample_name: name.to_owned(),
+                volume_millibels: 0,
+                pan_millibels: 0,
+            },
+            false,
+        )
+    }
 }
 
 fn resolve_speech_sample(
@@ -7501,7 +7547,7 @@ fn resolve_speech_sample(
     voice_index: usize,
     concept: &str,
     tags: &[(String, String)],
-) -> Option<String> {
+) -> Option<dark::ResolvedSoundSchema> {
     let speech_db = gamesys.speech_db();
     if voice_index >= speech_db.voices.len() {
         return None;
@@ -7562,7 +7608,9 @@ fn resolve_speech_sample(
         .map(|dist| dist.sample(&mut rng))
         .unwrap_or_else(|_| rng.gen_range(0..samples.len()));
 
-    Some(samples[selected_index].sample_name.clone())
+    gamesys
+        .sound_schema
+        .resolve_sample(schema_id, samples[selected_index].sample_name.clone())
 }
 
 /// Stable identity of the entity a sound came from, for the audio log.
@@ -7579,30 +7627,34 @@ fn play_environmental_sound(
     audio_handle: AudioHandle,
     position: Vector3<f32>,
 ) {
-    let maybe_audio_file = gamesys.get_random_environmental_sound(&query);
-    if maybe_audio_file.is_some() {
-        let audio_file = maybe_audio_file.unwrap();
-        let audio_clip = asset_cache.get(&AUDIO_IMPORTER, &format!("{audio_file}.wav").to_owned());
+    if let Some(resolved) = gamesys.get_random_environmental_sound(&query) {
+        let audio_clip = asset_cache.get(&AUDIO_IMPORTER, &format!("{}.wav", resolved.sample_name));
 
         info!(
             "Playing clip: {} handle: {:?} position: {:?}",
-            audio_file, &audio_handle, position
+            resolved.sample_name, &audio_handle, position
         );
         // Log the resolved play so headless tooling (debug runtime
         // /v1/audio/recent) can assert a schema actually played.
         let duration = audio_clip.total_duration();
         let handle_id = audio_handle.id();
-        let preempted = engine::audio::play_spatial_audio(
+        let gain = resolved.linear_gain();
+        let preempted = engine::audio::play_spatial_audio_with_gain(
             audio_context,
             position,
             None,
             audio_handle,
             None,
             audio_clip,
+            gain,
         );
         crate::audio_log::record_stops(&preempted);
         crate::audio_log::record(crate::audio_log::SoundRecord {
-            sample: &audio_file,
+            sample: &resolved.sample_name,
+            volume_millibels: Some(resolved.volume_millibels),
+            gain,
+            pan_millibels: Some(resolved.pan_millibels),
+            pan_applied: false,
             tags: query.tag_values(),
             position: [position.x, position.y, position.z],
             duration,

--- a/shock2vr/src/scenes/frontend_sfx.rs
+++ b/shock2vr/src/scenes/frontend_sfx.rs
@@ -25,7 +25,9 @@
 
 use engine::{
     assets::asset_cache::AssetCache,
-    audio::{AudioContext, AudioHandle, PlayOptions, play_audio_with, stop_audio},
+    audio::{
+        AudioContext, AudioHandle, AudioPlaybackSettings, play_audio_with_settings, stop_audio,
+    },
 };
 use shipyard::EntityId;
 use tracing::warn;
@@ -124,9 +126,10 @@ impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
             self.hum = if self.play(
                 HUM_SOUND,
                 &handle,
-                PlayOptions {
-                    volume: HUM_VOLUME,
+                AudioPlaybackSettings {
+                    gain: HUM_VOLUME,
                     looping: true,
+                    ..Default::default()
                 },
                 asset_cache,
                 audio_context,
@@ -141,9 +144,9 @@ impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
             self.play(
                 sound,
                 &AudioHandle::new(),
-                PlayOptions {
-                    volume,
-                    looping: false,
+                AudioPlaybackSettings {
+                    gain: volume,
+                    ..Default::default()
                 },
                 asset_cache,
                 audio_context,
@@ -174,7 +177,7 @@ impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
         &mut self,
         name: &'static str,
         handle: &AudioHandle,
-        options: PlayOptions,
+        settings: AudioPlaybackSettings,
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) -> bool {
@@ -184,10 +187,15 @@ impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
             return false;
         };
         let duration = clip.total_duration();
-        let preempted = play_audio_with(audio_context, handle.clone(), None, clip, options);
+        let preempted =
+            play_audio_with_settings(audio_context, handle.clone(), None, clip, settings);
         crate::audio_log::record_stops(&preempted);
         crate::audio_log::record(crate::audio_log::SoundRecord {
             sample: name,
+            volume_millibels: None,
+            gain: settings.gain,
+            pan_millibels: None,
+            pan_applied: false,
             tags: vec![("kind".to_owned(), "menu".to_owned())],
             position: [0.0, 0.0, 0.0],
             duration,

--- a/tools/dark_query/src/main.rs
+++ b/tools/dark_query/src/main.rs
@@ -762,7 +762,10 @@ fn handle_sound_command(tags: &[String]) -> Result<()> {
 
     println!("Query: {:?}", query);
     match result {
-        Some(sound_file) => println!("Result: {}", sound_file),
+        Some(sound) => println!(
+            "Result: {} (volume {} millibels, pan {} millibels)",
+            sound.sample_name, sound.volume_millibels, sound.pan_millibels
+        ),
         None => println!("No matching sounds found"),
     }
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -676,6 +676,14 @@ export interface PlayedSound {
   frame: number;
   /** Resolved schema sample name without extension (e.g. "bulmet2"). */
   sample: string;
+  /** Dark-schema volume in millibels, or null for a direct sample. */
+  volume_millibels: number | null;
+  /** Linear gain assigned to the audio sink. */
+  gain: number;
+  /** Resolved Dark-schema pan in millibels, or null for a direct sample. */
+  pan_millibels: number | null;
+  /** False when positional 3D audio supersedes the schema's fixed pan. */
+  pan_applied: boolean;
   /** The schema query's (tag, value) pairs (e.g. ["event", "collision"]). */
   tags: [string, string][];
   position: [number, number, number];

--- a/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
+++ b/tools/shock2-sdk/test/audio-message-diagnostics.e2e.test.ts
@@ -69,6 +69,17 @@ test(
     assert.equal(sound.still_playing, true, "a clip this long is still playing");
     assert.equal(sound.stopped_at_sim_time, null);
 
+    // trg0001 has no local play params: it inherits -500 millibels from
+    // SPEECH_BRIEFING. The resolved gain is delivered to the spatial sink;
+    // world-space positioning supersedes schema pan, as in the original.
+    assert.equal(sound.volume_millibels, -500);
+    assert.ok(
+      Math.abs(sound.gain - 0.5623413) < 0.000001,
+      `expected -500 millibels to reach the sink as gain 0.5623413, got ${sound.gain}`,
+    );
+    assert.equal(sound.pan_millibels, 0);
+    assert.equal(sound.pan_applied, false);
+
     // TrapSound narrations play spatially at their authored station, like the
     // original engine's object sounds (pre-change the log recorded [0,0,0]).
     const [tx, ty, tz] = trap.position;

--- a/tools/shock2-sdk/test/keypad.e2e.test.ts
+++ b/tools/shock2-sdk/test/keypad.e2e.test.ts
@@ -115,6 +115,8 @@ test(
     await game.screenshot("keypad-panel-open.png");
 
     // --- Click 4-5-1-0-0 via the pointer channels ---
+    const audioBefore = await game.audio.recent();
+    const lastAudioSequence = audioBefore.sounds.at(-1)?.sequence ?? 0;
     // Rects come from /v1/ui in normalized screen space (letterbox-corrected),
     // so the click point is just the rect center.
     const clickElement = async (el: UiElement) => {
@@ -140,6 +142,25 @@ test(
       await clickElement(el);
     }
     await game.screenshot("keypad-code-entered.png");
+
+    // Each digit emits the real `keypad` schema, whose P$SchPlayPa authors
+    // -1500 millibels and fixed -1000 pan. Both must reach the non-spatial
+    // sink rather than playing at full, centered volume.
+    const recentAudio = (await game.audio.recent()).sounds.filter(
+      (sound) => sound.sequence > lastAudioSequence,
+    );
+    const keypadSound = recentAudio.find(
+      (sound) =>
+        sound.sample === "bkeypad" &&
+        sound.volume_millibels === -1500 &&
+        sound.pan_millibels === -1000,
+    );
+    assert.ok(
+      keypadSound,
+      `entering a digit should resolve keypad's authored volume and fixed pan; got ${JSON.stringify(recentAudio)}`,
+    );
+    assert.ok(Math.abs(keypadSound.gain - 0.17782794) < 0.000001);
+    assert.equal(keypadSound.pan_applied, true);
 
     // --- The SwitchLinked door must open (TranslatingDoor slides ~2.4 units) ---
     await game.step({ frames: 120 }); // ~2s for the door to travel


### PR DESCRIPTION
## Summary

- parse the retail `P$SchPlayPa` / `sSchemaPlayParams` layout (`flags`, `volume`, `pan`, `initialDelay`, `fade`, all 32-bit) and hydrate schema inheritance
- resolve a schema to its frequency-weighted sample plus authored volume/pan without changing sample weighting
- apply millibel gain at the real rodio sink, apply fixed/ranged schema pan to listener-relative sounds, and keep world-space panning for positional sounds
- carry resolved volume/pan through scripted sounds, speech, and environmental one-shots, and expose applied settings through `/v1/audio/recent`
- preserve #939 live emitter tracking and head-relative listener ears while adding schema gain to positional sinks

Fixes #871

## Reproduction and root cause

`SoundSchema::read` only loaded `SchSamp` and direct symbolic names. `resolve_schema` returned a bare sample string, so the playback path had no authored settings to propagate and every schema one-shot used default sink gain/pan.

The retail `shock2.gam` contains a uniform 20-byte `P$SchPlayPa` record. Representative objective values:

- `linebeep`: volume `-2500`, pan `0`
- `log0219`: inherits volume `-300`, fixed pan `-1000` from `SPEECH_LOGS`
- Earth `trg0001`: inherits volume `-500` from `SPEECH_BRIEFING`
- keypad `bkeypad`: volume `-1500`, fixed pan `-1000`

Negative-first evidence:

- the retail-gamesys integration test was added first and failed on base because `SoundSchema` had no play-param resolution (`no method named resolve`)
- the engine sink test was added first and failed because there was no playback-settings path and no panned sink append

## Rebase reconciliation

Rebased onto current `origin/main` through `e09fc08`, including #939. The generic positional sink still stores `TrackedEmitter<entity>`, refreshes the live source position every update, and derives ears from head rotation. The gain-aware spatial entry point carries both the source entity and schema gain. Only listener-relative/static playback uses the ordinary rodio `Sink` plus channel-volume pan.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `DARK_ASSET_PATH=/Users/bryan/ss2-data-unpacked cargo test -p dark -p engine -p shock2vr`: passed; `shock2vr` 615 passed on the overlap-reconciled tree, with dark/engine suites also green
- `RUSTFLAGS="-D warnings" cargo check -p dark -p engine -p shock2vr -p desktop_runtime -p debug_runtime -p dark_query`: passed; final-head follow-up also passed for dark/engine/shock2vr/debug runtime
- SDK fast: 245 total, 26 passed, 219 E2E-gated skipped, 0 failed
- retail parser/inheritance, millibel conversion, fixed/ranged pan, and exact five-word parser tests: passed
- engine audio tests: 4 passed, including #939 live emitter refresh and #871 rodio gain/channel-pan propagation
- #939 listener-head-rotation and live-runtime-transform tests: passed
- focused live Earth: `/v1/audio/recent` reported inherited volume `-500`, gain `0.5623413`, and `pan_applied=false` for the spatial sink
- focused live keypad: sample `bkeypad`, volume `-1500`, gain `0.17782794`, pan `-1000`, and `pan_applied=true`
- full SDK E2E after audio/spatial conflict reconciliation: 245 total, 235 passed, 7 skipped, 3 failed; both changed audio scenarios and all 23 mission-load smokes passed
  - two failures match known unrelated baselines: creature-loot reader binding and SHODAN assassin corpse drift
  - the third was a transient AI last-known-position null lookup on the pre-advance tree; its required isolated rerun on clean current main passed 1/1, and the final rebased branch passed the same scenario 1/1 after the newly merged patrol fix

## PR visuals

Manager-approved non-renderable rationale: this change only alters audio sample amplitude and stereo channel balance at the sink. Renderer and simulation frames are unchanged, so deterministic GIF/PNG captures would be identical and misleading.

Objective substitutes:

- parsed retail authored values above, including inherited `log0219` values
- the rodio sink/queue test proves linear gain and left/right channel multipliers reach production sink primitives
- live `/v1/audio/recent` observations prove both positional volume and listener-relative volume/pan propagation
- #939 coexistence tests prove tracked emitter position and head-relative ears remain live

## Scope and risk

- positional sounds retain world-space panning; schema pan is visible in telemetry but not applied, matching the original 3D update behavior
- `initialDelay` and `fade` are parsed as part of the exact record layout but are not implemented by this volume/pan fix
- `P$AmbientHacked` ambient-object behavior is intentionally unchanged
