### PR TITLE
chore(android): link a shared APK signing key into each checkout

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,11 +123,19 @@ cargo dr --release --experimental teleport
     - Add android target: `rustup target add aarch64-linux-android`
     - Install adb: `brew install android-platform-tools`
 
-- Create a `develop.keystore`. (ie, https://stackoverflow.com/questions/25975320/create-android-keystory-private-key-command-line)
-  - Make sure the password matches in the Cargo.toml file:
+- Create a `develop.keystore` for signing release APKs. Keep it **outside** the
+  repo - it is gitignored, so a copy inside one clone is invisible to every other
+  clone and worktree:
   ```sh
-  keytool -genkey -v -keystore develop.keystore -alias com_tommybuilds_shock2quest  -keyalg RSA -keysize 2048 -validity 10000
+  mkdir -p ~/.shock2quest
+  keytool -genkey -v -keystore ~/.shock2quest/develop.keystore \
+    -alias com_tommybuilds_shock2quest -keyalg RSA -keysize 2048 -validity 10000
   ```
+  - The password must match `keystore_password` in
+    `runtimes/oculus_runtime/Cargo.toml`.
+  - `set_up_android_sdk.sh` symlinks it into whichever checkout you source it
+    from, so each new clone or worktree picks it up with no extra step. Set
+    `SHOCK2QUEST_KEYSTORE` to keep it somewhere else.
 - Make sure [Developer Mode is enabled on your Quest device](https://www.reddit.com/r/OculusQuest/comments/17sa8n6/tutorial_quest_3_developer_mode_4_easy_steps/)
 - Make sure `adb` is installed and working. With Oculus connected, run `adb devices` and verify your headset shows up
 - Tweak `runtimes/oculus_runtime/set_up_android_sdk.sh` to match your paths

--- a/runtimes/oculus_runtime/set_up_android_sdk.sh
+++ b/runtimes/oculus_runtime/set_up_android_sdk.sh
@@ -71,3 +71,26 @@ echo "  PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
 echo "  CC: ${CC}"
 echo "  HOST_CC: ${HOST_CC}"
 echo "  CC_aarch64_apple_darwin: ${CC_aarch64_apple_darwin}"
+
+# --- APK signing key -------------------------------------------------------
+# `develop.keystore` is gitignored, so every fresh clone and every git worktree
+# starts without one and `cargo apk build --release` fails at the signing step
+# with a bare FileNotFoundException. Cargo.toml has to name a repo-relative path
+# (it is committed, so it cannot hold an absolute one), so keep the real key
+# outside the repo and link it in here. Override the location with
+# SHOCK2QUEST_KEYSTORE.
+KEYSTORE_SHARED="${SHOCK2QUEST_KEYSTORE:-$HOME/.shock2quest/develop.keystore}"
+KEYSTORE_LOCAL="$(pwd)/develop.keystore"
+if [ -e "${KEYSTORE_LOCAL}" ]; then
+  : # already present (a real file or a link from a previous run) - leave it be
+elif [ -f "${KEYSTORE_SHARED}" ]; then
+  ln -s "${KEYSTORE_SHARED}" "${KEYSTORE_LOCAL}"
+  echo "Linked develop.keystore -> ${KEYSTORE_SHARED}"
+else
+  echo "WARNING: no develop.keystore here, and none at ${KEYSTORE_SHARED}."
+  echo "  Debug builds are fine; release builds will fail to sign. Create one:"
+  echo "    mkdir -p \"$(dirname "${KEYSTORE_SHARED}")\""
+  echo "    keytool -genkey -v -keystore \"${KEYSTORE_SHARED}\" \\"
+  echo "      -alias com_tommybuilds_shock2quest -keyalg RSA -keysize 2048 -validity 10000"
+  echo "  The password must match keystore_password in runtimes/oculus_runtime/Cargo.toml."
+fi


### PR DESCRIPTION
## Summary

`develop.keystore` is gitignored, so **every fresh clone and every git worktree starts
without one**. `cargo apk build --release` then dies at the signing step with a bare
Java `FileNotFoundException` stack trace, which reads like a broken toolchain rather
than a missing file. (This bit me setting up a second checkout.)

`Cargo.toml` can't solve it — it's committed, so
`[package.metadata.android.signing.release] path` has to stay repo-relative and can't
point at a shared absolute location. cargo-apk doesn't expand env vars there either.

So the fix goes in the script every Android build already sources: keep one real key
at `~/.shock2quest/develop.keystore` and let `set_up_android_sdk.sh` symlink it into
whichever checkout it's sourced from. Override the location with `SHOCK2QUEST_KEYSTORE`.

## Behaviour

Three cases, all verified by hand:

| State | Result |
| --- | --- |
| Key already in the checkout (real file or link) | left untouched |
| No key here, shared key exists | symlinked in, one line of output |
| No key anywhere | warning + the exact `keytool` command, build continues |

The last case deliberately warns rather than failing: debug builds don't need signing,
and the script is sourced for every Android build, not just release ones. It also does
**not** auto-generate a key — the password has to match `keystore_password` in
`Cargo.toml`, so creating one should be a deliberate act.

## Verification

- Fresh `git worktree`: keystore absent before sourcing, symlinked after.
- `RUSTFLAGS="-D warnings" cargo apk build --release` signs successfully through the
  symlink in a checkout that has no real key of its own.
- Missing-key path prints the warning and the `keytool` command with the overridden
  path substituted correctly (`SHOCK2QUEST_KEYSTORE=/nonexistent/nope.keystore`).
- `bash -n` clean.

No Rust changes.
