### PR TITLE
test(e2e): clean up the saves the suite leaves behind

### DIFF
--- a/tools/shock2-sdk/package.json
+++ b/tools/shock2-sdk/package.json
@@ -17,12 +17,14 @@
     "build": "tsc",
     "pretest": "node scripts/check-deps.mjs",
     "test": "tsc && node --test \"dist/test/*.test.js\"",
-    "pretest:e2e": "node scripts/check-deps.mjs",
+    "pretest:e2e": "node scripts/check-deps.mjs && npm run clean:saves",
     "test:e2e": "tsc && SHOCK2_E2E=1 node --test --test-concurrency=1 \"dist/test/*.test.js\"",
     "pretest:e2e:reliability": "node scripts/check-deps.mjs",
     "test:e2e:reliability": "tsc && node scripts/reliability.mjs",
     "preanim-smoothness": "node scripts/check-deps.mjs",
-    "anim-smoothness": "tsc && node dist/scripts/anim-smoothness.js"
+    "anim-smoothness": "tsc && node dist/scripts/anim-smoothness.js",
+    "clean:saves": "tsc && node scripts/clean-test-saves.mjs",
+    "posttest:e2e": "node scripts/clean-test-saves.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/tools/shock2-sdk/scripts/clean-test-saves.mjs
+++ b/tools/shock2-sdk/scripts/clean-test-saves.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Remove saves left behind by the e2e suite.
+//
+// Every e2e test names its save `<something>${sep}${Date.now()}`, so a 13-digit
+// millisecond suffix is a reliable marker for a test-generated file - no human
+// types one, and it is the only kind that *accumulates* (a fresh name every
+// run). Nothing else is touched: a real `save1.sav`, and fixed-name fixtures
+// like `frontier.sav` or `map-e2e.sav` that tests deliberately write once and
+// reload, are all left alone.
+//
+// This matters because the data root is usually the player's *retail install*
+// (`DARK_ASSET_PATH`), and saves are written to `<data root>/saves`. Left
+// alone the suite accumulates hundreds of files inside the game install, where
+// a store client's "verify files" can trip over them.
+//
+// Runs before the suite (so a crashed run is cleaned up next time) and after
+// it, and can be invoked directly with `npm run clean:saves`.
+
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { findRepoRoot } from "../dist/src/index.js";
+
+/**
+ * `<name><-|_><13-digit epoch ms>.sav` - what every e2e test produces. Both
+ * separators occur in the suite (`camera_alert_e2e_...`, `flat-ui-drag-save-...`).
+ */
+const TEST_SAVE = /[-_]\d{13}\.sav$/;
+
+const repoRoot = findRepoRoot(process.cwd()) ?? process.cwd();
+const roots = [
+  process.env.DARK_ASSET_PATH,
+  join(repoRoot, "Data"),
+  join(repoRoot, "..", "Data"),
+].filter(Boolean);
+
+const dryRun = process.argv.includes("--dry-run");
+
+let removed = 0;
+const seen = new Set();
+for (const root of roots) {
+  const dir = join(root, "saves");
+  if (seen.has(dir) || !existsSync(dir)) continue;
+  seen.add(dir);
+  for (const entry of readdirSync(dir)) {
+    if (!TEST_SAVE.test(entry)) continue;
+    const path = join(dir, entry);
+    if (!statSync(path).isFile()) continue;
+    if (dryRun) {
+      console.log(`would remove ${path}`);
+    } else {
+      rmSync(path);
+    }
+    removed += 1;
+  }
+}
+
+if (removed > 0) {
+  const verb = dryRun ? "would remove" : "removed";
+  console.log(`clean-test-saves: ${verb} ${removed} test save(s)`);
+}


### PR DESCRIPTION
## Summary

The e2e suite leaves its saves behind, and they land somewhere they really shouldn't.

Saves go to `<data root>/saves` — and the data root is normally the player's **retail
game install** (whatever `DARK_ASSET_PATH` points at). Every e2e test that saves picks a
fresh `${Date.now()}` name and never cleans up, so the suite accumulates files inside the
game install forever. Two local data roots had **178** and **131** stray saves before
this.

That's bad for two reasons: a storefront client's "verify/repair files" has no reason to
be happy about unexpected files in the install, and the pile buries any real save the
player has (`save1.sav` was sitting in the middle of it).

## Approach

40 test files call `save()`. Rather than touch all of them, this keys on what their names
have in common: a **13-digit millisecond suffix**. That marker is precise in both
directions —

- No human types one, and it is the only kind that *accumulates* (a fresh name every run).
- Fixed-name fixtures that tests deliberately write once and reload — `frontier.sav`,
  `map-e2e.sav`, `log-reader-e2e.sav`, `ops_frontier_iter*.sav`, the `pr370_*` comparison
  saves — don't match, and neither does a real `save1.sav`.

Both separators actually in use are covered (`camera_alert_e2e_<ts>` and
`flat-ui-drag-save-<ts>`; only the underscore form was obvious at first).

## Wiring

Runs **before** the suite as well as after. `post*` doesn't run when a script fails, so
the pre-hook is what actually guarantees a crashed or interrupted run gets cleaned up —
the post-hook just means a passing run leaves nothing behind immediately.

`npm run clean:saves` invokes it directly, and `--dry-run` lists what would go without
removing anything.

## Verification

Dry-run audited against both local data roots before deleting anything: 118 and 130
matched. After running it, zero timestamped saves remain and every fixed-name fixture plus
`save1.sav` survived (48 files preserved in one root, all accounted for).

`npm test` — 26 pass, unchanged. CI runs only `npm test`, so the `pre/posttest:e2e` hooks
don't affect it.

## Not addressed here

This stops the accumulation; it doesn't change *where* saves go. Writing player saves into
the read-only asset tree is still questionable — on Quest they'd land in
`/sdcard/shock2quest/saves`, alongside the pushed archives. That's survivable in practice
(assets get copied once, and the app has write access there — verified on a Quest 3), but
a platform-appropriate user-data directory would be the real fix.
