### PR TITLE
fix(gameplay): prevent ineffective upgrades

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -322,6 +322,60 @@ fn apply_psi_kit_use(world: &World, entity_id: EntityId, amount: i32) -> PsiKitU
     }
 }
 
+/// Raise only the live maximum HP pool. Buying Endurance is not healing: the
+/// original stat promises more maximum hit points, while Tank's separate O/S
+/// effect deliberately raises both current and maximum HP.
+fn increase_player_max_hit_points(world: &World, player: EntityId, amount: u32) -> bool {
+    let mut maximums = world
+        .borrow::<ViewMut<dark::properties::PropMaxHitPoints>>()
+        .unwrap();
+    if let Ok(maximum) = (&mut maximums).get(player) {
+        maximum.hit_points = maximum.hit_points.saturating_add(amount);
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod endurance_upgrade_tests {
+    use super::*;
+
+    #[test]
+    fn endurance_raises_maximum_hp_without_healing() {
+        let mut world = World::new();
+        let player = world.add_entity((
+            PropHitPoints { hit_points: 25 },
+            dark::properties::PropMaxHitPoints { hit_points: 30 },
+        ));
+
+        assert!(increase_player_max_hit_points(
+            &world,
+            player,
+            crate::scripts::gui::ENDURANCE_HP_PER_LEVEL,
+        ));
+        assert_eq!(
+            world
+                .borrow::<View<dark::properties::PropMaxHitPoints>>()
+                .unwrap()
+                .get(player)
+                .unwrap()
+                .hit_points,
+            35
+        );
+        assert_eq!(
+            world
+                .borrow::<View<PropHitPoints>>()
+                .unwrap()
+                .get(player)
+                .unwrap()
+                .hit_points,
+            25,
+            "an Endurance upgrade must not double as a heal"
+        );
+    }
+}
+
 /// First-person player-melee idle clip (motiondb ActorType 1, `+plyrmelee:0`),
 /// used to pose the flat melee viewmodel in its ready stance.
 const MELEE_IDLE_CLIP: &str = "ph212203";
@@ -4873,6 +4927,24 @@ impl MissionCore {
                     // pre-validates for feedback): re-quote from the cost
                     // tables, spend atomically, then raise the target.
                     use crate::scripts::gui::{apply_purchase, upgrade_quote};
+                    let endurance_target = matches!(
+                        target,
+                        crate::scripts::gui::TrainerTarget::Stat(
+                            crate::player_stats::Stat::Endurance
+                        )
+                    );
+                    if endurance_target
+                        && self
+                            .world
+                            .borrow::<View<dark::properties::PropMaxHitPoints>>()
+                            .map_or(true, |maximums| maximums.get(player_entity).is_err())
+                    {
+                        warn!(
+                            "Trainer purchase {:?} refused: player has no maximum-HP pool",
+                            target
+                        );
+                        continue;
+                    }
                     let costs = self
                         .world
                         .borrow::<UniqueView<GlobalTrainerCosts>>()
@@ -4880,25 +4952,41 @@ impl MissionCore {
                         .0
                         .clone();
                     if let Some(costs) = costs {
-                        let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
-                        let stats = quests.player_stats_mut();
-                        match upgrade_quote(&costs, stats, target) {
-                            Some(cost) if stats.spend_cyber_modules(cost) => {
-                                apply_purchase(stats, target);
-                                info!(
-                                    "Trainer purchase {:?} (-{} modules, balance {})",
-                                    target, cost, stats.cyber_modules
-                                );
+                        let purchased = {
+                            let mut quests =
+                                self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
+                            let stats = quests.player_stats_mut();
+                            match upgrade_quote(&costs, stats, target) {
+                                Some(cost) if stats.spend_cyber_modules(cost) => {
+                                    apply_purchase(stats, target);
+                                    info!(
+                                        "Trainer purchase {:?} (-{} modules, balance {})",
+                                        target, cost, stats.cyber_modules
+                                    );
+                                    true
+                                }
+                                Some(cost) => {
+                                    info!(
+                                        "Trainer purchase {:?} refused: costs {}, balance {}",
+                                        target, cost, stats.cyber_modules
+                                    );
+                                    false
+                                }
+                                None => {
+                                    info!(
+                                        "Trainer purchase {:?} refused: maxed/locked/unavailable",
+                                        target
+                                    );
+                                    false
+                                }
                             }
-                            Some(cost) => {
-                                info!(
-                                    "Trainer purchase {:?} refused: costs {}, balance {}",
-                                    target, cost, stats.cyber_modules
-                                );
-                            }
-                            None => {
-                                info!("Trainer purchase {:?} refused: maxed/locked", target);
-                            }
+                        };
+                        if purchased && endurance_target {
+                            increase_player_max_hit_points(
+                                &self.world,
+                                player_entity,
+                                crate::scripts::gui::ENDURANCE_HP_PER_LEVEL,
+                            );
                         }
                     } else {
                         warn!("TrainerPurchase dropped: gamesys has no cost tables");

--- a/shock2vr/src/player_stats.rs
+++ b/shock2vr/src/player_stats.rs
@@ -22,9 +22,9 @@
 //!
 //! Deferred (storage + grants only, per issue #453): career-specific stat
 //! baselines (all careers start from the uniform [`PlayerStats::default`]
-//! baseline for now), and *derived gameplay effects* - Endurance->maxHP scaling
-//! and wiring the granted psi disciplines into `crate::psi` known powers. Those
-//! are noted here so a follow-up can pick them up.
+//! baseline for now), and wiring granted psi disciplines into `crate::psi`
+//! known powers. The upgrade UI only sells primary stats with live consumers:
+//! Endurance->maxHP and Cyber Affinity->hacking; see `scripts::gui::trainer`.
 
 use std::collections::BTreeSet;
 

--- a/shock2vr/src/scripts/gui/trainer.rs
+++ b/shock2vr/src/scripts/gui/trainer.rs
@@ -20,6 +20,11 @@
 //! persistence lands. UNDO is deferred (the shared `Gui` layer has no
 //! panel-open/close lifecycle to snapshot against). Costs are Normal
 //! difficulty (no difficulty setting exists yet).
+//!
+//! A stat is only sold when it has a live gameplay consumer. Endurance raises
+//! maximum HP and Cyber Affinity feeds hacking odds; Strength, Psionics, and
+//! Agility stay visible but unavailable until their advertised systems exist.
+//! This prevents a stored-only stat bump from consuming irreplaceable modules.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::gamesys::TrainerCostTables;
@@ -55,8 +60,22 @@ pub const STAT_CAP: i32 = 6;
 pub const SKILL_CAP: i32 = 6;
 pub const PSI_TIER_CAP: i32 = 5;
 
+/// Normal difficulty grants five maximum hit points per Endurance level. The
+/// original manual documents the stat as raising maximum HP; the retail Normal
+/// table is `30 + 5 * END`. shock2quest has no difficulty setting yet, matching
+/// the Normal-only trainer prices above.
+pub const ENDURANCE_HP_PER_LEVEL: u32 = 5;
+
+/// Whether a stat has a real gameplay consumer and is therefore safe to sell.
+/// Keep this gate shared by display, immediate feedback, and authoritative
+/// effect handling so a future caller cannot bypass the module-loss guard.
+pub fn stat_upgrade_available(stat: Stat) -> bool {
+    matches!(stat, Stat::Endurance | Stat::CyberAffinity)
+}
+
 /// The cost of buying `target`'s next level given the player's current sheet,
-/// or `None` if it cannot be bought (maxed, or an out-of-order psi tier).
+/// or `None` if it cannot be bought (unavailable, maxed, or an out-of-order
+/// psi tier).
 /// Shared by the panel (for display/refusal) and the `TrainerPurchase` effect
 /// handler (the authoritative re-validation before mutating).
 pub fn upgrade_quote(
@@ -66,6 +85,9 @@ pub fn upgrade_quote(
 ) -> Option<i32> {
     match target {
         TrainerTarget::Stat(stat) => {
+            if !stat_upgrade_available(stat) {
+                return None;
+            }
             let level = stats.stat_level(stat);
             if !(1..STAT_CAP).contains(&level) {
                 return None;
@@ -294,6 +316,9 @@ impl Gui<TrainerGuiState, TrainerGuiMsg> for TrainerGui {
                 // unavailable, not maxed.
                 None => "(offline)".to_string(),
                 Some(costs) => match (row.target, upgrade_quote(costs, &stats, row.target)) {
+                    (TrainerTarget::Stat(stat), _) if !stat_upgrade_available(stat) => {
+                        "unavailable".to_string()
+                    }
                     (TrainerTarget::PsiTier(_), Some(cost)) => {
                         format!("unlock: {} cm", cost)
                     }
@@ -360,6 +385,14 @@ impl Gui<TrainerGuiState, TrainerGuiMsg> for TrainerGui {
                 Effect::NoEffect,
             );
         };
+        if matches!(target, TrainerTarget::Stat(stat) if !stat_upgrade_available(*stat)) {
+            return (
+                TrainerGuiState {
+                    message: Some("Upgrade unavailable in this build.".to_string()),
+                },
+                Effect::NoEffect,
+            );
+        }
         match upgrade_quote(&costs, stats, *target) {
             // A psi tier beyond the next one is locked, not maxed - give the
             // faithful refusal for each.
@@ -384,7 +417,11 @@ impl Gui<TrainerGuiState, TrainerGuiMsg> for TrainerGui {
             ),
             Some(cost) => (
                 TrainerGuiState {
-                    message: Some(format!("Upgrade complete (-{} cm)", cost)),
+                    message: Some(if matches!(target, TrainerTarget::Stat(Stat::Endurance)) {
+                        format!("Max HP +{} (-{} cm)", ENDURANCE_HP_PER_LEVEL, cost)
+                    } else {
+                        format!("Upgrade complete (-{} cm)", cost)
+                    }),
                 },
                 Effect::TrainerPurchase { target: *target },
             ),
@@ -415,21 +452,21 @@ mod tests {
     #[test]
     fn stat_quotes_follow_statcost_and_cap_at_6() {
         let costs = tables();
-        let mut stats = PlayerStats::new(); // strength 1
+        let mut stats = PlayerStats::new(); // endurance 1
         assert_eq!(
-            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Strength)),
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Endurance)),
             Some(3)
         );
-        stats.raise_stat(Stat::Strength); // 2
+        stats.raise_stat(Stat::Endurance); // 2
         assert_eq!(
-            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Strength)),
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Endurance)),
             Some(8)
         );
         for _ in 0..4 {
-            stats.raise_stat(Stat::Strength);
+            stats.raise_stat(Stat::Endurance);
         } // 6 = cap
         assert_eq!(
-            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Strength)),
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Endurance)),
             None
         );
     }
@@ -495,5 +532,27 @@ mod tests {
         assert_eq!(stats.endurance, 2);
         apply_purchase(&mut stats, TrainerTarget::Skill(Skill::Repair));
         assert_eq!(stats.skills.repair, 1);
+    }
+
+    #[test]
+    fn stat_trainer_only_quotes_upgrades_with_live_gameplay_effects() {
+        let costs = tables();
+        let stats = PlayerStats::new();
+
+        assert_eq!(
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::Endurance)),
+            Some(3)
+        );
+        assert_eq!(
+            upgrade_quote(&costs, &stats, TrainerTarget::Stat(Stat::CyberAffinity)),
+            Some(3)
+        );
+        for unsupported in [Stat::Strength, Stat::PsionicAbility, Stat::Agility] {
+            assert_eq!(
+                upgrade_quote(&costs, &stats, TrainerTarget::Stat(unsupported)),
+                None,
+                "{unsupported:?} must not be sold until it has a gameplay effect"
+            );
+        }
     }
 }

