### PR TITLE
fix(melee): time flat hits to swing event

### DIFF
--- a/dark/src/motion/mod.rs
+++ b/dark/src/motion/mod.rs
@@ -303,7 +303,10 @@ bitflags! {
         const UNK1 = 1 << 9;
         const UNK2 = 1 << 10;
         const UNK3 = 1 << 11;
-        const UNK4 = 1 << 12;
+        /// Game-specific trigger 1 (`MF_TRIGGER1`). System Shock 2 registers
+        /// this flag on the player-arm swing to make a melee weapon physical;
+        /// the shipped `leftswing` clip authors it at frame 20.
+        const TRIGGER1 = 1 << 12;
 
         /// Melee contact window open / close - the frames during which a swing
         /// can connect (the Dark "damage hitbox" triggers that ShockEd's motion

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -5548,7 +5548,15 @@ impl MissionCore {
         if self.interaction.viewmodel_entity() != Some(entity) {
             return; // weapon changed; leave None -> static idle
         }
-        let (next, _flags, events, _disp) = AnimationPlayer::update(&player, dt);
+        let (next, flags, events, _disp) = AnimationPlayer::update(&player, dt);
+        if !flags.is_empty() {
+            self.script_world.dispatch(Message {
+                to: entity,
+                payload: MessagePayload::AnimationFlagTriggered {
+                    motion_flags: flags,
+                },
+            });
+        }
         let completed = events
             .iter()
             .any(|e| matches!(e, AnimationEvent::Completed));
@@ -5561,6 +5569,12 @@ impl MissionCore {
     /// `update_flat_melee_anim` drops it back to the static idle). Driven by
     /// `Effect::FlatMeleeSwing` on a melee attack.
     fn queue_flat_melee_swing(&mut self, asset_cache: &mut AssetCache, entity_id: EntityId) {
+        // Do not let release/pull chatter restart the clip before its authored
+        // hit frame (or manufacture extra hits). A new swing is accepted only
+        // after the current one returns to idle.
+        if self.flat_melee_anim.is_some() {
+            return;
+        }
         if let Some(clip) =
             asset_cache.get_opt(&ANIMATION_CLIP_IMPORTER, &format!("{MELEE_SWING_CLIP}_.mc"))
         {

--- a/shock2vr/src/scripts/melee_weapon.rs
+++ b/shock2vr/src/scripts/melee_weapon.rs
@@ -143,10 +143,15 @@ impl Script for MeleeWeapon {
         _physics: &PhysicsWorld,
         msg: &MessagePayload,
     ) -> Effect {
+        // The legacy literal `wrench` script can still back a VR physical
+        // weapon, but contact is never a flat damage source. Flat player melee
+        // resolves once from WeaponScript at the authored swing event.
+        if !is_vr(world) {
+            return Effect::NoEffect;
+        }
+
         match msg {
-            // Legacy literal `wrench` script (Maintenance Tool -2949): keep its
-            // historical flat contact damage rather than re-tuning a shipped
-            // path from a VR bugfix. Tracked with its flat gating in #951.
+            // Legacy literal `wrench` script (Maintenance Tool -2949).
             MessagePayload::Collided { with } => melee_impact(entity_id, *with, world, 1.0),
             _ => Effect::NoEffect,
         }
@@ -372,5 +377,19 @@ mod tests {
             collide(&mut script, &world, weapon, target),
             Effect::NoEffect
         ));
+    }
+
+    #[test]
+    fn legacy_melee_collision_is_inert_outside_vr() {
+        let (world, weapon, target) = test_world(PresentationMode::Flat);
+
+        let effect = MeleeWeapon::new().handle_message(
+            weapon,
+            &world,
+            &PhysicsWorld::new(),
+            &MessagePayload::Collided { with: target },
+        );
+
+        assert!(matches!(effect, Effect::NoEffect));
     }
 }

--- a/shock2vr/src/scripts/weapon_script.rs
+++ b/shock2vr/src/scripts/weapon_script.rs
@@ -103,19 +103,19 @@ impl Script for WeaponScript {
                     .get(selected_ammo % projectiles.len().max(1))
                     .cloned();
 
-                // A weapon with no Projectile link is melee. In flat mode a swing
-                // is a short forward raycast along the crosshair ray
-                // (RuntimePropFlatAim); a hit deals melee damage. (VR melee
-                // damages through its trigger-gated physical contact handler
-                // and has no flat aim, so it just no-ops here.)
+                // A weapon with no Projectile link is melee. In flat mode the
+                // trigger starts the authored player-arm swing; its MF_TRIGGER1
+                // animation event resolves the short aimed raycast later, at
+                // visible impact. (VR has no flat aim and damages through its
+                // trigger-gated physical contact handler.)
                 if maybe_projectile.is_none() {
-                    if let Ok(aim) = world
+                    if world
                         .borrow::<View<RuntimePropFlatAim>>()
                         .unwrap()
                         .get(entity_id)
-                        .copied()
+                        .is_ok()
                     {
-                        return melee_swing(physics, entity_id, aim, world);
+                        return Effect::FlatMeleeSwing { entity_id };
                     }
                 }
 
@@ -216,23 +216,30 @@ impl Script for WeaponScript {
                 }
                 Effect::Multiple(effects)
             }
+            MessagePayload::AnimationFlagTriggered { motion_flags }
+                if motion_flags.contains(dark::motion::MotionFlags::TRIGGER1)
+                    && ordered_projectile_links(world, entity_id).is_empty() =>
+            {
+                let Ok(aim) = world
+                    .borrow::<View<RuntimePropFlatAim>>()
+                    .unwrap()
+                    .get(entity_id)
+                    .copied()
+                else {
+                    return Effect::NoEffect;
+                };
+                flat_melee_hit(physics, aim, world)
+            }
             MessagePayload::TriggerRelease => Effect::NoEffect,
             _ => Effect::NoEffect,
         }
     }
 }
 
