### PR TITLE
fix(ai): parse authored awareness delays

### DIFF
--- a/dark/src/properties/mod.rs
+++ b/dark/src/properties/mod.rs
@@ -1220,7 +1220,9 @@ pub fn get<R: io::Read + io::Seek + 'static>() -> (
             accumulator::latest,
         ),
         define_prop(
-            "P$AI_AwrDel2",
+            // The editor property is AI_AwrDel2, but Dark's 11-character
+            // chunk-name field truncates its on-disk key to AI_AwrDel.
+            "P$AI_AwrDel",
             PropAIAwareDelay::read,
             identity,
             accumulator::latest,
@@ -2552,14 +2554,6 @@ mod tests {
     /// is exactly how `P$AI_AlertCap` went unparsed for every entity.
     #[test]
     fn registered_chunk_names_fit_the_11_char_chunk_field() {
-        // `P$AI_AwrDel2` is the same bug (the real chunk is `P$AI_AwrDel`), but
-        // the one shipped entry - Security Camera, template -367 - stores
-        // to_two = -1, a sentinel `AlertnessTimings::from_aware_delay` would
-        // turn into a ~50-day escalation delay, so simply renaming it would
-        // stop cameras alerting. Left broken deliberately until the sentinel is
-        // handled; see the tracking issue.
-        const KNOWN_TRUNCATED: [&str; 1] = ["P$AI_AwrDel2"];
-
         let (props, _, _) = get::<io::Cursor<Vec<u8>>>();
         let too_long: Vec<String> = props
             .iter()
@@ -2567,13 +2561,25 @@ mod tests {
             // `__`-prefixed names are internal runtime-only properties with no
             // chunk on disk, so the field width does not apply to them.
             .filter(|name| !name.starts_with("__"))
-            .filter(|name| name.len() > 11 && !KNOWN_TRUNCATED.contains(&name.as_str()))
+            .filter(|name| name.len() > 11)
             .collect();
         assert!(
             too_long.is_empty(),
             "these registered property names exceed the 11-character chunk-name \
              field and can never match a chunk: {too_long:?}"
         );
+    }
+
+    /// Regression guard for #887: the editor-facing property name is
+    /// `AI_AwrDel2`, but Dark's 11-character on-disk chunk key is truncated to
+    /// `P$AI_AwrDel`. Registering the editor name can never match retail data.
+    #[test]
+    fn ai_aware_delay_uses_the_retail_chunk_name() {
+        let (props, _, _) = get::<io::Cursor<Vec<u8>>>();
+        let names: Vec<String> = props.iter().map(|prop| prop.name()).collect();
+
+        assert!(names.iter().any(|name| name == "P$AI_AwrDel"));
+        assert!(!names.iter().any(|name| name == "P$AI_AwrDel2"));
     }
 
     #[test]

--- a/dark/src/properties/prop_ai_aware_delay.rs
+++ b/dark/src/properties/prop_ai_aware_delay.rs
@@ -3,24 +3,24 @@ use std::io;
 use serde::{Deserialize, Serialize};
 use shipyard::Component;
 
-use crate::ss2_common::{read_bytes, read_u32};
+use crate::ss2_common::{read_bytes, read_i32};
 
 #[derive(Debug, Component, Clone, Serialize, Deserialize)]
 pub struct PropAIAwareDelay {
-    pub to_two: u32,
-    pub to_three: u32,
-    pub two_reuse: u32,
-    pub three_reuse: u32,
-    pub ignore_range: u32,
+    pub to_two: i32,
+    pub to_three: i32,
+    pub two_reuse: i32,
+    pub three_reuse: i32,
+    pub ignore_range: i32,
 }
 
 impl PropAIAwareDelay {
     pub fn read<T: io::Read + io::Seek>(reader: &mut T, len: u32) -> PropAIAwareDelay {
-        let to_two = read_u32(reader);
-        let to_three = read_u32(reader);
-        let two_reuse = read_u32(reader);
-        let three_reuse = read_u32(reader);
-        let ignore_range = read_u32(reader);
+        let to_two = read_i32(reader);
+        let to_three = read_i32(reader);
+        let two_reuse = read_i32(reader);
+        let three_reuse = read_i32(reader);
+        let ignore_range = read_i32(reader);
 
         const EXPECTED_SIZE: u32 = 20;
         if len > EXPECTED_SIZE {
@@ -35,5 +35,25 @@ impl PropAIAwareDelay {
             three_reuse,
             ignore_range,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::PropAIAwareDelay;
+
+    #[test]
+    fn reads_the_retail_negative_reaction_time_sentinel() {
+        let mut bytes = Vec::new();
+        for value in [-1_i32, 4000, 10000, 10000, 0] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+
+        let delay = PropAIAwareDelay::read(&mut Cursor::new(bytes), 20);
+
+        assert_eq!(delay.to_two, -1);
+        assert_eq!(delay.to_three, 4000);
     }
 }

--- a/shock2vr/src/scripts/ai/alertness.rs
+++ b/shock2vr/src/scripts/ai/alertness.rs
@@ -96,15 +96,21 @@ impl AlertnessTimings {
     /// - `three_reuse`: decay time from level 3
     /// - `ignore_range`: time to return to Lowest
     pub fn from_aware_delay(delay: &PropAIAwareDelay) -> Self {
-        let to_two_secs = delay.to_two as f32 / 1000.0;
+        // The retail Security Camera authors -1 for `to_two`. Looking Glass's
+        // runtime stored this field unsigned and added the resulting UINT_MAX
+        // directly to the current timer, wrapping its expiration to `now - 1`:
+        // an immediately expired reaction delay. Preserve that behavior by
+        // clamping negative serialized values to zero before conversion.
+        let seconds = |milliseconds: i32| milliseconds.max(0) as f32 / 1000.0;
+        let to_two_secs = seconds(delay.to_two);
         Self {
             // Split to_two between Lowest->Low and Low->Moderate transitions
             to_low: to_two_secs / 2.0,
             to_moderate: to_two_secs / 2.0,
-            to_high: delay.to_three as f32 / 1000.0,
-            from_high: delay.three_reuse as f32 / 1000.0,
-            from_moderate: delay.two_reuse as f32 / 1000.0,
-            from_low: delay.ignore_range as f32 / 1000.0,
+            to_high: seconds(delay.to_three),
+            from_high: seconds(delay.three_reuse),
+            from_moderate: seconds(delay.two_reuse),
+            from_low: seconds(delay.ignore_range),
         }
     }
 }
@@ -501,6 +507,24 @@ mod tests {
         assert_eq!(timings.from_high, 6.0);
         assert_eq!(timings.from_moderate, 5.0);
         assert_eq!(timings.from_low, 7.0);
+    }
+
+    /// Retail Security Camera authors `to_two = -1`. The original Dark
+    /// engine passes that bit pattern through its unsigned timer arithmetic,
+    /// making the timer immediately expired; it is not a multi-day delay.
+    #[test]
+    fn test_from_aware_delay_treats_minus_one_as_immediate() {
+        let mut bytes = Vec::new();
+        for value in [-1_i32, 4000, 10000, 10000, 0] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        let delay = PropAIAwareDelay::read(&mut std::io::Cursor::new(bytes), 20);
+
+        let timings = AlertnessTimings::from_aware_delay(&delay);
+
+        assert_eq!(timings.to_low, 0.0);
+        assert_eq!(timings.to_moderate, 0.0);
+        assert_eq!(timings.to_high, 4.0);
     }
 
     #[test]

--- a/shock2vr/src/scripts/ai/animated_monster_ai.rs
+++ b/shock2vr/src/scripts/ai/animated_monster_ai.rs
@@ -238,11 +238,11 @@ impl AnimatedMonsterAI {
 
         // Build default aware delay for monsters (faster than cameras/turrets)
         let default_aware_delay = PropAIAwareDelay {
-            to_two: (DEFAULT_ESCALATE_SECONDS * 1000.0) as u32,
-            to_three: (DEFAULT_ESCALATE_SECONDS * 1000.0) as u32,
-            two_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
-            three_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
-            ignore_range: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
+            to_two: (DEFAULT_ESCALATE_SECONDS * 1000.0) as i32,
+            to_three: (DEFAULT_ESCALATE_SECONDS * 1000.0) as i32,
+            two_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
+            three_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
+            ignore_range: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
         };
 
         let aware_delay = v_aware_delay

--- a/shock2vr/src/scripts/ai/camera_ai.rs
+++ b/shock2vr/src/scripts/ai/camera_ai.rs
@@ -279,11 +279,11 @@ impl CameraAI {
 
         // Build default aware delay using the same constants as before
         let default_aware_delay = PropAIAwareDelay {
-            to_two: (ALERT_ESCALATE_SECONDS * 1000.0) as u32,
-            to_three: (ALERT_ESCALATE_SECONDS * 1000.0) as u32,
-            two_reuse: (ALERT_DECAY_SECONDS * 1000.0) as u32,
-            three_reuse: (ALERT_DECAY_SECONDS * 1000.0) as u32,
-            ignore_range: (ALERT_DECAY_SECONDS * 1000.0) as u32,
+            to_two: (ALERT_ESCALATE_SECONDS * 1000.0) as i32,
+            to_three: (ALERT_ESCALATE_SECONDS * 1000.0) as i32,
+            two_reuse: (ALERT_DECAY_SECONDS * 1000.0) as i32,
+            three_reuse: (ALERT_DECAY_SECONDS * 1000.0) as i32,
+            ignore_range: (ALERT_DECAY_SECONDS * 1000.0) as i32,
         };
 
         let aware_delay = v_aware_delay

--- a/shock2vr/src/scripts/ai/turret_ai.rs
+++ b/shock2vr/src/scripts/ai/turret_ai.rs
@@ -140,11 +140,11 @@ impl TurretAI {
 
         // Build default aware delay for turrets
         let default_aware_delay = PropAIAwareDelay {
-            to_two: (DEFAULT_ESCALATE_SECONDS * 1000.0) as u32,
-            to_three: (DEFAULT_ESCALATE_SECONDS * 1000.0) as u32,
-            two_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
-            three_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
-            ignore_range: (DEFAULT_DECAY_SECONDS * 1000.0) as u32,
+            to_two: (DEFAULT_ESCALATE_SECONDS * 1000.0) as i32,
+            to_three: (DEFAULT_ESCALATE_SECONDS * 1000.0) as i32,
+            two_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
+            three_reuse: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
+            ignore_range: (DEFAULT_DECAY_SECONDS * 1000.0) as i32,
         };
 
         let aware_delay = v_aware_delay

--- a/tools/shock2-sdk/test/camera-aware-delay.e2e.test.ts
+++ b/tools/shock2-sdk/test/camera-aware-delay.e2e.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8223);
+
+// MedSci1 object 102 is a Security Camera with an unobstructed view from the
+// authored floor position used below. Runtime entity ids vary between runs.
+const CAMERA_TEMPLATE_ID = 102;
+
+function prop(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((property) => property.name === name)?.value;
+}
+
+test(
+  "security cameras honor the authored immediate-to-moderate awareness delay",
+  { skip: !e2eEnabled, timeout: 900_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci1.mis",
+      port: basePort,
+    });
+
+    const [camera] = await game.entities.byTemplate(CAMERA_TEMPLATE_ID);
+    assert.ok(camera, `medsci1 should contain camera ${CAMERA_TEMPLATE_ID}`);
+    assert.equal(prop(await game.entities.detail(camera.id), "Model"), "camgrn");
+
+    // Enter the camera's real scan cone. Template -367 authors to_two=-1,
+    // which the original engine treats as an already-expired reaction timer,
+    // and to_three=4000ms.
+    const [cx, cy, cz] = camera.position;
+    await game.player.teleport({ x: cx - 2.83, y: cy - 1.9, z: cz + 2.83 });
+
+    await game.step({ frames: 1 });
+    let detail = await game.entities.detail(camera.id);
+    assert.equal(prop(detail, "AIAlertness"), "Moderate");
+    assert.equal(prop(detail, "Model"), "camyel");
+
+    // Three seconds later the authored four-second high-alert delay is still
+    // running; after the fourth second it expires and the camera turns red.
+    await game.step({ frames: 180 });
+    detail = await game.entities.detail(camera.id);
+    assert.equal(prop(detail, "AIAlertness"), "Moderate");
+    assert.equal(prop(detail, "Model"), "camyel");
+
+    await game.step({ frames: 61 });
+    detail = await game.entities.detail(camera.id);
+    assert.equal(prop(detail, "AIAlertness"), "High");
+    assert.equal(prop(detail, "Model"), "camred");
+  },
+);


### PR DESCRIPTION
## Summary

- register the retail `P$AI_AwrDel` chunk key so authored awareness delays are parsed
- preserve the property's signed serialized fields, including Security Camera's `to_two = -1`
- map negative reaction-delay sentinels to an immediate timer instead of a multi-day delay
- cover the retail parser key, sentinel conversion, and player-observable camera timing

## Reproduction and retail audit

On exact base `e09fc084e2b528da3639932cfa486dce310188c8`, `cargo dq templates 367` reported `P$AI_AwrDel (20 bytes)` as unparsed. The registered key was `P$AI_AwrDel2`, which cannot fit Dark's 11-character chunk-name payload and therefore cannot match the retail chunk.

A raw chunk-table audit of `shock2.gam` and all 23 retail missions found exactly one authored payload:

```text
shock2.gam template -367 Security Camera: (-1, 4000, 10000, 10000, 0)
all 23 *.mis P$AI_AwrDel chunks: 0 records
```

Mission cameras inherit that gamesys template value. After the fix, `cargo dq templates 367` reports:

```text
PropAIAwareDelay { to_two: -1, to_three: 4000, two_reuse: 10000, three_reuse: 10000, ignore_range: 0 }
```

## Sentinel semantics

[OpenDarkEngine's SS2 schema](https://github.com/volca02/openDarkEngine/blob/7a2d7baaf0fc5194a9066a635c6f44b0f7b26c56/scripts/shock2/ss2-types.dtype#L1087-L1094) describes the serialized values as signed `int32`. The original [Looking Glass awareness struct](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/ai/aiaware.h#L108-L117) stores the same bits unsigned, and [passes `toTwo` directly into `cAITimer::Set`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/ai/aibassns.cpp#L1886-L1921). [`cAITimer::Set`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/ai/aiutils.h#L335-L340) adds the period to current time, so `UINT_MAX` wraps expiration to `now - 1`: the timer is immediately expired. Thus retail `-1` means no reaction delay, not default and not infinite.

Before the fix, the negative-first timing test observed `2,147,483.8s` for each split transition. The fixed adapter produces `0s` to Moderate and preserves the authored `4s` delay to High.

## Validation

- negative-first parser-key test failed on base, then passed
- negative-first sentinel timing test failed on base (`2,147,483.8s`), then passed
- `cargo test -p dark`: 120 passed (110 unit + 10 mission-loading)
- `cargo test -p shock2vr --lib`: 655 passed
- `RUSTFLAGS="-D warnings" cargo check -p dark -p shock2vr -p desktop_runtime -p debug_runtime`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- SDK fast suite: 250 total, 26 passed, 224 opt-in skipped
- focused camera-aware-delay E2E: 1 passed
- existing camera alert save/load E2E: passed
- full serial SDK E2E: 250 total, 242 passed, 7 configured skips, 1 unrelated failure
  - all 23 mission-load smoke tests passed
  - the sole failure is the existing creature-loot reader binding (`undefined !== 251`), reproduced identically on exact base and tracked by #931

## Visual evidence

![Security Camera alert timing comparison](https://gist.githubusercontent.com/tommy-xr/0c333bf46c5c3bbc7203c8a0b38e5304/raw/c12a73adf07aad95359f9d1311f9b781fa256c14/issue887-camera-alert-timing.gif)

<sub>Retail Security Camera now skips the authored -1 moderate-delay timer and reaches red after its authored four-second high-alert delay. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep).</sub>

### Current result

![Current Security Camera red alert after 242 frames](https://gist.githubusercontent.com/tommy-xr/0c333bf46c5c3bbc7203c8a0b38e5304/raw/f182526b9b7bc23759773f38e9f021def268afae/issue887-current-red-t242.png)

### Before → after

![Base remains yellow while the fix reaches red after the same 242 frames](https://gist.githubusercontent.com/tommy-xr/0c333bf46c5c3bbc7203c8a0b38e5304/raw/41f7622a052e00648677683ae0d546da5720dfd1/issue887-before-after-t242.png)

Fixes #887