### PR TITLE
docs: require the 25th Anniversary install

### DIFF
--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -44,10 +44,11 @@ Pass `--serial SERIAL` before the command when more than one device is attached.
 
 ## Preflight
 
-Resolve the device and confirm required game data. Either install layout is
-valid, so probe for both: a 25th Anniversary Remaster install (recommended)
-keeps everything inside `sshock2.kpf` and has *no* loose gamesys or missions,
-while a classic install has them loose at the data root.
+Resolve the device and confirm required game data. A 25th Anniversary Remaster
+install - what the game targets - keeps everything inside `sshock2.kpf` and has
+*no* loose gamesys or missions. Probe for the legacy loose layout too, since a
+device provisioned before the remaster still carries it and that is worth
+identifying rather than reading as "no data".
 
 ```sh
 adb devices -l
@@ -61,8 +62,8 @@ adb -s SERIAL shell '
 
 Statting `shock2.gam` alone reports "missing data" on a correctly-provisioned
 remaster install. Note which layout answered: the remaster's upgraded models and
-textures are what the VR hand and weapon work targets, so a visual difference
-between two runs can simply be a different asset layout.
+textures are what the VR hands and weapons target, so a visual difference
+between two runs can simply be a device still on the legacy layout.
 
 The repository data and device data must describe the same workload. Sync the
 retail game data before interpreting visual or performance differences.

--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -44,15 +44,25 @@ Pass `--serial SERIAL` before the command when more than one device is attached.
 
 ## Preflight
 
-Resolve the device and confirm required game data:
+Resolve the device and confirm required game data. Either install layout is
+valid, so probe for both: a 25th Anniversary Remaster install (recommended)
+keeps everything inside `sshock2.kpf` and has *no* loose gamesys or missions,
+while a classic install has them loose at the data root.
 
 ```sh
 adb devices -l
-adb -s SERIAL shell ls -l \
-  /sdcard/shock2quest/shock2.gam \
-  /sdcard/shock2quest/motiondb.bin \
-  /sdcard/shock2quest/earth.mis
+adb -s SERIAL shell '
+  ls -l /sdcard/shock2quest/sshock2.kpf /sdcard/shock2quest/mods/ 2>/dev/null \
+    || ls -l /sdcard/shock2quest/shock2.gam \
+             /sdcard/shock2quest/motiondb.bin \
+             /sdcard/shock2quest/earth.mis
+'
 ```
+
+Statting `shock2.gam` alone reports "missing data" on a correctly-provisioned
+remaster install. Note which layout answered: the remaster's upgraded models and
+textures are what the VR hand and weapon work targets, so a visual difference
+between two runs can simply be a different asset layout.
 
 The repository data and device data must describe the same workload. Sync the
 retail game data before interpreting visual or performance differences.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,11 +25,21 @@
 
 ### 2. Provide data files
 
+shock2quest reads an unmodified retail install. Two layouts are supported:
+
+- **25th Anniversary Remaster (recommended)** — the data lives inside KPF
+  archives. You need `sshock2.kpf` and the `mods/` folder. The remaster's
+  upgraded models and textures are what the VR hand and weapon work is built
+  against. (`sshock2ee-vault.kpf` is a bonus gallery and the root
+  `sshock2ee.kpf` is frontend-only — neither is read; skip them.)
+- **Classic (1999) install** — loose `*.mis` files plus the `res/` folder of
+  `.crf` archives. Still supported, but missing the upgraded VR art.
+
 Either copy the files into the repo, or point the engine at an existing copy.
 
 **Option A — copy into `Data/`**
 
-- Copy local game files (\*.mis, res folder) into the `shock2quest/Data` folder
+- Copy the files above into the `shock2quest/Data` folder
 
 **Option B — set `DARK_ASSET_PATH`**
 
@@ -41,8 +51,9 @@ export DARK_ASSET_PATH=/path/to/your/shock2/data
 ```
 
 **Either way, the data directory must contain at least one _sentinel_ file** —
-`shock2.gam`, `res/obj.crf`, `res/mesh.crf`, or `motiondb.bin`. This is how the
-engine recognizes a directory as game data.
+`sshock2.kpf` (remaster), or `shock2.gam`, `res/obj.crf`, `res/mesh.crf`, or
+`motiondb.bin` (classic). This is how the engine recognizes a directory as game
+data.
 
 > **Gotcha:** if `DARK_ASSET_PATH` is set but contains no sentinel, it does *not*
 > fail. It logs a warning and falls back to searching `./Data`, `../Data`,
