### PR TITLE
fix(debug): ignore sensors in default raycasts

### DIFF
--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -292,7 +292,9 @@ curl -X POST http://127.0.0.1:8080/v1/screenshot \
 Omitting `collision_groups` defaults to `["world", "entity"]`. Supported
 names are `world`, `entity`, `selectable`, `player`, `ui`, `hitbox`, `raycast`,
 and `all`; the older documented name `level` is accepted as an alias for
-`world`. Unknown names and explicit empty masks return HTTP 400.
+`world`. Unknown names and explicit empty masks return HTTP 400. Sensors are
+ignored by default so room triggers do not look like distance-zero occluders;
+pass `"ignore_sensors": false` to probe sensor volumes deliberately.
 
 ## Key Files
 

--- a/runtimes/debug_runtime/src/commands.rs
+++ b/runtimes/debug_runtime/src/commands.rs
@@ -252,6 +252,7 @@ pub struct RayCastRequest {
     pub end: [f32; 3],
     pub collision_groups: Option<Vec<String>>,
     pub max_distance: Option<f32>,
+    /// Defaults to true; pass false to probe trigger and other sensor volumes.
     pub ignore_sensors: Option<bool>,
 }
 

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -945,7 +945,7 @@ fn process_command(
                     groups: request
                         .collision_groups
                         .unwrap_or_else(|| vec!["world".to_string(), "entity".to_string()]),
-                    ignore_sensors: request.ignore_sensors.unwrap_or(false),
+                    ignore_sensors: normalize_raycast_ignore_sensors(request.ignore_sensors),
                 };
 
                 // Perform the raycast
@@ -3010,6 +3010,10 @@ async fn list_transitions(
 }
 
 /// HTTP handler for physics raycast
+fn normalize_raycast_ignore_sensors(ignore_sensors: Option<bool>) -> bool {
+    ignore_sensors.unwrap_or(true)
+}
+
 fn normalize_raycast_collision_groups(
     collision_groups: Option<Vec<String>>,
 ) -> Result<Vec<String>, (StatusCode, String)> {
@@ -3760,6 +3764,13 @@ mod shutdown_tests {
             normalize_raycast_collision_groups(None).unwrap(),
             ["world", "entity"]
         );
+    }
+
+    #[test]
+    fn raycast_ignores_sensors_by_default_with_explicit_opt_in() {
+        assert!(normalize_raycast_ignore_sensors(None));
+        assert!(normalize_raycast_ignore_sensors(Some(true)));
+        assert!(!normalize_raycast_ignore_sensors(Some(false)));
     }
 
     #[test]

--- a/tools/shock2-sdk/README.md
+++ b/tools/shock2-sdk/README.md
@@ -123,6 +123,8 @@ Raycasts default to `world` and `entity`. Supported groups are `world`,
 `entity`, `selectable`, `player`, `ui`, `hitbox`, `raycast`, and `all`;
 `level` remains accepted as an alias for `world`. Unknown groups and explicit
 empty masks are rejected with HTTP 400 instead of being reported as clear rays.
+Sensors are ignored by default so room triggers do not look like distance-zero
+occluders; pass `ignore_sensors: false` when deliberately probing sensor volumes.
 
 To attach to a runtime you started yourself (`cargo dbgr -- --mission ... --port 8080`):
 

--- a/tools/shock2-sdk/src/types.ts
+++ b/tools/shock2-sdk/src/types.ts
@@ -278,6 +278,7 @@ export interface RayCastRequest {
   /** Defaults to `["world", "entity"]`; an explicit empty list is invalid. */
   collision_groups?: RayCastCollisionGroup[];
   max_distance?: number;
+  /** Defaults to `true`; pass `false` to probe trigger and other sensor volumes. */
   ignore_sensors?: boolean;
 }
 

--- a/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
+++ b/tools/shock2-sdk/test/raycast-groups.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   GameServer,
   HttpClient,
   HttpError,
+  type RayCastResult,
 } from "../src/index.js";
 
 const e2eEnabled = process.env.SHOCK2_E2E === "1";
