### PR TITLE
fix(vr): prevent held melee actor launches

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -1944,11 +1944,25 @@ impl Default for DynamicPhysicsOptions {
 }
 
 #[derive(Clone, Copy)]
-pub struct CollisionGroup(InteractionGroups);
+pub struct CollisionGroup {
+    collision: InteractionGroups,
+    solver: InteractionGroups,
+}
 
 impl CollisionGroup {
+    fn solid(collision: InteractionGroups) -> CollisionGroup {
+        CollisionGroup {
+            collision,
+            // Ordinary contacts solve exactly when they collide. Keeping the
+            // two filters together by default makes the one deliberate split
+            // in `held_melee` explicit and prevents stale all-groups solver
+            // state when a collider changes roles.
+            solver: collision,
+        }
+    }
+
     pub fn hitbox() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: (InternalCollisionGroups::HITBOX.bits
                 | InternalCollisionGroups::RAYCAST.bits)
                 .into(),
@@ -1958,7 +1972,7 @@ impl CollisionGroup {
     }
 
     pub fn ui() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::UI.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             test_mode: Default::default(),
@@ -1966,7 +1980,7 @@ impl CollisionGroup {
     }
 
     pub fn entity() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             test_mode: Default::default(),
@@ -1978,14 +1992,28 @@ impl CollisionGroup {
     /// ignoring the player's own capsule. Damage is still owned by the
     /// weapon's trigger-gated script; this group only preserves contact events.
     pub fn held_melee() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        let collision = InteractionGroups {
             memberships: InternalCollisionGroups::ENTITY.bits.into(),
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::ENTITIES.bits
                 | InternalCollisionGroups::SELECTABLE.bits)
                 .into(),
             test_mode: Default::default(),
-        })
+        };
+        let solver = InteractionGroups {
+            memberships: InternalCollisionGroups::ENTITY.bits.into(),
+            // Contact generation still includes ACTOR through `collision`,
+            // so TriggeredMeleeWeapon receives CollisionStarted and owns the
+            // authored damage. Only Rapier's physical impulse is suppressed:
+            // a controller-driven kinematic pose must not launch a living
+            // dynamic capsule. World and loose-prop response remains solid.
+            filter: (InternalCollisionGroups::WORLD.bits
+                | InternalCollisionGroups::ENTITY.bits
+                | InternalCollisionGroups::SELECTABLE.bits)
+                .into(),
+            test_mode: Default::default(),
+        };
+        CollisionGroup { collision, solver }
     }
 
     /// Collision behavior for a living creature capsule. It collides exactly
