### PR TITLE
feat(oculus): file-gated remote input injection over adb

### DIFF
--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -168,8 +168,18 @@ Patched channels are an **override**, not a replacement: the frame loop still
 builds its `InputContext` from OpenXR and only the claimed channels are
 overwritten, so a human can wear the headset while an agent nudges one channel.
 `null` (or `POST /v1/control/input/clear`) releases a channel back to the
-controller. The channel vocabulary is `shock2vr::input::remote`, shared verbatim
-with `runtimes/debug_runtime` (`runtimes/oculus_runtime/src/debug_input.rs`).
+controller; releasing a channel that was never claimed is a 400, so a typo'd
+release cannot silently leave the real override latched. Claims persist until
+released - **clear before disconnecting**, or the wearer is left holding
+whatever the agent set. The channel vocabulary is `shock2vr::input::remote`,
+shared verbatim with `runtimes/debug_runtime`
+(`runtimes/oculus_runtime/src/debug_input.rs`).
+
+Caveat: `head.rotation` / `head.look` drive aim and locomotion direction only -
+the rendered view still comes from the OpenXR views, so claiming them
+desynchronizes what a wearer sees from where the game thinks they are aiming
+(and `head.look`'s yaw/pitch is the flat camera convention, not the VR head
+frame). Prefer the hand channels for VR interaction.
 
 ## Toward a device debug runtime
 

--- a/.claude/skills/vr-device-loop/SKILL.md
+++ b/.claude/skills/vr-device-loop/SKILL.md
@@ -145,6 +145,32 @@ When opening or updating a PR, use the `pr-visuals` hosting and embedding
 workflow, but use these Quest artifacts whenever the claim depends on device
 behavior. Include before/after device captures for visual modifications.
 
+## Drive input on the device
+
+The device runtime can accept remote input, so menu/aim/trigger interaction is
+verifiable without a human in the headset. It is gated on a port file (env vars
+do not reach an Android app) and binds loopback only:
+
+```bash
+adb shell "echo 8171 > /sdcard/shock2quest/debug-port.txt"   # then (re)launch
+adb logcat -d RustStdoutStderr:V '*:S' | grep SHOCK2QUEST_DEBUG_SERVER
+adb forward tcp:8171 tcp:8171
+
+curl -s http://127.0.0.1:8171/v1/status
+curl -s -X POST http://127.0.0.1:8171/v1/control/input \
+  -d '{"right_hand.rotation":[0,0,0,1],"right_hand.trigger":1.0}'
+curl -s -X POST http://127.0.0.1:8171/v1/control/input -d '{"right_hand.trigger":null}'
+curl -s -X POST http://127.0.0.1:8171/v1/input/action -d '{"action":"QuickSave"}'
+adb shell rm /sdcard/shock2quest/debug-port.txt              # disable again
+```
+
+Patched channels are an **override**, not a replacement: the frame loop still
+builds its `InputContext` from OpenXR and only the claimed channels are
+overwritten, so a human can wear the headset while an agent nudges one channel.
+`null` (or `POST /v1/control/input/clear`) releases a channel back to the
+controller. The channel vocabulary is `shock2vr::input::remote`, shared verbatim
+with `runtimes/debug_runtime` (`runtimes/oculus_runtime/src/debug_input.rs`).
+
 ## Toward a device debug runtime
 
 Prefer a thin loopback-only HTTP server reached through `adb forward`, sharing
@@ -152,9 +178,10 @@ wire types and behavior with `runtimes/debug_runtime`, rather than a separate
 automation model. Add it incrementally:
 
 1. `GET /v1/info` and `GET /v1/metrics` for mission, session state, frame
-   counter, views, and aggregate timings.
+   counter, views, and aggregate timings. (`GET /v1/status` covers mission +
+   frame counter today.)
 2. `POST /v1/screenshot` for a raw left/right swapchain capture.
