### PR TITLE
feat(ui): give the frontend its original menu sounds

### DIFF
--- a/engine/src/audio/mod.rs
+++ b/engine/src/audio/mod.rs
@@ -387,6 +387,16 @@ impl AudioClip {
             SourceType::Raw(source) => sink.append(source.clone()),
         }
     }
+
+    /// Append the clip so it repeats forever - a seamless bed (a menu hum, a
+    /// machine loop) rather than the re-append-when-empty pattern, which leaves
+    /// an audible gap of however long the caller takes to notice.
+    pub fn add_to_spatial_sink_looping(&self, sink: &SpatialSink) {
+        match &self.source {
+            SourceType::Bytes(source) => sink.append(source.clone().repeat_infinite()),
+            SourceType::Raw(source) => sink.append(source.clone().repeat_infinite()),
+        }
+    }
     pub fn add_to_sink(&self, sink: &Sink) {
         match &self.source {
             SourceType::Bytes(source) => sink.append(source.clone()),
@@ -471,6 +481,24 @@ pub fn stop_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     }
 }
 
+/// How a clip is played, beyond where it is played.
+#[derive(Clone, Copy, Debug)]
+pub struct PlayOptions {
+    /// Sink volume, 1.0 being the clip's own level.
+    pub volume: f32,
+    /// Repeat forever instead of playing once. `stop_audio` ends it.
+    pub looping: bool,
+}
+
+impl Default for PlayOptions {
+    fn default() -> Self {
+        PlayOptions {
+            volume: 1.0,
+            looping: false,
+        }
+    }
+}
+
 /// Plays audio at the listener origin (non-spatial).
 pub fn play_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     context: &mut AudioContext<TAmbientKey, TCue>,
@@ -478,10 +506,35 @@ pub fn play_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
 ) -> Vec<u64> {
+    play_audio_with(
+        context,
+        handle,
+        maybe_channel,
+        audio_clip,
+        PlayOptions::default(),
+    )
+}
+
+/// [`play_audio`] with explicit volume/looping - for non-diegetic audio that
+/// is not simply "play this once at full volume" (a looping menu bed).
+pub fn play_audio_with<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
+    context: &mut AudioContext<TAmbientKey, TCue>,
+    handle: AudioHandle,
+    maybe_channel: Option<AudioChannel>,
+    audio_clip: Rc<AudioClip>,
+    options: PlayOptions,
+) -> Vec<u64> {
     let position = (context.last_left_ear_position + context.last_right_ear_position) / 2.0;
 
     let id = handle.id;
-    let (sink, preempted) = play_audio_core(context, position, handle, maybe_channel, audio_clip);
+    let (sink, preempted) = play_audio_core(
+        context,
+        position,
+        handle,
+        maybe_channel,
+        audio_clip,
+        options,
+    );
 
     context.handle_to_sink.insert(id, SinkAdapter::fixed(sink));
     preempted
@@ -497,8 +550,14 @@ pub fn play_spatial_audio<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
 ) -> Vec<u64> {
     let id = handle.id;
     let scaled_position = position / SOUND_SCALE_FACTOR;
-    let (sink, preempted) =
-        play_audio_core(context, scaled_position, handle, maybe_channel, audio_clip);
+    let (sink, preempted) = play_audio_core(
+        context,
+        scaled_position,
+        handle,
+        maybe_channel,
+        audio_clip,
+        PlayOptions::default(),
+    );
 
     context
         .handle_to_sink
@@ -520,6 +579,7 @@ pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     handle: AudioHandle,
     maybe_channel: Option<AudioChannel>,
     audio_clip: Rc<AudioClip>,
+    options: PlayOptions,
 ) -> (SpatialSink, Vec<u64>) {
     // Handles whose playback this play cuts short. Reported back so callers
     // (the audio log) can mark them stopped - these preemptions never go
@@ -568,7 +628,12 @@ pub fn play_audio_core<TAmbientKey: Hash + Eq + Copy, TCue: Clone>(
     );
     let sink = rodio::SpatialSink::try_new(&context.handle, positions.0, positions.1, positions.2)
         .unwrap();
-    audio_clip.add_to_spatial_sink(&sink);
+    sink.set_volume(options.volume);
+    if options.looping {
+        audio_clip.add_to_spatial_sink_looping(&sink);
+    } else {
+        audio_clip.add_to_spatial_sink(&sink);
+    }
 
     //context.handle_to_sink.insert(handle.id, sink);
     (sink, preempted)

--- a/shock2vr/src/game_scene.rs
+++ b/shock2vr/src/game_scene.rs
@@ -84,6 +84,16 @@ pub trait GameScene {
         Vec::new()
     }
 
+    /// Called once, on the outgoing scene, just before it is replaced.
+    ///
+    /// A scene that started audio which outlives a single frame - anything
+    /// looping - must stop it here: the [`AudioContext`] belongs to `Game` and
+    /// keeps a sink alive until it drains, which a looping sink never does, so
+    /// dropping the scene alone would leave it playing forever. `handle_effects`
+    /// is not enough, because scenes are also replaced from paths that never
+    /// run it (a debug-runtime load, a level transition).
+    fn on_exit(&mut self, _audio_context: &mut AudioContext<EntityId, String>) {}
+
     /// Whether this scene wants a 2D mouse cursor (e.g. a menu). Flat runtimes
     /// show the OS cursor and populate `InputContext::pointer` when true; by
     /// default scenes capture the mouse for look.

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -662,7 +662,7 @@ impl Game {
             &self.options,
         );
         save_load::restore_player_vitals(&active_mission.mission_core.world, player_vitals);
-        self.active_game_scene = Box::new(active_mission);
+        self.set_active_scene(Box::new(active_mission));
         self.campaign_completed = false;
     }
 
@@ -709,7 +709,7 @@ impl Game {
             Mission::parse(&**asset_paths, &base_path, &parse_name, &global_context)
         });
 