@@ -1994,7 +2022,7 @@ impl CollisionGroup {
     /// blocking characters without also becoming transparent to physical
     /// projectiles and movable props.
     pub fn actor() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::ACTOR.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             test_mode: Default::default(),
@@ -2006,7 +2034,7 @@ impl CollisionGroup {
     /// but do not leave its old creature capsule solid to players, living AIs,
     /// moving terrain, or loose props.
     pub fn corpse() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
             filter: InternalCollisionGroups::WORLD.bits.into(),
             test_mode: Default::default(),
@@ -2017,7 +2045,7 @@ impl CollisionGroup {
     /// membership so player movement can detect ladder contact (see
     /// `PropPhysAttr.climbable`).
     pub fn climbable_entity() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: (InternalCollisionGroups::ENTITY.bits
                 | InternalCollisionGroups::CLIMBABLE.bits)
                 .into(),
@@ -2027,7 +2055,7 @@ impl CollisionGroup {
     }
 
     pub fn selectable() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
             filter: InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             test_mode: Default::default(),
@@ -2046,11 +2074,11 @@ impl CollisionGroup {
     /// still needs a collider there so the object stays frobbable and
     /// raycastable, so keep the collider and only take characters out of it.
     pub fn non_solid_to_characters(self) -> CollisionGroup {
-        let filter = self.0.filter.bits() & !InternalCollisionGroups::CHARACTERS.bits;
-        CollisionGroup(InteractionGroups {
-            memberships: self.0.memberships,
+        let filter = self.collision.filter.bits() & !InternalCollisionGroups::CHARACTERS.bits;
+        Self::solid(InteractionGroups {
+            memberships: self.collision.memberships,
             filter: filter.into(),
-            test_mode: self.0.test_mode,
+            test_mode: self.collision.test_mode,
         })
     }
 
@@ -2064,7 +2092,7 @@ impl CollisionGroup {
     /// ragdoll "explosion"). The filter still excludes the leftover creature
     /// capsule (`ACTOR`) and per-joint hitboxes (`HITBOX`).
     pub fn ragdoll() -> CollisionGroup {
-        CollisionGroup(InteractionGroups {
+        Self::solid(InteractionGroups {
             memberships: InternalCollisionGroups::SELECTABLE.bits.into(),
             filter: (InternalCollisionGroups::WORLD.bits
                 | InternalCollisionGroups::SELECTABLE.bits)
@@ -2580,7 +2608,8 @@ impl PhysicsWorld {
         let collider_handles = body.colliders().to_vec();
         for collider_handle in collider_handles {
             if let Some(collider) = self.collider_set.get_mut(collider_handle) {
-                collider.set_collision_groups(group.0);
+                collider.set_collision_groups(group.collision);
+                collider.set_solver_groups(group.solver);
             }
         }
     }
@@ -3322,7 +3351,8 @@ impl PhysicsWorld {
         collider.set_density(0.1);
         collider.set_enabled(true);
         collider.set_sensor(is_sensor);
-        collider.set_collision_groups(collision_group.0);
+        collider.set_collision_groups(collision_group.collision);
+        collider.set_solver_groups(collision_group.solver);
         collider
             .set_active_events(ActiveEvents::COLLISION_EVENTS | ActiveEvents::CONTACT_FORCE_EVENTS);
         collider.user_data = entity_id.inner() as u128;
@@ -3355,7 +3385,8 @@ impl PhysicsWorld {
         collider.set_enabled(true);
         collider.set_sensor(is_sensor);
         collider.user_data = entity_id.inner() as u128;
-        collider.set_collision_groups(collision_groups.0);
+        collider.set_collision_groups(collision_groups.collision);
+        collider.set_solver_groups(collision_groups.solver);
 
         self.collider_set
             .insert_with_parent(collider, handle, &mut self.rigid_body_set);
@@ -5081,7 +5112,8 @@ impl PhysicsWorld {
         let collider = ColliderBuilder::new(shape)
             .density(density)
             .translation(vec_to_nvec(offset))
-            .collision_groups(collision_group.0)
+            .collision_groups(collision_group.collision)
+            .solver_groups(collision_group.solver)
             .active_events(ActiveEvents::COLLISION_EVENTS | ActiveEvents::CONTACT_FORCE_EVENTS)
             .build();
 
@@ -5511,16 +5543,149 @@ mod tests {
         assert!(!body.blocks_player, "the weapon must ignore its owner");
         assert!(
             body.blocks_actor,
-            "the controller-driven weapon must retain physical actor contact"
+            "the controller-driven weapon must retain actor contact detection"
         );
         assert_eq!(body.linear_velocity, [0.0; 3]);
         assert_eq!(body.angular_velocity, [0.0; 3]);
 
         let body_handle = world.entity_id_to_body[&weapon];
         let collider_handle = world.rigid_body_set[body_handle].colliders()[0];
-        let active_types = world.collider_set[collider_handle].active_collision_types();
+        let collider = &world.collider_set[collider_handle];
+        let active_types = collider.active_collision_types();
         assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_KINEMATIC));
         assert!(active_types.contains(ActiveCollisionTypes::KINEMATIC_FIXED));
+        let actor = CollisionGroup::actor();
+        assert!(
+            collider.collision_groups().test(actor.collision),
+            "held melee must still generate actor contacts"
+        );
+        assert!(
+            !collider.solver_groups().test(actor.solver),
+            "held melee must not solve impulses against living actors"
+        );
+    }
+
+    /// A controller pose can move a held weapon much farther than ordinary
+    /// simulation motion in one frame. That contact must still report a
+    /// `CollisionStarted` for trigger-gated damage, but it must not transfer
+    /// the kinematic velocity into a living actor's dynamic capsule (#984).
+    ///
+    /// Negative-first: with collision groups also controlling the solver, the
+    /// controller sweep below launches the actor at 18 world units/s.
+    #[test]
+    fn held_melee_contacts_live_actor_without_solver_launch() {
+        let (mut world, mut player) = world_with_floor();
+        let weapon = EntityId::from_inner(2).unwrap();
+        let actor = EntityId::from_inner(3).unwrap();
+
+        let actor_handle = world.add_dynamic(
+            actor,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Capsule {
+                height: 0.8,
+                radius: 0.4,
+            },
+            CollisionGroup::actor(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_enabled_rotations(actor, false, false, false);
+        world.add_dynamic(
+            weapon,
+            vec3(-2.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(1.5, 0.3, 0.3)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions {
+                gravity_scale: 0.0,
+                restitution: 0.0,
+                friction: 0.0,
+            },
+        );
+        world.set_held_melee(weapon);
+
+        // Establish the initial broad-phase pose, then cross the actor in one
+        // ordinary 60 Hz controller update.
+        step(&mut world, &mut player, 1);
+        let mut events = Vec::new();
+        for x in [-1.0, -0.7, -0.4, -0.2, 0.0] {
+            world.set_position_rotation2(weapon, vec3(x, 1.0, 0.0), identity_quat());
+            let (_, mut frame_events) = world.update(vec3(0.0, 0.0, 0.0), &mut player);
+            events.append(&mut frame_events);
+        }
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                CollisionEvent::CollisionStarted {
+                    entity1_id,
+                    entity2_id,
+                } if (*entity1_id == weapon && *entity2_id == actor)
+                    || (*entity1_id == actor && *entity2_id == weapon)
+            )),
+            "held melee must keep reporting authentic actor contact"
+        );
+        let actor_velocity = world.get_velocity(actor).unwrap();
+        let actor_position = world.get_position(actor_handle).unwrap();
+        assert!(
+            actor_velocity.magnitude() < 1.0 && actor_position.x.abs() < 0.1,
+            "held melee solver launched the actor to {actor_position:?} at {actor_velocity:?}"
+        );
+    }
+
+    /// Held-only solver filtering must not leak into the ordinary loose-prop
+    /// body recreated by DropItem. Store/destroy removes the body entirely;
+    /// a later world instantiation must likewise start with authored solid
+    /// groups instead of inheriting the old held collider's filter.
+    #[test]
+    fn recreated_melee_body_restores_ordinary_actor_solver_contact() {
+        let mut world = PhysicsWorld::new();
+        let weapon = EntityId::from_inner(4).unwrap();
+        let actor = CollisionGroup::actor();
+        world.add_dynamic(
+            weapon,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(1.5, 0.3, 0.3)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        world.set_held_melee(weapon);
+        let held_handle = world.entity_id_to_body[&weapon];
+        let held_collider = &world.collider_set[world.rigid_body_set[held_handle].colliders()[0]];
+        assert!(!held_collider.solver_groups().test(actor.solver));
+
+        world.remove(weapon);
+        assert!(
+            !world.entity_id_to_body.contains_key(&weapon),
+            "store/destroy must remove the held physics body"
+        );
+
+        let loose_handle = world.add_dynamic(
+            weapon,
+            vec3(0.0, 1.0, 0.0),
+            identity_quat(),
+            vec3(0.0, 0.0, 0.0),
+            PhysicsShape::Cuboid(vec3(1.5, 0.3, 0.3)),
+            CollisionGroup::entity(),
+            false,
+            DynamicPhysicsOptions::default(),
+        );
+        let loose_collider = &world.collider_set[world.rigid_body_set[loose_handle].colliders()[0]];
+        assert!(
+            loose_collider.solver_groups().test(actor.solver),
+            "a dropped/recreated loose prop must restore ordinary actor response"
+        );
     }
 
     /// A collider deliberately made non-solid to characters must not remain an
@@ -5542,19 +5707,19 @@ mod tests {
         );
 
         assert!(
-            !obstacle.0.test(live_creature.0),
+            !obstacle.collision.test(live_creature.collision),
             "a player-passable collider must not stop a pursuing creature"
         );
         assert!(
-            physical_entity.0.test(live_creature.0),
+            physical_entity.collision.test(live_creature.collision),
             "ordinary props must remain solid to creatures"
         );
         assert!(
-            obstacle.0.test(physical_entity.0),
+            obstacle.collision.test(physical_entity.collision),
             "slow physical projectiles and movable props must still hit the obstacle"
         );
         assert!(
-            obstacle.0.test(generic_entity_ray),
+            obstacle.collision.test(generic_entity_ray),
             "selection/projectile rays must still hit the obstacle"
         );
     }
@@ -5640,7 +5805,7 @@ mod tests {
             InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),
             Default::default(),
         );
-        let live_creature = CollisionGroup::actor().0;
+        let live_creature = CollisionGroup::actor().collision;
         let terrain = InteractionGroups::new(
             InternalCollisionGroups::WORLD.bits.into(),
             InternalCollisionGroups::ALL_COLLIDABLE.bits.into(),

--- a/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-saved-vr-melee.e2e.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { GameServer } from "../src/index.js";
-import type { EntityDetailResult, EntitySummary, Vec3 } from "../src/index.js";
+import type {
+  EntityDetailResult,
+  EntitySummary,
+  PhysicsBodySummary,
+  Vec3,
+} from "../src/index.js";
 import { teleportVerified } from "./helpers/teleport.js";
 import { aimVrHandAt } from "./helpers/vr-hand.js";
 
@@ -26,7 +31,8 @@ const GUI_PIXEL_TO_WORLD_SIZE = 1 / 250;
 
 const add = (a: Vec3, b: Vec3): Vec3 => a.map((x, i) => x + b[i]) as Vec3;
 const sub = (a: Vec3, b: Vec3): Vec3 => a.map((x, i) => x - b[i]) as Vec3;
-const scale = (a: Vec3, factor: number): Vec3 => a.map((x) => x * factor) as Vec3;
+const scale = (a: Vec3, factor: number): Vec3 =>
+  a.map((x) => x * factor) as Vec3;
 const dot = (a: number[], b: number[]): number =>
   a.reduce((sum, x, i) => sum + x * b[i], 0);
 const cross = (a: Vec3, b: Vec3): Vec3 => [
@@ -88,7 +94,9 @@ async function byMissionId(
 }
 
 function hitPoints(detail: EntityDetailResult): number {
-  const property = detail.properties.find((candidate) => candidate.name === "HitPoints");
+  const property = detail.properties.find(
+    (candidate) => candidate.name === "HitPoints",
+  );
   assert.ok(property, `entity ${detail.entity_id} should expose HitPoints`);
   return Number(property.value);
 }
@@ -96,7 +104,12 @@ function hitPoints(detail: EntityDetailResult): number {
 // This is the production play-through gesture: orient the physical right hand
 // along the eye-to-target ray, wind up two units away, pull the trigger, and
 // sweep to 0.33 units. No damage/script message is injected by the test.
-async function poseWrench(game: GameServer, target: Vec3, distance: number): Promise<void> {
+async function poseWrench(
+  game: GameServer,
+  target: Vec3,
+  distance: number,
+  frames = 4,
+): Promise<void> {
   const info = await game.info();
   const pawn = info.player.position;
   const pawnQ = info.player.rotation;
@@ -113,7 +126,48 @@ async function poseWrench(game: GameServer, target: Vec3, distance: number): Pro
   });
   await game.input.set("right_hand.position", localPosition);
   await game.input.set("right_hand.rotation", localRotation);
-  await game.step({ frames: 4 });
+  await game.input.set("right_hand.squeeze", 1);
+  await game.step({ frames });
+}
+
+async function bodyFor(
+  game: GameServer,
+  entityId: number,
+): Promise<PhysicsBodySummary> {
+  const body = (await game.physics.bodies({ entityId })).bodies[0];
+  assert.ok(body, `entity ${entityId} should have one primary physics body`);
+  return body;
+}
+
+const distance = (a: Vec3, b: Vec3): number =>
+  Math.sqrt(a.reduce((sum, value, index) => sum + (value - b[index]) ** 2, 0));
+
+function assertBoundedActor(
+  before: PhysicsBodySummary,
+  after: PhysicsBodySummary,
+  label: string,
+  bounds: { displacement: number; speed: number } = {
+    displacement: 8,
+    speed: 10,
+  },
+): void {
+  assert.ok(
+    [...after.position, ...after.velocity].every(Number.isFinite),
+    `${label}: actor physics must stay finite: ${JSON.stringify(after)}`,
+  );
+  assert.ok(
+    distance(after.position, before.position) < bounds.displacement,
+    `${label}: held Wrench displaced the actor out of its lane: ${JSON.stringify(
+      {
+        before: before.position,
+        after: after.position,
+      },
+    )}`,
+  );
+  assert.ok(
+    Math.max(...after.velocity.map(Math.abs)) < bounds.speed,
+    `${label}: held Wrench gave the actor runaway linear velocity: ${JSON.stringify(after.velocity)}`,
+  );
 }
 
 async function damageMessagesSince(
@@ -132,7 +186,7 @@ async function damageMessagesSince(
 async function armedSweep(
   game: GameServer,
   target: EntitySummary,
-): Promise<{ sequence: number; targetId: number }> {
+): Promise<{ sequence: number; targetId: number; targetPoint: Vec3 }> {
   const live = await game.entities.detail(target.id);
   await game.player.teleport({
     x: live.position[0] + 0.815,
@@ -147,31 +201,83 @@ async function armedSweep(
 
   const afterTeleport = await game.entities.detail(target.id);
   const targetPoint =
-    afterTeleport.aim_points?.find((point) => point.classification === "torso")?.position ??
-    afterTeleport.position;
+    afterTeleport.aim_points?.find((point) => point.classification === "torso")
+      ?.position ?? afterTeleport.position;
   await poseWrench(game, targetPoint, 4);
   await game.step({ frames: 4 });
   await game.input.set("right_hand.trigger", 0);
   await game.step({ frames: 2 });
-  const sequence = (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+  const sequence =
+    (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
   await game.input.set("right_hand.trigger", 1);
   await game.step({ frames: 2 });
   await poseWrench(game, targetPoint, 0.33);
-  return { sequence, targetId: target.id };
+  return { sequence, targetId: target.id, targetPoint };
 }
 
-async function releaseTrigger(game: GameServer): Promise<void> {
+// The #984 report/review's live-torso incremental approach, with one necessary
+// correction: the Wrench's full model bounds can already overlap the actor at
+// a 1.5-unit hand-origin pose. Arm from a measured-clear four-unit pose, then
+// reacquire the moving torso for every 1.5 -> 1.0 -> 0.7 -> 0.4 -> 0.2 step.
+async function reviewedIncrementalSweep(
+  game: GameServer,
+  target: EntitySummary,
+): Promise<{ sequence: number; targetId: number; targetPoint: Vec3 }> {
+  const live = await game.entities.detail(target.id);
+  await game.player.teleport({
+    x: live.position[0] + 0.815,
+    y: live.position[1] + 0.236,
+    z: live.position[2] - 2.245,
+  });
+  await game.entities.sendMessage(target.id, {
+    type: "SetAlertness",
+    level: "Lowest",
+  });
+  await game.input.set("right_hand.trigger", 0);
+  let targetPoint =
+    live.aim_points?.find((point) => point.classification === "torso")
+      ?.position ?? live.position;
+  await poseWrench(game, targetPoint, 4, 4);
+
+  const sequence =
+    (await game.messages.recent()).messages.at(-1)?.sequence ?? 0;
+  await game.input.set("right_hand.trigger", 1);
+  await game.step({ frames: 2 });
+  for (const handDistance of [1.5, 1.0, 0.7, 0.4, 0.2]) {
+    const current = await game.entities.detail(target.id);
+    targetPoint =
+      current.aim_points?.find((point) => point.classification === "torso")
+        ?.position ?? current.position;
+    await poseWrench(game, targetPoint, handDistance, 1);
+  }
+  await game.step({ frames: 2 });
+  return { sequence, targetId: target.id, targetPoint };
+}
+
+async function releaseTrigger(
+  game: GameServer,
+  targetPoint?: Vec3,
+): Promise<void> {
   await game.input.set("right_hand.trigger", 0);
   await game.step({ frames: 2 });
+  if (targetPoint) {
+    await poseWrench(game, targetPoint, 4);
+  }
 }
 
-async function grabAuthoredCorpseWrench(game: GameServer): Promise<EntitySummary> {
+async function grabAuthoredCorpseWrench(
+  game: GameServer,
+): Promise<EntitySummary> {
   const corpse = await byMissionId(game, "MS Male Corpse", WRENCH_CORPSE);
   const corpseDetail = await game.entities.detail(corpse.id);
   const contained = corpseDetail.outgoing_links.filter((link) =>
     link.link_type.startsWith("Contains"),
   );
-  assert.equal(contained.length, 1, "corpse 1177 should contain only its Wrench");
+  assert.equal(
+    contained.length,
+    1,
+    "corpse 1177 should contain only its Wrench",
+  );
   assert.match(contained[0].target_name, /Wrench/i);
   const wrenchId = contained[0].target_id;
 
@@ -199,7 +305,9 @@ async function grabAuthoredCorpseWrench(game: GameServer): Promise<EntitySummary
   const panel = uiBodies[0];
   const ui = (await game.ui.state()).active_panel;
   assert.ok(ui, "corpse frob should expose its rendered loot panel");
-  const wrenchElement = ui.elements.find((element) => element.entity_id === wrenchId);
+  const wrenchElement = ui.elements.find(
+    (element) => element.entity_id === wrenchId,
+  );
   assert.ok(wrenchElement, "corpse panel should render Wrench 990");
   const panelFront = qrotate(panel.rotation, [0, 0, -1]);
   const eyeHeight = (await game.info()).player.camera_offset[1];
@@ -230,7 +338,11 @@ async function grabAuthoredCorpseWrench(game: GameServer): Promise<EntitySummary
     collision_groups: ["ui"],
     max_distance: 1,
   });
-  assert.equal(panelHit.entity_id, panel.entity_id, "hand ray should hit Wrench's slot");
+  assert.equal(
+    panelHit.entity_id,
+    panel.entity_id,
+    "hand ray should hit Wrench's slot",
+  );
   await game.input.set("right_hand.squeeze", 1);
   await game.step({ frames: 10 });
   assert.equal(
@@ -255,7 +367,7 @@ async function assertNineDamagePull(
     `${name} must start at its authored HP`,
   );
 
-  const { sequence, targetId } = await armedSweep(game, target);
+  const { sequence, targetId, targetPoint } = await armedSweep(game, target);
   assert.equal(
     await damageMessagesSince(game, sequence, targetId),
     1,
@@ -266,7 +378,90 @@ async function assertNineDamagePull(
     initialHp - 9,
     `${name} must take exactly 9 HP during the four-frame contact pose`,
   );
-  await releaseTrigger(game);
+  await releaseTrigger(game, targetPoint);
+}
+
+async function killShotgunWithThreeBoundedPulls(
+  game: GameServer,
+): Promise<void> {
+  const target = await byMissionId(game, "OG-Shotgun", SHOTGUN_HYBRID);
+  assert.equal(hitPoints(await game.entities.detail(target.id)), 24);
+
+  for (const [hit, expectedHp] of [15, 6, 0].entries()) {
+    const beforeBody = await bodyFor(game, target.id);
+    const { sequence, targetId, targetPoint } = await reviewedIncrementalSweep(
+      game,
+      target,
+    );
+    assert.equal(
+      await damageMessagesSince(game, sequence, targetId),
+      1,
+      `shotgun pull ${hit + 1} must emit exactly one Damage`,
+    );
+
+    if (expectedHp > 0) {
+      assert.equal(
+        hitPoints(await game.entities.detail(targetId)),
+        expectedHp,
+        `same OG-Shotgun must take one authored 9-HP hit on pull ${hit + 1}`,
+      );
+      assertBoundedActor(
+        beforeBody,
+        await bodyFor(game, targetId),
+        `pull ${hit + 1}`,
+      );
+    } else {
+      const fatalDetail = await game.entities.detail(targetId);
+      assert.ok(
+        hitPoints(fatalDetail) <= 0,
+        "the third normal pull must exhaust the same original OG-Shotgun's HP",
+      );
+      assertBoundedActor(
+        beforeBody,
+        await bodyFor(game, targetId),
+        `lethal pull ${hit + 1}`,
+      );
+    }
+
+    await releaseTrigger(game, targetPoint);
+    await game.step({ frames: 120 });
+    const settledBodies = (await game.physics.bodies({ entityId: targetId }))
+      .bodies;
+    if (expectedHp > 0) {
+      assert.equal(
+        settledBodies.length,
+        1,
+        "the live target must remain in the mission",
+      );
+      assertBoundedActor(
+        beforeBody,
+        settledBodies[0],
+        `pull ${hit + 1} after 120 ordinary frames`,
+        { displacement: 64, speed: 64 },
+      );
+    } else {
+      const corpse = await game.entities.detail(targetId);
+      assert.equal(
+        corpse.properties.find((property) => property.name === "AIBehavior")
+          ?.value,
+        "Dead",
+        "the third normal pull must leave the same original OG-Shotgun dead",
+      );
+      assert.equal(
+        settledBodies.length,
+        1,
+        "the dead OG-Shotgun should retain its lootable corpse body",
+      );
+      assert.deepEqual(settledBodies[0].collision_groups, ["selectable"]);
+      assert.equal(settledBodies[0].blocks_actor, false);
+      assertBoundedActor(
+        beforeBody,
+        settledBodies[0],
+        "lethal pull after 120 ordinary frames",
+        { displacement: 64, speed: 64 },
+      );
+    }
+  }
 }
 
 test(
@@ -312,7 +507,10 @@ test(
     // Preserve the exact positive mission identity that exposed #978 by
     // opening corpse 1177's physical VR panel and grabbing Wrench 990.
     const worldWrench = await grabAuthoredCorpseWrench(game);
-    assert.equal((await game.info()).player.right_hand_entity_id, worldWrench.id);
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      worldWrench.id,
+    );
 
     // The suite's save cleaner keys off a trailing 13-digit epoch, so every
     // name this test writes must end with `stamp`.
@@ -322,7 +520,10 @@ test(
     assert.equal((await game.load(saveName)).success, true);
     await game.step({ frames: 3 });
     let restoredWrench = await byMissionId(game, "Wrench", MEDSCI1_WRENCH);
-    assert.equal((await game.info()).player.right_hand_entity_id, restoredWrench.id);
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      restoredWrench.id,
+    );
 
     await game.transitionLevel("medsci2");
     await game.step({ frames: 5 });
@@ -333,7 +534,8 @@ test(
       "the concrete MedSci1 Wrench should remain wielded on MedSci2",
     );
     assert.equal(
-      (await game.physics.bodies({ entityId: restoredWrench.id })).bodies[0]?.body_type,
+      (await game.physics.bodies({ entityId: restoredWrench.id })).bodies[0]
+        ?.body_type,
       "kinematic",
     );
 
@@ -345,7 +547,10 @@ test(
     await assertNineDamagePull(game, "OG-Pipe", PIPE_HYBRID, 12);
     assert.equal((await game.load(combatBaseline)).success, true);
     await releaseTrigger(game);
-    await assertNineDamagePull(game, "OG-Shotgun", SHOTGUN_HYBRID, 24);
+    // #984's exact acceptance path: one shipped 24-HP target, three fully
+    // released and separated physical pulls, no replacement/reload between
+    // hits, and two seconds of ordinary simulation after every contact.
+    await killShotgunWithThreeBoundedPulls(game);
 
     // A second save/load proves the canonical identity is not a one-transition
     // accident. A one-HP authored world pane is also a non-creature control.
@@ -354,18 +559,43 @@ test(
     assert.equal((await game.load(roundTripSave)).success, true);
     await game.step({ frames: 3 });
     restoredWrench = await byMissionId(game, "Wrench", MEDSCI1_WRENCH);
-    assert.equal((await game.info()).player.right_hand_entity_id, restoredWrench.id);
+    assert.equal(
+      (await game.info()).player.right_hand_entity_id,
+      restoredWrench.id,
+    );
 
     const pane = await byMissionId(game, "Window 2", BREAKABLE_PANE);
-    const { sequence, targetId } = await armedSweep(game, pane);
+    const { sequence, targetId, targetPoint } = await armedSweep(game, pane);
     assert.equal(await damageMessagesSince(game, sequence, targetId), 1);
     assert.equal(
-      (await game.entities.list({ filter: "Window 2", limit: 30 })).entities.some(
-        (entity) => entity.id === targetId,
-      ),
+      (
+        await game.entities.list({ filter: "Window 2", limit: 30 })
+      ).entities.some((entity) => entity.id === targetId),
       false,
       "restored Wrench contact should still destroy an authored world pane",
     );
-    await releaseTrigger(game);
+    await releaseTrigger(game, targetPoint);
+
+    // Drop through the real VR squeeze edge. The held-only solver filter must
+    // leave with the old kinematic body: the recreated world Wrench is again a
+    // normal dynamic, actor-solid loose prop and remains finite under gravity.
+    await game.input.set("right_hand.position", [0, 0.6, -0.6]);
+    await game.input.set("right_hand.squeeze", 1);
+    await game.step({ frames: 2 });
+    await game.input.set("right_hand.squeeze", 0);
+    await game.step({ frames: 2 });
+    assert.equal((await game.info()).player.right_hand_entity_id, null);
+    const dropped = await bodyFor(game, restoredWrench.id);
+    assert.equal(dropped.body_type, "dynamic");
+    assert.equal(dropped.blocks_actor, true);
+    assert.equal(dropped.is_sensor, false);
+    await game.step({ frames: 120 });
+    const droppedSettled = await bodyFor(game, restoredWrench.id);
+    assert.ok(
+      [...droppedSettled.position, ...droppedSettled.velocity].every(
+        Number.isFinite,
+      ),
+      `dropped Wrench physics must remain finite: ${JSON.stringify(droppedSettled)}`,
+    );
   },
 );


### PR DESCRIPTION
## Summary

- preserve held-melee collision events and authored trigger-gated damage while excluding living actors from Rapier's physical contact solver
- apply collision and solver groups together on every collider creation and role transition so dropped, stored, restored, and recreated items cannot retain held-only state
- prove the exact saved-campaign path with concrete Wrench 990, MedSci2 OG-Shotgun 1392, three separately armed live-torso pulls, long-settle bounds, Window2, save/load, and a real VR drop

## Root cause

`PhysicsWorld::set_held_melee` changes the full pickup collider to `KinematicPositionBased`, but its collision filter also controlled solver response. A controller-driven contact therefore transferred the kinematic velocity to a living dynamic actor capsule. Collision events are required for `TriggeredMeleeWeapon`; the physical impulse is not.

The fix gives `CollisionGroup` explicit collision and solver filters. Ordinary roles mirror the two. Held melee keeps `ACTOR` in its collision filter, but excludes only `ACTOR` from its solver filter; world, loose-prop, and selectable contacts remain physically solid. Dropping or recreating the weapon applies the ordinary entity solver group.

## Negative-first proof

On the pre-rebase base `dd8e50305c41dc9b8c9ec36c4bedf2714d28d1af` (#980's head before the stack was rebuilt; the parent commit's content is unchanged, now `1c19c999`), the focused controller sweep first reported an authentic `CollisionStarted`, then moved the actor to x=1.2676 with vx=18.0. The same test on this commit retains `CollisionStarted` while actor displacement and velocity stay below 0.1 and 1.0 respectively.

## Verification

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` (697 passed; 2 doctests ignored)
- `npm test` in `tools/shock2-sdk` (26 passed; 236 E2E skipped)
- finalized saved-campaign MedSci VR melee E2E, twice unchanged (67.4s, 65.5s): Wrench 990 survives save/load + deck transition; same OG-Shotgun 1392 takes one Damage per fully separated pull, 24 -> 15 -> 6 -> dead; bounded immediately and after 120 frames per hit; second save/load; Window2 destruction; drop returns a finite dynamic actor-solid body
- existing broader VR melee/save-load and cross-presentation controls (3 passed)

## Visual verification

![held melee solver response comparison](https://gist.githubusercontent.com/tommy-xr/1d0bf2257d8bcd8cf91724dffe643f04/raw/held-melee-solver.gif)

<sub>Exact #980 base and #986 fixed builds; same fresh canonical Wrench -928, shipped MedSci2 OG-Shotgun 1392, teleport, trigger edge, and deterministic 1.5 -> 1.0 -> 0.7 -> 0.4 -> 0.2 live-torso controller sequence. Frame zero is byte-identical. Both emit one Damage and 24 -> 15; base contact reaches vy=+10.44 and lifts the actor, while fixed stays near the authored floor. Captured headlessly via `/v1/step` + `/v1/screenshot` at fixed 60 Hz.</sub>

![fixed held Wrench contact](https://gist.githubusercontent.com/tommy-xr/1d0bf2257d8bcd8cf91724dffe643f04/raw/held-melee-fixed.png)

### Before -> after

![held melee solver before and after](https://gist.githubusercontent.com/tommy-xr/1d0bf2257d8bcd8cf91724dffe643f04/raw/held-melee-before-after.png)

## Stack

Depends on #980 (`fix/978-canonical-saved-melee`, exact head `1c19c999`) and is the final member of stack #1006 (#967 → #968 → #975 → #755 → #980 → #986).

Fixes #984

