### PR TITLE
fix(vr): ignore held items in hand selection

### DIFF
--- a/shock2vr/src/interaction.rs
+++ b/shock2vr/src/interaction.rs
@@ -135,6 +135,7 @@ impl Default for VrInteraction {
 
 impl PlayerInteraction for VrInteraction {
     fn update(&mut self, ctx: &InteractionContext) -> Vec<VirtualHandEffect> {
+        let left_held_entity = self.left_hand.get_held_entity();
         let (right_hand, mut right_msgs) = VirtualHand::update(
             &self.right_hand,
             ctx.physics,
@@ -142,9 +143,13 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_pos,
             ctx.player_rotation,
             &ctx.input.right_hand,
+            left_held_entity,
         );
         self.right_hand = right_hand;
 
+        // Right updates first, so a same-frame right-hand grab is visible to
+        // the left hand and one physical item cannot enter both hand states.
+        let right_held_entity = self.right_hand.get_held_entity();
         let (left_hand, mut left_msgs) = VirtualHand::update(
             &self.left_hand,
             ctx.physics,
@@ -152,6 +157,7 @@ impl PlayerInteraction for VrInteraction {
             ctx.player_pos,
             ctx.player_rotation,
             &ctx.input.left_hand,
+            right_held_entity,
         );
         self.left_hand = left_hand;
 
@@ -228,6 +234,12 @@ impl PlayerInteraction for VrInteraction {
         entity_id: EntityId,
         hand: Handedness,
     ) -> Vec<VirtualHandEffect> {
+        // `Effect::GrabEntity` and save/load restoration enter through this
+        // path instead of the per-frame hand ray, so enforce the same single-
+        // owner invariant here too.
+        if self.left_hand.is_holding(entity_id) || self.right_hand.is_holding(entity_id) {
+            return Vec::new();
+        }
         if hand == Handedness::Left {
             self.left_hand = self.left_hand.grab_entity(world, entity_id);
         } else {
@@ -330,5 +342,139 @@ impl PlayerInteraction for FlatInteraction {
 
     fn flat_aim_ray(&self) -> Option<(Point3<f32>, Vector3<f32>)> {
         self.controller.aim_ray()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, vec3};
+    use dark::properties::{FrobFlag, PropFrobInfo, PropModelName};
+
+    use super::*;
+    use crate::{
+        input_context::InputContext,
+        physics::{CollisionGroup, DynamicPhysicsOptions, PhysicsShape},
+        scripts::MessagePayload,
+    };
+
+    fn identity() -> Quaternion<f32> {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    fn grabbable(world: &mut World) -> EntityId {
+        world.add_entity((
+            PropFrobInfo {
+                world_action: FrobFlag::MOVE,
+                inventory_action: FrobFlag::empty(),
+                tool_action: FrobFlag::empty(),
+            },
+            PropModelName("test_item".to_owned()),
+        ))
+    }
+
+    fn context<'a>(
+        world: &'a World,
+        physics: &'a PhysicsWorld,
+        input: &'a InputContext,
+    ) -> InteractionContext<'a> {
+        InteractionContext {
+            physics,
+            world,
+            input,
+            player_pos: vec3(0.0, 0.0, 0.0),
+            player_rotation: identity(),
+            head_rotation: identity(),
+            eye_height: 1.04,
+        }
+    }
+
+    fn step_physics(physics: &mut PhysicsWorld) {
+        let player = EntityId::from_inner(10_000).unwrap();
+        let mut player = physics.create_player(vec3(10.0, 10.0, 10.0), player);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player);
+    }
+
+    #[test]
+    fn one_item_cannot_be_grabbed_by_both_hands_on_the_same_frame() {
+        let mut world = World::new();
+        let item = grabbable(&mut world);
+        let mut physics = PhysicsWorld::new();
+        physics.add_dynamic(
+            item,
+            vec3(0.0, 0.0, -0.5),
+            identity(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.5, 0.5, 0.5)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        step_physics(&mut physics);
+        let mut input = InputContext::default();
+        input.left_hand.squeeze_value = 1.0;
+        input.right_hand.squeeze_value = 1.0;
+        let mut interaction = VrInteraction::new();
+
+        let effects = interaction.update(&context(&world, &physics, &input));
+
+        assert_eq!(
+            interaction.held_entities(),
+            (None, Some(item)),
+            "right-hand update wins ties; the left hand must see that the item is already held"
+        );
+        assert_eq!(
+            effects
+                .iter()
+                .filter(|effect| matches!(effect, VirtualHandEffect::HoldItem { entity_id } if *entity_id == item))
+                .count(),
+            1,
+            "one physical item must produce exactly one hold transition"
+        );
+    }
+
+    #[test]
+    fn a_held_item_does_not_receive_its_own_hands_hover() {
+        let mut world = World::new();
+        let item = grabbable(&mut world);
+        let mut physics = PhysicsWorld::new();
+        physics.add_dynamic(
+            item,
+            vec3(0.0, 0.0, -0.5),
+            identity(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(0.5, 0.5, 0.5)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        step_physics(&mut physics);
+        let mut input = InputContext::default();
+        input.left_hand.position = vec3(10.0, 0.0, 0.0);
+        input.right_hand.squeeze_value = 1.0;
+        let mut interaction = VrInteraction::new();
+        interaction.grab(&world, item, Handedness::Right);
+
+        let effects = interaction.update(&context(&world, &physics, &input));
+
+        assert!(
+            !effects.iter().any(|effect| matches!(
+                effect,
+                VirtualHandEffect::OutMessage { message }
+                    if message.to == item && matches!(message.payload, MessagePayload::Hover { .. })
+            )),
+            "a holding hand's ray must pass through its own item"
+        );
+    }
+
+    #[test]
+    fn externally_requested_grab_does_not_duplicate_an_existing_hold() {
+        let mut world = World::new();
+        let item = grabbable(&mut world);
+        let mut interaction = VrInteraction::new();
+
+        interaction.grab(&world, item, Handedness::Left);
+        interaction.grab(&world, item, Handedness::Right);
+
+        assert_eq!(interaction.held_entities(), (Some(item), None));
     }
 }

--- a/shock2vr/src/virtual_hand.rs
+++ b/shock2vr/src/virtual_hand.rs
@@ -200,6 +200,7 @@ impl VirtualHand {
         pawn_pos: Vector3<f32>,
         pawn_rot: Quaternion<f32>,
         input_hand: &Hand,
+        held_by_other_hand: Option<EntityId>,
     ) -> (VirtualHand, Vec<VirtualHandEffect>) {
         let handedness = prev.handedness;
         let hand_position = pawn_pos + HAND_OFFSET + pawn_rot.rotate_vector(input_hand.position);
@@ -208,9 +209,10 @@ impl VirtualHand {
         // Also do a raycast to provide the 'Hover' effect
         let ray_start = point3(hand_position.x, hand_position.y, hand_position.z);
         let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-        let result = physics.ray_cast(
+        let result = physics.ray_cast2(
             ray_start,
             forward,
+            100.0,
             // TODO: Two raycasts...
             // One for hit damage:
             //InternalCollisionGroups::HITBOX
@@ -219,6 +221,8 @@ impl VirtualHand {
                 | InternalCollisionGroups::WORLD
                 | InternalCollisionGroups::UI
                 | InternalCollisionGroups::RAYCAST,
+            prev.get_held_entity(),
+            true,
             //InternalCollisionGroups::all(),
             // One for frobbing:
             //CollisionGroups::WORLD | CollisionGroups::SELECTABLE,
@@ -321,6 +325,7 @@ impl VirtualHand {
                 world,
                 physics,
                 input_hand,
+                held_by_other_hand,
             ),
         };
 
@@ -408,12 +413,14 @@ fn handle_empty_hand_state(
     world: &World,
     physics: &PhysicsWorld,
     input_hand: &Hand,
+    held_by_other_hand: Option<EntityId>,
 ) -> (VirtualHand, Vec<VirtualHandEffect>) {
     let ray_start = point3(hand_position.x, hand_position.y, hand_position.z);
     let forward = hand_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-    let result = physics.ray_cast(
+    let result = physics.ray_cast2(
         ray_start,
         forward,
+        100.0,
         // TODO: Two raycasts...
         // One for hit damage,
         //InternalCollisionGroups::HITBOX
@@ -422,6 +429,8 @@ fn handle_empty_hand_state(
             | InternalCollisionGroups::WORLD
             | InternalCollisionGroups::UI
             | InternalCollisionGroups::RAYCAST,
+        held_by_other_hand,
+        true,
         // One for frobbing:
         //CollisionGroups::WORLD | CollisionGroups::SELECTABLE,
     );
@@ -471,7 +480,7 @@ fn handle_empty_hand_state(
             is_sensor: _,
         }) = result
         {
-            if can_grab_item(world, entity_id) {
+            if Some(entity_id) != held_by_other_hand && can_grab_item(world, entity_id) {
                 let position = &physics.get_position(rigid_body_handle).unwrap();
                 let _dir = hand_position - position;
                 msgs.push(VirtualHandEffect::HoldItem { entity_id });

--- a/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
+++ b/tools/shock2-sdk/test/vr-melee-contact.e2e.test.ts
@@ -269,3 +269,69 @@ test(
     );
   },
 );
+
+// Regression for #954. Keeping the real held-melee collider from #943 made it
+// selectable by both controller rays. The other hand could then acquire the
+// same runtime entity; releasing either hand restored dynamic physics while
+// the other continued hard-setting its transform every frame.
+test(
+  "a held VR melee weapon cannot hover or transfer into the other hand",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "command2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT_HELD_RAY ?? 8140),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+
+    const wrench = await byMissionId(game, "Wrench", WRENCH_MISSION_ID);
+    await game.player.teleport({
+      x: wrench.position[0],
+      y: wrench.position[1] - 1.4,
+      z: wrench.position[2] + 1.2,
+    });
+    await game.input.lookAtWorldPoint(wrench.position);
+    await game.input.set("right_hand.position", [0, 1.4, 0]);
+    await game.input.set("right_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("right_hand.squeeze", 0);
+    // The authored Wrench's held collider sits 0.2 above the right-hand ray.
+    // Put the left production ray through its center instead of using a debug
+    // grab command; this is the exact dual-hand path reported in #954.
+    await game.input.set("left_hand.position", [0, 1.6, 0]);
+    await game.input.set("left_hand.rotation", [0, 0, 0, 1]);
+    await game.input.set("left_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.right_hand_entity_id, wrench.id);
+
+    await game.input.set("left_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    const afterRejectedGrab = await game.info();
+    assert.equal(
+      afterRejectedGrab.player.wielded_entity_id,
+      null,
+      "the left hand must not acquire the Wrench already held on the right",
+    );
+    assert.equal(afterRejectedGrab.player.right_hand_entity_id, wrench.id);
+    assert.equal(
+      (await game.physics.bodies({ entityId: wrench.id })).bodies[0]?.body_type,
+      "kinematic",
+      "a rejected second-hand grab must leave #943's live held-melee body intact",
+    );
+
+    await game.input.set("left_hand.squeeze", 0);
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+    const afterRelease = await game.info();
+    assert.equal(afterRelease.player.wielded_entity_id, null);
+    assert.equal(afterRelease.player.right_hand_entity_id, null);
+    assert.equal(
+      (await game.physics.bodies({ entityId: wrench.id })).bodies[0]?.body_type,
+      "dynamic",
+      "the sole owner releasing the Wrench should restore ordinary loose-prop physics",
+    );
+  },
+);


### PR DESCRIPTION
Fixes #954

## Reproduction

On exact `origin/main` (`e09fc084`), the shipped `command2.mis` Wrench (discovered by stable mission object id 786) was grabbed through the production `VirtualHand` ray in `--vr`. A second production hand ray through the held collider hit the Wrench at distance zero. Squeezing made both player hand slots reference the same runtime entity. Releasing only the right hand then changed the Wrench to a dynamic body while the left hand continued treating it as held and hard-setting its transform.

The new unit and SDK regressions were added first and failed on the parent commit:

- 3/3 focused Rust interaction tests failed (self-hover, same-frame dual grab, external duplicate grab)
- the shipped-Wrench SDK scenario failed because the left hand acquired the right-held runtime id

## Root cause

#943 intentionally kept authored held-melee colliders live and kinematic so controller-driven contacts can deal the gamesys-authored damage. The hand interaction rays still used the generic `ray_cast` helper with no entity exclusion, so the holding hand could select its own collider. `VrInteraction` also updated each hand independently and had no invariant preventing one runtime entity from entering both hand states.

## Fix

- use the existing ignored-entity raycast path so a holding hand's selection ray passes through its own item
- pass the other hand's held entity into empty-hand selection so it cannot hover or acquire that collider
- preserve right-then-left update ordering and expose a same-frame right grab to the left update
- enforce the same single-owner invariant for externally requested grabs (inventory/effect and restore entry points)

This does not change collision membership, body type, contact events, or melee damage. #943's held collider remains live and kinematic until its sole owning hand releases it.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 657 passed; 2 doctests ignored
- `npm test` — 250 total; 26 passed, 224 opt-in E2E skipped
- focused real-runtime SDK regression — 1 passed
- full `vr-melee-contact.e2e.test.ts` — 3 passed, including #943 fresh and save/load contact-damage scenarios
- full serial SDK E2E — 242 functional scenarios passed, 7 explicit opt-in scenarios skipped, and 1 known baseline failure (`creature-loot`, tracked by #931); the same assertion (`undefined !== 251`) was reproduced independently on exact base `e09fc084`
- 14 scenarios initially prevented from launching after the shared build cache exhausted disk space — all 14/14 passed on a clean-cache serial rerun, including the 3 VR melee/held-item scenarios

## Visual evidence

![Matched exact-base/fix VR held-Wrench keypad interaction](https://gist.githubusercontent.com/tommy-xr/7bd203c091f8ae43fc799c5791b91033/raw/issue954-held-wrench-keypad.gif)

<sub>Matched deterministic `command2.mis --vr` runs: both production-grab the shipped Wrench (mission object 786), production-frob the shipped keypad (1609), and place the live held collider on the selection ray. Exact base stays blank during 4 → 5 → 6; the fix reaches the keypad and enters `456`, then Clear resets it. Captured headlessly through `/v1/step` + `/v1/screenshot`.</sub>

### Fixed still

![Fixed held-Wrench selection reaches keypad](https://gist.githubusercontent.com/tommy-xr/7bd203c091f8ae43fc799c5791b91033/raw/issue954-after.png)

### Before → after

![Exact base versus fixed held-Wrench keypad selection](https://gist.githubusercontent.com/tommy-xr/7bd203c091f8ae43fc799c5791b91033/raw/issue954-before-after.png)

## Compatibility / risk

- flatscreen interaction is untouched
- held-melee physics and contact damage are untouched
- right hand retains the existing tie-break priority only when both empty hands squeeze the same item on the same frame
- an item can be acquired normally after its sole owner actually drops it; only concurrent ownership is rejected
