### PR TITLE
fix(vr): arbitrate world panel presses per hand

### DIFF
--- a/shock2vr/src/gui/gui_script.rs
+++ b/shock2vr/src/gui/gui_script.rs
@@ -19,7 +19,7 @@ where
     cursor: Point2<f32>,
     gui: Box<dyn Gui<TState, TMsg>>,
     state: TState,
-    last_input_info: Option<GuiInputInfo>,
+    last_input_info_by_hand: [Option<GuiInputInfo>; 2],
     last_cursor: Option<GuiCursor>,
 }
 
@@ -34,7 +34,7 @@ where
             cursor: point2(0.0, 0.0),
             gui,
             state: TState::default(),
-            last_input_info: None,
+            last_input_info_by_hand: [None, None],
             last_cursor: None,
         }
     }
@@ -168,8 +168,12 @@ where
                 self.last_cursor = cursor_obj;
 
                 // Is the UI going to generate an event, based on the input state?
+                let hand_index = match hand {
+                    crate::vr_config::Handedness::Left => 0,
+                    crate::vr_config::Handedness::Right => 1,
+                };
                 let mut maybe_output_event = None;
-                if let Some(last) = &self.last_input_info {
+                if let Some(last) = &self.last_input_info_by_hand[hand_index] {
                     for c in canvas.elements() {
                         let maybe_event = c.get_event(last, &current_input_info);
                         if maybe_event.is_some() {
@@ -179,7 +183,7 @@ where
                 }
 
                 self.cursor = cursor;
-                self.last_input_info = Some(current_input_info);
+                self.last_input_info_by_hand[hand_index] = Some(current_input_info);
 
                 if let Some(output_event) = maybe_output_event {
                     let (state, effect) =
@@ -201,4 +205,102 @@ pub fn gui_script<TState: Default + 'static, TMsg: Clone + 'static>(
     gui: Box<dyn Gui<TState, TMsg>>,
 ) -> Box<dyn Script> {
     Box::new(GuiScript::new(gui))
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Vector2, Vector3, point2, vec2};
+
+    use super::*;
+    use crate::{gui, scripts::Script, vr_config::Handedness};
+
+    struct CountingGui;
+
+    impl Gui<usize, ()> for CountingGui {
+        fn get_components(
+            &self,
+            _cursor: &Option<GuiCursor>,
+            _entity_id: EntityId,
+            _world: &World,
+            _state: &usize,
+        ) -> Vec<GuiComponent<()>> {
+            vec![
+                gui::button(())
+                    .with_position(vec2(0.0, 0.0))
+                    .with_size(vec2(100.0, 100.0)),
+            ]
+        }
+
+        fn get_config(&self) -> crate::gui::GuiConfig {
+            crate::gui::GuiConfig {
+                world_offset: Vector3::new(0.0, 0.0, 0.0),
+                screen_size_in_pixels: Vector2::new(100.0, 100.0),
+            }
+        }
+
+        fn handle_msg(
+            &self,
+            _entity_id: EntityId,
+            _world: &World,
+            state: &usize,
+            _msg: &(),
+        ) -> (usize, Effect) {
+            (state + 1, Effect::NoEffect)
+        }
+    }
+
+    fn hover(hand: Handedness, pressed: bool) -> MessagePayload {
+        MessagePayload::GUIHover {
+            held_entity_id: None,
+            screen_coordinates: point2(0.5, 0.5),
+            is_triggered: pressed,
+            is_grabbing: false,
+            hand,
+        }
+    }
+
+    fn send(
+        script: &mut GuiScript<usize, ()>,
+        entity: EntityId,
+        world: &World,
+        hand: Handedness,
+        pressed: bool,
+    ) {
+        script.handle_message(entity, world, &PhysicsWorld::new(), &hover(hand, pressed));
+    }
+
+    #[test]
+    fn each_vr_hand_tracks_its_own_trigger_edge_over_one_shared_panel() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        let mut script = GuiScript::new(Box::new(CountingGui));
+
+        // VR dispatches the idle left hand before the active right hand each
+        // frame. One held physical trigger must remain one panel activation.
+        for pressed in [false, true, true, true] {
+            send(&mut script, entity, &world, Handedness::Left, false);
+            send(&mut script, entity, &world, Handedness::Right, pressed);
+        }
+        assert_eq!(script.state, 1);
+
+        // Release and press again: one new physical edge is one new action.
+        send(&mut script, entity, &world, Handedness::Left, false);
+        send(&mut script, entity, &world, Handedness::Right, false);
+        send(&mut script, entity, &world, Handedness::Left, false);
+        send(&mut script, entity, &world, Handedness::Right, true);
+        assert_eq!(script.state, 2);
+    }
+
+    #[test]
+    fn one_hand_panel_press_still_fires_once_until_release() {
+        let mut world = World::new();
+        let entity = world.add_entity(());
+        let mut script = GuiScript::new(Box::new(CountingGui));
+
+        for pressed in [false, true, true, true, false, true] {
+            send(&mut script, entity, &world, Handedness::Right, pressed);
+        }
+
+        assert_eq!(script.state, 2);
+    }
 }

--- a/tools/shock2-sdk/test/earth-vr-world-panel-arbitration.e2e.test.ts
+++ b/tools/shock2-sdk/test/earth-vr-world-panel-arbitration.e2e.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, PhysicsBodySummary, Vec3 } from "../src/types.js";
+import {
+  carriedNaniteTotal,
+} from "./helpers/earth-replicator.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Production-VR regression for #962. The test opens and hacks Earth Technical
+// Training's authored replicator through its physical panel, then holds one
+// trigger for two fixed frames while both hands hover the same hacked-catalog
+// row. Before the fix, the idle hand re-armed the shared press state between
+// right-hand messages: the held gesture emitted repeated vends instead of one.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const EARTH_NANITES = 257;
+const EARTH_REPLICATOR = 262;
+const HE_CLIP_NAME = "*HE Clip*";
+const PANEL_HEIGHT_PX = 296;
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+
+type Hand = "left" | "right";
+
+interface DebugInputHand {
+  position: Vec3;
+  rotation: [number, number, number, number];
+}
+
+async function uiPanel(game: GameServer): Promise<PhysicsBodySummary> {
+  const panels = (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+  assert.equal(panels.length, 1, "expected one active production VR panel");
+  return panels[0];
+}
+
+function panelPoint(
+  panel: PhysicsBodySummary,
+  panelWidthPx: number,
+  pointPx: [number, number],
+): Vec3 {
+  const worldSize: Vec3 = [
+    panelWidthPx * GUI_PIXEL_TO_WORLD_SIZE,
+    PANEL_HEIGHT_PX * GUI_PIXEL_TO_WORLD_SIZE,
+    0,
+  ];
+  const [x, y] = pointPx;
+  const local: Vec3 = [
+    worldSize[0] * (0.5 - x / panelWidthPx),
+    worldSize[1] * (0.5 - y / PANEL_HEIGHT_PX),
+    0,
+  ];
+  return add(panel.position, quatRotate(panel.rotation, local));
+}
+
+async function aimHandAtPanelPoint(
+  game: GameServer,
+  panelWidthPx: number,
+  pointPx: [number, number],
+  hand: Hand,
+): Promise<void> {
+  const panel = await uiPanel(game);
+  const target = panelPoint(panel, panelWidthPx, pointPx);
+  const aim = await aimVrHandAt(game, target, 0.35);
+  if (hand === "left") {
+    // Reuse the production right-hand aiming calculation, then copy that
+    // ordinary controller pose onto the left input channels. The later right
+    // aim gives the two hands distinct points inside the same authored row.
+    const inputResponse = await fetch(`${game.baseUrl}/v1/control/input`);
+    assert.equal(inputResponse.ok, true, "live controller state should be inspectable");
+    const input = (await inputResponse.json()) as { right_hand: DebugInputHand };
+    await game.input.set("left_hand.position", input.right_hand.position);
+    await game.input.set("left_hand.rotation", input.right_hand.rotation);
+    await game.input.set("left_hand.trigger", 0);
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 3 });
+  }
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  assert.equal(
+    hit.entity_id,
+    panel.entity_id,
+    `${hand} production hand ray must hit panel point ${JSON.stringify(pointPx)}; ${JSON.stringify(hit)}`,
+  );
+}
+
+async function clickPanelPoint(
+  game: GameServer,
+  panelWidthPx: number,
+  pointPx: [number, number],
+): Promise<void> {
+  await aimHandAtPanelPoint(game, panelWidthPx, pointPx, "right");
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 2 });
+}
+
+async function vrFrobEntity(game: GameServer, entity: EntitySummary): Promise<void> {
+  const target = (await game.entities.detail(entity.id)).position;
+  await teleportVerified(game, {
+    x: target[0] + 0.5,
+    y: target[1] + 1,
+    z: target[2],
+  });
+  const aim = await aimVrHandAt(game, target, 0.3);
+  const hit = await game.raycast({
+    start: aim.start,
+    end: aim.target,
+    collision_groups: ["entity", "selectable", "world", "raycast"],
+    max_distance: 1,
+    ignore_sensors: true,
+  });
+  assert.equal(hit.entity_id, entity.id, "production hand ray must hit frob target");
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 2 });
+}
+
+async function openReplicator(
+  game: GameServer,
+  replicator: EntitySummary,
+): Promise<void> {
+  const [x, _y, z] = (await game.entities.detail(replicator.id)).position;
+  // The authored booth has one clear, collision-supported standing point.
+  // Keep the player there while the real HRM board advances over many frames
+  // so walk-away cleanup cannot correctly close a panel under a falling pawn.
+  await teleportVerified(game, {
+    x: x - 1.59,
+    y: 21.404,
+    z: z - 2.23,
+  });
+  const aim = await game.player.aimAt(replicator, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  await aimVrHandAt(game, aim.world_point, 0.35);
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 1 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 5 });
+  await uiPanel(game);
+}
+
+async function hackReplicator(
+  game: GameServer,
+  replicator: EntitySummary,
+): Promise<void> {
+  // Max Navy-tech aptitude removes critical mines while the authored HRM
+  // board, payment, node rolls, and success effect remain the real game path.
+  await game.player.setStats({ cyber_affinity: 6, skills: { hack: 6 } });
+
+  // PLUGHACK sidecar center, then START on the ordinary 188x296 HRM board.
+  await clickPanelPoint(game, 261, [42, 247]);
+  await clickPanelPoint(game, 188, [167, 260]);
+
+  // Exercise every board coordinate through the production panel. Empty cells
+  // and clicks after the board is won are authored no-ops. At 85% node success
+  // and zero mines, this fixed replay reaches connected-three; the reopened
+  // hacked catalog and its HE purchase below prove the persistent outcome.
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 5; x++) {
+      await clickPanelPoint(game, 188, [16 + x * 30 + 8, 48 + y * 36 + 8]);
+    }
+  }
+
+  // Walking away closes the transient board. Reopening the authored entity
+  // resets the won board to its hacked inventory, as normal gameplay does.
+  await teleportVerified(game, {
+    x: replicator.position[0] + 8,
+    y: replicator.position[1] + 1,
+    z: replicator.position[2],
+  });
+  await game.step({ frames: 2 });
+  assert.equal(
+    (await game.physics.bodies()).bodies.filter((body) =>
+      body.collision_groups.includes("ui"),
+    ).length,
+    0,
+    "walking away must close the won board",
+  );
+  await openReplicator(game, replicator);
+}
+
+test(
+  "Earth VR world panel arbitrates one held trigger independently per hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8202),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const [nanites] = await game.entities.byTemplate(EARTH_NANITES);
+    const [replicator] = await game.entities.byTemplate(EARTH_REPLICATOR);
+    assert.ok(nanites, "Earth should contain authored nanite pile 257");
+    assert.ok(replicator, "Earth should contain authored RepBase 262");
+
+    await vrFrobEntity(game, nanites);
+    assert.equal(await carriedNaniteTotal(game), 250);
+    await openReplicator(game, replicator);
+    await hackReplicator(game, replicator);
+    assert.equal(
+      await carriedNaniteTotal(game),
+      247,
+      "authored HRM start should charge three nanites",
+    );
+
+    const beforeIds = new Set(
+      (await game.entities.list({ filter: HE_CLIP_NAME, limit: 100 })).entities.map(
+        (entity) => entity.id,
+      ),
+    );
+
+    // Small HE Clip is hacked inventory row 0 (188x60 at y=10). Aim the two
+    // production hands at separate points inside that same button so both
+    // emit hover samples, then hold only the right trigger for two frames.
+    await aimHandAtPanelPoint(game, 188, [55, 40], "left");
+    await aimHandAtPanelPoint(game, 188, [133, 40], "right");
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      await carriedNaniteTotal(game),
+      177,
+      "one held physical trigger must charge exactly one 70-nanite vend",
+    );
+    const firstVendIds = (
+      await game.entities.list({ filter: HE_CLIP_NAME, limit: 100 })
+    ).entities.filter((entity) => !beforeIds.has(entity.id));
+    assert.equal(firstVendIds.length, 1, "two-hand hover must dispense exactly one HE clip");
+
+    // One-hand control: move the idle hand away, release/press again, and
+    // verify the ordinary authored row still produces exactly one new vend.
+    await game.input.set("left_hand.position", [0, -10, 0]);
+    await game.step({ frames: 2 });
+    await aimHandAtPanelPoint(game, 188, [94, 40], "right");
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    assert.equal(await carriedNaniteTotal(game), 107);
+    const allVendIds = (
+      await game.entities.list({ filter: HE_CLIP_NAME, limit: 100 })
+    ).entities.filter((entity) => !beforeIds.has(entity.id));
+    assert.equal(allVendIds.length, 2, "one-hand control must add one more HE clip");
+  },
+);


