### PR TITLE
fix(gameplay): ignore pickup after psi booster use

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -322,6 +322,66 @@ fn apply_psi_kit_use(world: &World, entity_id: EntityId, amount: i32) -> PsiKitU
     }
 }
 
+/// Move a still-live entity's containment link and mark it as no longer
+/// world-referenced. Effects are processed sequentially, so an earlier effect
+/// in the same batch may already have consumed the requested item.
+fn move_live_entity_into_container(
+    world: &mut World,
+    container_entity_id: EntityId,
+    dropped_entity_id: EntityId,
+) -> bool {
+    let is_alive = world
+        .borrow::<EntitiesView>()
+        .is_ok_and(|entities| entities.is_alive(dropped_entity_id));
+    if !is_alive {
+        return false;
+    }
+
+    // Give the item a cell in the container's grid, so it stays where it
+    // was put instead of being repacked on every draw. Computed before
+    // the borrow below, and *after* the item's own links are irrelevant -
+    // it is not in the container yet, so it cannot occupy a cell here.
+    let slot = {
+        let grid = crate::inventory::grid_for(world, container_entity_id);
+        let occupied =
+            crate::inventory::Inventory::from_container(world, container_entity_id, grid);
+        let dims = world
+            .borrow::<View<dark::properties::PropInventoryDimensions>>()
+            .ok()
+            .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
+            .unwrap_or((1, 1));
+        // A full container still takes the item (the drop is already
+        // permitted by the caller); it just has no cell to remember.
+        occupied
+            .first_free_slot(dims.0 as usize, dims.1 as usize)
+            .unwrap_or(0)
+    };
+
+    let mut was_able_to_drop = false;
+    {
+        // First, remove any existing contains links for the dropped entity.
+        let mut v_links = world.borrow::<ViewMut<Links>>().unwrap();
+
+        for (id, links) in (&mut v_links).iter().with_id() {
+            drop_contains_links_to(links, dropped_entity_id);
+
+            // If it is the container, add the replacement link.
+            if id == container_entity_id {
+                links.to_links.push(ToLink {
+                    link: Link::Contains(slot),
+                    to_entity_id: Some(dark::properties::WrappedEntityId(dropped_entity_id)),
+                    to_template_id: 0, // todo?
+                });
+                was_able_to_drop = true;
+            }
+        }
+    }
+    if was_able_to_drop {
+        world.add_component(dropped_entity_id, PropHasRefs(false));
+    }
+    was_able_to_drop
+}
+
 /// Raise only the live maximum HP pool. Buying Endurance is not healing: the
 /// original stat promises more maximum hit points, while Tank's separate O/S
 /// effect deliberately raises both current and maximum HP.
