### PR TITLE
feat(vr): expose audio log reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ However, you can play with a keyboard and a mouse, using the following hard-code
 - `P` - cycle the pathfinding test (set start → set goal → show path)
 - Quest VR: press the left controller's `X` button to place/toggle the backpack;
   point at a stored item and squeeze to retrieve it into that hand.
+- Quest VR: press the left controller's `Y` button to open the newest unread
+  audio log. Press `Y` again to close it; after every log is read, `Y` replays
+  the most recently collected log.
 - Directly equip a matching carried weapon with the original number-row bindings:
   `1` Wrench, `2` Pistol, `3` Shotgun, `4` Assault Rifle, `5` Laser Pistol,
   `6` EMP Rifle, `7` Electro Shock, `8` Grenade Launcher, `9` Stasis Field

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -353,6 +353,10 @@ fn main() {
         .create_action::<bool>("inventory", "Backpack Inventory", &[])
         .unwrap();
 
+    let audio_log_action = action_set
+        .create_action::<bool>("audio_log_reader", "Audio Log Reader", &[])
+        .unwrap();
+
     // Bind our actions to input devices using the given profile
     // If you want to access inputs specific to a particular device you may specify a different
     // interaction profile
@@ -437,7 +441,21 @@ fn main() {
                 xr::Binding::new(
                     &inventory_action,
                     xr_instance
-                        .string_to_path("/user/hand/left/input/x/click")
+                        .string_to_path(
+                            shock2vr::input::InputAction::MoveInventory
+                                .quest_touch_click_path()
+                                .expect("Quest backpack binding"),
+                        )
+                        .unwrap(),
+                ),
+                xr::Binding::new(
+                    &audio_log_action,
+                    xr_instance
+                        .string_to_path(
+                            shock2vr::input::InputAction::ReadLastUnreadLog
+                                .quest_touch_click_path()
+                                .expect("Quest audio-log binding"),
+                        )
                         .unwrap(),
                 ),
             ],
@@ -492,7 +510,8 @@ fn main() {
     );
 
     // Controller button edges feed the same semantic action dispatcher as the
-    // desktop and debug runtimes. X exposes the player-owned backpack panel.
+    // desktop and debug runtimes. X exposes the player-owned backpack panel;
+    // Y opens/closes and replays the player-owned audio-log reader.
     // (The debug input server below can inject the same actions remotely.)
     let mut action_state = shock2vr::input::InputActionState::new();
     // Opt-in remote control for on-device automation; `None` unless
@@ -606,6 +625,7 @@ fn main() {
                             crouch_toggled = false;
                             crouch_button_was_pressed = false;
                             action_state.release(shock2vr::input::InputAction::MoveInventory);
+                            action_state.release(shock2vr::input::InputAction::ReadLastUnreadLog);
                         }
                         xr::SessionState::STOPPING => {
                             session.end().unwrap();
@@ -705,6 +725,7 @@ fn main() {
             .current_state;
         let crouch_state = crouch_action.state(&session, xr::Path::NULL).unwrap();
         let inventory_state = inventory_action.state(&session, xr::Path::NULL).unwrap();
+        let audio_log_state = audio_log_action.state(&session, xr::Path::NULL).unwrap();
         // Only edge-detect while the action is live: with the session merely
         // VISIBLE (system overlay up), current_state reads false even though
         // the button may still be physically held, and treating that as a
@@ -715,13 +736,18 @@ fn main() {
             }
             crouch_button_was_pressed = crouch_state.current_state;
         }
-        if inventory_state.is_active && inventory_state.changed_since_last_sync {
-            if inventory_state.current_state {
-                action_state.trigger(shock2vr::input::InputAction::MoveInventory);
-            } else {
-                action_state.release(shock2vr::input::InputAction::MoveInventory);
-            }
-        }
+        action_state.sync_discrete_button(
+            shock2vr::input::InputAction::MoveInventory,
+            inventory_state.is_active,
+            inventory_state.changed_since_last_sync,
+            inventory_state.current_state,
+        );
+        action_state.sync_discrete_button(
+            shock2vr::input::InputAction::ReadLastUnreadLog,
+            audio_log_state.is_active,
+            audio_log_state.changed_since_last_sync,
+            audio_log_state.current_state,
+        );
 
         let left_trigger_value = left_trigger
             .state(&session, xr::Path::NULL)

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -453,7 +453,8 @@ pub struct DebugSkillLevelsRequest {
     pub research: Option<i32>,
 }
 
-/// Snapshot of the flat-mode UI state for debug introspection (`GET /v1/ui`).
+/// Snapshot of the active presentation's UI state for debug introspection
+/// (`GET /v1/ui`).
 /// `mode` is "shooter" (mouse-look, no cursor) or "use" (cursor-driven
 /// metagame UI, the original game's Tab mode). `active_panel` is the
 /// object-bound MFD panel opened by frobbing a GUI-bearing entity (keypad,
@@ -483,8 +484,8 @@ pub struct DebugUiCursor {
     pub label: Option<String>,
 }
 
-/// The open flat-mode MFD panel: which entity it is bound to and its element
-/// list, so clients can click real widgets instead of hardcoding pixels.
+/// The open MFD/world panel: which entity it is bound to and its element list,
+/// so clients can inspect real widgets instead of hardcoding pixels.
 #[derive(Debug, Serialize, Clone)]
 pub struct DebugUiPanel {
     /// Runtime entity id of the bound object (NOT stable across runs).

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -314,6 +314,81 @@ impl GuiManager {
         self.render_filtered(asset_cache, world, true)
     }
 
+    /// Read-only snapshot of the active VR panel using the exact normalized
+    /// component data its world-space renderer consumes. This extends the
+    /// existing `/v1/ui` contract across presentations without introducing a
+    /// debug-only UI path or re-laying out any element.
+    pub fn debug_active_elements(&self, world: &World) -> Vec<crate::game_scene::DebugUiElement> {
+        let Some(active) = self.active_panel else {
+            return Vec::new();
+        };
+        let Some(info) = self
+            .handle_to_instance
+            .values()
+            .find(|instance| instance.parent_entity == active)
+        else {
+            return Vec::new();
+        };
+        let panel = Rect::new(0.0, 0.0, info.canvas_size_px.x, info.canvas_size_px.y);
+        info.components
+            .iter()
+            .filter(|component| {
+                !matches!(
+                    component,
+                    GuiComponentRenderInfo::Image { texture, .. }
+                        if texture.eq_ignore_ascii_case("cursor.pcx")
+                )
+            })
+            .map(|component| {
+                let rect = component.canvas_rect(panel);
+                let normalized = [
+                    rect.x / panel.w,
+                    rect.y / panel.h,
+                    rect.w / panel.w,
+                    rect.h / panel.h,
+                ];
+                let (kind, texture, text, label, entity_id) = match component {
+                    GuiComponentRenderInfo::Image {
+                        texture,
+                        interactive,
+                        entity,
+                        label,
+                        ..
+                    } => (
+                        if *interactive { "button" } else { "image" },
+                        Some(texture.clone()),
+                        None,
+                        label.clone().or_else(|| {
+                            entity.and_then(|entity| {
+                                world
+                                    .borrow::<View<dark::properties::PropSymName>>()
+                                    .ok()
+                                    .and_then(|names| {
+                                        names.get(entity).ok().map(|name| name.0.clone())
+                                    })
+                            })
+                        }),
+                        entity.map(|entity| entity.inner() as i32),
+                    ),
+                    GuiComponentRenderInfo::Text { text, .. } => {
+                        ("text", None, Some(text.clone()), None, None)
+                    }
+                };
+                crate::game_scene::DebugUiElement {
+                    kind: kind.to_owned(),
+                    texture,
+                    text,
+                    label,
+                    entity_id,
+                    rect: [rect.x, rect.y, rect.w, rect.h],
+                    // In VR there is no screen-space MFD rectangle; retain the
+                    // field as panel-normalized coordinates for tooling.
+                    screen_rect: normalized,
+                }
+            })
+            .collect()
+    }
+
     fn render_filtered(
         &mut self,
         asset_cache: &mut AssetCache,

--- a/shock2vr/src/input/actions.rs
+++ b/shock2vr/src/input/actions.rs
@@ -85,10 +85,9 @@ pub enum InputAction {
     /// `M` key). No-op in VR. See `projects/flat-ui-panels.md` §5.
     ToggleMap,
 
-    /// Play back the most recently collected audio log the player has not read
-    /// yet, opening the reader on it (the original's `play_unread_log`).
-    /// Collecting a disc only files it in the PDA, so this is how a log is
-    /// actually read.
+    /// Open/play the newest unread audio log (the original's
+    /// `play_unread_log`), or replay the newest collected log once all are read.
+    /// Collecting a disc only files it in the PDA, so this is how it is read.
     ReadLastUnreadLog,
 }
 
@@ -168,6 +167,17 @@ impl InputAction {
             InputAction::ToggleMap => "ToggleMap",
         }
     }
+
+    /// Production Meta Quest Touch binding for the two player-owned panels.
+    /// Keeping these paths beside their semantic actions makes the Oculus
+    /// mapping host-testable even though that runtime only compiles for Android.
+    pub fn quest_touch_click_path(&self) -> Option<&'static str> {
+        match self {
+            InputAction::MoveInventory => Some("/user/hand/left/input/x/click"),
+            InputAction::ReadLastUnreadLog => Some("/user/hand/left/input/y/click"),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for InputAction {
@@ -221,6 +231,18 @@ mod tests {
     fn from_str_rejects_unknown_action() {
         let result = "NotARealAction".parse::<InputAction>();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn quest_touch_keeps_x_for_backpack_and_assigns_y_to_the_log_reader() {
+        assert_eq!(
+            InputAction::MoveInventory.quest_touch_click_path(),
+            Some("/user/hand/left/input/x/click")
+        );
+        assert_eq!(
+            InputAction::ReadLastUnreadLog.quest_touch_click_path(),
+            Some("/user/hand/left/input/y/click")
+        );
     }
 
     #[test]

--- a/shock2vr/src/input/dispatcher.rs
+++ b/shock2vr/src/input/dispatcher.rs
@@ -142,7 +142,9 @@ impl ActionDispatcher {
             effects.push(Effect::ToggleMap);
         }
         if state.just_triggered(InputAction::ReadLastUnreadLog) {
-            effects.push(Effect::ReadLastUnreadLog);
+            effects.push(Effect::ReadLastUnreadLog {
+                head_rotation: input_context.head.rotation,
+            });
         }
         effects
     }
@@ -157,6 +159,23 @@ mod tests {
         let state = InputActionState::new();
         let effects = ActionDispatcher::dispatch(&state, &InputContext::default());
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn audio_log_reader_carries_the_current_head_rotation() {
+        use cgmath::{Deg, Rotation3};
+
+        let mut state = InputActionState::new();
+        state.trigger(InputAction::ReadLastUnreadLog);
+        let mut input = InputContext::default();
+        input.head.rotation = cgmath::Quaternion::from_angle_y(Deg(37.0));
+
+        let effects = ActionDispatcher::dispatch(&state, &input);
+
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::ReadLastUnreadLog { head_rotation }] if *head_rotation == input.head.rotation
+        ));
     }
 
     #[test]

--- a/shock2vr/src/input/state.rs
+++ b/shock2vr/src/input/state.rs
@@ -46,6 +46,27 @@ impl InputActionState {
     pub fn release(&mut self, action: InputAction) {
         self.held.remove(&action);
     }
+
+    /// Feed one platform boolean action into semantic input state. OpenXR uses
+    /// `is_active`/`changed_since_last_sync`; keeping that edge policy here
+    /// makes Quest button mappings host-testable without compiling Android-only
+    /// runtime dependencies.
+    pub fn sync_discrete_button(
+        &mut self,
+        action: InputAction,
+        is_active: bool,
+        changed_since_last_sync: bool,
+        current_state: bool,
+    ) {
+        if !is_active || !changed_since_last_sync {
+            return;
+        }
+        if current_state {
+            self.trigger(action);
+        } else {
+            self.release(action);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -89,5 +110,33 @@ mod tests {
         state.trigger(InputAction::QuickSave);
         assert!(!state.just_triggered(InputAction::QuickLoad));
         assert!(!state.is_held(InputAction::QuickLoad));
+    }
+
+    #[test]
+    fn quest_x_backpack_and_y_reader_edges_remain_independent() {
+        let mut state = InputActionState::new();
+
+        state.sync_discrete_button(InputAction::MoveInventory, true, true, true);
+        assert!(state.just_triggered(InputAction::MoveInventory));
+        assert!(!state.just_triggered(InputAction::ReadLastUnreadLog));
+        state.clear_triggered();
+
+        state.sync_discrete_button(InputAction::ReadLastUnreadLog, true, true, true);
+        assert!(state.just_triggered(InputAction::ReadLastUnreadLog));
+        assert!(state.is_held(InputAction::MoveInventory));
+
+        state.sync_discrete_button(InputAction::MoveInventory, true, true, false);
+        assert!(!state.is_held(InputAction::MoveInventory));
+        assert!(state.is_held(InputAction::ReadLastUnreadLog));
+    }
+
+    #[test]
+    fn inactive_or_unchanged_platform_buttons_do_not_mint_edges() {
+        let mut state = InputActionState::new();
+        state.sync_discrete_button(InputAction::ReadLastUnreadLog, false, true, true);
+        state.sync_discrete_button(InputAction::ReadLastUnreadLog, true, false, true);
+
+        assert!(!state.just_triggered(InputAction::ReadLastUnreadLog));
+        assert!(!state.is_held(InputAction::ReadLastUnreadLog));
     }
 }

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -41,10 +41,10 @@ use dark::{
         PropFrameAnimState, PropHasRefs, PropHitPoints, PropLimbModel, PropLocalPlayer,
         PropModelName, PropMotionActorTags, PropObjState, PropParticleGroup,
         PropParticleLaunchInfo, PropPhysDimensions, PropPhysInitialVelocity, PropPhysState,
-        PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropTeleported,
-        PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState, PropTweqModelConfig,
-        PropertyDefinition, RenderType, TeleportSource, ToLink, TripFlags, TweqAnimationState,
-        WrappedEntityId,
+        PropPhysType, PropPlayerGun, PropPosition, PropRenderType, PropScripts, PropSymName,
+        PropTeleported, PropTripFlags, PropTweqDeleteConfig, PropTweqDeleteState,
+        PropTweqModelConfig, PropertyDefinition, RenderType, TeleportSource, ToLink, TripFlags,
+        TweqAnimationState, WrappedEntityId,
     },
     ss2_entity_info::{self, SystemShock2EntityInfo},
     tag_database::{TagQuery, TagQueryItem},
@@ -128,6 +128,13 @@ const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 const VR_BACKPACK_FORWARD: f32 = 5.0;
 const VR_BACKPACK_UP: f32 = 3.0;
 const VR_BACKPACK_WORLD_SCALE: f32 = 0.55;
+
+/// Head-relative authored-space placement for the narrow portrait reader.
+/// After Dark's scale conversion the panel center is 1.5 world units forward
+/// and 1.4 units above the player origin, keeping its 0.75 x 1.18 canvas fully
+/// framed and within ordinary controller reach.
+const VR_MEDIA_FORWARD: f32 = 3.75;
+const VR_MEDIA_UP: f32 = 3.5;
 
 fn presentation_world_panel_size(
     presentation: crate::PresentationMode,
@@ -608,6 +615,12 @@ pub struct GlobalTemplateObjIcons(pub HashMap<i32, String>);
 /// flat host. See `projects/flat-ui-panels.md` §5.
 #[derive(Unique, Clone, Copy)]
 pub struct MapPanelEntity(pub EntityId);
+
+/// Nonserialized player-owned host for the audio-log reader. Physical log
+/// discs belong to their source mission; this host is rebuilt on every mission
+/// so a persisted `(deck, log)` can be localized and replayed anywhere.
+#[derive(Unique, Clone, Copy)]
+pub struct MediaPanelEntity(pub EntityId);
 
 /// The automap location (`PropMapLoc`) of the mapped room the player most
 /// recently entered - the player's *current* map location. The automap uses it
@@ -1108,6 +1121,27 @@ impl MissionCore {
             ));
             world.add_unique(MapPanelEntity(entity));
         }
+
+        // Both presentations share the exact MediaGui canvas. Flat docks this
+        // synthetic host in its MFD slot; VR positions the same host in front
+        // of the player's current gaze and routes it through GuiManager.
+        let media_panel = world.add_entity((
+            Links::empty(),
+            PropScripts {
+                scripts: vec!["internal_media".to_owned()],
+                inherits: false,
+            },
+            dark::properties::PropTemplateId { template_id: -1 },
+            PropSymName("Audio Log Reader".to_owned()),
+            PropPosition {
+                position: vec3(0.0, 0.0, 0.0),
+                rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+                cell: 0,
+            },
+            RuntimePropTransform(Matrix4::identity()),
+            RuntimePropDoNotSerialize,
+        ));
+        world.add_unique(MediaPanelEntity(media_panel));
 
         world.add_unique(GlobalTemplateIdMap(template_to_entity_id.clone()));
 
@@ -3095,11 +3129,9 @@ impl MissionCore {
         }
     }
 
-    /// Consume an audio-log pickup while retaining its ECS entity as the
-    /// backing object for the currently open reader panel. Retail SS2 destroys
-    /// the disc after copying its log identity into the player's PDA; the
-    /// reader in this port is entity-bound, so removing its world presence is
-    /// the equivalent transition without invalidating the panel mid-frob.
+    /// Consume an audio-log pickup after copying its identity into the PDA.
+    /// The ECS entity remains as inert mission state, while playback binds the
+    /// shared MediaGui to the nonserialized player-owned reader host.
     ///
     /// `PropHasRefs(false)` persists through mission save/load, removing the
     /// model from rendering on both the current and reconstructed mission. The
@@ -3112,23 +3144,24 @@ impl MissionCore {
     }
 
     /// Resolve an audio log's reader strings from `level<deck>.str` and cache
-    /// them on the disc for `MediaGui` to render.
+    /// them on the supplied `MediaGui` host. Returns true only when a real
+    /// transcript was found, so callers never mark a log read or play audio
+    /// after opening an empty backdrop.
     ///
     /// `RuntimePropLogData` is runtime-only and deliberately not serialized, so
-    /// this runs both when the log is collected and again each time the reader
-    /// is opened - otherwise a log collected before a save would open a blank
-    /// backdrop after loading.
+    /// this runs each time the reader is opened - otherwise a log collected
+    /// before a save would open a blank backdrop after loading.
     fn attach_log_reader_strings(
         &mut self,
         entity_id: EntityId,
         deck: u32,
         log: u32,
         asset_cache: &mut AssetCache,
-    ) {
+    ) -> bool {
         let level_file = format!("level{deck:02}.str");
         let Some(strings) = asset_cache.get_opt(&dark::importers::STRINGS_IMPORTER, &level_file)
         else {
-            return;
+            return false;
         };
         // The .str values carry literal backslash-n escapes ("AMANPOUR
         // 07.JUL.14\nre: New code\n"); unescape them into real line breaks so
@@ -3138,15 +3171,17 @@ impl MissionCore {
                 .get(&format!("{prefix}{log}"))
                 .map(|s| s.replace("\\n", "\n"))
         };
-        self.world.add_component(
-            entity_id,
-            crate::runtime_props::RuntimePropLogData {
-                name: get("logname"),
-                text: get("logtext"),
-                portrait: get("logportrait"),
-                icon: get("logicon"),
-            },
-        );
+        let data = crate::runtime_props::RuntimePropLogData {
+            name: get("logname"),
+            text: get("logtext"),
+            portrait: get("logportrait"),
+            icon: get("logicon"),
+        };
+        if data.text.as_deref().is_none_or(str::is_empty) {
+            return false;
+        }
+        self.world.add_component(entity_id, data);
+        true
     }
 
     pub fn make_physical(&mut self, entity_id: EntityId) {
@@ -4012,115 +4047,145 @@ impl MissionCore {
                     deck,
                     log,
                 } => {
-                    // Record the log identity into the persistent collection...
+                    // Retail pickup files the identity and acknowledges it; it
+                    // does not play the log or open the reader. Quest now has
+                    // a production Y binding for the same explicit playback
+                    // action as flat presentation, so the old VR auto-play
+                    // stopgap is no longer needed.
                     {
                         let mut quests = self.world.borrow::<UniqueViewMut<QuestInfo>>().unwrap();
                         quests.collect_log(deck, log);
                     }
-                    self.attach_log_reader_strings(entity_id, deck, log, asset_cache);
-
-                    // VR has no discrete-action mapper yet, so `ReadLastUnreadLog`
-                    // is unreachable there and the disc is retired from the world
-                    // on collection - without this, a Quest player could never
-                    // hear a log at all. Flat keeps the faithful split (collecting
-                    // files it; reading plays it). Stopgap: remove once VR can
-                    // trigger the action (#921).
-                    if game_options.presentation_mode != crate::PresentationMode::Flat {
-                        effects.push_front(Effect::PlaySound {
-                            handle: AudioHandle::new(),
-                            source: Some(entity_id),
-                            name: format!("LOG{deck:02}{log:02}"),
-                            spatial: false,
-                        });
-                    }
                     // Retail copies the entry into the PDA and destroys the
-                    // pickup. Keep only the entity-bound reader state; retire
-                    // the disc from the rendered, physical, frobbable world.
+                    // pickup. Retire it from rendered, physical and container
+                    // presence; the player-owned reader carries presentation.
                     self.consume_log_pickup(entity_id);
                 }
 
-                Effect::ReadLastUnreadLog => {
-                    // The reader is entity-bound, so playback needs the disc
-                    // that carries this log. Logs collected on an earlier deck
-                    // left their disc behind with that mission (#741), so pick
-                    // the newest unread log that actually resolves here rather
-                    // than letting an unreachable one wedge the key forever.
-                    let unread: Vec<(u32, u32)> = self
+                Effect::ReadLastUnreadLog { head_rotation } => {
+                    let panel_entity = self
+                        .world
+                        .borrow::<UniqueView<MediaPanelEntity>>()
+                        .ok()
+                        .map(|panel| panel.0);
+                    let Some(panel_entity) = panel_entity else {
+                        game_log!(WARN, "audio log reader host is unavailable");
+                        continue;
+                    };
+
+                    // Y is also the production dismiss affordance in VR. The
+                    // next press re-enters this path, re-resolves and replays
+                    // the latest collected log even when it is already read.
+                    if game_options.presentation_mode == crate::PresentationMode::Vr
+                        && self.gui.active_panel() == Some(panel_entity)
+                    {
+                        self.gui.close_panel(
+                            &mut self.world,
+                            &mut self.physics,
+                            &mut self.script_world,
+                            &mut self.id_to_physics,
+                        );
+                        continue;
+                    }
+
+                    // Resolving a candidate's reader strings can fail (a log
+                    // collected on an earlier deck, a missing transcript), so
+                    // walk the preference-ordered candidates and open the first
+                    // one that actually resolves - taking only the front entry
+                    // would let one unresolvable log wedge the control forever
+                    // (it is never marked read, so it stays at the front).
+                    let candidates: Vec<(u32, u32)> = self
                         .world
                         .borrow::<UniqueView<QuestInfo>>()
-                        .map(|quest_info| {
-                            quest_info
-                                .collected_logs()
-                                .iter()
-                                .rev()
-                                .filter(|entry| !entry.read)
+                        .map(|quests| {
+                            quests
+                                .logs_for_reader()
                                 .map(|entry| (entry.deck, entry.log))
                                 .collect()
                         })
                         .unwrap_or_default();
-
-                    let target = {
-                        let v_log = self
-                            .world
-                            .borrow::<View<dark::properties::PropLog>>()
-                            .unwrap();
-                        let v_data = self
-                            .world
-                            .borrow::<View<crate::runtime_props::RuntimePropLogData>>()
-                            .unwrap();
-                        unread.into_iter().find_map(|(deck, log)| {
-                            // A (deck, log) pair is not unique across the
-                            // campaign - command1 object 2382 and command2 2379
-                            // both author deck 6 / log 5 - so prefer the disc
-                            // that was actually collected (only it carries the
-                            // resolved reader strings) over an untouched twin
-                            // still lying in the current mission.
-                            let mut matches = v_log
-                                .iter()
-                                .with_id()
-                                .filter(|(_, authored)| {
-                                    authored.deck == deck && authored.log == log
-                                })
-                                .map(|(entity_id, _)| entity_id);
-                            let first = matches.next()?;
-                            let collected = std::iter::once(first)
-                                .chain(matches)
-                                .find(|entity_id| v_data.get(*entity_id).is_ok());
-                            Some((collected.unwrap_or(first), deck, log))
-                        })
+                    if candidates.is_empty() {
+                        game_log!(INFO, "no collected audio log is available");
+                        continue;
+                    }
+                    let resolved = candidates.into_iter().find(|(deck, log)| {
+                        self.attach_log_reader_strings(panel_entity, *deck, *log, asset_cache)
+                    });
+                    let Some((deck, log)) = resolved else {
+                        game_log!(
+                            WARN,
+                            "unable to open audio log reader: no collected log has a localized transcript here"
+                        );
+                        continue;
                     };
+                    self.world.add_component(
+                        panel_entity,
+                        dark::properties::PropLog {
+                            deck,
+                            email: 33,
+                            log,
+                            note: 0,
+                            video: 0,
+                        },
+                    );
+                    self.script_world.dispatch(Message {
+                        to: panel_entity,
+                        payload: MessagePayload::PanelOpened,
+                    });
 
-                    match target {
-                        Some((disc, deck, log)) => {
-                            // Re-resolve the strings: they are runtime-only, so
-                            // a log collected before a save has none after load.
-                            self.attach_log_reader_strings(disc, deck, log, asset_cache);
-                            // Reaching the reader without a frob still needs the
-                            // per-open reset a frob-open would have given it
-                            // (the transcript starts at the top).
-                            self.script_world.dispatch(Message {
-                                to: disc,
-                                payload: MessagePayload::PanelOpened,
-                            });
-                            if let Ok(mut quest_info) =
-                                self.world.borrow::<UniqueViewMut<QuestInfo>>()
-                            {
-                                quest_info.mark_log_read(deck, log);
-                            }
-                            if game_options.presentation_mode == crate::PresentationMode::Flat {
-                                self.flat_ui.open_unbound(disc);
-                            }
-                            effects.push_front(Effect::PlaySound {
-                                handle: AudioHandle::new(),
-                                source: None,
-                                name: format!("LOG{deck:02}{log:02}"),
-                                spatial: false,
-                            });
-                        }
-                        None => {
-                            game_log!(INFO, "no unread log is readable here");
+                    match game_options.presentation_mode {
+                        crate::PresentationMode::Flat => self.flat_ui.open_unbound(panel_entity),
+                        crate::PresentationMode::Vr => {
+                            let (player_position, player_rotation) = {
+                                let player = self.world.borrow::<UniqueView<PlayerInfo>>().unwrap();
+                                (player.pos, player.rotation * head_rotation)
+                            };
+                            let offset = player_rotation
+                                * vec3(
+                                    0.0,
+                                    VR_MEDIA_UP / SCALE_FACTOR,
+                                    -VR_MEDIA_FORWARD / SCALE_FACTOR,
+                                );
+                            let panel_position = player_position + offset;
+                            let panel_rotation =
+                                Quaternion::from_angle_y(cgmath::Deg(180.0)) * player_rotation;
+                            self.world.add_component(
+                                panel_entity,
+                                PropPosition {
+                                    position: panel_position,
+                                    rotation: panel_rotation,
+                                    cell: 0,
+                                },
+                            );
+                            self.world.add_component(
+                                panel_entity,
+                                RuntimePropTransform(
+                                    Matrix4::from_translation(panel_position)
+                                        * Matrix4::from(panel_rotation),
+                                ),
+                            );
+                            self.gui.open_panel(
+                                panel_entity,
+                                false,
+                                &mut self.world,
+                                &mut self.physics,
+                                &mut self.script_world,
+                                &mut self.id_to_physics,
+                            );
                         }
                     }
+
+                    // Only after a localized reader is bound to the active
+                    // presentation do read state and audio advance together.
+                    if let Ok(mut quest_info) = self.world.borrow::<UniqueViewMut<QuestInfo>>() {
+                        quest_info.mark_log_read(deck, log);
+                    }
+                    effects.push_front(Effect::PlaySound {
+                        handle: AudioHandle::new(),
+                        source: None,
+                        name: format!("LOG{deck:02}{log:02}"),
+                        spatial: false,
+                    });
                 }
 
                 Effect::ToggleMap => {
@@ -8066,15 +8131,22 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                 .unwrap_or(0);
             (name, template_id)
         };
-        let active_panel = self.flat_ui.active_panel().map(|entity| {
-            let (name, template_id) = panel_identity(entity);
-            crate::game_scene::DebugUiPanel {
-                entity_id: entity.inner() as i32,
-                template_id,
-                name,
-                elements: self.flat_ui.debug_elements(&self.world),
-            }
-        });
+        let flat_panel = self.flat_ui.active_panel();
+        let active_panel = flat_panel
+            .or_else(|| self.gui.active_panel())
+            .map(|entity| {
+                let (name, template_id) = panel_identity(entity);
+                crate::game_scene::DebugUiPanel {
+                    entity_id: entity.inner() as i32,
+                    template_id,
+                    name,
+                    elements: if flat_panel == Some(entity) {
+                        self.flat_ui.debug_elements(&self.world)
+                    } else {
+                        self.gui.debug_active_elements(&self.world)
+                    },
+                }
+            });
         // The top-docked inventory strip (Tab metagame mode), same element
         // contract as the MFD panel.
         let strip = self.flat_ui.strip_entity().map(|entity| {

--- a/shock2vr/src/quest_info.rs
+++ b/shock2vr/src/quest_info.rs
@@ -128,6 +128,22 @@ impl QuestInfo {
         self.collected_logs.iter().rev().find(|entry| !entry.read)
     }
 
+    /// Candidates for the reader/replay control, in preference order: retail's
+    /// newest-unread-first ordering, then the already-read entries (newest
+    /// first) so the same control remains a replay affordance once everything
+    /// is read.
+    ///
+    /// This is a sequence rather than a single target because the caller has
+    /// to resolve each candidate's localized reader strings, which can fail
+    /// (a log collected on an earlier deck, a missing transcript). Offering
+    /// only the front entry would let one unresolvable log wedge the reader
+    /// forever; the caller skips to the next candidate instead.
+    pub fn logs_for_reader(&self) -> impl Iterator<Item = &CollectedLog> {
+        let unread = self.collected_logs.iter().rev().filter(|entry| !entry.read);
+        let read = self.collected_logs.iter().rev().filter(|entry| entry.read);
+        unread.chain(read)
+    }
+
     /// Mark a collected log as played back. Returns `true` when this flipped it
     /// from unread (re-reading an already-read log is a no-op).
     pub fn mark_log_read(&mut self, deck: u32, log: u32) -> bool {
@@ -244,13 +260,50 @@ mod log_tests {
     }
 
     #[test]
-    fn nothing_is_played_back_once_every_log_is_read() {
+    fn reader_replays_the_latest_collected_log_once_everything_is_read() {
         let mut quest_info = quest_info_with(&[(1, 1), (2, 2)]);
 
         quest_info.mark_log_read(1, 1);
         quest_info.mark_log_read(2, 2);
 
         assert!(quest_info.last_unread_log().is_none());
+        let replay = quest_info
+            .logs_for_reader()
+            .next()
+            .expect("latest log remains replayable");
+        assert_eq!((replay.deck, replay.log), (2, 2));
+    }
+
+    #[test]
+    fn reader_prefers_a_newer_unread_entry_before_replay_fallback() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+        quest_info.mark_log_read(3, 3);
+
+        let target = quest_info
+            .logs_for_reader()
+            .next()
+            .expect("older unread log remains");
+
+        assert_eq!((target.deck, target.log), (2, 2));
+    }
+
+    /// A log whose reader strings do not resolve here (collected on an earlier
+    /// deck, missing localized transcript) must not wedge the control forever:
+    /// the reader offers every collected entry in preference order so the
+    /// caller can skip to the next resolvable one.
+    #[test]
+    fn an_unresolvable_log_does_not_wedge_the_reader() {
+        let mut quest_info = quest_info_with(&[(1, 1), (2, 2), (3, 3)]);
+        quest_info.mark_log_read(3, 3);
+
+        let candidates: Vec<(u32, u32)> = quest_info
+            .logs_for_reader()
+            .map(|entry| (entry.deck, entry.log))
+            .collect();
+
+        // Unread newest-first, then the already-read entries newest-first as
+        // the replay fallback. Every collected log is reachable.
+        assert_eq!(candidates, vec![(2, 2), (1, 1), (3, 3)]);
     }
 
     /// Re-reading is a no-op, and an unknown log is not silently inserted.

--- a/shock2vr/src/runtime_props.rs
+++ b/shock2vr/src/runtime_props.rs
@@ -292,10 +292,10 @@ pub struct RuntimePropMapData {
 }
 
 // RuntimePropLogData - the resolved presentation strings for an audio log,
-// attached to the log-disc entity when it is frobbed (collected). The reader
+// attached to the player-owned media host when playback opens. The reader
 // panel (`MediaGui`) reads it to render the portrait/deck-icon/name/transcript.
 // Not serialized: it is a presentation cache derived from the string tables and
-// is re-resolved on the next frob (the log identity itself persists in
+// is re-resolved the next time the reader opens (the log identity persists in
 // `QuestInfo`).
 #[derive(Component, Clone, Debug)]
 pub struct RuntimePropLogData {

--- a/shock2vr/src/scripts/effect.rs
+++ b/shock2vr/src/scripts/effect.rs
@@ -181,23 +181,26 @@ pub enum Effect {
     },
 
     /// Record an audio log the player just frobbed into the persistent
-    /// collection (`QuestInfo`), resolve its transcript/portrait strings onto
-    /// the disc entity (`RuntimePropLogData`) for the reader panel, then retire
-    /// the pickup's world presence. Emitted by the log disc's `MediaGui` on
-    /// frob. `entity_id` is retained only as reader backing state; `deck`/`log`
-    /// key the `level<deck>.str` strings.
+    /// collection (`QuestInfo`), then retire the pickup's world presence.
+    /// Emitted by the log disc's `MediaGui` on frob. `deck`/`log` are the
+    /// durable identity later localized by the player-owned reader host.
     CollectLog {
         entity_id: EntityId,
         deck: u32,
         log: u32,
     },
 
-    /// Play back the most recently collected audio log the player has not read
-    /// yet (the original's `play_unread_log`): open the reader bound to that
-    /// disc's backing entity, mark it read, and play its `LOG<dd><nn>` audio.
-    /// No-op when every collected log has been read. Emitted by
-    /// `InputAction::ReadLastUnreadLog`.
-    ReadLastUnreadLog,
+    /// Play back the newest unread audio log (the original's
+    /// `play_unread_log`), falling back to replaying the newest collected log
+    /// once all are read. Opens the localized player-owned reader before
+    /// marking it read and playing its `LOG<dd><nn>` audio. No-op only when the
+    /// collection is empty or the authored transcript is unavailable.
+    ReadLastUnreadLog {
+        /// Head rotation at the input edge. VR uses it to place the
+        /// player-owned reader comfortably in the player's current gaze;
+        /// flat presentation ignores it.
+        head_rotation: Quaternion<f32>,
+    },
 
     /// Toggle the flat-mode automap panel (the original's BIOFULL MAP button /
     /// `M` key, `kOverlayMap 26`). Opens the wide map MFD bound to the

--- a/shock2vr/src/scripts/gui/media.rs
+++ b/shock2vr/src/scripts/gui/media.rs
@@ -1,14 +1,12 @@
 //! Audio-log / email reader MFD (`projects/flat-ui-panels.md` §1).
 //!
-//! The flat-mode reader panel matching the original game's email/log overlay: a
-//! `LOG.PCX` backdrop with the sender portrait, deck icon, header line and a word-wrapped,
-//! scrollable transcript. It is bound to the frobbed log-disc entity (the flat
-//! host's single-slot MFD), and reads its presentation strings from
-//! `RuntimePropLogData` - attached by the `Effect::CollectLog` handler when the
-//! disc is frobbed (that handler also records the log into the persistent
-//! `QuestInfo` collection and retires the physical pickup). The ECS entity stays
-//! alive only as reader backing state so the entity-bound panel remains valid
-//! after the retail-faithful one-shot pickup disappears from the world.
+//! The shared flat/VR reader panel matching the original game's email/log
+//! overlay: a `LOG.PCX` backdrop with sender portrait, deck icon, header and a
+//! word-wrapped, scrollable transcript. Pickup records a durable `(deck, log)`
+//! in `QuestInfo`; `ReadLastUnreadLog` resolves its localized presentation into
+//! `RuntimePropLogData` on a nonserialized player-owned host. Flat docks that
+//! exact canvas in its MFD slot, while VR maps it onto a head-positioned world
+//! panel through `GuiManager`.
 
 use cgmath::{Vector2, Vector3, vec2};
 use dark::properties::PropLog;

--- a/shock2vr/src/scripts/mod.rs
+++ b/shock2vr/src/scripts/mod.rs
@@ -924,6 +924,7 @@ impl ScriptWorld {
             "internal_collision_type" => Box::new(InternalCollisionType::new()),
             "internal_inventory" => gui_script(Box::new(ContainerGui::inv_container())),
             "internal_map" => gui_script(Box::new(MapGui)),
+            "internal_media" => gui_script(Box::new(MediaGui)),
             // "internal_inventory" => Box::new(PanicOnLoadScript::new("internal_inventory")),
             "internal_explosion" => Box::new(InternalExplosion::new()),
             "internal_frob_move" => Box::new(InternalFrobMove::new()),

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -582,7 +582,7 @@ export interface UiElement {
   screen_rect: [number, number, number, number];
 }
 
-/** The open flat-mode MFD panel (opened by frobbing a GUI-bearing entity). */
+/** The open MFD or VR world panel (opened by a production UI action/frob). */
 export interface UiPanel {
   /** Runtime entity id of the bound object (NOT stable across runs). */
   entity_id: number;
@@ -604,7 +604,7 @@ export interface UiCursor {
   label: string | null;
 }
 
-/** Flat-mode UI snapshot (GET /v1/ui). */
+/** Active-presentation UI snapshot (GET /v1/ui). */
 export interface UiState {
   mode: "shooter" | "use";
   /** The open MFD panel, or null when none is open. */

--- a/tools/shock2-sdk/test/log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/log-reader.e2e.test.ts
@@ -28,7 +28,8 @@ import { teleportVerified } from "./helpers/teleport.js";
 // texture wins - the archive-qualified assertions below fail on that build.
 //
 // Entity discovery is by stable template_id (1608 = the mission-file object
-// id); runtime entity ids are NOT stable across launches.
+// id); playback uses the synthetic player-owned reader host (template -1), so
+// it remains valid after the source disc's mission is gone.
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
 
 test(
@@ -98,8 +99,8 @@ test(
     );
     assert.equal(
       opened.active_panel.template_id,
-      1608,
-      "the reader panel should be bound to the Amanpour log entity",
+      -1,
+      "the reader panel should be bound to the player-owned media host",
     );
     assert.deepEqual(
       (await game.info()).player.collected_logs,

--- a/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-audio-log-reader.e2e.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { PhysicsBodySummary, UiPanel, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// Exact MedSci campaign regression for #921. This uses the authentic production
+// VR chain rather than a debug Frob shortcut:
+//
+//   corpse 1680 --Contains(0)--> Amanpour Log 1608
+//   hand trigger -> corpse ContainerGui world panel
+//   hand trigger on the rendered slot -> LogDiscScript collection
+//   Quest Y's semantic action -> player-owned MediaGui world panel
+//
+// Negative-first on PR #967's head: collection auto-plays LOG0220, the semantic
+// action marks it read and plays it again, but the corpse panel stays active and
+// no VR transcript ever renders. There is also no Oculus Y binding.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const AMANPOUR_CORPSE = 1680;
+const AMANPOUR_LOG = 1608;
+const PANEL_SIZE_PX: Vec3 = [188, 296, 0];
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const LOG_SLOT_CENTER_PX: Vec3 = [15 + 35 / 2, 153 + 34 / 2, 0];
+
+const uiBodies = async (game: GameServer): Promise<PhysicsBodySummary[]> =>
+  (await game.physics.bodies()).bodies.filter((body) =>
+    body.collision_groups.includes("ui"),
+  );
+
+const panelText = (panel: UiPanel): string =>
+  panel.elements
+    .filter((element) => element.kind === "text" && element.text)
+    .map((element) => element.text)
+    .join(" ");
+
+const log0220Count = async (game: GameServer): Promise<number> =>
+  (await game.audio.recent()).sounds.filter(
+    (sound) => sound.sample.toLowerCase() === "log0220",
+  ).length;
+
+async function collectAmanpourThroughVrCorpse(game: GameServer): Promise<void> {
+  const [corpse] = await game.entities.byTemplate(AMANPOUR_CORPSE);
+  assert.ok(corpse, "medsci1 must contain corpse 1680");
+  const contains = (await game.entities.detail(corpse.id)).outgoing_links.filter(
+    (link) => link.link_type.startsWith("Contains"),
+  );
+  assert.equal(contains.length, 1, "corpse 1680 should contain exactly one object");
+  const logId = contains[0].target_id;
+  assert.equal(
+    (await game.entities.detail(logId)).template_id,
+    AMANPOUR_LOG,
+    "corpse 1680 must contain the Amanpour mission object 1608",
+  );
+
+  await teleportVerified(game, {
+    x: corpse.position[0] + 1.2,
+    y: corpse.position[1] + 0.5,
+    z: corpse.position[2] + 1.2,
+  });
+  const corpseAim = await game.player.aimAt(corpse, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(corpseAim.target_confirmed, true, "corpse 1680 must be hand-reachable");
+  await aimVrHandAt(game, corpseAim.world_point);
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 5 });
+
+  const [corpsePanel] = await uiBodies(game);
+  assert.ok(corpsePanel, "production corpse frob must open its VR loot panel");
+  assert.equal((await uiBodies(game)).length, 1, "only the corpse panel should be open");
+
+  // Invert ProxyGuiScript's world -> normalized-canvas mapping for Contains(0),
+  // the first authored 35x34 slot in the 188x296 corpse canvas.
+  const panelSize: Vec3 = [
+    PANEL_SIZE_PX[0] * GUI_PIXEL_TO_WORLD_SIZE,
+    PANEL_SIZE_PX[1] * GUI_PIXEL_TO_WORLD_SIZE,
+    0,
+  ];
+  const u = LOG_SLOT_CENTER_PX[0] / PANEL_SIZE_PX[0];
+  const v = LOG_SLOT_CENTER_PX[1] / PANEL_SIZE_PX[1];
+  const localSlot: Vec3 = [panelSize[0] * (0.5 - u), panelSize[1] * (0.5 - v), 0];
+  const slotWorld = add(
+    corpsePanel.position,
+    quatRotate(corpsePanel.rotation, localSlot),
+  );
+  const panelAim = await aimVrHandAt(game, slotWorld, 0.35);
+  const hit = await game.raycast({
+    start: panelAim.start,
+    end: panelAim.target,
+    collision_groups: ["ui"],
+    max_distance: 1,
+  });
+  assert.equal(hit.entity_id, corpsePanel.entity_id, "hand ray must hit Log1608's slot");
+
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  await game.input.set("right_hand.trigger", 0);
+  await game.step({ frames: 5 });
+  assert.deepEqual((await game.info()).player.collected_logs, [
+    { deck: 2, log: 20, read: false },
+  ]);
+}
+
+async function assertAmanpourReader(game: GameServer): Promise<UiPanel> {
+  const panel = (await game.ui.state()).active_panel;
+  assert.ok(panel, "ReadLastUnreadLog must expose the active VR MediaGui panel");
+  assert.equal(panel.template_id, -1, "the reader must use its player-owned host");
+  const text = panelText(panel);
+  assert.ok(text.includes("45100"), `reader transcript must visibly contain 45100: ${text}`);
+  assert.ok(text.toUpperCase().includes("AMANPOUR"), `reader must identify Amanpour: ${text}`);
+  const textures = panel.elements
+    .filter((element) => element.kind === "image")
+    .map((element) => element.texture?.toLowerCase());
+  assert.ok(textures.includes("iface/log.pcx"));
+  assert.ok(textures.includes("amanpour.pcx"));
+  assert.ok(textures.includes("medicon.pcx"));
+  assert.equal((await uiBodies(game)).length, 1, "reader must replace, not overlap, corpse UI");
+  return panel;
+}
+
+test(
+  "Quest VR collects Amanpour through corpse 1680 and reopens its 45100 reader across save/load and decks",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8571),
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const beforeCollectionAudio = await log0220Count(game);
+    await collectAmanpourThroughVrCorpse(game);
+    assert.equal(
+      await log0220Count(game),
+      beforeCollectionAudio,
+      "VR pickup must only file the log; the production reader action owns playback",
+    );
+
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
+    assert.deepEqual((await game.info()).player.collected_logs, [
+      { deck: 2, log: 20, read: true },
+    ]);
+    assert.equal(await log0220Count(game), beforeCollectionAudio + 1);
+    await game.screenshot("vr-amanpour-reader-45100.png");
+
+    // Quest Y toggles the reader closed, then reopens/replays the latest entry
+    // even though it is already read.
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).active_panel, null);
+    assert.equal((await uiBodies(game)).length, 0);
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
+    assert.equal(await log0220Count(game), beforeCollectionAudio + 2);
+
+    const saveName = `issue921_vr_log_${Date.now()}`;
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    assert.equal((await game.ui.state()).active_panel, null, "load removes transient panel");
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
+
+    await game.transitionLevel("medsci2.mis");
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).mission, "medsci2.mis");
+    await game.input.trigger("ReadLastUnreadLog");
+    await game.step({ frames: 5 });
+    await assertAmanpourReader(game);
+
+    // PR #967's X/backpack affordance stays independent of Y. It replaces the
+    // reader through the same one-panel lifecycle and toggles away cleanly.
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    const backpack = (await game.ui.state()).active_panel;
+    assert.ok(backpack, "Quest X must still open the real backpack panel");
+    assert.ok(
+      backpack.elements.some(
+        (element) => element.kind === "image" && element.texture?.toLowerCase() === "invback.pcx",
+      ),
+      "Quest X must show the authored INVBACK canvas",
+    );
+    assert.equal((await uiBodies(game)).length, 1, "backpack replaces reader without overlap");
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    assert.equal((await uiBodies(game)).length, 0);
+  },
+);


### PR DESCRIPTION
## Dependency

**Stacked on #967 (`fix/964-vr-backpack-retrieval`). Review and merge #967 first.** This change deliberately composes its production Quest `X → MoveInventory` mapping and assigns the log reader to the still-free left-controller `Y` button.

## What changed

- add the production Oculus Touch `Y → ReadLastUnreadLog` binding while preserving `X → backpack`, with shared host tests pinning both paths and independent button edges
- file log pickups without the temporary VR auto-play; `Y` opens the newest unread log, toggles it closed, and reopens/replays the latest collected log after all entries are read
- present the authentic localized `MediaGui` canvas through `GuiManager` on a nonserialized player-owned, head-positioned VR host; flat presentation docks that same canvas in its existing MFD slot
- rebuild transcript/portrait/deck metadata from the durable `(deck, log)` identity after save/load and across missions, and mark read only after a real localized reader is bound
- expose the active VR panel through the existing read-only `/v1/ui` inspection contract so exact-mission E2E assertions observe the same resolved elements the renderer consumes

## Root cause and campaign evidence

Campaign: `earth → station → medsci1 · Navy tech · 25th Anniversary · VR · seed 976894603`

The failure had two independent layers: Oculus mapped only #967's `X → MoveInventory`, leaving `ReadLastUnreadLog` unreachable; and the semantic effect opened `MediaGui` only through `FlatUiHost`. In VR it marked the log read and played audio while leaving the corpse panel visible. Physical discs were also mission-owned and lookup considered unread entries only, preventing read replay and cross-mission use.

Negative-first against exact #967 head `e6785aa51e0b1829275575bbd0ba5923f6bc86f0` reproduced the authentic MedSci1 path: corpse 1680's real VR container panel → `Contains(0)` Log1608 click. The intended regression failed because collection immediately emitted LOG0220 while no transcript opened; the later semantic action still left the corpse panel active. The fixed scenario visibly renders Amanpour's localized transcript and **45100**, replaces the corpse panel, closes/reopens, replays an already-read entry, survives save/load and MedSci1→MedSci2 transition, and then verifies #967's X backpack still opens/closes alone.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 662 passed
- `cd tools/shock2-sdk && npm test` — 26 passed, 225 E2Es skipped by the expected gate
- focused exact VR E2E: `vr-audio-log-reader.e2e.test.ts` — passed
- focused flat reader E2Es: `log-reader.e2e.test.ts` — 2 passed
- #967 VR backpack regression: `vr-backpack.e2e.test.ts` — passed

Quest device preflight could not run because adb is unavailable on this host: `quest-device: spawnSync adb ENOENT`. Direct macOS compilation of the Android-only runtime is likewise unsupported by `ndk-sys`/`oboe-sys`; the actual production binding strings and button-edge policy are host-unit-tested, the shared VR semantics are exact-mission E2E-tested, and Android CI is required before merge.

## Visual evidence

![VR audio log reader demo](https://gist.githubusercontent.com/tommy-xr/1826ac4b19272cc0a9e6c0bafbc13b74/raw/pr968-vr-audio-log-reader.gif)

<sub>Exact MedSci1 VR sequence: corpse mission object 1680 → real container slot (`Contains(0)`) → Log1608 collection → production-equivalent `ReadLastUnreadLog`. The fixed runtime replaces the empty corpse panel with the localized Amanpour MediaGui, including access code `45100`. Captured headlessly through the debug runtime with deterministic fixed 60 Hz stepping.</sub>

![VR audio log reader still](https://gist.githubusercontent.com/tommy-xr/1826ac4b19272cc0a9e6c0bafbc13b74/raw/pr968-vr-audio-log-reader.png)

### Before → after

![PR 967 versus PR 968 VR audio log reader](https://gist.githubusercontent.com/tommy-xr/1826ac4b19272cc0a9e6c0bafbc13b74/raw/pr968-vr-audio-log-reader-before-after.png)

<sub>The same fresh-launch interaction and deterministic capture sequence ran against exact #967 head `e6785aa51e0b1829275575bbd0ba5923f6bc86f0` and fixed #968 commit `5405ca5121a664e02ad7198226e3e5e73a0914fd`. Their pre-action corpse screenshots are byte-identical. After the reader action, #967 reports no active VR panel and leaves the empty corpse GUI body; #968 exposes one player-owned MediaGui panel with `iface/log.pcx`, `amanpour.pcx`, `medicon.pcx`, and the localized transcript.</sub>

Fixes #921


