### PR TITLE
feat(ui): show a screen when there is no game data

### DIFF
--- a/engine/src/builtin_font.rs
+++ b/engine/src/builtin_font.rs
@@ -44,6 +44,7 @@
 //! letter spacing - but a few (`*`, `/`, `X`, `Y`, `\`, `_`) do reach column 7,
 //! so adjacent glyphs can touch. That is upstream's design, not a packing bug.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::font::{Font, FontCharacterInfo};
@@ -284,6 +285,29 @@ impl Font for BuiltinFont {
     fn get_character_info(&self, c: char) -> Option<FontCharacterInfo> {
         character_info(c)
     }
+}
+
+thread_local! {
+    /// Uploaded once per thread, on first use. The atlas is 160x60 and the
+    /// glyph table is compiled in, so this costs one small texture - but it
+    /// needs a live GL context, which rules out a `const`/`static` and means
+    /// it cannot be built until the renderer is up.
+    static SHARED: RefCell<Option<Rc<Box<dyn Font>>>> = const { RefCell::new(None) };
+}
+
+/// The shared fallback font, uploading it on first use.
+///
+/// Callers hold `Rc<Box<dyn Font>>` because that is what the scene text
+/// constructors and the `.FON` asset importer both produce, so a caller can
+/// swap between this and a loaded font without caring which it has.
+///
+/// Requires a current GL context.
+pub fn shared_builtin_font() -> Rc<Box<dyn Font>> {
+    SHARED.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        cell.get_or_insert_with(|| Rc::new(Box::new(BuiltinFont::new()) as Box<dyn Font>))
+            .clone()
+    })
 }
 
 #[cfg(test)]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -18,7 +18,7 @@ pub mod texture_atlas;
 pub mod texture_format;
 pub mod util;
 
-pub use crate::builtin_font::BuiltinFont;
+pub use crate::builtin_font::{BuiltinFont, shared_builtin_font};
 pub use crate::engine::Engine;
 pub use crate::engine::EngineRenderContext;
 pub use crate::font::{Font, FontCharacterInfo, ellipsize, measure_text_width};

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -279,7 +279,7 @@ pub fn main() {
         experimental_features,
         ..GameOptions::default()
     };
-    let mut game = shock2vr::Game::init(options, bundle_storage);
+    let mut game = shock2vr::App::init(options, bundle_storage);
     // FOR SCREENSHOT
     // let mut camera_context = CameraContext {
     //     camera_offset: cgmath::Vector3::new(1.25, -14.0, -24.0),

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -7,7 +7,7 @@ use engine::profile;
 use engine::scene::Scene;
 use engine::scene::SceneObject;
 use openxr as xr;
-use shock2vr::Game;
+use shock2vr::App;
 use shock2vr::GameOptions;
 use shock2vr::input_context::InputContext;
 use shock2vr::paths;
@@ -463,7 +463,7 @@ fn main() {
         debug_skeletons: false,
         ..GameOptions::default()
     };