-3. Existing input actions and control channels.
+3. ~~Existing input actions and control channels.~~ Done - see above.
 4. Entity/physics inspection only after the common interface is extracted.
 
 Keep OpenXR rendering focused while serving requests. A server that responds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,7 @@ dependencies = [
  "oboe 0.5.0",
  "openxr",
  "pcx",
+ "serde_json",
  "shock2vr",
  "tokio",
  "tracing",

--- a/projects/debug-runtime.md
+++ b/projects/debug-runtime.md
@@ -233,6 +233,12 @@ POST /v1/player/stats     - Provision skills/stats/psi tier/cyber modules
 POST /v1/screenshot       - Capture screenshot
 ```
 
+The `/v1/control/input` channel vocabulary lives in `shock2vr::input::remote`
+(not in this runtime), because the oculus runtime speaks the same channels for
+on-device automation - see the `vr-device-loop` skill. There it is applied as an
+override on top of the OpenXR-built `InputContext` (`InputOverrides`); here the
+runtime owns the context and patches it directly.
+
 ## Usage
 
 ### Starting the Debug Runtime

--- a/runtimes/debug_runtime/src/main.rs
+++ b/runtimes/debug_runtime/src/main.rs
@@ -32,10 +32,13 @@ use engine::{
 };
 use shock2vr::{
     Game, GameOptions, SpawnLocation,
-    input::{InputAction, InputActionState},
+    input::{InputAction, InputActionState, remote as remote_input},
     input_context::InputContext,
     time::Time,
 };
+// The remote-control channel vocabulary (`head.look`, `right_hand.trigger`, ...)
+// is shared with the oculus runtime's on-device input server.
+use remote_input::{apply_input_patch, head_rotation_from_yaw_pitch};
 
 // Property imports for state queries
 use dark::properties::{PropModelName, PropPosition, PropSymName, PropTemplateId};
@@ -168,26 +171,6 @@ const FIXED_STEP_DT: f32 = 1.0 / 60.0;
 /// so it caps `/v1/step` and `/v1/screenshot` latency at this duration; a few
 /// ms is a no-op for automation but returns the core the rest of the time.
 const IDLE_SLEEP: Duration = Duration::from_millis(4);
-
-/// Head rotation for a yaw/pitch (degrees), matching the desktop runtime's
-/// camera convention (`camera_forward` / `camera_rotation`): at `yaw=pitch=0`
-/// the forward is `(1,0,0)` fed through `look_at_rh`, i.e. looking toward `-X`.
-/// The SAME rotation drives both the render camera and `InputContext.head`, so
-/// the flat viewmodel (placed relative to the head) and the rendered view always
-/// agree - otherwise the viewmodel renders off-axis as a giant side-on slab.
-fn head_rotation_from_yaw_pitch(yaw_deg: f32, pitch_deg: f32) -> Quaternion<f32> {
-    use cgmath::{Decomposed, Rotation, Transform, point3};
-    let (yaw, pitch) = (yaw_deg.to_radians(), pitch_deg.to_radians());
-    let forward = point3(
-        yaw.cos() * pitch.cos(),
-        pitch.sin(),
-        yaw.sin() * pitch.cos(),
-    );
-    let up = vec3(0.0, 1.0, 0.0);
-    let decomposed: Decomposed<Vector3<f32>, Quaternion<f32>> =
-        Transform::look_at_rh(forward, point3(0.0, 0.0, 0.0), up);
-    decomposed.rot.invert()
-}
 
 fn default_camera_head_rotation() -> Quaternion<f32> {
     head_rotation_from_yaw_pitch(0.0, 0.0)
@@ -1813,203 +1796,6 @@ fn input_state_from_context(input: &InputContext) -> commands::InputState {
     }
 }
 
-/// Patch a single channel of the runtime-owned input state, returning false for
-/// an unrecognized channel or a value of the wrong shape. These persist across
-/// frames (a held trigger, a fixed aim), unlike the edge-triggered actions of
-/// `/v1/input/action`.
-///
-/// Recognized channels:
-/// - `head.rotation`                : `[x, y, z, w]` quaternion
-/// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z).
-///   **Pitch is POSITIVE DOWN** - `+60` looks at the floor, `-60` at the ceiling
-///   - matching the desktop runtime, where mouse-down increments pitch. The same
-///   rotation drives movement, so on a ladder `+pitch` descends and `-pitch`
-///   ascends - a test that pitches `-60` to "look down" at a ladder climbs UP,
-///   which is how issue #603's repro was written.
-/// - `{left,right}_hand.trigger`    : number in [0, 1] (alias `trigger_value`)
-/// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
-/// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
-/// - `{left,right}_hand.thumbstick` : `[x, y]`
-/// - `jump`                         : number `0` or `1`
-/// One line describing every recognized input channel, used in error messages so
-/// a bad request is self-documenting. Includes the locomotion semantics (which
-/// stick does what) since that is the game's convention, not guessable.
-fn input_channels_help() -> &'static str {
-    "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
-     pointer.position [x,y] in [0,1] (origin top-left; null clears), pointer.pressed 0|1, \
-     {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
-     {left,right}_hand.thumbstick [x,y], \
-     {left,right}_hand.position [x,y,z] (pawn-local), \
-     {left,right}_hand.rotation [x,y,z,w], \
-     crouch 0|1 (stand-up refused without headroom), \
-     jump 0|1 (held; launches on the grounded rising edge); \
-     locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
-     left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
-}
-
-fn apply_input_patch(input: &mut InputContext, channel: &str, value: &Value) -> Result<(), String> {
-    use cgmath::Vector2;
-
-    // Parse a scalar/array value for `channel`, attributing a clear error to the
-    // channel and value shape when it doesn't match.
-    fn num(channel: &str, v: &Value) -> Result<f32, String> {
-        v.as_f64()
-            .map(|f| f as f32)
-            .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))
-    }
-    fn arr(channel: &str, v: &Value, n: usize) -> Result<Vec<f32>, String> {
-        let a = v.as_array().ok_or_else(|| {
-            format!("channel '{channel}' expects an array of {n} numbers, got {v}")
-        })?;
-        if a.len() != n {
-            return Err(format!(
-                "channel '{channel}' expects {n} numbers, got {} ({v})",
-                a.len()
-            ));
-        }
-        a.iter()
-            .map(|e| num(channel, e))
-            .collect::<Result<Vec<_>, _>>()
-    }
-
-    // Hand channels: "<left|right>_hand.<field>"
-    if let Some((side, field)) = channel.split_once("_hand.") {
-        let hand = match side {
-            "left" => &mut input.left_hand,
-            "right" => &mut input.right_hand,
-            _ => {
-                return Err(format!(
-                    "unknown input channel '{channel}'; {}",
-                    input_channels_help()
-                ));
-            }
-        };
-        return match field {
-            "trigger" | "trigger_value" => {
-                hand.trigger_value = num(channel, value)?;
-                Ok(())
-            }
-            "squeeze" | "squeeze_value" => {
-                hand.squeeze_value = num(channel, value)?;
-                Ok(())
-            }
-            "a" | "a_value" => {
-                hand.a_value = num(channel, value)?;
-                Ok(())
-            }
-            "thumbstick" => {
-                let a = arr(channel, value, 2)?;
-                hand.thumbstick = Vector2::new(a[0], a[1]);
-                Ok(())
-            }
-            "position" => {
-                let p = arr(channel, value, 3)?;
-                hand.position = cgmath::vec3(p[0], p[1], p[2]);
-                Ok(())
-            }
-            "rotation" => {
-                let q = arr(channel, value, 4)?;
-                hand.rotation =
-                    cgmath::InnerSpace::normalize(Quaternion::new(q[3], q[0], q[1], q[2]));
-                Ok(())
-            }
-            _ => Err(format!(
-                "unknown input channel '{channel}'; {}",
-                input_channels_help()
-            )),
-        };
-    }
-
-    match channel {
-        "head.rotation" => {
-            let q = arr(channel, value, 4)?;
-            input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
-            Ok(())
-        }
-        // Desktop camera convention (yaw=pitch=0 looks toward -X); drives both
-        // the render camera and the viewmodel. Convenient for pointing the
-        // camera without hand-authoring a quaternion.
-        "head.look" => {
-            let yp = arr(channel, value, 2)?;
-            input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
-            Ok(())
-        }
-        // Flat-mode 2D pointer (cursor). Position is normalized [0,1] per
-        // axis, origin top-left; setting either channel materializes the
-        // pointer (it is `None` until first set). `pointer.position: null`
-        // clears the pointer back to `None` (scenes branch on Some/None, so
-        // the cleared state must be reachable for testing).
-        "pointer.position" => {
-            if value.is_null() {
-                input.pointer = None;
-                return Ok(());
-            }
-            let xy = arr(channel, value, 2)?;
-            if !(xy[0].is_finite() && xy[1].is_finite())
-                || !(0.0..=1.0).contains(&xy[0])
-                || !(0.0..=1.0).contains(&xy[1])
-            {
-                return Err(format!(
-                    "channel '{channel}' expects normalized coordinates in [0,1], got [{}, {}]",
-                    xy[0], xy[1]
-                ));
-            }
-            let pointer = input
-                .pointer
-                .get_or_insert(shock2vr::input_context::Pointer2D {
-                    position: cgmath::vec2(0.0, 0.0),
-                    pressed: false,
-                });
-            pointer.position = cgmath::vec2(xy[0], xy[1]);
-            Ok(())
-        }
-        "pointer.pressed" => {
-            let pressed = match num(channel, value)? {
-                v if v == 0.0 => false,
-                v if v == 1.0 => true,
-                v => {
-                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
-                }
-            };
-            let pointer = input
-                .pointer
-                .get_or_insert(shock2vr::input_context::Pointer2D {
-                    position: cgmath::vec2(0.0, 0.0),
-                    pressed: false,
-                });
-            pointer.pressed = pressed;
-            Ok(())
-        }
-        // Crouch request: like the desktop LeftControl hold. The ACTUAL state
-        // can lag (standing up is refused without headroom); observe it via
-        // the player's body y (the collider center drops when crouched).
-        "crouch" => {
-            input.crouch = match num(channel, value)? {
-                v if v == 0.0 => false,
-                v if v == 1.0 => true,
-                v => {
-                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
-                }
-            };
-            Ok(())
-        }
-        "jump" => {
-            input.jump = match num(channel, value)? {
-                v if v == 0.0 => false,
-                v if v == 1.0 => true,
-                v => {
-                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
-                }
-            };
-            Ok(())
-        }
-        _ => Err(format!(
-            "unknown input channel '{channel}'; {}",
-            input_channels_help()
-        )),
-    }
-}
-
 fn input_snapshot_from_context(input: &InputContext) -> InputSnapshot {
     fn hand_snapshot(hand: commands::InputHand) -> HandSnapshot {
         HandSnapshot {
@@ -3469,49 +3255,13 @@ async fn get_input_state(
     }
 }
 
-/// Parse a `/v1/control/input` POST body into input patches, accepting either
-/// shape:
-/// - explicit:  `{"channel": "right_hand.trigger", "value": 1.0}`
-/// - map form:  `{"right_hand.trigger": 1.0, "head.look": [30, 0]}`
-///
-/// The map form is detected when the object does NOT have both `channel` and
-/// `value` keys. Returns an actionable error (not a silent empty patch) when the
-/// body isn't a usable object, so a malformed request fails loudly.
+/// Parse a `/v1/control/input` POST body into input patches. The channel
+/// vocabulary and both accepted body shapes live in `shock2vr::input::remote`,
+/// shared with the oculus runtime's remote-input server.
 fn parse_input_patches(body: &serde_json::Value) -> Result<Vec<commands::InputPatch>, String> {
-    let obj = body.as_object().ok_or_else(|| {
-        format!(
-            "request body must be a JSON object, e.g. {{\"channel\":\"right_hand.trigger\",\"value\":1.0}} \
-             or {{\"right_hand.trigger\":1.0}}; {}",
-            input_channels_help()
-        )
-    })?;
-
-    // Explicit {channel, value} form.
-    if obj.contains_key("channel") && obj.contains_key("value") {
-        let channel = obj["channel"]
-            .as_str()
-            .ok_or_else(|| "\"channel\" must be a string".to_string())?
-            .to_string();
-        return Ok(vec![commands::InputPatch {
-            channel,
-            value: obj["value"].clone(),
-        }]);
-    }
-
-    if obj.is_empty() {
-        return Err(format!(
-            "no input channels in request; {}",
-            input_channels_help()
-        ));
-    }
-
-    // Map form: every key is a channel name.
-    Ok(obj
-        .iter()
-        .map(|(channel, value)| commands::InputPatch {
-            channel: channel.clone(),
-            value: value.clone(),
-        })
+    Ok(remote_input::parse_input_patches(body)?
+        .into_iter()
+        .map(|(channel, value)| commands::InputPatch { channel, value })
         .collect())
 }
 

--- a/runtimes/oculus_runtime/Cargo.toml
+++ b/runtimes/oculus_runtime/Cargo.toml
@@ -31,6 +31,11 @@ launch_mode = "singleTask"
 orientation = "landscape"
 resizeable_activity = false
 
+# Loopback-only debug input server (debug_input.rs): Android denies socket()/
+# bind() even on 127.0.0.1 to apps without INTERNET permission.
+[[package.metadata.android.uses_permission]]
+name = "android.permission.INTERNET"
+
 [[package.metadata.android.uses_permission]]
 name = "android.permission.WRITE_EXTERNAL_STORAGE"
 

--- a/runtimes/oculus_runtime/Cargo.toml
+++ b/runtimes/oculus_runtime/Cargo.toml
@@ -79,5 +79,6 @@ ndk-sys = "0.4.0"
 cgmath = "0.18.0"
 libm = "0.2.5"
 lazy_static = "1.4.0"
+serde_json = "1.0"
 tokio = { version = "1.22.0", features = ["full"] }
 tracing = "0.1.37"

--- a/runtimes/oculus_runtime/src/debug_input.rs
+++ b/runtimes/oculus_runtime/src/debug_input.rs
@@ -13,9 +13,11 @@
 //! unparseable => nothing is started. The listener binds loopback only, so it is
 //! reachable exclusively through `adb forward tcp:<port> tcp:<port>`.
 
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
 use std::{fs, thread};
 
 use serde_json::{Value, json};
@@ -25,13 +27,29 @@ use shock2vr::input_context::InputContext;
 
 pub const PORT_CONFIG_PATH: &str = "/sdcard/shock2quest/debug-port.txt";
 
+/// Connections are served one at a time, so a client that stalls mid-request
+/// would otherwise block every later request - including the `null` / `clear`
+/// that releases a latched movement override. Time the socket out instead.
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on a request body. `Content-Length` is attacker-supplied and the buffer
+/// is allocated up front, so an absurd length would OOM-kill the game.
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// Bound on queued actions, so a client that posts while the XR session is
+/// idle (the frame loop is not running, so nothing drains) cannot grow it
+/// without limit.
+const MAX_PENDING_ACTIONS: usize = 64;
+
 /// State shared between the HTTP thread and the frame loop.
 #[derive(Default)]
 struct SharedState {
     overrides: InputOverrides,
-    /// Actions posted since the last frame, delivered exactly once (they are
-    /// edge-triggered, unlike the level-held channels).
-    pending_actions: Vec<InputAction>,
+    /// Actions posted since the last frame. Delivered ONE PER FRAME, in order:
+    /// they are edge-triggered, and firing a whole queue into a single
+    /// `Game::update` would collapse a scripted sequence (save, then load) into
+    /// one dispatch.
+    pending_actions: VecDeque<InputAction>,
     frame: u64,
 }
 
@@ -76,11 +94,14 @@ impl DebugInputServer {
     /// deliver any queued discrete actions. Call once per frame, immediately
     /// before `game.update`.
     pub fn apply(&self, input: &mut InputContext, actions: &mut InputActionState) {
-        let mut state = self.state.lock().unwrap();
+        let mut state = lock(&self.state);
         state.frame += 1;
         state.overrides.apply(input);
-        for action in state.pending_actions.drain(..) {
+        if let Some(action) = state.pending_actions.pop_front() {
             actions.trigger(action);
+            // Single-shot semantics, matching the debug runtime: don't leave a
+            // remotely fired action held for the rest of the process.
+            actions.release(action);
         }
     }
 }
@@ -100,7 +121,17 @@ fn parse_port(raw: &str) -> Option<u16> {
     }
 }
 
+/// Lock the shared state, ignoring poisoning: a panic in the HTTP thread must
+/// not take the render thread down with it on the next frame.
+fn lock(state: &Arc<Mutex<SharedState>>) -> MutexGuard<'_, SharedState> {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn serve_connection(mut stream: TcpStream, state: &Arc<Mutex<SharedState>>, mission: &str) {
+    let _ = stream.set_read_timeout(Some(SOCKET_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(SOCKET_TIMEOUT));
     let (status, body) = match read_request(&mut stream) {
         Ok((method, path, body)) => handle_request(state, mission, &method, &path, &body),
         Err(message) => (400, json!({ "error": message })),
@@ -146,6 +177,11 @@ fn read_request(stream: &mut TcpStream) -> Result<(String, String, String), Stri
         }
     }
 
+    if content_length > MAX_BODY_BYTES {
+        return Err(format!(
+            "request body too large ({content_length} bytes, max {MAX_BODY_BYTES})"
+        ));
+    }
     let mut body = vec![0u8; content_length];
     if content_length > 0 {
         reader
@@ -167,7 +203,7 @@ fn handle_request(
     let path = path.split('?').next().unwrap_or(path);
     match (method, path) {
         ("GET", "/v1/status") => {
-            let state = state.lock().unwrap();
+            let state = lock(state);
             (
                 200,
                 json!({
@@ -178,7 +214,7 @@ fn handle_request(
             )
         }
         ("GET", "/v1/control/input") => {
-            let state = state.lock().unwrap();
+            let state = lock(state);
             (200, json!({ "overrides": state.overrides.channels() }))
         }
         ("POST", "/v1/control/input") => {
@@ -190,21 +226,24 @@ fn handle_request(
                 Ok(patches) => patches,
                 Err(error) => return (400, json!({ "error": error })),
             };
-            let mut state = state.lock().unwrap();
+            let mut state = lock(state);
+            // Apply the whole batch to a scratch copy first: a request whose
+            // second channel is bad must not leave the first one latched (the
+            // map form isn't even ordered by what the caller wrote).
+            let mut updated = state.overrides.clone();
             for (channel, value) in patches {
-                // Stop at the first bad channel so the caller gets an
-                // actionable error instead of a silent partial apply.
-                if let Err(error) = state.overrides.set(&channel, value) {
+                if let Err(error) = updated.set(&channel, value) {
                     return (400, json!({ "error": error }));
                 }
             }
+            state.overrides = updated;
             (
                 200,
                 json!({ "success": true, "overrides": state.overrides.channels() }),
             )
         }
         ("POST", "/v1/control/input/clear") => {
-            let mut state = state.lock().unwrap();
+            let mut state = lock(state);
             state.overrides.clear();
             (200, json!({ "success": true, "overrides": {} }))
         }
@@ -221,7 +260,14 @@ fn handle_request(
             };
             match name.parse::<InputAction>() {
                 Ok(action) => {
-                    state.lock().unwrap().pending_actions.push(action);
+                    let mut state = lock(state);
+                    if state.pending_actions.len() >= MAX_PENDING_ACTIONS {
+                        return (
+                            400,
+                            json!({ "error": "action queue is full; is the XR session running?" }),
+                        );
+                    }
+                    state.pending_actions.push_back(action);
                     (200, json!({ "success": true, "action": name }))
                 }
                 Err(_) => (
@@ -289,13 +335,28 @@ mod tests {
         assert_eq!(status, 200);
 
         let mut input = InputContext::default();
-        state.lock().unwrap().overrides.apply(&mut input);
+        lock(&state).overrides.apply(&mut input);
         assert_eq!(input.right_hand.trigger_value, 1.0);
 
         let (status, _) =
             handle_request(&state, "medsci1.mis", "POST", "/v1/control/input/clear", "");
         assert_eq!(status, 200);
-        assert!(state.lock().unwrap().overrides.is_empty());
+        assert!(lock(&state).overrides.is_empty());
+    }
+
+    /// A batch with a bad channel must leave NO part of itself latched.
+    #[test]
+    fn a_failed_batch_leaves_overrides_untouched() {
+        let state = Arc::new(Mutex::new(SharedState::default()));
+        let (status, _) = handle_request(
+            &state,
+            "medsci1.mis",
+            "POST",
+            "/v1/control/input",
+            "{\"right_hand.thumbstick\": [0.0, 1.0], \"bogus\": 1.0}",
+        );
+        assert_eq!(status, 400);
+        assert!(lock(&state).overrides.is_empty());
     }
 
     #[test]
@@ -317,6 +378,6 @@ mod tests {
             "{\"action\": \"NotAnAction\"}",
         );
         assert_eq!(status, 400);
-        assert!(state.lock().unwrap().pending_actions.is_empty());
+        assert!(lock(&state).pending_actions.is_empty());
     }
 }

--- a/runtimes/oculus_runtime/src/debug_input.rs
+++ b/runtimes/oculus_runtime/src/debug_input.rs
@@ -1,0 +1,322 @@
+//! On-device remote input, so an agent driving the headset over `adb` can aim
+//! the hands, hold the trigger, and fire discrete `InputAction`s without a human
+//! wearing it.
+//!
+//! It speaks the same channel vocabulary as the debug runtime
+//! (`shock2vr::input::remote`), but as an **override**: the frame loop still
+//! builds its `InputContext` from OpenXR every frame and this layers the claimed
+//! channels on top, so unclaimed channels keep their live controller values and
+//! a human can share the session with the agent.
+//!
+//! Gated on a config file (env vars do not reach an Android app):
+//! `/sdcard/shock2quest/debug-port.txt` holding a port number. Absent or
+//! unparseable => nothing is started. The listener binds loopback only, so it is
+//! reachable exclusively through `adb forward tcp:<port> tcp:<port>`.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::{fs, thread};
+
+use serde_json::{Value, json};
+use shock2vr::input::remote::InputOverrides;
+use shock2vr::input::{InputAction, InputActionState};
+use shock2vr::input_context::InputContext;
+
+pub const PORT_CONFIG_PATH: &str = "/sdcard/shock2quest/debug-port.txt";
+
+/// State shared between the HTTP thread and the frame loop.
+#[derive(Default)]
+struct SharedState {
+    overrides: InputOverrides,
+    /// Actions posted since the last frame, delivered exactly once (they are
+    /// edge-triggered, unlike the level-held channels).
+    pending_actions: Vec<InputAction>,
+    frame: u64,
+}
+
+pub struct DebugInputServer {
+    state: Arc<Mutex<SharedState>>,
+}
+
+impl DebugInputServer {
+    /// Start the server if the port config file is present. Returns `None`
+    /// otherwise, which is the shipping configuration.
+    pub fn start_if_configured(mission: &str) -> Option<DebugInputServer> {
+        let port = parse_port(&fs::read_to_string(PORT_CONFIG_PATH).ok()?)?;
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+        let listener = match TcpListener::bind(addr) {
+            Ok(listener) => listener,
+            Err(error) => {
+                println!("SHOCK2QUEST_DEBUG_SERVER port={port} bind_error={error}");
+                return None;
+            }
+        };
+        println!("SHOCK2QUEST_DEBUG_SERVER port={port} mission={mission} status=listening");
+
+        let server = DebugInputServer {
+            state: Arc::new(Mutex::new(SharedState::default())),
+        };
+        let state = Arc::clone(&server.state);
+        let mission = mission.to_owned();
+        thread::spawn(move || {
+            // Requests are tiny and agent-driven, so connections are served one
+            // at a time - no runtime, no thread pool.
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => serve_connection(stream, &state, &mission),
+                    Err(error) => println!("SHOCK2QUEST_DEBUG_SERVER accept_error={error}"),
+                }
+            }
+        });
+        Some(server)
+    }
+
+    /// Layer the claimed channels over this frame's OpenXR-built input, and
+    /// deliver any queued discrete actions. Call once per frame, immediately
+    /// before `game.update`.
+    pub fn apply(&self, input: &mut InputContext, actions: &mut InputActionState) {
+        let mut state = self.state.lock().unwrap();
+        state.frame += 1;
+        state.overrides.apply(input);
+        for action in state.pending_actions.drain(..) {
+            actions.trigger(action);
+        }
+    }
+}
+
+/// Parse the debug-port config file: a single port number. Port 0 is rejected
+/// (it would bind an arbitrary port the host could not forward to).
+fn parse_port(raw: &str) -> Option<u16> {
+    match raw.trim().parse::<u16>() {
+        Ok(port) if port > 0 => Some(port),
+        _ => {
+            println!(
+                "SHOCK2QUEST_DEBUG_SERVER invalid_port={:?} file={PORT_CONFIG_PATH}",
+                raw.trim()
+            );
+            None
+        }
+    }
+}
+
+fn serve_connection(mut stream: TcpStream, state: &Arc<Mutex<SharedState>>, mission: &str) {
+    let (status, body) = match read_request(&mut stream) {
+        Ok((method, path, body)) => handle_request(state, mission, &method, &path, &body),
+        Err(message) => (400, json!({ "error": message })),
+    };
+    let body = body.to_string();
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n{body}",
+        reason = if status == 200 { "OK" } else { "Bad Request" },
+        len = body.len(),
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Minimal HTTP/1.1 request read: request line, headers (only `Content-Length`
+/// matters), then exactly that many body bytes.
+fn read_request(stream: &mut TcpStream) -> Result<(String, String, String), String> {
+    let mut reader = BufReader::new(stream);
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .map_err(|error| format!("failed to read request: {error}"))?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_owned();
+    let path = parts.next().unwrap_or_default().to_owned();
+    if method.is_empty() || path.is_empty() {
+        return Err("malformed request line".to_owned());
+    }
+
+    let mut content_length = 0usize;
+    loop {
+        let mut header = String::new();
+        let read = reader
+            .read_line(&mut header)
+            .map_err(|error| format!("failed to read headers: {error}"))?;
+        if read == 0 || header.trim().is_empty() {
+            break;
+        }
+        if let Some((name, value)) = header.split_once(':')
+            && name.trim().eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        reader
+            .read_exact(&mut body)
+            .map_err(|error| format!("failed to read body: {error}"))?;
+    }
+    let body = String::from_utf8(body).map_err(|_| "body is not valid UTF-8".to_owned())?;
+    Ok((method, path, body))
+}
+
+fn handle_request(
+    state: &Arc<Mutex<SharedState>>,
+    mission: &str,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> (u16, Value) {
+    // Ignore any query string; none of these endpoints take one.
+    let path = path.split('?').next().unwrap_or(path);
+    match (method, path) {
+        ("GET", "/v1/status") => {
+            let state = state.lock().unwrap();
+            (
+                200,
+                json!({
+                    "mission": mission,
+                    "frame": state.frame,
+                    "overrides": state.overrides.channels(),
+                }),
+            )
+        }
+        ("GET", "/v1/control/input") => {
+            let state = state.lock().unwrap();
+            (200, json!({ "overrides": state.overrides.channels() }))
+        }
+        ("POST", "/v1/control/input") => {
+            let value = match parse_body(body) {
+                Ok(value) => value,
+                Err(error) => return (400, json!({ "error": error })),
+            };
+            let patches = match shock2vr::input::remote::parse_input_patches(&value) {
+                Ok(patches) => patches,
+                Err(error) => return (400, json!({ "error": error })),
+            };
+            let mut state = state.lock().unwrap();
+            for (channel, value) in patches {
+                // Stop at the first bad channel so the caller gets an
+                // actionable error instead of a silent partial apply.
+                if let Err(error) = state.overrides.set(&channel, value) {
+                    return (400, json!({ "error": error }));
+                }
+            }
+            (
+                200,
+                json!({ "success": true, "overrides": state.overrides.channels() }),
+            )
+        }
+        ("POST", "/v1/control/input/clear") => {
+            let mut state = state.lock().unwrap();
+            state.overrides.clear();
+            (200, json!({ "success": true, "overrides": {} }))
+        }
+        ("POST", "/v1/input/action") => {
+            let value = match parse_body(body) {
+                Ok(value) => value,
+                Err(error) => return (400, json!({ "error": error })),
+            };
+            let name = match value.get("action").and_then(Value::as_str) {
+                Some(name) => name,
+                None => {
+                    return (400, json!({ "error": "expected {\"action\": \"<name>\"}" }));
+                }
+            };
+            match name.parse::<InputAction>() {
+                Ok(action) => {
+                    state.lock().unwrap().pending_actions.push(action);
+                    (200, json!({ "success": true, "action": name }))
+                }
+                Err(_) => (
+                    400,
+                    json!({
+                        "error": format!("unknown action '{name}'"),
+                        "actions": action_names(),
+                    }),
+                ),
+            }
+        }
+        ("GET", "/v1/input/actions") => (200, json!({ "actions": action_names() })),
+        _ => (
+            400,
+            json!({
+                "error": format!("unknown endpoint {method} {path}"),
+                "endpoints": [
+                    "GET /v1/status",
+                    "GET /v1/control/input",
+                    "POST /v1/control/input",
+                    "POST /v1/control/input/clear",
+                    "POST /v1/input/action",
+                    "GET /v1/input/actions",
+                ],
+            }),
+        ),
+    }
+}
+
+fn action_names() -> Vec<&'static str> {
+    InputAction::all().iter().map(|a| a.as_str()).collect()
+}
+
+/// Parse a JSON body regardless of `Content-Type` (matching the debug runtime's
+/// lenient behavior, so plain `curl -d '...'` works); an empty body is `{}`.
+fn parse_body(body: &str) -> Result<Value, String> {
+    if body.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    serde_json::from_str(body).map_err(|error| format!("invalid JSON body: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_port() {
+        assert_eq!(parse_port(" 8080\n"), Some(8080));
+        assert_eq!(parse_port(""), None);
+        assert_eq!(parse_port("0"), None);
+        assert_eq!(parse_port("not-a-port"), None);
+    }
+
+    #[test]
+    fn patches_and_clears_overrides() {
+        let state = Arc::new(Mutex::new(SharedState::default()));
+        let (status, _) = handle_request(
+            &state,
+            "medsci1.mis",
+            "POST",
+            "/v1/control/input",
+            "{\"right_hand.trigger\": 1.0}",
+        );
+        assert_eq!(status, 200);
+
+        let mut input = InputContext::default();
+        state.lock().unwrap().overrides.apply(&mut input);
+        assert_eq!(input.right_hand.trigger_value, 1.0);
+
+        let (status, _) =
+            handle_request(&state, "medsci1.mis", "POST", "/v1/control/input/clear", "");
+        assert_eq!(status, 200);
+        assert!(state.lock().unwrap().overrides.is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_channels_and_actions() {
+        let state = Arc::new(Mutex::new(SharedState::default()));
+        let (status, _) = handle_request(
+            &state,
+            "medsci1.mis",
+            "POST",
+            "/v1/control/input",
+            "{\"bogus\": 1.0}",
+        );
+        assert_eq!(status, 400);
+        let (status, _) = handle_request(
+            &state,
+            "medsci1.mis",
+            "POST",
+            "/v1/input/action",
+            "{\"action\": \"NotAnAction\"}",
+        );
+        assert_eq!(status, 400);
+        assert!(state.lock().unwrap().pending_actions.is_empty());
+    }
+}

--- a/runtimes/oculus_runtime/src/lib.rs
+++ b/runtimes/oculus_runtime/src/lib.rs
@@ -21,6 +21,7 @@ use std::env;
 use tracing;
 
 mod android_permissions;
+mod debug_input;
 mod frame_profiler;
 mod quest_config;
 mod refresh_rate;
@@ -481,8 +482,12 @@ fn main() {
     );
 
     // No discrete actions are mapped for VR controllers yet; this stays empty
-    // until an OculusInputMapper is added.
+    // until an OculusInputMapper is added (the debug input server below can
+    // inject them remotely).
     let mut action_state = shock2vr::input::InputActionState::new();
+    // Opt-in remote control for on-device automation; `None` unless
+    // /sdcard/shock2quest/debug-port.txt configures a port.
+    let debug_input = debug_input::DebugInputServer::start_if_configured(&mission);
     let mut vr_crouch = VrCrouchDetector::default();
     let mut pending_stage_change_time = None;
     // Button-crouch alternative to the physical detector: left thumbstick
@@ -795,6 +800,11 @@ fn main() {
         // The detector was already fed exactly once above (it keeps its
         // standing calibration warm even while the button latch is active).
         input_context.crouch = physically_crouched || crouch_toggled;
+        // Remote overrides are layered ON TOP of the live controller state, so
+        // only the channels an agent claimed are replaced.
+        if let Some(debug_input) = &debug_input {
+            debug_input.apply(&mut input_context, &mut action_state);
+        }
         let update_started = Instant::now();
         game.update(&time_context, &input_context, &mut action_state);
         let update_elapsed = update_started.elapsed();

--- a/runtimes/oculus_runtime/src/quest_config.rs
+++ b/runtimes/oculus_runtime/src/quest_config.rs
@@ -42,7 +42,7 @@ fn parse_mission(raw: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_mission;
+    use super::{DEFAULT_MISSION, parse_mission};
 
     #[test]
     fn accepts_missions_and_debug_scenes() {

--- a/shock2vr/src/input/mod.rs
+++ b/shock2vr/src/input/mod.rs
@@ -1,5 +1,6 @@
 mod actions;
 mod dispatcher;
+pub mod remote;
 mod state;
 
 pub use actions::*;

--- a/shock2vr/src/input/remote.rs
+++ b/shock2vr/src/input/remote.rs
@@ -75,10 +75,20 @@ pub fn apply_input_patch(
 ) -> Result<(), String> {
     // Parse a scalar/array value for `channel`, attributing a clear error to the
     // channel and value shape when it doesn't match.
+    // Non-finite values are rejected here rather than downstream: an override is
+    // re-applied every frame, so one NaN would poison aim/locomotion until it is
+    // released, with no clue where it came from.
     fn num(channel: &str, v: &Value) -> Result<f32, String> {
-        v.as_f64()
+        let n = v
+            .as_f64()
             .map(|f| f as f32)
-            .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))
+            .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))?;
+        if !n.is_finite() {
+            return Err(format!(
+                "channel '{channel}' expects a finite number, got {v}"
+            ));
+        }
+        Ok(n)
     }
     fn arr(channel: &str, v: &Value, n: usize) -> Result<Vec<f32>, String> {
         let a = v.as_array().ok_or_else(|| {
@@ -132,7 +142,15 @@ pub fn apply_input_patch(
             }
             "rotation" => {
                 let q = arr(channel, value, 4)?;
-                hand.rotation = Quaternion::new(q[3], q[0], q[1], q[2]).normalize();
+                let rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
+                // A zero quaternion normalizes to NaN, which would silently
+                // corrupt the hand transform every frame.
+                if rotation.magnitude2() <= 0.0 {
+                    return Err(format!(
+                        "channel '{channel}' expects a non-zero quaternion, got {value}"
+                    ));
+                }
+                hand.rotation = rotation.normalize();
                 Ok(())
             }
             _ => Err(format!(
@@ -268,6 +286,55 @@ pub fn parse_input_patches(body: &Value) -> Result<Vec<(String, Value)>, String>
         .collect())
 }
 
+fn unknown_channel(channel: &str) -> String {
+    format!(
+        "unknown input channel '{channel}'; {}",
+        input_channels_help()
+    )
+}
+
+/// The canonical name for a channel, plus whether it was the `head.look`
+/// spelling (which needs its value converted, see `canonical_channel_value`).
+/// Aliases collapse - `right_hand.trigger_value` is `right_hand.trigger`, and
+/// `head.look` is `head.rotation` - so two spellings of one field can never be
+/// held as two independent claims.
+fn canonical_channel(channel: &str) -> Result<(String, bool), String> {
+    if let Some((side, field)) = channel.split_once("_hand.") {
+        if side != "left" && side != "right" {
+            return Err(unknown_channel(channel));
+        }
+        let field = match field {
+            "trigger" | "trigger_value" => "trigger",
+            "squeeze" | "squeeze_value" => "squeeze",
+            "a" | "a_value" => "a",
+            "thumbstick" | "position" | "rotation" => field,
+            _ => return Err(unknown_channel(channel)),
+        };
+        return Ok((format!("{side}_hand.{field}"), false));
+    }
+    match channel {
+        "head.look" => Ok(("head.rotation".to_owned(), true)),
+        "head.rotation" | "pointer.position" | "pointer.pressed" | "crouch" | "jump" => {
+            Ok((channel.to_owned(), false))
+        }
+        _ => Err(unknown_channel(channel)),
+    }
+}
+
+/// Canonicalize a channel *and* its value: `head.look` is resolved to the
+/// quaternion it means, so it is stored as the same claim `head.rotation` would
+/// make.
+fn canonical_channel_value(channel: &str, value: Value) -> Result<(String, Value), String> {
+    let (canonical, is_look) = canonical_channel(channel)?;
+    if is_look {
+        let mut scratch = InputContext::default();
+        apply_input_patch(&mut scratch, channel, &value)?;
+        let r = scratch.head.rotation;
+        return Ok((canonical, serde_json::json!([r.v.x, r.v.y, r.v.z, r.s])));
+    }
+    Ok((canonical, value))
+}
+
 /// Channels an agent has claimed, layered over a runtime-built `InputContext`.
 ///
 /// This is the *override* half of remote control, used where the runtime cannot
@@ -294,13 +361,25 @@ impl InputOverrides {
     /// Claim (or, with `null`, release) a channel. The value is validated
     /// eagerly against a scratch context so a bad request is rejected at the
     /// call rather than silently mis-driving the game every frame after.
+    ///
+    /// Channels are stored under a canonical name, so an alias (`trigger_value`)
+    /// or an equivalent spelling (`head.look` for `head.rotation`) replaces the
+    /// claim it duplicates instead of latching a second, unreleasable copy of the
+    /// same field.
     pub fn set(&mut self, channel: &str, value: Value) -> Result<(), String> {
         if value.is_null() {
-            self.channels.remove(channel);
-            return Ok(());
+            // A release names a channel too, and a typo'd one ("thumstick")
+            // would otherwise report success while the real override stayed
+            // latched - the exact failure a remote driver cannot see.
+            let canonical = canonical_channel(channel)?.0;
+            return match self.channels.remove(&canonical) {
+                Some(_) => Ok(()),
+                None => Err(format!("channel '{channel}' is not currently overridden")),
+            };
         }
-        apply_input_patch(&mut InputContext::default(), channel, &value)?;
-        self.channels.insert(channel.to_owned(), value);
+        let (canonical, value) = canonical_channel_value(channel, value)?;
+        apply_input_patch(&mut InputContext::default(), &canonical, &value)?;
+        self.channels.insert(canonical, value);
         Ok(())
     }
 
@@ -401,6 +480,62 @@ mod tests {
         input.left_hand.thumbstick = Vector2::new(-1.0, -1.0);
         overrides.apply(&mut input);
         assert_eq!(input.left_hand.thumbstick, Vector2::new(-1.0, -1.0));
+    }
+
+    /// Two spellings of one field must be one claim, or releasing the spelling
+    /// you remember leaves the other latched forever.
+    #[test]
+    fn overrides_collapse_aliases_and_equivalent_spellings() {
+        let mut overrides = InputOverrides::new();
+        overrides
+            .set("right_hand.trigger_value", json!(1.0))
+            .unwrap();
+        overrides.set("right_hand.trigger", json!(0.5)).unwrap();
+        assert_eq!(overrides.channels().len(), 1);
+        overrides.set("right_hand.trigger", Value::Null).unwrap();
+        assert!(overrides.is_empty());
+
+        overrides.set("head.look", json!([30.0, 0.0])).unwrap();
+        overrides
+            .set("head.rotation", json!([0.0, 0.0, 0.0, 1.0]))
+            .unwrap();
+        assert_eq!(overrides.channels().len(), 1);
+        assert!(overrides.channels().contains_key("head.rotation"));
+    }
+
+    /// A misspelled release used to report success while the real override
+    /// stayed latched - invisible to a remote driver.
+    #[test]
+    fn releasing_an_unknown_or_unclaimed_channel_is_an_error() {
+        let mut overrides = InputOverrides::new();
+        overrides
+            .set("left_hand.thumbstick", json!([0.0, 1.0]))
+            .unwrap();
+        assert!(overrides.set("left_hand.thumstick", Value::Null).is_err());
+        assert_eq!(overrides.channels().len(), 1);
+        assert!(overrides.set("jump", Value::Null).is_err());
+        overrides.set("left_hand.thumbstick", Value::Null).unwrap();
+        assert!(overrides.is_empty());
+    }
+
+    /// Non-finite numbers and a degenerate quaternion would be re-applied every
+    /// frame, poisoning aim with no trace of where it came from.
+    #[test]
+    fn patch_rejects_non_finite_and_degenerate_values() {
+        let mut input = InputContext::default();
+        // 1e300 is a finite f64 that overflows to +inf as an f32.
+        assert!(apply_input_patch(&mut input, "right_hand.trigger", &json!(1e300)).is_err());
+        assert!(
+            apply_input_patch(&mut input, "left_hand.position", &json!([1.0, 1e300, 0.0])).is_err()
+        );
+        assert!(
+            apply_input_patch(
+                &mut input,
+                "left_hand.rotation",
+                &json!([0.0, 0.0, 0.0, 0.0])
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/shock2vr/src/input/remote.rs
+++ b/shock2vr/src/input/remote.rs
@@ -1,0 +1,423 @@
+//! Remote input control: the channel vocabulary an out-of-process agent uses to
+//! drive an `InputContext` (aim the head/hands, hold a trigger, push a stick).
+//!
+//! This lives in `shock2vr` rather than in a runtime because more than one
+//! runtime speaks it: the debug runtime *owns* its `InputContext` and patches it
+//! directly, while the oculus runtime rebuilds the context from OpenXR every
+//! frame and layers the patched channels ON TOP (see [`InputOverrides`]) so a
+//! human in the headset keeps every channel an agent has not claimed.
+
+use std::collections::BTreeMap;
+
+use cgmath::{InnerSpace, Quaternion, Vector2};
+use serde_json::Value;
+
+use crate::input_context::{InputContext, Pointer2D};
+
+/// Head rotation for a yaw/pitch (degrees), matching the desktop runtime's
+/// camera convention (`camera_forward` / `camera_rotation`): at `yaw=pitch=0`
+/// the forward is `(1,0,0)` fed through `look_at_rh`, i.e. looking toward `-X`.
+/// The SAME rotation drives both the render camera and `InputContext.head`, so
+/// the flat viewmodel (placed relative to the head) and the rendered view always
+/// agree - otherwise the viewmodel renders off-axis as a giant side-on slab.
+pub fn head_rotation_from_yaw_pitch(yaw_deg: f32, pitch_deg: f32) -> Quaternion<f32> {
+    use cgmath::{Decomposed, Rotation, Transform, Vector3, point3, vec3};
+    let (yaw, pitch) = (yaw_deg.to_radians(), pitch_deg.to_radians());
+    let forward = point3(
+        yaw.cos() * pitch.cos(),
+        pitch.sin(),
+        yaw.sin() * pitch.cos(),
+    );
+    let up = vec3(0.0, 1.0, 0.0);
+    let decomposed: Decomposed<Vector3<f32>, Quaternion<f32>> =
+        Transform::look_at_rh(forward, point3(0.0, 0.0, 0.0), up);
+    decomposed.rot.invert()
+}
+
+/// One line describing every recognized input channel, used in error messages so
+/// a bad request is self-documenting. Includes the locomotion semantics (which
+/// stick does what) since that is the game's convention, not guessable.
+pub fn input_channels_help() -> &'static str {
+    "valid channels: head.rotation [x,y,z,w], head.look [yaw_deg,pitch_deg], \
+     pointer.position [x,y] in [0,1] (origin top-left; null clears), pointer.pressed 0|1, \
+     {left,right}_hand.{trigger,squeeze,a} <number 0..1>, \
+     {left,right}_hand.thumbstick [x,y], \
+     {left,right}_hand.position [x,y,z] (pawn-local), \
+     {left,right}_hand.rotation [x,y,z,w], \
+     crouch 0|1 (stand-up refused without headroom), \
+     jump 0|1 (held; launches on the grounded rising edge); \
+     locomotion: right_hand.thumbstick [strafe, forward] moves the player, \
+     left_hand.thumbstick.x turns, left_hand.thumbstick.y flies up/down"
+}
+
+/// Patch a single channel of an `InputContext`, returning an actionable error for
+/// an unrecognized channel or a value of the wrong shape. These are level-held
+/// values (a held trigger, a fixed aim), unlike the edge-triggered discrete
+/// `InputAction`s.
+///
+/// Recognized channels:
+/// - `head.rotation`                : `[x, y, z, w]` quaternion
+/// - `head.look`                    : `[yaw_deg, pitch_deg]` convenience (forward = -Z).
+///   **Pitch is POSITIVE DOWN** - `+60` looks at the floor, `-60` at the ceiling
+///   - matching the desktop runtime, where mouse-down increments pitch. The same
+///   rotation drives movement, so on a ladder `+pitch` descends and `-pitch`
+///   ascends - a test that pitches `-60` to "look down" at a ladder climbs UP,
+///   which is how issue #603's repro was written.
+/// - `{left,right}_hand.trigger`    : number in [0, 1] (alias `trigger_value`)
+/// - `{left,right}_hand.squeeze`    : number in [0, 1] (alias `squeeze_value`)
+/// - `{left,right}_hand.a`          : number in [0, 1] (alias `a_value`)
+/// - `{left,right}_hand.thumbstick` : `[x, y]`
+/// - `jump`                         : number `0` or `1`
+pub fn apply_input_patch(
+    input: &mut InputContext,
+    channel: &str,
+    value: &Value,
+) -> Result<(), String> {
+    // Parse a scalar/array value for `channel`, attributing a clear error to the
+    // channel and value shape when it doesn't match.
+    fn num(channel: &str, v: &Value) -> Result<f32, String> {
+        v.as_f64()
+            .map(|f| f as f32)
+            .ok_or_else(|| format!("channel '{channel}' expects a number, got {v}"))
+    }
+    fn arr(channel: &str, v: &Value, n: usize) -> Result<Vec<f32>, String> {
+        let a = v.as_array().ok_or_else(|| {
+            format!("channel '{channel}' expects an array of {n} numbers, got {v}")
+        })?;
+        if a.len() != n {
+            return Err(format!(
+                "channel '{channel}' expects {n} numbers, got {} ({v})",
+                a.len()
+            ));
+        }
+        a.iter()
+            .map(|e| num(channel, e))
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    // Hand channels: "<left|right>_hand.<field>"
+    if let Some((side, field)) = channel.split_once("_hand.") {
+        let hand = match side {
+            "left" => &mut input.left_hand,
+            "right" => &mut input.right_hand,
+            _ => {
+                return Err(format!(
+                    "unknown input channel '{channel}'; {}",
+                    input_channels_help()
+                ));
+            }
+        };
+        return match field {
+            "trigger" | "trigger_value" => {
+                hand.trigger_value = num(channel, value)?;
+                Ok(())
+            }
+            "squeeze" | "squeeze_value" => {
+                hand.squeeze_value = num(channel, value)?;
+                Ok(())
+            }
+            "a" | "a_value" => {
+                hand.a_value = num(channel, value)?;
+                Ok(())
+            }
+            "thumbstick" => {
+                let a = arr(channel, value, 2)?;
+                hand.thumbstick = Vector2::new(a[0], a[1]);
+                Ok(())
+            }
+            "position" => {
+                let p = arr(channel, value, 3)?;
+                hand.position = cgmath::vec3(p[0], p[1], p[2]);
+                Ok(())
+            }
+            "rotation" => {
+                let q = arr(channel, value, 4)?;
+                hand.rotation = Quaternion::new(q[3], q[0], q[1], q[2]).normalize();
+                Ok(())
+            }
+            _ => Err(format!(
+                "unknown input channel '{channel}'; {}",
+                input_channels_help()
+            )),
+        };
+    }
+
+    match channel {
+        "head.rotation" => {
+            let q = arr(channel, value, 4)?;
+            input.head.rotation = Quaternion::new(q[3], q[0], q[1], q[2]);
+            Ok(())
+        }
+        // Desktop camera convention (yaw=pitch=0 looks toward -X); drives both
+        // the render camera and the viewmodel. Convenient for pointing the
+        // camera without hand-authoring a quaternion.
+        "head.look" => {
+            let yp = arr(channel, value, 2)?;
+            input.head.rotation = head_rotation_from_yaw_pitch(yp[0], yp[1]);
+            Ok(())
+        }
+        // Flat-mode 2D pointer (cursor). Position is normalized [0,1] per
+        // axis, origin top-left; setting either channel materializes the
+        // pointer (it is `None` until first set). `pointer.position: null`
+        // clears the pointer back to `None` (scenes branch on Some/None, so
+        // the cleared state must be reachable for testing).
+        "pointer.position" => {
+            if value.is_null() {
+                input.pointer = None;
+                return Ok(());
+            }
+            let xy = arr(channel, value, 2)?;
+            if !(xy[0].is_finite() && xy[1].is_finite())
+                || !(0.0..=1.0).contains(&xy[0])
+                || !(0.0..=1.0).contains(&xy[1])
+            {
+                return Err(format!(
+                    "channel '{channel}' expects normalized coordinates in [0,1], got [{}, {}]",
+                    xy[0], xy[1]
+                ));
+            }
+            let pointer = input.pointer.get_or_insert(Pointer2D {
+                position: cgmath::vec2(0.0, 0.0),
+                pressed: false,
+            });
+            pointer.position = cgmath::vec2(xy[0], xy[1]);
+            Ok(())
+        }
+        "pointer.pressed" => {
+            let pressed = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            let pointer = input.pointer.get_or_insert(Pointer2D {
+                position: cgmath::vec2(0.0, 0.0),
+                pressed: false,
+            });
+            pointer.pressed = pressed;
+            Ok(())
+        }
+        // Crouch request: like the desktop LeftControl hold. The ACTUAL state
+        // can lag (standing up is refused without headroom); observe it via
+        // the player's body y (the collider center drops when crouched).
+        "crouch" => {
+            input.crouch = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            Ok(())
+        }
+        "jump" => {
+            input.jump = match num(channel, value)? {
+                v if v == 0.0 => false,
+                v if v == 1.0 => true,
+                v => {
+                    return Err(format!("channel '{channel}' expects 0 or 1, got {v}"));
+                }
+            };
+            Ok(())
+        }
+        _ => Err(format!(
+            "unknown input channel '{channel}'; {}",
+            input_channels_help()
+        )),
+    }
+}
+
+/// Parse a remote-control request body into `(channel, value)` patches,
+/// accepting either shape:
+/// - explicit:  `{"channel": "right_hand.trigger", "value": 1.0}`
+/// - map form:  `{"right_hand.trigger": 1.0, "head.look": [30, 0]}`
+///
+/// The map form is detected when the object does NOT have both `channel` and
+/// `value` keys. Returns an actionable error (not a silent empty patch) when the
+/// body isn't a usable object, so a malformed request fails loudly.
+pub fn parse_input_patches(body: &Value) -> Result<Vec<(String, Value)>, String> {
+    let obj = body.as_object().ok_or_else(|| {
+        format!(
+            "request body must be a JSON object, e.g. {{\"channel\":\"right_hand.trigger\",\"value\":1.0}} \
+             or {{\"right_hand.trigger\":1.0}}; {}",
+            input_channels_help()
+        )
+    })?;
+
+    // Explicit {channel, value} form.
+    if obj.contains_key("channel") && obj.contains_key("value") {
+        let channel = obj["channel"]
+            .as_str()
+            .ok_or_else(|| "\"channel\" must be a string".to_string())?
+            .to_string();
+        return Ok(vec![(channel, obj["value"].clone())]);
+    }
+
+    if obj.is_empty() {
+        return Err(format!(
+            "no input channels in request; {}",
+            input_channels_help()
+        ));
+    }
+
+    // Map form: every key is a channel name.
+    Ok(obj
+        .iter()
+        .map(|(channel, value)| (channel.clone(), value.clone()))
+        .collect())
+}
+
+/// Channels an agent has claimed, layered over a runtime-built `InputContext`.
+///
+/// This is the *override* half of remote control, used where the runtime cannot
+/// simply own the context: the oculus runtime rebuilds `InputContext` from
+/// OpenXR every frame, so a patch has to be re-applied after that rebuild. Only
+/// the claimed channels are overwritten - everything else keeps the live
+/// controller value, so a human can still be in the headset while an agent
+/// nudges one channel.
+///
+/// A patch of JSON `null` *releases* the channel back to the controller (the one
+/// exception to [`apply_input_patch`]'s value shapes, where `pointer.position:
+/// null` means "no pointer" - the override layer has no way to express "hold the
+/// pointer cleared", and releasing is what a remote driver actually wants).
+#[derive(Debug, Default, Clone)]
+pub struct InputOverrides {
+    channels: BTreeMap<String, Value>,
+}
+
+impl InputOverrides {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Claim (or, with `null`, release) a channel. The value is validated
+    /// eagerly against a scratch context so a bad request is rejected at the
+    /// call rather than silently mis-driving the game every frame after.
+    pub fn set(&mut self, channel: &str, value: Value) -> Result<(), String> {
+        if value.is_null() {
+            self.channels.remove(channel);
+            return Ok(());
+        }
+        apply_input_patch(&mut InputContext::default(), channel, &value)?;
+        self.channels.insert(channel.to_owned(), value);
+        Ok(())
+    }
+
+    /// Release every claimed channel.
+    pub fn clear(&mut self) {
+        self.channels.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    /// The currently claimed channels, for reporting back to the caller.
+    pub fn channels(&self) -> &BTreeMap<String, Value> {
+        &self.channels
+    }
+
+    /// Overwrite the claimed channels on a freshly built context. Values were
+    /// validated in `set`, so failures here are impossible in practice and are
+    /// dropped rather than propagated (there is no caller to tell mid-frame).
+    pub fn apply(&self, input: &mut InputContext) {
+        for (channel, value) in &self.channels {
+            let _ = apply_input_patch(input, channel, value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn patch_sets_channels() {
+        let mut input = InputContext::default();
+        apply_input_patch(&mut input, "right_hand.trigger", &json!(1.0)).unwrap();
+        apply_input_patch(&mut input, "left_hand.thumbstick", &json!([0.5, -0.25])).unwrap();
+        assert_eq!(input.right_hand.trigger_value, 1.0);
+        assert_eq!(input.left_hand.thumbstick, Vector2::new(0.5, -0.25));
+    }
+
+    #[test]
+    fn patch_rejects_unknown_channel_and_bad_shape() {
+        let mut input = InputContext::default();
+        let err = apply_input_patch(&mut input, "right_hand.nope", &json!(1.0)).unwrap_err();
+        assert!(err.contains("unknown input channel"));
+        let err = apply_input_patch(&mut input, "head.look", &json!(1.0)).unwrap_err();
+        assert!(err.contains("expects an array"));
+    }
+
+    #[test]
+    fn parse_accepts_explicit_and_map_forms() {
+        assert_eq!(
+            parse_input_patches(&json!({"channel": "jump", "value": 1.0})).unwrap(),
+            vec![("jump".to_owned(), json!(1.0))]
+        );
+        let map = parse_input_patches(&json!({"jump": 1.0, "crouch": 0.0})).unwrap();
+        assert_eq!(map.len(), 2);
+        assert!(parse_input_patches(&json!([])).is_err());
+        assert!(parse_input_patches(&json!({})).is_err());
+    }
+
+    /// The override layer must be additive: a channel nobody claimed keeps the
+    /// value the runtime built from the real controllers this frame.
+    #[test]
+    fn overrides_leave_unclaimed_channels_alone() {
+        let mut overrides = InputOverrides::new();
+        overrides.set("right_hand.trigger", json!(1.0)).unwrap();
+
+        let mut input = InputContext::default();
+        input.right_hand.trigger_value = 0.0;
+        input.left_hand.trigger_value = 0.42;
+        input.left_hand.thumbstick = Vector2::new(0.1, 0.2);
+        overrides.apply(&mut input);
+
+        assert_eq!(input.right_hand.trigger_value, 1.0);
+        assert_eq!(input.left_hand.trigger_value, 0.42);
+        assert_eq!(input.left_hand.thumbstick, Vector2::new(0.1, 0.2));
+    }
+
+    /// A claimed channel wins every frame, even as the live value changes...
+    #[test]
+    fn overrides_win_until_released() {
+        let mut overrides = InputOverrides::new();
+        overrides
+            .set("left_hand.thumbstick", json!([0.0, 1.0]))
+            .unwrap();
+
+        let mut input = InputContext::default();
+        input.left_hand.thumbstick = Vector2::new(-1.0, -1.0);
+        overrides.apply(&mut input);
+        assert_eq!(input.left_hand.thumbstick, Vector2::new(0.0, 1.0));
+
+        // ...and `null` releases it back to the live controller value.
+        overrides.set("left_hand.thumbstick", Value::Null).unwrap();
+        assert!(overrides.is_empty());
+        let mut input = InputContext::default();
+        input.left_hand.thumbstick = Vector2::new(-1.0, -1.0);
+        overrides.apply(&mut input);
+        assert_eq!(input.left_hand.thumbstick, Vector2::new(-1.0, -1.0));
+    }
+
+    #[test]
+    fn overrides_validate_on_set() {
+        let mut overrides = InputOverrides::new();
+        assert!(overrides.set("bogus.channel", json!(1.0)).is_err());
+        assert!(overrides.set("jump", json!("yes")).is_err());
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn clear_releases_everything() {
+        let mut overrides = InputOverrides::new();
+        overrides.set("jump", json!(1.0)).unwrap();
+        overrides.set("crouch", json!(1.0)).unwrap();
+        assert_eq!(overrides.channels().len(), 2);
+        overrides.clear();
+        assert!(overrides.is_empty());
+    }
+}


### PR DESCRIPTION
# Remote input injection for the Quest build

Until now the only remote affordance on device was the mission file — verifying menu *interaction* on a Quest required a human in the headset. This adds a minimal, file-gated debug control server to `oculus_runtime`, sharing the debug runtime's input-channel vocabulary, so an agent (or developer at a desk) can aim the hands, pull the trigger, and fire discrete `InputAction`s over `adb forward`.

Stacked on #994 (the VR menu fixes it exists to verify).

## Design

- **Shared vocabulary, not a fork**: the input-channel patch logic moved from `debug_runtime` into a new `shock2vr::input::remote` module (`apply_input_patch`, `parse_input_patches`, `input_channels_help`, `head_rotation_from_yaw_pitch`, and the new `InputOverrides`). The debug runtime now calls the shared code — pure extraction, behavior pinned by its existing tests plus a live smoke check.
- **Override, not replacement**: the Quest loop still builds `InputContext` from OpenXR every frame; claimed channels are re-applied on top. Unclaimed channels keep live controller values, so a human can wear the headset while an agent nudges one channel. Channels are canonicalized (`trigger_value`→`trigger`, `head.look`→`head.rotation`) so two spellings can't latch independently; `null` releases a channel, releasing an unclaimed channel is an error, `POST /v1/control/input/clear` drops everything.
- **Gated and loopback-only**: the server starts only if `/sdcard/shock2quest/debug-port.txt` parses as a port (the same file-config pattern as `vr-mission.txt` — env vars don't reach Android apps), binds `127.0.0.1` only, and logs `SHOCK2QUEST_DEBUG_SERVER port=… status=listening` to logcat. No file → no thread, no socket. Implementation is a ~330-line `TcpListener` thread + `Mutex` polled once per frame; the only new dependency is `serde_json`.
- Endpoints: `GET/POST /v1/control/input`, `POST /v1/control/input/clear`, `POST /v1/input/action`, `GET /v1/input/actions`, `GET /v1/status`.
- `android.permission.INTERNET` is added to the manifest: Android denies `socket()`/`bind()` **even on loopback** without it — found on device (`bind_error=Operation not permitted`), fix verified on device.

## Usage

```bash
adb shell "echo 8171 > /sdcard/shock2quest/debug-port.txt"   # then (re)launch the app
adb forward tcp:8171 tcp:8171
curl -s http://127.0.0.1:8171/v1/status                      # {mission, frame, overrides}
curl -s -X POST http://127.0.0.1:8171/v1/control/input \
  -d '{"head.rotation":[0,0,0,1],"right_hand.rotation":[0,0,0,1],"right_hand.position":[0.53,1.63,-1.0]}'
curl -s -X POST http://127.0.0.1:8171/v1/control/input -d '{"right_hand.trigger":1.0}'   # …then 0.0
adb shell rm /sdcard/shock2quest/debug-port.txt              # disable
```

## Device verification (Quest 3, release APK)

The server was used to operate the VR main menu end-to-end with the headset resting on a desk — no human input:

| Hover New Game | Hover Quit |
| --- | --- |
| ![hover New Game](https://gist.githubusercontent.com/tommy-xr/d4f7bff6a1c9aae83027c28af5582c8e/raw/quest-hover-new-game.png) | ![hover Quit](https://gist.githubusercontent.com/tommy-xr/d4f7bff6a1c9aae83027c28af5582c8e/raw/quest-hover-quit.png) |

The highlight moves with the injected hand aim (confirmed numerically by label-row luminance, not just visually). Then a trigger pulse while hovering New Game:

![after click: earth.mis](https://gist.githubusercontent.com/tommy-xr/d4f7bff6a1c9aae83027c28af5582c8e/raw/quest-after-click.png)

<sub>The menu is gone and `earth.mis` is rendering — a remote click drove a real scene transition on device. Also verified on device: `/v1/status` frame counter advancing (~90 Hz), channel echo, null-release, release-of-unclaimed 400s, unknown action 400s, clear.</sub>

## Validation

- `cargo test -p shock2vr` 692 passed (10 new in `input::remote`: patch/apply, null-release, alias collapse, unclaimed-release error, non-finite/degenerate rejection, pass-through). Negative-tested where the task called for it.
- `cargo test -p debug_runtime --bins` 6 passed; live smoke of the refactored debug runtime (patch, step, read-back, help string, pointer-clear) — behavior identical pre/post extraction.
- `RUSTFLAGS="-D warnings" cargo check -p shock2vr -p desktop_runtime -p debug_runtime` clean; `cargo apk check` clean with `-D warnings`.
- Cross-engine review (Claude + Codex) applied: socket timeouts, bounded `Content-Length`, atomic batch apply, poison-safe locks, one-action-per-frame queue cap, quaternion sanity rejection.

## Known limitations

- `GET /v1/status` reports the boot mission, not in-game level transitions.
- No watchdog for stranded overrides — a disconnecting agent should `clear` first (documented in the vr-device-loop skill).
