### PR TITLE
feat(vr): expose backpack inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `I` - move the floating inventory in front of you
 - `Alt+S` / `Alt+L` - quick save / quick load
 - `P` - cycle the pathfinding test (set start → set goal → show path)
+- Quest VR: press the left controller's `X` button to place/toggle the backpack;
+  point at a stored item and squeeze to retrieve it into that hand.
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,
   `6` EMP Rifle, `7` Electro Shock, `8` Grenade Launcher, `9` Stasis Field

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -675,6 +675,7 @@ pub struct LinkInfo {
     pub link_type: String,
     pub target_id: i32,
     pub target_name: String,
+    pub contains_ordinal: Option<u32>,
 }
 
 /// Current state of the game
@@ -702,6 +703,7 @@ pub struct TimeInfo {
 #[derive(Debug, Serialize, Clone)]
 pub struct PlayerInfo {
     pub entity_id: Option<i32>,
+    pub inventory_entity_id: Option<i32>,
     pub position: [f32; 3],
     pub rotation: [f32; 4], // quaternion
     /// "alive", terminally "dead", or waiting for QBR reconstruction.

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -1410,6 +1410,7 @@ fn process_command(
                                 link_type: l.link_type,
                                 target_id: l.target_id,
                                 target_name: l.target_name,
+                                contains_ordinal: l.contains_ordinal,
                             })
                             .collect(),
                         incoming_links: detail
@@ -1419,6 +1420,7 @@ fn process_command(
                                 link_type: l.link_type,
                                 target_id: l.target_id,
                                 target_name: l.target_name,
+                                contains_ordinal: l.contains_ordinal,
                             })
                             .collect(),
                         aim_points: detail
