### PR TITLE
fix(inventory): keep items in the cell they were put in

### DIFF
--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -1,6 +1,42 @@
-use shipyard::EntityId;
+//! Inventory grids: which cell each contained item occupies.
+//!
+//! A containment link carries the item's cell as its data - the `Contains`
+//! ordinal is `y * width + x` - so an item keeps the cell it was put in
+//! instead of being repacked every time the panel is drawn. That ordinal is
+//! authored in the mission data and round-trips through save/load with the
+//! link, so this is also what makes a container's layout stable across a
+//! reload.
+
+use dark::properties::{Link, PropInventoryDimensions};
+use shipyard::{EntityId, Get, View, World};
+
 pub mod player_inventory_entity;
 pub use player_inventory_entity::*;
+
+/// The player's backpack grid, in cells (`invback.pcx` draws 15x3).
+pub const BACKPACK_GRID: (usize, usize) = (15, 3);
+
+/// A container's loot grid, in cells (`contain.pcx` draws 4x4).
+pub const CONTAINER_GRID: (usize, usize) = (4, 4);
+
+/// Ordinals at or above this are not grid cells - the original reserves the
+/// range for equipped/paperdoll slots. We do not model those yet; such an
+/// item simply has no cell and gets first-fit like an unplaced one.
+const EQUIP_SLOT_BASE: u32 = 1000;
+
+/// Which grid `container_entity` is drawn with. The player's backpack is
+/// wider than a container's loot panel, and the ordinal encodes `y * width +
+/// x`, so both sides of the containment link must agree on the width.
+pub fn grid_for(world: &World, container_entity: EntityId) -> (usize, usize) {
+    let is_backpack = world
+        .borrow::<View<PlayerInventoryEntity>>()
+        .map(|v| v.get(container_entity).is_ok())
+        .unwrap_or(false);
+    match is_backpack {
+        true => BACKPACK_GRID,
+        false => CONTAINER_GRID,
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct ContainedEntityInfo {
@@ -49,14 +85,91 @@ impl Inventory {
         self.items.iter()
     }
 
+    /// Lay out `container_entity`'s contents: every item that has a usable
+    /// stored cell keeps it, and only the rest are packed into what is left.
+    ///
+    /// Placement is in two passes on purpose - a first-fit item claiming a
+    /// cell before the item that actually owns it would evict the owner and
+    /// reintroduce exactly the shuffling the stored ordinal exists to stop.
+    pub fn from_container(world: &World, container_entity: EntityId, grid: (usize, usize)) -> Self {
+        let mut inventory = Inventory::new(grid.0, grid.1);
+
+        let mut contents =
+            crate::scripts::script_util::get_all_links_with_data(world, container_entity, |link| {
+                match link {
+                    Link::Contains(ordinal) => Some(*ordinal),
+                    _ => None,
+                }
+            });
+        // Ascending slot order, so an unplaced item fills the first hole
+        // rather than landing wherever link iteration happened to put it.
+        contents.sort_by_key(|(_entity, ordinal)| *ordinal);
+
+        let v_dims = world.borrow::<View<PropInventoryDimensions>>().unwrap();
+        let dims_of = |entity: EntityId| {
+            v_dims
+                .get(entity)
+                .map(|d| (d.width as usize, d.height as usize))
+                .unwrap_or((1, 1))
+        };
+
+        let mut unplaced = Vec::new();
+        for (entity, ordinal) in contents {
+            let (w, h) = dims_of(entity);
+            match inventory.cell_of(ordinal) {
+                Some((x, y)) if inventory.insert_if_fits(entity, x, y, w, h) => {}
+                // No cell, or the stored one no longer fits (a smaller grid,
+                // or another item already there): fall back to first-fit.
+                _ => unplaced.push((entity, w, h)),
+            }
+        }
+        for (entity, w, h) in unplaced {
+            inventory.insert_first_available(entity, w, h);
+        }
+
+        inventory
+    }
+
+    /// The cell an ordinal names, or `None` if it is not a cell in this grid
+    /// (an equip slot, or beyond the grid's bounds).
+    fn cell_of(&self, ordinal: u32) -> Option<(usize, usize)> {
+        if ordinal >= EQUIP_SLOT_BASE {
+            return None;
+        }
+        let slot = ordinal as usize;
+        match slot < self.width * self.height {
+            true => Some((slot % self.width, slot / self.width)),
+            false => None,
+        }
+    }
+
+    /// The ordinal naming `(x, y)` in this grid.
+    pub fn slot_at(&self, x: usize, y: usize) -> u32 {
+        (y * self.width + x) as u32
+    }
+
+    /// The first cell a `width` x `height` item fits in, scanning column by
+    /// column - the order the original packs in, so a tall item takes a fresh
+    /// column instead of straddling the top row.
+    pub fn first_free_slot(&self, width: usize, height: usize) -> Option<u32> {
+        for x in 0..self.width {
+            for y in 0..self.height {
+                if self.has_capacity(x, y, width, height) {
+                    return Some(self.slot_at(x, y));
+                }
+            }
+        }
+        None
+    }
+
     pub fn insert_first_available(
         &mut self,
         entity: EntityId,
         width: usize,
         height: usize,
     ) -> bool {
-        for y in 0..self.height {
-            for x in 0..self.width {
+        for x in 0..self.width {
+            for y in 0..self.height {
                 if self.insert_if_fits(entity, x, y, width, height) {
                     return true;
                 }
@@ -110,5 +223,137 @@ impl Inventory {
 
     fn get_index(&self, x: usize, y: usize) -> usize {
         y * self.width + x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{Links, ToLink, WrappedEntityId};
+
+    /// A container holding `(entity, stored ordinal)` pairs, every item 1x1.
+    fn container_with(slots: &[(EntityId, u32)]) -> (World, EntityId) {
+        let mut world = World::new();
+        let to_links = slots
+            .iter()
+            .map(|(entity, ordinal)| ToLink {
+                to_template_id: 0,
+                to_entity_id: Some(WrappedEntityId(*entity)),
+                link: Link::Contains(*ordinal),
+            })
+            .collect();
+        let container = world.add_entity(Links { to_links });
+        (world, container)
+    }
+
+    fn entities(n: usize) -> Vec<EntityId> {
+        let mut world = World::new();
+        (0..n).map(|_| world.add_entity(())).collect()
+    }
+
+    fn cell_of_item(inv: &Inventory, entity: EntityId) -> (usize, usize) {
+        inv.all_items()
+            .find(|i| i.entity == entity)
+            .map(|i| (i.x, i.y))
+            .expect("item should be laid out")
+    }
+
+    /// An item keeps the cell stored on its containment link - it is not
+    /// repacked into reading order.
+    #[test]
+    fn stored_slots_place_items() {
+        let ids = entities(2);
+        // Deliberately out of reading order: the second link names cell 0.
+        let (world, container) = container_with(&[(ids[0], 7), (ids[1], 0)]);
+        let inv = Inventory::from_container(&world, container, CONTAINER_GRID);
+
+        assert_eq!(
+            cell_of_item(&inv, ids[0]),
+            (3, 1),
+            "slot 7 in a 4-wide grid"
+        );
+        assert_eq!(cell_of_item(&inv, ids[1]), (0, 0));
+    }
+
+    /// The reported bug: taking an item out must not shuffle the others.
+    /// Without stored slots every item repacks from reading order, so
+    /// removing the first one slides all the rest up a cell.
+    #[test]
+    fn removing_an_item_leaves_the_others_where_they_were() {
+        let ids = entities(3);
+        let (world, container) = container_with(&[(ids[0], 0), (ids[1], 5), (ids[2], 9)]);
+
+        let before = Inventory::from_container(&world, container, CONTAINER_GRID);
+        let kept: Vec<(usize, usize)> = ids[1..]
+            .iter()
+            .map(|id| cell_of_item(&before, *id))
+            .collect();
+
+        // Take the first item out of the container.
+        let (world, container) = container_with(&[(ids[1], 5), (ids[2], 9)]);
+        let after = Inventory::from_container(&world, container, CONTAINER_GRID);
+
+        let now: Vec<(usize, usize)> = ids[1..]
+            .iter()
+            .map(|id| cell_of_item(&after, *id))
+            .collect();
+        assert_eq!(now, kept, "the remaining items must not move");
+    }
+
+    /// An item with no usable cell is packed into a hole, and must never
+    /// evict an item that does own its cell.
+    #[test]
+    fn unplaced_items_fill_holes_without_evicting_owners() {
+        let ids = entities(2);
+        // Ordinal 0 is "unset" for a runtime-inserted item; the other item
+        // genuinely owns cell 0.
+        let (world, container) = container_with(&[(ids[0], 0), (ids[1], 0)]);
+        let inv = Inventory::from_container(&world, container, CONTAINER_GRID);
+
+        let first = cell_of_item(&inv, ids[0]);
+        let second = cell_of_item(&inv, ids[1]);
+        assert_eq!(first, (0, 0), "the first claim on cell 0 keeps it");
+        assert_ne!(
+            second, first,
+            "the loser must be packed elsewhere, not stacked"
+        );
+    }
+
+    /// Equip-range ordinals are not cells; such an item still gets laid out.
+    #[test]
+    fn equip_slots_are_not_grid_cells() {
+        let ids = entities(1);
+        let (world, container) = container_with(&[(ids[0], EQUIP_SLOT_BASE + 2)]);
+        let inv = Inventory::from_container(&world, container, CONTAINER_GRID);
+        assert_eq!(
+            cell_of_item(&inv, ids[0]),
+            (0, 0),
+            "first-fit, not cell 1002"
+        );
+    }
+
+    /// A stored cell outside the grid (a container drawn smaller than the one
+    /// the ordinal was authored for) falls back rather than vanishing.
+    #[test]
+    fn out_of_range_slots_fall_back_to_first_fit() {
+        let ids = entities(1);
+        let (world, container) = container_with(&[(ids[0], 99)]);
+        let inv = Inventory::from_container(&world, container, CONTAINER_GRID);
+        assert_eq!(cell_of_item(&inv, ids[0]), (0, 0));
+    }
+
+    /// First-fit scans column by column, so a 1x3 item takes a fresh column
+    /// instead of straddling the top row (the original's packing order).
+    #[test]
+    fn first_free_slot_scans_by_column() {
+        let mut inv = Inventory::new(CONTAINER_GRID.0, CONTAINER_GRID.1);
+        let ids = entities(2);
+        assert_eq!(inv.first_free_slot(1, 3), Some(0));
+        inv.insert_if_fits(ids[0], 0, 0, 1, 3);
+        // Column 0 has one cell left, too short for another 1x3.
+        assert_eq!(inv.first_free_slot(1, 3), Some(inv.slot_at(1, 0)));
+        assert_eq!(inv.first_free_slot(1, 1), Some(inv.slot_at(0, 3)));
+        inv.insert_if_fits(ids[1], 0, 3, 1, 1);
+        assert_eq!(inv.first_free_slot(1, 1), Some(inv.slot_at(1, 0)));
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -2780,6 +2780,27 @@ impl MissionCore {
         container_entity_id: EntityId,
         dropped_entity_id: EntityId,
     ) -> bool {
+        // Give the item a cell in the container's grid, so it stays where it
+        // was put instead of being repacked on every draw. Computed before
+        // the borrow below, and *after* the item's own links are irrelevant -
+        // it is not in the container yet, so it cannot occupy a cell here.
+        let slot = {
+            let grid = crate::inventory::grid_for(&self.world, container_entity_id);
+            let occupied =
+                crate::inventory::Inventory::from_container(&self.world, container_entity_id, grid);
+            let dims = self
+                .world
+                .borrow::<View<dark::properties::PropInventoryDimensions>>()
+                .ok()
+                .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+                .unwrap_or((1, 1));
+            // A full container still takes the item (the drop is already
+            // permitted by the caller); it just has no cell to remember.
+            occupied
+                .first_free_slot(dims.0 as usize, dims.1 as usize)
+                .unwrap_or(0)
+        };
+
         let mut was_able_to_drop = false;
         {
             // First, remove any existing contains links for the dropped entity..
@@ -2791,7 +2812,7 @@ impl MissionCore {
                 // If it is the container, we'll add the link!
                 if id == container_entity_id {
                     links.to_links.push(ToLink {
-                        link: Link::Contains(0),
+                        link: Link::Contains(slot),
                         to_entity_id: Some(dark::properties::WrappedEntityId(dropped_entity_id)),
                         to_template_id: 0, // todo?
                     });

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -148,24 +148,12 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
                 .with_size(vec2(self.width, self.height)),
         ];
 
-        let mut contained_entities =
-            script_util::get_all_links_with_data(world, entity_id, |link| match link {
-                Link::Contains(ordinal) => Some(*ordinal),
-                _ => None,
-            });
-
-        contained_entities.sort_by(|a, b| a.1.cmp(&b.1));
-
-        let mut inventory = Inventory::new(self.num_slots_x, self.num_slots_y);
+        // Items keep the cell stored on their containment link; see
+        // `Inventory::from_container`.
+        let inventory =
+            Inventory::from_container(world, entity_id, (self.num_slots_x, self.num_slots_y));
 
         let v_inv_dims = world.borrow::<View<PropInventoryDimensions>>().unwrap();
-        for entity in contained_entities {
-            let inv_dims = v_inv_dims
-                .get(entity.0)
-                .map(|dims| (dims.width, dims.height))
-                .unwrap_or((1, 1));
-            inventory.insert_first_available(entity.0, inv_dims.0 as usize, inv_dims.1 as usize);
-        }
 
         let slot_pixel_width = SLOT_PITCH.x;
         let slot_pixel_height = SLOT_PITCH.y;


### PR DESCRIPTION
Follows #919/#920. Last piece of the inventory investigation: *why items move position*.

## Reproduction

Spawn four items, then remove one. Everything after it slides up a cell.

The cause is that the grid was recomputed from scratch on every draw - first-fit in whatever
order link iteration happened to return - and the one production insertion site wrote
`Link::Contains(0)` for everything:

```rust
// mission_core.rs, drop_entity_into_container
links.to_links.push(ToLink {
    link: Link::Contains(0),   // <- the item's grid cell, thrown away
    ...
```

So the layout was a function of link order rather than of where things actually were.

## How position is stored

There is no position property. Three separate pieces of data, easily conflated:

| What | Where | Meaning |
| --- | --- | --- |
| which cell | `LD$Contains` (the link's data) | one int: `slot = y * width + x` |
| how many cells | `P$InvDims` | footprint in cells (default 1x1) |
| how big it draws | the icon PCX's own pixels | authored art (see #920) |

Position lives on the *relationship*, not the object, so it travels with the link - which is
why save/load persistence falls out for free.

The ordinal is meaningless without a width: `7` is (3,1) in a 4-wide loot panel and (7,0) in
a 15-wide backpack, and the width is not stored anywhere. `grid_for()` is what keeps the
writer and the reader agreeing on it.

## Fix

- `Inventory::from_container` lays the grid out from the stored ordinals.
- `drop_entity_into_container` assigns a real cell instead of `0`.

Placement is **two-pass**: items that own a cell claim it first, and only then are the rest
packed into what is left. One pass would let a first-fit item take the cell its real owner
was about to claim - reintroducing exactly the shuffle this removes.

First-fit now scans **column by column**, matching the original's packing, so a 1x3 weapon
takes a fresh column instead of straddling the top row.

Ordinals `>= 1000` (the range the original reserves for equipped/paperdoll slots) and cells
outside the grid are treated as "no cell" and fall back to first-fit, rather than the item
vanishing.

## Scope note

I originally estimated ~15 insertion sites hardcoding `Contains(0)`. That was wrong - 14 of
them are test fixtures. There is exactly one production site, which is why this diff is
small. Authored mission contents already arrive with real ordinals parsed from `LD$Contains`;
only runtime insertions were discarding the cell.

## Verification

- negative-first: reverting the layout to the old repack fails
  `removing_an_item_leaves_the_others_where_they_were` with the exact reported symptom
  (remaining items slide from `(0,1),(0,2)` to `(0,0),(0,1)`), plus `stored_slots_place_items`
- six new unit tests: stored cells, removal stability, unplaced items not evicting owners,
  equip-range ordinals, out-of-range ordinals, column-major scan order
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p shock2vr` - 580 passed
- **live** (medsci1, headless): the backpack's link data is now real and distinct -
  `Contains(0) -> Pistol`, `Contains(1) -> Nanites`, `Contains(2) -> Wrench`,
  `Contains(16) -> Nanites` - decoding in a 15-wide grid to exactly the rendered rects. On
  `main` all four read `Contains(0)`.
- **save/load round-trip**: `/v1/save` then `/v1/load` returns the identical ordinals, so
  container layouts survive a reload.

## Known gap (not claimed by this PR)

Dragging an item to a *new* cell does not persist yet - the flat drag lifts to the cursor
and places, but the place path does not write a new ordinal. Items hold their cells across
draws, removals and save/load; a deliberate rearrange does not stick. Follow-up.


## Visual verification

medsci1, headless. Spawn Nanites → Pistol → Nanites → Wrench, open the inventory strip, then equip
the pistol (which removes it from the backpack). Same request sequence on both branches.

![inventory slot persistence](https://gist.githubusercontent.com/tommy-xr/13eaaf54db51e3db3eb369604f8b64ed/raw/inventory-slots.gif)

<sub>Both rows flip between the same two states. Top (main): the wrench jumps left into the freed cell. Bottom (this PR): nothing moves. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/13eaaf54db51e3db3eb369604f8b64ed/raw/inventory-slots-beforeafter.png)

Rects read from `GET /v1/ui` (canvas px, `[x, y, w, h]`) — the numeric ground truth behind the images:

| | 4 items | pistol removed |
| --- | --- | --- |
| **main** | Nanites `[6,17]`, Pistol `[41,17]`, Nanites `[76,17]`, Wrench `[111,17]` | Nanites `[6,17]`, Nanites `[41,17]`, Wrench `[76,17]` |
| **this PR** | Nanites `[6,17]`, Pistol `[41,17]`, Wrench `[76,17]`, Nanites `[6,51]` | Nanites `[6,17]`, Wrench `[76,17]`, Nanites `[6,51]` |

On `main` two of the three survivors move (the second Nanites 76 → 41 and the Wrench 111 → 76). On
this PR every surviving rect is byte-identical across the removal and the freed cell stays empty.

The four-item states also differ between branches, as expected: `main` packs row-major, so the
second Nanites lands at `[76,17]`; this PR packs column-major (matching the original), so it wraps
to `[6,51]` under the first stack and the 1x3 Wrench takes a fresh column.
