### PR TITLE
feat(engine): add a compiled-in fallback font

### DIFF
--- a/engine/src/builtin_font.rs
+++ b/engine/src/builtin_font.rs
@@ -1,0 +1,364 @@
+//! A fallback bitmap font compiled into the binary.
+//!
+//! Every other font in the game is loaded from the retail data (`METAFONT.FON`
+//! and friends, out of `intrface.crf` or the 25AE KPFs). That is fine until the
+//! thing we need to draw is "your game data is missing" - the screen that has to
+//! work when the asset cache has nothing to give. So this font ships as a table
+//! of glyph bitmaps compiled into the engine rather than an asset loaded through
+//! the cache, and it is the only font guaranteed to be available.
+//!
+//! # Provenance
+//!
+//! The glyph bitmaps are the printable-ASCII subset (U+0020..U+007E) of
+//! **unscii-8** by Viznut (<http://viznut.fi/unscii/>), which is in the
+//! **public domain**. Only the separate `unscii-16-full` variant carries a GPL
+//! obligation (it embeds GNU Unifont); the 8x8 variant used here does not.
+//! U+007F is included as a blank cell so the table is a full 16x6 grid.
+//!
+//! The table is the `U+0020`..`U+007F` rows of upstream `unscii-8.hex`
+//! verbatim, one 8-byte glyph per row. Each line of that file is
+//! `<codepoint>:<16 hex digits>`, so any entry is independently reproducible:
+//!
+//! ```text
+//! $ curl -s http://viznut.fi/unscii/unscii-8.hex | grep '^00041:'
+//! 00041:183C66667E666600          # == GLYPHS[0x41 - 0x20], the 'A' row below
+//! ```
+//!
+//! `the_table_matches_upstream_unscii_8` pins specific rows so a future edit or
+//! font swap cannot quietly drift from that attribution.
+//!
+//! # Layout
+//!
+//! Cells are packed row-major into a 16x6 grid, cell index `c - 0x20`. Each cell
+//! is the 8x8 glyph plus a 1px transparent border, because
+//! [`texture::init_from_memory`](crate::texture::init_from_memory) uploads with
+//! `GL_LINEAR` filtering and this font is drawn well above 1:1 - without the
+//! border, magnified sampling at a cell edge bleeds in the neighbouring glyph's
+//! column. The border is padding only: UVs address the inner 8x8, so the glyph
+//! metrics are unchanged by it.
+//!
+//! Unscii left-aligns glyphs in the cell and leaves the rightmost column (and,
+//! for characters without a descender, the bottom row) blank, so the cell is
+//! self-spacing: one advance equals one cell, and the font is monospace.
+
+use std::rc::Rc;
+
+use crate::font::{Font, FontCharacterInfo};
+use crate::texture::{self, Texture, TextureTrait};
+use crate::texture_format::{PixelFormat, RawTextureData};
+
+/// Side length of one glyph, in pixels.
+pub const GLYPH_PIXELS: u32 = 8;
+/// Transparent border around each glyph, in pixels. See the module docs.
+const CELL_PADDING: u32 = 1;
+/// Side length of one atlas cell: the glyph plus its border on both sides.
+const CELL_PIXELS: u32 = GLYPH_PIXELS + CELL_PADDING * 2;
+/// Glyph cells per atlas row.
+const ATLAS_COLUMNS: u32 = 16;
+/// Rows of glyph cells in the atlas.
+const ATLAS_ROWS: u32 = 6;
+/// Codepoint of the first cell in the atlas.
+const FIRST_CHAR: u32 = 0x20;
+
+/// Atlas width in pixels.
+pub const ATLAS_WIDTH: u32 = ATLAS_COLUMNS * CELL_PIXELS;
+/// Atlas height in pixels.
+pub const ATLAS_HEIGHT: u32 = ATLAS_ROWS * CELL_PIXELS;
+
+/// One byte per pixel row, most significant bit leftmost.
+#[rustfmt::skip]
+const GLYPHS: [[u8; GLYPH_PIXELS as usize]; (ATLAS_COLUMNS * ATLAS_ROWS) as usize] = [
+    [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], // U+0020 ' '
+    [0x18, 0x18, 0x18, 0x18, 0x18, 0x00, 0x18, 0x00], // U+0021 '!'
+    [0x66, 0x66, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00], // U+0022 '"'
+    [0x6C, 0x6C, 0xFE, 0x6C, 0xFE, 0x6C, 0x6C, 0x00], // U+0023 '#'
+    [0x18, 0x3E, 0x60, 0x3C, 0x06, 0x7C, 0x18, 0x00], // U+0024 '$'
+    [0x00, 0xC6, 0xCC, 0x18, 0x30, 0x66, 0xC6, 0x00], // U+0025 '%'
+    [0x38, 0x6C, 0x38, 0x76, 0xDC, 0xCC, 0x76, 0x00], // U+0026 '&'
+    [0x18, 0x18, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], // U+0027 "'"
+    [0x0C, 0x18, 0x30, 0x30, 0x30, 0x18, 0x0C, 0x00], // U+0028 '('
+    [0x30, 0x18, 0x0C, 0x0C, 0x0C, 0x18, 0x30, 0x00], // U+0029 ')'
+    [0x00, 0x66, 0x3C, 0xFF, 0x3C, 0x66, 0x00, 0x00], // U+002A '*'
+    [0x00, 0x18, 0x18, 0x7E, 0x18, 0x18, 0x00, 0x00], // U+002B '+'
+    [0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x18, 0x30], // U+002C ','
+    [0x00, 0x00, 0x00, 0x7E, 0x00, 0x00, 0x00, 0x00], // U+002D '-'
+    [0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x18, 0x00], // U+002E '.'
+    [0x03, 0x06, 0x0C, 0x18, 0x30, 0x60, 0xC0, 0x00], // U+002F '/'
+    [0x3C, 0x66, 0x6E, 0x76, 0x66, 0x66, 0x3C, 0x00], // U+0030 '0'
+    [0x18, 0x38, 0x18, 0x18, 0x18, 0x18, 0x7E, 0x00], // U+0031 '1'
+    [0x3C, 0x66, 0x0C, 0x18, 0x30, 0x60, 0x7E, 0x00], // U+0032 '2'
+    [0x3C, 0x66, 0x06, 0x1C, 0x06, 0x66, 0x3C, 0x00], // U+0033 '3'
+    [0x1C, 0x3C, 0x6C, 0xCC, 0xFE, 0x0C, 0x0C, 0x00], // U+0034 '4'
+    [0x7E, 0x60, 0x7C, 0x06, 0x06, 0x66, 0x3C, 0x00], // U+0035 '5'
+    [0x1C, 0x30, 0x60, 0x7C, 0x66, 0x66, 0x3C, 0x00], // U+0036 '6'
+    [0x7E, 0x06, 0x06, 0x0C, 0x18, 0x18, 0x18, 0x00], // U+0037 '7'
+    [0x3C, 0x66, 0x66, 0x3C, 0x66, 0x66, 0x3C, 0x00], // U+0038 '8'
+    [0x3C, 0x66, 0x66, 0x3E, 0x06, 0x0C, 0x38, 0x00], // U+0039 '9'
+    [0x00, 0x18, 0x18, 0x00, 0x00, 0x18, 0x18, 0x00], // U+003A ':'
+    [0x00, 0x18, 0x18, 0x00, 0x00, 0x18, 0x18, 0x30], // U+003B ';'
+    [0x0C, 0x18, 0x30, 0x60, 0x30, 0x18, 0x0C, 0x00], // U+003C '<'
+    [0x00, 0x00, 0x7E, 0x00, 0x7E, 0x00, 0x00, 0x00], // U+003D '='
+    [0x60, 0x30, 0x18, 0x0C, 0x18, 0x30, 0x60, 0x00], // U+003E '>'
+    [0x3C, 0x66, 0x06, 0x0C, 0x18, 0x00, 0x18, 0x00], // U+003F '?'
+    [0x7C, 0xC6, 0xDE, 0xDE, 0xDE, 0xC0, 0x7C, 0x00], // U+0040 '@'
+    [0x18, 0x3C, 0x66, 0x66, 0x7E, 0x66, 0x66, 0x00], // U+0041 'A'
+    [0x7C, 0x66, 0x66, 0x7C, 0x66, 0x66, 0x7C, 0x00], // U+0042 'B'
+    [0x3C, 0x66, 0x60, 0x60, 0x60, 0x66, 0x3C, 0x00], // U+0043 'C'
+    [0x78, 0x6C, 0x66, 0x66, 0x66, 0x6C, 0x78, 0x00], // U+0044 'D'
+    [0x7E, 0x60, 0x60, 0x7C, 0x60, 0x60, 0x7E, 0x00], // U+0045 'E'
+    [0x7E, 0x60, 0x60, 0x7C, 0x60, 0x60, 0x60, 0x00], // U+0046 'F'
+    [0x3C, 0x66, 0x60, 0x6E, 0x66, 0x66, 0x3E, 0x00], // U+0047 'G'
+    [0x66, 0x66, 0x66, 0x7E, 0x66, 0x66, 0x66, 0x00], // U+0048 'H'
+    [0x7E, 0x18, 0x18, 0x18, 0x18, 0x18, 0x7E, 0x00], // U+0049 'I'
+    [0x06, 0x06, 0x06, 0x06, 0x06, 0x66, 0x3C, 0x00], // U+004A 'J'
+    [0xC6, 0xCC, 0xD8, 0xF0, 0xD8, 0xCC, 0xC6, 0x00], // U+004B 'K'
+    [0x60, 0x60, 0x60, 0x60, 0x60, 0x60, 0x7E, 0x00], // U+004C 'L'
+    [0xC6, 0xEE, 0xFE, 0xD6, 0xC6, 0xC6, 0xC6, 0x00], // U+004D 'M'
+    [0xC6, 0xE6, 0xF6, 0xDE, 0xCE, 0xC6, 0xC6, 0x00], // U+004E 'N'
+    [0x3C, 0x66, 0x66, 0x66, 0x66, 0x66, 0x3C, 0x00], // U+004F 'O'
+    [0x7C, 0x66, 0x66, 0x7C, 0x60, 0x60, 0x60, 0x00], // U+0050 'P'
+    [0x3C, 0x66, 0x66, 0x66, 0x66, 0x6C, 0x36, 0x00], // U+0051 'Q'
+    [0x7C, 0x66, 0x66, 0x7C, 0x6C, 0x66, 0x66, 0x00], // U+0052 'R'
+    [0x3C, 0x66, 0x60, 0x3C, 0x06, 0x66, 0x3C, 0x00], // U+0053 'S'
+    [0x7E, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x00], // U+0054 'T'
+    [0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x3C, 0x00], // U+0055 'U'
+    [0x66, 0x66, 0x66, 0x66, 0x66, 0x3C, 0x18, 0x00], // U+0056 'V'
+    [0xC6, 0xC6, 0xC6, 0xD6, 0xFE, 0xEE, 0xC6, 0x00], // U+0057 'W'
+    [0xC3, 0x66, 0x3C, 0x18, 0x3C, 0x66, 0xC3, 0x00], // U+0058 'X'
+    [0xC3, 0x66, 0x3C, 0x18, 0x18, 0x18, 0x18, 0x00], // U+0059 'Y'
+    [0x7E, 0x06, 0x0C, 0x18, 0x30, 0x60, 0x7E, 0x00], // U+005A 'Z'
+    [0x3C, 0x30, 0x30, 0x30, 0x30, 0x30, 0x3C, 0x00], // U+005B '['
+    [0xC0, 0x60, 0x30, 0x18, 0x0C, 0x06, 0x03, 0x00], // U+005C '\\'
+    [0x3C, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x3C, 0x00], // U+005D ']'
+    [0x10, 0x38, 0x6C, 0xC6, 0x00, 0x00, 0x00, 0x00], // U+005E '^'
+    [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF], // U+005F '_'
+    [0x18, 0x0C, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00], // U+0060 '`'
+    [0x00, 0x00, 0x3C, 0x06, 0x3E, 0x66, 0x3E, 0x00], // U+0061 'a'
+    [0x60, 0x60, 0x7C, 0x66, 0x66, 0x66, 0x7C, 0x00], // U+0062 'b'
+    [0x00, 0x00, 0x3C, 0x60, 0x60, 0x60, 0x3C, 0x00], // U+0063 'c'
+    [0x06, 0x06, 0x3E, 0x66, 0x66, 0x66, 0x3E, 0x00], // U+0064 'd'
+    [0x00, 0x00, 0x3C, 0x66, 0x7E, 0x60, 0x3C, 0x00], // U+0065 'e'
+    [0x1C, 0x30, 0x7C, 0x30, 0x30, 0x30, 0x30, 0x00], // U+0066 'f'
+    [0x00, 0x00, 0x3E, 0x66, 0x66, 0x3E, 0x06, 0x7C], // U+0067 'g'
+    [0x60, 0x60, 0x7C, 0x66, 0x66, 0x66, 0x66, 0x00], // U+0068 'h'
+    [0x18, 0x00, 0x38, 0x18, 0x18, 0x18, 0x1E, 0x00], // U+0069 'i'
+    [0x0C, 0x00, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x78], // U+006A 'j'
+    [0x60, 0x60, 0x66, 0x6C, 0x78, 0x6C, 0x66, 0x00], // U+006B 'k'
+    [0x38, 0x18, 0x18, 0x18, 0x18, 0x18, 0x1E, 0x00], // U+006C 'l'
+    [0x00, 0x00, 0xCC, 0xFE, 0xD6, 0xD6, 0xC6, 0x00], // U+006D 'm'
+    [0x00, 0x00, 0x7C, 0x66, 0x66, 0x66, 0x66, 0x00], // U+006E 'n'
+    [0x00, 0x00, 0x3C, 0x66, 0x66, 0x66, 0x3C, 0x00], // U+006F 'o'
+    [0x00, 0x00, 0x7C, 0x66, 0x66, 0x7C, 0x60, 0x60], // U+0070 'p'
+    [0x00, 0x00, 0x3E, 0x66, 0x66, 0x3E, 0x06, 0x06], // U+0071 'q'
+    [0x00, 0x00, 0x7C, 0x66, 0x60, 0x60, 0x60, 0x00], // U+0072 'r'
+    [0x00, 0x00, 0x3E, 0x60, 0x3C, 0x06, 0x7C, 0x00], // U+0073 's'
+    [0x30, 0x30, 0x7E, 0x30, 0x30, 0x30, 0x1E, 0x00], // U+0074 't'
+    [0x00, 0x00, 0x66, 0x66, 0x66, 0x66, 0x3E, 0x00], // U+0075 'u'
+    [0x00, 0x00, 0x66, 0x66, 0x66, 0x3C, 0x18, 0x00], // U+0076 'v'
+    [0x00, 0x00, 0xC6, 0xC6, 0xD6, 0x7C, 0x6C, 0x00], // U+0077 'w'
+    [0x00, 0x00, 0xC6, 0x6C, 0x38, 0x6C, 0xC6, 0x00], // U+0078 'x'
+    [0x00, 0x00, 0x66, 0x66, 0x66, 0x3E, 0x06, 0x3C], // U+0079 'y'
+    [0x00, 0x00, 0x7E, 0x0C, 0x18, 0x30, 0x7E, 0x00], // U+007A 'z'
+    [0x0E, 0x18, 0x18, 0x70, 0x18, 0x18, 0x0E, 0x00], // U+007B '{'
+    [0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x00], // U+007C '|'
+    [0x70, 0x18, 0x18, 0x0E, 0x18, 0x18, 0x70, 0x00], // U+007D '}'
+    [0x76, 0xDC, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], // U+007E '~'
+    [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], // U+007F DEL (blank)
+];
+
+/// Top-left corner of `character`'s glyph (inside its padding), in atlas pixels.
+///
+/// `None` only for a codepoint outside the table. A blank-but-present glyph
+/// (the space) still returns its cell: the text renderer skips a character
+/// whose info is `None` *without advancing the pen*, so returning `None` for a
+/// space would collapse it.
+fn glyph_origin(character: char) -> Option<(u32, u32)> {
+    let index = (character as u32).checked_sub(FIRST_CHAR)?;
+    if index >= ATLAS_COLUMNS * ATLAS_ROWS {
+        return None;
+    }
+    let column = index % ATLAS_COLUMNS;
+    let row = index / ATLAS_COLUMNS;
+    Some((
+        column * CELL_PIXELS + CELL_PADDING,
+        row * CELL_PIXELS + CELL_PADDING,
+    ))
+}
+
+/// Metrics for `character`: the UV rect of its glyph and how far it advances
+/// the pen. Pure, so the metrics are testable without a GL context.
+fn character_info(character: char) -> Option<FontCharacterInfo> {
+    let (origin_x, origin_y) = glyph_origin(character)?;
+    // The padding is never sampled, so the UV rect is the exact glyph
+    // rectangle - no half-texel inset needed to keep neighbours out.
+    Some(FontCharacterInfo {
+        min_uv_x: origin_x as f32 / ATLAS_WIDTH as f32,
+        max_uv_x: (origin_x + GLYPH_PIXELS) as f32 / ATLAS_WIDTH as f32,
+        min_uv_y: origin_y as f32 / ATLAS_HEIGHT as f32,
+        max_uv_y: (origin_y + GLYPH_PIXELS) as f32 / ATLAS_HEIGHT as f32,
+        // Self-spacing square cells, so the advance is the glyph box.
+        advance: GLYPH_PIXELS as f32,
+    })
+}
+
+/// Expand the glyph table into an RGBA atlas: white where a glyph pixel is set,
+/// transparent black elsewhere, so a tint multiply colors the text and the
+/// alpha blend leaves the cell background alone.
+///
+/// Pure - no GL - so the packing is unit-testable headlessly.
+pub fn atlas_texture_data() -> RawTextureData {
+    let mut bytes = vec![0u8; (ATLAS_WIDTH * ATLAS_HEIGHT * 4) as usize];
+    for (index, bitmap) in GLYPHS.iter().enumerate() {
+        let column = index as u32 % ATLAS_COLUMNS;
+        let row = index as u32 / ATLAS_COLUMNS;
+        let origin_x = column * CELL_PIXELS + CELL_PADDING;
+        let origin_y = row * CELL_PIXELS + CELL_PADDING;
+        for (bitmap_row, pixels) in bitmap.iter().enumerate() {
+            for bitmap_column in 0..GLYPH_PIXELS {
+                if pixels >> (GLYPH_PIXELS - 1 - bitmap_column) & 1 == 0 {
+                    continue;
+                }
+                let x = origin_x + bitmap_column;
+                let y = origin_y + bitmap_row as u32;
+                let offset = ((y * ATLAS_WIDTH + x) * 4) as usize;
+                bytes[offset..offset + 4].copy_from_slice(&[255, 255, 255, 255]);
+            }
+        }
+    }
+
+    RawTextureData {
+        bytes,
+        width: ATLAS_WIDTH,
+        height: ATLAS_HEIGHT,
+        format: PixelFormat::RGBA,
+    }
+}
+
+/// The compiled-in fallback font. See the module docs.
+pub struct BuiltinFont {
+    texture: Rc<Texture>,
+}
+
+impl BuiltinFont {
+    /// Upload the glyph atlas and build the font. Requires a current GL context.
+    pub fn new() -> BuiltinFont {
+        BuiltinFont {
+            texture: Rc::new(texture::init_from_memory(atlas_texture_data())),
+        }
+    }
+}
+
+impl Font for BuiltinFont {
+    fn get_texture(&self) -> Rc<dyn TextureTrait> {
+        self.texture.clone()
+    }
+
+    fn base_height(&self) -> f32 {
+        GLYPH_PIXELS as f32
+    }
+
+    fn get_half_pixel(&self) -> f32 {
+        0.5 / ATLAS_WIDTH as f32
+    }
+
+    fn get_character_info(&self, c: char) -> Option<FontCharacterInfo> {
+        character_info(c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pixel(data: &RawTextureData, x: u32, y: u32) -> [u8; 4] {
+        let offset = ((y * data.width + x) * 4) as usize;
+        data.bytes[offset..offset + 4].try_into().unwrap()
+    }
+
+    /// Pins the attribution: these rows are upstream `unscii-8.hex` verbatim, so
+    /// an edit or font swap cannot quietly drift from the license reasoning in
+    /// the module docs.
+    #[test]
+    fn the_table_matches_upstream_unscii_8() {
+        // 00041:183C66667E666600
+        assert_eq!(
+            GLYPHS[('A' as usize) - 0x20],
+            [0x18, 0x3C, 0x66, 0x66, 0x7E, 0x66, 0x66, 0x00]
+        );
+        // 00020: blank
+        assert_eq!(GLYPHS[0], [0x00; 8]);
+        // 0007A:00007E0C18307E00
+        assert_eq!(
+            GLYPHS[('z' as usize) - 0x20],
+            [0x00, 0x00, 0x7E, 0x0C, 0x18, 0x30, 0x7E, 0x00]
+        );
+    }
+
+    #[test]
+    fn atlas_is_a_full_grid_of_padded_cells() {
+        let data = atlas_texture_data();
+        assert_eq!((data.width, data.height), (160, 60));
+        assert_eq!(data.bytes.len(), (160 * 60 * 4) as usize);
+        assert_eq!(GLYPHS.len(), (ATLAS_COLUMNS * ATLAS_ROWS) as usize);
+    }
+
+    /// The whole point of the padding: with `GL_LINEAR` magnification, a lit
+    /// pixel at a glyph's edge must not sit against the next cell's glyph.
+    #[test]
+    fn every_cell_is_surrounded_by_transparent_padding() {
+        let data = atlas_texture_data();
+        for row in 0..ATLAS_ROWS {
+            for column in 0..ATLAS_COLUMNS {
+                let x = column * CELL_PIXELS;
+                let y = row * CELL_PIXELS;
+                for offset in 0..CELL_PIXELS {
+                    // Top and left border of every cell.
+                    assert_eq!(pixel(&data, x + offset, y), [0, 0, 0, 0]);
+                    assert_eq!(pixel(&data, x, y + offset), [0, 0, 0, 0]);
+                }
+            }
+        }
+    }
+
+    /// Bit order: the most significant bit of a row byte is its leftmost pixel.
+    #[test]
+    fn glyph_bits_expand_most_significant_bit_first() {
+        let data = atlas_texture_data();
+        // 'A' is 0x18 on its top row: bits 3 and 4 set, so within the glyph the
+        // lit pixels of that row are columns 3 and 4.
+        let (origin_x, origin_y) = glyph_origin('A').unwrap();
+        assert_eq!(pixel(&data, origin_x + 3, origin_y), [255, 255, 255, 255]);
+        assert_eq!(pixel(&data, origin_x + 4, origin_y), [255, 255, 255, 255]);
+        assert_eq!(pixel(&data, origin_x + 2, origin_y), [0, 0, 0, 0]);
+    }
+
+    /// A space draws nothing but must still advance, because the text renderer
+    /// drops a `None` character *without* moving the pen.
+    #[test]
+    fn space_has_metrics_so_it_is_not_collapsed() {
+        let space = character_info(' ').expect("space must have metrics");
+        assert_eq!(space.advance, GLYPH_PIXELS as f32);
+    }
+
+    #[test]
+    fn characters_outside_printable_ascii_have_no_metrics() {
+        assert!(character_info('\u{00E9}').is_none());
+        assert!(character_info('\u{0080}').is_none());
+        assert!(character_info('\n').is_none());
+    }
+
+    #[test]
+    fn glyph_uvs_stay_inside_their_own_cell() {
+        let a = character_info('A').unwrap();
+        // One glyph box wide/tall, exactly.
+        let width = (a.max_uv_x - a.min_uv_x) * ATLAS_WIDTH as f32;
+        let height = (a.max_uv_y - a.min_uv_y) * ATLAS_HEIGHT as f32;
+        assert!((width - GLYPH_PIXELS as f32).abs() < 1e-4);
+        assert!((height - GLYPH_PIXELS as f32).abs() < 1e-4);
+        // 'A' is cell 33: column 1, row 2. Its glyph starts one pixel in.
+        assert_eq!(
+            glyph_origin('A'),
+            Some((1 * CELL_PIXELS + 1, 2 * CELL_PIXELS + 1))
+        );
+    }
+}

--- a/engine/src/builtin_font.rs
+++ b/engine/src/builtin_font.rs
@@ -24,8 +24,9 @@
 //! 00041:183C66667E666600          # == GLYPHS[0x41 - 0x20], the 'A' row below
 //! ```
 //!
-//! `the_table_matches_upstream_unscii_8` pins specific rows so a future edit or
-//! font swap cannot quietly drift from that attribution.
+//! `the_table_matches_upstream_unscii_8` pins specific rows, so an edit to the
+//! table fails a test rather than silently drifting from that attribution. The
+//! full 95-row table was diffed against upstream when it was added.
 //!
 //! # Layout
 //!
@@ -37,9 +38,11 @@
 //! column. The border is padding only: UVs address the inner 8x8, so the glyph
 //! metrics are unchanged by it.
 //!
-//! Unscii left-aligns glyphs in the cell and leaves the rightmost column (and,
-//! for characters without a descender, the bottom row) blank, so the cell is
-//! self-spacing: one advance equals one cell, and the font is monospace.
+//! The font is monospace: one advance is `GLYPH_PIXELS`, the *unpadded* glyph
+//! box (not `CELL_PIXELS`, which includes the border). Unscii left-aligns
+//! glyphs and most leave their rightmost column blank, which is what supplies
+//! letter spacing - but a few (`*`, `/`, `X`, `Y`, `\`, `_`) do reach column 7,
+//! so adjacent glyphs can touch. That is upstream's design, not a packing bug.
 
 use std::rc::Rc;
 
@@ -48,7 +51,7 @@ use crate::texture::{self, Texture, TextureTrait};
 use crate::texture_format::{PixelFormat, RawTextureData};
 
 /// Side length of one glyph, in pixels.
-pub const GLYPH_PIXELS: u32 = 8;
+const GLYPH_PIXELS: u32 = 8;
 /// Transparent border around each glyph, in pixels. See the module docs.
 const CELL_PADDING: u32 = 1;
 /// Side length of one atlas cell: the glyph plus its border on both sides.
@@ -61,9 +64,9 @@ const ATLAS_ROWS: u32 = 6;
 const FIRST_CHAR: u32 = 0x20;
 
 /// Atlas width in pixels.
-pub const ATLAS_WIDTH: u32 = ATLAS_COLUMNS * CELL_PIXELS;
+const ATLAS_WIDTH: u32 = ATLAS_COLUMNS * CELL_PIXELS;
 /// Atlas height in pixels.
-pub const ATLAS_HEIGHT: u32 = ATLAS_ROWS * CELL_PIXELS;
+const ATLAS_HEIGHT: u32 = ATLAS_ROWS * CELL_PIXELS;
 
 /// One byte per pixel row, most significant bit leftmost.
 #[rustfmt::skip]
@@ -189,8 +192,10 @@ fn glyph_origin(character: char) -> Option<(u32, u32)> {
 /// the pen. Pure, so the metrics are testable without a GL context.
 fn character_info(character: char) -> Option<FontCharacterInfo> {
     let (origin_x, origin_y) = glyph_origin(character)?;
-    // The padding is never sampled, so the UV rect is the exact glyph
-    // rectangle - no half-texel inset needed to keep neighbours out.
+    // Exact texel boundaries, with no half-texel inset: magnified linear
+    // sampling reaches at most half a texel past the rect, and what it reaches
+    // into is this glyph's own transparent border, so no neighbour can bleed
+    // in.
     Some(FontCharacterInfo {
         min_uv_x: origin_x as f32 / ATLAS_WIDTH as f32,
         max_uv_x: (origin_x + GLYPH_PIXELS) as f32 / ATLAS_WIDTH as f32,
@@ -201,13 +206,24 @@ fn character_info(character: char) -> Option<FontCharacterInfo> {
     })
 }
 
-/// Expand the glyph table into an RGBA atlas: white where a glyph pixel is set,
-/// transparent black elsewhere, so a tint multiply colors the text and the
-/// alpha blend leaves the cell background alone.
+/// Expand the glyph table into an RGBA atlas: every texel is white, and
+/// coverage lives entirely in the alpha channel.
+///
+/// The colour matters even where nothing is drawn. Blending is
+/// non-premultiplied (`SRC_ALPHA, ONE_MINUS_SRC_ALPHA`) and the text shader
+/// multiplies the tint by the sample, so a `GL_LINEAR` tap halfway between a
+/// lit and an unlit texel returns the average of both channels. Were the unlit
+/// texels transparent *black*, that tap would come back at half alpha and half
+/// brightness, fringing every magnified glyph edge with a dark halo. Keeping
+/// RGB white everywhere makes the interpolation touch alpha only. This is the
+/// same convention the `.FON` loader uses (`dark/src/font.rs`).
 ///
 /// Pure - no GL - so the packing is unit-testable headlessly.
-pub fn atlas_texture_data() -> RawTextureData {
-    let mut bytes = vec![0u8; (ATLAS_WIDTH * ATLAS_HEIGHT * 4) as usize];
+fn atlas_texture_data() -> RawTextureData {
+    let mut bytes = vec![255u8; (ATLAS_WIDTH * ATLAS_HEIGHT * 4) as usize];
+    for texel in bytes.chunks_exact_mut(4) {
+        texel[3] = 0;
+    }
     for (index, bitmap) in GLYPHS.iter().enumerate() {
         let column = index as u32 % ATLAS_COLUMNS;
         let row = index as u32 / ATLAS_COLUMNS;
@@ -220,8 +236,9 @@ pub fn atlas_texture_data() -> RawTextureData {
                 }
                 let x = origin_x + bitmap_column;
                 let y = origin_y + bitmap_row as u32;
+                // RGB is already white; coverage is alpha alone.
                 let offset = ((y * ATLAS_WIDTH + x) * 4) as usize;
-                bytes[offset..offset + 4].copy_from_slice(&[255, 255, 255, 255]);
+                bytes[offset + 3] = 255;
             }
         }
     }
@@ -239,6 +256,9 @@ pub struct BuiltinFont {
     texture: Rc<Texture>,
 }
 
+// No `Default`: constructing this uploads a texture, which needs a current GL
+// context - not something a `Default::default()` caller would expect.
+#[allow(clippy::new_without_default)]
 impl BuiltinFont {
     /// Upload the glyph atlas and build the font. Requires a current GL context.
     pub fn new() -> BuiltinFont {
@@ -275,9 +295,10 @@ mod tests {
         data.bytes[offset..offset + 4].try_into().unwrap()
     }
 
-    /// Pins the attribution: these rows are upstream `unscii-8.hex` verbatim, so
-    /// an edit or font swap cannot quietly drift from the license reasoning in
-    /// the module docs.
+    /// These rows are upstream `unscii-8.hex` verbatim. This detects an *edit* to
+    /// the table; it does not re-derive it from upstream, so it cannot catch a
+    /// wholesale swap to a differently-licensed font. Re-check by hand against
+    /// the URL in the module docs if the provenance is ever in question.
     #[test]
     fn the_table_matches_upstream_unscii_8() {
         // 00041:183C66667E666600
@@ -304,19 +325,40 @@ mod tests {
 
     /// The whole point of the padding: with `GL_LINEAR` magnification, a lit
     /// pixel at a glyph's edge must not sit against the next cell's glyph.
+    ///
+    /// Scans the whole atlas rather than sampling each cell's leading edge, so
+    /// an origin or stride error shows up as a lit pixel in a border.
     #[test]
-    fn every_cell_is_surrounded_by_transparent_padding() {
+    fn no_glyph_pixel_escapes_its_padded_cell() {
         let data = atlas_texture_data();
-        for row in 0..ATLAS_ROWS {
-            for column in 0..ATLAS_COLUMNS {
-                let x = column * CELL_PIXELS;
-                let y = row * CELL_PIXELS;
-                for offset in 0..CELL_PIXELS {
-                    // Top and left border of every cell.
-                    assert_eq!(pixel(&data, x + offset, y), [0, 0, 0, 0]);
-                    assert_eq!(pixel(&data, x, y + offset), [0, 0, 0, 0]);
+        for y in 0..ATLAS_HEIGHT {
+            for x in 0..ATLAS_WIDTH {
+                let inside_x = (x % CELL_PIXELS) >= CELL_PADDING
+                    && (x % CELL_PIXELS) < CELL_PADDING + GLYPH_PIXELS;
+                let inside_y = (y % CELL_PIXELS) >= CELL_PADDING
+                    && (y % CELL_PIXELS) < CELL_PADDING + GLYPH_PIXELS;
+                if !(inside_x && inside_y) {
+                    assert_eq!(
+                        pixel(&data, x, y),
+                        [255, 255, 255, 0],
+                        "lit or non-white texel in the border at ({x}, {y})"
+                    );
                 }
             }
+        }
+    }
+
+    /// Unlit texels must be white with zero alpha, not transparent black:
+    /// blending is non-premultiplied, so black would darken every magnified
+    /// glyph edge as `GL_LINEAR` interpolates toward it.
+    #[test]
+    fn unlit_texels_are_white_with_zero_alpha() {
+        let data = atlas_texture_data();
+        let (origin_x, origin_y) = glyph_origin('A').unwrap();
+        // 'A' row 0 is 0x18 - columns 3 and 4 lit, so column 0 is unlit.
+        assert_eq!(pixel(&data, origin_x, origin_y), [255, 255, 255, 0]);
+        for texel in data.bytes.chunks_exact(4) {
+            assert_eq!(&texel[0..3], &[255, 255, 255], "every texel is white");
         }
     }
 
@@ -329,7 +371,7 @@ mod tests {
         let (origin_x, origin_y) = glyph_origin('A').unwrap();
         assert_eq!(pixel(&data, origin_x + 3, origin_y), [255, 255, 255, 255]);
         assert_eq!(pixel(&data, origin_x + 4, origin_y), [255, 255, 255, 255]);
-        assert_eq!(pixel(&data, origin_x + 2, origin_y), [0, 0, 0, 0]);
+        assert_eq!(pixel(&data, origin_x + 2, origin_y), [255, 255, 255, 0]);
     }
 
     /// A space draws nothing but must still advance, because the text renderer

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod assets;
 pub mod audio;
-pub mod builtin_font;
+mod builtin_font;
 pub mod dds;
 mod engine;
 pub mod file_system;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assets;
 pub mod audio;
+pub mod builtin_font;
 pub mod dds;
 mod engine;
 pub mod file_system;
@@ -17,6 +18,7 @@ pub mod texture_atlas;
 pub mod texture_format;
 pub mod util;
 
+pub use crate::builtin_font::BuiltinFont;
 pub use crate::engine::Engine;
 pub use crate::engine::EngineRenderContext;
 pub use crate::font::{Font, FontCharacterInfo, ellipsize, measure_text_width};


### PR DESCRIPTION
## Summary

Adds a bitmap font compiled into the `engine` binary.

Every font the game draws today is loaded from the retail data (`METAFONT.FON`
and friends, out of `intrface.crf` or the 25AE KPFs). That is fine until the thing
we need to draw is **"your game data is missing"** — the screen that has to work
precisely when the asset cache has nothing to give. This font is always available
because it isn't an asset.

Prerequisite only: **nothing constructs `BuiltinFont` yet.** The consumer is the
missing-assets screen, which follows.

## Choices worth reviewing

- **unscii-8**, printable-ASCII subset, stored as a plain byte table so it diffs and
  reviews like code. Public domain — only the separate `unscii-16-full` variant
  carries a GPL obligation (it embeds GNU Unifont); the 8x8 variant does not.
- **1px transparent border per cell.** `texture::init_from_memory` uploads with
  `GL_LINEAR`, and this font draws well above 1:1, so unpadded cells would bleed the
  neighbouring glyph's column under magnified sampling. UVs address the inner 8x8, so
  the border costs nothing in metrics.
- **Coverage lives in alpha over white RGB**, never transparent black — see below.
- **Space returns metrics rather than `None`.** `scene_object::text_vertices` drops a
  character with no info *without advancing the pen*, so a `None` space would collapse
  it. (This is a deliberate divergence from the equivalent code in tommy-xr/functor,
  where the renderer advances separately.)

## Verification

`cargo test -p engine` — 53 pass. `cargo fmt --all --check`, `cargo clippy -p engine`
(no findings in the new file), `RUSTFLAGS="-D warnings" cargo check -p shock2vr
-p desktop_runtime -p debug_runtime`, and `cargo apk check` all clean.

Per the repo's testing rule, the tests were confirmed to fail without the code they
cover: setting `CELL_PADDING` to 0 fails 3, and reverting the alpha fix fails 3.

The generated atlas was rendered and read back to confirm the table expands to
legible, correctly-ordered glyphs — a systematic packing or bit-order error would not
be caught by asserting on three characters:

![Generated glyph atlas](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/atlas-check.png)

<sub>The atlas as produced by `atlas_texture_data()`, alpha channel shown, nearest-neighbour
upscaled 6x. Full printable ASCII, U+0020..U+007F, 16x6 cells.</sub>

## Review findings applied

`/xreview` ran three reviewers. The headline finding was raised **independently by both
engines**, and it was a real bug:

> Unlit atlas texels were transparent **black**. Blending is non-premultiplied and the
> text shader multiplies tint by sample, so a `GL_LINEAR` tap between a lit and an unlit
> texel returned half alpha *and* half brightness — a dark halo around every magnified
> glyph edge, not merely at cell borders. The `.FON` loader already avoids this by
> writing white RGB at zero alpha; this now does the same.

Notably, the comment justifying the UV rect claimed "the padding is never sampled" —
exactly backwards, since the border exists *because* sampling reaches into it. That
inverted reasoning is what concealed the bug, so the comment is corrected too.

Also applied: a docs claim that every glyph leaves its rightmost column blank was wrong
for six glyphs; one test asserted only each cell's top row and left column, both true by
construction and therefore unable to fail, now replaced with a whole-atlas scan; the
public surface is narrowed to `BuiltinFont`; and the upstream-table test no longer
overclaims — it detects an edit, it does not re-derive from upstream.

The de-dup pass returned "No actionable duplication" across all four strategies. It
confirmed `TexturePacker` is the engine's existing glyph packer but that reuse is
genuinely blocked here: `TextureAtlas` is private and exits only via `generate_texture()`,
which calls GL, so it cannot yield the pure `RawTextureData` these headless tests assert
on — and it packs edge-to-edge with no padding hook, which is the exact bleed this code
exists to prevent.

During review the full 95-row table was diffed against upstream `unscii-8.hex`:
**zero mismatches**.

