### PR TITLE
test(e2e): read looted creature logs on demand

### DIFF
--- a/tools/shock2-sdk/test/creature-loot.e2e.test.ts
+++ b/tools/shock2-sdk/test/creature-loot.e2e.test.ts
@@ -24,10 +24,10 @@ import { teleportVerified } from "./helpers/teleport.js";
 // PLAYTHROUGH scenario: Dr. Watts (734), an Invulnerable/Posing Male-MedSci
 // NPC, Contains the deck-2 log-14 disc whose transcript carries the conduit
 // access code 12451 (level02.str LogText14). Frobbing him opens his loot MFD so
-// the disc can be read. (Watts also inherits the always-open `containerscript`
-// from the root Object template, so his loot works independently of this fix;
-// the gated `creaturecontainer` recognises him as invulnerable and opens too,
-// coexisting without breaking his loot.)
+// the disc can be collected and read on demand. (Watts also inherits the
+// always-open `containerscript` from the root Object template, so his loot works
+// independently of this fix; the gated `creaturecontainer` recognises him as
+// invulnerable and opens too, coexisting without breaking his loot.)
 //
 // Discovery is by stable mission object id (the `template_id` /v1/entities
 // reports for level-authored entities); runtime entity ids are NOT stable.
@@ -162,18 +162,19 @@ test(
       "taking Watts' disc should record deck-2 log 14 (the 12451 code log)",
     );
 
-    // The disc's transcript surfaces 12451 in-fiction. Read it at the disc's own
-    // authored position (a contained disc keeps its position; standing at Watts
-    // is >4 units away, so the reader's walk-away auto-close would fire there).
+    // The disc's transcript surfaces 12451 in-fiction. Read it through the
+    // original's on-demand `play_unread_log` path at the disc's own authored
+    // position (the consumed entity remains as the reader backing state;
+    // standing at Watts is >4 units away, so walk-away auto-close would fire).
     const dp = (await game.entities.detail(codeDiscId)).position;
     await teleportVerified(game, { x: dp[0], y: dp[1] + 0.5, z: dp[2] });
-    await game.entities.sendMessage(codeDiscId, { type: "Frob" });
+    await game.input.trigger("ReadLastUnreadLog");
     await game.step({ frames: 5 });
     const reader = await activePanel();
     assert.equal(
       reader?.template_id,
       CODE_DISC,
-      "frobbing the looted disc should open the reader MFD bound to it",
+      "reading the looted disc should open the reader MFD bound to it",
     );
     const transcript = reader.elements
       .filter((e) => e.kind === "text" && e.text)


### PR DESCRIPTION
## Summary

- drive the Watts audio-log playthrough through `ReadLastUnreadLog`, the on-demand reader path introduced by #917
- keep the scenario's entity-binding and in-fiction `12451` transcript assertions
- update the scenario commentary and failure message to describe collection followed by on-demand reading

## Reproduction and root cause

On exact base `e09fc084e2b528da3639932cfa486dce310188c8`, the unchanged scenario deterministically failed after collecting Watts' disc:

```text
frobbing the looted disc should open the reader MFD bound to it
undefined !== 251
```

#917 intentionally changed audio-log frobs to file a log unread without opening a panel, and added `ReadLastUnreadLog` as the faithful `play_unread_log` path. Its dedicated log-reader scenarios were updated, but this older creature-loot playthrough still re-frobbed the consumed backing entity and asserted the pre-#917 contract. Production already behaves as designed; the stale driver was the bug.

## Negative-first and verification

- **Negative first, exact base:** `SHOCK2_E2E=1 node --test --test-concurrency=1 dist/test/creature-loot.e2e.test.js` — **0 passed, 1 failed** with `undefined !== 251` (30.6 s)
- **Corrected focused scenario:** same command — **1 passed, 0 failed** (11.0 s); repeated after rebase — **1 passed, 0 failed** (11.1 s)
  - the real `ReadLastUnreadLog` action opens a reader bound to mission object/template `251`
  - rendered transcript text still contains the in-fiction conduit code `12451`
- `npm test` — **26 passed, 0 failed, 223 E2E-gated skips**
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- full serial `npm run test:e2e` — **249 total: 241 passed, 1 failed, 7 skipped, 0 cancelled**
  - sole failure: pre-existing `shodan-corpse-drift.e2e.test.ts` (`dead Assassin 678 drifted 1.604 units`)
  - isolated detached exact-base rerun reproduced the identical assertion and positions (**0 passed, 1 failed**), conclusively classifying it as unrelated baseline behavior

## Visual assessment

This resolution is non-renderable: the diff changes only which existing SDK input action the test sends and its explanatory text; it changes no production binary, runtime behavior, UI description, or render path. A matched exact-base/fix capture of the corrected `ReadLastUnreadLog` sequence would be byte-identical and could not show the assertion/request-sequence correction, so a GIF or before/after would be misleading.

Objective player-observable substitutes from the deterministic runtime scenario:

| Observation | Exact base with stale sequence | Corrected sequence |
| --- | --- | --- |
| After collection | log is filed unread; no reader opens | same production behavior |
| Read request | second `Frob` leaves `active_panel` absent | `ReadLastUnreadLog` opens the reader |
| Reader result | `template_id` is `undefined` | bound to disc template `251`; transcript contains `12451` |

Fixes #931
