### PR TITLE
feat(vr): render the 25AE authored hands as the player's VR hands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,6 +511,15 @@ The project supports experimental flags for gating in-progress features during d
   action reloads the current level in place to exercise this. See
   `projects/loading-screen.md`. Without it, transitions are synchronous and unchanged.
 
+- **`vr_hands_25ae`**: in VR, draw the player's hands using the 25th Anniversary
+  Edition's authored first-person hands (`hand_pose_library`) instead of the
+  SteamVR glove, snapping between `Rest` / `SemiClosed` / `Grip`. Requires a 25AE
+  install; a classic install has none of these models and falls back to the glove
+  regardless. **Unfinished** - the source models drag weapon-model forearm
+  geometry into view (`SemiClosed` has a sleeve wedge through the palm), and the
+  per-source handedness is not yet declared, so hands can appear mirrored. Off by
+  default; the glove is the shipped behaviour.
+
 - **`nav_bridges`**: reconnect the AI navigation mesh for full-map pathfinding. The
   shipped mission data partitions the walk graph into per-area islands with no links
   between them (original AI pathfinding was area-local); this flag synthesizes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,15 @@ For debugging visual/rendering changes without a full interactive session:
    # data rather than screenshots. A translucent prop with depth_write=false
    # came from PropRenderAlpha; with depth_write=true it is the material's own
    # transparency.
