### PR TITLE
fix(gameplay): make comestibles heal and consume

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -273,6 +273,12 @@ enum PsiKitUseOutcome {
     DestroyEntity,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ComestibleUseOutcome {
+    NotUsed,
+    Consumed,
+}
+
 fn update_player_psi_points(world: &World, update: impl FnOnce(i32) -> i32) -> bool {
     let player_entity = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
     let mut psi_states = world
@@ -383,6 +389,46 @@ fn move_live_entity_into_container(
         world.add_component(dropped_entity_id, PropHasRefs(false));
     }
     was_able_to_drop
+}
+
+/// Apply one retail food/drink use against live state. The carried-source
+/// validation, bounded heal, and consumption decision occur in one effect
+/// pass, so duplicate queued uses of the same object cannot heal twice.
+fn apply_comestible_use(
+    world: &World,
+    entity_id: EntityId,
+    hit_points: i32,
+) -> ComestibleUseOutcome {
+    if hit_points <= 0
+        || !world
+            .borrow::<EntitiesView>()
+            .is_ok_and(|entities| entities.is_alive(entity_id))
+        || !crate::scripts::script_util::player_carried_items(world).contains(&entity_id)
+    {
+        return ComestibleUseOutcome::NotUsed;
+    }
+
+    let player = world.borrow::<UniqueView<PlayerInfo>>().unwrap().entity_id;
+    let maximum = world
+        .borrow::<View<dark::properties::PropMaxHitPoints>>()
+        .ok()
+        .and_then(|maximums| maximums.get(player).ok().map(|hp| hp.hit_points))
+        .map(|maximum| maximum.min(i32::MAX as u32) as i32);
+    let Some(maximum) = maximum else {
+        return ComestibleUseOutcome::NotUsed;
+    };
+
+    let mut current = world
+        .borrow::<ViewMut<dark::properties::PropHitPoints>>()
+        .unwrap();
+    let Ok(current) = (&mut current).get(player) else {
+        return ComestibleUseOutcome::NotUsed;
+    };
+    current.hit_points = current
+        .hit_points
+        .saturating_add(hit_points)
+        .clamp(0, maximum.max(0));
+    ComestibleUseOutcome::Consumed
 }
 
 /// Raise only the live maximum HP pool. Buying Endurance is not healing: the
@@ -4162,6 +4208,33 @@ impl MissionCore {
                     if outcome == PsiKitUseOutcome::DestroyEntity {
                         self.destroy_entity(entity_id);
                     }
+                    if !matches!(sound, Effect::NoEffect) {
+                        effects.push_front(sound);
+                    }
+                }
+
+                Effect::UseComestible {
+                    entity_id,
+                    hit_points,
+                } => {
+                    // Resolve the heal and source lifetime against the same
+                    // live world snapshot. A duplicate effect for an already
+                    // destroyed object safely no-ops; full health still
+                    // consumes, matching the retail script.
+                    if apply_comestible_use(&self.world, entity_id, hit_points)
+                        == ComestibleUseOutcome::NotUsed
+                    {
+                        continue;
+                    }
+
+                    let sound = crate::scripts::script_util::play_environmental_sound(
+                        &self.world,
+                        entity_id,
+                        "activate",
+                        vec![],
+                        AudioHandle::new(),
+                    );
+                    self.destroy_entity(entity_id);
                     if !matches!(sound, Effect::NoEffect) {
                         effects.push_front(sound);
                     }
@@ -8903,6 +8976,102 @@ mod psi_kit_use_tests {
                 .0,
             1
         );
+    }
+}
+
+#[cfg(test)]
+mod comestible_use_tests {
+    use dark::properties::{Link, Links, PropHitPoints, PropMaxHitPoints, ToLink, WrappedEntityId};
+    use shipyard::{EntitiesView, Get, View};
+
+    use super::*;
+
+    fn world_with_player(hit_points: i32, carried: bool) -> (World, EntityId, EntityId) {
+        let mut world = World::new();
+        let food = world.add_entity(());
+        let inventory = world.add_entity(if carried {
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(food)),
+                    link: Link::Contains(0),
+                }],
+            }
+        } else {
+            Links::empty()
+        });
+        let player = world.add_entity((
+            PropHitPoints { hit_points },
+            PropMaxHitPoints { hit_points: 30 },
+        ));
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, player, food)
+    }
+
+    fn player_hit_points(world: &World, player: EntityId) -> i32 {
+        world
+            .borrow::<View<PropHitPoints>>()
+            .unwrap()
+            .get(player)
+            .unwrap()
+            .hit_points
+    }
+
+    #[test]
+    fn carried_comestible_heals_one_and_is_marked_consumed() {
+        let (world, player, food) = world_with_player(20, true);
+
+        assert_eq!(
+            apply_comestible_use(&world, food, 1),
+            ComestibleUseOutcome::Consumed
+        );
+        assert_eq!(player_hit_points(&world, player), 21);
+    }
+
+    #[test]
+    fn full_health_still_consumes_without_overhealing() {
+        let (world, player, food) = world_with_player(30, true);
+
+        assert_eq!(
+            apply_comestible_use(&world, food, 1),
+            ComestibleUseOutcome::Consumed
+        );
+        assert_eq!(player_hit_points(&world, player), 30);
+    }
+
+    #[test]
+    fn already_destroyed_source_cannot_heal_twice() {
+        let (mut world, player, food) = world_with_player(20, true);
+
+        assert_eq!(
+            apply_comestible_use(&world, food, 1),
+            ComestibleUseOutcome::Consumed
+        );
+        world.delete_entity(food);
+        assert_eq!(
+            apply_comestible_use(&world, food, 1),
+            ComestibleUseOutcome::NotUsed
+        );
+        assert_eq!(player_hit_points(&world, player), 21);
+        assert!(!world.borrow::<EntitiesView>().unwrap().is_alive(food));
+    }
+
+    #[test]
+    fn world_object_cannot_bypass_inventory_use() {
+        let (world, player, food) = world_with_player(20, false);
+
+        assert_eq!(
+            apply_comestible_use(&world, food, 1),
+            ComestibleUseOutcome::NotUsed
+        );
+        assert_eq!(player_hit_points(&world, player), 20);
     }
 }
 