@@ -2880,52 +2940,15 @@ impl MissionCore {
         container_entity_id: EntityId,
         dropped_entity_id: EntityId,
     ) -> bool {
-        // Give the item a cell in the container's grid, so it stays where it
-        // was put instead of being repacked on every draw. Computed before
-        // the borrow below, and *after* the item's own links are irrelevant -
-        // it is not in the container yet, so it cannot occupy a cell here.
-        let slot = {
-            let grid = crate::inventory::grid_for(&self.world, container_entity_id);
-            let occupied =
-                crate::inventory::Inventory::from_container(&self.world, container_entity_id, grid);
-            let dims = self
-                .world
-                .borrow::<View<dark::properties::PropInventoryDimensions>>()
-                .ok()
-                .and_then(|v| v.get(dropped_entity_id).ok().map(|d| (d.width, d.height)))
-                .unwrap_or((1, 1));
-            // A full container still takes the item (the drop is already
-            // permitted by the caller); it just has no cell to remember.
-            occupied
-                .first_free_slot(dims.0 as usize, dims.1 as usize)
-                .unwrap_or(0)
-        };
-
-        let mut was_able_to_drop = false;
-        {
-            // First, remove any existing contains links for the dropped entity..
-            let mut v_links = self.world.borrow::<ViewMut<Links>>().unwrap();
-
-            for (id, links) in (&mut v_links).iter().with_id() {
-                drop_contains_links_to(links, dropped_entity_id);
-
-                // If it is the container, we'll add the link!
-                if id == container_entity_id {
-                    links.to_links.push(ToLink {
-                        link: Link::Contains(slot),
-                        to_entity_id: Some(dark::properties::WrappedEntityId(dropped_entity_id)),
-                        to_template_id: 0, // todo?
-                    });
-                    was_able_to_drop = true;
-                }
-            }
-        }
-        if was_able_to_drop {
-            self.world
-                .add_component(dropped_entity_id, PropHasRefs(false));
+        let moved = move_live_entity_into_container(
+            &mut self.world,
+            container_entity_id,
+            dropped_entity_id,
+        );
+        if moved {
             self.make_un_physical(dropped_entity_id);
         }
-        was_able_to_drop
+        moved
     }
 
     /// When an entity is replaced (e.g. a dead power cell recharged into a live
@@ -8656,7 +8679,7 @@ mod psi_kit_use_tests {
 
     fn world_with_player(psi_points: i32) -> World {
         let mut world = World::new();
-        let inventory_entity_id = world.add_entity(());
+        let inventory_entity_id = world.add_entity(Links::empty());
         let player = world.add_entity(PropPsiState {
             psi_points,
             max_psi_points: 50,
@@ -8675,13 +8698,23 @@ mod psi_kit_use_tests {
 
     fn apply_effect_batch(world: &mut World, effects: Vec<Effect>) {
         for effect in effects {
-            let Effect::UsePsiKit { entity_id, amount } = effect else {
-                panic!("unexpected effect in psi-kit test batch");
-            };
-            if apply_psi_kit_use(world, entity_id, amount) == PsiKitUseOutcome::DestroyEntity {
-                // Production performs MissionCore's canonical teardown here;
-                // this state-level regression has no render/physics/script maps.
-                world.delete_entity(entity_id);
+            match effect {
+                Effect::UsePsiKit { entity_id, amount } => {
+                    if apply_psi_kit_use(world, entity_id, amount)
+                        == PsiKitUseOutcome::DestroyEntity
+                    {
+                        // Production performs MissionCore's canonical teardown here;
+                        // this state-level regression has no render/physics/script maps.
+                        world.delete_entity(entity_id);
+                    }
+                }
+                Effect::DropEntityInfo {
+                    parent_entity_id,
+                    dropped_entity_id,
+                } => {
+                    move_live_entity_into_container(world, parent_entity_id, dropped_entity_id);
+                }
+                other => panic!("unexpected effect in psi-kit test batch: {other:?}"),
             }
         }
     }
@@ -8694,6 +8727,84 @@ mod psi_kit_use_tests {
             .get(player)
             .unwrap()
             .psi_points
+    }
+
+    fn inventory_contains(world: &World, entity_id: EntityId) -> bool {
+        let inventory = world
+            .borrow::<UniqueView<PlayerInfo>>()
+            .unwrap()
+            .inventory_entity_id;
+        world
+            .borrow::<View<Links>>()
+            .unwrap()
+            .get(inventory)
+            .unwrap()
+            .to_links
+            .iter()
+            .any(|link| {
+                matches!(link.link, Link::Contains(_))
+                    && link.to_entity_id.map(|wrapped| wrapped.0) == Some(entity_id)
+            })
+    }
+
+    #[test]
+    fn world_frob_psi_kit_batch_ignores_pickup_after_consumption() {
+        let mut world = world_with_player(5);
+        let inventory = world
+            .borrow::<UniqueView<PlayerInfo>>()
+            .unwrap()
+            .inventory_entity_id;
+        let booster = world.add_entity(PropStackCount(1));
+
+        // One world Frob is handled by both PsiKitScript and the engine's
+        // internal MOVE script, in this order, before either effect is applied.
+        apply_effect_batch(
+            &mut world,
+            vec![
+                Effect::UsePsiKit {
+                    entity_id: booster,
+                    amount: 20,
+                },
+                Effect::DropEntityInfo {
+                    parent_entity_id: inventory,
+                    dropped_entity_id: booster,
+                },
+            ],
+        );
+
+        assert_eq!(player_psi_points(&world), 25);
+        assert!(!world.borrow::<EntitiesView>().unwrap().is_alive(booster));
+        assert!(!inventory_contains(&world, booster));
+    }
+
+    #[test]
+    fn live_drop_entity_info_still_transfers_into_the_inventory() {
+        let mut world = world_with_player(5);
+        let inventory = world
+            .borrow::<UniqueView<PlayerInfo>>()
+            .unwrap()
+            .inventory_entity_id;
+        let booster = world.add_entity((PropStackCount(1), PropHasRefs(true)));
+
+        apply_effect_batch(
+            &mut world,
+            vec![Effect::DropEntityInfo {
+                parent_entity_id: inventory,
+                dropped_entity_id: booster,
+            }],
+        );
+
+        assert!(world.borrow::<EntitiesView>().unwrap().is_alive(booster));
+        assert!(inventory_contains(&world, booster));
+        assert_eq!(
+            world
+                .borrow::<View<PropHasRefs>>()
+                .unwrap()
+                .get(booster)
+                .unwrap()
+                .0,
+            false
+        );
     }
 
     #[test]

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -5,7 +5,9 @@ import { GameServer } from "../src/index.js";
 import type { EntitySummary, UiElement } from "../src/types.js";
 import { crossEarthTrainingTripwire } from "./helpers/earth-tripwire.js";
 import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { teleportVerified } from "./helpers/teleport.js";
 import { clickUiElement } from "./helpers/ui.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
 import { fireOnce } from "./helpers/weapon.js";
 
 // Honest Earth Psionic Training regression for #548. Runtime ids are
@@ -131,6 +133,68 @@ function hitPoints(detail: Awaited<ReturnType<GameServer["entities"]["detail"]>>
   assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
   return Number(property.value);
 }
+
+test(
+  "VR world-frob consumes one Psi Booster without racing its automatic pickup",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8200),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    await crossEarthTrainingTripwire(
+      game,
+      PSIONIC_ENTRY_TRIPWIRE,
+      PSIONIC_ENTRY_DESTINATION,
+    );
+    assert.equal(psiPoints(await game.info()), 5);
+
+    const booster = await exactlyOne(game, PSI_BOOSTERS[0], "authored Psi Booster");
+    const [x, y, z] = (await game.entities.detail(booster.id)).position;
+    await teleportVerified(game, { x: x + 0.4, y: y + 1, z });
+    const livePosition = (await game.entities.detail(booster.id)).position;
+    const aim = await aimVrHandAt(game, livePosition, 0.25);
+    const handHit = await game.raycast({
+      start: aim.start,
+      end: aim.target,
+      collision_groups: ["entity", "selectable", "world", "raycast"],
+      max_distance: 1,
+      ignore_sensors: true,
+    });
+    assert.equal(
+      handHit.entity_id,
+      booster.id,
+      `the production hand ray must hit the booster: ${JSON.stringify(handHit)}`,
+    );
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 2 });
+
+    assert.equal(
+      psiPoints(await game.info()),
+      25,
+      `the booster should restore exactly 20 psi; messages=${JSON.stringify(
+        (await game.messages.recent()).messages.slice(-5),
+      )}`,
+    );
+    assert.equal(
+      (await game.entities.byTemplate(booster.template_id)).length,
+      0,
+      "the one-unit booster should be consumed exactly once",
+    );
+    assert.equal(
+      (await game.player.inventory()).items.filter((item) => item.name === "Psi Booster")
+        .length,
+      0,
+      "the stale automatic pickup must not add the consumed booster to the backpack",
+    );
+  },
+);
 
 test(
   "Earth Psionic Training reduces, refills, casts, and cleans up through real objectives",


### PR DESCRIPTION
## Summary

- ignore a stale DropEntityInfo when an earlier effect in the same Frob batch consumed the source entity
- preserve containment transfer, slot assignment, and reference hiding for live dropped entities
- cover the exact authored Earth VR Psi Booster interaction as well as the effect ordering in a focused unit regression

## Reproduction and cause

A world Frob on the one-unit Earth Psi Booster produces UsePsiKit followed by the generic MOVE action DropEntityInfo. On main, UsePsiKit restores PSI and destroys the booster; DropEntityInfo then attempts to mutate the now-dead entity and panics while adding PropHasRefs.

The negative-first production VR scenario reproduced that crash through the actual right-hand trigger and authored Earth booster. The fix makes the containment transfer a no-op when its source is no longer alive, while leaving valid live transfers unchanged.

## Verification

- cargo fmt --all -- --check
- RUSTFLAGS=-D warnings cargo check -p shock2vr -p desktop_runtime -p debug_runtime
- cargo test -p shock2vr — 616 passed
- npm test in tools/shock2-sdk — 26 passed, 220 skipped E2E cases
- Earth production-VR SDK scenario — 2 passed: world-booster regression plus the full psionic-training objective

This is gameplay-state handling only; it does not alter rendered output, so no visual artifacts are required.

Campaign: custom Earth→Ops · Navy-tech · 25th Anniversary assets · VR · seed 976894603

Fixes #957