-/// A flat melee swing: play the swing animation, and raycast a short distance
-/// along the crosshair ray - a hit deals melee damage (hitbox proxies resolve to
-/// their parent). The swing animation plays whether or not the swing connects.
-fn melee_swing(
-    physics: &PhysicsWorld,
-    entity_id: EntityId,
-    aim: RuntimePropFlatAim,
-    world: &World,
-) -> Effect {
-    let mut effects = vec![Effect::FlatMeleeSwing { entity_id }];
-
+/// Resolve the authored hit event of a flat melee swing: raycast a short
+/// distance along the current crosshair ray and damage the hit entity (hitbox
+/// proxies resolve to their parent).
+fn flat_melee_hit(physics: &PhysicsWorld, aim: RuntimePropFlatAim, world: &World) -> Effect {
     let hit = physics.ray_cast(
         aim.origin,
         aim.forward.normalize() * MELEE_RANGE,
@@ -247,7 +254,7 @@ fn melee_swing(
     }) = hit
     {
         let target = resolve_proxy_entity(world, target);
-        effects.push(Effect::Send {
+        return Effect::Send {
             msg: Message {
                 to: target,
                 payload: MessagePayload::Damage {
@@ -265,9 +272,9 @@ fn melee_swing(
                     }),
                 },
             },
-        });
+        };
     }
-    Effect::Multiple(effects)
+    Effect::NoEffect
 }
 
 /// An empty-clip dry fire: no projectile or muzzle flash, just the weapon's