### PR DESCRIPTION
## Summary

- track world-panel trigger edges independently for the left and right VR hands
- keep one-hand panel input edge-triggered while preventing the idle hand from re-arming a held trigger
- cover the shared-panel dispatch order with unit tests and a production Earth VR hacked-replicator scenario

## Root cause

`GuiScript` kept one shared previous input state for a world panel. In VR, both hovering hands send `GUIHover` every frame, left before right. An idle left hand therefore replaced the held right hand's previous state and made the right trigger look newly pressed again on the next frame. The fix stores the previous input independently for each hand; flat presentation continues to use the right-hand slot.

## Production evidence

The matching deterministic replay uses the authored Earth replicator after the real PLUGHACK / paid HRM hacking flow. Both hands hover separate points in the Small HE Clip row, only the right trigger is held, and the runtime advances two fixed 60 Hz frames.

- Before (matching `origin/main` at `e09fc084`): 247 → 37 nanites, three new HE clips
- Fixed (`e8053b46`): 247 → 177 nanites, exactly one new HE clip
- Moving the left hand away and pressing again still performs exactly one additional vend

### Before — shared panel press state

![Before: one held right trigger repeats three HE vends](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/vr-world-panel-arbitration-before.gif)

### Fixed — independent per-hand press state

![Fixed: one held right trigger produces one HE vend](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/vr-world-panel-arbitration-fixed.gif)