-        self.active_game_scene = Box::new(LoadingScene::new());
+        self.set_active_scene(Box::new(LoadingScene::new()));
         self.pending_transition = Some(PendingTransition {
             level_name,
             spawn_loc,
@@ -758,7 +758,7 @@ impl Game {
             &self.options,
         );
         save_load::restore_player_vitals(&mission.mission_core.world, pending.player_vitals);
-        self.active_game_scene = Box::new(mission);
+        self.set_active_scene(Box::new(mission));
         self.campaign_completed = false;
 
         for entity_name in pending.entities_to_trigger {
@@ -1276,7 +1276,7 @@ impl Game {
         if was_crouched {
             mission.mission_core.restore_saved_crouch();
         }
-        self.active_game_scene = Box::new(mission);
+        self.set_active_scene(Box::new(mission));
         self.mission_to_save_data = level_map;
         self.campaign_completed = false;
         Ok(())
@@ -1422,17 +1422,17 @@ impl Game {
                 // forward is the screen's own recovery path (reload a save),
                 // which replaces the ledger wholesale.
                 self.pending_transition = None;
-                self.active_game_scene = Box::new(GameOverScene::new());
+                self.set_active_scene(Box::new(GameOverScene::new()));
             }
             GlobalEffect::ShowLoadGame => {
                 // A frontend screen swap, not a level transition: no ledger
                 // write-back, and any pending transition is abandoned.
                 self.pending_transition = None;
-                self.active_game_scene = Box::new(LoadGameScene::new());
+                self.set_active_scene(Box::new(LoadGameScene::new()));
             }
             GlobalEffect::ShowMainMenu => {
                 self.pending_transition = None;
-                self.active_game_scene = Box::new(MainMenuScene::new());
+                self.set_active_scene(Box::new(MainMenuScene::new()));
             }
             GlobalEffect::CompleteCampaign => {
                 // Preserve the destroyed head and the rest of the finale state
@@ -1455,13 +1455,21 @@ impl Game {
                 });
 
                 self.pending_transition = None;
-                self.active_game_scene = Box::new(cutscene);
+                self.set_active_scene(Box::new(cutscene));
                 self.campaign_completed = true;
             }
             GlobalEffect::Quit => {
                 self.should_quit = true;
             }
         }
+    }
+
+    /// Replace the active scene, giving the outgoing one a chance to release
+    /// what it owns beyond its own frame (see [`GameScene::on_exit`]). Every
+    /// scene swap goes through here so that hook cannot be forgotten.
+    fn set_active_scene(&mut self, scene: Box<dyn GameScene>) {
+        self.active_game_scene.on_exit(&mut self.audio_context);
+        self.active_game_scene = scene;
     }
 
     /// Get hand spotlights for enhanced lighting when experimental flag is enabled

--- a/shock2vr/src/scenes/frontend_sfx.rs
+++ b/shock2vr/src/scenes/frontend_sfx.rs
@@ -1,0 +1,232 @@
+//! Frontend (menu) sound effects, shared by every 2D screen.
+//!
+//! The original frontend is not silent: `res/snd/sfx/` ships the whole set the
+//! menus use - a looping bed (`mloop1`/`mloop2`), a rollover blip played when
+//! the cursor moves onto a widget (`MROLLOV1`/`MROLLOV2`), and a select click
+//! (`MSELECT1`/`MSELECT2`). Only the first of each pair is used here; the
+//! second is the same sound rerecorded and nothing in the shipped data says
+//! which screen takes which.
+//!
+//! A screen drives this from its own update/effect pass:
+//!
+//! - `hover(id)` once per update with whatever widget the pointer is over,
+//! - `click()` when a press activates one,
+//! - `pump(..)` from `handle_effects`, which is where a scene is handed the
+//!   [`AudioContext`],
+//! - `stop(..)` from `GameScene::on_exit`, so the bed ends with the screen
+//!   rather than playing on under the mission behind it. It has to be the exit
+//!   hook and not "the frame we emitted a scene-changing effect": scenes are
+//!   also replaced from paths that never reach `handle_effects`, and not every
+//!   global effect actually replaces the scene (a failed load leaves it up).
+//!
+//! Plays are mirrored into [`crate::audio_log`] so a headless test can assert
+//! the menu made noise (`GET /v1/audio/recent`) - there is no other way to
+//! observe audio without speakers.
+
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::{AudioContext, AudioHandle, PlayOptions, play_audio_with, stop_audio},
+};
+use shipyard::EntityId;
+use tracing::warn;
+
+use dark::importers::AUDIO_IMPORTER;
+
+/// Looping bed under every frontend screen.
+const HUM_SOUND: &str = "sfx/mloop1.wav";
+/// Blip when the pointer moves onto a widget.
+const ROLLOVER_SOUND: &str = "sfx/mrollov1.wav";
+/// Click when a widget is activated.
+const SELECT_SOUND: &str = "sfx/mselect1.wav";
+
+/// The bed sits under the interaction sounds rather than competing with them.
+const HUM_VOLUME: f32 = 0.35;
+/// Rollover fires on every widget the cursor crosses, so it is the quietest of
+/// the three.
+const ROLLOVER_VOLUME: f32 = 0.5;
+const SELECT_VOLUME: f32 = 0.8;
+
+/// Identifies the widget under the pointer. Only equality matters - a screen
+/// numbers its own widgets however it likes, as long as two different widgets
+/// never share an id.
+pub type WidgetId = usize;
+
+#[derive(Default)]
+pub struct FrontendSfx {
+    /// Widget the pointer was over on the previous update, so the rollover
+    /// fires once on entry rather than every frame it stays there.
+    hovered: Option<WidgetId>,
+    /// One-shots queued by `update`, played by the next `pump`.
+    pending: Vec<&'static str>,
+    /// The looping bed.
+    hum: Hum,
+}
+
+/// The bed's lifecycle. `Unavailable` is a latch: without it a missing
+/// `snd.crf` would re-hit the asset cache and warn once per frame, forever.
+#[derive(Default)]
+enum Hum {
+    #[default]
+    NotStarted,
+    Playing(AudioHandle),
+    Unavailable,
+}
+
+impl FrontendSfx {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The widget the pointer is over this update, or `None` when it is over
+    /// nothing actionable.
+    pub fn hover(&mut self, target: Option<WidgetId>) {
+        if target == self.hovered {
+            return;
+        }
+        self.hovered = target;
+        if target.is_some() {
+            self.pending.push(ROLLOVER_SOUND);
+        }
+    }
+
+    /// A widget was activated.
+    pub fn click(&mut self) {
+        self.pending.push(SELECT_SOUND);
+    }
+
+    /// Start the bed if it is not running, and play anything queued since the
+    /// last call.
+    pub fn pump(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) {
+        if matches!(self.hum, Hum::NotStarted) {
+            let handle = AudioHandle::new();
+            self.hum = if play(
+                HUM_SOUND,
+                &handle,
+                PlayOptions {
+                    volume: HUM_VOLUME,
+                    looping: true,
+                },
+                asset_cache,
+                audio_context,
+            ) {
+                Hum::Playing(handle)
+            } else {
+                Hum::Unavailable
+            };
+        }
+
+        for sound in std::mem::take(&mut self.pending) {
+            let volume = if sound == ROLLOVER_SOUND {
+                ROLLOVER_VOLUME
+            } else {
+                SELECT_VOLUME
+            };
+            play(
+                sound,
+                &AudioHandle::new(),
+                PlayOptions {
+                    volume,
+                    looping: false,
+                },
+                asset_cache,
+                audio_context,
+            );
+        }
+    }
+
+    /// Stop the bed. The screen's `GameScene::on_exit` calls this - a looping
+    /// sink never drains on its own, so nothing else would ever end it.
+    ///
+    /// One-shots are deliberately left alone: the select click that caused the
+    /// transition should finish over the screen that replaces this one.
+    pub fn stop(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        if let Hum::Playing(handle) = std::mem::take(&mut self.hum) {
+            stop_audio(audio_context, handle.clone());
+            crate::audio_log::record_stop(handle.id());
+        }
+    }
+}
+
+/// Play one frontend sound by asset name, reporting whether it was found.
+///
+/// The sounds live in `snd.crf` under `sfx/`, so they are addressed by their
+/// archive-relative path: the bare basenames are ambiguous across the mounted
+/// archives, and a menu that silently played some other `mloop1` would be
+/// worse than a silent one.
+fn play(
+    name: &'static str,
+    handle: &AudioHandle,
+    options: PlayOptions,
+    asset_cache: &mut AssetCache,
+    audio_context: &mut AudioContext<EntityId, String>,
+) -> bool {
+    let Some(clip) = asset_cache.get_opt(&AUDIO_IMPORTER, name) else {
+        warn!("frontend sfx: unable to load {name}");
+        return false;
+    };
+    let duration = clip.total_duration();
+    let preempted = play_audio_with(audio_context, handle.clone(), None, clip, options);
+    crate::audio_log::record_stops(&preempted);
+    crate::audio_log::record(crate::audio_log::SoundRecord {
+        sample: name,
+        tags: vec![("kind".to_owned(), "menu".to_owned())],
+        position: [0.0, 0.0, 0.0],
+        duration,
+        source_entity: None,
+        handle: Some(handle.id()),
+    });
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rollover_fires_once_per_widget_entry() {
+        let mut sfx = FrontendSfx::new();
+
+        sfx.hover(Some(2));
+        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+
+        // Staying on the same widget is not a new entry.
+        sfx.hover(Some(2));
+        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+
+        // Moving straight from one widget to another is.
+        sfx.hover(Some(3));
+        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND, ROLLOVER_SOUND]);
+    }
+
+    #[test]
+    fn leaving_a_widget_is_silent() {
+        let mut sfx = FrontendSfx::new();
+        sfx.hover(Some(1));
+        sfx.pending.clear();
+
+        sfx.hover(None);
+        assert!(sfx.pending.is_empty());
+    }
+
+    #[test]
+    fn re_entering_the_same_widget_fires_again() {
+        let mut sfx = FrontendSfx::new();
+        sfx.hover(Some(1));
+        sfx.hover(None);
+        sfx.pending.clear();
+
+        sfx.hover(Some(1));
+        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+    }
+
+    #[test]
+    fn click_queues_the_select_sound() {
+        let mut sfx = FrontendSfx::new();
+        sfx.click();
+        assert_eq!(sfx.pending, vec![SELECT_SOUND]);
+    }
+}

