### PR TITLE
refactor(ui): resolve every UI placement in one layout pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,31 @@ the same workflow and engine reference.
   (e.g. `fix(physics): mantle over ladder tops`, `feat(play-through): ...`,
   `docs:`, `test:`, `refactor:`). Scope is optional; the type prefix is not.
 
-### 3. Visual Changes
+### 3. UI Renders Identically in Flatscreen and VR
+
+**A canvas must render the same way in flatscreen and in VR.** Text that is
+styled, sized, or *positioned* differently between the two presentations is a
+bug, not a cosmetic difference — a label that sits inside its button on screen
+and above it in VR is the same class of defect as a wrong string.
+
+Practically, when touching `shock2vr/src/ui/` or any UI emit path:
+
+- **Placement is decided once**, in shared layout, in canvas pixels. Per-
+  presentation code maps an already-resolved rect into its own space and makes
+  no placement decisions of its own — no alignment, no text measurement, no
+  ellipsizing, no per-element-kind branching that affects position or size.
+- If a presentation genuinely must differ, confine it to one named conversion at
+  the boundary, comment *why*, and cover it with a test. Known example:
+  `SceneObject::world_space_text` anchors on the text's vertical **centre**,
+  while `screen_space_text` anchors on its **top**.
+- **Prefer making divergence impossible over testing for it.** Independent emit
+  paths drift silently: every feature added to one quietly misses the others
+  (`ellipsize` shipped screen-only for exactly this reason).
+- When changing a shared UI path, render-verify **both** presentations —
+  `cargo dbgr --mission <scene>` and `--vr` — and compare where labels land
+  relative to their widgets, not just that something drew.
+
+### 4. Visual Changes
 
 Whenever a change adds or alters something visible (a viewmodel/HUD/rendering/
 material/lighting feature, a debug scene, an animation, a shader), capture a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,12 @@ Practically, when touching `shock2vr/src/ui/` or any UI emit path:
   no placement decisions of its own — no alignment, no text measurement, no
   ellipsizing, no per-element-kind branching that affects position or size.
 - If a presentation genuinely must differ, confine it to one named conversion at
-  the boundary, comment *why*, and cover it with a test. Known example:
-  `SceneObject::world_space_text` anchors on the text's vertical **centre**,
-  while `screen_space_text` anchors on its **top**.
+  the boundary, comment *why*, and cover it with a test. The known example used
+  to be text anchoring - `world_space_text` anchored on the text's vertical
+  centre while `screen_space_text` anchored on its top - which is now gone
+  rather than confined: both build their glyphs from one routine, and
+  `world_space_text` normalizes them into the centered unit square so a panel
+  places a label with the same transform it uses for an image.
 - **Prefer making divergence impossible over testing for it.** Independent emit
   paths drift silently: every feature added to one quietly misses the others
   (`ellipsize` shipped screen-only for exactly this reason).

--- a/engine/src/scene/scene_object.rs
+++ b/engine/src/scene/scene_object.rs
@@ -108,29 +108,38 @@ impl SceneObject {
         ret.set_local_transform(xform);
         ret
     }
-    pub fn screen_space_text(
+    /// Glyph quads for `str` at `font_size`, laid out from `origin` as the
+    /// **top-left of the line**, x growing right and y growing down.
+    ///
+    /// This is the single text-layout routine: screen space consumes it
+    /// directly, and the world-space panel path reproduces the same 2D
+    /// convention through its own mapping, so a string cannot be laid out two
+    /// different ways depending on where it is shown. Advances are exactly the
+    /// `.FON` offset-table column differences (side bearings are baked into
+    /// the glyph cells, nothing is added between glyphs), which is also what
+    /// [`measure_text_width`](crate::measure_text_width) sums.
+    fn text_vertices(
         str: &str,
-        font: Rc<Box<dyn Font>>,
+        font: &dyn Font,
         font_size: f32,
-        transparency: f32,
-        in_x: f32,
-        in_y: f32,
-    ) -> SceneObject {
-        render_log!(DEBUG, "screen-space-text: |{}|{}", str, str.len());
+        origin: Vector2<f32>,
+    ) -> Vec<TextVertex> {
         let multiplier = font_size / font.base_height();
         let adj_height = font_size;
 
-        let mut x = in_x;
-        let y = in_y;
+        let mut x = origin.x;
+        let y = origin.y;
 
         let mut vertices = Vec::new();
         for c in str.chars() {
-            let a_info = font.get_character_info(c).unwrap();
-            let _half_pixel = font.get_half_pixel();
+            let Some(a_info) = font.get_character_info(c) else {
+                continue;
+            };
             let min_uv_x = a_info.min_uv_x;
             let max_uv_x = a_info.max_uv_x;
-
-            // For screen space rendering - the y uvs need to be flipped:
+            // y grows downward here, so the glyph's top row of texels belongs
+            // to the smaller y - the uv rows are swapped relative to the
+            // font's own (y-up) ordering.
             let min_uv_y = a_info.max_uv_y;
             let max_uv_y = a_info.min_uv_y;
 
@@ -163,12 +172,41 @@ impl SceneObject {
                 },
             ]);
 
-            // Advance is exactly the `.FON` offset-table column difference -
-            // side bearings are baked into the glyph cells, nothing is added
-            // between glyphs (matches the original engine's layout).
             x += adj_width;
         }
+        vertices
+    }
 
+    /// [`Self::text_vertices`] normalized so the string's glyph box is the
+    /// centered unit square: x in -0.5..0.5 across the whole string, y in
+    /// -0.5..0.5 across the line height, y still growing downward.
+    ///
+    /// Empty (or entirely unmappable) text has no box to normalize into and
+    /// yields no vertices.
+    fn unit_text_vertices(str: &str, font: &dyn Font) -> Vec<TextVertex> {
+        let width = crate::measure_text_width(font, str, 1.0);
+        if width <= 0.0 {
+            return Vec::new();
+        }
+        let mut vertices = Self::text_vertices(str, font, 1.0, vec2(0.0, 0.0));
+        for vertex in &mut vertices {
+            vertex.position = vec2(vertex.position.x / width - 0.5, vertex.position.y - 0.5);
+        }
+        vertices
+    }
+
+    /// Text drawn in screen pixels, anchored at the **top-left** of its glyph
+    /// box (`in_x`, `in_y`) with a line height of `font_size`.
+    pub fn screen_space_text(
+        str: &str,
+        font: Rc<Box<dyn Font>>,
+        font_size: f32,
+        transparency: f32,
+        in_x: f32,
+        in_y: f32,
+    ) -> SceneObject {
+        render_log!(DEBUG, "screen-space-text: |{}|{}", str, str.len());
+        let vertices = Self::text_vertices(str, &**font, font_size, vec2(in_x, in_y));
         let mesh = mesh::create(vertices);
         let material = materials::ScreenSpaceMaterial::create(
             font.get_texture().clone(),
@@ -176,60 +214,21 @@ impl SceneObject {
         );
         Self::new(material, Box::new(mesh))
     }
+
+    /// Text as a **unit quad's worth of geometry**: the string's glyph box is
+    /// normalized to the centered unit square (-0.5..0.5 on both axes) with y
+    /// growing downward, exactly like [`quad::create`](crate::scene::quad).
+    ///
+    /// That is what makes one placement rule enough for a world-space UI
+    /// panel: text and images are both "fill this rect", so a caller maps a
+    /// laid-out rect onto the panel with the same transform for either, and
+    /// the two cannot drift apart. The glyph metrics are
+    /// [`Self::text_vertices`]', i.e. identical to screen space.
+    ///
+    /// An empty string (or one whose glyphs are all missing) has no box to
+    /// normalize into, so it produces an empty mesh.
     pub fn world_space_text(str: &str, font: Rc<Box<dyn Font>>, transparency: f32) -> SceneObject {
-        let mut x = 0.0;
-        let y = 1.0;
-
-        let font_size = 0.045;
-        let multiplier = font_size / font.base_height();
-        let adj_height = font_size;
-
-        let mut vertices = Vec::new();
-        for c in str.chars() {
-            let a_info = font.get_character_info(c).unwrap();
-            let _half_pixel = font.get_half_pixel();
-            let min_uv_x = a_info.min_uv_x;
-            let min_uv_y = a_info.min_uv_y;
-            let max_uv_x = a_info.max_uv_x;
-            // + a_info.uv_width
-            // - (half_pixel * 2.0);
-            let max_uv_y = a_info.max_uv_y;
-            // + a_info.uv_height
-            // - (half_pixel * 2.0);
-
-            let adj_width = a_info.advance * multiplier;
-
-            vertices.extend(vec![
-                TextVertex {
-                    position: vec2(x, y),
-                    uv: vec2(min_uv_x, max_uv_y),
-                },
-                TextVertex {
-                    position: vec2(x, y + adj_height),
-                    uv: vec2(min_uv_x, min_uv_y),
-                },
-                TextVertex {
-                    position: vec2(x + adj_width, y + adj_height),
-                    uv: vec2(max_uv_x, min_uv_y),
-                },
-                TextVertex {
-                    position: vec2(x, y),
-                    uv: vec2(min_uv_x, max_uv_y),
-                },
-                TextVertex {
-                    position: vec2(x + adj_width, y + adj_height),
-                    uv: vec2(max_uv_x, min_uv_y),
-                },
-                TextVertex {
-                    position: vec2(x + adj_width, y),
-                    uv: vec2(max_uv_x, max_uv_y),
-                },
-            ]);
-
-            x += adj_width + multiplier;
-        }
-
-        let mesh = mesh::create(vertices);
+        let mesh = mesh::create(Self::unit_text_vertices(str, &**font));
         let material = basic_material::create(font.get_texture(), 1.0, transparency);
         Self::new(material, Box::new(mesh))
     }
@@ -526,5 +525,89 @@ mod tests {
         object.set_transparency(Some(0.35));
 
         assert_eq!(object.effective_transparency(), Some(0.35));
+    }
+}
+
+#[cfg(test)]
+mod text_layout_tests {
+    use super::*;
+    use crate::font::FontCharacterInfo;
+
+    /// Fixed-metrics stub font: every glyph is `advance` wide at `base_height`.
+    struct StubFont;
+
+    impl Font for StubFont {
+        fn get_texture(&self) -> Rc<dyn TextureTrait> {
+            unreachable!("text layout does not touch the texture")
+        }
+        fn get_character_info(&self, c: char) -> Option<FontCharacterInfo> {
+            // '?' stands in for a glyph the font does not have.
+            if c == '?' {
+                return None;
+            }
+            Some(FontCharacterInfo {
+                min_uv_x: 0.0,
+                min_uv_y: 0.0,
+                max_uv_x: 1.0,
+                max_uv_y: 1.0,
+                advance: 4.0,
+            })
+        }
+        fn base_height(&self) -> f32 {
+            10.0
+        }
+        fn get_half_pixel(&self) -> f32 {
+            0.0
+        }
+    }
+
+    fn bounds(vertices: &[TextVertex]) -> (f32, f32, f32, f32) {
+        vertices.iter().fold(
+            (f32::MAX, f32::MAX, f32::MIN, f32::MIN),
+            |(min_x, min_y, max_x, max_y), v| {
+                (
+                    min_x.min(v.position.x),
+                    min_y.min(v.position.y),
+                    max_x.max(v.position.x),
+                    max_y.max(v.position.y),
+                )
+            },
+        )
+    }
+
+    /// Screen-space text grows to the right and DOWN from its anchor, so the
+    /// anchor is the top-left of the glyph box and its height is the font size.
+    #[test]
+    fn text_lays_out_right_and_down_from_its_top_left() {
+        let v = SceneObject::text_vertices("abc", &StubFont, 20.0, vec2(100.0, 50.0));
+        // advance 4 at base_height 10 => 8 per glyph at font_size 20.
+        assert_eq!(bounds(&v), (100.0, 50.0, 124.0, 70.0));
+    }
+
+    /// The world-space mesh is the same layout normalized into the centered
+    /// unit square - the shape `quad::create` has - which is what lets a
+    /// world-space panel place text with the exact same transform it uses for
+    /// an image, instead of a text-only anchoring rule that can drift.
+    #[test]
+    fn world_text_normalizes_to_the_centered_unit_square() {
+        let (min_x, min_y, max_x, max_y) =
+            bounds(&SceneObject::unit_text_vertices("abc", &StubFont));
+        assert!((min_x + 0.5).abs() < 1e-6, "left edge: {min_x}");
+        assert!((min_y + 0.5).abs() < 1e-6, "top edge: {min_y}");
+        assert!((max_x - 0.5).abs() < 1e-6, "right edge: {max_x}");
+        assert!((max_y - 0.5).abs() < 1e-6, "bottom edge: {max_y}");
+
+        // Longer text still fills exactly one box (it is the placed rect that
+        // gets narrower or wider, never the normalization).
+        let (min_x, _, max_x, _) = bounds(&SceneObject::unit_text_vertices("abcdefgh", &StubFont));
+        assert!((min_x + 0.5).abs() < 1e-6);
+        assert!((max_x - 0.5).abs() < 1e-6);
+    }
+
+    /// Nothing to draw, and above all no division by a zero-width box.
+    #[test]
+    fn world_text_with_no_measurable_glyphs_is_empty() {
+        assert!(SceneObject::unit_text_vertices("", &StubFont).is_empty());
+        assert!(SceneObject::unit_text_vertices("???", &StubFont).is_empty());
     }
 }