--- a/shock2vr/src/scripts/gui/traits.rs
+++ b/shock2vr/src/scripts/gui/traits.rs
@@ -12,8 +12,8 @@
 //! `QuestInfo`, so it survives save/load and deck re-entry), and
 //! `Effect::AcquireOsTrait` applies the pick atomically. Live effects are
 //! implemented for the subset with existing consumers (Tank, Naturally Able,
-//! Replicator Expert - see [`live_effect_note`]); everything else is
-//! storage-only for now, listed per-trait in the PR.
+//! Replicator Expert - see [`live_effect_note`]); everything else stays visible
+//! but cannot consume a one-shot machine or trait slot until its effect exists.
 
 use cgmath::{Vector2, Vector3, vec2};
 use engine::assets::asset_cache::AssetCache;
@@ -110,6 +110,7 @@ fn machine_used(world: &World, machine: EntityId) -> bool {
 /// shipped table), used when a data install lacks it.
 const FALLBACK_HEADER_LABEL: &str = "Choose one upgrade.";
 const FALLBACK_USED_LABEL: &str = "Your OS has already been upgraded at this unit.";
+const UNAVAILABLE_LABEL: &str = "Upgrade unavailable in this build.";
 
 /// Preloaded trait-panel strings (`TRAITS.STR` descriptions plus the MISC.STR
 /// header / used-machine lines), added as a world unique at mission load so
@@ -298,6 +299,9 @@ impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
                 .map(|ctx| ctx.descriptions[(hovered - 1) as usize].clone())
                 .unwrap_or_else(|_| trait_name(hovered).to_owned());
             lines.push(description);
+            if live_effect_note(hovered).is_none() {
+                lines.push(UNAVAILABLE_LABEL.to_string());
+            }
         }
         // Word-wrap into the description box (the engine text path draws a
         // single unwrapped line; sentence-length TRAITS.STR text would run
