### PR TITLE
feat(ui): VR pointer and world panels for the load and game-over screens

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -91,8 +91,6 @@ screenshotted. Removed in `4ce6934`.
 
 - The label drifts a few px right of centre — world text likely renders at a
   slightly different scale than `measure_text_width` reports.
-- The **load screen** has no VR presentation yet, so "Load Game" in VR opens a
-  screen that is still flat-only.
 - Not verified on real hardware (no headset here); everything above is the
   debug runtime's `--vr` path.
 
@@ -193,11 +191,10 @@ Two real divergences this fixed, both visible on the VR main menu:
 VR MFD panel text had the same fixed-size problem relative to its own panel
 pixels; it now matches the flat MFD.
 
-Still open: the load-game screen has **no** world-space presentation at all —
-in `--vr` it falls back to the screen-space overlay (`LoadGameScene::render`
-returns nothing; `render_per_eye` draws for both modes). So the one canvas that
-exercises `fit_to_rect` is never actually shown on a panel. Ellipsizing now
-happens in layout, so it *will* be correct when that screen grows a VR panel.
+The load-game and game-over screens have since grown world-space presentations
+of their own — see "the whole frontend flow now works in VR" below. Ellipsizing
+happening in layout rather than in a presentation is exactly what made the load
+list come out right on the panel with no extra work.
 
 **Deferred: render-to-texture for world space.** Rendering the canvas to an
 offscreen target and mapping it onto the panel quad would make parity true *by
@@ -215,13 +212,42 @@ Consolidation makes world-space a thin mapper, so swapping that mapper for an
 RTT quad afterwards is a small contained change that can be benchmarked on
 device. Doing RTT first would bet the refactor on unverifiable engine work.
 
+## RESOLVED: the whole frontend flow now works in VR
+
+`feat/vr-menu-load-gameover` gives **`LoadGameScene` and `GameOverScene`** the
+same treatment the main menu already had, and factors the pointer rule out so
+there is one copy of it:
+
+- `ui::vr_frontend_pointer(input_context, canvas_size)` (new
+  `shock2vr/src/ui/frontend_pointer.rs`) is the single hand-ray pointer: panel
+  raycast, trigger-held hand wins, off-panel presses stay consumed. All three
+  screens call it; `test_support` there is the shared "aim a hand at a canvas
+  point" rig their tests use.
+- An **untracked controller** reports a *zero* quaternion, and cgmath's
+  `rotate_vector` passes it through unchanged - so the old code aimed a fixed
+  `(0,0,-1)` ray that lands dead centre on the panel. Guarded now.
+- Each screen has one `build_canvas`, consumed by `render_world_space` in VR and
+  `render_screen_space` in flat. Ellipsization already lived in layout, so the
+  load list's `fit_to_rect` came out right on the panel with no extra work.
+
+Two rising-edge holes surfaced in review and are fixed: game-over started
+`last_pressed: false`, so dying with the trigger still held could fire *Quit* on
+the first frame; and the pointer reported only the winning hand's trigger, so an
+idle hand resting on the panel released the other hand's held press.
+
+Verified end to end on the debug runtime's `--vr` path: menu -> Load Game ->
+row select -> Done -> menu, and death -> game-over panel -> LOAD -> `earth.mis`.
+
 ## What is left
 
 - **No hardware verification.** Everything is the debug runtime's `--vr` path; the
   Quest `DEFAULT_MISSION = main_menu` change is untested on device.
-- **The load screen has no VR presentation** - in `--vr` it falls back to the
-  screen-space overlay, so the one canvas using `fit_to_rect` never appears on a
-  panel. Small job now that `WorldPanel` + the layout pass exist.
+- **The presentation split is now a fourth copy.** `main_menu`, `load_game`,
+  `game_over` and `no_assets` each carry the same `render`/`render_per_eye` VR
+  early-return + `build_canvas` + panel dance, and a third copy of
+  `resolve_click_at`. Hoisting that into one helper beside `vr_frontend_pointer`
+  is the obvious next de-duplication (deliberately out of scope here, which was
+  the pointer only).
 - **Render-to-texture for world space** remains the better end state (parity by
   construction rather than by test). `engine` still has no render-target
   abstraction; consolidation has made the world mapper thin enough that swapping

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -177,7 +177,11 @@ impl GameOverScene {
             pointer: None,
             vr_pointer_canvas: None,
             head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
-            last_pressed: false,
+            // This screen is entered straight out of gameplay - very plausibly
+            // with the VR trigger still held from the shot that preceded the
+            // death - so it starts "already pressed": the next rising edge
+            // requires a real release first, and "Quit" cannot fire itself.
+            last_pressed: true,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
             sfx: FrontendSfx::new(),
         }
@@ -541,6 +545,30 @@ mod tests {
         assert_eq!(
             resolve_click_at(point, pressed, false, &rects, false).0,
             None
+        );
+    }
+
+    #[test]
+    fn a_trigger_held_from_the_death_that_opened_this_screen_does_not_click() {
+        // The screen is entered straight out of gameplay, so the trigger that
+        // was being fired can still be down on the first frame. Without the
+        // constructor's `last_pressed: true` that reads as a rising edge over
+        // whatever the ray happens to cross - up to and including Quit.
+        let rects = screen_rects(None);
+        let scene = GameOverScene::new();
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_at(rects[QUIT_RECT_INDEX].center(), 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+        );
+        assert!(pressed);
+        let (action, last) = resolve_click_at(point, pressed, scene.last_pressed, &rects, true);
+        assert_eq!(action, None, "a carried-over press must not activate Quit");
+
+        // Releasing and pressing again is a real click.
+        let (_, last) = resolve_click_at(point, false, last, &rects, true);
+        assert_eq!(
+            resolve_click_at(point, true, last, &rects, true).0,
+            Some(GameOverAction::Quit)
         );
     }
 

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -42,6 +42,13 @@ const BACKDROP_TEXTURE: &str = "GAMELOD.PCX";
 const LAYOUT_FILE: &str = "GAMELODR.BIN";
 /// Same display font the main menu uses (`res/intrface/METAFONT.FON`).
 const MENU_FONT: &str = "metafont.fon";
+/// The small in-game font the load screen draws save names in, so the one row
+/// this screen shows reads as the same kind of data.
+const LIST_FONT: &str = "mainfont.fon";
+/// Height of that single row, and the horizontal padding on each of its edges -
+/// matching the load screen's list geometry.
+const LIST_ROW_HEIGHT: f32 = 19.0;
+const LIST_TEXT_INSET: f32 = 8.0;
 /// The 4:3 art is letterboxed (not stretched) on non-4:3 windows.
 const SCALE_MODE: ScaleMode = ScaleMode::PreserveAspect;
 
@@ -221,10 +228,21 @@ impl GameOverScene {
             None => NO_SAVE_LABEL,
         };
         let list = rects[LIST_RECT_INDEX];
