### PR TITLE
fix(vr): restore released inventory item physics

### DIFF
--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -440,6 +440,109 @@ fn move_live_entity_into_container(
     was_able_to_drop
 }
 
+/// Restore a live hand-released item to ordinary world ownership.
+///
+/// Inventory items may have an authored `HasRefs(false)` and can retain a
+/// stale `Contains` link across hand/world transitions. Physics creation is
+/// intentionally performed only after this invariant is restored: entity
+/// creation treats an unreferenced object as non-world state and otherwise
+/// declines to give it a selectable body.
+fn restore_live_entity_world_refs(world: &mut World, entity_id: EntityId) -> bool {
+    let is_alive = world
+        .borrow::<EntitiesView>()
+        .is_ok_and(|entities| entities.is_alive(entity_id));
+    if !is_alive {
+        return false;
+    }
+
+    {
+        let mut links_view = world.borrow::<ViewMut<Links>>().unwrap();
+        for links in (&mut links_view).iter() {
+            drop_contains_links_to(links, entity_id);
+        }
+    }
+    world.add_component(entity_id, PropHasRefs(true));
+    true
+}
+
+#[cfg(test)]
+mod released_item_world_refs_tests {
+    use super::*;
+
+    fn contains(container: &Links, item: EntityId) -> bool {
+        container.to_links.iter().any(|link| {
+            matches!(link.link, Link::Contains(_))
+                && link.to_entity_id.map(|wrapped| wrapped.0) == Some(item)
+        })
+    }
+
+    #[test]
+    fn hand_release_restores_refs_and_clears_residual_containment() {
+        let mut world = World::new();
+        let item = world.add_entity(PropHasRefs(false));
+        let container = world.add_entity(Links {
+            to_links: vec![ToLink {
+                link: Link::Contains(4),
+                to_entity_id: Some(WrappedEntityId(item)),
+                to_template_id: 0,
+            }],
+        });
+
+        assert!(restore_live_entity_world_refs(&mut world, item));
+        assert!(
+            world
+                .borrow::<View<PropHasRefs>>()
+                .unwrap()
+                .get(item)
+                .unwrap()
+                .0
+        );
+        assert!(!contains(
+            world
+                .borrow::<View<Links>>()
+                .unwrap()
+                .get(container)
+                .unwrap(),
+            item,
+        ));
+    }
+
+    #[test]
+    fn ordinary_container_transfer_still_removes_world_refs() {
+        let mut world = World::new();
+        let item = world.add_entity(PropHasRefs(true));
+        let container = world.add_entity(Links::empty());
+
+        assert!(move_live_entity_into_container(&mut world, container, item));
+        assert!(
+            !world
+                .borrow::<View<PropHasRefs>>()
+                .unwrap()
+                .get(item)
+                .unwrap()
+                .0
+        );
+        assert!(contains(
+            world
+                .borrow::<View<Links>>()
+                .unwrap()
+                .get(container)
+                .unwrap(),
+            item,
+        ));
+    }
+
+    #[test]
+    fn late_release_effect_cannot_resurrect_a_consumed_item() {
+        let mut world = World::new();
+        let item = world.add_entity(PropHasRefs(false));
+        world.delete_entity(item);
+
+        assert!(!restore_live_entity_world_refs(&mut world, item));
+        assert!(!world.borrow::<EntitiesView>().unwrap().is_alive(item));
+    }
+}
+
 /// Apply one retail food/drink use against live state. The carried-source
 /// validation, bounded heal, and consumption decision occur in one effect
 /// pass, so duplicate queued uses of the same object cannot heal twice.
