### PR TITLE
fix(ai): let solid entity cover block sight

### DIFF
--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4443,8 +4443,11 @@ impl PhysicsWorld {
     }
 
     /// Raycast with living-actor membership while allowing the caller to
-    /// reject individual entity colliders. World geometry (which may not have
-    /// an ECS owner) is always retained. This is the visibility-query path:
+    /// reject individual entity colliders. The filter is consulted only for
+    /// colliders that carry an entity id, so ownerless colliders - world
+    /// geometry among them - are retained without being offered to it; an
+    /// entity-owned collider is subject to the filter whatever it represents.
+    /// This is the visibility-query path:
     /// actor membership naturally skips interaction-only bounds that do not
     /// block creatures, while the entity filter can pass through authored
     /// transparent objects without changing projectile or selection rays.

--- a/shock2vr/src/physics/mod.rs
+++ b/shock2vr/src/physics/mod.rs
@@ -4414,6 +4414,7 @@ impl PhysicsWorld {
             collision_groups,
             entity_to_ignore,
             ignore_sensors,
+            None,
         )
     }
 
@@ -4437,6 +4438,35 @@ impl PhysicsWorld {
             collision_groups,
             entity_to_ignore,
             ignore_sensors,
+            None,
+        )
+    }
+
+    /// Raycast with living-actor membership while allowing the caller to
+    /// reject individual entity colliders. World geometry (which may not have
+    /// an ECS owner) is always retained. This is the visibility-query path:
+    /// actor membership naturally skips interaction-only bounds that do not
+    /// block creatures, while the entity filter can pass through authored
+    /// transparent objects without changing projectile or selection rays.
+    pub fn ray_cast2_as_actor_with_entity_filter(
+        &self,
+        start_point: Point3<f32>,
+        direction: Vector3<f32>,
+        max_toi: f32,
+        collision_groups: InternalCollisionGroups,
+        entity_to_ignore: Option<EntityId>,
+        ignore_sensors: bool,
+        entity_filter: &dyn Fn(EntityId) -> bool,
+    ) -> Option<RayCastResult> {
+        self.ray_cast2_with_memberships(
+            InternalCollisionGroups::ACTOR,
+            start_point,
+            direction,
+            max_toi,
+            collision_groups,
+            entity_to_ignore,
+            ignore_sensors,
+            Some(entity_filter),
         )
     }
 