--- a/shock2vr/src/scenes/frontend_sfx.rs
+++ b/shock2vr/src/scenes/frontend_sfx.rs
@@ -46,52 +46,65 @@ const HUM_VOLUME: f32 = 0.35;
 const ROLLOVER_VOLUME: f32 = 0.5;
 const SELECT_VOLUME: f32 = 0.8;
 
-/// Identifies the widget under the pointer. Only equality matters - a screen
-/// numbers its own widgets however it likes, as long as two different widgets
-/// never share an id.
-pub type WidgetId = usize;
-
+/// Frontend sounds for one screen.
+///
+/// `TWidget` identifies the widget under the pointer; a screen passes its own
+/// action type, so the thing that decides *what was clicked* is also the thing
+/// that decides *what is hovered* - there is no second numbering to keep in
+/// step. Only equality is used.
 #[derive(Default)]
-pub struct FrontendSfx {
+pub struct FrontendSfx<TWidget> {
     /// Widget the pointer was over on the previous update, so the rollover
     /// fires once on entry rather than every frame it stays there.
-    hovered: Option<WidgetId>,
-    /// One-shots queued by `update`, played by the next `pump`.
-    pending: Vec<&'static str>,
+    hovered: Option<TWidget>,
+    /// One-shots queued by `update` with the level to play them at, played by
+    /// the next `pump`. Each sound carries its own level so adding one cannot
+    /// silently inherit another's.
+    pending: Vec<(&'static str, f32)>,
     /// The looping bed.
     hum: Hum,
+    /// Latched on the first sound that fails to load. All three live in the
+    /// same archive, so one miss means the set is not there - and without the
+    /// latch every hover would re-hit the asset cache and warn again.
+    unavailable: bool,
 }
 
-/// The bed's lifecycle. `Unavailable` is a latch: without it a missing
-/// `snd.crf` would re-hit the asset cache and warn once per frame, forever.
+/// The bed's lifecycle. `Stopped` is terminal: the screen that owned the bed is
+/// on its way out, and a restarted bed would be a looping sink with no owner
+/// left to stop it.
 #[derive(Default)]
 enum Hum {
     #[default]
     NotStarted,
     Playing(AudioHandle),
-    Unavailable,
+    Stopped,
 }
 
-impl FrontendSfx {
+impl<TWidget: Copy + PartialEq> FrontendSfx<TWidget> {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            hovered: None,
+            pending: Vec::new(),
+            hum: Hum::NotStarted,
+            unavailable: false,
+        }
     }
 
     /// The widget the pointer is over this update, or `None` when it is over
     /// nothing actionable.
-    pub fn hover(&mut self, target: Option<WidgetId>) {
+    pub fn hover(&mut self, target: Option<TWidget>) {
         if target == self.hovered {
             return;
         }
         self.hovered = target;
         if target.is_some() {
-            self.pending.push(ROLLOVER_SOUND);
+            self.pending.push((ROLLOVER_SOUND, ROLLOVER_VOLUME));
         }
     }
 
     /// A widget was activated.
     pub fn click(&mut self) {
-        self.pending.push(SELECT_SOUND);
+        self.pending.push((SELECT_SOUND, SELECT_VOLUME));
     }
 
     /// Start the bed if it is not running, and play anything queued since the
@@ -101,9 +114,14 @@ impl FrontendSfx {
         asset_cache: &mut AssetCache,
         audio_context: &mut AudioContext<EntityId, String>,
     ) {
+        if self.unavailable {
+            self.pending.clear();
+            return;
+        }
+
         if matches!(self.hum, Hum::NotStarted) {
             let handle = AudioHandle::new();
-            self.hum = if play(
+            self.hum = if self.play(
                 HUM_SOUND,
                 &handle,
                 PlayOptions {
@@ -115,17 +133,12 @@ impl FrontendSfx {
             ) {
                 Hum::Playing(handle)
             } else {
-                Hum::Unavailable
+                Hum::NotStarted
             };
         }
 
-        for sound in std::mem::take(&mut self.pending) {
-            let volume = if sound == ROLLOVER_SOUND {
-                ROLLOVER_VOLUME
-            } else {
-                SELECT_VOLUME
-            };
-            play(
+        for (sound, volume) in std::mem::take(&mut self.pending) {
+            self.play(
                 sound,
                 &AudioHandle::new(),
                 PlayOptions {
@@ -144,68 +157,85 @@ impl FrontendSfx {
     /// One-shots are deliberately left alone: the select click that caused the
     /// transition should finish over the screen that replaces this one.
     pub fn stop(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
-        if let Hum::Playing(handle) = std::mem::take(&mut self.hum) {
+        if let Hum::Playing(handle) = std::mem::replace(&mut self.hum, Hum::Stopped) {
             stop_audio(audio_context, handle.clone());
             crate::audio_log::record_stop(handle.id());
         }
+        self.hum = Hum::Stopped;
     }
-}
 
-/// Play one frontend sound by asset name, reporting whether it was found.
-///
-/// The sounds live in `snd.crf` under `sfx/`, so they are addressed by their
-/// archive-relative path: the bare basenames are ambiguous across the mounted
-/// archives, and a menu that silently played some other `mloop1` would be
-/// worse than a silent one.
-fn play(
-    name: &'static str,
-    handle: &AudioHandle,
-    options: PlayOptions,
-    asset_cache: &mut AssetCache,
-    audio_context: &mut AudioContext<EntityId, String>,
-) -> bool {
-    let Some(clip) = asset_cache.get_opt(&AUDIO_IMPORTER, name) else {
-        warn!("frontend sfx: unable to load {name}");
-        return false;
-    };
-    let duration = clip.total_duration();
-    let preempted = play_audio_with(audio_context, handle.clone(), None, clip, options);
-    crate::audio_log::record_stops(&preempted);
-    crate::audio_log::record(crate::audio_log::SoundRecord {
-        sample: name,
-        tags: vec![("kind".to_owned(), "menu".to_owned())],
-        position: [0.0, 0.0, 0.0],
-        duration,
-        source_entity: None,
-        handle: Some(handle.id()),
-    });
-    true
+    /// Play one frontend sound by asset name, reporting whether it was found.
+    ///
+    /// The sounds live in `snd.crf` under `sfx/`, so they are addressed by
+    /// their archive-relative path: the bare basenames are ambiguous across the
+    /// mounted archives, and a menu that silently played some other `mloop1`
+    /// would be worse than a silent one.
+    fn play(
+        &mut self,
+        name: &'static str,
+        handle: &AudioHandle,
+        options: PlayOptions,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
+    ) -> bool {
+        let Some(clip) = asset_cache.get_opt(&AUDIO_IMPORTER, name) else {
+            warn!("frontend sfx: unable to load {name}");
+            self.unavailable = true;
+            return false;
+        };
+        let duration = clip.total_duration();
+        let preempted = play_audio_with(audio_context, handle.clone(), None, clip, options);
+        crate::audio_log::record_stops(&preempted);
+        crate::audio_log::record(crate::audio_log::SoundRecord {
+            sample: name,
+            tags: vec![("kind".to_owned(), "menu".to_owned())],
+            position: [0.0, 0.0, 0.0],
+            duration,
+            source_entity: None,
+            handle: Some(handle.id()),
+        });
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Stand-in for a screen's action type: the rollover only ever compares
+    /// widgets for equality.
+    #[derive(Clone, Copy, PartialEq)]
+    enum Widget {
+        A,
+        B,
+    }
+
     #[test]
     fn rollover_fires_once_per_widget_entry() {
         let mut sfx = FrontendSfx::new();
 
-        sfx.hover(Some(2));
-        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+        sfx.hover(Some(Widget::A));
+        assert_eq!(sfx.pending, vec![(ROLLOVER_SOUND, ROLLOVER_VOLUME)]);
 
         // Staying on the same widget is not a new entry.
-        sfx.hover(Some(2));
-        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+        sfx.hover(Some(Widget::A));
+        assert_eq!(sfx.pending, vec![(ROLLOVER_SOUND, ROLLOVER_VOLUME)]);
 
         // Moving straight from one widget to another is.
-        sfx.hover(Some(3));
-        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND, ROLLOVER_SOUND]);
+        sfx.hover(Some(Widget::B));
+        assert_eq!(
+            sfx.pending,
+            vec![
+                (ROLLOVER_SOUND, ROLLOVER_VOLUME),
+                (ROLLOVER_SOUND, ROLLOVER_VOLUME)
+            ]
+        );
     }
 
     #[test]
     fn leaving_a_widget_is_silent() {
         let mut sfx = FrontendSfx::new();
-        sfx.hover(Some(1));
+        sfx.hover(Some(Widget::A));
         sfx.pending.clear();
 
         sfx.hover(None);
@@ -215,18 +245,18 @@ mod tests {
     #[test]
     fn re_entering_the_same_widget_fires_again() {
         let mut sfx = FrontendSfx::new();
-        sfx.hover(Some(1));
+        sfx.hover(Some(Widget::A));
         sfx.hover(None);
         sfx.pending.clear();
 
-        sfx.hover(Some(1));
-        assert_eq!(sfx.pending, vec![ROLLOVER_SOUND]);
+        sfx.hover(Some(Widget::A));
+        assert_eq!(sfx.pending, vec![(ROLLOVER_SOUND, ROLLOVER_VOLUME)]);
     }
 
     #[test]
     fn click_queues_the_select_sound() {
-        let mut sfx = FrontendSfx::new();
+        let mut sfx = FrontendSfx::<Widget>::new();
         sfx.click();
-        assert_eq!(sfx.pending, vec![SELECT_SOUND]);
+        assert_eq!(sfx.pending, vec![(SELECT_SOUND, SELECT_VOLUME)]);
     }
 }

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -25,7 +25,7 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::{GlobalContext, PlayerLifeState},
     save_load::{SaveFile, latest_save},
-    scenes::frontend_sfx::{FrontendSfx, WidgetId},
+    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
@@ -125,19 +125,6 @@ fn hit(point: Vector2<f32>, rects: &[Rect; 4], can_load: bool) -> Option<GameOve
     }
 }
 
-/// Which button the pointer is over, for the rollover sound.
-fn hovered_widget(
-    point: Option<Vector2<f32>>,
-    rects: &[Rect; 4],
-    can_load: bool,
-) -> Option<WidgetId> {
-    let action = hit(point?, rects, can_load)?;
-    Some(match action {
-        GameOverAction::Load => 0,
-        GameOverAction::Quit => 1,
-    })
-}
-
 pub struct GameOverScene {
     world: World,
     scene_name: String,
@@ -152,7 +139,7 @@ pub struct GameOverScene {
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
     /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx,
+    sfx: FrontendSfx<GameOverAction>,
 }
 
 impl GameOverScene {
@@ -216,7 +203,7 @@ impl GameScene for GameOverScene {
         self.last_pressed = last_pressed;
 
         self.sfx
-            .hover(hovered_widget(point, &rects, self.save.is_some()));
+            .hover(point.and_then(|p| hit(p, &rects, self.save.is_some())));
         if action.is_some() {
             self.sfx.click();
         }

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -25,6 +25,7 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::{GlobalContext, PlayerLifeState},
     save_load::{SaveFile, latest_save},
+    scenes::frontend_sfx::{FrontendSfx, WidgetId},
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
@@ -94,30 +95,47 @@ fn resolve_click(
     screen_size: Vector2<f32>,
     rects: &[Rect; 4],
     can_load: bool,
-) -> (Option<GameOverAction>, bool) {
+) -> (Option<GameOverAction>, bool, Option<Vector2<f32>>) {
     let Some(p) = pointer else {
-        return (None, false);
+        return (None, false, None);
     };
-    if !p.pressed || last_pressed {
-        return (None, p.pressed);
-    }
-
-    let action = pointer_to_canvas(
+    let canvas_point = pointer_to_canvas(
         vec2(CANVAS_W, CANVAS_H),
         p.position,
         screen_size,
         SCALE_MODE,
-    )
-    .and_then(|c| {
-        if can_load && rects[LOAD_RECT_INDEX].contains(c) {
-            Some(GameOverAction::Load)
-        } else if rects[QUIT_RECT_INDEX].contains(c) {
-            Some(GameOverAction::Quit)
-        } else {
-            None
-        }
-    });
-    (action, p.pressed)
+    );
+    if !p.pressed || last_pressed {
+        return (None, p.pressed, canvas_point);
+    }
+
+    let action = canvas_point.and_then(|c| hit(c, rects, can_load));
+    (action, p.pressed, canvas_point)
+}
+
+/// The button at a canvas point, if any. Shared by the click and the rollover
+/// sound so the two always agree on where a button is.
+fn hit(point: Vector2<f32>, rects: &[Rect; 4], can_load: bool) -> Option<GameOverAction> {
+    if can_load && rects[LOAD_RECT_INDEX].contains(point) {
+        Some(GameOverAction::Load)
+    } else if rects[QUIT_RECT_INDEX].contains(point) {
+        Some(GameOverAction::Quit)
+    } else {
+        None
+    }
+}
+
+/// Which button the pointer is over, for the rollover sound.
+fn hovered_widget(
+    point: Option<Vector2<f32>>,
+    rects: &[Rect; 4],
+    can_load: bool,
+) -> Option<WidgetId> {
+    let action = hit(point?, rects, can_load)?;
+    Some(match action {
+        GameOverAction::Load => 0,
+        GameOverAction::Quit => 1,
+    })
 }
 
 pub struct GameOverScene {
@@ -133,6 +151,8 @@ pub struct GameOverScene {
     /// Screen size from the latest render, so `update` maps the pointer into
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
+    /// The frontend's hum, rollover and select sounds.
+    sfx: FrontendSfx,
 }
 
 impl GameOverScene {
@@ -149,6 +169,7 @@ impl GameOverScene {
             pointer: None,
             last_pressed: false,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
+            sfx: FrontendSfx::new(),
         }
     }
 }
@@ -185,7 +206,7 @@ impl GameScene for GameOverScene {
         let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
 
         self.pointer = input_context.pointer;
-        let (action, last_pressed) = resolve_click(
+        let (action, last_pressed, point) = resolve_click(
             input_context.pointer,
             self.last_pressed,
             self.last_screen_size,
@@ -193,6 +214,12 @@ impl GameScene for GameOverScene {
             self.save.is_some(),
         );
         self.last_pressed = last_pressed;
+
+        self.sfx
+            .hover(hovered_widget(point, &rects, self.save.is_some()));
+        if action.is_some() {
+            self.sfx.click();
+        }
 
         match action {
             Some(GameOverAction::Load) => {
@@ -288,9 +315,10 @@ impl GameScene for GameOverScene {
         effects: Vec<Effect>,
         _global_context: &GlobalContext,
         _game_options: &GameOptions,
-        _asset_cache: &mut AssetCache,
-        _audio_context: &mut AudioContext<EntityId, String>,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
+        self.sfx.pump(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -298,6 +326,10 @@ impl GameScene for GameOverScene {
                 _ => None,
             })
             .collect()
+    }
+
+    fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.sfx.stop(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -336,7 +368,7 @@ mod tests {
     #[test]
     fn clicking_load_with_a_save_reloads() {
         let rects = screen_rects(None);
-        let (action, last) = resolve_click(
+        let (action, last, _) = resolve_click(
             pointer_at(rects[LOAD_RECT_INDEX], true),
             false,
             SCREEN,
@@ -350,7 +382,7 @@ mod tests {
     #[test]
     fn load_is_inert_without_a_save() {
         let rects = screen_rects(None);
-        let (action, _) = resolve_click(
+        let (action, _, _) = resolve_click(
             pointer_at(rects[LOAD_RECT_INDEX], true),
             false,
             SCREEN,
@@ -363,7 +395,7 @@ mod tests {
     #[test]
     fn quit_is_always_available() {
         let rects = screen_rects(None);
-        let (action, _) = resolve_click(
+        let (action, _, _) = resolve_click(
             pointer_at(rects[QUIT_RECT_INDEX], true),
             false,
             SCREEN,
@@ -376,7 +408,7 @@ mod tests {
     #[test]
     fn held_press_does_not_re_activate() {
         let rects = screen_rects(None);
-        let (action, last) = resolve_click(
+        let (action, last, _) = resolve_click(
             pointer_at(rects[LOAD_RECT_INDEX], true),
             true,
             SCREEN,
@@ -390,7 +422,7 @@ mod tests {
     #[test]
     fn clicking_outside_the_buttons_does_nothing() {
         let rects = screen_rects(None);
-        let (action, _) = resolve_click(
+        let (action, _, _) = resolve_click(
             pointer_at(rects[LIST_RECT_INDEX], true),
             false,
             SCREEN,

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -28,6 +28,7 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
     save_load::{SaveFile, all_saves},
+    scenes::frontend_sfx::{FrontendSfx, WidgetId},
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
@@ -187,33 +188,58 @@ fn resolve_click(
     rects: &[Rect; 4],
     visible_saves: usize,
     has_selection: bool,
-) -> (Option<LoadGameAction>, bool) {
+) -> (Option<LoadGameAction>, bool, Option<Vector2<f32>>) {
     let Some(p) = pointer else {
-        return (None, false);
+        return (None, false, None);
     };
-    if !p.pressed || last_pressed {
-        return (None, p.pressed);
-    }
-
-    let action = pointer_to_canvas(
+    let canvas_point = pointer_to_canvas(
         vec2(CANVAS_W, CANVAS_H),
         p.position,
         screen_size,
         SCALE_MODE,
-    )
-    .and_then(|c| {
-        if has_selection && rects[LOAD_RECT_INDEX].contains(c) {
-            return Some(LoadGameAction::Load);
-        }
-        if rects[DONE_RECT_INDEX].contains(c) {
-            return Some(LoadGameAction::Done);
-        }
-        // Rows past the end of the save list are empty backdrop, not buttons.
-        (0..visible_saves)
-            .find(|index| row_rect(rects[LIST_RECT_INDEX], *index).contains(c))
-            .map(LoadGameAction::Select)
-    });
-    (action, p.pressed)
+    );
+    if !p.pressed || last_pressed {
+        return (None, p.pressed, canvas_point);
+    }
+
+    let action = canvas_point.and_then(|c| hit(c, rects, visible_saves, has_selection));
+    (action, p.pressed, canvas_point)
+}
+
+/// What is at a canvas point: a save row, "Load" (only with a selection), or
+/// "Done". Shared by the click and the rollover sound so the two always agree.
+fn hit(
+    point: Vector2<f32>,
+    rects: &[Rect; 4],
+    visible_saves: usize,
+    has_selection: bool,
+) -> Option<LoadGameAction> {
+    if has_selection && rects[LOAD_RECT_INDEX].contains(point) {
+        return Some(LoadGameAction::Load);
+    }
+    if rects[DONE_RECT_INDEX].contains(point) {
+        return Some(LoadGameAction::Done);
+    }
+    // Rows past the end of the save list are empty backdrop, not buttons.
+    (0..visible_saves)
+        .find(|index| row_rect(rects[LIST_RECT_INDEX], *index).contains(point))
+        .map(LoadGameAction::Select)
+}
+
+/// Which button the pointer is over, for the rollover sound.
+///
+/// Rows are deliberately silent: they highlight on selection rather than on
+/// hover, so a blip over one would be a sound with no visible counterpart.
+fn hovered_widget(
+    point: Option<Vector2<f32>>,
+    rects: &[Rect; 4],
+    has_selection: bool,
+) -> Option<WidgetId> {
+    match hit(point?, rects, 0, has_selection)? {
+        LoadGameAction::Load => Some(0),
+        LoadGameAction::Done => Some(1),
+        LoadGameAction::Select(_) => None,
+    }
 }
 
 pub struct LoadGameScene {
@@ -231,6 +257,8 @@ pub struct LoadGameScene {
     /// Screen size from the latest render, so `update` can map the pointer into
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
+    /// The frontend's hum, rollover and select sounds.
+    sfx: FrontendSfx,
 }
 
 impl LoadGameScene {
@@ -253,6 +281,7 @@ impl LoadGameScene {
             // the next rising edge require a real release first.
             last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
+            sfx: FrontendSfx::new(),
         }
     }
 }
@@ -289,7 +318,7 @@ impl GameScene for LoadGameScene {
         let selected = self.selected.filter(|index| *index < visible);
 
         self.pointer = input_context.pointer;
-        let (action, last_pressed) = resolve_click(
+        let (action, last_pressed, point) = resolve_click(
             input_context.pointer,
             self.last_pressed,
             self.last_screen_size,
@@ -298,6 +327,12 @@ impl GameScene for LoadGameScene {
             selected.is_some(),
         );
         self.last_pressed = last_pressed;
+
+        self.sfx
+            .hover(hovered_widget(point, &rects, selected.is_some()));
+        if action.is_some() {
+            self.sfx.click();
+        }
 
         match action {
             Some(LoadGameAction::Select(index)) => {
@@ -436,9 +471,10 @@ impl GameScene for LoadGameScene {
         effects: Vec<Effect>,
         _global_context: &GlobalContext,
         _game_options: &GameOptions,
-        _asset_cache: &mut AssetCache,
-        _audio_context: &mut AudioContext<EntityId, String>,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
+        self.sfx.pump(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -446,6 +482,10 @@ impl GameScene for LoadGameScene {
                 _ => None,
             })
             .collect()
+    }
+
+    fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.sfx.stop(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -539,7 +579,7 @@ mod tests {
     #[test]
     fn held_press_does_not_re_activate() {
         let done = FALLBACK_RECTS[DONE_RECT_INDEX].center();
-        let (action, last) = resolve_click(
+        let (action, last, _) = resolve_click(
             pointer_at(done.x / CANVAS_W, done.y / CANVAS_H, true),
             true,
             SCREEN,
@@ -553,7 +593,7 @@ mod tests {
 
     #[test]
     fn no_pointer_means_no_action() {
-        let (action, last) = resolve_click(None, true, SCREEN, &FALLBACK_RECTS, 3, true);
+        let (action, last, _) = resolve_click(None, true, SCREEN, &FALLBACK_RECTS, 3, true);
         assert_eq!(action, None);
         assert!(!last);
     }

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -28,7 +28,7 @@ use crate::{
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
     save_load::{SaveFile, all_saves},
-    scenes::frontend_sfx::{FrontendSfx, WidgetId},
+    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
@@ -226,22 +226,6 @@ fn hit(
         .map(LoadGameAction::Select)
 }
 
-/// Which button the pointer is over, for the rollover sound.
-///
-/// Rows are deliberately silent: they highlight on selection rather than on
-/// hover, so a blip over one would be a sound with no visible counterpart.
-fn hovered_widget(
-    point: Option<Vector2<f32>>,
-    rects: &[Rect; 4],
-    has_selection: bool,
-) -> Option<WidgetId> {
-    match hit(point?, rects, 0, has_selection)? {
-        LoadGameAction::Load => Some(0),
-        LoadGameAction::Done => Some(1),
-        LoadGameAction::Select(_) => None,
-    }
-}
-
 pub struct LoadGameScene {
     world: World,
     scene_name: String,
@@ -258,7 +242,7 @@ pub struct LoadGameScene {
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
     /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx,
+    sfx: FrontendSfx<LoadGameAction>,
 }
 
 impl LoadGameScene {
@@ -328,8 +312,11 @@ impl GameScene for LoadGameScene {
         );
         self.last_pressed = last_pressed;
 
+        // Rows are deliberately silent: they highlight on selection rather
+        // than on hover, so a blip over one would have no visible counterpart.
+        // Passing 0 visible rows is what makes `hit` skip them.
         self.sfx
-            .hover(hovered_widget(point, &rects, selected.is_some()));
+            .hover(point.and_then(|p| hit(p, &rects, 0, selected.is_some())));
         if action.is_some() {
             self.sfx.click();
         }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -34,7 +34,7 @@ use crate::{
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
-    scenes::frontend_sfx::{FrontendSfx, WidgetId},
+    scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas},
@@ -314,16 +314,6 @@ fn resolve_click(
     }
 }
 
-/// Which menu entry the pointer is over, as a [`WidgetId`] for the rollover
-/// sound. Entries the port does not implement are not widgets.
-fn hovered_item(point: Option<Vector2<f32>>, rects: &[Rect]) -> Option<WidgetId> {
-    match hit(point?, rects)? {
-        MenuAction::NewGame => Some(0),
-        MenuAction::LoadGame => Some(1),
-        MenuAction::Quit => Some(2),
-    }
-}
-
 pub struct MainMenuScene {
     world: World,
     scene_name: String,
@@ -341,7 +331,7 @@ pub struct MainMenuScene {
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
     /// The frontend's hum, rollover and select sounds.
-    sfx: FrontendSfx,
+    sfx: FrontendSfx<MenuAction>,
 }
 
 impl MainMenuScene {
@@ -455,7 +445,7 @@ impl GameScene for MainMenuScene {
 
         // Hover and click feedback, from the same point that drives the
         // highlight - so a sound plays exactly when an entry lights up.
-        self.sfx.hover(hovered_item(point, &rects));
+        self.sfx.hover(point.and_then(|p| hit(p, &rects)));
         if action.is_some() {
             self.sfx.click();
         }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -34,6 +34,7 @@ use crate::{
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
+    scenes::frontend_sfx::{FrontendSfx, WidgetId},
     scripts::{Effect, GlobalEffect},
     time::Time,
     ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas},
@@ -270,6 +271,12 @@ fn resolve_click_at(
     if !pressed || last_pressed {
         return (None, pressed);
     }
+    (point.and_then(|p| hit(p, rects)), pressed)
+}
+
+/// The menu entry at a canvas point, if any. Shared by the click and the
+/// rollover sound so the two can never disagree about where an entry is.
+fn hit(point: Vector2<f32>, rects: &[Rect]) -> Option<MenuAction> {
     let mut canvas = UiCanvas::<MenuAction>::with_events(vec2(CANVAS_W, CANVAS_H));
     for (item, rect) in MENU_ITEMS.iter().zip(rects) {
         // Unimplemented entries get no hit region at all, so a click over one
@@ -280,7 +287,7 @@ fn resolve_click_at(
             canvas.button(*rect, "", action);
         }
     }
-    (point.and_then(|p| canvas.click_at(p)), pressed)
+    canvas.click_at(point)
 }
 
 /// Pure click resolution: on a rising press edge over an implemented item
@@ -291,7 +298,7 @@ fn resolve_click(
     last_pressed: bool,
     screen_size: Vector2<f32>,
     rects: &[Rect],
-) -> (Option<MenuAction>, bool) {
+) -> (Option<MenuAction>, bool, Option<Vector2<f32>>) {
     match pointer {
         Some(p) => {
             let point = pointer_to_canvas(
@@ -300,9 +307,20 @@ fn resolve_click(
                 screen_size,
                 SCALE_MODE,
             );
-            resolve_click_at(point, p.pressed, last_pressed, rects)
+            let (action, pressed) = resolve_click_at(point, p.pressed, last_pressed, rects);
+            (action, pressed, point)
         }
-        None => (None, false),
+        None => (None, false, None),
+    }
+}
+
+/// Which menu entry the pointer is over, as a [`WidgetId`] for the rollover
+/// sound. Entries the port does not implement are not widgets.
+fn hovered_item(point: Option<Vector2<f32>>, rects: &[Rect]) -> Option<WidgetId> {
+    match hit(point?, rects)? {
+        MenuAction::NewGame => Some(0),
+        MenuAction::LoadGame => Some(1),
+        MenuAction::Quit => Some(2),
     }
 }
 
@@ -322,6 +340,8 @@ pub struct MainMenuScene {
     /// Screen size from the latest render, so `update` can map the pointer into
     /// canvas space consistently with how the canvas is drawn.
     last_screen_size: Vector2<f32>,
+    /// The frontend's hum, rollover and select sounds.
+    sfx: FrontendSfx,
 }
 
 impl MainMenuScene {
@@ -341,6 +361,7 @@ impl MainMenuScene {
             // the next rising edge require a real release first.
             last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
+            sfx: FrontendSfx::new(),
         }
     }
 }
@@ -411,23 +432,33 @@ impl GameScene for MainMenuScene {
         // render regardless of which presentation drives the pointer.
         self.head_rotation = input_context.head.rotation;
 
-        let (action, last_pressed) = if game_options.presentation_mode == PresentationMode::Vr {
-            // VR has no 2D cursor: the pointer is where a controller ray meets
-            // the menu panel, and the trigger is the button.
-            let (point, pressed) = vr_pointer(input_context);
-            self.vr_pointer_canvas = point;
-            self.pointer = None;
-            resolve_click_at(point, pressed, self.last_pressed, &rects)
-        } else {
-            self.pointer = input_context.pointer;
-            resolve_click(
-                input_context.pointer,
-                self.last_pressed,
-                self.last_screen_size,
-                &rects,
-            )
-        };
+        let (action, last_pressed, point) =
+            if game_options.presentation_mode == PresentationMode::Vr {
+                // VR has no 2D cursor: the pointer is where a controller ray meets
+                // the menu panel, and the trigger is the button.
+                let (point, pressed) = vr_pointer(input_context);
+                self.vr_pointer_canvas = point;
+                self.pointer = None;
+                let (action, last_pressed) =
+                    resolve_click_at(point, pressed, self.last_pressed, &rects);
+                (action, last_pressed, point)
+            } else {
+                self.pointer = input_context.pointer;
+                resolve_click(
+                    input_context.pointer,
+                    self.last_pressed,
+                    self.last_screen_size,
+                    &rects,
+                )
+            };
         self.last_pressed = last_pressed;
+
+        // Hover and click feedback, from the same point that drives the
+        // highlight - so a sound plays exactly when an entry lights up.
+        self.sfx.hover(hovered_item(point, &rects));
+        if action.is_some() {
+            self.sfx.click();
+        }
 
         match action {
             Some(MenuAction::NewGame) => {
@@ -505,9 +536,10 @@ impl GameScene for MainMenuScene {
         effects: Vec<Effect>,
         _global_context: &GlobalContext,
         _game_options: &GameOptions,
-        _asset_cache: &mut AssetCache,
-        _audio_context: &mut AudioContext<EntityId, String>,
+        asset_cache: &mut AssetCache,
+        audio_context: &mut AudioContext<EntityId, String>,
     ) -> Vec<GlobalEffect> {
+        self.sfx.pump(asset_cache, audio_context);
         effects
             .into_iter()
             .filter_map(|e| match e {
@@ -515,6 +547,10 @@ impl GameScene for MainMenuScene {
                 _ => None,
             })
             .collect()
+    }
+
+    fn on_exit(&mut self, audio_context: &mut AudioContext<EntityId, String>) {
+        self.sfx.stop(audio_context);
     }
 
     fn wants_pointer(&self) -> bool {
@@ -553,7 +589,7 @@ mod tests {
     #[test]
     fn rising_edge_over_new_game_activates_it() {
         // Press edge over the top button (normalized ~ canvas (512, 37)).
-        let (action, last) = resolve_click(
+        let (action, last, _) = resolve_click(
             pointer_at(0.8, 0.078, true),
             false,
             SCREEN,
@@ -565,7 +601,7 @@ mod tests {
 
     #[test]
     fn rising_edge_over_quit_activates_it() {
-        let (action, _) = resolve_click(
+        let (action, _, _) = resolve_click(
             pointer_at(0.8, 0.870, true),
             false,
             SCREEN,
@@ -577,7 +613,7 @@ mod tests {
     #[test]
     fn held_press_does_not_re_activate() {
         // Already pressed last frame -> no new activation even over an item.
-        let (action, last) = resolve_click(
+        let (action, last, _) = resolve_click(
             pointer_at(0.8, 0.078, true),
             true,
             SCREEN,
@@ -589,7 +625,7 @@ mod tests {
 
     #[test]
     fn click_outside_items_does_nothing() {
-        let (action, _) = resolve_click(
+        let (action, _, _) = resolve_click(
             pointer_at(0.05, 0.05, true),
             false,
             SCREEN,
@@ -613,18 +649,18 @@ mod tests {
         let held = pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, true);
 
         // First frame after the swap: the press is held, not new.
-        let (action, last) = resolve_click(held, scene.last_pressed, SCREEN, &rects);
+        let (action, last, _) = resolve_click(held, scene.last_pressed, SCREEN, &rects);
         assert_eq!(action, None, "a carried-over press must not activate Quit");
         scene.last_pressed = last;
 
         // Releasing and pressing again is a real click.
-        let (_, last) = resolve_click(
+        let (_, last, _) = resolve_click(
             pointer_at(574.5 / CANVAS_W, 436.0 / CANVAS_H, false),
             scene.last_pressed,
             SCREEN,
             &rects,
         );
-        let (action, _) = resolve_click(held, last, SCREEN, &rects);
+        let (action, _, _) = resolve_click(held, last, SCREEN, &rects);
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
@@ -748,7 +784,7 @@ mod tests {
 
     #[test]
     fn no_pointer_means_no_action() {
-        let (action, last) = resolve_click(None, true, SCREEN, &menu_rects(None));
+        let (action, last, _) = resolve_click(None, true, SCREEN, &menu_rects(None));
         assert_eq!(action, None);
         assert!(!last);
     }
@@ -758,7 +794,7 @@ mod tests {
         // Rect 1 is "Load Game": canvas y 96..156, so y ~0.26 sits inside it.
         let rects = menu_rects(None);
         assert!(rects[1].contains(vec2(512.0, 126.0)));
-        let (action, _) = resolve_click(pointer_at(0.8, 0.2625, true), false, SCREEN, &rects);
+        let (action, _, _) = resolve_click(pointer_at(0.8, 0.2625, true), false, SCREEN, &rects);
         assert_eq!(action, Some(MenuAction::LoadGame));
     }
 
@@ -767,7 +803,7 @@ mod tests {
         // Rect 2 is "Options", still unimplemented: canvas y 172..232.
         let rects = menu_rects(None);
         assert!(rects[2].contains(vec2(512.0, 202.0)));
-        let (action, _) = resolve_click(pointer_at(0.8, 0.4208, true), false, SCREEN, &rects);
+        let (action, _, _) = resolve_click(pointer_at(0.8, 0.4208, true), false, SCREEN, &rects);
         assert_eq!(action, None);
     }
 

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -35,6 +35,7 @@ pub mod debug_ragdoll;
 pub mod debug_teleport;
 pub mod debug_turret;
 pub mod debug_weapons;
+pub mod frontend_sfx;
 pub mod game_over;
 pub mod load_game;
 pub mod loading;

--- a/tools/shock2-sdk/test/menu-audio.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-audio.e2e.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer, PLAYER_EYE_HEIGHT_WORLD } from "../src/index.js";
+import type { PlayedSound } from "../src/types.js";
+
+// End-to-end test for the frontend's sound: the original menus are not silent -
+// `res/snd/sfx/` ships a looping bed (mloop1), a rollover blip played when the
+// cursor moves onto a widget (MROLLOV1) and a select click (MSELECT1).
+//
+// The audio log is the only headless way to observe audio, so every assertion
+// here reads `GET /v1/audio/recent`.
+//
+// Negative-first: before the frontend played anything, the log stayed empty for
+// the whole sequence and every assertion below failed.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const HUM = "sfx/mloop1.wav";
+const ROLLOVER = "sfx/mrollov1.wav";
+const SELECT = "sfx/mselect1.wav";
+
+// Canvas-space widget centers on the 640x480 UI canvas, normalized to the
+// [0,1] pointer channel. MAINR.BIN stacks six 179x60 buttons at x=400 on a
+// 76px pitch: button 0 is "New Game", button 1 "Load Game".
+const CANVAS_W = 640;
+const CANVAS_H = 480;
+const norm = (x: number, y: number): [number, number] => [x / CANVAS_W, y / CANVAS_H];
+const menuEntry = (index: number): [number, number] =>
+  norm(400 + 179 / 2, 20 + index * 76 + 60 / 2);
+
+const NEW_GAME_ENTRY = menuEntry(0);
+const LOAD_GAME_ENTRY = menuEntry(1);
+// Empty backdrop to the left of the button column - over no widget at all.
+const NOTHING = norm(80, 240);
+
+async function played(game: GameServer): Promise<PlayedSound[]> {
+  const { sounds } = await game.audio.recent();
+  return sounds;
+}
+
+/** Samples played after `since` (exclusive), oldest first. */
+async function playedSince(game: GameServer, since: number): Promise<string[]> {
+  return (await played(game)).filter((s) => s.sequence > since).map((s) => s.sample);
+}
+
+async function lastSequence(game: GameServer): Promise<number> {
+  const sounds = await played(game);
+  return sounds.length === 0 ? 0 : sounds[sounds.length - 1].sequence;
+}
+
+async function hover(game: GameServer, [x, y]: [number, number]): Promise<void> {
+  await game.input.set("pointer.position", [x, y]);
+  await game.step({ frames: 5 });
+}
+
+test(
+  "the frontend plays the original hum, rollover and select sounds",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8122 });
+    await game.step({ frames: 10 });
+
+    // The bed starts with the screen and loops under it.
+    const hum = (await played(game)).find((s) => s.sample === HUM);
+    assert.ok(hum, "the menu should start the looping bed");
+    assert.equal(hum.still_playing, true, "the bed should still be playing");
+
+    // Moving onto a widget blips once - not once per frame it stays there.
+    let since = await lastSequence(game);
+    await hover(game, NEW_GAME_ENTRY);
+    await game.step({ frames: 30 });
+    assert.deepEqual(
+      await playedSince(game, since),
+      [ROLLOVER],
+      "entering an entry should blip exactly once",
+    );
+
+    // Off every widget: silence, and re-entry blips again.
+    since = await lastSequence(game);
+    await hover(game, NOTHING);
+    assert.deepEqual(await playedSince(game, since), [], "leaving an entry is silent");
+
+    since = await lastSequence(game);
+    await hover(game, LOAD_GAME_ENTRY);
+    assert.deepEqual(await playedSince(game, since), [ROLLOVER], "re-entry blips again");
+
+    // Clicking plays the select click, and hands the screen over: the bed ends
+    // with the menu rather than bleeding into what replaces it, and the load
+    // screen starts its own.
+    since = await lastSequence(game);
+    await game.input.set("pointer.pressed", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("pointer.pressed", 0);
+    await game.step({ frames: 6 });
+
+    assert.deepEqual(
+      await playedSince(game, since),
+      [SELECT, HUM],
+      "the click should play the select sound, and the next screen its own bed",
+    );
+
+    const beds = (await played(game)).filter((s) => s.sample === HUM);
+    assert.equal(beds.length, 2, "one bed per screen");
+    assert.ok(
+      beds[0].stopped_at_sim_time !== null,
+      "the menu's bed should stop when the menu does",
+    );
+    assert.equal(beds[1].still_playing, true, "the load screen's bed should be playing");
+  },
+);
+
+// The VR menu is the same canvas on a world-space panel, driven by a controller
+// ray instead of a cursor - so it must make the same sounds at the same moments
+// (AGENTS.md: "a canvas must render the same way in flatscreen and in VR").
+//
+// The runtime's VR head yaw is +90 degrees (the camera looks along -X), so the
+// panel hangs at x=-2 with canvas +x mapping to world +z and canvas +y to -y.
+// A hand placed on the button's world position and aimed along -X points at it.
+const PANEL_DISTANCE = 2;
+const PANEL_SIZE = { x: 2, y: 1.5 };
+/** 90-degree yaw: rotates a hand's -Z ray onto the panel's -X. */
+const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.7071068];
+
+/** Pawn-local position of a canvas point on the VR panel. */
+const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
+  -PANEL_DISTANCE,
+  PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
+  (u - 0.5) * PANEL_SIZE.x,
+];
+
+test(
+  "the VR menu plays the same sounds off the controller ray",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "main_menu",
+      port: 8123,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 10 });
+
+    assert.ok(
+      (await played(game)).some((s) => s.sample === HUM),
+      "the VR menu should start the bed too",
+    );
+
+    // Aim at "Load Game" - the ray origin is the button's own world position,
+    // so the ray runs straight down -X onto it.
+    let since = await lastSequence(game);
+    await game.input.set("right_hand.rotation", AIM_AT_PANEL);
+    const [, y, z] = panelPoint(LOAD_GAME_ENTRY);
+    await game.input.set("right_hand.position", [0, y, z]);
+    await game.step({ frames: 10 });
+    assert.deepEqual(
+      await playedSince(game, since),
+      [ROLLOVER],
+      "pointing the controller at an entry should blip once",
+    );
+
+    // The trigger is VR's click.
+    since = await lastSequence(game);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 3 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 8 });
+    assert.deepEqual(
+      await playedSince(game, since),
+      [SELECT, HUM],
+      "the trigger should select, and hand the bed over with the screen",
+    );
+  },
+);
+
+test(
+  "the bed stops when the menu is replaced without going through a click",
+  { skip: !e2eEnabled && "set SHOCK2_E2E=1 to run" },
+  async () => {
+    await using game = await GameServer.launch({ mission: "main_menu", port: 8124 });
+    await game.step({ frames: 10 });
+
+    const before = (await played(game)).find((s) => s.sample === HUM);
+    assert.ok(before, "the menu should start the bed");
+
+    // A level transition driven from outside the screen (the debug runtime's
+    // /v1/level, a save load, ...) never reaches the menu's effect handling.
+    // The bed loops forever, so nothing but an explicit stop ever ends it -
+    // before the scene-exit hook this played on under the mission for good.
+    await game.transitionLevel("earth.mis");
+    await game.step({ frames: 30 });
+
+    const after = (await played(game)).find((s) => s.sequence === before.sequence);
+    assert.ok(
+      after && after.stopped_at_sim_time !== null,
+      "the bed must stop when the menu is replaced",
+    );
+    assert.equal(
+      (await played(game)).filter((s) => s.sample === HUM).length,
+      1,
+      "and it must not restart under the mission",
+    );
+  },
+);


### PR DESCRIPTION
The original frontend is not silent — `res/snd/sfx/` (inside `snd.crf`) ships the whole set the menus use, and the names give it away:

| File | Role | Length |
| --- | --- | --- |
| `mloop1.wav` / `mloop2.wav` | looping bed under the screen | 2.2s / 2.0s |
| `MROLLOV1/2.WAV` | rollover blip when the pointer moves onto a widget | 0.03s |
| `MSELECT1/2.WAV` | select click | 0.23s / 0.39s |
| `MDONE.WAV` | (unused here) | 0.45s |

The port played none of them, so every menu screen was dead quiet. This adds the first of each pair to the main-menu, load-game and game-over screens. Nothing in the shipped data says which screen takes which of a numbered pair, so the `2`s and `MDONE` are left for later.

## How it fits together

`shock2vr/src/scenes/frontend_sfx.rs` owns all three sounds. A screen reports which widget the pointer is over each update; the blip fires once on entry, resolved by the **same hit-test that resolves the click**, so the sound and the highlight can never disagree about where a button is. `load_game`/`game_over` grew a shared `hit()` for exactly that reason, and `main_menu`'s hover now goes through its existing `UiCanvas` hit region instead of a second, subtly different rect scan.

That also makes the **VR** main menu work for free: it already funnels the controller ray through the same canvas point as the flat cursor, so the same code fires the same sounds ([AGENTS.md](../blob/main/AGENTS.md): a canvas must behave the same in both presentations). The load/game-over screens remain cursor-only for *input* (pre-existing — only the main menu got a VR path in #953), but their bed plays in both.

## Two things worth a reviewer's attention

**Looping.** The bed uses `repeat_infinite` via a new `PlayOptions { volume, looping }` on the non-spatial play path, not the re-append-when-empty pattern the environmental sink uses — that one leaves a gap of however long the caller takes to notice the sink drained. (The two existing beds in `AudioContext` still have that gap; converting them is a separate behavioral change to in-mission audio, so it is not in this PR.)

**Lifetime.** A looping sink never drains, so it needs an explicit stop, and `handle_effects` is not enough: scenes are also replaced from paths that never run it (a debug-runtime level transition, a save load). Hence `GameScene::on_exit(audio_context)`, called from a single `set_active_scene` that every scene swap now routes through. Without it the menu bed played on under the mission forever, stacking one more per menu visit — `menu-audio.e2e.test.ts` covers exactly that.

Known nit: crossing between two frontend screens restarts the bed from sample 0 rather than continuing it, since each screen owns its own. Making it continuous means hoisting ownership above the scenes.

## Verification

Audio has no visual output, so the evidence is the audio log (`GET /v1/audio/recent`) — a menu session in flat mode:

```
1 frame  1  sfx/mloop1.wav    stopped@0.833
2 frame 10  sfx/mrollov1.wav          <- pointer enters "New Game"
3 frame 45  sfx/mrollov1.wav          <- and "Load Game" (not once per frame between)
4 frame 50  sfx/mselect1.wav          <- click
5 frame 51  sfx/mloop1.wav            <- the load screen's own bed
```

and the same sequence in VR, driven by the controller ray and trigger instead.

- 4 unit tests (`frontend_sfx`) + 3 e2e cases (flat, VR, and the leak regression), each confirmed **failing without the change** and passing with it
- `cargo fmt` clean; `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean
- full SDK e2e suite: 253 tests, 245 pass, 1 fail — `creature-loot`, which also fails on `main` (#931)

## Follow-ups (not in scope here)

- The engine has three ways to loop a clip now; the two older ones gap.
- The load screen draws "Load" as enabled from an unfiltered selection while `update` gates the click on visible rows, so a stale out-of-range selection can show a lit button that does nothing (pre-existing; the new rollover correctly stays silent over it).