### PR TITLE
fix(physics): let players shove live creatures

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2435,11 +2435,12 @@ impl MissionCore {
                     transform
                         .0
                         .transform_vector(vec3(velocity.z, curr_velocity.y, -velocity.x));
-                let scaled = vec3(
+                let mut scaled = vec3(
                     adj_velocity.x * scale,
                     adj_velocity.y,
                     adj_velocity.z * scale,
                 );
+                scaled += self.physics.take_player_push_velocity(*id);
                 // A restored terminal death player has no queued motion, but
                 // even writing zero velocity wakes its deliberately sleeping
                 // dynamic corpse body. Leave physics ownership untouched:

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -12,7 +12,10 @@ use cgmath::{InnerSpace, Point3, Quaternion, Vector3, point3, vec3};
 use dark::{SCALE_FACTOR, mission::SystemShock2Level};
 use engine::scene::SceneObject;
 use rapier3d::{
-    control::{CharacterLength, EffectiveCharacterMovement, KinematicCharacterController},
+    control::{
+        CharacterCollision, CharacterLength, EffectiveCharacterMovement,
+        KinematicCharacterController,
+    },
     na,
     na::UnitQuaternion,
     prelude::*,
@@ -665,6 +668,10 @@ struct PlayerMovement {
     /// Horizontal part of a gravity-induced slope slide, carried into the
     /// next gravity pass so a seam does not erase the player's momentum.
     slope_displacement: Vector<Real>,
+    /// Live actor contacts from the player's intentional horizontal walk.
+    /// These are resolved against the dynamic bodies after the immutable
+    /// character-controller query is finished.
+    actor_collisions: Vec<CharacterCollision>,
 }
 
 /// The moving-terrain body the player is standing on, and where it was the
@@ -1223,6 +1230,7 @@ fn plan_climb_top_out(
             is_crouched: false,
         }),
         slope_displacement: Vector::zeros(),
+        actor_collisions: Vec::new(),
     })
 }
 
@@ -1488,6 +1496,7 @@ fn plan_jump_mantle(
             is_crouched,
         }),
         slope_displacement: Vector::zeros(),
+        actor_collisions: Vec::new(),
     })
 }
 
@@ -1661,6 +1670,7 @@ fn step_player_movement(
                 movement: mvt,
                 top_out: None,
                 slope_displacement: Vector::zeros(),
+                actor_collisions: Vec::new(),
             };
         }
     }
@@ -1681,7 +1691,21 @@ fn step_player_movement(
     // (there is no artificial upward movement): a combined walk+gravity cast
     // points into the floor the player rests on, which degenerates into
     // zero-progress resting contacts (see `PLAYER_REST_LIFT`).
-    let mut mvt = controller.move_shape(dt, queries, shape, pos, desired, |_c| ());
+    let mut walk_collisions = Vec::new();
+    let mut mvt = controller.move_shape(dt, queries, shape, pos, desired, |collision| {
+        walk_collisions.push(collision);
+    });
+    walk_collisions.retain(|collision| {
+        queries
+            .colliders
+            .get(collision.handle)
+            .is_some_and(|collider| {
+                collider
+                    .collision_groups()
+                    .memberships
+                    .intersects(InternalCollisionGroups::ACTOR.bits.into())
+            })
+    });
     let after_walk = Translation::from(mvt.translation) * pos;
     let gravity_step = Vector::y() * gravity;
     // A live jump owns vertical movement until it lands. Disable the
@@ -1833,6 +1857,7 @@ fn step_player_movement(
         movement: mvt,
         top_out: None,
         slope_displacement: next_slope_displacement,
+        actor_collisions: walk_collisions,
     }
 }
 
@@ -2231,6 +2256,11 @@ pub struct PhysicsWorld {
     // creature is touching the side of horizontally-moving kinematic terrain.
     // Ordinary supported movement, falling, and knockback allocate no entry.
     live_creature_sweep_recovery: HashMap<EntityId, LiveCreatureSweepRecovery>,
+
+    // Horizontal velocity transferred by this frame's kinematic-player shove.
+    // Creature animation publishes authored root velocity after player physics
+    // runs, so it consumes and adds this delta instead of overwriting it.
+    pending_player_push_velocity: HashMap<EntityId, Vector3<f32>>,
 
     // Dark PhysAttach links rigidly drive a kinematic child's translation
     // from its parent's next translation plus an authored world-space offset.
@@ -3156,6 +3186,16 @@ impl PhysicsWorld {
         }
     }
 