@@ -6734,6 +6837,9 @@ impl MissionCore {
                     }
                 }
                 VirtualHandEffect::DropItem { entity_id } => {
+                    if !restore_live_entity_world_refs(&mut self.world, entity_id) {
+                        continue;
+                    }
                     if self.is_vr_melee_weapon(entity_id) {
                         // Recreate from authored physics so the released item
                         // is an ordinary dynamic, harmless loose prop again.
@@ -7630,6 +7736,9 @@ impl crate::game_scene::DebuggableScene for MissionCore {
             .run(|v: View<dark::properties::PropMaxHitPoints>| {
                 v.get(id).ok().map(|hp| hp.hit_points)
             });
+        let has_refs = self
+            .world
+            .run(|v: View<PropHasRefs>| v.get(id).ok().map(|refs| refs.0));
         // Most ecologies author no explicit P$EcoState; they behave as Normal
         // until their script's first transition creates the component.
         let ecology_state = self.world.run(
@@ -7729,6 +7838,12 @@ impl crate::game_scene::DebuggableScene for MissionCore {
                     properties.push(DebugPropertyInfo {
                         name: "MaxHitPoints".to_string(),
                         value: max_hit_points.to_string(),
+                    });
+                }
+                if let Some(has_refs) = has_refs {
+                    properties.push(DebugPropertyInfo {
+                        name: "HasRefs".to_string(),
+                        value: has_refs.to_string(),
                     });
                 }
                 if let Some(state) = ecology_state {

--- a/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci2-vr-released-item.e2e.test.ts
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { GameServer, findRepoRoot } from "../src/index.js";
+import type { EntitySummary, UiElement, Vec3 } from "../src/types.js";
+import { teleportVerified } from "./helpers/teleport.js";
+import { add, aimVrHandAt, quatRotate } from "./helpers/vr-hand.js";
+
+// MedSci2 production-VR guard for #974: the whole carry cycle for an ordinary
+// contained prop, player-observable and using no direct Frob/Grab/Give message:
+//
+//   Desk 503 panel click -> Gameboy 72 into the backpack
+//   Quest-X backpack squeeze -> first world release -> world re-grab
+//   carry -> second world release -> selectable body -> save/load
+//
+// Every release must leave the exact live entity world-referenced
+// (`HasRefs(true)`), free of residual `Contains` links, and physically
+// selectable through the production ray.
+//
+// The item is deliberately an ordinary physical prop (the desk's Gameboy), not
+// the R&D card sharing the same desk: key sources are registered on the keyring
+// and consumed rather than carried, so they never reach this hand/world path.
+//
+// This scenario also passes on the parent - on this base the grab path already
+// restores refs for every case reachable from a real gesture - so it is a
+// standing guard on the invariant rather than a failing-before reproduction.
+// `restore_live_entity_world_refs`'s unit tests in `mission_core.rs` pin the
+// released-item behavior (including the consumed-entity case) directly.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const DESK = 503;
+const GAMEBOY = 72;
+const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
+const VR_BACKPACK_WORLD_SCALE = 0.55;
+const BACKPACK_PANEL_SIZE_PX: Vec3 = [635, 120, 0];
+
+function only(matches: EntitySummary[], label: string): EntitySummary {
+  assert.equal(matches.length, 1, `expected one ${label}, got ${matches.length}`);
+  return matches[0];
+}
+
+function savePath(saveName: string): string | undefined {
+  const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+  const roots = [
+    process.env.DARK_ASSET_PATH,
+    join(repoRoot, "Data"),
+    join(repoRoot, "..", "Data"),
+  ].filter((root): root is string => Boolean(root));
+  return roots
+    .map((root) => join(root, "saves", `${saveName}.sav`))
+    .find(existsSync);
+}
+
+function panelElementWorldPoint(
+  panel: { position: Vec3; rotation: [number, number, number, number] },
+  panelSizePx: Vec3,
+  worldScale: number,
+  element: UiElement,
+): Vec3 {
+  const centerX = element.rect[0] + element.rect[2] / 2;
+  const centerY = element.rect[1] + element.rect[3] / 2;
+  const width = panelSizePx[0] * GUI_PIXEL_TO_WORLD_SIZE * worldScale;
+  const height = panelSizePx[1] * GUI_PIXEL_TO_WORLD_SIZE * worldScale;
+  const local: Vec3 = [
+    width * (0.5 - centerX / panelSizePx[0]),
+    height * (0.5 - centerY / panelSizePx[1]),
+    0,
+  ];
+  return add(panel.position, quatRotate(panel.rotation, local));
+}
+
+async function hasRefs(game: GameServer, entityId: number): Promise<string | undefined> {
+  return (await game.entities.detail(entityId)).properties
+    .find((property) => property.name === "HasRefs")
+    ?.value.toLowerCase();
+}
+
+async function assertNoContains(game: GameServer, entityId: number): Promise<void> {
+  const detail = await game.entities.detail(entityId);
+  assert.equal(
+    detail.incoming_links.some((link) => link.link_type.startsWith("Contains")),
+    false,
+    "released item must have no incoming Contains link",
+  );
+  assert.equal(
+    detail.outgoing_links.some((link) => link.link_type.startsWith("Contains")),
+    false,
+    "released item must have no outgoing Contains link",
+  );
+}
+
+async function assertSelectableWorldItem(
+  game: GameServer,
+  item: EntitySummary,
+): Promise<void> {
+  const bodies = (await game.physics.bodies({ entityId: item.id })).bodies;
+  assert.equal(bodies.length, 1, "released item must have one authored physics body");
+  assert.ok(
+    bodies[0].collision_groups.includes("entity") && bodies[0].is_enabled,
+    `released item must have an enabled entity body: ${JSON.stringify(bodies[0])}`,
+  );
+  assert.equal(await hasRefs(game, item.id), "true");
+  await assertNoContains(game, item.id);
+
+  const current = only(await game.entities.byTemplate(GAMEBOY), "released Gameboy");
+  await teleportVerified(game, {
+    x: current.position[0] + 1.0,
+    y: current.position[1] + 0.5,
+    z: current.position[2] + 1.0,
+  });
+  await game.step({ frames: 3 });
+  const aim = await game.player.aimAt(current.id, {
+    hitbox: "center",
+    visibility: "required",
+  });
+  assert.equal(
+    aim.target_confirmed,
+    true,
+    `released item must be reachable through the production ray: ${JSON.stringify(aim)}`,
+  );
+}
+
+test(
+  "MedSci2 VR desk item survives a second world release",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async (t) => {
+    const saveName = `medsci2_vr_released_item_${Date.now()}`;
+    t.after(() => {
+      const path = savePath(saveName);
+      if (path) rmSync(path, { force: true });
+    });
+
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8602),
+      debugFlags: ["--vr"],
+      echoLogs: process.env.SHOCK2_ECHO_LOGS === "1",
+    });
+    await game.step({ frames: 5 });
+
+    const desk = only(await game.entities.byTemplate(DESK), "MedSci2 Desk 503");
+    const item = only(await game.entities.byTemplate(GAMEBOY), "MedSci2 Gameboy 72");
+    assert.equal(
+      (await game.entities.detail(desk.id)).outgoing_links.some(
+        (link) => link.target_id === item.id && link.link_type.startsWith("Contains"),
+      ),
+      true,
+      "Desk 503 must initially contain the exact Gameboy",
+    );
+    assert.equal((await game.physics.bodies({ entityId: item.id })).bodies.length, 0);
+    assert.notEqual(
+      await hasRefs(game, item.id),
+      "true",
+      "contained item must not begin world-referenced",
+    );
+
+    await teleportVerified(game, {
+      x: desk.position[0] + 1.2,
+      y: desk.position[1] + 0.5,
+      z: desk.position[2] + 1.2,
+    });
+    await game.step({ frames: 5 });
+    const deskAim = await game.player.aimAt(desk.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(deskAim.target_confirmed, true, JSON.stringify(deskAim));
+    await aimVrHandAt(game, deskAim.world_point, 0.35);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 5 });
+
+    const lootUi = (await game.ui.state()).active_panel;
+    assert.equal(lootUi?.entity_id, desk.id, "physical desk frob must open its loot panel");
+    const itemButton = lootUi.elements.find(
+      (element) => element.kind === "button" && element.entity_id === item.id,
+    );
+    assert.ok(itemButton, "Desk 503 panel must render exact Gameboy 72");
+    const lootPanel = (await game.physics.bodies()).bodies.find((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.ok(lootPanel, "loot panel must have a production VR collider");
+    const itemButtonWorld = panelElementWorldPoint(
+      lootPanel,
+      [188, 296, 0],
+      1,
+      itemButton,
+    );
+    await aimVrHandAt(game, itemButtonWorld, 0.35);
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 30 });
+
+    assert.equal(
+      (await game.player.inventory()).items.find((entry) => entry.entity_id === item.id)
+        ?.location,
+      "inventory",
+      "panel Take must move the physical Gameboy into the backpack",
+    );
+
+    // Put the backpack panel at a clear, level gaze, then retrieve its only
+    // item with the production VR hand ray and squeeze.
+    await game.input.set("head.look", [0, 0]);
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 5 });
+    const backpackUi = (await game.ui.state()).active_panel;
+    assert.ok(backpackUi, "MoveInventory must open the physical backpack panel");
+    const backpackItem = backpackUi.elements.find(
+      (element) => element.kind === "button" && element.entity_id === item.id,
+    );
+    assert.ok(backpackItem, "backpack must render the stowed Gameboy");
+    const backpackPanel = (await game.physics.bodies()).bodies.find((body) =>
+      body.collision_groups.includes("ui"),
+    );
+    assert.ok(backpackPanel, "backpack panel must have a production VR collider");
+    const backpackItemWorld = panelElementWorldPoint(
+      backpackPanel,
+      BACKPACK_PANEL_SIZE_PX,
+      VR_BACKPACK_WORLD_SCALE,
+      backpackItem,
+    );
+    await aimVrHandAt(game, backpackItemWorld, 0.35);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, item.id);
+    await assertNoContains(game, item.id);
+
+    await game.input.trigger("MoveInventory");
+    await game.step({ frames: 3 });
+    assert.equal(
+      (await game.physics.bodies()).bodies.some((body) =>
+        body.collision_groups.includes("ui"),
+      ),
+      false,
+      "Quest-X must close the backpack while squeeze keeps the item held",
+    );
+    assert.equal((await game.info()).player.right_hand_entity_id, item.id);
+
+    // First release works on the parent and supplies a real world body.
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    await assertSelectableWorldItem(game, item);
+
+    const firstDrop = only(await game.entities.byTemplate(GAMEBOY), "first-drop Gameboy");
+    const regrabAim = await game.player.aimAt(firstDrop.id, {
+      hitbox: "center",
+      visibility: "required",
+    });
+    assert.equal(regrabAim.target_confirmed, true, JSON.stringify(regrabAim));
+    await aimVrHandAt(game, regrabAim.world_point, 0.35, 1);
+    await game.step({ frames: 5 });
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      item.id,
+      "production world squeeze must re-grab the same live item",
+    );
+
+    // Carry it clear while keeping squeeze held, then re-release. Before #974
+    // this exact edge leaves HasRefs(false) and no selectable physics body.
+    await game.input.set("right_hand.position", [0.45, -0.15, -0.65]);
+    await game.step({ frames: 10 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 5 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    const secondDrop = only(await game.entities.byTemplate(GAMEBOY), "second-drop Gameboy");
+    await assertSelectableWorldItem(game, secondDrop);
+
+    assert.equal((await game.save(saveName)).success, true);
+    assert.equal((await game.load(saveName)).success, true);
+    await game.step({ frames: 5 });
+    const loaded = only(await game.entities.byTemplate(GAMEBOY), "loaded Gameboy");
+    await assertSelectableWorldItem(game, loaded);
+  },
+);