<sub>Production Earth VR hacked-replicator flow: both hands hover separate points in the Small HE Clip row while only the right trigger is held. Baseline: 247 → 37 nanites and three new HE clips. Fixed: 247 → 177 nanites and one new HE clip. Captured headlessly with deterministic fixed 60 Hz stepping.</sub>

### Before → after

![Before and after: repeated three-vend debit becomes exactly one 70-nanite vend](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/vr-world-panel-arbitration-before-after.png)

<details>
<summary>Deterministic source stills</summary>

#### Before

![Before, ready at 247 nanites](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/before-trigger-ready.png)

![Before, held trigger at 37 nanites and three new HE clips](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/before-held-trigger.png)

#### Fixed

![Fixed, ready at 247 nanites](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/fixed-trigger-ready.png)

![Fixed, held trigger at 177 nanites and one new HE clip](https://gist.githubusercontent.com/tommy-xr/6ff78963d5ae826d7c9e4e9a2486565e/raw/fixed-held-trigger.png)

</details>

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 656 passed, 2 ignored doctests (post-rebase)
- `npm --prefix tools/shock2-sdk test` — 26 passed, 224 E2E skipped (post-rebase)
- focused SDK production scenarios — 7 passed post-rebase: Earth hackable keypad, replicator economy/hacking, VR world-panel arbitration, flat keypad, VR container, VR elevator
- full pre-rebase SDK E2E suite — 246 total: 238 passed, 7 skipped, and the unrelated creature-loot reader assertion failed; isolated rerun reproduced that same existing Watts-disc failure (`undefined !== 251`)

## Campaign configuration

- Route: `earth -> station -> medsci1 -> medsci2 -> eng1 -> eng2 -> hydro2 -> hydro1 -> hydro3 -> ops2 -> ops1 -> ops3 -> ops4`
- Tweak: Navy tech
- Assets: 25th Anniversary (`/Users/bryan/ss2-25th`)
- Presentation: VR
- Seed: `976894603`

## Overlap

- Open PR #853 also touches `gui_script.rs` by adding the independent `accepts_tool` delegation near the end of the `Script` impl. This fix changes the per-hand input state and `GUIHover` path earlier in the file, so the edits are conceptually adjacent but do not overlap the same lines.

Fixes #962