+    /// Consume velocity transferred by the kinematic player's most recent
+    /// walk contact with this live actor. Creature animation root motion is
+    /// published after the physics update, so its normal velocity write adds
+    /// this delta rather than erasing the shove before Rapier can integrate it.
+    pub fn take_player_push_velocity(&mut self, entity_id: EntityId) -> Vector3<f32> {
+        self.pending_player_push_velocity
+            .remove(&entity_id)
+            .unwrap_or_else(|| vec3(0.0, 0.0, 0.0))
+    }
+
     pub fn get_rotation(&self, handle: RigidBodyHandle) -> Option<Quaternion<f32>> {
         let maybe_rigid_body = self.rigid_body_set.get(handle);
 
@@ -3420,6 +3460,7 @@ impl PhysicsWorld {
         }
         self.entity_id_to_body.remove(&entity_id);
         self.live_creature_sweep_recovery.remove(&entity_id);
+        self.pending_player_push_velocity.remove(&entity_id);
     }
 
     pub fn create_player(
@@ -3636,6 +3677,7 @@ impl PhysicsWorld {
             // event_handler: Box::new(event_handler),
             entity_id_to_body: HashMap::new(),
             live_creature_sweep_recovery: HashMap::new(),
+            pending_player_push_velocity: HashMap::new(),
             kinematic_attachments: HashMap::new(),
 
             debug_pipeline,
@@ -4087,6 +4129,7 @@ impl PhysicsWorld {
                     movement,
                     top_out,
                     slope_displacement: Vector::zeros(),
+                    actor_collisions: Vec::new(),
                 }
             } else {
                 // A compressed mantle restores the same standing/crouched
@@ -4160,6 +4203,74 @@ impl PhysicsWorld {
         self.rigid_body_set[player_handle.character_handle].enable_ccd(!is_top_out);
         let scripted_top_out_frame = was_top_out || is_top_out;
         let mvt = player_movement.movement;
+        let actor_collisions = player_movement.actor_collisions;
+
+        // Dark's dynamic character bodies shove one another at close range.
+        // Our player is kinematic, so Rapier's ordinary contact solver cannot
+        // transfer its requested motion to a live creature: two lightweight
+        // actors touching opposite sides of the capsule leave every cast at
+        // zero and pin the player permanently. Apply Rapier's character-body
+        // impulse approximation for the intentional walk contacts only. The
+        // actor-only query keeps floors, doors, corpses, hitboxes, and loose
+        // props unchanged; gravity, platform carry, and scripted mantles never
+        // generate a shove.
+        if !actor_collisions.is_empty() {
+            let character_mass = self.rigid_body_set[player_handle.character_handle].mass();
+            let actor_bodies = actor_collisions
+                .iter()
+                .filter_map(|collision| self.collider_set[collision.handle].parent())
+                .collect::<HashSet<_>>();
+            let before = actor_bodies
+                .iter()
+                .filter_map(|handle| {
+                    self.rigid_body_set.get(*handle).map(|body| {
+                        (
+                            *handle,
+                            EntityId::from_inner(body.user_data as u64),
+                            *body.linvel(),
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            let actor_filter = QueryFilter::new()
+                .groups(InteractionGroups::new(
+                    InternalCollisionGroups::PLAYER.bits.into(),
+                    InternalCollisionGroups::ACTOR.bits.into(),
+                    Default::default(),
+                ))
+                .exclude_rigid_body(player_handle.character_handle)
+                .exclude_sensors();
+            let mut queries = self.broad_phase.as_query_pipeline_mut(
+                dispatcher,
+                &mut self.rigid_body_set,
+                &mut self.collider_set,
+                actor_filter,
+            );
+            player_handle.controller.solve_character_collision_impulses(
+                self.integration_parameters.dt,
+                &mut queries,
+                character_shape.as_ref(),
+                character_mass,
+                &actor_collisions,
+            );
+            drop(queries);
+            for (handle, maybe_entity_id, velocity_before) in before {
+                let Some(entity_id) = maybe_entity_id else {
+                    continue;
+                };
+                let Some(body) = self.rigid_body_set.get(handle) else {
+                    continue;
+                };
+                let velocity_delta = *body.linvel() - velocity_before;
+                let delta = vec3(velocity_delta.x, 0.0, velocity_delta.z);
+                if delta.magnitude2() > 0.0 {
+                    self.pending_player_push_velocity
+                        .entry(entity_id)
+                        .and_modify(|pending| *pending += delta)
+                        .or_insert(delta);
+                }
+            }
+        }
 
         if is_top_out {
             player_handle.jump_velocity = None;
@@ -5367,6 +5478,60 @@ mod tests {
         assert!(
             obstacle.0.test(generic_entity_ray),
             "selection/projectile rays must still hit the obstacle"
+        );
+    }
+
+    /// A pair of lightweight live actors can settle against opposite sides of
+    /// the kinematic player capsule. Walking must transfer enough motion to
+    /// the dynamic actors to open an escape route instead of leaving every
+    /// character-controller cast at zero progress (#819).
+    ///
+    /// Negative-first: without character collision impulses, both actor
+    /// capsules remain fixed against the player and the requested walk makes
+    /// only 0.014 world units of progress across the full second.
+    #[test]
+    fn player_pushes_out_between_live_creatures() {
+        let (mut world, mut player) = world_with_floor();
+        world.set_player_translation(vec3(0.0, 1.2, 0.0), &mut player);
+
+        let actors = [1010, 1011].map(|entity| EntityId::from_inner(entity).unwrap());
+        for (entity_id, x, z) in [(actors[0], 0.362, -1.016), (actors[1], 0.082, 1.076)] {
+            world.add_dynamic(
+                entity_id,
+                vec3(x, 0.84, z),
+                identity_quat(),
+                vec3(0.0, 0.0, 0.0),
+                PhysicsShape::Capsule {
+                    height: 0.6,
+                    radius: 0.6,
+                },
+                CollisionGroup::actor(),
+                false,
+                DynamicPhysicsOptions {
+                    gravity_scale: 0.0,
+                    restitution: 0.0,
+                    friction: 0.0,
+                },
+            );
+            world.set_enabled_rotations(entity_id, false, false, false);
+        }
+
+        let start = world.get_player_translation(&player);
+        for _ in 0..60 {
+            world.update(vec3(1.0 / 6.0, 0.0, 0.0), &mut player);
+            // Mission animation publishes root motion after physics. Mimic
+            // that overwrite and prove the player shove is carried into it.
+            for actor in actors {
+                let push = world.take_player_push_velocity(actor);
+                let vertical = world.get_velocity(actor).unwrap().y;
+                world.set_velocity(actor, vec3(push.x, vertical, push.z));
+            }
+        }
+        let end = world.get_player_translation(&player);
+
+        assert!(
+            end.x - start.x > 1.0,
+            "player remained pinned between live creatures: {start:?} -> {end:?}"
         );
     }
 

--- a/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
+++ b/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary } from "../src/index.js";
+import { fireOnce } from "./helpers/weapon.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8491);
+
+// Stable Hydro3 mission object/template ids, never runtime entity ids.
+const NORTH_ARACHNID = 372;
+const SOUTH_ARACHNID = 373;
+
+function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find(
+    (candidate) => candidate.name === "HitPoints",
+  );
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+function planarDistance(
+  player: [number, number, number],
+  entity: EntitySummary,
+): number {
+  return Math.hypot(
+    player[0] - entity.position[0],
+    player[2] - entity.position[2],
+  );
+}
+
+test(
+  "Hydro3 Baby Arachnids can be pushed aside and hit by normal weapons",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "hydro3.mis",
+      port: basePort,
+    });
+    await game.step({ frames: 10 });
+
+    // Setup: stand midway between Hydro3's two authored Baby Arachnids and
+    // alert them. Their production chase brings the lightweight live actor
+    // capsules to opposite sides of the player, reproducing #819 without a
+    // debug-spawned stand-in or a hardcoded runtime entity id.
+    await game.player.teleport({ x: 50.55, y: -3.16, z: -26.6 });
+    await game.step({ frames: 5 });
+    await game.input.trigger("DebugAlertAll");
+
+    let north: EntitySummary | undefined;
+    let south: EntitySummary | undefined;
+    let bracketed = false;
+    for (let elapsed = 0; elapsed < 720; elapsed += 5) {
+      await game.step({ frames: 5 });
+      [north] = await game.entities.byTemplate(NORTH_ARACHNID);
+      [south] = await game.entities.byTemplate(SOUTH_ARACHNID);
+      assert.ok(north && south, "Hydro3 should retain both authored Baby Arachnids");
+      const player = (await game.info()).player.position;
+      const northVector = [
+        north.position[0] - player[0],
+        north.position[2] - player[2],
+      ];
+      const southVector = [
+        south.position[0] - player[0],
+        south.position[2] - player[2],
+      ];
+      const dot = northVector[0] * southVector[0] + northVector[1] * southVector[1];
+      bracketed =
+        planarDistance(player, north) < 1.2 &&
+        planarDistance(player, south) < 1.2 &&
+        dot < 0;
+      if (bracketed) break;
+    }
+    assert.ok(bracketed && north && south, "the two real arachnids should bracket the player");
+
+    // Freeze their chase only after the real AI has established contact. This
+    // keeps the wedge deterministic while retaining the production creature
+    // bodies/colliders that caused the saved-game trap.
+    await game.entities.sendMessage(north.id, {
+      type: "SetAlertness",
+      level: "Lowest",
+    });
+    await game.entities.sendMessage(south.id, {
+      type: "SetAlertness",
+      level: "Lowest",
+    });
+    await game.step({ frames: 2 });
+    const bracketInfo = await game.info();
+
+    // Negative-first: before player/actor shove transfer, walking directly
+    // into either dynamic capsule stops at contact (and the issue's saved
+    // frontier measured <0.0001u in every available heading).
+    const trapped = (await game.info()).player.position;
+    const adjacentNorth = await game.entities.detail(north.id);
+    await game.input.lookAtWorldPoint([
+      adjacentNorth.position[0],
+      trapped[1] + PLAYER_EYE_HEIGHT_WORLD,
+      adjacentNorth.position[2],
+    ]);
+    await game.input.set("right_hand.thumbstick", [0, 1]);
+    await game.step({ frames: 60 });
+    await game.input.set("right_hand.thumbstick", [0, 0]);
+    const escaped = (await game.info()).player.position;
+    const escapeDistance = Math.hypot(
+      escaped[0] - trapped[0],
+      escaped[2] - trapped[2],
+    );
+    assert.ok(
+      escapeDistance > 1,
+      `ordinary locomotion should push past live arachnids, moved ${escapeDistance}; ` +
+        `before=${JSON.stringify(trapped)} after=${JSON.stringify(escaped)} ` +
+        `hp=${bracketInfo.player.hit_points}`,
+    );
+
+    // Provisioning only supplies the loadout; aiming, firing, projectile
+    // raycasts, proxy resolution, melee reach, and damage all use production
+    // paths. This independently guards the issue's weapon-immunity symptom.
+    await game.input.trigger("SpawnDebugItem");
+    await game.step({ frames: 5 });
+    const pistolBefore = hitPoints(await game.entities.detail(north.id));
+    await game.player.aimAt(north, { hitbox: "torso", visibility: "required" });
+    await game.step({ frames: 3 });
+    await fireOnce(game);
+    await game.step({ frames: 5 });
+    assert.ok(
+      hitPoints(await game.entities.detail(north.id)) < pistolBefore,
+      "an aimed standard-pistol shot should damage the Baby Arachnid",
+    );
+
+    await game.player.spawnItem(-928); // Wrench
+    await game.input.trigger("EquipWrench");
+    await game.step({ frames: 3 });
+    const liveSouth = await game.entities.detail(south.id);
+    await game.player.teleport({
+      x: liveSouth.position[0] + 1.08,
+      y: escaped[1],
+      z: liveSouth.position[2],
+    });
+    await game.step({ frames: 5 });
+    const wrenchBefore = hitPoints(await game.entities.detail(south.id));
+    await game.player.aimAt(south, { hitbox: "torso", visibility: "required" });
+    await game.step({ frames: 3 });
+    await fireOnce(game);
+    await game.step({ frames: 30 });
+    assert.ok(
+      hitPoints(await game.entities.detail(south.id)) < wrenchBefore,
+      "an aimed wrench swing should damage the Baby Arachnid",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- resolve intentional player walk contacts against live actor bodies with the Rapier character impulse solver
- preserve the horizontal shove delta when creature animation publishes root-motion velocity later in the same frame
- add negative-first physics coverage plus a real Hydro3 SDK scenario for movement escape and normal pistol/wrench damage

## Reproduction and root cause

The exact reported save is `iter26_arachnid_wedge_repro.sav` (SHA-256 `0fe51d5fd4dcabde2285b2b6ee72422a98231211f8c9d1a0dac23384c025cf40`). Two authored Hydro3 Baby Arachnids, stable mission templates 372 and 373, bracket the player at 1.0955 and 1.0802 world units. On base, four one-second movement headings advance only 0.000052 to 0.000077 units, four bounded two-unit moves advance 0 to 0.000027 units, and jump rises only 0.083 units. Killing either adjacent arachnid immediately restores 3.81 units of normal walking.

The player uses a kinematic character controller. Its dynamic actor collision callbacks were discarded, so intentional locomotion could not transfer momentum to a creature. Rapier can solve that transfer, but creature animation publishes authored root velocity after physics and would overwrite the result. This change retains only actor contacts from intentional horizontal walking, solves those contacts with the real player mass, and carries only the horizontal actor velocity delta into that later root-motion write. Floors, doors, corpses, damage proxies, sensors, loose props, gravity, platform carry, and scripted mantles remain outside the shove query.

The reported weapon symptom is independently already fixed on current main: from the exact save, a standard pistol shot reduced the five-HP spider to zero, and two real wrench swings reduced the ten-HP spider 10 -> 4 -> 0 through live torso proxies. The new Hydro3 scenario locks that behavior in without broadening hitboxes or weapon raycasts.

## Negative-first evidence

- focused physics fixture on base: only 0.014 units of requested movement in one second between opposite live actor capsules
- durable Hydro3 scenario on base: zero planar progress for 60 production locomotion frames into the adjacent authored Baby Arachnid
- patched exact save: `(49.3188, -3.1399, -30.3796)` -> `(53.1004, -3.1560, -29.8800)`, 3.814 units planar in one second, with player HP unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` (575 passed)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `npm test` in `tools/shock2-sdk` (26 passed; 213 gated scenarios skipped)
- targeted real Hydro3 SDK scenario on frozen base (expected movement failure) and fix (pass: escape plus pistol and wrench damage)
- `npm run test:e2e` (231 passed, 7 fixture-dependent skips, 1 unrelated known failure tracked by #931: the existing Watts disc reader assertion)

## Visual evidence

### Exact saved-game pin → escape

![Matched base/fix Baby Arachnid locomotion](https://gist.githubusercontent.com/tommy-xr/b5da6e6787023f0d759da849d269a434/raw/baby-arachnid-movement.gif)

<sub>Matched headless capture from the exact Hydro3 save. Both refs load the save, step 5 frames, discover authored Baby Arachnids by stable mission templates 372/373, aim at the template-373 torso, then apply the same one-second production locomotion input (60 fixed-timestep frames). Base `87a74a5` remains pinned at 0.000 planar units; fix `8a29c81` displaces the live actors and moves 3.8120 units. Replay is slowed and holds the endpoint for review.</sub>

![Exact wedge before/after](https://gist.githubusercontent.com/tommy-xr/b5da6e6787023f0d759da849d269a434/raw/baby-arachnid-before-after.png)

<sub>The same stable template-373 spider is re-centered after each matched run: it remains face-to-face on base, but is 3.6533 planar units away after the fixed run. Save: `iter26_arachnid_wedge_repro.sav`, SHA-256 `0fe51d5fd4dcabde2285b2b6ee72422a98231211f8c9d1a0dac23384c025cf40`.</sub>

### Normal weapon damage

![Baby Arachnid pistol and wrench damage](https://gist.githubusercontent.com/tommy-xr/b5da6e6787023f0d759da849d269a434/raw/baby-arachnid-weapons.gif)

<sub>Fix ref, exact save. A production torso aim + standard-pistol trigger kills stable template 373 in one shot (5→0 HP). After debug-only wrench provisioning/equip, production aim, reach, swing, and damage kill stable template 372 in two swings (10→4→0 HP).</sub>

![Weapon hit proof](https://gist.githubusercontent.com/tommy-xr/b5da6e6787023f0d759da849d269a434/raw/baby-arachnid-weapon-proof.png)

<sub>Rendered first-person proof: pistol muzzle flash/hit spang and wrench contact. Captured via `/v1/step` + `/v1/screenshot`; runtime entity ids were discovered each launch and never hardcoded.</sub>

Fixes #819