@@ -396,5 +403,107 @@ pub(super) fn create_projectile(
             force_visible: true,
             ..CreateEntityOptions::default()
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Quaternion, point3, vec3};
+    use dark::{motion::MotionFlags, properties::Links};
+
+    use crate::physics::{CollisionGroup, PhysicsWorld};
+
+    use super::*;
+
+    fn flat_melee_fixture() -> (World, PhysicsWorld, EntityId, EntityId) {
+        let mut world = World::new();
+        let weapon = world.add_entity((
+            Links::empty(),
+            RuntimePropFlatAim {
+                origin: point3(0.0, 0.0, 0.0),
+                forward: vec3(0.0, 0.0, 1.0),
+            },
+        ));
+        let target = world.add_entity(());
+
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            target,
+            vec3(0.0, 0.0, 0.6),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            vec3(0.0, 0.0, 0.0),
+            vec3(0.2, 0.2, 0.2),
+            CollisionGroup::selectable(),
+            false,
+        );
+        // Populate Rapier's broad phase before the first query, as the real
+        // mission loop does each frame.
+        let player = world.add_entity(());
+        let mut player_handle = physics.create_player(vec3(100.0, 100.0, 100.0), player);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        assert!(
+            includes_damage_to(
+                flat_melee_hit(
+                    &physics,
+                    RuntimePropFlatAim {
+                        origin: point3(0.0, 0.0, 0.0),
+                        forward: vec3(0.0, 0.0, 1.0),
+                    },
+                    &world,
+                ),
+                target,
+            ),
+            "fixture must put a damageable target inside melee reach"
+        );
+
+        (world, physics, weapon, target)
+    }
+
+    fn includes_damage_to(effect: Effect, target: EntityId) -> bool {
+        Effect::flatten(vec![effect]).into_iter().any(|effect| {
+            matches!(
+                effect,
+                Effect::Send { msg }
+                    if msg.to == target
+                        && matches!(msg.payload, MessagePayload::Damage { .. })
+            )
+        })
+    }
+
+    #[test]
+    fn flat_melee_trigger_starts_the_animation_without_hitting_early() {
+        let (world, physics, weapon, target) = flat_melee_fixture();
+
+        let effect = WeaponScript::new().handle_message(
+            weapon,
+            &world,
+            &physics,
+            &MessagePayload::TriggerPull,
+        );
+
+        assert!(
+            !includes_damage_to(effect, target),
+            "the trigger edge is only the start of the visible swing"
+        );
+    }
+
+    #[test]
+    fn flat_melee_hits_on_the_authored_player_swing_trigger() {
+        let (world, physics, weapon, target) = flat_melee_fixture();
+
+        let effect = WeaponScript::new().handle_message(
+            weapon,
+            &world,
+            &physics,
+            &MessagePayload::AnimationFlagTriggered {
+                motion_flags: MotionFlags::TRIGGER1,
+            },
+        );
+
+        assert!(
+            includes_damage_to(effect, target),
+            "leftswing's MF_TRIGGER1 frame must resolve the aimed melee hit"
+        );
     }
 }

