### PR TITLE
fix(oculus): service Android events during startup

### DIFF
--- a/dark/src/mission/mod.rs
+++ b/dark/src/mission/mod.rs
@@ -116,6 +116,8 @@ pub struct TextureSize {
 }
 
 const LIGHTMAP_SIZE: u32 = 4096;
+/// Keep a long synchronous mission parse responsive to host-platform queues.
+const LOAD_EVENT_PUMP_CELL_INTERVAL: usize = 32;
 
 pub struct UVCalculationInfo {
     origin: Vector3<f32>,
@@ -147,6 +149,7 @@ pub fn read<T: io::Read + io::Seek>(
     links_with_data: &Vec<Box<dyn LinkDefinitionWithData>>,
     properties: &Vec<Box<dyn PropertyDefinition<T>>>,
 ) -> SystemShock2Level {
+    engine::platform::service_events();
     let table_of_contents = ss2_chunk_file_reader::read_table_of_contents(reader);
 
     let wr_ext = table_of_contents.has_chunk("WREXT".to_string()); // Extended representation
@@ -191,11 +194,16 @@ pub fn read<T: io::Read + io::Seek>(
     let mut cells: Vec<Cell> = Vec::new();
     let mut packer = TexturePacker::<image::Rgb<u8>>::new_rgb(LIGHTMAP_SIZE, LIGHTMAP_SIZE);
     for cell_idx in 0..wr_num_cells {
+        if cell_idx as usize % LOAD_EVENT_PUMP_CELL_INTERVAL == 0 {
+            engine::platform::service_events();
+        }
         let cell = Cell::read(reader, &mut packer, wr_ext, cell_idx, light_size);
         cells.push(cell);
     }
+    engine::platform::service_events();
 
     let bsp_tree = BspTree::read(reader, &cells);
+    engine::platform::service_events();
 
     if wr_ext {
         let _ = read_bytes(reader, wr_num_cells as usize);
@@ -217,6 +225,7 @@ pub fn read<T: io::Read + io::Seek>(
         properties,
         reader,
     );
+    engine::platform::service_events();
 
     let textures = TextureList::read(
         &table_of_contents,
@@ -226,12 +235,14 @@ pub fn read<T: io::Read + io::Seek>(
         reader,
     );
     let all_geometry = create_geometry(asset_paths, base_path, &cells, &textures.0);
+    engine::platform::service_events();
 
     let render_params = RenderParams::read(&table_of_contents, reader);
     let room_database = RoomDatabase::read(&table_of_contents, reader);
     let song_params = SongParams::read(&table_of_contents, reader);
     let map_params = MapParams::read(&table_of_contents, reader).unwrap_or_default();
     let path_database = PathDatabase::read(&table_of_contents, reader);
+    engine::platform::service_events();
 
     // Log AIPATH data if loaded
     if let Some(ref pathdb) = path_database {
@@ -308,7 +319,10 @@ fn create_geometry(
 ) -> Vec<SystemShock2Geometry> {
     let mut all_geometry: Vec<SystemShock2Geometry> = Vec::new();
     let mut cell_idx = 0;
-    for cell in cells {
+    for (cell_index, cell) in cells.iter().enumerate() {
+        if cell_index % LOAD_EVENT_PUMP_CELL_INTERVAL == 0 {
+            engine::platform::service_events();
+        }
         let num_render_polys = cell.textured_polygons.len();
 
         // Create geometry!

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -10,6 +10,7 @@ pub mod importers;
 pub mod logging;
 pub mod macros;
 pub mod materials;
+pub mod platform;
 pub mod scene;
 mod shader;
 mod shader_program;
@@ -37,4 +38,47 @@ pub fn opengles() -> Box<dyn Engine> {
 pub fn android() -> Box<dyn Engine> {
     let engine = gl_engine::init_android();
     Box::new(engine)
+}
+
+#[cfg(test)]
+mod platform_event_pump_tests {
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn count_call() {
+        CALLS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn services_the_callback_registered_for_the_current_thread() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        CALLS.store(0, Ordering::Relaxed);
+        crate::platform::set_event_pump(Some(count_call));
+
+        crate::platform::service_events();
+
+        assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+        crate::platform::set_event_pump(None);
+    }
+
+    #[test]
+    fn does_not_run_a_main_thread_callback_on_a_worker() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        CALLS.store(0, Ordering::Relaxed);
+        crate::platform::set_event_pump(Some(count_call));
+
+        std::thread::spawn(crate::platform::service_events)
+            .join()
+            .unwrap();
+
+        assert_eq!(CALLS.load(Ordering::Relaxed), 0);
+        crate::platform::service_events();
+        assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+        crate::platform::set_event_pump(None);
+    }
 }

--- a/engine/src/platform.rs
+++ b/engine/src/platform.rs
@@ -1,0 +1,28 @@
+//! Hooks for servicing host-platform work during synchronous engine operations.
+//!
+//! Some platform entry points own queues that must be drained on the entry
+//! thread even while a long game load is in progress. The hook is thread-local
+//! for that reason: a background mission parse must never try to service the
+//! Android main thread's looper.
+
+use std::cell::Cell;
+
+thread_local! {
+    static EVENT_PUMP: Cell<Option<fn()>> = const { Cell::new(None) };
+}
+
+/// Set or clear the event pump for the current thread.
+///
+/// The callback must be non-blocking because load loops invoke it at regular
+/// milestones. Runtimes without a platform queue leave the hook unset.
+pub fn set_event_pump(pump: Option<fn()>) {
+    EVENT_PUMP.set(pump);
+}
+
+/// Service pending platform events on the current thread, if configured.
+#[inline]
+pub fn service_events() {
+    if let Some(pump) = EVENT_PUMP.get() {
+        pump();
+    }
+}

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -463,6 +463,11 @@ fn main() {
         debug_skeletons: false,
         ..GameOptions::default()
     };
+    // NativeActivity owns Android lifecycle and input queues on this thread.
+    // Keep servicing them at milestones inside the synchronous first load,
+    // before the per-frame pump below exists.
+    #[cfg(target_os = "android")]
+    engine::platform::set_event_pump(Some(android_pump_events));
     let mut game = shock2vr::App::init(options, bundle_storage);
     println!(
         "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -920,6 +920,7 @@ impl Game {
     }
 
     pub fn init(options: GameOptions, bundle_storage: Arc<dyn Storage>) -> Game {
+        engine::platform::service_events();
         // Must happen before any model is loaded.
         let high_detail = Self::resolve_high_detail_meshes(&options.experimental_features);
         dark::high_detail::set_enabled(high_detail);
@@ -1016,12 +1017,14 @@ impl Game {
         // Global items
         let base_path = paths::data_root().to_string_lossy().into_owned();
         let mut asset_cache = AssetCache::new(base_path, asset_paths);
+        engine::platform::service_events();
 
         // TODO: Start ffmpeg stuff
         #[cfg(feature = "ffmpeg")]
         engine_ffmpeg::init().unwrap();
 
         let (properties, links, links_with_data) = dark::properties::get();
+        engine::platform::service_events();
 
         // Through the asset paths, like the missions and motiondb: on a 25AE
         // install the gamesys lives inside `sshock2.kpf`.
@@ -1046,12 +1049,14 @@ impl Game {
             &links_with_data,
             &properties,
         );
+        engine::platform::service_events();
 
         // Likewise: 25AE moves this to `data/res/mschema/motiondb.bin`.
         let motiondb_reader = asset_cache
             .get_raw_reader("motiondb.bin")
             .expect("motiondb.bin should be present in the mounted data");
         let motiondb = MotionDB::read(&mut *motiondb_reader.borrow_mut());
+        engine::platform::service_events();
 
         let mut audio_context = AudioContext::new();
 
@@ -1115,6 +1120,7 @@ impl Game {
             &global_context,
             &options,
         );
+        engine::platform::service_events();
 
         // log_entities_with_link(&active_mission.world, |link| {
         //     matches!(link, Link::AIWatchObj(_))

--- a/shock2vr/src/mission/mission_core.rs
+++ b/shock2vr/src/mission/mission_core.rs
@@ -117,6 +117,9 @@ pub const THE_PLAYER_TEMPLATE_ID: i32 = -384;
 /// floor-lying crumple pose doesn't start deeply interpenetrating the level
 /// trimesh (see `spawn_ragdoll`).
 const RAGDOLL_SPAWN_LIFT: f32 = 0.05;
+/// Cold model loads make entity initialization the longest main-thread load
+/// loop, so periodically let the host service its platform queues.
+const LOAD_EVENT_PUMP_ENTITY_INTERVAL: usize = 32;
 
 fn is_realtime_crumple(frame_count: f32) -> bool {
     // `humdieup1` is an authored "already dead" pose: three frames with no
@@ -690,6 +693,7 @@ impl MissionCore {
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
     ) -> MissionCore {
+        engine::platform::service_events();
         let game_entity_info = &global_context.gamesys;
         let _motiondb = &global_context.motiondb;
 
@@ -704,6 +708,7 @@ impl MissionCore {
         let entity_info =
             ss2_entity_info::merge_with_gamesys(&abstract_mission.entity_info, game_entity_info);
         let entity_info_rc = Arc::new(entity_info);
+        engine::platform::service_events();
 
         let speech_registry = SpeechVoiceRegistry::from_entity_info(&entity_info_rc);
         let screen_fade_texture: Rc<dyn TextureTrait> = Rc::new(init_from_memory2(
@@ -873,6 +878,7 @@ impl MissionCore {
             &abstract_mission.obj_map,
             &mut world,
         );
+        engine::platform::service_events();
         let template_to_entity_id = population.template_to_entity_id;
         let mission_script_entity_id_map = population.entity_id_map;
         let mission_saved_script_states = population.script_states;
@@ -1017,7 +1023,12 @@ impl MissionCore {
         }
 
         // Finally, instantiate these entities
-        for (entity_id, template_id) in entities_to_instantiate {
+        for (entity_index, (entity_id, template_id)) in
+            entities_to_instantiate.into_iter().enumerate()
+        {
+            if entity_index % LOAD_EVENT_PUMP_ENTITY_INTERVAL == 0 {
+                engine::platform::service_events();
+            }
             let created_entity = entity_creator::initialize_entity(
                 entity_id,
                 template_id,
@@ -1043,6 +1054,7 @@ impl MissionCore {
                 Matrix4::identity(),
             );
         }
+        engine::platform::service_events();
 
         restore_saved_script_namespaces(
             &mut script_world,
@@ -1346,6 +1358,7 @@ impl MissionCore {
             screen_fade_texture,
         };
         mission_core.process_virtual_hand_effects(asset_cache, held_restore_effects);
+        engine::platform::service_events();
         mission_core
     }
 

--- a/shock2vr/src/mission/mod.rs
+++ b/shock2vr/src/mission/mod.rs
@@ -86,12 +86,16 @@ impl Mission {
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
     ) -> Mission {
+        engine::platform::service_events();
         let mission_scene = dark::mission::to_scene(&level, asset_cache);
+        engine::platform::service_events();
         let song_params = level.song_params.clone();
         let room_db = level.room_database.clone();
         let map_params = level.map_params;
         let physics_geometry = create_physics_collider(&level);
+        engine::platform::service_events();
         let spatial_data = LevelSpatialData::from_level(&level);
+        engine::platform::service_events();
         let obj_map = level.obj_map.clone();
 
         let abstract_mission = AbstractMission {
@@ -120,6 +124,7 @@ impl Mission {
             held_item_save_data,
             game_options,
         );
+        engine::platform::service_events();
         Mission { mission_core }
     }
 
@@ -136,6 +141,7 @@ impl Mission {
         held_item_save_data: HeldItemSaveData,
         game_options: &GameOptions,
     ) -> Mission {
+        engine::platform::service_events();
         let base_path = asset_cache.base_path().to_string();
         let level = Self::parse(
             asset_cache.asset_paths(),
@@ -143,6 +149,7 @@ impl Mission {
             &mission,
             global_context,
         );
+        engine::platform::service_events();
         Self::build(
             level,
             mission,


### PR DESCRIPTION
## Summary

- register the existing bounded Android looper/input pump on the NativeActivity thread before the synchronous initial game load
- service that hook at game/mission load phase boundaries and every 32 cells or entity instantiations
- keep the hook thread-local so background mission parsing cannot access the Android main thread's looper
- add negative-first coverage for hook invocation and worker-thread isolation

## Reproduction and root cause

On the frozen issue base (`e09fc084e2b528da3639932cfa486dce310188c8`), the Oculus runtime called `Game::init` before the first steady-state `android_pump_events` call. That leaves NativeActivity lifecycle and input queues unserviced through the synchronous first mission load, matching the issue's Quest ANR evidence.

The hook test was added first and failed on the base with `E0433: could not find platform in crate engine`. The implementation makes that test pass and keeps the callback scoped to the registering thread.

Every aggregating startup loop that can grow with mission size now has bounded checkpoints (32 cells/entities). The remaining one-shot load phases are bracketed with checkpoints; observed desktop load instrumentation kept the largest one-shot phase below one second.

## Validation

- `RUSTFLAGS='-D warnings' cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p engine -p dark -p shock2vr --lib` — 47 + 110 + 665 passed after rebasing current `main`
- current-main SDK fast suite — 26 passed, 229 skipped, 0 failed
- current-main focused mission-load E2E — all 23 missions passed, including `shodan.mis`
- full serial SDK E2E on the frozen base — 249 tests: 241 passed, 1 failed, 7 skipped; all 23 mission loads, security/SHODAN, transitions, VR interaction, and weapon cases passed. The sole failure was the unrelated creature-loot reader assertion addressed by #971.
- [Android APK CI](https://github.com/tommy-xr/shock2quest/actions/runs/31813676996) — passed
- macOS, Ubuntu, Windows, and formatting CI — passed
- `cargo fmt --all -- --check`
- `git diff --check`

Six commits landed on `main` during the full E2E run. They were audited individually: only #970 and #977 touch the same files, in disjoint scene-swap and flat-melee-update hunks. Since this hook is unset/no-op in the debug runtime, the current-main all-mission scenario is the focused rerun that directly re-exercises the changed parse/build/init paths.

Fresh Quest validation was not possible: this host has no `adb`, its configured Android SDK/NDK paths are absent, and `cargo-apk` is not installed.

## Visual evidence

This changes event servicing/timing only and does not alter rendered content. The headless debug runtime cannot exercise Android's looper or the OS ANR dialog, so an identical-frame GIF would be misleading. Objective evidence is the negative-first hook/thread-affinity tests, exact load call-order coverage above, scoped builds/tests, and Android CI.

Fixes #910