@@ -119,8 +130,21 @@ cargo dr --release --experimental teleport
 - Make sure [Developer Mode is enabled on your Quest device](https://www.reddit.com/r/OculusQuest/comments/17sa8n6/tutorial_quest_3_developer_mode_4_easy_steps/)
 - Make sure `adb` is installed and working. With Oculus connected, run `adb devices` and verify your headset shows up
 - Tweak `runtimes/oculus_runtime/set_up_android_sdk.sh` to match your paths
-- Before running for the first time, you'll need to copy over the system shock 2 data files.
-  - From the root of the repo, run: `adb push Data/ /sdcard/shock2quest`
+- Before running for the first time, you'll need to copy over the System Shock 2 data files.
+  - **Remaster (recommended)** — from your install directory, ~1.2 GB:
+    ```sh
+    adb shell mkdir -p /sdcard/shock2quest/mods
+    adb push sshock2.kpf /sdcard/shock2quest/
+    for f in sshock2ee 400 shtup scp patch_ext; do
+      adb push "mods/$f.kpf" /sdcard/shock2quest/mods/
+    done
+    ```
+  - **Classic** — from the root of the repo: `adb push Data/ /sdcard/shock2quest`
+
+  The two can coexist on the device: the runtime switches to the remaster as
+  soon as `sshock2.kpf` is present, and does not mount the `.crf` archives at
+  all in that mode. Deleting the KPFs reverts to the classic install without
+  re-pushing it.
 
 ##### Running
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,17 +25,17 @@
 
 ### 2. Provide data files
 
-shock2quest reads an unmodified retail install. Two layouts are supported:
+shock2quest reads an unmodified **25th Anniversary Remaster** install. You need
+two things from it:
 
-- **25th Anniversary Remaster (recommended)** — the data lives inside KPF
-  archives. You need `sshock2.kpf` and the `mods/` folder. The remaster's
-  upgraded models and textures are what the VR hand and weapon work is built
-  against. (`sshock2ee-vault.kpf` is a bonus gallery and the root
-  `sshock2ee.kpf` is frontend-only — neither is read; skip them.)
-- **Classic (1999) install** — loose `*.mis` files plus the `res/` folder of
-  `.crf` archives. Still supported, but missing the upgraded VR art.
+- `sshock2.kpf` — the base game data.
+- the `mods/` folder — the remaster's upgraded models and textures, which the
+  VR hands and weapons are built against.
 
-Either copy the files into the repo, or point the engine at an existing copy.
+Skip `sshock2ee-vault.kpf` (a bonus gallery) and the root `sshock2ee.kpf`
+(frontend-only) — nothing reads either, and together they are ~1.5 GB.
+
+Either copy those into the repo, or point the engine at your install.
 
 **Option A — copy into `Data/`**
 
@@ -50,10 +50,11 @@ one copy of the data across several clones):
 export DARK_ASSET_PATH=/path/to/your/shock2/data
 ```
 
-**Either way, the data directory must contain at least one _sentinel_ file** —
-`sshock2.kpf` (remaster), or `shock2.gam`, `res/obj.crf`, `res/mesh.crf`, or
-`motiondb.bin` (classic). This is how the engine recognizes a directory as game
-data.
+**Either way, the data directory must contain a _sentinel_ file** —
+`sshock2.kpf`. This is how the engine recognizes a directory as game data.
+(`paths.rs` also accepts `shock2.gam`, `res/obj.crf`, `res/mesh.crf` and
+`motiondb.bin`, which is how a pre-remaster install is still picked up. That
+path is legacy and is missing the upgraded VR art.)
 
 > **Gotcha:** if `DARK_ASSET_PATH` is set but contains no sentinel, it does *not*
 > fail. It logs a warning and falls back to searching `./Data`, `../Data`,
@@ -130,21 +131,18 @@ cargo dr --release --experimental teleport
 - Make sure [Developer Mode is enabled on your Quest device](https://www.reddit.com/r/OculusQuest/comments/17sa8n6/tutorial_quest_3_developer_mode_4_easy_steps/)
 - Make sure `adb` is installed and working. With Oculus connected, run `adb devices` and verify your headset shows up
 - Tweak `runtimes/oculus_runtime/set_up_android_sdk.sh` to match your paths
-- Before running for the first time, you'll need to copy over the System Shock 2 data files.
-  - **Remaster (recommended)** — from your install directory, ~1.2 GB:
-    ```sh
-    adb shell mkdir -p /sdcard/shock2quest/mods
-    adb push sshock2.kpf /sdcard/shock2quest/
-    for f in sshock2ee 400 shtup scp patch_ext; do
-      adb push "mods/$f.kpf" /sdcard/shock2quest/mods/
-    done
-    ```
-  - **Classic** — from the root of the repo: `adb push Data/ /sdcard/shock2quest`
-
-  The two can coexist on the device: the runtime switches to the remaster as
-  soon as `sshock2.kpf` is present, and does not mount the `.crf` archives at
-  all in that mode. Deleting the KPFs reverts to the classic install without
-  re-pushing it.
+- Before running for the first time, you'll need to copy over the System Shock 2
+  data files. From your install directory (~1.2 GB):
+  ```sh
+  adb shell mkdir -p /sdcard/shock2quest/mods
+  adb push sshock2.kpf /sdcard/shock2quest/
+  for f in sshock2ee 400 shtup scp patch_ext; do
+    adb push "mods/$f.kpf" /sdcard/shock2quest/mods/
+  done
+  ```
+  The runtime switches to the remaster as soon as `sshock2.kpf` is present, and
+  does not mount the legacy `.crf` archives at all in that mode — so pushing
+  these over an older install is safe and needs no cleanup first.
 
 ##### Running
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A project to experience System Shock 2 in virtual reality. System Shock 2 is one
 
 This project is a [game engine recreation](https://en.wikipedia.org/wiki/Game_engine_recreation) of the [Dark engine](https://en.wikipedia.org/wiki/Dark_Engine) - geared towards VR experiences.
 
-You'll need a full retail copy of System Shock 2 in order to play - recommend purchasing at either [GoG](https://www.gog.com/game/system_shock_2) or [Steam](https://store.steampowered.com/app/238210/System_Shock_2/). 
+You'll need a full retail copy of System Shock 2 in order to play. The **25th Anniversary Remaster** is the recommended edition - purchase at either [GoG](https://www.gog.com/en/game/system_shockr_2_25th_anniversary_remaster) or [Steam](https://store.steampowered.com/app/866570/). The 1999 release was delisted from PC storefronts in October 2025, and the remaster also grants the original game in your library.
+
+A classic (1999) install still works, but the remaster's upgraded models and textures are what the VR hand and weapon work is built against. See [DEVELOPMENT.md](DEVELOPMENT.md) for both layouts.
 
 >NOTE: This is currently in a _pre-alpha_ state and not really playable in any meaningful way, yet. I also have to apologize for the quality of the code, this is my first Rust project - so certainly a lot of room for improvement (and a lot of hacks and experiments!) It's a project done in bits of spare time, but wanted to share out in case it is fun or useful for anyone.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A project to experience System Shock 2 in virtual reality. System Shock 2 is one
 
 This project is a [game engine recreation](https://en.wikipedia.org/wiki/Game_engine_recreation) of the [Dark engine](https://en.wikipedia.org/wiki/Dark_Engine) - geared towards VR experiences.
 
-You'll need a full retail copy of System Shock 2 in order to play. The **25th Anniversary Remaster** is the recommended edition - purchase at either [GoG](https://www.gog.com/en/game/system_shockr_2_25th_anniversary_remaster) or [Steam](https://store.steampowered.com/app/866570/). The 1999 release was delisted from PC storefronts in October 2025, and the remaster also grants the original game in your library.
+You'll need a full retail copy of **System Shock 2: 25th Anniversary Remaster** in order to play - purchase at either [GoG](https://www.gog.com/en/game/system_shockr_2_25th_anniversary_remaster) or [Steam](https://store.steampowered.com/app/866570/). Its upgraded models and textures are what the VR hands and weapons are built against.
 
-A classic (1999) install still works, but the remaster's upgraded models and textures are what the VR hand and weapon work is built against. See [DEVELOPMENT.md](DEVELOPMENT.md) for both layouts.
+Once installed, copy `sshock2.kpf` and the `mods/` folder from it - see [DEVELOPMENT.md](DEVELOPMENT.md) for desktop and Quest setup.
 
 >NOTE: This is currently in a _pre-alpha_ state and not really playable in any meaningful way, yet. I also have to apologize for the quality of the code, this is my first Rust project - so certainly a lot of room for improvement (and a lot of hacks and experiments!) It's a project done in bits of spare time, but wanted to share out in case it is fun or useful for anyone.
 


### PR DESCRIPTION
## Summary

Require the **25th Anniversary Remaster** and stop pointing anyone at the 1999
release. The engine has read both layouts for a while (`paths.rs` already accepts
`sshock2.kpf` as a sentinel, `data_files.rs` resolves the gamesys/missions/motiondb
out of the archive); only the prose lagged behind — and in one case an agent-facing
check was actively wrong.

Why the remaster, and only the remaster:

- Its upgraded models and textures are what the VR hands and weapons are built
  against, so the legacy install is a worse experience, not merely an older one.
- The 1999 release was delisted from PC storefronts in October 2025, so it is not
  something a new player can buy anyway.

The engine still *resolves* the legacy loose layout, so this doesn't drop support —
it drops the recommendation. `DEVELOPMENT.md` keeps one parenthetical about those
sentinels (removing it would make the doc wrong about `paths.rs`), and the device
preflight still probes for it, because a headset provisioned before the remaster is
worth identifying rather than reading as "no data".

## Changes

- **`README.md`** — names the remaster as recommended, with current store links
  (the old link pointed at the delisted 1999 listing).
- **`DEVELOPMENT.md`** — describes both layouts and which KPFs are actually read
  (`sshock2ee-vault.kpf` and the root `sshock2ee.kpf` are *not*, so ~1.5 GB is
  skipped); adds `sshock2.kpf` to the documented sentinel list; replaces the
  classic-only `adb push Data/` with per-layout Quest instructions.
- **`.claude/skills/vr-device-loop/SKILL.md`** — the preflight stat'd
  `shock2.gam` + `motiondb.bin` + `earth.mis`, **none of which exist in a remaster
  install**, so it reported "missing data" on a correctly-provisioned device. It now
  probes for either layout.

No code changes.

## Verification

The recommendation is backed by a measured device run rather than assumption —
25AE assets (base + all five mod archives) pushed to a Quest 3 and benchmarked
against the classic install, same release APK, rick1, 10 s warmup + 30 s sample:

| Metric | Classic | 25AE |
| --- | ---: | ---: |
| Refresh requested / active | 90 / 90 | 90 / 90 |
| VrApi FPS mean / min | 89.867 / 81 | 90 / 76 |
| Stale / torn | 40 / 0 | 39 / 0 |
| Engine update | 3.777 ms | 3.833 ms |
| Scene preparation | 0.597 ms | 0.593 ms |
| Two eyes | 1.600 ms | 1.458 ms |
| GPU load | 0.267 | 0.271 |
| **PSS** | 424.3 MiB | **582.9 MiB** |
| **`Game::init`** | 5479 ms | **4270 ms** |

**No frame-rate regression.** Memory rises by 159 MiB — far below the ~681 MB upper
bound projected in `projects/25th-anniversary-assets.md` §4a, because the Android
`MAX_EDGE` 256 px cap holds decoded texture size down. Startup is 22% *faster*,
most likely because one stored-zip index beats many `.crf` opens plus loose stats.

Caveats: single run per configuration, one mission, one vantage point. The FPS
minimum difference (81 vs 76) is within run-to-run noise at this sample size.

- store links verified to resolve (Steam page title confirms the remaster)
- `cargo fmt --all --check` — clean (no code touched)

## Visual evidence

Deterministic desktop capture — same mission, same fixed-timestep frame count, same
camera, only `DARK_ASSET_PATH` differs, so every difference is purely the assets:

![Desktop before/after, classic vs 25AE](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/pr-desktop-before-after.png)

<sub>medsci1, 120 stepped frames. The gurney gains panel structure and rails where the
classic model is a flat smeared plank; the ceiling lamp gains a rounded vented housing;
the wall pipes gain colour detail.</sub>

Quest 3 device capture of the same A/B (headset stationary between runs, so the head
pose matches closely):

![Quest 3 before/after, classic vs 25AE](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/pr-quest-before-after.png)

<sub>rick1 on device. The overhead catwalk gains panel ribbing, the door frame goes from
flat black to shaded grey, and the floor chevrons sharpen.</sub>

## Follow-up (not in this PR)

`tracing::info!` does not reach logcat on Android — only `println!` does — so the
`"25th Anniversary Edition install detected; mounting KPF archives"` line is
**invisible on device**. There is currently no way to tell from a device log which
asset layout the headset actually loaded; detection had to be confirmed visually.
A `println!` startup install summary would close this.