--- a/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
+++ b/tools/shock2-sdk/test/baby-arachnid.e2e.test.ts
@@ -142,7 +142,8 @@ test(
     await game.player.aimAt(south, { hitbox: "torso", visibility: "required" });
     await game.step({ frames: 3 });
     await fireOnce(game);
-    await game.step({ frames: 30 });
+    // leftswing's authored MF_TRIGGER1 is frame 20 at 30 fps (sim frame 41).
+    await game.step({ frames: 45 });
     assert.ok(
       hitPoints(await game.entities.detail(south.id)) < wrenchBefore,
       "an aimed wrench swing should damage the Baby Arachnid",

--- a/tools/shock2-sdk/test/flat-melee-animation-event.e2e.test.ts
+++ b/tools/shock2-sdk/test/flat-melee-animation-event.e2e.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult } from "../src/index.js";
+
+// Production regression for #951. The shipped player-arm `leftswing` motion is
+// 31 frames at 30 fps and authors MF_TRIGGER1 at frame 20. The original SS2
+// melee path makes the weapon physical at that flag; flat mode resolves its
+// aimed raycast at the same event. At the runtime's fixed 60 Hz step, the hit
+// therefore lands on simulation frame 41 after the trigger edge, never frame 1.
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+
+const TRAINING_DROID = 593;
+const WRENCH = -928;
+
+function hitPoints(detail: EntityDetailResult): number {
+  const property = detail.properties.find(
+    (candidate) => candidate.name === "HitPoints",
+  );
+  assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
+  return Number(property.value);
+}
+
+test(
+  "flat melee damages once at the authored swing event, not on trigger",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "earth.mis",
+      port: Number(process.env.SHOCK2_E2E_PORT ?? 8951),
+    });
+    await game.step({ frames: 5 });
+
+    // Provision and wield the real player Wrench through production inventory
+    // selection. Runtime ids shuffle, so discover both objects each launch.
+    await game.player.spawnItem(WRENCH);
+    await game.input.trigger("EquipWrench");
+    await game.step({ frames: 5 });
+    const [droid] = await game.entities.byTemplate(TRAINING_DROID);
+    assert.ok(droid, "Earth should contain its authored Training Droid");
+
+    // The droid is stationary on its authored platform. Settle just inside the
+    // Wrench ray's 1.2-world-unit reach and aim at a discovered torso proxy.
+    const [x, y, z] = (await game.entities.detail(droid.id)).position;
+    await game.player.teleport({ x: x + 1.2, y: y + 1, z });
+    await game.step({ frames: 60 });
+    const aim = await game.player.aimAt(droid, {
+      hitbox: "torso",
+      visibility: "required",
+    });
+    assert.equal(aim.entity_id, droid.id);
+    await game.step({ frames: 3 });
+
+    const before = hitPoints(await game.entities.detail(droid.id));
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+    assert.equal(
+      hitPoints(await game.entities.detail(droid.id)),
+      before,
+      "the trigger edge starts the visible swing but must not damage",
+    );
+
+    // Release/re-pull chatter while the arm is already swinging must neither
+    // restart the clip before its event nor manufacture a second attack.
+    await game.input.set("right_hand.trigger", 0);
+    await game.step({ frames: 1 });
+    await game.input.set("right_hand.trigger", 1);
+    await game.step({ frames: 1 });
+
+    // Three frames elapsed above; stop at total frame 40, immediately before
+    // frame-20 MF_TRIGGER1 is delivered by the 30-fps motion.
+    await game.step({ frames: 37 });
+    assert.equal(
+      hitPoints(await game.entities.detail(droid.id)),
+      before,
+      "damage must wait for leftswing's authored impact event",
+    );
+
+    await game.step({ frames: 1 });
+    const afterImpact = hitPoints(await game.entities.detail(droid.id));
+    assert.equal(
+      afterImpact,
+      before - 6,
+      "MF_TRIGGER1 should resolve exactly one aimed Wrench hit",
+    );
+
+    await game.step({ frames: 80 });
+    assert.equal(
+      hitPoints(await game.entities.detail(droid.id)),
+      afterImpact,
+      "one swing event must not deal repeated damage while trigger stays held",
+    );
+    await game.input.set("right_hand.trigger", 0);
+  },
+);


### PR DESCRIPTION
Fixes #951

## Summary

- treat the shipped player-arm `MF_TRIGGER1` motion flag as the single flat-melee impact event
- start the visible wrench swing on the trigger edge, then perform the existing short crosshair raycast only when that authored flag arrives
- reject trigger chatter while a swing is already active, so one swing cannot be restarted before its event or deal twice
- make the legacy literal `MeleeWeapon` collision path inert outside VR while preserving #943's trigger-gated VR contact behavior
- cover the real Earth Wrench/Training Droid path through trigger input, animation frames, raycast reach, runtime entity discovery, and HP

## Authored event provenance

The shipped `leftswing` motion is **31 frames at 30 fps** and carries raw flag bit `0x1000` at **frame 20**. `highswing` authors the same bit at frame 18. In the original engine sources:

- [`mvrflags.h` names `0x00001000` as `MF_TRIGGER1`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/motion/mvrflags.h#L38)
- [`shkmelee.cpp` registers `MF_TRIGGER1` on `PlayerArm()`](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkmelee.cpp#L568)
- [that callback makes the melee weapon physical](https://github.com/dima424658/darkengine/blob/4aa92d74e727a503954eb01914f69b3997324fc3/src/shock/shkmelee.cpp#L416-L420)

That is the faithful player-arm impact/connect event. It is distinct from `MELEE_CONTACT_START` (`0x2000`), which the shipped creature melee motions use for their contact windows.

At the fixed 60 Hz runtime step, `leftswing` crosses authored frame 20 on simulation frame **41** after the trigger edge.

## Negative-first reproduction

On exact base `e09fc084e2b528da3639932cfa486dce310188c8` in flat `earth.mis`, the SDK provisioned the real Wrench (`-928`), discovered the Training Droid by stable template `593`, moved inside the 1.2-unit melee ray, and aimed at a discovered torso proxy:

- HP started at 20
- trigger + one simulation frame immediately changed HP to 14, before visible impact
- stepping through the authored event left HP at 14: the event did nothing

The negative-first unit covering a real in-range Rapier selectable collider likewise failed because `TriggerPull` included `Damage`. A second negative-first unit sent `Collided` to the legacy `MeleeWeapon` in `PresentationMode::Flat` and failed because contact produced melee damage independently.

After the fix, the same production sequence holds HP at 20 through simulation frame 40, changes it to 14 exactly at frame 41, and holds at 14 for the rest of the swing even with release/re-pull chatter.

## Visual evidence

![Matched exact-base and fix Wrench swing](https://gist.githubusercontent.com/tommy-xr/6d432ad2aa6d89b332c4673c7055590f/raw/flat-melee-event.gif)

<sub>Exact base `e09fc08` (left) and fix `bd2c2ec` (right), driven by the same deterministic 60 Hz sequence in production `earth.mis`. The rendered Wrench and runtime-discovered Training Droid remain continuously framed: base applies damage on trigger frame 1, while the fix holds HP through frame 40 and applies its single hit at authored `MF_TRIGGER1` frame 41.</sub>

### Authored impact still

![Fixed Wrench impact at MF_TRIGGER1](https://gist.githubusercontent.com/tommy-xr/6d432ad2aa6d89b332c4673c7055590f/raw/flat-melee-impact-still.png)

<sub>Fix at simulation frame 41: the Wrench visibly crosses the target as the shipped `leftswing` event changes HP from 20 to 14.</sub>

### Trigger → authored impact

![Trigger and impact timing before and after](https://gist.githubusercontent.com/tommy-xr/6d432ad2aa6d89b332c4673c7055590f/raw/flat-melee-before-after.png)

<sub>Matched frames from fresh launches. Top: base damages before visible impact while the fix only starts the swing. Bottom: at the identical authored impact pose, base was already damaged and the fix applies damage now. Captured headlessly through `/v1/step` + `/v1/screenshot`; HP labels come from the same discovered runtime target.</sub>


## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p dark` — 108 unit + 10 integration passed
- `cargo test -p shock2vr` — 657 passed
- focused units — 2 flat event/trigger tests + 1 legacy flat-collision test passed
- `npm test` — 250 total: 26 passed, 224 opt-in E2E skipped
- new real-runtime Earth timing E2E — 1 passed
- affected Hydro3 Wrench E2E — 1 passed after waiting through the authored event
- #943 VR regression E2E — 2 passed (trigger-gated contact + save/load collider/contact)
- full serial `npm run test:e2e` — 250 total: 241 passed, 7 intentionally skipped, 2 unrelated failures; all 23 mission loads passed
  - `creature-loot` reader binding: current-main regression tracked by #931 (`undefined !== 251`)
  - SHODAN corpse drift: existing #716 behavior; exact base `e09fc08` independently fails with the identical 1.604-unit Assassin 678 movement (it also passed once in the first full run)

## Compatibility

- guns and all projectile/ammo/reload paths retain their existing trigger behavior; the event path is accepted only by weapons without Projectile links
- VR has no flat aim, so flat ray damage remains inert there and #943's physical-contact path remains authoritative
- loading mid-swing returns to harmless idle, matching the existing transient animation state and preventing a phantom delayed hit
- #954 is still open and touches `interaction.rs`, `virtual_hand.rs`, and its VR E2E only; no source overlap was found