@@ -1896,6 +1898,7 @@ fn capture_frame_snapshot(
             let state = game.player_state();
             PlayerInfo {
                 entity_id: state.as_ref().map(|s| s.entity_id),
+                inventory_entity_id: state.as_ref().map(|s| s.inventory_entity_id),
                 position: state
                     .as_ref()
                     .map(|s| s.position)

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -349,6 +349,10 @@ fn main() {
         .create_action::<bool>("crouch", "Crouch Toggle", &[])
         .unwrap();
 
+    let inventory_action = action_set
+        .create_action::<bool>("inventory", "Backpack Inventory", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -430,6 +434,12 @@ fn main() {
                         .string_to_path("/user/hand/left/input/thumbstick/click")
                         .unwrap(),
                 ),
+                xr::Binding::new(
+                    &inventory_action,
+                    xr_instance
+                        .string_to_path("/user/hand/left/input/x/click")
+                        .unwrap(),
+                ),
             ],
         )
         .unwrap();
@@ -481,9 +491,9 @@ fn main() {
         game_init_started.elapsed().as_secs_f64() * 1_000.0
     );
 
-    // No discrete actions are mapped for VR controllers yet; this stays empty
-    // until an OculusInputMapper is added (the debug input server below can
-    // inject them remotely).
+    // Controller button edges feed the same semantic action dispatcher as the
+    // desktop and debug runtimes. X exposes the player-owned backpack panel.
+    // (The debug input server below can inject the same actions remotely.)
     let mut action_state = shock2vr::input::InputActionState::new();
     // Opt-in remote control for on-device automation; `None` unless
     // /sdcard/shock2quest/debug-port.txt configures a port.
@@ -595,6 +605,7 @@ fn main() {
                             // otherwise resume invisibly crouched).
                             crouch_toggled = false;
                             crouch_button_was_pressed = false;
+                            action_state.release(shock2vr::input::InputAction::MoveInventory);
                         }
                         xr::SessionState::STOPPING => {
                             session.end().unwrap();
@@ -693,6 +704,7 @@ fn main() {
             .unwrap()
             .current_state;
         let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
+        let inventory_state = inventory_action.state(&session, xr::Path::NULL).unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -702,6 +714,13 @@ fn main() {
                 crouch_toggled = !crouch_toggled;
             }
             crouch_button_was_pressed = crouch_state.current_state;
+        }
+        if inventory_state.is_active && inventory_state.changed_since_last_sync {
+            if inventory_state.current_state {
+                action_state.trigger(shock2vr::input::InputAction::MoveInventory);
+            } else {
+                action_state.release(shock2vr::input::InputAction::MoveInventory);
+            }
         }
 
         let left_trigger_value = left_trigger

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -227,6 +227,9 @@ pub struct DebugLinkInfo {
     pub link_type: String,
     pub target_id: i32,
     pub target_name: String,
+    /// Inventory cell ordinal for `Contains` links. Kept separate from the
+    /// human-readable link label so tests can assert exact persisted slots.
+    pub contains_ordinal: Option<u32>,
 }
 
 /// Raycast hit result for debug queries

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -36,6 +36,9 @@ pub struct GuiInstanceInfo {
     #[allow(dead_code)]
     pub offset: Vector3<f32>,
     pub components: Vec<GuiComponentRenderInfo>,
+    /// Authored layout extent. This stays in canvas pixels even when a VR
+    /// presentation maps the panel onto a differently-sized physical quad.
+    pub canvas_size_px: Vector2<f32>,
     pub world_size: Vector2<f32>,
     pub physics_handle: RigidBodyHandle,
 }
@@ -74,6 +77,26 @@ impl GuiManager {
 
     pub fn active_panel(&self) -> Option<EntityId> {
         self.active_panel
+    }
+
+    /// Toggle one gameplay entity in the default-VR world-panel slot.
+    ///
+    /// Player-owned panels such as the backpack have no world object to frob,
+    /// so their production controller binding reaches the same panel lifecycle
+    /// directly. Object-bound panels still enter through `Effect::OpenPanel`.
+    pub fn toggle_panel(
+        &mut self,
+        entity: EntityId,
+        world: &mut World,
+        physics: &mut PhysicsWorld,
+        scripts: &mut ScriptWorld,
+        id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
+    ) {
+        if self.active_panel == Some(entity) {
+            self.close_panel(world, physics, scripts, id_to_physics);
+        } else {
+            self.open_panel(entity, false, world, physics, scripts, id_to_physics);
+        }
     }
 
     /// Bind the default-VR world-panel slot to one gameplay entity. Opening a
@@ -212,6 +235,7 @@ impl GuiManager {
         id_to_physics: &mut HashMap<EntityId, RigidBodyHandle>,
         handle: GuiHandle,
         parent_entity: EntityId,
+        canvas_size_px: Vector2<f32>,
         world_size: Vector2<f32>,
         offset: Vector3<f32>,
         components: Vec<GuiComponentRenderInfo>,
@@ -251,12 +275,14 @@ impl GuiManager {
                 proxy_entity: ent,
                 offset,
                 components,
+                canvas_size_px,
                 world_size,
                 physics_handle,
             });
         } else {
             let instance: &mut GuiInstanceInfo = self.handle_to_instance.get_mut(&handle).unwrap();
             instance.components = components;
+            instance.canvas_size_px = canvas_size_px;
             if instance.world_size != world_size {
                 instance.world_size = world_size;
                 world.add_component(instance.proxy_entity, GuiPropProxySize(world_size));
@@ -324,7 +350,7 @@ impl GuiManager {
             // Present the panel through the shared UI canvas, so the world
             // panel and the flat MFD overlay are two mappings of ONE layout
             // rather than two hand-written emit paths.
-            let size_px = info.world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
+            let size_px = info.canvas_size_px;
             let panel = Rect::new(0.0, 0.0, size_px.x, size_px.y);
             let elements = info
                 .components
@@ -371,6 +397,7 @@ mod tests {
             handle,
             parent,
             vec2(261.0, 296.0),
+            vec2(261.0, 296.0),
             vec3(0.0, 0.0, -1.0),
             Vec::new(),
         );
@@ -382,11 +409,13 @@ mod tests {
             handle,
             parent,
             vec2(188.0, 296.0),
+            vec2(188.0, 296.0),
             vec3(0.0, 0.0, -1.0),
             Vec::new(),
         );
 
         let instance = manager.handle_to_instance.get(&handle).unwrap();
+        assert_eq!(instance.canvas_size_px, vec2(188.0, 296.0));
         assert_eq!(instance.world_size, vec2(188.0, 296.0));
         assert_eq!(
             world
@@ -428,6 +457,7 @@ mod tests {
             &mut id_to_physics,
             GuiHandle::new(),
             first,
+            vec2(187.5, 295.0),
             vec2(0.75, 1.18),
             vec3(0.0, 1.0, 0.0),
             Vec::new(),
@@ -455,6 +485,51 @@ mod tests {
                 .unwrap()
                 .is_alive(first_proxy)
         );
+    }
+
+    #[test]
+    fn toggling_a_player_panel_closes_its_transient_proxy() {
+        let mut world = World::new();
+        let parent = world.add_entity((RuntimePropTransform(Matrix4::from_scale(1.0)),));
+        let mut physics = PhysicsWorld::new();
+        let mut scripts = ScriptWorld::new();
+        let mut id_to_physics = HashMap::new();
+        let mut manager = GuiManager::new();
+
+        manager.toggle_panel(
+            parent,
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+        );
+        assert_eq!(manager.active_panel(), Some(parent));
+
+        manager.update_ui(
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+            GuiHandle::new(),
+            parent,
+            vec2(635.0, 120.0),
+            vec2(2.54, 0.48),
+            vec3(0.0, 1.0, 0.0),
+            Vec::new(),
+        );
+        assert_eq!(manager.handle_to_instance.len(), 1);
+        assert_eq!(id_to_physics.len(), 1);
+
+        manager.toggle_panel(
+            parent,
+            &mut world,
+            &mut physics,
+            &mut scripts,
+            &mut id_to_physics,
+        );
+        assert_eq!(manager.active_panel(), None);
+        assert!(manager.handle_to_instance.is_empty());
+        assert!(id_to_physics.is_empty());
     }
 
     #[test]
@@ -494,6 +569,7 @@ mod tests {
             &mut id_to_physics,
             GuiHandle::new(),
             parent,
+            vec2(187.5, 295.0),
             vec2(0.75, 1.18),
             vec3(0.0, 1.0, 0.0),
             Vec::new(),

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -26,7 +26,8 @@ pub enum InputAction {
     /// Spawn a debug monster (og-pipe hybrid) in front of the player
     SpawnDebugMonster,
 
-    /// Reposition the inventory in front of the player
+    /// Reposition the inventory in front of the player. In VR this also
+    /// toggles its physical backpack panel; flat inventory remains Tab/use mode.
     MoveInventory,
 
     /// Cycle creatures to their next animation pose (debug hitbox/ragdoll inspection)

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -433,6 +433,10 @@ pub struct Game {
 #[derive(Clone, Debug)]
 pub struct PlayerStateSnapshot {
     pub entity_id: i32,
+    /// Runtime id of the player's backpack container. Exposed for deterministic
+    /// inventory/link assertions; like every concrete id it must be rediscovered
+    /// after load.
+    pub inventory_entity_id: i32,
     pub position: [f32; 3],
     pub rotation: [f32; 4],
     /// "alive", terminally "dead", or waiting for an activated QBR while
@@ -515,6 +519,7 @@ impl Game {
         });
         Some(PlayerStateSnapshot {
             entity_id: info.entity_id.inner() as i32,
+            inventory_entity_id: info.inventory_entity_id.inner() as i32,
             position: [info.pos.x, info.pos.y, info.pos.z],
             rotation: [
                 info.rotation.v.x,

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -121,6 +121,48 @@ const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
 /// loop, so periodically let the host service its platform queues.
 const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 
+/// Head-relative authored-space placement for the wide VR backpack canvas.
+/// After `SCALE_FACTOR` conversion this is 2 world units forward and 1.2 up.
+/// The shared canvas keeps its authored pixels; the physical VR boundary
+/// scales the unusually wide 15-column strip so all of it fits at arm's reach.
+const VR_BACKPACK_FORWARD: f32 = 5.0;
+const VR_BACKPACK_UP: f32 = 3.0;
+const VR_BACKPACK_WORLD_SCALE: f32 = 0.55;
+
+fn presentation_world_panel_size(
+    presentation: crate::PresentationMode,
+    is_player_backpack: bool,
+    authored_size: Vector2<f32>,
+) -> Vector2<f32> {
+    if presentation == crate::PresentationMode::Vr && is_player_backpack {
+        authored_size * VR_BACKPACK_WORLD_SCALE
+    } else {
+        authored_size
+    }
+}
+
+#[cfg(test)]
+mod vr_backpack_panel_tests {
+    use super::*;
+
+    #[test]
+    fn only_vr_scales_the_shared_backpack_canvas_at_the_world_boundary() {
+        let authored = vec2(635.0, 120.0) * crate::gui::GUI_PIXEL_TO_WORLD_SIZE;
+        assert_eq!(
+            presentation_world_panel_size(crate::PresentationMode::Flat, true, authored),
+            authored
+        );
+        assert_eq!(
+            presentation_world_panel_size(crate::PresentationMode::Vr, false, authored),
+            authored
+        );
+        assert_eq!(
+            presentation_world_panel_size(crate::PresentationMode::Vr, true, authored),
+            authored * VR_BACKPACK_WORLD_SCALE
+        );
+    }
+}
+
 fn is_realtime_crumple(frame_count: f32) -> bool {
     // `humdieup1` is an authored "already dead" pose: three frames with no
     // fall. It shares the human crumple+die schema, but is not a real-time
@@ -4586,6 +4628,20 @@ impl MissionCore {
                         || (game_options.presentation_mode == crate::PresentationMode::Vr
                             && self.gui.active_panel() == Some(parent_entity));
                     if update_world_panel {
+                        // `internal_inventory` is a 15-column strip: keep its
+                        // shared canvas/layout identical, but map that resolved
+                        // canvas to a comfortable physical width at the VR
+                        // presentation boundary. Ordinary object panels retain
+                        // their authored world size.
+                        let is_player_backpack = self
+                            .world
+                            .borrow::<UniqueView<PlayerInfo>>()
+                            .is_ok_and(|player| player.inventory_entity_id == parent_entity);
+                        let presentation_size = presentation_world_panel_size(
+                            game_options.presentation_mode,
+                            is_player_backpack,
+                            world_size,
+                        );
                         self.gui.update_ui(
                             &mut self.world,
                             &mut self.physics,
@@ -4593,7 +4649,8 @@ impl MissionCore {
                             &mut self.id_to_physics,
                             handle,
                             parent_entity,
-                            world_size,
+                            world_size / crate::gui::GUI_PIXEL_TO_WORLD_SIZE,
+                            presentation_size,
                             world_offset,
                             components,
                         );
@@ -5609,16 +5666,56 @@ impl MissionCore {
                     self.process_virtual_hand_effects(asset_cache, msgs);
                 }
                 Effect::PositionInventoryRelativeToPlayer { head_rotation } => {
-                    let (pos, rot) = {
+                    let (pos, rot, inventory_entity) = {
                         let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
-                        (player.pos, player.rotation * head_rotation)
+                        (
+                            player.pos,
+                            player.rotation * head_rotation,
+                            player.inventory_entity_id,
+                        )
                     };
-                    let forward = rot * vec3(0.0, 0.5 / SCALE_FACTOR, -8.0 / SCALE_FACTOR);
+                    // Keep the wide VR panel within an ordinary arm's reach;
+                    // the old placeholder cube sat farther out and commonly
+                    // landed the new canvas inside a nearby wall. Preserve that
+                    // diagnostic cube's established desktop placement.
+                    let distance = if game_options.presentation_mode == crate::PresentationMode::Vr
+                    {
+                        VR_BACKPACK_FORWARD
+                    } else {
+                        8.0
+                    };
+                    let vertical = if game_options.presentation_mode == crate::PresentationMode::Vr
+                    {
+                        VR_BACKPACK_UP
+                    } else {
+                        0.5
+                    };
+                    let forward =
+                        rot * vec3(0.0, vertical / SCALE_FACTOR, -distance / SCALE_FACTOR);
                     PlayerInventoryEntity::set_position_rotation(
                         &mut self.world,
                         pos + forward,
                         Quaternion::from_angle_y(cgmath::Deg(180.0)) * rot,
-                    )
+                    );
+
+                    // VR has no cursor/metagame mode: the controller binding
+                    // places and toggles the backpack's existing
+                    // `internal_inventory` GuiScript as a physical world
+                    // panel. Flat keeps its established MoveInventory behavior
+                    // unchanged; its real inventory is the Tab/use-mode strip.
+                    if game_options.presentation_mode == crate::PresentationMode::Vr {
+                        self.gui.toggle_panel(
+                            inventory_entity,
+                            &mut self.world,
+                            &mut self.physics,
+                            &mut self.script_world,
+                            &mut self.id_to_physics,
+                        );
+                        self.script_world.dispatch(Message {
+                            to: inventory_entity,
+                            payload: MessagePayload::PanelOpened,
+                        });
+                    }
                 }
                 Effect::TurnOffTweqs { entity_id } => {
                     self.world.run_with_data(turn_off_tweqs, entity_id);
@@ -6340,9 +6437,12 @@ impl MissionCore {
         // drawn on top in `render_per_eye`).
         scene.append(&mut self.interaction.render(asset_cache, &self.world));
 
-        // Render inventory
-        let inventory_objs = PlayerInventoryEntity::render(&self.world);
-        scene.extend(inventory_objs);
+        // The old synthetic blue inventory cube remains a desktop diagnostic.
+        // VR presents the authored INVBACK canvas through GuiManager instead.
+        if options.presentation_mode == crate::PresentationMode::Flat {
+            let inventory_objs = PlayerInventoryEntity::render(&self.world);
+            scene.extend(inventory_objs);
+        }
 
         // Render teleport arc + landing indicator
         if options.experimental_features.contains("teleport")
@@ -7651,6 +7751,10 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                                     .unwrap_or_else(|_| {
                                         format!("Entity_{}", target_entity.0.inner())
                                     }),
+                                contains_ordinal: match link.link {
+                                    dark::properties::Link::Contains(ordinal) => Some(ordinal),
+                                    _ => None,
+                                },
                             });
                         }
                     }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5704,6 +5704,7 @@ impl MissionCore {
                     // panel. Flat keeps its established MoveInventory behavior
                     // unchanged; its real inventory is the Tab/use-mode strip.
                     if game_options.presentation_mode == crate::PresentationMode::Vr {
+                        let was_open = self.gui.active_panel() == Some(inventory_entity);
                         self.gui.toggle_panel(
                             inventory_entity,
                             &mut self.world,
@@ -5711,10 +5712,16 @@ impl MissionCore {
                             &mut self.script_world,
                             &mut self.id_to_physics,
                         );
-                        self.script_world.dispatch(Message {
-                            to: inventory_entity,
-                            payload: MessagePayload::PanelOpened,
-                        });
+                        // Only the opening half of the toggle announces itself;
+                        // dispatching PanelOpened on the closing press would
+                        // have the backpack script re-populate a panel that is
+                        // no longer on screen.
+                        if !was_open {
+                            self.script_world.dispatch(Message {
+                                to: inventory_entity,
+                                payload: MessagePayload::PanelOpened,
+                            });
+                        }
                     }
                 }
                 Effect::TurnOffTweqs { entity_id } => {

--- a/shock2vr/src/scripts/gui/container.rs
+++ b/shock2vr/src/scripts/gui/container.rs
@@ -233,7 +233,11 @@ impl Gui<ContainerGuiState, ContainerGuiMsg> for ContainerGui {
 
     fn get_config(&self) -> GuiConfig {
         GuiConfig {
-            world_offset: Vector3::new(0.0, 1.0, 0.0),
+            // MoveInventory positions the wide backpack itself at viewing
+            // height; applying the object-panel lift again would put it above
+            // the player's comfortable field of view. Loot panels remain
+            // lifted beside their physical host.
+            world_offset: Vector3::new(0.0, if self.take_on_click { 1.0 } else { 0.0 }, 0.0),
             screen_size_in_pixels: Vector2::new(self.width, self.height),
         }
     }
@@ -475,6 +479,18 @@ mod tests {
             assert_eq!(position, expected_origin, "grid origin");
             assert_eq!(size, vec2(35.0, 34.0), "one cell of the shared pitch");
         }
+    }
+
+    #[test]
+    fn backpack_is_head_positioned_without_an_extra_host_offset() {
+        assert_eq!(
+            ContainerGui::inv_container().get_config().world_offset,
+            vec3(0.0, 0.0, 0.0)
+        );
+        assert_eq!(
+            ContainerGui::loot_container().get_config().world_offset,
+            vec3(0.0, 1.0, 0.0)
+        );
     }
 
     /// Every icon a panel draws for a contained item - the grid buttons and

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -125,6 +125,8 @@ export interface LinkInfo {
   link_type: string;
   target_id: number;
   target_name: string;
+  /** Exact inventory cell for a Contains link; null for other link types. */
+  contains_ordinal?: number | null;
 }
 
 export interface EntityDetailResult {
@@ -344,6 +346,8 @@ export interface RagdollMetricsResult {
 
 export interface PlayerSnapshot {
   entity_id: number | null;
+  /** Runtime id of the backpack container; rediscover it after save/load. */
+  inventory_entity_id?: number | null;
   position: Vec3;
   rotation: [number, number, number, number];
   /** Current player lifecycle. `dead` is the terminal death sequence (no

--- a/tools/shock2-sdk/test/vr-backpack-inventory.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-backpack-inventory.e2e.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntitySummary, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Default-VR regression for #964. This uses the real Earth Basic Juice
+// (mission object/template 355) and only production interactions:
+//
+//   hand trigger -> InternalFrobMove -> backpack Contains(slot 0)
+//   MoveInventory -> internal_inventory world panel
+//   hand squeeze over slot 0 -> ContainerGui::GrabEntity -> right hand
+//
+// The save/load occurs while the Juice is still stored, so the second half
+// proves that its authored containment slot and the VR retrieval path survive
+// entity re-instantiation. Runtime ids are intentionally rediscovered after
+// load; within each side of the load, the exact id must remain unchanged from
+// panel slot to hand.
+//
+// Negative-first: on main, MoveInventory only moves the synthetic inventory's
+// blue placeholder cube. It never opens internal_inventory, so no UI body is
+// present and the panel assertion fails.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const BASIC_JUICE = 355;
+const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const VR_BACKPACK_WORLD_SCALE = 0.55;
+const BACKPACK_SLOT_ZERO_CENTER_PX: Vec3 = [4 + 35 / 2, 17 + 34 / 2, 0];
+
+async function exactBasicJuice(game: GameServer): Promise<EntitySummary> {
+  const matches = await game.entities.byTemplate(BASIC_JUICE);
+  assert.equal(
+    matches.length,
+    1,
+    `expected the exact Earth Basic Juice (355), got ${JSON.stringify(matches)}`,
+  );
+  return matches[0];
+}
+
+async function backpackContainsLink(game: GameServer, itemId: number) {
+  const backpackId = (await game.info()).player.inventory_entity_id;
+  assert.ok(backpackId, "the production snapshot must expose the live backpack id");
+  const link = (await game.entities.detail(backpackId)).outgoing_links.find(
+    (candidate) =>
+      candidate.target_id === itemId && candidate.link_type.startsWith("Contains"),
+  );
+  assert.ok(link, `backpack ${backpackId} must contain exact item ${itemId}`);
+  return { backpackId, link };
+}
+
+test(
+  "VR backpack exposes stored Earth Juice and retrieves its exact slot into a hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8564),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const juiceBeforeSave = await exactBasicJuice(game);
+    await teleportVerified(game, {
+      x: juiceBeforeSave.position[0] + 1.0,
+      y: juiceBeforeSave.position[1] + 0.4,
+      z: juiceBeforeSave.position[2] + 1.0,
+    });
+    const juiceAim = await game.player.aimAt(juiceBeforeSave, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(juiceAim.target_confirmed, true, "the Basic Juice must be physically reachable");
+    await aimVrHandAt(game, juiceAim.world_point, 0.35);
+
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    const storedBeforeSave = (await game.player.inventory()).items.find(
+      (item) => item.entity_id === juiceBeforeSave.id,
+    );
+    assert.equal(
+      storedBeforeSave?.location,
+      "inventory",
+      "the exact physically-frobbed Juice must enter the backpack",
+    );
+    const containsBeforeSave = await backpackContainsLink(game, juiceBeforeSave.id);
+    assert.equal(containsBeforeSave.link.contains_ordinal, 0, "Juice must occupy exact slot 0");
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+
+    const saveName = `issue964_vr_backpack_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+
+    const juiceAfterLoad = await exactBasicJuice(game);
+    const storedAfterLoad = (await game.player.inventory()).items.find(
+      (item) => item.entity_id === juiceAfterLoad.id,
+    );
+    assert.equal(
+      storedAfterLoad?.location,
+      "inventory",
+      "save/load must preserve the Juice in its backpack slot",
+    );
+    const containsAfterLoad = await backpackContainsLink(game, juiceAfterLoad.id);
+    assert.equal(
+      containsAfterLoad.link.contains_ordinal,
+      0,
+      "save/load must preserve exact backpack slot 0",
+    );
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+
+    // Open from a level gaze instead of inheriting the downward pickup look.
+    // MoveInventory deliberately follows the head so a real player can place
+    // the panel clear of nearby geometry by looking where they want it.
+    await game.input.set("head.look", [0, 0]);
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+
+    const uiBodies = (await game.physics.bodies()).bodies.filter((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.equal(
+      uiBodies.length,
+      1,
+      "MoveInventory in VR must expose one physical internal_inventory panel",
+    );
+    const panel = uiBodies[0];
+    assert.equal(panel.body_type, "kinematic");
+
+    // Invert ProxyGuiScript's world -> normalized-canvas mapping for the exact
+    // center of slot 0. Juice is the only stored item, and its saved Contains
+    // ordinal is zero, so a squeeze here must retrieve that same runtime id.
+    const panelSize: Vec3 = [
+      BACKPACK_PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE * VR_BACKPACK_WORLD_SCALE,
+      BACKPACK_PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE * VR_BACKPACK_WORLD_SCALE,
+      0,
+    ];
+    const u = BACKPACK_SLOT_ZERO_CENTER_PX[0] / BACKPACK_PANEL_SIZE_PX[0];
+    const v = BACKPACK_SLOT_ZERO_CENTER_PX[1] / BACKPACK_PANEL_SIZE_PX[1];
+    const localSlot: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+    const slotWorld = add(panel.position, quatRotate(panel.rotation, localSlot));
+
+    await game.input.set("left_hand.rotation", [0, 1, 0, 0]);
+    const panelAim = await aimVrHandAt(game, slotWorld, 0.35);
+    const panelHit = await game.raycast({
+      start: panelAim.start,
+      end: panelAim.target,
+      collision_groups: ["ui"],
+      max_distance: 1,
+    });
+    assert.equal(panelHit.entity_id, panel.entity_id, "the hand ray must hit backpack slot 0");
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 5 });
+
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      juiceAfterLoad.id,
+      "squeezing slot 0 must retrieve the exact rendered Juice into the right hand",
+    );
+    const retrieved = (await game.player.inventory()).items.find(
+      (item) => item.entity_id === juiceAfterLoad.id,
+    );
+    assert.equal(retrieved?.location, "right_hand");
+    assert.equal(
+      (await game.entities.detail(containsAfterLoad.backpackId)).outgoing_links.some(
+        (link) => link.target_id === juiceAfterLoad.id && link.link_type.startsWith("Contains"),
+      ),
+      false,
+      "retrieval must sever the exact slot-0 Contains link",
+    );
+
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.physics.bodies()).bodies.filter((body) =>
+        body.collision_groups.includes("ui"),
+      ).length,
+      0,
+      "the same production action must close the transient backpack panel",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- route VR `MoveInventory` through the existing `PlayerInventoryEntity` / `internal_inventory` GuiScript and default world-panel lifecycle
- bind Quest left-controller `X` to that shared input action, toggle the panel on repeated presses, and remove the old VR-only placeholder cube
- keep the authored 635×120 layout shared with flatscreen while mapping only its physical VR boundary to a fully framed, readable head-relative panel
- expose the live backpack id and exact `Contains` ordinal to debug/SDK inspection so the regression can assert entity, slot, and location transitions across save/load

## Root cause

VR storage was already faithful: the physical world-Frob path moved the exact object under the player backpack's `Contains` link, and `ContainerGui` item buttons already emitted hand-specific `GrabEntity` effects. The missing connection was entirely on exposure/input: `MoveInventory` only repositioned a synthetic blue cube, never selected the backpack as `GuiManager::active_panel`, while the Oculus runtime supplied no mapped discrete action.

Negative-first on current `origin/main`, a production Earth VR run physically stored Basic Juice (template 355) in exact backpack slot 0, then failed because `MoveInventory` produced **0 UI bodies** and no retrieval surface. The same production sequence now creates one kinematic UI body, grabs that exact loaded Juice id into the right hand, severs slot 0, and closes cleanly.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 657 passed
- `cd tools/shock2-sdk && npm test` — 250 total; 26 passed, 224 E2E-gated
- focused production E2E (serial):
  - `inventory-strip.e2e.test.js`
  - `vr-backpack-inventory.e2e.test.js`
  - `vr-container-world-panel.e2e.test.js`
  - 3 passed

Local Oculus APK validation was unavailable because this machine has neither `cargo-apk` nor the configured Android NDK path; the Android CI job remains the authoritative compile check.

## Visual verification

![VR backpack physical retrieval](https://gist.githubusercontent.com/tommy-xr/f35b197f7a508c7742ad674c61316abb/raw/vr-backpack-demo.gif)

<sub>Exact Earth Basic Juice in slot 0, selected with the production VR hand ray and retrieved into the right hand. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Fixed stills

![Fully framed VR backpack](https://gist.githubusercontent.com/tommy-xr/f35b197f7a508c7742ad674c61316abb/raw/vr-backpack-still.png)

![Authored Basic Juice held after retrieval](https://gist.githubusercontent.com/tommy-xr/f35b197f7a508c7742ad674c61316abb/raw/vr-backpack-retrieved.png)

### Current main → fixed

![Current main blue placeholder cube versus fixed authored inventory panel](https://gist.githubusercontent.com/tommy-xr/f35b197f7a508c7742ad674c61316abb/raw/vr-backpack-before-after.png)

## Play-through campaign

- Route: `earth -> station -> medsci1 -> medsci2 -> eng1 -> eng2 -> hydro2 -> hydro1 -> hydro3 -> ops2 -> ops1 -> ops3 -> ops4`
- Career: Navy tech; hack/repair/modify whenever possible
- Assets: 25th Anniversary at `/Users/bryan/ss2-25th`
- Presentation: VR (`--vr`)
- Seed: `976894603`

Fixes #964
