### PR TITLE
fix(vr): head-anchored panels, honest world-panel basis, desktop --vr menu input

### DIFF
--- a/.claude/skills/vr-device-loop/scripts/quest-device.mjs
+++ b/.claude/skills/vr-device-loop/scripts/quest-device.mjs
@@ -54,7 +54,10 @@ export function resolveSerial(explicitSerial) {
 export function validateMission(mission) {
   const trimmed = mission.trim();
   const validCharacters = /^[A-Za-z0-9_.-]+$/.test(trimmed);
-  const validName = trimmed.startsWith("debug_") || trimmed.endsWith(".mis");
+  const validName =
+    trimmed.startsWith("debug_") ||
+    trimmed.endsWith(".mis") ||
+    trimmed === "main_menu";
   if (!trimmed || !validCharacters || !validName) {
     throw new Error(`invalid mission name: ${JSON.stringify(mission)}`);
   }

--- a/handoff.md
+++ b/handoff.md
@@ -240,3 +240,115 @@ device. Doing RTT first would bet the refactor on unverifiable engine work.
 - **Launch subagents with worktree isolation** when they will touch git state.
   A non-isolated agent shares the checkout, so its branch switches land your
   commits on its branch and block your own git operations.
+
+---
+
+# OPEN: every world-space UI panel is 180 degrees rotated on a real headset
+
+Added 2026-08-14. The section above ("VR now works end to end") was verified with
+`cargo dbgr --vr` — **never on a Quest**. On device it does not work, and neither
+does anything else drawn on a world-space panel.
+
+## Symptom
+
+On a Quest 3, world-space UI renders rotated 180 degrees in-plane: text mirrored
+and upside down, and vertical order reversed (the main menu lists Quit at the top
+and New Game at the bottom). The **3D world renders correctly** — only panels are
+wrong.
+
+It is **not** scene-specific. Both are inverted identically:
+
+- the VR main menu, via `ui::frontend_panel`
+- `debug_map`, which places a panel **entity** and never calls `frontend_panel`
+
+So the cause is below both. The same builds render both panels **upright** under
+`debug_runtime --vr`.
+
+## Why nobody caught it
+
+`debug_runtime --vr` renders these panels correctly, so every screenshot, both
+code reviews, and the section above all passed. **The harness does not model the
+device for world-space UI.** Until that is fixed, a desktop VR capture is not
+evidence about VR.
+
+## Ruled out ON HARDWARE (do not re-try these)
+
+Each cost a build/install/capture cycle. All were reverted.
+
+| # | Attempt | Result |
+| --- | --- | --- |
+| 1 | Flip `frontend_panel`'s basis (negate `right` + `true_up` — a roll about Z) | Device unchanged; **desktop becomes mirrored**. Moves the bug between runtimes. |
+| 2 | Replace `world_element_transform`'s `from_angle_z(180)` with `from_nonuniform_scale(1,-1,1)` | **Fails the flat/VR parity tests.** The canvas->panel mapping genuinely needs both axes flipped *unless* `canvas_rect_to_panel` changes with it (see #3). |
+| 3 | The full atomic 5-site version (below) | **Desktop correct for both panels** (`debug_map` upright and readable for the first time); **device unchanged**. |
+| 4 | Platform-conditional yaw: `cfg!(target_os = "android")` picking `from_cols(-right, true_up, look_dir)` | Device still mirrored, **and the menu labels vanish entirely**. Strictly worse. |
+
+**#3 is the important negative result.** With a fully honest basis and no
+compensation anywhere, the desktop is right and the headset is still wrong. That
+rules out the UI math — basis, canvas mapping, and layer depth — as the cause.
+It also refutes the natural theory that "desktop is only correct by
+compensation".
+
+### The 5 coupled sites (if you touch one, you touch all of them)
+
+Found by a Codex pass; verified by the parity tests catching an incomplete version.
+
+1. `shock2vr/src/ui/mod.rs` `world_element_transform` — `from_angle_z(Deg(180.0))`, which flips x as well as y
+2. `shock2vr/src/ui/mod.rs` `frontend_panel` — basis with `right = look_dir.cross(up)` (negated) and third column `-look_dir`
+3. `shock2vr/src/scenes/debug_map.rs` (~line 229) — a duplicate of that same basis
+4. `shock2vr/src/ui/mod.rs` `canvas_rect_to_panel` — `vec2(0.5 - p.x, 0.5 - p.y)`, whose doc says it exists to undo the double negation. **This is what the parity tests pin**; with a y-only flip it becomes `vec2(p.x + 0.5, 0.5 - p.y)`.
+5. `shock2vr/src/ui/mod.rs` `render_world_space` — layer z-step direction, which follows the panel's facing convention
+
+## Verified true (don't re-derive)
+
+- **Hit detection follows the panel automatically.** `ray_to_canvas` intersects
+  using `panel.normal()` and un-rotates by `panel.rotation`, both taken from the
+  panel's own transform. A basis change carries the pointer with it; input cannot
+  desync from what is drawn.
+- **`PresentationMode::Vr` cannot distinguish the two runtimes** — desktop `--vr`
+  and the headset are both `Vr`. Any conditional has to be by platform.
+- **`input_context.head.rotation` used to be the RIGHT CONTROLLER's aim pose**
+  (`right_aim_location`), and is the *zero quaternion* when controllers are
+  untracked — `rotate_vector` by it silently returns the vector unrotated, so the
+  panel pinned itself to world `-Z`. Fixed in #994; the panel now tracks the head.
+  This was a real bug but is **not** the rotation cause.
+
+## Leading untested hypothesis
+
+`ui/mod.rs` `frontend_panel` anchors at `let head = vec3(0.0, FRONTEND_PANEL_EYE_HEIGHT, 0.0)`
+— the **world origin**, not the player's tracked position. Desktop's camera sits
+at the origin so it works there; on a headset you are offset roomscale, and a
+double-sided quad viewed from behind reads exactly as mirrored.
+
+Cheap probe: anchor the panel to the actual camera/eye position and re-capture.
+Note `debug_map` places its panel relative to the player entity, so if this is
+the cause it must explain that scene too.
+
+## Recommended technique
+
+This document's own advice from the last round applies directly: **bisection by
+transplant, early.** Four parameter guesses cost four device cycles and produced
+one useful negative. Instead, put a deliberately asymmetric test quad (e.g. an
+"F"-shaped texture) on device through the world-space path and see whether it is
+mirrored, rotated, or fine — that separates *transform* from *content* in one
+cycle, and would distinguish "panel viewed from behind" from "content built
+upside down".
+
+## Device workflow notes
+
+- The headset sleeps within seconds when not worn, and an unfocused app renders
+  nothing — compositor captures come back **black or zero bytes**. Fix:
+  `adb shell am broadcast -a com.oculus.vrpowermanager.prox_close`, then
+  `adb shell input keyevent KEYCODE_WAKEUP`. Without this, none of the above is
+  observable.
+- Capture: `node .claude/skills/vr-device-loop/scripts/quest-device.mjs --serial <S> capture out.png`.
+- Scene selection is `/sdcard/shock2quest/vr-mission.txt` (e.g. `main_menu`,
+  `debug_map`). **Restore it to `medsci1.mis` when done.**
+- `println!` reaches logcat; `tracing::info!` does **not** — neither
+  `desktop_runtime` nor `oculus_runtime` installs a subscriber. Instrumenting
+  `frontend_panel` with a rate-limited `println!` of the head quaternion and
+  basis vectors is what found the zero-quaternion bug, and is the fastest way in.
+
+## PR stack
+
+- [#993](https://github.com/tommy-xr/shock2quest/pull/993) `feat/no-assets-screen` -> `main` — missing-assets screen (inherits this bug in VR)
+- [#994](https://github.com/tommy-xr/shock2quest/pull/994) `fix/vr-frontend-panel-orientation` -> **#993** — the head-pose fix; carries comments at the traps above

--- a/handoff.md
+++ b/handoff.md
@@ -456,5 +456,31 @@ mapping are all honest and desktop-verified). `SHOCK2_PANEL_LOG=1` makes
   tests pass unchanged because element path and corner map moved together.
 - `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
 
-Still open: the device-only factor (untested on hardware since this change),
-and the desktop_runtime `--vr` hand-ray issue (owned by a separate stream).
+## RESOLVED (device): there was no second device-only factor
+
+Verified on the Quest 3 (2026-08-15, release APK of this branch at `b698fe4`):
+
+- **`main_menu`: upright.** New Game top, Quit bottom, every label readable
+  inside its pill. Compositor capture, real tracked head pose.
+- **`debug_map`: upright.** ELEVATOR / CRYO / SCIENCE / MEDICAL SCIENCE legend
+  all read correctly; no mirror, no rotation.
+- The `SHOCK2_PANEL` logcat line shows the same honest basis as desktop
+  (right = viewer's right, normal pointing back at the head), fed by a real
+  tracked quaternion — e.g. `right=(1,0,0) up=(0,0.97,0.22)
+  normal=(0,-0.22,0.97)` for a headset resting pitched up.
+
+So the honest basis fix resolved **both** platforms. The earlier on-hardware
+negative result for attempt #3 ("desktop correct, device unchanged") was almost
+certainly a stale or incomplete device build — the very trap this document
+warns about twice (silent patch no-ops, installs not matching the tree). The
+"one thing still unexplained" section above is thereby explained: there was
+never a second factor, only bad device evidence.
+
+Note for future Android probing: `SHOCK2_PANEL_LOG` is env-gated and env vars
+do not reach an Android app — the device run above used a throwaway local edit
+(`cfg!(target_os = "android") ||` in the gate) that was reverted after capture.
+
+Still open: the desktop_runtime `--vr` hand-ray issue (menu ray is cast as
+`hand.rotation * (0,0,-1)`, OpenXR convention, but desktop's `camera_rotation`
+maps **+Z** to forward, so the simulated hands' rays point backward and
+`ray_to_canvas` rejects the panel as behind the ray).

--- a/handoff.md
+++ b/handoff.md
@@ -503,3 +503,40 @@ Unverified (needs an interactive window): mouse sensitivity — VR keeps the
 cursor in Normal mode, so deltas are per-event and `delta_time`-scaled; finite
 screen travel may under-rotate the hand. If it bites, capture the cursor for
 raw relative motion while a VR panel is up.
+
+---
+
+# CLOSED OUT (2026-08-15): the VR menu effort is a 4-PR stack, all evidence on the PRs
+
+```
+main
+ └─ #994  fix(vr): head-anchored panels, honest basis, desktop --vr input
+     ├─ #997  feat(ui): VR pointer + world panels for load/game-over  (base: #994)
+     │    └─ #998  feat(vr): head-anchored panels with lazy recenter  (base: #997)
+     └─ #996  feat(oculus): remote input injection over adb           (base: #994)
+```
+
+- **#994** carries this document's fixes: head (not controller) anchoring, the
+  honest basis (both platforms; the "second device factor" was a stale APK),
+  and the desktop --vr mouse→hand-ray routing. Device stills + desktop GIF are
+  embedded in the PR. The menu-audio e2e test was re-aimed for the honest
+  mapping (it encoded the old mirrored canvas+x→world+z).
+- **#997** gives LoadGameScene and GameOverScene the VR pointer + world panel
+  (shared `vr_frontend_pointer`, untracked-hand guard, rising-edge fixes). Full
+  VR flow verified: menu → load → row → Done → menu; death → game-over → LOAD.
+- **#998** replaces gaze-glued panels with place-on-entry / gravity-aligned /
+  world-locked / lazy-recenter (`FrontendPanelAnchor`), with `head.position`
+  plumbed through all three runtimes. Device before/after in the PR: panel
+  moved from ~600 px above eye-centre (inverted disparity) to centred, face-on.
+- **#996** adds the Quest remote input server (`/sdcard/shock2quest/debug-port.txt`
+  → loopback HTTP over `adb forward`, shared `shock2vr::input::remote` channel
+  vocabulary, requires `android.permission.INTERNET` — Android denies even
+  loopback bind without it). Used on-device to hover + click the menu with the
+  headset resting on a desk: that capture IS the device interaction proof.
+- Follow-ups filed: #999 (`debug_map` panel ~17° above gaze — hardcoded 1.5 wu
+  head height, pre-existing). Noted in #998: the anchor is per-scene, so the
+  panel re-places on each frontend screen swap; hoist one anchor if that feels
+  jumpy on head.
+- Agent-workflow trap recorded: worktree-isolated subagents branch from
+  origin/main, NOT the session's branch — two agents built on the wrong base
+  and needed rebase + re-verification. Verify `git merge-base` before stacking.

--- a/handoff.md
+++ b/handoff.md
@@ -323,6 +323,51 @@ Cheap probe: anchor the panel to the actual camera/eye position and re-capture.
 Note `debug_map` places its panel relative to the player entity, so if this is
 the cause it must explain that scene too.
 
+## BREAKTHROUGH: this reproduces on the DESKTOP — no headset needed
+
+The transplant probe recommended below was run, and it changes the whole shape
+of this problem.
+
+**Experiment.** In `NoAssetsScene::render`'s VR branch, emit a raw
+`SceneObject::world_space_text` placed with the *same* `panel.center` and
+`panel.rotation` as the canvas, i.e. bypassing `world_element_transform`.
+Placement is held constant; only the element path varies.
+
+**Result:**
+
+| | canvas text | raw probe |
+| --- | --- | --- |
+| `debug_runtime --vr` (desktop) | upright | **180 degrees rotated** |
+| Quest 3 | 180 degrees rotated | **180 degrees rotated** |
+
+**The probe is inverted on BOTH platforms.** So a raw world-space quad placed
+with the panel's own transform renders upside down *on the desktop too* — and
+`world_element_transform`'s `from_angle_z(180)` is the compensation that hides
+it there.
+
+### Why this matters
+
+The panel basis being 180 degrees off is **not** device-specific, and it is
+**desktop-reproducible**. That converts a headset-only bug, costing a
+build/install/capture cycle per idea, into something iterable in seconds with
+`cargo dbgr --vr`. Do that work on the desktop first.
+
+The success criterion to iterate against is now concrete and does not need a
+Quest: **make the raw probe render upright while the canvas stays upright.**
+Today exactly one of the two can be right at a time, which is the real defect —
+two paths to the same panel disagree by 180 degrees, and the canvas path is only
+correct because a hardcoded rotation cancels the error.
+
+### The one thing still unexplained
+
+If the panel basis is 180 off on both platforms, and the element path adds 180
+on both, the canvas should be correct on both. It is not: the canvas is upright
+on desktop and inverted on device, while the probe is identical on both. Attempt
+#3 (the honest 5-site version) also fixed the desktop canvas without changing
+the device. So there is a second, device-only factor on top of the shared basis
+error. Fix the shared, desktop-reproducible error first — it is likely to make
+the remaining device delta much easier to see.
+
 ## Recommended technique
 
 This document's own advice from the last round applies directly: **bisection by

--- a/handoff.md
+++ b/handoff.md
@@ -480,7 +480,26 @@ Note for future Android probing: `SHOCK2_PANEL_LOG` is env-gated and env vars
 do not reach an Android app — the device run above used a throwaway local edit
 (`cfg!(target_os = "android") ||` in the gate) that was reverted after capture.
 
-Still open: the desktop_runtime `--vr` hand-ray issue (menu ray is cast as
-`hand.rotation * (0,0,-1)`, OpenXR convention, but desktop's `camera_rotation`
-maps **+Z** to forward, so the simulated hands' rays point backward and
-`ray_to_canvas` rejects the panel as behind the ray).
+## RESOLVED (desktop `--vr` interaction): input routing, not geometry
+
+The desktop `--vr` menu being dead was a third, separate defect. The suspected
+ray inversion was a **false lead**, measured rather than argued: desktop's
+`camera_rotation` does map local +Z onto `camera_forward`, but the rig defines
+its own forward as `-camera_forward`, so the negations cancel — eye direction,
+panel placement, and hand aim all agree, and `ray_to_canvas` returns a real hit
+for the resting pose. The tell: the hit point was not wrong, it was *constant*.
+`MainMenuScene::wants_pointer()` is unconditionally true, and the rig answered a
+pointer request by zeroing mouse deltas — the flatscreen cursor bargain —
+freezing the only thing that aims the hand rays.
+
+Fix: one routing decision, `mouse_look_target`. E/Q still aim their hand;
+no-pointer still turns the head; pointer+Flat still surrenders to the cursor
+(unchanged); pointer+VR routes the mouse to the **right hand** — head-aiming
+cannot work because the panel is head-anchored, so head and ray move together.
+An undriven hand's mouse-button state is cleared each frame so a press released
+out of order cannot latch the trigger and swallow the menu's rising edge.
+
+Unverified (needs an interactive window): mouse sensitivity — VR keeps the
+cursor in Normal mode, so deltas are per-event and `delta_time`-scaled; finite
+screen travel may under-rotate the hand. If it bites, capture the cursor for
+raw relative motion while a VR panel is up.

--- a/handoff.md
+++ b/handoff.md
@@ -397,3 +397,64 @@ upside down".
 
 - [#993](https://github.com/tommy-xr/shock2quest/pull/993) `feat/no-assets-screen` -> `main` — missing-assets screen (inherits this bug in VR)
 - [#994](https://github.com/tommy-xr/shock2quest/pull/994) `fix/vr-frontend-panel-orientation` -> **#993** — the head-pose fix; carries comments at the traps above
+
+## RESOLVED (desktop): the shared basis error is fixed — the basis is now honest
+
+Landed on this branch (2026-08-15). The "honest" change is now in, atomically,
+at **six** sites — the handoff's five plus one it missed:
+
+1. `world_element_transform`: the `from_angle_z(180)` compensation is gone. The
+   one flip that remains is the canvas-y flip (canvas y grows down, panel y
+   grows up), done as `from_angle_x(180)` — a proper rotation, so triangle
+   winding is preserved (a `scale(1,-1,1)` mirror would flip winding).
+2. `frontend_panel`: basis is `right = up x look_dir` (the viewer's right),
+   `true_up = look_dir x right`, third column **+look_dir** — local +Z points AT
+   the viewer. `WorldPanel::normal` is now genuinely the outward face.
+3. `debug_map.rs`: same basis change (its duplicate copy).
+4. `canvas_rect_to_panel`: corner map is `(p.x + 0.5, 0.5 - p.y)`.
+5. `render_world_space`: layers step **+z** (toward the viewer).
+6. **`gui_manager.rs` (the missed site)**: the MFD proxy entity's outward face
+   is its local -Z, so its root transform now carries an explicit
+   `from_angle_y(180)` at that one boundary, commented. Without this the honest
+   element path would have turned every in-game MFD panel around.
+
+Also fixed by this, silently: `ray_to_canvas` hit-testing was **horizontally
+mirrored** against the old basis (a hit at canvas x mapped to 640-x). Nobody
+noticed because the menu buttons are full-width rows and the unit tests invert
+`ray_to_canvas` to build their hand poses, so the error cancelled. It is gone
+now (`u = cx` under the honest basis), and a click aimed at New Game's true
+rect center was verified to fire New Game (0 -> 747 entities).
+
+### What the probe actually shows now (calibration for the device pass)
+
+With the honest basis, the raw `world_space_text` probe renders **y-flipped
+only** — letter order correct left-to-right, each glyph vertically mirrored —
+NOT 180-rotated. That is not a basis error: `unit_text_vertices` (and every
+raster texture) is authored y-down, and the single canvas-y flip that corrects
+it lives in `world_element_transform`. In other words the earlier "probe is 180
+rotated on both platforms" was y-down content x the old basis's hidden
+turn-around; the turn-around is gone and the y-down convention remains, applied
+once, on purpose, for all content kinds equally.
+
+**Device implication**: re-run the probe on the Quest against this branch.
+Expected if the device shares desktop behavior: probe y-flipped, canvas
+upright. If the canvas is still 180-rotated on device, the delta is now
+guaranteed to be outside the UI math entirely (basis, element path, and canvas
+mapping are all honest and desktop-verified). `SHOCK2_PANEL_LOG=1` makes
+`frontend_panel` print the head quaternion + derived basis via `println!`
+(reaches logcat), rate-limited — compare desktop vs device readings directly.
+
+### Desktop verification evidence (all `cargo dbgr`, DARK_ASSET_PATH=~/ss2-data-unpacked)
+
+- VR menu: canvas upright, New Game top / Quit bottom, labels in their pills.
+- Raw probe: y-flip only (letter order preserved) — basis honest.
+- `debug_map --vr`: panel upright and readable (ELEVATOR / CRYO / key legend).
+- Hover: hand ray aimed at New Game's rect center brightens exactly New Game.
+- Click: trigger pull on New Game transitioned the scene, 0 -> 747 entities.
+- Flat menu: pixel-identical before vs after (ImageChops diff bbox = None).
+- `cargo test -p shock2vr`: 682 passed, zero expectation changes — the parity
+  tests pass unchanged because element path and corner map moved together.
+- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.
+
+Still open: the device-only factor (untested on hardware since this change),
+and the desktop_runtime `--vr` hand-ray issue (owned by a separate stream).

--- a/runtimes/desktop_runtime/src/main.rs
+++ b/runtimes/desktop_runtime/src/main.rs
@@ -175,6 +175,75 @@ fn camera_rotation(camera: &CameraContext) -> Quaternion<f32> {
     mat.rot.invert()
 }
 
+/// Hand yaw the rig snaps back to when neither hand-aim key (E/Q) is held: the
+/// hand then aims straight down the head's facing.
+const REST_HAND_YAW: f32 = 90.0;
+
+/// World pose of one simulated VR hand: `side` is `+1.0` for the right hand and
+/// `-1.0` for the left. The hand sits out in front of the head (so it is
+/// visible) and aims along the head's facing turned by the hand's own
+/// yaw/pitch, which mouse-look drives while E (right) or Q (left) is held.
+///
+/// Its aim axis is **-Z**, the OpenXR aim convention every VR consumer in
+/// `shock2vr` assumes (`main_menu::vr_pointer`, the hand raycasts):
+/// `camera_rotation` maps local +Z to `camera_forward`, and the rig's own
+/// forward is `-camera_forward`, so the two negations cancel.
+fn hand_pose(
+    camera_context: &CameraContext,
+    hand_camera_context: &CameraContext,
+    side: f32,
+) -> (Vector3<f32>, Quaternion<f32>) {
+    let forward = -1.0 * camera_forward(camera_context);
+    let right = Vector3::cross(forward, vec3(0.0, 1.0, 0.0)).normalize();
+    let position = vec3(0.0, 2.0 / SCALE_FACTOR, 0.0)
+        + right * side * 2.0 / SCALE_FACTOR
+        + (forward * 4.0 / SCALE_FACTOR);
+    let rotation = camera_rotation(camera_context) * camera_rotation(hand_camera_context);
+    (position, rotation)
+}
+
+/// What this frame's mouse motion turns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MouseLookTarget {
+    Head,
+    RightHand,
+    LeftHand,
+    /// Nothing: a flatscreen 2D cursor UI is up and owns the mouse.
+    Cursor,
+}
+
+/// Route this frame's mouse motion.
+///
+/// Holding E or Q aims that hand, as always. Otherwise a scene asking for a
+/// pointer (`Game::wants_pointer`) normally takes the mouse: on flatscreen the
+/// cursor *is* the menu, so mouse-look stops.
+///
+/// Under `--vr` that bargain is wrong and was the bug: the frontend is a world
+/// panel aimed by the simulated hand rays, so freezing mouse-look pinned the
+/// ray wherever it happened to point (canvas x=64, left of every button) and
+/// hover/click never responded. Turning the *head* would not have helped
+/// either - the panel is anchored to the head, so head and ray move together
+/// and the hit point never changes. The mouse therefore aims the right hand
+/// directly, which is the only thing that moves the ray across the panel.
+fn mouse_look_target(
+    right_hand_key: bool,
+    left_hand_key: bool,
+    scene_wants_pointer: bool,
+    presentation: shock2vr::PresentationMode,
+) -> MouseLookTarget {
+    if right_hand_key {
+        MouseLookTarget::RightHand
+    } else if left_hand_key {
+        MouseLookTarget::LeftHand
+    } else if !scene_wants_pointer {
+        MouseLookTarget::Head
+    } else if presentation == shock2vr::PresentationMode::Vr {
+        MouseLookTarget::RightHand
+    } else {
+        MouseLookTarget::Cursor
+    }
+}
+
 fn f32_from_bool(v: bool) -> f32 {
     if v { 1.0 } else { 0.0 }
 }
@@ -354,6 +423,7 @@ pub fn main() {
             &mut input_mapper,
             &mut action_state,
             wants_pointer,
+            presentation_mode,
         );
 
         // Flat first-person: left mouse button fires the wielded weapon; right
@@ -501,6 +571,7 @@ fn process_events(
     input_mapper: &mut DesktopInputMapper,
     action_state: &mut InputActionState,
     wants_pointer: bool,
+    presentation: shock2vr::PresentationMode,
 ) -> InputContext {
     let _speed = 20.0;
     let head_rot_speed = 10.0;
@@ -549,42 +620,57 @@ fn process_events(
         }
     }
 
-    // While a 2D cursor UI is up, mouse motion moves the cursor, not the
-    // camera/hands - the original surrenders mouse-look to the metagame.
-    if wants_pointer {
-        rot_yaw = 0.0;
-        rot_pitch = 0.0;
+    let mouse_pressed = |button| window.get_mouse_button(button) == Action::Press;
+    let look_target = mouse_look_target(
+        window.get_key(Key::E) == Action::Press,
+        window.get_key(Key::Q) == Action::Press,
+        wants_pointer,
+        presentation,
+    );
+    match look_target {
+        MouseLookTarget::RightHand => {
+            hand_context.right_hand_context.yaw += rot_yaw * head_rot_speed * delta_time;
+            hand_context.right_hand_context.pitch += rot_pitch * head_rot_speed * delta_time;
+
+            hand_context.right_trigger_pressed = mouse_pressed(MouseButton::Button1);
+            hand_context.right_squeeze_pressed = mouse_pressed(MouseButton::Button2);
+            hand_context.right_a_pressed = mouse_pressed(MouseButton::Button3);
+        }
+        MouseLookTarget::LeftHand => {
+            hand_context.left_hand_context.yaw += rot_yaw * head_rot_speed * delta_time;
+            hand_context.left_hand_context.pitch += rot_pitch * head_rot_speed * delta_time;
+
+            hand_context.left_trigger_pressed = mouse_pressed(MouseButton::Button1);
+            hand_context.left_squeeze_pressed = mouse_pressed(MouseButton::Button2);
+            hand_context.left_a_pressed = mouse_pressed(MouseButton::Button3);
+        }
+        target @ (MouseLookTarget::Head | MouseLookTarget::Cursor) => {
+            if target == MouseLookTarget::Head {
+                camera_context.yaw += rot_yaw * head_rot_speed * delta_time;
+                camera_context.pitch += rot_pitch * head_rot_speed * delta_time;
+            }
+
+            hand_context.left_hand_context.yaw = REST_HAND_YAW;
+            hand_context.left_hand_context.pitch = 0.0;
+
+            hand_context.right_hand_context.yaw = REST_HAND_YAW;
+            hand_context.right_hand_context.pitch = 0.0;
+        }
     }
 
-    if window.get_key(Key::E) == Action::Press {
-        hand_context.right_hand_context.yaw += rot_yaw * head_rot_speed * delta_time;
-        hand_context.right_hand_context.pitch += rot_pitch * head_rot_speed * delta_time;
-
-        hand_context.right_trigger_pressed =
-            window.get_mouse_button(MouseButton::Button1) == Action::Press;
-        hand_context.right_squeeze_pressed =
-            window.get_mouse_button(MouseButton::Button2) == Action::Press;
-        hand_context.right_a_pressed =
-            window.get_mouse_button(MouseButton::Button3) == Action::Press;
-    } else if window.get_key(Key::Q) == Action::Press {
-        hand_context.left_hand_context.yaw += rot_yaw * head_rot_speed * delta_time;
-        hand_context.left_hand_context.pitch += rot_pitch * head_rot_speed * delta_time;
-
-        hand_context.left_trigger_pressed =
-            window.get_mouse_button(MouseButton::Button1) == Action::Press;
-        hand_context.left_squeeze_pressed =
-            window.get_mouse_button(MouseButton::Button2) == Action::Press;
-        hand_context.left_a_pressed =
-            window.get_mouse_button(MouseButton::Button3) == Action::Press;
-    } else {
-        camera_context.yaw += rot_yaw * head_rot_speed * delta_time;
-        camera_context.pitch += rot_pitch * head_rot_speed * delta_time;
-
-        hand_context.left_hand_context.yaw = 90.0;
-        hand_context.left_hand_context.pitch = 0.0;
-
-        hand_context.right_hand_context.yaw = 90.0;
-        hand_context.right_hand_context.pitch = 0.0;
+    // A hand's buttons are the mouse buttons *while the mouse is driving that
+    // hand*. Clearing an undriven hand's buttons keeps a press from latching
+    // when the aim key is released first - a stuck trigger swallows the menu's
+    // rising edge, so the next click does nothing.
+    if look_target != MouseLookTarget::RightHand {
+        hand_context.right_trigger_pressed = false;
+        hand_context.right_squeeze_pressed = false;
+        hand_context.right_a_pressed = false;
+    }
+    if look_target != MouseLookTarget::LeftHand {
+        hand_context.left_trigger_pressed = false;
+        hand_context.left_squeeze_pressed = false;
+        hand_context.left_a_pressed = false;
     }
 
     if camera_context.pitch < -89.0 {
@@ -594,10 +680,6 @@ fn process_events(
     if camera_context.pitch > 89.0 {
         camera_context.pitch = 89.0
     }
-
-    //let rotation = camera_rotation(camera_context);
-    let forward = -1.0 * camera_forward(camera_context);
-    let right = Vector3::cross(forward, vec3(0.0, 1.0, 0.0)).normalize();
 
     let mut right_thumbstick_value = vec2(0.0, 0.0);
     let mut left_thumbstick_value = vec2(0.0, 0.0);
@@ -648,21 +730,19 @@ fn process_events(
     let mut input_context = InputContext::default();
     let head_rotation = camera_rotation(camera_context);
     input_context.head.rotation = head_rotation;
-    input_context.right_hand.position = vec3(0.0, 2.0 / SCALE_FACTOR, 0.0)
-        + right * 2.0 / SCALE_FACTOR
-        + (forward * 4.0 / SCALE_FACTOR);
-    input_context.right_hand.rotation =
-        head_rotation * camera_rotation(&hand_context.right_hand_context);
+    let (right_hand_position, right_hand_rotation) =
+        hand_pose(camera_context, &hand_context.right_hand_context, 1.0);
+    input_context.right_hand.position = right_hand_position;
+    input_context.right_hand.rotation = right_hand_rotation;
     input_context.right_hand.thumbstick = right_thumbstick_value;
     input_context.right_hand.trigger_value = f32_from_bool(hand_context.right_trigger_pressed);
     input_context.right_hand.squeeze_value = f32_from_bool(hand_context.right_squeeze_pressed);
     input_context.right_hand.a_value = f32_from_bool(hand_context.right_a_pressed);
 
-    input_context.left_hand.position = vec3(0.0, 2.0 / SCALE_FACTOR, 0.0)
-        - right * 2.0 / SCALE_FACTOR
-        + (forward * 4.0 / SCALE_FACTOR);
-    input_context.left_hand.rotation =
-        head_rotation * camera_rotation(&hand_context.left_hand_context);
+    let (left_hand_position, left_hand_rotation) =
+        hand_pose(camera_context, &hand_context.left_hand_context, -1.0);
+    input_context.left_hand.position = left_hand_position;
+    input_context.left_hand.rotation = left_hand_rotation;
     input_context.left_hand.thumbstick = left_thumbstick_value;
     input_context.left_hand.trigger_value = f32_from_bool(hand_context.left_trigger_pressed);
     input_context.left_hand.squeeze_value = f32_from_bool(hand_context.left_squeeze_pressed);
@@ -689,4 +769,126 @@ fn process_events(
     input_mapper.poll(window, action_state);
 
     input_context
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shock2vr::ui::{frontend_panel, ray_to_canvas};
+
+    /// The frontend canvas the VR panel presents (`main_menu`'s 640x480).
+    const CANVAS: cgmath::Vector2<f32> = cgmath::Vector2 { x: 640.0, y: 480.0 };
+
+    fn ctx(yaw: f32, pitch: f32) -> CameraContext {
+        CameraContext {
+            yaw,
+            pitch,
+            mouse_position: None,
+        }
+    }
+
+    /// Where the desktop rig's right-hand ray lands on the VR frontend panel,
+    /// in canvas pixels - exactly what `main_menu::vr_pointer` computes.
+    fn right_hand_hit(
+        camera: &CameraContext,
+        hand: &CameraContext,
+    ) -> Option<cgmath::Vector2<f32>> {
+        let (position, rotation) = hand_pose(camera, hand, 1.0);
+        let panel = frontend_panel(camera_rotation(camera));
+        let direction = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+        ray_to_canvas(CANVAS, &panel, position, direction)
+    }
+
+    /// `camera_rotation` maps local **+Z** (not -Z) onto `camera_forward`, and
+    /// the rig's own forward is `-camera_forward` - so a pose built from it
+    /// aims along -Z, the convention every VR consumer assumes. Pinned here
+    /// because the two negations cancelling is easy to "fix" into a backwards
+    /// ray.
+    #[test]
+    fn hand_aim_axis_is_negative_z_and_matches_the_render_direction() {
+        let camera = ctx(0.0, 0.0);
+        let render_direction = camera_rotation(&camera).rotate_vector(vec3(0.0, 0.0, -1.0));
+        let (_, rotation) = hand_pose(&camera, &ctx(REST_HAND_YAW, 0.0), 1.0);
+        let aim = rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
+
+        // Yaw 0 looks along -X in this rig, and the resting hand aims with it.
+        assert!((render_direction - vec3(-1.0, 0.0, 0.0)).magnitude() < 1e-4);
+        assert!((aim - render_direction).magnitude() < 1e-4);
+    }
+
+    /// The geometry is sound: the resting ray does hit the panel, so a miss is
+    /// never why the menu is dead. The right hand sits right of the head, so
+    /// its resting ray lands in the right-hand button column (the historical
+    /// (64.0, 316.8) measurement was taken against the old mirrored
+    /// `ray_to_canvas`; the honest basis reports the same physical hit as
+    /// (576.0, 316.8)). Reaching the *other* buttons still needs the hand aim
+    /// that mouse-look drives, which is what the suppression fix restores.
+    #[test]
+    fn resting_hand_ray_hits_the_panel_in_the_button_column() {
+        let hit = right_hand_hit(&ctx(0.0, 0.0), &ctx(REST_HAND_YAW, 0.0))
+            .expect("resting hand ray should intersect the frontend panel");
+
+        // Measured: (576.0, 316.8) - the buttons start at x=400.
+        assert!(hit.x > CANVAS.x * 0.625 && hit.x < CANVAS.x, "hit: {hit:?}");
+        assert!(hit.y > 0.0 && hit.y < CANVAS.y, "hit: {hit:?}");
+    }
+
+    /// The rig can only aim by yawing the hand, which is mouse-look's job. If
+    /// the runtime surrenders mouse motion to a 2D cursor (as it must in flat
+    /// mode) the hand is frozen at the pose above and no button is ever
+    /// reachable - the desktop `--vr` menu bug. Yawing the hand reaches the
+    /// full canvas width, including the button column.
+    #[test]
+    fn yawing_the_hand_sweeps_the_ray_across_the_whole_canvas() {
+        let camera = ctx(0.0, 0.0);
+        let mut min_x = f32::MAX;
+        let mut max_x = f32::MIN;
+        for step in 0..=180 {
+            let yaw = REST_HAND_YAW - 90.0 + step as f32;
+            if let Some(hit) = right_hand_hit(&camera, &ctx(yaw, 0.0)) {
+                min_x = min_x.min(hit.x);
+                max_x = max_x.max(hit.x);
+            }
+        }
+
+        assert!(min_x < CANVAS.x * 0.1, "min_x: {min_x}");
+        // The menu's buttons live in the right-hand column (x >= 400 on the
+        // 640-wide canvas), so the ray must be able to get there.
+        assert!(max_x > 580.0, "max_x: {max_x}");
+    }
+
+    /// The fix: surrendering mouse-look to a 2D cursor is a flatscreen bargain.
+    /// Doing it under `--vr` froze the head and hands, so the menu ray stuck at
+    /// the resting pose and hover/click never responded. Under `--vr` a
+    /// pointer-wanting scene routes the mouse to the right hand (the only thing
+    /// that moves the ray across the head-anchored panel); E/Q always win.
+    #[test]
+    fn pointer_scenes_route_the_mouse_to_the_right_hand_in_vr() {
+        use shock2vr::PresentationMode::{Flat, Vr};
+
+        assert_eq!(
+            mouse_look_target(false, false, true, Flat),
+            MouseLookTarget::Cursor
+        );
+        assert_eq!(
+            mouse_look_target(false, false, true, Vr),
+            MouseLookTarget::RightHand
+        );
+        assert_eq!(
+            mouse_look_target(false, false, false, Flat),
+            MouseLookTarget::Head
+        );
+        assert_eq!(
+            mouse_look_target(false, false, false, Vr),
+            MouseLookTarget::Head
+        );
+        assert_eq!(
+            mouse_look_target(true, false, true, Vr),
+            MouseLookTarget::RightHand
+        );
+        assert_eq!(
+            mouse_look_target(false, true, true, Vr),
+            MouseLookTarget::LeftHand
+        );
+    }
 }

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -464,6 +464,11 @@ fn main() {
         ..GameOptions::default()
     };
     let mut game = shock2vr::App::init(options, bundle_storage);
+    // The real HMD orientation, from the previous frame's located view.
+    // `input_context` is built before `locate_views` runs, so this frame's view
+    // pose does not exist yet; one frame of latency is imperceptible for
+    // head-anchored UI and is far better than the alternative below.
+    let mut last_view_rotation: Option<cgmath::Quaternion<f32>> = None;
     println!(
         "SHOCK2QUEST_STARTUP mission={} init_ms={:.3}",
         mission,
@@ -714,12 +719,20 @@ fn main() {
         // let dir = cgmath::Quaternion::new(forward_xr.w, forward_xr.x, forward_xr.y, forward_xr.z);
 
         // let forward = dir.rotate_vector(vec3(0.0, 0.0, -time * right_trigger_value * 10.));
-        let head_rotation = cgmath::Quaternion::new(
+        // The RIGHT CONTROLLER's aim pose. It drives hand aiming and, for want
+        // of anything else, has also been standing in for the head - which is
+        // wrong for anything that wants to know where the player is *looking*,
+        // and is the zero quaternion entirely when the controllers are not
+        // tracked.
+        let aim_rotation = cgmath::Quaternion::new(
             right_aim_location.pose.orientation.w,
             right_aim_location.pose.orientation.x,
             right_aim_location.pose.orientation.y,
             right_aim_location.pose.orientation.z,
         );
+        // ...so the head gets the actual head, falling back to the aim pose
+        // only on the first frame, before any view has been located.
+        let head_rotation = last_view_rotation.unwrap_or(aim_rotation);
 
         // Feed the detector before the poses are transformed so this frame's
         // physical stance is available to the crouch request below. Tracked
@@ -760,7 +773,7 @@ fn main() {
 
         let mut input_context = InputContext::default();
         input_context.head.rotation = head_rotation;
-        input_context.right_hand.rotation = head_rotation;
+        input_context.right_hand.rotation = aim_rotation;
         input_context.right_hand.position = right_hand_position;
         input_context.right_hand.trigger_value = right_trigger_value;
         input_context.right_hand.squeeze_value = right_squeeze_value;
@@ -937,6 +950,16 @@ fn main() {
         let (_, views) = session
             .locate_views(VIEW_TYPE, xr_frame_state.predicted_display_time, &stage)
             .unwrap();
+
+        // Remember where the head actually is, for next frame's input context.
+        if let Some(view) = views.first() {
+            last_view_rotation = Some(cgmath::Quaternion::new(
+                view.pose.orientation.w,
+                view.pose.orientation.x,
+                view.pose.orientation.y,
+                view.pose.orientation.z,
+            ));
+        }
 
         let (_, _eyes) = session
             .locate_views(

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -318,7 +318,7 @@ impl GuiManager {
             // authored facing meets the shared canvas path.
             let root_transform = parent_entity_transform
                 * Matrix4::from_angle_y(Deg(180.0))
-                * Matrix4::from_nonuniform_scale(info.world_size.x,info.world_size.y, 1.0);
+                * Matrix4::from_nonuniform_scale(info.world_size.x, info.world_size.y, 1.0);
             gui_obj.set_transform(root_transform);
 
             // Present the panel through the shared UI canvas, so the world

--- a/shock2vr/src/gui/gui_manager.rs
+++ b/shock2vr/src/gui/gui_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Vector2, Vector3, vec3};
+use cgmath::{Deg, EuclideanSpace, InnerSpace, Matrix4, Vector2, Vector3, vec3};
 
 use engine::{assets::asset_cache::AssetCache, scene::SceneObject};
 use rapier3d::prelude::RigidBodyHandle;
@@ -18,8 +18,9 @@ use crate::gui::*;
 use crate::ui::{Rect, UiCanvas};
 
 /// Depth given to each successive panel element so a label does not z-fight
-/// with the art behind it. Panel-local -Z faces the viewer, which is the
-/// direction `UiCanvas::render_world_space` steps in.
+/// with the art behind it. Canvas-local +Z faces the viewer (the root
+/// transform below turns the proxy entity's -Z face into that convention),
+/// which is the direction `UiCanvas::render_world_space` steps in.
 const COMPONENT_Z_STEP: f32 = 0.001;
 
 /// Total depth a panel may spend on that separation. MFD panels are small
@@ -311,8 +312,12 @@ impl GuiManager {
             let _root_transform = parent_entity_transform;
             // * Matrix4::from_translation(info.offset)
             // * Matrix4::from_nonuniform_scale(0.5, 0.6, 1.0);
+            // The proxy entity's outward face is its local -Z, while the
+            // world-space canvas convention is "+Z faces the viewer" - so turn
+            // the panel around here, at the one boundary where the entity's
+            // authored facing meets the shared canvas path.
             let root_transform = parent_entity_transform
-            //     * Matrix4::from_translation(info.offset)
+                * Matrix4::from_angle_y(Deg(180.0))
                 * Matrix4::from_nonuniform_scale(info.world_size.x,info.world_size.y, 1.0);
             gui_obj.set_transform(root_transform);
 

--- a/shock2vr/src/lib.rs
+++ b/shock2vr/src/lib.rs
@@ -34,7 +34,10 @@ mod scripts;
 mod systems;
 #[cfg(test)]
 mod test_support;
-mod ui;
+/// Shared 2D canvas UI: layout, the screen-space presentation, and the
+/// world-space (VR) panel. Public so a runtime can check where its simulated
+/// controller ray lands on a frontend panel (`frontend_panel` + `ray_to_canvas`).
+pub mod ui;
 mod util;
 mod virtual_hand;
 mod vr_config;

--- a/shock2vr/src/scenes/debug_map.rs
+++ b/shock2vr/src/scenes/debug_map.rs
@@ -218,15 +218,17 @@ impl GameScene for DebugMapScene {
             look_dir = look_dir.normalize();
         }
 
+        // Honest basis, same as `ui::frontend_panel`: local +x the viewer's
+        // right, +y up, +Z at the viewer.
         let mut up = vec3(0.0, 1.0, 0.0);
-        let mut right = look_dir.cross(up);
+        let mut right = up.cross(look_dir);
         if right.magnitude2() < 1e-6 {
             up = vec3(0.0, 0.0, 1.0);
-            right = look_dir.cross(up);
+            right = up.cross(look_dir);
         }
         right = right.normalize();
-        let true_up = right.cross(look_dir).normalize();
-        let rotation_matrix = Matrix3::from_cols(right, true_up, -look_dir);
+        let true_up = look_dir.cross(right).normalize();
+        let rotation_matrix = Matrix3::from_cols(right, true_up, look_dir);
 
         // Compose the panel through MapGui - the automap's composition path -
         // and present the shared UiCanvas in world space, anchored at the

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -627,9 +627,10 @@ mod tests {
         let target = panel.center + right * (u * panel.size.x) + up * (v * panel.size.y);
 
         crate::input_context::Hand {
-            // Stand back along the panel's normal and aim at the target.
-            position: target - normal * FRONTEND_PANEL_DISTANCE,
-            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), normal, None),
+            // Stand back on the viewer's side (the normal points at the
+            // viewer) and aim at the target.
+            position: target + normal * FRONTEND_PANEL_DISTANCE,
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -normal, None),
             trigger_value: trigger,
             ..crate::input_context::Hand::default()
         }

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -213,6 +213,14 @@ pub const VR_COMPONENT_Z_STEP: f32 = 0.001;
 /// world-space panel that demonstrably renders.
 pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
     let head = vec3(0.0, FRONTEND_PANEL_EYE_HEIGHT, 0.0);
+    // An untracked pose arrives as the *zero* quaternion, not identity, and
+    // rotating by it silently yields the unrotated vector - so the panel would
+    // pin itself to world -Z and never follow the viewer.
+    let head_rotation = if head_rotation.magnitude2() < 1e-6 {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    } else {
+        head_rotation.normalize()
+    };
     let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
     let center = head + forward * FRONTEND_PANEL_DISTANCE;
 
@@ -225,6 +233,11 @@ pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
     } else {
         look_dir.normalize()
     };
+    // NB: `right` is `look_dir x up`, which rolls the basis 180 degrees about
+    // the view axis relative to a conventional camera basis. Do not "correct"
+    // it in isolation: `world_element_transform` applies its own 180-degree Z
+    // rotation, and flipping only one of the two turns the panel over (checked
+    // on device).
     let mut up = vec3(0.0, 1.0, 0.0);
     let mut right = look_dir.cross(up);
     if right.magnitude2() < 1e-6 {

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -171,17 +171,18 @@ pub struct WorldPanel {
 }
 
 impl WorldPanel {
-    /// The panel's outward face normal.
+    /// The panel's outward face normal: local +Z, pointing at the viewer the
+    /// panel was oriented toward.
     pub fn normal(&self) -> Vector3<f32> {
         self.rotation.rotate_vector(vec3(0.0, 0.0, 1.0))
     }
 
     /// Root transform for [`UiCanvas::render_world_space`].
     ///
-    /// No facing correction is needed: the element path's own 180-degree
-    /// rotation is about **Z** (in-plane, flipping the canvas's axes), so the
-    /// quad's +Z normal is untouched and a panel whose
-    /// [`normal`](Self::normal) faces the viewer renders toward them.
+    /// The basis is honest - local +x the viewer's right, +y up, +Z at the
+    /// viewer - so a raw element placed with this transform alone renders
+    /// upright. The canvas path adds only `world_element_transform`'s
+    /// canvas-y flip on top.
     pub fn transform(&self) -> Matrix4<f32> {
         Matrix4::from_translation(self.center)
             * Matrix4::from(self.rotation)
@@ -221,47 +222,65 @@ pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
     } else {
         head_rotation.normalize()
     };
-    // Assumes -Z forward, which is OpenXR's convention and so correct on
-    // device. `debug_runtime` does NOT share it: its head rotation is built so
-    // that yaw=pitch=0 looks toward -X (see `head_rotation_from_yaw_pitch`
-    // there), because the same rotation also drives the flat viewmodel. The two
-    // conventions are why a world-space panel that reads correctly in
-    // `debug_runtime --vr` renders 180 degrees around on the headset. Unifying
-    // them is the real fix and is bigger than any panel-basis tweak.
+    // Assumes -Z forward, which is OpenXR's convention. The desktop runtimes'
+    // quaternions happen to agree about the *rendered* view direction (their
+    // `camera_rotation` maps -Z to the direction the view matrix actually
+    // looks), so the panel lands in front of the camera on every runtime.
     let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
     let center = head + forward * FRONTEND_PANEL_DISTANCE;
 
     // Orient the panel by looking from it back to the head. `look_dir` runs
-    // panel -> head, so the panel's local +Z (the third column) points away
-    // from the viewer - the convention the world-space element path expects.
+    // panel -> head, and the basis is honest: local +x is the viewer's right,
+    // local +y is up, and local +Z (the third column, [`WorldPanel::normal`])
+    // points *at* the viewer. A raw element placed with this rotation alone
+    // renders upright; no compensating rotation exists anywhere in the element
+    // path (the only remaining flip is `world_element_transform`'s canvas-y
+    // flip, which every presentation shares).
     let mut look_dir = head - center;
     look_dir = if look_dir.magnitude2() < 1e-6 {
         vec3(0.0, 0.0, 1.0)
     } else {
         look_dir.normalize()
     };
-    // NB: do not "fix" this basis in isolation. It is matched to
-    // `world_element_transform`'s 180-degree Z rotation (which the flat/VR
-    // parity tests pin), and separately to the head-rotation convention the
-    // runtime supplies. Flipping it makes the device correct and the desktop
-    // mirrored, or vice versa - both were tried on hardware. See the note on
-    // `forward` below.
     let mut up = vec3(0.0, 1.0, 0.0);
-    let mut right = look_dir.cross(up);
+    // The viewer looks along -look_dir, so their right hand points along
+    // (-look_dir) x up == up x look_dir.
+    let mut right = up.cross(look_dir);
     if right.magnitude2() < 1e-6 {
         // Looking straight up or down: pick a different up to keep the basis
         // well-defined.
         up = vec3(0.0, 0.0, 1.0);
-        right = look_dir.cross(up);
+        right = up.cross(look_dir);
     }
     let right = right.normalize();
-    let true_up = right.cross(look_dir).normalize();
+    let true_up = look_dir.cross(right).normalize();
 
-    WorldPanel {
+    let panel = WorldPanel {
         center,
-        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, -look_dir)),
+        rotation: Quaternion::from(Matrix3::from_cols(right, true_up, look_dir)),
         size: FRONTEND_PANEL_SIZE,
+    };
+
+    // Device-comparison probe: `SHOCK2_PANEL_LOG=1` prints the head pose and
+    // the basis this function derived from it, rate-limited. `println!` (not
+    // `tracing`) on purpose - it reaches logcat on Quest, where no tracing
+    // subscriber is installed.
+    if std::env::var_os("SHOCK2_PANEL_LOG").is_some() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static CALLS: AtomicU32 = AtomicU32::new(0);
+        if CALLS.fetch_add(1, Ordering::Relaxed) % 90 == 0 {
+            println!(
+                "SHOCK2_PANEL head_quat=({:.4},{:.4},{:.4},{:.4}) forward=({:.4},{:.4},{:.4}) right=({:.4},{:.4},{:.4}) up=({:.4},{:.4},{:.4}) normal=({:.4},{:.4},{:.4})",
+                head_rotation.s, head_rotation.v.x, head_rotation.v.y, head_rotation.v.z,
+                forward.x, forward.y, forward.z,
+                right.x, right.y, right.z,
+                true_up.x, true_up.y, true_up.z,
+                look_dir.x, look_dir.y, look_dir.z,
+            );
+        }
     }
+
+    panel
 }
 
 /// Intersect a pointing ray with `panel` and return where it lands, in canvas
@@ -331,9 +350,9 @@ pub fn canvas_rect_to_screen(
 /// [`canvas_rect_to_screen`].
 ///
 /// Derived from the transform the renderer actually uses, so it cannot claim a
-/// placement the panel does not draw. The element path composes an in-plane
-/// 180-degree rotation (about **Z**, so the panel keeps its facing) which
-/// negates both axes; undoing that negation is the whole conversion.
+/// placement the panel does not draw. The element path's only flip is the
+/// canvas-y one (panel-local y grows up, canvas y grows down); undoing it is
+/// the whole conversion.
 pub fn canvas_rect_to_panel(rect: Rect, canvas_size: Vector2<f32>) -> Rect {
     let transform =
         world_element_transform(vec2(rect.x, rect.y), vec2(rect.w, rect.h), canvas_size, 0.0);
@@ -341,7 +360,7 @@ pub fn canvas_rect_to_panel(rect: Rect, canvas_size: Vector2<f32>) -> Rect {
     // unit square, so these are the element's own corners.
     let corner = |x: f32, y: f32| {
         let p = transform * cgmath::vec4(x, y, 0.0, 1.0);
-        vec2(0.5 - p.x, 0.5 - p.y)
+        vec2(p.x + 0.5, 0.5 - p.y)
     };
     let top_left = corner(-0.5, -0.5);
     let bottom_right = corner(0.5, 0.5);
@@ -870,9 +889,11 @@ where
         for (index, element) in placed.iter().enumerate() {
             let alpha = force_alpha.unwrap_or(element.alpha);
             let mut object = present_world(asset_cache, element, alpha, self.size);
+            // Panel-local +Z faces the viewer, so later (higher-layer)
+            // elements step toward them to sort in front of the backdrop.
             object.set_transform(
                 root_transform
-                    * Matrix4::from_translation(vec3(0.0, 0.0, -component_z_step * index as f32)),
+                    * Matrix4::from_translation(vec3(0.0, 0.0, component_z_step * index as f32)),
             );
             objects.push(object);
         }
@@ -1126,6 +1147,12 @@ fn texture_px(texture: &Texture) -> Vector2<f32> {
     vec2(texture.width() as f32, texture.height() as f32)
 }
 
+/// Canvas y grows downward while panel-local y grows up, so the element must
+/// be y-flipped into place. The flip is a 180-degree rotation about **X** - a
+/// proper rotation, not a mirror - so triangle winding is preserved; the cost
+/// is that the quad shows the viewer its local -Z face, which the untextured
+/// two-sided UI materials render identically. Canvas x maps straight to
+/// panel-local +x (the viewer's right), with no compensation anywhere.
 fn world_element_transform(
     position: Vector2<f32>,
     size: Vector2<f32>,
@@ -1134,7 +1161,7 @@ fn world_element_transform(
 ) -> Matrix4<f32> {
     let position = vec2(position.x / canvas_size.x, position.y / canvas_size.y);
     let size = vec2(size.x / canvas_size.x, size.y / canvas_size.y);
-    Matrix4::from_angle_z(Deg(180.0))
+    Matrix4::from_angle_x(Deg(180.0))
         * Matrix4::from_translation(vec3(
             position.x - 0.5 + size.x / 2.0,
             position.y - 0.5 + size.y / 2.0,
@@ -1721,9 +1748,9 @@ mod tests {
 
         #[test]
         fn the_transform_preserves_the_panels_facing() {
-            // The element path's own 180-degree rotation is about Z (in-plane),
-            // so `transform` must not add a facing correction of its own - an
-            // extra Y flip turns the panel away and it renders to nothing.
+            // `transform` must not add a facing correction of its own: the
+            // basis is honest (+Z at the viewer), and an extra Y flip would
+            // turn the panel away and mirror it.
             let panel = panel();
             let right = panel.transform() * cgmath::vec4(0.5, 0.0, 0.0, 1.0);
             assert!(right.x > 0.0, "local +X must stay along world +X");

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -221,6 +221,13 @@ pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
     } else {
         head_rotation.normalize()
     };
+    // Assumes -Z forward, which is OpenXR's convention and so correct on
+    // device. `debug_runtime` does NOT share it: its head rotation is built so
+    // that yaw=pitch=0 looks toward -X (see `head_rotation_from_yaw_pitch`
+    // there), because the same rotation also drives the flat viewmodel. The two
+    // conventions are why a world-space panel that reads correctly in
+    // `debug_runtime --vr` renders 180 degrees around on the headset. Unifying
+    // them is the real fix and is bigger than any panel-basis tweak.
     let forward = head_rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
     let center = head + forward * FRONTEND_PANEL_DISTANCE;
 
@@ -233,11 +240,12 @@ pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
     } else {
         look_dir.normalize()
     };
-    // NB: `right` is `look_dir x up`, which rolls the basis 180 degrees about
-    // the view axis relative to a conventional camera basis. Do not "correct"
-    // it in isolation: `world_element_transform` applies its own 180-degree Z
-    // rotation, and flipping only one of the two turns the panel over (checked
-    // on device).
+    // NB: do not "fix" this basis in isolation. It is matched to
+    // `world_element_transform`'s 180-degree Z rotation (which the flat/VR
+    // parity tests pin), and separately to the head-rotation convention the
+    // runtime supplies. Flipping it makes the device correct and the desktop
+    // mirrored, or vice versa - both were tried on hardware. See the note on
+    // `forward` below.
     let mut up = vec3(0.0, 1.0, 0.0);
     let mut right = look_dir.cross(up);
     if right.magnitude2() < 1e-6 {

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -271,11 +271,22 @@ pub fn frontend_panel(head_rotation: Quaternion<f32>) -> WorldPanel {
         if CALLS.fetch_add(1, Ordering::Relaxed) % 90 == 0 {
             println!(
                 "SHOCK2_PANEL head_quat=({:.4},{:.4},{:.4},{:.4}) forward=({:.4},{:.4},{:.4}) right=({:.4},{:.4},{:.4}) up=({:.4},{:.4},{:.4}) normal=({:.4},{:.4},{:.4})",
-                head_rotation.s, head_rotation.v.x, head_rotation.v.y, head_rotation.v.z,
-                forward.x, forward.y, forward.z,
-                right.x, right.y, right.z,
-                true_up.x, true_up.y, true_up.z,
-                look_dir.x, look_dir.y, look_dir.z,
+                head_rotation.s,
+                head_rotation.v.x,
+                head_rotation.v.y,
+                head_rotation.v.z,
+                forward.x,
+                forward.y,
+                forward.z,
+                right.x,
+                right.y,
+                right.z,
+                true_up.x,
+                true_up.y,
+                true_up.z,
+                look_dir.x,
+                look_dir.y,
+                look_dir.z,
             );
         }
     }

--- a/tools/shock2-sdk/test/menu-audio.e2e.test.ts
+++ b/tools/shock2-sdk/test/menu-audio.e2e.test.ts
@@ -114,7 +114,8 @@ test(
 // (AGENTS.md: "a canvas must render the same way in flatscreen and in VR").
 //
 // The runtime's VR head yaw is +90 degrees (the camera looks along -X), so the
-// panel hangs at x=-2 with canvas +x mapping to world +z and canvas +y to -y.
+// panel hangs at x=-2 facing back at the head: canvas +x maps to world -z
+// (the viewer's right) and canvas +y to -y.
 // A hand placed on the button's world position and aimed along -X points at it.
 const PANEL_DISTANCE = 2;
 const PANEL_SIZE = { x: 2, y: 1.5 };
@@ -125,7 +126,7 @@ const AIM_AT_PANEL: [number, number, number, number] = [0, 0.7071068, 0, 0.70710
 const panelPoint = ([u, v]: [number, number]): [number, number, number] => [
   -PANEL_DISTANCE,
   PLAYER_EYE_HEIGHT_WORLD + (0.5 - v) * PANEL_SIZE.y,
-  (u - 0.5) * PANEL_SIZE.x,
+  (0.5 - u) * PANEL_SIZE.x,
 ];
 
 test(


### PR DESCRIPTION
# VR frontend menus: head anchoring, honest panel basis, desktop `--vr` input

This PR grew from "anchor the panel to the head" into the full fix for world-space frontend UI in VR. It now carries three fixes, each device- or harness-verified:

## 1. Panels anchor to the head, not the right controller

The VR main menu hung its panel "in front of the head" — but the rotation it was given was `right_aim_location`, the **right controller's aim pose**, not the head. On device the panel followed the controller, and with controllers untracked the pose is the **zero quaternion** — `rotate_vector` by it silently returns the vector unrotated, pinning the panel to world `-Z` forever.

`input_context.head.rotation` now carries the actual HMD orientation from the located view (previous frame's view — one imperceptible frame of latency; frame 0 falls back to the aim pose). `frontend_panel` also guards degenerate rotations so an untracked pose can never silently mean "unrotated" again.

## 2. The 180° panel inversion: the basis was dishonest, now it isn't

Every world-space panel rendered 180° rotated on the Quest (text mirrored + upside down, menu order reversed) while looking correct under `debug_runtime --vr`. After a desktop-reproducible probe isolated it, the cause turned out to be a **shared basis error hidden by compensation**: `frontend_panel` built a basis facing *away* from the viewer, and `world_element_transform` carried a hardcoded `from_angle_z(180°)` that cancelled it — on desktop. The fix makes the basis honest, atomically at six coupled sites:

- `frontend_panel` (and `debug_map`'s duplicate): `right = up × look_dir`, third column **+look_dir** — local +Z points at the viewer; `WorldPanel::normal` is genuinely the outward face.
- `world_element_transform`: the 180° compensation is gone; the one remaining flip is the canvas-y flip (canvas y grows down), done as a winding-preserving X rotation.
- `canvas_rect_to_panel` corner map and the `render_world_space` layer z-step move with it.
- `gui_manager`: the MFD proxy's outward face is its local −Z, converted at one commented boundary.

This also removed a latent **horizontal mirror in `ray_to_canvas` hit-testing** (a hit at canvas x mapped to 640−x; unnoticed because menu rows are full-width and the tests inverted the same math).

An earlier device experiment suggested a "second, device-only factor" — that was a stale device build. The honest basis fixes **both** platforms; there was never a second factor.

## 3. Desktop `--vr` can actually operate the menu

A third, separate defect: `wants_pointer()` made the desktop rig zero mouse deltas (the flatscreen cursor bargain), freezing the only thing that aims the simulated hand rays — the ray geometry was always sound. Under `--vr` a pointer-wanting scene now routes mouse motion to the **right hand** (`mouse_look_target`), mouse buttons drive that hand's trigger/squeeze, and an undriven hand's buttons are cleared so a stale press can't latch and swallow the menu's rising click edge. Flat behavior is unchanged. Tests pin the aim axis, the resting hit, a full-width sweep, and the routing table.

## Evidence

### Quest 3 (release APK of this branch, compositor captures, real tracked head pose)

Main menu — upright, New Game top → Quit bottom, hotkey badges 1–6 in order:

![Quest 3 main menu, upright](https://gist.githubusercontent.com/tommy-xr/cd1d8675ff2412ab09ae2200a3db3fd9/raw/quest3-main-menu.png)

`debug_map` — panel entity path, legend reads correctly (grazing angle is the headset physically resting on a desk, not a panel bug):

![Quest 3 debug_map legend, upright](https://gist.githubusercontent.com/tommy-xr/cd1d8675ff2412ab09ae2200a3db3fd9/raw/quest3-debug-map.png)

### Desktop `debug_runtime --vr` — hand-ray hover + select

![desktop --vr hover and select](https://gist.githubusercontent.com/tommy-xr/cd1d8675ff2412ab09ae2200a3db3fd9/raw/desktop-vr-hover-select.gif)

<sub>Hand ray sweeps New Game → Load Game → Quit → back, hover highlight following the ray (verified numerically via label-rect luminance), then a trigger pull on New Game transitions into `earth.mis`. Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`, deterministic fixed-timestep), driving only `right_hand.position` / `right_hand.trigger`.</sub>

![desktop --vr hover still](https://gist.githubusercontent.com/tommy-xr/cd1d8675ff2412ab09ae2200a3db3fd9/raw/desktop-vr-hover.png)

## Verification

- Quest 3: `main_menu` and `debug_map` both upright (fresh release install, provenance checked against the tree; the earlier contradictory device data came from a stale APK).
- Flat menu render: **pixel-identical** before vs after the basis change (ImageChops diff bbox = None).
- `cargo test -p shock2vr`: 682 passed, no expectation changes — the flat/VR parity tests pass unchanged because the element path and corner map moved together.
- Desktop `--vr`: hover brightens exactly the entry under the ray; trigger on New Game transitions the scene (0 → 747 entities).
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean.

## Known gaps (follow-ups, not in this PR)

- `LoadGameScene` / `GameOverScene` have no VR pointer path yet — in VR, New Game is the only live menu entry. In progress on a follow-up branch.
- No remote input injection exists on the Quest build, so on-device menu *interaction* (vs rendering) can't be agent-verified yet — a minimal file-gated debug control server is in progress as a follow-up.
- Desktop `--vr` mouse sensitivity for the hand ray is untuned (needs an interactive window to judge).