@@ -16,7 +17,7 @@ const wallRay = {
 };
 
 test(
-  "raycast validates collision groups and keeps the level alias world-visible",
+  "raycast defaults ignore sensors while groups remain validated and compatible",
   { skip: !e2eEnabled, timeout: 600_000 },
   async () => {
     await using game = await GameServer.launch({
@@ -59,17 +60,29 @@ test(
       "an explicit empty mask should receive a clear 400 response",
     );
 
-    // Omission remains the convenient common case and must include world
-    // geometry. Start just outside the Midwife capsule so the wall is first.
+    // Omission remains the convenient common case and must ignore room-trigger
+    // sensors. This origin is inside a Base Room sensor; the wall is the first
+    // solid surface along the ray.
     const defaultHit = await game.raycast({
       start: [79.0, -1.6, 32.0],
       end: wallRay.end,
-      ignore_sensors: true,
     });
     assert.equal(defaultHit.hit, true, "default raycast should see the Hydro2 wall");
     assert.ok(
       defaultHit.distance !== null && Math.abs(defaultHit.distance - 0.6015) < 0.01,
       `expected the nearby Hydro2 wall, got ${JSON.stringify(defaultHit)}`,
     );
+
+    // Raw HTTP callers can still opt in when they are deliberately probing
+    // trigger volumes.
+    const sensorHit = await client.post<RayCastResult>("/v1/physics/raycast", {
+      start: [79.0, -1.6, 32.0],
+      end: wallRay.end,
+      ignore_sensors: false,
+    });
+    assert.equal(sensorHit.hit, true);
+    assert.equal(sensorHit.is_sensor, true);
+    assert.equal(sensorHit.entity_name, "Base Room");
+    assert.equal(sensorHit.distance, 0);
   },
 );


### PR DESCRIPTION
Fixes #834

## Summary

- ignore Rapier sensor colliders when `/v1/physics/raycast` omits `ignore_sensors`
- preserve explicit `ignore_sensors: false` for deliberate trigger/sensor probing
- document the default consistently in Rust, the TypeScript SDK, and debug-runtime docs
- extend the existing Hydro2 raycast E2E across SDK-default and raw-HTTP opt-in behavior

The collision-group half of #834 was already fixed by #879: omitted groups resolve to `world` + `entity`, `level` remains a compatibility alias for `world`, and unknown/empty groups return HTTP 400. This PR preserves and re-verifies that contract.

## Reproduction and root cause

On exact base `e09fc084`, a raw ray starting inside MedSci1's `Base Room` trigger returned the sensor at the ray origin:

```text
omitted ignore_sensors -> HTTP 200, Base Room, is_sensor=true, distance=0
ignore_sensors=true    -> HTTP 200, solid world hit, distance=0.20000005
```

The negative-first Hydro2 E2E likewise failed because an SDK ray from `[79.0,-1.6,32.0]` returned the enclosing `Base Room` sensor at distance 0 instead of the wall at distance 0.6015.

`RayCastRequest.ignore_sensors` is optional, but the game-loop conversion used `unwrap_or(false)`. Changing that normalization to default true fixes both raw HTTP and SDK callers while leaving explicit false unchanged. Production physics, gameplay raycasts, stepping, and scene state are untouched.

## Fixed behavior

Matched raw requests against Hydro2 after the fix:

```text
omitted ignore_sensors -> HTTP 200, is_sensor=false, wall distance=0.60154545
ignore_sensors=false   -> HTTP 200, Base Room, is_sensor=true, distance=0
collision_groups=level -> HTTP 200, world distance=1.5946623
collision_groups=bogus -> HTTP 400 with the supported-group list
```

## Compatibility audit

- all repository SDK raycast call sites were reviewed
- world/headroom/movement callers passed in the serial E2E suite
- both omitted `ui`-group callers passed: the VR container hand ray and the Rec elevator world panel across save/load/transition
- broad selection callers that already request `ignore_sensors: true` remain unchanged
- open PRs touching the large debug schemas/runtime files modify distant entity/save/VR-hand hunks; none overlaps the raycast default or this regression test

## Verification

- negative-first focused E2E: **failed on base** with `Base Room`, `is_sensor=true`, `distance=0`
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check -p debug_runtime`
- `RUSTFLAGS="-D warnings" cargo test -p debug_runtime raycast_ -- --nocapture`: **4 passed**
- focused `raycast-groups.e2e.test.ts`: **1 passed**
- `npm test`: **249 total, 26 passed, 223 opt-in skipped, 0 failed**
- full serial `npm run test:e2e`: **249 total, 240 passed, 7 fixture-gated skipped, 2 known main-baseline failures**, duration 3,703,015 ms
  - creature-loot reader binding: same `undefined !== 251` failure tracked by #931; reproduced in isolation and does not call raycast
  - SHODAN corpse settling: Assassin 678 drifted the same 1.604 units reproduced on exact base during this sweep; reproduced in isolation and does not call raycast
- all 23 mission-load smoke tests passed in the full suite
- the dedicated raycast regression and every audited caller passed in the full suite

## Visual assessment

Manager-approved as non-renderable under the required `pr-visuals` gate. This changes only the hit selected by a read-only debug HTTP query and SDK documentation/tests. The endpoint cannot mutate simulation stepping, gameplay, scene contents, or rendering, so matched screenshots would be byte-identical and misleading. The objective raw JSON response evidence above is the appropriate before/after artifact.