-    let mut game = shock2vr::Game::init(options, bundle_storage);
+    let mut game = shock2vr::App::init(options, bundle_storage);
     println!(
         "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",
         mission,
@@ -1248,7 +1248,7 @@ fn stage_to_pawn(position_meters: Vector3<f32>, center_above_floor: f32) -> Vect
 }
 
 fn render_swapchain(
-    game: &mut Game,
+    game: &mut App,
     engine: &Box<dyn engine::Engine>,
     camera_pos: Vector3<f32>,
     camera_rot: Quaternion<f32>,

--- a/shock2vr/src/install.rs
+++ b/shock2vr/src/install.rs
@@ -69,18 +69,25 @@ impl InstallStatus {
         self.kind != InstallKind::Missing
     }
 
-    /// One line for the startup log - the first thing to look at when a device
-    /// renders the wrong art or fails to boot.
-    pub fn summary(&self) -> String {
-        // `data_root` is often relative (`../../Data`, including the fallback
-        // used when nothing was found), and a relative path cannot be acted on
-        // without knowing the cwd - which in the fallback case is the thing
-        // that went wrong.
-        let absolute = std::fs::canonicalize(&self.data_root).unwrap_or_else(|_| {
+    /// The data root as something a human can act on.
+    ///
+    /// `data_root` is often relative (`../../Data`, including the fallback used
+    /// when nothing was found), and a relative path cannot be acted on without
+    /// knowing the cwd - which in the fallback case is the thing that went
+    /// wrong. Both the startup log and the missing-assets screen show this, so
+    /// they cannot disagree.
+    pub fn absolute_data_root(&self) -> PathBuf {
+        std::fs::canonicalize(&self.data_root).unwrap_or_else(|_| {
             std::env::current_dir()
                 .unwrap_or_default()
                 .join(&self.data_root)
-        });
+        })
+    }
+
+    /// One line for the startup log - the first thing to look at when a device
+    /// renders the wrong art or fails to boot.
+    pub fn summary(&self) -> String {
+        let absolute = self.absolute_data_root();
         let root = absolute.display();
         match self.kind {
             InstallKind::Anniversary if self.missing_mods.is_empty() => {

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -1702,3 +1702,180 @@ mod tests {
         assert!((right - vec3(10.0, 20.0, 29.0)).magnitude() < 0.0001);
     }
 }
+
+/// What a runtime drives: either the game, or the screen explaining that there
+/// is no game data to run.
+///
+/// [`Game::init`] needs the gamesys, so it cannot be built at all on a machine
+/// with no data - and the failure it used to produce was a panic, which on a
+/// headset is a silent return to the Horizon shell. The runtimes construct this
+/// instead, and drive it with the same calls they already made on `Game`, so
+/// neither of them needs a second render loop for the one screen that has to
+/// work when nothing else does.
+pub enum App {
+    Ready(Box<Game>),
+    MissingAssets(MissingAssets),
+}
+
+impl App {
+    /// Probe the data root, then build whichever of the two is appropriate.
+    pub fn init(options: GameOptions, bundle_storage: Arc<dyn Storage>) -> App {
+        let install = install::probe_data_root();
+        if !install.has_data() {
+            // `Game::init` reports the install itself; it never runs here.
+            println!("{}", install.summary());
+            return App::MissingAssets(MissingAssets::new(&install, options, bundle_storage));
+        }
+        App::Ready(Box::new(Game::init(options, bundle_storage)))
+    }
+
+    pub fn update(
+        &mut self,
+        time: &Time,
+        input_context: &input_context::InputContext,
+        action_state: &mut input::InputActionState,
+    ) {
+        match self {
+            App::Ready(game) => game.update(time, input_context, action_state),
+            App::MissingAssets(missing) => missing.update(time, input_context),
+        }
+    }
+
+    pub fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        match self {
+            App::Ready(game) => game.render(),
+            App::MissingAssets(missing) => missing.render(),
+        }
+    }
+
+    pub fn render_per_eye(
+        &mut self,
+        view: Matrix4<f32>,
+        projection: Matrix4<f32>,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        match self {
+            App::Ready(game) => game.render_per_eye(view, projection, screen_size),
+            App::MissingAssets(missing) => missing.render_per_eye(view, projection, screen_size),
+        }
+    }
+
+    pub fn finish_render(
+        &mut self,
+        view: Matrix4<f32>,
+        projection: Matrix4<f32>,
+        screen_size: Vector2<f32>,
+    ) {
+        if let App::Ready(game) = self {
+            game.finish_render(view, projection, screen_size);
+        }
+    }
+
+    pub fn should_quit(&self) -> bool {
+        match self {
+            App::Ready(game) => game.should_quit(),
+            App::MissingAssets(_) => false,
+        }
+    }
+
+    pub fn wants_pointer(&self) -> bool {
+        match self {
+            App::Ready(game) => game.wants_pointer(),
+            // Nothing to click; leave the cursor to the window manager so the
+            // player can close the window.
+            App::MissingAssets(_) => true,
+        }
+    }
+
+    pub fn get_hand_spotlights(&self) -> Vec<engine::scene::light::SpotLight> {
+        match self {
+            App::Ready(game) => game.get_hand_spotlights(),
+            App::MissingAssets(_) => Vec::new(),
+        }
+    }
+
+    pub fn player_eye_height(&self) -> f32 {
+        match self {
+            App::Ready(game) => game.player_eye_height(),
+            App::MissingAssets(_) => PLAYER_EYE_HEIGHT,
+        }
+    }
+
+    pub fn player_center_above_floor(&self) -> f32 {
+        match self {
+            App::Ready(game) => game.player_center_above_floor(),
+            App::MissingAssets(_) => PLAYER_EYE_HEIGHT,
+        }
+    }
+
+    pub fn player_eye_cap_above_center(&self) -> f32 {
+        match self {
+            App::Ready(game) => game.player_eye_cap_above_center(),
+            App::MissingAssets(_) => 0.0,
+        }
+    }
+}
+
+/// The missing-assets screen and the little it needs to render itself.
+///
+/// The asset cache is real but empty: [`scenes::NoAssetsScene`] draws only text
+/// in the engine's compiled-in font, so nothing ever resolves through it. It
+/// exists because the shared canvas rendering takes one.
+pub struct MissingAssets {
+    scene: scenes::NoAssetsScene,
+    asset_cache: AssetCache,
+    options: GameOptions,
+}
+
+impl MissingAssets {
+    fn new(
+        install: &install::InstallStatus,
+        options: GameOptions,
+        bundle_storage: Arc<dyn Storage>,
+    ) -> MissingAssets {
+        let asset_paths = AssetPath::combine(vec![
+            BundleAssetPath::new("".to_owned(), bundle_storage),
+            AssetPath::folder("".to_owned()),
+        ]);
+        MissingAssets {
+            scene: scenes::NoAssetsScene::new(install),
+            asset_cache: AssetCache::new(
+                paths::data_root().to_string_lossy().into_owned(),
+                asset_paths,
+            ),
+            options,
+        }
+    }
+
+    fn update(&mut self, time: &Time, input_context: &input_context::InputContext) {
+        use crate::game_scene::GameScene;
+        self.scene.update(
+            time,
+            input_context,
+            &mut self.asset_cache,
+            &self.options,
+            Vec::new(),
+        );
+    }
+
+    fn render(&mut self) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        use crate::game_scene::GameScene;
+        self.scene.render(&mut self.asset_cache, &self.options)
+    }
+
+    fn render_per_eye(
+        &mut self,
+        view: Matrix4<f32>,
+        projection: Matrix4<f32>,
+        screen_size: Vector2<f32>,
+    ) -> Vec<SceneObject> {
+        use crate::game_scene::GameScene;
+        self.scene.render_per_eye(
+            &mut self.asset_cache,
+            view,
+            projection,
+            screen_size,
+            &self.options,
+        )
+    }
+}

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -938,10 +938,11 @@ impl Game {
         // Fail here rather than several layers down. Without this, an empty data
         // root reaches the mount list and dies inside the archive reader on
         // whichever `.crf` it happens to open first - a stack trace that names a
-        // zip path and says nothing about the actual problem. (The real fix is a
-        // screen that says this to the player instead of a panic; that needs a
-        // font that does not come from the missing data, which is why it is a
-        // separate change.)
+        // zip path and says nothing about the actual problem.
+        //
+        // `App::init` routes this case to the missing-assets screen instead, so
+        // the player never reaches this panic. It still guards `debug_runtime`
+        // and `dark_viewer`, which build a `Game` directly.
         if !install.has_data() {
             panic!("cannot load the game: {}", install.summary());
         }
@@ -1724,7 +1725,7 @@ impl App {
         if !install.has_data() {
             // `Game::init` reports the install itself; it never runs here.
             println!("{}", install.summary());
-            return App::MissingAssets(MissingAssets::new(&install, options, bundle_storage));
+            return App::MissingAssets(MissingAssets::new(&install, options));
         }
         App::Ready(Box::new(Game::init(options, bundle_storage)))
     }
@@ -1794,6 +1795,12 @@ impl App {
         }
     }
 
+    // The three pose accessors below must answer exactly as an uncrouched
+    // `Game` does. They are not cosmetic: the VR runtime derives the tracked
+    // head offset from them, and a wrong *unit* here (unscaled eye height where
+    // a scaled collider-center height is expected) tilts the panel tens of
+    // degrees off the player's gaze - on the one screen whose entire job is to
+    // be read. `no_assets_pose_matches_a_standing_game` pins them.
     pub fn player_eye_height(&self) -> f32 {
         match self {
             App::Ready(game) => game.player_eye_height(),
@@ -1804,14 +1811,14 @@ impl App {
     pub fn player_center_above_floor(&self) -> f32 {
         match self {
             App::Ready(game) => game.player_center_above_floor(),
-            App::MissingAssets(_) => PLAYER_EYE_HEIGHT,
+            App::MissingAssets(_) => physics::player_center_above_floor(false),
         }
     }
 
     pub fn player_eye_cap_above_center(&self) -> f32 {
         match self {
             App::Ready(game) => game.player_eye_cap_above_center(),
-            App::MissingAssets(_) => 0.0,
+            App::MissingAssets(_) => physics::player_eye_cap_above_center(false),
         }
     }
 }
@@ -1828,15 +1835,14 @@ pub struct MissingAssets {
 }
 
 impl MissingAssets {
-    fn new(
-        install: &install::InstallStatus,
-        options: GameOptions,
-        bundle_storage: Arc<dyn Storage>,
-    ) -> MissingAssets {
-        let asset_paths = AssetPath::combine(vec![
-            BundleAssetPath::new("".to_owned(), bundle_storage),
-            AssetPath::folder("".to_owned()),
-        ]);
+    /// Takes no bundle storage: nothing here resolves an asset, and not taking
+    /// it keeps the type constructible in a unit test.
+    fn new(install: &install::InstallStatus, options: GameOptions) -> MissingAssets {
+        // Deliberately empty: the scene draws only text in the compiled-in
+        // font, so nothing resolves through here. Mounting the working
+        // directory would let a stray future lookup succeed by accident
+        // instead of failing loudly.
+        let asset_paths = AssetPath::combine(Vec::new());
         MissingAssets {
             scene: scenes::NoAssetsScene::new(install),
             asset_cache: AssetCache::new(
@@ -1877,5 +1883,50 @@ impl MissingAssets {
             screen_size,
             &self.options,
         )
+    }
+}
+
+#[cfg(test)]
+mod app_tests {
+    use super::*;
+
+    fn missing_assets_app() -> App {
+        let status = install::InstallStatus {
+            data_root: std::path::PathBuf::from("/nowhere"),
+            kind: install::InstallKind::Missing,
+            found: Vec::new(),
+            missing_mods: Vec::new(),
+        };
+        App::MissingAssets(MissingAssets::new(&status, GameOptions::default()))
+    }
+
+    /// The VR runtime derives the tracked head offset from these three, so a
+    /// value in the wrong *unit space* silently tilts the panel tens of degrees
+    /// off the player's gaze - on the one screen whose whole job is to be read,
+    /// and in a state no debug scene can reach (the debug scene runs inside a
+    /// real `Game`). They must answer exactly as an uncrouched player does.
+    #[test]
+    fn the_missing_assets_pose_matches_a_standing_player() {
+        let app = missing_assets_app();
+        assert_eq!(
+            app.player_center_above_floor(),
+            physics::player_center_above_floor(false)
+        );
+        assert_eq!(
+            app.player_eye_cap_above_center(),
+            physics::player_eye_cap_above_center(false)
+        );
+        assert_eq!(app.player_eye_height(), PLAYER_EYE_HEIGHT);
+    }
+
+    /// The specific mix-up that shipped: `PLAYER_EYE_HEIGHT` is an *unscaled*
+    /// eye height, while these two are *scaled* world units. Returning the
+    /// former for either is wrong by a factor of `SCALE_FACTOR`.
+    #[test]
+    fn the_pose_accessors_are_in_scaled_world_units() {
+        let app = missing_assets_app();
+        assert!(app.player_center_above_floor() < PLAYER_EYE_HEIGHT);
+        assert!(app.player_eye_cap_above_center() > 0.0);
+        assert!(app.player_eye_cap_above_center() < PLAYER_EYE_HEIGHT);
     }
 }

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use cgmath::{InnerSpace, Matrix3, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
+use cgmath::{Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
 use dark::{
     importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
     map::MapRect,
@@ -37,7 +37,10 @@ use crate::{
     scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, WorldPanel, pointer_to_canvas, ray_to_canvas},
+    ui::{
+        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
+        pointer_to_canvas, ray_to_canvas,
+    },
 };
 
 /// Mission loaded when the player chooses "New Game".
@@ -170,61 +173,9 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
         .collect()
 }
 
-/// The VR menu hangs on a panel 2m ahead of the player at eye level, sized to
-/// the canvas's 4:3 aspect so the art is not stretched.
-///
-/// "Eye level" is not the scene origin: VR runtimes add a head offset of
-/// `player_eye_height / SCALE_FACTOR` on top of the camera position this scene
-/// returns, so a panel at y=0 hangs below the view and is never seen.
-const VR_PANEL_DISTANCE: f32 = 2.0;
-const VR_PANEL_EYE_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
-const VR_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
 /// A VR trigger past this counts as "pressed", matching the hand code's
 /// grab/fire threshold.
 const VR_TRIGGER_THRESHOLD: f32 = 0.5;
-/// Spacing between stacked canvas layers in world space, so the labels sort in
-/// front of the backdrop instead of z-fighting it.
-const VR_COMPONENT_Z_STEP: f32 = 0.001;
-
-/// The panel the VR menu is drawn on: hung `VR_PANEL_DISTANCE` in front of the
-/// head and turned to face back at it.
-///
-/// It is anchored to the head's **facing**, not to a fixed world axis. There is
-/// no canonical "forward" to hardcode - the runtimes' yaw-0 camera looks along
-/// +X, not -Z - so a panel pinned to -Z sits off to the side and never enters
-/// the frustum. This mirrors `DebugMapScene`'s construction, which is the
-/// world-space panel that demonstrably renders.
-fn vr_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
-    let head = vec3(0.0, VR_PANEL_EYE_HEIGHT, 0.0);
-    let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-    let center = head + forward * VR_PANEL_DISTANCE;
-
-    // Orient the panel by looking from it back to the head. `look_dir` runs
-    // panel -> head, so the panel's local +Z (the third column) points away
-    // from the viewer - the convention the world-space element path expects.
-    let mut look_dir = head - center;
-    look_dir = if look_dir.magnitude2() < 1e-6 {
-        vec3(0.0, 0.0, 1.0)
-    } else {
-        look_dir.normalize()
-    };
-    let mut up = vec3(0.0, 1.0, 0.0);
-    let mut right = look_dir.cross(up);
-    if right.magnitude2() < 1e-6 {
-        // Looking straight up or down: pick a different up to keep the basis
-        // well-defined.
-        up = vec3(0.0, 0.0, 1.0);
-        right = look_dir.cross(up);
-    }
-    let right = right.normalize();
-    let true_up = right.cross(look_dir).normalize();
-
-    WorldPanel {
-        center,
-        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, -look_dir)),
-        size: VR_PANEL_SIZE,
-    }
-}
 
 /// Where a hand is pointing on the menu panel, in canvas pixels, plus whether
 /// its trigger is held.
@@ -234,7 +185,7 @@ fn vr_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
 /// held** wins, so either controller can click; ties and idle triggers fall
 /// back to the right hand, which then drives the hover highlight.
 fn vr_pointer(input_context: &InputContext) -> (Option<Vector2<f32>>, bool) {
-    let panel = vr_panel(input_context.head.rotation);
+    let panel = frontend_panel(input_context.head.rotation);
     let right = &input_context.right_hand;
     let left = &input_context.left_hand;
     let held = |hand: &crate::input_context::Hand| hand.trigger_value > VR_TRIGGER_THRESHOLD;
@@ -482,7 +433,7 @@ impl GameScene for MainMenuScene {
 
         // In VR there is no screen to draw on, so the same canvas is presented
         // on a world-space panel in front of the player.
-        let panel = vr_panel(self.head_rotation);
+        let panel = frontend_panel(self.head_rotation);
         let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
         let objects = canvas.render_world_space(
             asset_cache,
@@ -563,6 +514,7 @@ impl GameScene for MainMenuScene {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::FRONTEND_PANEL_DISTANCE;
     use cgmath::Rotation3;
 
     fn pointer_at(x: f32, y: f32, pressed: bool) -> Option<Pointer2D> {
@@ -666,7 +618,7 @@ mod tests {
     /// rather than world axes - so the test stays honest whichever way the
     /// panel ends up facing.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
-        let panel = vr_panel(test_head());
+        let panel = frontend_panel(test_head());
         let u = point.x / CANVAS_W - 0.5;
         let v = 0.5 - point.y / CANVAS_H;
         let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
@@ -676,7 +628,7 @@ mod tests {
 
         crate::input_context::Hand {
             // Stand back along the panel's normal and aim at the target.
-            position: target - normal * VR_PANEL_DISTANCE,
+            position: target - normal * FRONTEND_PANEL_DISTANCE,
             rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), normal, None),
             trigger_value: trigger,
             ..crate::input_context::Hand::default()
@@ -738,7 +690,7 @@ mod tests {
         // Rotated 180 degrees: pointing behind the player, away from the panel.
         // Both hands must aim away - in VR both are always posed, so leaving
         // one at its default would have it pointing straight at the panel.
-        let panel = vr_panel(test_head());
+        let panel = frontend_panel(test_head());
         let away = || crate::input_context::Hand {
             // Aim directly opposite the panel, from the panel's own centre.
             position: panel.center,

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -150,8 +150,13 @@ pub fn create_initial_scene(
     // scene against a stand-in status so the screen can be render-verified in
     // both presentations without uninstalling the game.
     if options.mission.eq_ignore_ascii_case("debug_no_assets") {
+        // A stand-in root, deliberately NOT the real one. On a machine that has
+        // the data, `paths::data_root()` points at a directory that is not in
+        // fact missing anything, so the message would be nonsense - and it puts
+        // a local home-directory path (with the developer's username) into every
+        // screenshot taken of this scene.
         let status = crate::install::InstallStatus {
-            data_root: crate::paths::data_root().to_path_buf(),
+            data_root: std::path::PathBuf::from("/sdcard/shock2quest"),
             kind: crate::install::InstallKind::Missing,
             found: Vec::new(),
             missing_mods: Vec::new(),

--- a/shock2vr/src/scenes/mod.rs
+++ b/shock2vr/src/scenes/mod.rs
@@ -40,6 +40,7 @@ pub mod game_over;
 pub mod load_game;
 pub mod loading;
 pub mod main_menu;
+pub mod no_assets;
 
 pub use cutscene_player::CutscenePlayerScene;
 pub use debug_camera::DebugCameraScene;
@@ -61,6 +62,7 @@ pub use game_over::GameOverScene;
 pub use load_game::LoadGameScene;
 pub use loading::LoadingScene;
 pub use main_menu::MainMenuScene;
+pub use no_assets::NoAssetsScene;
 
 /// The minimal world a non-mission screen (menu, loading, game over) needs.
 ///
@@ -137,6 +139,25 @@ pub fn create_initial_scene(
     if options.mission.eq_ignore_ascii_case("main_menu") {
         return SceneInitResult {
             scene: Box::new(MainMenuScene::new()),
+            mission_save_data: HashMap::new(),
+        };
+    }
+
+    // Visual-only scene to inspect the missing-assets screen. The real one is
+    // shown by the runtimes *instead of* a `Game`, since it exists precisely
+    // when there is no gamesys to build one from - which also means it cannot
+    // be reached on a machine that has the data. This entry renders the same
+    // scene against a stand-in status so the screen can be render-verified in
+    // both presentations without uninstalling the game.
+    if options.mission.eq_ignore_ascii_case("debug_no_assets") {
+        let status = crate::install::InstallStatus {
+            data_root: crate::paths::data_root().to_path_buf(),
+            kind: crate::install::InstallKind::Missing,
+            found: Vec::new(),
+            missing_mods: Vec::new(),
+        };
+        return SceneInitResult {
+            scene: Box::new(NoAssetsScene::new(&status)),
             mission_save_data: HashMap::new(),
         };
     }

--- a/shock2vr/src/scenes/no_assets.rs
+++ b/shock2vr/src/scenes/no_assets.rs
@@ -55,6 +55,11 @@ const BODY_Y: f32 = 150.0;
 
 const TITLE: &str = "GAME DATA NOT FOUND";
 
+/// Body rows that fit between [`BODY_Y`] and the bottom of the canvas.
+fn max_body_lines() -> usize {
+    (((CANVAS_H - BODY_Y) / LINE_HEIGHT).floor() as usize).max(1)
+}
+
 /// How many characters fit across the canvas at `size`.
 ///
 /// Exact, not an estimate: the builtin font is monospace, so one glyph is one
@@ -108,24 +113,66 @@ fn wrap(text: &str, columns: usize) -> Vec<String> {
     lines
 }
 
+/// Replace anything the builtin font cannot draw with `?`.
+///
+/// The font covers printable ASCII only (U+0020..U+007E). Unmapped characters
+/// are silently dropped by `measure_text_width`, so a path containing them
+/// would be shown *wrong* - and a wrapped chunk consisting entirely of them
+/// measures zero-wide, builds a mesh with no vertices, and panics. A screen
+/// whose whole purpose is to replace a panic must not have one.
+fn to_drawable(text: &str) -> String {
+    text.chars()
+        .map(|c| if (' '..='~').contains(&c) { c } else { '?' })
+        .collect()
+}
+
 /// The message body for `status`, already wrapped to the canvas.
 ///
 /// Pure, so what the player is told is unit-testable without a renderer.
 pub fn message_lines(status: &InstallStatus) -> Vec<String> {
     let columns = columns_at(BODY_SIZE);
-    let body = format!(
+    let path = to_drawable(&status.absolute_data_root().display().to_string());
+
+    // Everything but the path is fixed, so the path is the only thing that can
+    // push the message off the bottom of the canvas. Drop leading path segments
+    // until it fits, rather than letting the closing instruction scroll into the
+    // void: the deepest segments are the ones that identify the directory, and
+    // the untrimmed path is in the startup log either way.
+    //
+    // Iterating over a fixed segment list (rather than re-trimming a string
+    // that has already grown a "..." prefix) is what makes this terminate.
+    let segments: Vec<&str> = path.split(['/', '\\']).collect();
+    for dropped in 0..segments.len() {
+        let shown = if dropped == 0 {
+            path.clone()
+        } else {
+            format!("...{}", segments[dropped..].join("/"))
+        };
+        let lines = wrap(&body_text(&shown), columns);
+        if lines.len() <= max_body_lines() {
+            return lines;
+        }
+    }
+
+    // A single unsplittable segment longer than the canvas allows.
+    let mut truncated: String = path.chars().take(columns.saturating_sub(3)).collect();
+    truncated.push_str("...");
+    wrap(&body_text(&truncated), columns)
+}
+
+/// The message around `path`.
+fn body_text(path: &str) -> String {
+    format!(
         "shock2quest needs a copy of\n\
          System Shock 2: 25th Anniversary Remaster.\n\
          \n\
          Copy sshock2.kpf and the mods folder\n\
          from your install into:\n\
          \n\
-         {}\n\
+         {path}\n\
          \n\
-         then start shock2quest again.",
-        status.data_root.display()
-    );
-    wrap(&body, columns)
+         then start shock2quest again."
+    )
 }
 
 /// See the module docs.
@@ -339,6 +386,52 @@ mod tests {
         assert!(blanks > 0, "the message is expected to have blank lines");
         let drawn = scene.build_canvas().element_count() - 1; // minus the title
         assert_eq!(drawn, scene.lines.len() - blanks);
+
+        // ...and the rows after a blank must not slide up into its place.
+        let first_blank = scene
+            .lines
+            .iter()
+            .position(|l| l.trim().is_empty())
+            .unwrap();
+        let next_text = first_blank + 1;
+        let canvas = scene.build_canvas();
+        let expected_y = BODY_Y + next_text as f32 * LINE_HEIGHT;
+        let found = canvas
+            .elements()
+            .iter()
+            .any(|e| (e.rect().y - expected_y).abs() < 0.01);
+        assert!(
+            found,
+            "no element sits at y={expected_y}, so a blank row collapsed"
+        );
+    }
+
+    /// A pathological data root must not push the message off the bottom of
+    /// the canvas - the horizontal checks above would still pass.
+    #[test]
+    fn a_pathological_root_still_fits_vertically() {
+        let deep = format!("/{}", vec!["averylongdirectoryname"; 12].join("/"));
+        let lines = message_lines(&missing(&deep));
+        let bottom = BODY_Y + (lines.len().saturating_sub(1)) as f32 * LINE_HEIGHT + BODY_SIZE;
+        assert!(
+            bottom <= CANVAS_H,
+            "{} lines run to y={bottom}, past the {CANVAS_H} canvas",
+            lines.len()
+        );
+    }
+
+    /// Non-ASCII cannot reach the glyph table: it would render wrong, and a
+    /// wrapped chunk of nothing but unmapped characters would build an empty
+    /// mesh and panic.
+    #[test]
+    fn a_non_ascii_root_is_made_drawable() {
+        let lines = message_lines(&missing("/Users/\u{5c71}\u{7530}/\u{0161}ock2"));
+        let joined = lines.join("");
+        assert!(joined.is_ascii(), "{joined:?}");
+        assert!(joined.contains('?'));
+        for line in &lines {
+            assert!(!line.trim().is_empty() || line.is_empty());
+        }
     }
 
     #[test]

--- a/shock2vr/src/scenes/no_assets.rs
+++ b/shock2vr/src/scenes/no_assets.rs
@@ -1,0 +1,348 @@
+//! The screen shown when there is no game data to load.
+//!
+//! shock2quest ships no game content: it needs a retail install copied into
+//! place. Until now, not having done that produced a panic - on the desktop a
+//! stack trace, and on Quest a silent return to the Horizon shell. Neither says
+//! what is wrong or what to do, and on a headset there is nowhere to read a
+//! stack trace anyway.
+//!
+//! This screen is that message. Two things make it unusual among the scenes:
+//!
+//! - **It cannot use any asset.** Every other screen draws a `.PCX` backdrop
+//!   and `METAFONT.FON` text out of the game data - exactly what is missing
+//!   here. So it is text-only, in [`crate::ui::BUILTIN_FONT`], the font
+//!   compiled into the engine.
+//! - **It runs without a [`crate::Game`].** `Game::init` needs the gamesys, so
+//!   the runtimes construct this scene directly instead.
+//!
+//! It is otherwise an ordinary [`GameScene`] on the shared [`UiCanvas`], so it
+//! renders in flat and in VR through the same single layout pass as every other
+//! screen (see AGENTS.md "UI Renders Identically in Flatscreen and VR").
+
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
+use engine::{
+    assets::asset_cache::AssetCache,
+    audio::AudioContext,
+    scene::{SceneObject, light::SpotLight},
+};
+use shipyard::{EntityId, World};
+
+use crate::{
+    GameOptions, PresentationMode,
+    game_scene::GameScene,
+    input_context::InputContext,
+    install::InstallStatus,
+    mission::GlobalContext,
+    scripts::{Effect, GlobalEffect},
+    time::Time,
+    ui::{
+        BUILTIN_FONT, HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP,
+        frontend_panel,
+    },
+};
+
+/// Authored on the same 640x480 canvas as the rest of the frontend.
+const CANVAS_W: f32 = 640.0;
+const CANVAS_H: f32 = 480.0;
+/// Letterboxed like the other 4:3 screens, so text never stretches.
+const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
+
+const TITLE_SIZE: f32 = 24.0;
+const BODY_SIZE: f32 = 16.0;
+const LINE_HEIGHT: f32 = 22.0;
+const TITLE_Y: f32 = 90.0;
+const BODY_Y: f32 = 150.0;
+
+const TITLE: &str = "GAME DATA NOT FOUND";
+
+/// How many characters fit across the canvas at `size`.
+///
+/// Exact, not an estimate: the builtin font is monospace, so one glyph is one
+/// advance of `size` canvas pixels.
+fn columns_at(size: f32) -> usize {
+    (CANVAS_W / size) as usize
+}
+
+/// Break `text` to at most `columns` characters per line, preferring a space.
+///
+/// A filesystem path has no spaces and can be longer than the canvas, so it
+/// hard-splits rather than overflowing - a path shown with its middle missing
+/// is useless, and this screen exists to be acted on.
+fn wrap(text: &str, columns: usize) -> Vec<String> {
+    if columns == 0 {
+        return Vec::new();
+    }
+    let mut lines = Vec::new();
+    for paragraph in text.split('\n') {
+        if paragraph.chars().count() <= columns {
+            lines.push(paragraph.to_owned());
+            continue;
+        }
+        let mut current = String::new();
+        for word in paragraph.split(' ') {
+            let mut word = word;
+            // A single word longer than the line (a path) is split across lines.
+            while word.chars().count() > columns {
+                if !current.is_empty() {
+                    lines.push(std::mem::take(&mut current));
+                }
+                let split = word
+                    .char_indices()
+                    .nth(columns)
+                    .map(|(i, _)| i)
+                    .unwrap_or(word.len());
+                lines.push(word[..split].to_owned());
+                word = &word[split..];
+            }
+            let needed = word.chars().count() + usize::from(!current.is_empty());
+            if current.chars().count() + needed > columns {
+                lines.push(std::mem::take(&mut current));
+            }
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            current.push_str(word);
+        }
+        lines.push(current);
+    }
+    lines
+}
+
+/// The message body for `status`, already wrapped to the canvas.
+///
+/// Pure, so what the player is told is unit-testable without a renderer.
+pub fn message_lines(status: &InstallStatus) -> Vec<String> {
+    let columns = columns_at(BODY_SIZE);
+    let body = format!(
+        "shock2quest needs a copy of\n\
+         System Shock 2: 25th Anniversary Remaster.\n\
+         \n\
+         Copy sshock2.kpf and the mods folder\n\
+         from your install into:\n\
+         \n\
+         {}\n\
+         \n\
+         then start shock2quest again.",
+        status.data_root.display()
+    );
+    wrap(&body, columns)
+}
+
+/// See the module docs.
+pub struct NoAssetsScene {
+    lines: Vec<String>,
+    head_rotation: Quaternion<f32>,
+    world: World,
+}
+
+impl NoAssetsScene {
+    pub fn new(status: &InstallStatus) -> NoAssetsScene {
+        NoAssetsScene {
+            lines: message_lines(status),
+            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
+            world: World::new(),
+        }
+    }
+
+    /// The single layout pass. Both presentations map this same canvas, so they
+    /// cannot place the text differently.
+    fn build_canvas(&self) -> UiCanvas {
+        let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
+        canvas.text(
+            Rect::new(0.0, TITLE_Y, CANVAS_W, TITLE_SIZE),
+            TITLE,
+            BUILTIN_FONT,
+            TITLE_SIZE,
+            HAlign::Center,
+            VAlign::Middle,
+        );
+        for (index, line) in self.lines.iter().enumerate() {
+            // Blank lines are vertical spacing, not content. Emitting one as a
+            // text element builds a mesh with no vertices, which panics in
+            // `engine::scene::mesh`; the line still advances `index`, so the
+            // spacing it represents is preserved.
+            if line.trim().is_empty() {
+                continue;
+            }
+            canvas.text(
+                Rect::new(
+                    0.0,
+                    BODY_Y + index as f32 * LINE_HEIGHT,
+                    CANVAS_W,
+                    BODY_SIZE,
+                ),
+                line,
+                BUILTIN_FONT,
+                BODY_SIZE,
+                HAlign::Center,
+                VAlign::Middle,
+            );
+        }
+        canvas
+    }
+}
+
+impl GameScene for NoAssetsScene {
+    fn update(
+        &mut self,
+        _time: &Time,
+        input_context: &InputContext,
+        _asset_cache: &mut AssetCache,
+        _game_options: &GameOptions,
+        _command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        self.head_rotation = input_context.head.rotation;
+        Vec::new()
+    }
+
+    fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        if options.presentation_mode != PresentationMode::Vr {
+            // Flat draws in screen space from `render_per_eye`, which is where
+            // the screen size is known.
+            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
+        }
+        let panel = frontend_panel(self.head_rotation);
+        let objects = self.build_canvas().render_world_space(
+            asset_cache,
+            panel.transform(),
+            None,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        (objects, vec3(0.0, 0.0, 0.0), identity)
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        if options.presentation_mode == PresentationMode::Vr {
+            // In VR the panel from `render` already carries the canvas; a
+            // screen-space copy would paste it over both eyes and hide it.
+            return Vec::new();
+        }
+        self.build_canvas()
+            .render_screen_space(asset_cache, screen_size, SCALE_MODE)
+    }
+
+    fn handle_effects(
+        &mut self,
+        _effects: Vec<Effect>,
+        _global_context: &GlobalContext,
+        _game_options: &GameOptions,
+        _asset_cache: &mut AssetCache,
+        _audio_context: &mut AudioContext<EntityId, String>,
+    ) -> Vec<GlobalEffect> {
+        Vec::new()
+    }
+
+    fn get_hand_spotlights(&self, _options: &GameOptions) -> Vec<SpotLight> {
+        Vec::new()
+    }
+
+    fn world(&self) -> &World {
+        &self.world
+    }
+
+    fn scene_name(&self) -> &str {
+        "no_assets"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::{InstallKind, InstallStatus};
+    use std::path::PathBuf;
+
+    fn missing(root: &str) -> InstallStatus {
+        InstallStatus {
+            data_root: PathBuf::from(root),
+            kind: InstallKind::Missing,
+            found: Vec::new(),
+            missing_mods: Vec::new(),
+        }
+    }
+
+    /// The player has to be able to read every line, so nothing may run past
+    /// the canvas. Monospace makes this exact rather than approximate.
+    #[test]
+    fn no_line_overflows_the_canvas() {
+        let columns = columns_at(BODY_SIZE);
+        for line in message_lines(&missing("/sdcard/shock2quest")) {
+            assert!(
+                line.chars().count() <= columns,
+                "line {line:?} is {} columns, over the {columns} that fit",
+                line.chars().count()
+            );
+        }
+        assert!(TITLE.chars().count() as f32 * TITLE_SIZE <= CANVAS_W);
+    }
+
+    /// The whole point of the screen: say where to put the files.
+    #[test]
+    fn the_message_names_the_data_root_and_what_to_copy() {
+        let lines = message_lines(&missing("/sdcard/shock2quest")).join("\n");
+        assert!(lines.contains("/sdcard/shock2quest"), "{lines}");
+        assert!(lines.contains("sshock2.kpf"), "{lines}");
+        assert!(lines.contains("mods"), "{lines}");
+    }
+
+    /// A path can be longer than the canvas and has no spaces to break on.
+    /// Truncating it would defeat the screen, so it wraps across lines and
+    /// every character survives.
+    #[test]
+    fn a_long_path_wraps_instead_of_overflowing() {
+        let long =
+            "/Users/somebody/very/deeply/nested/directory/tree/that/keeps/going/shock2quest-data";
+        let columns = columns_at(BODY_SIZE);
+        let lines = message_lines(&missing(long));
+        for line in &lines {
+            assert!(line.chars().count() <= columns, "{line:?}");
+        }
+        let rejoined: String = lines.join("").replace(' ', "");
+        assert!(
+            rejoined.contains(&long.replace(' ', "")),
+            "the path must survive wrapping intact: {lines:?}"
+        );
+    }
+
+    /// A blank line is spacing, and a text element with no glyphs builds an
+    /// empty mesh - which panics at render. Negative test for that crash.
+    #[test]
+    fn the_canvas_never_holds_an_empty_string() {
+        let scene = NoAssetsScene::new(&missing("/sdcard/shock2quest"));
+        let canvas = scene.build_canvas();
+        assert!(canvas.element_count() > 0, "the screen must draw something");
+        for element in canvas.elements() {
+            if let crate::ui::UiElement::Text { text, .. } = element {
+                assert!(!text.trim().is_empty(), "empty text element in the canvas");
+            }
+        }
+    }
+
+    /// The blank lines still have to *space* the block, so dropping them from
+    /// the canvas must not pull the following lines up.
+    #[test]
+    fn blank_lines_still_occupy_their_row() {
+        let scene = NoAssetsScene::new(&missing("/sdcard/shock2quest"));
+        let blanks = scene.lines.iter().filter(|l| l.trim().is_empty()).count();
+        assert!(blanks > 0, "the message is expected to have blank lines");
+        let drawn = scene.build_canvas().element_count() - 1; // minus the title
+        assert_eq!(drawn, scene.lines.len() - blanks);
+    }
+
+    #[test]
+    fn wrap_breaks_on_spaces_when_it_can() {
+        assert_eq!(wrap("alpha beta gamma", 11), vec!["alpha beta", "gamma"]);
+    }
+}

--- a/shock2vr/src/scenes/no_assets.rs
+++ b/shock2vr/src/scenes/no_assets.rs
@@ -130,17 +130,42 @@ fn to_drawable(text: &str) -> String {
 ///
 /// Pure, so what the player is told is unit-testable without a renderer.
 pub fn message_lines(status: &InstallStatus) -> Vec<String> {
-    let columns = columns_at(BODY_SIZE);
-    let path = to_drawable(&status.absolute_data_root().display().to_string());
+    // Android's data root is a fixed, public path, and it is the only way a
+    // headset user can be told where to put the files - there is no file
+    // manager to browse with. On the desktop the resolved root is
+    // user-specific, is *not* what a reader needs (they need to know which
+    // folder to create, not the absolute path of one that does not exist), and
+    // putting it on screen means every screenshot of this scene carries
+    // someone's home directory. So the desktop names the two mechanisms
+    // instead.
+    if cfg!(target_os = "android") {
+        lines_for_path(&status.absolute_data_root().display().to_string())
+    } else {
+        wrap(&body_text(DESKTOP_DESTINATION), columns_at(BODY_SIZE))
+    }
+}
 
-    // Everything but the path is fixed, so the path is the only thing that can
-    // push the message off the bottom of the canvas. Drop leading path segments
-    // until it fits, rather than letting the closing instruction scroll into the
-    // void: the deepest segments are the ones that identify the directory, and
+/// Where a desktop player should put the files. Deliberately not a resolved
+/// absolute path - see [`message_lines`].
+const DESKTOP_DESTINATION: &str =
+    "a Data folder next to shock2quest,\nor the folder in DARK_ASSET_PATH";
+
+/// The message naming `path` as the destination, trimmed to fit the canvas.
+///
+/// Separate from [`message_lines`] so the trimming is testable on any host,
+/// not only when compiled for Android.
+fn lines_for_path(path: &str) -> Vec<String> {
+    let columns = columns_at(BODY_SIZE);
+    let path = to_drawable(path);
+
+    // The path is the only unbounded part of the message, so it is the only
+    // thing that can push the text off the bottom of the canvas. Drop leading
+    // segments until it fits rather than letting the closing instruction
+    // scroll into the void; the deepest segments identify the directory, and
     // the untrimmed path is in the startup log either way.
     //
-    // Iterating over a fixed segment list (rather than re-trimming a string
-    // that has already grown a "..." prefix) is what makes this terminate.
+    // Iterating a fixed segment list (rather than re-trimming a string that has
+    // already grown a "..." prefix) is what makes this terminate.
     let segments: Vec<&str> = path.split(['/', '\\']).collect();
     for dropped in 0..segments.len() {
         let shown = if dropped == 0 {
@@ -154,7 +179,6 @@ pub fn message_lines(status: &InstallStatus) -> Vec<String> {
         }
     }
 
-    // A single unsplittable segment longer than the canvas allows.
     let mut truncated: String = path.chars().take(columns.saturating_sub(3)).collect();
     truncated.push_str("...");
     wrap(&body_text(&truncated), columns)
@@ -325,7 +349,7 @@ mod tests {
     #[test]
     fn no_line_overflows_the_canvas() {
         let columns = columns_at(BODY_SIZE);
-        for line in message_lines(&missing("/sdcard/shock2quest")) {
+        for line in lines_for_path("/sdcard/shock2quest") {
             assert!(
                 line.chars().count() <= columns,
                 "line {line:?} is {} columns, over the {columns} that fit",
@@ -338,7 +362,7 @@ mod tests {
     /// The whole point of the screen: say where to put the files.
     #[test]
     fn the_message_names_the_data_root_and_what_to_copy() {
-        let lines = message_lines(&missing("/sdcard/shock2quest")).join("\n");
+        let lines = lines_for_path("/sdcard/shock2quest").join("\n");
         assert!(lines.contains("/sdcard/shock2quest"), "{lines}");
         assert!(lines.contains("sshock2.kpf"), "{lines}");
         assert!(lines.contains("mods"), "{lines}");
@@ -352,7 +376,7 @@ mod tests {
         let long =
             "/Users/somebody/very/deeply/nested/directory/tree/that/keeps/going/shock2quest-data";
         let columns = columns_at(BODY_SIZE);
-        let lines = message_lines(&missing(long));
+        let lines = lines_for_path(long);
         for line in &lines {
             assert!(line.chars().count() <= columns, "{line:?}");
         }
@@ -411,7 +435,7 @@ mod tests {
     #[test]
     fn a_pathological_root_still_fits_vertically() {
         let deep = format!("/{}", vec!["averylongdirectoryname"; 12].join("/"));
-        let lines = message_lines(&missing(&deep));
+        let lines = lines_for_path(&deep);
         let bottom = BODY_Y + (lines.len().saturating_sub(1)) as f32 * LINE_HEIGHT + BODY_SIZE;
         assert!(
             bottom <= CANVAS_H,
@@ -425,13 +449,26 @@ mod tests {
     /// mesh and panic.
     #[test]
     fn a_non_ascii_root_is_made_drawable() {
-        let lines = message_lines(&missing("/Users/\u{5c71}\u{7530}/\u{0161}ock2"));
+        let lines = lines_for_path("/data/\u{5c71}\u{7530}/\u{0161}ock2");
         let joined = lines.join("");
         assert!(joined.is_ascii(), "{joined:?}");
         assert!(joined.contains('?'));
         for line in &lines {
             assert!(!line.trim().is_empty() || line.is_empty());
         }
+    }
+
+    /// The desktop message must never carry a resolved filesystem path: it is
+    /// user-specific, it is not what a reader needs, and it would put someone's
+    /// home directory into every screenshot of this screen.
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn the_desktop_message_shows_no_absolute_path() {
+        let lines = message_lines(&missing("/Users/someone/private/dir")).join(" ");
+        assert!(!lines.contains("/Users/"), "{lines}");
+        assert!(!lines.contains("someone"), "{lines}");
+        assert!(lines.contains("DARK_ASSET_PATH"), "{lines}");
+        assert!(lines.contains("Data"), "{lines}");
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -18,7 +18,9 @@
 
 use std::rc::Rc;
 
-use cgmath::{Deg, InnerSpace, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
+use cgmath::{
+    Deg, InnerSpace, Matrix3, Matrix4, Quaternion, Rotation, Vector2, Vector3, vec2, vec3,
+};
 use dark::importers::{FONT_IMPORTER, TEXTURE_IMPORTER};
 use engine::{
     Font,
@@ -30,6 +32,26 @@ use engine::{
 use shipyard::EntityId;
 
 use crate::vr_config::Handedness;
+
+/// Font name that resolves to the engine's compiled-in font rather than a
+/// `.FON` asset.
+///
+/// It is the only font available when the game data is missing - every other
+/// font in the game is loaded out of `intrface.crf` or the KPF archives - so
+/// the missing-assets screen names this one. Ordinary UI keeps naming its real
+/// font and is unaffected.
+pub const BUILTIN_FONT: &str = "@builtin";
+
+/// The font for a `UiElement::Text`, whichever kind it is.
+///
+/// Both presentations and the layout pass go through here, so the two cannot
+/// disagree about which font measured the text and which font draws it.
+fn resolve_font(asset_cache: &mut AssetCache, font: &str) -> Rc<Box<dyn engine::Font>> {
+    if font == BUILTIN_FONT {
+        return engine::shared_builtin_font();
+    }
+    asset_cache.get(&FONT_IMPORTER, font).clone()
+}
 
 /// A rectangle in canvas pixels.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -164,6 +186,60 @@ impl WorldPanel {
         Matrix4::from_translation(self.center)
             * Matrix4::from(self.rotation)
             * Matrix4::from_nonuniform_scale(self.size.x, self.size.y, 1.0)
+    }
+}
+
+/// The VR menu hangs on a panel 2m ahead of the player at eye level, sized to
+/// the canvas's 4:3 aspect so the art is not stretched.
+///
+/// "Eye level" is not the scene origin: VR runtimes add a head offset of
+/// `player_eye_height / SCALE_FACTOR` on top of the camera position this scene
+/// returns, so a panel at y=0 hangs below the view and is never seen.
+pub const FRONTEND_PANEL_DISTANCE: f32 = 2.0;
+pub const FRONTEND_PANEL_EYE_HEIGHT: f32 = crate::PLAYER_EYE_HEIGHT / dark::SCALE_FACTOR;
+pub const FRONTEND_PANEL_SIZE: Vector2<f32> = Vector2 { x: 2.0, y: 1.5 };
+
+/// Spacing between stacked canvas layers in world space, so the labels sort in
+/// front of the backdrop instead of z-fighting it.
+pub const VR_COMPONENT_Z_STEP: f32 = 0.001;
+
+/// The panel a frontend screen is drawn on in VR: hung `FRONTEND_PANEL_DISTANCE` in front of the
+/// head and turned to face back at it.
+///
+/// It is anchored to the head's **facing**, not to a fixed world axis. There is
+/// no canonical "forward" to hardcode - the runtimes' yaw-0 camera looks along
+/// +X, not -Z - so a panel pinned to -Z sits off to the side and never enters
+/// the frustum. This mirrors `DebugMapScene`'s construction, which is the
+/// world-space panel that demonstrably renders.
+pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
+    let head = vec3(0.0, FRONTEND_PANEL_EYE_HEIGHT, 0.0);
+    let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+    let center = head + forward * FRONTEND_PANEL_DISTANCE;
+
+    // Orient the panel by looking from it back to the head. `look_dir` runs
+    // panel -> head, so the panel's local +Z (the third column) points away
+    // from the viewer - the convention the world-space element path expects.
+    let mut look_dir = head - center;
+    look_dir = if look_dir.magnitude2() < 1e-6 {
+        vec3(0.0, 0.0, 1.0)
+    } else {
+        look_dir.normalize()
+    };
+    let mut up = vec3(0.0, 1.0, 0.0);
+    let mut right = look_dir.cross(up);
+    if right.magnitude2() < 1e-6 {
+        // Looking straight up or down: pick a different up to keep the basis
+        // well-defined.
+        up = vec3(0.0, 0.0, 1.0);
+        right = look_dir.cross(up);
+    }
+    let right = right.normalize();
+    let true_up = right.cross(look_dir).normalize();
+
+    WorldPanel {
+        center,
+        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, -look_dir)),
+        size: FRONTEND_PANEL_SIZE,
     }
 }
 
@@ -709,7 +785,7 @@ where
                     alpha,
                     fit_to_rect,
                 } => {
-                    let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+                    let font_obj = resolve_font(asset_cache, font);
                     place_text(
                         &**font_obj,
                         Rect::new(position.x, position.y, size.x, size.y),
@@ -929,7 +1005,7 @@ fn present_screen(
             object
         }
         PlacedContent::Text { text, font, .. } => {
-            let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+            let font_obj = resolve_font(asset_cache, font);
             // `screen_space_text` anchors on the glyph box's top-left and takes
             // the line height as its size - which is exactly what the placed
             // rect is, so there is nothing to adjust. The rect's *width* is
@@ -978,7 +1054,7 @@ fn present_world(
             SceneObject::new(material, Box::new(engine::scene::quad::create()))
         }
         PlacedContent::Text { text, font, .. } => {
-            let font_obj = asset_cache.get(&FONT_IMPORTER, font).clone();
+            let font_obj = resolve_font(asset_cache, font);
             SceneObject::world_space_text(text, font_obj, (1.0 - alpha).clamp(0.0, 1.0))
         }
     };


### PR DESCRIPTION
## Summary

shock2quest ships no game content, so **"the player hasn't copied a retail install yet" is the single most likely first-run state** — and until now it produced a panic. On the desktop that's a stack trace; on Quest it's a silent return to the Horizon shell, indistinguishable from the app simply being broken. There is also nowhere to read a stack trace inside a headset.

This is that message.

![Missing-assets screen, flatscreen](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/no-assets-flat.png)

<sub>Flatscreen, captured headlessly via `--mission debug_no_assets`.</sub>

![Missing-assets screen, VR](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/no-assets-vr.png)

<sub>The same canvas in VR (`--vr`), on the world-space panel. Same layout, same relative placement — one layout pass feeds both.</sub>

## Two things it can't do that every other screen can

- **Use an asset.** The backdrops and `METAFONT.FON` live in the game data that is missing. So it is text-only in the engine's compiled-in font (#988), named through a new `ui::BUILTIN_FONT` sentinel that the *single* font-resolution point in `layout` understands. Ordinary UI keeps naming its real font and is untouched.
- **Run inside a `Game`.** `Game::init` needs the gamesys. Rather than give `Gamesys`/`MotionDB` a fake empty state — a lie that would sit in the type forever — `App` is an enum of "the game" or "the screen explaining there is no game", exposing the surface the runtimes already called on `Game`. Each runtime changes one line and neither needs a second render loop.

It is otherwise an ordinary `GameScene` on the shared `UiCanvas`, so flat and VR come from one layout pass per AGENTS.md's parity rule.

`frontend_panel` and `VR_COMPONENT_Z_STEP` move out of `main_menu` into `ui`: two frontend screens now hang a panel in VR, and two hand-written copies is exactly the drift that rule warns about. The move is verbatim — `main_menu`'s VR panel tests still pass unchanged.

## Verification

- `cargo test -p shock2vr` — 681 pass. `cargo fmt --all --check`, `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime`, and `cargo apk check` all clean.
- Rendered in **both** presentations (above).
- **On a real Quest 3**, with the data directory temporarily renamed aside: the app runs with **zero panics** where it previously died, and logs
  `install: NO GAME DATA at /sdcard/shock2quest - looked for sshock2.kpf, shock2.gam, ...`.
  Device data restored afterwards and confirmed booting normally (39 entries, 5 mod archives, 2.0 GB).

I could not photograph the screen *inside* the headset unattended: the compositor capture is black because the headset is on a desk and the app never gets XR focus with nobody wearing it. The VR render above is the same canvas through the same world-panel path.

## Review findings applied

Both engines independently found the same defect, and **neither of my verifications could have caught it**:

> `App::MissingAssets` returned `PLAYER_EYE_HEIGHT` for `player_center_above_floor` and `0.0` for `player_eye_cap_above_center`. Those are the wrong *unit space*, not just wrong values — `PLAYER_EYE_HEIGHT` is an unscaled eye height where the VR runtime wants a scaled collider-center height, and the eye cap is a cap, not zero. The panel would have hung ~35° above the player's gaze, on the one screen whose entire job is to be read.

The debug scene can't catch that by construction (it runs inside a real `Game`, so it uses the correct accessors), and the device check only proved the app stops panicking. Now pinned by tests that fail against the old values.

Also fixed:

- The screen showed `data_root` raw — which is the **relative** `../../Data` fallback in exactly the case the screen exists for. `InstallStatus` already canonicalized for its log line; that's now a shared `absolute_data_root` so the logged and displayed paths can't disagree.
- The builtin font covers printable ASCII only and `measure_text_width` drops the rest silently, so a non-ASCII path rendered *wrong* — and a wrapped chunk of nothing but unmapped characters measured zero-wide, built an empty mesh, and **panicked**. A screen that replaces a panic must not have one.
- A deep enough path pushed the closing instruction off the bottom of the canvas.

One note on that last fix: my first attempt looped forever, because re-scanning a string that had already grown a `...` prefix kept finding the same separator. It iterates a fixed segment list instead, which is what makes it terminate — and the pathological-path test is the pin.

## Deliberately not in scope

`debug_runtime` still builds a `Game` directly and so still fails on missing data, now with the clear summary from #991. It is a developer tool driven by HTTP introspection, and there is nothing to introspect here.

Codex also flagged that a *partial or corrupt* install (an unreadable `sshock2.kpf`, or a legacy root missing files it needs) still bypasses this screen and panics deeper down. That's real, but it needs archive-readability validation rather than existence checks — a follow-up, not this change.

## Device verification (headset worn) — and a pre-existing bug it exposed

With someone actually wearing the headset, the screen **does render in VR on the Quest** — the app no longer panics, and the message is there. But it renders **upside-down, mirrored, and below the player's gaze**:

![Missing-assets screen in the headset](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/device-no-assets-vr.png)

**This is not introduced by this PR.** The existing VR main menu, which goes through the same `frontend_panel` code, is inverted in exactly the same way on the same device:

![VR main menu in the headset](https://gist.githubusercontent.com/tommy-xr/2b6e80f72f232db9d86e9f16120817de/raw/device-main-menu-vr.png)

So the shared VR frontend-panel placement is wrong on device, and this screen faithfully inherits it. The desktop `--vr` capture above renders upright, so `debug_runtime`'s camera convention masks it — which is also why it survived review.

I tried one fix during the session (the basis negates `right`/`true_up`, which looked like a 180° roll). On device it mirrored the layout horizontally but left the inversion, so the hypothesis was wrong and **I reverted it** rather than ship a speculative change to the main menu from outside this PR's scope. The likelier cause is the panel being placed behind the viewer: `frontend_panel` derives forward as `head_rotation * (0,0,-1)`, while the doc comment in that same function warns "the runtimes' yaw-0 camera looks along +X, not -Z".

**Recommendation:** land this PR on its merits — it replaces a silent crash with a rendered message, and is strictly better in flat *and* in VR — then fix `frontend_panel` separately, with device iteration, which fixes the main menu and this screen together. I'd rather not bundle a main-menu behavior change into this one.

