### PR TITLE
feat(shock2vr): probe and report the install layout at startup

### DIFF
--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -20,9 +20,6 @@ use engine::assets::asset_paths::{AbstractAssetPath, AssetPath, ReadableAndSeeka
 
 use crate::zip_asset_path::ZipAssetPath;
 
-/// The single archive a 25th Anniversary Edition install ships its data in.
-const BASE_ARCHIVE: &str = "sshock2.kpf";
-
 /// Where that archive keeps the gamesys and the missions.
 const ARCHIVE_DATA_PREFIX: &str = "data/";
 
@@ -30,7 +27,7 @@ const ARCHIVE_DATA_PREFIX: &str = "data/";
 /// classic one. The remaster ships its data inside `sshock2.kpf`; a classic
 /// install has loose `.crf` archives instead.
 pub fn is_25th_anniversary_install(data_root: &Path) -> bool {
-    data_root.join(BASE_ARCHIVE).exists()
+    crate::install::is_anniversary(data_root)
 }
 
 /// The archive mounts that hold the raw data files, highest priority first.
@@ -42,7 +39,10 @@ pub fn data_file_mounts(data_root: &Path) -> Vec<Box<dyn AbstractAssetPath>> {
         return Vec::new();
     }
 
-    let archive = data_root.join(BASE_ARCHIVE).to_string_lossy().into_owned();
+    let archive = data_root
+        .join(crate::install::ANNIVERSARY_SENTINEL)
+        .to_string_lossy()
+        .into_owned();
     vec![
         // `motiondb.bin` moved from the data root to `res/mschema/`, and the
         // missions + gamesys live under `data/`.
@@ -88,7 +88,7 @@ fn archived_mission_names(data_root: &Path) -> BTreeMap<String, String> {
     if !is_25th_anniversary_install(data_root) {
         return BTreeMap::new();
     }
-    let Ok(file) = std::fs::File::open(data_root.join(BASE_ARCHIVE)) else {
+    let Ok(file) = std::fs::File::open(data_root.join(crate::install::ANNIVERSARY_SENTINEL)) else {
         return BTreeMap::new();
     };
     let Ok(archive) = zip::ZipArchive::new(std::io::BufReader::new(file)) else {
@@ -147,7 +147,7 @@ mod tests {
 
     /// Write a stand-in for the 25AE archive holding `entries`.
     fn write_archive(root: &Path, entries: &[(&str, &[u8])]) {
-        let file = std::fs::File::create(root.join(BASE_ARCHIVE)).unwrap();
+        let file = std::fs::File::create(root.join(crate::install::ANNIVERSARY_SENTINEL)).unwrap();
         let mut writer = zip::ZipWriter::new(file);
         for (name, contents) in entries {
             writer

--- a/shock2vr/src/data_files.rs
+++ b/shock2vr/src/data_files.rs
@@ -141,35 +141,9 @@ pub fn open_data_file(name: &str) -> Option<Box<dyn ReadableAndSeekable>> {
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};
-    use std::path::PathBuf;
 
     use super::*;
-
-    /// A scratch directory that removes itself when the test ends.
-    struct TempDir(PathBuf);
-
-    impl TempDir {
-        fn new(name: &str) -> TempDir {
-            let path = std::env::temp_dir().join(format!(
-                "shock2vr-data-files-{}-{}",
-                std::process::id(),
-                name
-            ));
-            let _ = std::fs::remove_dir_all(&path);
-            std::fs::create_dir_all(&path).unwrap();
-            TempDir(path)
-        }
-
-        fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
+    use crate::test_support::TempDir;
 
     /// Write a stand-in for the 25AE archive holding `entries`.
     fn write_archive(root: &Path, entries: &[(&str, &[u8])]) {

--- a/shock2vr/src/install.rs
+++ b/shock2vr/src/install.rs
@@ -17,11 +17,21 @@ use std::path::{Path, PathBuf};
 
 /// The archive a 25th Anniversary install keeps its data in. Its presence is
 /// what distinguishes the two layouts.
-pub const ANNIVERSARY_SENTINEL: &str = "sshock2.kpf";
+pub(crate) const ANNIVERSARY_SENTINEL: &str = "sshock2.kpf";
+
+/// Whether `data_root` holds a 25th Anniversary install.
+///
+/// The single predicate: `data_files` mounts from it, `Game::init` picks a
+/// mount list from it, and [`probe`] classifies from it, so the three cannot
+/// disagree. `is_file` rather than `exists` so a directory or dangling link
+/// named `sshock2.kpf` is not mistaken for the archive.
+pub(crate) fn is_anniversary(data_root: &Path) -> bool {
+    data_root.join(ANNIVERSARY_SENTINEL).is_file()
+}
 
 /// Files that mark a directory as a *pre-remaster* game-data root. That install
 /// has the gamesys and `.crf` archives loose; the remaster has none of them.
-pub const LEGACY_SENTINELS: &[&str] =
+pub(crate) const LEGACY_SENTINELS: &[&str] =
     &["shock2.gam", "res/obj.crf", "res/mesh.crf", "motiondb.bin"];
 
 /// Which install layout a data root holds.
@@ -37,12 +47,12 @@ pub enum InstallKind {
 }
 
 /// What a data root holds, and what it is missing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct InstallStatus {
     pub data_root: PathBuf,
     pub kind: InstallKind,
     /// Data files found, in probe order.
-    pub found: Vec<String>,
+    pub found: Vec<&'static str>,
     /// Mod archives the remaster should have but doesn't. Always empty unless
     /// [`InstallKind::Anniversary`].
     ///
@@ -50,7 +60,7 @@ pub struct InstallStatus {
     /// that is otherwise *silent*: copying `sshock2.kpf` without `mods/` boots
     /// perfectly and renders the original 1999 art, so it looks like a working
     /// install and reads as "the upgrade did nothing".
-    pub missing_mods: Vec<String>,
+    pub missing_mods: Vec<&'static str>,
 }
 
 impl InstallStatus {
@@ -62,7 +72,16 @@ impl InstallStatus {
     /// One line for the startup log - the first thing to look at when a device
     /// renders the wrong art or fails to boot.
     pub fn summary(&self) -> String {
-        let root = self.data_root.display();
+        // `data_root` is often relative (`../../Data`, including the fallback
+        // used when nothing was found), and a relative path cannot be acted on
+        // without knowing the cwd - which in the fallback case is the thing
+        // that went wrong.
+        let absolute = std::fs::canonicalize(&self.data_root).unwrap_or_else(|_| {
+            std::env::current_dir()
+                .unwrap_or_default()
+                .join(&self.data_root)
+        });
+        let root = absolute.display();
         match self.kind {
             InstallKind::Anniversary if self.missing_mods.is_empty() => {
                 format!(
@@ -71,8 +90,8 @@ impl InstallStatus {
                 )
             }
             InstallKind::Anniversary => format!(
-                "install: 25th Anniversary at {root} ({}) - INCOMPLETE, missing {}; \
-                 the upgraded art will not load",
+                "install: 25th Anniversary at {root} ({}) - missing mod layers: {}; \
+                 art from those layers will not load",
                 self.found.join(", "),
                 self.missing_mods.join(", ")
             ),
@@ -95,20 +114,20 @@ pub fn probe(data_root: &Path) -> InstallStatus {
     let mut found = Vec::new();
     let mut missing_mods = Vec::new();
 
-    let kind = if data_root.join(ANNIVERSARY_SENTINEL).exists() {
-        found.push(ANNIVERSARY_SENTINEL.to_owned());
+    let kind = if is_anniversary(data_root) {
+        found.push(ANNIVERSARY_SENTINEL);
         for archive in crate::MOD_ARCHIVES {
             if data_root.join(archive).exists() {
-                found.push((*archive).to_owned());
+                found.push(*archive);
             } else {
-                missing_mods.push((*archive).to_owned());
+                missing_mods.push(*archive);
             }
         }
         InstallKind::Anniversary
     } else {
         for sentinel in LEGACY_SENTINELS {
             if data_root.join(sentinel).exists() {
-                found.push((*sentinel).to_owned());
+                found.push(*sentinel);
             }
         }
         if found.is_empty() {
@@ -167,7 +186,7 @@ mod tests {
         let status = probe(dir.path());
         assert_eq!(status.kind, InstallKind::Anniversary);
         assert_eq!(status.missing_mods.len(), crate::MOD_ARCHIVES.len());
-        assert!(status.summary().contains("INCOMPLETE"));
+        assert!(status.summary().contains("missing mod layers"));
     }
 
     #[test]

--- a/shock2vr/src/install.rs
+++ b/shock2vr/src/install.rs
@@ -1,0 +1,219 @@
+//! What game data is actually present, decided in one place before anything
+//! mounts it.
+//!
+//! Until this existed, "which install is this?" was answered implicitly and in
+//! pieces: [`crate::paths::data_root`] searched for sentinel files,
+//! [`crate::data_files::is_25th_anniversary_install`] checked for one archive,
+//! and `Game::init` built one of two mount lists and then panicked on a missing
+//! `shock2.gam`. Nothing reported the answer, which made a wrongly-provisioned
+//! device indistinguishable from a broken build - on Quest the panic is just a
+//! return to the Horizon shell.
+//!
+//! This module answers the question once, as a pure function of the filesystem,
+//! so it can be logged at startup, unit-tested headlessly, and (later) shown to
+//! the player on a screen that has no assets to draw itself with.
+
+use std::path::{Path, PathBuf};
+
+/// The archive a 25th Anniversary install keeps its data in. Its presence is
+/// what distinguishes the two layouts.
+pub const ANNIVERSARY_SENTINEL: &str = "sshock2.kpf";
+
+/// Files that mark a directory as a *pre-remaster* game-data root. That install
+/// has the gamesys and `.crf` archives loose; the remaster has none of them.
+pub const LEGACY_SENTINELS: &[&str] =
+    &["shock2.gam", "res/obj.crf", "res/mesh.crf", "motiondb.bin"];
+
+/// Which install layout a data root holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallKind {
+    /// A 25th Anniversary install - what the game targets.
+    Anniversary,
+    /// A pre-remaster install. Still resolves, but is missing the upgraded art
+    /// the VR hands and weapons are built against.
+    Legacy,
+    /// No recognizable game data.
+    Missing,
+}
+
+/// What a data root holds, and what it is missing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallStatus {
+    pub data_root: PathBuf,
+    pub kind: InstallKind,
+    /// Data files found, in probe order.
+    pub found: Vec<String>,
+    /// Mod archives the remaster should have but doesn't. Always empty unless
+    /// [`InstallKind::Anniversary`].
+    ///
+    /// Worth reporting on its own because it is the one provisioning mistake
+    /// that is otherwise *silent*: copying `sshock2.kpf` without `mods/` boots
+    /// perfectly and renders the original 1999 art, so it looks like a working
+    /// install and reads as "the upgrade did nothing".
+    pub missing_mods: Vec<String>,
+}
+
+impl InstallStatus {
+    /// Whether there is anything to load at all.
+    pub fn has_data(&self) -> bool {
+        self.kind != InstallKind::Missing
+    }
+
+    /// One line for the startup log - the first thing to look at when a device
+    /// renders the wrong art or fails to boot.
+    pub fn summary(&self) -> String {
+        let root = self.data_root.display();
+        match self.kind {
+            InstallKind::Anniversary if self.missing_mods.is_empty() => {
+                format!(
+                    "install: 25th Anniversary at {root} ({})",
+                    self.found.join(", ")
+                )
+            }
+            InstallKind::Anniversary => format!(
+                "install: 25th Anniversary at {root} ({}) - INCOMPLETE, missing {}; \
+                 the upgraded art will not load",
+                self.found.join(", "),
+                self.missing_mods.join(", ")
+            ),
+            InstallKind::Legacy => format!(
+                "install: pre-remaster at {root} ({}) - no {ANNIVERSARY_SENTINEL}, \
+                 so the upgraded art is unavailable",
+                self.found.join(", ")
+            ),
+            InstallKind::Missing => format!(
+                "install: NO GAME DATA at {root} - looked for {ANNIVERSARY_SENTINEL}, {}",
+                LEGACY_SENTINELS.join(", ")
+            ),
+        }
+    }
+}
+
+/// Probe `data_root` for game data. Pure: touches only the filesystem, mounts
+/// nothing, and never panics on a missing or unreadable root.
+pub fn probe(data_root: &Path) -> InstallStatus {
+    let mut found = Vec::new();
+    let mut missing_mods = Vec::new();
+
+    let kind = if data_root.join(ANNIVERSARY_SENTINEL).exists() {
+        found.push(ANNIVERSARY_SENTINEL.to_owned());
+        for archive in crate::MOD_ARCHIVES {
+            if data_root.join(archive).exists() {
+                found.push((*archive).to_owned());
+            } else {
+                missing_mods.push((*archive).to_owned());
+            }
+        }
+        InstallKind::Anniversary
+    } else {
+        for sentinel in LEGACY_SENTINELS {
+            if data_root.join(sentinel).exists() {
+                found.push((*sentinel).to_owned());
+            }
+        }
+        if found.is_empty() {
+            InstallKind::Missing
+        } else {
+            InstallKind::Legacy
+        }
+    };
+
+    InstallStatus {
+        data_root: data_root.to_path_buf(),
+        kind,
+        found,
+        missing_mods,
+    }
+}
+
+/// Probe the data root the game will actually load from.
+pub fn probe_data_root() -> InstallStatus {
+    probe(crate::paths::data_root())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TempDir;
+
+    fn touch(root: &Path, relative: &str) {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"x").unwrap();
+    }
+
+    #[test]
+    fn a_root_with_the_base_archive_and_every_mod_is_a_complete_remaster() {
+        let dir = TempDir::new("install-complete");
+        touch(dir.path(), ANNIVERSARY_SENTINEL);
+        for archive in crate::MOD_ARCHIVES {
+            touch(dir.path(), archive);
+        }
+
+        let status = probe(dir.path());
+        assert_eq!(status.kind, InstallKind::Anniversary);
+        assert!(status.missing_mods.is_empty());
+        assert!(status.has_data());
+        assert_eq!(status.found.len(), 1 + crate::MOD_ARCHIVES.len());
+    }
+
+    /// The silent provisioning failure: the game boots and renders, just with
+    /// the original art, so nothing else in the system would report it.
+    #[test]
+    fn a_remaster_without_its_mods_is_reported_as_incomplete() {
+        let dir = TempDir::new("install-no-mods");
+        touch(dir.path(), ANNIVERSARY_SENTINEL);
+
+        let status = probe(dir.path());
+        assert_eq!(status.kind, InstallKind::Anniversary);
+        assert_eq!(status.missing_mods.len(), crate::MOD_ARCHIVES.len());
+        assert!(status.summary().contains("INCOMPLETE"));
+    }
+
+    #[test]
+    fn a_root_with_only_legacy_sentinels_is_a_pre_remaster_install() {
+        let dir = TempDir::new("install-legacy");
+        touch(dir.path(), "shock2.gam");
+        touch(dir.path(), "res/obj.crf");
+
+        let status = probe(dir.path());
+        assert_eq!(status.kind, InstallKind::Legacy);
+        assert_eq!(status.found, vec!["shock2.gam", "res/obj.crf"]);
+        assert!(status.has_data());
+    }
+
+    /// The base archive wins outright: `Game::init` mounts the KPF list and
+    /// never touches the `.crf`s, so a root holding both is a remaster.
+    #[test]
+    fn the_base_archive_wins_over_leftover_legacy_files() {
+        let dir = TempDir::new("install-both");
+        touch(dir.path(), ANNIVERSARY_SENTINEL);
+        touch(dir.path(), "shock2.gam");
+        touch(dir.path(), "res/obj.crf");
+
+        assert_eq!(probe(dir.path()).kind, InstallKind::Anniversary);
+    }
+
+    #[test]
+    fn an_empty_root_has_no_data_and_says_where_it_looked() {
+        let dir = TempDir::new("install-empty");
+
+        let status = probe(dir.path());
+        assert_eq!(status.kind, InstallKind::Missing);
+        assert!(!status.has_data());
+        assert!(status.found.is_empty());
+        let summary = status.summary();
+        assert!(summary.contains("NO GAME DATA"));
+        assert!(summary.contains(ANNIVERSARY_SENTINEL));
+        assert!(summary.contains("shock2.gam"));
+    }
+
+    /// A path that does not exist at all must probe, not panic - it is the
+    /// first-run state on a device where nothing has been copied yet.
+    #[test]
+    fn a_nonexistent_root_probes_as_missing() {
+        let status = probe(Path::new("/definitely/not/a/data/root"));
+        assert_eq!(status.kind, InstallKind::Missing);
+        assert!(status.summary().contains("/definitely/not/a/data/root"));
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -926,11 +926,12 @@ impl Game {
         info!("high-detail (PMNM) meshes: {high_detail}");
 
         // What data is actually here, decided once and reported before anything
-        // mounts it. `println!` rather than `info!`: only `debug_runtime`
-        // installs a tracing subscriber, so an `info!` is dropped on both the
-        // desktop and the Quest - the two places this line is needed most. On
-        // Quest it is the only way to tell a wrongly-provisioned headset from a
-        // broken build.
+        // mounts it. `println!` rather than `info!`: neither `desktop_runtime`
+        // nor `oculus_runtime` installs a tracing subscriber, so an `info!` here
+        // is dropped on the desktop and on the Quest - the two places this line
+        // is needed most. On Quest it is the only way to tell a
+        // wrongly-provisioned headset from a broken build. (ndk-glue redirects
+        // stdout into logcat, so `println!` does arrive there.)
         let install = install::probe_data_root();
         println!("{}", install.summary());
 
@@ -1023,9 +1024,12 @@ impl Game {
 
         // Through the asset paths, like the missions and motiondb: on a 25AE
         // install the gamesys lives inside `sshock2.kpf`.
-        let game_reader = asset_cache
-            .get_raw_reader("shock2.gam")
-            .unwrap_or_else(|| panic!("cannot load the game: {}", install.summary()));
+        let game_reader = asset_cache.get_raw_reader("shock2.gam").unwrap_or_else(|| {
+            panic!(
+                "cannot load the game: shock2.gam not found in the mounted data ({})",
+                install.summary()
+            )
+        });
 
         let _strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -4,6 +4,7 @@ pub mod hand_pose;
 pub mod hand_pose_library;
 pub mod input;
 pub mod input_context;
+pub mod install;
 pub mod inventory;
 pub mod message_trace;
 pub mod save_load;
@@ -31,6 +32,8 @@ pub mod research;
 mod runtime_props;
 mod scripts;
 mod systems;
+#[cfg(test)]
+mod test_support;
 mod ui;
 mod util;
 mod virtual_hand;
@@ -173,7 +176,7 @@ const RESOURCE_FAMILIES: &[&str] = &[
 /// 41 of its 42 string tables are `$`-token stubs that KEX resolves through
 /// `localization/loc_english.txt`, which we do not implement - honouring them
 /// renders raw keys like `$PSI6` in place of real text.
-const MOD_ARCHIVES: &[&str] = &[
+pub(crate) const MOD_ARCHIVES: &[&str] = &[
     "mods/sshock2ee.kpf",
     "mods/400.kpf",
     "mods/shtup.kpf",
@@ -922,10 +925,29 @@ impl Game {
         dark::high_detail::set_enabled(high_detail);
         info!("high-detail (PMNM) meshes: {high_detail}");
 
+        // What data is actually here, decided once and reported before anything
+        // mounts it. `println!` rather than `info!`: only `debug_runtime`
+        // installs a tracing subscriber, so an `info!` is dropped on both the
+        // desktop and the Quest - the two places this line is needed most. On
+        // Quest it is the only way to tell a wrongly-provisioned headset from a
+        // broken build.
+        let install = install::probe_data_root();
+        println!("{}", install.summary());
+
+        // Fail here rather than several layers down. Without this, an empty data
+        // root reaches the mount list and dies inside the archive reader on
+        // whichever `.crf` it happens to open first - a stack trace that names a
+        // zip path and says nothing about the actual problem. (The real fix is a
+        // screen that says this to the player instead of a panic; that needs a
+        // font that does not come from the missing data, which is why it is a
+        // separate change.)
+        if !install.has_data() {
+            panic!("cannot load the game: {}", install.summary());
+        }
+
         // A 25th Anniversary install keeps everything inside KPF archives, so it
-        // needs a different mount list from a classic install's loose `.crf`s.
-        let asset_paths = if is_25th_anniversary_install() {
-            info!("25th Anniversary Edition install detected; mounting KPF archives");
+        // needs a different mount list from a pre-remaster install's loose `.crf`s.
+        let asset_paths = if install.kind == install::InstallKind::Anniversary {
             AssetPath::combine(build_25th_anniversary_mounts(bundle_storage.clone()))
         } else {
             AssetPath::combine(vec![
@@ -1003,7 +1025,7 @@ impl Game {
         // install the gamesys lives inside `sshock2.kpf`.
         let game_reader = asset_cache
             .get_raw_reader("shock2.gam")
-            .expect("shock2.gam should be present in the mounted data");
+            .unwrap_or_else(|| panic!("cannot load the game: {}", install.summary()));
 
         let _strings = asset_cache.get(&STRINGS_IMPORTER, "objname.str");
 

--- a/shock2vr/src/paths.rs
+++ b/shock2vr/src/paths.rs
@@ -21,18 +21,6 @@ static DATA_ROOT: OnceLock<PathBuf> = OnceLock::new();
 const DESKTOP_CANDIDATES: &[&str] = &["./Data", "../Data", "../../Data", "."];
 
 #[cfg(not(target_os = "android"))]
-/// Files that mark a directory as a game-data root. A classic install has the
-/// loose gamesys and `.crf` archives; a 25th Anniversary Edition install has
-/// none of those at the root, keeping everything inside `sshock2.kpf` instead.
-const SENTINELS: &[&str] = &[
-    "shock2.gam",
-    "res/obj.crf",
-    "res/mesh.crf",
-    "motiondb.bin",
-    "sshock2.kpf",
-];
-
-#[cfg(not(target_os = "android"))]
 pub fn data_root() -> &'static Path {
     DATA_ROOT.get_or_init(resolve_desktop_data_root).as_path()
 }
@@ -68,8 +56,8 @@ fn resolve_desktop_data_root() -> PathBuf {
 
 #[cfg(not(target_os = "android"))]
 fn candidate_has_sentinel(path: &Path) -> bool {
-    SENTINELS
-        .iter()
-        .map(|sentinel| path.join(sentinel))
-        .any(|probe| probe.exists())
+    // One owner for "what counts as game data": `install` names both the
+    // remaster's single archive and the pre-remaster loose files, and probes
+    // the same set to report which layout was found.
+    crate::install::probe(path).has_data()
 }

--- a/shock2vr/src/save_load/save_files.rs
+++ b/shock2vr/src/save_load/save_files.rs
@@ -80,14 +80,8 @@ fn latest_save_in(directory: &Path) -> Option<SaveFile> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::TempDir;
     use std::time::Duration;
-
-    fn scratch_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("shock2vr_save_files_{name}"));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
-        dir
-    }
 
     fn write_save(dir: &Path, name: &str) {
         fs::write(dir.join(name), b"save").unwrap();
@@ -103,26 +97,29 @@ mod tests {
 
     #[test]
     fn empty_directory_has_no_latest_save() {
-        let dir = scratch_dir("empty");
-        assert_eq!(latest_save_in(&dir), None);
+        let dir = TempDir::new("save-files-empty");
+        assert_eq!(latest_save_in(dir.path()), None);
     }
 
     #[test]
     fn non_save_files_are_ignored() {
-        let dir = scratch_dir("filter");
-        write_save(&dir, "notes.txt");
-        assert_eq!(latest_save_in(&dir), None);
+        let dir = TempDir::new("save-files-filter");
+        write_save(dir.path(), "notes.txt");
+        assert_eq!(latest_save_in(dir.path()), None);
     }
 
     #[test]
     fn all_saves_lists_every_save_most_recent_first() {
-        let dir = scratch_dir("listing");
-        write_save(&dir, "old.sav");
+        let dir = TempDir::new("save-files-listing");
+        write_save(dir.path(), "old.sav");
         std::thread::sleep(Duration::from_millis(20));
-        write_save(&dir, "new.sav");
-        write_save(&dir, "notes.txt");
+        write_save(dir.path(), "new.sav");
+        write_save(dir.path(), "notes.txt");
 
-        let names: Vec<String> = all_saves_in(&dir).into_iter().map(|s| s.name).collect();
+        let names: Vec<String> = all_saves_in(dir.path())
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
         assert_eq!(names, vec!["new".to_owned(), "old".to_owned()]);
     }
 
@@ -136,27 +133,27 @@ mod tests {
         // Ties must resolve the same way they did when `latest_save` was a
         // `max_by` over (modified, name): the greater name wins, so it heads
         // the list and stays what `latest_save` returns.
-        let dir = scratch_dir("ties");
-        write_save(&dir, "alpha.sav");
-        write_save(&dir, "beta.sav");
-        let saves = all_saves_in(&dir);
+        let dir = TempDir::new("save-files-ties");
+        write_save(dir.path(), "alpha.sav");
+        write_save(dir.path(), "beta.sav");
+        let saves = all_saves_in(dir.path());
         // Only meaningful when the filesystem really gave them equal mtimes.
         if saves[0].modified == saves[1].modified {
             assert_eq!(saves[0].name, "beta");
-            assert_eq!(latest_save_in(&dir).unwrap().name, "beta");
+            assert_eq!(latest_save_in(dir.path()).unwrap().name, "beta");
         }
     }
 
     #[test]
     fn the_most_recently_written_save_wins() {
-        let dir = scratch_dir("recency");
-        write_save(&dir, "old.sav");
+        let dir = TempDir::new("save-files-recency");
+        write_save(dir.path(), "old.sav");
         // Sleep past the filesystem's mtime granularity before the newer write.
         std::thread::sleep(Duration::from_millis(20));
-        write_save(&dir, "new.sav");
+        write_save(dir.path(), "new.sav");
 
-        let latest = latest_save_in(&dir).expect("a save should be found");
+        let latest = latest_save_in(dir.path()).expect("a save should be found");
         assert_eq!(latest.name, "new");
-        assert_eq!(latest.path, dir.join("new.sav"));
+        assert_eq!(latest.path, dir.path().join("new.sav"));
     }
 }

--- a/shock2vr/src/test_support.rs
+++ b/shock2vr/src/test_support.rs
@@ -1,16 +1,28 @@
 //! Helpers shared by unit tests across the crate.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Makes each directory unique regardless of `name`. Without it, uniqueness is
+/// a crate-global convention enforced by nothing, and `new` starts with
+/// `remove_dir_all` - so two tests that happened to pick the same name would
+/// delete each other's fixtures mid-run.
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// A scratch directory that removes itself when the test ends.
 ///
-/// `name` must be unique per test: the path is derived from it, so two tests
-/// sharing a name would share a directory and race.
+/// `name` only labels the directory for a human reading `/tmp`; uniqueness
+/// comes from the pid and a counter, so no two live `TempDir`s collide.
 pub struct TempDir(PathBuf);
 
 impl TempDir {
     pub fn new(name: &str) -> TempDir {
-        let path = std::env::temp_dir().join(format!("shock2vr-{}-{}", std::process::id(), name));
+        let path = std::env::temp_dir().join(format!(
+            "shock2vr-{}-{}-{}",
+            std::process::id(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            name
+        ));
         let _ = std::fs::remove_dir_all(&path);
         std::fs::create_dir_all(&path).unwrap();
         TempDir(path)

--- a/shock2vr/src/test_support.rs
+++ b/shock2vr/src/test_support.rs
@@ -1,0 +1,28 @@
+//! Helpers shared by unit tests across the crate.
+
+use std::path::{Path, PathBuf};
+
+/// A scratch directory that removes itself when the test ends.
+///
+/// `name` must be unique per test: the path is derived from it, so two tests
+/// sharing a name would share a directory and race.
+pub struct TempDir(PathBuf);
+
+impl TempDir {
+    pub fn new(name: &str) -> TempDir {
+        let path = std::env::temp_dir().join(format!("shock2vr-{}-{}", std::process::id(), name));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        TempDir(path)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}


### PR DESCRIPTION
## Summary

"Which game data is this?" was answered implicitly, in three places, and reported
nowhere:

- `paths::data_root` searched for sentinel files,
- `data_files::is_25th_anniversary_install` checked for one archive,
- `Game::init` picked a mount list from that, then panicked on a missing `shock2.gam`.

So a wrongly-provisioned machine was indistinguishable from a broken build. On Quest
that panic is just a return to the Horizon shell with no message.

`install::probe` answers it once, as a pure function of the filesystem, and `Game::init`
prints one line before mounting anything.

## Why this came up

While verifying the 25AE asset push on a Quest 3, there was **no way to confirm from a
device log which asset layout the headset had actually loaded**. It had to be inferred
from a PSS delta and then confirmed by comparing screenshots.

The cause turned out not to be Android: **neither `desktop_runtime` nor `oculus_runtime`
installs a tracing subscriber at all**, so every `tracing::info!` in the game — including
`"25th Anniversary Edition install detected"` — is dropped on both. Hence `println!`
here, which ndk-glue does route into logcat. (Giving those runtimes a subscriber is worth
doing, but it is a separate change.)

## Output

Verified against four real data roots:

```
install: 25th Anniversary at /path/to/ss2-25th (sshock2.kpf, mods/sshock2ee.kpf, mods/400.kpf, mods/shtup.kpf, mods/scp.kpf, mods/patch_ext.kpf)
install: pre-remaster at /path/to/ss2-data-unpacked (shock2.gam, res/obj.crf, res/mesh.crf, motiondb.bin) - no sshock2.kpf, so the upgraded art is unavailable
install: 25th Anniversary at .../base-only (sshock2.kpf) - missing mod layers: mods/sshock2ee.kpf, ...; art from those layers will not load
install: NO GAME DATA at /path/to/Data - looked for sshock2.kpf, shock2.gam, res/obj.crf, res/mesh.crf, motiondb.bin
```

And on a Quest 3, which is the case that motivated it:

```
I RustStdoutStderr: install: 25th Anniversary at /storage/emulated/0/shock2quest (sshock2.kpf, mods/sshock2ee.kpf, mods/400.kpf, mods/shtup.kpf, mods/scp.kpf, mods/patch_ext.kpf)
```

**Missing mod archives are reported separately on purpose.** That is the one provisioning
mistake which is otherwise completely silent: copying `sshock2.kpf` without `mods/` boots
and renders perfectly, just with the original 1999 art — so it looks like a working
install and reads as "the upgrade did nothing".

## Also

- `paths::candidate_has_sentinel` and `data_files::is_25th_anniversary_install` both
  delegate to the probe, so the sentinel list and the `sshock2.kpf` literal have one
  owner instead of copies that can drift.
- An empty data root now fails immediately with that summary, instead of dying several
  layers down inside the archive reader on whichever `.crf` it opened first.
- `TempDir` moves from `data_files`'s test module into a shared `test_support`; the new
  tests reuse it, and `save_files`'s weaker private copy (no cleanup, no pid) is gone.

## Verification

`cargo test -p shock2vr` — 671 pass. `cargo fmt --all --check`, `RUSTFLAGS="-D warnings"
cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, and `cargo apk check` clean.
Release APK built, installed, and launched on a Quest 3 to capture the logcat line above.

Note: `cargo test -p shock2vr` also surfaces a **pre-existing** warning on `main` —
`unused import: cgmath::Rotation3` at `scenes/main_menu.rs:566`. CI misses it because CI
runs `cargo check`, not `cargo test`. Left alone as unrelated.

## Review findings applied

`/xreview`. The strongest finding was raised by **all three reviewers**: the module
claimed to consolidate the install decision but only swapped the `Game::init` call site,
leaving `"sshock2.kpf"` declared twice and the layout decided in three places. Now
genuinely one predicate.

Others worth noting:

- The new panic had stopped naming `shock2.gam`. `motiondb.bin` alone is a legal legacy
  sentinel, so `has_data()` can pass and land on a message asserting data *was* found
  while never naming the missing file — strictly worse than what it replaced.
- The summary printed a relative root, unactionable without the cwd — and the fallback
  case is precisely where the cwd is the problem. Now absolute.
- "INCOMPLETE ... the upgraded art will not load" overstated it (both engines):
  `anniversary_family_mounts` skips missing archives by design, so remaining layers still
  load.
- `is_file` rather than `exists`, so a directory named `sshock2.kpf` isn't mistaken for
  the archive.
- `TempDir` uniqueness is now structural (pid + counter) rather than a documented
  convention — `new` opens with `remove_dir_all`, so a duplicate name would have deleted
  a concurrently-running test's fixtures.

Reviewers explicitly cleared: no recursion or `OnceLock` re-entrancy between
`candidate_has_sentinel` → `probe` → `data_root`; the Android `cfg` split; that
`sshock2.kpf`-as-authoritative matches what `Game::init` mounts; and that the new early
panic is unreachable in any flow that previously worked.

