### PR TITLE
feat(vr): use held consumables through authored actions

### DIFF
--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -276,7 +276,7 @@ impl VirtualHand {
                         msgs.push(VirtualHandEffect::OutMessage {
                             message: Message {
                                 to: entity_id,
-                                payload: MessagePayload::TriggerPull,
+                                payload: held_trigger_press_payload(world, entity_id),
                             },
                         });
                     }
@@ -508,6 +508,29 @@ fn get_held_position_orientation(
     vr_config::get_vr_hand_model_adjustments_from_entity(entity_id, world, handedness)
 }
 
+/// Translate a production VR trigger press into the held object's authored
+/// interaction. Retail consumables expose `inventory_action = SCRIPT`; using
+/// one from a hand must therefore send the same `Frob` their inventory UI
+/// would send. Weapons (including the Psi Amp) keep their dedicated trigger
+/// protocol even though the Weapon archetype also inherits that inventory
+/// flag. The decision stays tied to Dark's production frob metadata.
+fn held_trigger_press_payload(world: &World, entity_id: EntityId) -> MessagePayload {
+    let has_scripted_inventory_use = world
+        .borrow::<View<PropFrobInfo>>()
+        .map(|frob_info| {
+            frob_info
+                .get(entity_id)
+                .is_ok_and(|frob_info| frob_info.inventory_action.contains(FrobFlag::SCRIPT))
+        })
+        .unwrap_or(false);
+
+    if has_scripted_inventory_use && !is_wieldable_weapon(world, entity_id) {
+        MessagePayload::Frob
+    } else {
+        MessagePayload::TriggerPull
+    }
+}
+
 pub(crate) fn can_grab_item(world: &World, entity_id: EntityId) -> bool {
     let v_prop_frobinfo = world.borrow::<View<PropFrobInfo>>().unwrap();
 
@@ -591,5 +614,87 @@ fn resolve_hit_proxy_entity(world: &World, ray_cast_result: RayCastResult) -> Ra
     RayCastResult {
         maybe_entity_id: maybe_new_entity_id,
         ..ray_cast_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark::properties::{PropFrobInfo, PropPlayerGun};
+
+    fn scripted_inventory_use() -> PropFrobInfo {
+        PropFrobInfo {
+            world_action: FrobFlag::MOVE,
+            inventory_action: FrobFlag::SCRIPT,
+            tool_action: FrobFlag::empty(),
+        }
+    }
+
+    fn player_gun() -> PropPlayerGun {
+        PropPlayerGun {
+            flags: 0,
+            hand_model: "held_h".to_owned(),
+            icon_file: String::new(),
+            model_offset: vec3(0.0, 0.0, 0.0),
+            fire_offset: vec3(0.0, 0.0, 0.0),
+            heading: 0,
+            reload_pitch: 0,
+            reload_rate: 0,
+            gun_type: 0,
+        }
+    }
+
+    fn held_trigger_payload(world: &World, entity_id: EntityId) -> MessagePayload {
+        let hand = VirtualHand::new(Handedness::Right).grab_entity(world, entity_id);
+        let mut input = Hand::default();
+        input.squeeze_value = 1.0;
+        input.trigger_value = 1.0;
+
+        let (_, effects) = VirtualHand::update(
+            &hand,
+            &PhysicsWorld::new(),
+            world,
+            Vector3::zero(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            &input,
+        );
+
+        effects
+            .into_iter()
+            .find_map(|effect| match effect {
+                VirtualHandEffect::OutMessage { message } if message.to == entity_id => {
+                    Some(message.payload)
+                }
+                _ => None,
+            })
+            .expect("a rising trigger edge should message the actual held entity")
+    }
+
+    /// Negative-first regression for #958: a held retail consumable owns an
+    /// authored inventory SCRIPT action. The production VR trigger gesture
+    /// must request that same Frob action instead of weapon fire.
+    #[test]
+    fn held_scripted_inventory_item_uses_its_authored_frob_action() {
+        let mut world = World::new();
+        let booster = world.add_entity(scripted_inventory_use());
+
+        assert!(matches!(
+            held_trigger_payload(&world, booster),
+            MessagePayload::Frob
+        ));
+    }
+
+    /// Guns and the Psi Amp both carry PropPlayerGun, so their trigger must
+    /// continue reaching WeaponScript/PsiAmpScript as TriggerPull even though
+    /// their inherited inventory action is also SCRIPT.
+    #[test]
+    fn held_player_gun_preserves_trigger_pull() {
+        let mut world = World::new();
+        let weapon_or_psi_amp = world.add_entity((scripted_inventory_use(), player_gun()));
+
+        assert!(matches!(
+            held_trigger_payload(&world, weapon_or_psi_amp),
+            MessagePayload::TriggerPull
+        ));
     }
 }

--- a/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-psionic-training.e2e.test.ts
@@ -134,6 +134,198 @@ function hitPoints(detail: Awaited<ReturnType<GameServer["entities"]["detail"]>>
   return Number(property.value);
 }
 
+// Negative-first production-VR regression for #958. On the parent commit the
+// squeeze really holds mission object 275, but the holder trigger sends only
+// TriggerPull. PsiKitScript never sees its authored inventory Frob, leaving PSI
+// at five and the exact held entity alive. This test intentionally does not use
+// a direct Frob, Give, inventory-strip click, or debug vitals mutation.
+test(
+  "VR uses the actual held Earth Psi Booster through its authored inventory action",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8201),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    await crossEarthTrainingTripwire(
+      game,
+      PSIONIC_ENTRY_TRIPWIRE,
+      PSIONIC_ENTRY_DESTINATION,
+    );
+    assert.equal(
+      psiPoints(await game.info()),
+      5,
+      "the held-consumable regression starts from the authored course value",
+    );
+
+    const booster = await exactlyOne(game, PSI_BOOSTERS[0], "authored Psi Booster");
+    const boosterBodies = (await game.physics.bodies({ entityId: booster.id })).bodies;
+    assert.equal(boosterBodies.length, 1, "booster 275 must begin as one physical world item");
+    // MOVE pickups are dynamically instantiated one sixth of a Dark unit
+    // above PropPosition. Aim at the live body, not the authored transform;
+    // aiming at the latter passes underneath this tiny hypo collider.
+    const boosterPosition = boosterBodies[0].position;
+    // The three boosters are only 0.4 units apart along x. Stand on object
+    // 275's lower-x side so it is the first selectable body on this ray.
+    await teleportVerified(game, {
+      x: boosterPosition[0] - 1.5,
+      y: boosterPosition[1] - 0.42,
+      z: boosterPosition[2],
+    });
+    const handRay = await aimVrHandAt(game, boosterPosition, 0.15);
+    const hit = await game.raycast({
+      start: handRay.start,
+      end: handRay.target,
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      max_distance: 1,
+      ignore_sensors: true,
+    });
+    assert.equal(
+      hit.entity_id,
+      booster.id,
+      `the production hand ray must select booster 275: ${JSON.stringify({ booster, boosterBodies, handRay, hit, player: (await game.info()).player.position })}`,
+    );
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    const heldBeforeUse = await game.info();
+    assert.equal(
+      heldBeforeUse.player.right_hand_entity_id,
+      booster.id,
+      "the regression must use the actual entity held by the right VR hand",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some(
+        (item) => item.entity_id === booster.id && item.location === "right_hand",
+      ),
+      "the exact held booster must be part of the player's carried state",
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: booster.id })).bodies.length,
+      0,
+      "a genuinely held item must already be outside world-ray selection",
+    );
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+
+    const afterUse = await game.info();
+    const messageTrace = await game.messages.recent();
+    const heldItemMessages = messageTrace.messages.filter(
+      (message) => message.to.entity_id === booster.id,
+    );
+    assert.ok(
+      heldItemMessages.some((message) => message.payload === "Frob"),
+      "the holder trigger must route the authored inventory Frob to the exact held booster",
+    );
+    assert.ok(
+      !heldItemMessages.some((message) => message.payload === "TriggerPull"),
+      "a held consumable must not receive the weapon TriggerPull protocol",
+    );
+    assert.equal(
+      psiPoints(afterUse),
+      25,
+      "one holder-trigger gesture must restore exactly the retail 20 PSI",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(booster.template_id)).length,
+      0,
+      "using the one-unit mission object must consume that exact held entity",
+    );
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      null,
+      "canonical entity teardown must release the hand after consumption",
+    );
+    assert.ok(
+      !(await game.player.inventory()).items.some((item) => item.entity_id === booster.id),
+      "the consumed held id must leave all carried locations",
+    );
+    for (const remainingTemplate of PSI_BOOSTERS.slice(1)) {
+      assert.equal(
+        (await game.entities.byTemplate(remainingTemplate)).length,
+        1,
+        "using one held unit must not consume either neighboring course booster",
+      );
+    }
+
+    // Continue the room's authored VR lesson. This also proves that the
+    // generic consumable decision did not steal TriggerPull from the Psi Amp.
+    await game.input.set("right_hand.trigger", 0);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+
+    const amp = await exactlyOne(game, PSI_AMP, "authored Psi Amp");
+    const ampBodies = (await game.physics.bodies({ entityId: amp.id })).bodies;
+    assert.equal(ampBodies.length, 1, "the authored Psi Amp should be physically supplied");
+    const ampPosition = ampBodies[0].position;
+    await teleportVerified(game, {
+      x: ampPosition[0] - 1.5,
+      y: ampPosition[1] - 0.42,
+      z: ampPosition[2],
+    });
+    await aimVrHandAt(game, ampPosition, 0.18);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      amp.id,
+      "the production hand must hold the course's actual Psi Amp",
+    );
+
+    await game.input.trigger("CyclePsiPower");
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.selected_psi_power, "Cryokinesis");
+
+    const droid = await exactlyOne(game, TRAINING_DROID, "Training Droid");
+    const droidHpBefore = hitPoints(await game.entities.detail(droid.id));
+    const droidPosition = (await game.entities.detail(droid.id)).position;
+    await teleportVerified(game, {
+      x: droidPosition[0] - 4,
+      y: droidPosition[1],
+      z: droidPosition[2],
+    });
+    const droidAim = await game.player.aimAt(droid, {
+      hitbox: "torso",
+      // The VR projectile starts at the hand, not the camera. Stage the hand
+      // directly in front of the live torso below and let that production ray
+      // be the authoritative clearance check.
+      visibility: "unchecked",
+    });
+    await aimVrHandAt(game, droidAim.world_point, 0.45, 1);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 61 });
+    assert.equal(
+      psiPoints(await game.info()),
+      24,
+      "the held Psi Amp must preserve TriggerPull and spend one PSI on Cryokinesis",
+    );
+    assert.ok(
+      hitPoints(await game.entities.detail(droid.id)) < droidHpBefore,
+      "the real held-Amp cast must damage the course's Training Droid",
+    );
+
+    await crossEarthTrainingTripwire(
+      game,
+      PSIONIC_EXIT_TRIPWIRE,
+      PSIONIC_EXIT_DESTINATION,
+    );
+    const exited = await game.info();
+    assert.equal(exited.player.right_hand_entity_id, null);
+    assert.equal((await game.player.inventory()).count, 0);
+    assert.equal((await game.entities.byTemplate(PSI_AMP)).length, 0);
+    assert.equal((await game.entities.byTemplate(PSI_BOOSTERS[0])).length, 0);
+    for (const templateId of PSI_BOOSTERS.slice(1)) {
+      assert.equal((await game.entities.byTemplate(templateId)).length, 1);
+    }
+  },
+);
+
 test(
   "VR world-frob consumes one Psi Booster without racing its automatic pickup",
   { skip: !e2eEnabled, timeout: 600_000 },

--- a/tools/shock2-sdk/test/helpers/vr-hand.ts
+++ b/tools/shock2-sdk/test/helpers/vr-hand.ts
@@ -62,11 +62,13 @@ function quatFromTo(from: Vec3, to: Vec3): Quat {
   return quatNormalize([...cross(a, b), 1 + d]);
 }
 
-/** Aim the production VR hand ray at a world point without direct entity messages. */
+/** Aim the production VR hand ray at a world point without direct entity
+ * messages. Pass `squeeze = 1` to preserve an already-held item while aiming. */
 export async function aimVrHandAt(
   game: GameServer,
   target: Vec3,
   standOff = 0.45,
+  squeeze = 0,
 ): Promise<{ start: Vec3; target: Vec3 }> {
   const snapshot = await game.info();
   const pawn = snapshot.player.position;
@@ -90,7 +92,7 @@ export async function aimVrHandAt(
   await game.input.set("right_hand.position", localHand);
   await game.input.set("right_hand.rotation", localHandRotation);
   await game.input.set("right_hand.trigger", 0);
-  await game.input.set("right_hand.squeeze", 0);
+  await game.input.set("right_hand.squeeze", squeeze);
   await game.step({ frames: 3 });
   return { start: worldHand, target };
 }


### PR DESCRIPTION
## Summary

- route a held VR trigger press through an item's authored inventory `SCRIPT` action, so real held consumables receive `Frob`
- preserve `TriggerPull` for wieldable weapons and the Psi Amp
- cover the exact Earth object 275 production path: hand-grab it at 5 PSI, trigger once, restore exactly 20 PSI, consume that runtime entity, and leave the neighboring boosters intact
- continue through the authored Psi Amp/droid/exit lesson to guard the full Earth Psionic course

This is data-driven by `PropFrobInfo` plus the existing wieldable-weapon classification. It does not add a debug action, hard-code the Psi Booster template, or mutate PSI/inventory state outside the existing script/effect flow. The separate world-Frob race in #957 is intentionally out of scope.

Fixes #958

## Campaign context

`custom Earth→Ops · Navy-tech · 25th Anniversary assets · VR · seed 976894603`

## Validation

- `RUSTFLAGS="-D warnings" CARGO_TARGET_DIR=/Users/bryan/code/shock2quest2/target cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `CARGO_TARGET_DIR=/Users/bryan/code/shock2quest2/target cargo test -p shock2vr` — 616 passed
- `cd tools/shock2-sdk && npm test` — 26 passed, 220 opt-in E2E skipped
- production VR Earth Psi Booster regression — passed
- full Earth Psionic Training regression — passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Visual evidence

Deterministic headless debug-runtime capture (`/v1/step` + `/v1/screenshot`) of the real VR hand gesture. The loop starts with object 275 held at 5 PSI, then shows that exact instance disappear after one trigger press.

![VR-held Psi Booster use](https://gist.githubusercontent.com/tommy-xr/0e93fa4646b5120caa46bcd519865a5a/raw/c49e487496e7c338b713ae750ba679f5b622bb25/vr-psi-booster-use.gif)

Still after the gesture: the held booster is gone and the other two authored course boosters remain.

![Held Psi Booster consumed](https://gist.githubusercontent.com/tommy-xr/0e93fa4646b5120caa46bcd519865a5a/raw/c49e487496e7c338b713ae750ba679f5b622bb25/vr-psi-booster-used.png)

Matching `origin/main` → PR capture, driven by the same fixed-step request sequence. Runtime inspection alongside these frames recorded base `PSI 5 / held id still alive`; the PR recorded `PSI 25 / hand empty / exact id gone`.

![origin/main versus PR held Psi Booster result](https://gist.githubusercontent.com/tommy-xr/0e93fa4646b5120caa46bcd519865a5a/raw/c49e487496e7c338b713ae750ba679f5b622bb25/vr-psi-booster-before-after.png)

[Binary-safe source gist](https://gist.github.com/tommy-xr/0e93fa4646b5120caa46bcd519865a5a)