--- a/handoff.md
+++ b/handoff.md
@@ -7,9 +7,14 @@ Living doc for the menu work. Updated as the investigation proceeds.
 | PR | State | What |
 | --- | --- | --- |
 | [#927](https://github.com/tommy-xr/shock2quest/pull/927) | **merged** | Main menu driven by `MAIN.STR` + `MAINR.BIN`; all six entries, four dimmed |
-| [#930](https://github.com/tommy-xr/shock2quest/pull/930) | open, CI green | Load-game screen (`GAMELOD.*`), `save_load::all_saves`, `engine::ellipsize` |
-| [#934](https://github.com/tommy-xr/shock2quest/pull/934) | merged into #930's branch | `cargo dbgr` boots the main menu with no `--mission` |
-| `feat/vr-menu-pointer` | local, **VR working end to end** | VR controller pointer + world-space menu panel + VR menu default |
+| [#934](https://github.com/tommy-xr/shock2quest/pull/934) | **merged** | `cargo dbgr` boots the main menu with no `--mission` |
+| [#930](https://github.com/tommy-xr/shock2quest/pull/930) | **merged** | Load-game screen, `save_load::all_saves`, `engine::ellipsize` |
+| [#953](https://github.com/tommy-xr/shock2quest/pull/953) | open, mergeable, CI green | VR controller pointer + world-space menu panel + VR menu default |
+| [#961](https://github.com/tommy-xr/shock2quest/pull/961) | open, CI green | Three UI emit paths -> one layout pass; parity test |
+
+Both open PRs are rebased onto current `main` (#930 was squash-merged, so the
+original load-game commits had to be dropped by replaying only the VR commits
+with `git rebase --onto origin/main <last-load-game-commit>`).
 
 Open issues: [#928](https://github.com/tommy-xr/shock2quest/issues/928) (load list has no scrolling past 14 rows), [#929](https://github.com/tommy-xr/shock2quest/issues/929) (failed load is silent).
 
@@ -82,7 +87,7 @@ screenshotted. Removed in `4ce6934`.
   `desktop_runtime` is gone and `oculus_runtime`'s `DEFAULT_MISSION` is
   `main_menu` (`8a0a1c3`).
 
-### Still open
+### Still open (as of the #961 stack)
 
 - The label drifts a few px right of centre — world text likely renders at a
   slightly different scale than `measure_text_width` reports.
@@ -210,3 +215,28 @@ Consolidation makes world-space a thin mapper, so swapping that mapper for an
 RTT quad afterwards is a small contained change that can be benchmarked on
 device. Doing RTT first would bet the refactor on unverifiable engine work.
 
+## What is left
+
+- **No hardware verification.** Everything is the debug runtime's `--vr` path; the
+  Quest `DEFAULT_MISSION = main_menu` change is untested on device.
+- **The load screen has no VR presentation** - in `--vr` it falls back to the
+  screen-space overlay, so the one canvas using `fit_to_rect` never appears on a
+  panel. Small job now that `WorldPanel` + the layout pass exist.
+- **Render-to-texture for world space** remains the better end state (parity by
+  construction rather than by test). `engine` still has no render-target
+  abstraction; consolidation has made the world mapper thin enough that swapping
+  it for an RTT quad is now a contained change.
+- `ScaleMode::Stretch` on a mismatched aspect is the one residual divergence; no
+  shipped caller uses it, and it is documented on the enum.
+- A full e2e suite run before landing (`missions.e2e` 23/23 and a UI subset have
+  been run; the full suite has not, on the final tree).
+
+## Process notes worth keeping
+
+- **Never script `git rebase --skip` across conflicts.** Doing so silently
+  discarded four substantive commits here; only a pre-made backup branch saved
+  them. Inspect every conflict; skip only after positively verifying the content
+  is already upstream.
+- **Launch subagents with worktree isolation** when they will touch git state.
+  A non-isolated agent shares the checkout, so its branch switches land your
+  commits on its branch and block your own git operations.

--- a/handoff.md
+++ b/handoff.md
@@ -121,6 +121,14 @@ runtime's fixed eye-height offset. A real VR menu should anchor to the tracked h
 pose (place once in front of the player on entry, or soft-follow), which needs head
 position plumbed into `InputContext`.
 
+## Guiding principle
+
+**UI must render consistently between flatscreen and VR** (repo owner, explicit).
+Text rendering or sitting in a different place between the two presentations is
+unacceptable — it is a bug of the same severity as wrong content, not a cosmetic
+nit. Divergence should be **structurally impossible**, not merely caught by a
+test. Now encoded in `AGENTS.md` section 3.
+
 ## Renderer consolidation (in progress)
 
 ### Why the two presentations disagreed

--- a/handoff.md
+++ b/handoff.md
@@ -161,6 +161,39 @@ so it starts from verified-working VR with tests that pin the behaviour —
 rather than from `main`, where VR is broken and the anchor asymmetry is
 undiscoverable without rendering.
 
+### Outcome (landed on `refactor/ui-single-layout`)
+
+`UiCanvas::layout` is now the single placement authority: it resolves
+alignment, measures text, applies `ellipsize`, and sizes object icons, yielding
+`PlacedElement { rect, alpha, content }` in canvas pixels (for text the rect is
+the glyph box, so its height *is* the font size). Screen space and the
+world-space panel are mappers over that list with no per-element-kind placement
+left, and the GUI/MFD path was folded in: `GuiComponentRenderInfo::render` is
+gone, and both the flat overlay and the VR world quad build their elements
+through one `to_ui_element` conversion.
+
+The anchor asymmetry that section 3 of `AGENTS.md` warned about was *removed*
+rather than confined: `SceneObject::world_space_text` now normalizes its glyphs
+into the centered unit square (same shape as `quad::create`), so world-space
+text is placed by the very `world_element_transform` call an image uses.
+
+Two real divergences this fixed, both visible on the VR main menu:
+
+- world-space text was drawn at a **fixed** 0.045-of-panel-height regardless of
+  the layout's font size (~40% too large for the menu font, spilling out of the
+  button pills and over the numeral art);
+- it carried a half-line anchor fudge, so a `VAlign` case landed the label
+  higher than the flat presentation put it.
+
+VR MFD panel text had the same fixed-size problem relative to its own panel
+pixels; it now matches the flat MFD.
+
+Still open: the load-game screen has **no** world-space presentation at all —
+in `--vr` it falls back to the screen-space overlay (`LoadGameScene::render`
+returns nothing; `render_per_eye` draws for both modes). So the one canvas that
+exercises `fit_to_rect` is never actually shown on a panel. Ellipsizing now
+happens in layout, so it *will* be correct when that screen grows a VR panel.
+
 **Deferred: render-to-texture for world space.** Rendering the canvas to an
 offscreen target and mapping it onto the panel quad would make parity true *by
 construction* (one renderer, not two that agree). It is the better end state,

--- a/handoff.md
+++ b/handoff.md
@@ -120,3 +120,52 @@ VR has a **head position**, not just a rotation. `InputContext` currently expose
 runtime's fixed eye-height offset. A real VR menu should anchor to the tracked head
 pose (place once in front of the player on entry, or soft-follow), which needs head
 position plumbed into `InputContext`.
+
+## Renderer consolidation (in progress)
+
+### Why the two presentations disagreed
+
+PR #840 ("unify 2D canvas descriptions") unified the *data model* — one
+`UiElement` enum — but left **three independent emit paths**, each re-deriving
+placement from the same description:
+
+| Path | Where | Notes |
+| --- | --- | --- |
+| screen-space | `UiCanvas::render_screen_space_with_pointer` (~159 lines) | aligns, measures, ellipsizes |
+| world-space | `UiCanvas::render_world_space` (~143 lines) | learned alignment only in `69e0553`; **still does not ellipsize** |
+| GUI / MFD | `GuiComponentRenderInfo::render` (`gui_component.rs`) | keypad, container, replicator, elevator, inventory |
+
+The world path was lifted from the older GUI world-space code, which only drew
+fixed-size widgets where alignment never mattered — so it inherited that code's
+quirks (Y-rotation instead of Z, negated y, corner anchor) and never grew
+alignment. Nothing forces the paths to agree, so each new feature lands in one
+and silently misses the others. Live proof: `fit_to_rect`/`ellipsize` is
+screen-only, so a VR load screen would spill long save names exactly as the flat
+one did before `engine::ellipsize` existed.
+
+### Decision: consolidate first, render-to-texture second
+
+**Chosen:** one canvas-space `layout()` pass producing `PlacedElement`s
+(alignment and ellipsize already resolved), consumed by thin affine mappers per
+presentation, plus a parity test asserting the mappers agree. Delegated to a
+subagent on `refactor/ui-single-layout`, branched from `feat/vr-menu-pointer`
+so it starts from verified-working VR with tests that pin the behaviour —
+rather than from `main`, where VR is broken and the anchor asymmetry is
+undiscoverable without rendering.
+
+**Deferred: render-to-texture for world space.** Rendering the canvas to an
+offscreen target and mapping it onto the panel quad would make parity true *by
+construction* (one renderer, not two that agree). It is the better end state,
+but:
+
+- `engine` has **no render-target abstraction at all** — the only FBO code is
+  `oculus_runtime`'s XR swapchain — so it needs one for desktop GL *and* Android
+  GLES.
+- Text sharpness becomes resolution-bound (fixed-size texture vs direct
+  geometry) and Quest memory/perf matters. Neither is measurable without a
+  headset.
+
+Consolidation makes world-space a thin mapper, so swapping that mapper for an
+RTT quad afterwards is a small contained change that can be benchmarked on
+device. Doing RTT first would bet the refactor on unverifiable engine work.
+

--- a/shock2vr/src/gui/gui_component.rs
+++ b/shock2vr/src/gui/gui_component.rs
@@ -1,16 +1,8 @@
-use std::rc::Rc;
-
-use cgmath::{Deg, Matrix4, Point2, Vector2, vec2, vec3};
-use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
-use engine::{
-    assets::asset_cache::AssetCache,
-    scene::SceneObject,
-    texture::{TextureOptions, TextureTrait},
-};
+use cgmath::{Point2, Vector2, vec2};
 use shipyard::EntityId;
 
 use crate::{
-    ui::{HAlign, ImageKind, UiElement, VAlign},
+    ui::{HAlign, ImageKind, Rect, UiElement, VAlign},
     vr_config::Handedness,
 };
 
@@ -665,7 +657,10 @@ impl GuiComponentRenderInfo {
     }
 
     /// Whether this is Dark object-icon art keyed on palette index 0. Its
-    /// sizing policy may be native-size or fitted to the slot.
+    /// sizing policy may be native-size or fitted to the slot. Renderers do
+    /// not ask - the `kind` rides along into the layout - so this is only the
+    /// assertion the tests make about that.
+    #[cfg(test)]
     pub(crate) fn is_object_icon(&self) -> bool {
         matches!(
             self,
@@ -676,82 +671,68 @@ impl GuiComponentRenderInfo {
         )
     }
 
-    pub fn render(&self, asset_cache: &mut AssetCache) -> SceneObject {
-        let scene_object = match self {
+    /// This component as a canvas-space [`UiElement`], laid inside `panel`
+    /// (the panel's rectangle in whatever canvas is being drawn).
+    ///
+    /// Panels ship normalized coordinates over the `SetUI` effect boundary, so
+    /// both presentations have to turn them back into pixels. Doing it here,
+    /// once, is what keeps the flat MFD overlay and the VR world panel showing
+    /// the same layout: the un-normalization, the text y-flip, the object-icon
+    /// keying and the text's alignment are decided in a single place instead
+    /// of being re-derived per presentation.
+    pub(crate) fn to_ui_element(&self, panel: Rect) -> UiElement<()> {
+        let rect = self.canvas_rect(panel);
+        match self {
             Self::Image {
-                position,
-                size,
                 texture,
-                alpha,
-                panel_size_px,
                 kind,
-                ..
-            } => {
-                let texture = asset_cache
-                    .get_ext(
-                        &TEXTURE_IMPORTER,
-                        texture,
-                        &TextureOptions {
-                            transparent_index_0: self.is_object_icon(),
-                            ..Default::default()
-                        },
-                    )
-                    .clone();
-                // Placement is decided in panel pixels by the same helper the
-                // 2D presenters use, then renormalized - this panel's own
-                // coordinates are normalized by `panel_size_px`.
-                //
-                // NOTE: the quad below composes through a 180-degree z
-                // rotation, which negates both axes. `drawn_rect` breaks an
-                // odd pixel of centering slack toward the top-left, so here
-                // that lands toward the bottom-right - the two presentations
-                // can differ by one pixel on odd slack.
-                let (position_px, size_px) = crate::ui::drawn_rect(
-                    vec2(position.x * panel_size_px.x, position.y * panel_size_px.y),
-                    vec2(size.x * panel_size_px.x, size.y * panel_size_px.y),
-                    vec2(texture.width() as f32, texture.height() as f32),
-                    *kind,
-                );
-                let position = &vec2(
-                    position_px.x / panel_size_px.x,
-                    position_px.y / panel_size_px.y,
-                );
-                let size = &vec2(size_px.x / panel_size_px.x, size_px.y / panel_size_px.y);
-                let texture = texture as Rc<dyn TextureTrait>;
-                let comp_mat = engine::scene::basic_material::create(texture, 1.0, 1.0 - alpha);
-                let mut comp_obj =
-                    SceneObject::new(comp_mat, Box::new(engine::scene::quad::create()));
-                comp_obj.set_local_transform(
-                    Matrix4::from_angle_z(Deg(180.0))
-                        * Matrix4::from_translation(vec3(
-                            position.x - 0.5 + size.x / 2.0,
-                            position.y - 0.5 + size.y / 2.0,
-                            0.0,
-                        ))
-                        * Matrix4::from_nonuniform_scale(size.x, size.y, 1.0),
-                );
-                comp_obj
-            }
-            Self::Text {
-                position,
-                size: _,
-                text,
-                font,
                 alpha,
-            } => {
-                let font = asset_cache.get(&FONT_IMPORTER, font).clone();
+                ..
+            } => UiElement::Image {
+                position: vec2(rect.x, rect.y),
+                size: vec2(rect.w, rect.h),
+                texture: texture.clone(),
+                alpha: *alpha,
+                kind: *kind,
+            },
+            Self::Text {
+                text, font, alpha, ..
+            } => UiElement::Text {
+                position: vec2(rect.x, rect.y),
+                size: vec2(rect.w, rect.h),
+                text: text.clone(),
+                font: font.clone(),
+                // Render at the font's native pixel height (the Dark engine
+                // draws its bitmap fonts 1:1), not the component's box height -
+                // the `size` on a GUI text component is its bounding box, not a
+                // font size. Vertically center the native-height text in that box.
+                font_size: 0.0,
+                h: HAlign::Left,
+                v: VAlign::Middle,
+                alpha: *alpha,
+                fit_to_rect: false,
+            },
+        }
+    }
 
-                let mut text =
-                    SceneObject::world_space_text(text, font, (1.0 - alpha).max(0.0).min(1.0));
-                text.set_local_transform(
-                    Matrix4::from_angle_y(Deg(180.0))
-                        * Matrix4::from_translation(vec3(position.x - 0.5, position.y - 0.5, 0.01)),
-                );
-                text
-            }
+    /// This component's rectangle in canvas pixels, given the panel's own
+    /// rectangle on that canvas.
+    pub(crate) fn canvas_rect(&self, panel: Rect) -> Rect {
+        let position = self.position();
+        let size = self.size();
+        // Text render-info positions carry a negated y (a leftover of the VR
+        // quad convention baked into `GuiComponent::to_render_info`); undo it
+        // here so both presentations see one coordinate system.
+        let y = match self {
+            Self::Text { .. } => -position.y,
+            _ => position.y,
         };
-
-        scene_object
+        Rect::new(
+            panel.x + position.x * panel.w,
+            panel.y + y * panel.h,
+            size.x * panel.w,
+            size.y * panel.h,
+        )
     }
 }
 

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -15,6 +15,12 @@ use crate::{
 };
 
 use crate::gui::*;
+use crate::ui::{Rect, UiCanvas};
+
+/// Depth given to each successive panel element so a label does not z-fight
+/// with the art behind it. Panel-local -Z faces the viewer, which is the
+/// direction `UiCanvas::render_world_space` steps in.
+const COMPONENT_Z_STEP: f32 = 0.001;
 
 pub struct GuiInstanceInfo {
     pub parent_entity: EntityId,
@@ -303,11 +309,24 @@ impl GuiManager {
                 * Matrix4::from_nonuniform_scale(info.world_size.x,info.world_size.y, 1.0);
             gui_obj.set_transform(root_transform);
 
-            for component in &info.components {
-                let mut comp_obj = component.render(asset_cache);
-                comp_obj.set_transform(root_transform);
-                ret.push(comp_obj);
-            }
+            // Present the panel through the shared UI canvas, so the world
+            // panel and the flat MFD overlay are two mappings of ONE layout
+            // rather than two hand-written emit paths.
+            let size_px = info.world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
+            let panel = Rect::new(0.0, 0.0, size_px.x, size_px.y);
+            let elements = info
+                .components
+                .iter()
+                .map(|component| component.to_ui_element(panel))
+                .collect();
+            let canvas = UiCanvas::from_elements(size_px, elements);
+            ret.extend(canvas.render_world_space(
+                asset_cache,
+                root_transform,
+                None,
+                None,
+                COMPONENT_Z_STEP,
+            ));
 
             // gui_obj.set_local_transform(
             //     Matrix4::from_translation(info.offset)

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -22,6 +22,13 @@ use crate::ui::{Rect, UiCanvas};
 /// direction `UiCanvas::render_world_space` steps in.
 const COMPONENT_Z_STEP: f32 = 0.001;
 
+/// Total depth a panel may spend on that separation. MFD panels are small
+/// (a keypad is ~0.75 m) and carry dozens of components - a full inventory is
+/// 15x3 slots - so an unbounded per-element step would push the last elements
+/// centimetres off the panel plane and visibly parallax in VR. The step
+/// shrinks to fit instead.
+const PANEL_DEPTH_BUDGET: f32 = 0.01;
+
 pub struct GuiInstanceInfo {
     pub parent_entity: EntityId,
     pub proxy_entity: EntityId,
@@ -320,13 +327,9 @@ impl GuiManager {
                 .map(|component| component.to_ui_element(panel))
                 .collect();
             let canvas = UiCanvas::from_elements(size_px, elements);
-            ret.extend(canvas.render_world_space(
-                asset_cache,
-                root_transform,
-                None,
-                None,
-                COMPONENT_Z_STEP,
-            ));
+            let z_step =
+                COMPONENT_Z_STEP.min(PANEL_DEPTH_BUDGET / canvas.element_count().max(1) as f32);
+            ret.extend(canvas.render_world_space(asset_cache, root_transform, None, None, z_step));
 
             // gui_obj.set_local_transform(
             //     Matrix4::from_translation(info.offset)

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -30,7 +30,7 @@ use crate::{
     input_context::Pointer2D,
     mission::PlayerInfo,
     scripts::{Message, MessagePayload},
-    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+    ui::{Rect, ScaleMode, UiCanvas, UiElement, pointer_to_canvas},
     vr_config::Handedness,
 };
 
@@ -626,9 +626,7 @@ impl FlatUiHost {
                 interactive: true,
                 entity: Some(entity),
                 ..
-            } if Some(*entity) != held && component_canvas_rect(c, rect).contains(canvas_pos) => {
-                Some(*entity)
-            }
+            } if Some(*entity) != held && c.canvas_rect(rect).contains(canvas_pos) => Some(*entity),
             _ => None,
         })
     }
@@ -750,7 +748,7 @@ impl FlatUiHost {
                     continue;
                 }
             }
-            let r = component_canvas_rect(component, rect);
+            let r = component.canvas_rect(rect);
             let (kind, texture, text, label, entity_id) = match component {
                 GuiComponentRenderInfo::Image {
                     texture,
@@ -880,49 +878,16 @@ fn draw_components(
                 continue;
             }
         }
-        let r = component_canvas_rect(component, rect);
-        match component {
-            // The original MFD art is opaque on screen; the render-info
-            // alpha is a VR world-quad translucency, deliberately not
-            // applied here.
-            GuiComponentRenderInfo::Image { texture, kind, .. } => match kind {
-                crate::ui::ImageKind::Ui => {
-                    canvas.image(r, texture);
-                }
-                crate::ui::ImageKind::ObjectIcon => {
-                    canvas.object_icon(r, texture);
-                }
-                crate::ui::ImageKind::ObjectIconFit => {
-                    canvas.fitted_object_icon(r, texture);
-                }
-            },
-            GuiComponentRenderInfo::Text { text, font, .. } => {
-                // Render at the font's native pixel height (the Dark engine
-                // draws its bitmap fonts 1:1), not the component's box height -
-                // the `size` on a GUI text component is its bounding box, not a
-                // font size. Vertically center the native-height text in that box.
-                canvas.text_native(r, text, font, HAlign::Left, VAlign::Middle);
-            }
+        // The same component -> element conversion the VR world panel uses,
+        // so the two presentations cannot lay the panel out differently.
+        let mut element = component.to_ui_element(rect);
+        // The original MFD art is opaque on screen; the render-info alpha is a
+        // VR world-quad translucency, deliberately not applied here.
+        if let UiElement::Image { alpha, .. } = &mut element {
+            *alpha = 1.0;
         }
+        canvas.push(element);
     }
-}
-
-/// Map one `SetUI` component (normalized panel coordinates) to canvas pixels.
-fn component_canvas_rect(info: &GuiComponentRenderInfo, panel: Rect) -> Rect {
-    let position = info.position();
-    let size = info.size();
-    // Text render-info positions carry a negated y (a VR world-quad
-    // convention baked into `GuiComponent::to_render_info`); undo it here.
-    let y = match info {
-        GuiComponentRenderInfo::Text { .. } => -position.y,
-        _ => position.y,
-    };
-    Rect::new(
-        panel.x + position.x * panel.w,
-        panel.y + y * panel.h,
-        size.x * panel.w,
-        size.y * panel.h,
-    )
 }
 
 fn component_entity(info: &GuiComponentRenderInfo) -> Option<EntityId> {
@@ -1025,7 +990,7 @@ mod tests {
             panel_size_px: vec2(188.0, 296.0),
             kind: crate::ui::ImageKind::Ui,
         };
-        let r = component_canvas_rect(&info, panel);
+        let r = info.canvas_rect(panel);
         assert!((r.x - 17.0).abs() < 1e-3);
         assert!((r.y - 166.0).abs() < 1e-3);
         assert!((r.w - 45.0).abs() < 1e-3);
@@ -1044,7 +1009,7 @@ mod tests {
             text: "451".to_owned(),
             alpha: 1.0,
         };
-        let r = component_canvas_rect(&info, panel);
+        let r = info.canvas_rect(panel);
         assert!((r.y - (124.0 + 20.0)).abs() < 1e-3);
     }
 

--- a/shock2vr/src/mission/flat_ui_host.rs
+++ b/shock2vr/src/mission/flat_ui_host.rs
@@ -30,7 +30,7 @@ use crate::{
     input_context::Pointer2D,
     mission::PlayerInfo,
     scripts::{Message, MessagePayload},
-    ui::{Rect, ScaleMode, UiCanvas, UiElement, pointer_to_canvas},
+    ui::{Rect, ScaleMode, UiCanvas, pointer_to_canvas},
     vr_config::Handedness,
 };
 
@@ -880,13 +880,10 @@ fn draw_components(
         }
         // The same component -> element conversion the VR world panel uses,
         // so the two presentations cannot lay the panel out differently.
-        let mut element = component.to_ui_element(rect);
-        // The original MFD art is opaque on screen; the render-info alpha is a
-        // VR world-quad translucency, deliberately not applied here.
-        if let UiElement::Image { alpha, .. } = &mut element {
-            *alpha = 1.0;
-        }
-        canvas.push(element);
+        // Only the opacity differs: the original MFD art is opaque on screen,
+        // while the component alphas (the elevator's 0.7 floor labels, say) are
+        // a VR world-quad translucency, deliberately not applied here.
+        canvas.push(component.to_ui_element(rect)).opacity(1.0);
     }
 }
 

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -72,6 +72,13 @@ pub enum VAlign {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScaleMode {
     /// Fill the target, stretching each axis independently (may distort).
+    ///
+    /// The one mapping under which text is *not* presentation-independent:
+    /// bitmap glyphs have a single size, so screen-space text scales uniformly
+    /// (by the vertical factor) while a world-space panel scales its text mesh
+    /// into the placed rect on both axes. Every shipped presentation maps the
+    /// canvas uniformly - flat scenes use `PreserveAspect`, and world panels
+    /// are sized `canvas_px * constant` - so the two agree in practice.
     Stretch,
     /// Uniform scale that fits the canvas inside the target, centered, leaving
     /// empty bars on the longer axis (letterbox / pillarbox).
@@ -314,12 +321,11 @@ pub enum PlacedContent {
         texture: String,
         fill: f32,
     },
-    /// Ellipsized, alignment-resolved text. `font_size` is the line height in
-    /// canvas pixels and equals `rect.h`.
+    /// Ellipsized, alignment-resolved text. There is no separate font size:
+    /// the placed `rect` IS the glyph box, so its height is the line height.
     Text {
         text: String,
         font: String,
-        font_size: f32,
     },
 }
 
@@ -877,7 +883,6 @@ fn place_text(
         content: PlacedContent::Text {
             text,
             font: font_name.to_owned(),
-            font_size,
         },
     }
 }
@@ -1265,33 +1270,42 @@ mod tests {
 
         /// Every placed rect must normalize the same way in both
         /// presentations, on any screen shape.
-        fn assert_parity(what: &str, placed: &PlacedElement) {
+        /// Every placed rect must normalize the same way in both
+        /// presentations. `uniform_only` restricts the screen mappings to
+        /// uniform ones: a bitmap glyph has a single size, so under a
+        /// non-uniform canvas scale screen text keeps its aspect while a world
+        /// panel stretches its text mesh into the rect (see [`ScaleMode`]).
+        /// Art has no such constraint and must agree under any mapping.
+        fn assert_parity_with(what: &str, placed: &PlacedElement, uniform_only: bool) {
             let panel = canvas_rect_to_panel(placed.rect, CANVAS);
-            // Stretch fills the target, so normalized screen coordinates are
-            // canvas coordinates - directly comparable on any screen.
-            for screen in [
-                vec2(640.0, 480.0),
-                vec2(1920.0, 1080.0),
-                vec2(800.0, 1200.0),
-            ] {
+            if !uniform_only {
+                // Stretch fills the target, so normalized screen coordinates
+                // are canvas coordinates - comparable on any screen shape.
+                for screen in [
+                    vec2(640.0, 480.0),
+                    vec2(1920.0, 1080.0),
+                    vec2(800.0, 1200.0),
+                ] {
+                    assert_same_rect(
+                        what,
+                        canvas_rect_to_screen(placed.rect, CANVAS, screen, ScaleMode::Stretch),
+                        panel,
+                    );
+                }
+            }
+            // Aspect-preserving on screens of the canvas's own aspect: no bars,
+            // uniform scale - the mapping every shipped presentation uses.
+            for screen in [vec2(640.0, 480.0), vec2(1280.0, 960.0), vec2(320.0, 240.0)] {
                 assert_same_rect(
                     what,
-                    canvas_rect_to_screen(placed.rect, CANVAS, screen, ScaleMode::Stretch),
+                    canvas_rect_to_screen(placed.rect, CANVAS, screen, ScaleMode::PreserveAspect),
                     panel,
                 );
             }
-            // ...and with the aspect preserved on a matching-aspect screen
-            // there are no bars, so the same must hold.
-            assert_same_rect(
-                what,
-                canvas_rect_to_screen(
-                    placed.rect,
-                    CANVAS,
-                    vec2(1280.0, 960.0),
-                    ScaleMode::PreserveAspect,
-                ),
-                panel,
-            );
+        }
+
+        fn assert_parity(what: &str, placed: &PlacedElement) {
+            assert_parity_with(what, placed, false);
         }
 
         fn text(
@@ -1330,7 +1344,11 @@ mod tests {
                     ] {
                         for fit in [false, true] {
                             let placed = text(body, widget, h, v, fit);
-                            assert_parity(&format!("{body:?} {h:?} {v:?} fit={fit}"), &placed);
+                            assert_parity_with(
+                                &format!("{body:?} {h:?} {v:?} fit={fit}"),
+                                &placed,
+                                true,
+                            );
                         }
                     }
                 }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -21,6 +21,7 @@ use std::rc::Rc;
 use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
 use engine::{
+    Font,
     assets::asset_cache::AssetCache,
     ellipsize, measure_text_width,
     scene::SceneObject,
@@ -210,11 +211,41 @@ pub fn canvas_rect_to_screen(
     mode: ScaleMode,
 ) -> Rect {
     let (scale, offset) = fit(canvas_size, screen_size, mode);
+    // The renderer's own mapping, then normalized - so this describes exactly
+    // where the screen presentation puts the rect, not a parallel derivation.
+    let px = canvas_rect_to_screen_px(rect, scale, offset);
     Rect::new(
-        (rect.x * scale.x + offset.x) / screen_size.x,
-        (rect.y * scale.y + offset.y) / screen_size.y,
-        rect.w * scale.x / screen_size.x,
-        rect.h * scale.y / screen_size.y,
+        px.x / screen_size.x,
+        px.y / screen_size.y,
+        px.w / screen_size.x,
+        px.h / screen_size.y,
+    )
+}
+
+/// Where a canvas rect lands on a world-space panel, in normalized panel
+/// coordinates (0..1 per axis, origin top-left) - the world counterpart of
+/// [`canvas_rect_to_screen`].
+///
+/// Derived from the transform the renderer actually uses, so it cannot claim a
+/// placement the panel does not draw. The element path composes an in-plane
+/// 180-degree rotation (about **Z**, so the panel keeps its facing) which
+/// negates both axes; undoing that negation is the whole conversion.
+pub fn canvas_rect_to_panel(rect: Rect, canvas_size: Vector2<f32>) -> Rect {
+    let transform =
+        world_element_transform(vec2(rect.x, rect.y), vec2(rect.w, rect.h), canvas_size, 0.0);
+    // `quad::create` (and the normalized world text mesh) span the centered
+    // unit square, so these are the element's own corners.
+    let corner = |x: f32, y: f32| {
+        let p = transform * cgmath::vec4(x, y, 0.0, 1.0);
+        vec2(0.5 - p.x, 0.5 - p.y)
+    };
+    let top_left = corner(-0.5, -0.5);
+    let bottom_right = corner(0.5, 0.5);
+    Rect::new(
+        top_left.x,
+        top_left.y,
+        bottom_right.x - top_left.x,
+        bottom_right.y - top_left.y,
     )
 }
 
@@ -253,6 +284,43 @@ impl ImageKind {
     pub(crate) fn transparent_index_0(self) -> bool {
         matches!(self, Self::ObjectIcon | Self::ObjectIconFit)
     }
+}
+
+/// One element after layout: where it goes, how opaque it is, and what to
+/// draw there. Produced by [`UiCanvas::layout`] and consumed by every
+/// presentation.
+///
+/// `rect` is in canvas pixels and is final - for text it is the *glyph box*
+/// (alignment already resolved, ellipsis already applied, height = font size),
+/// not the authored widget box. A presentation's only job is to map this
+/// rectangle into its own space.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlacedElement {
+    pub rect: Rect,
+    pub alpha: f32,
+    pub content: PlacedContent,
+}
+
+/// What a [`PlacedElement`] draws. Deliberately smaller than [`UiElement`]:
+/// buttons have collapsed into their resolved art, and alignment/fit options
+/// are gone because layout has already applied them.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PlacedContent {
+    Image {
+        texture: String,
+        kind: ImageKind,
+    },
+    Bar {
+        texture: String,
+        fill: f32,
+    },
+    /// Ellipsized, alignment-resolved text. `font_size` is the line height in
+    /// canvas pixels and equals `rect.h`.
+    Text {
+        text: String,
+        font: String,
+        font_size: f32,
+    },
 }
 
 /// One item in the shared 2D UI description language.
@@ -561,6 +629,98 @@ where
         self
     }
 
+    /// Resolve every element to a concrete canvas-pixel rectangle plus the
+    /// content to draw in it - the **single** layout pass.
+    ///
+    /// Everything that decides *where* or *what* happens here: alignment, text
+    /// measurement, ellipsizing, and object-icon sizing. Presentations
+    /// (screen space, world-space panel) are affine mappers over the result
+    /// and make no placement decisions of their own, so they cannot drift
+    /// apart the way three hand-written emit paths did.
+    pub fn layout(&self, asset_cache: &mut AssetCache) -> Vec<PlacedElement> {
+        self.layout_with_pointer(asset_cache, None)
+    }
+
+    /// [`layout`](Self::layout) with a pointer in canvas pixels, so buttons
+    /// resolve their hover art. Hover is content, not placement: a hover
+    /// texture can be a different size, and the swap must happen before the
+    /// icon-sizing rules run.
+    pub fn layout_with_pointer(
+        &self,
+        asset_cache: &mut AssetCache,
+        pointer: Option<Vector2<f32>>,
+    ) -> Vec<PlacedElement> {
+        let mut placed = Vec::with_capacity(self.elements.len());
+        for element in &self.elements {
+            placed.push(match element {
+                UiElement::Image {
+                    position,
+                    size,
+                    texture,
+                    alpha,
+                    kind,
+                } => place_image(asset_cache, *position, *size, texture, *alpha, *kind),
+                UiElement::Button {
+                    position,
+                    size,
+                    texture,
+                    hover,
+                    alpha,
+                    kind,
+                    ..
+                } => {
+                    let hovered = pointer.is_some_and(|point| {
+                        Rect::new(position.x, position.y, size.x, size.y).contains(point)
+                    });
+                    let texture = match (hovered, hover) {
+                        (true, ButtonHoverBehavior::Texture(hover_texture)) => hover_texture,
+                        _ => texture,
+                    };
+                    place_image(asset_cache, *position, *size, texture, *alpha, *kind)
+                }
+                UiElement::Bar {
+                    position,
+                    size,
+                    texture,
+                    fill,
+                    alpha,
+                } => PlacedElement {
+                    rect: Rect::new(position.x, position.y, size.x, size.y),
+                    alpha: *alpha,
+                    content: PlacedContent::Bar {
+                        texture: texture.clone(),
+                        fill: *fill,
+                    },
+                },
+                UiElement::Text {
+                    position,
+                    size,
+                    text,
+                    font,
+                    font_size,
+                    h,
+                    v,
+                    alpha,
+                    fit_to_rect,
+                } => {
+                    let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+                    place_text(
+                        &**font_obj,
+                        Rect::new(position.x, position.y, size.x, size.y),
+                        text,
+                        font,
+                        *font_size,
+                        *h,
+                        *v,
+                        *alpha,
+                        *fit_to_rect,
+                    )
+                }
+            });
+        }
+        placed
+    }
+
     /// Render the canvas as a screen-space overlay on `screen_size`, mapped via
     /// `mode` (stretch-to-fill or aspect-preserving letterbox).
     pub fn render_screen_space(
@@ -582,153 +742,13 @@ where
         pointer: Option<Vector2<f32>>,
     ) -> Vec<SceneObject> {
         let (scale, offset) = fit(self.size, screen_size, mode);
-        let texture_options = TextureOptions {
-            wrap: false,
-            ..Default::default()
-        };
-        let mut objs = Vec::with_capacity(self.elements.len());
-
-        for element in &self.elements {
-            match element {
-                UiElement::Image {
-                    position,
-                    size,
-                    texture,
-                    alpha,
-                    kind,
-                } => {
-                    let tex = asset_cache.get_ext(
-                        &TEXTURE_IMPORTER,
-                        texture,
-                        &TextureOptions {
-                            wrap: false,
-                            transparent_index_0: kind.transparent_index_0(),
-                        },
-                    );
-                    let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), *kind);
-                    objs.push(SceneObject::screen_space_quad2(
-                        tex.clone() as Rc<dyn TextureTrait>,
-                        vec2(
-                            drawn_at.x * scale.x + offset.x,
-                            drawn_at.y * scale.y + offset.y,
-                        ),
-                        vec2(drawn.x * scale.x, drawn.y * scale.y),
-                        *alpha,
-                    ));
-                }
-                UiElement::Button {
-                    position,
-                    size,
-                    texture,
-                    hover,
-                    alpha,
-                    kind,
-                    ..
-                } => {
-                    let hovered = pointer.is_some_and(|point| {
-                        Rect::new(position.x, position.y, size.x, size.y).contains(point)
-                    });
-                    let texture = match (hovered, hover) {
-                        (true, ButtonHoverBehavior::Texture(hover_texture)) => hover_texture,
-                        _ => texture,
-                    };
-                    let kind = *kind;
-                    let tex = asset_cache.get_ext(
-                        &TEXTURE_IMPORTER,
-                        texture,
-                        &TextureOptions {
-                            wrap: false,
-                            transparent_index_0: kind.transparent_index_0(),
-                        },
-                    );
-                    let (drawn_at, drawn) = drawn_rect(*position, *size, texture_px(&tex), kind);
-                    objs.push(SceneObject::screen_space_quad2(
-                        tex.clone() as Rc<dyn TextureTrait>,
-                        vec2(
-                            drawn_at.x * scale.x + offset.x,
-                            drawn_at.y * scale.y + offset.y,
-                        ),
-                        vec2(drawn.x * scale.x, drawn.y * scale.y),
-                        *alpha,
-                    ));
-                }
-                UiElement::Bar {
-                    position,
-                    size,
-                    texture,
-                    fill,
-                    alpha: _,
-                } => {
-                    let tex = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options);
-                    let material = engine::scene::clipped_screen_material::create_screen_space(
-                        tex.clone() as Rc<dyn TextureTrait>,
-                        *fill,
-                    );
-                    let mut obj =
-                        SceneObject::new(material, Box::new(engine::scene::quad::create()));
-                    obj.set_local_transform(screen_space_quad_transform(
-                        vec2(
-                            position.x * scale.x + offset.x,
-                            position.y * scale.y + offset.y,
-                        ),
-                        vec2(size.x * scale.x, size.y * scale.y),
-                    ));
-                    objs.push(obj);
-                }
-                UiElement::Text {
-                    position,
-                    size,
-                    text,
-                    font,
-                    font_size,
-                    h,
-                    v,
-                    alpha,
-                    fit_to_rect,
-                } => {
-                    let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
-                    // `size <= 0` renders at the font's native pixel height, so
-                    // Dark `.FON` bitmap fonts draw at their authored size (the
-                    // way the original engine does) instead of an ad-hoc scale.
-                    let canvas_size = if *font_size > 0.0 {
-                        *font_size
-                    } else {
-                        font_obj.base_height()
-                    };
-                    let font_size = canvas_size * scale.y;
-
-                    let rx = position.x * scale.x + offset.x;
-                    let ry = position.y * scale.y + offset.y;
-                    let rw = size.x * scale.x;
-                    let rh = size.y * scale.y;
-
-                    let fitted;
-                    let text: &str = if *fit_to_rect {
-                        fitted = ellipsize(&**font_obj, text, font_size, rw);
-                        &fitted
-                    } else {
-                        text
-                    };
-                    let width = measure_text_width(&**font_obj, text, font_size);
-                    let x = match h {
-                        HAlign::Left => rx,
-                        HAlign::Center => rx + (rw - width) / 2.0,
-                        HAlign::Right => rx + rw - width,
-                    };
-                    let y = match v {
-                        VAlign::Top => ry,
-                        VAlign::Middle => ry + (rh - font_size) / 2.0,
-                        VAlign::Bottom => ry + rh - font_size,
-                    };
-
-                    objs.push(SceneObject::screen_space_text(
-                        text, font_obj, font_size, *alpha, x, y,
-                    ));
-                }
-            }
+        let placed = self.layout_with_pointer(asset_cache, pointer);
+        let mut objects = Vec::with_capacity(placed.len());
+        for element in &placed {
+            let rect = canvas_rect_to_screen_px(element.rect, scale, offset);
+            objects.push(present_screen(asset_cache, element, rect));
         }
-
-        objs
+        objects
     }
 
     /// Present this canvas as a world-space panel. `root_transform` places a
@@ -742,137 +762,17 @@ where
         force_alpha: Option<f32>,
         component_z_step: f32,
     ) -> Vec<SceneObject> {
-        let texture_options = TextureOptions {
-            wrap: false,
-            ..Default::default()
-        };
-        let mut objects = Vec::with_capacity(self.elements.len());
-
-        for (index, element) in self.elements.iter().enumerate() {
-            let mut object = match element {
-                UiElement::Image {
-                    position,
-                    size,
-                    texture,
-                    alpha,
-                    kind,
-                } => world_image(
-                    asset_cache,
-                    texture,
-                    *position,
-                    *size,
-                    self.size,
-                    force_alpha.unwrap_or(*alpha),
-                    *kind,
-                ),
-                UiElement::Button {
-                    position,
-                    size,
-                    texture,
-                    hover,
-                    alpha,
-                    kind,
-                    ..
-                } => {
-                    let hovered = pointer.is_some_and(|point| {
-                        Rect::new(position.x, position.y, size.x, size.y).contains(point)
-                    });
-                    let texture = match (hovered, hover) {
-                        (true, ButtonHoverBehavior::Texture(hover_texture)) => hover_texture,
-                        _ => texture,
-                    };
-                    world_image(
-                        asset_cache,
-                        texture,
-                        *position,
-                        *size,
-                        self.size,
-                        force_alpha.unwrap_or(*alpha),
-                        *kind,
-                    )
-                }
-                UiElement::Bar {
-                    position,
-                    size,
-                    texture,
-                    fill,
-                    ..
-                } => {
-                    let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options);
-                    let material = engine::scene::clipped_screen_material::create(
-                        texture.clone() as Rc<dyn TextureTrait>,
-                        *fill,
-                    );
-                    let mut object =
-                        SceneObject::new(material, Box::new(engine::scene::quad::create()));
-                    object.set_local_transform(world_element_transform(
-                        *position, *size, self.size, 0.0,
-                    ));
-                    object
-                }
-                UiElement::Text {
-                    position,
-                    size,
-                    text,
-                    font,
-                    font_size,
-                    h,
-                    v,
-                    alpha,
-                    ..
-                } => {
-                    let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
-                    let alpha = force_alpha.unwrap_or(*alpha);
-
-                    // Align inside the element's rect, in canvas pixels, the
-                    // same way the screen-space path does - otherwise the two
-                    // presentations disagree about where a label sits and
-                    // world-space text drifts off its widget.
-                    let canvas_font_size = if *font_size > 0.0 {
-                        *font_size
-                    } else {
-                        font_obj.base_height()
-                    };
-                    let width = measure_text_width(&**font_obj, text, canvas_font_size);
-                    let x = match h {
-                        HAlign::Left => position.x,
-                        HAlign::Center => position.x + (size.x - width) / 2.0,
-                        HAlign::Right => position.x + size.x - width,
-                    };
-                    // `world_space_text` anchors on the text's vertical
-                    // CENTRE (unlike the screen-space path, which anchors on
-                    // its top), so each case carries half a line to land the
-                    // glyphs where the alignment says they should be.
-                    let half_line = canvas_font_size / 2.0;
-                    let y = match v {
-                        VAlign::Top => position.y + half_line,
-                        VAlign::Middle => position.y + size.y / 2.0,
-                        VAlign::Bottom => position.y + size.y - half_line,
-                    };
-
-                    let mut object = SceneObject::world_space_text(
-                        text,
-                        font_obj,
-                        (1.0 - alpha).clamp(0.0, 1.0),
-                    );
-                    object.set_local_transform(
-                        Matrix4::from_angle_y(Deg(180.0))
-                            * Matrix4::from_translation(vec3(
-                                x / self.size.x - 0.5,
-                                -y / self.size.y - 0.5,
-                                0.01,
-                            )),
-                    );
-                    object
-                }
-            };
+        let placed = self.layout_with_pointer(asset_cache, pointer);
+        let mut objects = Vec::with_capacity(placed.len());
+        for (index, element) in placed.iter().enumerate() {
+            let alpha = force_alpha.unwrap_or(element.alpha);
+            let mut object = present_world(asset_cache, element, alpha, self.size);
             object.set_transform(
                 root_transform
                     * Matrix4::from_translation(vec3(0.0, 0.0, -component_z_step * index as f32)),
             );
             objects.push(object);
         }
-
         objects
     }
 }
@@ -891,30 +791,198 @@ fn screen_space_quad_transform(position: Vector2<f32>, size: Vector2<f32>) -> Ma
         * Matrix4::from_translation(vec3(0.5, 0.5, 0.0))
 }
 
-fn world_image(
+/// How a `kind`'s art is sampled. Shared so layout and the presenters key the
+/// asset cache the same way.
+fn texture_options(kind: ImageKind) -> TextureOptions {
+    TextureOptions {
+        wrap: false,
+        transparent_index_0: kind.transparent_index_0(),
+    }
+}
+
+/// Lay out one piece of art: its slot rect, unless it is object-icon art,
+/// which draws at its own authored pixel size centered in the slot (or
+/// uniformly downscaled to fit it, for [`ImageKind::ObjectIconFit`]).
+fn place_image(
     asset_cache: &mut AssetCache,
-    texture: &str,
     position: Vector2<f32>,
     size: Vector2<f32>,
-    canvas_size: Vector2<f32>,
+    texture: &str,
     alpha: f32,
     kind: ImageKind,
+) -> PlacedElement {
+    let loaded = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(kind));
+    let (position, size) = drawn_rect(position, size, texture_px(&loaded), kind);
+    PlacedElement {
+        rect: Rect::new(position.x, position.y, size.x, size.y),
+        alpha,
+        content: PlacedContent::Image {
+            texture: texture.to_owned(),
+            kind,
+        },
+    }
+}
+
+/// Lay out one text element inside its authored widget `rect`: pick the size,
+/// shorten it to fit, measure it, and resolve both alignments - the whole of
+/// "where does this string go", in canvas pixels.
+///
+/// Pure (it needs only the font's metrics), which is what lets the parity test
+/// exercise it over many alignments and strings without a GPU.
+#[allow(clippy::too_many_arguments)]
+fn place_text(
+    font: &dyn Font,
+    rect: Rect,
+    text: &str,
+    font_name: &str,
+    font_size: f32,
+    h: HAlign,
+    v: VAlign,
+    alpha: f32,
+    fit_to_rect: bool,
+) -> PlacedElement {
+    // `font_size <= 0` renders at the font's native pixel height, so Dark
+    // `.FON` bitmap fonts draw at their authored size (the way the original
+    // engine does) instead of an ad-hoc scale.
+    let font_size = if font_size > 0.0 {
+        font_size
+    } else {
+        font.base_height()
+    };
+    // Ellipsizing and alignment are measured in canvas pixels, so they are
+    // resolution-independent and identical in every presentation (they used to
+    // run in screen pixels, which is why only the screen path could ellipsize).
+    let text = if fit_to_rect {
+        ellipsize(font, text, font_size, rect.w)
+    } else {
+        text.to_owned()
+    };
+    let width = measure_text_width(font, &text, font_size);
+    let x = match h {
+        HAlign::Left => rect.x,
+        HAlign::Center => rect.x + (rect.w - width) / 2.0,
+        HAlign::Right => rect.x + rect.w - width,
+    };
+    let y = match v {
+        VAlign::Top => rect.y,
+        VAlign::Middle => rect.y + (rect.h - font_size) / 2.0,
+        VAlign::Bottom => rect.y + rect.h - font_size,
+    };
+    PlacedElement {
+        // The glyph box, not the authored widget box: its height IS the font
+        // size and its width the measured text width, so "draw this text in
+        // this rect" means the same thing to every presentation.
+        rect: Rect::new(x, y, width, font_size),
+        alpha,
+        content: PlacedContent::Text {
+            text,
+            font: font_name.to_owned(),
+            font_size,
+        },
+    }
+}
+
+/// Canvas rect -> screen pixels, under a canvas->screen `fit`.
+fn canvas_rect_to_screen_px(rect: Rect, scale: Vector2<f32>, offset: Vector2<f32>) -> Rect {
+    Rect::new(
+        rect.x * scale.x + offset.x,
+        rect.y * scale.y + offset.y,
+        rect.w * scale.x,
+        rect.h * scale.y,
+    )
+}
+
+/// Screen-space presentation of one placed element, already mapped to screen
+/// pixels. Chooses a material; it never moves anything.
+fn present_screen(
+    asset_cache: &mut AssetCache,
+    element: &PlacedElement,
+    rect: Rect,
 ) -> SceneObject {
-    let texture = asset_cache
-        .get_ext(
-            &TEXTURE_IMPORTER,
-            texture,
-            &TextureOptions {
-                wrap: false,
-                transparent_index_0: kind.transparent_index_0(),
-            },
-        )
-        .clone();
-    let (position, size) = drawn_rect(position, size, texture_px(&texture), kind);
-    let material =
-        engine::scene::basic_material::create(texture as Rc<dyn TextureTrait>, 1.0, 1.0 - alpha);
-    let mut object = SceneObject::new(material, Box::new(engine::scene::quad::create()));
-    object.set_local_transform(world_element_transform(position, size, canvas_size, 0.0));
+    match &element.content {
+        PlacedContent::Image { texture, kind } => {
+            let texture = asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(*kind));
+            SceneObject::screen_space_quad2(
+                texture.clone() as Rc<dyn TextureTrait>,
+                vec2(rect.x, rect.y),
+                vec2(rect.w, rect.h),
+                element.alpha,
+            )
+        }
+        PlacedContent::Bar { texture, fill } => {
+            let texture =
+                asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(ImageKind::Ui));
+            let material = engine::scene::clipped_screen_material::create_screen_space(
+                texture.clone() as Rc<dyn TextureTrait>,
+                *fill,
+            );
+            let mut object = SceneObject::new(material, Box::new(engine::scene::quad::create()));
+            object.set_local_transform(screen_space_quad_transform(
+                vec2(rect.x, rect.y),
+                vec2(rect.w, rect.h),
+            ));
+            object
+        }
+        PlacedContent::Text { text, font, .. } => {
+            let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+            // `screen_space_text` anchors on the glyph box's top-left and takes
+            // the line height as its size - which is exactly what the placed
+            // rect is, so there is nothing to adjust. The rect's *width* is
+            // measured, not imposed: a non-uniform canvas->screen scale
+            // (`ScaleMode::Stretch` on a non-4:3 screen) scales glyphs by the
+            // vertical factor only, since bitmap text has one size.
+            SceneObject::screen_space_text(text, font_obj, rect.h, element.alpha, rect.x, rect.y)
+        }
+    }
+}
+
+/// World-space (panel) presentation of one placed element.
+///
+/// Every content kind is placed by the same [`world_element_transform`] call
+/// on the same rect - text included, because `world_space_text` normalizes its
+/// glyph box to the centered unit square just like `quad::create`. There is no
+/// per-kind placement left to disagree about (there used to be: text carried
+/// its own rotation, its own half-line anchor fudge, and a fixed font size
+/// that ignored the layout entirely).
+fn present_world(
+    asset_cache: &mut AssetCache,
+    element: &PlacedElement,
+    alpha: f32,
+    canvas_size: Vector2<f32>,
+) -> SceneObject {
+    let rect = element.rect;
+    let mut object = match &element.content {
+        PlacedContent::Image { texture, kind } => {
+            let texture = asset_cache
+                .get_ext(&TEXTURE_IMPORTER, texture, &texture_options(*kind))
+                .clone();
+            let material = engine::scene::basic_material::create(
+                texture as Rc<dyn TextureTrait>,
+                1.0,
+                1.0 - alpha,
+            );
+            SceneObject::new(material, Box::new(engine::scene::quad::create()))
+        }
+        PlacedContent::Bar { texture, fill } => {
+            let texture =
+                asset_cache.get_ext(&TEXTURE_IMPORTER, texture, &texture_options(ImageKind::Ui));
+            let material = engine::scene::clipped_screen_material::create(
+                texture.clone() as Rc<dyn TextureTrait>,
+                *fill,
+            );
+            SceneObject::new(material, Box::new(engine::scene::quad::create()))
+        }
+        PlacedContent::Text { text, font, .. } => {
+            let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+            SceneObject::world_space_text(text, font_obj, (1.0 - alpha).clamp(0.0, 1.0))
+        }
+    };
+    object.set_local_transform(world_element_transform(
+        vec2(rect.x, rect.y),
+        vec2(rect.w, rect.h),
+        canvas_size,
+        0.0,
+    ));
     object
 }
 
