### PR TITLE
feat(vr): make the main menu work in VR

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,95 @@
+# Handoff — flatscreen/VR frontend menus
+
+Living doc for the menu work. Updated as the investigation proceeds.
+
+## Shipped / in review
+
+| PR | State | What |
+| --- | --- | --- |
+| [#927](https://github.com/tommy-xr/shock2quest/pull/927) | **merged** | Main menu driven by `MAIN.STR` + `MAINR.BIN`; all six entries, four dimmed |
+| [#930](https://github.com/tommy-xr/shock2quest/pull/930) | open, CI green | Load-game screen (`GAMELOD.*`), `save_load::all_saves`, `engine::ellipsize` |
+| [#934](https://github.com/tommy-xr/shock2quest/pull/934) | merged into #930's branch | `cargo dbgr` boots the main menu with no `--mission` |
+| `feat/vr-menu-pointer` | **local, blocked** | VR controller pointer + VR menu presentation |
+
+Open issues: [#928](https://github.com/tommy-xr/shock2quest/issues/928) (load list has no scrolling past 14 rows), [#929](https://github.com/tommy-xr/shock2quest/issues/929) (failed load is silent).
+
+## Key data facts
+
+- Frontend screens are fully data-driven: `<SCREEN>.PCX` + `<SCREEN>R.BIN` (LTRB `int16` rects) + `<SCREEN>.STR`.
+- **`.STR` keys are listed in REVERSE screen order.** `MAIN.STR` is quit/intro/credits/options/load_game/new_game = bottom-to-top. Confirmed by the backdrop's own numbered slots 1-6.
+- SCP ships redrawn backdrops **with retuned `*R.BIN`** (e.g. `SIMR.BIN` row 0 `400,20 179x76` -> `417,22 158x69`), so hardcoded rects are wrong on modded/25AE installs.
+- 25AE keeps the legacy frontend intact (`sshock2.kpf`); its remaster layer has **zero** `intrface/` files. A KEX-style menu would be from scratch: no layout data, `@2x` BC7 DDS art, TTF fonts (we have no TTF support).
+
+## Current blocker: the VR menu panel renders only when enormous
+
+`MainMenuScene::render` presents its `UiCanvas` on a `WorldPanel` via
+`render_world_space`. The panel is blank at sane sizes.
+
+### Measured (D = 2m, 45-degree FOV, flat mode with the world path forced)
+
+| Panel W | Result |
+| --- | --- |
+| 2.0 | blank |
+| 4.0 | blank |
+| 6.0 | blank |
+| 8.0 | **renders** (479 colours) |
+
+Equal `W/D` ratios give **byte-identical** images (W=8/D=2 == W=20/D=5), which is
+what proves the transform maths is sound.
+
+### Verified correct by instrumentation
+
+```
+root = translate(0, 1.04, -2) * scale(2.0, 1.5, 1)
+elem0 corners -> (-1.000, 0.290, -2.000) .. (1.000, 1.790, -2.000)
+```
+
+Camera is at `(0, 1.04, 0)` (scene returns origin; the runtime adds
+`head_offset = player_eye_height / SCALE_FACTOR = 1.04`). Visible half-extents at
+z=-2 are +-1.10 x +-0.83. The panel is +-1.00 x +-0.75 — **fully inside the
+frustum, centred** — and still black.
+
+### Ruled out
+
+- Facing (tested both orientations; `gl::CULL_FACE` is commented out in `gl_engine`)
+- Eye height / vertical placement, and straddling the screen edge
+- `force_alpha` and the `pointer` argument (matched `debug_map`'s values exactly)
+- VR specifically — blank in flat too, with the world path forced
+- Frustum culling — `gl_engine::render` draws every object unconditionally
+- Size alone — `debug_map` renders a **smaller** panel (1.28x0.96) via the same call
+
+### Next suspect
+
+`SceneObject::draw_opaque` only draws geometry when
+`material.draw_opaque(..)` returns **true**; otherwise the object is expected to
+be picked up by the transparent pass. Check what `basic_material`'s
+`draw_opaque`/`draw_transparent` return for these objects' alpha, and whether
+either pass actually issues a draw call.
+
+## Method traps (both cost real time)
+
+- **PNG byte size is not a content signal.** A solid image compresses identically
+  at any colour, so "same bytes" does NOT mean "same picture". Count colours:
+  `len(Image.open(p).convert('RGB').getcolors(maxcolors=300000))`.
+- **Flat clears black, VR clears red**, and `MAIN.PCX` is mostly black art — so
+  "not rendering" and "rendering dark art" look identical.
+- **zsh does not word-split unquoted vars**, so `for cfg in "2 1.5 2"; do set -- $cfg` silently runs one config. Use `bash <<'EOF'` for sweeps.
+- The debug runtime **ignores `should_quit`**, so menu Quit paths cannot be verified there.
+
+## Repro
+
+```bash
+# Fast iteration: panel is env-tunable on the branch's experiment build
+PANEL_W=8.0 PANEL_H=6.0 PANEL_D=2.0 DARK_ASSET_PATH=~/ss2-25th \
+  ./target/debug/debug_runtime --mission main_menu --port 8140
+curl -s -X POST localhost:8140/v1/step -d '{"frames":6}'
+curl -s -X POST localhost:8140/v1/screenshot -d '{"filename":"/tmp/p.png"}'
+```
+
+## Design note (not yet implemented)
+
+VR has a **head position**, not just a rotation. `InputContext` currently exposes
+`head.rotation` only, so the panel is placed relative to the scene origin plus the
+runtime's fixed eye-height offset. A real VR menu should anchor to the tracked head
+pose (place once in front of the player on entry, or soft-follow), which needs head
+position plumbed into `InputContext`.

--- a/handoff.md
+++ b/handoff.md
@@ -9,7 +9,7 @@ Living doc for the menu work. Updated as the investigation proceeds.
 | [#927](https://github.com/tommy-xr/shock2quest/pull/927) | **merged** | Main menu driven by `MAIN.STR` + `MAINR.BIN`; all six entries, four dimmed |
 | [#930](https://github.com/tommy-xr/shock2quest/pull/930) | open, CI green | Load-game screen (`GAMELOD.*`), `save_load::all_saves`, `engine::ellipsize` |
 | [#934](https://github.com/tommy-xr/shock2quest/pull/934) | merged into #930's branch | `cargo dbgr` boots the main menu with no `--mission` |
-| `feat/vr-menu-pointer` | local, renders in flat | VR controller pointer + world-space menu panel |
+| `feat/vr-menu-pointer` | local, **VR working end to end** | VR controller pointer + world-space menu panel + VR menu default |
 
 Open issues: [#928](https://github.com/tommy-xr/shock2quest/issues/928) (load list has no scrolling past 14 rows), [#929](https://github.com/tommy-xr/shock2quest/issues/929) (failed load is silent).
 
@@ -56,15 +56,40 @@ Bisection by transplant: swap the menu's canvas into `debug_map` (renders) and
 *content* in one step, after a long stretch of fruitless parameter tweaking.
 Worth reaching for much earlier next time.
 
+### Third fix: the VR view was inside a red box
+
+`Game::render_per_eye` appended a red `color_material` cube **in VR only**:
+
+```rust
+from_scale(0.25) * from_translation(vec3(0.0, 4.0, 0.0))   // -> centred at (0, 1.0, 0)
+```
+
+The VR camera sits at eye height `(0, 1.04, 0)` — *inside* a cube spanning
++-0.125 — so every VR frame rendered the inside of a red box and hid the scene.
+That is why `debug_map` was blank in VR too, which made it look like a menu
+problem. An earlier comment ("keep it out of the clean flatscreen view") had
+gated it to VR rather than deleting it, hiding the damage in the mode nobody
+screenshotted. Removed in `4ce6934`.
+
+### VR now works end to end
+
+- Panel renders in VR (7 canvas objects, 14618 distinct colours).
+- Controller ray **hover** highlights the entry under it ("New Game" bright,
+  "Load Game" dim).
+- Trigger **activates**: aiming at "New Game" and pulling took the scene from
+  0 entities to 747.
+- `--vr` with **no `--mission`** boots the menu, so the VR special case in
+  `desktop_runtime` is gone and `oculus_runtime`'s `DEFAULT_MISSION` is
+  `main_menu` (`8a0a1c3`).
+
 ### Still open
 
 - The label drifts a few px right of centre — world text likely renders at a
   slightly different scale than `measure_text_width` reports.
-- **World-space panels do not render in the debug runtime's `--vr` mode at
-  all** — `debug_map` is blank there too, so this is a harness limitation rather
-  than menu code. VR presentation needs verifying on desktop `--vr` or a Quest.
-- VR runtimes still default to a mission rather than the menu; flipping that
-  waits on the point above.
+- The **load screen** has no VR presentation yet, so "Load Game" in VR opens a
+  screen that is still flat-only.
+- Not verified on real hardware (no headset here); everything above is the
+  debug runtime's `--vr` path.
 
 ## Method traps (both cost real time)
 

--- a/handoff.md
+++ b/handoff.md
@@ -9,7 +9,7 @@ Living doc for the menu work. Updated as the investigation proceeds.
 | [#927](https://github.com/tommy-xr/shock2quest/pull/927) | **merged** | Main menu driven by `MAIN.STR` + `MAINR.BIN`; all six entries, four dimmed |
 | [#930](https://github.com/tommy-xr/shock2quest/pull/930) | open, CI green | Load-game screen (`GAMELOD.*`), `save_load::all_saves`, `engine::ellipsize` |
 | [#934](https://github.com/tommy-xr/shock2quest/pull/934) | merged into #930's branch | `cargo dbgr` boots the main menu with no `--mission` |
-| `feat/vr-menu-pointer` | **local, blocked** | VR controller pointer + VR menu presentation |
+| `feat/vr-menu-pointer` | local, renders in flat | VR controller pointer + world-space menu panel |
 
 Open issues: [#928](https://github.com/tommy-xr/shock2quest/issues/928) (load list has no scrolling past 14 rows), [#929](https://github.com/tommy-xr/shock2quest/issues/929) (failed load is silent).
 
@@ -20,51 +20,51 @@ Open issues: [#928](https://github.com/tommy-xr/shock2quest/issues/928) (load li
 - SCP ships redrawn backdrops **with retuned `*R.BIN`** (e.g. `SIMR.BIN` row 0 `400,20 179x76` -> `417,22 158x69`), so hardcoded rects are wrong on modded/25AE installs.
 - 25AE keeps the legacy frontend intact (`sshock2.kpf`); its remaster layer has **zero** `intrface/` files. A KEX-style menu would be from scratch: no layout data, `@2x` BC7 DDS art, TTF fonts (we have no TTF support).
 
-## Current blocker: the VR menu panel renders only when enormous
+## RESOLVED: the world-space menu panel now renders
 
-`MainMenuScene::render` presents its `UiCanvas` on a `WorldPanel` via
-`render_world_space`. The panel is blank at sane sizes.
+**Root cause: there is no canonical "forward" axis to hardcode.** The panel was
+pinned to a fixed `-Z` offset from the scene origin, but the runtimes' yaw-0
+camera looks along **+X**:
 
-### Measured (D = 2m, 45-degree FOV, flat mode with the world path forced)
-
-| Panel W | Result |
-| --- | --- |
-| 2.0 | blank |
-| 4.0 | blank |
-| 6.0 | blank |
-| 8.0 | **renders** (479 colours) |
-
-Equal `W/D` ratios give **byte-identical** images (W=8/D=2 == W=20/D=5), which is
-what proves the transform maths is sound.
-
-### Verified correct by instrumentation
-
-```
-root = translate(0, 1.04, -2) * scale(2.0, 1.5, 1)
-elem0 corners -> (-1.000, 0.290, -2.000) .. (1.000, 1.790, -2.000)
+```rust
+// runtimes/debug_runtime/src/main.rs
+fn head_rotation_from_yaw_pitch(yaw_deg, pitch_deg) {
+    let forward = point3(yaw.cos()*pitch.cos(), pitch.sin(), yaw.sin()*pitch.cos());
 ```
 
-Camera is at `(0, 1.04, 0)` (scene returns origin; the runtime adds
-`head_offset = player_eye_height / SCALE_FACTOR = 1.04`). Visible half-extents at
-z=-2 are +-1.10 x +-0.83. The panel is +-1.00 x +-0.75 — **fully inside the
-frustum, centred** — and still black.
+At yaw 0 that is `(1,0,0)`. (The doc comment on the `head.look` channel claiming
+"forward = -Z" is wrong.) The panel sat ~90 degrees off to the side, permanently
+outside the frustum — which explains every symptom: only an enormous panel's edge
+crept into view, and equal width/distance ratios produced byte-identical slivers.
 
-### Ruled out
+**Fix** (`5c8cba1`): place the panel at `head + (head_rotation * -Z) * distance`
+and orient it by looking from the panel back to the head — i.e. exactly what
+`DebugMapScene` does. `head_rotation` is now tracked on **every** update, not
+only on the VR branch (that omission silently left it at identity and cost an
+extra round of debugging).
 
-- Facing (tested both orientations; `gl::CULL_FACE` is commented out in `gl_engine`)
-- Eye height / vertical placement, and straddling the screen edge
-- `force_alpha` and the `pointer` argument (matched `debug_map`'s values exactly)
-- VR specifically — blank in flat too, with the world path forced
-- Frustum culling — `gl_engine::render` draws every object unconditionally
-- Size alone — `debug_map` renders a **smaller** panel (1.28x0.96) via the same call
+**Second fix** (`69e0553`): world-space text ignored its rect and alignment, so
+labels floated up-left of their buttons. It now aligns like the screen-space
+path — with the caveat that `SceneObject::world_space_text` anchors on the
+text's vertical **centre** while the screen-space path anchors on its **top**,
+so each `VAlign` case carries half a line.
 
-### Next suspect
+### How it was found
 
-`SceneObject::draw_opaque` only draws geometry when
-`material.draw_opaque(..)` returns **true**; otherwise the object is expected to
-be picked up by the transparent pass. Check what `basic_material`'s
-`draw_opaque`/`draw_transparent` return for these objects' alpha, and whether
-either pass actually issues a draw call.
+Bisection by transplant: swap the menu's canvas into `debug_map` (renders) and
+`debug_map`'s canvas into the menu (blank). That isolated *transform* from
+*content* in one step, after a long stretch of fruitless parameter tweaking.
+Worth reaching for much earlier next time.
+
+### Still open
+
+- The label drifts a few px right of centre — world text likely renders at a
+  slightly different scale than `measure_text_width` reports.
+- **World-space panels do not render in the debug runtime's `--vr` mode at
+  all** — `debug_map` is blank there too, so this is a harness limitation rather
+  than menu code. VR presentation needs verifying on desktop `--vr` or a Quest.
+- VR runtimes still default to a mission rather than the menu; flipping that
+  waits on the point above.
 
 ## Method traps (both cost real time)
 
@@ -75,6 +75,8 @@ either pass actually issues a draw call.
   "not rendering" and "rendering dark art" look identical.
 - **zsh does not word-split unquoted vars**, so `for cfg in "2 1.5 2"; do set -- $cfg` silently runs one config. Use `bash <<'EOF'` for sweeps.
 - The debug runtime **ignores `should_quit`**, so menu Quit paths cannot be verified there.
+- A silent `str.replace` in a patch script can no-op and send you chasing a
+  phantom; assert the pattern matched.
 
 ## Repro
 

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -254,15 +254,13 @@ pub fn main() {
         shock2vr::PresentationMode::Flat
     };
 
-    // With no explicit mission, flat boots the (mouse-driven) main menu; the VR
-    // rig has no pointer, so it boots straight into the first mission.
-    let mission_arg = args.mission.clone().unwrap_or_else(|| {
-        if args.vr {
-            "earth.mis".to_owned()
-        } else {
-            "main_menu".to_owned()
-        }
-    });
+    // With no explicit mission, both presentations boot the main menu. VR used
+    // to skip it because the rig had no pointer; it now drives the menu with a
+    // controller ray, so there is nothing to special-case.
+    let mission_arg = args
+        .mission
+        .clone()
+        .unwrap_or_else(|| "main_menu".to_owned());
     let (mission, spawn_location) = parse_mission(&mission_arg);
 
     let options = GameOptions {

--- a/runtimes/oculus_runtime/src/quest_config.rs
+++ b/runtimes/oculus_runtime/src/quest_config.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
-pub const DEFAULT_MISSION: &str = "earth.mis";
+/// Booted when no mission is configured: the main menu, which VR drives with a
+/// controller ray (see `MainMenuScene`'s world-space panel).
+pub const DEFAULT_MISSION: &str = "main_menu";
 pub const MISSION_CONFIG_PATH: &str = "/sdcard/shock2quest/vr-mission.txt";
 
 pub fn configured_mission() -> String {
@@ -29,7 +31,11 @@ fn parse_mission(raw: &str) -> Option<String> {
     let valid_characters = mission
         .bytes()
         .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'));
-    let valid_name = mission.starts_with("debug_") || mission.ends_with(".mis");
+    // `main_menu` is a scene name rather than a file, and it is the default -
+    // so the parser must accept what `DEFAULT_MISSION` already is, otherwise a
+    // player could not configure the value the game boots into anyway.
+    let valid_name =
+        mission.starts_with("debug_") || mission.ends_with(".mis") || mission == DEFAULT_MISSION;
 
     (!mission.is_empty() && valid_characters && valid_name).then(|| mission.to_owned())
 }
@@ -49,6 +55,12 @@ mod tests {
         assert_eq!(parse_mission("../earth.mis"), None);
         assert_eq!(parse_mission("/sdcard/earth.mis"), None);
         assert_eq!(parse_mission("earth"), None);
+        // The default must round-trip through the validator.
+        assert_eq!(
+            parse_mission(DEFAULT_MISSION),
+            Some(DEFAULT_MISSION.to_owned())
+        );
+        assert_eq!(parse_mission("  main_menu  "), Some("main_menu".to_owned()));
         assert_eq!(parse_mission("earth.mis --flag"), None);
     }
 }

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1516,17 +1516,12 @@ impl Game {
         projection: Matrix4<f32>,
         screen_size: Vector2<f32>,
     ) -> Vec<SceneObject> {
-        let hand_material = engine::scene::color_material::create(vec3(1.0, 0.0, 0.0));
-        let transform = Matrix4::from_scale(0.25) * Matrix4::from_translation(vec3(0.0, 4.0, 0.0));
-        let mut hand_obj = SceneObject::new(hand_material, Box::new(engine::scene::cube::create()));
-        hand_obj.set_transform(transform);
-
         // Sample for rendering
         let font = self.asset_cache.get(&FONT_IMPORTER, "mainfont.fon");
         // let text_obj_0_0 =
         //     SceneObject::screen_space_text("0, 0", font.clone(), 16.0, 0.5, 0.0, 0.0);
 
-        let mut objs = self.active_game_scene.render_per_eye(
+        let objs = self.active_game_scene.render_per_eye(
             &mut self.asset_cache,
             view,
             projection,
@@ -1559,10 +1554,6 @@ impl Game {
         // 4 years earlier
         // Ramsey Recruitment Ctr
         // let text_string = "Ramsey Recruitment Ctr.";
-        // Debug placeholder cube; keep it out of the clean flatscreen view.
-        if self.options.presentation_mode == PresentationMode::Vr {
-            objs.extend(vec![hand_obj /*  text_obj_dynamic*/]);
-        }
         objs
     }
 

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use cgmath::{Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::{
     importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
     map::MapRect,
@@ -30,13 +30,15 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions,
+    GameOptions, PresentationMode,
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+    ui::{
+        HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas,
+    },
 };
 
 /// Mission loaded when the player chooses "New Game".
@@ -169,6 +171,85 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
         .collect()
 }
 
+/// The VR menu hangs on a panel 2m ahead of the player at eye level, sized to
+/// the canvas's 4:3 aspect so the art is not stretched.
+const VR_PANEL_DISTANCE: f32 = 2.0;
+const VR_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
+/// A VR trigger past this counts as "pressed", matching the hand code's
+/// grab/fire threshold.
+const VR_TRIGGER_THRESHOLD: f32 = 0.5;
+/// Spacing between stacked canvas layers in world space, so the labels sort in
+/// front of the backdrop instead of z-fighting it.
+const VR_COMPONENT_Z_STEP: f32 = 0.001;
+
+/// The panel the VR menu is drawn on. Fixed relative to the scene origin (the
+/// menu has no pawn to follow), facing the default camera direction.
+fn vr_panel() -> WorldPanel {
+    WorldPanel {
+        center: vec3(0.0, 0.0, -VR_PANEL_DISTANCE),
+        rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        size: VR_PANEL_SIZE,
+    }
+}
+
+/// Where a hand is pointing on the menu panel, in canvas pixels, plus whether
+/// its trigger is held.
+///
+/// Both controllers are always posed in VR, so "whichever hand hits the panel"
+/// would always resolve to the same one. Instead a hand **with its trigger
+/// held** wins, so either controller can click; ties and idle triggers fall
+/// back to the right hand, which then drives the hover highlight.
+fn vr_pointer(input_context: &InputContext) -> (Option<Vector2<f32>>, bool) {
+    let panel = vr_panel();
+    let right = &input_context.right_hand;
+    let left = &input_context.left_hand;
+    let held = |hand: &crate::input_context::Hand| hand.trigger_value > VR_TRIGGER_THRESHOLD;
+
+    let order = if held(left) && !held(right) {
+        [left, right]
+    } else {
+        [right, left]
+    };
+
+    for hand in order {
+        let direction = hand.rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+        if let Some(point) =
+            ray_to_canvas(vec2(CANVAS_W, CANVAS_H), &panel, hand.position, direction)
+        {
+            return (Some(point), held(hand));
+        }
+    }
+
+    // Neither hand points at the menu; report the trigger anyway so a press
+    // that starts off-panel is still consumed as "held" rather than becoming a
+    // fresh edge the moment the ray crosses onto a button.
+    (None, held(right) || held(left))
+}
+
+/// Shared click core: both presentations reduce to "a point on the canvas plus
+/// a pressed flag", so the rising-edge rule and the hit regions live here once.
+fn resolve_click_at(
+    point: Option<Vector2<f32>>,
+    pressed: bool,
+    last_pressed: bool,
+    rects: &[Rect],
+) -> (Option<MenuAction>, bool) {
+    if !pressed || last_pressed {
+        return (None, pressed);
+    }
+    let mut canvas = UiCanvas::<MenuAction>::with_events(vec2(CANVAS_W, CANVAS_H));
+    for (item, rect) in MENU_ITEMS.iter().zip(rects) {
+        // Unimplemented entries get no hit region at all, so a click over one
+        // falls through as "nothing was clicked".
+        if let Some(action) = item.action {
+            // The backdrop already contains the button art; this button is the
+            // shared canvas hit region for its label.
+            canvas.button(*rect, "", action);
+        }
+    }
+    (point.and_then(|p| canvas.click_at(p)), pressed)
+}
+
 /// Pure click resolution: on a rising press edge over an implemented item
 /// (`rects` is parallel to [`MENU_ITEMS`]), return its action. Also returns the
 /// new `last_pressed` to track for the next frame.
@@ -180,28 +261,13 @@ fn resolve_click(
 ) -> (Option<MenuAction>, bool) {
     match pointer {
         Some(p) => {
-            let action = if p.pressed && !last_pressed {
-                let mut canvas = UiCanvas::<MenuAction>::with_events(vec2(CANVAS_W, CANVAS_H));
-                for (item, rect) in MENU_ITEMS.iter().zip(rects) {
-                    // Unimplemented entries get no hit region at all, so a
-                    // click over one falls through as "nothing was clicked".
-                    if let Some(action) = item.action {
-                        // The backdrop already contains the button art; this
-                        // button is the shared canvas hit region for its label.
-                        canvas.button(*rect, "", action);
-                    }
-                }
-                pointer_to_canvas(
-                    vec2(CANVAS_W, CANVAS_H),
-                    p.position,
-                    screen_size,
-                    SCALE_MODE,
-                )
-                .and_then(|point| canvas.click_at(point))
-            } else {
-                None
-            };
-            (action, p.pressed)
+            let point = pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            );
+            resolve_click_at(point, p.pressed, last_pressed, rects)
         }
         None => (None, false),
     }
@@ -212,6 +278,9 @@ pub struct MainMenuScene {
     scene_name: String,
     /// Pointer from the latest update, used for hover highlighting in render.
     pointer: Option<Pointer2D>,
+    /// Where the VR controller ray last met the panel, in canvas pixels. The
+    /// VR counterpart of `pointer`, already in canvas space.
+    vr_pointer_canvas: Option<Vector2<f32>>,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` can map the pointer into
@@ -227,6 +296,7 @@ impl MainMenuScene {
             world,
             scene_name: "main_menu".to_owned(),
             pointer: None,
+            vr_pointer_canvas: None,
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
             // widgets overlap (the load screen's "Done" center falls inside
@@ -235,6 +305,46 @@ impl MainMenuScene {
             last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
         }
+    }
+}
+
+impl MainMenuScene {
+    /// The menu, described once. Screen-space and world-space presentation
+    /// differ only in how this canvas is rendered, so the two can never drift
+    /// apart in layout, labels, or which entries look actionable.
+    ///
+    /// `pointer_canvas` is the hover position in canvas pixels, whatever
+    /// produced it - the mouse or a VR controller ray.
+    fn build_canvas(
+        &self,
+        asset_cache: &mut AssetCache,
+        pointer_canvas: Option<Vector2<f32>>,
+    ) -> UiCanvas {
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+
+        // Full-screen backdrop.
+        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "MAIN.PCX");
+
+        // Menu items, centered in their button and brighter when hovered.
+        // Button rects come from the original `MAINR.BIN` layout and labels
+        // from `MAIN.STR` (both cached by the asset cache after first load).
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
+        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
+        let labels = menu_labels(strings.as_deref());
+        for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
+            let opacity = if item.action.is_none() {
+                DISABLED_OPACITY
+            } else if pointer_canvas.is_some_and(|pp| rect.contains(pp)) {
+                HOVER_OPACITY
+            } else {
+                IDLE_OPACITY
+            };
+            canvas
+                .text_native(*rect, label, MENU_FONT, HAlign::Center, VAlign::Middle)
+                .opacity(opacity);
+        }
+        canvas
     }
 }
 
@@ -250,7 +360,7 @@ impl GameScene for MainMenuScene {
         time: &Time,
         input_context: &InputContext,
         asset_cache: &mut AssetCache,
-        _game_options: &GameOptions,
+        game_options: &GameOptions,
         _command_effects: Vec<Effect>,
     ) -> Vec<Effect> {
         if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
@@ -260,13 +370,22 @@ impl GameScene for MainMenuScene {
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
 
-        self.pointer = input_context.pointer;
-        let (action, last_pressed) = resolve_click(
-            input_context.pointer,
-            self.last_pressed,
-            self.last_screen_size,
-            &rects,
-        );
+        let (action, last_pressed) = if game_options.presentation_mode == PresentationMode::Vr {
+            // VR has no 2D cursor: the pointer is where a controller ray meets
+            // the menu panel, and the trigger is the button.
+            let (point, pressed) = vr_pointer(input_context);
+            self.vr_pointer_canvas = point;
+            self.pointer = None;
+            resolve_click_at(point, pressed, self.last_pressed, &rects)
+        } else {
+            self.pointer = input_context.pointer;
+            resolve_click(
+                input_context.pointer,
+                self.last_pressed,
+                self.last_screen_size,
+                &rects,
+            )
+        };
         self.last_pressed = last_pressed;
 
         match action {
@@ -289,16 +408,28 @@ impl GameScene for MainMenuScene {
 
     fn render(
         &mut self,
-        _asset_cache: &mut AssetCache,
-        _options: &GameOptions,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
     ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        // The menu is drawn in screen space in `render_per_eye` (which has the
-        // screen size); the 3D scene is empty.
-        (
-            Vec::new(),
-            vec3(0.0, 0.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        )
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        // In flat presentation the menu is drawn in screen space in
+        // `render_per_eye` (which has the screen size); the 3D scene is empty.
+        if options.presentation_mode != PresentationMode::Vr {
+            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
+        }
+
+        // In VR there is no screen to draw on, so the same canvas is presented
+        // on a world-space panel in front of the player.
+        let panel = vr_panel();
+        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
+        let objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            self.vr_pointer_canvas.map(|p| vec2(p.x, p.y)),
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        (objects, vec3(0.0, 0.0, 0.0), identity)
     }
 
     fn render_per_eye(
@@ -310,18 +441,6 @@ impl GameScene for MainMenuScene {
         _options: &GameOptions,
     ) -> Vec<SceneObject> {
         self.last_screen_size = screen_size;
-        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
-
-        // Full-screen backdrop.
-        canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), "MAIN.PCX");
-
-        // Menu items, centered in their button and brighter when hovered.
-        // Button rects come from the original `MAINR.BIN` layout and labels
-        // from `MAIN.STR` (both cached by the asset cache after first load).
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
-        let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
-        let labels = menu_labels(strings.as_deref());
         let pointer_canvas = self.pointer.and_then(|p| {
             pointer_to_canvas(
                 vec2(CANVAS_W, CANVAS_H),
@@ -330,19 +449,7 @@ impl GameScene for MainMenuScene {
                 SCALE_MODE,
             )
         });
-        for ((item, rect), label) in MENU_ITEMS.iter().zip(&rects).zip(&labels) {
-            let opacity = if item.action.is_none() {
-                DISABLED_OPACITY
-            } else if pointer_canvas.is_some_and(|pp| rect.contains(pp)) {
-                HOVER_OPACITY
-            } else {
-                IDLE_OPACITY
-            };
-            canvas
-                .text_native(*rect, label, MENU_FONT, HAlign::Center, VAlign::Middle)
-                .opacity(opacity);
-        }
-
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
         canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
     }
 
@@ -383,6 +490,7 @@ impl GameScene for MainMenuScene {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgmath::Rotation3;
 
     fn pointer_at(x: f32, y: f32, pressed: bool) -> Option<Pointer2D> {
         Some(Pointer2D {
@@ -471,6 +579,104 @@ mod tests {
         );
         let (action, _) = resolve_click(held, last, SCREEN, &rects);
         assert_eq!(action, Some(MenuAction::Quit));
+    }
+
+    /// A hand pointing at a given canvas point on the VR panel, with the
+    /// trigger at `trigger`. Built by inverting `ray_to_canvas`: place the hand
+    /// at the panel-plane offset and aim straight down -Z.
+    fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
+        let panel = vr_panel();
+        let u = point.x / CANVAS_W - 0.5;
+        let v = 0.5 - point.y / CANVAS_H;
+        crate::input_context::Hand {
+            position: vec3(u * panel.size.x, v * panel.size.y, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            trigger_value: trigger,
+            ..crate::input_context::Hand::default()
+        }
+    }
+
+    fn vr_input(hand: crate::input_context::Hand) -> InputContext {
+        InputContext {
+            right_hand: hand,
+            ..InputContext::default()
+        }
+    }
+
+    #[test]
+    fn a_vr_ray_maps_onto_the_menu_items() {
+        // Aim at the center of "New Game" (rect 0) and pull the trigger.
+        let rects = menu_rects(None);
+        let target = rects[0].center();
+        let (point, pressed) = vr_pointer(&vr_input(hand_aimed_at(target, 1.0)));
+        let point = point.expect("the ray should land on the panel");
+        assert!(
+            rects[0].contains(point),
+            "expected the ray to land in the New Game rect, got {point:?}"
+        );
+        assert!(pressed, "a fully pulled trigger is a press");
+
+        let (action, _) = resolve_click_at(Some(point), pressed, false, &rects);
+        assert_eq!(action, Some(MenuAction::NewGame));
+    }
+
+    #[test]
+    fn the_left_hand_can_drive_the_menu_too() {
+        // The right hand sits at its default pose, which points straight at the
+        // panel center - so the left hand only wins because its trigger is the
+        // one being held.
+        let rects = menu_rects(None);
+        let input = InputContext {
+            left_hand: hand_aimed_at(rects[5].center(), 1.0),
+            ..InputContext::default()
+        };
+        let (point, pressed) = vr_pointer(&input);
+        let point = point.expect("the left hand should land on the panel");
+        assert!(rects[5].contains(point));
+        assert_eq!(
+            resolve_click_at(Some(point), pressed, false, &rects).0,
+            Some(MenuAction::Quit)
+        );
+    }
+
+    #[test]
+    fn a_light_vr_trigger_is_not_a_press() {
+        let rects = menu_rects(None);
+        let (_, pressed) = vr_pointer(&vr_input(hand_aimed_at(rects[0].center(), 0.2)));
+        assert!(!pressed, "a barely-touched trigger must not click");
+    }
+
+    #[test]
+    fn aiming_away_from_the_vr_panel_yields_no_point() {
+        // Rotated 180 degrees: pointing behind the player, away from the panel.
+        // Both hands must aim away - in VR both are always posed, so leaving
+        // one at its default would have it pointing straight at the panel.
+        let away = || crate::input_context::Hand {
+            rotation: Quaternion::from_angle_y(cgmath::Deg(180.0)),
+            trigger_value: 1.0,
+            ..crate::input_context::Hand::default()
+        };
+        let input = InputContext {
+            right_hand: away(),
+            left_hand: away(),
+            ..InputContext::default()
+        };
+        let (point, pressed) = vr_pointer(&input);
+        assert_eq!(point, None);
+        // The trigger is still reported so the held press is consumed rather
+        // than becoming a fresh edge when the ray swings back onto a button.
+        assert!(pressed);
+        assert_eq!(resolve_click_at(point, pressed, false, &menu_rects(None)).0, None);
+    }
+
+    #[test]
+    fn a_vr_press_held_across_frames_clicks_once() {
+        let rects = menu_rects(None);
+        let point = Some(rects[0].center());
+        let (action, last) = resolve_click_at(point, true, false, &rects);
+        assert_eq!(action, Some(MenuAction::NewGame));
+        // Still held on the next frame: no repeat.
+        assert_eq!(resolve_click_at(point, true, last, &rects).0, None);
     }
 
     #[test]

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -36,9 +36,7 @@ use crate::{
     mission::GlobalContext,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{
-        HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas,
-    },
+    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas},
 };
 
 /// Mission loaded when the player chooses "New Game".
@@ -681,7 +679,10 @@ mod tests {
         // The trigger is still reported so the held press is consumed rather
         // than becoming a fresh edge when the ray swings back onto a button.
         assert!(pressed);
-        assert_eq!(resolve_click_at(point, pressed, false, &menu_rects(None)).0, None);
+        assert_eq!(
+            resolve_click_at(point, pressed, false, &menu_rects(None)).0,
+            None
+        );
     }
 
     #[test]

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use cgmath::{Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
+use cgmath::{InnerSpace, Matrix3, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::{
     importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
     map::MapRect,
@@ -185,12 +185,42 @@ const VR_TRIGGER_THRESHOLD: f32 = 0.5;
 /// front of the backdrop instead of z-fighting it.
 const VR_COMPONENT_Z_STEP: f32 = 0.001;
 
-/// The panel the VR menu is drawn on. Fixed relative to the scene origin (the
-/// menu has no pawn to follow), facing the default camera direction.
-fn vr_panel() -> WorldPanel {
+/// The panel the VR menu is drawn on: hung `VR_PANEL_DISTANCE` in front of the
+/// head and turned to face back at it.
+///
+/// It is anchored to the head's **facing**, not to a fixed world axis. There is
+/// no canonical "forward" to hardcode - the runtimes' yaw-0 camera looks along
+/// +X, not -Z - so a panel pinned to -Z sits off to the side and never enters
+/// the frustum. This mirrors `DebugMapScene`'s construction, which is the
+/// world-space panel that demonstrably renders.
+fn vr_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
+    let head = vec3(0.0, VR_PANEL_EYE_HEIGHT, 0.0);
+    let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+    let center = head + forward * VR_PANEL_DISTANCE;
+
+    // Orient the panel by looking from it back to the head. `look_dir` runs
+    // panel -> head, so the panel's local +Z (the third column) points away
+    // from the viewer - the convention the world-space element path expects.
+    let mut look_dir = head - center;
+    look_dir = if look_dir.magnitude2() < 1e-6 {
+        vec3(0.0, 0.0, 1.0)
+    } else {
+        look_dir.normalize()
+    };
+    let mut up = vec3(0.0, 1.0, 0.0);
+    let mut right = look_dir.cross(up);
+    if right.magnitude2() < 1e-6 {
+        // Looking straight up or down: pick a different up to keep the basis
+        // well-defined.
+        up = vec3(0.0, 0.0, 1.0);
+        right = look_dir.cross(up);
+    }
+    let right = right.normalize();
+    let true_up = right.cross(look_dir).normalize();
+
     WorldPanel {
-        center: vec3(0.0, VR_PANEL_EYE_HEIGHT, -VR_PANEL_DISTANCE),
-        rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        center,
+        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, -look_dir)),
         size: VR_PANEL_SIZE,
     }
 }
@@ -203,7 +233,7 @@ fn vr_panel() -> WorldPanel {
 /// held** wins, so either controller can click; ties and idle triggers fall
 /// back to the right hand, which then drives the hover highlight.
 fn vr_pointer(input_context: &InputContext) -> (Option<Vector2<f32>>, bool) {
-    let panel = vr_panel();
+    let panel = vr_panel(input_context.head.rotation);
     let right = &input_context.right_hand;
     let left = &input_context.left_hand;
     let held = |hand: &crate::input_context::Hand| hand.trigger_value > VR_TRIGGER_THRESHOLD;
@@ -284,6 +314,9 @@ pub struct MainMenuScene {
     /// Where the VR controller ray last met the panel, in canvas pixels. The
     /// VR counterpart of `pointer`, already in canvas space.
     vr_pointer_canvas: Option<Vector2<f32>>,
+    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// where `update` hit-tested it.
+    head_rotation: Quaternion<f32>,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` can map the pointer into
@@ -300,6 +333,7 @@ impl MainMenuScene {
             scene_name: "main_menu".to_owned(),
             pointer: None,
             vr_pointer_canvas: None,
+            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
             // widgets overlap (the load screen's "Done" center falls inside
@@ -373,6 +407,10 @@ impl GameScene for MainMenuScene {
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = menu_rects(layout.as_deref().map(|r| r.as_slice()));
 
+        // The panel hangs off the head's facing, so this is needed for the
+        // render regardless of which presentation drives the pointer.
+        self.head_rotation = input_context.head.rotation;
+
         let (action, last_pressed) = if game_options.presentation_mode == PresentationMode::Vr {
             // VR has no 2D cursor: the pointer is where a controller ray meets
             // the menu panel, and the trigger is the button.
@@ -423,7 +461,7 @@ impl GameScene for MainMenuScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = vr_panel();
+        let panel = vr_panel(self.head_rotation);
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
         let objects = canvas.render_world_space(
             asset_cache,
@@ -593,17 +631,27 @@ mod tests {
     /// A hand pointing at a given canvas point on the VR panel, with the
     /// trigger at `trigger`. Built by inverting `ray_to_canvas`: place the hand
     /// at the panel-plane offset and aim straight down -Z.
+    /// The head facing the tests aim against: the default camera orientation.
+    fn test_head() -> Quaternion<f32> {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    /// A hand aimed at a given canvas point, derived from the panel's own basis
+    /// rather than world axes - so the test stays honest whichever way the
+    /// panel ends up facing.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
-        let panel = vr_panel();
+        let panel = vr_panel(test_head());
         let u = point.x / CANVAS_W - 0.5;
         let v = 0.5 - point.y / CANVAS_H;
+        let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        let normal = panel.normal();
+        let target = panel.center + right * (u * panel.size.x) + up * (v * panel.size.y);
+
         crate::input_context::Hand {
-            position: vec3(
-                panel.center.x + u * panel.size.x,
-                panel.center.y + v * panel.size.y,
-                0.0,
-            ),
-            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            // Stand back along the panel's normal and aim at the target.
+            position: target - normal * VR_PANEL_DISTANCE,
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), normal, None),
             trigger_value: trigger,
             ..crate::input_context::Hand::default()
         }
@@ -664,8 +712,11 @@ mod tests {
         // Rotated 180 degrees: pointing behind the player, away from the panel.
         // Both hands must aim away - in VR both are always posed, so leaving
         // one at its default would have it pointing straight at the panel.
+        let panel = vr_panel(test_head());
         let away = || crate::input_context::Hand {
-            rotation: Quaternion::from_angle_y(cgmath::Deg(180.0)),
+            // Aim directly opposite the panel, from the panel's own centre.
+            position: panel.center,
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -panel.normal(), None),
             trigger_value: 1.0,
             ..crate::input_context::Hand::default()
         };

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -173,7 +173,12 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
 
 /// The VR menu hangs on a panel 2m ahead of the player at eye level, sized to
 /// the canvas's 4:3 aspect so the art is not stretched.
+///
+/// "Eye level" is not the scene origin: VR runtimes add a head offset of
+/// `player_eye_height / SCALE_FACTOR` on top of the camera position this scene
+/// returns, so a panel at y=0 hangs below the view and is never seen.
 const VR_PANEL_DISTANCE: f32 = 2.0;
+const VR_PANEL_EYE_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
 const VR_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
 /// A VR trigger past this counts as "pressed", matching the hand code's
 /// grab/fire threshold.
@@ -186,7 +191,7 @@ const VR_COMPONENT_Z_STEP: f32 = 0.001;
 /// menu has no pawn to follow), facing the default camera direction.
 fn vr_panel() -> WorldPanel {
     WorldPanel {
-        center: vec3(0.0, 0.0, -VR_PANEL_DISTANCE),
+        center: vec3(0.0, VR_PANEL_EYE_HEIGHT, -VR_PANEL_DISTANCE),
         rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
         size: VR_PANEL_SIZE,
     }
@@ -438,9 +443,15 @@ impl GameScene for MainMenuScene {
         _view: cgmath::Matrix4<f32>,
         _projection: cgmath::Matrix4<f32>,
         screen_size: Vector2<f32>,
-        _options: &GameOptions,
+        options: &GameOptions,
     ) -> Vec<SceneObject> {
         self.last_screen_size = screen_size;
+        // In VR the menu lives on a world-space panel drawn by `render`; a
+        // screen-space copy here would paste the whole canvas over both eyes
+        // and hide it.
+        if options.presentation_mode == PresentationMode::Vr {
+            return Vec::new();
+        }
         let pointer_canvas = self.pointer.and_then(|p| {
             pointer_to_canvas(
                 vec2(CANVAS_W, CANVAS_H),
@@ -589,7 +600,11 @@ mod tests {
         let u = point.x / CANVAS_W - 0.5;
         let v = 0.5 - point.y / CANVAS_H;
         crate::input_context::Hand {
-            position: vec3(u * panel.size.x, v * panel.size.y, 0.0),
+            position: vec3(
+                panel.center.x + u * panel.size.x,
+                panel.center.y + v * panel.size.y,
+                0.0,
+            ),
             rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             trigger_value: trigger,
             ..crate::input_context::Hand::default()

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -147,6 +147,11 @@ impl WorldPanel {
     }
 
     /// Root transform for [`UiCanvas::render_world_space`].
+    ///
+    /// No facing correction is needed: the element path's own 180-degree
+    /// rotation is about **Z** (in-plane, flipping the canvas's axes), so the
+    /// quad's +Z normal is untouched and a panel whose
+    /// [`normal`](Self::normal) faces the viewer renders toward them.
     pub fn transform(&self) -> Matrix4<f32> {
         Matrix4::from_translation(self.center)
             * Matrix4::from(self.rotation)
@@ -1229,11 +1234,22 @@ mod tests {
         fn the_transform_scales_to_the_panel_size() {
             let panel = panel();
             // The canvas is authored in 0..1 space, so the transform must take
-            // the unit square to the panel's metres.
+            // the unit square to the panel's metres, centered on the panel.
             let corner = panel.transform() * cgmath::vec4(0.5, 0.5, 0.0, 1.0);
-            assert!((corner.x - 1.0).abs() < 1e-5, "half-width should be 1m");
-            assert!((corner.y - 0.75).abs() < 1e-5, "half-height should be 0.75m");
+            assert!(corner.x.abs() - 1.0 < 1e-5, "half-width should be 1m");
+            assert!(corner.y.abs() - 0.75 < 1e-5, "half-height should be 0.75m");
             assert!((corner.z + 2.0).abs() < 1e-5, "panel sits 2m ahead");
+        }
+
+        #[test]
+        fn the_transform_preserves_the_panels_facing() {
+            // The element path's own 180-degree rotation is about Z (in-plane),
+            // so `transform` must not add a facing correction of its own - an
+            // extra Y flip turns the panel away and it renders to nothing.
+            let panel = panel();
+            let right = panel.transform() * cgmath::vec4(0.5, 0.0, 0.0, 1.0);
+            assert!(right.x > 0.0, "local +X must stay along world +X");
+            assert!((panel.normal().z - 1.0).abs() < 1e-5);
         }
     }
 }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -812,20 +812,54 @@ where
                 }
                 UiElement::Text {
                     position,
+                    size,
                     text,
                     font,
+                    font_size,
+                    h,
+                    v,
                     alpha,
                     ..
                 } => {
-                    let font = asset_cache.get(&FONT_IMPORTER, font).clone();
+                    let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
                     let alpha = force_alpha.unwrap_or(*alpha);
-                    let mut object =
-                        SceneObject::world_space_text(text, font, (1.0 - alpha).clamp(0.0, 1.0));
+
+                    // Align inside the element's rect, in canvas pixels, the
+                    // same way the screen-space path does - otherwise the two
+                    // presentations disagree about where a label sits and
+                    // world-space text drifts off its widget.
+                    let canvas_font_size = if *font_size > 0.0 {
+                        *font_size
+                    } else {
+                        font_obj.base_height()
+                    };
+                    let width = measure_text_width(&**font_obj, text, canvas_font_size);
+                    let x = match h {
+                        HAlign::Left => position.x,
+                        HAlign::Center => position.x + (size.x - width) / 2.0,
+                        HAlign::Right => position.x + size.x - width,
+                    };
+                    // `world_space_text` anchors on the text's vertical
+                    // CENTRE (unlike the screen-space path, which anchors on
+                    // its top), so each case carries half a line to land the
+                    // glyphs where the alignment says they should be.
+                    let half_line = canvas_font_size / 2.0;
+                    let y = match v {
+                        VAlign::Top => position.y + half_line,
+                        VAlign::Middle => position.y + size.y / 2.0,
+                        VAlign::Bottom => position.y + size.y - half_line,
+                    };
+
+                    let mut object = SceneObject::world_space_text(
+                        text,
+                        font_obj,
+                        (1.0 - alpha).clamp(0.0, 1.0),
+                    );
                     object.set_local_transform(
                         Matrix4::from_angle_y(Deg(180.0))
                             * Matrix4::from_translation(vec3(
-                                position.x / self.size.x - 0.5,
-                                -position.y / self.size.y - 0.5,
+                                x / self.size.x - 0.5,
+                                -y / self.size.y - 0.5,
                                 0.01,
                             )),
                     );

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -1178,11 +1178,21 @@ mod tests {
         #[test]
         fn the_corners_map_to_the_canvas_corners() {
             // Top-left in world terms (-x, +y) is canvas (0, 0).
-            let hit = ray_to_canvas(CANVAS, &panel(), vec3(-1.0, 0.75, 0.0), vec3(0.0, 0.0, -1.0))
-                .expect("the corner should hit");
+            let hit = ray_to_canvas(
+                CANVAS,
+                &panel(),
+                vec3(-1.0, 0.75, 0.0),
+                vec3(0.0, 0.0, -1.0),
+            )
+            .expect("the corner should hit");
             assert_close(hit, vec2(0.0, 0.0));
-            let hit = ray_to_canvas(CANVAS, &panel(), vec3(1.0, -0.75, 0.0), vec3(0.0, 0.0, -1.0))
-                .expect("the corner should hit");
+            let hit = ray_to_canvas(
+                CANVAS,
+                &panel(),
+                vec3(1.0, -0.75, 0.0),
+                vec3(0.0, 0.0, -1.0),
+            )
+            .expect("the corner should hit");
             assert_close(hit, vec2(640.0, 480.0));
         }
 
@@ -1208,7 +1218,10 @@ mod tests {
             // 45 degrees right of straight ahead, from the origin: at 2m the
             // hit is 2m to the right, well outside the 1m half-width.
             let direction = vec3(1.0, 0.0, -1.0).normalize();
-            assert_eq!(ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), direction), None);
+            assert_eq!(
+                ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), direction),
+                None
+            );
             // A gentler angle stays on the panel and lands right of center.
             let direction = vec3(0.25, 0.0, -1.0).normalize();
             let hit = ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), direction)

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -18,7 +18,7 @@
 
 use std::rc::Rc;
 
-use cgmath::{Deg, Matrix4, Vector2, vec2, vec3};
+use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
 use engine::{
     assets::asset_cache::AssetCache,
@@ -126,6 +126,78 @@ pub fn pointer_to_canvas(
 /// under `mode` - the rect analogue (and inverse) of [`pointer_to_canvas`].
 /// Lets clients (e.g. the debug runtime's `GET /v1/ui`) aim a normalized
 /// pointer at a canvas rect without re-deriving the letterbox math.
+/// A flat UI panel placed in the world: where it is, which way it faces, and
+/// how big it is in metres. Frontend scenes in VR present their canvas on one
+/// of these instead of on the screen.
+#[derive(Debug, Clone, Copy)]
+pub struct WorldPanel {
+    /// Center of the panel, in world space.
+    pub center: Vector3<f32>,
+    /// Panel orientation. The panel's face normal is this rotation applied to
+    /// +Z, so an identity rotation faces the default camera direction.
+    pub rotation: Quaternion<f32>,
+    /// Panel size in metres (width, height).
+    pub size: Vector2<f32>,
+}
+
+impl WorldPanel {
+    /// The panel's outward face normal.
+    pub fn normal(&self) -> Vector3<f32> {
+        self.rotation.rotate_vector(vec3(0.0, 0.0, 1.0))
+    }
+
+    /// Root transform for [`UiCanvas::render_world_space`].
+    pub fn transform(&self) -> Matrix4<f32> {
+        Matrix4::from_translation(self.center)
+            * Matrix4::from(self.rotation)
+            * Matrix4::from_nonuniform_scale(self.size.x, self.size.y, 1.0)
+    }
+}
+
+/// Intersect a pointing ray with `panel` and return where it lands, in canvas
+/// pixels - the VR counterpart of [`pointer_to_canvas`].
+///
+/// `canvas_size` is the panel's authored pixel canvas (e.g. 640x480).
+/// Returns `None` when the ray is parallel to the panel, points away from it,
+/// or lands outside its bounds, so a caller can treat "not pointing at the
+/// menu" the same way flat treats "cursor off the canvas".
+pub fn ray_to_canvas(
+    canvas_size: Vector2<f32>,
+    panel: &WorldPanel,
+    ray_origin: Vector3<f32>,
+    ray_direction: Vector3<f32>,
+) -> Option<Vector2<f32>> {
+    let normal = panel.normal();
+    let denominator = ray_direction.dot(normal);
+    // Parallel to the panel (or close enough that the intersection is
+    // numerically meaningless).
+    if denominator.abs() < 1e-6 {
+        return None;
+    }
+
+    let distance = (panel.center - ray_origin).dot(normal) / denominator;
+    // The panel is behind the ray, not in front of it.
+    if distance <= 0.0 {
+        return None;
+    }
+
+    let hit = ray_origin + ray_direction * distance;
+    let local = hit - panel.center;
+    // Undo the panel's rotation to get panel-local axes.
+    let inverse = panel.rotation.conjugate();
+    let local = inverse.rotate_vector(local);
+
+    // Panel-local -> [0,1] with the origin at the top-left, matching the
+    // canvas convention (y grows downward on the canvas, upward in the world).
+    let u = local.x / panel.size.x + 0.5;
+    let v = 0.5 - local.y / panel.size.y;
+    if !(0.0..=1.0).contains(&u) || !(0.0..=1.0).contains(&v) {
+        return None;
+    }
+
+    Some(vec2(u * canvas_size.x, v * canvas_size.y))
+}
+
 pub fn canvas_rect_to_screen(
     rect: Rect,
     canvas_size: Vector2<f32>,
@@ -1030,5 +1102,138 @@ mod tests {
                 }
             ]
         ));
+    }
+
+    mod world_panel {
+        use super::*;
+        use cgmath::{Deg, Rotation3};
+
+        /// A 4:3 panel 2m in front of the origin, facing back toward it.
+        fn panel() -> WorldPanel {
+            WorldPanel {
+                center: vec3(0.0, 0.0, -2.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                size: vec2(2.0, 1.5),
+            }
+        }
+
+        const CANVAS: Vector2<f32> = Vector2 { x: 640.0, y: 480.0 };
+
+        fn assert_close(actual: Vector2<f32>, expected: Vector2<f32>) {
+            assert!(
+                (actual.x - expected.x).abs() < 0.01 && (actual.y - expected.y).abs() < 0.01,
+                "expected {:?}, got {:?}",
+                expected,
+                actual
+            );
+        }
+
+        #[test]
+        fn a_ray_down_the_axis_hits_the_canvas_center() {
+            let hit = ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, -1.0));
+            assert_close(hit.expect("the ray should hit"), vec2(320.0, 240.0));
+        }
+
+        #[test]
+        fn world_up_is_canvas_up() {
+            // Aiming above center must land in the TOP half of the canvas
+            // (canvas y grows downward, world y grows upward) - the flip is
+            // exactly the kind of thing that silently inverts a menu.
+            let hit = ray_to_canvas(
+                CANVAS,
+                &panel(),
+                vec3(0.0, 0.375, 0.0),
+                vec3(0.0, 0.0, -1.0),
+            )
+            .expect("the ray should hit");
+            assert_close(hit, vec2(320.0, 120.0));
+            assert!(hit.y < 240.0, "aiming up must map to the top of the canvas");
+        }
+
+        #[test]
+        fn world_right_is_canvas_right() {
+            let hit = ray_to_canvas(CANVAS, &panel(), vec3(0.5, 0.0, 0.0), vec3(0.0, 0.0, -1.0))
+                .expect("the ray should hit");
+            assert_close(hit, vec2(480.0, 240.0));
+        }
+
+        #[test]
+        fn a_ray_past_the_edge_misses() {
+            // Just outside the panel's 2m width.
+            assert_eq!(
+                ray_to_canvas(CANVAS, &panel(), vec3(1.01, 0.0, 0.0), vec3(0.0, 0.0, -1.0)),
+                None
+            );
+            assert_eq!(
+                ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.76, 0.0), vec3(0.0, 0.0, -1.0)),
+                None
+            );
+        }
+
+        #[test]
+        fn the_corners_map_to_the_canvas_corners() {
+            // Top-left in world terms (-x, +y) is canvas (0, 0).
+            let hit = ray_to_canvas(CANVAS, &panel(), vec3(-1.0, 0.75, 0.0), vec3(0.0, 0.0, -1.0))
+                .expect("the corner should hit");
+            assert_close(hit, vec2(0.0, 0.0));
+            let hit = ray_to_canvas(CANVAS, &panel(), vec3(1.0, -0.75, 0.0), vec3(0.0, 0.0, -1.0))
+                .expect("the corner should hit");
+            assert_close(hit, vec2(640.0, 480.0));
+        }
+
+        #[test]
+        fn a_ray_pointing_away_misses() {
+            // The panel is behind the ray, so there is no forward hit.
+            assert_eq!(
+                ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 1.0)),
+                None
+            );
+        }
+
+        #[test]
+        fn a_ray_parallel_to_the_panel_misses() {
+            assert_eq!(
+                ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), vec3(1.0, 0.0, 0.0)),
+                None
+            );
+        }
+
+        #[test]
+        fn an_angled_ray_lands_off_center() {
+            // 45 degrees right of straight ahead, from the origin: at 2m the
+            // hit is 2m to the right, well outside the 1m half-width.
+            let direction = vec3(1.0, 0.0, -1.0).normalize();
+            assert_eq!(ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), direction), None);
+            // A gentler angle stays on the panel and lands right of center.
+            let direction = vec3(0.25, 0.0, -1.0).normalize();
+            let hit = ray_to_canvas(CANVAS, &panel(), vec3(0.0, 0.0, 0.0), direction)
+                .expect("a gentle angle should still hit");
+            assert!(hit.x > 320.0, "a rightward angle must land right of center");
+        }
+
+        #[test]
+        fn a_rotated_panel_still_maps_correctly() {
+            // Yaw the panel 90 degrees so it faces +X, and place it to the
+            // player's right. Pointing along +X must hit its center.
+            let panel = WorldPanel {
+                center: vec3(2.0, 0.0, 0.0),
+                rotation: Quaternion::from_angle_y(Deg(-90.0)),
+                size: vec2(2.0, 1.5),
+            };
+            let hit = ray_to_canvas(CANVAS, &panel, vec3(0.0, 0.0, 0.0), vec3(1.0, 0.0, 0.0))
+                .expect("the rotated panel should be hit");
+            assert_close(hit, vec2(320.0, 240.0));
+        }
+
+        #[test]
+        fn the_transform_scales_to_the_panel_size() {
+            let panel = panel();
+            // The canvas is authored in 0..1 space, so the transform must take
+            // the unit square to the panel's metres.
+            let corner = panel.transform() * cgmath::vec4(0.5, 0.5, 0.0, 1.0);
+            assert!((corner.x - 1.0).abs() < 1e-5, "half-width should be 1m");
+            assert!((corner.y - 0.75).abs() < 1e-5, "half-height should be 0.75m");
+            assert!((corner.z + 2.0).abs() < 1e-5, "panel sits 2m ahead");
+        }
     }
 }


### PR DESCRIPTION
**Stacked on #930.**

## What

The main menu now works in VR: it hangs on a world-space panel, a controller ray drives it, and `--vr` with no `--mission` boots into it.

![VR menu controller sweep](https://gist.githubusercontent.com/tommy-xr/df7db01a5468150fc2c54ec270c36607/raw/vr_menu.gif)

<sub>Right controller sweeping the six entries in `--vr`. Hover follows the ray; the four unimplemented entries stay dim and take no clicks. Captured headlessly through the debug runtime (`/v1/control/input` hand pose + `/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/df7db01a5468150fc2c54ec270c36607/raw/vr_beforeafter.png)

Every VR frame was previously **the inside of a red box** — see the third fix below.

## Hover, at two ends of the sweep

![hover comparison](https://gist.githubusercontent.com/tommy-xr/df7db01a5468150fc2c54ec270c36607/raw/vr_hover_ab.png)

<sub>Left: ray on "New Game". Right: ray on "Quit". Options / Credits / Intro stay dim in both.</sub>

## Three bugs, none of them where I first looked

**1. The panel was pinned to a fixed axis.** It hung at a fixed `-Z` offset from the scene origin — but there is no canonical forward to hardcode. The runtimes' yaw-0 camera looks along **+X**:

```rust
let forward = point3(yaw.cos()*pitch.cos(), pitch.sin(), yaw.sin()*pitch.cos());  // yaw 0 -> (1,0,0)
```

(The `head.look` doc comment claiming "forward = -Z" is wrong.) The panel sat ~90° off to the side, permanently outside the frustum. It now hangs at `head + (head_rotation * -Z) * distance`, oriented by looking back at the head — the same construction `DebugMapScene` uses.

**2. World-space text ignored its rect and alignment.** Labels floated up-left of their buttons. Now aligned like the screen-space path, with one non-obvious asymmetry called out in the code: `SceneObject::world_space_text` anchors on the text's vertical **centre** where the screen-space path anchors on its **top**, so each `VAlign` carries half a line.

**3. `Game::render_per_eye` appended a red debug cube in VR only.**

```rust
let hand_material = color_material::create(vec3(1.0, 0.0, 0.0));   // RED
from_scale(0.25) * from_translation(vec3(0.0, 4.0, 0.0))           // -> centred at (0, 1.0, 0)
```

The VR camera sits at eye height `(0, 1.04, 0)` — **inside** a cube spanning ±0.125 — so it painted over the whole scene. This is why `debug_map` was blank in VR too, which is what disguised it as a menu problem for so long. An earlier comment ("keep it out of the clean flatscreen view") had gated it to VR rather than deleting it, hiding the damage in the mode nobody screenshots. It is vestigial — its companion text objects were already commented out, and it tracks nothing despite the `hand_` naming.

## Hand priority is not "first hand that hits"

Both controllers are always posed, so the right hand's default pose points straight at the panel and the left could never have clicked anything. A hand **with its trigger held** wins; ties fall back to the right hand, which drives hover.

## Verification

Interaction is pure math, so it is unit-tested without a headset — 11 tests on the panel/ray math, 5 on the menu path:

- ray down the axis hits the canvas centre; **world-up maps to canvas-up** (the flip that would silently invert a menu)
- corners map to canvas corners; off-panel, behind-the-ray and parallel rays all miss
- a yawed panel still maps correctly
- a VR ray lands on the right item and clicks it; a light trigger does not click; a held press clicks once; either hand can drive it

Rendered checks through the debug runtime:

| Check | Result |
| --- | --- |
| Panel renders in VR | 7 canvas objects, 14618 distinct colours |
| Controller hover | "New Game" bright, "Load Game" dim |
| Trigger activates | **0 → 747 entities** |
| `--vr`, no `--mission` | boots the menu and renders it |

605 `shock2vr` + 41 `engine` unit tests; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

`quest_config::parse_mission` accepted only `debug_*` or `*.mis`, so it would have **rejected the value that is now the default**. It now accepts `DEFAULT_MISSION`, with a test pinning the round-trip.

## Not verified / follow-ups

- **No real hardware.** Everything above is the debug runtime's `--vr` path; the Quest default is unverified on device.
- **The load screen has no VR presentation**, so "Load Game" in VR opens a still-flat screen — a gap this PR makes reachable.
- Labels drift a few px right of centre; world text likely renders at a slightly different scale than `measure_text_width` reports.

`handoff.md` (added here) carries the root causes, the bisect-by-transplant technique that found them, and the measurement traps that cost time.