### PR DESCRIPTION
Fixes #974

## Summary

- Restore every live hand-released item to world ownership before authored physics recreation.
- Clear residual incoming `Contains` links and insert-or-replace `PropHasRefs(true)` without changing `StoreItem` container drops.
- Add a MedSci2 production-VR carry-cycle guard covering Desk 503 / Gameboy 72 through two releases and save/load.
- Expose live `HasRefs` in entity debug detail so the E2E asserts the actual persisted invariant.

## Root cause

`VirtualHandEffect::DropItem` called `make_physical` while a formerly contained live entity could still carry `HasRefs(false)` or a residual `Contains` link. Authored physics creation correctly declines non-world entities, so clearing the hand could strand the live object with no owner and no selectable body.

The release path now restores the world-ownership invariant first, then recreates authored physics. `StoreItem` remains the separate legitimate-container path and still writes `HasRefs(false)`.

## Scope note after the stack rebuild

This PR was originally cut on top of the earlier #743 keycard branch, and its evidence used R&D Card 772. It now sits directly on #968, and #743 is an independent PR against `main` where a key source registers on the keyring and is consumed — a keycard never reaches this hand/world path at all. The E2E was therefore reworked onto the Gameboy (obj 72), an ordinary physical prop sharing Desk 503, and no longer asserts anything about keycards.