-        canvas.text_native(
-            Rect::new(list.x, list.y, list.w, 20.0),
+        canvas.text_native_fit(
+            // Inset on both edges so an ellipsized name stops short of the
+            // panel rather than running flush with it.
+            Rect::new(
+                list.x + LIST_TEXT_INSET,
+                list.y,
+                (list.w - 2.0 * LIST_TEXT_INSET).max(0.0),
+                LIST_ROW_HEIGHT,
+            ),
             save_label,
-            MENU_FONT,
+            // Save names are player-authored and unbounded, so this row is
+            // drawn the way the load screen draws its list: the small font,
+            // ellipsized to the panel. In the screen's 20px MENU_FONT a
+            // typical name spills clear across the backdrop art.
+            LIST_FONT,
             HAlign::Center,
             VAlign::Middle,
         );

--- a/shock2vr/src/scenes/game_over.rs
+++ b/shock2vr/src/scenes/game_over.rs
@@ -20,7 +20,7 @@ use engine::{
 use shipyard::{EntityId, UniqueViewMut, World};
 
 use crate::{
-    GameOptions,
+    GameOptions, PresentationMode,
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::{GlobalContext, PlayerLifeState},
@@ -28,7 +28,10 @@ use crate::{
     scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+    ui::{
+        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
+        pointer_to_canvas, vr_frontend_pointer,
+    },
 };
 
 /// The screen is authored on the original 640x480 `GAMELOD.PCX` canvas.
@@ -85,6 +88,21 @@ fn screen_rects(layout: Option<&[MapRect]>) -> [Rect; 4] {
     rects
 }
 
+/// Shared click core: both presentations reduce to "a point on the canvas plus
+/// a pressed flag", so the rising-edge rule and the hit regions live here once.
+fn resolve_click_at(
+    point: Option<Vector2<f32>>,
+    pressed: bool,
+    last_pressed: bool,
+    rects: &[Rect; 4],
+    can_load: bool,
+) -> (Option<GameOverAction>, bool) {
+    if !pressed || last_pressed {
+        return (None, pressed);
+    }
+    (point.and_then(|c| hit(c, rects, can_load)), pressed)
+}
+
 /// Pure click resolution: on a rising press edge over an enabled button,
 /// return its action. Also returns the new `last_pressed` for the next frame.
 /// `can_load` disables "Load" when no save exists, so the screen never offers
@@ -105,12 +123,9 @@ fn resolve_click(
         screen_size,
         SCALE_MODE,
     );
-    if !p.pressed || last_pressed {
-        return (None, p.pressed, canvas_point);
-    }
-
-    let action = canvas_point.and_then(|c| hit(c, rects, can_load));
-    (action, p.pressed, canvas_point)
+    let (action, pressed) =
+        resolve_click_at(canvas_point, p.pressed, last_pressed, rects, can_load);
+    (action, pressed, canvas_point)
 }
 
 /// The button at a canvas point, if any. Shared by the click and the rollover
@@ -133,6 +148,12 @@ pub struct GameOverScene {
     save: Option<SaveFile>,
     /// Pointer from the latest update, used for hover highlighting in render.
     pointer: Option<Pointer2D>,
+    /// Where the VR controller ray last met the panel, in canvas pixels. The
+    /// VR counterpart of `pointer`, already in canvas space.
+    vr_pointer_canvas: Option<Vector2<f32>>,
+    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// where `update` hit-tested it.
+    head_rotation: Quaternion<f32>,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` maps the pointer into
@@ -154,6 +175,8 @@ impl GameOverScene {
             scene_name: "game_over".to_owned(),
             save: latest_save(),
             pointer: None,
+            vr_pointer_canvas: None,
+            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             last_pressed: false,
             last_screen_size: vec2(CANVAS_W, CANVAS_H),
             sfx: FrontendSfx::new(),
@@ -161,102 +184,23 @@ impl GameOverScene {
     }
 }
 
-impl Default for GameOverScene {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GameScene for GameOverScene {
-    fn update(
-        &mut self,
-        time: &Time,
-        input_context: &InputContext,
+impl GameOverScene {
+    /// The screen, described once. Screen-space and world-space presentation
+    /// differ only in how this canvas is rendered, so the two can never drift
+    /// apart in layout, labels, or which buttons look actionable.
+    ///
+    /// `pointer_canvas` is the hover position in canvas pixels, whatever
+    /// produced it - the mouse or a VR controller ray.
+    fn build_canvas(
+        &self,
         asset_cache: &mut AssetCache,
-        _game_options: &GameOptions,
-        command_effects: Vec<Effect>,
-    ) -> Vec<Effect> {
-        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
-            *world_time = time.clone();
-        }
-
-        // Discrete input actions (quick-load above all) must keep working here:
-        // this screen is the only thing left, so swallowing them would restore
-        // the dead end it exists to remove. Only global effects are meaningful
-        // without a mission; the rest have nothing to act on.
-        let mut effects: Vec<Effect> = command_effects
-            .into_iter()
-            .filter(|effect| matches!(effect, Effect::GlobalEffect(_)))
-            .collect();
-
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
-
-        self.pointer = input_context.pointer;
-        let (action, last_pressed, point) = resolve_click(
-            input_context.pointer,
-            self.last_pressed,
-            self.last_screen_size,
-            &rects,
-            self.save.is_some(),
-        );
-        self.last_pressed = last_pressed;
-
-        self.sfx
-            .hover(point.and_then(|p| hit(p, &rects, self.save.is_some())));
-        if action.is_some() {
-            self.sfx.click();
-        }
-
-        match action {
-            Some(GameOverAction::Load) => {
-                if let Some(save) = &self.save {
-                    effects.push(Effect::GlobalEffect(GlobalEffect::Load {
-                        file_name: save.path.to_string_lossy().into_owned(),
-                    }));
-                }
-            }
-            Some(GameOverAction::Quit) => effects.push(Effect::GlobalEffect(GlobalEffect::Quit)),
-            None => {}
-        }
-        effects
-    }
-
-    fn render(
-        &mut self,
-        _asset_cache: &mut AssetCache,
-        _options: &GameOptions,
-    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        // Drawn in screen space in `render_per_eye`; the 3D scene is empty.
-        (
-            Vec::new(),
-            vec3(0.0, 0.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        )
-    }
-
-    fn render_per_eye(
-        &mut self,
-        asset_cache: &mut AssetCache,
-        _view: cgmath::Matrix4<f32>,
-        _projection: cgmath::Matrix4<f32>,
-        screen_size: Vector2<f32>,
-        _options: &GameOptions,
-    ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
+        pointer_canvas: Option<Vector2<f32>>,
+    ) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
         let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
         let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
 
         canvas.text_native(
             rects[HEADER_RECT_INDEX],
@@ -294,6 +238,142 @@ impl GameScene for GameOverScene {
                 });
         }
 
+        canvas
+    }
+}
+
+impl Default for GameOverScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameScene for GameOverScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        game_options: &GameOptions,
+        command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        // Discrete input actions (quick-load above all) must keep working here:
+        // this screen is the only thing left, so swallowing them would restore
+        // the dead end it exists to remove. Only global effects are meaningful
+        // without a mission; the rest have nothing to act on.
+        let mut effects: Vec<Effect> = command_effects
+            .into_iter()
+            .filter(|effect| matches!(effect, Effect::GlobalEffect(_)))
+            .collect();
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+
+        // The panel hangs off the head's facing, so this is needed for the
+        // render regardless of which presentation drives the pointer.
+        self.head_rotation = input_context.head.rotation;
+
+        let (action, last_pressed, point) =
+            if game_options.presentation_mode == PresentationMode::Vr {
+                // VR has no 2D cursor: the pointer is where a controller ray meets
+                // the panel, and the trigger is the button.
+                let (point, pressed) = vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H));
+                self.vr_pointer_canvas = point;
+                self.pointer = None;
+                let (action, last_pressed) = resolve_click_at(
+                    point,
+                    pressed,
+                    self.last_pressed,
+                    &rects,
+                    self.save.is_some(),
+                );
+                (action, last_pressed, point)
+            } else {
+                self.pointer = input_context.pointer;
+                resolve_click(
+                    input_context.pointer,
+                    self.last_pressed,
+                    self.last_screen_size,
+                    &rects,
+                    self.save.is_some(),
+                )
+            };
+        self.last_pressed = last_pressed;
+
+        self.sfx
+            .hover(point.and_then(|p| hit(p, &rects, self.save.is_some())));
+        if action.is_some() {
+            self.sfx.click();
+        }
+
+        match action {
+            Some(GameOverAction::Load) => {
+                if let Some(save) = &self.save {
+                    effects.push(Effect::GlobalEffect(GlobalEffect::Load {
+                        file_name: save.path.to_string_lossy().into_owned(),
+                    }));
+                }
+            }
+            Some(GameOverAction::Quit) => effects.push(Effect::GlobalEffect(GlobalEffect::Quit)),
+            None => {}
+        }
+        effects
+    }
+
+    fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        // In flat presentation the screen is drawn in screen space in
+        // `render_per_eye` (which has the screen size); the 3D scene is empty.
+        if options.presentation_mode != PresentationMode::Vr {
+            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
+        }
+
+        // In VR there is no screen to draw on, so the same canvas is presented
+        // on a world-space panel in front of the player.
+        let panel = frontend_panel(self.head_rotation);
+        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
+        let objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            self.vr_pointer_canvas,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        (objects, vec3(0.0, 0.0, 0.0), identity)
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        self.last_screen_size = screen_size;
+        // In VR the screen lives on a world-space panel drawn by `render`; a
+        // screen-space copy here would paste the whole canvas over both eyes
+        // and hide it.
+        if options.presentation_mode == PresentationMode::Vr {
+            return Vec::new();
+        }
+        let pointer_canvas = self.pointer.and_then(|p| {
+            pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            )
+        });
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
         canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
     }
 
@@ -417,6 +497,60 @@ mod tests {
             true,
         );
         assert_eq!(action, None);
+    }
+
+    /// A hand aimed at a canvas point on this screen's VR panel.
+    fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
+        crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
+    }
+
+    fn vr_input(hand: crate::input_context::Hand) -> InputContext {
+        InputContext {
+            right_hand: hand,
+            ..InputContext::default()
+        }
+    }
+
+    #[test]
+    fn a_vr_ray_can_press_load_and_quit() {
+        let rects = screen_rects(None);
+        for (index, expected) in [
+            (LOAD_RECT_INDEX, GameOverAction::Load),
+            (QUIT_RECT_INDEX, GameOverAction::Quit),
+        ] {
+            let (point, pressed) = vr_frontend_pointer(
+                &vr_input(hand_aimed_at(rects[index].center(), 1.0)),
+                vec2(CANVAS_W, CANVAS_H),
+            );
+            let point = point.expect("the ray should land on the panel");
+            assert!(rects[index].contains(point));
+            assert_eq!(
+                resolve_click_at(Some(point), pressed, false, &rects, true).0,
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn a_vr_ray_over_load_is_inert_without_a_save() {
+        let rects = screen_rects(None);
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_at(rects[LOAD_RECT_INDEX].center(), 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+        );
+        assert_eq!(
+            resolve_click_at(point, pressed, false, &rects, false).0,
+            None
+        );
+    }
+
+    #[test]
+    fn a_vr_press_held_across_frames_clicks_once() {
+        let rects = screen_rects(None);
+        let point = Some(rects[QUIT_RECT_INDEX].center());
+        let (action, last) = resolve_click_at(point, true, false, &rects, true);
+        assert_eq!(action, Some(GameOverAction::Quit));
+        assert_eq!(resolve_click_at(point, true, last, &rects, true).0, None);
     }
 
     #[test]

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -23,7 +23,7 @@ use shipyard::{EntityId, UniqueViewMut, World};
 use std::collections::HashMap;
 
 use crate::{
-    GameOptions,
+    GameOptions, PresentationMode,
     game_scene::GameScene,
     input_context::{InputContext, Pointer2D},
     mission::GlobalContext,
@@ -31,7 +31,10 @@ use crate::{
     scenes::frontend_sfx::FrontendSfx,
     scripts::{Effect, GlobalEffect},
     time::Time,
-    ui::{HAlign, Rect, ScaleMode, UiCanvas, VAlign, pointer_to_canvas},
+    ui::{
+        HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
+        pointer_to_canvas, vr_frontend_pointer,
+    },
 };
 
 /// The screen is authored on the original 640x480 `GAMELOD.PCX` canvas.
@@ -178,6 +181,25 @@ fn row_text_rect(list: Rect, index: usize) -> Rect {
     )
 }
 
+/// Shared click core: both presentations reduce to "a point on the canvas plus
+/// a pressed flag", so the rising-edge rule and the hit regions live here once.
+fn resolve_click_at(
+    point: Option<Vector2<f32>>,
+    pressed: bool,
+    last_pressed: bool,
+    rects: &[Rect; 4],
+    visible_saves: usize,
+    has_selection: bool,
+) -> (Option<LoadGameAction>, bool) {
+    if !pressed || last_pressed {
+        return (None, pressed);
+    }
+    (
+        point.and_then(|c| hit(c, rects, visible_saves, has_selection)),
+        pressed,
+    )
+}
+
 /// Pure click resolution: on a rising press edge, map the pointer to whatever
 /// it is over - a save row, "Load" (only when a save is selected), or "Done".
 /// Also returns the new `last_pressed` to track for the next frame.
@@ -198,12 +220,15 @@ fn resolve_click(
         screen_size,
         SCALE_MODE,
     );
-    if !p.pressed || last_pressed {
-        return (None, p.pressed, canvas_point);
-    }
-
-    let action = canvas_point.and_then(|c| hit(c, rects, visible_saves, has_selection));
-    (action, p.pressed, canvas_point)
+    let (action, pressed) = resolve_click_at(
+        canvas_point,
+        p.pressed,
+        last_pressed,
+        rects,
+        visible_saves,
+        has_selection,
+    );
+    (action, pressed, canvas_point)
 }
 
 /// What is at a canvas point: a save row, "Load" (only with a selection), or
@@ -236,6 +261,12 @@ pub struct LoadGameScene {
     selected: Option<usize>,
     /// Pointer from the latest update, used for hover highlighting in render.
     pointer: Option<Pointer2D>,
+    /// Where the VR controller ray last met the panel, in canvas pixels. The
+    /// VR counterpart of `pointer`, already in canvas space.
+    vr_pointer_canvas: Option<Vector2<f32>>,
+    /// Head facing from the latest update, so `render` hangs the panel exactly
+    /// where `update` hit-tested it.
+    head_rotation: Quaternion<f32>,
     /// Whether the pointer was pressed last frame (for rising-edge clicks).
     last_pressed: bool,
     /// Screen size from the latest render, so `update` can map the pointer into
@@ -258,6 +289,8 @@ impl LoadGameScene {
             saves,
             selected,
             pointer: None,
+            vr_pointer_canvas: None,
+            head_rotation: Quaternion::new(1.0, 0.0, 0.0, 0.0),
             // A press held across a scene swap must not read as a click
             // here: both screens sit on the same 640x480 canvas and their
             // widgets overlap (the load screen's "Done" center falls inside
@@ -270,100 +303,18 @@ impl LoadGameScene {
     }
 }
 
-impl Default for LoadGameScene {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GameScene for LoadGameScene {
-    fn update(
-        &mut self,
-        time: &Time,
-        input_context: &InputContext,
+impl LoadGameScene {
+    /// The screen, described once. Screen-space and world-space presentation
+    /// differ only in how this canvas is rendered, so the two can never drift
+    /// apart in layout, labels, or which widgets look actionable.
+    ///
+    /// `pointer_canvas` is the hover position in canvas pixels, whatever
+    /// produced it - the mouse or a VR controller ray.
+    fn build_canvas(
+        &self,
         asset_cache: &mut AssetCache,
-        _game_options: &GameOptions,
-        _command_effects: Vec<Effect>,
-    ) -> Vec<Effect> {
-        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
-            *world_time = time.clone();
-        }
-
-        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
-        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
-        let visible = self
-            .saves
-            .len()
-            .min(visible_row_count(rects[LIST_RECT_INDEX]));
-
-        // Only a save the player can actually see is loadable. The constructor
-        // preselects row 0 from `saves` alone, which a layout too short to show
-        // a single row would otherwise turn into a "Load" for an invisible one.
-        let selected = self.selected.filter(|index| *index < visible);
-
-        self.pointer = input_context.pointer;
-        let (action, last_pressed, point) = resolve_click(
-            input_context.pointer,
-            self.last_pressed,
-            self.last_screen_size,
-            &rects,
-            visible,
-            selected.is_some(),
-        );
-        self.last_pressed = last_pressed;
-
-        // Rows are deliberately silent: they highlight on selection rather
-        // than on hover, so a blip over one would have no visible counterpart.
-        // Passing 0 visible rows is what makes `hit` skip them.
-        self.sfx
-            .hover(point.and_then(|p| hit(p, &rects, 0, selected.is_some())));
-        if action.is_some() {
-            self.sfx.click();
-        }
-
-        match action {
-            Some(LoadGameAction::Select(index)) => {
-                self.selected = Some(index);
-                Vec::new()
-            }
-            Some(LoadGameAction::Load) => selected
-                .and_then(|index| self.saves.get(index))
-                .map(|save| {
-                    vec![Effect::GlobalEffect(GlobalEffect::Load {
-                        file_name: save.path.to_string_lossy().into_owned(),
-                    })]
-                })
-                .unwrap_or_default(),
-            Some(LoadGameAction::Done) => {
-                vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)]
-            }
-            None => Vec::new(),
-        }
-    }
-
-    fn render(
-        &mut self,
-        _asset_cache: &mut AssetCache,
-        _options: &GameOptions,
-    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
-        // The screen is drawn in screen space in `render_per_eye` (which has
-        // the screen size); the 3D scene is empty.
-        (
-            Vec::new(),
-            vec3(0.0, 0.0, 0.0),
-            Quaternion::new(1.0, 0.0, 0.0, 0.0),
-        )
-    }
-
-    fn render_per_eye(
-        &mut self,
-        asset_cache: &mut AssetCache,
-        _view: cgmath::Matrix4<f32>,
-        _projection: cgmath::Matrix4<f32>,
-        screen_size: Vector2<f32>,
-        _options: &GameOptions,
-    ) -> Vec<SceneObject> {
-        self.last_screen_size = screen_size;
+        pointer_canvas: Option<Vector2<f32>>,
+    ) -> UiCanvas {
         let mut canvas = UiCanvas::new(vec2(CANVAS_W, CANVAS_H));
         canvas.image(Rect::new(0.0, 0.0, CANVAS_W, CANVAS_H), BACKDROP_TEXTURE);
 
@@ -371,14 +322,6 @@ impl GameScene for LoadGameScene {
         let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
         let strings = asset_cache.get_opt(&STRINGS_IMPORTER, LABELS_FILE);
         let strings = strings.as_deref();
-        let pointer_canvas = self.pointer.and_then(|p| {
-            pointer_to_canvas(
-                vec2(CANVAS_W, CANVAS_H),
-                p.position,
-                screen_size,
-                SCALE_MODE,
-            )
-        });
 
         canvas.text_native(
             rects[HEADER_RECT_INDEX],
@@ -450,6 +393,153 @@ impl GameScene for LoadGameScene {
                 .opacity(opacity);
         }
 
+        canvas
+    }
+}
+
+impl Default for LoadGameScene {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameScene for LoadGameScene {
+    fn update(
+        &mut self,
+        time: &Time,
+        input_context: &InputContext,
+        asset_cache: &mut AssetCache,
+        game_options: &GameOptions,
+        _command_effects: Vec<Effect>,
+    ) -> Vec<Effect> {
+        if let Ok(mut world_time) = self.world.borrow::<UniqueViewMut<Time>>() {
+            *world_time = time.clone();
+        }
+
+        let layout = asset_cache.get_opt(&UI_LAYOUT_IMPORTER, LAYOUT_FILE);
+        let rects = screen_rects(layout.as_deref().map(|r| r.as_slice()));
+        let visible = self
+            .saves
+            .len()
+            .min(visible_row_count(rects[LIST_RECT_INDEX]));
+
+        // Only a save the player can actually see is loadable. The constructor
+        // preselects row 0 from `saves` alone, which a layout too short to show
+        // a single row would otherwise turn into a "Load" for an invisible one.
+        let selected = self.selected.filter(|index| *index < visible);
+
+        // The panel hangs off the head's facing, so this is needed for the
+        // render regardless of which presentation drives the pointer.
+        self.head_rotation = input_context.head.rotation;
+
+        let (action, last_pressed, point) =
+            if game_options.presentation_mode == PresentationMode::Vr {
+                // VR has no 2D cursor: the pointer is where a controller ray meets
+                // the panel, and the trigger is the button.
+                let (point, pressed) = vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H));
+                self.vr_pointer_canvas = point;
+                self.pointer = None;
+                let (action, last_pressed) = resolve_click_at(
+                    point,
+                    pressed,
+                    self.last_pressed,
+                    &rects,
+                    visible,
+                    selected.is_some(),
+                );
+                (action, last_pressed, point)
+            } else {
+                self.pointer = input_context.pointer;
+                resolve_click(
+                    input_context.pointer,
+                    self.last_pressed,
+                    self.last_screen_size,
+                    &rects,
+                    visible,
+                    selected.is_some(),
+                )
+            };
+        self.last_pressed = last_pressed;
+
+        // Rows are deliberately silent: they highlight on selection rather
+        // than on hover, so a blip over one would have no visible counterpart.
+        // Passing 0 visible rows is what makes `hit` skip them.
+        self.sfx
+            .hover(point.and_then(|p| hit(p, &rects, 0, selected.is_some())));
+        if action.is_some() {
+            self.sfx.click();
+        }
+
+        match action {
+            Some(LoadGameAction::Select(index)) => {
+                self.selected = Some(index);
+                Vec::new()
+            }
+            Some(LoadGameAction::Load) => selected
+                .and_then(|index| self.saves.get(index))
+                .map(|save| {
+                    vec![Effect::GlobalEffect(GlobalEffect::Load {
+                        file_name: save.path.to_string_lossy().into_owned(),
+                    })]
+                })
+                .unwrap_or_default(),
+            Some(LoadGameAction::Done) => {
+                vec![Effect::GlobalEffect(GlobalEffect::ShowMainMenu)]
+            }
+            None => Vec::new(),
+        }
+    }
+
+    fn render(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        options: &GameOptions,
+    ) -> (Vec<SceneObject>, Vector3<f32>, Quaternion<f32>) {
+        let identity = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        // In flat presentation the screen is drawn in screen space in
+        // `render_per_eye` (which has the screen size); the 3D scene is empty.
+        if options.presentation_mode != PresentationMode::Vr {
+            return (Vec::new(), vec3(0.0, 0.0, 0.0), identity);
+        }
+
+        // In VR there is no screen to draw on, so the same canvas is presented
+        // on a world-space panel in front of the player.
+        let panel = frontend_panel(self.head_rotation);
+        let canvas = self.build_canvas(asset_cache, self.vr_pointer_canvas);
+        let objects = canvas.render_world_space(
+            asset_cache,
+            panel.transform(),
+            self.vr_pointer_canvas,
+            None,
+            VR_COMPONENT_Z_STEP,
+        );
+        (objects, vec3(0.0, 0.0, 0.0), identity)
+    }
+
+    fn render_per_eye(
+        &mut self,
+        asset_cache: &mut AssetCache,
+        _view: cgmath::Matrix4<f32>,
+        _projection: cgmath::Matrix4<f32>,
+        screen_size: Vector2<f32>,
+        options: &GameOptions,
+    ) -> Vec<SceneObject> {
+        self.last_screen_size = screen_size;
+        // In VR the screen lives on a world-space panel drawn by `render`; a
+        // screen-space copy here would paste the whole canvas over both eyes
+        // and hide it.
+        if options.presentation_mode == PresentationMode::Vr {
+            return Vec::new();
+        }
+        let pointer_canvas = self.pointer.and_then(|p| {
+            pointer_to_canvas(
+                vec2(CANVAS_W, CANVAS_H),
+                p.position,
+                screen_size,
+                SCALE_MODE,
+            )
+        });
+        let canvas = self.build_canvas(asset_cache, pointer_canvas);
         canvas.render_screen_space(asset_cache, screen_size, SCALE_MODE)
     }
 
@@ -639,6 +729,69 @@ mod tests {
                 Some(LoadGameAction::Select(0))
             );
         }
+    }
+
+    /// A hand aimed at a canvas point on this screen's VR panel.
+    fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
+        crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
+    }
+
+    fn vr_input(hand: crate::input_context::Hand) -> InputContext {
+        InputContext {
+            right_hand: hand,
+            ..InputContext::default()
+        }
+    }
+
+    #[test]
+    fn a_vr_ray_can_press_done() {
+        let done = FALLBACK_RECTS[DONE_RECT_INDEX].center();
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_at(done, 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+        );
+        let point = point.expect("the ray should land on the panel");
+        assert!(FALLBACK_RECTS[DONE_RECT_INDEX].contains(point));
+        assert!(pressed);
+        assert_eq!(
+            resolve_click_at(Some(point), pressed, false, &FALLBACK_RECTS, 0, false).0,
+            Some(LoadGameAction::Done)
+        );
+    }
+
+    #[test]
+    fn a_vr_ray_can_select_a_save_row_and_load_it() {
+        let list = FALLBACK_RECTS[LIST_RECT_INDEX];
+        let row = row_rect(list, 2).center();
+        let (point, pressed) =
+            vr_frontend_pointer(&vr_input(hand_aimed_at(row, 1.0)), vec2(CANVAS_W, CANVAS_H));
+        let point = point.expect("the ray should land on the panel");
+        assert_eq!(
+            resolve_click_at(Some(point), pressed, false, &FALLBACK_RECTS, 3, false).0,
+            Some(LoadGameAction::Select(2))
+        );
+
+        // With a selection, the same rig over "Load" performs the load.
+        let load = FALLBACK_RECTS[LOAD_RECT_INDEX].center();
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_at(load, 1.0)),
+            vec2(CANVAS_W, CANVAS_H),
+        );
+        assert_eq!(
+            resolve_click_at(point, pressed, false, &FALLBACK_RECTS, 3, true).0,
+            Some(LoadGameAction::Load)
+        );
+    }
+
+    #[test]
+    fn a_vr_press_held_across_frames_clicks_once() {
+        let point = Some(FALLBACK_RECTS[DONE_RECT_INDEX].center());
+        let (action, last) = resolve_click_at(point, true, false, &FALLBACK_RECTS, 0, false);
+        assert_eq!(action, Some(LoadGameAction::Done));
+        assert_eq!(
+            resolve_click_at(point, true, last, &FALLBACK_RECTS, 0, false).0,
+            None
+        );
     }
 
     #[test]

--- a/shock2vr/src/scenes/load_game.rs
+++ b/shock2vr/src/scenes/load_game.rs
@@ -426,7 +426,10 @@ impl GameScene for LoadGameScene {
         // Only a save the player can actually see is loadable. The constructor
         // preselects row 0 from `saves` alone, which a layout too short to show
         // a single row would otherwise turn into a "Load" for an invisible one.
-        let selected = self.selected.filter(|index| *index < visible);
+        // Clamped on the field rather than into a local, so `build_canvas` draws
+        // "Load" disabled in exactly the cases the click rejects it.
+        self.selected = self.selected.filter(|index| *index < visible);
+        let selected = self.selected;
 
         // The panel hangs off the head's facing, so this is needed for the
         // render regardless of which presentation drives the pointer.

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -407,7 +407,7 @@ impl GameScene for MainMenuScene {
         let objects = canvas.render_world_space(
             asset_cache,
             panel.transform(),
-            self.vr_pointer_canvas.map(|p| vec2(p.x, p.y)),
+            self.vr_pointer_canvas,
             None,
             VR_COMPONENT_Z_STEP,
         );

--- a/shock2vr/src/scenes/main_menu.rs
+++ b/shock2vr/src/scenes/main_menu.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use cgmath::{Quaternion, Rotation, Vector2, Vector3, vec2, vec3};
+use cgmath::{Quaternion, Vector2, Vector3, vec2, vec3};
 use dark::{
     importers::{STRINGS_IMPORTER, UI_LAYOUT_IMPORTER},
     map::MapRect,
@@ -39,7 +39,7 @@ use crate::{
     time::Time,
     ui::{
         HAlign, Rect, ScaleMode, UiCanvas, VAlign, VR_COMPONENT_Z_STEP, frontend_panel,
-        pointer_to_canvas, ray_to_canvas,
+        pointer_to_canvas, vr_frontend_pointer,
     },
 };
 
@@ -173,42 +173,11 @@ fn menu_labels(strings: Option<&HashMap<String, String>>) -> Vec<String> {
         .collect()
 }
 
-/// A VR trigger past this counts as "pressed", matching the hand code's
-/// grab/fire threshold.
-const VR_TRIGGER_THRESHOLD: f32 = 0.5;
-
 /// Where a hand is pointing on the menu panel, in canvas pixels, plus whether
-/// its trigger is held.
-///
-/// Both controllers are always posed in VR, so "whichever hand hits the panel"
-/// would always resolve to the same one. Instead a hand **with its trigger
-/// held** wins, so either controller can click; ties and idle triggers fall
-/// back to the right hand, which then drives the hover highlight.
+/// its trigger is held. The rule is the frontend's, not this screen's, so it
+/// lives in [`vr_frontend_pointer`].
 fn vr_pointer(input_context: &InputContext) -> (Option<Vector2<f32>>, bool) {
-    let panel = frontend_panel(input_context.head.rotation);
-    let right = &input_context.right_hand;
-    let left = &input_context.left_hand;
-    let held = |hand: &crate::input_context::Hand| hand.trigger_value > VR_TRIGGER_THRESHOLD;
-
-    let order = if held(left) && !held(right) {
-        [left, right]
-    } else {
-        [right, left]
-    };
-
-    for hand in order {
-        let direction = hand.rotation.rotate_vector(vec3(0.0, 0.0, -1.0));
-        if let Some(point) =
-            ray_to_canvas(vec2(CANVAS_W, CANVAS_H), &panel, hand.position, direction)
-        {
-            return (Some(point), held(hand));
-        }
-    }
-
-    // Neither hand points at the menu; report the trigger anyway so a press
-    // that starts off-panel is still consumed as "held" rather than becoming a
-    // fresh edge the moment the ray crosses onto a button.
-    (None, held(right) || held(left))
+    vr_frontend_pointer(input_context, vec2(CANVAS_W, CANVAS_H))
 }
 
 /// Shared click core: both presentations reduce to "a point on the canvas plus
@@ -514,8 +483,6 @@ impl GameScene for MainMenuScene {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::FRONTEND_PANEL_DISTANCE;
-    use cgmath::Rotation3;
 
     fn pointer_at(x: f32, y: f32, pressed: bool) -> Option<Pointer2D> {
         Some(Pointer2D {
@@ -606,34 +573,9 @@ mod tests {
         assert_eq!(action, Some(MenuAction::Quit));
     }
 
-    /// A hand pointing at a given canvas point on the VR panel, with the
-    /// trigger at `trigger`. Built by inverting `ray_to_canvas`: place the hand
-    /// at the panel-plane offset and aim straight down -Z.
-    /// The head facing the tests aim against: the default camera orientation.
-    fn test_head() -> Quaternion<f32> {
-        Quaternion::new(1.0, 0.0, 0.0, 0.0)
-    }
-
-    /// A hand aimed at a given canvas point, derived from the panel's own basis
-    /// rather than world axes - so the test stays honest whichever way the
-    /// panel ends up facing.
+    /// A hand aimed at a canvas point on this screen's VR panel.
     fn hand_aimed_at(point: Vector2<f32>, trigger: f32) -> crate::input_context::Hand {
-        let panel = frontend_panel(test_head());
-        let u = point.x / CANVAS_W - 0.5;
-        let v = 0.5 - point.y / CANVAS_H;
-        let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
-        let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
-        let normal = panel.normal();
-        let target = panel.center + right * (u * panel.size.x) + up * (v * panel.size.y);
-
-        crate::input_context::Hand {
-            // Stand back on the viewer's side (the normal points at the
-            // viewer) and aim at the target.
-            position: target + normal * FRONTEND_PANEL_DISTANCE,
-            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -normal, None),
-            trigger_value: trigger,
-            ..crate::input_context::Hand::default()
-        }
+        crate::ui::test_support::hand_aimed_at(vec2(CANVAS_W, CANVAS_H), point, trigger)
     }
 
     fn vr_input(hand: crate::input_context::Hand) -> InputContext {
@@ -691,14 +633,7 @@ mod tests {
         // Rotated 180 degrees: pointing behind the player, away from the panel.
         // Both hands must aim away - in VR both are always posed, so leaving
         // one at its default would have it pointing straight at the panel.
-        let panel = frontend_panel(test_head());
-        let away = || crate::input_context::Hand {
-            // Aim directly opposite the panel, from the panel's own centre.
-            position: panel.center,
-            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -panel.normal(), None),
-            trigger_value: 1.0,
-            ..crate::input_context::Hand::default()
-        };
+        let away = || crate::ui::test_support::hand_aimed_away(1.0);
         let input = InputContext {
             right_hand: away(),
             left_hand: away(),

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -1,0 +1,182 @@
+//! The VR pointer shared by every frontend screen.
+//!
+//! In VR there is no 2D cursor: the "pointer" is where a controller ray meets
+//! the screen's [`frontend_panel`], and the trigger is the button. That rule is
+//! identical for the main menu, the load screen and the game-over screen, so it
+//! lives here once rather than being re-derived per scene - the same reason
+//! placement lives in one layout pass (see `AGENTS.md` section 3): independent
+//! copies drift silently.
+
+use cgmath::{InnerSpace, Quaternion, Rotation, Vector2, Vector3, vec3};
+
+use crate::{
+    input_context::{Hand, InputContext},
+    ui::{frontend_panel, ray_to_canvas},
+};
+
+/// A VR trigger past this counts as "pressed", matching the hand code's
+/// grab/fire threshold.
+pub const VR_TRIGGER_THRESHOLD: f32 = 0.5;
+
+/// The direction a hand points, or `None` when the controller is not tracked.
+///
+/// An untracked hand reports a zero quaternion rather than an identity one.
+/// Rotating by it collapses the ray to the zero vector, so guarding here keeps
+/// an untracked controller from being treated as a hand aimed anywhere at all.
+fn hand_ray(rotation: Quaternion<f32>) -> Option<Vector3<f32>> {
+    if rotation.magnitude2() < 1e-6 {
+        return None;
+    }
+    Some(rotation.normalize().rotate_vector(vec3(0.0, 0.0, -1.0)))
+}
+
+fn held(hand: &Hand) -> bool {
+    hand.trigger_value > VR_TRIGGER_THRESHOLD
+}
+
+/// Where a hand is pointing on a frontend screen's panel, in canvas pixels,
+/// plus whether its trigger is held.
+///
+/// Both controllers are always posed in VR, so "whichever hand hits the panel"
+/// would always resolve to the same one. Instead a hand **with its trigger
+/// held** wins, so either controller can click; ties and idle triggers fall
+/// back to the right hand, which then drives the hover highlight.
+pub fn vr_frontend_pointer(
+    input_context: &InputContext,
+    canvas_size: Vector2<f32>,
+) -> (Option<Vector2<f32>>, bool) {
+    let panel = frontend_panel(input_context.head.rotation);
+    let right = &input_context.right_hand;
+    let left = &input_context.left_hand;
+
+    let order = if held(left) && !held(right) {
+        [left, right]
+    } else {
+        [right, left]
+    };
+
+    for hand in order {
+        let Some(direction) = hand_ray(hand.rotation) else {
+            continue;
+        };
+        if let Some(point) = ray_to_canvas(canvas_size, &panel, hand.position, direction) {
+            return (Some(point), held(hand));
+        }
+    }
+
+    // Neither hand points at the screen; report the trigger anyway so a press
+    // that starts off-panel is still consumed as "held" rather than becoming a
+    // fresh edge the moment the ray crosses onto a button.
+    (None, held(right) || held(left))
+}
+
+/// Test-only rig for aiming a controller at a canvas point, shared by the
+/// frontend scenes' tests so each one exercises the real `vr_frontend_pointer`
+/// rather than a hand-rolled approximation of it.
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+    use crate::ui::FRONTEND_PANEL_DISTANCE;
+
+    /// The head facing the tests aim against: the default camera orientation.
+    pub fn test_head() -> Quaternion<f32> {
+        Quaternion::new(1.0, 0.0, 0.0, 0.0)
+    }
+
+    /// A hand aimed at a given canvas point, derived from the panel's own basis
+    /// rather than world axes - so the tests stay honest whichever way the
+    /// panel ends up facing. This is the inverse of [`ray_to_canvas`].
+    pub fn hand_aimed_at(canvas_size: Vector2<f32>, point: Vector2<f32>, trigger: f32) -> Hand {
+        let panel = frontend_panel(test_head());
+        let u = point.x / canvas_size.x - 0.5;
+        let v = 0.5 - point.y / canvas_size.y;
+        let right = panel.rotation.rotate_vector(vec3(1.0, 0.0, 0.0));
+        let up = panel.rotation.rotate_vector(vec3(0.0, 1.0, 0.0));
+        let normal = panel.normal();
+        let target = panel.center + right * (u * panel.size.x) + up * (v * panel.size.y);
+
+        Hand {
+            // Stand back on the viewer's side (the panel's normal points at the
+            // viewer) and aim at the target.
+            position: target + normal * FRONTEND_PANEL_DISTANCE,
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), -normal, None),
+            trigger_value: trigger,
+            ..Hand::default()
+        }
+    }
+
+    /// A hand on the viewer's side of the panel, aimed directly away from it.
+    pub fn hand_aimed_away(trigger: f32) -> Hand {
+        let panel = frontend_panel(test_head());
+        let normal = panel.normal();
+        Hand {
+            position: panel.center + normal * FRONTEND_PANEL_DISTANCE,
+            rotation: Quaternion::from_arc(vec3(0.0, 0.0, -1.0), normal, None),
+            trigger_value: trigger,
+            ..Hand::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+    use cgmath::{Zero, vec2};
+
+    const CANVAS: Vector2<f32> = Vector2 { x: 640.0, y: 480.0 };
+
+    fn vr_input(right: Hand, left: Hand) -> InputContext {
+        InputContext {
+            right_hand: right,
+            left_hand: left,
+            ..InputContext::default()
+        }
+    }
+
+    #[test]
+    fn an_untracked_hand_yields_no_pointer() {
+        // A zero rotation is what a runtime reports for a controller that is
+        // not tracked. Treating it as a rotation would aim a ray straight down
+        // -Z from the origin, which can land on the panel and drive the
+        // highlight (or a click) from a controller nobody is holding.
+        let untracked = Hand {
+            rotation: Quaternion::zero(),
+            // At eye level, where a hand held up in front of the player sits.
+            position: vec3(0.0, crate::ui::FRONTEND_PANEL_EYE_HEIGHT, 0.0),
+            trigger_value: 1.0,
+            ..Hand::default()
+        };
+        let (point, _) = vr_frontend_pointer(&vr_input(untracked.clone(), untracked), CANVAS);
+        assert_eq!(
+            point, None,
+            "an untracked controller must not report a pointer"
+        );
+    }
+
+    #[test]
+    fn a_tracked_hand_still_points_when_the_other_is_untracked() {
+        let untracked = Hand {
+            rotation: Quaternion::zero(),
+            ..Hand::default()
+        };
+        let target = vec2(320.0, 240.0);
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(untracked, hand_aimed_at(CANVAS, target, 1.0)),
+            CANVAS,
+        );
+        let point = point.expect("the tracked hand should land on the panel");
+        assert!((point.x - target.x).abs() < 1.0 && (point.y - target.y).abs() < 1.0);
+        assert!(pressed);
+    }
+
+    #[test]
+    fn aiming_away_yields_no_point_but_keeps_the_trigger() {
+        let (point, pressed) = vr_frontend_pointer(
+            &vr_input(hand_aimed_away(1.0), hand_aimed_away(1.0)),
+            CANVAS,
+        );
+        assert_eq!(point, None);
+        assert!(pressed);
+    }
+}

--- a/shock2vr/src/ui/frontend_pointer.rs
+++ b/shock2vr/src/ui/frontend_pointer.rs
@@ -49,6 +49,7 @@ pub fn vr_frontend_pointer(
     let right = &input_context.right_hand;
     let left = &input_context.left_hand;
 
+    let any_held = held(right) || held(left);
     let order = if held(left) && !held(right) {
         [left, right]
     } else {
@@ -56,18 +57,25 @@ pub fn vr_frontend_pointer(
     };
 
     for hand in order {
+        // While a trigger is down, only the hand holding it may supply the
+        // point: otherwise an idle hand resting on the panel would report
+        // "not pressed" and clear the held state, so sweeping the pressed hand
+        // onto a button would read as a fresh edge and click it.
+        if any_held && !held(hand) {
+            continue;
+        }
         let Some(direction) = hand_ray(hand.rotation) else {
             continue;
         };
         if let Some(point) = ray_to_canvas(canvas_size, &panel, hand.position, direction) {
-            return (Some(point), held(hand));
+            return (Some(point), any_held);
         }
     }
 
-    // Neither hand points at the screen; report the trigger anyway so a press
-    // that starts off-panel is still consumed as "held" rather than becoming a
-    // fresh edge the moment the ray crosses onto a button.
-    (None, held(right) || held(left))
+    // Nothing points at the screen; report the trigger anyway so a press that
+    // starts off-panel is still consumed as "held" rather than becoming a fresh
+    // edge the moment the ray crosses onto a button.
+    (None, any_held)
 }
 
 /// Test-only rig for aiming a controller at a canvas point, shared by the
@@ -106,8 +114,14 @@ pub mod test_support {
     }
 
     /// A hand on the viewer's side of the panel, aimed directly away from it.
+    ///
+    /// The origin is deliberately off the panel plane: sitting exactly on
+    /// `panel.center` makes `ray_to_canvas` bail on distance before it ever
+    /// looks at the direction, so the test would pass even aimed at the panel.
     pub fn hand_aimed_away(trigger: f32) -> Hand {
         let panel = frontend_panel(test_head());
+        // The panel's normal points at the viewer, so this stands in front of
+        // it and looks the other way.
         let normal = panel.normal();
         Hand {
             position: panel.center + normal * FRONTEND_PANEL_DISTANCE,
@@ -168,6 +182,24 @@ mod tests {
         let point = point.expect("the tracked hand should land on the panel");
         assert!((point.x - target.x).abs() < 1.0 && (point.y - target.y).abs() < 1.0);
         assert!(pressed);
+    }
+
+    #[test]
+    fn an_idle_hand_on_the_panel_does_not_release_the_other_hands_trigger() {
+        // Left trigger held but aimed off-panel, right hand idle and resting on
+        // it. Reporting the right hand's idle trigger would clear `last_pressed`
+        // and turn the still-held left press into a fresh edge as soon as it
+        // swept onto a button - a click nobody made.
+        let input = vr_input(
+            hand_aimed_at(CANVAS, vec2(320.0, 240.0), 0.0),
+            hand_aimed_away(1.0),
+        );
+        let (point, pressed) = vr_frontend_pointer(&input, CANVAS);
+        assert!(pressed, "a held trigger must stay reported as held");
+        assert_eq!(
+            point, None,
+            "the idle hand must not supply a point while the other is pressed"
+        );
     }
 
     #[test]

--- a/shock2vr/src/ui/mod.rs
+++ b/shock2vr/src/ui/mod.rs
@@ -33,6 +33,11 @@ use shipyard::EntityId;
 
 use crate::vr_config::Handedness;
 
+mod frontend_pointer;
+#[cfg(test)]
+pub use frontend_pointer::test_support;
+pub use frontend_pointer::vr_frontend_pointer;
+
 /// Font name that resolves to the engine's compiled-in font rather than a
 /// `.FON` asset.
 ///


### PR DESCRIPTION
# VR pointer + world panels for the load and game-over screens

Stacked on #994. Until now `MainMenuScene` was the only frontend screen with a VR path — `LoadGameScene` and `GameOverScene` consumed only the flat `Pointer2D` (which is `None` in VR), so **"New Game" was the only live menu entry in a headset**, and dying in VR left you on a screen you couldn't operate.

## What changed

- **One shared pointer rule** — new `shock2vr/src/ui/frontend_pointer.rs` (`vr_frontend_pointer`): `frontend_panel(head.rotation)` raycast per hand, rising edge on trigger > 0.5, a held-trigger hand wins else right hand, off-panel keeps the trigger reported so a press started off-panel can't fake a rising edge. `main_menu`'s private copy is deleted; all three scenes call the same function (the repo's "make divergence impossible" principle). Its `test_support` rig (aim a hand at a canvas point) is shared by all three scenes' tests.
- **Untracked-hand guard**: cgmath silently returns the input vector when rotating by a zero quaternion, so an untracked controller used to aim a fixed ray at dead-center of the panel (negative-tested: without the guard the pointer reads `(320, 240)`). An untracked hand now yields no pointer.
- **Load + game-over screens get world panels**: `build_canvas()` extracted from each scene's flat path; in VR the same canvas renders onto `frontend_panel(...)` via `render_world_space`. No placement decisions duplicated — both presentations consume the one layout pass, so `ellipsize`/`fit_to_rect` (long save names) came out correct on the panel with zero extra work.

### Edge cases found by cross-engine review (each with a regression test)

- `GameOverScene` is entered mid-combat: starting `last_pressed: false` meant dying **with the trigger held** read as a rising edge on frame 1 and could instantly click Quit. It now starts `true`.
- The pointer reported only the winning hand's trigger, so an idle hand resting on the panel cleared the held state and let a sweep click a button; a held trigger now restricts which hand may supply the point.
- `load_game` clamped its selected row into a local, letting a zero-row layout draw "Load" as actionable while clicks rejected it; the field is clamped now.
- The game-over save name overflowed its panel; it now uses the load screen's small font, insets, and ellipsization.

## Screenshots (debug runtime `--vr`, hand ray driven over HTTP)

Menu → Load Game, hover following the ray:

![menu hover Load Game](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r01-menu-hover-load.png)

The load screen as a world panel — save list, ellipsized names, Load/Done on the viewer's right:

![load screen world panel](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r02-load-screen-panel.png)

| Row selected by click | Hover Done |
| --- | --- |
| ![row selected](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r03-load-row-selected.png) | ![hover Done](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r04-load-hover-done.png) |

Game-over panel after dying in `debug_minimal` (save name fitted, hover moving LOAD ↔ QUIT):

| Hover LOAD | Hover QUIT |
| --- | --- |
| ![game over hover load](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r06-gameover-hover-load.png) | ![game over hover quit](https://gist.githubusercontent.com/tommy-xr/c191b31873e55966da19e6bf4e03d599/raw/r07-gameover-hover-quit.png) |

<sub>Captured headlessly via the debug runtime (`/v1/step` + `/v1/screenshot`), hand driven through `right_hand.position/rotation/trigger`. Clicking Done returned to the menu without the carried press firing Quit; full flow menu → load → row → Done → menu, and death → game-over → LOAD → resumed mission, both driven end-to-end.</sub>

## Validation

- `cargo test -p shock2vr` 693 passed; `cargo test -p desktop_runtime` 5 passed; `RUSTFLAGS="-D warnings"` check clean across shock2vr/desktop/debug runtimes; touched files rustfmt-clean.
- e2e (SHOCK2_E2E=1): missions 23/23, load-game-screen 2/2, menu-audio 3/3 (incl. the VR controller-ray sound probe), flat-ui-plumbing, player-death 4/4, save-load 3/3, cross-mode-held-load, quickload-missing — zero failures.
- Flat presentation re-checked for parity after every change (canvas built by the same `build_canvas`, placement from the shared layout pass).

## Notes

- The flat/VR presentation split (`render`/`render_per_eye` + `build_canvas`) is now a fourth verbatim copy across the frontend scenes, and `resolve_click_at` a third — flagged in `handoff.md` as the next extraction rather than widening this diff.