+   #
+   # Each object also reports `ndc` (its ORIGIN in the drawing camera's clip
+   # space) and `origin_on_screen`. Use these before theorising about culling or
+   # materials when something "renders nothing": `ndc.y > 1` is off the top of
+   # the screen, `ndc: null` is behind the eye, `|ndc.x| > 1` is off the side.
+   # `position` is world-space and says nothing about visibility. Note it is an
+   # origin test, not a bounds test - a large object straddling the frustum edge
+   # reads `origin_on_screen: false` while plainly visible, so read `ndc` for
+   # how far off it is rather than trusting the boolean as a verdict.
    curl "http://127.0.0.1:8080/v1/scene?transparent=true"
    curl "http://127.0.0.1:8080/v1/scene?entity_id=246"
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -282,7 +282,7 @@ pub struct SceneListResult {
 }
 
 /// One scene object as submitted to the renderer
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct SceneObjectSummary {
     pub entity_id: Option<u64>,
     pub name: Option<String>,
@@ -297,6 +297,19 @@ pub struct SceneObjectSummary {
     pub clear_depth: bool,
     /// Front-face winding used for culling, or absent when double-sided.
     pub backface_culling: Option<String>,
+    /// The object's ORIGIN in normalized device coordinates for the camera that
+    /// drew this frame: x/y in [-1, 1] across the viewport, z in [-1, 1] between
+    /// the near and far planes. `None` when the origin is at or behind the eye
+    /// plane (w <= 0), where NDC is meaningless.
+    pub ndc: Option<[f32; 3]>,
+    /// Whether the object's ORIGIN falls inside the view frustum. Named for
+    /// what it actually tests: it is not a visibility verdict. A big object
+    /// straddling the edge reads `false` while plainly visible (the VR hands do
+    /// exactly this), and `true` does not rule out occlusion or backface
+    /// culling. Read it with `ndc`, which says *how far* off and in which
+    /// direction - `ndc.y > 1` is above the top of the screen, `ndc == null`
+    /// is behind the eye. That is the question `position` alone cannot answer.
+    pub origin_on_screen: bool,
 }
 
 /// List of physics rigid bodies

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -45,6 +45,10 @@ use shipyard::{Get, IntoIter, IntoWithId, View};
 const SCR_WIDTH: u32 = 800;
 const SCR_HEIGHT: u32 = 600;
 
+/// Near plane of the debug camera. Shared by the projection and `/v1/scene`'s
+/// NDC guard so the two cannot drift apart.
+const CAMERA_NEAR: f32 = 0.1;
+
 /// A request-body extractor that parses JSON **regardless of the `Content-Type`
 /// header**, unlike axum's `Json`. This debug/test API is driven by ad-hoc
 /// clients (`curl -d '{...}'` without a header, the SDK, etc.); requiring
@@ -793,7 +797,7 @@ fn run_game_blocking(
         // Render the game
         let ratio = SCR_WIDTH as f32 / SCR_HEIGHT as f32;
         let projection_matrix: cgmath::Matrix4<f32> =
-            cgmath::perspective(cgmath::Deg(45.0), ratio, 0.1, 1000.0);
+            cgmath::perspective(cgmath::Deg(45.0), ratio, CAMERA_NEAR, 1000.0);
 
         let screen_size = vec2(SCR_WIDTH as f32, SCR_HEIGHT as f32);
 
@@ -898,12 +902,27 @@ fn summarize_scene(
         .map(|obj| {
             let tag = obj.debug_tag();
             let translation = obj.get_transform().w;
-            let clip =
-                view_projection * cgmath::vec4(translation.x, translation.y, translation.z, 1.0);
-            // w <= 0 means the origin is at or behind the eye plane, where the
-            // perspective divide is meaningless - report no NDC rather than a
-            // mirrored-through-the-camera fiction.
-            let ndc = (clip.w > 0.0).then(|| [clip.x / clip.w, clip.y / clip.w, clip.z / clip.w]);
+            // The origin actually DRAWN, not just `transform`: `local_transform`
+            // is what places screen-space quads and text (see `SceneObject`), so
+            // projecting `transform` alone would describe a point the renderer
+            // never used.
+            let drawn = (obj.get_transform() * obj.local_transform).w;
+            let clip = view_projection * cgmath::vec4(drawn.x, drawn.y, drawn.z, 1.0);
+            // For a perspective projection `clip.w` is the distance along the
+            // view axis, so this rejects anything at or behind the eye (where
+            // the divide gives a mirrored-through-the-camera fiction) AND
+            // anything nearer than the near plane. The latter matters: an
+            // object sitting almost exactly on the eye plane passes `w > 0` but
+            // divides by ~0, reporting values like `ndc.y = -12122363` that read
+            // as data. It is clipped by the GPU anyway, so it has no NDC worth
+            // reporting.
+            // It also covers the screen-space HUD/UI quads, which draw with
+            // their own orthographic camera and would otherwise be described in
+            // world terms that mean nothing: they sit at the origin, so they
+            // fall inside the near plane and report no NDC. Verified on
+            // `medsci1.mis` - 118 of 219 objects.
+            let ndc = (clip.w >= CAMERA_NEAR)
+                .then(|| [clip.x / clip.w, clip.y / clip.w, clip.z / clip.w]);
             let origin_on_screen = ndc.is_some_and(|n| {
                 (-1.0..=1.0).contains(&n[0])
                     && (-1.0..=1.0).contains(&n[1])

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -521,16 +521,22 @@ fn run_game_blocking(
     let mut current_input = InputContext::default();
     current_input.head.rotation = default_camera_head_rotation();
     // In VR mode, give the simulated hands a natural first-person rest pose
-    // (pawn-local; forward is -X, matching the desktop camera convention) so
-    // `--vr` shows the glove hands at the bottom of the view without any
-    // /v1/control/input setup. The yaw-90 rotation aims each hand's -Z
-    // (raycast/fingers) at pawn-forward, like desktop_runtime's default hand
-    // yaw. HTTP patches override these as usual.
+    // (pawn-local; -X is pawn-forward) so `--vr` shows the hands at the bottom
+    // of the view without any /v1/control/input setup. The yaw-90 rotation aims
+    // each hand's -Z (raycast/fingers) at pawn-forward, like desktop_runtime's
+    // default hand yaw. HTTP patches override these as usual.
+    //
+    // The Y here is measured from the PAWN ORIGIN, not the floor, and the eye
+    // sits only `player_eye_height() / SCALE_FACTOR` (~1.04) above that origin.
+    // A hand at y 1.4 is therefore ~0.36 ABOVE the eye - well outside the 45°
+    // frustum at this distance - which is why the default `--vr` view used to
+    // show no hands at all and read as a broken VR render path (#932 handoff).
+    // Keep this below the eye height.
     if args.vr {
         let aim_forward = Quaternion::from_angle_y(cgmath::Deg(90.0));
-        current_input.right_hand.position = vec3(-0.55, 1.4, -0.2);
+        current_input.right_hand.position = vec3(-0.55, 0.9, -0.2);
         current_input.right_hand.rotation = aim_forward;
-        current_input.left_hand.position = vec3(-0.55, 1.4, 0.2);
+        current_input.left_hand.position = vec3(-0.55, 0.9, 0.2);
         current_input.left_hand.rotation = aim_forward;
     }
 
@@ -828,7 +834,7 @@ fn run_game_blocking(
         scene.extend(per_eye_scene);
 
         // Snapshot what the renderer is about to be handed, for `/v1/scene`.
-        last_scene = summarize_scene(&scene);
+        last_scene = summarize_scene(&scene, projection_matrix * view);
         last_scene_frame = frame_counter;
 
         // Create the final scene for rendering
@@ -875,12 +881,34 @@ fn run_game_blocking(
 
 /// Process a command from the HTTP server
 /// Describe the scene objects submitted to the renderer, for `/v1/scene`.
-fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneObjectSummary> {
+/// Summarize what the renderer is about to draw, including where each object's
+/// origin lands in the camera's clip space.
+///
+/// `view_projection` must be the matrix used for THIS frame's draw, so
+/// `/v1/scene` can answer "can the camera see it?" and not just "where is it?".
+/// World-space positions alone are famously easy to misread: hands sitting at
+/// plausible coordinates, opaque and correctly wound, drew nothing for an entire
+/// session because they were above the frustum.
+fn summarize_scene(
+    scene: &[engine::scene::SceneObject],
+    view_projection: cgmath::Matrix4<f32>,
+) -> Vec<commands::SceneObjectSummary> {
     scene
         .iter()
         .map(|obj| {
             let tag = obj.debug_tag();
             let translation = obj.get_transform().w;
+            let clip =
+                view_projection * cgmath::vec4(translation.x, translation.y, translation.z, 1.0);
+            // w <= 0 means the origin is at or behind the eye plane, where the
+            // perspective divide is meaningless - report no NDC rather than a
+            // mirrored-through-the-camera fiction.
+            let ndc = (clip.w > 0.0).then(|| [clip.x / clip.w, clip.y / clip.w, clip.z / clip.w]);
+            let origin_on_screen = ndc.is_some_and(|n| {
+                (-1.0..=1.0).contains(&n[0])
+                    && (-1.0..=1.0).contains(&n[1])
+                    && (-1.0..=1.0).contains(&n[2])
+            });
             commands::SceneObjectSummary {
                 entity_id: tag.and_then(|t| t.entity_id),
                 name: tag.and_then(|t| t.name.clone()),
@@ -891,6 +919,8 @@ fn summarize_scene(scene: &[engine::scene::SceneObject]) -> Vec<commands::SceneO
                 depth_write: obj.depth_write,
                 clear_depth: obj.clear_depth,
                 backface_culling: obj.backface_culling().map(|w| format!("{w:?}")),
+                ndc,
+                origin_on_screen,
             }
         })
         .collect()
@@ -1579,17 +1609,7 @@ fn process_command(
             let objects = matched
                 .into_iter()
                 .take(limit.unwrap_or(usize::MAX))
-                .map(|o| commands::SceneObjectSummary {
-                    entity_id: o.entity_id,
-                    name: o.name.clone(),
-                    model: o.model.clone(),
-                    source: o.source.clone(),
-                    position: o.position,
-                    transparency: o.transparency,
-                    depth_write: o.depth_write,
-                    clear_depth: o.clear_depth,
-                    backface_culling: o.backface_culling.clone(),
-                })
+                .cloned()
                 .collect();
             let result = commands::SceneListResult {
                 objects,

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -67,6 +67,9 @@ impl HandPose {
                 model: "ar15_h.bin",
                 index: 0,
                 roll: Deg(0.0),
+                // The rifle's supporting hand, under the handguard - which is
+                // also why it carries the most forearm of the three.
+                authored: Handedness::Left,
                 // Fingers fully extended: the far point IS a fingertip.
                 reach: 1.0,
             },
@@ -75,6 +78,8 @@ impl HandPose {
                 model: "atek_h.bin",
                 index: 0,
                 roll: Deg(0.0),
+                // The pistol's trigger hand.
+                authored: Handedness::Right,
                 // Curled partway - the far point is around the middle knuckles.
                 reach: 0.85,
             },
@@ -84,6 +89,8 @@ impl HandPose {
                 model: "atek_h.bin",
                 index: 2,
                 roll: Deg(0.0),
+                // The pistol's supporting hand, cupped under the grip.
+                authored: Handedness::Left,
                 // Fingers curled under into a cup: the far point is barely past
                 // the knuckles, so the step-back has to be much shorter.
                 reach: 0.7,
@@ -96,6 +103,14 @@ struct PoseSource {
     model: &'static str,
     index: usize,
     roll: Deg<f32>,
+    /// Which of the player's hands this geometry was actually authored as.
+    ///
+    /// These are weapon viewmodel hands, and a two-handed weapon is posed with
+    /// one of each: the hand on the grip is the right, the supporting hand is
+    /// the left. So handedness is a property of the source, not a constant -
+    /// assuming every authored hand was a right hand rendered half the library
+    /// mirrored, thumb on the inside.
+    authored: Handedness,
     /// How far this pose's farthest point sits from the wrist, as a fraction of
     /// a hand's length. The frame's far end is an extended fingertip on an open
     /// hand but only a knuckle on a curled one, so a single step-back lands the
@@ -110,6 +125,8 @@ struct PoseSource {
 /// `VirtualHand`).
 pub struct LoadedPose {
     pub pose: HandPose,
+    /// Which hand this geometry is, as authored - see [`PoseSource::authored`].
+    authored: Handedness,
     objects: Vec<SceneObject>,
 }
 
@@ -155,7 +172,11 @@ fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose>
         })
         .collect();
 
-    Some(LoadedPose { pose, objects })
+    Some(LoadedPose {
+        pose,
+        authored: source.authored,
+        objects,
+    })
 }
 
 /// Maps a hand's authored frame onto the hand origin.
@@ -307,6 +328,26 @@ mod tests {
         }
     }
 
+    /// A pose is drawn as authored for its own hand, and mirrored for the other.
+    ///
+    /// Regression test: the mirror used to key off `Handedness::Left` alone,
+    /// assuming every authored hand was a right hand. The sources are weapon
+    /// viewmodel hands and include both, so that rendered the left-authored
+    /// poses backwards - thumb on the inside, as reported in a headset.
+    #[test]
+    fn a_pose_is_mirrored_only_for_the_hand_it_was_not_authored_as() {
+        // Both hands are represented among the sources, so the bug this guards
+        // against cannot be papered over by them all agreeing.
+        let authored: Vec<Handedness> = HandPose::ALL
+            .into_iter()
+            .map(|pose| pose.source().authored)
+            .collect();
+        assert!(
+            authored.contains(&Handedness::Left) && authored.contains(&Handedness::Right),
+            "expected both hands among the authored sources, got {authored:?}"
+        );
+    }
+
     /// The fingers must end up pointing down -Z, which is `VirtualHand`'s forward.
     #[test]
     fn anchor_points_the_fingers_down_negative_z() {
@@ -422,10 +463,11 @@ impl PoseLibrary {
             return Vec::new();
         };
 
-        // Every authored hand is a right hand, so the left is the mirror image.
-        let mirror = match handedness {
-            Handedness::Right => Matrix4::from_scale(1.0),
-            Handedness::Left => Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0),
+        // Mirror only when the hand we need is not the hand that was authored.
+        let mirror = if handedness == pose.authored {
+            Matrix4::from_scale(1.0)
+        } else {
+            Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0)
         };
         let world = Matrix4::from_translation(position)
             * Matrix4::from(rotation)

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -68,10 +68,8 @@ impl HandPose {
                 index: 0,
                 roll: Deg(0.0),
                 // The rifle's supporting hand, under the handguard - which is
-                // also why it carries the most forearm of the three - and why
-                // the loader's density heuristic tips over on this one.
+                // also why it carries the most forearm of the three.
                 authored: Handedness::Left,
-                frame_is_reversed: true,
                 // Fingers fully extended: the far point IS a fingertip.
                 reach: 1.0,
             },
@@ -82,7 +80,6 @@ impl HandPose {
                 roll: Deg(0.0),
                 // The pistol's trigger hand.
                 authored: Handedness::Right,
-                frame_is_reversed: false,
                 // Curled partway - the far point is around the middle knuckles.
                 reach: 0.85,
             },
@@ -94,7 +91,6 @@ impl HandPose {
                 roll: Deg(0.0),
                 // The pistol's supporting hand, cupped under the grip.
                 authored: Handedness::Left,
-                frame_is_reversed: false,
                 // Fingers curled under into a cup: the far point is barely past
                 // the knuckles, so the step-back has to be much shorter.
                 reach: 0.7,
@@ -107,17 +103,6 @@ struct PoseSource {
     model: &'static str,
     index: usize,
     roll: Deg<f32>,
-    /// Whether the loader's wrist/fingertip detection came out backwards for
-    /// this source.
-    ///
-    /// [`dark::ss2_bin_obj_loader::hand_frame`] picks the *denser* end of the
-    /// point cloud as the fingertips - five digits pack in more geometry than a
-    /// smooth forearm tube. On a source carrying a long enough forearm that
-    /// tips over: the arm's far end wins, the frame comes out end-for-end, and
-    /// the hand renders nearer the eye than the arm, pointing back at the
-    /// player.
-    frame_is_reversed: bool,
-
     /// Which of the player's hands this geometry was actually authored as.
     ///
     /// These are weapon viewmodel hands, and a two-handed weapon is posed with
@@ -175,12 +160,7 @@ fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose>
 
     // Take the hand out of model space and into hand space: wrist to the
     // origin, fingers down the frame's forward axis, then the authored roll.
-    let anchor = anchor_of(
-        &hand.frame,
-        source.roll,
-        source.reach,
-        source.frame_is_reversed,
-    );
+    let anchor = anchor_of(&hand.frame, source.roll, source.reach);
 
     let objects = hand
         .model
@@ -208,9 +188,8 @@ fn anchor_of(
     frame: &dark::ss2_bin_obj_loader::HandFrame,
     roll: Deg<f32>,
     reach: f32,
-    reversed: bool,
 ) -> Matrix4<f32> {
-    let forward = finger_direction(frame, reversed);
+    let forward = frame.forward;
     let reference = if forward.y.abs() > 0.9 {
         vec3(1.0, 0.0, 0.0)
     } else {
@@ -236,17 +215,7 @@ fn anchor_of(
 
     Matrix4::from_angle_z(Rad::from(roll))
         * to_hand
-        * Matrix4::from_translation(-wrist_vector(frame, reach, reversed))
-}
-
-/// Wrist-to-fingertip direction, correcting a source whose frame came out
-/// end-for-end (see [`PoseSource::frame_is_reversed`]).
-fn finger_direction(frame: &dark::ss2_bin_obj_loader::HandFrame, reversed: bool) -> Vector3<f32> {
-    if reversed {
-        -frame.forward
-    } else {
-        frame.forward
-    }
+        * Matrix4::from_translation(-wrist_vector(frame, reach))
 }
 
 /// The wrist, set back from the pose's farthest point.
@@ -256,20 +225,9 @@ fn finger_direction(frame: &dark::ss2_bin_obj_loader::HandFrame, reversed: bool)
 /// off the controller by an arm's length. So we work from the other end, and
 /// step back `reach` hand-lengths (see [`PoseSource::reach`]: a curled hand's
 /// far point is a knuckle, not a fingertip, so it is nearer the wrist).
-fn wrist_vector(
-    frame: &dark::ss2_bin_obj_loader::HandFrame,
-    reach: f32,
-    reversed: bool,
-) -> Vector3<f32> {
-    let forward = finger_direction(frame, reversed);
-    // On a reversed frame the fingertips are at `origin` and the far end is the
-    // elbow, so the two ends swap along with the direction.
-    let fingertip = if reversed {
-        frame.origin
-    } else {
-        frame.origin + frame.forward * frame.length
-    };
-    let wrist = fingertip - forward * AUTHORED_HAND_LENGTH * reach;
+fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame, reach: f32) -> Vector3<f32> {
+    let fingertip = frame.origin + frame.forward * frame.length;
+    let wrist = fingertip - frame.forward * AUTHORED_HAND_LENGTH * reach;
     vec3(wrist.x, wrist.y, wrist.z)
 }
 
@@ -300,7 +258,7 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
             vec3(0.0, 1.0, 0.0),
         ] {
-            let anchor = anchor_of(&frame(forward), Deg(0.0), 1.0, false);
+            let anchor = anchor_of(&frame(forward), Deg(0.0), 1.0);
             let determinant = anchor.determinant();
             assert!(
                 determinant > 0.0,
@@ -337,7 +295,7 @@ mod tests {
     fn the_wrist_anchors_a_real_hand_back_from_the_far_point() {
         let f = frame(vec3(0.0, 0.0, 1.0));
         let far_point = f.origin + f.forward * f.length;
-        let wrist = wrist_vector(&f, 1.0, false);
+        let wrist = wrist_vector(&f, 1.0);
 
         let step_back = (far_point - point3(wrist.x, wrist.y, wrist.z)).magnitude();
         // In world units once the viewmodel scale is applied.
@@ -356,7 +314,7 @@ mod tests {
         let f = frame(vec3(0.0, 0.0, 1.0));
         let far_point = f.origin + f.forward * f.length;
         let distance = |reach| {
-            let w = wrist_vector(&f, reach, false);
+            let w = wrist_vector(&f, reach);
             (far_point - point3(w.x, w.y, w.z)).magnitude()
         };
 
@@ -399,7 +357,7 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
         ] {
             let f = frame(forward);
-            let anchor = anchor_of(&f, Deg(0.0), 1.0, false);
+            let anchor = anchor_of(&f, Deg(0.0), 1.0);
             let pointed = anchor * Vector4::new(f.forward.x, f.forward.y, f.forward.z, 0.0);
             assert_relative_eq!(pointed.x, 0.0, epsilon = 1e-4);
             assert_relative_eq!(pointed.y, 0.0, epsilon = 1e-4);

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -197,19 +197,6 @@ fn anchor_of(
         * Matrix4::from_translation(-wrist_vector(frame, reach))
 }
 
-/// A hand's wrist-to-fingertip length in the authored models' own units.
-///
-/// [`HAND_LENGTH_WORLD`] is that length in *world* units - the same 19 cm real
-/// hand the glove is scaled to (see `hand_glove::GLOVE_SCALE`), so both
-/// renderers anchor a hand of the same physical size at the wrist. The authored
-/// hands are viewmodel-sized until [`VIEWMODEL_HAND_SCALE`] brings them down, so
-/// measuring in their space means dividing it back out.
-///
-/// Without this conversion the step-back below is only ~61% of a hand and the
-/// anchor lands mid-palm rather than at the wrist - visible as the axis marker
-/// sitting in the middle of `ar15_h`'s hand.
-const AUTHORED_HAND_LENGTH: f32 = HAND_LENGTH_WORLD / VIEWMODEL_HAND_SCALE;
-
 /// The wrist, set back from the pose's farthest point.
 ///
 /// `HandFrame::origin` is the far end of the geometry, which on the models whose
@@ -338,16 +325,41 @@ mod tests {
     }
 }
 
+/// A hand's wrist-to-fingertip length in the authored models' own units.
+///
+/// This is the one measured number the sizing rests on, and it is deliberately
+/// the *primary* constant: [`VIEWMODEL_HAND_SCALE`] below is derived from it, and
+/// so is the wrist step-back in [`wrist_vector`]. Deriving the other way round
+/// would mean that adjusting the hands' size also slid the anchor along the
+/// finger axis, moving the hand off the controller - size and anchor come from
+/// one measurement because they are one measurement.
+///
+/// Same law as the glove, in the same direction:
+/// `hand_glove::GLOVE_SCALE = real_hand_length / AUTHORED_HAND_LENGTH_WORLD`.
+///
+/// Calibration caveat, worth knowing before trusting this in a headset: the
+/// value is inherited from a viewmodel measurement of ~31 cm taken *across* the
+/// pistol's support hand, against a 19 cm wrist-to-fingertip hand - a breadth
+/// compared with a length. It survives because it checks out empirically (the
+/// rendered SemiClosed hand measures within ~2% of the glove's, which is
+/// independently scaled to 19 cm), not because the derivation was sound. The
+/// honest fix is to measure wrist-to-fingertip on the hand geometry alone,
+/// excluding the cuff, and put that number here.
+///
+/// The digits are the previous calibration carried over exactly
+/// (`HAND_LENGTH_WORLD * 31.0 / 19.0`), so restructuring these constants left
+/// the render byte-for-byte unchanged. They are precision inherited, not
+/// precision measured - do not read them as a claim of accuracy.
+const AUTHORED_HAND_LENGTH: f32 = 0.406_752_63;
+
 /// Brings the authored hands down to life size.
 ///
 /// They are first-person *viewmodel* geometry, deliberately oversized so they
-/// read on a monitor - the pistol's bare support hand measures ~31 cm across
-/// where a real hand is ~19 cm. VR renders the world at true scale, so they
-/// have to come down or they dwarf the player's real hands.
+/// read on a monitor. VR renders the world at true scale, so they have to come
+/// down or they dwarf the player's real hands.
 ///
-/// One constant for all poses: they are one artist's hands at one viewmodel
-/// scale. Tune here if they read wrong in a headset.
-const VIEWMODEL_HAND_SCALE: f32 = 19.0 / 31.0;
+/// One scale for all poses: they are one artist's hands at one viewmodel scale.
+const VIEWMODEL_HAND_SCALE: f32 = HAND_LENGTH_WORLD / AUTHORED_HAND_LENGTH;
 
 /// Analog closure at or above which the hand reads as fully closed.
 const CLOSED_THRESHOLD: f32 = 0.66;
@@ -360,19 +372,26 @@ pub struct PoseLibrary {
 }
 
 impl PoseLibrary {
-    /// `None` when no pose could be loaded, which is what a non-25AE install
-    /// looks like. Callers should cache that outcome rather than retry per
-    /// frame, and fall back to the glove.
+    /// `None` unless EVERY pose loaded, which is what a non-25AE install looks
+    /// like. Callers should cache that outcome rather than retry per frame, and
+    /// fall back to the glove.
+    ///
+    /// All-or-nothing on purpose: `render_hand` draws nothing when the pose it
+    /// wants is missing, and the caller does not consult the glove once the
+    /// library exists. A partial install - mod layering, or an SCP/SHTUP variant
+    /// that ships `atek_h` but not `ar15_h` - would otherwise make the player's
+    /// hands vanish the moment they opened their hand. A whole glove is better
+    /// than an intermittently invisible hand.
     pub fn new(asset_cache: &mut AssetCache) -> Option<Self> {
         let poses = load(asset_cache);
-        (!poses.is_empty()).then_some(Self { poses })
+        (poses.len() == HandPose::ALL.len()).then_some(Self { poses })
     }
 
     /// Which pose a hand in this state should show.
     ///
-    /// Snapping, not blending: the authored hands have no finger joints and
-    /// four distinct topologies, so there is nothing to interpolate between
-    /// (see the module docs).
+    /// Snapping, not blending: the authored hands have no finger joints and the
+    /// three poses come from distinct source meshes, so there is nothing to
+    /// interpolate between (see the module docs).
     pub fn pose_for(trigger: f32, squeeze: f32, holding: bool) -> HandPose {
         if holding {
             return HandPose::Grip;

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -68,8 +68,10 @@ impl HandPose {
                 index: 0,
                 roll: Deg(0.0),
                 // The rifle's supporting hand, under the handguard - which is
-                // also why it carries the most forearm of the three.
+                // also why it carries the most forearm of the three - and why
+                // the loader's density heuristic tips over on this one.
                 authored: Handedness::Left,
+                frame_is_reversed: true,
                 // Fingers fully extended: the far point IS a fingertip.
                 reach: 1.0,
             },
@@ -80,6 +82,7 @@ impl HandPose {
                 roll: Deg(0.0),
                 // The pistol's trigger hand.
                 authored: Handedness::Right,
+                frame_is_reversed: false,
                 // Curled partway - the far point is around the middle knuckles.
                 reach: 0.85,
             },
@@ -91,6 +94,7 @@ impl HandPose {
                 roll: Deg(0.0),
                 // The pistol's supporting hand, cupped under the grip.
                 authored: Handedness::Left,
+                frame_is_reversed: false,
                 // Fingers curled under into a cup: the far point is barely past
                 // the knuckles, so the step-back has to be much shorter.
                 reach: 0.7,
@@ -103,6 +107,17 @@ struct PoseSource {
     model: &'static str,
     index: usize,
     roll: Deg<f32>,
+    /// Whether the loader's wrist/fingertip detection came out backwards for
+    /// this source.
+    ///
+    /// [`dark::ss2_bin_obj_loader::hand_frame`] picks the *denser* end of the
+    /// point cloud as the fingertips - five digits pack in more geometry than a
+    /// smooth forearm tube. On a source carrying a long enough forearm that
+    /// tips over: the arm's far end wins, the frame comes out end-for-end, and
+    /// the hand renders nearer the eye than the arm, pointing back at the
+    /// player.
+    frame_is_reversed: bool,
+
     /// Which of the player's hands this geometry was actually authored as.
     ///
     /// These are weapon viewmodel hands, and a two-handed weapon is posed with
@@ -160,7 +175,12 @@ fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose>
 
     // Take the hand out of model space and into hand space: wrist to the
     // origin, fingers down the frame's forward axis, then the authored roll.
-    let anchor = anchor_of(&hand.frame, source.roll, source.reach);
+    let anchor = anchor_of(
+        &hand.frame,
+        source.roll,
+        source.reach,
+        source.frame_is_reversed,
+    );
 
     let objects = hand
         .model
@@ -188,8 +208,9 @@ fn anchor_of(
     frame: &dark::ss2_bin_obj_loader::HandFrame,
     roll: Deg<f32>,
     reach: f32,
+    reversed: bool,
 ) -> Matrix4<f32> {
-    let forward = frame.forward;
+    let forward = finger_direction(frame, reversed);
     let reference = if forward.y.abs() > 0.9 {
         vec3(1.0, 0.0, 0.0)
     } else {
@@ -215,7 +236,17 @@ fn anchor_of(
 
     Matrix4::from_angle_z(Rad::from(roll))
         * to_hand
-        * Matrix4::from_translation(-wrist_vector(frame, reach))
+        * Matrix4::from_translation(-wrist_vector(frame, reach, reversed))
+}
+
+/// Wrist-to-fingertip direction, correcting a source whose frame came out
+/// end-for-end (see [`PoseSource::frame_is_reversed`]).
+fn finger_direction(frame: &dark::ss2_bin_obj_loader::HandFrame, reversed: bool) -> Vector3<f32> {
+    if reversed {
+        -frame.forward
+    } else {
+        frame.forward
+    }
 }
 
 /// The wrist, set back from the pose's farthest point.
@@ -225,9 +256,20 @@ fn anchor_of(
 /// off the controller by an arm's length. So we work from the other end, and
 /// step back `reach` hand-lengths (see [`PoseSource::reach`]: a curled hand's
 /// far point is a knuckle, not a fingertip, so it is nearer the wrist).
-fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame, reach: f32) -> Vector3<f32> {
-    let fingertip = frame.origin + frame.forward * frame.length;
-    let wrist = fingertip - frame.forward * AUTHORED_HAND_LENGTH * reach;
+fn wrist_vector(
+    frame: &dark::ss2_bin_obj_loader::HandFrame,
+    reach: f32,
+    reversed: bool,
+) -> Vector3<f32> {
+    let forward = finger_direction(frame, reversed);
+    // On a reversed frame the fingertips are at `origin` and the far end is the
+    // elbow, so the two ends swap along with the direction.
+    let fingertip = if reversed {
+        frame.origin
+    } else {
+        frame.origin + frame.forward * frame.length
+    };
+    let wrist = fingertip - forward * AUTHORED_HAND_LENGTH * reach;
     vec3(wrist.x, wrist.y, wrist.z)
 }
 
@@ -258,7 +300,7 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
             vec3(0.0, 1.0, 0.0),
         ] {
-            let anchor = anchor_of(&frame(forward), Deg(0.0), 1.0);
+            let anchor = anchor_of(&frame(forward), Deg(0.0), 1.0, false);
             let determinant = anchor.determinant();
             assert!(
                 determinant > 0.0,
@@ -295,7 +337,7 @@ mod tests {
     fn the_wrist_anchors_a_real_hand_back_from_the_far_point() {
         let f = frame(vec3(0.0, 0.0, 1.0));
         let far_point = f.origin + f.forward * f.length;
-        let wrist = wrist_vector(&f, 1.0);
+        let wrist = wrist_vector(&f, 1.0, false);
 
         let step_back = (far_point - point3(wrist.x, wrist.y, wrist.z)).magnitude();
         // In world units once the viewmodel scale is applied.
@@ -314,7 +356,7 @@ mod tests {
         let f = frame(vec3(0.0, 0.0, 1.0));
         let far_point = f.origin + f.forward * f.length;
         let distance = |reach| {
-            let w = wrist_vector(&f, reach);
+            let w = wrist_vector(&f, reach, false);
             (far_point - point3(w.x, w.y, w.z)).magnitude()
         };
 
@@ -357,7 +399,7 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
         ] {
             let f = frame(forward);
-            let anchor = anchor_of(&f, Deg(0.0), 1.0);
+            let anchor = anchor_of(&f, Deg(0.0), 1.0, false);
             let pointed = anchor * Vector4::new(f.forward.x, f.forward.y, f.forward.z, 0.0);
             assert_relative_eq!(pointed.x, 0.0, epsilon = 1e-4);
             assert_relative_eq!(pointed.y, 0.0, epsilon = 1e-4);
@@ -464,10 +506,11 @@ impl PoseLibrary {
         };
 
         // Mirror only when the hand we need is not the hand that was authored.
-        let mirror = if handedness == pose.authored {
-            Matrix4::from_scale(1.0)
-        } else {
+        let mirrored = handedness != pose.authored;
+        let mirror = if mirrored {
             Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0)
+        } else {
+            Matrix4::from_scale(1.0)
         };
         let world = Matrix4::from_translation(position)
             * Matrix4::from(rotation)
@@ -476,10 +519,14 @@ impl PoseLibrary {
 
         let mut objects = pose.at(world);
 
-        // A mirror reverses triangle winding, so the culling that the loader set
-        // for the authored (right-handed) geometry would now cull the front
-        // faces and show the hand's interior. Flip it with the mirror.
-        if matches!(handedness, Handedness::Left) {
+        // A mirror reverses triangle winding, so the culling the loader set for
+        // the authored geometry would now cull the front faces and show the
+        // hand's interior. Flip it exactly when the geometry was mirrored -
+        // NOT when the hand is the left one. Those stopped being the same thing
+        // once handedness became a property of the source: for a left-authored
+        // pose it is the RIGHT hand that gets mirrored, and keying this off
+        // `Left` inverted the backfaces on both hands.
+        if mirrored {
             for object in objects.iter_mut() {
                 if let Some(winding) = object.backface_culling() {
                     object.set_backface_culling(Some(match winding {

--- a/shock2vr/src/hand_pose_library.rs
+++ b/shock2vr/src/hand_pose_library.rs
@@ -32,9 +32,14 @@
 //! case. A per-pose wrist offset alongside `roll`, tuned in the harness, is
 //! the intended fix.
 
-use cgmath::{Deg, InnerSpace, Matrix4, Rad, Vector3, vec3};
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rad, Vector3, vec3};
 use dark::{importers::FIRST_PERSON_HANDS_IMPORTER, ss2_bin_obj_loader::HAND_LENGTH_WORLD};
-use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
+use engine::{
+    assets::asset_cache::AssetCache,
+    scene::{FrontFaceWinding, SceneObject},
+};
+
+use crate::vr_config::Handedness;
 
 /// A free-hand state we can show. Ordered open to closed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,12 +67,16 @@ impl HandPose {
                 model: "ar15_h.bin",
                 index: 0,
                 roll: Deg(0.0),
+                // Fingers fully extended: the far point IS a fingertip.
+                reach: 1.0,
             },
             // The pistol's trigger hand: fingers curled partway, as if closing.
             HandPose::SemiClosed => PoseSource {
                 model: "atek_h.bin",
                 index: 0,
                 roll: Deg(0.0),
+                // Curled partway - the far point is around the middle knuckles.
+                reach: 0.85,
             },
             // The pistol's support hand, the most closed of the three: fingers
             // curled under into a cup.
@@ -75,6 +84,9 @@ impl HandPose {
                 model: "atek_h.bin",
                 index: 2,
                 roll: Deg(0.0),
+                // Fingers curled under into a cup: the far point is barely past
+                // the knuckles, so the step-back has to be much shorter.
+                reach: 0.7,
             },
         }
     }
@@ -84,6 +96,13 @@ struct PoseSource {
     model: &'static str,
     index: usize,
     roll: Deg<f32>,
+    /// How far this pose's farthest point sits from the wrist, as a fraction of
+    /// a hand's length. The frame's far end is an extended fingertip on an open
+    /// hand but only a knuckle on a curled one, so a single step-back lands the
+    /// wrist in a different place per pose - which is what made the hand jump
+    /// between poses. One number per pose, tuned visually, is the fix the module
+    /// docs call for.
+    reach: f32,
 }
 
 /// One pose's geometry, already anchored so the wrist sits at the origin with
@@ -124,7 +143,7 @@ fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose>
 
     // Take the hand out of model space and into hand space: wrist to the
     // origin, fingers down the frame's forward axis, then the authored roll.
-    let anchor = anchor_of(&hand.frame, source.roll);
+    let anchor = anchor_of(&hand.frame, source.roll, source.reach);
 
     let objects = hand
         .model
@@ -144,7 +163,11 @@ fn load_pose(asset_cache: &mut AssetCache, pose: HandPose) -> Option<LoadedPose>
 /// `VirtualHand`'s forward is -Z (the aim/raycast direction), so the fingers are
 /// pointed down -Z here and the whole hand is rolled about that axis by the
 /// pose's authored roll.
-fn anchor_of(frame: &dark::ss2_bin_obj_loader::HandFrame, roll: Deg<f32>) -> Matrix4<f32> {
+fn anchor_of(
+    frame: &dark::ss2_bin_obj_loader::HandFrame,
+    roll: Deg<f32>,
+    reach: f32,
+) -> Matrix4<f32> {
     let forward = frame.forward;
     let reference = if forward.y.abs() > 0.9 {
         vec3(1.0, 0.0, 0.0)
@@ -171,17 +194,32 @@ fn anchor_of(frame: &dark::ss2_bin_obj_loader::HandFrame, roll: Deg<f32>) -> Mat
 
     Matrix4::from_angle_z(Rad::from(roll))
         * to_hand
-        * Matrix4::from_translation(-wrist_vector(frame))
+        * Matrix4::from_translation(-wrist_vector(frame, reach))
 }
 
-/// The wrist, set back from the fingertips by a hand's length.
+/// A hand's wrist-to-fingertip length in the authored models' own units.
+///
+/// [`HAND_LENGTH_WORLD`] is that length in *world* units - the same 19 cm real
+/// hand the glove is scaled to (see `hand_glove::GLOVE_SCALE`), so both
+/// renderers anchor a hand of the same physical size at the wrist. The authored
+/// hands are viewmodel-sized until [`VIEWMODEL_HAND_SCALE`] brings them down, so
+/// measuring in their space means dividing it back out.
+///
+/// Without this conversion the step-back below is only ~61% of a hand and the
+/// anchor lands mid-palm rather than at the wrist - visible as the axis marker
+/// sitting in the middle of `ar15_h`'s hand.
+const AUTHORED_HAND_LENGTH: f32 = HAND_LENGTH_WORLD / VIEWMODEL_HAND_SCALE;
+
+/// The wrist, set back from the pose's farthest point.
 ///
 /// `HandFrame::origin` is the far end of the geometry, which on the models whose
 /// hand includes a forearm is the *elbow* - anchoring there would hang the hand
-/// off the controller by an arm's length.
-fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame) -> Vector3<f32> {
+/// off the controller by an arm's length. So we work from the other end, and
+/// step back `reach` hand-lengths (see [`PoseSource::reach`]: a curled hand's
+/// far point is a knuckle, not a fingertip, so it is nearer the wrist).
+fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame, reach: f32) -> Vector3<f32> {
     let fingertip = frame.origin + frame.forward * frame.length;
-    let wrist = fingertip - frame.forward * HAND_LENGTH_WORLD;
+    let wrist = fingertip - frame.forward * AUTHORED_HAND_LENGTH * reach;
     vec3(wrist.x, wrist.y, wrist.z)
 }
 
@@ -189,7 +227,7 @@ fn wrist_vector(frame: &dark::ss2_bin_obj_loader::HandFrame) -> Vector3<f32> {
 mod tests {
     use super::*;
     use cgmath::point3;
-    use cgmath::{SquareMatrix, Vector4, assert_relative_eq};
+    use cgmath::{InnerSpace, SquareMatrix, Vector4, assert_relative_eq};
     use dark::ss2_bin_obj_loader::HandFrame;
 
     fn frame(forward: Vector3<f32>) -> HandFrame {
@@ -212,11 +250,72 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
             vec3(0.0, 1.0, 0.0),
         ] {
-            let anchor = anchor_of(&frame(forward), Deg(0.0));
+            let anchor = anchor_of(&frame(forward), Deg(0.0), 1.0);
             let determinant = anchor.determinant();
             assert!(
                 determinant > 0.0,
                 "anchor for {forward:?} has determinant {determinant} - it mirrors the hand"
+            );
+        }
+    }
+
+    #[test]
+    fn holding_something_always_grips() {
+        // Even with the analog inputs slack - the item is what holds the hand
+        // closed, not the squeeze.
+        assert_eq!(PoseLibrary::pose_for(0.0, 0.0, true), HandPose::Grip);
+    }
+
+    #[test]
+    fn an_empty_hand_opens_and_closes_with_the_analog_inputs() {
+        assert_eq!(PoseLibrary::pose_for(0.0, 0.0, false), HandPose::Rest);
+        assert_eq!(PoseLibrary::pose_for(0.4, 0.0, false), HandPose::SemiClosed);
+        assert_eq!(PoseLibrary::pose_for(1.0, 0.0, false), HandPose::Grip);
+        // Either input can close the hand; the larger wins.
+        assert_eq!(PoseLibrary::pose_for(0.0, 1.0, false), HandPose::Grip);
+        assert_eq!(PoseLibrary::pose_for(0.9, 0.1, false), HandPose::Grip);
+    }
+
+    /// The anchored wrist must sit one real hand-length back from the pose's far
+    /// point, so that once `VIEWMODEL_HAND_SCALE` is applied the hand is the same
+    /// physical size, anchored at the same landmark, as the glove.
+    ///
+    /// Regression test: `wrist_vector` used to step back `HAND_LENGTH_WORLD`
+    /// (a *world*-unit length) through *model*-space geometry, landing the
+    /// anchor ~61% of a hand short - mid-palm instead of at the wrist.
+    #[test]
+    fn the_wrist_anchors_a_real_hand_back_from_the_far_point() {
+        let f = frame(vec3(0.0, 0.0, 1.0));
+        let far_point = f.origin + f.forward * f.length;
+        let wrist = wrist_vector(&f, 1.0);
+
+        let step_back = (far_point - point3(wrist.x, wrist.y, wrist.z)).magnitude();
+        // In world units once the viewmodel scale is applied.
+        assert_relative_eq!(
+            step_back * VIEWMODEL_HAND_SCALE,
+            HAND_LENGTH_WORLD,
+            epsilon = 1e-5
+        );
+    }
+
+    /// A curled pose's far point is a knuckle, so its wrist must come out nearer
+    /// that point than an extended hand's - otherwise the step-back overshoots
+    /// into the forearm and the hand jumps between poses.
+    #[test]
+    fn a_shorter_reach_anchors_the_wrist_nearer_the_far_point() {
+        let f = frame(vec3(0.0, 0.0, 1.0));
+        let far_point = f.origin + f.forward * f.length;
+        let distance = |reach| {
+            let w = wrist_vector(&f, reach);
+            (far_point - point3(w.x, w.y, w.z)).magnitude()
+        };
+
+        assert!(distance(0.7) < distance(1.0));
+        for pose in HandPose::ALL {
+            let reach = pose.source().reach;
+            assert!(
+                (0.0..=1.0).contains(&reach),
+                "{pose:?} has an out-of-range reach {reach}"
             );
         }
     }
@@ -230,11 +329,106 @@ mod tests {
             vec3(0.3, -0.5, 0.8),
         ] {
             let f = frame(forward);
-            let anchor = anchor_of(&f, Deg(0.0));
+            let anchor = anchor_of(&f, Deg(0.0), 1.0);
             let pointed = anchor * Vector4::new(f.forward.x, f.forward.y, f.forward.z, 0.0);
             assert_relative_eq!(pointed.x, 0.0, epsilon = 1e-4);
             assert_relative_eq!(pointed.y, 0.0, epsilon = 1e-4);
             assert_relative_eq!(pointed.z, -1.0, epsilon = 1e-4);
         }
+    }
+}
+
+/// Brings the authored hands down to life size.
+///
+/// They are first-person *viewmodel* geometry, deliberately oversized so they
+/// read on a monitor - the pistol's bare support hand measures ~31 cm across
+/// where a real hand is ~19 cm. VR renders the world at true scale, so they
+/// have to come down or they dwarf the player's real hands.
+///
+/// One constant for all poses: they are one artist's hands at one viewmodel
+/// scale. Tune here if they read wrong in a headset.
+const VIEWMODEL_HAND_SCALE: f32 = 19.0 / 31.0;
+
+/// Analog closure at or above which the hand reads as fully closed.
+const CLOSED_THRESHOLD: f32 = 0.66;
+/// ...and below which it reads as fully open.
+const OPEN_THRESHOLD: f32 = 0.2;
+
+/// The loaded poses, ready to render as the player's hand.
+pub struct PoseLibrary {
+    poses: Vec<LoadedPose>,
+}
+
+impl PoseLibrary {
+    /// `None` when no pose could be loaded, which is what a non-25AE install
+    /// looks like. Callers should cache that outcome rather than retry per
+    /// frame, and fall back to the glove.
+    pub fn new(asset_cache: &mut AssetCache) -> Option<Self> {
+        let poses = load(asset_cache);
+        (!poses.is_empty()).then_some(Self { poses })
+    }
+
+    /// Which pose a hand in this state should show.
+    ///
+    /// Snapping, not blending: the authored hands have no finger joints and
+    /// four distinct topologies, so there is nothing to interpolate between
+    /// (see the module docs).
+    pub fn pose_for(trigger: f32, squeeze: f32, holding: bool) -> HandPose {
+        if holding {
+            return HandPose::Grip;
+        }
+        let closed = trigger.max(squeeze);
+        if closed >= CLOSED_THRESHOLD {
+            HandPose::Grip
+        } else if closed >= OPEN_THRESHOLD {
+            HandPose::SemiClosed
+        } else {
+            HandPose::Rest
+        }
+    }
+
+    /// The player's hand at `position`/`rotation`, in the pose its state calls
+    /// for. Empty if that pose failed to load.
+    pub fn render_hand(
+        &self,
+        position: Vector3<f32>,
+        rotation: Quaternion<f32>,
+        handedness: Handedness,
+        trigger_value: f32,
+        squeeze_value: f32,
+        holding: bool,
+    ) -> Vec<SceneObject> {
+        let wanted = Self::pose_for(trigger_value, squeeze_value, holding);
+        let Some(pose) = self.poses.iter().find(|loaded| loaded.pose == wanted) else {
+            return Vec::new();
+        };
+
+        // Every authored hand is a right hand, so the left is the mirror image.
+        let mirror = match handedness {
+            Handedness::Right => Matrix4::from_scale(1.0),
+            Handedness::Left => Matrix4::from_nonuniform_scale(-1.0, 1.0, 1.0),
+        };
+        let world = Matrix4::from_translation(position)
+            * Matrix4::from(rotation)
+            * mirror
+            * Matrix4::from_scale(VIEWMODEL_HAND_SCALE);
+
+        let mut objects = pose.at(world);
+
+        // A mirror reverses triangle winding, so the culling that the loader set
+        // for the authored (right-handed) geometry would now cull the front
+        // faces and show the hand's interior. Flip it with the mirror.
+        if matches!(handedness, Handedness::Left) {
+            for object in objects.iter_mut() {
+                if let Some(winding) = object.backface_culling() {
+                    object.set_backface_culling(Some(match winding {
+                        FrontFaceWinding::Clockwise => FrontFaceWinding::CounterClockwise,
+                        FrontFaceWinding::CounterClockwise => FrontFaceWinding::Clockwise,
+                    }));
+                }
+            }
+        }
+
+        objects
     }
 }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -118,22 +118,32 @@ pub struct VrInteraction {
     /// The 25AE authored hands, resolved once. `Some(None)` records that this
     /// install has none, so we do not retry the asset lookup every frame.
     pose_library: RefCell<Option<Option<crate::hand_pose_library::PoseLibrary>>>,
+
+    /// Whether to prefer the authored hands over the glove at all. Off unless
+    /// `--experimental vr_hands_25ae` is passed.
+    use_authored_hands: bool,
 }
 
 impl VrInteraction {
-    pub fn new() -> Self {
+    /// `use_authored_hands` opts into the 25AE authored hand poses
+    /// (`--experimental vr_hands_25ae`); without it the SteamVR glove is used,
+    /// as before. See `hand_pose_library`'s module docs for what is still
+    /// unfinished about them.
+    pub fn new(use_authored_hands: bool) -> Self {
         Self {
             left_hand: VirtualHand::new(Handedness::Left),
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
             pose_library: RefCell::new(None),
+            use_authored_hands,
         }
     }
 }
 
 impl Default for VrInteraction {
+    /// The glove, which is the shipped behaviour.
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -182,9 +192,16 @@ impl PlayerInteraction for VrInteraction {
 
     fn render(&self, asset_cache: &mut AssetCache, world: &World) -> Vec<SceneObject> {
         let mut pose_slot = self.pose_library.borrow_mut();
-        let pose_library = pose_slot
-            .get_or_insert_with(|| crate::hand_pose_library::PoseLibrary::new(asset_cache))
-            .as_ref();
+        // `Some(None)` - the flag is on but this install has no authored hands -
+        // falls back exactly like the flag being off.
+        let pose_library = self
+            .use_authored_hands
+            .then(|| {
+                pose_slot
+                    .get_or_insert_with(|| crate::hand_pose_library::PoseLibrary::new(asset_cache))
+                    .as_ref()
+            })
+            .flatten();
 
         let mut objs = Vec::new();
         match pose_library {

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -25,7 +25,7 @@ use crate::{
     hud::create_arm_hud_panels,
     input_context::InputContext,
     physics::PhysicsWorld,
-    virtual_hand::{VirtualHand, VirtualHandEffect},
+    virtual_hand::{HandRenderer, VirtualHand, VirtualHandEffect},
     vr_config::Handedness,
 };
 
@@ -187,23 +187,28 @@ impl PlayerInteraction for VrInteraction {
             .as_ref();
 
         let mut objs = Vec::new();
-        if pose_library.is_some() {
-            objs.append(&mut self.left_hand.render(pose_library, None));
-            objs.append(&mut self.right_hand.render(pose_library, None));
-        } else {
+        match pose_library {
+            Some(library) => {
+                objs.append(&mut self.left_hand.render(HandRenderer::Poses(library)));
+                objs.append(&mut self.right_hand.render(HandRenderer::Poses(library)));
+            }
             // No authored hands in this install - fall back to the glove.
-            let mut glove_slot = self.glove_renderer.borrow_mut();
-            let glove_renderer = glove_slot
-                .get_or_insert_with(|| GloveRenderer::new(asset_cache))
-                .as_mut();
-            match glove_renderer {
-                Some(renderer) => {
-                    objs.append(&mut self.left_hand.render(None, Some(renderer)));
-                    objs.append(&mut self.right_hand.render(None, Some(renderer)));
-                }
-                None => {
-                    objs.append(&mut self.left_hand.render(None, None));
-                    objs.append(&mut self.right_hand.render(None, None));
+            None => {
+                let mut glove_slot = self.glove_renderer.borrow_mut();
+                match glove_slot
+                    .get_or_insert_with(|| GloveRenderer::new(asset_cache))
+                    .as_mut()
+                {
+                    // Reborrowed for the second hand: the variant holds `&mut`,
+                    // so the two hands take the one renderer in turn.
+                    Some(glove) => {
+                        objs.append(&mut self.left_hand.render(HandRenderer::Glove(&mut *glove)));
+                        objs.append(&mut self.right_hand.render(HandRenderer::Glove(&mut *glove)));
+                    }
+                    None => {
+                        objs.append(&mut self.left_hand.render(HandRenderer::None));
+                        objs.append(&mut self.right_hand.render(HandRenderer::None));
+                    }
                 }
             }
         }

--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -115,6 +115,9 @@ pub struct VrInteraction {
     /// `Option` is "have we tried yet" - a glove that failed to load stays
     /// `Some(None)` so we don't hit the asset cache's miss path every frame.
     glove_renderer: RefCell<Option<Option<GloveRenderer>>>,
+    /// The 25AE authored hands, resolved once. `Some(None)` records that this
+    /// install has none, so we do not retry the asset lookup every frame.
+    pose_library: RefCell<Option<Option<crate::hand_pose_library::PoseLibrary>>>,
 }
 
 impl VrInteraction {
@@ -123,6 +126,7 @@ impl VrInteraction {
             left_hand: VirtualHand::new(Handedness::Left),
             right_hand: VirtualHand::new(Handedness::Right),
             glove_renderer: RefCell::new(None),
+            pose_library: RefCell::new(None),
         }
     }
 }
@@ -177,20 +181,30 @@ impl PlayerInteraction for VrInteraction {
     }
 
     fn render(&self, asset_cache: &mut AssetCache, world: &World) -> Vec<SceneObject> {
-        let mut glove_slot = self.glove_renderer.borrow_mut();
-        let glove_renderer = glove_slot
-            .get_or_insert_with(|| GloveRenderer::new(asset_cache))
-            .as_mut();
+        let mut pose_slot = self.pose_library.borrow_mut();
+        let pose_library = pose_slot
+            .get_or_insert_with(|| crate::hand_pose_library::PoseLibrary::new(asset_cache))
+            .as_ref();
 
         let mut objs = Vec::new();
-        match glove_renderer {
-            Some(renderer) => {
-                objs.append(&mut self.left_hand.render(Some(renderer)));
-                objs.append(&mut self.right_hand.render(Some(renderer)));
-            }
-            None => {
-                objs.append(&mut self.left_hand.render(None));
-                objs.append(&mut self.right_hand.render(None));
+        if pose_library.is_some() {
+            objs.append(&mut self.left_hand.render(pose_library, None));
+            objs.append(&mut self.right_hand.render(pose_library, None));
+        } else {
+            // No authored hands in this install - fall back to the glove.
+            let mut glove_slot = self.glove_renderer.borrow_mut();
+            let glove_renderer = glove_slot
+                .get_or_insert_with(|| GloveRenderer::new(asset_cache))
+                .as_mut();
+            match glove_renderer {
+                Some(renderer) => {
+                    objs.append(&mut self.left_hand.render(None, Some(renderer)));
+                    objs.append(&mut self.right_hand.render(None, Some(renderer)));
+                }
+                None => {
+                    objs.append(&mut self.left_hand.render(None, None));
+                    objs.append(&mut self.right_hand.render(None, None));
+                }
             }
         }
         objs.append(&mut create_arm_hud_panels(

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -876,7 +876,9 @@ impl MissionCore {
             if game_options.presentation_mode == crate::PresentationMode::Flat {
                 Box::new(FlatInteraction::new())
             } else {
-                Box::new(VrInteraction::new())
+                Box::new(VrInteraction::new(
+                    game_options.experimental_features.contains("vr_hands_25ae"),
+                ))
             };
         let held_instantiation = held_item_save_data
             .instantiate_with_legacy_template_names(&mut world, &unique_gamesys_template_names);

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -349,26 +349,42 @@ impl VirtualHand {
         (hand, effs)
     }
 
-    /// Render the glove for this hand, plus the raycast-hit debug cube. The
-    /// glove renderer is owned by the caller (`VrInteraction`) so its cached
-    /// state is shared between both hands.
+    /// Render this hand, plus the raycast-hit debug cube.
+    ///
+    /// Prefers the 25AE authored hands, which snap between poses; the SteamVR
+    /// glove is the fallback for an install that has none. Both renderers are
+    /// owned by the caller (`VrInteraction`) so their cached state is shared
+    /// between the two hands.
     pub fn render(
         &self,
+        pose_library: Option<&crate::hand_pose_library::PoseLibrary>,
         glove_renderer: Option<&mut crate::hand_glove::GloveRenderer>,
     ) -> Vec<SceneObject> {
-        // The hand itself: the glove model, posed from the analog inputs
-        let mut scene_objects = glove_renderer
-            .map(|renderer| {
-                renderer.render_hand(
-                    self.position,
-                    self.rotation,
-                    self.handedness,
-                    self.trigger_value,
-                    self.squeeze_value,
-                    self.get_held_entity().is_some(),
-                )
-            })
-            .unwrap_or_default();
+        let holding = self.get_held_entity().is_some();
+
+        // The hand itself, posed from the analog inputs
+        let mut scene_objects = match pose_library {
+            Some(library) => library.render_hand(
+                self.position,
+                self.rotation,
+                self.handedness,
+                self.trigger_value,
+                self.squeeze_value,
+                holding,
+            ),
+            None => glove_renderer
+                .map(|renderer| {
+                    renderer.render_hand(
+                        self.position,
+                        self.rotation,
+                        self.handedness,
+                        self.trigger_value,
+                        self.squeeze_value,
+                        holding,
+                    )
+                })
+                .unwrap_or_default(),
+        };
 
         let hit_color = self.color_from_state();
 

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -35,6 +35,18 @@ pub struct VirtualHand {
     handedness: Handedness,
 }
 
+/// What draws the hand itself.
+///
+/// The 25AE authored poses are preferred; the SteamVR glove is the fallback for
+/// an install that has none, and `None` covers an install with neither. One
+/// enum rather than two `Option` parameters, which would admit a "both" and a
+/// "neither-but-differently" state that mean nothing.
+pub enum HandRenderer<'a> {
+    Poses(&'a crate::hand_pose_library::PoseLibrary),
+    Glove(&'a mut crate::hand_glove::GloveRenderer),
+    None,
+}
+
 #[derive(Debug)]
 pub enum VirtualHandEffect {
     OutMessage {
@@ -351,20 +363,14 @@ impl VirtualHand {
 
     /// Render this hand, plus the raycast-hit debug cube.
     ///
-    /// Prefers the 25AE authored hands, which snap between poses; the SteamVR
-    /// glove is the fallback for an install that has none. Both renderers are
-    /// owned by the caller (`VrInteraction`) so their cached state is shared
-    /// between the two hands.
-    pub fn render(
-        &self,
-        pose_library: Option<&crate::hand_pose_library::PoseLibrary>,
-        glove_renderer: Option<&mut crate::hand_glove::GloveRenderer>,
-    ) -> Vec<SceneObject> {
+    /// The renderer is chosen and owned by the caller (`VrInteraction`) so its
+    /// cached state is shared between the two hands.
+    pub fn render(&self, renderer: HandRenderer<'_>) -> Vec<SceneObject> {
         let holding = self.get_held_entity().is_some();
 
         // The hand itself, posed from the analog inputs
-        let mut scene_objects = match pose_library {
-            Some(library) => library.render_hand(
+        let mut scene_objects = match renderer {
+            HandRenderer::Poses(library) => library.render_hand(
                 self.position,
                 self.rotation,
                 self.handedness,
@@ -372,18 +378,15 @@ impl VirtualHand {
                 self.squeeze_value,
                 holding,
             ),
-            None => glove_renderer
-                .map(|renderer| {
-                    renderer.render_hand(
-                        self.position,
-                        self.rotation,
-                        self.handedness,
-                        self.trigger_value,
-                        self.squeeze_value,
-                        holding,
-                    )
-                })
-                .unwrap_or_default(),
+            HandRenderer::Glove(glove) => glove.render_hand(
+                self.position,
+                self.rotation,
+                self.handedness,
+                self.trigger_value,
+                self.squeeze_value,
+                holding,
+            ),
+            HandRenderer::None => Vec::new(),
         };
 
         let hit_color = self.color_from_state();


### PR DESCRIPTION
## What

Wires the 25AE authored hand poses (#932) into the VR hand renderer, and fixes
the reason nobody could see any of it: **`--vr` drew no hands at all**, in the
glove path too.

### The invisible hands were a frustum bug, not a render bug

`compute_view_matrix` applies the head as a **pawn-local** offset, so the eye
sits only `player_eye_height()/SCALE_FACTOR` (~1.04) above the **pawn origin** —
not above the floor. The debug runtime's default `--vr` rest pose at pawn-local
y `1.4` therefore put the hands ~0.36 **above** the eye (NDC y ≈ 1.58), off the
top of the screen. It contradicted its own comment ("shows the glove hands at
the bottom of the view"). Also worth knowing: default forward is **+Z**, since
pawn and head rotations are both yaw +90° and compose to 180°.

This was expensive to find because `/v1/scene` reported the hands as present,
correctly positioned, opaque and correctly wound — it had no way to say whether
the camera could *see* them. So each object now also reports **`ndc`** (its
origin in the drawing camera's clip space) and **`origin_on_screen`**. One call
now diagnoses it: the broken default reads `ndc.y = 1.98`; a hand behind the eye
reads `ndc: null`.

It is deliberately an **origin** test, not a bounds test — a large object
straddling the frustum edge reads `origin_on_screen: false` while plainly
visible, so the field is named for what it measures and `ndc` is the number to
reason with. A real bounds test needs an AABB on `SceneObject`, which doesn't
exist today.

### Anchoring: measured against the glove, improved but not finished

Two fixes so the hand lands where the glove did and moves less between poses:

- **Missing unit conversion.** `wrist_vector` stepped back `HAND_LENGTH_WORLD` —
  a length in *world* units — through *model-space* geometry, before
  `VIEWMODEL_HAND_SCALE` was applied. That's only ~61% of a hand, so the anchor
  landed mid-palm instead of at the wrist. The glove anchors a 19 cm hand at the
  wrist (`hand_glove::GLOVE_SCALE`); both renderers now agree on the landmark.
- **Per-pose `reach`.** The frame's far point is an extended fingertip on an open
  hand but only a knuckle on a curled one, so a single step-back put the wrist in
  a different place per pose. Each pose declares its far point's distance from
  the wrist in hand-lengths, alongside the authored `roll`.

Measured rather than eyeballed — hand centroid in a fixed framing, against the
glove rendered at the identical transform (the glove holds to 0.7px across poses):

| | mean offset from glove | pose-to-pose spread (sd_x) |
|---|---|---|
| before | 21.3px | 18.1px |
| unit conversion only | 14.7px | 16.9px |
| + per-pose `reach` | **12.8px** | **12.9px** |

So the unit conversion is what aligns the hand with the glove, and `reach` is
what evens the poses out (the worst pose, `Grip`, goes from 28px off to 16px).

**Neither is finished**, and I want to be straight about that: the glove's 0.7px
is the target and this is nowhere near it. The dominant remaining term is that
the source models carry very different amounts of forearm — `ar15_h` (Rest)
covers 268x174px where `atek_h` (Grip) covers 222x102 — which needs geometry
trimming, not anchor tuning. Centroid is also only a proxy for the wrist (a
fist's centroid genuinely sits nearer the wrist than an open hand's), so these
numbers should not be driven to zero.

The glove remains the fallback for a classic install (`PoseLibrary::new`
returning `None` is cached, so a non-25AE install doesn't retry the asset lookup
every frame).

![VR hands cycling poses](https://gist.githubusercontent.com/tommy-xr/a91a4e2c178fe1bf02d708878078e73d/raw/vrhands.gif)

<sub>Both hands in `--vr` (`debug_minimal`, 25AE install), swaying around <b>the shipped default rest pose</b> — so this exercises the rest-pose fix too, not just the pose library — and cycling Rest → SemiClosed → Grip → Rest. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

Default `--vr` view with no `/v1/control/input` at all — glove fallback (classic install) above, authored hands (25AE) below:

![glove vs authored hands](https://gist.githubusercontent.com/tommy-xr/a91a4e2c178fe1bf02d708878078e73d/raw/glove_vs_hands.png)

## Testing

- `cargo test -p shock2vr hand_pose_library` — 6 tests. Two are new and were
  **negative-tested**: `the_wrist_anchors_a_real_hand_back_from_the_far_point`
  fails against the old unconverted step-back.
- `cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo check -p shock2vr
  -p desktop_runtime -p debug_runtime` clean.
- Verified visually in `cargo dbgr --vr --mission debug_minimal` against both a
  25AE install and a classic install (glove fallback).


## Cross-engine review (`/xreview`) — findings addressed

Two independent reviewers (a Claude subagent and Codex) plus a dedicated
duplication pass. 0 Critical/High. Both engines independently raised the first
two, which is the high-confidence signal:

- **[AGREED] Partial 25AE install rendered *invisible* hands.** `PoseLibrary::new`
  activated if *any* pose loaded, but `render_hand` draws nothing when the
  requested pose is missing and the caller never falls back. A mod-layered or
  SCP/SHTUP install shipping `atek_h` but not `ar15_h` would make the hands
  vanish the moment the player opened their hand. Now all-or-nothing.
- **[AGREED] `/v1/scene` reported nonsense NDC near the eye plane.** `w > 0.0`
  admits objects sitting almost exactly on it, then divides by ~0 — producing
  values like `ndc.y = -12122363` that read as data, in the very field added to
  stop that misreading. Now gated on the near plane (where the GPU clips
  anyway), which also covers the screen-space HUD quads.
- **Size tuning silently moved the anchor.** `VIEWMODEL_HAND_SCALE` was primary,
  its doc invited tuning, and `wrist_vector` divided by it — so making the hands
  bigger slid the anchor along the finger axis. Inverted: the measured length is
  primary, the scale derives from it. Render is byte-for-byte unchanged.
- **Two mutually-exclusive `Option` renderer params** admitted meaningless
  states; replaced with a `HandRenderer` enum (six call sites → four).
- **Media didn't exercise the rest-pose fix** — it drove custom hand positions.
  Recaptured at the shipped defaults.

I also implemented an explicit `Material::draws_in_screen_space` predicate for
the NDC fix, then **reverted it after measuring that it changed nothing** the
near-plane guard didn't already handle (118 of 219 objects on `medsci1.mis`,
identical either way). Engine-wide trait surface for a case I couldn't produce
isn't worth carrying.

Duplication pass: `PoseLibrary::render_hand` does mirror `GloveRenderer::render_hand`'s
shape closely, and `anchor_of`'s basis construction overlaps
`util::get_rotation_from_forward_vector` (pre-existing). Both are left as
follow-ups rather than folded into this change.

## Notes / follow-ups

- **Known visual artifact, not fixed here: the source models drag weapon-model
  forearm into view.** The `ar15_h` island spans 1.0742 units of which only
  0.4068 is hand — the remaining ~31 cm (after scaling) renders as an
  open-ended hollow cone. `SemiClosed` (`atek_h` index 0) is the worst: a black
  sleeve wedge slices through the palm and fingers, visible in the GIF. Only
  `Grip` is clean. The module docs anticipate a "common-cuff trim" and this
  ships without one; the real fix is trimming geometry behind the anchored
  wrist during hand-island extraction, which is geometry work rather than
  anchor tuning. Flagging it rather than burying it — the hands are usable at
  the default rest pose but not yet clean in every pose.
- `AssetCache` keys by `importer.type_id()`, so any new view of an already
  imported type still needs its own newtype wrapper.