@@ -344,6 +348,8 @@ impl Gui<TraitGuiState, TraitGuiMsg> for TraitGui {
                 Some("This upgrade unit is not responding.".to_string())
             } else if machine_used(world, entity_id) {
                 Some(used_label(world))
+            } else if live_effect_note(*trait_id).is_none() {
+                Some(UNAVAILABLE_LABEL.to_string())
             } else if stats.has_os_trait(*trait_id) {
                 Some(format!("{} is already installed.", trait_name(*trait_id)))
             } else if stats.os_traits.len() >= OS_TRAIT_SLOTS {
@@ -453,5 +459,30 @@ mod tests {
         // Degenerate inputs.
         assert!(wrap_text("", 10).is_empty());
         assert_eq!(wrap_text("word", 10), vec!["word".to_string()]);
+    }
+
+    #[test]
+    fn storage_only_trait_does_not_consume_the_machine() {
+        let mut world = World::new();
+        world.add_unique(QuestInfo::new());
+        let machine = world.add_entity((dark::properties::PropTemplateId { template_id: 133 },));
+
+        let (state, effect) = TraitGui.handle_msg(
+            machine,
+            &world,
+            &TraitGuiState::default(),
+            &TraitGuiMsg::Pick(4), // Speedy has no locomotion consumer yet.
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+        assert_eq!(state.message.as_deref(), Some(UNAVAILABLE_LABEL));
+        assert_eq!(
+            world
+                .borrow::<UniqueView<QuestInfo>>()
+                .unwrap()
+                .read_quest_bit_value(&used_bit_name(133)),
+            dark::properties::QuestBitValue::UNKNOWN,
+            "a refused trait must leave the one-shot machine unused"
+        );
     }
 }

--- a/tools/shock2-sdk/test/os-traits.e2e.test.ts
+++ b/tools/shock2-sdk/test/os-traits.e2e.test.ts
@@ -8,10 +8,11 @@ import { teleportVerified } from "./helpers/teleport.js";
 // End-to-end test for the O/S upgrade (trait) machine MFD (flat UI 6f / PR C3).
 // Opt-in (SHOCK2_E2E=1); requires game assets in Data/.
 //
-// The trait machine offers a one-time pick from all 16 O/S traits (free, per
-// the original). The pick is stored on the persistent character sheet, the
-// machine becomes single-use (a quest bit keyed by its stable mission object
-// id), and implemented trait effects apply (Tank: +5 max AND current HP -
+// The trait machine shows all 16 O/S traits (free, per the original), but only
+// choices with live effects can consume its one-time pick. The chosen trait is
+// stored on the persistent character sheet, the machine becomes single-use (a
+// quest bit keyed by its stable mission object id), and implemented effects
+// apply (Tank: +5 max AND current HP -
 // original behavior: buying at 25/30 yields 30/35 - live and re-derived
 // across loads).
 //
@@ -110,12 +111,25 @@ test(
       traitButton(name, els);
     }
 
+    // --- A storage-only trait refuses clearly and leaves this one-shot
+    // machine available for a live choice. ---
+    await clickElement(game, traitButton("Speedy", els));
+    await game.step({ frames: 3 });
+    assert.deepEqual((await stats()).os_traits, [], "unsupported trait is not recorded");
+    let refreshed = await game.ui.state();
+    assert.ok(
+      refreshed.active_panel!.elements.some(
+        (e) => e.kind === "text" && e.text?.includes("Upgrade unavailable"),
+      ),
+      "the panel explains why the trait cannot be selected",
+    );
+
     // --- Pick Tank: stored + live +5 max AND current HP (the original
     // raises both - buying wounded at 25/30 yields 30/35). The player can't
     // be wounded headlessly (it has no scripts, so a debug Damage message is
     // dropped), but the current-HP grant is still observable at full health:
     // ceiling-only would leave 30/35, the original behavior yields 35/35. ---
-    await clickElement(game, traitButton("Tank", els));
+    await clickElement(game, traitButton("Tank", refreshed.active_panel!.elements));
     await game.step({ frames: 3 });
     const afterPick = await stats();
     assert.deepEqual(afterPick.os_traits, [8], "Tank (trait 8) is recorded");
@@ -133,7 +147,7 @@ test(
     await game.screenshot("traits-after-pick.png");
 
     // --- The machine is now single-use: a second pick refuses. ---
-    const refreshed = await game.ui.state();
+    refreshed = await game.ui.state();
     assert.ok(refreshed.active_panel, "panel stays open after the pick");
     await clickElement(game, traitButton("Speedy", refreshed.active_panel.elements));
     await game.step({ frames: 3 });

--- a/tools/shock2-sdk/test/trainer.e2e.test.ts
+++ b/tools/shock2-sdk/test/trainer.e2e.test.ts
@@ -10,8 +10,9 @@ import { teleportVerified } from "./helpers/teleport.js";
 //
 // The four medsci1 trainer machines open category upgrade panels: rows list
 // the current level and the cost of the next level from the gamesys cost
-// tables (STATCOST 3/8/15/30/50 etc.), and buying spends cyber modules and
-// raises the stat persistently (save/load + level transition).
+// tables (STATCOST 3/8/15/30/50 etc.). Only stats with live effects may be
+// bought: Endurance raises maximum HP, Cybernetics feeds the hacking path, and
+// storage-only stats refuse without spending modules.
 //
 // Negative-first: on the C1 base, frobbing the Stats Trainer hits the
 // intentional SkillTrainerScript no-op stub (#424) - /v1/ui reports no active
@@ -20,7 +21,7 @@ const e2eEnabled = process.env.SHOCK2_E2E === "1";
 const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8170);
 
 test(
-  "trainer MFD: frob opens the stats panel, buying Strength spends modules persistently",
+  "trainer MFD: Endurance 1->4 costs 26 modules and raises max HP persistently",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     const saveName = `trainer_e2e_${Date.now()}`;
@@ -36,34 +37,14 @@ test(
       return s;
     };
 
-    // --- Fund the player: fire every module award in the level (EXP traps
-    // carry PropExp, cookie piles their stack count). Discovery is by name +
-    // script, never by runtime id. ---
-    let expected = 0;
-    for (const e of (await game.entities.list({ filter: "Experience Trap" })).entities) {
-      const detail = await game.entities.detail(e.id);
-      const exp = detail.properties.find((p) => p.name === "Exp");
-      if (exp && Number(exp.value) > 0) {
-        await game.entities.sendMessage(e.id, { type: "TurnOn" });
-        expected += Number(exp.value);
-      }
-    }
-    for (const e of (await game.entities.list({ filter: "EXP" })).entities) {
-      const detail = await game.entities.detail(e.id);
-      const isCookie = detail.properties.some(
-        (p) => p.name === "Scripts" && p.value.includes("ExpCookie"),
-      );
-      const stack = detail.properties.find((p) => p.name === "StackCount");
-      if (isCookie && stack && Number(stack.value) > 0) {
-        await game.entities.sendMessage(e.id, { type: "Frob" });
-        expected += Number(stack.value);
-      }
-    }
-    await game.step({ frames: 5 });
-    const funded = await stats();
-    assert.equal(funded.cyber_modules, expected, "all module awards landed");
-    assert.ok(expected >= 3, `need at least 3 modules to buy Strength (got ${expected})`);
-    const baseStrength = funded.strength;
+    // Provision only the currency; purchases still go through the real MFD,
+    // button messages, effect queue, cost table, and live player properties.
+    const funded = await game.player.setStats({ cyber_modules: 26 });
+    assert.equal(funded.cyber_modules, 26);
+    assert.equal(funded.endurance, 1, "the regression starts at Endurance 1");
+    const beforePlayer = (await game.info()).player;
+    const baseMaxHp = beforePlayer.max_hit_points;
+    assert.ok(baseMaxHp != null, "player should have a maximum-HP pool");
 
     // --- Find the Stats Trainer (mission id 1352 is its stable template_id)
     // and get within the panel's walk-away radius. ---
@@ -91,24 +72,26 @@ test(
     await game.screenshot("trainer-panel-open.png");
 
     // --- The panel lists labeled rows with current level + cost from the
-    // gamesys STATCOST table (Strength 1 -> 2 costs 3). ---
+    // gamesys STATCOST table (Endurance 1 -> 2 costs 3). Unsupported stats
+    // remain listed but clearly unavailable instead of quoting a price. ---
     const textEl = (needle: string, els: UiElement[]) =>
       els.find((e) => e.kind === "text" && e.text?.includes(needle));
     const els = opened.active_panel.elements;
     for (const label of ["Strength", "Endurance", "Agility", "Psionics", "Cybernetics"]) {
       assert.ok(textEl(label, els), `panel should list a "${label}" row`);
     }
-    const strengthDetail = textEl(`lvl ${baseStrength} > ${baseStrength + 1}: 3 cm`, els);
+    const enduranceDetail = textEl("lvl 1 > 2: 3 cm", els);
     assert.ok(
-      strengthDetail,
-      `the Strength row should quote the STATCOST cost (3 cm), got: ${JSON.stringify(
+      enduranceDetail,
+      `the Endurance row should quote the STATCOST cost (3 cm), got: ${JSON.stringify(
         els.filter((e) => e.kind === "text").map((e) => e.text),
       )}`,
     );
-    assert.ok(textEl(`modules: ${expected}`, els), "panel shows the module pool");
+    assert.ok(textEl("unavailable", els), "storage-only stats are marked unavailable");
+    assert.ok(textEl("modules: 26", els), "panel shows the module pool");
 
-    // --- Click the Strength row's buy button by its semantic label (the
-    // shared button-label mechanism from the elevator PR). ---
+    // --- A storage-only stat refuses without taking currency. The same
+    // machine then remains usable for a supported purchase. ---
     const rowButton = (label: string, from: UiElement[]) => {
       const el = from.find((e) => e.kind === "button" && e.label === label);
       assert.ok(el, `the panel should expose a buy button labeled "${label}"`);
@@ -125,62 +108,65 @@ test(
     };
     await clickElement(rowButton("Strength", els));
     await game.step({ frames: 3 });
-
-    // --- The purchase applied: strength +1, modules -3, panel refreshed. ---
-    const afterBuy = await stats();
-    assert.equal(afterBuy.strength, baseStrength + 1, "Strength rose by one");
-    assert.equal(afterBuy.cyber_modules, expected - 3, "3 modules were spent");
-    const refreshed = await game.ui.state();
-    assert.ok(refreshed.active_panel, "panel stays open after a purchase");
-    assert.ok(
-      textEl(`modules: ${expected - 3}`, refreshed.active_panel.elements),
-      "the module pool readout refreshed",
+    assert.deepEqual(await stats(), funded, "refused stat leaves the sheet and modules unchanged");
+    assert.equal(
+      (await game.info()).player.max_hit_points,
+      baseMaxHp,
+      "refused stat leaves live HP unchanged",
     );
-    await game.screenshot("trainer-after-buy.png");
+    let refreshed = await game.ui.state();
+    assert.ok(
+      textEl("Upgrade unavailable", refreshed.active_panel!.elements),
+      "the panel explains the refusal",
+    );
 
-    // --- Refusal: the next Strength level costs 8 (STATCOST row 2); drain
-    // the balance below it by buying if needed, then assert refusal. ---
-    // With the medsci1 awards (9 modules) the balance is now 6 < 8, so a
-    // second click must refuse: message shown, nothing changes.
-    const balance = afterBuy.cyber_modules;
-    if (balance < 8) {
-      await clickElement(rowButton("Strength", refreshed.active_panel.elements));
+    // --- Reproduce issue #813's exact transaction: levels 1->4 cost
+    // 3 + 8 + 15 = 26 modules. Each purchase changes the live maximum-HP pool
+    // by the retail Normal-difficulty five points. ---
+    for (const [level, cost] of [[2, 3], [3, 8], [4, 15]] as const) {
+      await clickElement(rowButton("Endurance", refreshed.active_panel!.elements));
       await game.step({ frames: 3 });
-      const afterRefusal = await stats();
-      assert.equal(afterRefusal.strength, afterBuy.strength, "refused buy: no stat change");
-      assert.equal(
-        afterRefusal.cyber_modules,
-        balance,
-        "refused buy: no modules spent",
-      );
-      const refusalUi = await game.ui.state();
+      const afterBuy = await stats();
+      assert.equal(afterBuy.endurance, level, `Endurance rose to ${level}`);
+      const spent = level === 2 ? 3 : level === 3 ? 11 : 26;
+      assert.equal(afterBuy.cyber_modules, 26 - spent, `${cost} modules were spent`);
       assert.ok(
-        textEl("Insufficient cyber modules", refusalUi.active_panel!.elements),
-        "the panel shows the insufficient-modules error",
+        textEl("Max HP +5", (await game.ui.state()).active_panel!.elements),
+        "the panel reports the live Endurance benefit",
       );
-      await game.screenshot("trainer-refusal.png");
+      refreshed = await game.ui.state();
     }
+    const afterPurchases = (await game.info()).player;
+    assert.equal(afterPurchases.max_hit_points, baseMaxHp + 15, "three levels grant +15 max HP");
+    assert.equal(afterPurchases.hit_points, beforePlayer.hit_points, "Endurance does not heal");
+    await game.screenshot("trainer-after-endurance-4.png");
 
     // --- Persistence: save/load, then a level transition. ---
     await game.save(saveName);
     await game.load(saveName);
     await game.step({ frames: 3 });
     const afterLoad = await stats();
-    assert.equal(afterLoad.strength, baseStrength + 1, "strength survives save/load");
-    assert.equal(afterLoad.cyber_modules, expected - 3, "balance survives save/load");
+    assert.equal(afterLoad.endurance, 4, "Endurance survives save/load");
+    assert.equal(afterLoad.cyber_modules, 0, "spent balance survives save/load");
+    assert.equal(
+      (await game.info()).player.max_hit_points,
+      baseMaxHp + 15,
+      "Endurance-derived max HP survives save/load",
+    );
 
     await game.transitionLevel("eng1.mis");
     await game.step({ frames: 3 });
     const afterTransition = await stats();
     assert.equal(
-      afterTransition.strength,
-      baseStrength + 1,
-      "strength survives a level transition",
+      afterTransition.endurance,
+      4,
+      "Endurance survives a level transition",
     );
+    assert.equal(afterTransition.cyber_modules, 0, "balance survives a level transition");
     assert.equal(
-      afterTransition.cyber_modules,
-      expected - 3,
-      "balance survives a level transition",
+      (await game.info()).player.max_hit_points,
+      baseMaxHp + 15,
+      "Endurance-derived max HP survives a level transition",
     );
   },
 );


### PR DESCRIPTION
## Summary

- implement the documented Endurance benefit: each purchased level raises maximum HP by 5 without healing current HP
- audit every primary-stat and O/S choice and refuse choices that do not yet have a live gameplay consumer, before currency or a one-shot machine can be consumed
- make unavailable rows and refusals explicit in the rendered trainer UI

## Root cause and audit

`TrainerPurchase` spent cyber modules and raised the stored stat, but did not update the player's live maximum-HP property. The stat panel also quoted every primary stat even when no gameplay system read it. Likewise, an O/S machine accepted all 16 traits although only three had implemented effects; those picks were free, but consumed a trait slot and the one-use machine.

| Upgrade | Result after this change |
| --- | --- |
| Endurance | Purchasable; +5 live maximum HP per level |
| Cyber Affinity | Purchasable; already consumed by hacking/keypad odds |
| Strength, Psionic Ability, Agility | Visible, clearly unavailable, no modules spent |
| Naturally Able (6) | Purchasable; existing +8 cyber modules effect |
| Tank (8) | Purchasable; existing +5 current/max HP effect |
| Replicator Expert (13) | Purchasable; existing 20% replicator discount |
| Remaining 13 O/S traits | Visible, clearly unavailable, machine/slot not consumed |

The official manual defines Endurance as increasing maximum HP. This repo currently has Normal-only trainer prices/no difficulty setting, so the implementation uses the retail Normal progression of five maximum HP per purchased Endurance level. It increments the player's existing max-HP pool instead of replacing it, preserving career/template/custom baselines.

References: [System Shock 2 manual](https://cdn.akamai.steamstatic.com/steam/apps/238210/manuals/System%20Shock%202%20-%20Manual.pdf), [Normal-difficulty stat formula analysis](https://gamefaqs.gamespot.com/pc/185706-system-shock-2/faqs/41882)

## Reproduction and verification

Negative tests were added and observed failing on `origin/main`: the stat trainer still quoted Strength, and selecting storage-only Speedy returned `AcquireOsTrait` and consumed the machine.

- pre-fix live UI: Endurance 1 -> 4 spent 3 + 8 + 15 = 26 modules while maximum HP remained 30
- focused Rust tests: `cargo test -p shock2vr` — 577 passed
- warning-denied build: `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- formatting: `cargo fmt --all -- --check`; `git diff --check`
- SDK unit suite: `npm test` — 26 passed, 212 opt-in E2E skipped
- targeted real-runtime trainer scenario passed: real Stats Trainer template 1352, unsupported Strength refusal, Endurance 1 -> 4, 26 -> 0 modules, max HP 30 -> 45, current HP unchanged, save/load + mission transition persistence
- targeted real-runtime O/S scenario passed: Speedy refused without consuming the machine, then Tank succeeded on that same machine; persistence checks passed
- full serial SDK E2E: 229 passed, 7 skipped, 2 unrelated known baseline failures (creature-loot reader binding tracked by #931; SHODAN assassin corpse drift). All 23 mission-load smokes and both issue-specific scenarios passed.

## Visual verification

![Issue #813 Endurance trainer purchases](https://gist.githubusercontent.com/tommy-xr/c1aee88b339fcfd962e2465e844f84ea/raw/issue813-after.gif)

<sub>Starting with 26 cyber modules at Endurance 1, three real trainer-row clicks spend 3 + 8 + 15 modules and raise maximum HP from 30 to 45 without healing current HP. Captured headlessly in `medsci1.mis` via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Final trainer state

![Fixed trainer panel after the third Endurance purchase](https://gist.githubusercontent.com/tommy-xr/c1aee88b339fcfd962e2465e844f84ea/raw/issue813-after.png)

### Before -> after

![Before and after comparison of the Endurance purchase result and HP HUD](https://gist.githubusercontent.com/tommy-xr/c1aee88b339fcfd962e2465e844f84ea/raw/issue813-before-after.png)

## Risk

Historical saves that already lost modules to ineffective purchases are not retroactively compensated because there is no reliable purchase ledger from which to reconstruct them.

Fixes #813
