### PR TITLE
feat(dark): read a container's authored grid from P$ContainDims

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -313,6 +313,26 @@ impl PropMotionActorTags {
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropSelfIllumination(pub f32);
 
+/// A container's inventory grid, in cells. The `Contains` link's ordinal is
+/// `y * width + x` against *this* width, so it is what makes a stored cell
+/// mean anything.
+///
+/// NOTE: the editor calls this `ContainDims`, but chunk names are stored in a
+/// 12-byte field, so on disk it is `P$ContainDi` - see the registration below.
+#[derive(Debug, Component, Clone, Serialize, Deserialize)]
+pub struct PropContainDimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl PropContainDimensions {
+    pub fn read<T: io::Read + io::Seek>(reader: &mut T, _len: u32) -> PropContainDimensions {
+        let width = read_u32(reader);
+        let height = read_u32(reader);
+        PropContainDimensions { width, height }
+    }
+}
+
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropInventoryDimensions {
     pub width: u32,
@@ -1408,6 +1428,14 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             "P$HUDSelect",
             |reader, _len| read_bool(reader),
             PropHUDSelect,
+            accumulator::latest,
+        ),
+        define_prop(
+            // Truncated on disk from `P$ContainDims`: chunk names live in a
+            // 12-byte field (same trap as `P$AI_AlertC`).
+            "P$ContainDi",
+            PropContainDimensions::read,
+            identity,
             accumulator::latest,
         ),
         define_prop(

--- a/shock2vr/src/inventory/mod.rs
+++ b/shock2vr/src/inventory/mod.rs
@@ -7,7 +7,7 @@
 //! link, so this is also what makes a container's layout stable across a
 //! reload.
 
-use dark::properties::{Link, PropInventoryDimensions};
+use dark::properties::{Link, PropContainDimensions, PropInventoryDimensions};
 use shipyard::{EntityId, Get, View, World};
 
 pub mod player_inventory_entity;
@@ -27,15 +27,29 @@ const EQUIP_SLOT_BASE: u32 = 1000;
 /// Which grid `container_entity` is drawn with. The player's backpack is
 /// wider than a container's loot panel, and the ordinal encodes `y * width +
 /// x`, so both sides of the containment link must agree on the width.
+///
+/// A container's grid is authored as `P$ContainDims`; every container in the
+/// shipped game declares 4x4, which is also the fallback for anything that
+/// does not declare one. The backpack's width is not read from the world yet -
+/// the original derives it from Strength (see the tracking issue), so it stays
+/// at its maximum here.
 pub fn grid_for(world: &World, container_entity: EntityId) -> (usize, usize) {
     let is_backpack = world
         .borrow::<View<PlayerInventoryEntity>>()
         .map(|v| v.get(container_entity).is_ok())
         .unwrap_or(false);
-    match is_backpack {
-        true => BACKPACK_GRID,
-        false => CONTAINER_GRID,
+    if is_backpack {
+        return BACKPACK_GRID;
     }
+    world
+        .borrow::<View<PropContainDimensions>>()
+        .ok()
+        .and_then(|v| v.get(container_entity).ok().map(|d| (d.width, d.height)))
+        // A zero dimension would make every cell decode to nothing; treat it
+        // as unauthored rather than trusting it.
+        .filter(|(w, h)| *w > 0 && *h > 0)
+        .map(|(w, h)| (w as usize, h as usize))
+        .unwrap_or(CONTAINER_GRID)
 }
 
 #[derive(Clone, Debug)]
@@ -317,6 +331,37 @@ mod tests {
             second, first,
             "the loser must be packed elsewhere, not stacked"
         );
+    }
+
+    /// A container's authored `ContainDims` decides the width its ordinals
+    /// decode against - get that wrong and every stored cell lands somewhere
+    /// else. Shipped containers all declare 4x4, but the value is data.
+    #[test]
+    fn container_grid_comes_from_authored_contain_dims() {
+        use dark::properties::PropContainDimensions;
+
+        let mut world = World::new();
+        let plain = world.add_entity(());
+        assert_eq!(grid_for(&world, plain), CONTAINER_GRID, "fallback");
+
+        let wide = world.add_entity(PropContainDimensions {
+            width: 6,
+            height: 2,
+        });
+        assert_eq!(grid_for(&world, wide), (6, 2));
+
+        // Slot 7 is (3,1) in a 4-wide grid but (1,1) in a 6-wide one.
+        let six = Inventory::new(6, 2);
+        assert_eq!(six.cell_of(7), Some((1, 1)));
+        let four = Inventory::new(4, 4);
+        assert_eq!(four.cell_of(7), Some((3, 1)));
+
+        // A degenerate authored value must not swallow the grid.
+        let zero = world.add_entity(PropContainDimensions {
+            width: 0,
+            height: 4,
+        });
+        assert_eq!(grid_for(&world, zero), CONTAINER_GRID);
     }
 
     /// Equip-range ordinals are not cells; such an item still gets laid out.


### PR DESCRIPTION
Stacked on #947 (base: `fix/inventory-slot-persistence`). Follow-up to a question that came
out of reviewing that PR: *is there really no inventory-position property?*

## What prompted this

#947 stores an item's grid cell in the `Contains` link's ordinal (`slot = y * width + x`)
and hardcodes the container width at 4. Checking whether a position property existed turned
up something adjacent that does: **`P$ContainDims`**, the container's grid size, authored in
`shock2.gam` and not parsed by us at all.

Parsing the chunk out of the gamesys directly:

```
P$ContainDi: 5 records
   obj -162: (4, 4)     obj -2890: (4, 4)     obj -379: (4, 4)
   obj -2899: (4, 4)    obj -2887: (4, 4)
```

So the hardcoded 4x4 is *empirically correct for every container in the shipped game* - but
it is a constant standing in for authored data, and the width is load-bearing: get it wrong
and every stored cell decodes to a different place (slot 7 is (3,1) in a 4-wide grid and
(1,1) in a 6-wide one).

(For completeness on the original question: there is no position property. Scanning all 482
distinct `P$` chunk names across `shock2.gam` and three missions for `inv|pos|slot|cell|
cont|loc` yields `InvDims`, `InvCursor`, `InvRendType`, `InvLimbModel` - dimensions, cursor
art, render type, model. The cell exists only as link data.)

## Fix

- Parse `P$ContainDims` into `PropContainDimensions`.
- `grid_for()` reads it, falling back to 4x4 for containers that do not declare one.
- A zero dimension is treated as unauthored rather than trusted - it would make every cell
  decode to nothing.

### The chunk-name trap

Registered as **`P$ContainDi`**, not `P$ContainDims`: chunk names live in a 12-byte field, so
the editor's name is truncated on disk and an exact-match lookup on the full name silently
never fires. Same trap as `P$AI_AlertC` (#886); the existing
`registered_chunk_names_fit_the_11_char_chunk_field` guard covers the new name.

## Verification

- **against real data**: `cargo dq templates 162` (Monsters - every creature container
  inherits it) now reports `PropContainDimensions { width: 4, height: 4 }`. Before this
  change the property did not exist, so it appeared nowhere.
- new unit test `container_grid_comes_from_authored_contain_dims`: fallback when unauthored,
  authored dims honored, the same ordinal decoding to different cells under different widths,
  and a degenerate `0` width not swallowing the grid
- `cargo test -p dark` - 96 passed (incl. the chunk-name guard)
- `cargo test -p shock2vr` - 581 passed
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo fmt --all -- --check`

No behavior change on shipped data - every container authors 4x4, which is what was
hardcoded. This removes the assumption rather than fixing a visible bug, so there is nothing
to show visually.

## Related

- #947 - the cell persistence this supports
- #948 - the backpack's width should likewise come from Strength instead of always being 15