@@ -4449,6 +4479,7 @@ impl PhysicsWorld {
         collision_groups: InternalCollisionGroups,
         entity_to_ignore: Option<EntityId>,
         ignore_sensors: bool,
+        entity_filter: Option<&dyn Fn(EntityId) -> bool>,
     ) -> Option<RayCastResult> {
         // Guard against degenerate rays. A zero-length direction normalizes to
         // NaN, and a NaN/zero ray direction sends parry's `clip_aabb_line` down
@@ -4493,6 +4524,11 @@ impl PhysicsWorld {
             let data = collider.user_data;
             let maybe_entity_id = EntityId::from_inner(data as u64);
             if maybe_entity_id == entity_to_ignore {
+                return false;
+            }
+            if let (Some(entity_id), Some(entity_filter)) = (maybe_entity_id, entity_filter)
+                && !entity_filter(entity_id)
+            {
                 return false;
             }
             // A degenerate collider (zero-extent / non-finite AABB, e.g.

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -846,6 +846,20 @@ fn resolve_proxy_entity(world: &World, entity_id: EntityId) -> EntityId {
 /// surfaces that remain, fully rendered objects occlude while authored alpha
 /// (the Windows archetype is 0.45) and non-rendered helpers pass sight. Proxy
 /// hitboxes are classified through their visible owner.
+///
+/// Creatures never occlude, in any state. A packmate's capsule must not hide
+/// the player from the AI behind it - a pack closing on the player would blind
+/// everything but its front rank, leaving sight stricter than line of fire -
+/// and the same has to hold once that packmate dies, or an AI would see
+/// through the body standing up and be blinded by it a second later. Corpses
+/// and ragdoll limbs are `SELECTABLE` rather than `ACTOR`, so deciding this
+/// here rather than by dropping `ACTOR` from the collision mask is what covers
+/// every state from one place. The original engine's sight cast tests world
+/// geometry plus an explicit list of vision-blocking objects (doors and
+/// anything authored to block AI vision); creatures are never in it. Line of
+/// FIRE stays stricter and keeps reasoning about allies (see
+/// `has_line_of_fire`): a packmate does not hide the player, but it is still a
+/// reason not to shoot.
 fn entity_occludes_sight(
     world: &World,
     observer: EntityId,
@@ -854,6 +868,14 @@ fn entity_occludes_sight(
 ) -> bool {
     let entity_id = resolve_proxy_entity(world, hit_entity);
     if entity_id == observer || entity_id == target {
+        return false;
+    }
+
+    let is_creature = world
+        .borrow::<View<PropCreature>>()
+        .map(|creatures| creatures.contains(entity_id))
+        .unwrap_or(false);
+    if is_creature {
         return false;
     }
 
@@ -1489,6 +1511,43 @@ mod sight_occlusion_tests {
         assert!(
             !player_is_in_line_of_fire(&scene),
             "transparent physical cover must keep the projectile gate unchanged"
+        );
+    }
+
+    #[test]
+    fn a_living_creature_does_not_occlude_sight_but_does_block_the_shot() {
+        let mut scene = sight_scene(CollisionGroup::actor());
+        scene.world.add_component(
+            scene.blocker,
+            (PropCreature(0), PropHitPoints { hit_points: 10 }),
+        );
+
+        assert!(
+            player_is_visible(&scene),
+            "a packmate standing in the way must not hide the player"
+        );
+        assert!(
+            !player_is_in_line_of_fire(&scene),
+            "a living ally in the way must still suppress the shot"
+        );
+    }
+
+    /// A corpse keeps its creature identity but swaps `ACTOR` membership for
+    /// `SELECTABLE`. Today it is already unreachable by an actor-membership
+    /// ray, so this passes for two independent reasons - it is here to catch a
+    /// future regrouping that puts bodies back in the ray's path and leaves an
+    /// AI seeing through a packmate standing up but blinded by its corpse.
+    #[test]
+    fn a_creature_corpse_does_not_occlude_sight_either() {
+        let mut scene = sight_scene(CollisionGroup::corpse());
+        scene.world.add_component(
+            scene.blocker,
+            (PropCreature(0), PropHitPoints { hit_points: 0 }),
+        );
+
+        assert!(
+            player_is_visible(&scene),
+            "a body on the floor must not hide the player any more than it did standing"
         );
     }
 

--- a/shock2vr/src/scripts/ai/ai_util.rs
+++ b/shock2vr/src/scripts/ai/ai_util.rs
@@ -826,6 +826,88 @@ fn is_player_psi_invisible(world: &World) -> bool {
         .unwrap_or(false)
 }
 
+const SIGHT_COLLISION_GROUPS: InternalCollisionGroups = InternalCollisionGroups::WORLD
+    .union(InternalCollisionGroups::ENTITIES)
+    .union(InternalCollisionGroups::SELECTABLE);
+
+fn resolve_proxy_entity(world: &World, entity_id: EntityId) -> EntityId {
+    world
+        .borrow::<View<RuntimePropProxyEntity>>()
+        .ok()
+        .and_then(|v| v.get(entity_id).ok().map(|proxy| proxy.0))
+        .unwrap_or(entity_id)
+}
+
+/// Whether an entity-backed physical surface should stop an AI sight ray.
+///
+/// The ray itself uses actor membership, so model-bounds colliders authored
+/// only for frobbing/selecting are already excluded by the same collision
+/// filter that lets creatures walk through them. Of the genuinely physical
+/// surfaces that remain, fully rendered objects occlude while authored alpha
+/// (the Windows archetype is 0.45) and non-rendered helpers pass sight. Proxy
+/// hitboxes are classified through their visible owner.
+fn entity_occludes_sight(
+    world: &World,
+    observer: EntityId,
+    target: EntityId,
+    hit_entity: EntityId,
+) -> bool {
+    let entity_id = resolve_proxy_entity(world, hit_entity);
+    if entity_id == observer || entity_id == target {
+        return false;
+    }
+
+    let is_not_rendered = world
+        .borrow::<View<PropRenderType>>()
+        .map(|render_types| {
+            render_types.get(entity_id).is_ok_and(|render_type| {
+                matches!(render_type.0, RenderType::NoRender | RenderType::EditorOnly)
+            })
+        })
+        .unwrap_or(false);
+    if is_not_rendered {
+        return false;
+    }
+
+    world
+        .borrow::<View<PropRenderAlpha>>()
+        .map(|render_alpha| {
+            render_alpha
+                .get(entity_id)
+                .map(|render_alpha| render_alpha.0 >= 1.0)
+                .unwrap_or(true)
+        })
+        .unwrap_or(true)
+}
+
+fn has_clear_sight_between(
+    observer: EntityId,
+    target: EntityId,
+    start_point: Point3<f32>,
+    end_point: Point3<f32>,
+    world: &World,
+    physics: &PhysicsWorld,
+) -> bool {
+    let to_target = end_point - start_point;
+    let distance_squared = to_target.magnitude2();
+    if distance_squared <= 1.0e-12 {
+        return true;
+    }
+    let distance = distance_squared.sqrt();
+    let occludes = |hit_entity| entity_occludes_sight(world, observer, target, hit_entity);
+    physics
+        .ray_cast2_as_actor_with_entity_filter(
+            start_point,
+            to_target / distance,
+            distance,
+            SIGHT_COLLISION_GROUPS,
+            Some(observer),
+            true,
+            &occludes,
+        )
+        .is_none()
+}
+
 /// Check if the player is visible from an entity (raycast only, no FOV check)
 ///
 /// This is a basic visibility check that only verifies line-of-sight.
@@ -841,21 +923,14 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
     if let Ok(ent_pos) = v_current_pos.get(from_entity) {
         let start_point = point3(0.0, 0.0, 0.0) + ent_pos.position;
         let end_point = point3(0.0, 0.0, 0.0) + u_player.pos;
-        let direction = (end_point - start_point).normalize();
-        let distance = (end_point - start_point).magnitude();
-        let result = physics.ray_cast2(
+        return has_clear_sight_between(
+            from_entity,
+            u_player.entity_id,
             start_point,
-            direction,
-            distance,
-            InternalCollisionGroups::WORLD,
-            Some(from_entity),
-            true,
+            end_point,
+            world,
+            physics,
         );
-
-        // If we didn't hit anything - player visible!
-        // Currently, the ray cast doesn't intersect player...
-        // TODO: Check for entities, but pass-through transparent ones (ie, glass/windows)
-        return result.is_none();
     };
 
     false
@@ -863,14 +938,14 @@ pub fn is_player_visible(from_entity: EntityId, world: &World, physics: &Physics
 
 /// Whether `from_entity` has a clear line of FIRE to `target` (its known
 /// aim point - see `chase_target`) - the occlusion gate for standing
-/// ranged attacks. Unlike `is_player_visible`
-/// (sight: WORLD geometry only), this also tests door and prop colliders,
-/// because projectiles collide with those - an AI allowed to stop and
-/// shoot through a closed door or a crate stands rooted firing into it
-/// for as long as its target stays known (issue #481's stand-and-shoot
-/// freeze). Living allies block the shot, while an enemy creature or the
-/// intended target counts as clear. This preserves pursuit/attack against
-/// enemies without letting converged ranged AIs shoot through their own side.
+/// ranged attacks. This intentionally remains stricter than sight: projectiles
+/// collide with transparent glass and small physical props too, so an AI
+/// allowed to stop and shoot through them stands rooted firing into the
+/// obstacle for as long as its target stays known (issue #481's
+/// stand-and-shoot freeze). Living allies block the shot, while an enemy
+/// creature or the intended target counts as clear. This preserves
+/// pursuit/attack against enemies without letting converged ranged AIs shoot
+/// through their own side.
 pub fn has_line_of_fire(
     from_entity: EntityId,
     world: &World,
@@ -933,11 +1008,7 @@ fn has_line_of_fire_from(
         Some(hit) => hit
             .maybe_entity_id
             .map(|id| {
-                let id = world
-                    .borrow::<View<RuntimePropProxyEntity>>()
-                    .ok()
-                    .and_then(|v| v.get(id).ok().map(|proxy| proxy.0))
-                    .unwrap_or(id);
+                let id = resolve_proxy_entity(world, id);
                 if target_entity == id {
                     return true;
                 }
@@ -1054,18 +1125,14 @@ pub fn is_player_visible_in_fov(
         // Player is in FOV, now check line-of-sight
         let start_point = point3(0.0, 0.0, 0.0) + entity_pos;
         let end_point = point3(0.0, 0.0, 0.0) + player_pos;
-        let direction = (end_point - start_point).normalize();
-        let distance = (end_point - start_point).magnitude();
-        let result = physics.ray_cast2(
+        return has_clear_sight_between(
+            from_entity,
+            u_player.entity_id,
             start_point,
-            direction,
-            distance,
-            InternalCollisionGroups::WORLD,
-            Some(from_entity),
-            true,
+            end_point,
+            world,
+            physics,
         );
-
-        return result.is_none();
     };
 
     false
@@ -1279,5 +1346,222 @@ mod line_of_fire_tests {
             &physics,
             vec3(0.0, 0.0, 5.0),
         ));
+    }
+}
+
+#[cfg(test)]
+mod sight_occlusion_tests {
+    use super::*;
+    use crate::{
+        mission::PlayerInfo,
+        physics::{CollisionGroup, PlayerHandle},
+    };
+
+    struct SightScene {
+        world: World,
+        physics: PhysicsWorld,
+        observer: EntityId,
+        blocker: EntityId,
+        player_handle: PlayerHandle,
+    }
+
+    fn identity_rotation() -> Quaternion<f32> {
+        Quaternion::from_sv(1.0, vec3(0.0, 0.0, 0.0))
+    }
+
+    fn sight_scene(group: CollisionGroup) -> SightScene {
+        let mut world = World::new();
+        let observer = world.add_entity(PropPosition {
+            position: vec3(0.0, 0.0, 0.0),
+            cell: 0,
+            rotation: identity_rotation(),
+        });
+        let blocker = world.add_entity(());
+        let player = world.add_entity(());
+        let inventory = world.add_entity(());
+        world.add_unique(PlayerInfo {
+            pos: vec3(0.0, 0.0, 10.0),
+            rotation: identity_rotation(),
+            entity_id: player,
+            left_hand_entity_id: None,
+            right_hand_entity_id: None,
+            inventory_entity_id: inventory,
+        });
+
+        let mut physics = PhysicsWorld::new();
+        physics.add_kinematic(
+            blocker,
+            vec3(0.0, 0.0, 5.0),
+            identity_rotation(),
+            vec3(0.0, 0.0, 0.0),
+            vec3(1.0, 2.0, 1.0),
+            group,
+            false,
+        );
+        let mut player_handle = physics.create_player(vec3(50.0, 50.0, 50.0), player);
+        physics.update(vec3(0.0, 0.0, 0.0), &mut player_handle);
+
+        SightScene {
+            world,
+            physics,
+            observer,
+            blocker,
+            player_handle,
+        }
+    }
+
+    fn player_is_visible(scene: &SightScene) -> bool {
+        is_player_visible(scene.observer, &scene.world, &scene.physics)
+    }
+
+    fn player_is_in_line_of_fire(scene: &SightScene) -> bool {
+        has_line_of_fire(
+            scene.observer,
+            &scene.world,
+            &scene.physics,
+            vec3(0.0, 0.0, 10.0),
+        )
+    }
+
+    #[test]
+    fn opaque_solid_entity_occludes_sight() {
+        let scene = sight_scene(CollisionGroup::entity());
+
+        assert!(
+            !player_is_visible(&scene),
+            "a solid entity collider between the observer and player must block sight"
+        );
+    }
+
+    #[test]
+    fn opaque_cover_hands_ranged_attack_back_to_pursuit() {
+        let mut scene = sight_scene(CollisionGroup::entity());
+        scene.world.add_component(
+            scene.observer,
+            Links {
+                to_links: vec![ToLink {
+                    to_template_id: -1,
+                    to_entity_id: None,
+                    link: Link::AIRangedWeapon,
+                }],
+            },
+        );
+
+        assert!(
+            crate::scripts::ai::behavior::attack_behavior_for_distance(
+                &scene.world,
+                &scene.physics,
+                scene.observer,
+            )
+            .is_none(),
+            "closed cover must make the ranged behavior resume pursuit",
+        );
+
+        scene.physics.set_position_rotation2(
+            scene.blocker,
+            vec3(10.0, 0.0, 5.0),
+            identity_rotation(),
+        );
+        scene
+            .physics
+            .update(vec3(0.0, 0.0, 0.0), &mut scene.player_handle);
+
+        let behavior = crate::scripts::ai::behavior::attack_behavior_for_distance(
+            &scene.world,
+            &scene.physics,
+            scene.observer,
+        )
+        .expect("open line of fire should select the ranged attack");
+        assert_eq!(behavior.borrow().name(), "RangedAttack");
+    }
+
+    #[test]
+    fn authored_transparency_passes_sight_but_still_blocks_projectiles() {
+        let mut scene = sight_scene(CollisionGroup::entity());
+        scene
+            .world
+            .add_component(scene.blocker, PropRenderAlpha(0.45));
+
+        assert!(
+            player_is_visible(&scene),
+            "the shipped Windows alpha must remain transparent to sight"
+        );
+        assert!(
+            !player_is_in_line_of_fire(&scene),
+            "transparent physical cover must keep the projectile gate unchanged"
+        );
+    }
+
+    #[test]
+    fn interaction_only_selectable_bounds_do_not_occlude_sight() {
+        let scene = sight_scene(CollisionGroup::selectable().non_solid_to_characters());
+
+        assert!(
+            player_is_visible(&scene),
+            "a collider retained only for frobbing must not become visual cover"
+        );
+        assert!(
+            !player_is_in_line_of_fire(&scene),
+            "the generic projectile query must remain independent of sight"
+        );
+    }
+
+    #[test]
+    fn transparent_proxy_is_classified_through_its_owner() {
+        let mut scene = sight_scene(CollisionGroup::entity());
+        let visible_owner = scene.world.add_entity(PropRenderAlpha(0.45));
+        scene
+            .world
+            .add_component(scene.blocker, RuntimePropProxyEntity(visible_owner));
+
+        assert!(
+            player_is_visible(&scene),
+            "a transparent owner must not become opaque through a physics proxy"
+        );
+    }
+
+    #[test]
+    fn non_rendered_physics_helpers_do_not_occlude_sight() {
+        let mut scene = sight_scene(CollisionGroup::entity());
+        scene
+            .world
+            .add_component(scene.blocker, PropRenderType(RenderType::NoRender));
+
+        assert!(player_is_visible(&scene));
+    }
+
+    #[test]
+    fn a_closed_standard_door_occludes_and_its_open_pose_restores_sight() {
+        let mut scene = sight_scene(CollisionGroup::entity());
+        scene.world.add_component(
+            scene.blocker,
+            PropTranslatingDoor {
+                door_type: 0,
+                closed: 0.0,
+                open: 10.0,
+                speed: 1.0,
+                axis: 2,
+                state: 0,
+                base_closed_location: vec3(0.0, 0.0, 5.0),
+                base_open_location: vec3(10.0, 0.0, 5.0),
+                base_location: vec3(0.0, 0.0, 5.0),
+            },
+        );
+
+        assert!(!player_is_visible(&scene), "the closed door must occlude");
+
+        scene.physics.set_position_rotation2(
+            scene.blocker,
+            vec3(10.0, 0.0, 5.0),
+            identity_rotation(),
+        );
+        scene
+            .physics
+            .update(vec3(0.0, 0.0, 0.0), &mut scene.player_handle);
+
+        assert!(
+            player_is_visible(&scene),
+            "moving the door collider to its open pose must restore sight"
+        );
     }
 }

--- a/tools/shock2-sdk/test/medsci-sight-occlusion.e2e.test.ts
+++ b/tools/shock2-sdk/test/medsci-sight-occlusion.e2e.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GameServer } from "../src/index.js";
+import type { EntityDetailResult, EntitySummary, Vec3 } from "../src/index.js";
+
+const e2eEnabled = process.env.SHOCK2_E2E === "1";
+const basePort = Number(process.env.SHOCK2_E2E_PORT ?? 8560);
+
+// Stable MedSci2 mission-object identities. Runtime entity ids are assigned
+// afresh on every launch and are deliberately discovered below.
+const SOUTH_CATWALK_MONKEY = 437;
+const SOUTH_CATWALK_DOOR = 76;
+const SOUTH_CATWALK_WINDOW = 420;
+
+function property(detail: EntityDetailResult, name: string): string | undefined {
+  return detail.properties.find((candidate) => candidate.name === name)?.value;
+}
+
+async function soleMissionObject(
+  game: GameServer,
+  name: string,
+  missionObject: number,
+): Promise<EntitySummary> {
+  const entity = (await game.entities.list({ filter: name, limit: 100 })).entities.find(
+    (candidate) => candidate.template_id === missionObject,
+  );
+  assert.ok(entity, `MedSci2 mission object ${missionObject} (${name}) should exist`);
+  return entity;
+}
+
+async function waitForVisible(
+  game: GameServer,
+  entityId: number,
+  expected: boolean,
+  frames = 60,
+): Promise<EntityDetailResult> {
+  for (let frame = 0; frame < frames; frame += 5) {
+    await game.step({ frames: 5 });
+    const detail = await game.entities.detail(entityId);
+    if (property(detail, "AITargetVisible") === String(expected)) return detail;
+  }
+  const detail = await game.entities.detail(entityId);
+  assert.equal(
+    property(detail, "AITargetVisible"),
+    String(expected),
+    `entity ${entityId} did not publish visibility=${expected}`,
+  );
+  return detail;
+}
+
+test(
+  "MedSci2 entity door freezes a hidden monster target and opening clears it",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: basePort,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const monkey = await soleMissionObject(
+      game,
+      "Blue Monkey",
+      SOUTH_CATWALK_MONKEY,
+    );
+    const door = await soleMissionObject(
+      game,
+      "Sci Med Door",
+      SOUTH_CATWALK_DOOR,
+    );
+
+    const northOfDoor: Vec3 = [17.2, -0.356, -107.0];
+    const southOfDoor: Vec3 = [17.2, -0.356, -116.0];
+    const terrainRay = await game.raycast({
+      start: northOfDoor,
+      end: southOfDoor,
+      collision_groups: ["world"],
+      ignore_sensors: true,
+    });
+    assert.equal(terrainRay.hit, false, "terrain must leave the doorway open");
+
+    const projectileRay = await game.raycast({
+      start: northOfDoor,
+      end: southOfDoor,
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.equal(projectileRay.entity_id, door.id);
+
+    // First let the authored monkey acquire the player north of the closed
+    // door. Moving due south keeps the target in the same FOV; only the door
+    // changes the answer.
+    await game.player.teleport({ x: 17.2, y: 0.5, z: -107.0 });
+    await game.entities.sendMessage(monkey.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    const exposed = await waitForVisible(game, monkey.id, true);
+    const exposedLastKnown = property(exposed, "AILastKnown");
+    assert.ok(exposedLastKnown, "exposure should publish a last-known target");
+
+    await game.player.teleport({ x: 17.2, y: 0.5, z: -116.0 });
+    const hidden = await waitForVisible(game, monkey.id, false);
+    const hiddenLastKnown = property(hidden, "AILastKnown");
+    assert.ok(hiddenLastKnown, "losing sight should retain a last-known target");
+
+    // A second hidden coordinate must not leak through the cover. One frame
+    // isolates the awareness refresh from subsequent asynchronous pursuit.
+    await game.player.teleport({ x: 17.2, y: 0.5, z: -117.0 });
+    await game.step({ frames: 1 });
+    const movedBehindCover = await game.entities.detail(monkey.id);
+    assert.equal(property(movedBehindCover, "AITargetVisible"), "false");
+    assert.equal(property(movedBehindCover, "AILastKnown"), hiddenLastKnown);
+
+    // The same authored door slides fully out of the ray when frobbed. The
+    // production projectile mask remains unchanged: closed blocks, open does
+    // not.
+    await game.entities.sendMessage(door.id, { type: "TurnOn" });
+    await game.step({ frames: 90 });
+    const openRay = await game.raycast({
+      start: northOfDoor,
+      end: southOfDoor,
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.notEqual(openRay.entity_id, door.id, "open door must clear its doorway");
+
+    // Return to the unobstructed control point after proving that the authored
+    // open pose cleared the same ray; ordinary awareness must still resume.
+    await game.player.teleport({ x: 17.2, y: 0.5, z: -107.0 });
+    await game.entities.sendMessage(monkey.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    const reacquired = await waitForVisible(game, monkey.id, true, 180);
+    assert.notEqual(property(reacquired, "AILastKnown"), hiddenLastKnown);
+  },
+);
+
+test(
+  "MedSci2 transparent window preserves sight but still blocks projectiles",
+  { skip: !e2eEnabled, timeout: 600_000 },
+  async () => {
+    await using game = await GameServer.launch({
+      mission: "medsci2.mis",
+      port: basePort + 1,
+      debugFlags: ["--vr"],
+    });
+    await game.step({ frames: 5 });
+
+    const window = await soleMissionObject(
+      game,
+      "UBWindow",
+      SOUTH_CATWALK_WINDOW,
+    );
+
+    // Spawn the ordinary debug hybrid north of the authored glass while the
+    // player stands on the same sight line. Its initial facing therefore
+    // remains valid when the player moves to the far side of the pane.
+    const known = new Set(
+      (await game.entities.list({ filter: "OG-Pipe", limit: 50 })).entities.map(
+        (entity) => entity.id,
+      ),
+    );
+    await game.player.teleport({ x: 12.8, y: 0.5, z: -110.5 });
+    await game.input.set("head.look", [90, 0]);
+    await game.step({ frames: 15 });
+    await game.input.trigger("SpawnDebugMonster");
+    await game.step({ frames: 5 });
+    const hybrid = (
+      await game.entities.list({ filter: "OG-Pipe", limit: 50 })
+    ).entities.find((entity) => !known.has(entity.id));
+    assert.ok(hybrid, "SpawnDebugMonster should create the transparent-sight observer");
+
+    await game.player.teleport({ x: 12.8, y: 0.5, z: -116.0 });
+    await game.entities.sendMessage(hybrid.id, {
+      type: "SetAlertness",
+      level: "High",
+    });
+    const visibleThroughGlass = await waitForVisible(game, hybrid.id, true, 120);
+    assert.equal(property(visibleThroughGlass, "AITargetVisible"), "true");
+
+    const projectileRay = await game.raycast({
+      start: [12.8, 0.6, -107.0],
+      end: [12.8, 0.6, -116.0],
+      collision_groups: ["world", "entity", "selectable"],
+      ignore_sensors: true,
+    });
+    assert.equal(projectileRay.entity_id, window.id);
+  },
+);


### PR DESCRIPTION
## Summary

- make monster/camera/turret sight use an actor-membership ray across world, entity, and selectable collision groups
- classify entity hits through their visible proxy owner so opaque solid cover blocks sight while authored alpha, non-rendered helpers, and interaction-only bounds pass through
- **stop creatures from occluding sight, in any state**: a packmate's capsule hid the player from the AI behind it, so a pack closing on the player blinded everything but its front rank and sight ended up stricter than line of fire
- keep projectile line-of-fire stricter and unchanged: transparent physical glass and small props still stop shots, and a living ally still suppresses the shot
- correct the `ray_cast2_as_actor_with_entity_filter` doc comment: the filter is skipped for *ownerless* colliders, not for world geometry as such
- add negative-first unit coverage plus authored MedSci2 VR scenarios for the south-catwalk door and UBWindow

## Creatures never occlude

The original engine's sight cast tests world geometry plus an explicit list of vision-blocking objects (doors and anything authored to block AI vision); creatures are never in it.

This is decided in `entity_occludes_sight` rather than by dropping `ACTOR` from the collision mask. A corpse keeps its creature identity but swaps `ACTOR` membership for `SELECTABLE`, so a mask-level exemption would only cover the living — an AI would see through a packmate standing up and be blinded by the same body a second later. One rule, every state.

## Before → after

![AI entity-cover sight before/after](https://gist.githubusercontent.com/tommy-xr/440f936a4b781e6472d07ba4824517ee/raw/entity-sight-before-after.gif)

<sub>Same MedSci2 VR sequence on PR #980 and this fix: the baseline refreshes the live hidden target through the closed entity-backed door; the fixed query publishes no through-cover target. Captured headlessly via deterministic fixed-timestep `/v1/step` + `/v1/screenshot`.</sub>

![Labeled before/after still](https://gist.githubusercontent.com/tommy-xr/440f936a4b781e6472d07ba4824517ee/raw/entity-sight-before-after.png)

## Multi-point sight sampling: attempted, then backed out

Sight is still a single ray from the observer's origin to the player's origin. Multi-point sampling was implemented on this branch and **removed again**, because it is a real regression rather than a refinement, and it belongs in its own PR.

What was tried: rays starting at the observer's eye (placed at the same fraction of body height as the player's, from the observer's own authored body size) and aimed at several points on the player — body centre and eye height, each with lateral offsets taken perpendicular to the sight direction, sized from the player's live collider so they shrink when crouching. Visible if any ray is clear. That is a superset of the original engine's geometry, which raises the ray by an authored per-AI eye offset and aims at the player's head rather than the body origin.

Why it was backed out — measured, not assumed:

- `chase-last-seen.e2e.test.ts` and `search-behavior.e2e.test.ts` both **pass on the base commit and fail with sampling enabled**: the chasing AI abandons the last-seen position (1.44 → 8.64 units) and the searcher never begins its search.
- The failures are unchanged when the lateral offsets are halved, and unchanged when the observer eye offset is disabled entirely — so it is the **target-side** sampling, not the eye placement or the lateral width. The authored "no line of sight" pockets these scenarios rely on hide the player's body origin but not their head.

That is a genuine design question — either those pockets need re-authoring or the sampled set needs to be narrower than the player's real silhouette — and it should be settled with the scenarios in hand rather than tuned blind. Filed as follow-up work; this PR ships the two changes that are unambiguously correct.

Also noted while reviewing, deliberately out of scope: `has_line_of_fire` starts at the object origin rather than an eye, so sight and line of fire do not share one viewpoint.

## Validation

Negative-first — each fails with just its own change backed out:

- `opaque_solid_entity_occludes_sight` failed on PR #980 head `dd8e5030` because the entity collider was ignored
- `a_living_creature_does_not_occlude_sight_but_does_block_the_shot` fails without the creature exemption, and asserts the other half too: a living ally still suppresses the shot
- `a_creature_corpse_does_not_occlude_sight_either` is a forward-looking guard (a corpse is already unreachable by an actor-membership ray today, so it passes for two reasons — it catches a future regrouping that puts bodies back in the ray's path)

Plus:

- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`
- `cargo test -p shock2vr` — 725 passed
- `cargo test -p shock2vr scripts::ai::ai_util::sight_occlusion_tests` — 9 passed
- targeted e2e after the backout — `chase-last-seen`, `search-behavior`, `ai-reacquire`, `ally-line-of-fire`, `shodan-corpse-drift` — 7 passed, 0 failed
- full `npm run test:e2e` was run on the sampling version to catch the regression above
- rebased onto `main` @ `245cd692`
- reviewed by two independent adversarial reviewers; the corpse/living inversion they found is the reason the exemption lives in `entity_occludes_sight` rather than in the collision mask

Campaign configuration: earth-to-ops custom · Navy · 25th Anniversary · VR · seed 976894603.

Fixes #985