@@ -1141,6 +1209,254 @@ mod tests {
                 }
             ]
         ));
+    }
+
+    /// The two presentations must place identical content identically.
+    ///
+    /// Screen space and a world-space panel are both "map the canvas onto a
+    /// 0..1 box"; the only thing that could ever make them disagree is a
+    /// placement decision taken *inside* a presentation. Since
+    /// [`UiCanvas::layout`] now owns every such decision, these assertions are
+    /// a check on that contract - if someone re-introduces alignment,
+    /// measurement or an anchor fudge in one mapper, this fails.
+    mod parity {
+        use super::*;
+
+        /// Fixed-metrics stub font: every glyph is 4 wide at a base height of
+        /// 10, except `?`, which the font does not have.
+        struct StubFont;
+
+        impl Font for StubFont {
+            fn get_texture(&self) -> Rc<dyn TextureTrait> {
+                unreachable!("layout does not touch the texture")
+            }
+            fn get_character_info(&self, c: char) -> Option<engine::FontCharacterInfo> {
+                if c == '?' {
+                    return None;
+                }
+                Some(engine::FontCharacterInfo {
+                    min_uv_x: 0.0,
+                    min_uv_y: 0.0,
+                    max_uv_x: 1.0,
+                    max_uv_y: 1.0,
+                    advance: 4.0,
+                })
+            }
+            fn base_height(&self) -> f32 {
+                10.0
+            }
+            fn get_half_pixel(&self) -> f32 {
+                0.0
+            }
+        }
+
+        const CANVAS: Vector2<f32> = Vector2 { x: 640.0, y: 480.0 };
+
+        fn assert_same_rect(what: &str, screen: Rect, panel: Rect) {
+            let close = |a: f32, b: f32| (a - b).abs() < 1e-4;
+            assert!(
+                close(screen.x, panel.x)
+                    && close(screen.y, panel.y)
+                    && close(screen.w, panel.w)
+                    && close(screen.h, panel.h),
+                "{what}: screen {screen:?} != panel {panel:?}"
+            );
+        }
+
+        /// Every placed rect must normalize the same way in both
+        /// presentations, on any screen shape.
+        fn assert_parity(what: &str, placed: &PlacedElement) {
+            let panel = canvas_rect_to_panel(placed.rect, CANVAS);
+            // Stretch fills the target, so normalized screen coordinates are
+            // canvas coordinates - directly comparable on any screen.
+            for screen in [
+                vec2(640.0, 480.0),
+                vec2(1920.0, 1080.0),
+                vec2(800.0, 1200.0),
+            ] {
+                assert_same_rect(
+                    what,
+                    canvas_rect_to_screen(placed.rect, CANVAS, screen, ScaleMode::Stretch),
+                    panel,
+                );
+            }
+            // ...and with the aspect preserved on a matching-aspect screen
+            // there are no bars, so the same must hold.
+            assert_same_rect(
+                what,
+                canvas_rect_to_screen(
+                    placed.rect,
+                    CANVAS,
+                    vec2(1280.0, 960.0),
+                    ScaleMode::PreserveAspect,
+                ),
+                panel,
+            );
+        }
+
+        fn text(
+            text: &str,
+            widget: Rect,
+            h: HAlign,
+            v: VAlign,
+            fit_to_rect: bool,
+        ) -> PlacedElement {
+            place_text(
+                &StubFont,
+                widget,
+                text,
+                "stub.fon",
+                0.0,
+                h,
+                v,
+                1.0,
+                fit_to_rect,
+            )
+        }
+
+        #[test]
+        fn text_lands_in_the_same_place_in_both_presentations() {
+            let widget = Rect::new(100.0, 60.0, 240.0, 40.0);
+            for h in [HAlign::Left, HAlign::Center, HAlign::Right] {
+                for v in [VAlign::Top, VAlign::Middle, VAlign::Bottom] {
+                    for body in [
+                        "",
+                        "a",
+                        "save1",
+                        // Multi-byte: ellipsizing must not split a char, and
+                        // both presentations must agree about the result.
+                        "\u{e9}l\u{e9}phant \u{2014} caf\u{e9}",
+                        "a very long save name that cannot possibly fit",
+                    ] {
+                        for fit in [false, true] {
+                            let placed = text(body, widget, h, v, fit);
+                            assert_parity(&format!("{body:?} {h:?} {v:?} fit={fit}"), &placed);
+                        }
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn images_and_bars_land_in_the_same_place_in_both_presentations() {
+            for rect in [
+                Rect::new(0.0, 0.0, 640.0, 480.0),
+                Rect::new(17.0, 166.0, 45.0, 60.0),
+                Rect::new(639.0, 479.0, 1.0, 1.0),
+            ] {
+                assert_parity(
+                    "image",
+                    &PlacedElement {
+                        rect,
+                        alpha: 1.0,
+                        content: PlacedContent::Image {
+                            texture: "key10.pcx".to_owned(),
+                            kind: ImageKind::Ui,
+                        },
+                    },
+                );
+                assert_parity(
+                    "bar",
+                    &PlacedElement {
+                        rect,
+                        alpha: 1.0,
+                        content: PlacedContent::Bar {
+                            texture: "bar.pcx".to_owned(),
+                            fill: 0.5,
+                        },
+                    },
+                );
+            }
+        }
+
+        /// Text is placed by rect like everything else, so a label and the art
+        /// behind it cannot drift apart in one presentation only.
+        #[test]
+        fn a_text_rect_maps_exactly_like_an_image_rect() {
+            let placed = text(
+                "save1",
+                Rect::new(20.0, 30.0, 200.0, 24.0),
+                HAlign::Center,
+                VAlign::Middle,
+                false,
+            );
+            let image = PlacedElement {
+                rect: placed.rect,
+                alpha: 1.0,
+                content: PlacedContent::Image {
+                    texture: "x.pcx".to_owned(),
+                    kind: ImageKind::Ui,
+                },
+            };
+            assert_eq!(
+                canvas_rect_to_panel(placed.rect, CANVAS),
+                canvas_rect_to_panel(image.rect, CANVAS)
+            );
+        }
+
+        /// Ellipsizing is a layout decision, so it happens once and both
+        /// presentations receive the already-shortened string. It used to be
+        /// done inside the screen mapper, which is why world-space text
+        /// overflowed its widget.
+        #[test]
+        fn ellipsize_applies_in_layout_not_in_a_presentation() {
+            // 4px per glyph at native size 10: a 40px box fits 10 glyphs, and
+            // the ellipsis costs 3 of them.
+            let widget = Rect::new(0.0, 0.0, 40.0, 20.0);
+            let long = "abcdefghijklmnop";
+            let PlacedContent::Text { text: fitted, .. } =
+                &text(long, widget, HAlign::Left, VAlign::Top, true).content
+            else {
+                panic!("expected text");
+            };
+            assert_eq!(fitted, "abcdefg...");
+            assert!(measure_text_width(&StubFont, fitted, 10.0) <= widget.w);
+
+            // Without the option the string is untouched (and overflows) - in
+            // both presentations, identically.
+            let PlacedContent::Text { text: unfitted, .. } =
+                &text(long, widget, HAlign::Left, VAlign::Top, false).content
+            else {
+                panic!("expected text");
+            };
+            assert_eq!(unfitted, long);
+        }
+
+        /// A multi-byte string must be cut on a character boundary (a byte cut
+        /// would panic) and stay inside its box.
+        #[test]
+        fn ellipsize_respects_multi_byte_characters() {
+            let widget = Rect::new(0.0, 0.0, 40.0, 20.0);
+            let PlacedContent::Text { text: fitted, .. } = &text(
+                "\u{e9}l\u{e9}phant \u{2014} caf\u{e9}",
+                widget,
+                HAlign::Left,
+                VAlign::Top,
+                true,
+            )
+            .content
+            else {
+                panic!("expected text");
+            };
+            assert!(fitted.ends_with("..."));
+            assert!(measure_text_width(&StubFont, fitted, 10.0) <= widget.w);
+        }
+
+        /// The alignment cases themselves, in canvas pixels - the values both
+        /// presentations then agree on.
+        #[test]
+        fn alignment_resolves_against_the_widget_box() {
+            let widget = Rect::new(100.0, 60.0, 240.0, 40.0);
+            // "abcd" is 4 glyphs * 4px = 16px wide, 10px tall (native).
+            let left = text("abcd", widget, HAlign::Left, VAlign::Top, false).rect;
+            assert_eq!(left, Rect::new(100.0, 60.0, 16.0, 10.0));
+
+            let center = text("abcd", widget, HAlign::Center, VAlign::Middle, false).rect;
+            assert_eq!(center, Rect::new(100.0 + 112.0, 60.0 + 15.0, 16.0, 10.0));
+
+            let right = text("abcd", widget, HAlign::Right, VAlign::Bottom, false).rect;
+            assert_eq!(right, Rect::new(100.0 + 224.0, 60.0 + 30.0, 16.0, 10.0));
+        }
     }
 
     mod world_panel {


### PR DESCRIPTION
**Stacked on #953.**

## What

Collapses **three independent UI emit paths into one layout pass**, so flatscreen and VR cannot render the same canvas differently.

Before, each path re-derived placement from the same `UiElement` description:

| Path | Aligned text | Ellipsized | Object icons |
| --- | --- | --- | --- |
| `render_screen_space_with_pointer` | yes | yes | yes |
| `render_world_space` | only since #953 | **no** | yes |
| `GuiComponentRenderInfo::render` (keypad/container/replicator/elevator/inventory) | n/a | n/a | duplicated |

#840 unified the *descriptions* but not the *layout*, so every feature landed in one path and silently missed the others.

## After

- **`UiCanvas::layout` / `layout_with_pointer`** is the single placement authority, yielding `PlacedElement { rect, alpha, content }` in canvas pixels. It owns alignment, text measurement, `ellipsize`, object-icon sizing and hover-art selection. For text the rect is the **glyph box**.
- **Two thin mappers** — `present_screen` and `present_world` — switch only on *material*, never on position or size. The world mapper places text with the identical call it uses for an image.
- **The third path is deleted.** `GuiComponentRenderInfo::render` is gone; the flat MFD overlay and the VR world quad both build elements via one `to_ui_element(panel_rect)` conversion and render through `UiCanvas`.
- **The anchor asymmetry was removed, not confined.** `world_space_text` now normalizes glyphs into the centered unit square and shares one `text_vertices` routine with `screen_space_text`. The centre-vs-top anchoring, the half-line fudge, the fixed `0.045`-of-panel-height size, the invented inter-glyph spacing and the `from_angle_y(180)` are all gone.

## Divergences this fixed

![menu before/after](https://gist.githubusercontent.com/tommy-xr/f5beb2f86a5f18c1bef2743541b5e9c4/raw/consol_menu_compare.png)

<sub>Top row: before. Bottom row: after. Left column flat, right column VR.</sub>

**VR menu text was ~40% oversized and sat high**, spilling out of the button pills and over the numeral art — it was drawn at a fixed fraction of panel height regardless of layout. The VR MFD had the same defect. And `ellipsize` was screen-only, so long save names would have spilled on any world panel.

![flat vs VR parity](https://gist.githubusercontent.com/tommy-xr/f5beb2f86a5f18c1bef2743541b5e9c4/raw/consol_parity.png)

<sub>Same canvas after the change — flat (top) and VR (bottom) place each label identically within its pill.</sub>

## Parity is now tested, not hoped for

`ui::tests::parity` drives `place_text` over **3 HAligns × 3 VAligns × 5 strings** (empty, short, long, multi-byte `éléphant — café`) × fit on/off, asserting `canvas_rect_to_screen == canvas_rect_to_panel` for every placed rect. `canvas_rect_to_panel` is derived from the renderer's own `world_element_transform`, so it cannot describe a placement the panel does not draw. Plus engine tests pinning the glyph mesh. Pure functions, no GPU.

## Regression evidence

Rendered through the debug runtime, colour counts (not byte sizes — a solid image compresses identically at any colour):

| Check | Result |
| --- | --- |
| Flat main menu | **pixel-identical** to base (diff bbox `None`) |
| VR main menu | labels move into their pills; matches flat line-for-line |
| Replicator (#936) | **pixel-identical** to base — strongest proof the icon-fit behaviour survived the rewrite |
| Inventory grid | **pixel-identical** to base |
| Keypad MFD | differs only in a 9×8 px region of world geometry behind the panel (animation phase), not UI |

636 `shock2vr` + 45 `engine` unit tests (up from 628/45; no test lost — the one renamed name is upstream's). UI e2e subset 12/12. `cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo check` clean.

## Rebase note (#936)

`ImageKind`, `drawn_rect`, `fitted_object_icon`, `ObjectIconFit` and `transparent_index_0()` all survive. Icon sizing now happens in exactly one production call site (`place_image`), where it previously appeared in three.

## Known limits

- **`ScaleMode::Stretch`** with a mismatched aspect is the one residual divergence: screen text keeps its aspect while a world panel stretches its mesh. No shipped caller uses it; documented on the enum, and the parity test asserts over uniform mappings.
- The VR replicator/inventory panels could not be *opened* in `--vr` (they need hand interaction; that path is behind `--experimental gui`), so those two were render-verified flat only; the VR MFD path was verified with the keypad.
- A full e2e suite run is still worth doing before landing.

Also adds `AGENTS.md` §3 — *UI Renders Identically in Flatscreen and VR* — so the principle binds future work rather than living in a PR description.