Measured honestly on this base, the reworked scenario **also passes without the fix**: the `GrabEntity` path already restores `HasRefs` and drops `Contains` for every case a real gesture can reach here, so the E2E is a standing guard on the release invariant rather than a failing-before reproduction. The three `restore_live_entity_world_refs` unit tests are what pin the behavior directly (including refusing to resurrect a consumed entity, which the drop path can otherwise be handed after the item is gone).

## Production-VR coverage

The deterministic MedSci2 scenario performs:

1. physical Desk 503 frob and exact Gameboy-72 panel click;
2. physical Quest-X backpack squeeze;
3. first world release;
4. production world re-grab and carried move;
5. second release;
6. required production-equivalent ray selection;
7. named save/load and the same body/ref/link/ray assertions.

After both the second release and reload, the exact live item has one enabled authored entity body, `HasRefs(true)`, no incoming/outgoing `Contains`, and is selected by the production ray.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- focused unit regressions: 3 passed (restore refs/remove containment, preserve legitimate container transfer, do not resurrect a consumed item)
- `cargo test -p shock2vr` — 742 passed
- reworked MedSci2 production-VR E2E — pass in ~21s
- `npm test` in `tools/shock2-sdk` — 26 passed

## Visual evidence (captured on the original base)

![MedSci2 second release and save-load](https://gist.githubusercontent.com/tommy-xr/60118a63bff5ece5a52a0b35d222257f/raw/pr975-medsci2-demo.gif)

<sub>Captured before the stack rebuild, on the earlier #743-based parent where the released card was stranded. It illustrates the failure mode the invariant guards against; it is not a capture of this branch's current base.</sub>

### Before → after

![Before and after: missing zero-body item versus selectable authored item](https://gist.githubusercontent.com/tommy-xr/60118a63bff5ece5a52a0b35d222257f/raw/pr975-medsci2-before-after.png)

<sub>Before: the released live object is absent above the desk. After: its authored body is visible and ray-selectable after the same release stage. [Hosted media and capture note](https://gist.github.com/tommy-xr/60118a63bff5ece5a52a0b35d222257f).</sub>