--- a/shock2vr/src/scripts/comestible.rs
+++ b/shock2vr/src/scripts/comestible.rs
@@ -1,0 +1,130 @@
+use shipyard::{EntityId, World};
+
+use crate::physics::PhysicsWorld;
+
+use super::{Effect, MessagePayload, Script, script_util::player_carried_items};
+
+/// Retail food and drink inventory use.
+///
+/// The shipped 25AE `allobjs` module handles `FrobInvEnd`: it adds one hit
+/// point to the frobber, plays the object's authored Activate environmental
+/// sound, and destroys the object. The port's `Frob` payload is shared by
+/// world pickup and inventory use, so the carried-item check preserves the
+/// object's inherited world `MOVE` action while selecting the authored
+/// inventory `SCRIPT` path.
+pub struct Comestible;
+
+impl Comestible {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Script for Comestible {
+    fn handle_message(
+        &mut self,
+        entity_id: EntityId,
+        world: &World,
+        _physics: &PhysicsWorld,
+        msg: &MessagePayload,
+    ) -> Effect {
+        if !matches!(msg, MessagePayload::Frob) || !player_carried_items(world).contains(&entity_id)
+        {
+            return Effect::NoEffect;
+        }
+
+        Effect::UseComestible {
+            entity_id,
+            hit_points: 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{Link, Links, ToLink, WrappedEntityId};
+    use shipyard::World;
+
+    use crate::{
+        mission::PlayerInfo,
+        physics::PhysicsWorld,
+        scripts::{Effect, MessagePayload, Script},
+    };
+
+    use super::Comestible;
+
+    fn world_with_food(carried: bool) -> (World, shipyard::EntityId) {
+        let mut world = World::new();
+        let food = world.add_entity(());
+        let inventory = world.add_entity(if carried {
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: 0,
+                    to_entity_id: Some(WrappedEntityId(food)),
+                    link: Link::Contains(0),
+                }],
+            }
+        } else {
+            Links::empty()
+        });
+        let player = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 0.0),
+            rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+        (world, food)
+    }
+
+    #[test]
+    fn carried_food_requests_one_atomic_retail_use() {
+        let (world, food) = world_with_food(true);
+
+        let effect = Comestible::new().handle_message(
+            food,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(
+            effect,
+            Effect::UseComestible {
+                entity_id,
+                hit_points: 1,
+            } if entity_id == food
+        ));
+    }
+
+    #[test]
+    fn world_frob_remains_owned_by_inherited_move_action() {
+        let (world, food) = world_with_food(false);
+
+        let effect = Comestible::new().handle_message(
+            food,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Frob,
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+
+    #[test]
+    fn unrelated_messages_do_nothing() {
+        let (world, food) = world_with_food(true);
+
+        let effect = Comestible::new().handle_message(
+            food,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::TurnOn { from: food },
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
+    }
+}

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -246,6 +246,14 @@ pub enum Effect {
         amount: i32,
     },
 
+    /// Atomically apply a retail food/drink use against the live player and
+    /// consume the source object. Comestibles always disappear, including at
+    /// full health; the hit-point increase is clamped to the authored maximum.
+    UseComestible {
+        entity_id: EntityId,
+        hit_points: i32,
+    },
+
     /// Install a soft on the character sheet and consume the object it came
     /// from. Emitted by `scripts::auto_install_soft` when a soft is frobbed in
     /// the world or taken from a container. The applier does the atomic

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -14,6 +14,7 @@ mod camera_alert;
 mod chemical;
 mod choose_mission;
 mod choose_service;
+mod comestible;
 mod core_room;
 mod create_sound;
 mod cs9;
@@ -107,6 +108,7 @@ use crate::gui::gui_script;
 use self::chemical::ChemicalScript;
 use self::choose_mission::ChooseMissionScript;
 use self::choose_service::ChooseServiceScript;
+use self::comestible::Comestible;
 /// Preloaded elevator floor labels (from MISC.STR) + current mission, added as
 /// a world unique at mission load so the (`AssetCache`-less) `ElevatorGui` can
 /// read them at draw time.
@@ -1051,7 +1053,7 @@ impl ScriptWorld {
             "statboostimplant" => Box::new(UnimplementedScript::new(&script_name)),
 
             // earth:
-            "comestible" => Box::new(UnimplementedScript::new(&script_name)),
+            "comestible" => Box::new(Comestible::new()),
             "liquor" => Box::new(NoopScript::new()),
 
             // Not implemented - new medsci1 ones:

--- a/tools/shock2-sdk/test/comestible.e2e.test.ts
+++ b/tools/shock2-sdk/test/comestible.e2e.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, UiElement } from "../src/types.js";
+import { earthWorldUse } from "./helpers/earth-world-use.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { clickUiElement } from "./helpers/ui.js";
+import { aimVrHandAt } from "./helpers/vr-hand.js";
+
+// Production Earth regression for #965. The two concrete mission objects are
+// inherited from the real gamesys Comestible archetypes:
+//
+//   object 355 -> Juice bottle (-966, foodtype drink)
+//   object 352 -> Chips (-92, foodtype chips)
+//
+// The shipped 25AE allobjs module heals the frobber by one, plays the
+// environmental Activate event, and destroys the source even at full HP.
+// Negative-first: on main both inventory gestures deliver the correct Frob,
+// but Comestible is an UnimplementedScript, so HP and the exact item are
+// unchanged.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const BASIC_CHIPS = 352;
+const BASIC_JUICE = 355;
+
+async function exactlyOne(
+  game: GameServer,
+  templateId: number,
+  label: string,
+): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(templateId);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one ${label} (${templateId}), got ${JSON.stringify(matches)}`,
+  );
+  return matches[0];
+}
+
+function hp(info: Awaited<ReturnType<GameServer["info"]>>): number {
+  assert.notEqual(info.player.hit_points, null, "Earth player should have hit points");
+  return info.player.hit_points as number;
+}
+
+async function stripItem(
+  game: GameServer,
+  entityId: number,
+): Promise<UiElement> {
+  const ui = await game.ui.state();
+  assert.equal(ui.mode, "use", "flat comestible use must happen in live use mode");
+  const item = ui.strip?.elements.find((candidate) => candidate.entity_id === entityId);
+  assert.ok(item, `inventory strip should expose carried comestible ${entityId}`);
+  return item;
+}
+
+async function useInventoryItem(game: GameServer, entityId: number): Promise<void> {
+  const item = await stripItem(game, entityId);
+  await clickUiElement(game, item);
+  assert.equal(
+    (await game.ui.state()).cursor?.entity_id,
+    entityId,
+    "first click should lift the exact carried comestible",
+  );
+  await clickUiElement(game, item);
+  assert.equal(
+    (await game.ui.state()).cursor,
+    null,
+    "second click should complete authored inventory use",
+  );
+}
+
+test(
+  "Earth flat inventory use consumes Juice and Chips with retail one-HP semantics",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8225),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+    });
+    await game.step({ frames: 5 });
+
+    const initial = await game.info();
+    assert.equal(hp(initial), 30);
+    assert.equal(initial.player.max_hit_points, 30);
+    const playerId = initial.player.entity_id;
+    assert.notEqual(playerId, null, "Earth should have a live player");
+
+    const juice = await exactlyOne(game, BASIC_JUICE, "Basic Juice bottle");
+    const chips = await exactlyOne(game, BASIC_CHIPS, "Basic Chips");
+    await earthWorldUse(game, juice);
+    await earthWorldUse(game, chips);
+    const carried = await game.player.inventory();
+    assert.ok(carried.items.some((item) => item.entity_id === juice.id));
+    assert.ok(carried.items.some((item) => item.entity_id === chips.id));
+
+    await game.input.trigger("ToggleUseMode");
+    await game.step({ frames: 5 });
+
+    // Retail consumes a comestible at full HP; the health service simply
+    // clamps the one-point heal to MAX_HP.
+    const audioBefore =
+      (await game.audio.recent()).sounds.at(-1)?.sequence ?? 0;
+    await useInventoryItem(game, juice.id);
+    assert.equal(hp(await game.info()), 30);
+    assert.equal(
+      (await game.entities.byTemplate(BASIC_JUICE)).length,
+      0,
+      "full-health use must consume exactly the authored Juice bottle",
+    );
+    assert.ok(
+      (await game.player.inventory()).items.some((item) => item.entity_id === chips.id),
+      "using Juice must leave the neighboring Chips untouched",
+    );
+    const activationSounds = (await game.audio.recent()).sounds.filter(
+      (sound) =>
+        sound.sequence > audioBefore &&
+        sound.tags.some(
+          ([tag, value]) => tag === "event" && value === "activate",
+        ) &&
+        sound.tags.some(
+          ([tag, value]) => tag === "foodtype" && value === "drink",
+        ),
+    );
+    assert.equal(
+      activationSounds.length,
+      1,
+      `Juice must play its authored Activate schema exactly once: ${JSON.stringify(activationSounds)}`,
+    );
+
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 10 });
+    await game.step({ frames: 2 });
+    assert.equal(hp(await game.info()), 20);
+
+    await useInventoryItem(game, chips.id);
+    assert.equal(hp(await game.info()), 21, "Chips should restore exactly one HP");
+    assert.equal(
+      (await game.entities.byTemplate(BASIC_CHIPS)).length,
+      0,
+      "partial-health use must consume exactly the authored Chips",
+    );
+    assert.equal((await game.player.inventory()).count, 0);
+
+    // HP and object destruction are ordinary mission state, not script-private
+    // latches: prove both survive the canonical save/load path.
+    await game.save("comestible-flat-complete");
+    await game.load("comestible-flat-complete");
+    assert.equal(hp(await game.info()), 21);
+    assert.equal((await game.entities.byTemplate(BASIC_JUICE)).length, 0);
+    assert.equal((await game.entities.byTemplate(BASIC_CHIPS)).length, 0);
+    assert.equal((await game.player.inventory()).count, 0);
+  },
+);
+
+test(
+  "Earth VR held Juice uses the same authored Frob and consumes exactly once",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8226),
+      repoRoot: process.env.SHOCK2_E2E_REPO_ROOT,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const initial = await game.info();
+    const playerId = initial.player.entity_id;
+    assert.notEqual(playerId, null, "Earth should have a live player");
+    await game.entities.sendMessage(playerId!, { type: "Damage", amount: 10 });
+    await game.step({ frames: 2 });
+    assert.equal(hp(await game.info()), 20);
+
+    const juice = await exactlyOne(game, BASIC_JUICE, "Basic Juice bottle");
+    // Juice begins slightly above its display surface and is still falling
+    // during the first frames. Settle the genuine body before composing the
+    // tiny bottle's production hand ray.
+    await game.step({ frames: 120 });
+    const bodies = (await game.physics.bodies({ entityId: juice.id })).bodies;
+    assert.equal(bodies.length, 1, "authored Juice should begin as one world body");
+    let bodyPosition = bodies[0].position;
+    await teleportVerified(game, {
+      x: bodyPosition[0] - 1.5,
+      y: bodyPosition[1] - 0.42,
+      z: bodyPosition[2],
+    });
+    await game.step({ frames: 60 });
+    const settledBodies = (await game.physics.bodies({ entityId: juice.id })).bodies;
+    assert.equal(settledBodies.length, 1);
+    bodyPosition = settledBodies[0].position;
+    const handRay = await aimVrHandAt(game, bodyPosition, 0.8);
+    const hit = await game.raycast({
+      start: handRay.start,
+      end: handRay.target,
+      collision_groups: ["entity", "selectable", "world", "ui", "raycast"],
+      max_distance: 1,
+      ignore_sensors: true,
+    });
+    assert.equal(
+      hit.entity_id,
+      juice.id,
+      `production hand ray must select exact Juice: ${JSON.stringify({ juice, bodies, handRay, hit })}`,
+    );
+
+    await game.input.set("right_hand.squeeze", 1);
+    // PlayerInfo snapshots held entities at the start of the next frame after
+    // the interaction takes ownership, so advance one grab frame plus one
+    // observation frame.
+    await game.step({ frames: 2 });
+    const afterGrabInfo = await game.info();
+    assert.equal(
+      afterGrabInfo.player.right_hand_entity_id,
+      juice.id,
+      `right VR hand must physically hold the exact authored Juice: ${JSON.stringify({ handRay, hit, afterGrabInfo })}`,
+    );
+    assert.equal(
+      (await game.physics.bodies({ entityId: juice.id })).bodies.length,
+      0,
+      "held Juice must already be outside world-ray selection",
+    );
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+
+    const trace = await game.messages.recent();
+    const foodMessages = trace.messages.filter(
+      (message) => message.to.entity_id === juice.id,
+    );
+    assert.ok(
+      foodMessages.some((message) => message.payload === "Frob"),
+      "holder trigger must deliver the authored inventory Frob",
+    );
+    assert.ok(
+      !foodMessages.some((message) => message.payload === "TriggerPull"),
+      "food must not receive the weapon trigger protocol",
+    );
+    assert.equal(hp(await game.info()), 21, "one VR use should restore exactly one HP");
+    assert.equal(
+      (await game.entities.byTemplate(BASIC_JUICE)).length,
+      0,
+      "the one holder-trigger edge must consume exactly the held Juice",
+    );
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    assert.ok(
+      !(await game.player.inventory()).items.some((item) => item.entity_id === juice.id),
+      "destroyed Juice must leave every carried location",
+    );
+    assert.equal(
+      (await game.entities.byTemplate(BASIC_CHIPS)).length,
+      1,
+      "using Juice must not consume the neighboring Chips",
+    );
+
+    // Holding the trigger for more frames must not apply another heal after
+    // canonical teardown removed the source entity.
+    await game.step({ frames: 30 });
+    assert.equal(hp(await game.info()), 21);
+    assert.equal((await game.entities.byTemplate(BASIC_JUICE)).length, 0);
+  },
+);


### PR DESCRIPTION
## Summary

- replace the `Comestible` placeholder with the authored inventory-use behavior
- restore one bounded hit point, play the object's `Activate` environmental schema, and consume the source even at full health
- keep scripts pure by returning an atomic `UseComestible` effect; the mission effect applier owns health mutation and canonical entity teardown
- cover exact Earth 25AE Juice/Chips behavior through both flat inventory and physical VR held-item paths

## Retail evidence

The shipped 25AE `allobjs-windows-x86_64.dll` `Comestible` `FrobInvEnd` handler calls the health service with `+1` for the frobber, emits environmental `Event Activate`, and destroys the source without a full-health guard. Earth objects 355 (Juice, archetype -966) and 352 (Chips, archetype -92) inherit `world_action=MOVE` and `inventory_action=SCRIPT`; neither authors `StackCount`, so each concrete source is destroyed as one item.

## Dependency / merge order

**Depends on #960 and must merge after it.** This PR is based on `feat/958-vr-held-consumables`, so its diff contains only Comestible work while CI and the VR E2E include #960's authored held-item `Frob` delivery. It does not duplicate #960 in a main-based diff.

## Test plan

- `cargo fmt --all -- --check` (passed)
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` (passed)
- `cargo test -p shock2vr` (623 passed)
- `npm test` in `tools/shock2-sdk` (26 passed, 224 E2E skipped by design)
- focused Earth flat E2E: exact Juice + Chips, full/partial HP, Activate schema, one-item destruction, neighboring-item isolation, save/load (passed)
- focused Earth VR E2E: exact Juice 355, real world ray + physical hold, `Frob` not `TriggerPull`, HP 20→21, one destruction, held-trigger idempotence (passed)

## Visual verification

![Earth Comestible demo](https://gist.githubusercontent.com/tommy-xr/5489e396ef26ea4af4327e2a4f9d0b27/raw/comestible-demo.gif)

<sub>Earth's authored Juice use now restores one bounded HP, plays its activation sound, and removes the exact inventory item. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

![Fixed Earth Comestible still](https://gist.githubusercontent.com/tommy-xr/5489e396ef26ea4af4327e2a4f9d0b27/raw/comestible-fixed.png)

### Before → after

![Current main versus fixed Earth Juice use](https://gist.githubusercontent.com/tommy-xr/5489e396ef26ea4af4327e2a4f9d0b27/raw/comestible-before-after.png)

The matching request sequence uses Earth object 355 through the production flat inventory path at 20/30 HP. Current main leaves the Juice and HP unchanged (HUD 67%); the fix consumes that exact object and raises HP to 21/30 (HUD 70%).

## Play-through configuration

- route: `earth.mis -> station.mis -> medsci1.mis -> medsci2.mis -> eng1.mis -> eng2.mis -> hydro2.mis -> hydro1.mis -> hydro3.mis -> ops2.mis -> ops1.mis -> ops3.mis -> ops4.mis`
- career: Navy / technical specialization
- assets: System Shock 2 25th Anniversary at `/Users/bryan/ss2-25th`
- presentation: VR
- seed: `976894603`

Fixes #965
