### PR TITLE
fix(automap): use authored map rotation

### DIFF
--- a/dark/src/mission/map_params.rs
+++ b/dark/src/mission/map_params.rs
@@ -1,0 +1,133 @@
+//! Mission-authored automap parameters (`MAPPARAM`).
+//!
+//! Looking Glass defines the version-1 file variable as `sMapParams`, a single
+//! 32-bit `BOOL m_rotatehack` (`shock/shkparam.h` + `shock/shkparam.cpp`). The
+//! file-var reset path zeroes its storage before a mission load, so a missing
+//! or unreadable chunk faithfully defaults to the normal, non-hack mapping.
+
+use std::io::{self, SeekFrom};
+
+use tracing::warn;
+
+use crate::ss2_chunk_file_reader::ChunkFileTableOfContents;
+
+/// Automap coordinate mapping authored for one mission.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MapParams {
+    /// The original engine's exceptional 90-degree map-page mapping.
+    pub rotate_hack: bool,
+}
+
+impl MapParams {
+    /// Read the exact retail `MAPPARAM` v1.0 layout.
+    ///
+    /// Returns `None` for absent, malformed, or unknown-version chunks. The
+    /// mission loader then uses [`MapParams::default`], matching Dark's
+    /// zero-filled file-variable reset instead of guessing from map markers.
+    pub fn read<T: io::Read + io::Seek>(
+        table_of_contents: &ChunkFileTableOfContents,
+        reader: &mut T,
+    ) -> Option<Self> {
+        let chunk = table_of_contents.get_chunk("MAPPARAM".to_owned())?;
+        if (chunk.version_major, chunk.version_minor) != (1, 0) || chunk.length != 4 {
+            warn!(
+                "Unsupported MAPPARAM chunk version {}.{} or length {}; using the default map mapping",
+                chunk.version_major, chunk.version_minor, chunk.length
+            );
+            return None;
+        }
+
+        reader.seek(SeekFrom::Start(chunk.offset)).ok()?;
+        let mut bytes = [0u8; 4];
+        if reader.read_exact(&mut bytes).is_err() {
+            warn!("Truncated MAPPARAM chunk; using the default map mapping");
+            return None;
+        }
+        Some(Self {
+            rotate_hack: u32::from_le_bytes(bytes) != 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use crate::ss2_chunk_file_reader;
+
+    use super::MapParams;
+
+    const CHUNK_OFFSET: u32 = 272;
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_name(bytes: &mut Vec<u8>, name: &str) {
+        let mut field = [0u8; 12];
+        field[..name.len()].copy_from_slice(name.as_bytes());
+        bytes.extend_from_slice(&field);
+    }
+
+    /// Minimal Dark tag file carrying one optional mission file-var chunk.
+    fn chunk_file(payload: Option<&[u8]>, version: (u32, u32)) -> Cursor<Vec<u8>> {
+        let payload_len = payload.map_or(0, <[u8]>::len) as u32;
+        let inventory_offset = CHUNK_OFFSET + payload.map_or(0, |_| 24 + payload_len);
+        let mut bytes = Vec::new();
+
+        push_u32(&mut bytes, inventory_offset);
+        push_u32(&mut bytes, 0);
+        push_u32(&mut bytes, 1);
+        bytes.extend_from_slice(&[0; 256]);
+        push_u32(&mut bytes, 0xEFBEADDE);
+        assert_eq!(bytes.len(), CHUNK_OFFSET as usize);
+
+        if let Some(payload) = payload {
+            push_name(&mut bytes, "MAPPARAM");
+            push_u32(&mut bytes, version.0);
+            push_u32(&mut bytes, version.1);
+            push_u32(&mut bytes, 0);
+            bytes.extend_from_slice(payload);
+            push_u32(&mut bytes, 1);
+            push_name(&mut bytes, "MAPPARAM");
+            push_u32(&mut bytes, CHUNK_OFFSET);
+            push_u32(&mut bytes, payload_len);
+        } else {
+            push_u32(&mut bytes, 0);
+        }
+
+        Cursor::new(bytes)
+    }
+
+    fn read(payload: Option<&[u8]>, version: (u32, u32)) -> Option<MapParams> {
+        let mut reader = chunk_file(payload, version);
+        let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+        MapParams::read(&table_of_contents, &mut reader)
+    }
+
+    #[test]
+    fn reads_retail_v1_bool_layout() {
+        assert_eq!(
+            read(Some(&0u32.to_le_bytes()), (1, 0)),
+            Some(MapParams { rotate_hack: false })
+        );
+        assert_eq!(
+            read(Some(&1u32.to_le_bytes()), (1, 0)),
+            Some(MapParams { rotate_hack: true })
+        );
+        // Dark's BOOL semantics treat every non-zero 32-bit value as true.
+        assert_eq!(
+            read(Some(&2u32.to_le_bytes()), (1, 0)),
+            Some(MapParams { rotate_hack: true })
+        );
+    }
+
+    #[test]
+    fn rejects_absent_malformed_or_unknown_chunks() {
+        assert_eq!(read(None, (1, 0)), None);
+        assert_eq!(read(Some(&[1, 0, 0]), (1, 0)), None);
+        assert_eq!(read(Some(&[1, 0, 0, 0, 0]), (1, 0)), None);
+        assert_eq!(read(Some(&1u32.to_le_bytes()), (0, 9)), None);
+        assert_eq!(read(Some(&1u32.to_le_bytes()), (1, 1)), None);
+    }
+}

--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -1,6 +1,7 @@
 mod bsp_tree;
 mod cell;
 mod cell_portal;
+mod map_params;
 pub mod path_database;
 mod plane;
 pub mod render_params;
@@ -13,6 +14,7 @@ pub mod texture_list;
 pub use bsp_tree::*;
 pub use cell::*;
 pub use cell_portal::*;
+pub use map_params::MapParams;
 pub use path_database::{CellDoor, PathDatabase};
 pub use plane::*;
 
@@ -82,6 +84,7 @@ pub struct SystemShock2Level {
 
     pub room_database: RoomDatabase,
     pub song_params: SongParams,
+    pub map_params: MapParams,
     pub bsp_tree: BspTree,
     pub path_database: Option<PathDatabase>,
 }
@@ -227,6 +230,7 @@ pub fn read<T: io::Read + io::Seek>(
     let render_params = RenderParams::read(&table_of_contents, reader);
     let room_database = RoomDatabase::read(&table_of_contents, reader);
     let song_params = SongParams::read(&table_of_contents, reader);
+    let map_params = MapParams::read(&table_of_contents, reader).unwrap_or_default();
     let path_database = PathDatabase::read(&table_of_contents, reader);
 
     // Log AIPATH data if loaded
@@ -263,6 +267,7 @@ pub fn read<T: io::Read + io::Seek>(
         entity_info,
         room_database,
         song_params,
+        map_params,
         path_database,
     }
 }

--- a/dark/tests/mission_loading.rs
+++ b/dark/tests/mission_loading.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-use dark::mission::PathDatabase;
+use dark::mission::{MapParams, PathDatabase};
 use dark::properties::{self, Link};
 use dark::ss2_chunk_file_reader;
 use dark::ss2_entity_info::{self, SystemShock2EntityInfo};
@@ -49,6 +49,13 @@ fn load_path_database(data: &Path, mission: &str) -> Option<PathDatabase> {
     let mut reader = BufReader::new(file);
     let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
     PathDatabase::read(&toc, &mut reader)
+}
+
+fn load_map_params(data: &Path, mission: &str) -> Option<MapParams> {
+    let file = File::open(data.join(mission)).expect("mission file should open");
+    let mut reader = BufReader::new(file);
+    let toc = ss2_chunk_file_reader::read_table_of_contents(&mut reader);
+    MapParams::read(&toc, &mut reader)
 }
 
 /// Parse a mission's entity info (properties + links) directly from its own
@@ -93,6 +100,49 @@ fn all_missions(data: &Path) -> Vec<String> {
         .map(|e| e.file_name().to_string_lossy().into_owned())
         .filter(|name| name.ends_with(".mis"))
         .collect()
+}
+
+#[test]
+fn retail_missions_parse_authored_map_rotation() {
+    let Some(data) = data_root() else {
+        eprintln!("SKIP: no Data/ assets (set DARK_ASSET_PATH to run)");
+        return;
+    };
+    let retail_missions = [
+        "command1.mis",
+        "command2.mis",
+        "earth.mis",
+        "eng1.mis",
+        "eng2.mis",
+        "hydro1.mis",
+        "hydro2.mis",
+        "hydro3.mis",
+        "many.mis",
+        "medsci1.mis",
+        "medsci2.mis",
+        "ops1.mis",
+        "ops2.mis",
+        "ops3.mis",
+        "ops4.mis",
+        "rec1.mis",
+        "rec2.mis",
+        "rec3.mis",
+        "rick1.mis",
+        "rick2.mis",
+        "rick3.mis",
+        "shodan.mis",
+        "station.mis",
+    ];
+
+    for mission in retail_missions {
+        let params = load_map_params(&data, mission)
+            .unwrap_or_else(|| panic!("{mission}: retail MAPPARAM v1.0 should parse"));
+        let expected_rotate_hack = matches!(mission, "command1.mis" | "command2.mis");
+        assert_eq!(
+            params.rotate_hack, expected_rotate_hack,
+            "{mission}: unexpected authored rotate-hack flag"
+        );
+    }
 }
 
 #[test]

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -668,6 +668,7 @@ pub struct AbstractMission {
     pub animated_lightmaps: Option<dark::mission::AnimatedLightmapController>,
     pub song_params: SongParams,
     pub room_db: RoomDatabase,
+    pub map_params: dark::mission::MapParams,
     pub physics_geometry: Option<Collider>,
     pub spatial_data: Option<Box<dyn SpatialQueryEngine>>,
     pub entity_info: SystemShock2EntityInfo,
@@ -946,6 +947,7 @@ impl MissionCore {
                 RuntimePropDoNotSerialize,
                 crate::runtime_props::RuntimePropMapData {
                     mission: mission.clone(),
+                    map_params: abstract_mission.map_params,
                     revealed_rects,
                     explored_rects,
                 },

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -89,6 +89,7 @@ impl Mission {
         let mission_scene = dark::mission::to_scene(&level, asset_cache);
         let song_params = level.song_params.clone();
         let room_db = level.room_database.clone();
+        let map_params = level.map_params;
         let physics_geometry = create_physics_collider(&level);
         let spatial_data = LevelSpatialData::from_level(&level);
         let obj_map = level.obj_map.clone();
@@ -98,6 +99,7 @@ impl Mission {
             animated_lightmaps: Some(mission_scene.animated_lightmaps),
             song_params,
             room_db,
+            map_params,
             physics_geometry,
             spatial_data: Some(Box::new(spatial_data)),
             entity_info: level.entity_info,

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -275,13 +275,16 @@ pub struct RuntimePropLaunchedProjectile;
 
 // RuntimePropMapData - the automap page data for the current mission, attached
 // to the synthetic map-panel entity at mission init: the mission's level file
-// name (for the per-level `intrface/<LEVEL>/english/` art paths) and the decal
-// rects from P001RA.BIN / P001XA.BIN (empty when the mission ships no automap).
-// Not serialized - rebuilt from mission data on every load.
+// name (for the per-level `intrface/<LEVEL>/english/` art paths), its authored
+// `MAPPARAM`, and the decal rects from P001RA.BIN / P001XA.BIN (empty when the
+// mission ships no automap). Not serialized - rebuilt from mission data on
+// every load.
 #[derive(Component, Clone, Debug)]
 pub struct RuntimePropMapData {
     /// Level file name as loaded (e.g. "medsci1.mis").
     pub mission: String,
+    /// Mission-authored automap axis mapping (`MAPPARAM`).
+    pub map_params: dark::mission::MapParams,
     /// Bright "revealed" decal rects (P001RA.BIN), indexed by map location.
     pub revealed_rects: Vec<dark::map::MapRect>,
     /// Dim "explored" decal rects (P001XA.BIN), indexed by map location.

--- a/shock2vr/src/scenes/debug_common.rs
+++ b/shock2vr/src/scenes/debug_common.rs
@@ -134,6 +134,7 @@ impl DebugSceneBuilder {
                 song: String::new(),
             },
             room_db: RoomDatabase { rooms: Vec::new() },
+            map_params: dark::mission::MapParams::default(),
             physics_geometry,
             spatial_data: None,
             entity_info: SystemShock2EntityInfo::empty(),

--- a/shock2vr/src/scenes/debug_map.rs
+++ b/shock2vr/src/scenes/debug_map.rs
@@ -175,6 +175,7 @@ impl GameScene for DebugMapScene {
                 self.map_entity,
                 RuntimePropMapData {
                     mission: MAP_MISSION.to_string(),
+                    map_params: dark::mission::MapParams::default(),
                     revealed_rects,
                     explored_rects,
                 },

--- a/shock2vr/src/scripts/gui/map.rs
+++ b/shock2vr/src/scripts/gui/map.rs
@@ -52,22 +52,16 @@ pub struct MapGuiState {}
 #[derive(Clone)]
 pub enum MapGuiMsg {}
 
-/// KNOWN LIMITATION (xreview, both engines): the rotate-hack detection below is
-/// a heuristic - a level whose page mapping is legitimately non-uniform in
-/// scale (or near-tied between assignments) could get a mirrored/mis-placed
-/// player marker (cosmetic; decals are unaffected). medsci1 is verified from
-/// mission data; verify other decks' markers visually before trusting them
-/// (follow-up tracked on the PR).
-///
 /// World->page mapping solved from the level's two `MapRef` scale markers
-/// (`frame == -1`): each maps a world position to page pixels. Some level maps
-/// are drawn rotated 90 degrees (the original's `m_rotatehack`), which swaps
-/// which world axis feeds which page axis - detected here by picking the axis
-/// assignment whose two scale factors are closest in magnitude (the page art is
-/// uniformly scaled; the wrong assignment produces wildly mismatched scales).
+/// (`frame == -1`): each maps a world position to page pixels. `MAPPARAM` tells
+/// us which authored axis assignment to solve. The original's normal mapping
+/// is Dark y->page x and Dark x->page y; its rotate hack is Dark x->page x and
+/// Dark y->page y. `dark::ss2_common::read_vec3` converts those horizontal Dark
+/// x/y axes to engine -x/z, so normal maps are `swapped` here and rotate-hack
+/// maps are direct. The signed fitted scales absorb the x-axis negation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MapTransform {
-    /// Page x/y fed by world z/x (rotated map) instead of x/z.
+    /// Page x/y fed by engine world z/x (normal map) instead of x/z.
     swapped: bool,
     sx: f32,
     bx: f32,
@@ -76,8 +70,16 @@ pub struct MapTransform {
 }
 
 impl MapTransform {
-    /// Solve from two (world (x, z), page (x, y)) reference pairs.
-    pub fn solve(w1: (f32, f32), p1: (f32, f32), w2: (f32, f32), p2: (f32, f32)) -> Option<Self> {
+    /// Solve the authored assignment from two (world (x, z), page (x, y))
+    /// reference pairs. A degenerate authored assignment fails rather than
+    /// inferring the other one from marker scale uniformity.
+    pub fn solve(
+        rotate_hack: bool,
+        w1: (f32, f32),
+        p1: (f32, f32),
+        w2: (f32, f32),
+        p2: (f32, f32),
+    ) -> Option<Self> {
         let fit = |a1: f32, out1: f32, a2: f32, out2: f32| -> Option<(f32, f32)> {
             let da = a2 - a1;
             if da.abs() < 1e-3 {
@@ -86,38 +88,20 @@ impl MapTransform {
             let s = (out2 - out1) / da;
             Some((s, out1 - s * a1))
         };
-        let direct = match (fit(w1.0, p1.0, w2.0, p2.0), fit(w1.1, p1.1, w2.1, p2.1)) {
-            (Some((sx, bx)), Some((sy, by))) => Some(MapTransform {
-                swapped: false,
-                sx,
-                bx,
-                sy,
-                by,
-            }),
-            _ => None,
+        let (x1, y1, x2, y2, swapped) = if rotate_hack {
+            (w1.0, w1.1, w2.0, w2.1, false)
+        } else {
+            (w1.1, w1.0, w2.1, w2.0, true)
         };
-        let swapped = match (fit(w1.1, p1.0, w2.1, p2.0), fit(w1.0, p1.1, w2.0, p2.1)) {
-            (Some((sx, bx)), Some((sy, by))) => Some(MapTransform {
-                swapped: true,
-                sx,
-                bx,
-                sy,
-                by,
-            }),
-            _ => None,
-        };
-        // Prefer the assignment with the more uniform |scale| pair.
-        let uniformity = |t: &MapTransform| (t.sx.abs() - t.sy.abs()).abs() / t.sx.abs().max(1e-6);
-        match (direct, swapped) {
-            (Some(d), Some(s)) => Some(if uniformity(&d) <= uniformity(&s) {
-                d
-            } else {
-                s
-            }),
-            (Some(d), None) => Some(d),
-            (None, Some(s)) => Some(s),
-            (None, None) => None,
-        }
+        let (sx, bx) = fit(x1, p1.0, x2, p2.0)?;
+        let (sy, by) = fit(y1, p1.1, y2, p2.1)?;
+        Some(MapTransform {
+            swapped,
+            sx,
+            bx,
+            sy,
+            by,
+        })
     }
 
     /// Map a world (x, z) to page pixels.
@@ -163,10 +147,11 @@ pub fn place_player_pip(
     markers: &[MapRefMarker],
     current_location: Option<i32>,
     world_pos: (f32, f32),
+    rotate_hack: bool,
 ) -> Option<(f32, f32)> {
     let mut scale_markers = markers.iter().filter(|m| m.frame == -1);
     let (m1, m2) = (scale_markers.next()?, scale_markers.next()?);
-    let transform = MapTransform::solve(m1.world, m1.page, m2.world, m2.page)?;
+    let transform = MapTransform::solve(rotate_hack, m1.world, m1.page, m2.world, m2.page)?;
     if let Some(marker) = current_location.and_then(|loc| markers.iter().find(|m| m.frame == loc)) {
         let (dx, dy) =
             transform.apply_delta(world_pos.0 - marker.world.0, world_pos.1 - marker.world.1);
@@ -282,6 +267,7 @@ impl Gui<MapGuiState, MapGuiMsg> for MapGui {
                     &collect_markers(world),
                     current_location,
                     (player.pos.x, player.pos.z),
+                    data.map_params.rotate_hack,
                 )
             });
         if let Some((px, py)) = pip {
@@ -325,19 +311,19 @@ mod tests {
 
     /// The real medsci1 scale markers (mission ids 1032/1034, `frame == -1`):
     /// world (-40.311, 32.874) -> page (536, 239) and world (44.685, -76.399)
-    /// -> page (232, 10). medsci1's page art is drawn rotated (world z feeds
-    /// page x), so the solver must pick the swapped assignment - the direct one
-    /// produces wildly non-uniform scales (-3.58 vs 2.10).
+    /// -> page (232, 10). medsci1 authors the normal mapping (world z feeds
+    /// page x), so the solver must use the swapped assignment.
     #[test]
     fn medsci1_transform_is_axis_swapped_and_exact() {
         let t = MapTransform::solve(
+            false,
             (-40.311_17, 32.874_435),
             (536.0, 239.0),
             (44.685_417, -76.398_605),
             (232.0, 10.0),
         )
         .expect("two distinct markers must solve");
-        assert!(t.swapped, "medsci1's map is rotated (z -> page x)");
+        assert!(t.swapped, "medsci1 uses the normal crossed-axis mapping");
         // Both markers must round-trip exactly.
         let (x1, y1) = t.apply(-40.311_17, 32.874_435);
         assert!((x1 - 536.0).abs() < 0.5 && (y1 - 239.0).abs() < 0.5);
@@ -351,7 +337,7 @@ mod tests {
     fn degenerate_markers_do_not_solve() {
         // Identical world points can't span a transform.
         assert_eq!(
-            MapTransform::solve((1.0, 2.0), (10.0, 20.0), (1.0, 2.0), (30.0, 40.0)),
+            MapTransform::solve(false, (1.0, 2.0), (10.0, 20.0), (1.0, 2.0), (30.0, 40.0)),
             None
         );
     }
@@ -394,20 +380,20 @@ mod tests {
     fn pip_uses_per_frame_marker_for_inset_locations() {
         let markers = medsci1_markers();
         // Standing exactly at the frame-2 marker's world position.
-        let (px, py) = place_player_pip(&markers, Some(2), (-19.003_445, -54.242_805))
+        let (px, py) = place_player_pip(&markers, Some(2), (-19.003_445, -54.242_805), false)
             .expect("markers must place the pip");
         assert!((px - 72.0).abs() < 0.5 && (py - 127.0).abs() < 0.5);
         // The global affine would have placed it far away (in the upper
         // level's drawing of that world x/z) - the relocation matters.
-        let (gx, gy) = place_player_pip(&markers, None, (-19.003_445, -54.242_805)).unwrap();
+        let (gx, gy) = place_player_pip(&markers, None, (-19.003_445, -54.242_805), false).unwrap();
         assert!(((px - gx).abs() + (py - gy).abs()) > 50.0);
         // A position a few world units into the room stays inside the
         // location's inset rect, LTRB (25, 100, 144, 169).
-        let (nx, ny) = place_player_pip(&markers, Some(2), (-22.0, -58.0)).unwrap();
+        let (nx, ny) = place_player_pip(&markers, Some(2), (-22.0, -58.0), false).unwrap();
         assert!((25.0..=144.0).contains(&nx), "pip x {nx} outside inset");
         assert!((100.0..=169.0).contains(&ny), "pip y {ny} outside inset");
         // Same for map location 0's marker (inset rect LTRB (26, 30, 93, 90)).
-        let (fx, fy) = place_player_pip(&markers, Some(0), (11.585_943, 7.603_475)).unwrap();
+        let (fx, fy) = place_player_pip(&markers, Some(0), (11.585_943, 7.603_475), false).unwrap();
         assert!((fx - 92.0).abs() < 0.5 && (fy - 30.0).abs() < 0.5);
     }
 
@@ -417,6 +403,7 @@ mod tests {
     fn pip_falls_back_to_global_affine_without_per_frame_marker() {
         let markers = medsci1_markers();
         let t = MapTransform::solve(
+            false,
             markers[0].world,
             markers[0].page,
             markers[1].world,
@@ -424,7 +411,7 @@ mod tests {
         )
         .unwrap();
         for current in [None, Some(4), Some(9)] {
-            let (px, py) = place_player_pip(&markers, current, (10.0, -20.0)).unwrap();
+            let (px, py) = place_player_pip(&markers, current, (10.0, -20.0), false).unwrap();
             let (ex, ey) = t.apply(10.0, -20.0);
             assert!((px - ex).abs() < 1e-3 && (py - ey).abs() < 1e-3);
         }
@@ -434,17 +421,40 @@ mod tests {
     fn pip_needs_two_scale_markers() {
         let mut markers = medsci1_markers();
         markers.remove(0);
-        assert_eq!(place_player_pip(&markers, None, (0.0, 0.0)), None);
+        assert_eq!(place_player_pip(&markers, None, (0.0, 0.0), false), None);
     }
 
     #[test]
-    fn unrotated_map_picks_the_direct_assignment() {
+    fn rotate_hack_map_picks_the_direct_assignment() {
         // Synthetic level: page x = 2*wx + 100, page y = -2*wz + 200.
-        let t = MapTransform::solve((0.0, 0.0), (100.0, 200.0), (50.0, -50.0), (200.0, 300.0))
-            .expect("solvable");
+        let t = MapTransform::solve(
+            true,
+            (0.0, 0.0),
+            (100.0, 200.0),
+            (50.0, -50.0),
+            (200.0, 300.0),
+        )
+        .expect("solvable");
         assert!(!t.swapped);
         let (px, py) = t.apply(10.0, 10.0);
         assert!((px - 120.0).abs() < 1e-3);
         assert!((py - 180.0).abs() < 1e-3);
+    }
+
+    /// Authored data must win even when the old uniform-scale heuristic would
+    /// have selected the other axis assignment. These are medsci1's markers,
+    /// whose uniformity favors swapped axes; forcing the rotate hack must use
+    /// the direct assignment instead.
+    #[test]
+    fn authored_rotate_hack_selects_axes_without_inference() {
+        let t = MapTransform::solve(
+            true,
+            (-40.311_17, 32.874_435),
+            (536.0, 239.0),
+            (44.685_417, -76.398_605),
+            (232.0, 10.0),
+        )
+        .expect("both direct axes span a transform");
+        assert!(!t.swapped);
     }
 }


### PR DESCRIPTION
## Summary

- parse the mission-authored `MAPPARAM` v1.0 file variable as its exact one-`BOOL` layout
- carry the typed map parameters through level parsing and mission construction into the automap panel
- select the authored world-to-page axis assignment instead of inferring it from scale uniformity
- default absent, malformed, or unsupported chunks to the normal mapping, matching the original file-variable reset behavior

Fixes #491

## Reproduction and source confirmation

On the base ref, `MapTransform::solve` constructed both axis assignments and picked whichever had the more uniform scale magnitudes. The negative-first test `authored_rotate_hack_selects_axes_without_inference` did not compile because there was no authored input to the solver; after adding that input, it demonstrates that an authored rotate-hack choice wins even for medsci1 marker values that make the old heuristic strongly prefer the other assignment.

The released Looking Glass source defines [`sMapParams`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkparam.h#L209-L214) as exactly one 32-bit `BOOL`, registers [`MAPPARAM` as mission file-var v1.0](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkparam.cpp#L796-L826), and [consults `m_rotatehack` in the automap coordinate conversion](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkmap.cpp#L276-L362). Its file-variable reset [zero-fills the block](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/framewrk/filevar.cpp#L71-L74), which establishes the safe missing/malformed fallback without retaining the heuristic.

The original normal mapping crosses Dark x/y; the rotate hack maps them directly. This port converts those horizontal axes to engine -x/z, so `false` selects engine z/x and `true` selects engine x/z. Signed fitted scale absorbs the x negation.

## Retail audit

All 23 retail mission files carry `MAPPARAM` version 1.0 with an exact four-byte payload. `command1.mis` and `command2.mis` author `1`; the other 21 author `0`.

All 15 missions with two global `MapRef` scale markers agree with the old heuristic, confirming that this is a fidelity/robustness replacement with intentionally unchanged retail pixels:

| Mission | Authored mapping | Old heuristic | Uniformity direct / swapped | Winning margin |
|---|---:|---:|---:|---:|
| command1 | direct | direct | 0.00387 / 0.95739 | 0.95351 |
| command2 | direct | direct | 0.04492 / 0.07337 | 0.02845 |
| eng1 | swapped | swapped | 0.39922 / 0.00833 | 0.39088 |
| eng2 | swapped | swapped | 0.84153 / 0.01263 | 0.82890 |
| hydro1 | swapped | swapped | 0.95200 / 0.01285 | 0.93915 |
| hydro2 | swapped | swapped | 0.45848 / 0.00211 | 0.45637 |
| hydro3 | swapped | swapped | 0.30819 / 0.00471 | 0.30348 |
| medsci1 | swapped | swapped | 0.41406 / 0.03156 | 0.38251 |
| medsci2 | swapped | swapped | 0.72459 / 0.00393 | 0.72067 |
| ops2 | swapped | swapped | 0.83485 / 0.00344 | 0.83141 |
| ops3 | swapped | swapped | 0.64738 / 0.00310 | 0.64429 |
| ops4 | swapped | swapped | 0.32473 / 0.01516 | 0.30956 |
| rec1 | swapped | swapped | 0.76656 / 0.01707 | 0.74949 |
| rec2 | swapped | swapped | 0.28832 / 0.01007 | 0.27825 |
| rec3 | swapped | swapped | 0.60223 / 0.01797 | 0.58426 |

The eight missions without two global scale markers are `earth`, `many`, `ops1`, `rick1`, `rick2`, `rick3`, `shodan`, and `station`; their chunks still parse and no solver guess is attempted.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark` — 108 unit + 10 retail integration tests passed
- `cargo test -p shock2vr` — 596 passed
- `SHOCK2_E2E=1 node --test --test-reporter=spec dist/test/map.e2e.test.js` — automap scenario passed
- `npm run test:e2e` on rebased head `c200f43` — 245 total: 236 passed, 2 unrelated known failures, 7 intentional skips (59m10s); automap, all 23 retail mission loads, and the newly landed load-screen/ecology scenarios passed. The failures were the existing creature-loot reader binding tracked by #931 and the known SHODAN corpse-drift assertion.
- `losing sight of the player triggers a search of the last-known position` — passed both an isolated retry (30.8s) and the final full-suite run (32.0s)

## Visual proof

![Matched automap player-pip movement](https://gist.githubusercontent.com/tommy-xr/a2d419124b6500f2502009eeb035af7a/raw/a2ab49107923688c222eaf49e1c494ae1bf61dee/pr491-mapparam-demo.gif)

<sub>Both real flat automap panels on exact fix `c200f4307244c6cff8e7a946cbc349a420ec19d0`: `command1.mis` parses authored `MAPPARAM=1` and uses the rotated/direct engine x/z mapping; `medsci1.mis` parses authored `MAPPARAM=0` and uses the normal/crossed engine z/x mapping. Captured headlessly from fresh launches with deterministic fixed-timestep requests: step 10, `ToggleMap`, step 5, then hold `right_hand.thumbstick=[0,1]` for 96 frames while capturing every 4 frames.</sub>

### After stills: start → moved

![Automap panels immediately after opening](https://gist.githubusercontent.com/tommy-xr/a2d419124b6500f2502009eeb035af7a/raw/a2ab49107923688c222eaf49e1c494ae1bf61dee/pr491-after-start.png)

![Automap panels after 96 fixed movement frames](https://gist.githubusercontent.com/tommy-xr/a2d419124b6500f2502009eeb035af7a/raw/a2ab49107923688c222eaf49e1c494ae1bf61dee/pr491-after-end.png)

<sub>The red `PLRPIP.PCX` player marker remains on the authored page transform and visibly moves in both missions.</sub>

### Before → after

![Base and fix MAPPARAM before/after comparison](https://gist.githubusercontent.com/tommy-xr/a2d419124b6500f2502009eeb035af7a/raw/a2ab49107923688c222eaf49e1c494ae1bf61dee/pr491-before-after.png)

<sub>Exact base `eb21ed8d5308013b64f22acd35cc98dd099ea684` versus fix `c200f4307244c6cff8e7a946cbc349a420ec19d0`, replaying the same sequence from a fresh launch. The automap panel pixels are identical at all 25 matched capture times for both missions (opening frame plus 24 four-frame movement samples), as expected because the retail-authored flags agree with the replaced heuristic. The identical rendered output proves this is a fidelity-path replacement: authored mission intent now selects the axes without changing correct retail presentation.</sub>
